### PR TITLE
Added log for orphan tables

### DIFF
--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -556,7 +556,7 @@ impl<T: WasmInstance> WasmInstanceActor<T> {
             for orphan in known_tables.into_keys() {
                 if !orphan.starts_with("st_") {
                     self.system_logger()
-                        .warn(format!("Orphaned table: {}", orphan.clone()).as_str());
+                        .warn(format!("Orphaned table: {}", orphan).as_str());
                     tainted.push(orphan);
                 }
             }


### PR DESCRIPTION
# Description of Changes

 - When we are marking a table as an orphan we now have a log. Currently we have a bug where SpacetimeDB thinks that the schema of all tables have changed and I think we're getting into a situation where they're all being marked as orphans. Added logs for visibility.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
