### PR TITLE
Add primary key class variable to table autogen in python

### DIFF
--- a/crates/cli/src/subcommands/generate/python.rs
+++ b/crates/cli/src/subcommands/generate/python.rs
@@ -257,7 +257,7 @@ fn autogen_python_product_table_common(
                 .unwrap()
                 .iter()
                 .enumerate()
-                .find_map(|(idx, attr)| attr.is_primary().then(|| idx))
+                .find_map(|(idx, attr)| attr.is_primary().then_some(idx))
                 .map(|idx| {
                     let field_name = product_type.elements[idx]
                         .name


### PR DESCRIPTION
# Description of Changes

Add primary key class variable to table autogen in python

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
