### PR TITLE
Make API call errors convertible to String

### DIFF
--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -460,6 +460,11 @@ impl<T: TableType> fmt::Display for UniqueConstraintViolation<T> {
         )
     }
 }
+impl<T: TableType> From<UniqueConstraintViolation<T>> for String {
+    fn from(err: UniqueConstraintViolation<T>) -> Self {
+        err.to_string()
+    }
+}
 impl<T: TableType> std::error::Error for UniqueConstraintViolation<T> {}
 
 impl<T: TableType> sealed::InsertResult for Result<T, UniqueConstraintViolation<T>> {

--- a/crates/sats/src/buffer.rs
+++ b/crates/sats/src/buffer.rs
@@ -22,7 +22,11 @@ impl fmt::Display for DecodeError {
         }
     }
 }
-
+impl From<DecodeError> for String {
+    fn from(err: DecodeError) -> Self {
+        err.to_string()
+    }
+}
 impl std::error::Error for DecodeError {}
 
 impl From<Utf8Error> for DecodeError {

--- a/modules/rust-wasm-test/src/lib.rs
+++ b/modules/rust-wasm-test/src/lib.rs
@@ -80,10 +80,7 @@ pub fn test(ctx: ReducerContext, arg: TestA, arg2: TestB, arg3: TestC) -> anyhow
         });
     }
 
-    let mut row_count = 0;
-    for _row in TestA::iter() {
-        row_count += 1;
-    }
+    let row_count = TestA::iter().count();
 
     log::info!("Row count before delete: {:?}", row_count);
 
@@ -91,10 +88,7 @@ pub fn test(ctx: ReducerContext, arg: TestA, arg2: TestB, arg3: TestC) -> anyhow
         delete_eq(1, 0, &AlgebraicValue::U32(row))?;
     }
 
-    let mut row_count = 0;
-    for _row in TestA::iter() {
-        row_count += 1;
-    }
+    let row_count = TestA::iter().count();
 
     match TestE::insert(TestE {
         id: 0,
@@ -106,10 +100,7 @@ pub fn test(ctx: ReducerContext, arg: TestA, arg2: TestB, arg3: TestC) -> anyhow
 
     log::info!("Row count after delete: {:?}", row_count);
 
-    let mut other_row_count = 0;
-    for _row in query!(|row: TestA| row.x >= 0 && row.x <= u32::MAX) {
-        other_row_count += 1;
-    }
+    let other_row_count = query!(|row: TestA| row.x >= 0 && row.x <= u32::MAX).count();
 
     log::info!("Row count filtered by condition: {:?}", other_row_count);
 
@@ -119,7 +110,7 @@ pub fn test(ctx: ReducerContext, arg: TestA, arg2: TestB, arg3: TestC) -> anyhow
 
 #[spacetimedb(reducer)]
 pub fn add_player(name: String) -> Result<(), String> {
-    TestE::insert(TestE { id: 0, name }).map_err(|_| "Duplicate row entry.".to_string())?;
+    TestE::insert(TestE { id: 0, name })?;
     Ok(())
 }
 


### PR DESCRIPTION
# Description of Changes

Per https://www.notion.so/clockworklabs/All-module-API-call-Errors-should-be-convertable-to-String-b629c878c541483daf5176a72cfe4b26.

Also does some minor cleanup / refactoring.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
