### PR TITLE
Making C# reducer args classes partial

### DIFF
--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -1371,7 +1371,7 @@ pub fn autogen_csharp_reducer(ctx: &GenCtx, reducer: &ReducerDef, namespace: &st
     writeln!(output).unwrap();
 
     //Args struct
-    writeln!(output, "public class {func_name_pascal_case}ArgsStruct").unwrap();
+    writeln!(output, "public partial class {func_name_pascal_case}ArgsStruct").unwrap();
     writeln!(output, "{{").unwrap();
     {
         indent_scope!(output);

--- a/crates/cli/tests/snapshots/codegen__codegen_output.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_output.snap
@@ -62,7 +62,7 @@ namespace SpacetimeDB
 		}
 	}
 
-	public class AddPlayerArgsStruct
+	public partial class AddPlayerArgsStruct
 	{
 		public string Name;
 	}
@@ -286,7 +286,7 @@ namespace SpacetimeDB
 		}
 	}
 
-	public class RepeatingTestArgsStruct
+	public partial class RepeatingTestArgsStruct
 	{
 		public ulong PrevTime;
 	}
@@ -738,7 +738,7 @@ namespace SpacetimeDB
 		}
 	}
 
-	public class TestArgsStruct
+	public partial class TestArgsStruct
 	{
 		public SpacetimeDB.TestA Arg;
 		public SpacetimeDB.TestB Arg2;
@@ -803,7 +803,7 @@ namespace SpacetimeDB
 		}
 	}
 
-	public class UpdateArgsStruct
+	public partial class UpdateArgsStruct
 	{
 	}
 }


### PR DESCRIPTION
# Description of Changes

Making C# reducer args classes partial to allow easier extensibility

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
