### PR TITLE
Derek/csharp sdk

### DIFF
--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -1240,12 +1240,6 @@ pub fn autogen_csharp_reducer(ctx: &GenCtx, reducer: &ReducerDef, namespace: &st
         {
             indent_scope!(output);
 
-            //           SpacetimeDBClient.instance.InternalCallReducer(new SpacetimeDBClient.Message
-            // 			{
-            // 				fn = "create_new_player",
-            // 				args = new object[] { playerId, position },
-            // 			});
-
             // Tell the network manager to send this message
             writeln!(output, "var _argArray = new object[] {{{}}};", json_args).unwrap();
             writeln!(output, "var _message = new SpacetimeDBClient.ReducerCallRequest {{").unwrap();


### PR DESCRIPTION
# Description of Changes

Changes to support moving the UnitySDK to a CSharpSDK

This is the change to BitcraftClient to use this new SDK: https://github.com/clockworklabs/BitCraftClient/pull/2120/files

CSharpSDK is in the SpacetimeDBUnitySDK repo: https://github.com/clockworklabs/SpacetimeDBUnitySDK/pull/34

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
