### PR TITLE
Fix schema equivalence check when updating a module

### DIFF
--- a/test/tests/update-module.sh
+++ b/test/tests/update-module.sh
@@ -16,12 +16,15 @@ use spacetimedb::{println, spacetimedb};
 
 #[spacetimedb(table)]
 pub struct Person {
+    #[primarykey]
+    #[autoinc]
+    id: u64,
     name: String,
 }
 
 #[spacetimedb(reducer)]
 pub fn add(name: String) {
-    Person::insert(Person { name });
+    Person::insert(Person { id: 0, name });
 }
 
 #[spacetimedb(reducer)]
@@ -57,6 +60,9 @@ use spacetimedb::spacetimedb;
 
 #[spacetimedb(table)]
 pub struct Person {
+    #[primarykey]
+    #[autoinc]
+    id: u64,
     name: String,
     age: u8,
 }
@@ -71,6 +77,9 @@ use spacetimedb::{println, spacetimedb};
 
 #[spacetimedb(table)]
 pub struct Person {
+    #[primarykey]
+    #[autoinc]
+    id: u64,
     name: String,
 }
 


### PR DESCRIPTION
`IndexDef` contains a table id, which is not yet known (i.e. zero) when constructing `TableDef` from the module describers. But it /is/ known for the schema obtained from the database catalog, so schemas compare inequal even if they're structurally equivalent.

Fixed by just updating the proposed schema for known tables before comparing. Also update the smoke test to contain an indexed column.