### PR TITLE
Rename the APIs

### DIFF
--- a/crates/bench/src/spacetime.rs
+++ b/crates/bench/src/spacetime.rs
@@ -29,7 +29,7 @@ fn build_db() -> ResultBench<DbResult> {
     Ok((stdb, table_id))
 }
 
-fn insert(db: &RelationalDB, tx: &mut MutTxId, table_id: u32, run: Runs) -> ResultBench<()> {
+fn insert_row(db: &RelationalDB, tx: &mut MutTxId, table_id: u32, run: Runs) -> ResultBench<()> {
     for row in run.data() {
         db.insert(
             tx,
@@ -63,7 +63,7 @@ pub fn prefill_data(db: &DbResult, run: Runs) -> ResultBench<()> {
     let (conn, table_id) = db;
 
     let mut tx = conn.begin_tx();
-    insert(conn, &mut tx, *table_id, run)?;
+    insert_row(conn, &mut tx, *table_id, run)?;
 
     conn.commit_tx(tx)?;
     Ok(())
@@ -103,7 +103,7 @@ pub fn select_no_index(pool: &mut Pool<DbResult>, run: Runs) -> ResultBench<()> 
     for i in run.range().skip(1) {
         let i = i as u64;
         let _r = conn
-            .scan(&tx, table_id)?
+            .iter(&tx, table_id)?
             .map(|r| Data {
                 a: *r.view().elements[0].as_i32().unwrap(),
                 b: *r.view().elements[1].as_u64().unwrap(),

--- a/crates/bindings-sys/src/lib.rs
+++ b/crates/bindings-sys/src/lib.rs
@@ -96,7 +96,8 @@ pub mod raw {
         /// The rows found are bsatn encoded and then concatenated.
         /// The resulting byte string from the concatenation is written
         /// to a fresh buffer with the buffer's identifier written to the WASM pointer `out`.
-        pub fn _seek_eq(table_id: u32, col_id: u32, value: *const u8, value_len: usize, out: *mut Buffer) -> u16;
+        pub fn _iter_by_col_eq(table_id: u32, col_id: u32, value: *const u8, value_len: usize, out: *mut Buffer)
+            -> u16;
 
         /// Insert a row into the table identified by `table_id`,
         /// where the row is read from the byte slice `row_ptr` in WASM memory,
@@ -113,7 +114,7 @@ pub mod raw {
         /// The number of rows deleted is written to the WASM pointer `out`.
         ///
         /// Returns an error if no columns were deleted or if the column wasn't found.
-        pub fn _delete_eq(table_id: u32, col_id: u32, value: *const u8, value_len: usize, out: *mut u32) -> u16;
+        pub fn _delete_by_col_eq(table_id: u32, col_id: u32, value: *const u8, value_len: usize, out: *mut u32) -> u16;
 
         /*
         /// Deletes the primary key pointed to at by `pk` in the table identified by `table_id`.
@@ -464,8 +465,8 @@ pub fn create_index(index_name: &str, table_id: u32, index_type: u8, col_ids: &[
 /// The resulting byte string from the concatenation is written
 /// to a fresh buffer with a handle to it returned as a `Buffer`.
 #[inline]
-pub fn seek_eq(table_id: u32, col_id: u32, val: &[u8]) -> Result<Buffer, Errno> {
-    unsafe { call(|out| raw::_seek_eq(table_id, col_id, val.as_ptr(), val.len(), out)) }
+pub fn iter_by_col_eq(table_id: u32, col_id: u32, val: &[u8]) -> Result<Buffer, Errno> {
+    unsafe { call(|out| raw::_iter_by_col_eq(table_id, col_id, val.as_ptr(), val.len(), out)) }
 }
 
 /// Insert `row`, provided as a byte slice, into the table identified by `table_id`.
@@ -480,8 +481,8 @@ pub fn insert(table_id: u32, row: &mut [u8]) -> Result<(), Errno> {
 /// Returns the number of rows deleted
 /// or an error if no columns were deleted or if the column wasn't found.
 #[inline]
-pub fn delete_eq(table_id: u32, col_id: u32, value: &[u8]) -> Result<u32, Errno> {
-    unsafe { call(|out| raw::_delete_eq(table_id, col_id, value.as_ptr(), value.len(), out)) }
+pub fn delete_by_col_eq(table_id: u32, col_id: u32, value: &[u8]) -> Result<u32, Errno> {
+    unsafe { call(|out| raw::_delete_by_col_eq(table_id, col_id, value.as_ptr(), value.len(), out)) }
 }
 
 /*

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -166,11 +166,11 @@ pub fn insert<T: TableType>(table_id: u32, row: T) -> T::InsertResult {
 /// to a fresh buffer with a handle to it returned as a `Buffer`.
 ///
 /// Panics when serialization fails.
-pub fn seek_eq(table_id: u32, col_id: u8, val: &impl Serialize) -> Result<Buffer> {
+pub fn iter_by_col_eq(table_id: u32, col_id: u8, val: &impl Serialize) -> Result<Buffer> {
     with_row_buf(|bytes| {
         // Encode `val` as bsatn into `bytes` and then use that.
         bsatn::to_writer(bytes, val).unwrap();
-        sys::seek_eq(table_id, col_id as u32, bytes)
+        sys::iter_by_col_eq(table_id, col_id as u32, bytes)
     })
 }
 
@@ -184,11 +184,11 @@ pub fn seek_eq(table_id: u32, col_id: u8, val: &impl Serialize) -> Result<Buffer
 /// or an error if no columns were deleted or if the column wasn't found.
 ///
 /// Panics when serialization fails.
-pub fn delete_eq(table_id: u32, col_id: u8, eq_value: &impl Serialize) -> Result<u32> {
+pub fn delete_by_col_eq(table_id: u32, col_id: u8, eq_value: &impl Serialize) -> Result<u32> {
     with_row_buf(|bytes| {
         // Encode `val` as bsatn into `bytes` and then use that.
         bsatn::to_writer(bytes, eq_value).unwrap();
-        sys::delete_eq(table_id, col_id.into(), bytes)
+        sys::delete_by_col_eq(table_id, col_id.into(), bytes)
     })
 }
 
@@ -538,7 +538,7 @@ pub mod query {
         val: &T,
     ) -> Option<Table> {
         // Find the row with a match.
-        let slice: &mut &[u8] = &mut &*seek_eq(Table::table_id(), COL_IDX, val).unwrap().read();
+        let slice: &mut &[u8] = &mut &*iter_by_col_eq(Table::table_id(), COL_IDX, val).unwrap().read();
         // We will always find either 0 or 1 rows here due to the unique constraint.
         match slice.remaining() {
             0 => None,
@@ -577,7 +577,7 @@ pub mod query {
     /// This is exposed as `delete_by_{$field_name}` on types with `#[spacetimedb(table)]`.
     #[doc(hidden)]
     pub fn delete_by_field<Table: TableType, T: UniqueValue, const COL_IDX: u8>(val: &T) -> bool {
-        let result = delete_eq(Table::table_id(), COL_IDX, val);
+        let result = delete_by_col_eq(Table::table_id(), COL_IDX, val);
         match result {
             Err(_) => {
                 // TODO: Returning here was supposed to signify an error,

--- a/crates/core/src/db/cursor.rs
+++ b/crates/core/src/db/cursor.rs
@@ -2,7 +2,7 @@ use crate::error::DBError;
 use spacetimedb_sats::relation::{DbTable, RowCount};
 use spacetimedb_sats::ProductValue;
 
-use super::datastore::locking_tx_datastore::ScanIter;
+use super::datastore::locking_tx_datastore::Iter;
 
 #[derive(Debug, Clone, Copy)]
 pub enum CatalogKind {
@@ -15,11 +15,11 @@ pub enum CatalogKind {
 /// Common wrapper for relational iterators that work like cursors.
 pub struct TableCursor<'a> {
     pub table: DbTable,
-    pub iter: ScanIter<'a>,
+    pub iter: Iter<'a>,
 }
 
 impl<'a> TableCursor<'a> {
-    pub fn new(table: DbTable, iter: ScanIter<'a>) -> Result<Self, DBError> {
+    pub fn new(table: DbTable, iter: Iter<'a>) -> Result<Self, DBError> {
         Ok(Self { table, iter })
     }
 }

--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -11,12 +11,9 @@ pub struct DbMetrics {
     pub tdb_commit_time: Histogram,
     pub rdb_create_table_time: HistogramVec,
     pub rdb_drop_table_time: HistogramVec,
-    pub rdb_scan_time: HistogramVec,
-    pub rdb_scan_raw_time: HistogramVec,
-    pub rdb_scan_pk_time: HistogramVec,
-    pub rdb_insert_time: HistogramVec,
-    pub rdb_delete_pk_time: HistogramVec,
-    pub rdb_delete_in_time: HistogramVec,
+    pub rdb_iter_time: HistogramVec,
+    pub rdb_insert_row_time: HistogramVec,
+    pub rdb_delete_by_rel_time: HistogramVec,
 }
 
 pub static DB_METRICS: Lazy<DbMetrics> = Lazy::new(DbMetrics::new);
@@ -60,38 +57,17 @@ impl DbMetrics {
                 &["table_id"],
             )
             .unwrap(),
-            rdb_scan_time: HistogramVec::new(
-                HistogramOpts::new("spacetime_rdb_scan_time", "The time spent scanning a table"),
+            rdb_iter_time: HistogramVec::new(
+                HistogramOpts::new("spacetime_rdb_iter_time", "The time spent iterating a table"),
                 &["table_id"],
             )
             .unwrap(),
-            rdb_scan_raw_time: HistogramVec::new(
-                HistogramOpts::new("spacetime_rdb_scan_raw_time", "The time spent scanning a table"),
+            rdb_insert_row_time: HistogramVec::new(
+                HistogramOpts::new("spacetime_rdb_insert_row_time", "The time spent inserting into a table"),
                 &["table_id"],
             )
             .unwrap(),
-            rdb_scan_pk_time: HistogramVec::new(
-                HistogramOpts::new(
-                    "spacetime_rdb_scan_pk_time",
-                    "The time spent scanning a table using its primary key",
-                ),
-                &["table_id"],
-            )
-            .unwrap(),
-            rdb_insert_time: HistogramVec::new(
-                HistogramOpts::new("spacetime_rdb_insert_time", "The time spent inserting into a table"),
-                &["table_id"],
-            )
-            .unwrap(),
-            rdb_delete_pk_time: HistogramVec::new(
-                HistogramOpts::new(
-                    "spacetime_rdb_delete_pk_time",
-                    "The time spent deleting from a table using its primary key",
-                ),
-                &["table_id"],
-            )
-            .unwrap(),
-            rdb_delete_in_time: HistogramVec::new(
+            rdb_delete_by_rel_time: HistogramVec::new(
                 HistogramOpts::new(
                     "spacetime_rdb_delete_in_time",
                     "The time spent deleting values in a set from a table",
@@ -115,17 +91,12 @@ impl DbMetrics {
         self.registry
             .register(Box::new(self.rdb_drop_table_time.clone()))
             .unwrap();
-        self.registry.register(Box::new(self.rdb_scan_time.clone())).unwrap();
+        self.registry.register(Box::new(self.rdb_iter_time.clone())).unwrap();
         self.registry
-            .register(Box::new(self.rdb_scan_raw_time.clone()))
-            .unwrap();
-        self.registry.register(Box::new(self.rdb_scan_pk_time.clone())).unwrap();
-        self.registry.register(Box::new(self.rdb_insert_time.clone())).unwrap();
-        self.registry
-            .register(Box::new(self.rdb_delete_pk_time.clone()))
+            .register(Box::new(self.rdb_insert_row_time.clone()))
             .unwrap();
         self.registry
-            .register(Box::new(self.rdb_delete_in_time.clone()))
+            .register(Box::new(self.rdb_delete_by_rel_time.clone()))
             .unwrap();
     }
 }
@@ -139,12 +110,9 @@ metrics_delegator!(TDB_SCAN_TIME, tdb_scan_time: Histogram);
 metrics_delegator!(TDB_COMMIT_TIME, tdb_commit_time: Histogram);
 metrics_delegator!(RDB_CREATE_TABLE_TIME, rdb_create_table_time: HistogramVec);
 metrics_delegator!(RDB_DROP_TABLE_TIME, rdb_drop_table_time: HistogramVec);
-metrics_delegator!(RDB_SCAN_TIME, rdb_scan_time: HistogramVec);
-metrics_delegator!(RDB_SCAN_RAW_TIME, rdb_scan_raw_time: HistogramVec);
-metrics_delegator!(RDB_SCAN_PK_TIME, rdb_scan_pk_time: HistogramVec);
-metrics_delegator!(RDB_INSERT_TIME, rdb_insert_time: HistogramVec);
-metrics_delegator!(RDB_DELETE_PK_TIME, rdb_delete_pk_time: HistogramVec);
-metrics_delegator!(RDB_DELETE_IN_TIME, rdb_delete_in_time: HistogramVec);
+metrics_delegator!(RDB_ITER_TIME, rdb_iter_time: HistogramVec);
+metrics_delegator!(RDB_INSERT_TIME, rdb_insert_row_time: HistogramVec);
+metrics_delegator!(RDB_DELETE_BY_REL_TIME, rdb_delete_by_rel_time: HistogramVec);
 
 pub fn register_custom_metrics() {
     DB_METRICS.register_custom_metrics()

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1,14 +1,12 @@
 use super::commit_log::CommitLog;
-use super::datastore::locking_tx_datastore::{Data, DataRef, MutTxId, RangeScanIter, RowId, ScanIter, SeekIter};
+use super::datastore::locking_tx_datastore::{Data, DataRef, Iter, IterByColEq, IterByColRange, MutTxId, RowId};
 use super::datastore::traits::{
     ColId, DataRow, IndexDef, IndexId, MutTx, MutTxDatastore, SequenceDef, SequenceId, TableDef, TableId, TableSchema,
 };
 use super::message_log::MessageLog;
 use super::messages::transaction::Transaction;
 use super::relational_operators::Relation;
-use crate::db::db_metrics::{
-    RDB_DELETE_IN_TIME, RDB_DELETE_PK_TIME, RDB_DROP_TABLE_TIME, RDB_INSERT_TIME, RDB_SCAN_TIME,
-};
+use crate::db::db_metrics::{RDB_DELETE_BY_REL_TIME, RDB_DROP_TABLE_TIME, RDB_INSERT_TIME, RDB_ITER_TIME};
 use crate::db::messages::commit::Commit;
 use crate::db::ostorage::hashmap_object_db::HashMapObjectDB;
 use crate::db::ostorage::ObjectDB;
@@ -16,8 +14,9 @@ use crate::error::{DBError, DatabaseError, TableError};
 use crate::hash::Hash;
 use crate::util::prometheus_handle::HistogramVecHandle;
 use fs2::FileExt;
+use prometheus::HistogramVec;
+use spacetimedb_lib::ColumnIndexAttribute;
 use spacetimedb_lib::{data_key::ToDataKey, PrimaryKey};
-use spacetimedb_lib::{ColumnIndexAttribute, DataKey};
 use spacetimedb_sats::{AlgebraicType, AlgebraicValue, ProductType, ProductValue};
 use std::fs::File;
 use std::ops::RangeBounds;
@@ -25,6 +24,11 @@ use std::path::Path;
 use std::sync::{Arc, Mutex};
 
 use super::datastore::locking_tx_datastore::Locking;
+
+/// Starts histogram prometheus measurements for `table_id`.
+fn measure(hist: &'static HistogramVec, table_id: u32) {
+    HistogramVecHandle::new(hist, vec![format!("{}", table_id)]).start();
+}
 
 pub const ST_TABLES_NAME: &str = "st_table";
 pub const ST_COLUMNS_NAME: &str = "st_columns";
@@ -270,9 +274,7 @@ impl RelationalDB {
     }
 
     pub fn drop_table(&self, tx: &mut MutTxId, table_id: u32) -> Result<(), DBError> {
-        let mut measure = HistogramVecHandle::new(&RDB_DROP_TABLE_TIME, vec![format!("{}", table_id)]);
-        measure.start();
-
+        measure(&RDB_DROP_TABLE_TIME, table_id);
         self.inner.drop_table_mut_tx(tx, TableId(table_id))
     }
 
@@ -354,12 +356,12 @@ impl RelationalDB {
         self.inner.drop_index_mut_tx(tx, index_id)
     }
 
-    // AKA: iter
+    /// Returns an iterator,
+    /// yielding every row in the table identified by `table_id`.
     #[tracing::instrument(skip(self, tx))]
-    pub fn scan<'a>(&'a self, tx: &'a MutTxId, table_id: u32) -> Result<ScanIter<'a>, DBError> {
-        let mut measure = HistogramVecHandle::new(&RDB_SCAN_TIME, vec![format!("{}", table_id)]);
-        measure.start();
-        self.inner.scan_mut_tx(tx, TableId(table_id))
+    pub fn iter<'a>(&'a self, tx: &'a MutTxId, table_id: u32) -> Result<Iter<'a>, DBError> {
+        measure(&RDB_ITER_TIME, table_id);
+        self.inner.iter_mut_tx(tx, TableId(table_id))
     }
 
     /// Returns an iterator,
@@ -368,33 +370,37 @@ impl RelationalDB {
     ///
     /// Matching is defined by `Ord for AlgebraicValue`.
     #[tracing::instrument(skip(self, tx))]
-    pub fn seek<'a>(
+    pub fn iter_by_col_eq<'a>(
         &'a self,
         tx: &'a mut MutTxId,
         table_id: u32,
         col_id: u32,
         value: &'a AlgebraicValue,
-    ) -> Result<SeekIter<'a>, DBError> {
-        self.inner.seek_mut_tx(tx, TableId(table_id), ColId(col_id), value)
+    ) -> Result<IterByColEq<'a>, DBError> {
+        self.inner
+            .iter_by_col_eq_mut_tx(tx, TableId(table_id), ColId(col_id), value)
     }
 
-    pub fn range_scan<'a, R: RangeBounds<AlgebraicValue> + 'a>(
+    /// Returns an iterator,
+    /// yielding every row in the table identified by `table_id`,
+    /// where the column data identified by `col_id` matches what is within `range`.
+    ///
+    /// Matching is defined by `Ord for AlgebraicValue`.
+    pub fn iter_by_col_range<'a, R: RangeBounds<AlgebraicValue> + 'a>(
         &'a self,
         tx: &'a MutTxId,
         table_id: u32,
         col_id: u32,
         range: R,
-    ) -> Result<RangeScanIter<'a, R>, DBError> {
+    ) -> Result<IterByColRange<'a, R>, DBError> {
         self.inner
-            .range_scan_mut_tx(tx, TableId(table_id), ColId(col_id), range)
+            .iter_by_col_range_mut_tx(tx, TableId(table_id), ColId(col_id), range)
     }
 
     #[tracing::instrument(skip(self, tx))]
     pub fn insert(&self, tx: &mut MutTxId, table_id: u32, row: ProductValue) -> Result<ProductValue, DBError> {
-        let mut measure = HistogramVecHandle::new(&RDB_INSERT_TIME, vec![format!("{}", table_id)]);
-        measure.start();
-
-        self.inner.insert_row_mut_tx(tx, TableId(table_id), row)
+        measure(&RDB_INSERT_TIME, table_id);
+        self.inner.insert_mut_tx(tx, TableId(table_id), row)
     }
 
     #[tracing::instrument(skip_all)]
@@ -409,18 +415,23 @@ impl RelationalDB {
         self.insert(tx, table_id, row)
     }
 
+    /*
     #[tracing::instrument(skip_all)]
     pub fn delete_pk(&self, tx: &mut MutTxId, table_id: u32, row_id: DataKey) -> Result<bool, DBError> {
-        let mut measure = HistogramVecHandle::new(&RDB_DELETE_PK_TIME, vec![format!("{}", table_id)]);
-        measure.start();
+        measure(&RDB_DELETE_PK_TIME, table_id);
         self.inner.delete_row_mut_tx(tx, TableId(table_id), RowId(row_id))
     }
+    */
 
     #[tracing::instrument(skip_all)]
-    pub fn delete_in<R: Relation>(&self, tx: &mut MutTxId, table_id: u32, relation: R) -> Result<Option<u32>, DBError> {
-        let mut measure = HistogramVecHandle::new(&RDB_DELETE_IN_TIME, vec![format!("{}", table_id)]);
-        measure.start();
-        self.inner.delete_rows_in_mut_tx(tx, TableId(table_id), relation)
+    pub fn delete_by_rel<R: Relation>(
+        &self,
+        tx: &mut MutTxId,
+        table_id: u32,
+        relation: R,
+    ) -> Result<Option<u32>, DBError> {
+        measure(&RDB_DELETE_BY_REL_TIME, table_id);
+        self.inner.delete_by_rel_mut_tx(tx, TableId(table_id), relation)
     }
 
     /// Generated the next value for the [SequenceId]
@@ -596,7 +607,7 @@ mod tests {
         stdb.insert(&mut tx, table_id, product![AlgebraicValue::I32(1)])?;
 
         let mut rows = stdb
-            .scan(&tx, table_id)?
+            .iter(&tx, table_id)?
             .map(|r| *r.view().elements[0].as_i32().unwrap())
             .collect::<Vec<i32>>();
         rows.sort();
@@ -622,7 +633,7 @@ mod tests {
 
         let tx = stdb.begin_tx();
         let mut rows = stdb
-            .scan(&tx, table_id)?
+            .iter(&tx, table_id)?
             .map(|r| *r.view().elements[0].as_i32().unwrap())
             .collect::<Vec<i32>>();
         rows.sort();
@@ -646,7 +657,7 @@ mod tests {
         stdb.insert(&mut tx, table_id, product![AlgebraicValue::I32(1)])?;
 
         let mut rows = stdb
-            .range_scan(&tx, table_id, 0, AlgebraicValue::I32(0)..)?
+            .iter_by_col_range(&tx, table_id, 0, AlgebraicValue::I32(0)..)?
             .map(|r| *r.view().elements[0].as_i32().unwrap())
             .collect::<Vec<i32>>();
         rows.sort();
@@ -672,7 +683,7 @@ mod tests {
 
         let tx = stdb.begin_tx();
         let mut rows = stdb
-            .range_scan(&tx, table_id, 0, AlgebraicValue::I32(0)..)?
+            .iter_by_col_range(&tx, table_id, 0, AlgebraicValue::I32(0)..)?
             .map(|r| *r.view().elements[0].as_i32().unwrap())
             .collect::<Vec<i32>>();
         rows.sort();
@@ -717,7 +728,7 @@ mod tests {
 
         let tx = stdb.begin_tx();
         let mut rows = stdb
-            .scan(&tx, table_id)?
+            .iter(&tx, table_id)?
             .map(|r| *r.view().elements[0].as_i32().unwrap())
             .collect::<Vec<i32>>();
         rows.sort();
@@ -750,7 +761,7 @@ mod tests {
         stdb.insert(&mut tx, table_id, product![AlgebraicValue::I64(0)])?;
 
         let mut rows = stdb
-            .range_scan(&tx, table_id, 0, AlgebraicValue::I64(0)..)?
+            .iter_by_col_range(&tx, table_id, 0, AlgebraicValue::I64(0)..)?
             .map(|r| *r.view().elements[0].as_i64().unwrap())
             .collect::<Vec<i64>>();
         rows.sort();
@@ -783,7 +794,7 @@ mod tests {
         stdb.insert(&mut tx, table_id, product![AlgebraicValue::I64(6)])?;
 
         let mut rows = stdb
-            .range_scan(&tx, table_id, 0, AlgebraicValue::I64(0)..)?
+            .iter_by_col_range(&tx, table_id, 0, AlgebraicValue::I64(0)..)?
             .map(|r| *r.view().elements[0].as_i64().unwrap())
             .collect::<Vec<i64>>();
         rows.sort();
@@ -823,7 +834,7 @@ mod tests {
         stdb.insert(&mut tx, table_id, product![AlgebraicValue::I64(1)])?;
 
         let mut rows = stdb
-            .range_scan(&tx, table_id, 0, AlgebraicValue::I64(0)..)?
+            .iter_by_col_range(&tx, table_id, 0, AlgebraicValue::I64(0)..)?
             .map(|r| *r.view().elements[0].as_i64().unwrap())
             .collect::<Vec<i64>>();
         rows.sort();
@@ -911,7 +922,7 @@ mod tests {
         stdb.insert(&mut tx, table_id, product![AlgebraicValue::I64(0)])?;
 
         let mut rows = stdb
-            .range_scan(&tx, table_id, 0, AlgebraicValue::I64(0)..)?
+            .iter_by_col_range(&tx, table_id, 0, AlgebraicValue::I64(0)..)?
             .map(|r| *r.view().elements[0].as_i64().unwrap())
             .collect::<Vec<i64>>();
         rows.sort();
@@ -974,14 +985,14 @@ mod tests {
         let table_id = stdb.create_table(&mut tx, schema)?;
 
         let indexes = stdb
-            .scan(&tx, ST_INDEXES_ID.0)?
+            .iter(&tx, ST_INDEXES_ID.0)?
             .map(|x| StIndexRow::try_from(x.view()).unwrap().to_owned())
             .filter(|x| x.table_id == table_id)
             .collect::<Vec<_>>();
         assert_eq!(indexes.len(), 3, "Wrong number of indexes");
 
         let sequences = stdb
-            .scan(&tx, ST_SEQUENCES_ID.0)?
+            .iter(&tx, ST_SEQUENCES_ID.0)?
             .map(|x| StSequenceRow::try_from(x.view()).unwrap().to_owned())
             .filter(|x| x.table_id == table_id)
             .collect::<Vec<_>>();
@@ -990,14 +1001,14 @@ mod tests {
         stdb.drop_table(&mut tx, table_id)?;
 
         let indexes = stdb
-            .scan(&tx, ST_INDEXES_ID.0)?
+            .iter(&tx, ST_INDEXES_ID.0)?
             .map(|x| StIndexRow::try_from(x.view()).unwrap().to_owned())
             .filter(|x| x.table_id == table_id)
             .collect::<Vec<_>>();
         assert_eq!(indexes.len(), 0, "Wrong number of indexes");
 
         let sequences = stdb
-            .scan(&tx, ST_SEQUENCES_ID.0)?
+            .iter(&tx, ST_SEQUENCES_ID.0)?
             .map(|x| StSequenceRow::try_from(x.view()).unwrap().to_owned())
             .filter(|x| x.table_id == table_id)
             .collect::<Vec<_>>();
@@ -1033,7 +1044,7 @@ mod tests {
         assert_eq!(Some("YourTable"), table_name.as_deref());
         // Also make sure we've removed the old ST_TABLES_ID row
         let mut n = 0;
-        for row in stdb.scan(&tx, ST_TABLES_ID)? {
+        for row in stdb.iter(&tx, ST_TABLES_ID)? {
             let table = StTableRow::try_from(row.view())?;
             if table.table_id == table_id {
                 n += 1;

--- a/crates/core/src/host/tracelog/instance_trace.rs
+++ b/crates/core/src/host/tracelog/instance_trace.rs
@@ -2,7 +2,7 @@
 
 use crate::host::Timestamp;
 use crate::messages::instance_db_trace_log::{
-    CreateIndex, DeleteEq, GetTableId, Insert, InstanceEvent, InstanceEventType,
+    CreateIndex, DeleteByColEq, GetTableId, Insert, InstanceEvent, InstanceEventType,
 };
 use flate2::write::GzEncoder;
 use flate2::Compression;
@@ -145,7 +145,7 @@ impl TraceLog {
     }
     */
 
-    pub fn delete_eq(
+    pub fn delete_by_col_eq(
         &mut self,
         start_time: SystemTime,
         duration: Duration,
@@ -154,7 +154,7 @@ impl TraceLog {
         buffer: Vec<u8>,
         deleted_count: u32,
     ) {
-        let event = InstanceEventType::DeleteEq(DeleteEq {
+        let event = InstanceEventType::DeleteByColEq(DeleteByColEq {
             table_id,
             col_id,
             buffer,

--- a/crates/core/src/host/tracelog/replay.rs
+++ b/crates/core/src/host/tracelog/replay.rs
@@ -17,7 +17,7 @@ pub enum ReplayEventType {
     Insert,
     // DeletePk(bool),
     // DeleteValue(bool),
-    DeleteEq(u32),
+    DeleteByColEq(u32),
     // DeleteRange(u32),
     // CreateTable(u32),
     Iter(Vec<u8>),
@@ -44,7 +44,7 @@ impl From<InstanceEventType> for ReplayEventType {
     fn from(event: InstanceEventType) -> Self {
         match event {
             InstanceEventType::Insert(_) => Self::Insert,
-            InstanceEventType::DeleteEq(event) => Self::DeleteEq(event.result_deleted_count),
+            InstanceEventType::DeleteByColEq(event) => Self::DeleteByColEq(event.result_deleted_count),
             /*
             InstanceEventType::DeletePk(event) => Self::DeletePk(event.result_success),
             InstanceEventType::DeleteValue(event) => Self::DeleteValue(event.result_success),
@@ -114,11 +114,11 @@ fn execute_event(instance_env: &InstanceEnv, event: &InstanceEventType) -> anyho
             ReplayEventType::DeleteValue(result_success)
         }
         */
-        InstanceEventType::DeleteEq(delete) => {
+        InstanceEventType::DeleteByColEq(delete) => {
             let result_count = instance_env
-                .delete_eq(delete.table_id, delete.col_id, &delete.buffer)
+                .delete_by_col_eq(delete.table_id, delete.col_id, &delete.buffer)
                 .unwrap();
-            ReplayEventType::DeleteEq(result_count)
+            ReplayEventType::DeleteByColEq(result_count)
         }
         /*
         InstanceEventType::DeleteRange(delete) => {

--- a/crates/core/src/host/wasmer/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmer/wasm_instance_env.rs
@@ -230,7 +230,7 @@ impl WasmInstanceEnv {
     ///
     /// Returns an error if no columns were deleted or if the column wasn't found.
     #[tracing::instrument(skip_all)]
-    pub fn delete_eq(
+    pub fn delete_by_col_eq(
         caller: FunctionEnvMut<'_, Self>,
         table_id: u32,
         col_id: u32,
@@ -238,9 +238,9 @@ impl WasmInstanceEnv {
         value_len: u32,
         out: WasmPtr<u32>,
     ) -> RtResult<u16> {
-        Self::cvt_ret(caller, "delete_eq", out, |caller, mem| {
+        Self::cvt_ret(caller, "delete_by_col_eq", out, |caller, mem| {
             let value = mem.read_bytes(&caller, value, value_len)?;
-            Ok(caller.data().instance_env.delete_eq(table_id, col_id, &value)?)
+            Ok(caller.data().instance_env.delete_by_col_eq(table_id, col_id, &value)?)
         })
     }
 
@@ -395,7 +395,7 @@ impl WasmInstanceEnv {
     /// The resulting byte string from the concatenation is written
     /// to a fresh buffer with the buffer's identifier written to the WASM pointer `out`.
     #[tracing::instrument(skip_all)]
-    pub fn seek_eq(
+    pub fn iter_by_col_eq(
         caller: FunctionEnvMut<'_, Self>,
         table_id: u32,
         col_id: u32,
@@ -403,12 +403,12 @@ impl WasmInstanceEnv {
         val_len: u32,
         out: WasmPtr<BufferIdx>,
     ) -> RtResult<u16> {
-        Self::cvt_ret(caller, "seek_eq", out, |mut caller, mem| {
+        Self::cvt_ret(caller, "iter_by_col_eq", out, |mut caller, mem| {
             // Read the test value from WASM memory.
             let value = mem.read_bytes(&caller, val, val_len)?;
 
             // Find the relevant rows.
-            let data = caller.data().instance_env.seek_eq(table_id, col_id, &value)?;
+            let data = caller.data().instance_env.iter_by_col_eq(table_id, col_id, &value)?;
 
             // Insert the encoded + concatenated rows into a new buffer and return its id.
             Ok(caller.data_mut().buffers.insert(data.into()))

--- a/crates/core/src/host/wasmer/wasmer_module.rs
+++ b/crates/core/src/host/wasmer/wasmer_module.rs
@@ -57,10 +57,10 @@ impl WasmerModule {
             "spacetime" => {
                 "_schedule_reducer" => Function::new_typed_with_env(store, env, WasmInstanceEnv::schedule_reducer),
                 "_cancel_reducer" => Function::new_typed_with_env(store, env, WasmInstanceEnv::cancel_reducer),
-                "_delete_eq" => Function::new_typed_with_env(
+                "_delete_by_col_eq" => Function::new_typed_with_env(
                     store,
                     env,
-                    WasmInstanceEnv::delete_eq,
+                    WasmInstanceEnv::delete_by_col_eq,
                 ),
                 /*
                 "_delete_pk" => Function::new_typed_with_env(
@@ -101,10 +101,10 @@ impl WasmerModule {
                     env,
                     WasmInstanceEnv::create_index,
                 ),
-                "_seek_eq" => Function::new_typed_with_env(
+                "_iter_by_col_eq" => Function::new_typed_with_env(
                     store,
                     env,
-                    WasmInstanceEnv::seek_eq,
+                    WasmInstanceEnv::iter_by_col_eq,
                 ),
                 "_iter_start" => Function::new_typed_with_env(
                     store,

--- a/crates/core/src/messages/instance_db_trace_log.rs
+++ b/crates/core/src/messages/instance_db_trace_log.rs
@@ -23,7 +23,7 @@ pub struct DeleteValue {
 }
 */
 #[derive(Clone, Serialize, Deserialize)]
-pub struct DeleteEq {
+pub struct DeleteByColEq {
     pub table_id: u32,
     pub col_id: u32,
     pub buffer: Vec<u8>,
@@ -71,7 +71,7 @@ pub struct InstanceEvent {
 #[derive(Clone, Serialize, Deserialize)]
 pub enum InstanceEventType {
     Insert(Insert),
-    DeleteEq(DeleteEq),
+    DeleteByColEq(DeleteByColEq),
     /*
     DeletePk(DeletePk),
     DeleteValue(DeleteValue),

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -104,7 +104,7 @@ fn get_table<'a>(
     Ok(match query {
         SourceExpr::MemTable(x) => Box::new(RelIter::new(head, row_count, x)) as Box<IterRows<'_>>,
         SourceExpr::DbTable(x) => {
-            let iter = stdb.scan(tx, x.table_id)?;
+            let iter = stdb.iter(tx, x.table_id)?;
             Box::new(TableCursor::new(x, iter)?) as Box<IterRows<'_>>
         }
     })
@@ -160,7 +160,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
                 todo!("How deal with mutating values?")
             }
             Table::DbTable(t) => {
-                let count = self.db.delete_in(self.tx, t.table_id, rows)?;
+                let count = self.db.delete_by_rel(self.tx, t.table_id, rows)?;
                 Ok(Code::Value(count.unwrap_or_default().into()))
             }
         }

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -205,7 +205,7 @@ metrics_delegator!(
 metrics_delegator!(INSTANCE_ENV_INSERT, instance_env_insert: HistogramVec);
 // metrics_delegator!(INSTANCE_ENV_DELETE_PK, instance_env_delete_pk: HistogramVec);
 // metrics_delegator!(INSTANCE_ENV_DELETE_VALUE, instance_env_delete_value: HistogramVec);
-metrics_delegator!(INSTANCE_ENV_DELETE_EQ, instance_env_delete_eq: HistogramVec);
+metrics_delegator!(INSTANCE_ENV_DELETE_BY_COL_EQ, instance_env_delete_eq: HistogramVec);
 //metrics_delegator!(INSTANCE_ENV_DELETE_RANGE, instance_env_delete_range: HistogramVec);
 
 pub fn register_custom_metrics() {

--- a/modules/rust-wasm-test/src/lib.rs
+++ b/modules/rust-wasm-test/src/lib.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::disallowed_names)]
 
 use spacetimedb::{
-    delete_eq, query, spacetimedb, AlgebraicValue, Deserialize, ReducerContext, SpacetimeType, Timestamp,
+    delete_by_col_eq, query, spacetimedb, AlgebraicValue, Deserialize, ReducerContext, SpacetimeType, Timestamp,
 };
 use spacetimedb_lib::bsatn;
 
@@ -85,7 +85,7 @@ pub fn test(ctx: ReducerContext, arg: TestA, arg2: TestB, arg3: TestC) -> anyhow
     log::info!("Row count before delete: {:?}", row_count);
 
     for row in 5..10 {
-        delete_eq(1, 0, &AlgebraicValue::U32(row))?;
+        delete_by_col_eq(1, 0, &AlgebraicValue::U32(row))?;
     }
 
     let row_count = TestA::iter().count();


### PR DESCRIPTION
# Description of Changes

(This is just https://github.com/clockworklabs/SpacetimeDB/pull/26 so that it can be merged into master.)

The naming scheme is (irrelevant details removed):

```rust
fn iter(table_id: TableId) -> Result<Iter>;

fn iter_by_col_range<R: RangeBounds<AlgebraicValue>>(table_id: TableId, col_id: ColId, range: R)
    -> Result<IterByColRange<R>>;

fn iter_by_col_eq(table_id: TableId, col_id: ColId, value: &AlgebraicValue) -> Result<IterByColEq>;

fn get(table_id: TableId, row_id: RowId) -> Result<Option<DataRef>>;

fn delete(table_id: TableId, row_id: RowId) -> Result<bool>;

fn delete_by_rel<R: IntoIterator<Item = ProductValue>>(table_id: TableId, relation: R) -> Result<Option<u32>>;

fn insert(table_id: TableId, row: ProductValue) -> Result<ProductValue>;
```


# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*

See above.
