### PR TITLE
JWT Keys are stored in named volume

### DIFF
--- a/docker-compose-live.yml
+++ b/docker-compose-live.yml
@@ -6,6 +6,7 @@ services:
     image: registry.digitalocean.com/clockwork/spacetimedb${REGISTRY_SUFFIX}:latest
     volumes:
       - /stdb
+      - key_files:/etc/spacetimedb
     command: start
     privileged: true
     environment:
@@ -26,3 +27,5 @@ services:
     image: registry.digitalocean.com/clockwork/spacetimedb_prometheus${REGISTRY_SUFFIX}:latest
   grafana:
     image: registry.digitalocean.com/clockwork/spacetimedb_grafana${REGISTRY_SUFFIX}:latest
+volumes:
+  key_files:

--- a/docker-compose-release.yml
+++ b/docker-compose-release.yml
@@ -15,6 +15,7 @@ services:
       - ./crates/bindings-macro:/usr/src/app/crates/bindings-macro
       - ./crates/bindings-sys:/usr/src/app/crates/bindings-sys
       - ./crates/vm:/usr/src/app/crates/vm
+      - key_files:/etc/spacetimedb
       - /stdb
     ports:
       - "3000:80"
@@ -44,4 +45,5 @@ services:
       context: ./packages/grafana
     ports:
       - "3001:3000"
-
+volumes:
+  key_files:

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -19,6 +19,7 @@ services:
       - ./crates/vm:/usr/src/app/crates/vm
       - ./crates/client-api-messages:/usr/src/app/crates/client-api-messages
       - ./flamegraphs:/usr/src/app/flamegraphs
+      - key_files:/etc/spacetimedb
       - /stdb
     ports:
       - "3000:80"
@@ -38,3 +39,5 @@ services:
 networks:
   spacetimedb_default:
      name: spacetimedb_default
+volumes:
+  key_files:


### PR DESCRIPTION
# Description of Changes

 - This makes it so that if you `docker-compose down && docker-compose up` the SpacetimeDB docker container, then you will not lose your JWT signing keys. This solves the terrible issue of constantly having to run `spacetime identity remove --all`
 - Note for Tyler: I've added this config to live as well. I'm assuming we don't want to clear our signing keys even if we're clearing the stdb data.

# Testing Instructions

```bash
docker-compose down
docker-compose up node
spacetime identity remove --all --force
# This should always succeed because we have no identities
spacetime publish bitcraft -s
docker-compose down
docker-compose up node

# Then publish bitcraft and see if you're still able to publish bitcraft
spacetime publish bitcraft -s
```

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
