### PR TITLE
CLI `generate`: friendlier error message when module compilation fails

### DIFF
--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -89,7 +89,18 @@ pub fn exec(args: &clap::ArgMatches) -> anyhow::Result<()> {
 
     let wasm_file = match wasm_file {
         Some(x) => x,
-        None => crate::tasks::build(project_path, skip_clippy, build_debug)?,
+        None => match crate::tasks::build(project_path, skip_clippy, build_debug) {
+            Ok(wasm_file) => wasm_file,
+            Err(e) => {
+                return Err(anyhow::anyhow!(
+                    "{:?}
+
+Failed to compile module {:?}. See cargo errors above for more details.",
+                    e,
+                    project_path,
+                ))
+            }
+        },
     };
 
     if !out_dir.exists() {


### PR DESCRIPTION
# Description of Changes

When running `spacetime generate` on a module which fails to compile, the last line of the output is now a human-readable error message which includes the module path and instructions to review the build errors.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
