### PR TITLE
Nits: More specific error responses when authorization fails

### DIFF
--- a/crates/client-api/src/auth.rs
+++ b/crates/client-api/src/auth.rs
@@ -84,7 +84,7 @@ impl<S: ControlNodeDelegate + Send + Sync> axum::extract::FromRequestParts<S> fo
             Err(e) => match e.reason() {
                 // Leave it to handlers to decide on unauthorized requests.
                 TypedHeaderRejectionReason::Missing => Ok(Self { auth: None }),
-                TypedHeaderRejectionReason::Error(_) | _ => Err(AuthorizationRejection {
+                _ => Err(AuthorizationRejection {
                     reason: AuthorizationRejectionReason::Header(e),
                 }),
             },
@@ -116,7 +116,7 @@ impl IntoResponse for AuthorizationRejection {
             AuthorizationRejectionReason::Jwt(JwtErrorKind::InvalidSignature) => ROTATED.into_response(),
             AuthorizationRejectionReason::Header(rejection) => match rejection.reason() {
                 TypedHeaderRejectionReason::Missing => REQUIRED.into_response(),
-                TypedHeaderRejectionReason::Error(_) | _ => rejection.into_response(),
+                _ => rejection.into_response(),
             },
             _ => INVALID.into_response(),
         }


### PR DESCRIPTION
# Description of Changes

 - Restoring Mazdak's nits from #46

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
