### PR TITLE
Cargo profile for building CLI more quickly

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -35,7 +35,6 @@ rpath = false
 
 [profile.release-fast]
 inherits = "release"
-opt-level = 3
 lto = "thin"
 
 [profile.dev]


### PR DESCRIPTION
# Description of Changes

<https://www.notion.so/clockworklabs/Investigate-compile-time-in-release-b4245f3bb6f6479dba92dd1a8f5c080c?pvs=4>

## Clean compilation

Profile: `release`

```
    ...
    Finished release [optimized + debuginfo] target(s) in 2m 55s
   Replacing /Users/boppy/.cargo/bin/spacetime
    Replaced package `spacetimedb-cli v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/cli)` with `spacetimedb-cli v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/cli)` (executable `spacetime`)
```

Profile: `release-fast`

```
    ...
    Finished release-fast [optimized + debuginfo] target(s) in 1m 01s
   Replacing /Users/boppy/.cargo/bin/spacetime
    Replaced package `spacetimedb-cli v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/cli)` with `spacetimedb-cli v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/cli)` (executable `spacetime`)
```

Clean compliation speedup: ~1 minute 54 seconds

## Incremental compilation

These tests were done by compiling the specified profile, then making a small edit to `main.rs` and then compiling again.

Profile: `release`
```
  Installing spacetimedb-cli v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/cli)
    Updating crates.io index
   Compiling spacetimedb-bindings-macro v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/bindings-macro)
   Compiling spacetimedb-sats v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/sats)
   Compiling spacetimedb-lib v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/lib)
   Compiling spacetimedb-cli v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/cli)
    Finished release [optimized + debuginfo] target(s) in 2m 31s
   Replacing /Users/boppy/.cargo/bin/spacetime
    Replaced package `spacetimedb-cli v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/cli)` with `spacetimedb-cli v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/cli)` (executable `spacetime`)
```

Profile: `release-fast`
```
  Installing spacetimedb-cli v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/cli)
    Updating crates.io index
   Compiling spacetimedb-cli v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/cli)
    Finished release-fast [optimized + debuginfo] target(s) in 32.46s
   Replacing /Users/boppy/.cargo/bin/spacetime
    Replaced package `spacetimedb-cli v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/cli)` with `spacetimedb-cli v0.5.0 (/Users/boppy/clockwork/workspace3/SpacetimeDB/crates/cli)` (executable `spacetime`
```

Incremental speedup: ~2 minutes

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
