### PR TITLE
Provisional 'subscribe to all' functionality

### DIFF
--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -80,9 +80,10 @@ pub(crate) fn run_query(
     execute_single_sql(db, tx, CrudExpr::Query(query.clone()), auth)
 }
 
-//TODO: Is certainly semantically wrong to [SUBSCRIBE_TO_ALL_QUERY] because it only can return back
-//the changes that are valid for the tables in scope *right now* instead of **continuously update** the changes
-//of the database, with system table modifications (add/remove tables, indexes, ...).
+// TODO: It's semantically wrong to `SUBSCRIBE_TO_ALL_QUERY`
+// as it only can return back the changes valid for the tables in scope *right now*
+// instead of **continuously updating** the db changes
+// with system table modifications (add/remove tables, indexes, ...).
 /// Compile from `SQL` into a [`Query`].
 ///
 /// NOTE: When the `input` query is equal to [`SUBSCRIBE_TO_ALL_QUERY`],


### PR DESCRIPTION
# Description of Changes

Add the ability to “send me everything” query.

It use the special 

```sql
SELECT * FROM *
```

to trigger this.

This semantically doesn't seem right, or at least confusing from the POV of subscriptions: It means  "send back what you have right now" instead of "keep streaming back all the changes".

This means this will break (ie changes to the database schema could fail in subsequent runs):

```sql
subscribe SELECT * FROM *
CREATE TABLE a
INSERT INTO a
DROP TABLE a
CREATE TABLE b
```

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
