### PR TITLE
Remove crash if fails to decode ModuleDef from bsatn

### DIFF
--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -88,6 +88,7 @@ impl std::fmt::Display for VersionTuple {
 
 extern crate self as spacetimedb_lib;
 
+//WARNING: Change this structure(or any of their members) is an ABI change.
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, de::Deserialize, ser::Serialize)]
 pub struct TableDef {
     pub name: String,
@@ -170,6 +171,7 @@ impl ser::Serialize for ReducerArgsWithSchema<'_> {
     }
 }
 
+//WARNING: Change this structure(or any of their members) is an ABI change.
 #[derive(Debug, Clone, Default, de::Deserialize, ser::Serialize)]
 pub struct ModuleDef {
     pub typespace: sats::Typespace,

--- a/crates/sats/src/bsatn/de.rs
+++ b/crates/sats/src/bsatn/de.rs
@@ -19,7 +19,7 @@ impl<'a, 'de, R: BufReader<'de>> Deserializer<'a, R> {
 
 impl de::Error for DecodeError {
     fn custom(msg: impl std::fmt::Display) -> Self {
-        unreachable!("tried to create error `{msg}` but there shouldn't be any errors")
+        DecodeError::Other(msg.to_string())
     }
 
     fn unknown_variant_tag<'de, T: de::SumVisitor<'de>>(_tag: u8, _expected: &T) -> Self {

--- a/crates/sats/src/buffer.rs
+++ b/crates/sats/src/buffer.rs
@@ -11,6 +11,7 @@ pub enum DecodeError {
     BufferLength,
     InvalidTag,
     InvalidUtf8,
+    Other(String),
 }
 
 impl fmt::Display for DecodeError {
@@ -19,6 +20,7 @@ impl fmt::Display for DecodeError {
             DecodeError::BufferLength => f.write_str("data too short"),
             DecodeError::InvalidTag => f.write_str("invalid tag for enum"),
             DecodeError::InvalidUtf8 => f.write_str("invalid utf8"),
+            DecodeError::Other(err) => f.write_str(err),
         }
     }
 }


### PR DESCRIPTION
# Description of Changes


Ok I see why is failing, in ModuleDef.tables is TableDef and there are the new fields I added and they can't read back the value. Now the issue is that requires some kind of migration if the idea is to survive. I remove the crash, and the server output the error but the client gets a blank error: 

```bash
--SERVER
2023-07-04T16:21:14.575327Z ERROR crates/client-api/src/lib.rs:153: internal error: error getting module description: error decoding module description: DecodeError for StTableType: ``. Expected 'system' | 'user': error decoding module description: DecodeError for StTableType: ``. Expected 'system' | 'user': DecodeError for StTableType: ``. Expected 'system' | 'user'

--CLIENT

➜ spacetime publish
    Finished dev [unoptimized + debuginfo] target(s) in 0.31s
Error:

```

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
