### PR TITLE
Upgrade ABI version

### DIFF
--- a/crates/bindings-sys/src/lib.rs
+++ b/crates/bindings-sys/src/lib.rs
@@ -34,7 +34,7 @@ use alloc::boxed::Box;
 /// can run a module declaring `X.Y` if and only if `X == A && Y <= B`.
 /// So, the minor version is intended for backwards-compatible changes, e.g. adding a new function,
 /// and the major version is for fully breaking changes.
-pub const ABI_VERSION: u32 = 0x0002_0000;
+pub const ABI_VERSION: u32 = 0x0003_0000;
 
 /// Provides a raw set of sys calls which abstractions can be built atop of.
 pub mod raw {

--- a/crates/core/src/host/wasmer/wasmer_module.rs
+++ b/crates/core/src/host/wasmer/wasmer_module.rs
@@ -49,7 +49,7 @@ impl WasmerModule {
         WasmerModule { module, engine }
     }
 
-    pub const IMPLEMENTED_ABI: abi::VersionTuple = abi::VersionTuple::new(2, 0);
+    pub const IMPLEMENTED_ABI: abi::VersionTuple = abi::VersionTuple::new(3, 0);
 
     fn imports(&self, store: &mut Store, env: &FunctionEnv<WasmInstanceEnv>) -> Imports {
         const _: () = assert!(WasmerModule::IMPLEMENTED_ABI.eq(spacetimedb_lib::MODULE_ABI_VERSION));

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -38,7 +38,7 @@ pub use type_value::{AlgebraicValue, ProductValue};
 
 pub use spacetimedb_sats as sats;
 
-pub const MODULE_ABI_VERSION: VersionTuple = VersionTuple::new(2, 0);
+pub const MODULE_ABI_VERSION: VersionTuple = VersionTuple::new(3, 0);
 
 // if it ends up we need more fields in the future, we can split one of them in two
 #[derive(PartialEq, Eq, Copy, Clone, Debug)]


### PR DESCRIPTION
# Description of Changes

For some reason the update in the `mamcx/bug_crash_auth_field` does not show up. This fix the change in ABI version.

# API

 - [x] This is a breaking change to the module API
 - [x] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
