### PR TITLE
Accomodate new cloud architecture

### DIFF
--- a/crates/cli/src/subcommands/dns.rs
+++ b/crates/cli/src/subcommands/dns.rs
@@ -183,6 +183,7 @@ pub async fn exec_set_name(mut config: Config, args: &ArgMatches) -> Result<(), 
                 )),
             };
         }
+        InsertDomainResult::OtherError(e) => return Err(anyhow::anyhow!(e)),
     }
 
     Ok(())

--- a/crates/lib/src/name.rs
+++ b/crates/lib/src/name.rs
@@ -39,6 +39,9 @@ pub enum InsertDomainResult {
     PermissionDenied {
         domain: DomainName,
     },
+
+    /// Some unspecified error occurred.
+    OtherError(String),
 }
 
 #[derive(Clone, Copy, Debug)]


### PR DESCRIPTION
Contains two minor fixes, and a larger change to adapt the `client-api` to the new architecture. Submitting as one patch in order to be able track the tip as a submodule, and not lose sanity.

Note that the exact trait interface for `client-api` is still up for discussion.