### PR TITLE
Release fast in docker

### DIFF
--- a/crates/standalone/Dockerfile
+++ b/crates/standalone/Dockerfile
@@ -22,11 +22,12 @@ COPY --from=planner /usr/src/app/recipe.json .
 ENV CARGO_INCREMENTAL=0
 
 ARG CARGO_PROFILE=release
+ARG SPACETIME_CARGO_PROFILE=release
 
-RUN cargo chef cook -p spacetimedb-standalone --profile=${CARGO_PROFILE}
+RUN cargo chef cook -p spacetimedb-standalone --profile=${SPACETIME_CARGO_PROFILE}
 
 COPY . .
-RUN cargo build -p spacetimedb-standalone --profile=${CARGO_PROFILE} --locked
+RUN cargo build -p spacetimedb-standalone --profile=${SPACETIME_CARGO_PROFILE} --locked
 
 FROM builder as env-dev
 ENV SPACETIMEDB_LOG_CONFIG=/usr/src/app/crates/standalone/log.conf
@@ -35,7 +36,8 @@ ENV SPACETIMEDB_JWT_PRIV_KEY=/etc/spacetimedb/id_ecdsa
 ENV PATH="/usr/src/app/target/debug:${PATH}"
 
 FROM debian as env-release
-COPY --from=builder /usr/src/app/target/release/spacetimedb /usr/local/bin/
+ARG SPACETIME_CARGO_PROFILE=release
+COPY --from=builder /usr/src/app/target/${SPACETIME_CARGO_PROFILE}/spacetimedb /usr/local/bin/
 COPY --from=builder /usr/src/app/crates/standalone/log.conf /etc/spacetimedb/
 
 FROM env-${CARGO_PROFILE}

--- a/docker-compose-release.yml
+++ b/docker-compose-release.yml
@@ -5,6 +5,8 @@ services:
     build:
       context: ./
       dockerfile: ./crates/standalone/Dockerfile
+      args:
+        SPACETIME_CARGO_PROFILE: release-fast
     volumes:
       - ./crates/standalone:/usr/src/app/crates/standalone
       - ./crates/core:/usr/src/app/crates/core

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -7,6 +7,7 @@ services:
       dockerfile: ./crates/standalone/Dockerfile
       args:
         CARGO_PROFILE: dev
+        SPACETIME_CARGO_PROFILE: dev
     volumes:
       - ./crates/standalone:/usr/src/app/crates/standalone
       - ./crates/core:/usr/src/app/crates/core


### PR DESCRIPTION
# Description of Changes

 - BitCraft team needs a faster way to build SpacetimeDB, this profile gives comparable performance to `release` but builds much more quickly.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
