### PR TITLE
Removing 'repl' as a distinct option for the 'cli' 

### DIFF
--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -49,7 +49,6 @@ pub async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Re
         "init" => init::exec(config, args).await,
         "build" => build::exec(config, args).await,
         "server" => server::exec(config, args).await,
-        "repl" => repl::exec(config, args).await,
         #[cfg(feature = "tracelogging")]
         "tracelog" => tracelog::exec(config, args).await,
         unknown => Err(anyhow::anyhow!("Invalid subcommand: {}", unknown)),

--- a/crates/cli/src/subcommands/repl.rs
+++ b/crates/cli/src/subcommands/repl.rs
@@ -1,7 +1,5 @@
-use crate::api::ClientApi;
-use crate::sql::{parse_req, run_sql};
-use crate::Config;
-use clap::ArgMatches;
+use crate::api::{ClientApi, Connection};
+use crate::sql::run_sql;
 use colored::*;
 use std::io::Write;
 
@@ -39,8 +37,7 @@ sort by
 .clear
 ";
 
-pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    let con = parse_req(config, args).await?;
+pub async fn exec(con: Connection) -> Result<(), anyhow::Error> {
     let database = con.database.clone();
     let mut rl = Editor::<ReplHelper, DefaultHistory>::new().unwrap();
     if rl.load_history(".history.txt").is_err() {

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -111,9 +111,10 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str) -> Result<(), an
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let interactive = args.get_one::<bool>("interactive").unwrap_or(&false);
-
     if *interactive {
-        crate::repl::exec(config, args).await?;
+        let con = parse_req(config, args).await?;
+
+        crate::repl::exec(con).await?;
     } else {
         let query = args.get_one::<String>("query").unwrap();
 


### PR DESCRIPTION
# Description of Changes

and move into the `sql` invocation with an `--interactive` optional flag.

Example:

```bash
-- NEW
spacetime sql quickstart --interactive

-- Send a query & try to be interactive are mutually exclusive options:
spacetime sql quickstart  "SELECT * FROM Person" --interactive
error: the argument '<query>' cannot be used with '--interactive'

Usage: spacetime sql <--interactive|query> <database>

For more information, try '--help'.
```

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
