### PR TITLE
Codegen fixes for typescript and python

### DIFF
--- a/crates/cli/src/subcommands/generate/python.rs
+++ b/crates/cli/src/subcommands/generate/python.rs
@@ -224,7 +224,7 @@ fn autogen_python_product_table_common(
         writeln!(output).unwrap();
         writeln!(
             output,
-            "from spacetimedb_python_sdk.spacetimedb_client import SpacetimeDBClient"
+            "from spacetimedb_sdk.spacetimedb_client import SpacetimeDBClient"
         )
         .unwrap();
     } else {
@@ -545,7 +545,7 @@ pub fn autogen_python_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String {
 
     writeln!(
         output,
-        "from spacetimedb_python_sdk.spacetimedb_client import SpacetimeDBClient"
+        "from spacetimedb_sdk.spacetimedb_client import SpacetimeDBClient"
     )
     .unwrap();
     writeln!(output).unwrap();

--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -720,7 +720,7 @@ fn autogen_typescript_product_table_common(
                         .as_ref()
                         .expect("autogen'd tuples should have field names")
                         .replace("r#", "");
-                    format!("\"{}\"", field_name)
+                    format!("\"{}\"", field_name.to_case(Case::Camel))
                 })
             {
                 writeln!(


### PR DESCRIPTION
Fix case on primary_key for typescript
Fix name of python sdk package for python

NOTE: These are both showstopper bugs for these sdks