### PR TITLE
Fixed clippy lint issue

### DIFF
--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -57,7 +57,7 @@ impl CommitLog {
         }
     }
 
-    fn generate_commit<D: MutTxDatastore<RowId = RowId>>(&self, tx_data: &TxData, datastore: &D) -> Option<Vec<u8>> {
+    fn generate_commit<D: MutTxDatastore<RowId = RowId>>(&self, tx_data: &TxData, _datastore: &D) -> Option<Vec<u8>> {
         let mut unwritten_commit = self.unwritten_commit.lock().unwrap();
         let writes = tx_data
             .records


### PR DESCRIPTION
# Description of Changes

The issue was introduced here: https://github.com/clockworklabs/SpacetimeDB/commit/8386884df43bf46c88310033cb0e238cae27a1a0

 - Ran `cargo clippy --fix --all`

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
