### PR TITLE
Improve release build times

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -24,10 +24,9 @@ default-members = ["crates/cli"]
 
 [profile.release]
 opt-level = 3
-debug = true
 debug-assertions = false
 overflow-checks = false
-lto = true
+lto = "thin"
 panic = 'unwind'
 incremental = false
 codegen-units = 16


### PR DESCRIPTION
Thin LTO should be about as good as far LTO, but much faster, and debug info is something that takes enormous amount of time to handle throughout build pipeline but something we don't usually need in release builds (symbol information should be enough if it's backtraces that we're interested in).

This cuts `cargo build --release` for the CLI from 9m 40s to 5m 20s on my machine.

# Description of Changes



# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
