### PR TITLE
Fix C# Tags for Enums

### DIFF
--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -615,12 +615,18 @@ fn autogen_csharp_product_table_common(
                     AlgebraicType::Sum(sum) => {
                         if is_option_type(sum) {
                             writeln!(output, "[SpacetimeDB.Some]").unwrap();
-                        } else if is_enum(sum) {
-                            writeln!(
-                                output,
-                                "[Newtonsoft.Json.JsonConverter(typeof(SpacetimeDB.EnumConverter))]"
-                            )
-                            .unwrap();
+                        } else {
+                            unimplemented!()
+                        }
+                    }
+                    AlgebraicType::Ref(type_ref) => {
+                        let ref_type = &ctx.typespace.types[type_ref.idx()];
+                        if let AlgebraicType::Sum(sum_type) = ref_type {
+                            if is_enum(sum_type) {
+                                writeln!(output, "[SpacetimeDB.Enum]").unwrap();
+                            } else {
+                                unimplemented!()
+                            }
                         }
                     }
                     _ => {}


### PR DESCRIPTION
# Description of Changes

 - In C# we need to tag enum members with a `[SpacetimeDB.Enum]` tag, otherwise our custom serialization logic for enums won't work. This either has been broken or has never worked. If you have some types in rust like this:
```rust
#[SpacetimeType]
pub enum EnumValue {
  Item,
  Cargo
}

#[SpacetimeType]
pub struct MyType {
 pub value: EnumValue
}
```

These types need to be generated in C# as:
```cs
public enum EnumValue {
  Item,
  Cargo
}

public class MyType {
    [SpacetimeDB.Enum]
    public EnumValue value;
}
```

Before this PR, the tag was being omitted.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
