### PR TITLE
Fixed Update Snapshots Script

### DIFF
--- a/tools/update-test-snapshots.sh
+++ b/tools/update-test-snapshots.sh
@@ -23,6 +23,6 @@ if ! cmd_exists cargo-insta; then
   esac
 fi
 
-cargo build -p rust-wasm-test --release --target wasm32-unknown-unknown
+cargo build -p rust-wasm-test-module --release --target wasm32-unknown-unknown
 
 cargo insta test --review -p spacetimedb-cli


### PR DESCRIPTION
# Description of Changes

 - Fixed the `update-insta-snapshots.sh` script, we had renamed `rust-wasm-test` to `rust-wasm-test-module` which broke the script.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
