### PR TITLE
Make ColumnIndexAttribute bitflags in the ABI

### DIFF
--- a/crates/core/src/host/wasmer/wasmer_module.rs
+++ b/crates/core/src/host/wasmer/wasmer_module.rs
@@ -49,7 +49,7 @@ impl WasmerModule {
         WasmerModule { module, engine }
     }
 
-    pub const IMPLEMENTED_ABI: abi::VersionTuple = abi::VersionTuple::new(3, 0);
+    pub const IMPLEMENTED_ABI: abi::VersionTuple = abi::VersionTuple::new(4, 0);
 
     fn imports(&self, store: &mut Store, env: &FunctionEnv<WasmInstanceEnv>) -> Imports {
         const _: () = assert!(WasmerModule::IMPLEMENTED_ABI.eq(spacetimedb_lib::MODULE_ABI_VERSION));


### PR DESCRIPTION
# Description of Changes

As we're adding more variants, it's getting harder to keep track of the "A implies B" relationships between enum variants and to correctly do checks like "is this column autoinc" in different places.

Using bitflags makes expressing those relationships more natural and checking simpler - e.g. you can just do `contains(AUTO_INC)` as a single bit operation instead of having to remember and list all possible variants that imply autoinc, especially if we're going to add more flags in the future.

Initially I was going to make this change just in C# module generator and convert between ABI enum and bitflags over there, but it seems better to do this at ABI level so it simplifies Rust handling as well.

# API

 - [x] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*

ABI representation of ColumnIndexAttribute (its numeric values) will be different after this change.