### PR TITLE
Fix output of multiple queries & commands that not return a table

### DIFF
--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -77,7 +77,7 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str) -> Result<(), an
 
     let stmt_result_json: Vec<StmtResultJson> = serde_json::from_str(&json)?;
 
-    //If you get a table, print the results, if return empty is likely a command like `INSERT`
+    // Print only `OK for empty tables as it's likely a command like `INSERT`.
     if stmt_result_json.is_empty() {
         println!("OK");
         return Ok(());


### PR DESCRIPTION
# Description of Changes

Remove wrong validation of empty result set and also correctly output as many tables are returned by multiple commands, ie this works now:

```bash
-- Before only the first SELECT was printed
spacetime sql "bitcraft" "SELECT * from st_table; SELECT * FROM st_indexes"

-- Before it show an "invalid query" error
spacetime sql "bitcraft" "CREATE TABLE f (inventory_id BIGINT)"
```

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
