### PR TITLE
Return an error when scheduling a reducer with a long delay

### DIFF
--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -14,7 +14,7 @@ use crate::util::prometheus_handle::HistogramVecHandle;
 use crate::util::ResultInspectExt;
 use crate::worker_metrics::{INSTANCE_ENV_DELETE_BY_COL_EQ, INSTANCE_ENV_INSERT};
 
-use super::scheduler::{ScheduledReducerId, Scheduler};
+use super::scheduler::{ScheduleError, ScheduledReducerId, Scheduler};
 use super::timestamp::Timestamp;
 use super::tracelog::instance_trace::TraceLog;
 use crate::vm::DbProgram;
@@ -54,7 +54,12 @@ impl InstanceEnv {
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn schedule(&self, reducer: String, args: Vec<u8>, time: Timestamp) -> ScheduledReducerId {
+    pub fn schedule(
+        &self,
+        reducer: String,
+        args: Vec<u8>,
+        time: Timestamp,
+    ) -> Result<ScheduledReducerId, ScheduleError> {
         self.scheduler.schedule(reducer, args, time)
     }
 


### PR DESCRIPTION
# Description of Changes

Prior to this commit, it was possible for a module to crash SpacetimeDB by scheduling a reducer with a delay longer than ~2yrs. This was due to our use of `tokio_utils::time::DelayQueue` to handle scheduling. `DelayQueue`'s internal data structure imposes a limit of 64^6 ms on delays, a little more than two years.
Attempting to insert with a delay longer than that panics.

With this commit, we avoid the panic by checking ourselves that the requested delay is not longer than 64^6 ms.
This requires bubbling a `ScheduleError` up from `Scheduler::schedule` to `WasmInstanceEnv::schedule`, where it is converted into a `RuntimeError` which crashes the module.

`Scheduler::schedule` could also fail because its transaction to compute a new id was fallible. This seems unlikely to ever fail, and if it does, we have bigger problems, so `unwrap`ping might still be reasonable for that case, but this commit converts it into a handle-able `Err`or anyway, as there's essentially no cost in complexity to doing so.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
