### PR TITLE
Cargo Fmt on Generated Rust Files

### DIFF
--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -448,7 +448,9 @@ fn format_files(generated_files: Vec<PathBuf>, lang: Language) -> anyhow::Result
                 cmd!("rustfmt", path.to_str().unwrap()).run()?;
             }
         }
-        _ => {}
+        Language::Csharp => {}
+        Language::TypeScript => {}
+        Language::Python => {}
     }
 
     Ok(())


### PR DESCRIPTION
# Description of Changes

 - All client sdk files that are generated in rust are now formatted correctly.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
