### PR TITLE
Use SpacetimeDB Large Runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -9,7 +9,7 @@ name: CI
 jobs:
   docker_smoketests:
     name: Smoketests
-    runs-on: ubuntu-latest
+    runs-on: spacetimedb-runner
     steps:
       - uses: actions/checkout@v3
 
@@ -23,7 +23,7 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: ubuntu-latest
+    runs-on: spacetimedb-runner
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -40,7 +40,7 @@ jobs:
 
   lints:
     name: Lints
-    runs-on: ubuntu-latest
+    runs-on: spacetimedb-runner
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -56,7 +56,7 @@ jobs:
 
   wasm_bindings:
     name: Build and test wasm bindings
-    runs-on: ubuntu-latest
+    runs-on: spacetimedb-runner
     steps:
       - uses: actions/checkout@v3
 


### PR DESCRIPTION
# Description of Changes

 - This enables the use of the large github runner that we've configured.

Testsuite before this change:
<img width="854" alt="image" src="https://github.com/clockworklabs/SpacetimeDB/assets/4099508/bc384419-45b3-4bc0-ba05-7b011539a9e1">

After:
<img width="937" alt="image" src="https://github.com/clockworklabs/SpacetimeDB/assets/4099508/69d21492-5205-40f0-8eaa-36bed412fba2">


# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
