### PR TITLE
Add SDK API breakage checkbox to PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -6,5 +6,6 @@
 
  - [ ] This is a breaking change to the module API
  - [ ] This is a breaking change to the ClientAPI
+ - [ ] This is a breaking change to the SDK API
 
 *If the API is breaking, please state below what will break*


### PR DESCRIPTION
# Description of Changes

The Rust SDK lives in this repository and exposes an API on which Rust clients will depend, distinct from both the module API and the ClientAPI (which is the protocols all SDKs use to commuticate with a module).

This commit adds a checkbox to the PR template, in the style of the two existing checkboxes, to identify breaking changes to the SDK API.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
