### PR TITLE
[SDK] Generated on-reducer callback register functions.

### DIFF
--- a/crates/cli/src/subcommands/generate/rust.rs
+++ b/crates/cli/src/subcommands/generate/rust.rs
@@ -676,7 +676,7 @@ pub fn autogen_rust_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String {
     out.newline();
 
     // Function definition for conveinent once_on callback function.
-    write!(out, "{}", ALLOW_UNUSED).unwrap();
+    writeln!(out, "{}", ALLOW_UNUSED).unwrap();
     write!(
         out,
         "pub fn once_on_{}(__callback: impl FnOnce(&Identity, Status",
@@ -712,6 +712,24 @@ pub fn autogen_rust_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String {
                 },
                 "})\n",
             )
+        },
+        "}\n",
+    );
+
+    out.newline();
+
+    // Function definition for callback-canceling `remove_on_{reducer}` function.
+    writeln!(out, "{}", ALLOW_UNUSED).unwrap();
+    write!(
+        out,
+        "pub fn remove_on_{}(id: ReducerCallbackId<{}>) ",
+        func_name, type_name,
+    )
+    .unwrap();
+    out.delimited_block(
+        "{",
+        |out| {
+            writeln!(out, "{}::remove_on_reducer(id);", type_name,).unwrap();
         },
         "}\n",
     );


### PR DESCRIPTION
# Description of Changes

Prior to this commit, to register an on-reducer callback for a reducer `set_name`, a client author would write `SetNameArgs::on_reducer(...)`, with their callback accepting a reference to a `SetNameArgs` which contained the reducer arguments.

Now, in addition to that interface, we generate a function `on_set_name`, which accepts a callback that takes the arguments unpacked, rather than as a struct.

That is, for the quickstart's `set_name` reducer, we generate:

```rust
pub fn on_set_name(
    mut __callback: impl FnMut(&Identity, Status, &String) + Send + 'static,
) -> ReducerCallbackId<SetNameArgs> {
    SetNameArgs::on_reducer(move |__identity, __status, __args| {
        let SetNameArgs { name } = __args;
        __callback(__identity, __status, name);
    })
}
```

Note the use of double-underscored variable names to avoid name collisions, since we can't `gensym` a unique name.

We also generate `once_on_set_name`, which is like `on_set_name`, but takes a `FnOnce` instead of a `FnMut`.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
