### PR TITLE
Benches refactor

### DIFF
--- a/crates/bench/benches/db.rs
+++ b/crates/bench/benches/db.rs
@@ -22,7 +22,7 @@ fn bench_insert_tx_per_row(c: &mut Criterion) {
     let run = Runs::Tiny;
     let mut group = build_group(c, "insert_row", run);
 
-    // Factor out the db creation because is IO that generate noise
+    // Factor out the db creation as it is IO that generates noise.
     group.bench_function(BenchmarkId::new(SQLITE, 1), |b| {
         b.iter_batched(
             || sqlite::create_db(0).unwrap(),


### PR DESCRIPTION
# Description of Changes

Moving out from the bench timings the creation of `dbs` because is expensive -in special for spacetime that creates folders vs sqlite just a file- and generates noise.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
