### PR TITLE
Fix Fragile Smoketest

### DIFF
--- a/test/tests/cancel-reducer.sh
+++ b/test/tests/cancel-reducer.sh
@@ -14,10 +14,10 @@ use spacetimedb::{println, spacetimedb, ScheduleToken};
 
 #[spacetimedb(init)]
 fn init() {
-    let token = spacetimedb::schedule!("10ms", reducer(1));
+    let token = spacetimedb::schedule!("100ms", reducer(1));
     token.cancel();
-    let token = spacetimedb::schedule!("100ms", reducer(2));
-    spacetimedb::schedule!("50ms", do_cancel(token));
+    let token = spacetimedb::schedule!("1000ms", reducer(2));
+    spacetimedb::schedule!("500ms", do_cancel(token));
 }
 
 #[spacetimedb(reducer)]


### PR DESCRIPTION
# Description of Changes

 - The `cancel-reducer` smoketest sometimes fails when the github runner is especially busy. Basically SpacetimeDB isn't able to cancel the test reducer before it executes because SpacetimeDB is too busy running other tests.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
