### PR TITLE
Change Default SpacetimeDB URL

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -33,7 +33,7 @@ const CONFIG_FILENAME: &str = "config.toml";
 const SPACETIME_FILENAME: &str = "spacetime.toml";
 const DOT_SPACETIME_FILENAME: &str = ".spacetime.toml";
 
-const DEFAULT_HOST: &str = "spacetimedb.com/spacetimedb";
+const DEFAULT_HOST: &str = "testnet.spacetimedb.com";
 const DEFAULT_PROTOCOL: &str = "https";
 
 impl Config {


### PR DESCRIPTION
# Description of Changes

 - We're now deploying to `https://testnet.spacetimedb.com` instead of `https://spacetimedb.com/spacetimedb`.

**NOTE: For compatibility reasons both URLs are supported for now**

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
