### PR TITLE
Revert toolchain to 1.69 because upstream bug on wasmer for macOS M CPUs

### DIFF
--- a/crates/cli/src/tasks.rs
+++ b/crates/cli/src/tasks.rs
@@ -115,9 +115,11 @@ fn has_wasm_bindgen(module: &wasmbin::Module) -> bool {
     module
         .find_std_section::<wasmbin::sections::payload::Import>()
         .and_then(|imports| imports.try_contents().ok())
-        .is_some_and(|imports| imports.iter().any(check_import))
+        .map(|imports| imports.iter().any(check_import))
+        .unwrap_or(false)
         || module
             .find_std_section::<wasmbin::sections::payload::Export>()
             .and_then(|exports| exports.try_contents().ok())
-            .is_some_and(|exports| exports.iter().any(check_export))
+            .map(|exports| exports.iter().any(check_export))
+            .unwrap_or(false)
 }

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -386,7 +386,6 @@ impl InstanceEnv {
     }
 
     #[tracing::instrument(skip_all)]
-    #[allow(clippy::let_with_type_underscore)] // I have no idea why clippy is issuing this warning
     pub fn iter(&self, table_id: u32) -> impl Iterator<Item = Result<Vec<u8>, NodesError>> {
         use genawaiter::{sync::gen, yield_, GeneratorState};
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -1,5 +1,3 @@
-#![allow(clippy::let_with_type_underscore)] // can remove once tokio-rs/tracing#2609 mereges
-
 use std::path::{Path, PathBuf};
 
 use once_cell::sync::Lazy;

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.70"
+channel = "1.69"
 profile = "default"
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
# Description of Changes

- Until this upstream bug is fixed we need to revert to `1.69` so running in standalone works on macOs: https://github.com/wasmerio/wasmer/issues/4072

This is triggered by running reduces by bitCraft, for example.

- Remove unnecessary lints checks


# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
