### PR TITLE
Fix/improve incorrect serialization/deserialization of commit messages

### DIFF
--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -58,6 +58,13 @@ impl CommitLog {
     }
 
     fn generate_commit<D: MutTxDatastore<RowId = RowId>>(&self, tx_data: &TxData, _datastore: &D) -> Option<Vec<u8>> {
+        // We are not creating a commit for empty transactions.
+        // The reason for this is that empty transactions get encoded as 0 bytes,
+        // so a commit containing an empty transaction contains no useful information.
+        if tx_data.records.is_empty() {
+            return None;
+        }
+
         let mut unwritten_commit = self.unwritten_commit.lock().unwrap();
         let writes = tx_data
             .records

--- a/crates/core/src/db/messages/commit.rs
+++ b/crates/core/src/db/messages/commit.rs
@@ -42,12 +42,12 @@ impl Commit {
 
         let mut dst = [0u8; 8];
         dst.copy_from_slice(&bytes[read_count..read_count + 8]);
-        let min_tx_offset = u64::from_le_bytes(dst);
+        let commit_offset = u64::from_le_bytes(dst);
         read_count += 8;
 
         let mut dst = [0u8; 8];
         dst.copy_from_slice(&bytes[read_count..read_count + 8]);
-        let commit_offset = u64::from_le_bytes(dst);
+        let min_tx_offset = u64::from_le_bytes(dst);
         read_count += 8;
 
         let mut transactions: Vec<Arc<Transaction>> = Vec::new();

--- a/crates/core/src/db/messages/transaction.rs
+++ b/crates/core/src/db/messages/transaction.rs
@@ -17,18 +17,26 @@ impl Transaction {
 
         let mut bytes_read = 0;
 
-        let mut writes: Vec<Write> = Vec::new();
-        while bytes_read < bytes.len() {
+        let mut dst = [0u8; 4];
+        dst.copy_from_slice(&bytes[bytes_read..bytes_read + 4]);
+        let writes_count = u32::from_le_bytes(dst);
+        bytes_read += 4;
+
+        let mut writes: Vec<Write> = Vec::with_capacity(writes_count as usize);
+
+        let mut count = 0;
+        while bytes_read < bytes.len() && count < writes_count {
             let (write, read) = Write::decode(&bytes[bytes_read..]);
             bytes_read += read;
             writes.push(write);
+            count += 1;
         }
 
         (Transaction { writes }, bytes_read)
     }
 
     pub fn encoded_len(&self) -> usize {
-        let mut count = 0;
+        let mut count = 4;
         for write in &self.writes {
             count += write.encoded_len();
         }
@@ -36,6 +44,8 @@ impl Transaction {
     }
 
     pub fn encode(&self, bytes: &mut Vec<u8>) {
+        bytes.extend((self.writes.len() as u32).to_le_bytes());
+
         for write in &self.writes {
             write.encode(bytes);
         }


### PR DESCRIPTION
# Description of Changes

Fixes the following issues with the serialization of the commit log:
1. The deserialization of commit offset and min tx offset values were reversed
2. The transaction count was added to the serialization of a commit. This wasn't currently an issue because every commit has a single transaction. However with multiple transactions this would lead to issues
3. Empty transactions are not added to the commit log. This caused an inconsistency between the min tx offset value before and after serialization because empty transactions are serialized to 0 bytes, which when deserialized was interpreted as no transaction

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
This isn't exactly a break in the APIs but it's a change in the serialization/deserialization of the commit log, which means that existing databases will not startup correctly with this change