### PR TITLE
Add get primary key value/type functions to csharp autogen code

### DIFF
--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -1113,6 +1113,37 @@ fn autogen_csharp_access_funcs_for_struct(
                 .unwrap();
         }
         writeln!(output, "}}").unwrap();
+        writeln!(output).unwrap();
+
+        writeln!(
+            output,
+            "public static SpacetimeDB.SATS.AlgebraicValue GetPrimaryKeyValue(SpacetimeDB.SATS.AlgebraicValue v)"
+        )
+        .unwrap();
+        writeln!(output, "{{").unwrap();
+        {
+            indent_scope!(output);
+            writeln!(output, "return v.AsProductValue().elements[{}];", primary_col_index).unwrap();
+        }
+        writeln!(output, "}}").unwrap();
+        writeln!(output).unwrap();
+
+        writeln!(
+            output,
+            "public static SpacetimeDB.SATS.AlgebraicType GetPrimaryKeyType(SpacetimeDB.SATS.AlgebraicType t)"
+        )
+        .unwrap();
+        writeln!(output, "{{").unwrap();
+        {
+            indent_scope!(output);
+            writeln!(
+                output,
+                "return t.product.elements[{}].algebraicType;",
+                primary_col_index
+            )
+            .unwrap();
+        }
+        writeln!(output, "}}").unwrap();
     } else {
         writeln!(
             output,


### PR DESCRIPTION
# Description of Changes

Adding two new functions GetPrimaryKeyValue and GetPrimaryKeyType to the C# autogen classes for each table.
These are used int he csharp SDK to optimize performance when checking if an update has and insert and a delete operation with identical primary keys.


# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
