### PR TITLE
Fix lint on test

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -52,7 +52,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        run: cargo clippy --all --features odb_rocksdb,odb_sled,tracelogging -- -D warnings
+        run: cargo clippy --all --tests --features odb_rocksdb,odb_sled,tracelogging -- -D warnings
 
   wasm_bindings:
     name: Build and test wasm bindings


### PR DESCRIPTION
# Description of Changes

The github action misses clippy lints on tests. Add `--tests` to the `clippy` action and fix one in the codebase.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
