### PR TITLE
spacetime start 2

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1126,7 +1126,16 @@ version = "4.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
 dependencies = [
- "dirs-sys",
+ "dirs-sys 0.3.7",
+]
+
+[[package]]
+name = "dirs"
+version = "5.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
+dependencies = [
+ "dirs-sys 0.4.1",
 ]
 
 [[package]]
@@ -1138,6 +1147,18 @@ dependencies = [
  "libc",
  "redox_users",
  "winapi",
+]
+
+[[package]]
+name = "dirs-sys"
+version = "0.4.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "520f05a5cbd335fae5a99ff7a6ab8627577660ee5cfd6a94a6a929b52ff0321c"
+dependencies = [
+ "libc",
+ "option-ext",
+ "redox_users",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2502,6 +2523,12 @@ dependencies = [
  "pkg-config",
  "vcpkg",
 ]
+
+[[package]]
+name = "option-ext"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
 name = "os_pipe"
@@ -3941,7 +3968,7 @@ dependencies = [
  "clap 4.3.10",
  "colored",
  "convert_case",
- "dirs",
+ "dirs 4.0.0",
  "duct",
  "email_address",
  "futures",
@@ -3954,6 +3981,7 @@ dependencies = [
  "serde_json",
  "slab",
  "spacetimedb-lib",
+ "spacetimedb-standalone",
  "syntect",
  "tabled",
  "tempfile",
@@ -4086,6 +4114,7 @@ dependencies = [
  "anyhow",
  "bytes",
  "chrono",
+ "clap 4.3.10",
  "enum-as-inner",
  "hex",
  "insta",
@@ -4156,6 +4185,7 @@ dependencies = [
  "async-trait",
  "axum",
  "clap 4.3.10",
+ "dirs 5.0.1",
  "hostname",
  "http",
  "log",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,7 +17,7 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.2.4", features = ["derive", "env"] }
+clap = { version = "4.2.4", features = ["derive", "env", "string"] }
 reqwest = { version = "0.11.10", features = ["stream", "json"] }
 tokio = { version = "1", features = ["full"] }
 anyhow = { version = "1.0.57", features = ["backtrace"] }
@@ -26,7 +26,8 @@ serde_json = { version = "1.0", features = ["raw_value", "preserve_order"] }
 toml = "0.5"
 dirs = "4.0"
 tabled = "0.8.0"
-spacetimedb-lib = { path = "../lib", version = "0.5.0" }
+spacetimedb-lib = { path = "../lib", version = "0.5.0", features = ["cli"] }
+spacetimedb-standalone = { path = "../standalone", version = "0.5.0", optional = true }
 convert_case = "0.6.0"
 wasmtime = { version = "7", default-features = false, features = ["cranelift"] }
 colored = "2.0.0"
@@ -49,3 +50,5 @@ insta = { version = "1.21.0", features = ["toml"] }
 
 [features]
 tracelogging = []
+standalone = ["spacetimedb-standalone"]
+default = ["standalone"]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4,11 +4,13 @@ mod edit_distance;
 mod subcommands;
 mod tasks;
 pub mod util;
-
 use clap::{ArgMatches, Command};
 
 pub use config::Config;
 pub use subcommands::*;
+
+#[cfg(feature = "standalone")]
+use spacetimedb_standalone::subcommands::start;
 
 pub fn get_subcommands() -> Vec<Command> {
     vec![
@@ -29,6 +31,8 @@ pub fn get_subcommands() -> Vec<Command> {
         #[cfg(feature = "tracelogging")]
         tracelog::cli(),
         server::cli(),
+        #[cfg(feature = "standalone")]
+        start::cli(false),
     ]
 }
 
@@ -51,6 +55,8 @@ pub async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Re
         "server" => server::exec(config, args).await,
         #[cfg(feature = "tracelogging")]
         "tracelog" => tracelog::exec(config, args).await,
+        #[cfg(feature = "standalone")]
+        "start" => start::exec(args).await,
         unknown => Err(anyhow::anyhow!("Invalid subcommand: {}", unknown)),
     }
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,5 +1,6 @@
 use clap::Command;
 use spacetimedb_cli::*;
+use spacetimedb_lib::util;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {

--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -260,10 +260,8 @@ fn find_of_type_in_schema<'v, 't: 'v>(
 
     let iter = entities
         .into_iter()
-        .filter(|(_, value)| {
-            let Some(obj) = value.as_object() else {
-                return false;
-            };
+        .filter(move |(_, value)| {
+            let Some(obj) = value.as_object() else { return false; };
             obj.get("type").filter(|x| x.as_str() == Some(ty)).is_some()
         })
         .map(|(key, value)| (key.as_str(), value));

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -1,47 +1,10 @@
-use std::process::exit;
-
-use clap::{
-    error::{ContextKind, ContextValue},
-    ArgMatches, Command,
-};
-
 use reqwest::RequestBuilder;
 use serde::Deserialize;
 use spacetimedb_lib::name::{is_address, DnsLookupResponse, RegisterTldResult, ReverseDNSResponse};
 use spacetimedb_lib::Identity;
+use std::process::exit;
 
 use crate::config::{Config, IdentityConfig};
-
-pub fn match_subcommand_or_exit(command: Command) -> (String, ArgMatches) {
-    let mut command_clone = command.clone();
-    let result = command.try_get_matches();
-    let args = match result {
-        Ok(args) => args,
-        Err(e) => match e.kind() {
-            clap::error::ErrorKind::MissingSubcommand => {
-                let cmd = e
-                    .context()
-                    .find_map(|c| match c {
-                        (ContextKind::InvalidSubcommand, ContextValue::String(cmd)) => {
-                            Some(cmd.split_ascii_whitespace().last().unwrap())
-                        }
-                        _ => None,
-                    })
-                    .expect("The InvalidArg to be present in the context of UnknownArgument.");
-                match command_clone.find_subcommand_mut(cmd) {
-                    Some(subcmd) => subcmd.print_help().unwrap(),
-                    None => command_clone.print_help().unwrap(),
-                }
-                exit(0);
-            }
-            _ => {
-                e.exit();
-            }
-        },
-    };
-    let (cmd, subcommand_args) = args.subcommand().unwrap();
-    (cmd.to_string(), subcommand_args.clone())
-}
 
 /// Determine the address of the `database`.
 pub async fn database_address(config: &Config, database: &str) -> Result<String, anyhow::Error> {

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -8,7 +8,7 @@ pub mod json;
 pub mod sql;
 
 pub static STDB_PATH: Lazy<PathBuf> =
-    Lazy::new(|| PathBuf::from(std::env::var_os("STDB_PATH").unwrap_or_else(|| "/stdb".into())));
+    Lazy::new(|| PathBuf::from(std::env::var_os("STDB_PATH").expect("STDB_PATH must be set")));
 
 pub fn stdb_path<S>(s: &S) -> PathBuf
 where

--- a/crates/core/src/startup.rs
+++ b/crates/core/src/startup.rs
@@ -15,15 +15,9 @@ pub fn configure_tracing() {
     // once you are done.
     let conf_file = std::env::var_os("SPACETIMEDB_LOG_CONFIG")
         .map(PathBuf::from)
-        .unwrap_or_else(|| {
-            let local = Path::new("log.conf");
-            if local.exists() {
-                local.to_owned()
-            } else {
-                "/etc/spacetimedb/log.conf".into()
-            }
-        });
-    let logs_path: String = std::env::var("SPACETIMEDB_LOGS_PATH").unwrap_or("/var/log".into());
+        .expect("SPACETIMEDB_LOG_CONFIG must be set to a valid path to a log config file");
+    let logs_path: String = std::env::var("SPACETIMEDB_LOGS_PATH")
+        .expect("SPACETIMEDB_LOGS_PATH must be set to a valid path to a log directory");
 
     let timer = tracing_subscriber::fmt::time();
     let format = tracing_subscriber::fmt::format::Format::default()

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -16,6 +16,7 @@ required-features = ["serde"]
 [features]
 default = ["serde"]
 serde = ["dep:serde", "spacetimedb-sats/serde", "dep:serde_with", "chrono/serde"]
+cli = ["clap"]
 
 [dependencies]
 enum-as-inner = "0.6"
@@ -29,6 +30,7 @@ spacetimedb-bindings-macro = { path = "../bindings-macro", version = "0.5.0" }
 spacetimedb-sats = { path = "../sats", version = "0.5.0" }
 serde_with = { version = "2.2.0", optional = true }
 chrono = { version = "0.4.23", optional = true, default-features = false }
+clap = { version = "4.2.4", optional = true }
 
 [dev-dependencies]
 rand = "0.8.5"

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -25,6 +25,8 @@ pub mod auth;
 pub mod recovery;
 pub mod relation;
 pub mod table;
+#[cfg(feature = "cli")]
+pub mod util;
 pub mod version;
 
 pub use spacetimedb_sats::bsatn;

--- a/crates/lib/src/util.rs
+++ b/crates/lib/src/util.rs
@@ -1,0 +1,34 @@
+use clap::error::{ContextKind, ContextValue};
+use clap::{ArgMatches, Command};
+use std::process::exit;
+
+pub fn match_subcommand_or_exit(command: Command) -> (String, ArgMatches) {
+    let mut command_clone = command.clone();
+    let result = command.try_get_matches();
+    let args = match result {
+        Ok(args) => args,
+        Err(e) => match e.kind() {
+            clap::error::ErrorKind::MissingSubcommand => {
+                let cmd = e
+                    .context()
+                    .find_map(|c| match c {
+                        (ContextKind::InvalidSubcommand, ContextValue::String(cmd)) => {
+                            Some(cmd.split_ascii_whitespace().last().unwrap())
+                        }
+                        _ => None,
+                    })
+                    .expect("The InvalidArg to be present in the context of UnknownArgument.");
+                match command_clone.find_subcommand_mut(cmd) {
+                    Some(subcmd) => subcmd.print_help().unwrap(),
+                    None => command_clone.print_help().unwrap(),
+                }
+                exit(0);
+            }
+            _ => {
+                e.exit();
+            }
+        },
+    };
+    let (cmd, subcommand_args) = args.subcommand().unwrap();
+    (cmd.to_string(), subcommand_args.clone())
+}

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -17,13 +17,13 @@ required-features = [] # Features required to build this target (N/A for lib)
 
 [dependencies]
 spacetimedb-core = { path = "../core" }
-spacetimedb-lib = { path = "../lib" }
+spacetimedb-lib = { path = "../lib", features = ["cli"] }
 spacetimedb-client-api = { path = "../client-api" }
 tokio = { version = "1.2", features = ["full"] }
 anyhow = { version = "1.0.57", features = ["backtrace"] }
 prometheus = "0.13.0"
 hostname = "^0.3"
-clap = { version = "4.2.4", features = ["derive"] }
+clap = { version = "4.2.4", features = ["derive", "string"] }
 sled = "0.34.7"
 async-trait = "0.1.60"
 log = "0.4.16"
@@ -31,6 +31,7 @@ axum = "0.6"
 openssl = "0.10.54"
 http = "0.2.9"
 tower-http = { version = "0.4.1", features = ["cors"]}
+dirs = "5.0.1"
 
 [dev-dependencies]
 serde_json = "1.0"

--- a/crates/standalone/src/main.rs
+++ b/crates/standalone/src/main.rs
@@ -1,3 +1,4 @@
+use clap::Command;
 use anyhow::Context;
 use clap::Parser;
 use clap::Subcommand;
@@ -10,94 +11,25 @@ use spacetimedb_standalone::StandaloneEnv;
 use std::net::TcpListener;
 use tokio::runtime::Builder;
 
+use spacetimedb_lib::util;
+use spacetimedb_standalone::*;
 use std::panic;
 use std::process;
 
-#[derive(Debug, Clone)]
-pub struct Config {
-    pub listen_addr: String,
-    pub advertise_addr: String,
-}
-
-impl Config {
-    const DEFAULT_ADDR: &str = "0.0.0.0:80";
-    pub async fn new(listen_addr: String, advertise_addr: Option<String>) -> anyhow::Result<Self> {
-        let advertise_addr = match advertise_addr {
-            Some(a) => a,
-            None if listen_addr == Self::DEFAULT_ADDR => {
-                let hostname = hostname::get().unwrap().into_string().unwrap();
-                let addr = hostname + ":80";
-                let _ = tokio::net::lookup_host(&addr)
-                    .await
-                    .context("failed to resolve hostname")?;
-                addr
-            }
-            None => listen_addr.clone(),
-        };
-        Ok(Self {
-            listen_addr,
-            advertise_addr,
-        })
-    }
-}
-
-async fn start(config: Config) -> anyhow::Result<()> {
-    startup::configure_tracing();
-
-    // Metrics for pieces under worker_node/ related to reducer hosting, etc.
-    worker_metrics::register_custom_metrics();
-
-    // Metrics for our use of db/.
-    db_metrics::register_custom_metrics();
-
-    let ctx = spacetimedb_client_api::ArcEnv(StandaloneEnv::init().await?);
-
-    let service = router().with_state(ctx).into_make_service();
-
-    let tcp = TcpListener::bind(config.listen_addr).unwrap();
-    log::debug!("Starting SpacetimeDB listening on {}", tcp.local_addr().unwrap());
-    axum::Server::from_tcp(tcp)?.serve(service).await?;
-    Ok(())
-}
-
-async fn version() -> anyhow::Result<()> {
-    // e.g. kubeadm version: &version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.2", GitCommit:"f66044f4361b9f1f96f0053dd46cb7dce5e990a8", GitTreeState:"clean", BuildDate:"2022-06-15T14:20:54Z", GoVersion:"go1.18.3", Compiler:"gc", Platform:"linux/arm64"}
-    println!("0.0.0");
-    Ok(())
-}
-
 async fn async_main() -> anyhow::Result<()> {
-    let args = Args::parse();
-    match args.command {
-        Subcommands::Start {
-            advertise_addr,
-            listen_addr,
-        } => {
-            let config = Config::new(listen_addr, advertise_addr).await?;
-            start(config).await?
-        }
-        Subcommands::Version => version().await?,
-    }
+    let (cmd, subcommand_args) = util::match_subcommand_or_exit(get_command());
+    exec_subcommand(&cmd, &subcommand_args).await?;
     Ok(())
 }
 
-#[derive(Subcommand, Debug)]
-enum Subcommands {
-    /// Run this command in order to set up the SpacetimeDB control plane
-    Start {
-        /// <node-host>:<node-port>
-        #[arg(short, long)]
-        advertise_addr: Option<String>,
-
-        #[arg(short, long, default_value = Config::DEFAULT_ADDR)]
-        listen_addr: String,
-    },
-    /// Print the version of spacetime
-    Version,
-}
-
-#[derive(Parser, Debug)]
-#[command(author, version, long_about=None, about=r#"
+fn get_command() -> Command {
+    Command::new("spacetimedb")
+        .args_conflicts_with_subcommands(true)
+        .subcommand_required(true)
+        .subcommands(get_subcommands())
+        .help_expected(true)
+        .help_template(
+            r#"
 ┌──────────────────────────────────────────────────────────┐
 │ spacetimedb                                              │
 │ Run a standalone SpacetimeDB instance                    │
@@ -109,10 +41,8 @@ Example usage:
 ┌──────────────────────────────────────────────────────────┐
 │ machine# spacetimedb start                               │
 └──────────────────────────────────────────────────────────┘
-"#)]
-struct Args {
-    #[clap(subcommand)]
-    command: Subcommands,
+"#,
+        )
 }
 
 fn main() {

--- a/crates/standalone/src/main.rs
+++ b/crates/standalone/src/main.rs
@@ -1,14 +1,5 @@
-use anyhow::Context;
 use clap::Command;
-use clap::Parser;
-use clap::Subcommand;
 
-use spacetimedb::db::db_metrics;
-use spacetimedb::startup;
-use spacetimedb::worker_metrics;
-use spacetimedb_standalone::routes::router;
-use spacetimedb_standalone::StandaloneEnv;
-use std::net::TcpListener;
 use tokio::runtime::Builder;
 
 use spacetimedb_lib::util;

--- a/crates/standalone/src/main.rs
+++ b/crates/standalone/src/main.rs
@@ -1,5 +1,5 @@
-use clap::Command;
 use anyhow::Context;
+use clap::Command;
 use clap::Parser;
 use clap::Subcommand;
 

--- a/crates/standalone/src/subcommands/mod.rs
+++ b/crates/standalone/src/subcommands/mod.rs
@@ -1,0 +1,2 @@
+pub mod start;
+pub mod version;

--- a/crates/standalone/src/subcommands/start.rs
+++ b/crates/standalone/src/subcommands/start.rs
@@ -6,7 +6,6 @@ use clap::{Arg, ArgMatches};
 use spacetimedb::db::db_metrics;
 use spacetimedb::{startup, worker_metrics};
 use std::net::TcpListener;
-use std::sync::Arc;
 
 #[cfg(feature = "string")]
 impl From<std::string::String> for OsStr {
@@ -181,7 +180,7 @@ pub async fn exec(args: &ArgMatches) -> anyhow::Result<()> {
     // Metrics for our use of db/.
     db_metrics::register_custom_metrics();
 
-    let ctx = spacetimedb_client_api::ArcEnv(Arc::new(StandaloneEnv::init().await?));
+    let ctx = spacetimedb_client_api::ArcEnv(StandaloneEnv::init().await?);
 
     let service = router().with_state(ctx).into_make_service();
 

--- a/crates/standalone/src/subcommands/start.rs
+++ b/crates/standalone/src/subcommands/start.rs
@@ -1,0 +1,192 @@
+use crate::routes::router;
+use crate::util::{create_dir_or_err, create_file_with_contents};
+use crate::StandaloneEnv;
+use clap::ArgAction::SetTrue;
+use clap::{Arg, ArgMatches};
+use spacetimedb::db::db_metrics;
+use spacetimedb::{startup, worker_metrics};
+use std::net::TcpListener;
+use std::sync::Arc;
+
+#[cfg(feature = "string")]
+impl From<std::string::String> for OsStr {
+    fn from(name: std::string::String) -> Self {
+        Self::from_string(name.into())
+    }
+}
+
+pub fn cli(is_standalone: bool) -> clap::Command {
+    let mut log_conf_path_arg = Arg::new("log_conf_path")
+        .long("log-conf-path")
+        .help("The path of the file that contains the log configuration for SpacetimeDB (SPACETIMEDB_LOG_CONFIG)");
+    let mut log_dir_path_arg = Arg::new("log_dir_path")
+        .long("log-dir-path")
+        .help("The path to the directory that should contain logs for SpacetimeDB (SPACETIMEDB_LOGS_PATH)");
+    let mut database_path_arg = Arg::new("database_path")
+        .help("The path to the directory that should contain the database files for SpacetimeDB (STDB_PATH)");
+    let mut jwt_pub_key_path_arg = Arg::new("jwt_pub_key_path")
+        .long("jwt-pub-key-path")
+        .help("The path to the public jwt key for verifying identities (SPACETIMEDB_JWT_PUB_KEY)");
+    let mut jwt_priv_key_path_arg = Arg::new("jwt_priv_key_path")
+        .long("jwt-priv-key-path")
+        .help("The path to the private jwt key for issuing identities (SPACETIMEDB_JWT_PRIV_KEY)");
+
+    // the default root for files, this *should* be the home directory unless it cannot be determined.
+    let default_root = if let Some(dir) = dirs::home_dir() {
+        dir
+    } else {
+        println!("Warning: home directory not found, using current directory.");
+        std::env::current_dir().unwrap()
+    }
+    .to_str()
+    .unwrap()
+    .to_string();
+
+    // If this isn't standalone, we provide default values
+    if !is_standalone {
+        log_conf_path_arg = log_conf_path_arg.default_value(format!("{}/.spacetime/log.conf", default_root));
+        log_dir_path_arg = log_dir_path_arg.default_value(format!("{}/.spacetime", default_root));
+        database_path_arg = database_path_arg.default_value(format!("{}/.spacetime/stdb", default_root));
+        jwt_pub_key_path_arg = jwt_pub_key_path_arg.default_value(format!("{}/.spacetime/id_ecdsa.pub", default_root));
+        jwt_priv_key_path_arg = jwt_priv_key_path_arg.default_value(format!("{}/.spacetime/id_ecdsa", default_root));
+    } else {
+        log_conf_path_arg = log_conf_path_arg.default_value("/etc/spacetimedb/log.conf");
+        log_dir_path_arg = log_dir_path_arg.default_value("/var/log");
+        database_path_arg = database_path_arg.default_value("/stdb");
+        jwt_pub_key_path_arg = jwt_pub_key_path_arg.default_value("/etc/spacetimedb/id_ecdsa.pub");
+        jwt_priv_key_path_arg = jwt_priv_key_path_arg.default_value("/etc/spacetimedb/id_ecdsa");
+    }
+
+    clap::Command::new("start")
+        .about("Starts a standalone SpacetimeDB instance")
+        .long_about("Starts a standalone SpacetimeDB instance. This command recognizes the following environment variables: \
+                \n\tSPACETIMEDB_LOG_CONFIG: The path to the log configuration file. \
+                \n\tSPACETIMEDB_LOGS_PATH: The path to the directory that should contain logs for SpacetimeDB. \
+                \n\tSTDB_PATH: The path to the directory that should contain the database files for SpacetimeDB. \
+                \n\tSPACETIMEDB_JWT_PUB_KEY: The path to the public jwt key for verifying identities. \
+                \n\tSPACETIMEDB_JWT_PRIV_KEY: The path to the private jwt key for issuing identities. \
+                \n\tSPACETIMEDB_TRACY: Set to 1 to enable Tracy profiling.\
+                \n\nWarning: If you set a value on the command line, it will override the value set in the environment variable.")
+        .arg(
+            Arg::new("listen_addr")
+                .long("listen-addr")
+                .short('l')
+                .default_value(if is_standalone { "0.0.0.0:80" } else { "127.0.0.1:3000" })
+                .help(if is_standalone
+                {
+                    "The address and port where SpacetimeDB should listen for connections. This defaults to to listen on all IP addresses on port 80."
+                } else {
+                    "The address and port where SpacetimeDB should listen for connections. This defaults to local connections only on port 3000. Use an IP address or 0.0.0.0 in order to allow remote connections to SpacetimeDB."
+                }),
+        )
+        .arg(log_conf_path_arg)
+        .arg(log_dir_path_arg)
+        .arg(database_path_arg)
+        .arg(
+            Arg::new("allow_create")
+                .long("allow-create")
+                .action(SetTrue)
+                .help("Allows for the creation of files and directories that don't exist"),
+        )
+        .arg(
+            Arg::new("enable_tracy")
+                .long("enable-tracy")
+                .action(SetTrue)
+                .help("Enable Tracy profiling (SPACETIMEDB_TRACY)"),
+        )
+        .arg(jwt_pub_key_path_arg)
+        .arg(jwt_priv_key_path_arg)
+        // We still want to keep the executable name `spacetimedb` when we're executing as a standalone, but
+        // we want the executable name to be `spacetime` when we're executing this from the CLI. We have to
+        // pass these strings with static lifetimes so we can't do any dynamic string manipulation here.
+        .after_help(if is_standalone {
+            "Run `spacetimedb help start` for more detailed information."
+        } else {
+            "Run `spacetime help start` for more information."
+        })
+}
+
+/// Sets an environment variable. Print a warning if already set.
+fn set_env_with_warning(env_name: &str, env_value: &str) {
+    if std::env::var(env_name).is_ok() {
+        println!("Warning: {} is set in the environment, but was also passed on the command line. The value passed on the command line will be used.", env_name);
+    }
+    std::env::set_var(env_name, env_value);
+}
+
+/// Reads an argument from the `ArgMatches`.
+///
+/// If the argument is the default and the environment variable is already set,
+/// then we don't want to use the default value.
+/// This function will return `None` in that case.
+fn read_argument<'a>(args: &'a ArgMatches, arg_name: &str, env_name: &str) -> Option<&'a String> {
+    let env_is_set = std::env::var(env_name).is_ok();
+    let is_default = args.value_source(arg_name) == Some(clap::parser::ValueSource::DefaultValue);
+
+    if env_is_set && is_default {
+        None
+    } else {
+        args.get_one::<String>(arg_name)
+    }
+}
+
+pub async fn exec(args: &ArgMatches) -> anyhow::Result<()> {
+    let listen_addr = args.get_one::<String>("listen_addr").unwrap();
+    let allow_create = args.get_flag("allow_create");
+    let log_conf_path = read_argument(args, "log_conf_path", "SPACETIMEDB_LOG_CONFIG");
+    let log_dir_path = read_argument(args, "log_dir_path", "SPACETIMEDB_LOGS_PATH");
+    let stdb_path = read_argument(args, "database_path", "STDB_PATH");
+    let jwt_pub_key_path = read_argument(args, "jwt_pub_key_path", "SPACETIMEDB_JWT_PUB_KEY");
+    let jwt_priv_key_path = read_argument(args, "jwt_priv_key_path", "SPACETIMEDB_JWT_PRIV_KEY");
+    let enable_tracy = args.get_flag("enable_tracy");
+
+    if let Some(log_conf_path) = log_conf_path {
+        create_file_with_contents(
+            allow_create,
+            log_conf_path,
+            include_str!("../../../../crates/standalone/log.conf"),
+        )?;
+        set_env_with_warning("SPACETIMEDB_LOG_CONFIG", log_conf_path);
+    }
+
+    if let Some(log_dir_path) = log_dir_path {
+        create_dir_or_err(allow_create, log_dir_path)?;
+        set_env_with_warning("SPACETIMEDB_LOGS_PATH", log_dir_path);
+    }
+
+    if let Some(stdb_path) = stdb_path {
+        create_dir_or_err(allow_create, stdb_path)?;
+        set_env_with_warning("STDB_PATH", stdb_path);
+    }
+
+    // If this doesn't exist, we will create it later, just set the env variable for now
+    if let Some(jwt_pub_key_path) = jwt_pub_key_path {
+        set_env_with_warning("SPACETIMEDB_JWT_PUB_KEY", jwt_pub_key_path);
+    }
+
+    // If this doesn't exist, we will create it later, just set the env variable for now
+    if let Some(jwt_priv_key_path) = jwt_priv_key_path {
+        set_env_with_warning("SPACETIMEDB_JWT_PRIV_KEY", jwt_priv_key_path);
+    }
+
+    if enable_tracy {
+        set_env_with_warning("SPACETIMEDB_TRACY", "1");
+    }
+
+    startup::configure_tracing();
+
+    // Metrics for pieces under worker_node/ related to reducer hosting, etc.
+    worker_metrics::register_custom_metrics();
+
+    // Metrics for our use of db/.
+    db_metrics::register_custom_metrics();
+
+    let ctx = spacetimedb_client_api::ArcEnv(Arc::new(StandaloneEnv::init().await?));
+
+    let service = router().with_state(ctx).into_make_service();
+
+    let tcp = TcpListener::bind(listen_addr).unwrap();
+    log::debug!("Starting SpacetimeDB listening on {}", tcp.local_addr().unwrap());
+    axum::Server::from_tcp(tcp)?.serve(service).await?;
+    Ok(())
+}

--- a/crates/standalone/src/subcommands/version.rs
+++ b/crates/standalone/src/subcommands/version.rs
@@ -1,0 +1,31 @@
+use clap::{Arg, ArgAction::SetTrue, ArgMatches};
+
+const CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
+
+pub fn cli() -> clap::Command {
+    clap::Command::new("version")
+        .about("Print the version of the command line tool")
+        .after_help("Run `spacetimedb help version` for more detailed information.\n")
+        .arg(
+            Arg::new("cli")
+                .short('c')
+                .long("cli")
+                .action(SetTrue)
+                .help("Prints only the CLI version"),
+        )
+}
+
+pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
+    // e.g. kubeadm version: &version.Info{Major:"1", Minor:"24", GitVersion:"v1.24.2", GitCommit:"f66044f4361b9f1f96f0053dd46cb7dce5e990a8", GitTreeState:"clean", BuildDate:"2022-06-15T14:20:54Z", GoVersion:"go1.18.3", Compiler:"gc", Platform:"linux/arm64"}
+    if args.get_flag("cli") {
+        println!("{}", CLI_VERSION);
+        return Ok(());
+    }
+
+    println!(
+        "spacetimedb tool version {}; spacetimedb-lib version {};",
+        CLI_VERSION,
+        spacetimedb_lib::version::spacetimedb_lib_version()
+    );
+    Ok(())
+}

--- a/crates/standalone/src/util.rs
+++ b/crates/standalone/src/util.rs
@@ -1,0 +1,48 @@
+use std::env;
+use std::path::Path;
+
+/// If `allow_create` is set to true and the directory is missing, create it.
+/// Otherwise, if `allow_create` is set to false
+/// and the directory is missing an error is returned.
+/// Otherwise if the directory does exist, do nothing.
+pub fn create_dir_or_err(allow_create: bool, path: &str) -> anyhow::Result<()> {
+    if !Path::new(path).is_dir() {
+        if !allow_create {
+            return Err(anyhow::anyhow!(
+                "Directory {} does not exist, pass --allow-create to create it",
+                path
+            ));
+        }
+        println!("Creating directory {}", path);
+        std::fs::create_dir_all(path)?;
+    }
+    Ok(())
+}
+
+/// If `allow_create` is set to true and the file (and parent directory) is missing, create it with
+/// `contents`. Otherwise if the file doesn't exist and `allow_create` is set to false, an error is
+/// returned. Otherwise if the file does exist, do nothing.
+pub fn create_file_with_contents(allow_create: bool, path: &str, contents: &str) -> anyhow::Result<()> {
+    create_dir_or_err(allow_create, Path::new(path).parent().unwrap().to_str().unwrap())?;
+    if !Path::new(path).is_file() {
+        if !allow_create {
+            return Err(anyhow::anyhow!(
+                "File {} does not exist, pass --allow-create to create it",
+                path
+            ));
+        }
+        println!("Creating file {}", path);
+        std::fs::write(path, contents)?;
+    }
+    Ok(())
+}
+
+/// Returns the name of the current executable without the tail extension and the path.
+pub fn get_exe_name() -> String {
+    let exe_path = env::current_exe().expect("Failed to get executable path");
+    let executable_name = Path::new(&exe_path)
+        .file_stem()
+        .and_then(|n| n.to_str())
+        .unwrap_or("unknown");
+    executable_name.to_string()
+}

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -1,6 +1,5 @@
-use spacetimedb::stdb_path;
 use std::env;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 
 pub mod modules;
 
@@ -10,6 +9,10 @@ pub fn set_key_env_vars() {
             env::set_var(var, Path::new(env!("CARGO_MANIFEST_DIR")).join("../..").join(path));
         }
     };
-    set_if_not_exist("SPACETIMEDB_JWT_PUB_KEY", stdb_path("id_ecdsa.pub"));
-    set_if_not_exist("SPACETIMEDB_JWT_PRIV_KEY", stdb_path("id_ecdsa"));
+
+    set_if_not_exist("STDB_PATH", PathBuf::from("/stdb"));
+    set_if_not_exist("SPACETIMEDB_LOGS_PATH", PathBuf::from("/var/log"));
+    set_if_not_exist("SPACETIMEDB_LOG_CONFIG", PathBuf::from("/stdb/log.conf"));
+    set_if_not_exist("SPACETIMEDB_JWT_PUB_KEY", PathBuf::from("/stdb/id_ecdsa.pub"));
+    set_if_not_exist("SPACETIMEDB_JWT_PRIV_KEY", PathBuf::from("/stdb/id_ecdsa"));
 }


### PR DESCRIPTION
# Description of Changes

Previous PR: https://github.com/clockworklabs/SpacetimeDB/pull/91

 - This enables users to start a new spacetime server instance via: `spacetime start`
 - `standalone` is now a *default* feature for the `spacetimedb-cli` crate, if this feature is enabled then standalone will be compiled into the cli. If this feature isn't enabled then `spacetime start` will not work but will substantially speed up the compilation time of the `spacetimedb-cli` crate.

This command contains all of the options that were previously available in `spacetimedb start`, plus some options that I've added for convienence. The help section is explicit about its operation:

```
boppy@boppy-macbook SpacetimeDB % cargo run -- start --help
Starts a standalone SpacetimeDB instance. This command recognizes the following environment variables: 
	SPACETIMEDB_LOG_CONFIG: The path to the log configuration file. 
	SPACETIMEDB_LOGS_PATH: The path to the directory that should contain logs for SpacetimeDB. 
	STDB_PATH: The path to the directory that should contain the database files for SpacetimeDB. 
	SPACETIMEDB_JWT_PUB_KEY: The path to the public jwt key for verifying identities. 
	SPACETIMEDB_JWT_PRIV_KEY: The path to the private jwt key for issuing identities. 
	SPACETIMEDB_TRACY: Set to 1 to enable Tracy profiling.

Warning: If you set a value on the command line, it will override the value set in the environment variable.

Usage: spacetime start [OPTIONS] [database_path]

Arguments:
  [database_path]  The path to the directory that should contain the database files for SpacetimeDB (STDB_PATH) [default: /Users/boppy/.spacetime/stdb]

Options:
  -l, --listen-addr <listen_addr>
          The address and port where SpacetimeDB should listen for connections. [default: 127.0.0.1:3000]
      --log-conf-path <log_conf_path>
          The path of the file that contains the log configuration for SpacetimeDB (SPACETIMEDB_LOG_CONFIG) [default: /Users/boppy/.spacetime/log.conf]
      --log-dir-path <log_dir_path>
          The path to the directory that should contain logs for SpacetimeDB (SPACETIMEDB_LOGS_PATH) [default: /Users/boppy/.spacetime]
      --allow-create
          Allows for the creation of files and directories that don't exist
      --enable-tracy
          Enable Tracy profiling (SPACETIMEDB_TRACY)
      --jwt-pub-key-path <jwt_pub_key_path>
          The path to the public jwt key for verifying identities (SPACETIMEDB_JWT_PUB_KEY) [default: /Users/boppy/.spacetime/id_ecdsa.pub]
      --jwt-priv-key-path <jwt_priv_key_path>
          The path to the private jwt key for issuing identities (SPACETIMEDB_JWT_PRIV_KEY) [default: /Users/boppy/.spacetime/id_ecdsa]
  -h, --help
          Print help

Run `spacetime help start` for more information.
```

You can start a new instance of spacetimedb with just:
```bash
spacetime start --allow-create
```

Internally our developers may find it useful to create another database via:
```bash
spacetime start --allow-create "~/.spacetime/another_database"
```

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
