### PR TITLE
Enable odb_sled feature

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -108,7 +108,7 @@ features = ["lz4"] # if we link bzip, we get multiple defs
 odb_rocksdb = ["dep:rocksdb"]
 odb_sled = []
 tracelogging = []
-default = ["tracelogging"]
+default = ["tracelogging", "odb_sled"]
 
 [dev-dependencies]
 rusqlite = {version = "0.29.0", features = ["bundled", "column_decltype"]}

--- a/crates/core/benches/odb_flavor_bench.rs
+++ b/crates/core/benches/odb_flavor_bench.rs
@@ -35,9 +35,9 @@ fn generate_random_sized_value() -> Vec<u8> {
 #[derive(Clone, Copy)]
 pub enum ODBFlavor {
     HashMap,
-    #[cfg(feature = "odb_rocksdb")]
-    Sled,
     #[cfg(feature = "odb_sled")]
+    Sled,
+    #[cfg(feature = "odb_rocksdb")]
     Rocks,
 }
 impl Display for ODBFlavor {

--- a/crates/core/src/database_instance_context.rs
+++ b/crates/core/src/database_instance_context.rs
@@ -1,7 +1,7 @@
 use super::database_logger::DatabaseLogger;
 use crate::address::Address;
 use crate::db::message_log::MessageLog;
-use crate::db::ostorage::hashmap_object_db::HashMapObjectDB;
+use crate::db::ostorage::sled_object_db::SledObjectDB;
 use crate::db::ostorage::ObjectDB;
 use crate::db::relational_db::RelationalDB;
 use crate::identity::Identity;
@@ -73,6 +73,6 @@ impl DatabaseInstanceContext {
     }
 
     pub(crate) fn make_default_ostorage(path: impl AsRef<Path>) -> Box<dyn ObjectDB + Send> {
-        Box::new(HashMapObjectDB::open(path).unwrap())
+        Box::new(SledObjectDB::open(path).unwrap())
     }
 }


### PR DESCRIPTION
# Description of Changes
Use sled instead of the hashmap impelmentation for object db.
For BitCraft this reduced loading time after a spacetimedb restart by approximately 3 minutes.


# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
