### PR TITLE
Benches refactor

### DIFF
--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -23,12 +23,11 @@ spacetimedb-standalone = { path = "../standalone" }
 spacetimedb-client-api = { path = "../client-api" }
 spacetimedb-testing = { path = "../testing" }
 
-clap.workspace = true
-rusqlite.workspace = true
-criterion.workspace = true
-tempdir.workspace = true
-rand.workspace = true
-tokio.workspace = true
-serde_json.workspace = true
 anyhow.workspace = true
-byte-unit.workspace = true
+clap.workspace = true
+criterion.workspace = true
+rand.workspace = true
+rusqlite.workspace = true
+serde_json.workspace = true
+tempdir.workspace = true
+tokio.workspace = true

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -24,6 +24,7 @@ spacetimedb-client-api = { path = "../client-api" }
 spacetimedb-testing = { path = "../testing" }
 
 anyhow.workspace = true
+byte-unit.workspace = true
 clap.workspace = true
 criterion.workspace = true
 rand.workspace = true

--- a/crates/bench/benches/db.rs
+++ b/crates/bench/benches/db.rs
@@ -24,21 +24,21 @@ fn bench_insert_tx_per_row(c: &mut Criterion, fsync: bool) {
     let parameter = if fsync { "fsync" } else { "no-fsync" };
 
     // Factor out the db creation because is IO that generate noise
-    group.bench_function(BenchmarkId::new(SQLITE, 1), |b| {
+    group.bench_function(BenchmarkId::new(SQLITE, parameter), |b| {
         b.iter_batched(
-            || sqlite::create_db(0).unwrap(),
+            || sqlite::create_db(0, true).unwrap(),
             |path| {
-                let mut conn = sqlite::open_conn(&path).unwrap();
+                let mut conn = sqlite::open_conn(&path, fsync).unwrap();
                 sqlite::insert_tx_per_row(&mut conn, run).unwrap();
             },
             SIZE,
         );
     });
-    group.bench_function(BenchmarkId::new(SPACETIME, 1), |b| {
+    group.bench_function(BenchmarkId::new(SPACETIME, parameter), |b| {
         b.iter_batched(
-            || spacetime::create_db(0).unwrap(),
+            || spacetime::create_db(0, true).unwrap(),
             |path| {
-                let (conn, _, table_id) = spacetime::open_conn(&path).unwrap();
+                let (conn, _, table_id) = spacetime::open_conn(&path, fsync).unwrap();
                 spacetime::insert_tx_per_row(&conn, table_id, run).unwrap();
             },
             SIZE,
@@ -48,27 +48,66 @@ fn bench_insert_tx_per_row(c: &mut Criterion, fsync: bool) {
     group.finish();
 }
 
-fn bench_insert_tx(c: &mut Criterion) {
+fn bench_insert_tx(c: &mut Criterion, fsync: bool) {
     let run = Runs::Small;
     let mut group = build_group(c, "insert_bulk_rows", run);
+    let parameter = if fsync { "fsync" } else { "no-fsync" };
 
     // Factor out the db creation because is IO that generate noise
-    group.bench_function(BenchmarkId::new(SQLITE, 2), |b| {
+    group.bench_function(BenchmarkId::new(SQLITE, parameter), |b| {
         b.iter_batched(
-            || sqlite::create_db(0).unwrap(),
+            || sqlite::create_db(0, true).unwrap(),
             |path| {
-                let mut conn = sqlite::open_conn(&path).unwrap();
+                let mut conn = sqlite::open_conn(&path, fsync).unwrap();
                 sqlite::insert_tx(&mut conn, run).unwrap();
             },
             SIZE,
         );
     });
-    group.bench_function(BenchmarkId::new(SPACETIME, 2), |b| {
+    group.bench_function(BenchmarkId::new(SPACETIME, parameter), |b| {
         b.iter_batched(
-            || spacetime::create_db(0).unwrap(),
+            || spacetime::create_db(0, true).unwrap(),
             |path| {
-                let (conn, _, table_id) = spacetime::open_conn(&path).unwrap();
+                let (conn, _, table_id) = spacetime::open_conn(&path, fsync).unwrap();
                 spacetime::insert_tx(&conn, table_id, run).unwrap();
+            },
+            SIZE,
+        );
+    });
+
+    group.finish();
+}
+
+fn bench_select_no_index(c: &mut Criterion, fsync: bool) {
+    let run = Runs::Tiny;
+    let mut group = build_group(c, "select_index_no", run);
+    let parameter = if fsync { "fsync" } else { "no-fsync" };
+
+    // Factor out the db creation because is IO that generate noise
+    group.bench_function(BenchmarkId::new(SQLITE, parameter), |b| {
+        b.iter_batched(
+            || {
+                let path = sqlite::create_db(0, true).unwrap();
+                sqlite::db_prefill(&path, run, true).unwrap();
+                path
+            },
+            |path| {
+                let mut conn = sqlite::open_conn(&path, fsync).unwrap();
+                sqlite::select_no_index(&mut conn, run).unwrap();
+            },
+            SIZE,
+        );
+    });
+    group.bench_function(BenchmarkId::new(SPACETIME, parameter), |b| {
+        b.iter_batched(
+            || {
+                let path = spacetime::create_db(0, true).unwrap();
+                spacetime::db_prefill(&path, run, true).unwrap();
+                path
+            },
+            |path| {
+                let (conn, _, table_id) = spacetime::open_conn(&path, fsync).unwrap();
+                spacetime::select_no_index(&conn, table_id, run).unwrap();
             },
             SIZE,
         );
@@ -99,35 +138,6 @@ fn bench_select_no_index_with_fsync(c: &mut Criterion) {
 
 fn bench_select_no_index_no_fsync(c: &mut Criterion) {
     bench_select_no_index(c, false);
-}
-
-fn bench_select_no_index(c: &mut Criterion) {
-    let run = Runs::Tiny;
-    let mut group = build_group(c, "select_index_no", run);
-
-    // Factor out the db creation because is IO that generate noise
-    group.bench_function(BenchmarkId::new(SQLITE, 3), |b| {
-        b.iter_batched(
-            || sqlite::create_db(0).unwrap(),
-            |path| {
-                let mut conn = sqlite::open_conn(&path).unwrap();
-                sqlite::select_no_index(&mut conn, run).unwrap();
-            },
-            SIZE,
-        );
-    });
-    group.bench_function(BenchmarkId::new(SPACETIME, 3), |b| {
-        b.iter_batched(
-            || spacetime::create_db(0).unwrap(),
-            |path| {
-                let (conn, _, table_id) = spacetime::open_conn(&path).unwrap();
-                spacetime::select_no_index(&conn, table_id, run).unwrap();
-            },
-            SIZE,
-        );
-    });
-
-    group.finish();
 }
 
 // Note: Reflex this same benchmarks in `main.rs`

--- a/crates/bench/benches/db.rs
+++ b/crates/bench/benches/db.rs
@@ -1,14 +1,18 @@
 //! Benchmarks for evaluating how we fare against sqlite
 
 use criterion::measurement::WallTime;
-use criterion::{criterion_group, criterion_main, BenchmarkGroup, BenchmarkId, Criterion, SamplingMode, Throughput};
+use criterion::{
+    criterion_group, criterion_main, BatchSize, BenchmarkGroup, BenchmarkId, Criterion, SamplingMode, Throughput,
+};
 use spacetimedb_bench::prelude::*;
+use std::time::Duration;
 
 fn build_group<'a>(c: &'a mut Criterion, named: &str, run: Runs) -> BenchmarkGroup<'a, WallTime> {
     let mut group = c.benchmark_group(named);
+    // We need to restrict the amount of iterations and set the benchmark for "large" operations.
     group.throughput(Throughput::Elements(run as u64));
     group.sample_size(DB_POOL as usize);
-    group.sampling_mode(SamplingMode::Linear);
+    group.sampling_mode(SamplingMode::Flat);
     group
 }
 
@@ -17,51 +21,60 @@ fn bench_insert_tx_per_row(c: &mut Criterion, fsync: bool) {
     let mut group = build_group(c, "insert_row", run);
     let parameter = if fsync { "fsync" } else { "no-fsync" };
 
-    group.bench_function(BenchmarkId::new(SQLITE, parameter), |b| {
-        let mut pool = Pool::new(false, fsync).unwrap();
-        b.iter(|| sqlite::insert_tx_per_row(&mut pool, run).unwrap())
+    group.bench_function(BenchmarkId::new(SQLITE, 1), |b| {
+        let mut db_instance = 0;
+        b.iter_batched(
+            || {
+                let path = sqlite::create_db(db_instance).unwrap();
+                db_instance += 1;
+                path
+            },
+            |data| {
+                let mut conn = sqlite::open_conn(&data).unwrap();
+                sqlite::insert_tx_per_row(&mut conn, run).unwrap();
+            },
+            BatchSize::NumBatches(DB_POOL as u64),
+        );
     });
-    group.bench_function(BenchmarkId::new(SPACETIME, parameter), |b| {
-        let mut pool = Pool::new(false, fsync).unwrap();
-        b.iter(|| spacetime::insert_tx_per_row(&mut pool, run).unwrap())
-    });
+    // group.bench_function(BenchmarkId::new(SPACETIME, 1), |b| {
+    //     let mut pool = Pool::new(false).unwrap();
+    //     b.iter_with_setup(|| spacetime::insert_tx_per_row(&mut pool, run).unwrap())
+    // });
 
     group.finish();
 }
-
-fn bench_insert_tx(c: &mut Criterion, fsync: bool) {
-    let run = Runs::Small;
-    let mut group = build_group(c, "insert_bulk_rows", run);
-    let parameter = if fsync { "fsync" } else { "no-fsync" };
-
-    group.bench_function(BenchmarkId::new(SQLITE, parameter), |b| {
-        let mut pool = Pool::new(true, fsync).unwrap();
-        b.iter(|| sqlite::insert_tx(&mut pool, run))
-    });
-    group.bench_function(BenchmarkId::new(SPACETIME, parameter), |b| {
-        let mut pool = Pool::new(true, fsync).unwrap();
-        b.iter(|| spacetime::insert_tx(&mut pool, run))
-    });
-
-    group.finish();
-}
-
-fn bench_select_no_index(c: &mut Criterion, fsync: bool) {
-    let run = Runs::Tiny;
-    let mut group = build_group(c, "select_index_no", run);
-    let parameter = if fsync { "fsync" } else { "no-fsync" };
-
-    group.bench_function(BenchmarkId::new(SQLITE, parameter), |b| {
-        let mut pool = Pool::new(true, fsync).unwrap();
-        b.iter(|| sqlite::select_no_index(&mut pool, run).unwrap())
-    });
-    group.bench_function(BenchmarkId::new(SPACETIME, parameter), |b| {
-        let mut pool = Pool::new(true, fsync).unwrap();
-        b.iter(|| spacetime::select_no_index(&mut pool, run).unwrap())
-    });
-
-    group.finish();
-}
+//
+// fn bench_insert_tx(c: &mut Criterion) {
+//     let run = Runs::Small;
+//     let mut group = build_group(c, "insert_bulk_rows", run);
+//
+//     group.bench_function(BenchmarkId::new(SQLITE, 2), |b| {
+//         let mut pool = Pool::new(true).unwrap();
+//         b.iter(|| sqlite::insert_tx(&mut pool, run))
+//     });
+//     group.bench_function(BenchmarkId::new(SPACETIME, 2), |b| {
+//         let mut pool = Pool::new(true).unwrap();
+//         b.iter(|| spacetime::insert_tx(&mut pool, run))
+//     });
+//
+//     group.finish();
+// }
+//
+// fn bench_select_no_index(c: &mut Criterion) {
+//     let run = Runs::Tiny;
+//     let mut group = build_group(c, "select_index_no", run);
+//
+//     group.bench_function(BenchmarkId::new(SQLITE, 3), |b| {
+//         let mut pool = Pool::new(true).unwrap();
+//         b.iter(|| sqlite::select_no_index(&mut pool, run).unwrap())
+//     });
+//     group.bench_function(BenchmarkId::new(SPACETIME, 3), |b| {
+//         let mut pool = Pool::new(true).unwrap();
+//         b.iter(|| spacetime::select_no_index(&mut pool, run).unwrap())
+//     });
+//
+//     group.finish();
+// }
 
 fn bench_insert_tx_per_row_with_fsync(c: &mut Criterion) {
     bench_insert_tx_per_row(c, true);

--- a/crates/bench/benches/db.rs
+++ b/crates/bench/benches/db.rs
@@ -1,18 +1,20 @@
 //! Benchmarks for evaluating how we fare against sqlite
 
 use criterion::measurement::WallTime;
-use criterion::{
-    criterion_group, criterion_main, BatchSize, BenchmarkGroup, BenchmarkId, Criterion, SamplingMode, Throughput,
-};
+use criterion::{criterion_group, criterion_main, BatchSize, BenchmarkGroup, BenchmarkId, Criterion, Throughput};
 use spacetimedb_bench::prelude::*;
 use std::time::Duration;
 
+// IMPORTANT!: It needs this option to run the setup once per `.iter`!
+const SIZE: BatchSize = BatchSize::PerIteration;
+
 fn build_group<'a>(c: &'a mut Criterion, named: &str, run: Runs) -> BenchmarkGroup<'a, WallTime> {
     let mut group = c.benchmark_group(named);
-    // We need to restrict the amount of iterations and set the benchmark for "large" operations.
+
     group.throughput(Throughput::Elements(run as u64));
     group.sample_size(DB_POOL as usize);
-    group.sampling_mode(SamplingMode::Flat);
+    group.measurement_time(Duration::from_secs(5));
+
     group
 }
 
@@ -21,60 +23,59 @@ fn bench_insert_tx_per_row(c: &mut Criterion, fsync: bool) {
     let mut group = build_group(c, "insert_row", run);
     let parameter = if fsync { "fsync" } else { "no-fsync" };
 
+    // Factor out the db creation because is IO that generate noise
     group.bench_function(BenchmarkId::new(SQLITE, 1), |b| {
-        let mut db_instance = 0;
         b.iter_batched(
-            || {
-                let path = sqlite::create_db(db_instance).unwrap();
-                db_instance += 1;
-                path
-            },
-            |data| {
-                let mut conn = sqlite::open_conn(&data).unwrap();
+            || sqlite::create_db(0).unwrap(),
+            |path| {
+                let mut conn = sqlite::open_conn(&path).unwrap();
                 sqlite::insert_tx_per_row(&mut conn, run).unwrap();
             },
-            BatchSize::NumBatches(DB_POOL as u64),
+            SIZE,
         );
     });
-    // group.bench_function(BenchmarkId::new(SPACETIME, 1), |b| {
-    //     let mut pool = Pool::new(false).unwrap();
-    //     b.iter_with_setup(|| spacetime::insert_tx_per_row(&mut pool, run).unwrap())
-    // });
+    group.bench_function(BenchmarkId::new(SPACETIME, 1), |b| {
+        b.iter_batched(
+            || spacetime::create_db(0).unwrap(),
+            |path| {
+                let (conn, _, table_id) = spacetime::open_conn(&path).unwrap();
+                spacetime::insert_tx_per_row(&conn, table_id, run).unwrap();
+            },
+            SIZE,
+        );
+    });
 
     group.finish();
 }
-//
-// fn bench_insert_tx(c: &mut Criterion) {
-//     let run = Runs::Small;
-//     let mut group = build_group(c, "insert_bulk_rows", run);
-//
-//     group.bench_function(BenchmarkId::new(SQLITE, 2), |b| {
-//         let mut pool = Pool::new(true).unwrap();
-//         b.iter(|| sqlite::insert_tx(&mut pool, run))
-//     });
-//     group.bench_function(BenchmarkId::new(SPACETIME, 2), |b| {
-//         let mut pool = Pool::new(true).unwrap();
-//         b.iter(|| spacetime::insert_tx(&mut pool, run))
-//     });
-//
-//     group.finish();
-// }
-//
-// fn bench_select_no_index(c: &mut Criterion) {
-//     let run = Runs::Tiny;
-//     let mut group = build_group(c, "select_index_no", run);
-//
-//     group.bench_function(BenchmarkId::new(SQLITE, 3), |b| {
-//         let mut pool = Pool::new(true).unwrap();
-//         b.iter(|| sqlite::select_no_index(&mut pool, run).unwrap())
-//     });
-//     group.bench_function(BenchmarkId::new(SPACETIME, 3), |b| {
-//         let mut pool = Pool::new(true).unwrap();
-//         b.iter(|| spacetime::select_no_index(&mut pool, run).unwrap())
-//     });
-//
-//     group.finish();
-// }
+
+fn bench_insert_tx(c: &mut Criterion) {
+    let run = Runs::Small;
+    let mut group = build_group(c, "insert_bulk_rows", run);
+
+    // Factor out the db creation because is IO that generate noise
+    group.bench_function(BenchmarkId::new(SQLITE, 2), |b| {
+        b.iter_batched(
+            || sqlite::create_db(0).unwrap(),
+            |path| {
+                let mut conn = sqlite::open_conn(&path).unwrap();
+                sqlite::insert_tx(&mut conn, run).unwrap();
+            },
+            SIZE,
+        );
+    });
+    group.bench_function(BenchmarkId::new(SPACETIME, 2), |b| {
+        b.iter_batched(
+            || spacetime::create_db(0).unwrap(),
+            |path| {
+                let (conn, _, table_id) = spacetime::open_conn(&path).unwrap();
+                spacetime::insert_tx(&conn, table_id, run).unwrap();
+            },
+            SIZE,
+        );
+    });
+
+    group.finish();
+}
 
 fn bench_insert_tx_per_row_with_fsync(c: &mut Criterion) {
     bench_insert_tx_per_row(c, true);
@@ -98,6 +99,35 @@ fn bench_select_no_index_with_fsync(c: &mut Criterion) {
 
 fn bench_select_no_index_no_fsync(c: &mut Criterion) {
     bench_select_no_index(c, false);
+}
+
+fn bench_select_no_index(c: &mut Criterion) {
+    let run = Runs::Tiny;
+    let mut group = build_group(c, "select_index_no", run);
+
+    // Factor out the db creation because is IO that generate noise
+    group.bench_function(BenchmarkId::new(SQLITE, 3), |b| {
+        b.iter_batched(
+            || sqlite::create_db(0).unwrap(),
+            |path| {
+                let mut conn = sqlite::open_conn(&path).unwrap();
+                sqlite::select_no_index(&mut conn, run).unwrap();
+            },
+            SIZE,
+        );
+    });
+    group.bench_function(BenchmarkId::new(SPACETIME, 3), |b| {
+        b.iter_batched(
+            || spacetime::create_db(0).unwrap(),
+            |path| {
+                let (conn, _, table_id) = spacetime::open_conn(&path).unwrap();
+                spacetime::select_no_index(&conn, table_id, run).unwrap();
+            },
+            SIZE,
+        );
+    });
+
+    group.finish();
 }
 
 // Note: Reflex this same benchmarks in `main.rs`

--- a/crates/bench/flamegraph.sh
+++ b/crates/bench/flamegraph.sh
@@ -11,5 +11,11 @@ cd "$(dirname "$0")"
 # sqlite vs spacetime
 cargo build --release
 bench="../../target/release/spacetimedb-bench"
+# How many Dbs to create
+total_create=1
+
+$bench --db spacetime create-db $total_create
+$bench --db sqlite create-db $total_create
+
 cargo flamegraph --deterministic --notes "sqlite ${1}"     -o sqlite.svg    -- --db sqlite ${1}
 cargo flamegraph --deterministic --notes "spacetime ${1}"  -o spacetime.svg -- --db spacetime ${1}

--- a/crates/bench/hyperfine.sh
+++ b/crates/bench/hyperfine.sh
@@ -12,9 +12,12 @@ cd "$(dirname "$0")"
 cargo build --release
 bench="../../target/release/spacetimedb-bench"
 total_dbs=10
+total_warmup=5
+# How many Dbs to create, total_dbs + total_warmup
+total_create=15
 
-$bench --db spacetime create-db $total_dbs
-$bench --db sqlite create-db $total_dbs
+$bench --db spacetime create-db $total_create
+$bench --db sqlite create-db $total_create
 
 # Add --show-output to see errors...
-hyperfine --show-output  --parameter-scan db 0 $total_dbs --shell=none --export-json out.json --warmup 5 --runs $total_dbs "${bench} --db spacetime ${1} {db}" "${bench} --db sqlite ${1} {db}"
+hyperfine --shell=none --export-json out.json --warmup $total_warmup --runs $total_dbs "${bench} --db spacetime ${1}" "${bench} --db sqlite ${1}"

--- a/crates/bench/hyperfine.sh
+++ b/crates/bench/hyperfine.sh
@@ -11,5 +11,10 @@ cd "$(dirname "$0")"
 # sqlite vs spacetime
 cargo build --release
 bench="../../target/release/spacetimedb-bench"
+total_dbs=10
+
+$bench --db spacetime create-db $total_dbs
+$bench --db sqlite create-db $total_dbs
+
 # Add --show-output to see errors...
-hyperfine --shell=none --export-json out.json --warmup 1 --runs 1 "${bench} --db spacetime ${1}" "${bench} --db sqlite ${1}"
+hyperfine --show-output  --parameter-scan db 0 $total_dbs --shell=none --export-json out.json --warmup 5 --runs $total_dbs "${bench} --db spacetime ${1} {db}" "${bench} --db sqlite ${1} {db}"

--- a/crates/bench/src/data.rs
+++ b/crates/bench/src/data.rs
@@ -10,7 +10,7 @@ pub trait BuildDb {
 }
 
 pub struct Pool<T> {
-    instance: u8,
+    pub(crate) instance: u8,
     pub(crate) prefill: bool,
     pub(crate) fsync: bool,
     _x: PhantomData<T>,

--- a/crates/bench/src/data.rs
+++ b/crates/bench/src/data.rs
@@ -1,37 +1,6 @@
-use crate::utils::{encode, ResultBench, START_B};
+use crate::utils::{encode, START_B};
 use clap::ValueEnum;
-use std::marker::PhantomData;
 use std::ops::Range;
-
-pub trait BuildDb {
-    fn build(prefill: bool, fsync: bool) -> ResultBench<Self>
-    where
-        Self: Sized;
-}
-
-pub struct Pool<T> {
-    pub(crate) instance: u8,
-    pub(crate) prefill: bool,
-    pub(crate) fsync: bool,
-    _x: PhantomData<T>,
-}
-
-impl<T: BuildDb> Pool<T> {
-    pub fn new(prefill: bool, fsync: bool) -> ResultBench<Self> {
-        Ok(Self {
-            instance: 0,
-            prefill,
-            fsync,
-            _x: Default::default(),
-        })
-    }
-
-    #[allow(clippy::should_implement_trait)]
-    pub fn next(&mut self) -> ResultBench<T> {
-        self.instance += 1;
-        T::build(self.prefill, self.fsync)
-    }
-}
 
 #[derive(Debug)]
 pub struct Data {

--- a/crates/bench/src/data.rs
+++ b/crates/bench/src/data.rs
@@ -1,5 +1,6 @@
 use crate::utils::{encode, START_B};
 use clap::ValueEnum;
+use std::iter::{Skip, Take};
 use std::ops::Range;
 
 #[derive(Debug)]
@@ -40,6 +41,12 @@ impl Runs {
     pub fn range(self) -> Range<u16> {
         let x = self as u16;
         0..x
+    }
+
+    // Range that divides the size of the run in batches of `START_B`, skipping the first
+    pub fn range_selects(self) -> Take<Skip<Range<u16>>> {
+        let x = self as u16;
+        (0..x).skip(1).take((self.range().end as u64 / START_B) as usize)
     }
 
     pub fn data(self) -> impl Iterator<Item = Data> {

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -6,7 +6,6 @@ pub(crate) mod utils;
 pub mod prelude {
     pub use crate::data::*;
     pub use crate::utils::{ResultBench, DB_POOL, SPACETIME, SQLITE, START_B};
-    pub(crate) use tempdir::TempDir;
 
     pub use crate::spacetime;
     pub use crate::sqlite;

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -1,4 +1,6 @@
 use clap::{Parser, Subcommand};
+use rusqlite::Connection;
+use spacetimedb::db::relational_db::RelationalDB;
 use spacetimedb_bench::prelude::*;
 
 /// Bencher for SpacetimeDB
@@ -16,24 +18,18 @@ struct Cli {
 enum Commands {
     /// Generate insert, each generate a transaction
     Insert {
-        /// Which DB to select ie: 1.db, 2.db, etc...
-        db: usize,
         /// How many rows
         #[arg(value_enum)]
         rows: Option<Runs>,
     },
     /// Generate insert in bulk enclosed in a single transaction
     InsertBulk {
-        /// Which DB to select ie: 1.db, 2.db, etc...
-        db: usize,
         /// How many rows
         #[arg(value_enum)]
         rows: Option<Runs>,
     },
     /// Run queries without a index
     SelectNoIndex {
-        /// Which DB to select ie: 1.db, 2.db, etc...
-        db: usize,
         /// How many rows
         #[arg(value_enum)]
         rows: Option<Runs>,
@@ -45,48 +41,75 @@ enum Commands {
     },
 }
 
-macro_rules! bench_fn {
-    ($cli:ident, $db:ident, $fun:ident, $run:expr) => {{
-        let run = $run;
-        let db_instance = $db;
-
-        match $cli.db {
-            DbEngine::Sqlite => {
-                let path = sqlite::db_path_instance(db_instance);
-                let mut conn = sqlite::open_conn(&path)?;
-                sqlite::$fun(&mut conn, run)
-            }
-            DbEngine::Spacetime => {
-                let path = spacetime::db_path(db_instance);
-                let (conn, _tmp_dir, table_id) = spacetime::open_conn(&path)?;
-                spacetime::$fun(&conn, table_id, run)
-            }
+fn bench_fn<Space, Sqlite>(cli: Cli, space: Space, sqlite: Sqlite, run: Runs) -> ResultBench<()>
+where
+    Space: Fn(&RelationalDB, u32, Runs) -> ResultBench<()>,
+    Sqlite: Fn(&mut Connection, Runs) -> ResultBench<()>,
+{
+    match cli.db {
+        DbEngine::Sqlite => {
+            let db_instance = sqlite::get_counter()?;
+            let path = sqlite::db_path_instance(db_instance);
+            let mut conn = sqlite::open_conn(&path)?;
+            sqlite(&mut conn, run)?;
+            sqlite::set_counter(db_instance + 1)?;
+            Ok(())
         }
-    }};
+        DbEngine::Spacetime => {
+            let db_instance = spacetime::get_counter()?;
+            let path = spacetime::db_path(db_instance);
+            let (conn, _tmp_dir, table_id) = spacetime::open_conn(&path)?;
+            space(&conn, table_id, run)?;
+            spacetime::set_counter(db_instance + 1)?;
+            Ok(())
+        }
+    }
 }
 
+/// The workflow for running the bench without interference of creation of the database on disk
+/// that is expensive and generate noise specially in the case of spacetime that create many folder/files is:
+///
+/// - Run `--db ENGINE create-db $total_create` for pre-create the dbs like `0.db, 1.db...$total_create`
+/// - Execute the bench with `--db spacetime NAME`
+///
+/// For picking which db to use, this hack is implemented:
+///
+/// - Save with `set_counter(0)` a file with the start of the "iteration"
+/// - Load with `get_counter()` the file with the current `db id`
+/// - Execute the bench
+/// - Save the `db id` of the next iteration with `set_counter(db_id + 1)`
+///
+/// NOTE: This is workaround for `hyperfine` where is not possible to know which run is the one this command is invoked
+/// see https://github.com/sharkdp/hyperfine/issues/667
 fn main() -> ResultBench<()> {
+    // Note: Mirror this benchmarks in `benches/db.rs`
     let cli = Cli::parse();
-
     match cli.command {
-        Commands::Insert { db, rows } => {
-            bench_fn!(cli, db, insert_tx_per_row, rows.unwrap_or(Runs::Tiny))
-        }
-        Commands::InsertBulk { db, rows } => {
-            // bench_fn!(cli, insert_tx, rows.unwrap_or(Runs::Small), true)
-            Ok(())
-        }
-        Commands::SelectNoIndex { db, rows } => {
-            // bench_fn!(cli, select_no_index, rows.unwrap_or(Runs::Tiny), true)
-            Ok(())
-        }
+        Commands::Insert { rows } => bench_fn(
+            cli,
+            spacetime::insert_tx_per_row,
+            sqlite::insert_tx_per_row,
+            rows.unwrap_or(Runs::Tiny),
+        ),
+        Commands::InsertBulk { rows } => bench_fn(
+            cli,
+            spacetime::insert_tx,
+            sqlite::insert_tx,
+            rows.unwrap_or(Runs::Small),
+        ),
+        Commands::SelectNoIndex { rows } => bench_fn(
+            cli,
+            spacetime::select_no_index,
+            sqlite::select_no_index,
+            rows.unwrap_or(Runs::Tiny),
+        ),
         Commands::CreateDb { total_dbs } => match cli.db {
             DbEngine::Sqlite => {
-                sqlite::create_db(total_dbs)?;
+                sqlite::create_dbs(total_dbs)?;
                 Ok(())
             }
             DbEngine::Spacetime => {
-                spacetime::create_db(total_dbs)?;
+                spacetime::create_dbs(total_dbs)?;
                 Ok(())
             }
         },

--- a/crates/bench/src/main.rs
+++ b/crates/bench/src/main.rs
@@ -16,36 +16,50 @@ struct Cli {
 enum Commands {
     /// Generate insert, each generate a transaction
     Insert {
+        /// Which DB to select ie: 1.db, 2.db, etc...
+        db: usize,
         /// How many rows
         #[arg(value_enum)]
         rows: Option<Runs>,
     },
     /// Generate insert in bulk enclosed in a single transaction
     InsertBulk {
+        /// Which DB to select ie: 1.db, 2.db, etc...
+        db: usize,
         /// How many rows
         #[arg(value_enum)]
         rows: Option<Runs>,
     },
     /// Run queries without a index
     SelectNoIndex {
+        /// Which DB to select ie: 1.db, 2.db, etc...
+        db: usize,
         /// How many rows
         #[arg(value_enum)]
         rows: Option<Runs>,
     },
+    /// Create a database and return the path (so we can skip this expensive setup in bench's)
+    CreateDb {
+        /// How many DBs to pre-create ie: 3 = 1.db, 2.db, 3.db
+        total_dbs: usize,
+    },
 }
 
 macro_rules! bench_fn {
-    ($cli:ident, $fun:ident, $run:expr, $prefill:literal, $fsync:literal) => {{
+    ($cli:ident, $db:ident, $fun:ident, $run:expr) => {{
         let run = $run;
+        let db_instance = $db;
 
         match $cli.db {
             DbEngine::Sqlite => {
-                let mut pool = Pool::new($prefill, $fsync)?;
-                sqlite::$fun(&mut pool, run)
+                let path = sqlite::db_path_instance(db_instance);
+                let mut conn = sqlite::open_conn(&path)?;
+                sqlite::$fun(&mut conn, run)
             }
             DbEngine::Spacetime => {
-                let mut pool = Pool::new($prefill, $fsync)?;
-                spacetime::$fun(&mut pool, run)
+                let path = spacetime::db_path(db_instance);
+                let (conn, _tmp_dir, table_id) = spacetime::open_conn(&path)?;
+                spacetime::$fun(&conn, table_id, run)
             }
         }
     }};
@@ -55,32 +69,26 @@ fn main() -> ResultBench<()> {
     let cli = Cli::parse();
 
     match cli.command {
-        Commands::Insert { rows } => {
-            bench_fn!(
-                cli,
-                insert_tx_per_row,
-                rows.unwrap_or(Runs::Tiny),
-                false, // prefill
-                true   // fsync
-            )
+        Commands::Insert { db, rows } => {
+            bench_fn!(cli, db, insert_tx_per_row, rows.unwrap_or(Runs::Tiny))
         }
-        Commands::InsertBulk { rows } => {
-            bench_fn!(
-                cli,
-                insert_tx,
-                rows.unwrap_or(Runs::Small),
-                true,  // prefill
-                false  // fsync
-            )
+        Commands::InsertBulk { db, rows } => {
+            // bench_fn!(cli, insert_tx, rows.unwrap_or(Runs::Small), true)
+            Ok(())
         }
-        Commands::SelectNoIndex { rows } => {
-            bench_fn!(
-                cli,
-                select_no_index,
-                rows.unwrap_or(Runs::Tiny),
-                true,  // prefill
-                false  // fsync
-            )
+        Commands::SelectNoIndex { db, rows } => {
+            // bench_fn!(cli, select_no_index, rows.unwrap_or(Runs::Tiny), true)
+            Ok(())
         }
+        Commands::CreateDb { total_dbs } => match cli.db {
+            DbEngine::Sqlite => {
+                sqlite::create_db(total_dbs)?;
+                Ok(())
+            }
+            DbEngine::Spacetime => {
+                spacetime::create_db(total_dbs)?;
+                Ok(())
+            }
+        },
     }
 }

--- a/crates/bench/src/spacetime.rs
+++ b/crates/bench/src/spacetime.rs
@@ -18,7 +18,7 @@ pub fn db_path(db_instance: usize) -> PathBuf {
 }
 
 pub fn open_conn(path: &PathBuf) -> ResultBench<DbResult> {
-    let stdb = open_db(path)?;
+    let stdb = open_db(path, false)?;
 
     let tx = stdb.begin_tx();
 
@@ -40,7 +40,7 @@ pub fn create_db(db_instance: usize) -> ResultBench<PathBuf> {
         std::fs::remove_dir_all(&path)?;
     }
 
-    let stdb = open_db(&path)?;
+    let stdb = open_db(&path, false)?;
     let mut tx = stdb.begin_tx();
 
     stdb.create_table(

--- a/crates/bench/src/spacetime.rs
+++ b/crates/bench/src/spacetime.rs
@@ -1,17 +1,48 @@
 use crate::prelude::*;
-use spacetimedb::db::datastore::locking_tx_datastore::MutTxId;
 use spacetimedb::db::datastore::traits::TableDef;
 use spacetimedb::db::relational_db::{open_db, RelationalDB};
+use spacetimedb_lib::auth::StTableType;
 use spacetimedb_lib::sats::product;
 use spacetimedb_lib::{AlgebraicType, AlgebraicValue, ProductType};
+use std::env::temp_dir;
+use std::path::PathBuf;
 
-type DbResult = (RelationalDB, TempDir, u32);
+type DbResult = (RelationalDB, PathBuf, u32);
 
-fn init_db(in_memory: bool, fsync: bool) -> ResultBench<(TempDir, u32)> {
-    let tmp_dir = TempDir::new("stdb_test")?;
-    let stdb = open_db(tmp_dir.path(), in_memory, fsync)?;
+pub fn db_path(db_instance: usize) -> PathBuf {
+    let mut tmp_dir = temp_dir();
+    tmp_dir.push("stdb_bench");
+    tmp_dir.push(db_instance.to_string());
+    tmp_dir
+}
+
+pub fn open_conn(path: &PathBuf) -> ResultBench<DbResult> {
+    let stdb = open_db(path)?;
+
+    let tx = stdb.begin_tx();
+
+    let table_id = stdb
+        .get_all_tables(&tx)?
+        .iter()
+        .find(|x| x.table_type == StTableType::User)
+        .map(|x| x.table_id)
+        .unwrap();
+
+    stdb.rollback_tx(tx);
+
+    Ok((stdb, path.clone(), table_id))
+}
+
+pub fn create_db(db_instance: usize) -> ResultBench<()> {
+    let path = db_path(db_instance);
+    if path.exists() {
+        std::fs::remove_dir_all(&path)?;
+    }
+
+    let stdb = open_db(&path)?;
     let mut tx = stdb.begin_tx();
-    let table_id = stdb.create_table(
+
+    stdb.create_table(
         &mut tx,
         TableDef::from(ProductType::from_iter([
             ("a", AlgebraicType::I32),
@@ -19,64 +50,43 @@ fn init_db(in_memory: bool, fsync: bool) -> ResultBench<(TempDir, u32)> {
             ("c", AlgebraicType::String),
         ])),
     )?;
+
     stdb.commit_tx(tx)?;
-    Ok((tmp_dir, table_id))
-}
-
-fn build_db(in_memory: bool, fsync: bool) -> ResultBench<DbResult> {
-    let (tmp_dir, table_id) = init_db(in_memory, fsync)?;
-    let stdb = open_db(&tmp_dir, in_memory, fsync)?;
-    Ok((stdb, tmp_dir, table_id))
-}
-
-fn insert_row(db: &RelationalDB, tx: &mut MutTxId, table_id: u32, run: Runs) -> ResultBench<()> {
-    for row in run.data() {
-        db.insert(
-            tx,
-            table_id,
-            product![
-                AlgebraicValue::I32(row.a),
-                AlgebraicValue::U64(row.b),
-                AlgebraicValue::String(row.c),
-            ],
-        )?;
-    }
 
     Ok(())
 }
+//
+// fn insert_row(db: &RelationalDB, tx: &mut MutTxId, table_id: u32, run: Runs) -> ResultBench<()> {
+//     for row in run.data() {
+//         db.insert_raw(
+//             tx,
+//             table_id,
+//             product![
+//                 AlgebraicValue::I32(row.a),
+//                 AlgebraicValue::U64(row.b),
+//                 AlgebraicValue::String(row.c),
+//             ],
+//         )?;
+//     }
+//
+//     Ok(())
+// }
+//
+// impl BuildDb for DbResult {
+//     fn build(prefill: bool) -> ResultBench<Self>
+//     where
+//         Self: Sized,
+//     {
+//         let db = init_db("test", prefill)?;
+//
+//         Ok(db)
+//     }
+// }
 
-impl BuildDb for DbResult {
-    fn build(prefill: bool, fsync: bool) -> ResultBench<Self>
-    where
-        Self: Sized,
-    {
-        // For benchmarking, we are concerned with the persistent version of the database.
-        let in_memory = false;
-        let db = build_db(in_memory, fsync)?;
-
-        if prefill {
-            prefill_data(&db, Runs::Small)?;
-        }
-        Ok(db)
-    }
-}
-
-pub fn prefill_data(db: &DbResult, run: Runs) -> ResultBench<()> {
-    let (conn, _tmp_dir, table_id) = db;
-
+pub fn insert_tx_per_row(conn: &RelationalDB, table_id: u32, run: Runs) -> ResultBench<()> {
     let mut tx = conn.begin_tx();
-    insert_row(conn, &mut tx, *table_id, run)?;
-
-    conn.commit_tx(tx)?;
-    Ok(())
-}
-
-pub fn insert_tx_per_row(pool: &mut Pool<DbResult>, run: Runs) -> ResultBench<()> {
-    let (conn, _tmp_dir, table_id) = pool.next()?;
 
     for row in run.data() {
-        let mut tx = conn.begin_tx();
-
         conn.insert(
             &mut tx,
             table_id,
@@ -86,36 +96,36 @@ pub fn insert_tx_per_row(pool: &mut Pool<DbResult>, run: Runs) -> ResultBench<()
                 AlgebraicValue::String(row.c),
             ],
         )?;
-        conn.commit_tx(tx)?;
     }
+    conn.commit_tx(tx)?;
     Ok(())
 }
-
-pub fn insert_tx(pool: &mut Pool<DbResult>, _run: Runs) -> ResultBench<()> {
-    pool.prefill = true;
-    pool.next()?;
-    Ok(())
-}
-
-pub fn select_no_index(pool: &mut Pool<DbResult>, run: Runs) -> ResultBench<()> {
-    let (conn, _tmp_dir, table_id) = pool.next()?;
-
-    let tx = conn.begin_tx();
-
-    for i in run.range().skip(1) {
-        let i = i as u64;
-        let _r = conn
-            .iter(&tx, table_id)?
-            .map(|r| Data {
-                a: *r.view().elements[0].as_i32().unwrap(),
-                b: *r.view().elements[1].as_u64().unwrap(),
-                c: r.view().elements[2].as_string().unwrap().clone(),
-            })
-            .filter(|x| x.b >= i * START_B && x.b < (START_B + (i * START_B)))
-            .collect::<Vec<_>>();
-
-        assert_eq!(_r.len() as u64, START_B);
-        //dbg!(_r.len());
-    }
-    Ok(())
-}
+//
+// pub fn insert_tx(pool: &mut Pool<DbResult>, _run: Runs) -> ResultBench<()> {
+//     pool.prefill = true;
+//     pool.next()?;
+//     Ok(())
+// }
+//
+// pub fn select_no_index(pool: &mut Pool<DbResult>, run: Runs) -> ResultBench<()> {
+//     let (conn, _tmp_dir, table_id) = pool.next()?;
+//
+//     let tx = conn.begin_tx();
+//
+//     for i in run.range().skip(1) {
+//         let i = i as u64;
+//         let _r = conn
+//             .iter(&tx, table_id)?
+//             .map(|r| Data {
+//                 a: *r.view().elements[0].as_i32().unwrap(),
+//                 b: *r.view().elements[1].as_u64().unwrap(),
+//                 c: r.view().elements[2].as_string().unwrap().clone(),
+//             })
+//             .filter(|x| x.b >= i * START_B && x.b < (START_B + (i * START_B)))
+//             .collect::<Vec<_>>();
+//
+//         assert_eq!(_r.len() as u64, START_B);
+//         //dbg!(_r.len());
+//     }
+//     Ok(())
+// }

--- a/crates/bench/src/sqlite.rs
+++ b/crates/bench/src/sqlite.rs
@@ -131,10 +131,8 @@ mod tests {
     #[test]
     fn test() -> ResultBench<()> {
         let run = Runs::Tiny;
-        let mut db_instance = 0;
-        let path = create_db(db_instance).unwrap();
+        let path = create_db(0).unwrap();
         let mut conn = sqlite::open_conn(&path).unwrap();
-        db_instance += 1;
         insert_tx_per_row(&mut conn, run).unwrap();
         Ok(())
     }

--- a/crates/bench/src/sqlite.rs
+++ b/crates/bench/src/sqlite.rs
@@ -1,96 +1,103 @@
 use crate::prelude::*;
-use rusqlite::{Connection, Transaction};
+use rusqlite::Connection;
+use std::env::temp_dir;
+use std::path::PathBuf;
 
-impl BuildDb for Connection {
-    fn build(prefill: bool, fsync: bool) -> ResultBench<Self>
-    where
-        Self: Sized,
-    {
-        let tmp_dir = TempDir::new("sqlite_test")?;
-        let mut db = Connection::open(tmp_dir.path().join("test.db"))?;
-        // For sqlite benchmarks we should set synchronous to either full or off which more
-        // closely aligns with wal_fsync=true and wal_fsync=false respectively in stdb.
-        db.execute_batch(if fsync {
-            "PRAGMA journal_mode = WAL; PRAGMA synchronous = full;"
-        } else {
-            "PRAGMA journal_mode = WAL; PRAGMA synchronous = off;"
-        })?;
+pub fn db_path() -> PathBuf {
+    let mut tmp_dir = temp_dir();
+    tmp_dir.push("sqlite_bench");
+    tmp_dir
+}
 
-        db.execute_batch(
-            "CREATE TABLE data (
+pub fn db_path_instance(db_instance: usize) -> PathBuf {
+    db_path().join(format!("{db_instance}.db"))
+}
+
+pub fn open_conn(path: &PathBuf) -> ResultBench<Connection> {
+    let db = Connection::open(path)?;
+    db.execute_batch(
+        "PRAGMA journal_mode = WAL;
+            PRAGMA synchronous = normal;",
+    )?;
+
+    Ok(db)
+}
+
+pub fn create_db(db_instance: usize) -> ResultBench<PathBuf> {
+    let path = db_path();
+    if !path.exists() {
+        std::fs::create_dir_all(&path)?;
+    }
+    let path = db_path_instance(db_instance);
+    if path.exists() {
+        std::fs::remove_file(&path)?;
+    }
+
+    let db = open_conn(&path)?;
+
+    db.execute_batch(
+        "CREATE TABLE data (
             a INTEGER PRIMARY KEY,
             b BIGINT NOT NULL,
             c TEXT);",
-        )?;
+    )?;
 
-        if prefill {
-            prefill_data(&mut db, Runs::Small)?;
-        }
-        Ok(db)
-    }
+    Ok(path)
 }
 
-fn insert(db: &Transaction, run: Runs) -> ResultBench<()> {
+pub fn insert_tx_per_row(conn: &mut Connection, run: Runs) -> ResultBench<()> {
     for row in run.data() {
-        db.execute(
-            &format!("INSERT INTO data (a, b, c) VALUES({} ,{}, '{}');", row.a, row.b, row.c),
-            (),
-        )?;
-    }
-
-    Ok(())
-}
-
-pub fn prefill_data(db: &mut Connection, run: Runs) -> ResultBench<()> {
-    let tx = db.transaction()?;
-
-    insert(&tx, run)?;
-
-    tx.commit()?;
-
-    Ok(())
-}
-
-pub fn insert_tx_per_row(pool: &mut Pool<Connection>, run: Runs) -> ResultBench<()> {
-    let db = pool.next()?;
-    for row in run.data() {
-        db.execute(
+        conn.execute(
             &format!("INSERT INTO data VALUES({} ,{}, '{}');", row.a, row.b, row.c),
             (),
         )?;
     }
     Ok(())
 }
+//
+// pub fn insert_tx(pool: &mut Pool<Connection>, _run: Runs) -> ResultBench<()> {
+//     Ok(())
+// }
+//
+// pub fn select_no_index(pool: &mut Pool<Connection>, run: Runs) -> ResultBench<()> {
+//     // let db = pool.next()?;
+//     // for i in run.range().skip(1) {
+//     //     let i = i as u64;
+//     //     let sql = &format!(
+//     //         "SELECT * FROM data WHERE b >= {} AND b < {}",
+//     //         i * START_B,
+//     //         START_B + (i * START_B)
+//     //     );
+//     //
+//     //     //dbg!(sql);
+//     //     let mut stmt = db.prepare(sql)?;
+//     //     let _r = stmt
+//     //         .query_map([], |row| {
+//     //             Ok(Data {
+//     //                 a: row.get(0)?,
+//     //                 b: row.get(1)?,
+//     //                 c: row.get(2)?,
+//     //             })
+//     //         })?
+//     //         .collect::<Vec<_>>();
+//     //     assert_eq!(_r.len() as u64, START_B);
+//     //     //dbg!(_r.len());
+//     // }
+//     Ok(())
+// }
 
-pub fn insert_tx(pool: &mut Pool<Connection>, _run: Runs) -> ResultBench<()> {
-    pool.next()?;
+#[cfg(test)]
+mod tests {
+    use super::*;
 
-    Ok(())
-}
-
-pub fn select_no_index(pool: &mut Pool<Connection>, run: Runs) -> ResultBench<()> {
-    let db = pool.next()?;
-    for i in run.range().skip(1) {
-        let i = i as u64;
-        let sql = &format!(
-            "SELECT * FROM data WHERE b >= {} AND b < {}",
-            i * START_B,
-            START_B + (i * START_B)
-        );
-
-        //dbg!(sql);
-        let mut stmt = db.prepare(sql)?;
-        let _r = stmt
-            .query_map([], |row| {
-                Ok(Data {
-                    a: row.get(0)?,
-                    b: row.get(1)?,
-                    c: row.get(2)?,
-                })
-            })?
-            .collect::<Vec<_>>();
-        assert_eq!(_r.len() as u64, START_B);
-        //dbg!(_r.len());
+    #[test]
+    fn test() -> ResultBench<()> {
+        let run = Runs::Tiny;
+        let mut db_instance = 0;
+        let path = create_db(db_instance).unwrap();
+        let mut conn = sqlite::open_conn(&path).unwrap();
+        db_instance += 1;
+        insert_tx_per_row(&mut conn, run).unwrap();
+        Ok(())
     }
-    Ok(())
 }

--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -2154,6 +2154,17 @@ impl MutTxDatastore for Locking {
     ) -> super::Result<ProductValue> {
         tx.lock.insert(table_id, row)
     }
+
+    fn insert_batch_mut_tx<'a>(
+        &'a self,
+        tx: &'a mut Self::MutTxId,
+        table_id: TableId,
+        row: ProductValue,
+    ) -> crate::db::datastore::Result<ProductValue> {
+        // tx.lock.insert(table_id, row)
+        tx.lock.insert_row_internal(table_id, row.clone())?;
+        Ok(row)
+    }
 }
 
 #[cfg(test)]

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -1,8 +1,8 @@
 use crate::db::relational_db::ST_TABLES_ID;
 use core::fmt;
 use spacetimedb_lib::auth::{StAccess, StTableType};
-use spacetimedb_lib::relation::{DbTable, FieldName, FieldOnly, Header, TableField};
-use spacetimedb_lib::{ColumnIndexAttribute, DataKey};
+use spacetimedb_lib::relation::{calculate_hash, DbTable, FieldName, FieldOnly, Header, TableField};
+use spacetimedb_lib::DataKey;
 use spacetimedb_sats::{AlgebraicType, AlgebraicValue, ProductType, ProductTypeElement, ProductValue};
 use spacetimedb_vm::expr::SourceExpr;
 use std::{ops::RangeBounds, sync::Arc};
@@ -280,7 +280,7 @@ pub struct TableDef {
 impl From<ProductType> for TableDef {
     fn from(value: ProductType) -> Self {
         Self {
-            table_name: "".to_string(),
+            table_name: format!("t_{:x}", calculate_hash(&value)),
             columns: value
                 .elements
                 .iter()
@@ -474,6 +474,13 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
         relation: R,
     ) -> Result<Option<u32>>;
     fn insert_mut_tx<'a>(
+        &'a self,
+        tx: &'a mut Self::MutTxId,
+        table_id: TableId,
+        row: ProductValue,
+    ) -> Result<ProductValue>;
+
+    fn insert_batch_mut_tx<'a>(
         &'a self,
         tx: &'a mut Self::MutTxId,
         table_id: TableId,

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -2,7 +2,7 @@ use crate::db::relational_db::ST_TABLES_ID;
 use core::fmt;
 use spacetimedb_lib::auth::{StAccess, StTableType};
 use spacetimedb_lib::relation::{calculate_hash, DbTable, FieldName, FieldOnly, Header, TableField};
-use spacetimedb_lib::DataKey;
+use spacetimedb_lib::{ColumnIndexAttribute, DataKey};
 use spacetimedb_sats::{AlgebraicType, AlgebraicValue, ProductType, ProductTypeElement, ProductValue};
 use spacetimedb_vm::expr::SourceExpr;
 use std::{ops::RangeBounds, sync::Arc};
@@ -178,13 +178,13 @@ pub struct ConstraintDef {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableSchema {
-    pub(crate) table_id: u32,
-    pub(crate) table_name: String,
+    pub table_id: u32,
+    pub table_name: String,
     pub(crate) columns: Vec<ColumnSchema>,
     pub(crate) indexes: Vec<IndexSchema>,
     pub(crate) constraints: Vec<ConstraintSchema>,
-    pub(crate) table_type: StTableType,
-    pub(crate) table_access: StAccess,
+    pub table_type: StTableType,
+    pub table_access: StAccess,
 }
 
 impl TableSchema {

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -439,6 +439,12 @@ impl RelationalDB {
         self.inner.insert_mut_tx(tx, TableId(table_id), row)
     }
 
+    #[tracing::instrument(skip(self, tx))]
+    pub fn insert_raw(&self, tx: &mut MutTxId, table_id: u32, row: ProductValue) -> Result<ProductValue, DBError> {
+        measure(&RDB_INSERT_TIME, table_id);
+        self.inner.insert_batch_mut_tx(tx, TableId(table_id), row)
+    }
+
     #[tracing::instrument(skip_all)]
     pub fn insert_bytes_as_row(
         &self,

--- a/crates/lib/src/data_key.rs
+++ b/crates/lib/src/data_key.rs
@@ -12,13 +12,13 @@ pub enum DataKey {
 
 impl DataKey {
     /// The minimum possible value for a DataKey, used for sorting DataKeys
-    pub fn min_datakey() -> Self {
+    pub const fn min_datakey() -> Self {
         DataKey::Data(InlineData { len: 0, buf: [0; 31] })
     }
 
     /// The maximum possible value for a DataKey, used for sorting DataKeys
-    pub fn max_datakey() -> Self {
-        DataKey::Hash(super::Hash::from_slice(&[255; 32]))
+    pub const fn max_datakey() -> Self {
+        DataKey::Hash(super::Hash { data: [255; 32] })
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Moving out from the bench timings the creation of dbs because is expensive -in special for spacetime that creates folders vs sqlite just a file- and generates noise.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
