### PR TITLE
Provisional 'subscribe to all' functionality

### DIFF
--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -149,7 +149,7 @@ impl ModuleSubscriptionActor {
         let queries: QuerySet = subscription
             .query_strings
             .into_iter()
-            .map(|query| compile_query(&self.relational_db, tx, &query))
+            .map(|query| compile_query(&self.relational_db, tx, &auth, &query))
             .collect::<Result<_, _>>()?;
 
         let sub = match self.subscriptions.iter_mut().find(|s| s.queries == queries) {

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -99,7 +99,7 @@ pub(crate) fn run_query(
 /// }
 /// ```
 ///
-/// WARNING: If [SUBSCRIBE_TO_ALL_QUERY] is only valid to repeated calls as long there is not change on database schema, and the clients must `unsubscribe` before modify it.
+/// WARNING: [`SUBSCRIBE_TO_ALL_QUERY`] is only valid for repeated calls as long there is not change on database schema, and the clients must `unsubscribe` before modify it.
 #[tracing::instrument(skip(relational_db, auth, tx))]
 pub fn compile_query(
     relational_db: &RelationalDB,
@@ -113,7 +113,7 @@ pub fn compile_query(
     }
 
     if input == SUBSCRIBE_TO_ALL_QUERY {
-        return QuerySet::get_all(relational_db, *auth);
+        return QuerySet::get_all(relational_db, tx, auth);
     }
 
     let mut queries = Vec::new();
@@ -160,16 +160,15 @@ mod tests {
 
     fn make_data(
         db: &RelationalDB,
+        tx: &mut MutTxId,
         table_name: &str,
         head: &ProductType,
         row: &ProductValue,
     ) -> ResultTest<(TableSchema, MemTable, DatabaseTableUpdate, QueryExpr)> {
-        let mut tx = db.begin_tx();
         let table = mem_table(head.clone(), [row.clone()]);
-        let table_id = create_table_with_rows(db, &mut tx, table_name, head.clone(), &[row.clone()])?;
+        let table_id = create_table_with_rows(db, tx, table_name, head.clone(), &[row.clone()])?;
 
-        let schema = db.schema_for_table(&tx, table_id).unwrap();
-        // db.commit_tx(tx)?;
+        let schema = db.schema_for_table(tx, table_id).unwrap();
 
         let op = TableOp {
             op_type: 1,
@@ -190,6 +189,7 @@ mod tests {
 
     fn make_inv(
         db: &RelationalDB,
+        tx: &mut MutTxId,
         access: StAccess,
     ) -> ResultTest<(TableSchema, MemTable, DatabaseTableUpdate, QueryExpr)> {
         let table_name = if access == StAccess::Public {
@@ -201,7 +201,7 @@ mod tests {
         let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
         let row = product!(1u64, "health");
 
-        let (schema, table, data, q) = make_data(db, table_name, &head, &row)?;
+        let (schema, table, data, q) = make_data(db, tx, table_name, &head, &row)?;
 
         // For filtering out the hidden field `OP_TYPE_FIELD_NAME`
         let fields = &[
@@ -214,12 +214,15 @@ mod tests {
         Ok((schema, table, data, q))
     }
 
-    fn make_player(db: &RelationalDB) -> ResultTest<(TableSchema, MemTable, DatabaseTableUpdate, QueryExpr)> {
+    fn make_player(
+        db: &RelationalDB,
+        tx: &mut MutTxId,
+    ) -> ResultTest<(TableSchema, MemTable, DatabaseTableUpdate, QueryExpr)> {
         let table_name = "player";
         let head = ProductType::from_iter([("player_id", BuiltinType::U64), ("name", BuiltinType::String)]);
         let row = product!(2u64, "jhon doe");
 
-        let (schema, table, data, q) = make_data(db, table_name, &head, &row)?;
+        let (schema, table, data, q) = make_data(db, tx, table_name, &head, &row)?;
 
         // For filtering out the hidden field `OP_TYPE_FIELD_NAME`
         let fields = &[
@@ -232,9 +235,15 @@ mod tests {
         Ok((schema, table, data, q))
     }
 
-    fn check_query(db: &RelationalDB, table: &MemTable, q: &QueryExpr, data: &DatabaseTableUpdate) -> ResultTest<()> {
+    fn check_query(
+        db: &RelationalDB,
+        table: &MemTable,
+        tx: &mut MutTxId,
+        q: &QueryExpr,
+        data: &DatabaseTableUpdate,
+    ) -> ResultTest<()> {
         let q = to_mem_table(q.clone(), &data);
-        let result = run_query(&db, &q, AuthCtx::for_testing())?;
+        let result = run_query(&db, tx, &q, AuthCtx::for_testing())?;
 
         assert_eq!(
             Some(table.as_without_table_name()),
@@ -244,48 +253,53 @@ mod tests {
         Ok(())
     }
 
+    fn get_result(result: DatabaseUpdate) -> Vec<ProductValue> {
+        result
+            .tables
+            .iter()
+            .map(|x| x.ops.iter().map(|x| x.row.clone()))
+            .flatten()
+            .sorted()
+            .collect::<Vec<_>>()
+    }
+
     fn check_query_incr(
         db: &RelationalDB,
+        tx: &mut MutTxId,
         s: &QuerySet,
         update: &DatabaseUpdate,
         total_tables: usize,
         rows: &[ProductValue],
     ) -> ResultTest<()> {
-        let result = s.eval_incr(&db, &update, AuthCtx::for_testing())?;
+        let result = s.eval_incr(&db, tx, &update, AuthCtx::for_testing())?;
         assert_eq!(
             result.tables.len(),
             total_tables,
             "Must return the correct number of tables"
         );
 
-        let result = result
-            .tables
-            .iter()
-            .map(|x| x.ops.iter().map(|x| x.row.clone()))
-            .flatten()
-            .sorted()
-            .collect::<Vec<_>>();
+        let result = get_result(result);
 
         assert_eq!(result, rows, "Must return the correct row(s)");
 
         Ok(())
     }
 
-    fn check_query_eval(db: &RelationalDB, s: &QuerySet, total_tables: usize, rows: &[ProductValue]) -> ResultTest<()> {
-        let result = s.eval(&db, AuthCtx::for_testing())?;
+    fn check_query_eval(
+        db: &RelationalDB,
+        tx: &mut MutTxId,
+        s: &QuerySet,
+        total_tables: usize,
+        rows: &[ProductValue],
+    ) -> ResultTest<()> {
+        let result = s.eval(&db, tx, AuthCtx::for_testing())?;
         assert_eq!(
             result.tables.len(),
             total_tables,
             "Must return the correct number of tables"
         );
 
-        let result = result
-            .tables
-            .iter()
-            .map(|x| x.ops.iter().map(|x| x.row.clone()))
-            .flatten()
-            .sorted()
-            .collect::<Vec<_>>();
+        let result = get_result(result);
 
         assert_eq!(result, rows, "Must return the correct row(s)");
 
@@ -295,16 +309,17 @@ mod tests {
     #[test]
     fn test_subscribe() -> ResultTest<()> {
         let (db, _tmp_dir) = make_test_db()?;
+        let mut tx = db.begin_tx();
 
-        let (schema, table, data, q) = make_inv(&db, StAccess::Public)?;
+        let (schema, table, data, q) = make_inv(&db, &mut tx, StAccess::Public)?;
         assert_eq!(schema.table_type, StTableType::User);
         assert_eq!(schema.table_access, StAccess::Public);
 
         let q_1 = to_mem_table(q.clone(), &data);
-        check_query(&db, &table, &q_1, &data)?;
+        check_query(&db, &table, &mut tx, &q_1, &data)?;
 
         let q_2 = q.with_select_cmp(OpCmp::Eq, FieldName::named("inventory", "inventory_id"), scalar(1u64));
-        check_query(&db, &table, &q_2, &data)?;
+        check_query(&db, &table, &mut tx, &q_2, &data)?;
 
         Ok(())
     }
@@ -313,13 +328,14 @@ mod tests {
     #[test]
     fn test_subscribe_private() -> ResultTest<()> {
         let (db, _tmp_dir) = make_test_db()?;
+        let mut tx = db.begin_tx();
 
-        let (schema, table, data, q) = make_inv(&db, StAccess::Private)?;
+        let (schema, table, data, q) = make_inv(&db, &mut tx, StAccess::Private)?;
         assert_eq!(schema.table_type, StTableType::User);
         assert_eq!(schema.table_access, StAccess::Private);
 
         let row = product!(1u64, "health");
-        check_query(&db, &table, &q, &data)?;
+        check_query(&db, &table, &mut tx, &q, &data)?;
 
         //SELECT * FROM inventory
         let q_all = QueryExpr::new(db_table((&schema).into(), "_inventory", schema.table_id));
@@ -360,7 +376,7 @@ mod tests {
             tables: vec![data.clone()],
         };
 
-        check_query_incr(&db, &s, &update, 3, &[row])?;
+        check_query_incr(&db, &mut tx, &s, &update, 3, &[row])?;
 
         let q = QueryExpr::new(db_table((&schema).into(), "_inventory", schema.table_id));
 
@@ -394,8 +410,9 @@ mod tests {
     #[test]
     fn test_subscribe_dedup() -> ResultTest<()> {
         let (db, _tmp_dir) = make_test_db()?;
+        let mut tx = db.begin_tx();
 
-        let (schema, _table, _data, _q) = make_inv(&db, StAccess::Private)?;
+        let (schema, _table, _data, _q) = make_inv(&db, &mut tx, StAccess::Private)?;
 
         //SELECT * FROM inventory
         let q_all = QueryExpr::new(db_table((&schema).into(), "inventory", schema.table_id));
@@ -414,7 +431,7 @@ mod tests {
             },
         ]);
 
-        check_query_eval(&db, &s, 3, &[product!(1u64, "health")])?;
+        check_query_eval(&db, &mut tx, &s, 3, &[product!(1u64, "health")])?;
 
         let row = product!(1u64, "health");
 
@@ -438,7 +455,7 @@ mod tests {
 
         let update = DatabaseUpdate { tables: vec![data] };
 
-        check_query_incr(&db, &s, &update, 3, &[row])?;
+        check_query_incr(&db, &mut tx, &s, &update, 3, &[row])?;
 
         Ok(())
     }
@@ -455,9 +472,10 @@ mod tests {
     #[test]
     fn test_subscribe_commutative() -> ResultTest<()> {
         let (db, _tmp_dir) = make_test_db()?;
+        let mut tx = db.begin_tx();
 
-        let (_, _, _, q_1) = make_inv(&db, StAccess::Public)?;
-        let (_, _, _, q_2) = make_player(&db)?;
+        let (_, _, _, q_1) = make_inv(&db, &mut tx, StAccess::Public)?;
+        let (_, _, _, q_2) = make_player(&db, &mut tx)?;
 
         let s = QuerySet(vec![
             Query {
@@ -504,7 +522,7 @@ mod tests {
         run(&db, &mut tx, sql_create, AuthCtx::for_testing())?;
 
         let sql_query = "SELECT * FROM MobileEntityState JOIN EnemyState ON MobileEntityState.entity_id = EnemyState.entity_id WHERE location_x > 96000 AND MobileEntityState.location_x < 192000 AND MobileEntityState.location_z > 96000 AND MobileEntityState.location_z < 192000";
-        let q = compile_query(&db, &tx, sql_query)?;
+        let q = compile_query(&db, &mut tx, &AuthCtx::for_testing(), sql_query)?;
 
         for q in q.queries {
             assert_eq!(
@@ -520,18 +538,21 @@ mod tests {
     #[test]
     fn test_subscribe_all() -> ResultTest<()> {
         let (db, _tmp_dir) = make_test_db()?;
-        let (schema_1, _, _, _) = make_inv(&db, StAccess::Public)?;
-        let (schema_2, _, _, _) = make_player(&db)?;
+        let mut tx = db.begin_tx();
+
+        let (schema_1, _, _, _) = make_inv(&db, &mut tx, StAccess::Public)?;
+        let (schema_2, _, _, _) = make_player(&db, &mut tx)?;
         let row_1 = product!(1u64, "health");
         let row_2 = product!(2u64, "jhon doe");
 
         let s = QuerySet(vec![compile_query(
             &db,
+            &mut tx,
+            &AuthCtx::for_testing(),
             SUBSCRIBE_TO_ALL_QUERY,
-            AuthCtx::for_testing(),
         )?]);
 
-        check_query_eval(&db, &s, 2, &[row_1.clone(), row_2.clone()])?;
+        check_query_eval(&db, &mut tx, &s, 2, &[row_1.clone(), row_2.clone()])?;
 
         let row1 = TableOp {
             op_type: 0,
@@ -563,7 +584,7 @@ mod tests {
 
         let row_1 = product!(1u64, "health");
         let row_2 = product!(2u64, "jhon doe");
-        check_query_incr(&db, &s, &update, 2, &[row_1, row_2])?;
+        check_query_incr(&db, &mut tx, &s, &update, 2, &[row_1, row_2])?;
 
         Ok(())
     }

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -316,7 +316,7 @@ mod tests {
         assert_eq!(schema.table_type, StTableType::User);
         assert_eq!(schema.table_access, StAccess::Public);
 
-        let q_1 = to_mem_table(q.clone(), &data);
+        let q_1 = q.clone();
         check_query(&db, &table, &mut tx, &q_1, &data)?;
 
         let q_2 = q.with_select_cmp(OpCmp::Eq, FieldName::named("inventory", "inventory_id"), scalar(1u64));

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -180,7 +180,7 @@ mod tests {
         let data = DatabaseTableUpdate {
             table_id,
             table_name: table_name.to_string(),
-            ops: vec![op.clone()],
+            ops: vec![op],
         };
 
         let q = QueryExpr::new(db_table((&schema).into(), table_name, table_id));
@@ -243,8 +243,8 @@ mod tests {
         q: &QueryExpr,
         data: &DatabaseTableUpdate,
     ) -> ResultTest<()> {
-        let q = to_mem_table(q.clone(), &data);
-        let result = run_query(&db, tx, &q, AuthCtx::for_testing())?;
+        let q = to_mem_table(q.clone(), data);
+        let result = run_query(db, tx, &q, AuthCtx::for_testing())?;
 
         assert_eq!(
             Some(table.as_without_table_name()),
@@ -258,8 +258,7 @@ mod tests {
         result
             .tables
             .iter()
-            .map(|x| x.ops.iter().map(|x| x.row.clone()))
-            .flatten()
+            .flat_map(|x| x.ops.iter().map(|x| x.row.clone()))
             .sorted()
             .collect::<Vec<_>>()
     }
@@ -272,7 +271,7 @@ mod tests {
         total_tables: usize,
         rows: &[ProductValue],
     ) -> ResultTest<()> {
-        let result = s.eval_incr(&db, tx, &update, AuthCtx::for_testing())?;
+        let result = s.eval_incr(db, tx, update, AuthCtx::for_testing())?;
         assert_eq!(
             result.tables.len(),
             total_tables,
@@ -293,7 +292,7 @@ mod tests {
         total_tables: usize,
         rows: &[ProductValue],
     ) -> ResultTest<()> {
-        let result = s.eval(&db, tx, AuthCtx::for_testing())?;
+        let result = s.eval(db, tx, AuthCtx::for_testing())?;
         assert_eq!(
             result.tables.len(),
             total_tables,
@@ -492,15 +491,8 @@ mod tests {
         let s = QuerySet(vec![Query { queries: vec![q_2] }, Query { queries: vec![q_1] }]);
 
         let result_2 = s.eval(&db, &mut tx, AuthCtx::for_testing())?;
-        let to_row = |of: DatabaseUpdate| {
-            of.tables
-                .iter()
-                .flat_map(|x| x.ops.iter().map(|x| x.row.clone()))
-                .sorted()
-                .collect::<Vec<_>>()
-        };
 
-        assert_eq!(to_row(result_1), to_row(result_2));
+        assert_eq!(get_result(result_1), get_result(result_2));
 
         Ok(())
     }
@@ -523,7 +515,7 @@ mod tests {
         run(&db, &mut tx, sql_create, AuthCtx::for_testing())?;
 
         let sql_query = "SELECT * FROM MobileEntityState JOIN EnemyState ON MobileEntityState.entity_id = EnemyState.entity_id WHERE location_x > 96000 AND MobileEntityState.location_x < 192000 AND MobileEntityState.location_z > 96000 AND MobileEntityState.location_z < 192000";
-        let q = compile_query(&db, &mut tx, &AuthCtx::for_testing(), sql_query)?;
+        let q = compile_query(&db, &tx, &AuthCtx::for_testing(), sql_query)?;
 
         for q in q.queries {
             assert_eq!(
@@ -548,7 +540,7 @@ mod tests {
 
         let s = QuerySet(vec![compile_query(
             &db,
-            &mut tx,
+            &tx,
             &AuthCtx::for_testing(),
             SUBSCRIBE_TO_ALL_QUERY,
         )?]);
@@ -558,13 +550,13 @@ mod tests {
         let row1 = TableOp {
             op_type: 0,
             row_pk: row_1.to_data_key().to_bytes(),
-            row: row_1.clone(),
+            row: row_1,
         };
 
         let row2 = TableOp {
             op_type: 1,
             row_pk: row_2.to_data_key().to_bytes(),
-            row: row_2.clone(),
+            row: row_2,
         };
 
         let data1 = DatabaseTableUpdate {

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -4,11 +4,14 @@ use crate::error::{DBError, SubscriptionError};
 use crate::host::module_host::DatabaseTableUpdate;
 use crate::sql::compiler::compile_sql;
 use crate::sql::execute::execute_single_sql;
+use crate::subscription::subscription::QuerySet;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::relation::{Column, FieldName, MemTable, RelValue};
 use spacetimedb_lib::DataKey;
 use spacetimedb_sats::AlgebraicType;
 use spacetimedb_vm::expr::{Crud, CrudExpr, DbType, QueryExpr, SourceExpr};
+
+pub const SUBSCRIBE_TO_ALL_QUERY: &str = "SELECT * FROM *";
 
 pub enum QueryDef {
     Table(String),
@@ -82,11 +85,35 @@ pub(crate) fn run_query(
     execute_single_sql(db, tx, CrudExpr::Query(query.clone()), auth)
 }
 
-#[tracing::instrument(skip(relational_db, tx))]
-pub fn compile_query(relational_db: &RelationalDB, tx: &MutTxId, input: &str) -> Result<Query, DBError> {
+//TODO: Is certainly semantically wrong to [SUBSCRIBE_TO_ALL_QUERY] because it only can return back
+//the changes that are valid for the tables in scope *right now* instead of **continuously update** the changes
+//of the database, with system table modifications (add/remove tables, indexes, ...).
+/// Compile from `SQL` into a [`Query`].
+///
+/// NOTE: When the `input` query is equal to [`SUBSCRIBE_TO_ALL_QUERY`],
+/// **compilation is bypassed** and the equivalent of the following is done:
+///
+///```rust,ignore
+/// for t in db.user_tables {
+///   query.push(format!("SELECT * FROM {t}"));
+/// }
+/// ```
+///
+/// WARNING: If [SUBSCRIBE_TO_ALL_QUERY] is only valid to repeated calls as long there is not change on database schema, and the clients must `unsubscribe` before modify it.
+#[tracing::instrument(skip(relational_db, auth, tx))]
+pub fn compile_query(
+    relational_db: &RelationalDB,
+    tx: &MutTxId,
+    auth: &AuthCtx,
+    input: &str,
+) -> Result<Query, DBError> {
     let input = input.trim();
     if input.is_empty() {
         return Err(SubscriptionError::Empty.into());
+    }
+
+    if input == SUBSCRIBE_TO_ALL_QUERY {
+        return QuerySet::get_all(relational_db, *auth);
     }
 
     let mut queries = Vec::new();
@@ -115,84 +142,169 @@ pub fn compile_query(relational_db: &RelationalDB, tx: &MutTxId, input: &str) ->
 #[cfg(test)]
 mod tests {
     use super::*;
+    use crate::db::datastore::traits::TableSchema;
     use crate::db::relational_db::tests_utils::make_test_db;
     use crate::host::module_host::{DatabaseTableUpdate, DatabaseUpdate, TableOp};
     use crate::sql::execute::run;
     use crate::subscription::subscription::QuerySet;
-    use crate::vm::tests::create_table_from_program;
-    use crate::vm::DbProgram;
+    use crate::vm::tests::create_table_with_rows;
     use itertools::Itertools;
     use spacetimedb_lib::auth::{StAccess, StTableType};
     use spacetimedb_lib::data_key::ToDataKey;
     use spacetimedb_lib::error::ResultTest;
     use spacetimedb_lib::relation::FieldName;
     use spacetimedb_lib::Identity;
-    use spacetimedb_sats::{product, BuiltinType, ProductType};
+    use spacetimedb_sats::{product, BuiltinType, ProductType, ProductValue};
     use spacetimedb_vm::dsl::{db_table, mem_table, scalar};
     use spacetimedb_vm::operator::OpCmp;
 
-    #[test]
-    fn test_subscribe() -> ResultTest<()> {
-        let (db, _tmp_dir) = make_test_db()?;
-
+    fn make_data(
+        db: &RelationalDB,
+        table_name: &str,
+        head: &ProductType,
+        row: &ProductValue,
+    ) -> ResultTest<(TableSchema, MemTable, DatabaseTableUpdate, QueryExpr)> {
         let mut tx = db.begin_tx();
-
-        let p = &mut DbProgram::new(&db, &mut tx, AuthCtx::for_testing());
-
-        let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
-
-        let row = product!(1u64, "health");
         let table = mem_table(head.clone(), [row.clone()]);
-        let table_id = create_table_from_program(p, "inventory", head.clone(), &[row.clone()])?;
+        let table_id = create_table_with_rows(db, &mut tx, table_name, head.clone(), &[row.clone()])?;
 
         let schema = db.schema_for_table(&tx, table_id).unwrap();
         // db.commit_tx(tx)?;
 
         let op = TableOp {
             op_type: 1,
-            row_pk: vec![],
-            row,
+            row_pk: row.to_data_key().to_bytes(),
+            row: row.clone(),
         };
 
         let data = DatabaseTableUpdate {
             table_id,
-            table_name: "inventory".to_string(),
+            table_name: table_name.to_string(),
             ops: vec![op.clone()],
         };
-        // For filtering out the hidden field `OP_TYPE_FIELD_NAME`
-        let fields = &[
-            FieldName::named("inventory", "inventory_id").into(),
-            FieldName::named("inventory", "name").into(),
-        ];
 
-        let q = QueryExpr::new(db_table((&schema).into(), "inventory", table_id)).with_project(fields);
+        let q = QueryExpr::new(db_table((&schema).into(), table_name, table_id));
 
-        let q = to_mem_table(q, &data);
-        let result = run_query(&db, &mut tx, &q, AuthCtx::for_testing())?;
+        Ok((schema, table, data, q))
+    }
 
-        assert_eq!(
-            Some(table.as_without_table_name()),
-            result.first().map(|x| x.as_without_table_name())
-        );
-
-        let data = DatabaseTableUpdate {
-            table_id,
-            table_name: "inventory".to_string(),
-            ops: vec![op],
+    fn make_inv(
+        db: &RelationalDB,
+        access: StAccess,
+    ) -> ResultTest<(TableSchema, MemTable, DatabaseTableUpdate, QueryExpr)> {
+        let table_name = if access == StAccess::Public {
+            "inventory"
+        } else {
+            "_inventory"
         };
 
-        let q = QueryExpr::new(db_table((&schema).into(), "inventory", table_id))
-            .with_select_cmp(OpCmp::Eq, FieldName::named("inventory", "inventory_id"), scalar(1u64))
-            .with_project(fields);
+        let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
+        let row = product!(1u64, "health");
 
-        let q = to_mem_table(q, &data);
-        let result = run_query(&db, &mut tx, &q, AuthCtx::for_testing())?;
+        let (schema, table, data, q) = make_data(db, table_name, &head, &row)?;
 
-        let table = mem_table(head, vec![product!(1u64, "health")]);
+        // For filtering out the hidden field `OP_TYPE_FIELD_NAME`
+        let fields = &[
+            FieldName::named(table_name, "inventory_id").into(),
+            FieldName::named(table_name, "name").into(),
+        ];
+
+        let q = q.with_project(fields);
+
+        Ok((schema, table, data, q))
+    }
+
+    fn make_player(db: &RelationalDB) -> ResultTest<(TableSchema, MemTable, DatabaseTableUpdate, QueryExpr)> {
+        let table_name = "player";
+        let head = ProductType::from_iter([("player_id", BuiltinType::U64), ("name", BuiltinType::String)]);
+        let row = product!(2u64, "jhon doe");
+
+        let (schema, table, data, q) = make_data(db, table_name, &head, &row)?;
+
+        // For filtering out the hidden field `OP_TYPE_FIELD_NAME`
+        let fields = &[
+            FieldName::named(table_name, "player_id").into(),
+            FieldName::named(table_name, "name").into(),
+        ];
+
+        let q = q.with_project(fields);
+
+        Ok((schema, table, data, q))
+    }
+
+    fn check_query(db: &RelationalDB, table: &MemTable, q: &QueryExpr, data: &DatabaseTableUpdate) -> ResultTest<()> {
+        let q = to_mem_table(q.clone(), &data);
+        let result = run_query(&db, &q, AuthCtx::for_testing())?;
+
         assert_eq!(
             Some(table.as_without_table_name()),
             result.first().map(|x| x.as_without_table_name())
         );
+
+        Ok(())
+    }
+
+    fn check_query_incr(
+        db: &RelationalDB,
+        s: &QuerySet,
+        update: &DatabaseUpdate,
+        total_tables: usize,
+        rows: &[ProductValue],
+    ) -> ResultTest<()> {
+        let result = s.eval_incr(&db, &update, AuthCtx::for_testing())?;
+        assert_eq!(
+            result.tables.len(),
+            total_tables,
+            "Must return the correct number of tables"
+        );
+
+        let result = result
+            .tables
+            .iter()
+            .map(|x| x.ops.iter().map(|x| x.row.clone()))
+            .flatten()
+            .sorted()
+            .collect::<Vec<_>>();
+
+        assert_eq!(result, rows, "Must return the correct row(s)");
+
+        Ok(())
+    }
+
+    fn check_query_eval(db: &RelationalDB, s: &QuerySet, total_tables: usize, rows: &[ProductValue]) -> ResultTest<()> {
+        let result = s.eval(&db, AuthCtx::for_testing())?;
+        assert_eq!(
+            result.tables.len(),
+            total_tables,
+            "Must return the correct number of tables"
+        );
+
+        let result = result
+            .tables
+            .iter()
+            .map(|x| x.ops.iter().map(|x| x.row.clone()))
+            .flatten()
+            .sorted()
+            .collect::<Vec<_>>();
+
+        assert_eq!(result, rows, "Must return the correct row(s)");
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_subscribe() -> ResultTest<()> {
+        let (db, _tmp_dir) = make_test_db()?;
+
+        let (schema, table, data, q) = make_inv(&db, StAccess::Public)?;
+        assert_eq!(schema.table_type, StTableType::User);
+        assert_eq!(schema.table_access, StAccess::Public);
+
+        let q_1 = to_mem_table(q.clone(), &data);
+        check_query(&db, &table, &q_1, &data)?;
+
+        let q_2 = q.with_select_cmp(OpCmp::Eq, FieldName::named("inventory", "inventory_id"), scalar(1u64));
+        check_query(&db, &table, &q_2, &data)?;
 
         Ok(())
     }
@@ -202,51 +314,15 @@ mod tests {
     fn test_subscribe_private() -> ResultTest<()> {
         let (db, _tmp_dir) = make_test_db()?;
 
-        let mut tx = db.begin_tx();
-        let p = &mut DbProgram::new(&db, &mut tx, AuthCtx::for_testing());
-
-        let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
-
-        let row = product!(1u64, "health");
-        let table = mem_table(head.clone(), [row.clone()]);
-        let table_id = create_table_from_program(p, "_inventory", head, &[row.clone()])?;
-
-        let schema = db.schema_for_table(&tx, table_id).unwrap();
+        let (schema, table, data, q) = make_inv(&db, StAccess::Private)?;
         assert_eq!(schema.table_type, StTableType::User);
         assert_eq!(schema.table_access, StAccess::Private);
 
-        //db.commit_tx(tx)?;
-
-        let op = TableOp {
-            op_type: 0,
-            row_pk: vec![],
-            row: row.clone(),
-        };
-
-        let data = DatabaseTableUpdate {
-            table_id,
-            table_name: "_inventory".to_string(),
-            ops: vec![op],
-        };
-        // For filtering out the hidden field `OP_TYPE_FIELD_NAME`
-        let fields = &[
-            FieldName::named("_inventory", "inventory_id").into(),
-            FieldName::named("_inventory", "name").into(),
-        ];
-
-        let q = QueryExpr::new(db_table((&schema).into(), "_inventory", table_id)).with_project(fields);
-
-        let q = to_mem_table(q, &data);
-
-        let result = run_query(&db, &mut tx, &q, AuthCtx::for_testing())?;
-
-        assert_eq!(
-            Some(table.as_without_table_name()),
-            result.first().map(|x| x.as_without_table_name())
-        );
+        let row = product!(1u64, "health");
+        check_query(&db, &table, &q, &data)?;
 
         //SELECT * FROM inventory
-        let q_all = QueryExpr::new(db_table((&schema).into(), "_inventory", table_id));
+        let q_all = QueryExpr::new(db_table((&schema).into(), "_inventory", schema.table_id));
         //SELECT * FROM inventory WHERE inventory_id = 1
         let q_id =
             q_all
@@ -275,7 +351,7 @@ mod tests {
         };
 
         let data = DatabaseTableUpdate {
-            table_id,
+            table_id: schema.table_id,
             table_name: "_inventory".to_string(),
             ops: vec![row1, row2],
         };
@@ -284,16 +360,9 @@ mod tests {
             tables: vec![data.clone()],
         };
 
-        let result = s.eval_incr(&db, &mut tx, &update, AuthCtx::for_testing())?;
-        assert_eq!(result.tables.len(), 3, "Must return 3 tables");
-        assert_eq!(
-            result.tables.iter().map(|x| x.ops.len()).sum::<usize>(),
-            1,
-            "Must return 1 row"
-        );
-        assert_eq!(result.tables[0].ops[0].row, row, "Must return the correct row");
+        check_query_incr(&db, &s, &update, 3, &[row])?;
 
-        let q = QueryExpr::new(db_table((&schema).into(), "_inventory", table_id)).with_project(fields);
+        let q = QueryExpr::new(db_table((&schema).into(), "_inventory", schema.table_id));
 
         let q = to_mem_table(q, &data);
         //Try access the private table
@@ -321,23 +390,15 @@ mod tests {
     //SELECT * FROM table
     //SELECT * FROM table WHERE id=1
     //```
-    // return just one row
+    // return just one row for both incr & direct subscriptions
     #[test]
     fn test_subscribe_dedup() -> ResultTest<()> {
         let (db, _tmp_dir) = make_test_db()?;
 
-        let mut tx = db.begin_tx();
-        let p = &mut DbProgram::new(&db, &mut tx, AuthCtx::for_testing());
-
-        let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
-        let row = product!(1u64, "health");
-        let table_id = create_table_from_program(p, "inventory", head, &[row.clone()])?;
-
-        let schema = db.schema_for_table(&tx, table_id).unwrap();
-        //db.commit_tx(tx)?;
+        let (schema, _table, _data, _q) = make_inv(&db, StAccess::Private)?;
 
         //SELECT * FROM inventory
-        let q_all = QueryExpr::new(db_table((&schema).into(), "inventory", table_id));
+        let q_all = QueryExpr::new(db_table((&schema).into(), "inventory", schema.table_id));
         //SELECT * FROM inventory WHERE inventory_id = 1
         let q_id =
             q_all
@@ -353,48 +414,9 @@ mod tests {
             },
         ]);
 
-        let result = s.eval(&db, &mut tx, AuthCtx::for_testing())?;
-        assert_eq!(result.tables.len(), 3, "Must return 3 tables");
-        assert_eq!(
-            result.tables.iter().map(|x| x.ops.len()).sum::<usize>(),
-            1,
-            "Must return 1 row"
-        );
-        assert_eq!(result.tables[0].ops[0].row, row, "Must return the correct row");
+        check_query_eval(&db, &s, 3, &[product!(1u64, "health")])?;
 
-        Ok(())
-    }
-
-    #[test]
-    fn test_subscribe_dedup_incr() -> ResultTest<()> {
-        let (db, _tmp_dir) = make_test_db()?;
-
-        let mut tx = db.begin_tx();
-        let p = &mut DbProgram::new(&db, &mut tx, AuthCtx::for_testing());
-
-        let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
         let row = product!(1u64, "health");
-        let table_id = create_table_from_program(p, "inventory", head, &[row.clone()])?;
-
-        let schema = db.schema_for_table(&tx, table_id).unwrap();
-        //db.commit_tx(tx)?;
-
-        //SELECT * FROM inventory
-        let q_all = QueryExpr::new(db_table((&schema).into(), "inventory", table_id));
-        //SELECT * FROM inventory WHERE inventory_id = 1
-        let q_id =
-            q_all
-                .clone()
-                .with_select_cmp(OpCmp::Eq, FieldName::named("inventory", "inventory_id"), scalar(1u64));
-
-        let s = QuerySet(vec![
-            Query {
-                queries: vec![q_all.clone()],
-            },
-            Query {
-                queries: vec![q_all, q_id],
-            },
-        ]);
 
         let row1 = TableOp {
             op_type: 0,
@@ -409,21 +431,14 @@ mod tests {
         };
 
         let data = DatabaseTableUpdate {
-            table_id,
+            table_id: schema.table_id,
             table_name: "inventory".to_string(),
             ops: vec![row1, row2],
         };
 
         let update = DatabaseUpdate { tables: vec![data] };
 
-        let result = s.eval_incr(&db, &mut tx, &update, AuthCtx::for_testing())?;
-        assert_eq!(result.tables.len(), 3, "Must return 3 tables");
-        assert_eq!(
-            result.tables.iter().map(|x| x.ops.len()).sum::<usize>(),
-            1,
-            "Must return 1 row"
-        );
-        assert_eq!(result.tables[0].ops[0].row, row, "Must return the correct row");
+        check_query_incr(&db, &s, &update, 3, &[row])?;
 
         Ok(())
     }
@@ -440,23 +455,9 @@ mod tests {
     #[test]
     fn test_subscribe_commutative() -> ResultTest<()> {
         let (db, _tmp_dir) = make_test_db()?;
-        let mut tx = db.begin_tx();
-        let p = &mut DbProgram::new(&db, &mut tx, AuthCtx::for_testing());
 
-        let head_1 = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
-        let row_1 = product!(1u64, "health");
-        let table_id_1 = create_table_from_program(p, "inventory", head_1, &[row_1])?;
-
-        let head_2 = ProductType::from_iter([("player_id", BuiltinType::U64), ("name", BuiltinType::String)]);
-        let row_2 = product!(2u64, "jhon doe");
-        let table_id_2 = create_table_from_program(p, "player", head_2, &[row_2])?;
-
-        let schema_1 = db.schema_for_table(&tx, table_id_1).unwrap();
-        let schema_2 = db.schema_for_table(&tx, table_id_2).unwrap();
-        //db.commit_tx(tx)?;
-
-        let q_1 = QueryExpr::new(db_table((&schema_1).into(), "inventory", table_id_1));
-        let q_2 = QueryExpr::new(db_table((&schema_2).into(), "player", table_id_2));
+        let (_, _, _, q_1) = make_inv(&db, StAccess::Public)?;
+        let (_, _, _, q_2) = make_player(&db)?;
 
         let s = QuerySet(vec![
             Query {
@@ -497,7 +498,7 @@ mod tests {
         let sql_create = "\
         insert into MobileEntityState (entity_id, location_x, location_z, destination_x, destination_z, is_running, timestamp, dimension) values (1, 96001, 96001, 96001, 1867045146, false, 17167179743690094247, 3926297397);\
         insert into MobileEntityState (entity_id, location_x, location_z, destination_x, destination_z, is_running, timestamp, dimension) values (2, 96001, 191000, 191000, 1560020888, true, 2947537077064292621, 445019304);
-        
+
         insert into EnemyState (entity_id, herd_id, status, type, direction) values (1, 1181485940, 1633678837, 1158301365, 132191327);
         insert into EnemyState (entity_id, herd_id, status, type, direction) values (2, 2017368418, 194072456, 34423057, 1296770410);";
         run(&db, &mut tx, sql_create, AuthCtx::for_testing())?;
@@ -512,6 +513,58 @@ mod tests {
                 "Not return results"
             );
         }
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_subscribe_all() -> ResultTest<()> {
+        let (db, _tmp_dir) = make_test_db()?;
+        let (schema_1, _, _, _) = make_inv(&db, StAccess::Public)?;
+        let (schema_2, _, _, _) = make_player(&db)?;
+        let row_1 = product!(1u64, "health");
+        let row_2 = product!(2u64, "jhon doe");
+
+        let s = QuerySet(vec![compile_query(
+            &db,
+            SUBSCRIBE_TO_ALL_QUERY,
+            AuthCtx::for_testing(),
+        )?]);
+
+        check_query_eval(&db, &s, 2, &[row_1.clone(), row_2.clone()])?;
+
+        let row1 = TableOp {
+            op_type: 0,
+            row_pk: row_1.to_data_key().to_bytes(),
+            row: row_1.clone(),
+        };
+
+        let row2 = TableOp {
+            op_type: 1,
+            row_pk: row_2.to_data_key().to_bytes(),
+            row: row_2.clone(),
+        };
+
+        let data1 = DatabaseTableUpdate {
+            table_id: schema_1.table_id,
+            table_name: "inventory".to_string(),
+            ops: vec![row1],
+        };
+
+        let data2 = DatabaseTableUpdate {
+            table_id: schema_2.table_id,
+            table_name: "player".to_string(),
+            ops: vec![row2],
+        };
+
+        let update = DatabaseUpdate {
+            tables: vec![data1, data2],
+        };
+
+        let row_1 = product!(1u64, "health");
+        let row_2 = product!(2u64, "jhon doe");
+        check_query_incr(&db, &s, &update, 2, &[row_1, row_2])?;
+
         Ok(())
     }
 }

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -85,9 +85,10 @@ pub(crate) fn run_query(
     execute_single_sql(db, tx, CrudExpr::Query(query.clone()), auth)
 }
 
-//TODO: Is certainly semantically wrong to [SUBSCRIBE_TO_ALL_QUERY] because it only can return back
-//the changes that are valid for the tables in scope *right now* instead of **continuously update** the changes
-//of the database, with system table modifications (add/remove tables, indexes, ...).
+// TODO: It's semantically wrong to `SUBSCRIBE_TO_ALL_QUERY`
+// as it only can return back the changes valid for the tables in scope *right now*
+// instead of **continuously updating** the db changes
+// with system table modifications (add/remove tables, indexes, ...).
 /// Compile from `SQL` into a [`Query`].
 ///
 /// NOTE: When the `input` query is equal to [`SUBSCRIBE_TO_ALL_QUERY`],

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -65,20 +65,16 @@ impl QuerySet {
     /// Queries all the [`StTableType::User`] tables *right now*
     /// and turns them into [`QueryExpr`],
     /// the moral equivalent of `SELECT * FROM table`.
-    pub(crate) fn get_all(relational_db: &RelationalDB, auth: AuthCtx) -> Result<Query, DBError> {
-        relational_db.with_auto_commit(|tx| {
-            let tables = relational_db.get_all_tables(tx)?;
-            let same_owner = auth.owner == auth.caller;
-            let queries = tables
-                .iter()
-                .filter(|t| {
-                    t.table_type == StTableType::User
-                        && (same_owner || t.table_access == StAccess::Public)
-                })
-                .map(QueryExpr::new)
-                .collect();
-            Ok(Query { queries })
-        })
+    pub(crate) fn get_all(relational_db: &RelationalDB, tx: &MutTxId, auth: &AuthCtx) -> Result<Query, DBError> {
+        let tables = relational_db.get_all_tables(tx)?;
+        let same_owner = auth.owner == auth.caller;
+        let queries = tables
+            .iter()
+            .filter(|t| t.table_type == StTableType::User && (same_owner || t.table_access == StAccess::Public))
+            .map(QueryExpr::new)
+            .collect();
+
+        Ok(Query { queries })
     }
 
     /// Incremental evaluation of `rows` that matched the [Query] (aka subscriptions)

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -1,7 +1,9 @@
+use spacetimedb_lib::auth::{StAccess, StTableType};
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::relation::RelValue;
 use spacetimedb_lib::PrimaryKey;
 use spacetimedb_sats::{AlgebraicValue, BuiltinValue};
+use spacetimedb_vm::expr::QueryExpr;
 use std::collections::HashSet;
 
 use super::query::Query;
@@ -60,6 +62,25 @@ fn pk_for_row(row: &RelValue) -> PrimaryKey {
 }
 
 impl QuerySet {
+    /// Queries all the [`StTableType::User`] tables *right now*
+    /// and turns them into [`QueryExpr`],
+    /// the moral equivalent of `SELECT * FROM table`.
+    pub(crate) fn get_all(relational_db: &RelationalDB, auth: AuthCtx) -> Result<Query, DBError> {
+        relational_db.with_auto_commit(|tx| {
+            let tables = relational_db.get_all_tables(tx)?;
+            let same_owner = auth.owner == auth.caller;
+            let queries = tables
+                .iter()
+                .filter(|t| {
+                    t.table_type == StTableType::User
+                        && (same_owner || t.table_access == StAccess::Public)
+                })
+                .map(QueryExpr::new)
+                .collect();
+            Ok(Query { queries })
+        })
+    }
+
     /// Incremental evaluation of `rows` that matched the [Query] (aka subscriptions)
     ///
     /// This is equivalent to run a `trigger` on `INSERT/UPDATE/DELETE`, run the [Query] and see if the `row` is matched.

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -189,7 +189,7 @@ impl SourceExpr {
 
     pub fn table_access(&self) -> StAccess {
         match self {
-            SourceExpr::MemTable(_) => StAccess::Public,
+            SourceExpr::MemTable(x) => x.table_access,
             SourceExpr::DbTable(x) => x.table_access,
         }
     }


### PR DESCRIPTION
# Description of Changes

Add the ability to “send me everything” query.

It use the special 

```sql
SELECT * FROM *
```

to trigger this.

This semantically doesn't seem right, or at least confusing from the POV of subscriptions: It means  "send back what you have right now" instead of "keep streaming back all the changes".

This means this will break (ie changes to the database schema could fail in subsequent runs):

```sql
subscribe SELECT * FROM *
CREATE TABLE a
INSERT INTO a
DROP TABLE a
CREATE TABLE b
```

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI

*If the API is breaking, please state below what will break*
