### PR TITLE
Shuffle `#[allow]` attributes around to make rust-analyzer happy

### DIFF
--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -784,11 +784,11 @@ fn spacetimedb_tabletype_impl(item: syn::DeriveInput) -> syn::Result<TokenStream
     };
 
     let filter_impl = quote! {
-        #[allow(non_camel_case_types)]
         const _: () = {
             #[derive(Debug, spacetimedb::Serialize, spacetimedb::Deserialize)]
             #[sats(crate = spacetimedb::spacetimedb_lib)]
             #[repr(u8)]
+            #[allow(non_camel_case_types)]
             pub enum FieldIndex {
                 #(#field_names),*
             }

--- a/crates/bindings-macro/src/module.rs
+++ b/crates/bindings-macro/src/module.rs
@@ -277,6 +277,7 @@ pub(crate) fn derive_deserialize(ty: &SatsType<'_>) -> TokenStream {
                         }
                     }
 
+                    #[allow(non_camel_case_types)]
                     enum __ProductFieldIdent {
                         #(#field_names,)*
                     }
@@ -332,6 +333,7 @@ pub(crate) fn derive_deserialize(ty: &SatsType<'_>) -> TokenStream {
                         }
                     }
 
+                    #[allow(non_camel_case_types)]
                     enum __Variant {
                         #(#variant_idents,)*
                     }


### PR DESCRIPTION
# Description of Changes

For reasons that escape me, rust-analyzer seems to only respect `#[allow(non_camel_case_types)]` attributes within proc macros if they apply directly to the type definition.

Regular rustc seems to accept those attributes when applied to any enclosing scope, as does rust-analyzer outside of proc macros.

At least on my machine, shuffling the `#[allow]` attributes seems to have quieted a rust-analyzer lint
which incorrectly advised users to name their table columns in `camelCase`.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
