### PR TITLE
Release and live use --allow-create

### DIFF
--- a/docker-compose-live.yml
+++ b/docker-compose-live.yml
@@ -7,7 +7,7 @@ services:
     volumes:
       - /stdb
       - key_files:/etc/spacetimedb
-    command: start
+    command: start --allow-create
     privileged: true
     environment:
       ENV: live

--- a/docker-compose-release.yml
+++ b/docker-compose-release.yml
@@ -20,7 +20,7 @@ services:
     ports:
       - "3000:80"
     privileged: true
-    command: start
+    command: start --allow-create
     environment:
       RUST_BACKTRACE: 1
       ENV: release


### PR DESCRIPTION
# Description of Changes

 - Both release and live depend on the `log.conf` file to be created by spacetimedb, which requires that this flag be used.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
