### PR TITLE
Don't panic the CLI when an identity does not exist

### DIFF
--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -236,7 +236,7 @@ async fn exec_remove(mut config: Config, args: &ArgMatches) -> Result<(), anyhow
         } else {
             config.delete_identity_config_by_name(identity_or_name.as_str())
         }
-        .unwrap_or_else(|| panic!("No such identity or name: {}", identity_or_name));
+        .ok_or(anyhow::anyhow!("No such identity or name: {}", identity_or_name))?;
         config.update_default_identity();
         config.save();
         println!(" Removed identity");


### PR DESCRIPTION
# Description of Changes

Previously we would panic here. Now we will give a much better error message and still exit with a non-zero exit code.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
