### PR TITLE
Fix openssl bindings to always use the feature 'vendored'

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -50,3 +50,8 @@ rpath = false
 
 [profile.bench]
 debug = true
+
+[workspace.dependencies]
+# Vendor the openssl we rely on, rather than depend on a
+# potentially very old system version.
+openssl = { version = "0.10", features = ["vendored"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,9 +18,7 @@ name = "odb_flavor_bench"
 harness = false
 
 [dependencies]
-# Vendor the openssl we rely on, rather than depend on a
-# potentially very old system version.
-openssl = { version = "0.10", features = ["vendored"] }
+openssl.workspace = true
 
 tokio = { version = "1.2", features = ["full"] }
 wasmer = "3.1.*"

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -29,7 +29,7 @@ sled = "0.34.7"
 async-trait = "0.1.60"
 log = "0.4.16"
 axum = "0.6"
-openssl = "0.10.54"
+openssl.workspace = true
 http = "0.2.9"
 tower-http = { version = "0.4.1", features = ["cors"]}
 dirs = "5.0.1"


### PR DESCRIPTION
# Description of Changes

Also, we need to document that is necessary to install `cmake` / `perl` for building the `vendored` openssl binding.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
