### PR TITLE
Remove sendgrid from standalone

### DIFF
--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -180,7 +180,7 @@ async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Result
 /// Executes the `identity set-default` command which sets the default identity.
 async fn exec_set_default(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let identity = config
-        .resolve_name_to_identity(args.get_one::<String>("identity").map(|s| s.as_ref()))
+        .resolve_name_to_identity(args.get_one::<String>("identity").map(|s| s.as_ref()))?
         .unwrap();
     config.set_default_identity(identity);
     config.save();
@@ -433,7 +433,7 @@ async fn exec_find(config: Config, args: &ArgMatches) -> Result<(), anyhow::Erro
 /// Executes the `identity token` command which prints the token for an identity.
 async fn exec_token(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let identity_or_name = config
-        .resolve_name_to_identity(args.get_one::<String>("identity").map(|s| s.as_str()))
+        .resolve_name_to_identity(args.get_one::<String>("identity").map(|s| s.as_str()))?
         .unwrap();
     let ic = config
         .get_identity_config_by_identity(identity_or_name.as_str())
@@ -446,7 +446,7 @@ async fn exec_token(config: Config, args: &ArgMatches) -> Result<(), anyhow::Err
 async fn exec_set_name(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let cloned_config = config.clone();
     let identity_or_name = cloned_config
-        .resolve_name_to_identity(args.get_one::<String>("identity").map(|s| s.as_ref()))
+        .resolve_name_to_identity(args.get_one::<String>("identity").map(|s| s.as_ref()))?
         .unwrap();
     let new_name = args.get_one::<String>("name").unwrap().as_ref();
     let old_nickname = config.set_identity_nickname(identity_or_name.as_ref(), new_name)?;
@@ -470,7 +470,7 @@ async fn exec_set_name(mut config: Config, args: &ArgMatches) -> Result<(), anyh
 async fn exec_set_email(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let email = args.get_one::<String>("email").unwrap().clone();
     let identity = config
-        .resolve_name_to_identity(args.get_one::<String>("identity").map(|s| s.as_ref()))
+        .resolve_name_to_identity(args.get_one::<String>("identity").map(|s| s.as_ref()))?
         .unwrap();
     let identity_config = config
         .get_identity_config_by_identity(identity.as_str())
@@ -503,7 +503,7 @@ async fn exec_set_email(config: Config, args: &ArgMatches) -> Result<(), anyhow:
 async fn exec_recover(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let email = args.get_one::<String>("email").unwrap();
     let identity = config
-        .resolve_name_to_identity(args.get_one::<String>("identity").map(|s| s.as_str()))
+        .resolve_name_to_identity(args.get_one::<String>("identity").map(|s| s.as_str()))?
         .unwrap();
 
     let query_params = vec![

--- a/crates/cli/src/subcommands/logs.rs
+++ b/crates/cli/src/subcommands/logs.rs
@@ -84,7 +84,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let follow = args.get_flag("follow");
 
     let cloned_config = config.clone();
-    let identity = cloned_config.resolve_name_to_identity(args.get_one::<String>("identity").map(|x| x.as_str()));
+    let identity = cloned_config.resolve_name_to_identity(args.get_one::<String>("identity").map(|x| x.as_str()))?;
     let auth_header = get_auth_header(&mut config, false, identity.as_deref())
         .await
         .map(|x| x.0);

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -92,7 +92,7 @@ pub fn cli() -> clap::Command {
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let cloned_config = config.clone();
-    let identity = cloned_config.resolve_name_to_identity(args.get_one::<String>("identity").map(|s| s.as_str()));
+    let identity = cloned_config.resolve_name_to_identity(args.get_one::<String>("identity").map(|s| s.as_str()))?;
     let name_or_address = args.get_one::<String>("name|address");
     let path_to_project = args.get_one::<PathBuf>("path_to_project").unwrap();
     let host_type = args.get_one::<String>("host_type").unwrap();

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -134,7 +134,7 @@ pub async fn select_identity_config(
             resolve_identity_to_identity_config(identity_or_name)
         } else {
             // First check to see if we can convert the name to an identity, then return the config for that identity
-            match config.resolve_name_to_identity(Some(identity_or_name)) {
+            match config.resolve_name_to_identity(Some(identity_or_name))? {
                 None => Err(anyhow::anyhow!("No such identity for name: {}", identity_or_name,)),
                 Some(identity) => resolve_identity_to_identity_config(&identity),
             }

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -43,7 +43,6 @@ pub struct StandaloneEnv {
     object_db: ObjectDb,
     host_controller: Arc<HostController>,
     client_actor_index: ClientActorIndex,
-    sendgrid: Option<SendGridController>,
     public_key: DecodingKey,
     private_key: EncodingKey,
 }
@@ -57,7 +56,6 @@ impl StandaloneEnv {
         let energy_monitor = Arc::new(StandaloneEnergyMonitor::new());
         let host_controller = Arc::new(HostController::new(energy_monitor.clone()));
         let client_actor_index = ClientActorIndex::new();
-        let sendgrid = SendGridController::new();
         let (public_key, private_key) = get_or_create_keys()?;
         let this = Arc::new(Self {
             worker_db,
@@ -66,7 +64,6 @@ impl StandaloneEnv {
             object_db,
             host_controller,
             client_actor_index,
-            sendgrid,
             public_key,
             private_key,
         });
@@ -306,8 +303,10 @@ impl spacetimedb_client_api::ControlCtx for StandaloneEnv {
         &self.control_db
     }
 
+    /// Standalone SpacetimeDB does not support SendGrid as a means to
+    /// reissue authentication tokens.
     fn sendgrid_controller(&self) -> Option<&SendGridController> {
-        self.sendgrid.as_ref()
+        None
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Remove the sendgrid controller from the standalone program.

Additionally, turn some panics in the CLI into bubbled-up errors, when identities cannot be found.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
