### PR TITLE
Auto-upgrade C# deps on installation

### DIFF
--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Codegen" Version="0.6.0" />
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.6.1" />
+    <PackageReference Include="SpacetimeDB.Codegen" Version="0.6.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.6.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
Apparently, unlike Cargo, NuGet defaults to installing *lowest* compatible version instead of *highest* one unless explicit `*` is set.

Changing this to avoid having to manually update templates on patch releases.

# Description of Changes



# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
