### PR TITLE
Default docker command

### DIFF
--- a/crates/standalone/Dockerfile
+++ b/crates/standalone/Dockerfile
@@ -44,3 +44,4 @@ EXPOSE 3000
 
 ENV RUST_BACKTRACE=1
 ENTRYPOINT ["spacetimedb"]
+CMD ["start"]


### PR DESCRIPTION
# Description of Changes

 - This sets the default docker command to `start` (which invokes `spacetimedb start`). If you specify your own arguments on the command line then those arguments will override `start`. This is backwards compatible with all of our infra, including docker-compose files.

We're mainly doing this to make running in docker easier for new users, should be as simple as:

```bash
docker run -p 3000:3000 clockworkslabs/spacetimedb
```

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
