### PR TITLE
Terminate background smoke tests on exit

### DIFF
--- a/test/run-smoke-tests.sh
+++ b/test/run-smoke-tests.sh
@@ -183,6 +183,12 @@ TESTS_NAME=()
 TESTS_PROJECT_PATH=()
 TESTS_CONFIG_FILE=()
 
+if [ "$RUN_PARALLEL" == "true" ] ; then
+	# Make sure background tests are torn down even if we don't get to `wait`
+	# for them (e.g. on ^C).
+	trap 'x="$(jobs -pr)"; [ -n "$x"] && kill "$x"' SIGINT SIGTERM EXIT
+fi
+
 for smoke_test in "${TESTS[@]}" ; do
 	if [ ${#EXCLUDE_TESTS[@]} -ne 0 ] && list_contains "$smoke_test" "${EXCLUDE_TESTS[@]}"; then
 		echo "Skipping test $smoke_test"

--- a/test/run-smoke-tests.sh
+++ b/test/run-smoke-tests.sh
@@ -183,11 +183,18 @@ TESTS_NAME=()
 TESTS_PROJECT_PATH=()
 TESTS_CONFIG_FILE=()
 
-if [ "$RUN_PARALLEL" == "true" ] ; then
-	# Make sure background tests are torn down even if we don't get to `wait`
-	# for them (e.g. on ^C).
-	trap 'x="$(jobs -pr)"; [ -n "$x"] && kill "$x"' SIGINT SIGTERM EXIT
-fi
+# Make sure background tests are torn down even if we don't get to `wait`
+# for them (e.g. on ^C). Mainly for $RUN_PARALLEL.
+terminate_jobs() {
+	local running=""
+	running="$(jobs -pr)"
+	if [ -n "$running" ]; then
+		kill "$running"
+	else
+		echo "no running jobs"
+	fi
+}
+trap 'terminate_jobs' SIGINT SIGTERM EXIT
 
 for smoke_test in "${TESTS[@]}" ; do
 	if [ ${#EXCLUDE_TESTS[@]} -ne 0 ] && list_contains "$smoke_test" "${EXCLUDE_TESTS[@]}"; then

--- a/test/run-smoke-tests.sh
+++ b/test/run-smoke-tests.sh
@@ -190,8 +190,6 @@ terminate_jobs() {
 	running="$(jobs -pr)"
 	if [ -n "$running" ]; then
 		kill "$running"
-	else
-		echo "no running jobs"
 	fi
 }
 trap 'terminate_jobs' SIGINT SIGTERM EXIT


### PR DESCRIPTION
# Description of Changes

If you press ^C at an unfortunate time when running with `--parallel`, the background jobs keep running. Install a trap so that doesn't happen.


# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
