### PR TITLE
Remove unused datastore traits

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -100,7 +100,7 @@ impl RelationalDB {
                     last_commit_offset = Some(commit.commit_offset);
                     for transaction in commit.transactions {
                         transaction_offset += 1;
-                        // NOTE: Although I am creating a blobstore transaction in a
+                        // NOTE: Although I am creating a datastore transaction in a
                         // one to one fashion for each message log transaction, this
                         // is just to reduce memory usage while inserting. We don't
                         // really care about inserting these transactionally as long


### PR DESCRIPTION
We previously anticipated factoring the database in such a way that the typed vs untyped distinctions, and the transactional vs not, semantics would be more visible. We have not used these distinctions and no longer need to expose these traits.

# Description of Changes



# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
