### PR TITLE
Fix recovery of sequences after restart

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -497,13 +497,12 @@ impl Inner {
                 .committed_state
                 .tables
                 .get(&TableId(sequence.table_id))
-                .map(|x| x.schema.table_type == StTableType::System)
-                .unwrap_or(false);
+                .map_or(false, |x| x.schema.table_type == StTableType::System)
 
             let schema = (&sequence).into();
 
             let mut seq = Sequence::new(schema);
-            //Now we need to recover the last allocation value...
+            // Now we need to recover the last allocation value.
             if !is_system_table && seq.value < sequence.allocated + 1 {
                 seq.value = sequence.allocated + 1;
             }
@@ -593,7 +592,7 @@ impl Inner {
 
             // If there are allocated sequence values, return the new value, if it is not bigger than
             // the upper range of `sequence.allocated`
-            if let Some(value) = sequence.gen_next_value() {
+            if let Some(value) = sequence.gen_next_value().filter(|v| v < sequence.allocated()) {
                 if value < sequence.allocated() {
                     return Ok(value);
                 }

--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -384,6 +384,7 @@ impl Inner {
 
             // If any columns are auto incrementing, we need to create a sequence
             // NOTE: This code with the `seq_start` is particularly fragile.
+            // TODO: If we exceed  `SEQUENCE_PREALLOCATION_AMOUNT` we will get a unique violation
             if col.is_autoinc {
                 // The database is bootstrapped with the total of `SystemTables::total_` that identify what is the start of the sequence
                 let (seq_start, seq_id): (i128, SequenceId) = match TableId(schema.table_id) {
@@ -490,10 +491,26 @@ impl Inner {
         let rows = st_sequences.scan_rows().cloned().collect::<Vec<_>>();
         for row in rows {
             let sequence = StSequenceRow::try_from(&row)?;
+            // TODO: The system tables have initialized their value already, but this is wrong:
+            // If we exceed  `SEQUENCE_PREALLOCATION_AMOUNT` we will get a unique violation
+            let is_system_table = self
+                .committed_state
+                .tables
+                .get(&TableId(sequence.table_id))
+                .map(|x| x.schema.table_type == StTableType::System)
+                .unwrap_or(false);
+
             let schema = (&sequence).into();
+
+            let mut seq = Sequence::new(schema);
+            //Now we need to recover the last allocation value...
+            if !is_system_table && seq.value < sequence.allocated + 1 {
+                seq.value = sequence.allocated + 1;
+            }
+
             self.sequence_state
                 .sequences
-                .insert(SequenceId(sequence.sequence_id), Sequence::new(schema));
+                .insert(SequenceId(sequence.sequence_id), seq);
         }
         Ok(())
     }
@@ -574,9 +591,12 @@ impl Inner {
                 return Err(SequenceError::NotFound(seq_id).into());
             };
 
-            // If there are allocated sequence values, return the new value.
+            // If there are allocated sequence values, return the new value, if it is not bigger than
+            // the upper range of `sequence.allocated`
             if let Some(value) = sequence.gen_next_value() {
-                return Ok(value);
+                if value < sequence.allocated() {
+                    return Ok(value);
+                }
             }
         }
         // Allocate new sequence values
@@ -597,8 +617,7 @@ impl Inner {
             };
             let old_seq_row_id = RowId(old_seq_row.to_data_key());
             let mut seq_row = StSequenceRow::try_from(&old_seq_row)?;
-            let num_to_allocate = 1024;
-            seq_row.allocated = sequence.nth_value(num_to_allocate);
+            seq_row.allocated = sequence.nth_value(SEQUENCE_PREALLOCATION_AMOUNT as usize);
             sequence.set_allocation(seq_row.allocated);
             (seq_row, old_seq_row_id)
         };
@@ -631,7 +650,7 @@ impl Inner {
             sequence_name: seq.sequence_name.as_str(),
             table_id: seq.table_id,
             col_id: seq.col_id,
-            allocated: 0,
+            allocated: seq.start.unwrap_or(1),
             increment: seq.increment,
             start: seq.start.unwrap_or(1),
             min_value: seq.min_value.unwrap_or(1),

--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -593,9 +593,7 @@ impl Inner {
             // If there are allocated sequence values, return the new value, if it is not bigger than
             // the upper range of `sequence.allocated`
             if let Some(value) = sequence.gen_next_value().filter(|v| v < &sequence.allocated()) {
-                if value < sequence.allocated() {
-                    return Ok(value);
-                }
+                return Ok(value);
             }
         }
         // Allocate new sequence values

--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -497,7 +497,7 @@ impl Inner {
                 .committed_state
                 .tables
                 .get(&TableId(sequence.table_id))
-                .map_or(false, |x| x.schema.table_type == StTableType::System)
+                .map_or(false, |x| x.schema.table_type == StTableType::System);
 
             let schema = (&sequence).into();
 
@@ -592,7 +592,7 @@ impl Inner {
 
             // If there are allocated sequence values, return the new value, if it is not bigger than
             // the upper range of `sequence.allocated`
-            if let Some(value) = sequence.gen_next_value().filter(|v| v < sequence.allocated()) {
+            if let Some(value) = sequence.gen_next_value().filter(|v| v < &sequence.allocated()) {
                 if value < sequence.allocated() {
                     return Ok(value);
                 }

--- a/crates/core/src/db/datastore/locking_tx_datastore/sequence.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/sequence.rs
@@ -2,7 +2,7 @@ use crate::db::datastore::traits::SequenceSchema;
 
 pub struct Sequence {
     schema: SequenceSchema,
-    value: i128,
+    pub(crate) value: i128,
 }
 
 impl Sequence {
@@ -44,6 +44,10 @@ impl Sequence {
         let value = self.value;
         self.value = self.next_value();
         Some(value)
+    }
+
+    pub fn allocated(&self) -> i128 {
+        self.schema.allocated
     }
 
     pub fn next_value(&self) -> i128 {

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -887,9 +887,8 @@ mod tests {
             .collect::<Vec<i64>>();
         rows.sort();
 
-        //TODO: This need the PR that recover the auto_inc, this is for check the db is correctly reopened...
-        //assert_eq!(rows, vec![1, 2]);
-        assert_eq!(rows, vec![1]);
+        // Check the second row start after `SEQUENCE_PREALLOCATION_AMOUNT`
+        assert_eq!(rows, vec![1, 4099]);
         Ok(())
     }
 


### PR DESCRIPTION
# Description of Changes

When the `db` is restarted, the sequences are initialized with the `start`for generate the `next value` and that cause to generate `unique violations` on insert.

Now, it use the `allocated` value to set the `next value`.

For testing, use:

### Module

```rust
use spacetimedb::{log, spacetimedb};

#[spacetimedb(table)]
pub struct Person {
    #[autoinc]
    #[unique]
    id: i32,
    name: String,
}

#[spacetimedb(reducer)]
pub fn add(name: String) {
    Person::insert(Person { id: 0, name });
}

#[spacetimedb(reducer)]
pub fn say_hello() {
    for person in Person::iter() {
        log::info!("Hello, {}!", person.name);
    }
    log::info!("Hello, World!");
}
```

### Start DB
```bash
➜ rm -rf /tmp/stdb
➜ ./run_standalone.sh
```
### Set some data
```bash
➜ spacetime publish quickstart -c -s
➜ spacetime call quickstart add '["test"]'
```
### Inspect data
```bash
➜ spacetime sql quickstart "SELECT * from st_sequence"
sequence_id | sequence_name   | table_id | col_id | increment | start | min_value | max_malue                               | allocated
-------------+-----------------+----------+--------+-----------+-------+-----------+-----------------------------------------+-----------
 0           | table_id_seq    | 0        | 0      | 1         | 4     | 1         | 4294967295                              | 4096
 2           | index_id_seq    | 3        | 0      | 1         | 4     | 1         | 4294967295                              | 4096
 1           | sequence_id_seq | 2        | 0      | 1         | 3     | 1         | 4294967295                              | 4096
 3           | Person_id_seq   | 4        | 0      | 1         | 1     | 1         | 170141183460469231731687303715884105727 | 4097

➜ spacetime sql quickstart "SELECT * from Person;"
 id | name
----+------
 1  | test
```
### Restart db
```bash
➜./run_standalone.sh
```
### More data
```bash
➜ spacetime call quickstart add '["test"]'

 sequence_id | sequence_name   | table_id | col_id | increment | start | min_value | max_malue                               | allocated
-------------+-----------------+----------+--------+-----------+-------+-----------+-----------------------------------------+-----------
 0           | table_id_seq    | 0        | 0      | 1         | 4     | 1         | 4294967295                              | 4096
 2           | index_id_seq    | 3        | 0      | 1         | 4     | 1         | 4294967295                              | 4096
 1           | sequence_id_seq | 2        | 0      | 1         | 3     | 1         | 4294967295                              | 4096
 3           | Person_id_seq   | 4        | 0      | 1         | 1     | 1         | 170141183460469231731687303715884105727 | 8195

➜ spacetime sql quickstart "SELECT * from Person;"
 id   | name
------+------
 1    | test
 4099 | test
```

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
