### PR TITLE
Implement `Display` for `NameOrAddress`

### DIFF
--- a/crates/client-api/src/util.rs
+++ b/crates/client-api/src/util.rs
@@ -1,6 +1,7 @@
 mod flat_csv;
 pub mod websocket;
 
+use core::fmt;
 use std::net::IpAddr;
 
 use axum::body::{Bytes, HttpBody};
@@ -104,5 +105,14 @@ impl<'de> serde::Deserialize<'de> for NameOrAddress {
                 NameOrAddress::Name(s)
             }
         })
+    }
+}
+
+impl fmt::Display for NameOrAddress {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        match self {
+            Self::Address(addr) => f.write_str(&addr.to_hex()),
+            Self::Name(name) => f.write_str(name),
+        }
     }
 }


### PR DESCRIPTION
# Description of Changes

Mainly for debugging, but hesitant to override the `Debug` impl for `Address` with the hex representation.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
