### PR TITLE
Return parsed `DomainName` alongside `Address` when resolving `NameOrAddress`

### DIFF
--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -69,7 +69,7 @@ pub async fn call(
 
     let args = ReducerArgs::Json(body);
 
-    let address = name_or_address.resolve(&*worker_ctx).await?;
+    let address = name_or_address.resolve(&*worker_ctx).await?.into();
     let database = worker_ctx_find_database(&*worker_ctx, &address).await?.ok_or_else(|| {
         log::error!("Could not find database: {}", address.to_hex());
         (StatusCode::NOT_FOUND, "No such database.")
@@ -254,7 +254,7 @@ pub async fn describe(
     Query(DescribeQueryParams { expand }): Query<DescribeQueryParams>,
     auth: SpacetimeAuthHeader,
 ) -> axum::response::Result<impl IntoResponse> {
-    let address = name_or_address.resolve(&*worker_ctx).await?;
+    let address = name_or_address.resolve(&*worker_ctx).await?.into();
     let database = worker_ctx_find_database(&*worker_ctx, &address)
         .await?
         .ok_or((StatusCode::NOT_FOUND, "No such database."))?;
@@ -308,7 +308,7 @@ pub async fn catalog(
     Query(DescribeQueryParams { expand }): Query<DescribeQueryParams>,
     auth: SpacetimeAuthHeader,
 ) -> axum::response::Result<impl IntoResponse> {
-    let address = name_or_address.resolve(&*worker_ctx).await?;
+    let address = name_or_address.resolve(&*worker_ctx).await?.into();
     let database = worker_ctx_find_database(&*worker_ctx, &address)
         .await?
         .ok_or((StatusCode::NOT_FOUND, "No such database."))?;
@@ -354,7 +354,7 @@ pub async fn info(
     State(worker_ctx): State<Arc<dyn WorkerCtx>>,
     Path(InfoParams { name_or_address }): Path<InfoParams>,
 ) -> axum::response::Result<impl IntoResponse> {
-    let address = name_or_address.resolve(&*worker_ctx).await?;
+    let address = name_or_address.resolve(&*worker_ctx).await?.into();
     let database = worker_ctx_find_database(&*worker_ctx, &address)
         .await?
         .ok_or((StatusCode::NOT_FOUND, "No such database."))?;
@@ -403,7 +403,7 @@ pub async fn logs(
     //       Should all the others change?
     let auth = auth_or_unauth(auth)?;
 
-    let address = name_or_address.resolve(&*worker_ctx).await?;
+    let address = name_or_address.resolve(&*worker_ctx).await?.into();
     let database = worker_ctx_find_database(&*worker_ctx, &address)
         .await?
         .ok_or((StatusCode::NOT_FOUND, "No such database."))?;
@@ -503,7 +503,7 @@ pub async fn sql(
     // which queries this identity is allowed to execute against the database.
     let auth = auth.get_or_create(&*worker_ctx).await?;
 
-    let address = name_or_address.resolve(&*worker_ctx).await?;
+    let address = name_or_address.resolve(&*worker_ctx).await?.into();
     let database = worker_ctx_find_database(&*worker_ctx, &address)
         .await?
         .ok_or((StatusCode::NOT_FOUND, "No such database."))?;
@@ -800,9 +800,8 @@ pub async fn publish(
     // Parse the address or convert the name to a usable address
     let db_address = if let Some(name_or_address) = name_or_address.clone() {
         match name_or_address.try_resolve(&*ctx).await? {
-            Ok(address) => address,
-            Err(name) => {
-                let domain = name.parse().map_err(DomainParsingRejection)?;
+            Ok(resolved) => resolved.into(),
+            Err(domain) => {
                 // Client specified a name which doesn't yet exist
                 // Create a new DNS record and a new address to assign to it
                 let address = ctx.control_db().alloc_spacetime_address().await.map_err(log_and_500)?;

--- a/crates/client-api/src/routes/subscribe.rs
+++ b/crates/client-api/src/routes/subscribe.rs
@@ -41,7 +41,7 @@ pub async fn handle_websocket(
 ) -> axum::response::Result<impl IntoResponse> {
     let auth = auth.get_or_create(&*worker_ctx).await?;
 
-    let address = name_or_address.resolve(&*worker_ctx).await?;
+    let address = name_or_address.resolve(&*worker_ctx).await?.into();
 
     let (res, ws_upgrade, protocol) =
         ws.select_protocol([(BIN_PROTOCOL, Protocol::Binary), (TEXT_PROTOCOL, Protocol::Text)]);

--- a/crates/client-api/src/util.rs
+++ b/crates/client-api/src/util.rs
@@ -79,14 +79,12 @@ impl NameOrAddress {
 
     /// Resolve this [`NameOrAddress`].
     ///
-    /// If `self` is a [`NameOrAddress::Address`], the returned
-    /// [`ResolvedAddress`] contains only an [`Address`] and a `None`
-    /// [`DomainName`].
+    /// If `self` is a [`NameOrAddress::Address`], the inner [`Address`] is
+    /// returned in a [`ResolvedAddress`] without a [`DomainName`].
     ///
     /// Otherwise, if `self` is a [`NameOrAddress::Name`], the [`Address`] is
-    /// looked up by that name in the SpacetimeDB DNS and the returned
-    /// [`ResolvedAddress`] contains both an [`Address`] and `Some`
-    /// [`DomainName`].
+    /// looked up by that name in the SpacetimeDB DNS and returned in a
+    /// [`ResolvedAddress`] alongside `Some` [`DomainName`].
     ///
     /// Errors are returned if [`NameOrAddress::Name`] cannot be parsed into a
     /// [`DomainName`], or the DNS lookup fails.


### PR DESCRIPTION
# Description of Changes

Helps to avoid repeatedly parsing `DomainName`, and to simplify the `/database/publish` handler (not included in this patch).


# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
