### PR TITLE
More compact representation of `DomainName`

### DIFF
--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -626,7 +626,7 @@ pub async fn register_tld(
     // so, unless you are the owner, this will fail, hence not using get_or_create
     let auth = auth_or_bad_request(auth)?;
 
-    let tld = tld.parse::<DomainName>().map_err(DomainParsingRejection)?.into_tld();
+    let tld = tld.parse::<DomainName>().map_err(DomainParsingRejection)?.into();
     let result = ctx
         .control_db()
         .spacetime_register_tld(tld, auth.identity)

--- a/crates/core/src/control_db.rs
+++ b/crates/core/src/control_db.rs
@@ -123,9 +123,7 @@ impl ControlDb {
             None => {
                 if try_register_tld {
                     // Let's try to automatically register this TLD for the identity
-                    let result = self
-                        .spacetime_register_tld(domain.into_tld(), owner_identity)
-                        .await?;
+                    let result = self.spacetime_register_tld(domain.to_tld(), owner_identity).await?;
                     if let RegisterTldResult::Success { .. } = result {
                         // This identity now owns this TLD
                     } else {
@@ -229,7 +227,7 @@ impl ControlDb {
     ///  * `domain` - The domain to lookup
     pub async fn spacetime_lookup_tld(&self, domain: impl AsRef<TldRef>) -> Result<Option<Identity>> {
         let tree = self.db.open_tree("top_level_domains")?;
-        match tree.get(domain.as_str().to_lowercase().as_bytes())? {
+        match tree.get(domain.as_ref().to_lowercase().as_bytes())? {
             Some(owner) => Ok(Some(Identity::from_slice(&owner[..]))),
             None => Ok(None),
         }

--- a/crates/core/src/control_db.rs
+++ b/crates/core/src/control_db.rs
@@ -6,7 +6,7 @@ use crate::identity::Identity;
 use crate::messages::control_db::{Database, DatabaseInstance, EnergyBalance, IdentityEmail, Node};
 use crate::stdb_path;
 
-use spacetimedb_lib::name::{DomainName, DomainParsingError, InsertDomainResult, RegisterTldResult, Tld};
+use spacetimedb_lib::name::{DomainName, DomainParsingError, InsertDomainResult, RegisterTldResult, Tld, TldRef};
 use spacetimedb_lib::recovery::RecoveryCode;
 use spacetimedb_sats::bsatn;
 
@@ -124,7 +124,7 @@ impl ControlDb {
                 if try_register_tld {
                     // Let's try to automatically register this TLD for the identity
                     let result = self
-                        .spacetime_register_tld(domain.tld().clone(), owner_identity)
+                        .spacetime_register_tld(domain.tld().to_owned(), owner_identity)
                         .await?;
                     if let RegisterTldResult::Success { .. } = result {
                         // This identity now owns this TLD
@@ -167,7 +167,8 @@ impl ControlDb {
     /// * `owner_identity` - The identity that should own this domain name.
     pub async fn spacetime_register_tld(&self, tld: Tld, owner_identity: Identity) -> Result<RegisterTldResult> {
         let tree = self.db.open_tree("top_level_domains")?;
-        let current_owner = tree.get(tld.as_lowercase().as_bytes())?;
+        let key = tld.to_lowercase();
+        let current_owner = tree.get(&key)?;
         match current_owner {
             Some(owner) => {
                 if Identity::from_slice(&owner[..]) == owner_identity {
@@ -177,7 +178,7 @@ impl ControlDb {
                 }
             }
             None => {
-                tree.insert(tld.as_lowercase().as_bytes(), owner_identity.as_bytes())?;
+                tree.insert(key, owner_identity.as_bytes())?;
                 Ok(RegisterTldResult::Success { domain: tld })
             }
         }
@@ -226,9 +227,9 @@ impl ControlDb {
     ///
     /// # Arguments
     ///  * `domain` - The domain to lookup
-    pub async fn spacetime_lookup_tld(&self, domain: &Tld) -> Result<Option<Identity>> {
+    pub async fn spacetime_lookup_tld(&self, domain: impl AsRef<TldRef>) -> Result<Option<Identity>> {
         let tree = self.db.open_tree("top_level_domains")?;
-        match tree.get(domain.as_lowercase().as_bytes())? {
+        match tree.get(domain.as_ref().to_lowercase().as_bytes())? {
             Some(owner) => Ok(Some(Identity::from_slice(&owner[..]))),
             None => Ok(None),
         }

--- a/crates/core/src/control_db.rs
+++ b/crates/core/src/control_db.rs
@@ -124,7 +124,7 @@ impl ControlDb {
                 if try_register_tld {
                     // Let's try to automatically register this TLD for the identity
                     let result = self
-                        .spacetime_register_tld(domain.tld().to_owned(), owner_identity)
+                        .spacetime_register_tld(domain.into_tld(), owner_identity)
                         .await?;
                     if let RegisterTldResult::Success { .. } = result {
                         // This identity now owns this TLD
@@ -229,7 +229,7 @@ impl ControlDb {
     ///  * `domain` - The domain to lookup
     pub async fn spacetime_lookup_tld(&self, domain: impl AsRef<TldRef>) -> Result<Option<Identity>> {
         let tree = self.db.open_tree("top_level_domains")?;
-        match tree.get(domain.as_ref().to_lowercase().as_bytes())? {
+        match tree.get(domain.as_str().to_lowercase().as_bytes())? {
             Some(owner) => Ok(Some(Identity::from_slice(&owner[..]))),
             None => Ok(None),
         }

--- a/crates/core/src/control_db/tests.rs
+++ b/crates/core/src/control_db/tests.rs
@@ -19,19 +19,19 @@ async fn test_register_tld() -> anyhow::Result<()> {
     })
     .await??;
 
-    cdb.spacetime_register_tld(domain.tld().clone(), *ALICE).await?;
+    cdb.spacetime_register_tld(domain.tld().to_owned(), *ALICE).await?;
     let owner = cdb.spacetime_lookup_tld(domain.tld()).await?;
     assert_eq!(owner, Some(*ALICE));
 
-    let unauthorized = cdb.spacetime_register_tld(domain.tld().clone(), *BOB).await?;
+    let unauthorized = cdb.spacetime_register_tld(domain.tld().to_owned(), *BOB).await?;
     assert!(matches!(unauthorized, RegisterTldResult::Unauthorized { .. }));
-    let already_registered = cdb.spacetime_register_tld(domain.tld().clone(), *ALICE).await?;
+    let already_registered = cdb.spacetime_register_tld(domain.tld().to_owned(), *ALICE).await?;
     assert!(matches!(
         already_registered,
         RegisterTldResult::AlreadyRegistered { .. }
     ));
-    let (mixed, _) = DomainName::from_str("amAZe")?.into_parts();
-    let already_registered = cdb.spacetime_register_tld(mixed, *ALICE).await?;
+    let domain = DomainName::from_str("amAZe")?;
+    let already_registered = cdb.spacetime_register_tld(domain.tld().to_owned(), *ALICE).await?;
     assert!(matches!(
         already_registered,
         RegisterTldResult::AlreadyRegistered { .. }
@@ -59,7 +59,7 @@ async fn test_domain() -> anyhow::Result<()> {
 
     // Check Alice owns TLD
     let unauthorized = cdb
-        .spacetime_insert_domain(&addr, domain.tld().clone().into(), *BOB, true)
+        .spacetime_insert_domain(&addr, domain.tld().to_owned().into(), *BOB, true)
         .await?;
     assert!(matches!(unauthorized, InsertDomainResult::PermissionDenied { .. }));
 

--- a/crates/core/src/control_db/tests.rs
+++ b/crates/core/src/control_db/tests.rs
@@ -19,19 +19,19 @@ async fn test_register_tld() -> anyhow::Result<()> {
     })
     .await??;
 
-    cdb.spacetime_register_tld(domain.tld().to_owned(), *ALICE).await?;
+    cdb.spacetime_register_tld(domain.into_tld(), *ALICE).await?;
     let owner = cdb.spacetime_lookup_tld(domain.tld()).await?;
     assert_eq!(owner, Some(*ALICE));
 
-    let unauthorized = cdb.spacetime_register_tld(domain.tld().to_owned(), *BOB).await?;
+    let unauthorized = cdb.spacetime_register_tld(domain.into_tld(), *BOB).await?;
     assert!(matches!(unauthorized, RegisterTldResult::Unauthorized { .. }));
-    let already_registered = cdb.spacetime_register_tld(domain.tld().to_owned(), *ALICE).await?;
+    let already_registered = cdb.spacetime_register_tld(domain.into_tld(), *ALICE).await?;
     assert!(matches!(
         already_registered,
         RegisterTldResult::AlreadyRegistered { .. }
     ));
     let domain = DomainName::from_str("amAZe")?;
-    let already_registered = cdb.spacetime_register_tld(domain.tld().to_owned(), *ALICE).await?;
+    let already_registered = cdb.spacetime_register_tld(domain.into_tld(), *ALICE).await?;
     assert!(matches!(
         already_registered,
         RegisterTldResult::AlreadyRegistered { .. }
@@ -59,7 +59,7 @@ async fn test_domain() -> anyhow::Result<()> {
 
     // Check Alice owns TLD
     let unauthorized = cdb
-        .spacetime_insert_domain(&addr, domain.tld().to_owned().into(), *BOB, true)
+        .spacetime_insert_domain(&addr, domain.into_tld().into(), *BOB, true)
         .await?;
     assert!(matches!(unauthorized, InsertDomainResult::PermissionDenied { .. }));
 

--- a/crates/core/src/control_db/tests.rs
+++ b/crates/core/src/control_db/tests.rs
@@ -19,19 +19,19 @@ async fn test_register_tld() -> anyhow::Result<()> {
     })
     .await??;
 
-    cdb.spacetime_register_tld(domain.into_tld(), *ALICE).await?;
+    cdb.spacetime_register_tld(domain.to_tld(), *ALICE).await?;
     let owner = cdb.spacetime_lookup_tld(domain.tld()).await?;
     assert_eq!(owner, Some(*ALICE));
 
-    let unauthorized = cdb.spacetime_register_tld(domain.into_tld(), *BOB).await?;
+    let unauthorized = cdb.spacetime_register_tld(domain.to_tld(), *BOB).await?;
     assert!(matches!(unauthorized, RegisterTldResult::Unauthorized { .. }));
-    let already_registered = cdb.spacetime_register_tld(domain.into_tld(), *ALICE).await?;
+    let already_registered = cdb.spacetime_register_tld(domain.to_tld(), *ALICE).await?;
     assert!(matches!(
         already_registered,
         RegisterTldResult::AlreadyRegistered { .. }
     ));
     let domain = DomainName::from_str("amAZe")?;
-    let already_registered = cdb.spacetime_register_tld(domain.into_tld(), *ALICE).await?;
+    let already_registered = cdb.spacetime_register_tld(domain.to_tld(), *ALICE).await?;
     assert!(matches!(
         already_registered,
         RegisterTldResult::AlreadyRegistered { .. }
@@ -59,7 +59,7 @@ async fn test_domain() -> anyhow::Result<()> {
 
     // Check Alice owns TLD
     let unauthorized = cdb
-        .spacetime_insert_domain(&addr, domain.into_tld().into(), *BOB, true)
+        .spacetime_insert_domain(&addr, domain.to_tld().into(), *BOB, true)
         .await?;
     assert!(matches!(unauthorized, InsertDomainResult::PermissionDenied { .. }));
 

--- a/crates/lib/src/name.rs
+++ b/crates/lib/src/name.rs
@@ -125,9 +125,8 @@ pub enum SetDefaultDomainResult {
 /// of a full [`DomainName`]. A [`Tld`] is also a valid [`DomainName`], and can
 /// be converted to this type.
 ///
-/// Note that [`PartialEq`] compares the exact string representation of
-/// the [`Tld`], as one would expect, but the SpacetimeDB registry compares the
-/// lowercase representation of it.
+/// Note that the SpacetimeDB DNS registry may apply additional restrictions on
+/// what TLDs can be registered.
 #[derive(Debug, Clone, PartialEq, Eq)]
 #[cfg_attr(feature = "serde", derive(serde::Serialize))]
 pub struct Tld(String);

--- a/crates/lib/src/name.rs
+++ b/crates/lib/src/name.rs
@@ -1,7 +1,8 @@
 use core::fmt;
-use std::{ops::Deref, str::FromStr};
+use std::{borrow::Borrow, ops::Deref, str::FromStr};
 
 use serde::{Deserialize, Serialize};
+use spacetimedb_sats::{impl_deserialize, impl_serialize, impl_st};
 
 #[cfg(test)]
 mod tests;
@@ -118,147 +119,125 @@ pub enum SetDefaultDomainResult {
     },
 }
 
-/// A part (component) of a [`DomainName`].
+/// The top level domain part of a [`DomainName`].
 ///
-/// [`DomainPart`]s are compared case-insensitively using their Unicode
-/// lowercase mapping. The original string is used for [`Display`] and
-/// [`Serialize`] purposes.
+/// This newtype witnesses that the TLD is well-formed as per the parsing rules
+/// of a full [`DomainName`]. A [`Tld`] is also a valid [`DomainName`], and can
+/// be converted to this type.
 ///
-/// **Note**: case-insensitive comparison is not the same as unicode case
-/// folding. For example, using case folding, "MASSE" and "Maße" compare as
-/// equal, while lower-casing each doesn't. Using case folding here would be
-/// preferable, as it can detect some instances of words which contain similar-
-/// looking, but distinct characters. This would, however, require support from
-/// SATS or some other way to allow custom collations in STDB.
-///
-/// Currently, both casings are retained (even if they are the same), as we will
-/// likely need both for storage. This may change in the future.
-#[derive(Debug, Clone)]
-pub struct DomainPart {
-    lower: String,
-    mixed: String,
-}
+/// Note that [`PartialEq`] compares the exact string representation of
+/// the [`Tld`], as one would expect, but the SpacetimeDB registry compares the
+/// lowercase representation of it.
+#[derive(Debug, Clone, PartialEq, Eq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize))]
+pub struct Tld(String);
 
-impl DomainPart {
-    pub fn as_lowercase(&self) -> &str {
-        &self.lower
-    }
-
+impl Tld {
     pub fn as_str(&self) -> &str {
-        &self.mixed
+        &self.0
     }
 
-    pub fn is_empty(&self) -> bool {
-        self.mixed.is_empty()
-    }
-
-    /// Length of the original string, in bytes.
-    pub fn len(&self) -> usize {
-        self.mixed.len()
+    pub fn to_lowercase(&self) -> String {
+        self.as_str().to_lowercase()
     }
 }
 
-impl PartialEq for DomainPart {
-    fn eq(&self, other: &Self) -> bool {
-        self.lower.eq(&other.lower)
+impl AsRef<str> for Tld {
+    fn as_ref(&self) -> &str {
+        self.as_str()
     }
 }
 
-impl Serialize for DomainPart {
-    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
-    where
-        S: serde::Serializer,
-    {
-        serializer.serialize_str(self.mixed.as_ref())
+impl AsRef<TldRef> for Tld {
+    fn as_ref(&self) -> &TldRef {
+        TldRef::new(&self.0)
     }
 }
 
-impl<'de> Deserialize<'de> for DomainPart {
+impl fmt::Display for Tld {
+    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
+        f.write_str(&self.0)
+    }
+}
+
+impl From<DomainName> for Tld {
+    fn from(value: DomainName) -> Self {
+        let mut name = value.domain_name;
+        name.truncate(value.tld_offset);
+        Self(name)
+    }
+}
+
+impl_st!([] Tld, _ts => spacetimedb_lib::AlgebraicType::String);
+impl_serialize!([] Tld, (self, ser) => spacetimedb_sats::ser::Serialize::serialize(&self.0, ser));
+impl_deserialize!([] Tld, de => {
+    let s: String = spacetimedb_sats::de::Deserialize::deserialize(de)?;
+    parse_domain_tld(&s).map_err(spacetimedb_sats::de::Error::custom)?;
+    Ok(Self(s))
+});
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for Tld {
     fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
     where
         D: serde::Deserializer<'de>,
     {
-        let s = String::deserialize(deserializer)?;
-        DomainPart::try_from(s).map_err(serde::de::Error::custom)
+        let s: String = serde::Deserialize::deserialize(deserializer)?;
+        parse_domain_tld(&s).map_err(serde::de::Error::custom)?;
+        Ok(Self(s))
     }
 }
 
-impl fmt::Display for DomainPart {
-    fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        f.write_str(&self.mixed)
+/// A slice of a [`Tld`], akin to [`str`].
+#[derive(Debug, PartialEq, Eq)]
+#[repr(transparent)]
+pub struct TldRef(str);
+
+impl TldRef {
+    // Private to enforce parsing
+    fn new(s: &str) -> &Self {
+        // SAFETY: `TldRef` is just a wrapper around `str` with the same memory
+        // representation (`repr(transparent)`), therefore converting `&str` to
+        // `&TldRef` is safe.
+        unsafe { &*(s as *const str as *const TldRef) }
+    }
+
+    pub fn as_str(&self) -> &str {
+        &self.0
     }
 }
 
-impl TryFrom<String> for DomainPart {
-    type Error = DomainParsingError;
-
-    fn try_from(value: String) -> Result<Self, Self::Error> {
-        if value.is_empty() {
-            Err(ParseError::Empty.into())
-        } else if value.contains(|c: char| c.is_whitespace()) {
-            Err(ParseError::Whitespace { input: value }.into())
-        } else {
-            Ok(Self {
-                lower: value.to_lowercase(),
-                mixed: value,
-            })
-        }
+impl AsRef<TldRef> for TldRef {
+    fn as_ref(&self) -> &TldRef {
+        self
     }
 }
 
-impl FromStr for DomainPart {
-    type Err = DomainParsingError;
-
-    fn from_str(s: &str) -> Result<Self, Self::Err> {
-        Self::try_from(s.to_owned())
-    }
-}
-
-/// The top level domain part of a [`DomainName`].
-///
-/// This newtype witnesses that the TLD is well-formed as per the parsing rules
-/// of a full [`DomainName`]. A [`Tld`] is also a valid [`DomainPart`] and valid
-/// [`DomainName`], and can be converted to these types.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
-pub struct Tld(DomainPart);
-
-impl TryFrom<DomainPart> for Tld {
-    type Error = DomainParsingError;
-
-    fn try_from(part: DomainPart) -> Result<Self, Self::Error> {
-        if part.as_str().chars().count() > MAX_CHARS_PART {
-            Err(ParseError::TooLong { part }.into())
-        } else if is_address(part.as_str()) {
-            Err(ParseError::Address { part }.into())
-        } else {
-            Ok(Self(part))
-        }
-    }
-}
-
-impl Deref for Tld {
-    type Target = DomainPart;
+impl Deref for TldRef {
+    type Target = str;
 
     fn deref(&self) -> &Self::Target {
         &self.0
     }
 }
 
-impl fmt::Display for Tld {
+impl Borrow<TldRef> for Tld {
+    fn borrow(&self) -> &TldRef {
+        TldRef::new(&self.0)
+    }
+}
+
+impl ToOwned for TldRef {
+    type Owned = Tld;
+
+    fn to_owned(&self) -> Self::Owned {
+        Tld(self.0.to_owned())
+    }
+}
+
+impl fmt::Display for TldRef {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        self.0.fmt(f)
-    }
-}
-
-impl From<Tld> for DomainName {
-    fn from(tld: Tld) -> Self {
-        Self { tld, sub_domain: None }
-    }
-}
-
-impl From<Tld> for DomainPart {
-    fn from(tld: Tld) -> Self {
-        tld.0
+        f.write_str(&self.0)
     }
 }
 
@@ -287,69 +266,56 @@ impl From<Tld> for DomainPart {
 /// Each segment in a database name can contain any UTF-8 character, except for
 /// whitespace and '/'. The maximum segment length is 64 characters.
 ///
-/// [`DomainName`]s consist of [`DomainPart`]s, and are compared case-
-/// insensitively. Note, however, that the [`fmt::Display`] and [`Serialize`]
-/// impls will use the original, (potentially) mixed-case representation.
+/// Note that [`PartialEq`] compares the exact string representation of a
+/// [`DomainName`], as one would expect, but the SpacetimeDB registry compares
+/// the lowercase representation of it.
 ///
 /// To construct a valid [`DomainName`], use [`parse_domain_name`] or the
 /// [`FromStr`] impl.
-#[derive(Debug, Clone, PartialEq, Serialize, Deserialize)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DomainName {
-    /// The top level domain for the domain name. For example:
-    ///
-    ///  * `clockworklabs/bitcraft`
-    ///
-    /// Here, `clockworklabs` is the tld.
-    tld: Tld,
-    /// The part after the top level domain, this is not required. For example:
-    ///
-    ///  * `clockworklabs/bitcraft`
-    ///
-    /// Here, `bitcraft` is the subdomain.
-    sub_domain: Option<DomainPart>,
+    // Iff there is a subdomain, next char in `domain_name` is '/'.
+    tld_offset: usize,
+    domain_name: String,
 }
 
 impl DomainName {
-    pub fn tld(&self) -> &Tld {
-        &self.tld
+    pub fn as_str(&self) -> &str {
+        &self.domain_name
     }
 
-    /// Drop subdomain, if any, and return only the TLD
-    pub fn into_tld(self) -> Tld {
-        self.tld
+    pub fn tld(&self) -> &TldRef {
+        TldRef::new(&self.domain_name[..self.tld_offset])
     }
 
-    pub fn sub_domain(&self) -> Option<&DomainPart> {
-        self.sub_domain.as_ref()
+    pub fn as_tld(&self) -> Tld {
+        self.tld().to_owned()
+    }
+
+    pub fn sub_domain(&self) -> Option<&str> {
+        if self.tld_offset + 1 < self.domain_name.len() {
+            Some(&self.domain_name[self.tld_offset + 1..])
+        } else {
+            None
+        }
     }
 
     /// Render the name as a lower-case, '/'-separated string, suitable for use
     /// as a unique constrained field in a database.
     pub fn to_lowercase(&self) -> String {
-        let mut s = String::with_capacity(
-            self.tld.lower.len() + self.sub_domain.as_ref().map(|part| part.lower.len() + 1).unwrap_or(0),
-        );
-        s.push_str(&self.tld.lower);
-        if let Some(sub) = &self.sub_domain {
-            s.push('/');
-            s.push_str(&sub.lower);
-        }
-        s
+        self.as_str().to_lowercase()
     }
+}
 
-    pub fn into_parts(self) -> (Tld, Option<DomainPart>) {
-        (self.tld, self.sub_domain)
+impl AsRef<str> for DomainName {
+    fn as_ref(&self) -> &str {
+        self.as_str()
     }
 }
 
 impl fmt::Display for DomainName {
     fn fmt(&self, f: &mut fmt::Formatter) -> fmt::Result {
-        write!(f, "{}", self.tld)?;
-        if let Some(sub) = &self.sub_domain {
-            write!(f, "/{}", sub)?;
-        }
-
-        Ok(())
+        f.write_str(&self.domain_name)
     }
 }
 
@@ -361,7 +327,46 @@ impl FromStr for DomainName {
     }
 }
 
-#[derive(Debug, Clone, Serialize, Deserialize)]
+impl From<Tld> for DomainName {
+    fn from(tld: Tld) -> Self {
+        let domain_name = tld.0;
+        Self {
+            tld_offset: domain_name.len(),
+            domain_name,
+        }
+    }
+}
+
+impl_st!([] DomainName, _ts => spacetimedb_lib::AlgebraicType::String);
+impl_serialize!([] DomainName, (self, ser) => spacetimedb_sats::ser::Serialize::serialize(self.as_str(), ser));
+impl_deserialize!([] DomainName, de => {
+    let s: String = spacetimedb_sats::de::Deserialize::deserialize(de)?;
+    parse_domain_name(s).map_err(spacetimedb_sats::de::Error::custom)
+});
+
+#[cfg(feature = "serde")]
+impl serde::Serialize for DomainName {
+    fn serialize<S>(&self, serializer: S) -> Result<S::Ok, S::Error>
+    where
+        S: serde::Serializer,
+    {
+        serde::Serialize::serialize(self.as_str(), serializer)
+    }
+}
+
+#[cfg(feature = "serde")]
+impl<'de> serde::Deserialize<'de> for DomainName {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let s: String = serde::Deserialize::deserialize(deserializer)?;
+        parse_domain_name(s).map_err(serde::de::Error::custom)
+    }
+}
+
+#[derive(Debug, Clone)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct ReverseDNSResponse {
     pub names: Vec<DomainName>,
 }
@@ -384,17 +389,19 @@ enum ParseError {
     #[error("Database names cannot be empty")]
     Empty,
     #[error("Addresses cannot be database names: `{part}`")]
-    Address { part: DomainPart },
+    Address { part: String },
     #[error("Database names must not start with a slash: `{input}`")]
     StartsSlash { input: String },
     #[error("Database names must not end with a slash: `{input}`")]
     EndsSlash { input: String },
     #[error("Database names must not have 2 consecutive slashes: `{input}`")]
     SlashSlash { input: String },
+    #[error("Domain name parts must not contain slashes: `{part}`")]
+    ContainsSlash { part: String },
     #[error("Database names must not contain whitespace: `{input}`")]
     Whitespace { input: String },
     #[error("Domain name parts must be shorter than {MAX_CHARS_PART} characters: `{part}`")]
-    TooLong { part: DomainPart },
+    TooLong { part: String },
     #[error("Domains cannot have more the {MAX_SUBDOMAINS} subdomains: `{input}`")]
     TooManySubdomains { input: String },
 }
@@ -408,58 +415,92 @@ pub const MAX_SUBDOMAINS: usize = 256;
 /// Parses a [`DomainName`].
 ///
 /// For more information, see the documentation of [`DomainName`].
-pub fn parse_domain_name(domain: &str) -> Result<DomainName, DomainParsingError> {
-    if domain.is_empty() {
+pub fn parse_domain_name<S>(domain: S) -> Result<DomainName, DomainParsingError>
+where
+    S: AsRef<str> + Into<String>,
+{
+    let input = domain.as_ref();
+    if input.is_empty() {
         return Err(ParseError::Empty.into());
     }
-    let mut parts = domain.split('/');
+    let mut parts = input.split('/');
 
     let tld = parts.next().ok_or(ParseError::Empty)?;
+    // Check len for refined error.
     if tld.is_empty() {
-        return Err(ParseError::StartsSlash {
-            input: domain.to_owned(),
-        }
-        .into());
+        return Err(ParseError::StartsSlash { input: domain.into() }.into());
     }
-    let tld = DomainPart::from_str(tld).and_then(Tld::try_from)?;
+    parse_domain_tld(tld)?;
+    let tld_offset = tld.len();
 
-    let mut sub_domain = String::with_capacity(domain.len() - tld.len());
     let mut parts = parts.peekable();
     for (i, part) in parts.by_ref().enumerate() {
         if i + 1 > MAX_SUBDOMAINS {
-            return Err(ParseError::TooManySubdomains {
-                input: domain.to_owned(),
-            }
-            .into());
+            return Err(ParseError::TooManySubdomains { input: domain.into() }.into());
         }
         if part.is_empty() {
             // no idea why borrowchk accepts this lol
             let err = if parts.peek().is_some() {
-                ParseError::SlashSlash {
-                    input: domain.to_owned(),
-                }
+                ParseError::SlashSlash { input: domain.into() }
             } else {
-                ParseError::EndsSlash {
-                    input: domain.to_owned(),
-                }
+                ParseError::EndsSlash { input: domain.into() }
             };
             return Err(err.into());
         }
-        if part.chars().count() > MAX_CHARS_PART {
-            return Err(ParseError::TooLong { part: tld.into() }.into());
-        }
-
-        if i > 0 {
-            sub_domain.push('/');
-        }
-        sub_domain.push_str(part);
+        parse_domain_segment(part)?;
     }
 
-    let sub_domain = if sub_domain.is_empty() {
-        None
-    } else {
-        Some(DomainPart::try_from(sub_domain)?)
-    };
+    Ok(DomainName {
+        tld_offset,
+        domain_name: domain.into(),
+    })
+}
 
-    Ok(DomainName { tld, sub_domain })
+fn parse_domain_segment(input: &str) -> Result<(), ParseError> {
+    DomainSegment::try_from(input).map(|_| ())
+}
+
+fn parse_domain_tld(input: &str) -> Result<(), ParseError> {
+    DomainTld::try_from(input).map(|_| ())
+}
+
+/// Parsing helper to validate (path) segments of a [`DomainName`], without
+/// consuming the input.
+struct DomainSegment<'a>(&'a str);
+
+impl<'a> TryFrom<&'a str> for DomainSegment<'a> {
+    type Error = ParseError;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        if value.is_empty() {
+            Err(ParseError::Empty)
+        } else if value.chars().count() > MAX_CHARS_PART {
+            Err(ParseError::TooLong { part: value.to_owned() })
+        } else if value.contains(|c: char| c.is_whitespace()) {
+            Err(ParseError::Whitespace {
+                input: value.to_string(),
+            })
+        } else {
+            Ok(Self(value))
+        }
+    }
+}
+
+/// Parsing helper to validate a [`DomainSegment`] is a valid [`Tld`], without
+/// consuming the input.
+struct DomainTld<'a>(&'a str);
+
+impl<'a> TryFrom<&'a str> for DomainTld<'a> {
+    type Error = ParseError;
+
+    fn try_from(value: &'a str) -> Result<Self, Self::Error> {
+        let DomainSegment(value) = DomainSegment::try_from(value)?;
+        if value.contains('/') {
+            Err(ParseError::ContainsSlash { part: value.to_owned() })
+        } else if is_address(value) {
+            Err(ParseError::Address { part: value.to_owned() })
+        } else {
+            Ok(Self(value))
+        }
+    }
 }

--- a/crates/lib/src/name.rs
+++ b/crates/lib/src/name.rs
@@ -280,6 +280,7 @@ pub struct DomainName {
 }
 
 impl DomainName {
+    /// Returns a string slice with the domain name.
     pub fn as_str(&self) -> &str {
         &self.domain_name
     }
@@ -456,11 +457,11 @@ where
     })
 }
 
-fn parse_domain_segment(input: &str) -> Result<(), ParseError> {
+fn ensure_domain_segment(input: &str) -> Result<(), ParseError> {
     DomainSegment::try_from(input).map(|_| ())
 }
 
-fn parse_domain_tld(input: &str) -> Result<(), ParseError> {
+fn ensure_domain_tld(input: &str) -> Result<(), ParseError> {
     DomainTld::try_from(input).map(|_| ())
 }
 
@@ -486,8 +487,8 @@ impl<'a> TryFrom<&'a str> for DomainSegment<'a> {
     }
 }
 
-/// Parsing helper to validate a [`DomainSegment`] is a valid [`Tld`], without
-/// consuming the input.
+/// Parsing helper to validate that a [`DomainSegment`] is a valid [`Tld`],
+/// without consuming the input.
 struct DomainTld<'a>(&'a str);
 
 impl<'a> TryFrom<&'a str> for DomainTld<'a> {

--- a/crates/lib/src/name/tests.rs
+++ b/crates/lib/src/name/tests.rs
@@ -1,40 +1,68 @@
+use std::iter;
+
+use itertools::Itertools as _;
 use proptest::prelude::*;
 
 use super::*;
 
+fn gen_valid_domain_name() -> impl Strategy<Value = String> {
+    "[\\S&&[^/]]{1,64}(/[\\S&&[^/]]{1,64}){0,255}"
+}
+
 proptest! {
     #[test]
-    fn prop_domain_part_displays_input(s in "\\S{1,64}") {
-        let dp = DomainPart::try_from(s).unwrap();
-        prop_assert_eq!(dp.as_str(), &dp.to_string());
+    fn prop_domain_name_parses(s in gen_valid_domain_name()) {
+        let domain = parse_domain_name(s);
+        prop_assert!(matches!(domain, Ok(_)), "expected ok, got err: {domain:?}")
     }
 
     #[test]
-    fn prop_domain_part_serdes_input(s in "\\S{1,64}") {
-        let dp = DomainPart::try_from(s).unwrap();
-        let js = serde_json::to_string(&dp).unwrap();
-        let de: DomainPart = serde_json::from_str(&js).unwrap();
-        prop_assert_eq!(dp.as_str(), de.as_str());
+    fn prop_domain_name_displays_input(s in gen_valid_domain_name()) {
+        let domain = DomainName::from_str(&s).unwrap();
+        prop_assert_eq!(s, domain.to_string())
     }
 
     #[test]
-    fn prop_domain_part_compares_lowercase(s in "\\S{1,64}") {
-        let a = DomainPart::try_from(s.to_lowercase()).unwrap();
-        let b = DomainPart::try_from(s).unwrap();
-        prop_assert_eq!(a, b);
-    }
-
-    #[test]
-    fn prop_domain_name_parser_is_equivalent_to_this_horrifying_regex(
-        s in "[\\S&&[^/]]{1,64}(/[\\S&&[^/]]{1,64}){0,255}"
+    fn prop_domain_name_into_parse(
+        tld in "[\\S&&[^/]]{1,64}",
+        sub in prop::option::of(gen_valid_domain_name())
     ) {
-        prop_assert!(matches!(parse_domain_name(&s), Ok(_)))
+        let domain = parse_domain_name(iter::once(tld.as_str()).chain(sub.as_deref()).join("/")).unwrap();
+        prop_assert_eq!(&tld, domain.tld().as_str());
+        prop_assert_eq!(sub.as_deref(), domain.sub_domain());
+        let domain_tld = Tld::from(domain);
+        prop_assert_eq!(&tld, domain_tld.as_str());
+    }
+
+    #[test]
+    fn prop_domain_name_serde(s in gen_valid_domain_name()) {
+        let a = parse_domain_name(s).unwrap();
+        let js = serde_json::to_string(&a).unwrap();
+        eprintln!("json: `{js}`");
+        let b: DomainName = serde_json::from_str(&js).unwrap();
+        prop_assert_eq!(a, b)
+    }
+
+    #[test]
+    fn prop_domain_name_sats(s in gen_valid_domain_name()) {
+        let a = parse_domain_name(s).unwrap();
+        let bsatn = spacetimedb_sats::bsatn::to_vec(&a).unwrap();
+        let b: DomainName = spacetimedb_sats::bsatn::from_slice(&bsatn).unwrap();
+        prop_assert_eq!(a, b)
+    }
+
+    #[test]
+    fn prop_domain_name_inequality(a in gen_valid_domain_name(), b in gen_valid_domain_name()) {
+        prop_assume!(a != b);
+        let a = parse_domain_name(a).unwrap();
+        let b = parse_domain_name(b).unwrap();
+        prop_assert_ne!(a, b);
     }
 
     #[test]
     fn prop_domain_name_must_not_start_with_slash(s in "/\\S{1,100}") {
         assert!(matches!(
-           parse_domain_name(&s),
+           parse_domain_name(s),
            Err(DomainParsingError(ParseError::StartsSlash { .. })),
         ))
     }
@@ -42,7 +70,7 @@ proptest! {
     #[test]
     fn prop_domain_name_must_not_end_with_slash(s in "[\\S&&[^/]]{1,64}/") {
         assert!(matches!(
-            parse_domain_name(&s),
+            parse_domain_name(s),
             Err(DomainParsingError(ParseError::EndsSlash { .. }))
         ))
     }
@@ -50,15 +78,15 @@ proptest! {
     #[test]
     fn prop_domain_name_must_not_contain_slashslash(s in "[\\S&&[^/]]{1,25}//[\\S&&[^/]]{1,25}") {
         assert!(matches!(
-            parse_domain_name(&s),
+            parse_domain_name(s),
             Err(DomainParsingError(ParseError::SlashSlash { .. }))
         ))
     }
 
     #[test]
-    fn prop_domain_name_must_not_contain_whitespace(s in "[\\S&&[^/]]{0,25}\\s{1,25}[\\S&&[^/]]{0,25}") {
+    fn prop_domain_name_must_not_contain_whitespace(s in "[\\S&&[^/]]{0,10}\\s{1,10}[\\S&&[^/]]{0,10}") {
         assert!(matches!(
-            parse_domain_name(&s),
+            parse_domain_name(s),
             Err(DomainParsingError(ParseError::Whitespace { .. }))
         ))
     }
@@ -66,7 +94,7 @@ proptest! {
     #[test]
     fn prop_domain_name_parts_must_not_exceed_max_chars(s in "[\\S&&[^/]]{65}(/[\\S&&[^/]]{65})*") {
         assert!(matches!(
-            parse_domain_name(&s),
+            parse_domain_name(s),
             Err(DomainParsingError(ParseError::TooLong { .. }))
         ))
     }
@@ -74,7 +102,7 @@ proptest! {
     #[test]
     fn prop_domain_name_cannot_have_unlimited_subdomains(s in "[\\S&&[^/]]{1,64}(/[\\S&&[^/]]{1,64}){257}") {
         assert!(matches!(
-            parse_domain_name(&s),
+            parse_domain_name(s),
             Err(DomainParsingError(ParseError::TooManySubdomains { .. }))
         ))
     }
@@ -83,7 +111,7 @@ proptest! {
     fn prop_tld_cannot_be_address(addr_bytes in any::<[u8; 16]>()) {
         let addr = hex::encode(addr_bytes);
         assert!(matches!(
-            parse_domain_name(&addr),
+            parse_domain_name(addr),
             Err(DomainParsingError(ParseError::Address { .. }))
         ))
     }
@@ -91,16 +119,13 @@ proptest! {
     #[test]
     fn prop_but_tld_can_be_some_other_hex_value(bytes in any::<[u8; 32]>()) {
         let addr = hex::encode(bytes);
-        prop_assert!(matches!(parse_domain_name(&addr), Ok(_)))
+        prop_assert!(matches!(parse_domain_name(addr), Ok(_)))
     }
 }
 
 #[test]
-fn test_domain_part_cannot_be_empty() {
-    assert!(matches!(
-        DomainPart::try_from(String::new()),
-        Err(DomainParsingError(ParseError::Empty))
-    ))
+fn test_domain_segment_cannot_be_empty() {
+    assert!(matches!(DomainSegment::try_from(""), Err(ParseError::Empty)))
 }
 
 #[test]
@@ -109,4 +134,14 @@ fn test_domain_name_cannot_be_empty() {
         parse_domain_name(""),
         Err(DomainParsingError(ParseError::Empty))
     ))
+}
+
+#[test]
+fn test_tld_is_domain_name() {
+    let dom = parse_domain_name("spacetimedb/drop").unwrap();
+    let tld = Tld::from(dom);
+    let dom = DomainName::from(tld);
+
+    assert_eq!("spacetimedb", dom.tld().as_str());
+    assert_eq!(None, dom.sub_domain());
 }

--- a/crates/lib/src/name/tests.rs
+++ b/crates/lib/src/name/tests.rs
@@ -3,6 +3,8 @@ use std::iter;
 use itertools::Itertools as _;
 use proptest::prelude::*;
 
+use spacetimedb_sats::bsatn;
+
 use super::*;
 
 fn gen_valid_domain_name() -> impl Strategy<Value = String> {
@@ -46,8 +48,8 @@ proptest! {
     #[test]
     fn prop_domain_name_sats(s in gen_valid_domain_name()) {
         let a = parse_domain_name(s).unwrap();
-        let bsatn = spacetimedb_sats::bsatn::to_vec(&a).unwrap();
-        let b: DomainName = spacetimedb_sats::bsatn::from_slice(&bsatn).unwrap();
+        let bsatn = bsatn::to_vec(&a).unwrap();
+        let b: DomainName = bsatn::from_slice(&bsatn).unwrap();
         prop_assert_eq!(a, b)
     }
 


### PR DESCRIPTION
# Description of Changes

It seemed at some point feasible to pass a custom `Ord` dictionary to STDB _somehow_, but it isn't. As `DomainName` gets lowered to a `String` anyway, we can represent it more compactly as a `String` + offset to where the TLD part ends.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
