### PR TITLE
Add `/identity/public-key` route to get ECDSA public key

### DIFF
--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -84,16 +84,32 @@ pub trait ControlCtx: ControlNodeDelegate + Send + Sync {
 }
 
 #[async_trait]
+/// Access to the SpacetimeDB control plane.
+///
+/// Implementors of this trait are able to delegate requests to a `ControlCtx`
+/// through some unspecified method.
+/// In SpacetimeDB-standalone, this manifests as a direct in-program call to the control node.
+/// In SpacetimeDB-cloud, worker nodes' `ControlNodeDelegate` implementations
+/// may make network requests to the control node to handle some of these methods.
 pub trait ControlNodeDelegate: Send + Sync {
+    /// Resolve a database name to an address.
     async fn spacetime_dns(&self, domain: &DomainName) -> spacetimedb::control_db::Result<Option<Address>>;
 
+    /// Create a new, unique `Identity`.
     async fn alloc_spacetime_identity(&self) -> spacetimedb::control_db::Result<Identity>;
 
+    /// Subtract `amount` from the energy balance of `identity`.
     async fn withdraw_energy(&self, identity: &Identity, amount: EnergyQuanta) -> spacetimedb::control_db::Result<()>;
 
+    /// Return a JWT decoding key for verifying credentials.
     fn public_key(&self) -> &DecodingKey;
+
+    /// Return a JWT encoding key for signing credentials.
     fn private_key(&self) -> &EncodingKey;
 
+    /// Return the public key used to verify JWTs, as the bytes of a PEM public key file.
+    ///
+    /// The `/identity/public-key` route calls this method to return the public key to callers.
     fn public_key_bytes(&self) -> &[u8];
 }
 

--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -93,6 +93,8 @@ pub trait ControlNodeDelegate: Send + Sync {
 
     fn public_key(&self) -> &DecodingKey;
     fn private_key(&self) -> &EncodingKey;
+
+    fn public_key_bytes(&self) -> &[u8];
 }
 
 pub struct ArcEnv<T: ?Sized>(pub Arc<T>);
@@ -134,6 +136,9 @@ impl<T: ControlNodeDelegate + ?Sized> ControlNodeDelegate for ArcEnv<T> {
     fn private_key(&self) -> &EncodingKey {
         self.0.private_key()
     }
+    fn public_key_bytes(&self) -> &[u8] {
+        self.0.public_key_bytes()
+    }
 }
 
 #[async_trait]
@@ -155,6 +160,9 @@ impl<T: ControlNodeDelegate + ?Sized> ControlNodeDelegate for Arc<T> {
     }
     fn private_key(&self) -> &EncodingKey {
         (**self).private_key()
+    }
+    fn public_key_bytes(&self) -> &[u8] {
+        (**self).public_key_bytes()
     }
 }
 

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -46,6 +46,7 @@ pub struct StandaloneEnv {
     client_actor_index: ClientActorIndex,
     public_key: DecodingKey,
     private_key: EncodingKey,
+    public_key_bytes: Box<[u8]>,
 
     /// The following config applies to the whole environment minus the control_db and object_db.
     config: Config,
@@ -60,7 +61,7 @@ impl StandaloneEnv {
         let energy_monitor = Arc::new(StandaloneEnergyMonitor::new());
         let host_controller = Arc::new(HostController::new(energy_monitor.clone()));
         let client_actor_index = ClientActorIndex::new();
-        let (public_key, private_key) = get_or_create_keys()?;
+        let (public_key, private_key, public_key_bytes) = get_or_create_keys()?;
         let this = Arc::new(Self {
             worker_db,
             control_db,
@@ -70,6 +71,8 @@ impl StandaloneEnv {
             client_actor_index,
             public_key,
             private_key,
+            public_key_bytes,
+
             config,
         });
         energy_monitor.set_standalone_env(this.clone());
@@ -77,7 +80,7 @@ impl StandaloneEnv {
     }
 }
 
-fn get_or_create_keys() -> anyhow::Result<(DecodingKey, EncodingKey)> {
+fn get_or_create_keys() -> anyhow::Result<(DecodingKey, EncodingKey, Box<[u8]>)> {
     let public_key_path =
         get_key_path("SPACETIMEDB_JWT_PUB_KEY").expect("SPACETIMEDB_JWT_PUB_KEY must be set to a valid path");
     let private_key_path =
@@ -101,10 +104,12 @@ fn get_or_create_keys() -> anyhow::Result<(DecodingKey, EncodingKey)> {
         anyhow::bail!("Unable to read private key for JWT token signing");
     }
 
-    let encoding_key = EncodingKey::from_ec_pem(&private_key_bytes.unwrap())?;
-    let decoding_key = DecodingKey::from_ec_pem(&public_key_bytes.unwrap())?;
+    let public_key_bytes = Box::<[u8]>::from(public_key_bytes.unwrap());
 
-    Ok((decoding_key, encoding_key))
+    let encoding_key = EncodingKey::from_ec_pem(&private_key_bytes.unwrap())?;
+    let decoding_key = DecodingKey::from_ec_pem(&public_key_bytes)?;
+
+    Ok((decoding_key, encoding_key, public_key_bytes))
 }
 
 fn read_key(path: &Path) -> anyhow::Result<Vec<u8>> {
@@ -339,6 +344,9 @@ impl spacetimedb_client_api::ControlNodeDelegate for StandaloneEnv {
     }
     fn private_key(&self) -> &EncodingKey {
         &self.private_key
+    }
+    fn public_key_bytes(&self) -> &[u8] {
+        &self.public_key_bytes
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Corollary to https://github.com/clockworklabs/SpacetimeDB/pull/155.

This commit adds a new endpoint to the `/identity` block, which returns the public key STDB uses to decode JWTs. This will allow clients, incl. the CLI and SDKs, to verify multiple identity/token pairs without spamming STDB with requests.

The public key can also be used as a "fingerprint", to identify the server. This will allow clients to determine:
- When multiple URIs or addresses refer to the same STDB instance.
- When a STDB instance has rotated its keys, so past identities become invalid.

Downsides to consider:

- I'm not aware of a good way to encode in the response (MIME type?) that we are specifically returning an ECDSA key. All the response includes is the MIME type `application/pem-certificate-chain` (which isn't even particularly accurate since this is only a public key), and the PEM file itself. Clients will have to "know" (i.e. we will hardcode) that we use ECDSA, which raises the barrier if we ever want to switch to a different algorithm.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
