### PR TITLE
Move cargo deps to the workspace

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1163,31 +1163,11 @@ dependencies = [
 
 [[package]]
 name = "dirs"
-version = "4.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca3aa72a6f96ea37bbc5aa912f6788242832f75369bdfdadcb0e38423f100059"
-dependencies = [
- "dirs-sys 0.3.7",
-]
-
-[[package]]
-name = "dirs"
 version = "5.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "44c45a9d03d6676652bcb5e724c7e988de1acad23a711b5217ab9cbecbec2225"
 dependencies = [
- "dirs-sys 0.4.1",
-]
-
-[[package]]
-name = "dirs-sys"
-version = "0.3.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1b1d1d91c932ef41c0f2663aa8b0ca0342d444d842c06914aa0a7e352d0bada6"
-dependencies = [
- "libc",
- "redox_users",
- "winapi",
+ "dirs-sys",
 ]
 
 [[package]]
@@ -4113,12 +4093,12 @@ name = "spacetimedb-cli"
 version = "0.6.0"
 dependencies = [
  "anyhow",
- "base64 0.13.1",
+ "base64 0.21.2",
  "cargo_metadata",
  "clap 4.3.10",
  "colored",
  "convert_case",
- "dirs 4.0.0",
+ "dirs",
  "duct",
  "email_address",
  "futures",
@@ -4189,7 +4169,7 @@ dependencies = [
  "anyhow",
  "async-trait",
  "backtrace",
- "base64 0.13.1",
+ "base64 0.21.2",
  "bytes",
  "bytestring",
  "clap 4.3.10",
@@ -4336,7 +4316,7 @@ dependencies = [
  "async-trait",
  "axum",
  "clap 4.3.10",
- "dirs 5.0.1",
+ "dirs",
  "hostname",
  "http",
  "log",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -70,6 +70,7 @@ console = { version = "0.15.6" }
 convert_case = "0.6.0"
 criterion = { version = "0.4.0", features = ["async", "async_tokio", "html_reports"] }
 crossbeam-channel = "0.5"
+cursive = "0.20"
 decorum = { version = "0.3.1", default-features = false, features = ["std"] }
 dirs = "5.0.1"
 duct = "0.13.5"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,6 +52,124 @@ rpath = false
 debug = true
 
 [workspace.dependencies]
+anyhow = { version = "1.0.68", features = ["backtrace"] }
+anymap = "0.12"
+async-trait = "0.1.68"
+axum = "0.6"
+arrayvec = "0.7.2"
+backtrace = "0.3.66"
+base64 = "0.21.2"
+byte-unit = "4.0.18"
+bytes = "1.2.1"
+bytestring = { version = "1.2.0", features = ["serde"] }
+cargo_metadata = "0.15.2"
+chrono = { version = "0.4.24", default-features = false }
+clap = { version = "4.2.4", features = ["derive"] }
+colored = "2.0.0"
+console = { version = "0.15.6" }
+convert_case = "0.6.0"
+criterion = { version = "0.4.0", features = ["async", "async_tokio", "html_reports"] }
+crossbeam-channel = "0.5"
+decorum = { version = "0.3.1", default-features = false, features = ["std"] }
+dirs = "5.0.1"
+duct = "0.13.5"
+email_address = "0.2.4"
+enum-as-inner = "0.6"
+flate2 = "1.0.24"
+fs2 = "0.4.3"
+fs-err = "2.9.0"
+futures = "0.3"
+futures-channel = "0.3"
+genawaiter = "0.99.1"
+getrandom = { version = "0.2.7", features = ["custom"] }
+glob = "0.3.1"
+hex = "0.4.3"
+hostname = "^0.3"
+home = "0.5"
+http = "0.2.9"
+humantime = "2.1.0"
+hyper = "0.14.18"
+im = "15.1"
+imara-diff = "0.1.3"
+indexmap = "1.9.2"
+insta = { version = "1.21.0", features = ["toml"] }
+is-terminal = "0.4"
+itertools = "0.10.5"
+jsonwebtoken = { version = "8.1.0" }
+lazy_static = "1.4.0"
+log = "0.4.17"
+once_cell = "1.16"
+parking_lot = { version = "0.12.1", features = ["send_guard", "arc_lock"] }
+pin-project-lite = "0.2.9"
+postgres-types = "0.2.5"
+proc-macro2 = "1.0"
+prometheus = "0.13.0"
+proptest = "1.2.0"
+prost = "0.10"
+prost-build = { version = "0.10" }
+quick-junit = { version = "0.3.2" }
+quote = "1.0.8"
+rand = "0.8.5"
+regex = "1"
+reqwest = { version = "0.11.10", features = ["stream", "json"] }
+rusqlite = {version = "0.29.0", features = ["bundled", "column_decltype"]}
+rustc-demangle = "0.1.21"
+rustc-hash = "1.1.0"
+rust_decimal = {version ="1.29.1", features = ["db-tokio-postgres"]}
+rustyline =  { version = "12.0.0", features = [] }
+scoped-tls = "1.0.1"
+scopeguard = "1.1.0"
+sendgrid = { version = "0.18.1", features = ["async"] }
+serde = "1.0.136"
+serde_json = { version = "1.0.87", features = ["raw_value"] }
+serde_path_to_error = "0.1.9"
+serde_with = { version = "2.2.0", features = ["base64", "hex"] }
+sha1 = "0.10.1"
+sha3 = "0.10.0"
+slab = "0.4.7"
+sled = "0.34.7"
+sqlparser = "0.34.0"
+sqllogictest-engines = "0.13.0"
+sqllogictest="0.13.2"
+strum = { version = "0.24.1", features = ["derive"] }
+syn = { version = "2", features = ["full", "extra-traits"] }
+syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"]}
+tabled = "0.8.0"
+tempdir = "0.3.7"
+tempfile = "3.3"
+termcolor = "1.2.0"
+thiserror = "1.0.37"
+tokio = { version = "1.25.1", features = ["full"] }
+tokio-util = { version = "0.7.4", features = ["time"] }
+tokio-postgres = { version = "0.7.8" , features = ["with-chrono-0_4"] }
+tokio-tungstenite = { version = "0.19", features = ["native-tls"] }
+toml = "0.5"
+tower-http = { version = "0.4.1", features = ["cors"]}
+tracing = "0.1"
+tracing-appender = "0.2.2"
+tracing-core = "0.1"
+tracing-flame = "0.2"
+tracing-log = "0.1"
+tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+url = "2.3.1"
+urlencoding = "2.1.2"
+uuid = { version = "1.2.1", features = ["v4"]}
+wasmbin = "0.6"
+wasmer = "3.1.*"
+wasmer-middlewares = "3.1.*"
+wasmer-vm = "3.1.*"
+wasmparser = "0.92.0"
+wasmtime = { version = "7", default-features = false, features = ["cranelift"] }
+
+# We use the "ondemand" feature to allow connecting after the start,
+# and reconnecting, from the tracy client to the database.
+# TODO(George): Need to be able to remove "broadcast" in some build configurations.
+tracing-tracy = { version = "0.10.2", features = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer", "broadcast", "ondemand" ]}
+
 # Vendor the openssl we rely on, rather than depend on a
 # potentially very old system version.
 openssl = { version = "0.10", features = ["vendored"] }
+
+# Rocksdb ostorage backend, linked only if "rocksdb" feature enabled.
+# if we link bzip, we get multiple defs
+rocksdb = {version = "0.19.0", default-features = false, features = ["lz4"]}

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -23,12 +23,12 @@ spacetimedb-standalone = { path = "../standalone" }
 spacetimedb-client-api = { path = "../client-api" }
 spacetimedb-testing = { path = "../testing" }
 
-clap = { version = "4.2.4", features = ["derive"] }
-rusqlite = {version = "0.29.0", features = ["bundled", "column_decltype"]}
-criterion = { version = "0.4.0", features = ["async", "async_tokio", "html_reports"] }
-tempdir = "0.3.7"
-rand = { version = "0.8.5", features = [] }
-tokio = { version = "1.25", features = ["full"]}
-serde_json = "1.0"
-anyhow = "1.0"
-byte-unit = "4.0.18"
+clap.workspace = true
+rusqlite.workspace = true
+criterion.workspace = true
+tempdir.workspace = true
+rand.workspace = true
+tokio.workspace = true
+serde_json.workspace = true
+anyhow.workspace = true
+byte-unit.workspace = true

--- a/crates/bindings-macro/Cargo.toml
+++ b/crates/bindings-macro/Cargo.toml
@@ -10,10 +10,8 @@ proc-macro = true
 # Benching off, because of https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 bench = false
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
-proc-macro2 = "1.0"
-syn = { version = "2", features = ["full", "extra-traits"] }
-quote = "1.0.8"
-humantime = "2.1.0"
+humantime.workspace = true
+proc-macro2.workspace = true
+quote.workspace = true
+syn.workspace = true

--- a/crates/bindings-sys/Cargo.toml
+++ b/crates/bindings-sys/Cargo.toml
@@ -10,4 +10,4 @@ description = "Easy support for interacting between SpacetimeDB and Rust."
 bench = false
 
 [dependencies]
-getrandom = { version = "0.2.7", features = ["custom"], optional = true }
+getrandom = {workspace = true, optional = true}

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -19,10 +19,11 @@ getrandom = ["spacetimedb-bindings-sys/getrandom"]
 spacetimedb-bindings-sys = { path = "../bindings-sys", version = "0.6.0" }
 spacetimedb-lib = { path = "../lib", default-features = false, version = "0.6.0"}
 spacetimedb-bindings-macro = { path = "../bindings-macro", version = "0.6.0"}
-once_cell = "1.15.0"
-scoped-tls = "1.0.1"
-log = "0.4.17"
+
+log.workspace = true
+once_cell.workspace = true
+scoped-tls.workspace = true
 
 [dev-dependencies]
-rand = "0.8.5"
-bytes = "1.2.1"
+rand.workspace = true
+bytes.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,36 +17,37 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-clap = { version = "4.2.4", features = ["derive", "env", "string"] }
-reqwest = { version = "0.11.10", features = ["stream", "json"] }
-tokio = { version = "1", features = ["full"] }
-anyhow = { version = "1.0.57", features = ["backtrace"] }
-serde = { version = "1.0.136" , features = ["derive"] }
-serde_json = { version = "1.0", features = ["raw_value", "preserve_order"] }
-toml = "0.5"
-dirs = "4.0"
-tabled = "0.8.0"
 spacetimedb-lib = { path = "../lib", version = "0.6.0", features = ["cli"] }
 spacetimedb-standalone = { path = "../standalone", version = "0.6.0", optional = true }
-convert_case = "0.6.0"
-wasmtime = { version = "7", default-features = false, features = ["cranelift"] }
-colored = "2.0.0"
-duct = "0.13.5"
-base64 = "0.13.1"
-slab = "0.4.7"
-cargo_metadata = "0.15.2"
-email_address = "0.2.4"
-termcolor = "1.2.0"
-is-terminal = "0.4"
-futures = "0.3"
-tempfile = "3.3"
-rustyline =  { version = "12.0.0", features = [] }
-syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"]}
-wasmbin = "0.6"
-itertools = "0.10"
+
+anyhow.workspace = true
+base64.workspace = true
+cargo_metadata.workspace = true
+clap = {workspace = true, features = ["derive", "env", "string"]}
+colored.workspace = true
+convert_case.workspace = true
+dirs.workspace = true
+duct.workspace = true
+email_address.workspace = true
+futures.workspace = true
+is-terminal.workspace = true
+itertools.workspace = true
+reqwest.workspace = true
+rustyline.workspace = true
+serde = { workspace = true, features = ["derive"] }
+serde_json = { workspace = true, features = ["raw_value", "preserve_order"] }
+slab.workspace = true
+syntect.workspace = true
+tabled.workspace = true
+tempfile.workspace = true
+termcolor.workspace = true
+tokio.workspace = true
+toml.workspace = true
+wasmbin.workspace = true
+wasmtime.workspace = true
 
 [dev-dependencies]
-insta = { version = "1.21.0", features = ["toml"] }
+insta.workspace = true
 
 [features]
 tracelogging = []

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -1,3 +1,4 @@
+use base64::{engine::general_purpose::STANDARD as BASE_64_STD, Engine as _};
 use reqwest::RequestBuilder;
 use serde::Deserialize;
 use spacetimedb_lib::name::{is_address, DnsLookupResponse, RegisterTldResult, ReverseDNSResponse};
@@ -190,7 +191,13 @@ pub async fn get_auth_header(
         };
         // The current form is: Authorization: Basic base64("token:<token>")
         let mut auth_header = String::new();
-        auth_header.push_str(format!("Basic {}", base64::encode(format!("token:{}", identity_config.token))).as_str());
+        auth_header.push_str(
+            format!(
+                "Basic {}",
+                BASE_64_STD.encode(format!("token:{}", identity_config.token))
+            )
+            .as_str(),
+        );
         match Identity::from_hex(identity_config.identity.clone()) {
             Ok(identity) => Some((auth_header, identity)),
             Err(_) => {

--- a/crates/client-api-messages/Cargo.toml
+++ b/crates/client-api-messages/Cargo.toml
@@ -6,8 +6,8 @@ license-file = "LICENSE"
 description = "Types for the SpacetimeDB client API messages"
 
 [dependencies]
-strum = { version = "0.24.1", features = ["derive"] }
-prost = "0.10"
+prost.workspace = true
+strum.workspace = true
 
 [build-dependencies]
-prost-build = { version = "0.10" }
+prost-build.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,89 +18,73 @@ name = "odb_flavor_bench"
 harness = false
 
 [dependencies]
-openssl.workspace = true
-
-tokio = { version = "1.2", features = ["full"] }
-wasmer = "3.1.*"
-wasmer-vm = "3.1.*"
-wasmer-middlewares = "3.1.*"
-hex = "0.4.3"
-prost = "0.10"
-lazy_static = "1.4.0"
-# wasmer-compiler-llvm = "2.2.1"
 spacetimedb-lib = { path = "../lib", version = "0.6.0" }
 spacetimedb-sats = { path = "../sats", version = "0.6.0" }
 spacetimedb-vm = { path = "../vm", version = "0.6.0" }
 spacetimedb-client-api-messages = { path = "../client-api-messages", version = "0.6.0" }
-log = "0.4.16"
-hyper = "0.14.18"
-tracing = "0.1"
-tracing-log = "0.1"
-# We use the "ondemand" feature to allow connecting after the start,
-# and reconnecting, from the tracy client to the database.
-# TODO(George): Need to be able to remove "broadcast" in some build configurations.
-tracing-tracy = { version = "0.10.2", features = [ "enable", "system-tracing", "context-switch-tracing", "sampling", "code-transfer", "broadcast", "ondemand" ]}
-tracing-core = "0.1"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
-tracing-appender = "0.2.2"
-tracing-flame = "0.2"
-serde = "1.0.136"
-serde_json = { version = "1.0", features = ["raw_value"] }
-anyhow = { version = "1.0.57", features = ["backtrace"] }
-thiserror = "1.0.37"
-jsonwebtoken = { version = "8.1.0" }
-sha1 = "0.10.1"
-base64 = "0.13.0"
-regex = "1"
-futures = "0.3"
-prometheus = "0.13.0"
-hostname = "^0.3"
-clap = { version = "4.2.4", features = ["derive"] }
-sled = "0.34.7"
-email_address = "0.2.3"
-sqlparser = "0.34.0"
-backtrace = "0.3.66"
-# pprof = { version = "0.10", features = ["flamegraph"] }
-# perf_monitor = "0.2"
-urlencoding = "2.1.2"
-fs2 = "0.4.3"
-once_cell = "1.16"
-sendgrid = { version = "0.18.1", features = ["async"] }
-itertools = "0.10.5"
-pin-project-lite = "0.2.9"
 
-slab = "0.4.7"
-
-# gluesql = "0.10"
-bytes = "1.2.0"
-strum = { version = "0.24.1", features = ["derive"] }
-scopeguard = "1.1.0"
-parking_lot = { version = "0.12.1", features = ["send_guard", "arc_lock"] }
-uuid = { version = "1.2.1", features = ["v4"]}
-crossbeam-channel = "0.5"
-
-# Used for tracelog
-imara-diff = "0.1.3"
-tempdir = "0.3.7"
-flate2 = "1.0.24"
-wasmparser = "0.92.0"
-tokio-util = { version = "0.7.4", features = ["time"] }
-rustc-demangle = "0.1.21"
-serde_with = { version = "2.2.0", features = ["base64", "hex"] }
-serde_path_to_error = "0.1.9"
-genawaiter = "0.99.1"
-async-trait = "0.1.66"
-bytestring = { version = "1.2.0", features = ["serde"] }
-indexmap = "1.9.2"
-rustc-hash = "1.1.0"
-url = "2.3.1"
-
+anyhow.workspace = true
+async-trait.workspace = true
+backtrace.workspace = true
+base64.workspace = true
+bytes.workspace = true
+bytestring.workspace = true
+clap.workspace = true
+crossbeam-channel.workspace = true
+email_address.workspace = true
+flate2.workspace = true
+fs2.workspace = true
+futures.workspace = true
+genawaiter.workspace = true
+hex.workspace = true
+hostname.workspace = true
+hyper.workspace = true
+imara-diff.workspace = true
+indexmap.workspace = true
+itertools.workspace = true
+jsonwebtoken.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+once_cell.workspace = true
+openssl.workspace = true
+parking_lot.workspace = true
+pin-project-lite.workspace = true
+prometheus.workspace = true
+prost.workspace = true
+regex.workspace = true
+rustc-demangle.workspace = true
+rustc-hash.workspace = true
+scopeguard.workspace = true
+sendgrid.workspace = true
+serde.workspace = true
+serde_json.workspace = true
+serde_path_to_error.workspace = true
+serde_with.workspace = true
+sha1.workspace = true
+slab.workspace = true
+sled.workspace = true
+sqlparser.workspace = true
+strum.workspace = true
+tempdir.workspace = true
+thiserror.workspace = true
+tokio-util.workspace = true
+tokio.workspace = true
+tracing-appender.workspace = true
+tracing-core.workspace = true
+tracing-flame.workspace = true
+tracing-log.workspace = true
+tracing-subscriber.workspace = true
+tracing-tracy.workspace = true
+tracing.workspace = true
+url.workspace = true
+urlencoding.workspace = true
+uuid.workspace = true
+wasmer-middlewares.workspace = true
+wasmer-vm.workspace = true
+wasmer.workspace = true
+wasmparser.workspace = true
 # Rocksdb ostorage backend, linked only if "rocksdb" feature enabled.
-[dependencies.rocksdb]
-version = "0.19.0"
-default-features = false
-optional = true
-features = ["lz4"] # if we link bzip, we get multiple defs
+rocksdb = {workspace = true, optional = true}
 
 [features]
 # Optional storage engines.
@@ -110,9 +94,9 @@ tracelogging = []
 default = ["tracelogging", "odb_sled"]
 
 [dev-dependencies]
-rusqlite = {version = "0.29.0", features = ["bundled", "column_decltype"]}
-criterion = { version = "0.4.0", features = ["async", "async_tokio", "html_reports"] }
-rand = "0.8.5"
+rusqlite.workspace = true
+criterion.workspace = true
+rand.workspace = true
 
 [build-dependencies]
-prost-build = { version = "0.10" }
+prost-build.workspace = true

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -1,3 +1,4 @@
+use super::{ArgsTuple, EnergyDiff, InvalidReducerArguments, ReducerArgs, ReducerCallResult, Timestamp};
 use crate::client::ClientConnectionSender;
 use crate::database_logger::LogLevel;
 use crate::db::datastore::traits::{TableId, TxData, TxOp};
@@ -8,6 +9,7 @@ use crate::identity::Identity;
 use crate::json::client_api::{SubscriptionUpdateJson, TableRowOperationJson, TableUpdateJson};
 use crate::protobuf::client_api::{table_row_operation, SubscriptionUpdate, TableRowOperation, TableUpdate};
 use crate::subscription::module_subscription_actor::ModuleSubscriptionManager;
+use base64::{engine::general_purpose::STANDARD as BASE_64_STD, Engine as _};
 use indexmap::IndexMap;
 use spacetimedb_lib::{ReducerDef, TableDef};
 use spacetimedb_sats::{ProductValue, Typespace, WithTypespace};
@@ -16,8 +18,6 @@ use std::convert::Infallible;
 use std::sync::Arc;
 use std::time::Duration;
 use tokio::sync::{mpsc, oneshot};
-
-use super::{ArgsTuple, EnergyDiff, InvalidReducerArguments, ReducerArgs, ReducerCallResult, Timestamp};
 
 #[derive(Debug, Default, Clone)]
 pub struct DatabaseUpdate {
@@ -123,7 +123,7 @@ impl DatabaseUpdate {
                         .ops
                         .into_iter()
                         .map(|op| {
-                            let row_pk = base64::encode(&op.row_pk);
+                            let row_pk = BASE_64_STD.encode(&op.row_pk);
                             TableRowOperationJson {
                                 op: if op.op_type == 1 {
                                     "insert".into()

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -14,7 +14,7 @@ pub fn stdb_path<S>(s: &S) -> PathBuf
 where
     S: AsRef<Path> + ?Sized,
 {
-    STDB_PATH.join(s)
+    dbg!(STDB_PATH.join(s))
 }
 
 // to let us be incremental in updating all the references to what used to be individual lazy_statics

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -19,22 +19,23 @@ serde = ["dep:serde", "spacetimedb-sats/serde", "dep:serde_with", "chrono/serde"
 cli = ["clap"]
 
 [dependencies]
-enum-as-inner = "0.6"
-sha3 = "0.10.0"
-serde = { version = "1.0.136", optional = true }
-hex = "0.4.3"
-thiserror = "1.0.37"
-itertools = "0.10.5"
-anyhow = "1.0.68"
 spacetimedb-bindings-macro = { path = "../bindings-macro", version = "0.6.0" }
 spacetimedb-sats = { path = "../sats", version = "0.6.0" }
-serde_with = { version = "2.2.0", optional = true }
-chrono = { version = "0.4.23", optional = true, default-features = false }
-clap = { version = "4.2.4", optional = true }
+
+anyhow.workspace = true
+chrono = { workspace = true, optional = true }
+clap = {workspace = true, optional = true }
+enum-as-inner.workspace = true
+hex.workspace = true
+itertools.workspace = true
+serde = { workspace = true, optional = true }
+serde_with = {workspace = true, optional = true }
+sha3.workspace = true
+thiserror.workspace = true
 
 [dev-dependencies]
-rand = "0.8.5"
-bytes = "1.2.1"
-serde_json = "1.0.87"
-insta = "1.21.0"
-proptest = "1.2.0"
+rand.workspace = true
+bytes.workspace = true
+serde_json.workspace = true
+insta.workspace = true
+proptest.workspace = true

--- a/crates/replay/Cargo.toml
+++ b/crates/replay/Cargo.toml
@@ -10,9 +10,9 @@ path = "src/main.rs"
 bench = false
 
 [dependencies]
-imara-diff = "0.1.3"
-tempdir = "0.3.7"
-serde_json = "1.0.87"
+imara-diff.workspace = true
+tempdir.workspace = true
+serde_json.workspace = true
 
 [dependencies.spacetimedb-core]
 path = "../core"

--- a/crates/sats/Cargo.toml
+++ b/crates/sats/Cargo.toml
@@ -11,16 +11,17 @@ description = "Spacetime Algebraic Type Notation"
 serde = ["dep:serde", "hex"]
 
 [dependencies]
-decorum = { version = "0.3.1", default-features = false, features = ["std"] }
-enum-as-inner = "0.6"
-serde = { version = "1.0.136", optional = true }
 spacetimedb-bindings-macro = { path = "../bindings-macro", version = "0.6.0" }
-hex = { version = "0.4.3", optional = true }
-itertools = "0.10.5"
-thiserror = "1.0.38"
-arrayvec = "0.7.2"
+
+arrayvec.workspace = true
+decorum.workspace = true
+enum-as-inner.workspace = true
+hex = { workspace = true, optional = true }
+itertools.workspace = true
+serde = { workspace = true, optional = true }
+thiserror.workspace = true
 
 [dev-dependencies]
-rand = "0.8.5"
-bytes = "1.2.1"
-proptest = "1.1.0"
+bytes.workspace = true
+proptest.workspace = true
+rand.workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -27,7 +27,7 @@ tokio.workspace = true
 tokio-tungstenite.workspace = true
 
 [dev-dependencies]
-# for cursive-chat example
-cursive = "0.20"
-futures-channel = "0.3"
 hex.workspace = true
+# for cursive-chat example
+cursive.workspace = true
+futures-channel.workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -11,24 +11,23 @@ description = "A Rust SDK for clients to interface with SpacetimeDB"
 spacetimedb-sats = { path = "../sats", version = "0.6.0" }
 spacetimedb-lib = { path = "../lib", version = "0.6.0" }
 spacetimedb-client-api-messages = { path = "../client-api-messages", version = "0.6.0" }
-tokio-tungstenite = { version = "0.19", features = ["native-tls"] }
-tokio = { version = "1.2", features = ["full"] }
-http = "0.2"
-anyhow = "1.0"
-futures = "0.3"
-prost = "0.10"
-log = "0.4"
-futures-channel = "0.3"
-anymap = "0.12"
-im = "15.1"
-base64 = "0.21"
-home = "0.5"
-lazy_static = "1.4"
+
+anyhow.workspace = true
+anymap.workspace = true
+base64.workspace = true
+futures.workspace = true
+futures-channel.workspace = true
+home.workspace = true
+http.workspace = true
+im.workspace = true
+lazy_static.workspace = true
+log.workspace = true
+prost.workspace = true
+tokio.workspace = true
+tokio-tungstenite.workspace = true
 
 [dev-dependencies]
-# for quickstart-chat example
-hex = "0.4"
 # for cursive-chat example
 cursive = "0.20"
 futures-channel = "0.3"
-
+hex.workspace = true

--- a/crates/sqltest/Cargo.toml
+++ b/crates/sqltest/Cargo.toml
@@ -9,21 +9,21 @@ spacetimedb-lib = { path = "../lib" }
 spacetimedb-core = { path = "../core" }
 spacetimedb-sats = { path = "../sats" }
 
-anyhow = { version = "1" }
-async-trait = "0.1.68"
-clap = { version = "4.2.4", features = ["derive"] }
-chrono = { version = "0.4.24" }
-console = { version = "0.15.6" }
-itertools = "0.10.5"
-glob = "0.3.1"
-fs-err = "2.9.0"
-futures = { version = "0.3", default-features = false }
-quick-junit = { version = "0.3.2" }
-postgres-types = "0.2.5"
-rust_decimal = {version ="1.29.1", features = ["db-tokio-postgres"]}
-rusqlite = {version = "0.29.0", features = ["bundled", "column_decltype"]}
-sqllogictest="0.13.2"
-sqllogictest-engines = "0.13.0"
-tempdir = "*"
-tokio = { version = "1.2", features = ["full"] }
-tokio-postgres = { version = "0.7.8" , features = ["with-chrono-0_4"] }
+anyhow.workspace = true
+async-trait.workspace = true
+chrono.workspace = true
+clap.workspace = true
+console.workspace = true
+fs-err.workspace = true
+futures.workspace = true
+glob.workspace = true
+itertools.workspace = true
+postgres-types.workspace = true
+quick-junit.workspace = true
+rusqlite.workspace = true
+rust_decimal.workspace = true
+sqllogictest-engines.workspace = true
+sqllogictest.workspace = true
+tempdir.workspace = true
+tokio.workspace = true
+tokio-postgres.workspace = true

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -20,19 +20,20 @@ required-features = [] # Features required to build this target (N/A for lib)
 spacetimedb-core = { path = "../core", version = "0.6.0" }
 spacetimedb-lib = { path = "../lib", version = "0.6.0", features = ["cli"] }
 spacetimedb-client-api = { path = "../client-api", version = "0.6.0" }
-tokio = { version = "1.2", features = ["full"] }
-anyhow = { version = "1.0.57", features = ["backtrace"] }
-prometheus = "0.13.0"
-hostname = "^0.3"
-clap = { version = "4.2.4", features = ["derive", "string"] }
-sled = "0.34.7"
-async-trait = "0.1.60"
-log = "0.4.16"
-axum = "0.6"
+
+anyhow.workspace = true
+async-trait.workspace = true
+axum.workspace = true
+clap = { workspace = true, features = ["derive", "string"] }
+dirs.workspace = true
+hostname.workspace = true
+http.workspace = true
+log.workspace = true
 openssl.workspace = true
-http = "0.2.9"
-tower-http = { version = "0.4.1", features = ["cors"]}
-dirs = "5.0.1"
+prometheus.workspace = true
+sled.workspace = true
+tokio.workspace = true
+tower-http.workspace = true
 
 [dev-dependencies]
-serde_json = "1.0"
+serde_json.workspace = true

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -3,15 +3,13 @@ name = "spacetimedb-testing"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [dependencies]
 spacetimedb-lib = { path = "../lib", version = "0.6.0" }
 spacetimedb-core = { path = "../core", version = "0.6.0" }
 spacetimedb-standalone = { path = "../standalone", version = "0.6.0" }
 spacetimedb-client-api = { path = "../client-api", version = "0.6.0" }
 
-tokio = { version = "1.25", features = ["full"]}
-anyhow = "1.0"
-serde_json = "1.0"
-wasmbin = "0.6"
+anyhow.workspace = true
+serde_json.workspace = true
+tokio.workspace = true
+wasmbin.workspace = true

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -6,11 +6,12 @@ license-file = "LICENSE"
 description = "A VM for SpacetimeDB"
 
 [dependencies]
-anyhow = { version = "1.0.57", features = ["backtrace"] }
 spacetimedb-sats= { path = "../sats", version = "0.6.0" }
 spacetimedb-lib = { path = "../lib", version = "0.6.0" }
-thiserror = "1.0.37"
-tracing = "0.1"
+
+anyhow.workspace = true
+thiserror.workspace = true
+tracing.workspace = true
 
 [dev-dependencies]
-tempdir = "0.3.7"
+tempdir.workspace = true

--- a/modules/benchmarks/Cargo.toml
+++ b/modules/benchmarks/Cargo.toml
@@ -11,4 +11,4 @@ crate-type = ["cdylib"]
 [dependencies]
 spacetimedb = { path = "../../crates/bindings" }
 
-anyhow = "1.0"
+anyhow.workspace = true

--- a/modules/quickstart-chat/Cargo.toml
+++ b/modules/quickstart-chat/Cargo.toml
@@ -10,4 +10,4 @@ crate-type = ["cdylib"]
 
 [dependencies]
 spacetimedb = { path = "../../crates/bindings" }
-log = "0.4"
+log.workspace = true

--- a/modules/rust-wasm-test/Cargo.toml
+++ b/modules/rust-wasm-test/Cargo.toml
@@ -12,7 +12,8 @@ bench = false
 
 
 [dependencies]
-anyhow = "1.0.0"
 spacetimedb = { path = "../../crates/bindings" }
 spacetimedb-lib = { path = "../../crates/lib" } # TODO: this should not ever be necessary. `spacetimedb` should provide all module dependencies.
-log = "0.4"
+
+anyhow.workspace = true
+log.workspace = true

--- a/modules/rust-wasm-test/Cargo.toml
+++ b/modules/rust-wasm-test/Cargo.toml
@@ -10,7 +10,6 @@ crate-type = ["cdylib"]
 # Benching off, because of https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 bench = false
 
-
 [dependencies]
 spacetimedb = { path = "../../crates/bindings" }
 spacetimedb-lib = { path = "../../crates/lib" } # TODO: this should not ever be necessary. `spacetimedb` should provide all module dependencies.

--- a/modules/spacetimedb-quickstart/Cargo.toml
+++ b/modules/spacetimedb-quickstart/Cargo.toml
@@ -3,8 +3,6 @@ name = "spacetimedb-quickstart-module"
 version = "0.1.0"
 edition = "2021"
 
-# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
-
 [lib]
 crate-type = ["cdylib"]
 


### PR DESCRIPTION
# Description of Changes

Switch to [workspace cargo deps](https://doc.rust-lang.org/cargo/reference/workspaces.html#the-dependencies-table) for better management & upgrades of deps.

Note: When 2 `.toml` have the same dependency but a different version, I pick the higher one.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
