### PR TITLE
Fix Docker Build (dont merge)

### DIFF
--- a/crates/standalone/Dockerfile
+++ b/crates/standalone/Dockerfile
@@ -1,43 +1,26 @@
-ARG CARGO_PROFILE=release
+FROM rust:1.69.0
 
-FROM rust:1.70 AS chef
-RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
-RUN cargo install cargo-chef@0.1.56
 WORKDIR /usr/src/app
-
-FROM chef AS planner
-COPY . .
-RUN cargo chef prepare --recipe-path recipe.json
-
-FROM chef AS builder
-
 RUN apt-get update && apt-get install -y protobuf-compiler
 
 RUN cargo install cargo-watch@8.4.0
 RUN cargo install flamegraph@0.6.2
 
-COPY --from=planner /usr/src/app/recipe.json .
+COPY . .
+COPY crates/standalone/log.conf /etc/spacetimedb/
 
 ENV CARGO_INCREMENTAL=0
-
 ARG CARGO_PROFILE=release
-
-RUN cargo chef cook -p spacetimedb-standalone --profile=${CARGO_PROFILE}
-
-COPY . .
-RUN cargo build -p spacetimedb-standalone --profile=${CARGO_PROFILE} --locked
-
-FROM builder as env-dev
 ENV SPACETIMEDB_LOG_CONFIG=/usr/src/app/crates/standalone/log.conf
 ENV SPACETIMEDB_JWT_PUB_KEY=/etc/spacetimedb/id_ecdsa.pub
 ENV SPACETIMEDB_JWT_PRIV_KEY=/etc/spacetimedb/id_ecdsa
+
+# We need the container to be able to find the spacetimedb binary reguardless
+# of whether we are building in debug or release
 ENV PATH="/usr/src/app/target/debug:${PATH}"
+ENV PATH="/usr/src/app/target/release:${PATH}"
 
-FROM debian as env-release
-COPY --from=builder /usr/src/app/target/release/spacetimedb /usr/local/bin/
-COPY --from=builder /usr/src/app/crates/standalone/log.conf /etc/spacetimedb/
-
-FROM env-${CARGO_PROFILE}
+RUN cargo build -p spacetimedb-standalone --profile=${CARGO_PROFILE} --locked
 
 EXPOSE 3000
 

--- a/crates/standalone/Dockerfile
+++ b/crates/standalone/Dockerfile
@@ -15,7 +15,7 @@ ENV SPACETIMEDB_LOG_CONFIG=/usr/src/app/crates/standalone/log.conf
 ENV SPACETIMEDB_JWT_PUB_KEY=/etc/spacetimedb/id_ecdsa.pub
 ENV SPACETIMEDB_JWT_PRIV_KEY=/etc/spacetimedb/id_ecdsa
 
-# We need the container to be able to find the spacetimedb binary reguardless
+# We need the container to be able to find the spacetimedb binary regardless
 # of whether we are building in debug or release
 ENV PATH="/usr/src/app/target/debug:${PATH}"
 ENV PATH="/usr/src/app/target/release:${PATH}"

--- a/crates/standalone/Dockerfile
+++ b/crates/standalone/Dockerfile
@@ -3,7 +3,7 @@ ARG CARGO_PROFILE=release
 FROM rust:1.70 AS chef
 RUN rust_target=$(rustc -vV | awk '/^host:/{ print $2 }') && \
   curl https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$rust_target.tgz -fL | tar xz -C $CARGO_HOME/bin
-RUN cargo binstall -y cargo-chef@0.1.56
+RUN cargo binstall -y cargo-chef@0.1.62
 WORKDIR /usr/src/app
 
 FROM chef AS planner

--- a/crates/standalone/Dockerfile
+++ b/crates/standalone/Dockerfile
@@ -1,9 +1,8 @@
 ARG CARGO_PROFILE=release
 
 FROM rust:1.70 AS chef
-RUN rust_target=$(rustc -vV | awk '/^host:/{ print $2 }') && \
-  curl https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$rust_target.tgz -fL | tar xz -C $CARGO_HOME/bin
-RUN cargo binstall -y cargo-chef@0.1.62
+RUN curl https://sh.rustup.rs -sSf | bash -s -- -y
+RUN cargo install cargo-chef@0.1.56
 WORKDIR /usr/src/app
 
 FROM chef AS planner
@@ -14,8 +13,8 @@ FROM chef AS builder
 
 RUN apt-get update && apt-get install -y protobuf-compiler
 
-RUN cargo binstall -y cargo-watch@8.4.0
-RUN cargo binstall -y flamegraph@0.6.2
+RUN cargo install cargo-watch@8.4.0
+RUN cargo install flamegraph@0.6.2
 
 COPY --from=planner /usr/src/app/recipe.json .
 

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,4 +1,4 @@
 [toolchain]
-channel = "1.69"
+channel = "1.69.0"
 profile = "default"
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
# Description of Changes

 - We didn't really change anything and the docker builds stopped working. It seems like binstall was updated and now requires that QUIC be installed on the host system. This PR just installs rustup normally and then installs all of our utils from that.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
