### PR TITLE
Upgrade contributor check perms

### DIFF
--- a/.github/workflows/contributor_check.yml
+++ b/.github/workflows/contributor_check.yml
@@ -25,5 +25,5 @@ jobs:
       - name: Verify author is contributor
         run: node .github/scripts/checkMembership.mjs
         env:
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
 

--- a/.github/workflows/contributor_check.yml
+++ b/.github/workflows/contributor_check.yml
@@ -8,7 +8,7 @@ jobs:
   permissions: read-all
   check_membership:
     name: Contributor Membership Check
-    runs-on: ubuntu-latest
+    runs-on: spacetimedb-runner
     steps:
       - name: Checkout code
         uses: actions/checkout@v2

--- a/.github/workflows/contributor_check.yml
+++ b/.github/workflows/contributor_check.yml
@@ -5,6 +5,7 @@ on:
     types: [opened, synchronize]
 
 jobs:
+  permissions: read-all
   check_membership:
     name: Contributor Membership Check
     runs-on: ubuntu-latest

--- a/.github/workflows/contributor_check.yml
+++ b/.github/workflows/contributor_check.yml
@@ -3,9 +3,9 @@ name: CI
 on:
   pull_request:
     types: [opened, synchronize]
+permissions: read-all
 
 jobs:
-  permissions: read-all
   check_membership:
     name: Contributor Membership Check
     runs-on: spacetimedb-runner


### PR DESCRIPTION
# Description of Changes

 - upgrade the read permissions of the `GITHUB_TOKEN` that is used for checking the author of a PR. This makes it so that we can keep members of the organization private instead of public.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
