### PR TITLE
One-off query support

### DIFF
--- a/crates/client-api-messages/protobuf/client_api.proto
+++ b/crates/client-api-messages/protobuf/client_api.proto
@@ -21,6 +21,10 @@ message Message {
         IdentityToken identityToken = 5;
         // client -> database, register SQL queries on which to receive updates.
         Subscribe subscribe = 6;
+        // client -> database, send a one-off SQL query without establishing a subscription.
+        OneOffQuery oneOffQuery = 7;
+        // database -> client, return results to a one off SQL query.
+        OneOffQueryResponse oneOffQueryResponse = 8;
     }
 }
 
@@ -190,4 +194,34 @@ message TableRowOperation {
 message TransactionUpdate {
     Event event = 1;
     SubscriptionUpdate subscriptionUpdate = 2;
+}
+
+/// A one-off query submission.
+///
+/// Query should be a "SELECT * FROM Table WHERE ...". Other types of queries will be rejected.
+/// Multiple such semicolon-delimited queries are allowed.
+///
+/// One-off queries are identified by a client-generated messageID.
+/// To avoid data leaks, the server will NOT cache responses to messages based on UUID!
+/// It also will not check for duplicate IDs. They are just a way to match responses to messages. 
+message OneOffQuery {
+    bytes messageId = 1;
+    string queryString = 2;
+}
+
+/// A one-off query response.
+/// Will contain either one error or multiple response rows.
+/// At most one of these messages will be sent in reply to any query.
+///
+/// The messageId will be identical to the one sent in the original query.
+message OneOffQueryResponse {
+    bytes messageId = 1;
+    string error = 2;
+    repeated OneOffTable tables = 3;
+}
+
+/// A table included as part of a one-off query.
+message OneOffTable {
+    string tableName = 2;
+    repeated bytes row = 4;
 }

--- a/crates/core/src/client/message_handlers.rs
+++ b/crates/core/src/client/message_handlers.rs
@@ -5,6 +5,7 @@ use crate::host::{EnergyDiff, ReducerArgs, Timestamp};
 use crate::identity::Identity;
 use crate::protobuf::client_api::{message, FunctionCall, Message, Subscribe};
 use crate::worker_metrics::{WEBSOCKET_REQUESTS, WEBSOCKET_REQUEST_MSG_SIZE};
+use base64::Engine;
 use bytes::Bytes;
 use bytestring::ByteString;
 use prost::Message as _;
@@ -20,6 +21,8 @@ pub enum MessageHandleError {
     InvalidMessage,
     #[error(transparent)]
     TextDecode(#[from] serde_json::Error),
+    #[error(transparent)]
+    Base64Decode(#[from] base64::DecodeError),
 
     #[error(transparent)]
     Execution(#[from] MessageExecutionError),
@@ -53,6 +56,10 @@ async fn handle_binary(client: &ClientConnection, message_buf: Vec<u8>) -> Resul
             DecodedMessage::Call { reducer, args }
         }
         Some(message::Type::Subscribe(subscription)) => DecodedMessage::Subscribe(subscription),
+        Some(message::Type::OneOffQuery(ref oneoff)) => DecodedMessage::OneOffQuery {
+            query_string: &oneoff.query_string[..],
+            message_id: &oneoff.message_id[..],
+        },
         _ => return Err(MessageHandleError::InvalidMessage),
     };
 
@@ -61,27 +68,50 @@ async fn handle_binary(client: &ClientConnection, message_buf: Vec<u8>) -> Resul
     Ok(())
 }
 
-async fn handle_text(client: &ClientConnection, message: String) -> Result<(), MessageHandleError> {
-    #[derive(serde::Deserialize)]
-    enum Message<'a> {
-        #[serde(rename = "call")]
-        Call {
-            #[serde(borrow, rename = "fn")]
-            func: std::borrow::Cow<'a, str>,
-            args: &'a serde_json::value::RawValue,
-        },
-        #[serde(rename = "subscribe")]
-        Subscribe { query_strings: Vec<String> },
-    }
+#[derive(serde::Deserialize)]
+enum RawJsonMessage<'a> {
+    #[serde(rename = "call")]
+    Call {
+        #[serde(borrow, rename = "fn")]
+        func: std::borrow::Cow<'a, str>,
+        args: &'a serde_json::value::RawValue,
+    },
+    #[serde(rename = "subscribe")]
+    Subscribe { query_strings: Vec<String> },
+    #[serde(rename = "one_off_query")]
+    OneOffQuery {
+        #[serde(borrow)]
+        query_string: std::borrow::Cow<'a, str>,
 
+        /// A base64-encoded string of bytes.
+        #[serde(borrow)]
+        message_id: std::borrow::Cow<'a, str>,
+    },
+}
+
+async fn handle_text(client: &ClientConnection, message: String) -> Result<(), MessageHandleError> {
     let message = ByteString::from(message);
-    let msg = serde_json::from_str::<Message>(&message)?;
+    let msg = serde_json::from_str::<RawJsonMessage>(&message)?;
+    let mut message_id_ = Vec::new();
     let msg = match msg {
-        Message::Call { ref func, args } => {
+        RawJsonMessage::Call { ref func, args } => {
             let args = ReducerArgs::Json(message.slice_ref(args.get()));
             DecodedMessage::Call { reducer: func, args }
         }
-        Message::Subscribe { query_strings } => DecodedMessage::Subscribe(Subscribe { query_strings }),
+        RawJsonMessage::Subscribe { query_strings } => DecodedMessage::Subscribe(Subscribe { query_strings }),
+        RawJsonMessage::OneOffQuery {
+            query_string: ref query,
+            message_id,
+        } => {
+            let _ = std::mem::replace(
+                &mut message_id_,
+                base64::engine::general_purpose::STANDARD.decode(&message_id[..])?,
+            );
+            DecodedMessage::OneOffQuery {
+                query_string: &query[..],
+                message_id: &message_id_[..],
+            }
+        }
     };
 
     msg.handle(client).await?;
@@ -90,8 +120,15 @@ async fn handle_text(client: &ClientConnection, message: String) -> Result<(), M
 }
 
 enum DecodedMessage<'a> {
-    Call { reducer: &'a str, args: ReducerArgs },
+    Call {
+        reducer: &'a str,
+        args: ReducerArgs,
+    },
     Subscribe(Subscribe),
+    OneOffQuery {
+        query_string: &'a str,
+        message_id: &'a [u8],
+    },
 }
 
 impl DecodedMessage<'_> {
@@ -102,6 +139,10 @@ impl DecodedMessage<'_> {
                 res.map(drop).map_err(|e| (Some(reducer), e.into()))
             }
             DecodedMessage::Subscribe(subscription) => client.subscribe(subscription).map_err(|e| (None, e.into())),
+            DecodedMessage::OneOffQuery {
+                query_string: query,
+                message_id,
+            } => client.one_off_query(query, message_id).await.map_err(|err| (None, err)),
         };
         res.map_err(|(reducer, err)| MessageExecutionError {
             reducer: reducer.map(str::to_owned),
@@ -111,7 +152,7 @@ impl DecodedMessage<'_> {
     }
 }
 
-/// An error that arises from
+/// An error that arises from executing a message.  
 #[derive(thiserror::Error, Debug)]
 #[error("error executing message (reducer: {reducer:?}) (err: {err:?})")]
 pub struct MessageExecutionError {
@@ -152,5 +193,27 @@ impl ServerMessage for MessageExecutionError {
             database_update: Default::default(),
         }
         .serialize_binary()
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::RawJsonMessage;
+
+    #[test]
+    fn parse_one_off_query() {
+        let message = r#"{ "one_off_query": { "message_id": "ywS3WFquDECZQ0UdLZN1IA==", "query_string": "SELECT * FROM User WHERE name != 'bananas'" } }"#;
+        let parsed = serde_json::from_str::<RawJsonMessage>(message).unwrap();
+
+        if let RawJsonMessage::OneOffQuery {
+            query_string: query,
+            message_id,
+        } = parsed
+        {
+            assert_eq!(query, "SELECT * FROM User WHERE name != 'bananas'");
+            assert_eq!(message_id, "ywS3WFquDECZQ0UdLZN1IA==");
+        } else {
+            panic!("wrong variant")
+        }
     }
 }

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -15,6 +15,7 @@ use crate::util::notify_once::NotifyOnce;
 use base64::{engine::general_purpose::STANDARD as BASE_64_STD, Engine as _};
 use futures::{Future, FutureExt};
 use indexmap::IndexMap;
+use spacetimedb_lib::relation::MemTable;
 use spacetimedb_lib::{ReducerDef, TableDef};
 use spacetimedb_sats::{ProductValue, Typespace, WithTypespace};
 use std::collections::HashMap;
@@ -210,6 +211,11 @@ pub trait Module: Send + Sync + 'static {
     fn create_instance(&self) -> Self::Instance;
     fn inject_logs(&self, log_level: LogLevel, message: &str);
     fn close(self);
+    fn one_off_query(
+        &self,
+        caller_identity: Identity,
+        query: String,
+    ) -> Result<Vec<spacetimedb_lib::relation::MemTable>, DBError>;
 
     #[cfg(feature = "tracelogging")]
     fn get_trace(&self) -> Option<bytes::Bytes>;
@@ -300,6 +306,11 @@ impl fmt::Debug for ModuleHost {
 trait DynModuleHost: Send + Sync + 'static {
     async fn get_instance(&self) -> Result<(&HostThreadpool, Box<dyn ModuleInstance>), NoSuchModule>;
     fn inject_logs(&self, log_level: LogLevel, message: &str);
+    fn one_off_query(
+        &self,
+        caller_identity: Identity,
+        query: String,
+    ) -> Result<Vec<spacetimedb_lib::relation::MemTable>, DBError>;
     fn start(&self);
     fn exit(&self) -> Closed<'_>;
     fn exited(&self) -> Closed<'_>;
@@ -362,6 +373,14 @@ impl<T: Module> DynModuleHost for HostControllerActor<T> {
 
     fn inject_logs(&self, log_level: LogLevel, message: &str) {
         self.module.inject_logs(log_level, message)
+    }
+
+    fn one_off_query(
+        &self,
+        caller_identity: Identity,
+        query: String,
+    ) -> Result<Vec<spacetimedb_lib::relation::MemTable>, DBError> {
+        self.module.one_off_query(caller_identity, query)
     }
 
     fn start(&self) {
@@ -561,6 +580,15 @@ impl ModuleHost {
 
     pub fn inject_logs(&self, log_level: LogLevel, message: &str) {
         self.inner.inject_logs(log_level, message)
+    }
+
+    pub async fn one_off_query(
+        &self,
+        caller_identity: Identity,
+        query: String,
+    ) -> Result<Vec<MemTable>, anyhow::Error> {
+        let result = self.inner.one_off_query(caller_identity, query)?;
+        Ok(result)
     }
 
     pub fn downgrade(&self) -> WeakModuleHost {

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -5,10 +5,13 @@ use std::time::{Duration, Instant};
 use crate::db::datastore::locking_tx_datastore::MutTxId;
 use crate::db::datastore::traits::{ColumnDef, IndexDef, IndexId, TableDef, TableSchema};
 use crate::host::scheduler::Scheduler;
+use crate::sql;
 use anyhow::Context;
 use bytes::Bytes;
 use spacetimedb_lib::buffer::DecodeError;
+use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::{bsatn, IndexType, ModuleDef};
+use spacetimedb_vm::expr::CrudExpr;
 
 use crate::client::ClientConnectionSender;
 use crate::database_instance_context::DatabaseInstanceContext;
@@ -248,6 +251,30 @@ impl<T: WasmModule> Module for WasmModuleHostActor<T> {
 
     fn close(self) {
         self.scheduler.close()
+    }
+
+    fn one_off_query(
+        &self,
+        caller_identity: Identity,
+        query: String,
+    ) -> Result<Vec<spacetimedb_lib::relation::MemTable>, DBError> {
+        let db = &self.worker_database_instance.relational_db;
+        let auth = AuthCtx::new(self.worker_database_instance.identity, caller_identity);
+        // TODO(jgilles): make this a read-only TX when those get added
+
+        db.with_read_only(|tx| {
+            log::debug!("One-off query: {query}");
+            // NOTE(jgilles): this returns errors about mutating queries as SubscriptionErrors, which is perhaps
+            // mildly confusing, since the user did not subscribe to anything. Should we rename SubscriptionError to ReadOnlyQueryError?
+            let compiled = crate::subscription::query::compile_read_only_query(db, tx, &auth, &query)?;
+
+            sql::execute::execute_sql(
+                db,
+                tx,
+                compiled.queries.into_iter().map(CrudExpr::Query).collect(),
+                auth,
+            )
+        })
     }
 }
 

--- a/crates/core/src/json/client_api.rs
+++ b/crates/core/src/json/client_api.rs
@@ -34,6 +34,7 @@ pub enum MessageJson {
     Event(EventJson),
     TransactionUpdate(TransactionUpdateJson),
     IdentityToken(IdentityTokenJson),
+    OneOffQueryResponse(OneOffQueryResponseJson),
 }
 
 impl MessageJson {
@@ -96,5 +97,18 @@ pub struct TransactionUpdateJson {
 pub struct StmtResultJson {
     pub schema: ProductType,
     #[serde_as(as = "Vec<Vec<Sats>>")]
+    pub rows: Vec<Vec<AlgebraicValue>>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OneOffQueryResponseJson {
+    pub message_id_base64: String,
+    pub error: Option<String>,
+    pub result: Vec<OneOffTableJson>,
+}
+
+#[derive(Debug, Clone, Serialize)]
+pub struct OneOffTableJson {
+    pub table_name: String,
     pub rows: Vec<Vec<AlgebraicValue>>,
 }

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -1,7 +1,7 @@
 use std::sync::Arc;
 
 use super::{
-    query::compile_query,
+    query::compile_read_only_query,
     subscription::{QuerySet, Subscription},
 };
 use crate::db::datastore::locking_tx_datastore::MutTxId;
@@ -149,7 +149,7 @@ impl ModuleSubscriptionActor {
         let queries: QuerySet = subscription
             .query_strings
             .into_iter()
-            .map(|query| compile_query(&self.relational_db, tx, &auth, &query))
+            .map(|query| compile_read_only_query(&self.relational_db, tx, &auth, &query))
             .collect::<Result<_, _>>()?;
 
         let sub = match self.subscriptions.iter_mut().find(|s| s.queries == queries) {


### PR DESCRIPTION
# Description of Changes

Support one-off queries without establishing a subscription. Took me a while to figure out all the routing. This is (NO LONGER) TOTALLY UNTESTED.

The SQL engine seems to support returning multiple tables so I've routed that through to the client, but I have no idea what queries would actually use that -- @mamcx ?

Also, I don't know how to validate that a query only SELECTs and doesn't do anything else.

@jdetter 

