### PR TITLE
Fix authentication for the TypeScript SDK

### DIFF
--- a/crates/client-api/src/auth.rs
+++ b/crates/client-api/src/auth.rs
@@ -124,9 +124,10 @@ impl<S: ControlNodeDelegate + Send + Sync> axum::extract::FromRequestParts<S> fo
                     //       it would be good to refactor it in the future, ie.
                     //       we don't really need to keep it as a value we get
                     //       from the header
-                    let new_token = encode_token(state.private_key(), identity).map_err(|_| AuthorizationRejection {
-                        reason: AuthorizationRejectionReason::CantEncodeAuthorizationToken,
-                    })?;
+                    let new_token =
+                        encode_token(state.private_key(), identity).map_err(|_| AuthorizationRejection {
+                            reason: AuthorizationRejectionReason::CantEncodeAuthorizationToken,
+                        })?;
                     creds = creds_from_str(&format!("token:{new_token}"))?;
                 }
 

--- a/crates/client-api/src/routes/identity.rs
+++ b/crates/client-api/src/routes/identity.rs
@@ -184,7 +184,7 @@ pub async fn create_websocket_token(
 ) -> axum::response::Result<impl IntoResponse> {
     match auth.auth {
         Some(auth) => {
-            let token = encode_token_with_expiry(ctx.private_key(), auth.identity, Some(60)).map_err(log_and_500)?;
+            let token = encode_token_with_expiry(ctx.private_key(), auth.identity, Some(30)).map_err(log_and_500)?;
             Ok(axum::Json(WebsocketTokenResponse { token }))
         }
         None => Err(StatusCode::UNAUTHORIZED)?,


### PR DESCRIPTION
# Description of Changes
TypeScript SDK returns a token in an onConnect callback. The current behaviour may be confusing when used with a short lived token, cause it will return the short lived token, not a long lived. Thus is someone decides to always save the token received from the callback, it will expire after 30s.

This commit changes the behaviour to generate a new long lived token if a short lived token is used


# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
