### PR TITLE
Move all remaining cargo deps to workspace deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4178,7 +4178,7 @@ dependencies = [
  "tempdir",
  "tokio",
  "tokio-stream",
- "tokio-tungstenite 0.18.0",
+ "tokio-tungstenite 0.19.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -51,6 +51,20 @@ rpath = false
 debug = true
 
 [workspace.dependencies]
+spacetimedb = { path = "crates/bindings", version = "0.6.1" }
+
+spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "0.6.1" }
+spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "0.6.1" }
+spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "0.6.1" }
+spacetimedb-client-api = { path = "crates/client-api", version = "0.6.1" }
+spacetimedb-core = { path = "crates/core", version = "0.6.1" }
+spacetimedb-lib = { path = "crates/lib", version = "0.6.1" }
+spacetimedb-sats = { path = "crates/sats", version = "0.6.1" }
+spacetimedb-standalone = { path = "crates/standalone", version = "0.6.1" }
+spacetimedb-vm = { path = "crates/vm", version = "0.6.1" }
+
+spacetimedb-testing = { path = "crates/testing", version = "0.1" }
+
 anyhow = { version = "1.0.68", features = ["backtrace"] }
 anymap = "0.12"
 async-trait = "0.1.68"
@@ -95,9 +109,11 @@ indexmap = "1.9.2"
 insta = { version = "1.21.0", features = ["toml"] }
 is-terminal = "0.4"
 itertools = "0.10.5"
+itoa = "1.0.9"
 jsonwebtoken = { version = "8.1.0" }
 lazy_static = "1.4.0"
 log = "0.4.17"
+mime = "0.3.17"
 once_cell = "1.16"
 parking_lot = { version = "0.12.1", features = ["send_guard", "arc_lock"] }
 pin-project-lite = "0.2.9"
@@ -143,6 +159,7 @@ thiserror = "1.0.37"
 tokio = { version = "1.25.1", features = ["full"] }
 tokio-util = { version = "0.7.4", features = ["time"] }
 tokio-postgres = { version = "0.7.8" , features = ["with-chrono-0_4"] }
+tokio-stream = "0.1.12"
 tokio-tungstenite = { version = "0.19", features = ["native-tls"] }
 toml = "0.5"
 tower-http = { version = "0.4.1", features = ["cors"]}

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -17,11 +17,11 @@ harness = false
 bench = false
 
 [dependencies]
-spacetimedb-lib = { path = "../lib" }
-spacetimedb-core = { path = "../core" }
-spacetimedb-standalone = { path = "../standalone" }
-spacetimedb-client-api = { path = "../client-api" }
-spacetimedb-testing = { path = "../testing" }
+spacetimedb-lib.workspace = true
+spacetimedb-core.workspace = true
+spacetimedb-standalone.workspace = true
+spacetimedb-client-api.workspace = true
+spacetimedb-testing.workspace = true
 
 clap.workspace = true
 rusqlite.workspace = true

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -16,9 +16,9 @@ bench = false
 getrandom = ["spacetimedb-bindings-sys/getrandom"]
 
 [dependencies]
-spacetimedb-bindings-sys = { path = "../bindings-sys", version = "0.6.1" }
-spacetimedb-lib = { path = "../lib", default-features = false, version = "0.6.1"}
-spacetimedb-bindings-macro = { path = "../bindings-macro", version = "0.6.1"}
+spacetimedb-bindings-sys.workspace = true
+spacetimedb-lib.workspace = true
+spacetimedb-bindings-macro.workspace = true
 
 log.workspace = true
 once_cell.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,8 +17,8 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-spacetimedb-lib = { path = "../lib", version = "0.6.1", features = ["cli"] }
-spacetimedb-standalone = { path = "../standalone", version = "0.6.1", optional = true }
+spacetimedb-lib = { workspace = true, features = ["cli"] }
+spacetimedb-standalone = { workspace = true, optional = true }
 
 anyhow.workspace = true
 base64.workspace = true

--- a/crates/client-api/Cargo.toml
+++ b/crates/client-api/Cargo.toml
@@ -6,28 +6,28 @@ license-file = "LICENSE"
 description = "The HTTP API for SpacetimeDB"
 
 [dependencies]
-spacetimedb-core = { path = "../core", version = "0.6.1" }
-tokio = { version = "1.2", features = ["full"] }
-lazy_static = "1.4.0"
-spacetimedb-lib = { path = "../lib", version = "0.6.1" }
-log = "0.4.4"
-serde = "1.0.136"
-serde_json = { version = "1.0", features = ["raw_value"] }
-anyhow = { version = "1.0.57", features = ["backtrace"] }
-regex = "1"
-prometheus = "0.13.0"
-email_address = "0.2.3"
-tempdir = "0.3.7"
-async-trait = "0.1.60"
-chrono = { version = "0.4.23", features = ["serde"]}
-rand = "0.8.5"
-axum = { version = "0.6.16", features = ["headers", "ws", "tracing"] }
-hyper = "0.14"
-http = "0.2"
-mime = "0.3.17"
-tokio-stream = { version = "0.1.12", features = ["sync"] }
-futures = "0.3"
-bytes = "1"
-bytestring = "1"
-tokio-tungstenite = "0.18.0"
-itoa = "1.0.9"
+spacetimedb-core.workspace = true
+tokio = { workspace = true, features = ["full"] }
+lazy_static.workspace = true
+spacetimedb-lib.workspace = true
+log.workspace = true
+serde.workspace = true
+serde_json = { workspace = true, features = ["raw_value"] }
+anyhow = { workspace = true, features = ["backtrace"] }
+regex.workspace = true
+prometheus.workspace = true
+email_address.workspace = true
+tempdir.workspace = true
+async-trait.workspace = true
+chrono = { workspace = true, features = ["serde"]}
+rand.workspace = true
+axum = { workspace = true, features = ["headers", "ws", "tracing"] }
+hyper.workspace = true
+http.workspace = true
+mime.workspace = true
+tokio-stream = { workspace = true, features = ["sync"] }
+futures.workspace = true
+bytes.workspace = true
+bytestring.workspace = true
+tokio-tungstenite.workspace = true
+itoa.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -18,10 +18,10 @@ name = "odb_flavor_bench"
 harness = false
 
 [dependencies]
-spacetimedb-lib = { path = "../lib", version = "0.6.1" }
-spacetimedb-sats = { path = "../sats", version = "0.6.1" }
-spacetimedb-vm = { path = "../vm", version = "0.6.1" }
-spacetimedb-client-api-messages = { path = "../client-api-messages", version = "0.6.1" }
+spacetimedb-lib.workspace = true
+spacetimedb-sats.workspace = true
+spacetimedb-vm.workspace = true
+spacetimedb-client-api-messages.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -19,8 +19,8 @@ serde = ["dep:serde", "spacetimedb-sats/serde", "dep:serde_with", "chrono/serde"
 cli = ["clap"]
 
 [dependencies]
-spacetimedb-bindings-macro = { path = "../bindings-macro", version = "0.6.1" }
-spacetimedb-sats = { path = "../sats", version = "0.6.1" }
+spacetimedb-bindings-macro.workspace = true
+spacetimedb-sats.workspace = true
 
 anyhow.workspace = true
 chrono = { workspace = true, optional = true }

--- a/crates/sats/Cargo.toml
+++ b/crates/sats/Cargo.toml
@@ -11,7 +11,7 @@ description = "Spacetime Algebraic Type Notation"
 serde = ["dep:serde", "hex"]
 
 [dependencies]
-spacetimedb-bindings-macro = { path = "../bindings-macro", version = "0.6.1" }
+spacetimedb-bindings-macro.workspace = true
 
 arrayvec.workspace = true
 decorum.workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -8,9 +8,9 @@ description = "A Rust SDK for clients to interface with SpacetimeDB"
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-spacetimedb-sats = { path = "../sats", version = "0.6.1" }
-spacetimedb-lib = { path = "../lib", version = "0.6.1" }
-spacetimedb-client-api-messages = { path = "../client-api-messages", version = "0.6.1" }
+spacetimedb-sats.workspace = true
+spacetimedb-lib.workspace = true
+spacetimedb-client-api-messages.workspace = true
 
 anyhow.workspace = true
 anymap.workspace = true

--- a/crates/sqltest/Cargo.toml
+++ b/crates/sqltest/Cargo.toml
@@ -5,9 +5,9 @@ edition = "2021"
 description = "Sql integration test for SpaceTimeDb"
 
 [dependencies]
-spacetimedb-lib = { path = "../lib" }
-spacetimedb-core = { path = "../core" }
-spacetimedb-sats = { path = "../sats" }
+spacetimedb-lib.workspace = true
+spacetimedb-core.workspace = true
+spacetimedb-sats.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -17,9 +17,9 @@ harness = true         # Use libtest harness.
 required-features = [] # Features required to build this target (N/A for lib)
 
 [dependencies]
-spacetimedb-core = { path = "../core", version = "0.6.1" }
-spacetimedb-lib = { path = "../lib", version = "0.6.1", features = ["cli"] }
-spacetimedb-client-api = { path = "../client-api", version = "0.6.1" }
+spacetimedb-core.workspace = true
+spacetimedb-lib = { workspace = true, features = ["cli"] }
+spacetimedb-client-api.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -4,10 +4,10 @@ version = "0.1.0"
 edition = "2021"
 
 [dependencies]
-spacetimedb-lib = { path = "../lib", version = "0.6.1" }
-spacetimedb-core = { path = "../core", version = "0.6.1" }
-spacetimedb-standalone = { path = "../standalone", version = "0.6.1" }
-spacetimedb-client-api = { path = "../client-api", version = "0.6.1" }
+spacetimedb-lib.workspace = true
+spacetimedb-core.workspace = true
+spacetimedb-standalone.workspace = true
+spacetimedb-client-api.workspace = true
 
 anyhow.workspace = true
 serde_json.workspace = true

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -6,8 +6,8 @@ license-file = "LICENSE"
 description = "A VM for SpacetimeDB"
 
 [dependencies]
-spacetimedb-sats= { path = "../sats", version = "0.6.1" }
-spacetimedb-lib = { path = "../lib", version = "0.6.1" }
+spacetimedb-sats.workspace = true
+spacetimedb-lib.workspace = true
 
 anyhow.workspace = true
 thiserror.workspace = true

--- a/modules/benchmarks/Cargo.toml
+++ b/modules/benchmarks/Cargo.toml
@@ -9,6 +9,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = { path = "../../crates/bindings" }
+spacetimedb.workspace = true
 
 anyhow.workspace = true

--- a/modules/quickstart-chat/Cargo.toml
+++ b/modules/quickstart-chat/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = { path = "../../crates/bindings" }
+spacetimedb.workspace = true
 log.workspace = true

--- a/modules/rust-wasm-test/Cargo.toml
+++ b/modules/rust-wasm-test/Cargo.toml
@@ -11,8 +11,8 @@ crate-type = ["cdylib"]
 bench = false
 
 [dependencies]
-spacetimedb = { path = "../../crates/bindings" }
-spacetimedb-lib = { path = "../../crates/lib" } # TODO: this should not ever be necessary. `spacetimedb` should provide all module dependencies.
+spacetimedb.workspace = true
+spacetimedb-lib.workspace = true # TODO: this should not ever be necessary. `spacetimedb` should provide all module dependencies.
 
 anyhow.workspace = true
 log.workspace = true

--- a/modules/spacetimedb-quickstart/Cargo.toml
+++ b/modules/spacetimedb-quickstart/Cargo.toml
@@ -7,4 +7,4 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = { path = "../../crates/bindings" }
+spacetimedb.workspace = true


### PR DESCRIPTION
# Description of Changes

@mamcx recently moved almost all deps to the top level workspace dependencies. This gets the stragglers.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
