### PR TITLE
Fix `SpacetimeType` for `Address`

### DIFF
--- a/crates/lib/src/address.rs
+++ b/crates/lib/src/address.rs
@@ -58,7 +58,7 @@ impl Address {
     }
 }
 
-impl_serialize!([] Address, (self, ser) =>self.0.to_be_bytes().serialize(ser));
+impl_serialize!([] Address, (self, ser) => self.0.to_be_bytes().serialize(ser));
 impl_deserialize!([] Address, de => <[u8; 16]>::deserialize(de).map(|v| Self(u128::from_be_bytes(v))));
 
 #[cfg(feature = "serde")]
@@ -82,7 +82,7 @@ impl<'de> serde::Deserialize<'de> for Address {
     }
 }
 
-impl_st!([] Address, _ts => sats::AlgebraicType::U128);
+impl_st!([] Address, _ts => sats::AlgebraicType::bytes());
 
 #[cfg(test)]
 mod tests {
@@ -107,27 +107,5 @@ mod tests {
             let de = serde_json::from_slice(&ser).unwrap();
             assert_eq!(addr, de);
         }
-    }
-
-    // At some point, using `Address` in a spacetimedb table was not working
-    // (buffer length errors were thrown when deserializing). This test exists
-    // to guard against a regression.
-    #[test]
-    fn test_addr_column_rountrip() {
-        use spacetimedb_bindings_macro::{Deserialize, Serialize};
-
-        #[derive(Debug, Eq, PartialEq, Serialize, Deserialize)]
-        struct MyTable {
-            name: String,
-            addr: Address,
-        }
-
-        let val = MyTable {
-            name: "example.com".into(),
-            addr: Address(rand::random()),
-        };
-        let ser = sats::bsatn::to_vec(&val).unwrap();
-        let de = sats::bsatn::from_slice(&ser).unwrap();
-        assert_eq!(val, de);
     }
 }


### PR DESCRIPTION
# Description of Changes

The `AlgebraicType` did not match the serialized representation.

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
