### PR TITLE
Provide serialization for `Result`

### DIFF
--- a/crates/sats/src/ser/impls.rs
+++ b/crates/sats/src/ser/impls.rs
@@ -78,6 +78,10 @@ impl_serialize!([T: Serialize] Option<T>, (self, ser) => match self {
     Some(v) => ser.serialize_variant(0, Some("some"), v),
     None => ser.serialize_variant(1, Some("none"), &()),
 });
+impl_serialize!([T: Serialize, E: Serialize] Result<T, E>, (self, ser) => match self {
+    Ok(v) => ser.serialize_variant(0, Some("ok"), v),
+    Err(e) => ser.serialize_variant(1, Some("err"), e),
+});
 impl_serialize!([K: Serialize, V: Serialize] BTreeMap<K, V>, (self, ser) => {
     let mut map = ser.serialize_map(self.len())?;
     for (k, v) in self {


### PR DESCRIPTION
# Description of Changes

Greatly improves DX when outcomes of computations need to be communicated via a table (e.g. for asynchronous operations).

Note that the derive macros do not currently support generic parameters properly, so working around the lack of impls for `Result` is ... tedious. I may submit a fix for this (the generics) separately.

Note also that it might be desirable to avoid the stringly variant tags in order to save space, but I'm unsure if that can be done (safely).

# API

 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
