### PR TITLE
Make ColumnIndexAttribute bitflags in the ABI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4075,6 +4075,7 @@ dependencies = [
 name = "spacetimedb-bindings-macro"
 version = "0.6.1"
 dependencies = [
+ "bitflags 2.3.3",
  "humantime",
  "proc-macro2",
  "quote",
@@ -4242,6 +4243,7 @@ name = "spacetimedb-lib"
 version = "0.6.1"
 dependencies = [
  "anyhow",
+ "bitflags 2.3.3",
  "bytes",
  "chrono",
  "clap 4.3.10",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -59,6 +59,7 @@ axum = "0.6"
 arrayvec = "0.7.2"
 backtrace = "0.3.66"
 base64 = "0.21.2"
+bitflags = "2.3.3"
 byte-unit = "4.0.18"
 bytes = "1.2.1"
 bytestring = { version = "1.2.0", features = ["serde"] }

--- a/crates/bindings-macro/Cargo.toml
+++ b/crates/bindings-macro/Cargo.toml
@@ -11,6 +11,7 @@ proc-macro = true
 bench = false
 
 [dependencies]
+bitflags.workspace = true
 humantime.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true

--- a/crates/bindings-sys/src/lib.rs
+++ b/crates/bindings-sys/src/lib.rs
@@ -34,7 +34,7 @@ use alloc::boxed::Box;
 /// can run a module declaring `X.Y` if and only if `X == A && Y <= B`.
 /// So, the minor version is intended for backwards-compatible changes, e.g. adding a new function,
 /// and the major version is for fully breaking changes.
-pub const ABI_VERSION: u32 = 0x0003_0000;
+pub const ABI_VERSION: u32 = 0x0004_0000;
 
 /// Provides a raw set of sys calls which abstractions can be built atop of.
 pub mod raw {

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -113,9 +113,9 @@ impl From<&ColumnSchema> for spacetimedb_lib::table::ColumnDef {
             // TODO(cloutiertyler): !!! This is not correct !!! We do not have the information regarding constraints here.
             // We should remove this field from the ColumnDef struct.
             attr: if value.is_autoinc {
-                spacetimedb_lib::ColumnIndexAttribute::AutoInc
+                spacetimedb_lib::ColumnIndexAttribute::AUTO_INC
             } else {
-                spacetimedb_lib::ColumnIndexAttribute::UnSet
+                spacetimedb_lib::ColumnIndexAttribute::UNSET
             },
             // if value.is_autoinc && value.is_unique {
             //     spacetimedb_lib::ColumnIndexAttribute::Identity

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -334,13 +334,18 @@ impl RelationalDB {
             return Ok(None);
         };
         let unique_index = table.indexes.iter().find(|x| x.col_id == col_id).map(|x| x.is_unique);
-        Ok(Some(match (column.is_autoinc, unique_index) {
-            (true, Some(true)) => ColumnIndexAttribute::Identity,
-            (true, Some(false) | None) => ColumnIndexAttribute::AutoInc,
-            (false, Some(true)) => ColumnIndexAttribute::Unique,
-            (false, Some(false)) => ColumnIndexAttribute::Indexed,
-            (false, None) => ColumnIndexAttribute::UnSet,
-        }))
+        let mut attr = ColumnIndexAttribute::UNSET;
+        if column.is_autoinc {
+            attr |= ColumnIndexAttribute::AUTO_INC;
+        }
+        if let Some(is_unique) = unique_index {
+            attr |= if is_unique {
+                ColumnIndexAttribute::UNIQUE
+            } else {
+                ColumnIndexAttribute::INDEXED
+            };
+        }
+        Ok(Some(attr))
     }
 
     #[tracing::instrument(skip_all)]

--- a/crates/core/src/host/wasmer/wasmer_module.rs
+++ b/crates/core/src/host/wasmer/wasmer_module.rs
@@ -45,7 +45,7 @@ impl WasmerModule {
         WasmerModule { module, engine }
     }
 
-    pub const IMPLEMENTED_ABI: abi::VersionTuple = abi::VersionTuple::new(3, 0);
+    pub const IMPLEMENTED_ABI: abi::VersionTuple = abi::VersionTuple::new(4, 0);
 
     fn imports(&self, store: &mut Store, env: &FunctionEnv<WasmInstanceEnv>) -> Imports {
         const _: () = assert!(WasmerModule::IMPLEMENTED_ABI.eq(spacetimedb_lib::MODULE_ABI_VERSION));

--- a/crates/core/src/sql/ast.rs
+++ b/crates/core/src/sql/ast.rs
@@ -766,7 +766,7 @@ fn column_def_type(named: &String, is_null: bool, data_type: &DataType) -> Resul
 
 /// Extract the column attributes into [ColumnIndexAttribute]
 fn compile_column_option(col: &SqlColumnDef) -> Result<(bool, ColumnIndexAttribute), PlanError> {
-    let mut attr = ColumnIndexAttribute::UnSet;
+    let mut attr = ColumnIndexAttribute::UNSET;
     let mut is_null = false;
 
     for x in &col.options {
@@ -778,11 +778,11 @@ fn compile_column_option(col: &SqlColumnDef) -> Result<(bool, ColumnIndexAttribu
                 is_null = false;
             }
             ColumnOption::Unique { is_primary } => {
-                if *is_primary {
-                    attr = ColumnIndexAttribute::PrimaryKey
+                attr = if *is_primary {
+                    ColumnIndexAttribute::PRIMARY_KEY
                 } else {
-                    attr = ColumnIndexAttribute::Unique
-                }
+                    ColumnIndexAttribute::UNIQUE
+                };
             }
             ColumnOption::Generated {
                 generated_as,
@@ -793,11 +793,7 @@ fn compile_column_option(col: &SqlColumnDef) -> Result<(bool, ColumnIndexAttribu
 
                 match generated_as {
                     GeneratedAs::ByDefault => {
-                        if attr == ColumnIndexAttribute::PrimaryKey {
-                            attr = ColumnIndexAttribute::PrimaryKeyAuto
-                        } else {
-                            attr = ColumnIndexAttribute::Identity
-                        }
+                        attr |= ColumnIndexAttribute::IDENTITY;
                     }
                     x => {
                         return Err(PlanError::Unsupported {

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -23,6 +23,7 @@ spacetimedb-bindings-macro = { path = "../bindings-macro", version = "0.6.1" }
 spacetimedb-sats = { path = "../sats", version = "0.6.1" }
 
 anyhow.workspace = true
+bitflags.workspace = true
 chrono = { workspace = true, optional = true }
 clap = {workspace = true, optional = true }
 enum-as-inner.workspace = true

--- a/crates/lib/src/table.rs
+++ b/crates/lib/src/table.rs
@@ -20,7 +20,7 @@ pub struct ProductTypeMeta {
 impl ProductTypeMeta {
     pub fn new(columns: ProductType) -> Self {
         Self {
-            attr: vec![ColumnIndexAttribute::UnSet; columns.elements.len()],
+            attr: vec![ColumnIndexAttribute::UNSET; columns.elements.len()],
             columns,
         }
     }
@@ -100,12 +100,9 @@ impl ProductTypeMeta {
         &'a self,
         row: &'a mut ProductValue,
     ) -> impl Iterator<Item = (ColumnDef, &'a mut AlgebraicValue)> + 'a {
-        self.iter().zip(row.elements.iter_mut()).filter(|(col, _)| {
-            matches!(
-                col.attr,
-                ColumnIndexAttribute::Identity | ColumnIndexAttribute::AutoInc | ColumnIndexAttribute::PrimaryKeyAuto
-            )
-        })
+        self.iter()
+            .zip(row.elements.iter_mut())
+            .filter(|(col, _)| col.attr.is_autoinc())
     }
 }
 


### PR DESCRIPTION
# Description of Changes

(This is reopened #72 with some fixes.)

As we're adding more variants, it's getting harder to keep track of the "A implies B" relationships between enum variants and to correctly do checks like "is this column autoinc" in different places.

Using bitflags makes expressing those relationships more natural and checking simpler - e.g. you can just do `contains(AUTO_INC)` as a single bit operation instead of having to remember and list all possible variants that imply autoinc, especially if we're going to add more flags in the future.

Initially I was going to make this change just in C# module generator and convert between ABI enum and bitflags over there, but it seems better to do this at ABI level so it simplifies Rust handling as well.

# API

 - [x] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
