### PR TITLE
test: Only update active toolchain

### DIFF
--- a/test/run-smoke-tests.sh
+++ b/test/run-smoke-tests.sh
@@ -44,6 +44,15 @@ while [ $# != 0 ] ; do
 	esac
 done
 
+# Make sure the active toolchain is installed including the wasm target (as
+# specified in rust-toolchain.toml), and clippy. Do NOT try to update other
+# toolchains people may have on their system, nor rustup itself -- this can take
+# a long time, e.g. when people have "nightly" installed without a specific
+# version.
+#
+# Note: `show active-toolchain` installs the toolchain if it is missing,
+# `update` adds the wasm target if the toolchain is there but without that
+# target.
 rustup update --no-self-update "$(rustup show active-toolchain|cut -d' ' -f1)"
 rustup component add clippy
 

--- a/test/run-smoke-tests.sh
+++ b/test/run-smoke-tests.sh
@@ -44,7 +44,7 @@ while [ $# != 0 ] ; do
 	esac
 done
 
-rustup update
+rustup update --no-self-update "$(rustup show active-toolchain|cut -d' ' -f1)"
 rustup component add clippy
 
 source "lib.include"


### PR DESCRIPTION
# Description of Changes

I have a bunch of toolchains installed, so unconditionally running `rustup update` can take a while. We only need the active one to be in sync with `rust-toolchain.toml`, though.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
