### PR TITLE
Fixed json serializer getting progressively slower

### DIFF
--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -1235,7 +1235,7 @@ pub fn autogen_csharp_reducer(ctx: &GenCtx, reducer: &ReducerDef, namespace: &st
             match &arg.algebraic_type {
                 AlgebraicType::Sum(sum_type) => {
                     if sum_type.as_option().is_some() {
-                        json_args.push_str(&format!("new SomeWrapper({})", arg_name));
+                        json_args.push_str(&format!("new SpacetimeDB.SomeWrapper<{}>({})", arg_type_str, arg_name));
                     } else {
                         json_args.push_str(&arg_name);
                     }
@@ -1250,7 +1250,9 @@ pub fn autogen_csharp_reducer(ctx: &GenCtx, reducer: &ReducerDef, namespace: &st
                     let ref_type = &ctx.typespace.types[type_ref.idx()];
                     if let AlgebraicType::Sum(sum_type) = ref_type {
                         if is_enum(sum_type) {
-                            json_args.push_str(format!("new EnumWrapper<{}>({})", arg_type_str, arg_name).as_str());
+                            json_args.push_str(
+                                format!("new SpacetimeDB.EnumWrapper<{}>({})", arg_type_str, arg_name).as_str(),
+                            );
                         } else {
                             unimplemented!()
                         }
@@ -1594,7 +1596,6 @@ pub fn autogen_csharp_globals(items: &[GenItem], namespace: &str) -> Vec<Vec<(St
         output.indent(1);
     }
 
-    writeln!(output, "[ReducerClass]").unwrap();
     writeln!(output, "public partial class Reducer").unwrap();
     writeln!(output, "{{").unwrap();
     {
@@ -1624,7 +1625,7 @@ pub fn autogen_csharp_globals(items: &[GenItem], namespace: &str) -> Vec<Vec<(St
         writeln!(output, "}}").unwrap();
     }
 
-    result.push(vec![("Reducer.cs".into(), output.into_inner())]);
+    result.push(vec![("ReducerJsonSettings.cs".into(), output.into_inner())]);
 
     result
 }

--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -1304,23 +1304,6 @@ pub fn autogen_csharp_reducer(ctx: &GenCtx, reducer: &ReducerDef, namespace: &st
 
             writeln!(
                 output,
-                "Newtonsoft.Json.JsonSerializerSettings _settings = new Newtonsoft.Json.JsonSerializerSettings"
-            )
-            .unwrap();
-            writeln!(output, "{{").unwrap();
-            {
-                indent_scope!(output);
-                writeln!(
-                    output,
-                    "Converters = {{ new SpacetimeDB.SomeWrapperConverter(), new SpacetimeDB.EnumWrapperConverter() }},"
-                )
-                .unwrap();
-                writeln!(output, "ContractResolver = new SpacetimeDB.JsonContractResolver(),").unwrap();
-            }
-            writeln!(output, "}};").unwrap();
-
-            writeln!(
-                output,
                 "SpacetimeDBClient.instance.InternalCallReducer(Newtonsoft.Json.JsonConvert.SerializeObject(_message, _settings));"
             )
                 .unwrap();
@@ -1612,7 +1595,29 @@ pub fn autogen_csharp_globals(items: &[GenItem], namespace: &str) -> Vec<Vec<(St
     }
 
     writeln!(output, "[ReducerClass]").unwrap();
-    writeln!(output, "public partial class Reducer {{ }}").unwrap();
+    writeln!(output, "public partial class Reducer").unwrap();
+    writeln!(output, "{{").unwrap();
+    {
+        indent_scope!(output);
+        writeln!(
+            output,
+            "private static Newtonsoft.Json.JsonSerializerSettings _settings = new Newtonsoft.Json.JsonSerializerSettings"
+        )
+        .unwrap();
+        writeln!(output, "{{").unwrap();
+        {
+            indent_scope!(output);
+            writeln!(
+                output,
+                "Converters = {{ new SpacetimeDB.SomeWrapperConverter(), new SpacetimeDB.EnumWrapperConverter() }},"
+            )
+            .unwrap();
+            writeln!(output, "ContractResolver = new SpacetimeDB.JsonContractResolver(),").unwrap();
+        }
+        writeln!(output, "}};").unwrap();
+    }
+    // Closing brace for struct ReducerArgs
+    writeln!(output, "}}").unwrap();
 
     if use_namespace {
         output.dedent(1);

--- a/crates/cli/tests/snapshots/codegen__codegen_output.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_output.snap
@@ -24,11 +24,6 @@ namespace SpacetimeDB
 				fn = "add_player",
 				args = _argArray,
 			};
-			Newtonsoft.Json.JsonSerializerSettings _settings = new Newtonsoft.Json.JsonSerializerSettings
-			{
-				Converters = { new SpacetimeDB.SomeWrapperConverter(), new SpacetimeDB.EnumWrapperConverter() },
-				ContractResolver = new SpacetimeDB.JsonContractResolver(),
-			};
 			NetworkManager.instance.InternalCallReducer(Newtonsoft.Json.JsonConvert.SerializeObject(_message, _settings));
 		}
 
@@ -247,11 +242,6 @@ namespace SpacetimeDB
 			var _message = new NetworkManager.ReducerCallRequest {
 				fn = "repeating_test",
 				args = _argArray,
-			};
-			Newtonsoft.Json.JsonSerializerSettings _settings = new Newtonsoft.Json.JsonSerializerSettings
-			{
-				Converters = { new SpacetimeDB.SomeWrapperConverter(), new SpacetimeDB.EnumWrapperConverter() },
-				ContractResolver = new SpacetimeDB.JsonContractResolver(),
 			};
 			NetworkManager.instance.InternalCallReducer(Newtonsoft.Json.JsonConvert.SerializeObject(_message, _settings));
 		}
@@ -694,11 +684,6 @@ namespace SpacetimeDB
 				fn = "test",
 				args = _argArray,
 			};
-			Newtonsoft.Json.JsonSerializerSettings _settings = new Newtonsoft.Json.JsonSerializerSettings
-			{
-				Converters = { new SpacetimeDB.SomeWrapperConverter(), new SpacetimeDB.EnumWrapperConverter() },
-				ContractResolver = new SpacetimeDB.JsonContractResolver(),
-			};
 			NetworkManager.instance.InternalCallReducer(Newtonsoft.Json.JsonConvert.SerializeObject(_message, _settings));
 		}
 
@@ -767,11 +752,6 @@ namespace SpacetimeDB
 			var _message = new NetworkManager.ReducerCallRequest {
 				fn = "__update__",
 				args = _argArray,
-			};
-			Newtonsoft.Json.JsonSerializerSettings _settings = new Newtonsoft.Json.JsonSerializerSettings
-			{
-				Converters = { new SpacetimeDB.SomeWrapperConverter(), new SpacetimeDB.EnumWrapperConverter() },
-				ContractResolver = new SpacetimeDB.JsonContractResolver(),
 			};
 			NetworkManager.instance.InternalCallReducer(Newtonsoft.Json.JsonConvert.SerializeObject(_message, _settings));
 		}


### PR DESCRIPTION
# Description of Changes

Steve:
- Fixed json serializer settings getting re-created every reducer call, leading to gradual performance decline
John:
- During the review of this PR I figured out that option serialization support in the C# SDK was completely broken, which required some changes here to fix.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

Requires this PR in order for the client to work: https://github.com/clockworklabs/spacetimedb-csharp-sdk/pull/51
