### PR TITLE
Install cargo-chef with --locked

### DIFF
--- a/crates/standalone/Dockerfile
+++ b/crates/standalone/Dockerfile
@@ -3,7 +3,7 @@
 ARG CARGO_PROFILE=release
 
 FROM rust:1.69.0 AS chef
-RUN cargo install cargo-chef@0.1.56
+RUN cargo install cargo-chef@0.1.56 --locked
 WORKDIR /usr/src/app
 
 FROM chef AS planner


### PR DESCRIPTION
We want to use the Cargo.lock file to use exactly the specified dependencies. Without this, versions of some (possibly transitive) dependenencies can advance, and in particular advance past the point of supporting our currently pinned rust toolchain.

# Description of Changes



# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
