### PR TITLE
Add --locked to building from source instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ curl https://sh.rustup.rs -sSf | sh
 git clone https://github.com/clockworklabs/SpacetimeDB
 # Build and install the CLI
 cd SpacetimeDB
-cargo install --path ./crates/cli
+cargo install --path ./crates/cli --locked
 ```
 
 Windows may require some extra dependencies be installed, including openssl and a specific version of perl. A guide for this will be available soon.


### PR DESCRIPTION
# Description of Changes

 - We have an issue right now where clap was updated and they messed something up which requires rust `1.70.0` and we're still on `1.69.0`. This improves the reliability of the build.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
