### PR TITLE
Bump C# for ABI 4.0

### DIFF
--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -9,8 +9,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Codegen" Version="0.6.*" />
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.6.*" />
+    <PackageReference Include="SpacetimeDB.Codegen" Version="0.7.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.7.*" />
   </ItemGroup>
 
   <ItemGroup>


### PR DESCRIPTION
# Description of Changes

This bumps C# dependency to be compatible with https://github.com/clockworklabs/SpacetimeDB/pull/212 when the next version of SpacetimeDB is released.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
