### PR TITLE
Allow disabling logging to disk

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -160,7 +160,7 @@ tracing-appender = "0.2.2"
 tracing-core = "0.1"
 tracing-flame = "0.2"
 tracing-log = "0.1"
-tracing-subscriber = { version = "0.3.16", features = ["env-filter"] }
+tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
 url = "2.3.1"
 urlencoding = "2.1.2"
 uuid = { version = "1.2.1", features = ["v4"]}

--- a/crates/core/src/startup.rs
+++ b/crates/core/src/startup.rs
@@ -3,6 +3,7 @@ use std::path::{Path, PathBuf};
 use std::time::Duration;
 use tracing_appender::rolling;
 use tracing_flame::FlameLayer;
+use tracing_subscriber::fmt::writer::BoxMakeWriter;
 use tracing_subscriber::fmt::writer::MakeWriterExt;
 use tracing_subscriber::layer::SubscriberExt;
 use tracing_subscriber::prelude::*;
@@ -27,8 +28,16 @@ pub fn configure_tracing() {
         .with_target(false)
         .compact();
 
+    let disable_disk_logging = std::env::var_os("SPACETIMEDB_DISABLE_DISK_LOGGING").is_some();
+
+    let write_to = if disable_disk_logging {
+        BoxMakeWriter::new(std::io::stdout)
+    } else {
+        BoxMakeWriter::new(std::io::stdout.and(rolling::daily(logs_path, "spacetimedb.log")))
+    };
+
     let fmt_layer = tracing_subscriber::fmt::Layer::default()
-        .with_writer(std::io::stdout.and(rolling::daily(logs_path, "spacetimedb.log")))
+        .with_writer(write_to)
         .event_format(format);
 
     let env_filter_layer = parse_from_file(&conf_file);


### PR DESCRIPTION
# Description of Changes

We don't want to write to disk on spacetimedb cloud. This PR allows disabling logging to disk

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
