### PR TITLE
Clippy: forbid `println` and friends

### DIFF
--- a/clippy.toml
+++ b/clippy.toml
@@ -1,0 +1,7 @@
+disallowed-macros = [
+    { path = "std::print",    reason = "print blocks on a global mutex for synchronization, and its output cannot be filtered. Use a log macro instead, or apply #[allow(disallowed-macros)] if this is test or CLI code." },
+    { path = "std::println",  reason = "println blocks on a global mutex for synchronization, and its output cannot be filtered. Use a log macro instead, or apply #[allow(disallowed-macros)] if this is test or CLI code." },
+    { path = "std::eprint",   reason = "eprint blocks on a global mutex for synchronization, and its output cannot be filtered. Use a log macro instead, or apply #[allow(disallowed-macros)] if this is test or CLI code." },
+    { path = "std::eprintln", reason = "eprintln blocks on a global mutex for synchronization, and its output cannot be filtered. Use a log macro instead, or apply #[allow(disallowed-macros)] if this is test or CLI code." },
+    { path = "std::dbg",      reason = "dbg blocks on a global mutex for synchronization, and its output cannot be filtered. Use a log macro instead, or apply #[allow(disallowed-macros)] if this is test or CLI code." },
+]

--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -848,7 +848,10 @@ fn spacetimedb_tabletype_impl(item: syn::DeriveInput) -> syn::Result<TokenStream
     };
 
     if std::env::var("PROC_MACRO_DEBUG").is_ok() {
-        println!("{}", emission);
+        {
+            #![allow(clippy::disallowed_macros)]
+            println!("{}", emission);
+        }
     }
 
     Ok(emission)
@@ -871,7 +874,10 @@ fn spacetimedb_index(
     };
 
     if std::env::var("PROC_MACRO_DEBUG").is_ok() {
-        println!("{}", output);
+        {
+            #![allow(clippy::disallowed_macros)]
+            println!("{}", output);
+        }
     }
 
     Ok(output)
@@ -908,7 +914,10 @@ fn spacetimedb_connect_disconnect(item: TokenStream, connect: bool) -> syn::Resu
     };
 
     if std::env::var("PROC_MACRO_DEBUG").is_ok() {
-        println!("{}", emission);
+        {
+            #![allow(clippy::disallowed_macros)]
+            println!("{}", emission);
+        }
     }
 
     Ok(emission)
@@ -975,7 +984,10 @@ pub fn schema_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
         };
 
         if std::env::var("PROC_MACRO_DEBUG").is_ok() {
-            println!("{}", emission);
+            {
+                #![allow(clippy::disallowed_macros)]
+                println!("{}", emission);
+            }
         }
 
         Ok(emission)

--- a/crates/cli/clippy.toml
+++ b/crates/cli/clippy.toml
@@ -1,0 +1,3 @@
+# Overwrite the root's disallowed-macros,
+# as the CLI is allowed to use println and friends.
+disallowed-macros = []

--- a/crates/client-api-messages/build.rs
+++ b/crates/client-api-messages/build.rs
@@ -2,7 +2,11 @@ use std::fs;
 
 fn main() {
     let proto_dir = "protobuf";
-    println!("cargo:rerun-if-changed={proto_dir}");
+
+    {
+        #![allow(clippy::disallowed_macros)]
+        println!("cargo:rerun-if-changed={proto_dir}");
+    }
 
     let protos = fs::read_dir(proto_dir)
         .unwrap()

--- a/crates/core/src/startup.rs
+++ b/crates/core/src/startup.rs
@@ -98,7 +98,7 @@ fn reload_config<S>(conf_file: &Path, reload_handle: &reload::Handle<EnvFilter, 
         std::thread::sleep(RELOAD_INTERVAL);
         if let Ok(modified) = conf_file.metadata().and_then(|m| m.modified()) {
             if prev_time.map_or(true, |prev| modified > prev) {
-                eprintln!("reloading log config...");
+                log::info!("reloading log config...");
                 prev_time = Some(modified);
                 if reload_handle.reload(parse_from_file(conf_file)).is_err() {
                     break;

--- a/crates/sqltest/clippy.toml
+++ b/crates/sqltest/clippy.toml
@@ -1,0 +1,3 @@
+# Overwrite the root's disallowed-macros,
+# as sqltest is allowed to use println and friends.
+disallowed-macros = []

--- a/crates/standalone/src/subcommands/mod.rs
+++ b/crates/standalone/src/subcommands/mod.rs
@@ -1,2 +1,5 @@
+// CLI commands are allowed to use println and friends.
+#![allow(clippy::disallowed_macros)]
+
 pub mod start;
 pub mod version;

--- a/crates/standalone/src/util.rs
+++ b/crates/standalone/src/util.rs
@@ -7,7 +7,7 @@ use std::path::Path;
 /// Otherwise if the directory does exist, do nothing.
 pub fn create_dir_or_err(path: &str) -> anyhow::Result<()> {
     if !Path::new(path).is_dir() {
-        println!("Creating directory {}", path);
+        log::info!("Creating directory {}", path);
         std::fs::create_dir_all(path)?;
     }
     Ok(())
@@ -19,7 +19,7 @@ pub fn create_dir_or_err(path: &str) -> anyhow::Result<()> {
 pub fn create_file_with_contents(path: &str, contents: &str) -> anyhow::Result<()> {
     create_dir_or_err(Path::new(path).parent().unwrap().to_str().unwrap())?;
     if !Path::new(path).is_file() {
-        println!("Creating file {}", path);
+        log::info!("Creating file {}", path);
         std::fs::write(path, contents)?;
     }
     Ok(())

--- a/crates/vm/src/main.rs
+++ b/crates/vm/src/main.rs
@@ -20,6 +20,8 @@ fn fib(n: u64) -> u64 {
 }
 
 fn main() {
+    #![allow(clippy::disallowed_macros)]
+
     let mut args = env::args().skip(1);
     let first = args.next();
 


### PR DESCRIPTION
# Description of Changes

We've had recurring issues with `println` calls sneaking in where `log` crate macros would be more appropriate. This commit adds a Clippy warning for uses of the global I/O macros, i.e. `print`, `println`, `eprint`, `eprintln` and `dbg`.

The lint is disabled by a more-specific `clippy.toml` in the `cli` and `sqltest` crates, as well as using `allow` attributes in `standalone`'s `subscommands` module.

Additionally, this commit converts a handful of prints in `core/utils` to `log::info`.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
