### PR TITLE
feat(311): Make right hand side of join generic

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -464,7 +464,7 @@ impl RelationalDB {
     #[tracing::instrument(skip(self, tx))]
     pub fn iter_by_col_eq<'a>(
         &'a self,
-        tx: &'a mut MutTxId,
+        tx: &'a MutTxId,
         table_id: u32,
         col_id: u32,
         value: AlgebraicValue,

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -429,10 +429,10 @@ pub fn build_query(mut result: Box<IterRows>, query: Vec<Query>) -> Result<Box<I
                 let col_rhs = FieldExpr::Name(q.col_rhs);
                 let key_lhs = col_lhs.clone();
                 let key_rhs = col_rhs.clone();
-                let row_rhs = q.rhs.row_count();
+                let row_rhs = q.rhs.source.row_count();
 
-                let head = q.rhs.head();
-                let rhs = match q.rhs {
+                let head = q.rhs.source.head();
+                let rhs = match q.rhs.source {
                     SourceExpr::MemTable(x) => Box::new(RelIter::new(head, row_rhs, x)) as Box<IterRows<'_>>,
                     SourceExpr::DbTable(_) => {
                         // let iter = stdb.scan(tx, x.table_id)?;
@@ -443,6 +443,8 @@ pub fn build_query(mut result: Box<IterRows>, query: Vec<Query>) -> Result<Box<I
                         todo!("How pass the db iter?")
                     }
                 };
+
+                let rhs = build_query(rhs, q.rhs.query)?;
 
                 let lhs = result;
                 let key_lhs_header = lhs.head().clone();


### PR DESCRIPTION
Fixes #311.

# Description of Changes
This change makes it so that our internal join representation can take arbitrary query expressions for its right argument.
Previously only base table references were supported.
This is will allow pushing operations like index scans below joins.


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
