### PR TITLE
feat(318): Push selections below joins in the general case

### DIFF
--- a/crates/core/src/sql/ast.rs
+++ b/crates/core/src/sql/ast.rs
@@ -106,7 +106,7 @@ pub struct Selection {
 
 impl Selection {
     pub fn with_cmp(op: OpQuery, lhs: ColumnOp, rhs: ColumnOp) -> Self {
-        let cmp = ColumnOp::cmp(op, lhs, rhs);
+        let cmp = ColumnOp::new(op, lhs, rhs);
         Selection { clause: cmp }
     }
 }
@@ -310,7 +310,7 @@ fn compile_expr_value(table: &From, field: Option<&ProductTypeElement>, of: SqlE
         SqlExpr::BinaryOp { left, op, right } => {
             let (op, lhs, rhs) = compile_bin_op(table, op, left, right)?;
 
-            return Ok(ColumnOp::cmp(op, lhs, rhs));
+            return Ok(ColumnOp::new(op, lhs, rhs));
         }
         SqlExpr::Nested(x) => {
             return compile_expr_value(table, field, *x);


### PR DESCRIPTION
Fixes #318.

# Description of Changes
Push selections below joins in the general case.
Even when selection is not sargable.


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
