### PR TITLE
fix(320): Incremental evaluation of index scan plans

### DIFF
--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -246,12 +246,6 @@ impl From<IndexScan> for ColumnOp {
                 lhs: field.into(),
                 rhs: value.into(),
             },
-            // Inclusive lower bound => field >= value
-            (Bound::Included(lower), Bound::Included(upper)) if lower == upper => ColumnOp::Cmp {
-                op: OpQuery::Cmp(OpCmp::Eq),
-                lhs: field.into(),
-                rhs: lower.into(),
-            },
             (Bound::Unbounded, Bound::Unbounded) => unreachable!(),
             (lower_bound, upper_bound) => {
                 let lhs = IndexScan {
@@ -280,6 +274,15 @@ impl From<IndexScan> for ColumnOp {
 pub enum SourceExpr {
     MemTable(MemTable),
     DbTable(DbTable),
+}
+
+impl From<Table> for SourceExpr {
+    fn from(value: Table) -> Self {
+        match value {
+            Table::MemTable(t) => SourceExpr::MemTable(t),
+            Table::DbTable(t) => SourceExpr::DbTable(t),
+        }
+    }
 }
 
 impl From<SourceExpr> for Table {


### PR DESCRIPTION
Fixes #320.

# Description of Changes
Previously index scans assumed an underlying DbTable.
Incremental subscription evaluation operates on MemTables.
This patch converts an index scan to a select for base MemTables.


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
