### PR TITLE
feat(332): Support incremental evaluation for index joins

### DIFF
--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -457,6 +457,7 @@ pub fn build_query(mut result: Box<IterRows>, query: Vec<Query>) -> Result<Box<I
 
                 let iter = lhs.join_inner(
                     rhs,
+                    col_lhs_header.extend(&col_rhs_header),
                     move |row| {
                         let f = row.get(&key_lhs, &key_lhs_header);
                         Ok(f.into())
@@ -470,6 +471,7 @@ pub fn build_query(mut result: Box<IterRows>, query: Vec<Query>) -> Result<Box<I
                         let r = r.get(&col_rhs, &col_rhs_header);
                         Ok(l == r)
                     },
+                    move |l, r| l.extend(r),
                 )?;
                 Box::new(iter)
             }

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -366,6 +366,16 @@ pub struct JoinExpr {
     pub col_rhs: FieldName,
 }
 
+impl From<IndexJoin> for JoinExpr {
+    fn from(value: IndexJoin) -> Self {
+        let pos = value.index_col as usize;
+        let rhs = value.probe_side;
+        let col_lhs = value.index_header.fields[pos].field.clone();
+        let col_rhs = value.probe_field;
+        JoinExpr::new(rhs, col_lhs, col_rhs)
+    }
+}
+
 impl JoinExpr {
     pub fn new(rhs: QueryExpr, col_lhs: FieldName, col_rhs: FieldName) -> Self {
         Self { rhs, col_lhs, col_rhs }


### PR DESCRIPTION
Fixes #332.

# Description of Changes
If an index semijoin is to be incrementally evaluated,
it is first converted to an inner join which supports MemTables.

As part of this change, I had to abstract the projection part of
the inner join spec to be able to express semijoins.


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
