### PR TITLE
Return the formatted error from `log_and_500`, so the CLI can report it

### DIFF
--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -1,6 +1,7 @@
 use std::sync::Arc;
 
 use async_trait::async_trait;
+use axum::response::ErrorResponse;
 use http::StatusCode;
 
 use spacetimedb::address::Address;
@@ -477,7 +478,7 @@ impl<T: NodeDelegate + ?Sized> NodeDelegate for Arc<T> {
     }
 }
 
-pub fn log_and_500(e: impl std::fmt::Display) -> StatusCode {
+pub fn log_and_500(e: impl std::fmt::Display) -> ErrorResponse {
     log::error!("internal error: {e:#}");
-    StatusCode::INTERNAL_SERVER_ERROR
+    (StatusCode::INTERNAL_SERVER_ERROR, format!("{e:#}")).into()
 }

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -331,6 +331,9 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
             return Ok(());
         };
         if &database.identity != identity {
+            // TODO: `PermissionDenied` should be a variant of `Error`,
+            //       so we can match on it and return better error responses
+            //       from HTTP endpoints.
             return Err(anyhow!(
                 "Permission denied: `{}` does not own database `{}`",
                 identity.to_hex(),


### PR DESCRIPTION
# Description of Changes

In the client API's `log_and_500`, return an `ErrorResponse` with a body derived from the error, rather than a bare 500 code.

Note that this exposes previously-internal error messages to users.

The error messages newly reported by the CLI are not beautiful, but they at least describe the failure. Also, this PR does not improve the status codes returned; errors in e.g. `/database/publish` always return 500 (`INTERNAL_SERVER_ERROR`), where they should often report more-specific errors, some of which put the client at fault rather than the server. Still, it's an improvement.

Attempting to publish to a name you don't own:

```
Error: Permission denied: `974ab31b518f46d0b59b0afee78abdf2dbf4df6e60a332dce9c373ab8bebcea6` does not own database `5ebd1221afb10aaf`
```

Attempting to publish a database with incompatible schema changes without `-c`:

```
Error: Database update rejected: incompatible schema changes for: ["Connected", "Disconnected"]
```

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
