### PR TITLE
Spacetime Upgrade

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2066,6 +2066,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "indicatif"
+version = "0.16.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2d207dc617c7a380ab07ff572a6e52fa202a2a8f355860ac9c38e23f8196be1b"
+dependencies = [
+ "console",
+ "lazy_static",
+ "number_prefix",
+ "regex",
+]
+
+[[package]]
 name = "insta"
 version = "1.34.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2637,6 +2649,12 @@ checksum = "2819ce041d2ee131036f4fc9d6ae7ae125a3a40e97ba64d04fe799ad9dabbb44"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "number_prefix"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "830b246a0e5f20af87141b25c173cd1b609bd7779a4617d6ec582abaf90870f3"
 
 [[package]]
 name = "object"
@@ -4190,6 +4208,7 @@ dependencies = [
  "email_address",
  "flate2",
  "futures",
+ "indicatif",
  "insta",
  "is-terminal",
  "itertools 0.11.0",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4195,6 +4195,7 @@ dependencies = [
  "itertools 0.11.0",
  "jsonwebtoken",
  "mimalloc",
+ "regex",
  "reqwest",
  "rustyline",
  "serde",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1506,6 +1506,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "filetime"
+version = "0.2.22"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d4029edd3e734da6fe05b6cd7bd2960760a616bd2ddd0d59a0124746d6272af0"
+dependencies = [
+ "cfg-if",
+ "libc",
+ "redox_syscall 0.3.5",
+ "windows-sys 0.48.0",
+]
+
+[[package]]
 name = "finl_unicode"
 version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4176,6 +4188,7 @@ dependencies = [
  "dirs",
  "duct",
  "email_address",
+ "flate2",
  "futures",
  "insta",
  "is-terminal",
@@ -4192,6 +4205,7 @@ dependencies = [
  "spacetimedb-standalone",
  "syntect",
  "tabled",
+ "tar",
  "tempfile",
  "termcolor",
  "tokio",
@@ -4748,6 +4762,17 @@ name = "tap"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
+
+[[package]]
+name = "tar"
+version = "0.4.40"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b16afcea1f22891c49a00c751c7b63b2233284064f11a200fc624137c51e2ddb"
+dependencies = [
+ "filetime",
+ "libc",
+ "xattr",
+]
 
 [[package]]
 name = "target-lexicon"
@@ -6189,6 +6214,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
 dependencies = [
  "tap",
+]
+
+[[package]]
+name = "xattr"
+version = "1.0.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f4686009f71ff3e5c4dbcf1a282d0a44db3f021ba69350cd42086b3e5f1c6985"
+dependencies = [
+ "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -107,6 +107,7 @@ hyper = "0.14.18"
 im = "15.1"
 imara-diff = "0.1.3"
 indexmap = "2.0.0"
+indicatif = "0.16"
 insta = { version = "1.21.0", features = ["toml"] }
 is-terminal = "0.4"
 itertools = "0.11.0"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -155,6 +155,8 @@ strum = { version = "0.25.0", features = ["derive"] }
 syn = { version = "2", features = ["full", "extra-traits"] }
 syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"] }
 tabled = "0.14.0"
+tar = "0.4"
+tempdir = "0.3.7"
 tempfile = "3.8"
 termcolor = "1.2.0"
 thiserror = "1.0.37"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -36,6 +36,7 @@ is-terminal.workspace = true
 itertools.workspace = true
 jsonwebtoken.workspace = true
 mimalloc.workspace = true
+regex.workspace = true
 reqwest.workspace = true
 rustyline.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -34,6 +34,7 @@ futures.workspace = true
 flate2.workspace = true
 is-terminal.workspace = true
 itertools.workspace = true
+indicatif.workspace = true
 jsonwebtoken.workspace = true
 mimalloc.workspace = true
 regex.workspace = true

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -31,6 +31,7 @@ dirs.workspace = true
 duct.workspace = true
 email_address.workspace = true
 futures.workspace = true
+flate2.workspace = true
 is-terminal.workspace = true
 itertools.workspace = true
 jsonwebtoken.workspace = true
@@ -42,6 +43,7 @@ serde_json = { workspace = true, features = ["raw_value", "preserve_order"] }
 slab.workspace = true
 syntect.workspace = true
 tabled.workspace = true
+tar.workspace = true
 tempfile.workspace = true
 termcolor.workspace = true
 tokio.workspace = true

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -31,6 +31,7 @@ pub fn get_subcommands() -> Vec<Command> {
         init::cli(),
         build::cli(),
         server::cli(),
+        upgrade::cli(),
         #[cfg(feature = "standalone")]
         start::cli(ProgramMode::CLI),
     ]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -56,6 +56,7 @@ pub async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Re
         "server" => server::exec(config, args).await,
         #[cfg(feature = "standalone")]
         "start" => start::exec(args).await,
+        "upgrade" => upgrade::exec(args).await,
         unknown => Err(anyhow::anyhow!("Invalid subcommand: {}", unknown)),
     }
 }

--- a/crates/cli/src/subcommands/mod.rs
+++ b/crates/cli/src/subcommands/mod.rs
@@ -13,4 +13,5 @@ pub mod publish;
 pub mod repl;
 pub mod server;
 pub mod sql;
+pub mod upgrade;
 pub mod version;

--- a/crates/cli/src/subcommands/upgrade.rs
+++ b/crates/cli/src/subcommands/upgrade.rs
@@ -56,7 +56,7 @@ pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
             version
         ),
     };
-    let release: Release = reqwest::blocking::get(&url)?.json()?;
+    let release: Release = reqwest::blocking::get(url)?.json()?;
 
     if release.tag_name == version::CLI_VERSION {
         println!("You're already running the latest version: {}", version::CLI_VERSION);
@@ -90,7 +90,7 @@ pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
         temp_path.clone()
     };
 
-    fs::copy(&new_exe_path, &current_exe_path)?;
+    fs::copy(&new_exe_path, current_exe_path)?;
 
     fs::remove_file(&temp_path)?;
     if download_name.ends_with(".tar.gz") {

--- a/crates/cli/src/subcommands/upgrade.rs
+++ b/crates/cli/src/subcommands/upgrade.rs
@@ -1,0 +1,103 @@
+use std::{env, fs};
+
+use crate::version;
+use clap::{Arg, ArgMatches};
+use flate2::read::GzDecoder;
+use serde::Deserialize;
+use tar::Archive;
+
+pub fn cli() -> clap::Command {
+    clap::Command::new("upgrade")
+        .about("Checks for updates for the currently running spacetime CLI tool")
+        .arg(Arg::new("version").help("The specific version to upgrade to"))
+        .after_help("Run `spacetime help upgrade` for more detailed information.\n")
+}
+
+#[derive(Deserialize)]
+struct ReleaseAsset {
+    name: String,
+    browser_download_url: String,
+}
+
+#[derive(Deserialize)]
+struct Release {
+    tag_name: String,
+    assets: Vec<ReleaseAsset>,
+}
+
+fn get_download_name() -> String {
+    let os = env::consts::OS;
+    let arch = env::consts::ARCH;
+
+    let os_str = match os {
+        "macos" => "darwin",
+        "windows" => return "spacetime.exe".to_string(),
+        "linux" => "linux",
+        _ => panic!("Unsupported OS"),
+    };
+
+    let arch_str = match arch {
+        "x86_64" => "amd64",
+        "aarch64" => "arm64",
+        _ => panic!("Unsupported architecture"),
+    };
+
+    format!("spacetime.{}-{}.tar.gz", os_str, arch_str)
+}
+
+pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
+    let version = args.get_one::<String>("version");
+    let current_exe_path = env::current_exe()?;
+
+    let url = match version {
+        None => "https://api.github.com/repos/clockworklabs/SpacetimeDB/releases/latest".to_string(),
+        Some(version) => format!(
+            "https://api.github.com/repos/clockworklabs/SpacetimeDB/releases/tags/{}",
+            version
+        ),
+    };
+    let release: Release = reqwest::blocking::get(&url)?.json()?;
+
+    if release.tag_name == version::CLI_VERSION {
+        println!("You're already running the latest version: {}", version::CLI_VERSION);
+        return Ok(());
+    }
+
+    let download_name = get_download_name();
+    let asset = release.assets.iter().find(|&asset| asset.name == download_name);
+
+    if asset.is_none() {
+        return Err(anyhow::anyhow!(
+            "No assets available for the detected OS and architecture."
+        ));
+    }
+
+    // Download the archive from the URL
+    let temp_path = format!("/tmp/{}", download_name);
+    let response = reqwest::blocking::get(&asset.unwrap().browser_download_url)?;
+    fs::write(&temp_path, response.bytes()?)?;
+
+    if download_name.ends_with(".tar.gz") {
+        let tar_gz = fs::File::open(&temp_path)?;
+        let tar = GzDecoder::new(tar_gz);
+        let mut archive = Archive::new(tar);
+        archive.unpack("/tmp/")?;
+    }
+
+    let new_exe_path = if download_name.ends_with(".tar.gz") {
+        "/tmp/spacetime".to_string()
+    } else {
+        temp_path.clone()
+    };
+
+    fs::copy(&new_exe_path, &current_exe_path)?;
+
+    fs::remove_file(&temp_path)?;
+    if download_name.ends_with(".tar.gz") {
+        fs::remove_file(new_exe_path)?;
+    }
+
+    println!("spacetime has been updated!");
+
+    Ok(())
+}

--- a/crates/cli/src/subcommands/upgrade.rs
+++ b/crates/cli/src/subcommands/upgrade.rs
@@ -176,10 +176,10 @@ pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
 
     let temp_dir = tempfile::tempdir()?.into_path();
     let temp_path = &temp_dir.join(download_name.clone());
-    download_with_progress(&client, &asset.unwrap().browser_download_url, &temp_path).await?;
+    download_with_progress(&client, &asset.unwrap().browser_download_url, temp_path).await?;
 
     if download_name.to_lowercase().ends_with(".tar.gz") || download_name.to_lowercase().ends_with("tgz") {
-        let tar_gz = fs::File::open(&temp_path)?;
+        let tar_gz = fs::File::open(temp_path)?;
         let tar = GzDecoder::new(tar_gz);
         let mut archive = Archive::new(tar);
         let mut spacetime_found = false;
@@ -198,7 +198,7 @@ pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
         }
     }
 
-    let new_exe_path = if temp_path.ends_with(".exe") {
+    let new_exe_path = if temp_path.to_str().unwrap().ends_with(".exe") {
         temp_path.clone()
     } else if download_name.ends_with(".tar.gz") {
         temp_dir.join("spacetime")
@@ -210,8 +210,8 @@ pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
     // Move the current executable into a temporary directory, which will later be deleted by the OS
     let current_exe_temp_dir = env::temp_dir();
     let current_exe_to_temp = current_exe_temp_dir.join("spacetime_old");
-    fs::rename(&current_exe_path, &current_exe_to_temp)?;
-    fs::rename(&new_exe_path, &current_exe_path)?;
+    fs::rename(&current_exe_path, current_exe_to_temp)?;
+    fs::rename(new_exe_path, &current_exe_path)?;
     fs::remove_dir_all(&temp_dir)?;
 
     println!("spacetime has been updated to version {}", release_version);

--- a/crates/cli/src/subcommands/upgrade.rs
+++ b/crates/cli/src/subcommands/upgrade.rs
@@ -207,10 +207,13 @@ pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
         return Err(anyhow::anyhow!("Unsupported download type"));
     };
 
-    let backup_exe_path = current_exe_path.with_extension("prev");
-    fs::rename(&current_exe_path, &backup_exe_path)?;
+    // Move the current executable into a temporary directory, which will later be deleted by the OS
+    let current_exe_temp_dir = env::temp_dir();
+    let current_exe_to_temp = current_exe_temp_dir.join("spacetime_old");
+    fs::rename(&current_exe_path, &current_exe_to_temp)?;
     fs::rename(&new_exe_path, &current_exe_path)?;
     fs::remove_dir_all(&temp_dir)?;
+
     println!("spacetime has been updated to version {}", release_version);
 
     Ok(())

--- a/crates/cli/src/subcommands/upgrade.rs
+++ b/crates/cli/src/subcommands/upgrade.rs
@@ -1,9 +1,13 @@
 use std::{env, fs};
 
+extern crate regex;
+
 use crate::version;
 use clap::{Arg, ArgMatches};
 use flate2::read::GzDecoder;
+use regex::Regex;
 use serde::Deserialize;
+use serde_json::Value;
 use tar::Archive;
 
 pub fn cli() -> clap::Command {
@@ -45,20 +49,63 @@ fn get_download_name() -> String {
     format!("spacetime.{}-{}.tar.gz", os_str, arch_str)
 }
 
+fn clean_version(version: &str) -> Option<String> {
+    let re = Regex::new(r"v?(\d+\.\d+\.\d+)").unwrap();
+    re.captures(version)
+        .and_then(|cap| cap.get(1))
+        .map(|match_| match_.as_str().to_string())
+}
+
+fn get_release_tag_from_version(release_version: &str) -> Result<Option<String>, reqwest::Error> {
+    let release_version = format!("v{}-beta", release_version);
+    let url = "https://api.github.com/repos/clockworklabs/SpacetimeDB/releases";
+    let client = reqwest::blocking::Client::new();
+    let releases: Vec<Value> = client
+        .get(url)
+        .header(
+            reqwest::header::USER_AGENT,
+            format!("SpacetimeDB CLI/{}", version::CLI_VERSION).as_str(),
+        )
+        .send()?
+        .json()?;
+
+    for release in releases.iter() {
+        if let Some(release_tag) = release["tag_name"].as_str() {
+            println!("Release: {}", release_tag.clone());
+            if release_tag.starts_with(&release_version) {
+                return Ok(Some(release_tag.to_string()));
+            }
+        }
+    }
+    Ok(None)
+}
+
 pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
     let version = args.get_one::<String>("version");
     let current_exe_path = env::current_exe()?;
 
     let url = match version {
         None => "https://api.github.com/repos/clockworklabs/SpacetimeDB/releases/latest".to_string(),
-        Some(version) => format!(
-            "https://api.github.com/repos/clockworklabs/SpacetimeDB/releases/tags/{}",
-            version
-        ),
+        Some(release_version) => {
+            let release_tag = get_release_tag_from_version(release_version)?;
+            if release_tag.is_none() {
+                return Err(anyhow::anyhow!("No release found for version {}", release_version));
+            }
+            format!(
+                "https://api.github.com/repos/clockworklabs/SpacetimeDB/releases/tags/{}",
+                release_tag.unwrap()
+            )
+        }
     };
-    let release: Release = reqwest::blocking::get(url)?.json()?;
 
-    if release.tag_name == version::CLI_VERSION {
+    let client = reqwest::Client::builder()
+        .user_agent(format!("SpacetimeDB CLI/{}", version::CLI_VERSION))
+        .build()?;
+
+    let release: Release = client.get(url).send().await?.json().await?;
+    let release_version = clean_version(&release.tag_name).unwrap();
+
+    if release_version == version::CLI_VERSION {
         println!("You're already running the latest version: {}", version::CLI_VERSION);
         return Ok(());
     }
@@ -75,7 +122,7 @@ pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
     println!(
         "You are currently running version {} of spacetime. The version you're upgrading to is {}.",
         version::CLI_VERSION,
-        release.tag_name
+        release_version,
     );
     println!(
         "This will replace the current executable at {}.",

--- a/crates/cli/src/subcommands/upgrade.rs
+++ b/crates/cli/src/subcommands/upgrade.rs
@@ -72,8 +72,25 @@ pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
         ));
     }
 
+    println!(
+        "You are currently running version {} of spacetime. The version you're upgrading to is {}.",
+        version::CLI_VERSION,
+        release.tag_name
+    );
+    println!(
+        "This will replace the current executable at {}.",
+        current_exe_path.display()
+    );
+    println!("Do you want to continue? [y/N]");
+    let mut input = String::new();
+    std::io::stdin().read_line(&mut input)?;
+    if input.trim().to_lowercase() != "y" || input.trim().to_lowercase() != "yes" {
+        println!("Aborting upgrade.");
+        return Ok(());
+    }
+
     // Download the archive from the URL
-    let temp_path = format!("/tmp/{}", download_name);
+    let temp_path = tempfile::tempdir()?.into_path().join(download_name);
     let response = reqwest::blocking::get(&asset.unwrap().browser_download_url)?;
     fs::write(&temp_path, response.bytes()?)?;
 

--- a/crates/cli/src/subcommands/upgrade.rs
+++ b/crates/cli/src/subcommands/upgrade.rs
@@ -207,7 +207,9 @@ pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
         return Err(anyhow::anyhow!("Unsupported download type"));
     };
 
-    fs::copy(&new_exe_path, current_exe_path)?;
+    let backup_exe_path = current_exe_path.with_extension("prev");
+    fs::rename(&current_exe_path, &backup_exe_path)?;
+    fs::rename(&new_exe_path, &current_exe_path)?;
     fs::remove_dir_all(&temp_dir)?;
     println!("spacetime has been updated to version {}", release_version);
 

--- a/crates/cli/src/subcommands/upgrade.rs
+++ b/crates/cli/src/subcommands/upgrade.rs
@@ -142,8 +142,11 @@ pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
         .user_agent(format!("SpacetimeDB CLI/{}", version::CLI_VERSION))
         .build()?;
 
+    print!("Finding version...");
+    std::io::stdout().flush()?;
     let release: Release = client.get(url).send().await?.json().await?;
     let release_version = clean_version(&release.tag_name).unwrap();
+    println!("done.");
 
     if release_version == version::CLI_VERSION {
         println!("You're already running the latest version: {}", version::CLI_VERSION);

--- a/crates/cli/src/subcommands/version.rs
+++ b/crates/cli/src/subcommands/version.rs
@@ -1,6 +1,6 @@
 use clap::{Arg, ArgAction::SetTrue, ArgMatches};
 
-const CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
+pub const CLI_VERSION: &str = env!("CARGO_PKG_VERSION");
 
 use crate::config::Config;
 


### PR DESCRIPTION
# Description of Changes

 - Adds `spacetime upgrade` command, which allows you to upgrade your spacetime-cli version to the latest version, or a version of your choosing.
 - If you already have the version that you're trying to upgrade to, then no action is performed

Note: Its possible to downgrade to a version of spacetimedb that doesn't have the `spacetime upgrade` command, which means in order to upgrade again you'll have to follow the installation instructions on the spacetimedb.com website.

This has been tested on all 3 platforms: macOS, Linux and Windows.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

## Testing

Try to upgrade to the latest version, 0.7.1:
```
> spacetime upgrade       
Finding version...done.
You are currently running version 0.7.2 of spacetime. The version you're upgrading to is 0.7.1.
This will replace the current executable at /Users/boppy/.cargo/bin/spacetime.
Do you want to continue? [y/N] y
  Downloading update... 13.40MiB/13.40MiB (0s)
spacetime has been updated to version 0.7.1
```
