### PR TITLE
Added Git Commit Hash to Version Command

### DIFF
--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -1,0 +1,8 @@
+use std::process::Command;
+
+// https://stackoverflow.com/questions/43753491/include-git-commit-hash-as-string-into-rust-program
+fn main() {
+    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
+    let git_hash = String::from_utf8(output.stdout).unwrap();
+    println!("cargo:rustc-env=GIT_HASH={}", git_hash);
+}

--- a/crates/cli/build.rs
+++ b/crates/cli/build.rs
@@ -2,7 +2,7 @@ use std::process::Command;
 
 // https://stackoverflow.com/questions/43753491/include-git-commit-hash-as-string-into-rust-program
 fn main() {
-    let output = Command::new("git").args(&["rev-parse", "HEAD"]).output().unwrap();
+    let output = Command::new("git").args(["rev-parse", "HEAD"]).output().unwrap();
     let git_hash = String::from_utf8(output.stdout).unwrap();
     println!("cargo:rustc-env=GIT_HASH={}", git_hash);
 }

--- a/crates/cli/src/subcommands/version.rs
+++ b/crates/cli/src/subcommands/version.rs
@@ -24,6 +24,7 @@ pub async fn exec(_config: Config, args: &ArgMatches) -> Result<(), anyhow::Erro
     }
 
     println!("Path: {}", std::env::current_exe()?.display());
+    println!("Commit: {}", env!("GIT_HASH"));
     println!(
         "spacetimedb tool version {}; spacetimedb-lib version {};",
         CLI_VERSION,


### PR DESCRIPTION
# Description of Changes

 - `spacetime version` now contains the git commit hash. This helps when debugging because commonly someone will say that they're on a specific version (0.6.1) but the commit they compiled is different than expected.

```
boppy@boppy-macbook SpacetimeDB % spacetime version
Path: /Users/boppy/.cargo/bin/spacetime
Commit: 0a3a9d63b5cb861b40dbc6a053529c728ae8551c
spacetimedb tool version 0.6.1; spacetimedb-lib version 0.6.1;
```

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
