### PR TITLE
Print the elapsed time & # of returned rows in the interactive repl

### DIFF
--- a/crates/cli/src/subcommands/repl.rs
+++ b/crates/cli/src/subcommands/repl.rs
@@ -41,7 +41,7 @@ sort by
 pub async fn exec(con: Connection) -> Result<(), anyhow::Error> {
     let database = con.database.clone();
     let mut rl = Editor::<ReplHelper, DefaultHistory>::new().unwrap();
-    let history = home_dir().unwrap_or_else(|| temp_dir()).join(".stdb.history.txt");
+    let history = home_dir().unwrap_or_else(temp_dir).join(".stdb.history.txt");
     if rl.load_history(&history).is_err() {
         eprintln!("No previous history.");
     }

--- a/crates/cli/src/subcommands/repl.rs
+++ b/crates/cli/src/subcommands/repl.rs
@@ -71,7 +71,7 @@ pub async fn exec(con: Connection) -> Result<(), anyhow::Error> {
                 sql => {
                     rl.add_history_entry(sql).ok();
 
-                    if let Err(err) = run_sql(api.sql(), sql).await {
+                    if let Err(err) = run_sql(api.sql(), sql, true).await {
                         eprintln!("{}", err.to_string().red())
                     }
                 }

--- a/crates/cli/src/subcommands/repl.rs
+++ b/crates/cli/src/subcommands/repl.rs
@@ -1,6 +1,8 @@
 use crate::api::{ClientApi, Connection};
 use crate::sql::run_sql;
 use colored::*;
+use dirs::home_dir;
+use std::env::temp_dir;
 
 use rustyline::completion::Completer;
 use rustyline::error::ReadlineError;
@@ -39,7 +41,8 @@ sort by
 pub async fn exec(con: Connection) -> Result<(), anyhow::Error> {
     let database = con.database.clone();
     let mut rl = Editor::<ReplHelper, DefaultHistory>::new().unwrap();
-    if rl.load_history(".history.txt").is_err() {
+    let history = home_dir().unwrap_or_else(|| temp_dir()).join(".stdb.history.txt");
+    if rl.load_history(&history).is_err() {
         eprintln!("No previous history.");
     }
     rl.set_helper(Some(ReplHelper::new().unwrap()));
@@ -84,7 +87,7 @@ pub async fn exec(con: Connection) -> Result<(), anyhow::Error> {
         }
     }
 
-    rl.save_history(".history.txt").ok();
+    rl.save_history(&history).ok();
 
     Ok(())
 }

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -2,7 +2,6 @@ use std::time::Instant;
 
 use crate::api::{from_json_seed, ClientApi, Connection, StmtResultJson};
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches};
-use colored::Colorize;
 use reqwest::RequestBuilder;
 use spacetimedb_lib::de::serde::SeedWrapper;
 use spacetimedb_lib::sats::{satn, Typespace};
@@ -76,15 +75,21 @@ pub(crate) async fn parse_req(mut config: Config, args: &ArgMatches) -> Result<C
     })
 }
 
-fn print_stats(now: Instant, rows: &[usize]) {
-    println!();
-    println!("{}: {:.2?}.", "[Elapsed  ]".red().bold(), now.elapsed());
-    for (result, count) in rows.iter().enumerate() {
-        println!("{}: {count} rows.", format!("[Result {result:>2}]").blue().bold());
+// Need to report back timings from each query from the backend instead of infer here...
+fn print_row_count(rows: usize, with_stats: bool) {
+    if with_stats {
+        let txt = if rows == 1 { "row" } else { "rows" };
+        println!("({rows} {txt})");
     }
 }
 
-pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str) -> Result<(), anyhow::Error> {
+fn print_timings(now: Instant, with_stats: bool) {
+    if with_stats {
+        println!("Time: {:.2?}", now.elapsed());
+    }
+}
+
+pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool) -> Result<(), anyhow::Error> {
     let now = Instant::now();
 
     let json = builder
@@ -99,12 +104,10 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str) -> Result<(), an
 
     // Print only `OK for empty tables as it's likely a command like `INSERT`.
     if stmt_result_json.is_empty() {
-        print_stats(now, &[]);
+        print_timings(now, with_stats);
         println!("OK");
         return Ok(());
     };
-
-    let mut count = Vec::with_capacity(stmt_result_json.len());
 
     for (i, stmt_result) in stmt_result_json.iter().enumerate() {
         let StmtResultJson { schema, rows } = &stmt_result;
@@ -117,8 +120,6 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str) -> Result<(), an
                 .enumerate()
                 .map(|(i, e)| e.name.clone().unwrap_or_else(|| format!("column {i}"))),
         );
-
-        count.push(rows.len());
 
         let typespace = Typespace::default();
         let ty = typespace.with_type(schema);
@@ -139,9 +140,9 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str) -> Result<(), an
         } else {
             println!("{}", table);
         }
+        print_row_count(rows.len(), with_stats);
     }
-
-    print_stats(now, &count);
+    print_timings(now, with_stats);
 
     Ok(())
 }
@@ -158,7 +159,7 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error
         let con = parse_req(config, args).await?;
         let api = ClientApi::new(con);
 
-        run_sql(api.sql(), query).await?;
+        run_sql(api.sql(), query, false).await?;
     }
     Ok(())
 }


### PR DESCRIPTION
# Description of Changes

To help do interactive timing of queries, now it print on the repl:

```bash
└──────────────────────────────────────────────────────────┘
🪐bitcraft>select * from st_table where table_id = 1
 table_id | table_name | table_type | table_access
----------+------------+------------+--------------
 1        | st_columns | system     | public

[Elapsed  ]: 14.62ms.
[Result  0]: 1 rows.
```

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
