### PR TITLE
Benchmarks: report tx/s as elements/s

### DIFF
--- a/crates/bench/benches/generic.rs
+++ b/crates/bench/benches/generic.rs
@@ -148,6 +148,9 @@ fn insert_1<DB: BenchDatabase, T: BenchTable + RandomTable>(
     let id = format!("insert_1/{table_params}/load={load}");
     let data = create_sequential::<T>(0xdeadbeef, load + 1, 1000);
 
+    // Each iteration performs one transaction.
+    g.throughput(criterion::Throughput::Elements(1));
+
     g.bench_function(&id, |b| {
         bench_harness(
             b,
@@ -180,6 +183,9 @@ fn insert_bulk<DB: BenchDatabase, T: BenchTable + RandomTable>(
 ) -> ResultBench<()> {
     let id = format!("insert_bulk/{table_params}/load={load}/count={count}");
     let data = create_sequential::<T>(0xdeadbeef, load + count, 1000);
+
+    // Each iteration performs one transaction, though it inserts many rows.
+    g.throughput(criterion::Throughput::Elements(1));
 
     g.bench_function(&id, |b| {
         bench_harness(
@@ -216,6 +222,10 @@ fn iterate<DB: BenchDatabase, T: BenchTable + RandomTable>(
     let data = create_sequential::<T>(0xdeadbeef, count, 1000);
 
     db.insert_bulk(table_id, data)?;
+
+    // Each iteration performs a single transaction,
+    // though it iterates across many rows.
+    g.throughput(criterion::Throughput::Elements(1));
 
     g.bench_function(&id, |b| {
         bench_harness(
@@ -260,6 +270,9 @@ fn filter<DB: BenchDatabase, T: BenchTable + RandomTable>(
     let data = create_sequential::<T>(0xdeadbeef, load, buckets as u64);
 
     db.insert_bulk(&table_id, data.clone())?;
+
+    // Each iteration performs a single transaction.
+    g.throughput(criterion::Throughput::Elements(1));
 
     // We loop through all buckets found in the sample data.
     // This mildly increases variance on the benchmark, but makes "mean_result_count" more accurate.
@@ -307,6 +320,9 @@ fn find<DB: BenchDatabase, T: BenchTable + RandomTable>(
     let data = create_sequential::<T>(0xdeadbeef, load, buckets as u64);
 
     db.insert_bulk(&table_id, data.clone())?;
+
+    // Each iteration performs a single transaction.
+    g.throughput(criterion::Throughput::Elements(1));
 
     // We loop through all buckets found in the sample data.
     // This mildly increases variance on the benchmark, but makes "mean_result_count" more accurate.


### PR DESCRIPTION
# Description of Changes

Based on my limited understanding of Criterion, I think we can get add transactions per second reporting to benchmarks using Criterion's Throughput::Elements tracking, by treating transactions as elements.

This is not ideal, as the output says e.g. `thrpt:  [38.763 Kelem/s 38.781 Kelem/s 38.799 Kelem/s]`, where we'd like `Ktx/s`, but it's not clear whether Criterion allows us that much customization.

Each of the benchmarks currently does one tx per iteration, so pass `Throughput::Elements(1)` for each of them. Do this as close to the test as possible, despite redundancy, in case we ever add benchmarks to the same group which do multiple transactions per iteration.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
