### PR TITLE
SDK tests use a tempdir as STDB_PATH, rather than ~/.spacetime

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1472,12 +1472,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "1.9.0"
+version = "2.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e51093e27b0797c359783294ca4f0a911c270184cb10f85783b118614a1501be"
-dependencies = [
- "instant",
-]
+checksum = "25cbce373ec4653f1a01a31e8a5e5ec0c622dc27ff9c4e6606eefef5cbbed4a5"
 
 [[package]]
 name = "fd-lock"
@@ -4494,6 +4491,7 @@ dependencies = [
  "spacetimedb-core",
  "spacetimedb-lib",
  "spacetimedb-standalone",
+ "tempfile",
  "tokio",
  "wasmbin",
 ]
@@ -4784,15 +4782,14 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.6.0"
+version = "3.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "31c0432476357e58790aaa47a8efb0c5138f137343f3b5f23bd36a27e3b0a6d6"
+checksum = "cb94d2f3cc536af71caac6b6fcebf65860b347e7ce0cc9ebe8f70d3e521054ef"
 dependencies = [
- "autocfg",
  "cfg-if",
  "fastrand",
  "redox_syscall 0.3.5",
- "rustix 0.37.21",
+ "rustix 0.38.1",
  "windows-sys 0.48.0",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,7 @@ syntect = { version = "5.0.0", default-features = false, features = [
 ] }
 tabled = "0.8.0"
 tempdir = "0.3.7"
-tempfile = "3.3"
+tempfile = "3.8"
 termcolor = "1.2.0"
 thiserror = "1.0.37"
 tokio = { version = "1.25.1", features = ["full"] }

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -19,6 +19,7 @@ duct.workspace = true
 lazy_static.workspace = true
 rand.workspace = true
 prost.workspace = true
+tempfile.workspace = true
 
 [dev-dependencies]
 serial_test.workspace = true


### PR DESCRIPTION
# Description of Changes

We've had continual issues with test isolation when developing breaking changes. This commit doesn't fully address those, but is a step in the right direction: the SDK tests now create a tempdir as their `STDB_PATH`, rather than using `~/.spacetime`.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
