### PR TITLE
Preliminary module-side interface for timing execution

### DIFF
--- a/crates/bindings-sys/src/lib.rs
+++ b/crates/bindings-sys/src/lib.rs
@@ -212,6 +212,24 @@ pub mod raw {
         /// Creates a buffer of size `data_len` in the host environment.
         /// The buffer is initialized with the contents at the `data` WASM pointer.
         pub fn _buffer_alloc(data: *const u8, data_len: usize) -> Buffer;
+
+        /// Begin a timing span.
+        ///
+        /// When the returned `u32` span ID is passed to [`_span_end`],
+        /// the duration between the calls will be printed to the module's logs.
+        ///
+        /// The slice (`name`, `name_len`) must be valid UTF-8 bytes.
+        pub fn _span_start(name: *const u8, name_len: usize) -> u32;
+
+        /// End a timing span.
+        ///
+        /// The `span_id` must be the result of a call to `_span_start`.
+        /// The duration between the two calls will be computed and printed to the module's logs.
+        ///
+        /// Behavior is unspecified
+        /// if `_span_end` is called on a `span_id` which is not the result of a call to `_span_start`,
+        /// or if `_span_end` is called multiple times with the same `span_id`.
+        pub fn _span_end(span_id: u32);
     }
 
     /// What strategy does the database index use?

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -7,8 +7,8 @@ mod impls;
 mod logger;
 #[doc(hidden)]
 pub mod rt;
-mod timestamp;
 pub mod time_span;
+mod timestamp;
 
 use spacetimedb_lib::buffer::{BufReader, BufWriter, Cursor, DecodeError};
 pub use spacetimedb_lib::de::{Deserialize, DeserializeOwned};

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -8,6 +8,7 @@ mod logger;
 #[doc(hidden)]
 pub mod rt;
 mod timestamp;
+pub mod time_span;
 
 use spacetimedb_lib::buffer::{BufReader, BufWriter, Cursor, DecodeError};
 pub use spacetimedb_lib::de::{Deserialize, DeserializeOwned};

--- a/crates/bindings/src/time_span.rs
+++ b/crates/bindings/src/time_span.rs
@@ -1,0 +1,23 @@
+pub struct Span {
+    span_id: u32,
+}
+
+impl Span {
+    pub fn start(name: &str) -> Self {
+        let name = name.as_bytes();
+        let id = unsafe { spacetimedb_bindings_sys::raw::_span_start(name.as_ptr(), name.len()) };
+        Self { span_id: id }
+    }
+
+    pub fn end(self) {
+        // just drop self
+    }
+}
+
+impl std::ops::Drop for Span {
+    fn drop(&mut self) {
+        unsafe {
+            spacetimedb_bindings_sys::raw::_span_end(self.span_id);
+        }
+    }
+}

--- a/crates/core/src/host/wasm_common.rs
+++ b/crates/core/src/host/wasm_common.rs
@@ -1,5 +1,7 @@
 pub mod module_host_actor;
 
+use std::time::Instant;
+
 use crate::error::{DBError, IndexError, NodesError};
 
 pub const CALL_REDUCER_DUNDER: &str = "__call_reducer__";
@@ -300,6 +302,23 @@ impl BufferIdx {
 
 decl_index!(BufferIterIdx => Box<dyn Iterator<Item = Result<bytes::Bytes, NodesError>> + Send + Sync>);
 pub(super) type BufferIters = ResourceSlab<BufferIterIdx>;
+
+pub(super) struct TimingSpan {
+    pub start: Instant,
+    pub name: Vec<u8>,
+}
+
+impl TimingSpan {
+    pub fn new(name: Vec<u8>) -> Self {
+        Self {
+            start: Instant::now(),
+            name,
+        }
+    }
+}
+
+decl_index!(TimingSpanIdx => TimingSpan);
+pub(super) type TimingSpanSet = ResourceSlab<TimingSpanIdx>;
 
 pub mod errnos {
     /// NOTE! This is copied from the bindings-sys crate.

--- a/crates/core/src/host/wasmer/wasmer_module.rs
+++ b/crates/core/src/host/wasmer/wasmer_module.rs
@@ -131,6 +131,8 @@ impl WasmerModule {
                 "_buffer_len" => Function::new_typed_with_env(store, env, WasmInstanceEnv::buffer_len),
                 "_buffer_consume" => Function::new_typed_with_env(store, env, WasmInstanceEnv::buffer_consume),
                 "_buffer_alloc" => Function::new_typed_with_env(store, env, WasmInstanceEnv::buffer_alloc),
+                "_span_start" => Function::new_typed_with_env(store, env, WasmInstanceEnv::span_start),
+                "_span_end" => Function::new_typed_with_env(store, env, WasmInstanceEnv::span_end),
             }
         }
     }
@@ -168,6 +170,7 @@ impl module_host_actor::WasmInstancePre for WasmerModule {
             mem: None,
             buffers: Default::default(),
             iters: Default::default(),
+            timing_spans: Default::default(),
         };
         let env = FunctionEnv::new(&mut store, env);
         let imports = self.imports(&mut store, &env);


### PR DESCRIPTION
# Description of Changes

At a high level, define a struct `Span` in `bindings` which manages a timing span, with methods `start` and `end` to begin and end timing, respectively. `Span::start` records the `Instant` of its call; `Span::end` computes the elapsed `Duration` and prints it to the module logs.

At a low level, add a slab of timing spans to WasmInstanceEnv, with ABI functions `_start_span` and `_end_span` to implement `Span::start` and `Span::end`.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
