### PR TITLE
Fix arm64 builds on Linux

### DIFF
--- a/.github/workflows/linux-client.yml
+++ b/.github/workflows/linux-client.yml
@@ -17,7 +17,7 @@ jobs:
 
       - name: Compile Aarch64 Docker
         run: |
-          docker build --platform=linux/amd64 -f crates/cli/Dockerfile -t cli .
+          docker build --platform=linux/aarch64 -f crates/cli/Dockerfile -t cli .
           mkdir build
           id=$(docker create cli)
           docker cp $id:/usr/local/bin/spacetime - > build/spacetime.linux-arm64.tar


### PR DESCRIPTION
# Description of Changes

It was building Intel/AMD64 executables instead of ARM64.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
