### PR TITLE
Fix AMD64 dependency error in CLI Docker Build

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -15,9 +15,12 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
       - name: Compile Aarch64 Docker
         run: |
-          docker build --platform=linux/aarch64 -f crates/cli/Dockerfile -t cli .
+          docker buildx build --platform=linux/arm64 -f crates/cli/Dockerfile -t cli .
           mkdir build
           id=$(docker create cli)
           docker cp $id:/usr/local/bin/spacetime - > build/spacetime.linux-arm64.tar


### PR DESCRIPTION
# Description of Changes

Fix errors with building CLI for Aarch64

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
