### PR TITLE
Bench for sql scan

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -190,7 +190,7 @@ wasmtime = { version = "7", default-features = false, features = ["cranelift"] }
 # We use the "ondemand" feature to allow connecting after the start,
 # and reconnecting, from the tracy client to the database.
 # TODO(George): Need to be able to remove "broadcast" in some build configurations.
-tracing-tracy = { version = "0.10.2", features = [
+tracing-tracy = { version = "0.10.3", features = [
   "enable",
   "system-tracing",
   "context-switch-tracing",

--- a/crates/bench/src/database.rs
+++ b/crates/bench/src/database.rs
@@ -38,6 +38,10 @@ pub trait BenchDatabase: Sized {
     /// Note: this can be non-generic because none of the implementations use the relevant generic argument.
     fn iterate(&mut self, table_id: &Self::TableId) -> ResultBench<()>;
 
+    /// Perform a `SELECT * FROM table`
+    /// Note: this can be non-generic because none of the implementations use the relevant generic argument.
+    fn sql_select(&mut self, table_id: &Self::TableId) -> ResultBench<()>;
+
     /// Filter the table on the specified column index for the specified value.
     fn filter<T: BenchTable>(
         &mut self,

--- a/crates/bench/src/database.rs
+++ b/crates/bench/src/database.rs
@@ -1,3 +1,4 @@
+use spacetimedb::db::datastore::traits::TableSchema;
 use spacetimedb_lib::AlgebraicValue;
 
 use crate::schemas::{BenchTable, IndexStrategy};
@@ -18,6 +19,9 @@ pub trait BenchDatabase: Sized {
         Self: Sized;
 
     fn create_table<T: BenchTable>(&mut self, table_style: IndexStrategy) -> ResultBench<Self::TableId>;
+
+    /// Return table metadata so we can remove this from the hot path
+    fn get_table<T: BenchTable>(&mut self, table_id: &Self::TableId) -> ResultBench<TableSchema>;
 
     /// Should not drop the table, only delete all the rows.
     fn clear_table(&mut self, table_id: &Self::TableId) -> ResultBench<()>;
@@ -41,20 +45,20 @@ pub trait BenchDatabase: Sized {
     /// Filter the table on the specified column index for the specified value.
     fn filter<T: BenchTable>(
         &mut self,
-        table_id: &Self::TableId,
+        table: &TableSchema,
         column_index: u32,
         value: AlgebraicValue,
     ) -> ResultBench<()>;
 
     /// Perform a `SELECT * FROM table`
     /// Note: this can be non-generic because none of the implementations use the relevant generic argument.
-    fn sql_select(&mut self, table_id: &Self::TableId) -> ResultBench<()>;
+    fn sql_select(&mut self, table: &TableSchema) -> ResultBench<()>;
 
     /// Perform a `SELECT * FROM table WHERE column = value`
     /// Note: this can be non-generic because none of the implementations use the relevant generic argument.
     fn sql_where<T: BenchTable>(
         &mut self,
-        table_id: &Self::TableId,
+        table: &TableSchema,
         column_index: u32,
         value: AlgebraicValue,
     ) -> ResultBench<()>;

--- a/crates/bench/src/database.rs
+++ b/crates/bench/src/database.rs
@@ -38,12 +38,21 @@ pub trait BenchDatabase: Sized {
     /// Note: this can be non-generic because none of the implementations use the relevant generic argument.
     fn iterate(&mut self, table_id: &Self::TableId) -> ResultBench<()>;
 
+    /// Filter the table on the specified column index for the specified value.
+    fn filter<T: BenchTable>(
+        &mut self,
+        table_id: &Self::TableId,
+        column_index: u32,
+        value: AlgebraicValue,
+    ) -> ResultBench<()>;
+
     /// Perform a `SELECT * FROM table`
     /// Note: this can be non-generic because none of the implementations use the relevant generic argument.
     fn sql_select(&mut self, table_id: &Self::TableId) -> ResultBench<()>;
 
-    /// Filter the table on the specified column index for the specified value.
-    fn filter<T: BenchTable>(
+    /// Perform a `SELECT * FROM table WHERE column = value`
+    /// Note: this can be non-generic because none of the implementations use the relevant generic argument.
+    fn sql_where<T: BenchTable>(
         &mut self,
         table_id: &Self::TableId,
         column_index: u32,

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -1,3 +1,7 @@
+use crate::schemas::BenchTable;
+use spacetimedb::db::datastore::traits::{ColumnSchema, TableSchema};
+use spacetimedb_lib::auth::{StAccess, StTableType};
+
 pub mod database;
 pub mod schemas;
 pub mod spacetime_module;
@@ -5,6 +9,30 @@ pub mod spacetime_raw;
 pub mod sqlite;
 
 pub type ResultBench<T> = Result<T, anyhow::Error>;
+
+pub(crate) fn create_schema<T: BenchTable>(table_name: &str) -> TableSchema {
+    let columns = T::product_type()
+        .elements
+        .into_iter()
+        .enumerate()
+        .map(|(pos, col)| ColumnSchema {
+            table_id: 0,
+            col_id: pos as u32,
+            col_name: col.name.unwrap(),
+            col_type: col.algebraic_type,
+            is_autoinc: false,
+        });
+
+    TableSchema {
+        table_id: 0,
+        table_name: table_name.to_string(),
+        indexes: vec![],
+        columns: columns.collect(),
+        constraints: vec![],
+        table_type: StTableType::System,
+        table_access: StAccess::Public,
+    }
+}
 
 #[cfg(test)]
 mod tests {

--- a/crates/bench/src/spacetime_module.rs
+++ b/crates/bench/src/spacetime_module.rs
@@ -171,6 +171,18 @@ impl BenchDatabase for SpacetimeModule {
         })
     }
 
+    fn sql_select(&mut self, table_id: &Self::TableId) -> ResultBench<()> {
+        let SpacetimeModule { runtime, module } = self;
+        let module = module.as_mut().unwrap();
+        let table_name = &table_id.pascal_case;
+        let sql = format!("SELECT * FROM  {table_name}");
+        let id = module.client.id.identity;
+        runtime.block_on(async move {
+            module.client.module.one_off_query(id, sql).await?;
+            Ok(())
+        })
+    }
+
     fn filter<T: BenchTable>(
         &mut self,
         table_id: &Self::TableId,

--- a/crates/bench/src/sqlite.rs
+++ b/crates/bench/src/sqlite.rs
@@ -214,6 +214,10 @@ impl BenchDatabase for SQLite {
         commit.execute(())?;
         Ok(())
     }
+
+    fn sql_select(&mut self, table_id: &Self::TableId) -> ResultBench<()> {
+        self.iterate(table_id)
+    }
 }
 
 /// Note: The rusqlite transaction API just invokes these statements,

--- a/crates/bench/src/sqlite.rs
+++ b/crates/bench/src/sqlite.rs
@@ -29,6 +29,8 @@ impl BenchDatabase for SQLite {
         "sqlite"
     }
 
+    type TableId = String;
+
     fn build(in_memory: bool, fsync: bool) -> ResultBench<Self>
     where
         Self: Sized,
@@ -52,8 +54,6 @@ impl BenchDatabase for SQLite {
             _temp_dir: temp_dir,
         })
     }
-
-    type TableId = String;
 
     /// We derive the SQLite schema from the AlgebraicType of the table.
     fn create_table<T: BenchTable>(
@@ -217,6 +217,15 @@ impl BenchDatabase for SQLite {
 
     fn sql_select(&mut self, table_id: &Self::TableId) -> ResultBench<()> {
         self.iterate(table_id)
+    }
+
+    fn sql_where<T: BenchTable>(
+        &mut self,
+        table_id: &Self::TableId,
+        column_index: u32,
+        value: AlgebraicValue,
+    ) -> ResultBench<()> {
+        self.filter::<T>(table_id, column_index, value)
     }
 }
 

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -119,10 +119,10 @@ impl From<IndexSchema> for IndexDef {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ColumnSchema {
-    pub(crate) table_id: u32,
-    pub(crate) col_id: u32,
-    pub(crate) col_name: String,
-    pub(crate) col_type: AlgebraicType,
+    pub table_id: u32,
+    pub col_id: u32,
+    pub col_name: String,
+    pub col_type: AlgebraicType,
     pub(crate) is_autoinc: bool,
 }
 
@@ -198,9 +198,9 @@ pub struct ConstraintDef {
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableSchema {
-    pub(crate) table_id: u32,
-    pub(crate) table_name: String,
-    pub(crate) columns: Vec<ColumnSchema>,
+    pub table_id: u32,
+    pub table_name: String,
+    pub columns: Vec<ColumnSchema>,
     pub(crate) indexes: Vec<IndexSchema>,
     pub(crate) constraints: Vec<ConstraintSchema>,
     pub(crate) table_type: StTableType,

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -123,7 +123,7 @@ pub struct ColumnSchema {
     pub col_id: u32,
     pub col_name: String,
     pub col_type: AlgebraicType,
-    pub(crate) is_autoinc: bool,
+    pub is_autoinc: bool,
 }
 
 impl From<&ColumnSchema> for spacetimedb_lib::table::ColumnDef {
@@ -201,10 +201,10 @@ pub struct TableSchema {
     pub table_id: u32,
     pub table_name: String,
     pub columns: Vec<ColumnSchema>,
-    pub(crate) indexes: Vec<IndexSchema>,
-    pub(crate) constraints: Vec<ConstraintSchema>,
-    pub(crate) table_type: StTableType,
-    pub(crate) table_access: StAccess,
+    pub indexes: Vec<IndexSchema>,
+    pub constraints: Vec<ConstraintSchema>,
+    pub table_type: StTableType,
+    pub table_access: StAccess,
 }
 
 impl TableSchema {

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -1,5 +1,6 @@
 use nonempty::NonEmpty;
 use std::collections::HashMap;
+use tracing::info;
 
 use crate::db::datastore::locking_tx_datastore::MutTxId;
 use crate::db::datastore::traits::{IndexSchema, TableSchema};
@@ -16,8 +17,9 @@ use spacetimedb_vm::expr::{ColumnOp, CrudExpr, DbType, Expr, IndexJoin, JoinExpr
 use spacetimedb_vm::operator::OpCmp;
 
 /// Compile the `SQL` expression into a `ast`
-#[tracing::instrument(skip(db, tx))]
+#[tracing::instrument(skip_all)]
 pub fn compile_sql(db: &RelationalDB, tx: &MutTxId, sql_text: &str) -> Result<Vec<CrudExpr>, DBError> {
+    info!(sql = sql_text);
     let ast = compile_to_ast(db, tx, sql_text)?;
 
     let mut results = Vec::with_capacity(ast.len());

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -82,7 +82,6 @@ pub fn execute_sql(
     let p = &mut DbProgram::new(db, tx, auth);
     let q = Expr::Block(ast.into_iter().map(|x| Expr::Crud(Box::new(x))).collect());
 
-    info!(query = ?q);
     let mut result = Vec::with_capacity(total);
     collect_result(&mut result, run_ast(p, q).into())?;
     Ok(result)

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -20,6 +20,7 @@ use spacetimedb_vm::program::{ProgramRef, ProgramVm};
 use spacetimedb_vm::rel_ops::RelOps;
 use std::collections::HashMap;
 use std::ops::RangeBounds;
+use tracing::debug;
 
 //TODO: This is partially duplicated from the `vm` crate to avoid borrow checker issues
 //and pull all that crate in core. Will be revisited after trait refactor
@@ -259,8 +260,10 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
         }
     }
 
+    #[tracing::instrument(skip_all, fields(table= query.table.table_name()))]
     fn _eval_query(&mut self, query: QueryCode) -> Result<Code, ErrorVm> {
         let table_access = query.table.table_access();
+        debug!(table = query.table.table_name());
 
         let result = build_query(self.db, self.tx, query)?;
         let head = result.head().clone();

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -260,7 +260,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
         }
     }
 
-    #[tracing::instrument(skip_all, fields(table= query.table.table_name()))]
+    #[tracing::instrument(skip_all)]
     fn _eval_query(&mut self, query: QueryCode) -> Result<Code, ErrorVm> {
         let table_access = query.table.table_access();
         debug!(table = query.table.table_name());

--- a/run_standalone_temp.sh
+++ b/run_standalone_temp.sh
@@ -35,4 +35,4 @@ export SPACETIMEDB_TRACY=1
 echo "DATABASE AT ${STDB_PATH}"
 echo "LOGS AT $STDB_PATH/logs"
 
-cargo run -p spacetimedb-standalone -- start -l 127.0.0.1:3000
+cargo run -p spacetimedb-standalone -- start -l 127.0.0.1:3000 --enable-tracy


### PR DESCRIPTION
# Description of Changes

Changes for hit the `500ms` target loading the `BitCraft` game:

- Bench for SQL queries: `SELECT * FROM table` /  `SELECT * FROM table WHERE pk = value`
- Instrument calls for tracy
- Add tracy support in `run_standalone_temp.sh`

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
