### PR TITLE
Fix deadlock

### DIFF
--- a/crates/client-api/src/routes/subscribe.rs
+++ b/crates/client-api/src/routes/subscribe.rs
@@ -274,6 +274,10 @@ async fn ws_client_actor(client: ClientConnection, mut ws: WebSocketStream, mut 
     log::debug!("Client connection ended");
     sendrx.close();
 
+    // clear the queue before we go on to clean up, or else we can get a situation like:
+    // https://rust-lang.github.io/wg-async/vision/submitted_stories/status_quo/aws_engineer/solving_a_deadlock.html
+    handle_queue.clear();
+
     // ignore NoSuchModule; if the module's already closed, that's fine
     let _ = client.module.subscription().remove_subscriber(client.id);
     let _ = client

--- a/crates/core/src/util/future_queue.rs
+++ b/crates/core/src/util/future_queue.rs
@@ -39,6 +39,11 @@ where
     pub fn push_unpin(&mut self, item: T) {
         self.queue.push_back(item)
     }
+    pub fn clear(self: Pin<&mut Self>) {
+        let mut me = self.project();
+        me.queue.clear();
+        me.fut.set(Fuse::terminated());
+    }
 }
 
 impl<T, F, Fut> Stream for FutureQueue<T, F, Fut>


### PR DESCRIPTION
# Description of Changes

Ok I guess it was kinda a deadlock in the semaphore. I guess that's why they say FuturesUnordered is a footgun, huh. Basically, it was given the permit but not waking up because we weren't polling `handle_queue` anymore at that point. See [Status quo of an AWS engineer: Solving a deadlock](https://rust-lang.github.io/wg-async/vision/submitted_stories/status_quo/aws_engineer/solving_a_deadlock.html).

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
