### PR TITLE
Disable Tracing in master for Release Mode

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -167,7 +167,7 @@ tokio-postgres = { version = "0.7.8", features = ["with-chrono-0_4"] }
 tokio-tungstenite = { version = "0.19", features = ["native-tls"] }
 toml = "0.5"
 tower-http = { version = "0.4.1", features = ["cors"] }
-tracing = "0.1.37"
+tracing = { version = "0.1.37", features = ["release_max_level_off"] }
 tracing-appender = "0.2.2"
 tracing-core = "0.1.31"
 tracing-flame = "0.2.0"


### PR DESCRIPTION
# Description of Changes

 - A PR was merged earlier this week that had a negative impact on performance: https://github.com/clockworklabs/SpacetimeDB/pull/349
 - This PR just disables tracing by default, which should mostly bring us back to where we were in terms of performance
 - This does so only for the release profile, not for the debug profile.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
