### PR TITLE
Build client binaries only on tag pushes

### DIFF
--- a/.github/workflows/linux-build.yml
+++ b/.github/workflows/linux-build.yml
@@ -4,12 +4,10 @@ on:
   push:
     tags:
       - '**'
-    branches:
-      - master
 
 jobs:
   linux-client:
-    runs-on: ubuntu-latest
+    runs-on: bare-metal
 
     steps:
       - name: Checkout

--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '**'
-    branches:
-      - master
 
 jobs:
   macos-client:

--- a/.github/workflows/windows-build.yml
+++ b/.github/workflows/windows-build.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '**'
-    branches:
-      - master
 
 jobs:
   windows-client:


### PR DESCRIPTION
# Description of Changes

Build client binaries only on tag pushes

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
