### PR TITLE
`build_csharp`: ensure project path exists 

### DIFF
--- a/crates/cli/src/tasks/csharp.rs
+++ b/crates/cli/src/tasks/csharp.rs
@@ -1,4 +1,6 @@
+use anyhow::Context;
 use duct::cmd;
+use std::fs;
 use std::path::{Path, PathBuf};
 
 pub(crate) fn build_csharp(project_path: &Path, _build_debug: bool) -> anyhow::Result<PathBuf> {
@@ -10,6 +12,14 @@ pub(crate) fn build_csharp(project_path: &Path, _build_debug: bool) -> anyhow::R
     if output_path.exists() {
         std::fs::remove_file(&output_path)?;
     }
+
+    // Ensure the project path exists.
+    fs::metadata(project_path).with_context(|| {
+        format!(
+            "The provided project path '{}' does not exist.",
+            project_path.to_str().unwrap()
+        )
+    })?;
 
     // run dotnet publish using cmd macro
     let result = cmd!("dotnet", "publish", "-c", "Release").dir(project_path).run();


### PR DESCRIPTION
# Description of Changes

This makes `spacetime generate --lang rust --project-path modules/sdk-test-connect-disconnect-cs` work better so that you don't get:
> `Error: Failed to build project. dotnet not found in path. Please install the .NET Core SDK.`

Written by @jdetter as part of #156.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
