### PR TITLE
SATS: misc refactoring

### DIFF
--- a/crates/bench/benches/generic.rs
+++ b/crates/bench/benches/generic.rs
@@ -9,7 +9,7 @@ use spacetimedb_bench::{
     schemas::{create_sequential, BenchTable, IndexStrategy, Location, Person, RandomTable, BENCH_PKEY_INDEX},
     spacetime_module, spacetime_raw, sqlite, ResultBench,
 };
-use spacetimedb_lib::{sats::BuiltinType, AlgebraicType};
+use spacetimedb_lib::sats::AlgebraicType;
 fn criterion_benchmark(c: &mut Criterion) {
     bench_suite::<sqlite::SQLite>(c, true).unwrap();
     bench_suite::<spacetime_raw::SpacetimeRaw>(c, true).unwrap();
@@ -294,9 +294,9 @@ fn _filter_setup<DB: BenchDatabase, T: BenchTable + RandomTable>(
     buckets: u32,
 ) -> ResultBench<(String, TableSchema, Vec<T>)> {
     let filter_column_type = match &T::product_type().elements[column_index as usize].algebraic_type {
-        AlgebraicType::Builtin(BuiltinType::String) => "string",
-        AlgebraicType::Builtin(BuiltinType::U32) => "u32",
-        AlgebraicType::Builtin(BuiltinType::U64) => "u64",
+        AlgebraicType::String => "string",
+        AlgebraicType::U32 => "u32",
+        AlgebraicType::U64 => "u64",
         _ => unimplemented!(),
     };
     let mean_result_count = load / buckets;

--- a/crates/bench/src/schemas.rs
+++ b/crates/bench/src/schemas.rs
@@ -52,29 +52,15 @@ impl BenchTable for Person {
     }
 
     fn product_type() -> sats::ProductType {
-        sats::ProductType::new(vec![
-            sats::ProductTypeElement {
-                name: Some("id".to_string()),
-                algebraic_type: sats::AlgebraicType::Builtin(sats::BuiltinType::U32),
-            },
-            sats::ProductTypeElement {
-                name: Some("name".to_string()),
-                algebraic_type: sats::AlgebraicType::Builtin(sats::BuiltinType::String),
-            },
-            sats::ProductTypeElement {
-                name: Some("age".to_string()),
-                algebraic_type: sats::AlgebraicType::Builtin(sats::BuiltinType::U64),
-            },
-        ])
+        [
+            ("id", sats::AlgebraicType::U32),
+            ("name", sats::AlgebraicType::String),
+            ("age", sats::AlgebraicType::U64),
+        ]
+        .into()
     }
     fn into_product_value(self) -> sats::ProductValue {
-        sats::ProductValue {
-            elements: vec![
-                sats::AlgebraicValue::Builtin(sats::BuiltinValue::U32(self.id)),
-                sats::AlgebraicValue::Builtin(sats::BuiltinValue::String(self.name)),
-                sats::AlgebraicValue::Builtin(sats::BuiltinValue::U64(self.age)),
-            ],
-        }
+        sats::product![self.id, self.name, self.age]
     }
 
     type SqliteParams = (u32, String, u64);
@@ -92,29 +78,15 @@ impl BenchTable for Location {
     }
 
     fn product_type() -> sats::ProductType {
-        sats::ProductType::new(vec![
-            sats::ProductTypeElement {
-                name: Some("id".to_string()),
-                algebraic_type: sats::AlgebraicType::Builtin(sats::BuiltinType::U32),
-            },
-            sats::ProductTypeElement {
-                name: Some("x".to_string()),
-                algebraic_type: sats::AlgebraicType::Builtin(sats::BuiltinType::U64),
-            },
-            sats::ProductTypeElement {
-                name: Some("y".to_string()),
-                algebraic_type: sats::AlgebraicType::Builtin(sats::BuiltinType::U64),
-            },
-        ])
+        [
+            ("id", sats::AlgebraicType::U32),
+            ("x", sats::AlgebraicType::U64),
+            ("y", sats::AlgebraicType::U64),
+        ]
+        .into()
     }
     fn into_product_value(self) -> sats::ProductValue {
-        sats::ProductValue {
-            elements: vec![
-                sats::AlgebraicValue::Builtin(sats::BuiltinValue::U32(self.id)),
-                sats::AlgebraicValue::Builtin(sats::BuiltinValue::U64(self.x)),
-                sats::AlgebraicValue::Builtin(sats::BuiltinValue::U64(self.y)),
-            ],
-        }
+        sats::product![self.id, self.x, self.y]
     }
 
     type SqliteParams = (u32, u64, u64);

--- a/crates/bench/src/spacetime_raw.rs
+++ b/crates/bench/src/spacetime_raw.rs
@@ -7,9 +7,8 @@ use spacetimedb::db::datastore::traits::{IndexDef, TableDef, TableSchema};
 use spacetimedb::db::relational_db::{open_db, RelationalDB};
 use spacetimedb::error::DBError;
 use spacetimedb::sql::execute::run;
-use spacetimedb_lib::identity::AuthCtx;
-use spacetimedb_lib::sats::BuiltinValue;
 use spacetimedb_lib::AlgebraicValue;
+use spacetimedb_lib::{identity::AuthCtx, sats::BuiltinValue};
 use std::hint::black_box;
 use tempdir::TempDir;
 
@@ -150,10 +149,10 @@ impl BenchDatabase for SpacetimeRaw {
 
             let table_name = &table.table_name;
 
-            let value = match value.as_builtin().unwrap() {
-                BuiltinValue::U32(x) => x.to_string(),
-                BuiltinValue::U64(x) => x.to_string(),
-                BuiltinValue::String(x) => format!("'{}'", x),
+            let value = match value {
+                AlgebraicValue::Builtin(BuiltinValue::U32(x)) => x.to_string(),
+                AlgebraicValue::Builtin(BuiltinValue::U64(x)) => x.to_string(),
+                AlgebraicValue::Builtin(BuiltinValue::String(x)) => format!("'{}'", x),
                 _ => {
                     unreachable!()
                 }

--- a/crates/bench/src/sqlite.rs
+++ b/crates/bench/src/sqlite.rs
@@ -8,10 +8,7 @@ use ahash::AHashMap;
 use lazy_static::lazy_static;
 use rusqlite::Connection;
 use spacetimedb::db::datastore::traits::TableSchema;
-use spacetimedb_lib::{
-    sats::{self},
-    AlgebraicType, AlgebraicValue, ProductType,
-};
+use spacetimedb_lib::{sats::BuiltinValue, AlgebraicType, AlgebraicValue, ProductType};
 use std::{
     fmt::Write,
     hint::black_box,
@@ -68,9 +65,8 @@ impl BenchDatabase for SQLite {
         for (i, column) in T::product_type().elements.iter().enumerate() {
             let column_name = column.name.clone().unwrap();
             let type_ = match column.algebraic_type {
-                AlgebraicType::Builtin(sats::BuiltinType::U32) => "INTEGER",
-                AlgebraicType::Builtin(sats::BuiltinType::U64) => "INTEGER",
-                AlgebraicType::Builtin(sats::BuiltinType::String) => "TEXT",
+                AlgebraicType::U32 | AlgebraicType::U64 => "INTEGER",
+                AlgebraicType::String => "TEXT",
                 _ => unimplemented!(),
             };
             let extra = if index_strategy == IndexStrategy::Unique && i == 0 {
@@ -192,19 +188,19 @@ impl BenchDatabase for SQLite {
 
         begin.execute(())?;
         match value {
-            AlgebraicValue::Builtin(sats::BuiltinValue::String(value)) => {
+            AlgebraicValue::Builtin(BuiltinValue::String(value)) => {
+                for _ in stmt.query_map((&*value,), |row| {
+                    black_box(row);
+                    Ok(())
+                })? {}
+            }
+            AlgebraicValue::Builtin(BuiltinValue::U32(value)) => {
                 for _ in stmt.query_map((value,), |row| {
                     black_box(row);
                     Ok(())
                 })? {}
             }
-            AlgebraicValue::Builtin(sats::BuiltinValue::U32(value)) => {
-                for _ in stmt.query_map((value,), |row| {
-                    black_box(row);
-                    Ok(())
-                })? {}
-            }
-            AlgebraicValue::Builtin(sats::BuiltinValue::U64(value)) => {
+            AlgebraicValue::Builtin(BuiltinValue::U64(value)) => {
                 for _ in stmt.query_map((value,), |row| {
                     black_box(row);
                     Ok(())

--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -453,7 +453,7 @@ impl TypespaceBuilder for ModuleBuilder {
             btree_map::Entry::Occupied(o) => *o.get(),
             btree_map::Entry::Vacant(v) => {
                 // Bind a fresh alias to the unit type.
-                let slot_ref = self.module.typespace.add(AlgebraicType::UNIT_TYPE);
+                let slot_ref = self.module.typespace.add(AlgebraicType::unit());
                 // Relate `typeid -> fresh alias`.
                 v.insert(slot_ref);
 

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -668,7 +668,7 @@ mod tests {
         let (stdb, _tmp_dir) = make_test_db()?;
 
         let mut tx = stdb.begin_tx();
-        let mut schema = TableDef::from(ProductType::from_iter([("my_col", AlgebraicType::I32)]));
+        let mut schema = TableDef::from(ProductType::from([("my_col", AlgebraicType::I32)]));
         schema.table_name = "MyTable".to_string();
         stdb.create_table(&mut tx, schema)?;
         stdb.commit_tx(tx)?;
@@ -682,7 +682,7 @@ mod tests {
 
         let mut tx = stdb.begin_tx();
 
-        let mut schema = TableDef::from(ProductType::from_iter([("my_col", AlgebraicType::I32)]));
+        let mut schema = TableDef::from(ProductType::from([("my_col", AlgebraicType::I32)]));
         schema.table_name = "MyTable".to_string();
         stdb.create_table(&mut tx, schema)?;
 
@@ -715,7 +715,7 @@ mod tests {
         let (stdb, _tmp_dir) = make_test_db()?;
 
         let mut tx = stdb.begin_tx();
-        let mut schema = TableDef::from(ProductType::from_iter([("my_col", AlgebraicType::I32)]));
+        let mut schema = TableDef::from(ProductType::from([("my_col", AlgebraicType::I32)]));
         schema.table_name = "MyTable".to_string();
         let table_id = stdb.create_table(&mut tx, schema)?;
         let t_id = stdb.table_id_from_name(&tx, "MyTable")?;
@@ -728,7 +728,7 @@ mod tests {
         let (stdb, _tmp_dir) = make_test_db()?;
 
         let mut tx = stdb.begin_tx();
-        let mut schema = TableDef::from(ProductType::from_iter([("my_col", AlgebraicType::I32)]));
+        let mut schema = TableDef::from(ProductType::from([("my_col", AlgebraicType::I32)]));
         schema.table_name = "MyTable".to_string();
         stdb.create_table(&mut tx, schema)?;
         let table_id = stdb.table_id_from_name(&tx, "MyTable")?.unwrap();
@@ -743,7 +743,7 @@ mod tests {
         let (stdb, _tmp_dir) = make_test_db()?;
 
         let mut tx = stdb.begin_tx();
-        let mut schema = TableDef::from(ProductType::from_iter([("my_col", AlgebraicType::I32)]));
+        let mut schema = TableDef::from(ProductType::from([("my_col", AlgebraicType::I32)]));
         schema.table_name = "MyTable".to_string();
         stdb.create_table(&mut tx, schema.clone())?;
         let result = stdb.create_table(&mut tx, schema);
@@ -757,7 +757,7 @@ mod tests {
 
         let mut tx = stdb.begin_tx();
 
-        let mut schema = TableDef::from(ProductType::from_iter([("my_col", AlgebraicType::I32)]));
+        let mut schema = TableDef::from(ProductType::from([("my_col", AlgebraicType::I32)]));
         schema.table_name = "MyTable".to_string();
         let table_id = stdb.create_table(&mut tx, schema)?;
 
@@ -781,7 +781,7 @@ mod tests {
 
         let mut tx = stdb.begin_tx();
 
-        let mut schema = TableDef::from(ProductType::from_iter([("my_col", AlgebraicType::I32)]));
+        let mut schema = TableDef::from(ProductType::from([("my_col", AlgebraicType::I32)]));
         schema.table_name = "MyTable".to_string();
         let table_id = stdb.create_table(&mut tx, schema)?;
 
@@ -807,7 +807,7 @@ mod tests {
 
         let mut tx = stdb.begin_tx();
 
-        let mut schema = TableDef::from(ProductType::from_iter([("my_col", AlgebraicType::I32)]));
+        let mut schema = TableDef::from(ProductType::from([("my_col", AlgebraicType::I32)]));
         schema.table_name = "MyTable".to_string();
         let table_id = stdb.create_table(&mut tx, schema)?;
 
@@ -831,7 +831,7 @@ mod tests {
 
         let mut tx = stdb.begin_tx();
 
-        let mut schema = TableDef::from(ProductType::from_iter([("my_col", AlgebraicType::I32)]));
+        let mut schema = TableDef::from(ProductType::from([("my_col", AlgebraicType::I32)]));
         schema.table_name = "MyTable".to_string();
         let table_id = stdb.create_table(&mut tx, schema)?;
 
@@ -857,7 +857,7 @@ mod tests {
 
         let mut tx = stdb.begin_tx();
 
-        let mut schema = TableDef::from(ProductType::from_iter([("my_col", AlgebraicType::I32)]));
+        let mut schema = TableDef::from(ProductType::from([("my_col", AlgebraicType::I32)]));
         schema.table_name = "MyTable".to_string();
         let table_id = stdb.create_table(&mut tx, schema)?;
         stdb.rollback_tx(tx);
@@ -874,7 +874,7 @@ mod tests {
 
         let mut tx = stdb.begin_tx();
 
-        let mut schema = TableDef::from(ProductType::from_iter([("my_col", AlgebraicType::I32)]));
+        let mut schema = TableDef::from(ProductType::from([("my_col", AlgebraicType::I32)]));
         schema.table_name = "MyTable".to_string();
         let table_id = stdb.create_table(&mut tx, schema)?;
         stdb.commit_tx(tx)?;

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -1,6 +1,6 @@
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::relation::MemTable;
-use spacetimedb_lib::{ProductType, ProductValue};
+use spacetimedb_sats::{ProductType, ProductValue};
 use spacetimedb_vm::eval::run_ast;
 use spacetimedb_vm::expr::{CodeResult, CrudExpr, Expr};
 use tracing::info;
@@ -104,7 +104,7 @@ pub(crate) mod tests {
     use spacetimedb_lib::auth::{StAccess, StTableType};
     use spacetimedb_lib::error::ResultTest;
     use spacetimedb_lib::relation::{Header, RelValue};
-    use spacetimedb_sats::{product, AlgebraicType, BuiltinType, ProductType};
+    use spacetimedb_sats::{product, AlgebraicType, ProductType};
     use spacetimedb_vm::dsl::{mem_table, scalar};
     use spacetimedb_vm::eval::create_game_data;
     use tempdir::TempDir;
@@ -118,7 +118,7 @@ pub(crate) mod tests {
         let (db, tmp_dir) = make_test_db()?;
 
         let mut tx = db.begin_tx();
-        let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
+        let head = ProductType::from([("inventory_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
         let rows: Vec<_> = (1..=total_rows).map(|i| product!(i, format!("health{i}"))).collect();
         create_table_with_rows(&db, &mut tx, "inventory", head.clone(), &rows)?;
         db.commit_tx(tx)?;
@@ -165,7 +165,7 @@ pub(crate) mod tests {
         assert_eq!(result.len(), 1, "Not return results");
         let result = result.first().unwrap().clone();
 
-        let head = ProductType::from_iter([("inventory_id", BuiltinType::U64)]);
+        let head = ProductType::from([("inventory_id", AlgebraicType::U64)]);
         let row = product!(1u64);
         let input = mem_table(head, vec![row]);
 
@@ -186,8 +186,8 @@ pub(crate) mod tests {
 
         assert_eq!(result.len(), 1, "Not return results");
         let result = result.first().unwrap().clone();
-        let schema = ProductType::from_iter([BuiltinType::I32]);
-        let row = product!(scalar(1));
+        let schema = ProductType::from([AlgebraicType::I32]);
+        let row = product!(1);
         let input = mem_table(schema, vec![row]);
 
         assert_eq!(result.as_without_table_name(), input.as_without_table_name(), "Scalar");
@@ -389,7 +389,7 @@ pub(crate) mod tests {
         WHERE x > 0 AND x <= 32 AND z > 0 AND z <= 32",
         )?[0];
 
-        let head = ProductType::from_iter([("entity_id", BuiltinType::U64), ("inventory_id", BuiltinType::U64)]);
+        let head = ProductType::from([("entity_id", AlgebraicType::U64), ("inventory_id", AlgebraicType::U64)]);
         let row1 = product!(100u64, 1u64);
         let input = mem_table(head, [row1]);
 
@@ -413,7 +413,7 @@ pub(crate) mod tests {
         WHERE x > 0 AND x <= 32 AND z > 0 AND z <= 32",
         )?[0];
 
-        let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
+        let head = ProductType::from([("inventory_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
         let row1 = product!(1u64, "health");
         let input = mem_table(head, [row1]);
 

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -159,7 +159,7 @@ mod tests {
     use spacetimedb_lib::error::ResultTest;
     use spacetimedb_lib::relation::FieldName;
     use spacetimedb_lib::Identity;
-    use spacetimedb_sats::{product, BuiltinType, ProductType, ProductValue};
+    use spacetimedb_sats::{product, ProductType, ProductValue};
     use spacetimedb_vm::dsl::{db_table, mem_table, scalar};
     use spacetimedb_vm::operator::OpCmp;
 
@@ -244,7 +244,7 @@ mod tests {
             "_inventory"
         };
 
-        let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
+        let head = ProductType::from([("inventory_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
         let row = product!(1u64, "health");
 
         let (schema, table, data, q) = make_data(db, tx, table_name, &head, &row)?;
@@ -265,7 +265,7 @@ mod tests {
         tx: &mut MutTxId,
     ) -> ResultTest<(TableSchema, MemTable, DatabaseTableUpdate, QueryExpr)> {
         let table_name = "player";
-        let head = ProductType::from_iter([("player_id", BuiltinType::U64), ("name", BuiltinType::String)]);
+        let head = ProductType::from([("player_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
         let row = product!(2u64, "jhon doe");
 
         let (schema, table, data, q) = make_data(db, tx, table_name, &head, &row)?;
@@ -356,7 +356,7 @@ mod tests {
         let (db, _) = make_test_db()?;
         let mut tx = db.begin_tx();
 
-        let schema = ProductType::from_iter([("u8", BuiltinType::U8)]);
+        let schema = ProductType::from([("u8", AlgebraicType::U8)]);
         let row = product!(1u8);
 
         // generate row id from row

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -517,7 +517,7 @@ pub(crate) mod tests {
     use crate::db::relational_db::{ST_COLUMNS_NAME, ST_INDEXES_NAME, ST_SEQUENCES_NAME, ST_TABLES_NAME};
     use spacetimedb_lib::error::ResultTest;
     use spacetimedb_lib::relation::{DbTable, FieldName};
-    use spacetimedb_sats::{product, AlgebraicType, BuiltinType, ProductType, ProductValue};
+    use spacetimedb_sats::{product, AlgebraicType, ProductType, ProductValue};
     use spacetimedb_vm::dsl::*;
     use spacetimedb_vm::eval::run_ast;
     use spacetimedb_vm::operator::OpCmp;
@@ -578,7 +578,7 @@ pub(crate) mod tests {
         let mut tx = stdb.begin_tx();
         let p = &mut DbProgram::new(&stdb, &mut tx, AuthCtx::for_testing());
 
-        let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
+        let head = ProductType::from([("inventory_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
         let row = product!(1u64, "health");
         let table_id = create_table_from_program(p, "inventory", head.clone(), &[row])?;
 
@@ -595,10 +595,10 @@ pub(crate) mod tests {
         };
 
         //The expected result
-        let inv = ProductType::from_iter([
-            (Some("inventory_id"), BuiltinType::U64),
-            (Some("name"), BuiltinType::String),
-            (None, BuiltinType::U64),
+        let inv = ProductType::from([
+            (Some("inventory_id"), AlgebraicType::U64),
+            (Some("name"), AlgebraicType::String),
+            (None, AlgebraicType::U64),
         ]);
         let row = product!(scalar(1u64), scalar("health"), scalar(1u64));
         let input = mem_table(inv, vec![row]);
@@ -692,7 +692,7 @@ pub(crate) mod tests {
     fn test_query_catalog_indexes() -> ResultTest<()> {
         let (db, _tmp_dir) = make_test_db()?;
 
-        let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
+        let head = ProductType::from([("inventory_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
         let row = product!(1u64, "health");
 
         let mut tx = db.begin_tx();

--- a/crates/lib/src/address.rs
+++ b/crates/lib/src/address.rs
@@ -1,6 +1,6 @@
 use anyhow::Context as _;
 use hex::FromHex as _;
-use sats::{impl_deserialize, impl_serialize, impl_st, AlgebraicType, ProductTypeElement};
+use sats::{impl_deserialize, impl_serialize, impl_st, AlgebraicType};
 use spacetimedb_bindings_macro::{Deserialize, Serialize};
 use std::{fmt, net::Ipv6Addr};
 
@@ -20,9 +20,7 @@ pub struct Address {
     __address_bytes: [u8; 16],
 }
 
-impl_st!([] Address, _ts => AlgebraicType::product(vec![
-    ProductTypeElement::new_named(AlgebraicType::bytes(), "__address_bytes")
-]));
+impl_st!([] Address, _ts => AlgebraicType::product([("__address_bytes", AlgebraicType::bytes())]));
 
 impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/lib/src/identity.rs
+++ b/crates/lib/src/identity.rs
@@ -1,5 +1,5 @@
 use spacetimedb_bindings_macro::{Deserialize, Serialize};
-use spacetimedb_sats::{impl_st, AlgebraicType, ProductTypeElement};
+use spacetimedb_sats::{impl_st, AlgebraicType};
 use std::{fmt, str::FromStr};
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord)]
@@ -30,9 +30,7 @@ pub struct Identity {
     __identity_bytes: [u8; 32],
 }
 
-impl_st!([] Identity, _ts => AlgebraicType::product(vec![
-    ProductTypeElement::new_named(AlgebraicType::bytes(), "__identity_bytes")
-]));
+impl_st!([] Identity, _ts => AlgebraicType::product([("__identity_bytes", AlgebraicType::bytes())]));
 
 impl Identity {
     const ABBREVIATION_LEN: usize = 16;

--- a/crates/lib/tests/serde.rs
+++ b/crates/lib/tests/serde.rs
@@ -25,7 +25,7 @@ fn test_json_mappings() {
             "quux",
             AlgebraicType::Sum(enumm([
                 ("Hash", AlgebraicType::bytes()),
-                ("Unit", AlgebraicType::UNIT_TYPE),
+                ("Unit", AlgebraicType::unit()),
             ])),
         ),
         ("and_peggy", AlgebraicType::option(AlgebraicType::F64)),

--- a/crates/sats/src/algebraic_type.rs
+++ b/crates/sats/src/algebraic_type.rs
@@ -5,9 +5,7 @@ use crate::algebraic_value::de::{ValueDeserializeError, ValueDeserializer};
 use crate::algebraic_value::ser::ValueSerializer;
 use crate::meta_type::MetaType;
 use crate::{de::Deserialize, ser::Serialize, MapType};
-use crate::{
-    AlgebraicTypeRef, AlgebraicValue, ArrayType, BuiltinType, ProductType, ProductTypeElement, SumType, SumTypeVariant,
-};
+use crate::{AlgebraicTypeRef, AlgebraicValue, ArrayType, BuiltinType, ProductType, SumType, SumTypeVariant};
 use enum_as_inner::EnumAsInner;
 
 /// The SpacetimeDB Algebraic Type System (SATS) is a structural type system in
@@ -117,6 +115,9 @@ pub enum AlgebraicType {
 
 #[allow(non_upper_case_globals)]
 impl AlgebraicType {
+    /// The first type in the typespace.
+    pub const ZERO_REF: Self = Self::Ref(AlgebraicTypeRef(0));
+
     /// The built-in Bool type.
     pub const Bool: Self = Self::Builtin(BuiltinType::Bool);
 
@@ -160,10 +161,16 @@ impl AlgebraicType {
     pub const String: Self = Self::Builtin(BuiltinType::String);
 
     /// The canonical 0-element unit type.
-    pub const UNIT_TYPE: Self = Self::product(Vec::new());
+    pub fn unit() -> Self {
+        let fs: [AlgebraicType; 0] = [];
+        Self::product(fs)
+    }
 
     /// The canonical 0-variant "never" / "absurd" / "void" type.
-    pub const NEVER_TYPE: Self = Self::sum(Vec::new());
+    pub fn never() -> Self {
+        let vs: [SumTypeVariant; 0] = [];
+        Self::sum(vs)
+    }
 }
 
 impl MetaType for AlgebraicType {
@@ -173,11 +180,11 @@ impl MetaType for AlgebraicType {
     /// This could alternatively be implemented
     /// as a regular AlgebraicValue or as a static variable.
     fn meta_type() -> Self {
-        AlgebraicType::sum(vec![
-            SumTypeVariant::new_named(SumType::meta_type(), "sum"),
-            SumTypeVariant::new_named(ProductType::meta_type(), "product"),
-            SumTypeVariant::new_named(BuiltinType::meta_type(), "builtin"),
-            SumTypeVariant::new_named(AlgebraicTypeRef::meta_type(), "ref"),
+        AlgebraicType::sum([
+            ("sum", SumType::meta_type()),
+            ("product", ProductType::meta_type()),
+            ("builtin", BuiltinType::meta_type()),
+            ("ref", AlgebraicTypeRef::meta_type()),
         ])
     }
 }
@@ -195,22 +202,19 @@ impl AlgebraicType {
         )
     }
 
-    /// Returns a sum type with the given `variants`.
-    pub const fn sum(variants: Vec<SumTypeVariant>) -> Self {
-        AlgebraicType::Sum(SumType { variants })
+    /// Returns a sum type with the given `sum`.
+    pub fn sum<S: Into<SumType>>(sum: S) -> Self {
+        AlgebraicType::Sum(sum.into())
     }
 
-    /// Returns a product type with the given `factors`.
-    pub const fn product(factors: Vec<ProductTypeElement>) -> Self {
-        AlgebraicType::Product(ProductType::new(factors))
+    /// Returns a product type with the given `prod`.
+    pub fn product<P: Into<ProductType>>(prod: P) -> Self {
+        AlgebraicType::Product(prod.into())
     }
 
     /// Returns a structural option type where `some_type` is the type for the `some` variant.
     pub fn option(some_type: Self) -> Self {
-        Self::sum(vec![
-            SumTypeVariant::new_named(some_type, "some"),
-            SumTypeVariant::unit("none"),
-        ])
+        Self::sum([("some", some_type), ("none", AlgebraicType::unit())])
     }
 
     /// Returns an unsized array type where the element type is `ty`.
@@ -226,7 +230,7 @@ impl AlgebraicType {
 
     /// Returns a sum type of unit variants with names taken from `var_names`.
     pub fn simple_enum<'a>(var_names: impl Iterator<Item = &'a str>) -> Self {
-        Self::sum(var_names.into_iter().map(SumTypeVariant::unit).collect())
+        Self::sum(var_names.into_iter().map(SumTypeVariant::unit).collect::<Vec<_>>())
     }
 
     pub fn as_value(&self) -> AlgebraicValue {
@@ -245,28 +249,28 @@ mod tests {
     use crate::satn::Satn;
     use crate::{
         algebraic_type::fmt::fmt_algebraic_type, algebraic_type::map_notation::fmt_algebraic_type as fmt_map,
-        algebraic_type_ref::AlgebraicTypeRef, product_type_element::ProductTypeElement, typespace::Typespace,
+        algebraic_type_ref::AlgebraicTypeRef, typespace::Typespace,
     };
     use crate::{ValueWithType, WithTypespace};
 
     #[test]
     fn never() {
-        assert_eq!("(|)", fmt_algebraic_type(&AlgebraicType::NEVER_TYPE).to_string());
+        assert_eq!("(|)", fmt_algebraic_type(&AlgebraicType::never()).to_string());
     }
 
     #[test]
     fn never_map() {
-        assert_eq!("{ ty_: Sum }", fmt_map(&AlgebraicType::NEVER_TYPE).to_string());
+        assert_eq!("{ ty_: Sum }", fmt_map(&AlgebraicType::never()).to_string());
     }
 
     #[test]
     fn unit() {
-        assert_eq!("()", fmt_algebraic_type(&AlgebraicType::UNIT_TYPE).to_string());
+        assert_eq!("()", fmt_algebraic_type(&AlgebraicType::unit()).to_string());
     }
 
     #[test]
     fn unit_map() {
-        assert_eq!("{ ty_: Product }", fmt_map(&AlgebraicType::UNIT_TYPE).to_string());
+        assert_eq!("{ ty_: Product }", fmt_map(&AlgebraicType::unit()).to_string());
     }
 
     #[test]
@@ -281,13 +285,13 @@ mod tests {
 
     #[test]
     fn option() {
-        let option = AlgebraicType::option(AlgebraicType::NEVER_TYPE);
+        let option = AlgebraicType::option(AlgebraicType::never());
         assert_eq!("(some: (|) | none: ())", fmt_algebraic_type(&option).to_string());
     }
 
     #[test]
     fn option_map() {
-        let option = AlgebraicType::option(AlgebraicType::NEVER_TYPE);
+        let option = AlgebraicType::option(AlgebraicType::never());
         assert_eq!(
             "{ ty_: Sum, some: { ty_: Sum }, none: { ty_: Product } }",
             fmt_map(&option).to_string()
@@ -315,22 +319,13 @@ mod tests {
     #[test]
     fn nested_products_and_sums() {
         let builtin = AlgebraicType::U8;
-        let product = AlgebraicType::product(vec![ProductTypeElement {
-            name: Some("thing".into()),
-            algebraic_type: AlgebraicType::U8,
-        }]);
-        let next = AlgebraicType::sum(vec![builtin.clone().into(), builtin.clone().into(), product.into()]);
-        let next = AlgebraicType::product(vec![
-            ProductTypeElement {
-                algebraic_type: builtin.clone(),
-                name: Some("test".into()),
-            },
-            next.into(),
-            builtin.into(),
-            ProductTypeElement {
-                algebraic_type: AlgebraicType::NEVER_TYPE,
-                name: Some("never".into()),
-            },
+        let product = AlgebraicType::product([("thing", AlgebraicType::U8)]);
+        let sum = AlgebraicType::sum([builtin.clone(), builtin.clone(), product]);
+        let next = AlgebraicType::product([
+            (Some("test"), builtin.clone()),
+            (None, sum),
+            (None, builtin),
+            (Some("never"), AlgebraicType::never()),
         ]);
         assert_eq!(
             "(test: U8, 1: (U8 | U8 | (thing: U8)), 2: U8, never: (|))",
@@ -344,7 +339,7 @@ mod tests {
 
     #[test]
     fn option_as_value() {
-        let option = AlgebraicType::option(AlgebraicType::NEVER_TYPE);
+        let option = AlgebraicType::option(AlgebraicType::never());
         let algebraic_type = AlgebraicType::meta_type();
         let typespace = Typespace::new(vec![algebraic_type]);
         let at_ref = AlgebraicType::Ref(AlgebraicTypeRef(0));
@@ -379,7 +374,7 @@ mod tests {
 
     #[test]
     fn option_from_value() {
-        let option = AlgebraicType::option(AlgebraicType::NEVER_TYPE);
+        let option = AlgebraicType::option(AlgebraicType::never());
         AlgebraicType::from_value(&option.as_value()).expect("No errors.");
     }
 

--- a/crates/sats/src/algebraic_value/ser.rs
+++ b/crates/sats/src/algebraic_value/ser.rs
@@ -90,7 +90,7 @@ pub struct SerializeArrayValue {
 
 impl ser::SerializeArray for SerializeArrayValue {
     type Ok = AlgebraicValue;
-    type Error = Infallible;
+    type Error = <ValueSerializer as ser::Serializer>::Error;
 
     fn serialize_element<T: ser::Serialize + ?Sized>(&mut self, elem: &T) -> Result<(), Self::Error> {
         self.array
@@ -112,7 +112,7 @@ pub struct SerializeMapValue {
 
 impl ser::SerializeMap for SerializeMapValue {
     type Ok = AlgebraicValue;
-    type Error = Infallible;
+    type Error = <ValueSerializer as ser::Serializer>::Error;
 
     fn serialize_entry<K: ser::Serialize + ?Sized, V: ser::Serialize + ?Sized>(
         &mut self,
@@ -137,7 +137,7 @@ pub struct SerializeProductValue {
 
 impl ser::SerializeSeqProduct for SerializeProductValue {
     type Ok = AlgebraicValue;
-    type Error = Infallible;
+    type Error = <ValueSerializer as ser::Serializer>::Error;
 
     fn serialize_element<T: ser::Serialize + ?Sized>(&mut self, elem: &T) -> Result<(), Self::Error> {
         self.elements.push(elem.serialize(ValueSerializer)?);

--- a/crates/sats/src/bsatn.rs
+++ b/crates/sats/src/bsatn.rs
@@ -65,7 +65,6 @@ macro_rules! codec_funcs {
 }
 
 codec_funcs!(crate::AlgebraicType);
-codec_funcs!(crate::BuiltinType);
 codec_funcs!(crate::ProductType);
 codec_funcs!(crate::SumType);
 codec_funcs!(crate::ProductTypeElement);
@@ -74,4 +73,3 @@ codec_funcs!(crate::SumTypeVariant);
 codec_funcs!(val: crate::AlgebraicValue);
 codec_funcs!(val: crate::ProductValue);
 codec_funcs!(val: crate::SumValue);
-codec_funcs!(val: crate::BuiltinValue);

--- a/crates/sats/src/builtin_type.rs
+++ b/crates/sats/src/builtin_type.rs
@@ -2,10 +2,7 @@ use crate::algebraic_value::de::{ValueDeserializeError, ValueDeserializer};
 use crate::algebraic_value::ser::ValueSerializer;
 use crate::meta_type::MetaType;
 use crate::{de::Deserialize, ser::Serialize};
-use crate::{
-    impl_deserialize, impl_serialize, AlgebraicType, AlgebraicTypeRef, AlgebraicValue, ProductTypeElement,
-    SumTypeVariant,
-};
+use crate::{impl_deserialize, impl_serialize, AlgebraicType, AlgebraicValue, SumTypeVariant};
 use enum_as_inner::EnumAsInner;
 
 /// Represents the built-in types in SATS.
@@ -91,9 +88,8 @@ impl MapType {
 
 impl MetaType for BuiltinType {
     fn meta_type() -> AlgebraicType {
-        let zero_ref = || AlgebraicType::Ref(AlgebraicTypeRef(0));
         // TODO: sats(rename_all = "lowercase"), otherwise json won't work.
-        AlgebraicType::sum(vec![
+        AlgebraicType::sum([
             SumTypeVariant::unit("bool"),
             SumTypeVariant::unit("i8"),
             SumTypeVariant::unit("u8"),
@@ -108,12 +104,9 @@ impl MetaType for BuiltinType {
             SumTypeVariant::unit("f32"),
             SumTypeVariant::unit("f64"),
             SumTypeVariant::unit("string"),
-            SumTypeVariant::new_named(zero_ref(), "array"),
+            SumTypeVariant::new_named(AlgebraicType::ZERO_REF, "array"),
             SumTypeVariant::new_named(
-                AlgebraicType::product(vec![
-                    ProductTypeElement::new_named(zero_ref(), "key_ty"),
-                    ProductTypeElement::new_named(zero_ref(), "ty"),
-                ]),
+                AlgebraicType::product([("key_ty", AlgebraicType::ZERO_REF), ("ty", AlgebraicType::ZERO_REF)]),
                 "map",
             ),
         ])

--- a/crates/sats/src/builtin_value.rs
+++ b/crates/sats/src/builtin_value.rs
@@ -169,24 +169,24 @@ impl ArrayValue {
     /// Determines (infers / synthesises) the type of the value.
     pub(crate) fn type_of(&self) -> ArrayType {
         let elem_ty = Box::new(match self {
-            ArrayValue::Sum(v) => Self::first_type_of(v, AlgebraicValue::type_of_sum),
-            ArrayValue::Product(v) => Self::first_type_of(v, AlgebraicValue::type_of_product),
-            ArrayValue::Bool(_) => AlgebraicType::Bool,
-            ArrayValue::I8(_) => AlgebraicType::I8,
-            ArrayValue::U8(_) => AlgebraicType::U8,
-            ArrayValue::I16(_) => AlgebraicType::I16,
-            ArrayValue::U16(_) => AlgebraicType::U16,
-            ArrayValue::I32(_) => AlgebraicType::I32,
-            ArrayValue::U32(_) => AlgebraicType::U32,
-            ArrayValue::I64(_) => AlgebraicType::I64,
-            ArrayValue::U64(_) => AlgebraicType::U64,
-            ArrayValue::I128(_) => AlgebraicType::I128,
-            ArrayValue::U128(_) => AlgebraicType::U128,
-            ArrayValue::F32(_) => AlgebraicType::F32,
-            ArrayValue::F64(_) => AlgebraicType::F64,
-            ArrayValue::String(_) => AlgebraicType::String,
-            ArrayValue::Array(v) => Self::first_type_of(v, |a| AlgebraicType::Builtin(BuiltinType::Array(a.type_of()))),
-            ArrayValue::Map(v) => Self::first_type_of(v, AlgebraicValue::type_of_map),
+            Self::Sum(v) => Self::first_type_of(v, AlgebraicValue::type_of_sum),
+            Self::Product(v) => Self::first_type_of(v, AlgebraicValue::type_of_product),
+            Self::Bool(_) => AlgebraicType::Bool,
+            Self::I8(_) => AlgebraicType::I8,
+            Self::U8(_) => AlgebraicType::U8,
+            Self::I16(_) => AlgebraicType::I16,
+            Self::U16(_) => AlgebraicType::U16,
+            Self::I32(_) => AlgebraicType::I32,
+            Self::U32(_) => AlgebraicType::U32,
+            Self::I64(_) => AlgebraicType::I64,
+            Self::U64(_) => AlgebraicType::U64,
+            Self::I128(_) => AlgebraicType::I128,
+            Self::U128(_) => AlgebraicType::U128,
+            Self::F32(_) => AlgebraicType::F32,
+            Self::F64(_) => AlgebraicType::F64,
+            Self::String(_) => AlgebraicType::String,
+            Self::Array(v) => Self::first_type_of(v, |a| AlgebraicType::Builtin(BuiltinType::Array(a.type_of()))),
+            Self::Map(v) => Self::first_type_of(v, AlgebraicValue::type_of_map),
         });
         ArrayType { elem_ty }
     }
@@ -194,30 +194,30 @@ impl ArrayValue {
     /// Helper for `type_of` above.
     /// Infers the `AlgebraicType` from the first element by running `then` on it.
     fn first_type_of<T>(arr: &[T], then: impl FnOnce(&T) -> AlgebraicType) -> AlgebraicType {
-        arr.first().map(then).unwrap_or_else(|| AlgebraicType::NEVER_TYPE)
+        arr.first().map(then).unwrap_or_else(AlgebraicType::never)
     }
 
     /// Returns the length of the array.
     pub fn len(&self) -> usize {
         match self {
-            ArrayValue::Sum(v) => v.len(),
-            ArrayValue::Product(v) => v.len(),
-            ArrayValue::Bool(v) => v.len(),
-            ArrayValue::I8(v) => v.len(),
-            ArrayValue::U8(v) => v.len(),
-            ArrayValue::I16(v) => v.len(),
-            ArrayValue::U16(v) => v.len(),
-            ArrayValue::I32(v) => v.len(),
-            ArrayValue::U32(v) => v.len(),
-            ArrayValue::I64(v) => v.len(),
-            ArrayValue::U64(v) => v.len(),
-            ArrayValue::I128(v) => v.len(),
-            ArrayValue::U128(v) => v.len(),
-            ArrayValue::F32(v) => v.len(),
-            ArrayValue::F64(v) => v.len(),
-            ArrayValue::String(v) => v.len(),
-            ArrayValue::Array(v) => v.len(),
-            ArrayValue::Map(v) => v.len(),
+            Self::Sum(v) => v.len(),
+            Self::Product(v) => v.len(),
+            Self::Bool(v) => v.len(),
+            Self::I8(v) => v.len(),
+            Self::U8(v) => v.len(),
+            Self::I16(v) => v.len(),
+            Self::U16(v) => v.len(),
+            Self::I32(v) => v.len(),
+            Self::U32(v) => v.len(),
+            Self::I64(v) => v.len(),
+            Self::U64(v) => v.len(),
+            Self::I128(v) => v.len(),
+            Self::U128(v) => v.len(),
+            Self::F32(v) => v.len(),
+            Self::F64(v) => v.len(),
+            Self::String(v) => v.len(),
+            Self::Array(v) => v.len(),
+            Self::Map(v) => v.len(),
         }
     }
 
@@ -266,24 +266,24 @@ impl ArrayValue {
     /// Optionally allocates the backing `Vec<_>`s with `capacity`.
     pub fn push(&mut self, val: AlgebraicValue, capacity: Option<usize>) -> Result<(), AlgebraicValue> {
         match (self, val) {
-            (ArrayValue::Sum(v), AlgebraicValue::Sum(val)) => v.push(val),
-            (ArrayValue::Product(v), AlgebraicValue::Product(val)) => v.push(val),
-            (ArrayValue::Bool(v), AlgebraicValue::Builtin(BuiltinValue::Bool(val))) => v.push(val),
-            (ArrayValue::I8(v), AlgebraicValue::Builtin(BuiltinValue::I8(val))) => v.push(val),
-            (ArrayValue::U8(v), AlgebraicValue::Builtin(BuiltinValue::U8(val))) => v.push(val),
-            (ArrayValue::I16(v), AlgebraicValue::Builtin(BuiltinValue::I16(val))) => v.push(val),
-            (ArrayValue::U16(v), AlgebraicValue::Builtin(BuiltinValue::U16(val))) => v.push(val),
-            (ArrayValue::I32(v), AlgebraicValue::Builtin(BuiltinValue::I32(val))) => v.push(val),
-            (ArrayValue::U32(v), AlgebraicValue::Builtin(BuiltinValue::U32(val))) => v.push(val),
-            (ArrayValue::I64(v), AlgebraicValue::Builtin(BuiltinValue::I64(val))) => v.push(val),
-            (ArrayValue::U64(v), AlgebraicValue::Builtin(BuiltinValue::U64(val))) => v.push(val),
-            (ArrayValue::I128(v), AlgebraicValue::Builtin(BuiltinValue::I128(val))) => v.push(val),
-            (ArrayValue::U128(v), AlgebraicValue::Builtin(BuiltinValue::U128(val))) => v.push(val),
-            (ArrayValue::F32(v), AlgebraicValue::Builtin(BuiltinValue::F32(val))) => v.push(val),
-            (ArrayValue::F64(v), AlgebraicValue::Builtin(BuiltinValue::F64(val))) => v.push(val),
-            (ArrayValue::String(v), AlgebraicValue::Builtin(BuiltinValue::String(val))) => v.push(val),
-            (ArrayValue::Array(v), AlgebraicValue::Builtin(BuiltinValue::Array { val })) => v.push(val),
-            (ArrayValue::Map(v), AlgebraicValue::Builtin(BuiltinValue::Map { val })) => v.push(val),
+            (Self::Sum(v), AlgebraicValue::Sum(val)) => v.push(val),
+            (Self::Product(v), AlgebraicValue::Product(val)) => v.push(val),
+            (Self::Bool(v), AlgebraicValue::Builtin(BuiltinValue::Bool(val))) => v.push(val),
+            (Self::I8(v), AlgebraicValue::Builtin(BuiltinValue::I8(val))) => v.push(val),
+            (Self::U8(v), AlgebraicValue::Builtin(BuiltinValue::U8(val))) => v.push(val),
+            (Self::I16(v), AlgebraicValue::Builtin(BuiltinValue::I16(val))) => v.push(val),
+            (Self::U16(v), AlgebraicValue::Builtin(BuiltinValue::U16(val))) => v.push(val),
+            (Self::I32(v), AlgebraicValue::Builtin(BuiltinValue::I32(val))) => v.push(val),
+            (Self::U32(v), AlgebraicValue::Builtin(BuiltinValue::U32(val))) => v.push(val),
+            (Self::I64(v), AlgebraicValue::Builtin(BuiltinValue::I64(val))) => v.push(val),
+            (Self::U64(v), AlgebraicValue::Builtin(BuiltinValue::U64(val))) => v.push(val),
+            (Self::I128(v), AlgebraicValue::Builtin(BuiltinValue::I128(val))) => v.push(val),
+            (Self::U128(v), AlgebraicValue::Builtin(BuiltinValue::U128(val))) => v.push(val),
+            (Self::F32(v), AlgebraicValue::Builtin(BuiltinValue::F32(val))) => v.push(val),
+            (Self::F64(v), AlgebraicValue::Builtin(BuiltinValue::F64(val))) => v.push(val),
+            (Self::String(v), AlgebraicValue::Builtin(BuiltinValue::String(val))) => v.push(val),
+            (Self::Array(v), AlgebraicValue::Builtin(BuiltinValue::Array { val })) => v.push(val),
+            (Self::Map(v), AlgebraicValue::Builtin(BuiltinValue::Map { val })) => v.push(val),
             (me, val) if me.is_empty() => *me = Self::from_one_with_capacity(val, capacity),
             (_, val) => return Err(val),
         }
@@ -466,7 +466,7 @@ impl Iterator for ArrayValueIntoIter {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            ArrayValueIntoIter::Sum(it) => it.next().map(AlgebraicValue::Sum),
+            ArrayValueIntoIter::Sum(it) => it.next().map(Into::into),
             ArrayValueIntoIter::Product(it) => it.next().map(Into::into),
             ArrayValueIntoIter::Bool(it) => it.next().map(Into::into),
             ArrayValueIntoIter::I8(it) => it.next().map(Into::into),
@@ -479,11 +479,11 @@ impl Iterator for ArrayValueIntoIter {
             ArrayValueIntoIter::U64(it) => it.next().map(Into::into),
             ArrayValueIntoIter::I128(it) => it.next().map(Into::into),
             ArrayValueIntoIter::U128(it) => it.next().map(Into::into),
-            ArrayValueIntoIter::F32(it) => it.next().map(|f| f32::from(f).into()),
-            ArrayValueIntoIter::F64(it) => it.next().map(|f| f64::from(f).into()),
+            ArrayValueIntoIter::F32(it) => it.next().map(Into::into),
+            ArrayValueIntoIter::F64(it) => it.next().map(Into::into),
             ArrayValueIntoIter::String(it) => it.next().map(Into::into),
-            ArrayValueIntoIter::Array(it) => it.next().map(AlgebraicValue::ArrayOf),
-            ArrayValueIntoIter::Map(it) => it.next().map(AlgebraicValue::map),
+            ArrayValueIntoIter::Array(it) => it.next().map(Into::into),
+            ArrayValueIntoIter::Map(it) => it.next().map(Into::into),
         }
     }
 }
@@ -514,7 +514,7 @@ impl Iterator for ArrayValueIterCloned<'_> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            ArrayValueIterCloned::Sum(it) => it.next().cloned().map(AlgebraicValue::Sum),
+            ArrayValueIterCloned::Sum(it) => it.next().cloned().map(Into::into),
             ArrayValueIterCloned::Product(it) => it.next().cloned().map(Into::into),
             ArrayValueIterCloned::Bool(it) => it.next().cloned().map(Into::into),
             ArrayValueIterCloned::I8(it) => it.next().cloned().map(Into::into),
@@ -527,11 +527,11 @@ impl Iterator for ArrayValueIterCloned<'_> {
             ArrayValueIterCloned::U64(it) => it.next().cloned().map(Into::into),
             ArrayValueIterCloned::I128(it) => it.next().cloned().map(Into::into),
             ArrayValueIterCloned::U128(it) => it.next().cloned().map(Into::into),
-            ArrayValueIterCloned::F32(it) => it.next().map(|f| f32::from(*f).into()),
-            ArrayValueIterCloned::F64(it) => it.next().map(|f| f64::from(*f).into()),
+            ArrayValueIterCloned::F32(it) => it.next().cloned().map(Into::into),
+            ArrayValueIterCloned::F64(it) => it.next().cloned().map(Into::into),
             ArrayValueIterCloned::String(it) => it.next().cloned().map(Into::into),
-            ArrayValueIterCloned::Array(it) => it.next().cloned().map(AlgebraicValue::ArrayOf),
-            ArrayValueIterCloned::Map(it) => it.next().cloned().map(AlgebraicValue::map),
+            ArrayValueIterCloned::Array(it) => it.next().cloned().map(Into::into),
+            ArrayValueIterCloned::Map(it) => it.next().cloned().map(Into::into),
         }
     }
 }

--- a/crates/sats/src/convert.rs
+++ b/crates/sats/src/convert.rs
@@ -1,8 +1,8 @@
 use crate::algebraic_type::AlgebraicType;
 use crate::algebraic_value::AlgebraicValue;
 use crate::builtin_type::BuiltinType;
-use crate::builtin_value::BuiltinValue;
-use crate::{ProductType, ProductTypeElement, ProductValue};
+use crate::builtin_value::{BuiltinValue, F32, F64};
+use crate::{ArrayValue, MapValue, ProductType, ProductValue, SumValue};
 
 impl From<BuiltinType> for AlgebraicType {
     fn from(x: BuiltinType) -> Self {
@@ -28,7 +28,7 @@ impl From<ProductValue> for AlgebraicValue {
 
 impl From<AlgebraicValue> for ProductValue {
     fn from(x: AlgebraicValue) -> Self {
-        Self { elements: vec![x] }
+        Self { elements: [x].into() }
     }
 }
 
@@ -38,29 +38,41 @@ impl From<&AlgebraicValue> for ProductValue {
     }
 }
 
-impl From<AlgebraicType> for ProductType {
-    fn from(x: AlgebraicType) -> Self {
-        Self::new(vec![x.into()])
+impl From<SumValue> for AlgebraicValue {
+    fn from(x: SumValue) -> Self {
+        Self::Sum(x)
     }
 }
 
-impl From<BuiltinType> for ProductTypeElement {
-    fn from(x: BuiltinType) -> Self {
-        Self::new(x.into(), None)
+impl From<ArrayValue> for AlgebraicValue {
+    fn from(x: ArrayValue) -> Self {
+        Self::ArrayOf(x)
+    }
+}
+
+impl From<MapValue> for AlgebraicValue {
+    fn from(x: MapValue) -> Self {
+        Self::map(x)
+    }
+}
+
+impl From<AlgebraicType> for ProductType {
+    fn from(x: AlgebraicType) -> Self {
+        Self::new([x.into()].into())
+    }
+}
+
+impl From<ProductType> for AlgebraicType {
+    fn from(x: ProductType) -> Self {
+        Self::Product(x)
     }
 }
 
 macro_rules! built_in {
     ($native:ty, $kind:ident) => {
-        impl From<$native> for BuiltinValue {
-            fn from(x: $native) -> Self {
-                BuiltinValue::$kind(x)
-            }
-        }
-
         impl From<$native> for AlgebraicValue {
             fn from(x: $native) -> Self {
-                AlgebraicValue::Builtin(x.into())
+                AlgebraicValue::Builtin(BuiltinValue::$kind(x))
             }
         }
     };
@@ -95,6 +107,8 @@ built_in!(i128, I128);
 built_in!(u128, U128);
 built_in_into!(f32, F32);
 built_in_into!(f64, F64);
+built_in_into!(F32, F32);
+built_in_into!(F64, F64);
 built_in!(String, String);
 built_in_into!(&str, String);
 built_in_into!(&[u8], Bytes);

--- a/crates/sats/src/de/impls.rs
+++ b/crates/sats/src/de/impls.rs
@@ -7,7 +7,7 @@ use std::marker::PhantomData;
 
 use crate::builtin_value::{F32, F64};
 use crate::{
-    AlgebraicType, AlgebraicValue, ArrayType, ArrayValue, BuiltinType, BuiltinValue, MapType, MapValue, ProductType,
+    AlgebraicType, AlgebraicValue, ArrayType, ArrayValue, BuiltinType, MapType, MapValue, ProductType,
     ProductTypeElement, ProductValue, SumType, SumValue, WithTypespace,
 };
 
@@ -300,40 +300,36 @@ impl<'de> DeserializeSeed<'de> for WithTypespace<'_, AlgebraicType> {
 
     fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Output, D::Error> {
         match self.ty() {
-            AlgebraicType::Sum(sum) => self.with(sum).deserialize(deserializer).map(AlgebraicValue::Sum),
-            AlgebraicType::Product(prod) => self.with(prod).deserialize(deserializer).map(AlgebraicValue::Product),
-            AlgebraicType::Builtin(b) => self.with(b).deserialize(deserializer).map(AlgebraicValue::Builtin),
+            AlgebraicType::Sum(sum) => self.with(sum).deserialize(deserializer).map(Into::into),
+            AlgebraicType::Product(prod) => self.with(prod).deserialize(deserializer).map(Into::into),
+            AlgebraicType::Builtin(b) => self.with(b).deserialize(deserializer),
             AlgebraicType::Ref(r) => self.resolve(*r).deserialize(deserializer),
         }
     }
 }
 
 impl<'de> DeserializeSeed<'de> for WithTypespace<'_, BuiltinType> {
-    type Output = BuiltinValue;
+    type Output = AlgebraicValue;
 
     fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Output, D::Error> {
-        Ok(match self.ty() {
-            BuiltinType::Bool => BuiltinValue::Bool(bool::deserialize(deserializer)?),
-            BuiltinType::I8 => BuiltinValue::I8(i8::deserialize(deserializer)?),
-            BuiltinType::U8 => BuiltinValue::U8(u8::deserialize(deserializer)?),
-            BuiltinType::I16 => BuiltinValue::I16(i16::deserialize(deserializer)?),
-            BuiltinType::U16 => BuiltinValue::U16(u16::deserialize(deserializer)?),
-            BuiltinType::I32 => BuiltinValue::I32(i32::deserialize(deserializer)?),
-            BuiltinType::U32 => BuiltinValue::U32(u32::deserialize(deserializer)?),
-            BuiltinType::I64 => BuiltinValue::I64(i64::deserialize(deserializer)?),
-            BuiltinType::U64 => BuiltinValue::U64(u64::deserialize(deserializer)?),
-            BuiltinType::I128 => BuiltinValue::I128(i128::deserialize(deserializer)?),
-            BuiltinType::U128 => BuiltinValue::U128(u128::deserialize(deserializer)?),
-            BuiltinType::F32 => BuiltinValue::F32(f32::deserialize(deserializer)?.into()),
-            BuiltinType::F64 => BuiltinValue::F64(f64::deserialize(deserializer)?.into()),
-            BuiltinType::String => BuiltinValue::String(String::deserialize(deserializer)?),
-            BuiltinType::Array(ty) => BuiltinValue::Array {
-                val: self.with(ty).deserialize(deserializer)?,
-            },
-            BuiltinType::Map(ty) => BuiltinValue::Map {
-                val: self.with(ty).deserialize(deserializer)?,
-            },
-        })
+        match self.ty() {
+            BuiltinType::Bool => bool::deserialize(deserializer).map(Into::into),
+            BuiltinType::I8 => i8::deserialize(deserializer).map(Into::into),
+            BuiltinType::U8 => u8::deserialize(deserializer).map(Into::into),
+            BuiltinType::I16 => i16::deserialize(deserializer).map(Into::into),
+            BuiltinType::U16 => u16::deserialize(deserializer).map(Into::into),
+            BuiltinType::I32 => i32::deserialize(deserializer).map(Into::into),
+            BuiltinType::U32 => u32::deserialize(deserializer).map(Into::into),
+            BuiltinType::I64 => i64::deserialize(deserializer).map(Into::into),
+            BuiltinType::U64 => u64::deserialize(deserializer).map(Into::into),
+            BuiltinType::I128 => i128::deserialize(deserializer).map(Into::into),
+            BuiltinType::U128 => u128::deserialize(deserializer).map(Into::into),
+            BuiltinType::F32 => f32::deserialize(deserializer).map(Into::into),
+            BuiltinType::F64 => f64::deserialize(deserializer).map(Into::into),
+            BuiltinType::String => String::deserialize(deserializer).map(Into::into),
+            BuiltinType::Array(ty) => self.with(ty).deserialize(deserializer).map(Into::into),
+            BuiltinType::Map(ty) => self.with(ty).deserialize(deserializer).map(Into::into),
+        }
     }
 }
 

--- a/crates/sats/src/de/serde.rs
+++ b/crates/sats/src/de/serde.rs
@@ -339,7 +339,7 @@ impl<'de, E: super::Error> super::VariantAccess<'de> for NoneAccess<E> {
     type Error = E;
     fn deserialize_seed<T: super::DeserializeSeed<'de>>(self, seed: T) -> Result<T::Output, Self::Error> {
         use crate::algebraic_value::de::*;
-        seed.deserialize(ValueDeserializer::new(crate::AlgebraicValue::UNIT))
+        seed.deserialize(ValueDeserializer::new(crate::AlgebraicValue::unit()))
             .map_err(|err| match err {
                 ValueDeserializeError::MismatchedType => E::custom("mismatched type"),
                 ValueDeserializeError::Custom(err) => E::custom(err),

--- a/crates/sats/src/meta_type.rs
+++ b/crates/sats/src/meta_type.rs
@@ -10,9 +10,9 @@ use crate::AlgebraicType;
 ///
 /// For example, the `MetaType` of [`ProductType`](crate::ProductType) is
 /// ```ignore
-/// AlgebraicType::product(vec![ProductTypeElement::new_named(
-///     AlgebraicType::array(ProductTypeElement::meta_type()),
+/// AlgebraicType::product([(
 ///     "elements",
+///     AlgebraicType::array(ProductTypeElement::meta_type()),
 /// )])
 /// ```
 pub trait MetaType {

--- a/crates/sats/src/product_type.rs
+++ b/crates/sats/src/product_type.rs
@@ -43,26 +43,25 @@ impl ProductType {
         Self { elements }
     }
 
-    /// Returns whether this is the special case of `spacetimedb_lib::Identity`.
-    pub fn is_identity(&self) -> bool {
+    /// Returns whether this is a "newtype" over bytes.
+    fn is_bytes_newtype(&self, check: &str) -> bool {
         match &*self.elements {
             [ProductTypeElement {
                 name: Some(name),
                 algebraic_type,
-            }] => name == "__identity_bytes" && algebraic_type.is_bytes(),
+            }] => name == check && algebraic_type.is_bytes(),
             _ => false,
         }
     }
 
+    /// Returns whether this is the special case of `spacetimedb_lib::Identity`.
+    pub fn is_identity(&self) -> bool {
+        self.is_bytes_newtype("__identity_bytes")
+    }
+
     /// Returns whether this is the special case of `spacetimedb_lib::Address`.
     pub fn is_address(&self) -> bool {
-        match &*self.elements {
-            [ProductTypeElement {
-                name: Some(name),
-                algebraic_type,
-            }] => name == "__address_bytes" && algebraic_type.is_bytes(),
-            _ => false,
-        }
+        self.is_bytes_newtype("__address_bytes")
     }
 
     /// Returns whether this is a special known type, currently `Address` or `Identity`.
@@ -92,12 +91,35 @@ impl<'a, I: Into<AlgebraicType>> FromIterator<(Option<&'a str>, I)> for ProductT
     }
 }
 
+impl From<Vec<ProductTypeElement>> for ProductType {
+    fn from(fields: Vec<ProductTypeElement>) -> Self {
+        ProductType::new(fields)
+    }
+}
+impl<const N: usize> From<[ProductTypeElement; N]> for ProductType {
+    fn from(fields: [ProductTypeElement; N]) -> Self {
+        ProductType::new(fields.into())
+    }
+}
+impl<const N: usize> From<[(Option<&str>, AlgebraicType); N]> for ProductType {
+    fn from(fields: [(Option<&str>, AlgebraicType); N]) -> Self {
+        fields.into_iter().collect()
+    }
+}
+impl<const N: usize> From<[(&str, AlgebraicType); N]> for ProductType {
+    fn from(fields: [(&str, AlgebraicType); N]) -> Self {
+        fields.into_iter().collect()
+    }
+}
+impl<const N: usize> From<[AlgebraicType; N]> for ProductType {
+    fn from(fields: [AlgebraicType; N]) -> Self {
+        fields.into_iter().collect()
+    }
+}
+
 impl MetaType for ProductType {
     fn meta_type() -> AlgebraicType {
-        AlgebraicType::product(vec![ProductTypeElement::new_named(
-            AlgebraicType::array(ProductTypeElement::meta_type()),
-            "elements",
-        )])
+        AlgebraicType::product([("elements", AlgebraicType::array(ProductTypeElement::meta_type()))])
     }
 }
 

--- a/crates/sats/src/product_type_element.rs
+++ b/crates/sats/src/product_type_element.rs
@@ -1,6 +1,6 @@
 use crate::meta_type::MetaType;
+use crate::AlgebraicType;
 use crate::{de::Deserialize, ser::Serialize};
-use crate::{AlgebraicType, AlgebraicTypeRef};
 
 /// A factor / element of a product type.
 ///
@@ -47,9 +47,9 @@ impl ProductTypeElement {
 
 impl MetaType for ProductTypeElement {
     fn meta_type() -> AlgebraicType {
-        AlgebraicType::product(vec![
-            Self::new_named(AlgebraicType::option(AlgebraicType::String), "name"),
-            Self::new_named(AlgebraicType::Ref(AlgebraicTypeRef(0)), "algebraic_type"),
+        AlgebraicType::product([
+            ("name", AlgebraicType::option(AlgebraicType::String)),
+            ("algebraic_type", AlgebraicType::ZERO_REF),
         ])
     }
 }

--- a/crates/sats/src/product_value.rs
+++ b/crates/sats/src/product_value.rs
@@ -20,7 +20,7 @@ pub struct ProductValue {
 macro_rules! product {
     [$($elems:expr),*$(,)?] => {
         $crate::ProductValue {
-            elements: vec![$($crate::AlgebraicValue::from($elems)),*]
+            elements: [$($crate::AlgebraicValue::from($elems)),*].into()
         }
     }
 }

--- a/crates/sats/src/resolve_refs.rs
+++ b/crates/sats/src/resolve_refs.rs
@@ -120,7 +120,7 @@ impl ResolveRefs for ProductType {
 impl ResolveRefs for ProductTypeElement {
     type Output = Self;
     fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output> {
-        Some(ProductTypeElement {
+        Some(Self {
             algebraic_type: this.map(|e| &e.algebraic_type)._resolve_refs(state)?,
             name: this.ty().name.clone(),
         })
@@ -143,7 +143,7 @@ impl ResolveRefs for SumType {
 impl ResolveRefs for SumTypeVariant {
     type Output = Self;
     fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output> {
-        Some(SumTypeVariant {
+        Some(Self {
             algebraic_type: this.map(|v| &v.algebraic_type)._resolve_refs(state)?,
             name: this.ty().name.clone(),
         })

--- a/crates/sats/src/sum_type.rs
+++ b/crates/sats/src/sum_type.rs
@@ -2,7 +2,7 @@ use crate::algebraic_value::de::{ValueDeserializeError, ValueDeserializer};
 use crate::algebraic_value::ser::ValueSerializer;
 use crate::meta_type::MetaType;
 use crate::{de::Deserialize, ser::Serialize};
-use crate::{AlgebraicType, AlgebraicValue, ProductTypeElement, SumTypeVariant};
+use crate::{AlgebraicType, AlgebraicValue, SumTypeVariant};
 
 /// A structural sum type.
 ///
@@ -72,12 +72,35 @@ impl SumType {
     }
 }
 
+impl From<Vec<SumTypeVariant>> for SumType {
+    fn from(fields: Vec<SumTypeVariant>) -> Self {
+        SumType::new(fields)
+    }
+}
+impl<const N: usize> From<[SumTypeVariant; N]> for SumType {
+    fn from(fields: [SumTypeVariant; N]) -> Self {
+        SumType::new(fields.into())
+    }
+}
+impl<const N: usize> From<[(Option<&str>, AlgebraicType); N]> for SumType {
+    fn from(fields: [(Option<&str>, AlgebraicType); N]) -> Self {
+        fields.map(|(s, t)| SumTypeVariant::new(t, s.map(<_>::into))).into()
+    }
+}
+impl<const N: usize> From<[(&str, AlgebraicType); N]> for SumType {
+    fn from(fields: [(&str, AlgebraicType); N]) -> Self {
+        fields.map(|(s, t)| SumTypeVariant::new_named(t, s)).into()
+    }
+}
+impl<const N: usize> From<[AlgebraicType; N]> for SumType {
+    fn from(fields: [AlgebraicType; N]) -> Self {
+        fields.map(SumTypeVariant::from).into()
+    }
+}
+
 impl MetaType for SumType {
     fn meta_type() -> AlgebraicType {
-        AlgebraicType::product(vec![ProductTypeElement::new_named(
-            AlgebraicType::array(SumTypeVariant::meta_type()),
-            "variants",
-        )])
+        AlgebraicType::product([("variants", AlgebraicType::array(SumTypeVariant::meta_type()))])
     }
 }
 

--- a/crates/sats/src/sum_type_variant.rs
+++ b/crates/sats/src/sum_type_variant.rs
@@ -1,7 +1,6 @@
 use crate::algebraic_type::AlgebraicType;
 use crate::meta_type::MetaType;
 use crate::{de::Deserialize, ser::Serialize};
-use crate::{AlgebraicTypeRef, ProductTypeElement};
 
 /// A variant of a sum type.
 ///
@@ -37,8 +36,8 @@ impl SumTypeVariant {
     }
 
     /// Returns a unit variant with `name`.
-    pub fn unit(name: impl AsRef<str>) -> Self {
-        Self::new_named(AlgebraicType::UNIT_TYPE, name)
+    pub fn unit(name: &str) -> Self {
+        Self::new_named(AlgebraicType::unit(), name)
     }
 
     /// Returns the name of the variant.
@@ -53,15 +52,15 @@ impl SumTypeVariant {
 
     /// Returns whether this is a unit variant.
     pub fn is_unit(&self) -> bool {
-        self.algebraic_type == AlgebraicType::UNIT_TYPE
+        self.algebraic_type == AlgebraicType::unit()
     }
 }
 
 impl MetaType for SumTypeVariant {
     fn meta_type() -> AlgebraicType {
-        AlgebraicType::product(vec![
-            ProductTypeElement::new_named(AlgebraicType::option(AlgebraicType::String), "name"),
-            ProductTypeElement::new_named(AlgebraicType::Ref(AlgebraicTypeRef(0)), "algebraic_type"),
+        AlgebraicType::product([
+            ("name", AlgebraicType::option(AlgebraicType::String)),
+            ("algebraic_type", AlgebraicType::ZERO_REF),
         ])
     }
 }

--- a/crates/sats/src/typespace.rs
+++ b/crates/sats/src/typespace.rs
@@ -120,7 +120,7 @@ pub trait TypespaceBuilder {
 ///     ['a, T: SpacetimeType] Foo<'a, T>,
 /// //  The `make_type` implementation where `ts: impl TypespaceBuilder`
 /// //  and the expression right of `=>` is an `AlgebraicType`.
-///     ts => AlgebraicType::product(vec![T::make_type(ts).into(), AlgebraicType::U8.into()])
+///     ts => AlgebraicType::product([T::make_type(ts), AlgebraicType::U8])
 /// );
 /// ```
 #[macro_export]
@@ -157,7 +157,7 @@ impl_primitives! {
     String => String,
 }
 
-impl_st!([] (), _ts => AlgebraicType::UNIT_TYPE);
+impl_st!([] (), _ts => AlgebraicType::unit());
 impl_st!([] &str, _ts => AlgebraicType::String);
 impl_st!([T: SpacetimeType] Vec<T>, ts => AlgebraicType::array(T::make_type(ts)));
 impl_st!([T: SpacetimeType] Option<T>, ts => AlgebraicType::option(T::make_type(ts)));

--- a/crates/sats/tests/encoding_roundtrip.rs
+++ b/crates/sats/tests/encoding_roundtrip.rs
@@ -5,8 +5,7 @@ use proptest::proptest;
 use spacetimedb_sats::buffer::DecodeError;
 use spacetimedb_sats::builtin_value::{F32, F64};
 use spacetimedb_sats::{
-    meta_type::MetaType, product, AlgebraicType, AlgebraicValue, BuiltinValue, ProductType, ProductTypeElement,
-    ProductValue,
+    meta_type::MetaType, product, AlgebraicType, AlgebraicValue, BuiltinValue, ProductType, ProductValue,
 };
 
 #[test]
@@ -106,7 +105,7 @@ fn algebraic_values() -> impl Strategy<Value = AlgebraicValue> {
 
 fn round_trip(value: AlgebraicValue) -> Result<(ProductValue, ProductValue), DecodeError> {
     let ty = value.type_of();
-    let schema = ProductType::new(vec![ProductTypeElement::new(ty, Some("x".to_string()))]);
+    let schema = ProductType::from([("x", ty)]);
 
     let row = product!(value);
 

--- a/crates/sqltest/src/sqlite.rs
+++ b/crates/sqltest/src/sqlite.rs
@@ -91,7 +91,7 @@ impl AsyncDB for Sqlite {
             for (name, dectype) in &mut columns {
                 let value = row.get::<_, Value>(name.as_str())?;
                 let (value, kind) = match value {
-                    Value::Null => ("null".into(), AlgebraicType::NEVER_TYPE),
+                    Value::Null => ("null".into(), AlgebraicType::never()),
                     Value::Integer(x) => (x.to_string(), AlgebraicType::I64),
                     Value::Real(x) => (format!("{:?}", x), AlgebraicType::F64),
                     Value::Text(x) => (format!("'{}'", x), AlgebraicType::String),

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -3,7 +3,6 @@ use std::collections::HashMap;
 use spacetimedb_lib::relation::{FieldExpr, MemTable, RelIter, Relation, Table};
 use spacetimedb_sats::algebraic_type::AlgebraicType;
 use spacetimedb_sats::algebraic_value::AlgebraicValue;
-use spacetimedb_sats::builtin_type::BuiltinType;
 use spacetimedb_sats::{product, ProductType, ProductValue};
 
 use crate::dsl::{bin_op, call_fn, if_, mem_table, scalar, var};
@@ -532,20 +531,20 @@ pub struct GameData {
 // Used internally for testing  SQL JOINS
 #[doc(hidden)]
 pub fn create_game_data() -> GameData {
-    let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
+    let head = ProductType::from([("inventory_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
     let row = product!(1u64, "health");
     let inv = mem_table(head, [row]);
 
-    let head = ProductType::from_iter([("entity_id", BuiltinType::U64), ("inventory_id", BuiltinType::U64)]);
+    let head = ProductType::from([("entity_id", AlgebraicType::U64), ("inventory_id", AlgebraicType::U64)]);
     let row1 = product!(100u64, 1u64);
     let row2 = product!(200u64, 1u64);
     let row3 = product!(300u64, 1u64);
     let player = mem_table(head, [row1, row2, row3]);
 
-    let head = ProductType::from_iter([
-        ("entity_id", BuiltinType::U64),
-        ("x", BuiltinType::F32),
-        ("z", BuiltinType::F32),
+    let head = ProductType::from([
+        ("entity_id", AlgebraicType::U64),
+        ("x", AlgebraicType::F32),
+        ("z", AlgebraicType::F32),
     ]);
     let row1 = product!(100u64, 0.0f32, 32.0f32);
     let row2 = product!(100u64, 1.0f32, 31.0f32);
@@ -789,7 +788,7 @@ mod tests {
         };
 
         //The expected result
-        let inv = ProductType::from_iter([(None, BuiltinType::I32), (Some("0_0"), BuiltinType::I32)]);
+        let inv = ProductType::from([(None, AlgebraicType::I32), (Some("0_0"), AlgebraicType::I32)]);
         let row = product!(scalar(1), scalar(1));
         let input = mem_table(inv, vec![row]);
 
@@ -803,7 +802,7 @@ mod tests {
     fn test_query_logic() {
         let p = &mut Program::new(AuthCtx::for_testing());
 
-        let inv = ProductType::from_iter([("id", BuiltinType::U64), ("name", BuiltinType::String)]);
+        let inv = ProductType::from([("id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
 
         let row = product!(scalar(1u64), scalar("health"));
 
@@ -829,7 +828,7 @@ mod tests {
     fn test_query() {
         let p = &mut Program::new(AuthCtx::for_testing());
 
-        let inv = ProductType::from_iter([("id", BuiltinType::U64), ("name", BuiltinType::String)]);
+        let inv = ProductType::from([("id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
 
         let row = product!(scalar(1u64), scalar("health"));
 
@@ -844,10 +843,10 @@ mod tests {
         };
 
         //The expected result
-        let inv = ProductType::from_iter([
-            (None, BuiltinType::U64),
-            (Some("id"), BuiltinType::U64),
-            (Some("name"), BuiltinType::String),
+        let inv = ProductType::from([
+            (None, AlgebraicType::U64),
+            (Some("id"), AlgebraicType::U64),
+            (Some("name"), AlgebraicType::String),
         ]);
         let row = product!(scalar(1u64), scalar("health"), scalar(1u64), scalar("health"));
         let input = mem_table(inv, vec![row]);
@@ -899,7 +898,7 @@ mod tests {
 
         let result = run_query(p, q.into());
 
-        let head = ProductType::from_iter([("entity_id", BuiltinType::U64), ("inventory_id", BuiltinType::U64)]);
+        let head = ProductType::from([("entity_id", AlgebraicType::U64), ("inventory_id", AlgebraicType::U64)]);
         let row1 = product!(100u64, 1u64);
         let input = mem_table(head, [row1]);
 
@@ -925,7 +924,7 @@ mod tests {
 
         let result = run_query(p, q.into());
 
-        let head = ProductType::from_iter([("inventory_id", BuiltinType::U64), ("name", BuiltinType::String)]);
+        let head = ProductType::from([("inventory_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
         let row1 = product!(1u64, "health");
         let input = mem_table(head, [row1]);
 

--- a/crates/vm/src/ops/parse.rs
+++ b/crates/vm/src/ops/parse.rs
@@ -1,6 +1,6 @@
 use crate::errors::{ErrorType, ErrorVm};
 use spacetimedb_sats::satn::Satn;
-use spacetimedb_sats::{AlgebraicType, AlgebraicValue, BuiltinType};
+use spacetimedb_sats::{AlgebraicType, AlgebraicValue};
 use std::fmt::Display;
 use std::str::FromStr;
 
@@ -34,26 +34,20 @@ where
 /// ```
 pub fn parse(value: &str, ty: &AlgebraicType) -> Result<AlgebraicValue, ErrorVm> {
     match ty {
-        AlgebraicType::Builtin(x) => match x {
-            BuiltinType::Bool => _parse::<bool>(value, ty),
-            BuiltinType::I8 => _parse::<i8>(value, ty),
-            BuiltinType::U8 => _parse::<u8>(value, ty),
-            BuiltinType::I16 => _parse::<i16>(value, ty),
-            BuiltinType::U16 => _parse::<u16>(value, ty),
-            BuiltinType::I32 => _parse::<i32>(value, ty),
-            BuiltinType::U32 => _parse::<u32>(value, ty),
-            BuiltinType::I64 => _parse::<i64>(value, ty),
-            BuiltinType::U64 => _parse::<u64>(value, ty),
-            BuiltinType::I128 => _parse::<i128>(value, ty),
-            BuiltinType::U128 => _parse::<u128>(value, ty),
-            BuiltinType::F32 => _parse::<f32>(value, ty),
-            BuiltinType::F64 => _parse::<f64>(value, ty),
-            BuiltinType::String => Ok(AlgebraicValue::String(value.to_string())),
-            x => Err(ErrorVm::Unsupported(format!(
-                "Can't parse '{value}' to {}",
-                x.to_satn_pretty()
-            ))),
-        },
+        &AlgebraicType::Bool => _parse::<bool>(value, ty),
+        &AlgebraicType::I8 => _parse::<i8>(value, ty),
+        &AlgebraicType::U8 => _parse::<u8>(value, ty),
+        &AlgebraicType::I16 => _parse::<i16>(value, ty),
+        &AlgebraicType::U16 => _parse::<u16>(value, ty),
+        &AlgebraicType::I32 => _parse::<i32>(value, ty),
+        &AlgebraicType::U32 => _parse::<u32>(value, ty),
+        &AlgebraicType::I64 => _parse::<i64>(value, ty),
+        &AlgebraicType::U64 => _parse::<u64>(value, ty),
+        &AlgebraicType::I128 => _parse::<i128>(value, ty),
+        &AlgebraicType::U128 => _parse::<u128>(value, ty),
+        &AlgebraicType::F32 => _parse::<f32>(value, ty),
+        &AlgebraicType::F64 => _parse::<f64>(value, ty),
+        &AlgebraicType::String => Ok(AlgebraicValue::String(value.to_string())),
         x => Err(ErrorVm::Unsupported(format!(
             "Can't parse '{value}' to {}",
             x.to_satn_pretty()

--- a/crates/vm/src/ops/shared.rs
+++ b/crates/vm/src/ops/shared.rs
@@ -9,5 +9,5 @@ where
 }
 
 pub(crate) fn to_bool(of: &AlgebraicValue) -> Option<bool> {
-    of.as_builtin().and_then(|x| x.as_bool()).copied()
+    of.as_bool().copied()
 }

--- a/crates/vm/src/typecheck.rs
+++ b/crates/vm/src/typecheck.rs
@@ -157,7 +157,6 @@ mod tests {
 
     use spacetimedb_lib::identity::AuthCtx;
     use spacetimedb_sats::algebraic_type::AlgebraicType;
-    use spacetimedb_sats::builtin_type::BuiltinType;
 
     use crate::dsl::{bin_op, scalar};
     use crate::eval::optimize;
@@ -179,10 +178,8 @@ mod tests {
     // #[test]
     // fn ty_value() {
     //     let p = &mut Program::new();
-    //
     //     let zero = scalar(0);
-    //
-    //     _expect(p, zero, BuiltinType::I32.into())
+    //     _expect_ast(p, zero, AlgebraicType::I32)
     // }
 
     #[test]
@@ -190,6 +187,6 @@ mod tests {
         let p = &mut Program::new(AuthCtx::for_testing());
 
         let ast = bin_op(OpMath::Add, scalar(0), scalar(1));
-        _expect_ast(p, ast, BuiltinType::I32.into())
+        _expect_ast(p, ast, AlgebraicType::I32)
     }
 }

--- a/crates/vm/src/types.rs
+++ b/crates/vm/src/types.rs
@@ -6,7 +6,6 @@ use crate::operator::*;
 use spacetimedb_sats::algebraic_type::map_notation::fmt_algebraic_type;
 use spacetimedb_sats::algebraic_type::AlgebraicType;
 use spacetimedb_sats::algebraic_value::AlgebraicValue;
-use spacetimedb_sats::builtin_type::BuiltinType;
 
 /// Describe a `type`. In the case of [Ty::Unknown] the type of [Expr] is
 /// not yet know and should be resolved by the type-checker.
@@ -43,12 +42,6 @@ impl fmt::Display for Ty {
     }
 }
 
-impl From<BuiltinType> for Ty {
-    fn from(x: BuiltinType) -> Self {
-        Ty::Val(x.into())
-    }
-}
-
 pub trait TypeOf {
     fn type_of(&self) -> Ty;
 }
@@ -67,25 +60,25 @@ impl TypeOf for AlgebraicValue {
 
 pub(crate) fn ty_op(op: Op) -> Vec<Ty> {
     match op {
-        Op::Cmp(_) | Op::Logic(_) => vec![BuiltinType::Bool.into()],
+        Op::Cmp(_) | Op::Logic(_) => vec![AlgebraicType::Bool.into()],
         Op::Unary(x) => match x {
-            OpUnary::Not => vec![BuiltinType::Bool.into()],
+            OpUnary::Not => vec![AlgebraicType::Bool.into()],
         },
         Op::Math(_) => vec![
-            BuiltinType::I8.into(),
-            BuiltinType::U8.into(),
-            BuiltinType::I16.into(),
-            BuiltinType::U16.into(),
-            BuiltinType::I32.into(),
-            BuiltinType::U32.into(),
-            BuiltinType::I32.into(),
-            BuiltinType::U32.into(),
-            BuiltinType::I64.into(),
-            BuiltinType::U64.into(),
-            BuiltinType::I128.into(),
-            BuiltinType::U128.into(),
-            BuiltinType::F32.into(),
-            BuiltinType::F64.into(),
+            AlgebraicType::I8.into(),
+            AlgebraicType::U8.into(),
+            AlgebraicType::I16.into(),
+            AlgebraicType::U16.into(),
+            AlgebraicType::I32.into(),
+            AlgebraicType::U32.into(),
+            AlgebraicType::I32.into(),
+            AlgebraicType::U32.into(),
+            AlgebraicType::I64.into(),
+            AlgebraicType::U64.into(),
+            AlgebraicType::I128.into(),
+            AlgebraicType::U128.into(),
+            AlgebraicType::F32.into(),
+            AlgebraicType::F64.into(),
         ],
     }
 }


### PR DESCRIPTION
# Description of Changes

Extracted from https://github.com/clockworklabs/SpacetimeDB/pull/156 plus some minor things added.

- Refactor some duplicated test code.
- Refactor `is_identity` + `is_address`.
- Simplify some code around sums and product creation.
- Prepare for getting rid of BuiltinValue & BuiltinType
   - Refer less to these types and instead to `AlgebraicValue` / `AlgebraicType`
   - Use `product![...]` more.
   - Add more conversions and remove some that are centered around BV/BT.
- Prepare for slim slices
   - Refer less to `vec![...]`

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
