### PR TITLE
Reduce cloning of `Header` & co

### DIFF
--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -796,11 +796,11 @@ impl<'a> TryFrom<&'a ProductValue> for StIndexRow<&'a str> {
 impl<Name: AsRef<str>> From<&StIndexRow<Name>> for ProductValue {
     fn from(x: &StIndexRow<Name>) -> Self {
         product![
-            AlgebraicValue::U32(x.index_id),
-            AlgebraicValue::U32(x.table_id),
+            x.index_id,
+            x.table_id,
             AlgebraicValue::ArrayOf(x.cols.clone()),
             AlgebraicValue::String(x.index_name.as_ref().to_string()),
-            AlgebraicValue::Bool(x.is_unique)
+            x.is_unique
         ]
     }
 }
@@ -863,15 +863,15 @@ impl<'a> TryFrom<&'a ProductValue> for StSequenceRow<&'a str> {
 impl<Name: AsRef<str>> From<&StSequenceRow<Name>> for ProductValue {
     fn from(x: &StSequenceRow<Name>) -> Self {
         product![
-            AlgebraicValue::U32(x.sequence_id),
+            x.sequence_id,
             AlgebraicValue::String(x.sequence_name.as_ref().to_string()),
-            AlgebraicValue::U32(x.table_id),
-            AlgebraicValue::U32(x.col_id),
-            AlgebraicValue::I128(x.increment),
-            AlgebraicValue::I128(x.start),
-            AlgebraicValue::I128(x.min_value),
-            AlgebraicValue::I128(x.max_value),
-            AlgebraicValue::I128(x.allocated),
+            x.table_id,
+            x.col_id,
+            x.increment,
+            x.start,
+            x.min_value,
+            x.max_value,
+            x.allocated,
         ]
     }
 }

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -287,7 +287,7 @@ impl From<&TableSchema> for ProductType {
 impl From<&TableSchema> for SourceExpr {
     fn from(value: &TableSchema) -> Self {
         SourceExpr::DbTable(DbTable::new(
-            &Header::from_product_type(&value.table_name, value.into()),
+            Header::from_product_type(value.table_name.clone(), value.into()),
             value.table_id,
             value.table_type,
             value.table_access,
@@ -297,13 +297,13 @@ impl From<&TableSchema> for SourceExpr {
 
 impl From<&TableSchema> for DbTable {
     fn from(value: &TableSchema) -> Self {
-        DbTable::new(&value.into(), value.table_id, value.table_type, value.table_access)
+        DbTable::new(value.into(), value.table_id, value.table_type, value.table_access)
     }
 }
 
 impl From<&TableSchema> for Header {
     fn from(value: &TableSchema) -> Self {
-        Header::from_product_type(&value.table_name, value.into())
+        Header::from_product_type(value.table_name.clone(), value.into())
     }
 }
 

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -236,7 +236,7 @@ fn compile_select(table: From, project: Vec<Column>, selection: Option<Selection
 
     let mut q = query(db_table_raw(
         ProductType::from(&table.root),
-        &table.root.table_name,
+        table.root.table_name.clone(),
         table.root.table_id,
         table.root.table_type,
         table.root.table_access,
@@ -246,7 +246,7 @@ fn compile_select(table: From, project: Vec<Column>, selection: Option<Selection
         for join in joins {
             match join {
                 Join::Inner { rhs, on } => {
-                    let t = db_table(rhs.into(), &rhs.table_name, rhs.table_id);
+                    let t = db_table(rhs.into(), rhs.table_name.clone(), rhs.table_id);
                     match on.op {
                         OpCmp::Eq => {}
                         x => unreachable!("Unsupported operator `{x}` for joins"),
@@ -357,7 +357,7 @@ fn compile_columns(table: &TableSchema, columns: Vec<FieldName>) -> DbTable {
     }
 
     DbTable::new(
-        &Header::new(&table.table_name, &new),
+        Header::new(table.table_name.clone(), new),
         table.table_id,
         table.table_type,
         table.table_access,

--- a/crates/lib/src/relation.rs
+++ b/crates/lib/src/relation.rs
@@ -89,10 +89,8 @@ impl FieldName {
     }
 
     pub fn table(&self) -> &str {
-        match self {
-            FieldName::Name { table, .. } => table,
-            FieldName::Pos { table, .. } => table,
-        }
+        let (FieldName::Name { table, .. } | FieldName::Pos { table, .. }) = self;
+        table
     }
 
     pub fn field(&self) -> FieldOnly {
@@ -103,6 +101,13 @@ impl FieldName {
     }
 
     pub fn field_name(&self) -> Option<&str> {
+        match self {
+            FieldName::Name { field, .. } => Some(field),
+            FieldName::Pos { .. } => None,
+        }
+    }
+
+    pub fn into_field_name(self) -> Option<String> {
         match self {
             FieldName::Name { field, .. } => Some(field),
             FieldName::Pos { .. } => None,
@@ -182,44 +187,41 @@ pub struct Header {
 
 impl From<Header> for ProductType {
     fn from(value: Header) -> Self {
-        ProductType::from_iter(value.fields.iter().map(|x| match &x.field {
-            FieldName::Name { field, .. } => ProductTypeElement::new_named(x.algebraic_type.clone(), field),
-            FieldName::Pos { .. } => ProductTypeElement::new(x.algebraic_type.clone(), None),
-        }))
+        ProductType::from_iter(
+            value
+                .fields
+                .into_iter()
+                .map(|x| ProductTypeElement::new(x.algebraic_type, x.field.into_field_name())),
+        )
     }
 }
 
 impl Header {
-    pub fn new(table_name: &str, fields: &[Column]) -> Self {
-        Self {
-            table_name: table_name.into(),
-            fields: fields.into(),
-        }
+    pub fn new(table_name: String, fields: Vec<Column>) -> Self {
+        Self { table_name, fields }
     }
 
-    pub fn from_product_type(table_name: &str, fields: ProductType) -> Self {
-        let mut cols = Vec::with_capacity(fields.elements.len());
+    pub fn from_product_type(table_name: String, fields: ProductType) -> Self {
+        let cols = fields
+            .elements
+            .into_iter()
+            .enumerate()
+            .map(|(pos, f)| {
+                let table = table_name.clone();
+                let name = match f.name {
+                    None => FieldName::Pos { table, field: pos },
+                    Some(field) => FieldName::Name { table, field },
+                };
+                Column::new(name, f.algebraic_type)
+            })
+            .collect();
 
-        for (pos, f) in fields.elements.into_iter().enumerate() {
-            let name = match f.name {
-                None => FieldName::Pos {
-                    table: table_name.into(),
-                    field: pos,
-                },
-                Some(x) => FieldName::Name {
-                    table: table_name.into(),
-                    field: x,
-                },
-            };
-            cols.push(Column::new(name, f.algebraic_type));
-        }
-
-        Self::new(table_name, &cols)
+        Self::new(table_name, cols)
     }
 
     pub fn for_mem_table(fields: ProductType) -> Self {
         let table_name = format!("mem#{:x}", calculate_hash(&fields));
-        Self::from_product_type(&table_name, fields)
+        Self::from_product_type(table_name, fields)
     }
 
     pub fn as_without_table_name(&self) -> HeaderOnlyField {
@@ -288,7 +290,7 @@ impl Header {
             }
         }
 
-        Ok(Self::new(&self.table_name, &p))
+        Ok(Self::new(self.table_name.clone(), p))
     }
 
     /// Adds the fields from `right` to this [`Header`],
@@ -313,7 +315,7 @@ impl Header {
             fields.push(f);
         }
 
-        Self::new(&self.table_name, &fields)
+        Self::new(self.table_name.clone(), fields)
     }
 }
 
@@ -376,7 +378,7 @@ impl RowCount {
 /// A [Relation] is anything that could be represented as a [Header] of `[ColumnName:ColumnType]` that
 /// generates rows/tuples of [AlgebraicValue] that exactly match that [Header].
 pub trait Relation {
-    fn head(&self) -> Header;
+    fn head(&self) -> &Header;
     /// Specify the size in rows of the [Relation].
     ///
     /// Warning: It should at least be precise in the lower-bound estimate.
@@ -515,17 +517,17 @@ pub struct MemTable {
 }
 
 impl MemTable {
-    pub fn new(head: &Header, table_access: StAccess, data: &[RelValue]) -> Self {
+    pub fn new(head: Header, table_access: StAccess, data: Vec<RelValue>) -> Self {
         assert_eq!(
             head.fields.len(),
             data.first()
                 .map(|x| x.data.elements.len())
                 .unwrap_or_else(|| head.fields.len()),
-            "Not match the number of columns between the header.len() <> data.len()"
+            "number of columns in `header.len() != data.len()`"
         );
         Self {
-            head: head.clone(),
-            data: data.into(),
+            head,
+            data,
             table_access,
         }
     }
@@ -533,12 +535,12 @@ impl MemTable {
     pub fn from_value(of: AlgebraicValue) -> Self {
         let head = Header::for_mem_table(of.type_of().into());
         let row = RelValue::new(of.into(), None);
-        Self::new(&head, StAccess::Public, &[row])
+        Self::new(head, StAccess::Public, [row].into())
     }
 
-    pub fn from_iter(head: &Header, data: impl Iterator<Item = ProductValue>) -> Self {
+    pub fn from_iter(head: Header, data: impl Iterator<Item = ProductValue>) -> Self {
         Self {
-            head: head.clone(),
+            head,
             data: data.map(|row| RelValue::new(row, None)).collect(),
             table_access: StAccess::Public,
         }
@@ -561,8 +563,8 @@ impl MemTable {
 }
 
 impl Relation for MemTable {
-    fn head(&self) -> Header {
-        self.head.clone()
+    fn head(&self) -> &Header {
+        &self.head
     }
 
     fn row_count(&self) -> RowCount {
@@ -580,9 +582,9 @@ pub struct DbTable {
 }
 
 impl DbTable {
-    pub fn new(head: &Header, table_id: u32, table_type: StTableType, table_access: StAccess) -> Self {
+    pub fn new(head: Header, table_id: u32, table_type: StTableType, table_access: StAccess) -> Self {
         Self {
-            head: head.clone(),
+            head,
             table_id,
             table_type,
             table_access,
@@ -591,8 +593,8 @@ impl DbTable {
 }
 
 impl Relation for DbTable {
-    fn head(&self) -> Header {
-        self.head.clone()
+    fn head(&self) -> &Header {
+        &self.head
     }
 
     fn row_count(&self) -> RowCount {
@@ -630,7 +632,7 @@ impl Table {
 }
 
 impl Relation for Table {
-    fn head(&self) -> Header {
+    fn head(&self) -> &Header {
         match self {
             Table::MemTable(x) => x.head(),
             Table::DbTable(x) => x.head(),

--- a/crates/vm/src/dsl.rs
+++ b/crates/vm/src/dsl.rs
@@ -31,27 +31,24 @@ where
     I: IntoIterator<Item = T>,
     T: Into<ProductValue>,
 {
-    MemTable::from_iter(&head.into(), iter.into_iter().map(Into::into))
+    MemTable::from_iter(head.into(), iter.into_iter().map(Into::into))
 }
 
 pub fn db_table_raw(
     head: ProductType,
-    name: &str,
+    name: String,
     table_id: u32,
     table_type: StTableType,
     table_access: StAccess,
 ) -> DbTable {
-    DbTable::new(
-        &Header::from_product_type(name, head),
-        table_id,
-        table_type,
-        table_access,
-    )
+    let header = Header::from_product_type(name, head);
+    DbTable::new(header, table_id, table_type, table_access)
 }
 
 /// Create a [DbTable] of type [StTableType::User] and derive `StAccess::for_name(name)`.
-pub fn db_table(head: ProductType, name: &str, table_id: u32) -> DbTable {
-    db_table_raw(head, name, table_id, StTableType::User, StAccess::for_name(name))
+pub fn db_table(head: ProductType, name: String, table_id: u32) -> DbTable {
+    let access = StAccess::for_name(&name);
+    db_table_raw(head, name, table_id, StTableType::User, access)
 }
 
 pub fn bin_op<O, A, B>(op: O, a: A, b: B) -> Expr

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -433,7 +433,7 @@ pub fn build_query(mut result: Box<IterRows>, query: Vec<Query>) -> Result<Box<I
                 let key_rhs = col_rhs.clone();
                 let row_rhs = q.rhs.source.row_count();
 
-                let head = q.rhs.source.head();
+                let head = q.rhs.source.head().clone();
                 let rhs = match q.rhs.source {
                     SourceExpr::MemTable(x) => Box::new(RelIter::new(head, row_rhs, x)) as Box<IterRows<'_>>,
                     SourceExpr::DbTable(_) => {
@@ -734,13 +734,13 @@ mod tests {
 
         let q = query(input).with_select_cmp(OpCmp::Eq, field, scalar(1));
 
-        let head = q.source.head();
+        let head = q.source.head().clone();
 
         let result = run_ast(p, q.into());
         let row = RelValue::new(scalar(1).into(), None);
         assert_eq!(
             result,
-            Code::Table(MemTable::new(&head, StAccess::Public, &[row])),
+            Code::Table(MemTable::new(head, StAccess::Public, [row].into())),
             "Query"
         );
     }
@@ -754,13 +754,13 @@ mod tests {
 
         let source = query(table.clone());
         let q = source.clone().with_project(&[field.into()], None);
-        let head = q.source.head();
+        let head = q.source.head().clone();
 
         let result = run_ast(p, q.into());
         let row = RelValue::new(input.into(), None);
         assert_eq!(
             result,
-            Code::Table(MemTable::new(&head, StAccess::Public, &[row])),
+            Code::Table(MemTable::new(head.clone(), StAccess::Public, [row].into())),
             "Project"
         );
 

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -333,7 +333,7 @@ impl SourceExpr {
 }
 
 impl Relation for SourceExpr {
-    fn head(&self) -> Header {
+    fn head(&self) -> &Header {
         match self {
             SourceExpr::MemTable(x) => x.head(),
             SourceExpr::DbTable(x) => x.head(),
@@ -1057,8 +1057,7 @@ impl fmt::Display for SourceExpr {
             SourceExpr::MemTable(x) => {
                 let ty = &AlgebraicType::Product(x.head().ty());
                 for row in &x.data {
-                    let val = AlgebraicValue::Product(row.data.clone());
-                    let x = fmt_value(ty, &val);
+                    let x = fmt_value(ty, &row.data.clone().into());
                     write!(f, "{x}")?;
                 }
                 Ok(())
@@ -1262,7 +1261,7 @@ impl AuthAccess for QueryCode {
 }
 
 impl Relation for QueryCode {
-    fn head(&self) -> Header {
+    fn head(&self) -> &Header {
         self.table.head()
     }
 

--- a/crates/vm/src/program.rs
+++ b/crates/vm/src/program.rs
@@ -171,7 +171,7 @@ impl ProgramVm for Program {
     fn eval_query(&mut self, query: CrudCode) -> Result<Code, ErrorVm> {
         match query {
             CrudCode::Query(query) => {
-                let head = query.head();
+                let head = query.head().clone();
                 let row_count = query.row_count();
                 let table_access = query.table.table_access();
                 let result = match query.table {
@@ -186,7 +186,7 @@ impl ProgramVm for Program {
                 let head = result.head().clone();
                 let rows: Vec<_> = result.collect_vec()?;
 
-                Ok(Code::Table(MemTable::new(&head, table_access, &rows)))
+                Ok(Code::Table(MemTable::new(head, table_access, rows)))
             }
             CrudCode::Insert { .. } => {
                 todo!()


### PR DESCRIPTION
# Description of Changes

The primary purpose of this PR is to nix some unnecessary `.clone()`s in `Header`, `MemTable` and friends by making cloning more explicit by not cloning inside constructor functions like `::new`.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
