### PR TITLE
Move the two `Box`es in `MapType` to one in `BuiltinType`

### DIFF
--- a/crates/sats/src/algebraic_type.rs
+++ b/crates/sats/src/algebraic_type.rs
@@ -224,8 +224,7 @@ impl AlgebraicType {
 
     /// Returns a map type from the type `key` to the type `value`.
     pub fn map(key: Self, value: Self) -> Self {
-        let value = MapType::new(key, value);
-        AlgebraicType::Builtin(BuiltinType::Map(value))
+        AlgebraicType::Builtin(BuiltinType::Map(Box::new(MapType::new(key, value))))
     }
 
     /// Returns a sum type of unit variants with names taken from `var_names`.

--- a/crates/sats/src/algebraic_type/map_notation.rs
+++ b/crates/sats/src/algebraic_type/map_notation.rs
@@ -1,7 +1,7 @@
 use super::AlgebraicType;
 use crate::builtin_type::BuiltinType;
 use crate::de::fmt_fn;
-use crate::{ArrayType, MapType};
+use crate::ArrayType;
 use std::fmt::{self, Formatter};
 
 /// Wraps an algebraic `ty` in a `Display` impl using a object/map JSON-like notation.
@@ -49,7 +49,7 @@ pub fn fmt_algebraic_type(ty: &AlgebraicType) -> impl '_ + fmt::Display {
                 BuiltinType::F64 => write!(f, ", 0: F64")?,
                 BuiltinType::String => write!(f, ", 0: String")?,
                 BuiltinType::Array(ArrayType { elem_ty }) => write!(f, ", 0: Array, 1: {}", fmt(elem_ty))?,
-                BuiltinType::Map(MapType { key_ty, ty }) => write!(f, "0: Map, 1: {}, 2: {}", fmt(key_ty), fmt(ty))?,
+                BuiltinType::Map(map) => write!(f, "0: Map, 1: {}, 2: {}", fmt(&map.key_ty), fmt(&map.ty))?,
             }
             write!(f, " }}")
         }

--- a/crates/sats/src/builtin_type.rs
+++ b/crates/sats/src/builtin_type.rs
@@ -49,7 +49,7 @@ pub enum BuiltinType {
     /// The type of map values consisting of a key type `key_ty` and value `ty`.
     /// Values [`BuiltinValue::Map(map)`](crate::BuiltinValue::Map) will have this type.
     /// The order of entries in a map value is observable.
-    Map(MapType),
+    Map(Box<MapType>),
 }
 
 impl MetaType for BuiltinType {

--- a/crates/sats/src/de/impls.rs
+++ b/crates/sats/src/de/impls.rs
@@ -328,7 +328,7 @@ impl<'de> DeserializeSeed<'de> for WithTypespace<'_, BuiltinType> {
             BuiltinType::F64 => f64::deserialize(deserializer).map(Into::into),
             BuiltinType::String => String::deserialize(deserializer).map(Into::into),
             BuiltinType::Array(ty) => self.with(ty).deserialize(deserializer).map(Into::into),
-            BuiltinType::Map(ty) => self.with(ty).deserialize(deserializer).map(Into::into),
+            BuiltinType::Map(ty) => self.with(&**ty).deserialize(deserializer).map(Into::into),
         }
     }
 }
@@ -466,7 +466,7 @@ impl<'de> DeserializeSeed<'de> for WithTypespace<'_, ArrayType> {
                     .deserialize_array_seed(BasicVecVisitor, self.with(ty))
                     .map(ArrayValue::Array),
                 AlgebraicType::Builtin(BuiltinType::Map(ty)) => deserializer
-                    .deserialize_array_seed(BasicVecVisitor, self.with(ty))
+                    .deserialize_array_seed(BasicVecVisitor, self.with(&**ty))
                     .map(ArrayValue::Map),
             };
         }
@@ -478,7 +478,7 @@ impl<'de> DeserializeSeed<'de> for WithTypespace<'_, MapType> {
 
     fn deserialize<D: Deserializer<'de>>(self, deserializer: D) -> Result<Self::Output, D::Error> {
         let MapType { key_ty, ty } = self.ty();
-        deserializer.deserialize_map_seed(BasicMapVisitor, self.with(&**key_ty), self.with(&**ty))
+        deserializer.deserialize_map_seed(BasicMapVisitor, self.with(key_ty), self.with(ty))
     }
 }
 

--- a/crates/sats/src/map_type.rs
+++ b/crates/sats/src/map_type.rs
@@ -5,18 +5,15 @@ use crate::{de::Deserialize, meta_type::MetaType, ser::Serialize, AlgebraicType}
 #[sats(crate = crate)]
 pub struct MapType {
     /// The key type of the map.
-    pub key_ty: Box<AlgebraicType>,
+    pub key_ty: AlgebraicType,
     /// The value type of the map.
-    pub ty: Box<AlgebraicType>,
+    pub ty: AlgebraicType,
 }
 
 impl MapType {
     /// Returns a map type with keys of type `key` and values of type `value`.
     pub fn new(key: AlgebraicType, value: AlgebraicType) -> Self {
-        Self {
-            key_ty: Box::new(key),
-            ty: Box::new(value),
-        }
+        Self { key_ty: key, ty: value }
     }
 }
 

--- a/crates/sats/src/ser/impls.rs
+++ b/crates/sats/src/ser/impls.rs
@@ -173,7 +173,7 @@ impl_serialize!([] ValueWithType<'_, BuiltinValue>, (self, ser) => match (self.v
     (BuiltinValue::F64(v), BuiltinType::F64) => ser.serialize_f64((*v).into()),
     (BuiltinValue::String(s), BuiltinType::String) => ser.serialize_str(s),
     (BuiltinValue::Array { val }, BuiltinType::Array(ty)) => self.with(ty, val).serialize(ser),
-    (BuiltinValue::Map { val }, BuiltinType::Map(ty)) => self.with(ty, val).serialize(ser),
+    (BuiltinValue::Map { val }, BuiltinType::Map(ty)) => self.with(&**ty, val).serialize(ser),
     (val, ty) => panic!("mismatched value and schema: {val:?} {ty:?}"),
 });
 impl_serialize!(
@@ -221,7 +221,7 @@ impl_serialize!([] ValueWithType<'_, ArrayValue>, (self, ser) => match (self.val
     (ArrayValue::Array(v), AlgebraicType::Builtin(BuiltinType::Array(ty))) => {
         self.with(ty, v).serialize(ser)
     }
-    (ArrayValue::Map(v), AlgebraicType::Builtin(BuiltinType::Map(m))) => self.with(m, v).serialize(ser),
+    (ArrayValue::Map(v), AlgebraicType::Builtin(BuiltinType::Map(m))) => self.with(&**m, v).serialize(ser),
     (val, _) if val.is_empty() => ser.serialize_array(0)?.end(),
     (val, ty) => panic!("mismatched value and schema: {val:?} {ty:?}"),
 });
@@ -230,7 +230,7 @@ impl_serialize!([] ValueWithType<'_, MapValue>, (self, ser) => {
     let MapType { key_ty, ty } = self.ty();
     let mut map = ser.serialize_map(val.len())?;
     for (key, val) in val {
-        map.serialize_entry(&self.with(&**key_ty, key), &self.with(&**ty, val))?;
+        map.serialize_entry(&self.with(key_ty, key), &self.with(ty, val))?;
     }
     map.end()
 });


### PR DESCRIPTION
# Description of Changes

Instead of having one `Box` around the `key_ty` and one around the (value) `ty`, we have one around the entire ´MapType`.
Why? Because both values tend to be accessed together so having one Box is more cache friendly. Moreover, this enables shrinking `AlgebraicType` later on, as `Box<MapType>` is 8 bytes vs. the old `MapType` being 16 bytes.

Extracted from https://github.com/clockworklabs/SpacetimeDB/pull/156.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
