### PR TITLE
More `AlgebraicType` conversions + use `derive_more::From` more

### DIFF
--- a/crates/lib/tests/serde.rs
+++ b/crates/lib/tests/serde.rs
@@ -23,10 +23,7 @@ fn test_json_mappings() {
         ("baz", AlgebraicType::array(AlgebraicType::String)),
         (
             "quux",
-            AlgebraicType::Sum(enumm([
-                ("Hash", AlgebraicType::bytes()),
-                ("Unit", AlgebraicType::unit()),
-            ])),
+            enumm([("Hash", AlgebraicType::bytes()), ("Unit", AlgebraicType::unit())]).into(),
         ),
         ("and_peggy", AlgebraicType::option(AlgebraicType::F64)),
     ]);

--- a/crates/sats/src/algebraic_type.rs
+++ b/crates/sats/src/algebraic_type.rs
@@ -6,6 +6,7 @@ use crate::algebraic_value::ser::ValueSerializer;
 use crate::meta_type::MetaType;
 use crate::{de::Deserialize, ser::Serialize, MapType};
 use crate::{AlgebraicTypeRef, AlgebraicValue, ArrayType, BuiltinType, ProductType, SumType, SumTypeVariant};
+use derive_more::From;
 use enum_as_inner::EnumAsInner;
 
 /// The SpacetimeDB Algebraic Type System (SATS) is a structural type system in
@@ -51,7 +52,7 @@ use enum_as_inner::EnumAsInner;
 ///     indexes: Array<(index_type: String)>,
 /// )
 /// ```
-#[derive(EnumAsInner, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize)]
+#[derive(EnumAsInner, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, Serialize, Deserialize, From)]
 #[sats(crate = crate)]
 pub enum AlgebraicType {
     /// A structural sum type.
@@ -219,12 +220,12 @@ impl AlgebraicType {
 
     /// Returns an unsized array type where the element type is `ty`.
     pub fn array(ty: Self) -> Self {
-        AlgebraicType::Builtin(BuiltinType::Array(ArrayType { elem_ty: Box::new(ty) }))
+        ArrayType { elem_ty: Box::new(ty) }.into()
     }
 
     /// Returns a map type from the type `key` to the type `value`.
     pub fn map(key: Self, value: Self) -> Self {
-        AlgebraicType::Builtin(BuiltinType::Map(Box::new(MapType::new(key, value))))
+        MapType::new(key, value).into()
     }
 
     /// Returns a sum type of unit variants with names taken from `var_names`.

--- a/crates/sats/src/algebraic_value.rs
+++ b/crates/sats/src/algebraic_value.rs
@@ -2,6 +2,7 @@ pub mod de;
 pub mod ser;
 
 use crate::{AlgebraicType, ArrayValue, BuiltinType, MapValue, ProductValue, SumValue};
+use derive_more::From;
 use enum_as_inner::EnumAsInner;
 use std::ops::{Bound, RangeBounds};
 
@@ -20,7 +21,7 @@ pub type F64 = decorum::Total<f64>;
 /// These are only values and not expressions.
 /// That is, they are canonical and cannot be simplified further by some evaluation.
 /// So forms like `42 + 24` are not represented in an `AlgebraicValue`.
-#[derive(EnumAsInner, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(EnumAsInner, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, From)]
 pub enum AlgebraicValue {
     /// A structural sum value.
     ///

--- a/crates/sats/src/array_value.rs
+++ b/crates/sats/src/array_value.rs
@@ -1,5 +1,4 @@
-use crate::algebraic_value::{F32, F64};
-use crate::{AlgebraicType, AlgebraicValue, ArrayType, BuiltinType, MapValue, ProductValue, SumValue};
+use crate::{AlgebraicType, AlgebraicValue, ArrayType, MapValue, ProductValue, SumValue, F32, F64};
 use nonempty::NonEmpty;
 use std::fmt;
 
@@ -73,7 +72,7 @@ impl ArrayValue {
             Self::F32(_) => AlgebraicType::F32,
             Self::F64(_) => AlgebraicType::F64,
             Self::String(_) => AlgebraicType::String,
-            Self::Array(v) => Self::first_type_of(v, |a| AlgebraicType::Builtin(BuiltinType::Array(a.type_of()))),
+            Self::Array(v) => Self::first_type_of(v, |a| a.type_of().into()),
             Self::Map(v) => Self::first_type_of(v, AlgebraicValue::type_of_map),
         });
         ArrayType { elem_ty }

--- a/crates/sats/src/convert.rs
+++ b/crates/sats/src/convert.rs
@@ -1,14 +1,7 @@
-use crate::algebraic_value::{F32, F64};
-use crate::{AlgebraicType, AlgebraicValue, ArrayValue, MapValue, ProductType, ProductValue, SumValue};
+use crate::{AlgebraicType, AlgebraicValue, ArrayType, BuiltinType, MapType, ProductType, ProductValue};
 
 impl crate::Value for AlgebraicValue {
     type Type = AlgebraicType;
-}
-
-impl From<ProductValue> for AlgebraicValue {
-    fn from(x: ProductValue) -> Self {
-        Self::Product(x)
-    }
 }
 
 impl From<AlgebraicValue> for ProductValue {
@@ -23,44 +16,22 @@ impl From<&AlgebraicValue> for ProductValue {
     }
 }
 
-impl From<SumValue> for AlgebraicValue {
-    fn from(x: SumValue) -> Self {
-        Self::Sum(x)
-    }
-}
-
-impl From<ArrayValue> for AlgebraicValue {
-    fn from(x: ArrayValue) -> Self {
-        Self::Array(x)
-    }
-}
-
-impl From<MapValue> for AlgebraicValue {
-    fn from(x: MapValue) -> Self {
-        Self::map(x)
-    }
-}
-
 impl From<AlgebraicType> for ProductType {
     fn from(x: AlgebraicType) -> Self {
         Self::new([x.into()].into())
     }
 }
 
-impl From<ProductType> for AlgebraicType {
-    fn from(x: ProductType) -> Self {
-        Self::Product(x)
+impl From<ArrayType> for AlgebraicType {
+    fn from(x: ArrayType) -> Self {
+        BuiltinType::Array(x).into()
     }
 }
 
-macro_rules! built_in {
-    ($native:ty, $kind:ident) => {
-        impl From<$native> for AlgebraicValue {
-            fn from(x: $native) -> Self {
-                Self::$kind(x)
-            }
-        }
-    };
+impl From<MapType> for AlgebraicType {
+    fn from(x: MapType) -> Self {
+        BuiltinType::Map(Box::new(x)).into()
+    }
 }
 
 macro_rules! built_in_into {
@@ -73,21 +44,7 @@ macro_rules! built_in_into {
     };
 }
 
-built_in!(bool, Bool);
-built_in!(i8, I8);
-built_in!(u8, U8);
-built_in!(i16, I16);
-built_in!(u16, U16);
-built_in!(i32, I32);
-built_in!(u32, U32);
-built_in!(i64, I64);
-built_in!(u64, U64);
-built_in!(i128, I128);
-built_in!(u128, U128);
 built_in_into!(f32, F32);
 built_in_into!(f64, F64);
-built_in_into!(F32, F32);
-built_in_into!(F64, F64);
-built_in!(String, String);
 built_in_into!(&str, String);
 built_in_into!(&[u8], Bytes);

--- a/crates/sats/src/resolve_refs.rs
+++ b/crates/sats/src/resolve_refs.rs
@@ -65,20 +65,11 @@ impl ResolveRefs for AlgebraicType {
     type Output = Self;
     fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output> {
         match this.ty() {
-            AlgebraicType::Sum(sum) => this.with(sum)._resolve_refs(state).map(Self::Sum),
-            AlgebraicType::Product(prod) => this.with(prod)._resolve_refs(state).map(Self::Product),
-            AlgebraicType::Builtin(b) => this.with(b)._resolve_refs(state).map(Self::Builtin),
             AlgebraicType::Ref(r) => this.with(r)._resolve_refs(state),
-        }
-    }
-}
-
-impl ResolveRefs for BuiltinType {
-    type Output = Self;
-    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output> {
-        match this.ty() {
-            BuiltinType::Array(ty) => this.with(ty)._resolve_refs(state).map(Self::Array),
-            BuiltinType::Map(m) => this.with(&**m)._resolve_refs(state).map(Box::new).map(Self::Map),
+            AlgebraicType::Sum(sum) => this.with(sum)._resolve_refs(state).map(Into::into),
+            AlgebraicType::Product(prod) => this.with(prod)._resolve_refs(state).map(Into::into),
+            AlgebraicType::Builtin(BuiltinType::Array(ty)) => this.with(ty)._resolve_refs(state).map(Into::into),
+            AlgebraicType::Builtin(BuiltinType::Map(m)) => this.with(&**m)._resolve_refs(state).map(Into::into),
             // These types are plain and cannot have refs in them.
             x => Some(x.clone()),
         }


### PR DESCRIPTION
# Description of Changes

Simplifies some code using `derive_more::From` and further simplifies review of https://github.com/clockworklabs/SpacetimeDB/pull/379.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
