### PR TITLE
Benchmark modules in release mode

### DIFF
--- a/crates/bench/src/spacetime_module.rs
+++ b/crates/bench/src/spacetime_module.rs
@@ -2,7 +2,7 @@ use spacetimedb::db::datastore::traits::TableSchema;
 use spacetimedb::db::{Config, FsyncPolicy, Storage};
 use spacetimedb_lib::sats::product;
 use spacetimedb_lib::{sats::ArrayValue, AlgebraicValue, ProductValue};
-use spacetimedb_testing::modules::{start_runtime, CompiledModule, ModuleHandle};
+use spacetimedb_testing::modules::{start_runtime, CompilationMode, CompiledModule, ModuleHandle};
 use tokio::runtime::Runtime;
 
 use crate::{
@@ -14,7 +14,7 @@ use crate::{
 
 lazy_static::lazy_static! {
     pub static ref BENCHMARKS_MODULE: CompiledModule =
-        CompiledModule::compile("benchmarks");
+        CompiledModule::compile("benchmarks", CompilationMode::Release);
 }
 
 /// A benchmark backend that invokes a spacetime module.

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -77,9 +77,15 @@ pub struct CompiledModule {
     program_bytes: OnceLock<Vec<u8>>,
 }
 
+#[derive(Debug, PartialEq, Eq)]
+pub enum CompilationMode {
+    Debug,
+    Release,
+}
+
 impl CompiledModule {
-    pub fn compile(name: &str) -> Self {
-        let path = spacetimedb_cli::build(&module_path(name), false, true).unwrap();
+    pub fn compile(name: &str, mode: CompilationMode) -> Self {
+        let path = spacetimedb_cli::build(&module_path(name), false, mode == CompilationMode::Debug).unwrap();
         Self {
             name: name.to_owned(),
             path,

--- a/crates/testing/src/sdk.rs
+++ b/crates/testing/src/sdk.rs
@@ -5,7 +5,7 @@ use std::thread::JoinHandle;
 use std::{collections::HashSet, fs::create_dir_all, sync::Mutex};
 
 use crate::invoke_cli;
-use crate::modules::{module_path, CompiledModule};
+use crate::modules::{module_path, CompilationMode, CompiledModule};
 use std::path::Path;
 use tempfile::TempDir;
 
@@ -110,7 +110,7 @@ impl Test {
     pub fn run(&self) {
         ensure_standalone_process();
 
-        let compiled = CompiledModule::compile(&self.module_name);
+        let compiled = CompiledModule::compile(&self.module_name, CompilationMode::Debug);
 
         generate_bindings(
             &self.generate_language,

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -1,27 +1,30 @@
 use serde_json::Value;
 use serial_test::serial;
-use spacetimedb_testing::modules::{CompiledModule, DEFAULT_CONFIG};
+use spacetimedb_testing::modules::{CompilationMode, CompiledModule, DEFAULT_CONFIG};
 
 // The tests MUST be run in sequence because they read the OS environment
 // and can cause a race when run in parallel.
 
 fn test_calling_a_reducer_in_module(module_name: &'static str) {
-    CompiledModule::compile(module_name).with_module_async(DEFAULT_CONFIG, |module| async move {
-        let json = r#"{"call": {"fn": "add", "args": ["Tyrion"]}}"#.to_string();
-        module.send(json).await.unwrap();
-        let json = r#"{"call": {"fn": "say_hello", "args": []}}"#.to_string();
-        module.send(json).await.unwrap();
+    CompiledModule::compile(module_name, CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            let json = r#"{"call": {"fn": "add", "args": ["Tyrion"]}}"#.to_string();
+            module.send(json).await.unwrap();
+            let json = r#"{"call": {"fn": "say_hello", "args": []}}"#.to_string();
+            module.send(json).await.unwrap();
 
-        let lines = module.read_log(Some(10)).await;
-        let lines: Vec<&str> = lines.trim().split('\n').collect();
+            let lines = module.read_log(Some(10)).await;
+            let lines: Vec<&str> = lines.trim().split('\n').collect();
 
-        assert_eq!(lines.len(), 4);
+            assert_eq!(lines.len(), 4);
 
-        let json: Value = serde_json::from_str(lines[2]).unwrap();
-        assert_eq!(json["message"], Value::String("Hello, Tyrion!".to_string()));
-        let json: Value = serde_json::from_str(lines[3]).unwrap();
-        assert_eq!(json["message"], Value::String("Hello, World!".to_string()));
-    });
+            let json: Value = serde_json::from_str(lines[2]).unwrap();
+            assert_eq!(json["message"], Value::String("Hello, Tyrion!".to_string()));
+            let json: Value = serde_json::from_str(lines[3]).unwrap();
+            assert_eq!(json["message"], Value::String("Hello, World!".to_string()));
+        },
+    );
 }
 
 #[test]
@@ -39,20 +42,23 @@ fn test_calling_a_reducer_csharp() {
 #[test]
 #[serial]
 fn test_calling_a_reducer_with_private_table() {
-    CompiledModule::compile("rust-wasm-test").with_module_async(DEFAULT_CONFIG, |module| async move {
-        let json = r#"{"call": {"fn": "add_private", "args": ["Tyrion"]}}"#.to_string();
-        module.send(json).await.unwrap();
-        let json = r#"{"call": {"fn": "query_private", "args": []}}"#.to_string();
-        module.send(json).await.unwrap();
+    CompiledModule::compile("rust-wasm-test", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            let json = r#"{"call": {"fn": "add_private", "args": ["Tyrion"]}}"#.to_string();
+            module.send(json).await.unwrap();
+            let json = r#"{"call": {"fn": "query_private", "args": []}}"#.to_string();
+            module.send(json).await.unwrap();
 
-        let lines = module.read_log(Some(10)).await;
-        let lines: Vec<&str> = lines.trim().split('\n').collect();
+            let lines = module.read_log(Some(10)).await;
+            let lines: Vec<&str> = lines.trim().split('\n').collect();
 
-        assert_eq!(lines.len(), 8);
+            assert_eq!(lines.len(), 8);
 
-        let json: Value = serde_json::from_str(lines[6]).unwrap();
-        assert_eq!(json["message"], Value::String("Private, Tyrion!".to_string()));
-        let json: Value = serde_json::from_str(lines[7]).unwrap();
-        assert_eq!(json["message"], Value::String("Private, World!".to_string()));
-    });
+            let json: Value = serde_json::from_str(lines[6]).unwrap();
+            assert_eq!(json["message"], Value::String("Private, Tyrion!".to_string()));
+            let json: Value = serde_json::from_str(lines[7]).unwrap();
+            assert_eq!(json["message"], Value::String("Private, World!".to_string()));
+        },
+    );
 }


### PR DESCRIPTION
# Description of Changes

Previously module benchmarks were running against modules compiled in debug mode, which made them much slower and not represent real-world performance.

This PR fixes that and adds explicit `CompilationMode` enum that needs to be passed to `CompiledModule::compile` to prevent accidental debug builds in other places.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
