### PR TITLE
feat(397): Add min and max value helpers for builtin types

### DIFF
--- a/crates/sats/src/algebraic_type.rs
+++ b/crates/sats/src/algebraic_type.rs
@@ -240,6 +240,46 @@ impl AlgebraicType {
     pub fn from_value(value: &AlgebraicValue) -> Result<Self, ValueDeserializeError> {
         Self::deserialize(ValueDeserializer::from_ref(value))
     }
+
+    #[inline]
+    /// Given an AlgebraicType, returns the min value for that type.
+    pub fn min_value(&self) -> Option<AlgebraicValue> {
+        match *self {
+            Self::I8 => Some(i8::MIN.into()),
+            Self::U8 => Some(u8::MIN.into()),
+            Self::I16 => Some(i16::MIN.into()),
+            Self::U16 => Some(u16::MIN.into()),
+            Self::I32 => Some(i32::MIN.into()),
+            Self::U32 => Some(u32::MIN.into()),
+            Self::I64 => Some(i64::MIN.into()),
+            Self::U64 => Some(u64::MIN.into()),
+            Self::I128 => Some(i128::MIN.into()),
+            Self::U128 => Some(u128::MIN.into()),
+            Self::F32 => Some(f32::MIN.into()),
+            Self::F64 => Some(f64::MIN.into()),
+            _ => None,
+        }
+    }
+
+    #[inline]
+    /// Given an AlgebraicType, returns the max value for that type.
+    pub fn max_value(&self) -> Option<AlgebraicValue> {
+        match *self {
+            Self::I8 => Some(i8::MAX.into()),
+            Self::U8 => Some(u8::MAX.into()),
+            Self::I16 => Some(i16::MAX.into()),
+            Self::U16 => Some(u16::MAX.into()),
+            Self::I32 => Some(i32::MAX.into()),
+            Self::U32 => Some(u32::MAX.into()),
+            Self::I64 => Some(i64::MAX.into()),
+            Self::U64 => Some(u64::MAX.into()),
+            Self::I128 => Some(i128::MAX.into()),
+            Self::U128 => Some(u128::MAX.into()),
+            Self::F32 => Some(f32::MAX.into()),
+            Self::F64 => Some(f64::MAX.into()),
+            _ => None,
+        }
+    }
 }
 
 #[cfg(test)]


### PR DESCRIPTION
Fixes #397.

Adding these helpers for computing multidimensional index bounds. Any unbounded or infinite dimensions need to be made finite by computing the min or max value for the type of said dimension.

For example
```
a < 5 and b < 6
```
needs to become
```
a >= MIN and a < 5 and b >= MIN and b < 5
```

# Description of Changes



# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
