### PR TITLE
Collect timing information about WASM execution in reducers

### DIFF
--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -77,6 +77,7 @@ pub struct EnergyStats {
 pub struct ExecuteResult<E> {
     pub energy: EnergyStats,
     pub execution_duration: Duration,
+    pub wasm_execution_duration: Duration,
     pub call_result: Result<Result<(), Box<str>>, E>,
 }
 
@@ -619,6 +620,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         let ExecuteResult {
             energy,
             execution_duration,
+            wasm_execution_duration,
             call_result,
         } = result;
 
@@ -632,9 +634,9 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         if execution_duration > FRAME_LEN_60FPS {
             // If we can't get your reducer done in a single frame
             // we should debug it.
-            log::debug!("Long running reducer {func_ident:?} took {execution_duration:?} to execute");
+            log::debug!("Long running reducer {func_ident:?} took {execution_duration:?} to execute, with {wasm_execution_duration:?} directly executing WASM");
         } else {
-            log::trace!("Reducer {func_ident:?} ran: {execution_duration:?}, {:?}", energy.used);
+            log::trace!("Reducer {func_ident:?} ran: total {execution_duration:?}, WASM-only {wasm_execution_duration:?}, consumed {:?} energy", energy.used);
         }
 
         REDUCER_COMPUTE_TIME

--- a/crates/core/src/host/wasmer/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmer/wasm_instance_env.rs
@@ -70,6 +70,11 @@ macro_rules! with_timing_paused {
 
         // Improvised try block: errors bubbled with `?` are captured in `res`,
         // and the `timing_before_enter_wasm` runs regardless.
+        //
+        // Clippy will warn about this if `body` doesn't include a `?` or `return`,
+        // because it's not smart enough to understand that macros can be invoked multiple times
+        // on different inputs.
+        #[allow(clippy::redundant_closure_call)]
         let res = (|| {
             $($body)*
         })();

--- a/crates/core/src/host/wasmer/wasmer_module.rs
+++ b/crates/core/src/host/wasmer/wasmer_module.rs
@@ -398,10 +398,7 @@ impl WasmerInstance {
         // e.g. evaluating queries.
         let duration = start.elapsed();
 
-        // Clear buffers and timing spans to avoid leaking data across reducer runs.
         self.env.as_mut(store).buffers.clear();
-        self.env.as_mut(store).iters.clear();
-        self.env.as_mut(store).timing_spans.clear();
 
         // .call(store, sender_buf.ptr.cast(), timestamp, args_buf.ptr, args_buf.len)
         // .and_then(|_| {});


### PR DESCRIPTION
# Description of Changes

This commit augments our logging of reducer execution time by logging the time spent specifically executing WASM code, in addition to the overall elapsed time.

This is accomplished by adding two time-related fields to `WasmInstanceEnv`, which we interact with in four contexts:
- before calling into a reducer.
- after returning from a reducer.
- after entering a host function called by a reducer.
- before returning from a host function called by a reducer.

The timings are probably not terribly precise,
as we necessarily capture a small amount of overhead during calls and returns, but they're good enough for our purposes,
i.e. knowing whether slow reducers are slow
because they spend a lot of time in the datastore, or because they spend a lot of time doing WASM computations.

EDIT: Converting to draft, as `perf` profiling seems to show this has non-negligible overhead when running BitCraft - slightly over 1% of time spent in a certain reducer we're concerned about. We'll need to figure out whether to feature-gate, whether the info is valuable enough to make the overhead worthwhile, or whether we can collect the same info in a more efficient way.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*
