### PR TITLE
Allow running `crates/sdk` test suite on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1085,7 +1085,7 @@ dependencies = [
  "libc",
  "log",
  "maplit",
- "ncurses",
+ "pancurses",
  "signal-hook",
  "term_size",
  "unicode-segmentation",
@@ -2756,6 +2756,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
+name = "pancurses"
+version = "0.17.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0352975c36cbacb9ee99bfb709b9db818bed43af57751797f8633649759d13db"
+dependencies = [
+ "libc",
+ "log",
+ "ncurses",
+ "pdcurses-sys",
+ "winreg 0.5.1",
+]
+
+[[package]]
 name = "papergrid"
 version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2819,6 +2832,16 @@ name = "paste"
 version = "1.0.12"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9f746c4065a8fa3fe23974dd82f15431cc8d40779821001404d10d2e79ca7d79"
+
+[[package]]
+name = "pdcurses-sys"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "084dd22796ff60f1225d4eb6329f33afaf4c85419d51d440ab6b8c6f4529166b"
+dependencies = [
+ "cc",
+ "libc",
+]
 
 [[package]]
 name = "peeking_take_while"
@@ -3550,7 +3573,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg",
+ "winreg 0.10.1",
 ]
 
 [[package]]
@@ -6171,6 +6194,15 @@ name = "windows_x86_64_msvc"
 version = "0.48.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1a515f5799fe4961cb532f983ce2b23082366b898e52ffbce459c86f67c8378a"
+
+[[package]]
+name = "winreg"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a27a759395c1195c4cc5cda607ef6f8f6498f64e78f7900f5de0a127a424704a"
+dependencies = [
+ "winapi",
+]
 
 [[package]]
 name = "winreg"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -84,7 +84,7 @@ criterion = { version = "0.4.0", features = [
   "html_reports",
 ] }
 crossbeam-channel = "0.5"
-cursive = "0.20"
+cursive = { version = "0.20", default-features = false, features = ["pancurses-backend"] }
 decorum = { version = "0.3.1", default-features = false, features = ["std"] }
 derive_more = "0.99.17"
 dirs = "5.0.1"


### PR DESCRIPTION
Had some `ncurses` builds fail today on my Windows machine. Apparently the approved solution of the `ncurses` crate is to not use it on windows:

https://github.com/jeaye/ncurses-rs/issues/127#issuecomment-506444431

The `pancurses` crate supports Linux and Windows -- and in theory OS X, if anybody's using that, it just falls back to the `ncurses` crate on any Unix -- so I switched `cursive`'s backend to use that.