### PR TITLE
Compile benchmarks in separate folder

### DIFF
--- a/crates/bench/src/spacetime_module.rs
+++ b/crates/bench/src/spacetime_module.rs
@@ -13,8 +13,16 @@ use crate::{
 };
 
 lazy_static::lazy_static! {
-    pub static ref BENCHMARKS_MODULE: CompiledModule =
-        CompiledModule::compile("benchmarks", CompilationMode::Release);
+    pub static ref BENCHMARKS_MODULE: CompiledModule = {
+        // Temporarily add CARGO_TARGET_DIR override to avoid conflicts with main target dir.
+        // Otherwise for some reason Cargo will mark all dependencies with build scripts as
+        // fresh - but only if running benchmarks (if modules are built in release mode).
+        // See https://github.com/clockworklabs/SpacetimeDB/issues/401.
+        std::env::set_var("CARGO_TARGET_DIR", concat!(env!("CARGO_MANIFEST_DIR"), "/target"));
+        let module = CompiledModule::compile("benchmarks", CompilationMode::Release);
+        std::env::remove_var("CARGO_TARGET_DIR");
+        module
+    };
 }
 
 /// A benchmark backend that invokes a spacetime module.


### PR DESCRIPTION
# Description of Changes

Imperfect workaround for #401 that caused clean rebuild of SpacetimeDB with all 3rd-party deps each time you do `cargo bench`.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
