### PR TITLE
test(414): multi-column index scan

### DIFF
--- a/crates/bench/src/spacetime_raw.rs
+++ b/crates/bench/src/spacetime_raw.rs
@@ -3,7 +3,7 @@ use crate::{
     schemas::{table_name, BenchTable, IndexStrategy},
     ResultBench,
 };
-use spacetimedb::db::datastore::traits::{IndexDef, TableDef};
+use spacetimedb::db::datastore::traits::{ColId, IndexDef, TableDef};
 use spacetimedb::db::relational_db::{open_db, RelationalDB};
 use spacetimedb_lib::sats::AlgebraicValue;
 use std::hint::black_box;
@@ -107,8 +107,9 @@ impl BenchDatabase for SpacetimeRaw {
         column_index: u32,
         value: AlgebraicValue,
     ) -> ResultBench<()> {
+        let col: ColId = column_index.into();
         self.db.with_auto_commit(|tx| {
-            for row in self.db.iter_by_col_eq(tx, *table_id, column_index, value)? {
+            for row in self.db.iter_by_col_eq(tx, *table_id, col, value)? {
                 black_box(row);
             }
             Ok(())

--- a/crates/core/src/db/datastore/locking_tx_datastore/table.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/table.rs
@@ -63,9 +63,9 @@ impl Table {
     /// Matching is defined by `Ord for AlgebraicValue`.
     pub(crate) fn index_seek(
         &self,
-        cols: NonEmpty<ColId>,
+        cols: &NonEmpty<ColId>,
         range: &impl RangeBounds<AlgebraicValue>,
     ) -> Option<BTreeIndexRangeIter<'_>> {
-        self.indexes.get(&cols).map(|index| index.seek(range))
+        self.indexes.get(cols).map(|index| index.seek(range))
     }
 }

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -1,5 +1,6 @@
 use crate::db::relational_db::ST_TABLES_ID;
 use core::fmt;
+use derive_more::From;
 use nonempty::NonEmpty;
 use spacetimedb_lib::auth::{StAccess, StTableType};
 use spacetimedb_lib::relation::{DbTable, FieldName, FieldOnly, Header, TableField};
@@ -12,10 +13,17 @@ use std::{ops::RangeBounds, sync::Arc};
 use super::{system_tables::StTableRow, Result};
 
 /// The `id` for [Sequence]
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, From)]
 pub struct TableId(pub(crate) u32);
-#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
+#[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd, From)]
 pub struct ColId(pub(crate) u32);
+
+impl From<ColId> for NonEmpty<ColId> {
+    fn from(value: ColId) -> Self {
+        NonEmpty::new(value)
+    }
+}
+
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 pub struct IndexId(pub(crate) u32);
 #[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
@@ -436,7 +444,7 @@ pub trait TxDatastore: DataRow + Tx {
         &'a self,
         tx: &'a Self::TxId,
         table_id: TableId,
-        col_id: ColId,
+        cols: NonEmpty<ColId>,
         range: R,
     ) -> Result<Self::IterByColRange<'a, R>>;
 
@@ -444,7 +452,7 @@ pub trait TxDatastore: DataRow + Tx {
         &'a self,
         tx: &'a Self::TxId,
         table_id: TableId,
-        col_id: ColId,
+        cols: NonEmpty<ColId>,
         value: AlgebraicValue,
     ) -> Result<Self::IterByColEq<'a>>;
 
@@ -504,14 +512,14 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
         &'a self,
         tx: &'a Self::MutTxId,
         table_id: TableId,
-        col_id: ColId,
+        cols: impl Into<NonEmpty<ColId>>,
         range: R,
     ) -> Result<Self::IterByColRange<'a, R>>;
     fn iter_by_col_eq_mut_tx<'a>(
         &'a self,
         tx: &'a Self::MutTxId,
         table_id: TableId,
-        col_id: ColId,
+        cols: impl Into<NonEmpty<ColId>>,
         value: AlgebraicValue,
     ) -> Result<Self::IterByColEq<'a>>;
     fn get_mut_tx<'a>(

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use crate::database_instance_context::DatabaseInstanceContext;
 use crate::database_logger::{BacktraceProvider, LogLevel, Record};
 use crate::db::datastore::locking_tx_datastore::MutTxId;
-use crate::db::datastore::traits::{DataRow, IndexDef};
+use crate::db::datastore::traits::{ColId, DataRow, IndexDef};
 use crate::error::{IndexError, NodesError};
 use crate::util::ResultInspectExt;
 
@@ -152,7 +152,7 @@ impl InstanceEnv {
         let eq_value = stdb.decode_column(tx, table_id, col_id, value)?;
 
         // Find all rows in the table where the column data equates to `value`.
-        let seek = stdb.iter_by_col_eq(tx, table_id, col_id, eq_value)?;
+        let seek = stdb.iter_by_col_eq(tx, table_id, ColId(col_id), eq_value)?;
         let seek = seek.map(|x| stdb.data_to_owned(x).into()).collect::<Vec<_>>();
 
         // Delete them and count how many we deleted and error if none.
@@ -313,7 +313,7 @@ impl InstanceEnv {
 
         // Find all rows in the table where the column data matches `value`.
         // Concatenate and return these rows using bsatn encoding.
-        let results = stdb.iter_by_col_eq(tx, table_id, col_id, value)?;
+        let results = stdb.iter_by_col_eq(tx, table_id, ColId(col_id), value)?;
         let mut bytes = Vec::new();
         for result in results {
             bsatn::to_writer(&mut bytes, result.view()).unwrap();

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -1,7 +1,7 @@
 //! The [DbProgram] that execute arbitrary queries & code against the database.
 use crate::db::cursor::{CatalogCursor, IndexCursor, TableCursor};
 use crate::db::datastore::locking_tx_datastore::{IterByColEq, MutTxId};
-use crate::db::datastore::traits::{ColumnDef, IndexDef, TableDef};
+use crate::db::datastore::traits::{ColId, ColumnDef, IndexDef, TableDef};
 use crate::db::relational_db::RelationalDB;
 use itertools::Itertools;
 use nonempty::NonEmpty;
@@ -153,7 +153,7 @@ fn iter_by_col_range<'a>(
     col_id: u32,
     range: impl RangeBounds<AlgebraicValue> + 'a,
 ) -> Result<Box<dyn RelOps + 'a>, ErrorVm> {
-    let iter = db.iter_by_col_range(tx, table.table_id, col_id, range)?;
+    let iter = db.iter_by_col_range(tx, table.table_id, ColId(col_id), range)?;
     Ok(Box::new(IndexCursor::new(table, iter)?) as Box<IterRows<'_>>)
 }
 
@@ -225,7 +225,7 @@ impl<'a, Rhs: RelOps> RelOps for IndexSemiJoin<'a, Rhs> {
                     let table_id = self.index_table;
                     let col_id = self.index_col;
                     let value = value.clone();
-                    let mut index_iter = self.db.iter_by_col_eq(self.tx, table_id, col_id, value)?;
+                    let mut index_iter = self.db.iter_by_col_eq(self.tx, table_id, ColId(col_id), value)?;
                     if let Some(value) = index_iter.next() {
                         self.index_iter = Some(index_iter);
                         return Ok(Some(value.into()));


### PR DESCRIPTION
Closes #414.

Adds a test for calling iter_by_col_eq with multiple columns. Ensures the index is scanned if an applicable multi-column index is present. To write this test, iter_by_col_eq was updated to take multiple columns.

# Description of Changes


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
