### PR TITLE
perf(353): Generate multi-column index scans for applicable predicates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4520,6 +4520,7 @@ version = "0.7.0"
 dependencies = [
  "anyhow",
  "derive_more",
+ "nonempty",
  "spacetimedb-lib",
  "spacetimedb-sats",
  "tempdir",

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -11,6 +11,7 @@ spacetimedb-lib = { path = "../lib", version = "0.7.0" }
 
 anyhow.workspace = true
 derive_more.workspace = true
+nonempty.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 


### PR DESCRIPTION
Closes #353.

# Description of Changes


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
