### PR TITLE
Simplify and document WasmInstanceEnv's interface

### DIFF
--- a/crates/core/src/host/wasmer/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmer/wasm_instance_env.rs
@@ -86,7 +86,8 @@ impl WasmInstanceEnv {
         self.mem.clone().expect("Initialized memory")
     }
 
-    /// Return a reference to the `InstanceEnv`.
+    /// Return a reference to the `InstanceEnv`,
+    /// which is responsible for DB instance and associated state.
     pub fn instance_env(&self) -> &InstanceEnv {
         &self.instance_env
     }

--- a/crates/core/src/host/wasmer/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmer/wasm_instance_env.rs
@@ -106,6 +106,7 @@ impl WasmInstanceEnv {
     /// Reset all of the state associated to a single reducer call.
     pub fn clear_reducer_state(&mut self) {
         // For the moment, we only explicitly clear the set of buffers.
+        // TODO: should we be clearing `iters` and/or `timing_spans`?
         self.buffers.clear();
     }
 

--- a/crates/core/src/host/wasmer/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmer/wasm_instance_env.rs
@@ -19,7 +19,7 @@ use super::{Mem, WasmError};
 /// and the database.
 ///
 /// A `WasmInstanceEnv` associates an `InstanceEnv` (responsible for
-/// the database instance and it's associated state) with a wasm
+/// the database instance and its associated state) with a wasm
 /// `Mem`. It also contains the resources (`Buffers` and
 /// `BufferIters`) needed to manage the ABI contract between modules
 /// and the host.

--- a/crates/core/src/host/wasmer/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmer/wasm_instance_env.rs
@@ -27,9 +27,8 @@ use super::{Mem, WasmError};
 /// Once created, a `WasmInstanceEnv` must be instantiated with a `Mem`
 /// exactly once.
 ///
-/// Some of the state associated to a `WasmInstanceEnv` is per module
-/// reducer invocation. For instance, module-defined timing spans
-/// are per reducer.
+/// Some of the state associated to a `WasmInstanceEnv` is per reducer invocation.
+/// For instance, module-defined timing spans are per reducer.
 pub(super) struct WasmInstanceEnv {
     /// The database `InstanceEnv` associated to this instance.
     instance_env: InstanceEnv,

--- a/crates/core/src/host/wasmer/wasmer_module.rs
+++ b/crates/core/src/host/wasmer/wasmer_module.rs
@@ -257,7 +257,7 @@ impl module_host_actor::WasmInstance for WasmerInstance {
     }
 
     fn instance_env(&self) -> &InstanceEnv {
-        &self.env.as_ref(&self.store).instance_env()
+        self.env.as_ref(&self.store).instance_env()
     }
 
     type Trap = wasmer::RuntimeError;

--- a/crates/core/src/host/wasmer/wasmer_module.rs
+++ b/crates/core/src/host/wasmer/wasmer_module.rs
@@ -166,13 +166,7 @@ impl module_host_actor::WasmInstancePre for WasmerModule {
 
     fn instantiate(&self, env: InstanceEnv, func_names: &FuncNames) -> Result<Self::Instance, InitializationError> {
         let mut store = Store::new(self.engine.clone());
-        let env = WasmInstanceEnv {
-            instance_env: env,
-            mem: None,
-            buffers: Default::default(),
-            iters: Default::default(),
-            timing_spans: Default::default(),
-        };
+        let env = WasmInstanceEnv::new(env);
         let env = FunctionEnv::new(&mut store, env);
         let imports = self.imports(&mut store, &env);
         let instance = Instance::new(&mut store, &self.module, &imports)
@@ -180,7 +174,7 @@ impl module_host_actor::WasmInstancePre for WasmerModule {
 
         let mem = Mem::extract(&instance.exports).unwrap();
 
-        env.as_mut(&mut store).mem = Some(mem);
+        env.as_mut(&mut store).instantiate(mem);
 
         // Note: this budget is just for initializers
         let budget = EnergyQuanta::DEFAULT_BUDGET.as_points();
@@ -201,8 +195,7 @@ impl module_host_actor::WasmInstancePre for WasmerModule {
                 Ok(errbuf) => {
                     let errbuf = env
                         .as_mut(&mut store)
-                        .buffers
-                        .take(errbuf)
+                        .take_buffer(errbuf)
                         .unwrap_or_else(|| "unknown error".as_bytes().into());
                     let errbuf = crate::util::string_from_utf8_lossy_owned(errbuf.into()).into();
                     // TODO: catch this and return the error message to the http client
@@ -246,10 +239,12 @@ impl WasmerInstance {
         let bytes = self
             .env
             .as_mut(store)
-            .buffers
-            .take(buf)
+            .take_buffer(buf)
             .ok_or(DescribeError::BadBuffer)?;
-        self.env.as_mut(store).buffers.clear();
+
+        // Clear all of the instance state associated to this describer call.
+        self.env.as_mut(store).clear_reducer_state();
+
         Ok(bytes)
     }
 }
@@ -262,7 +257,7 @@ impl module_host_actor::WasmInstance for WasmerInstance {
     }
 
     fn instance_env(&self) -> &InstanceEnv {
-        &self.env.as_ref(&self.store).instance_env
+        &self.env.as_ref(&self.store).instance_env()
     }
 
     type Trap = wasmer::RuntimeError;
@@ -321,7 +316,7 @@ impl WasmerInstance {
             .get_typed_function::<Args, u32>(store, reducer_symbol)
             .expect("invalid reducer");
 
-        let bufs = bufs.map(|data| self.env.as_mut(store).buffers.insert(data));
+        let bufs = bufs.map(|data| self.env.as_mut(store).insert_buffer(data));
 
         // let guard = pprof::ProfilerGuardBuilder::default().frequency(2500).build().unwrap();
 
@@ -336,13 +331,15 @@ impl WasmerInstance {
                 let errmsg = self
                     .env
                     .as_mut(store)
-                    .buffers
-                    .take(errbuf)
+                    .take_buffer(errbuf)
                     .ok_or_else(|| RuntimeError::new("invalid buffer handle"))?;
                 Err(crate::util::string_from_utf8_lossy_owned(errmsg.into()).into())
             })
         });
-        self.env.as_mut(store).buffers.clear();
+
+        // Clear all of the instance state associated to this single reducer call.
+        self.env.as_mut(store).clear_reducer_state();
+
         // .call(store, sender_buf.ptr.cast(), timestamp, args_buf.ptr, args_buf.len)
         // .and_then(|_| {});
         let duration = start.elapsed();


### PR DESCRIPTION
This abstracts out all the internals of WasmInstanceEnv, and provides a slightly higher level API. In particular, we expect to potentially add more state associated to a single reducer invocation, and it will be nice to interact with that in general rather than per type of state.

This also documents WasmInstanceEnv and its members.

# Description of Changes


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

1: This has no functional change, and adds a number of comments.

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
