### PR TITLE
Optimise binaries with wasm-opt

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -72,7 +72,7 @@ jobs:
 
       - name: Install latest wasm-opt for module optimisations
         run: |
-          curl https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-linux.tar.gz -L | tar xz -C /usr/local --strip-components=1
+          curl https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-linux.tar.gz -L | sudo tar xz -C /usr/local --strip-components=1
 
       - name: Criterion compare base branch
         if: ${{ env.PR_BASE_REF }}

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -70,6 +70,10 @@ jobs:
         run: |
           rustup component add clippy
 
+      - name: Install latest wasm-opt for module optimisations
+        run: |
+          curl https://github.com/WebAssembly/binaryen/releases/download/version_116/binaryen-version_116-x86_64-linux.tar.gz -L | tar xz -C /usr/local --strip-components=1
+
       - name: Criterion compare base branch
         if: ${{ env.PR_BASE_REF }}
         uses: clockworklabs/criterion-compare-action@main
@@ -88,5 +92,3 @@ jobs:
         if: always()
         run: |
           rm -fr /stdb/*
-
-

--- a/crates/cli/src/tasks/mod.rs
+++ b/crates/cli/src/tasks/mod.rs
@@ -18,10 +18,13 @@ pub fn build(project_path: &Path, skip_clippy: bool, build_debug: bool) -> anyho
         match cmd!("wasm-opt", "-O2", &wasm_path, "-o", &wasm_path_opt).run() {
             Ok(_) => wasm_path = wasm_path_opt,
             // Non-critical error for backward compatibility with users who don't have wasm-opt.
-            Err(err) => eprintln!(
-                "Could not optimise binary with wasm-opt: {}. Module might be running slower.",
-                err
-            ),
+            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
+                eprintln!("Could not find wasm-opt to optimise the module.");
+                eprintln!(
+                    "For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases."
+                );
+            }
+            Err(err) => return Err(err.into()),
         }
     }
     Ok(wasm_path)


### PR DESCRIPTION
# Description of Changes

Now that our ABI checks can handle binaries produced by wasm-opt, we can use it (if installed) to optimise produced Wasm binaries.

For now it's added as an optional step until we figure out a decent deployment strategy to automatically get it for the user. (There are some wrappers on crates.io, but they tend to lag behind modern versions and take a while to compile, whereas Binaryen provides official prebuilt binaries on Github.)

This gives an easy 8-10% performance boost in iteration benchmarks, much more for an empty table but that's less interesting.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,

1

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
