### PR TITLE
fix(428): Return only one message per table in subscription

### DIFF
--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -601,7 +601,7 @@ mod tests {
             tables: vec![data.clone()],
         };
 
-        check_query_incr(&db, &mut tx, &s, &update, 3, &[row])?;
+        check_query_incr(&db, &mut tx, &s, &update, 1, &[row])?;
 
         let q = QueryExpr::new(db_table((&schema).into(), "_inventory".to_owned(), schema.table_id));
 
@@ -656,7 +656,7 @@ mod tests {
             },
         ]);
 
-        check_query_eval(&db, &mut tx, &s, 3, &[product!(1u64, "health")])?;
+        check_query_eval(&db, &mut tx, &s, 1, &[product!(1u64, "health")])?;
 
         let row = product!(1u64, "health");
 
@@ -680,7 +680,7 @@ mod tests {
 
         let update = DatabaseUpdate { tables: vec![data] };
 
-        check_query_incr(&db, &mut tx, &s, &update, 3, &[row])?;
+        check_query_incr(&db, &mut tx, &s, &update, 1, &[row])?;
 
         Ok(())
     }


### PR DESCRIPTION
Fixes #428.

Before this change, if you had multiple queries for the same base table as part of a subscription, you would receive multiple DatabaseTableUpdate messages referencing the same table.

Clients did not expect nor handle such cases.

# Description of Changes


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
