### PR TITLE
Reuse Wasm-side buffer while reading iterators

### DIFF
--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -345,10 +345,8 @@ struct RawTableIter<De> {
     /// The underlying source of our `Buffer`s.
     inner: BufferIter,
 
-    /// The current position in the current buffer,
-    /// from which `deserializer` can read.
-    /// A value of `None` indicates that we need to pull another `Buffer` from `inner`.
-    reader: Option<Cursor<Box<[u8]>>>,
+    /// The current position in the buffer, from which `deserializer` can read.
+    reader: Cursor<Vec<u8>>,
 
     deserializer: De,
 }
@@ -357,7 +355,7 @@ impl<De: BufferDeserialize> RawTableIter<De> {
     fn new(iter: BufferIter, deserializer: De) -> Self {
         RawTableIter {
             inner: iter,
-            reader: None,
+            reader: Cursor::new(Vec::new()),
             deserializer,
         }
     }
@@ -368,30 +366,17 @@ impl<T, De: BufferDeserialize<Item = T>> Iterator for RawTableIter<De> {
 
     fn next(&mut self) -> Option<Self::Item> {
         loop {
-            // If we currently have some bytes in the buffer to still decode,
-            // do that. Otherwise, try to fetch the next buffer first.
-
-            match &self.reader {
-                Some(reader) => {
-                    if reader.remaining() == 0 {
-                        self.reader = None;
-                        continue;
-                    }
-                    break;
-                }
-                None => {
-                    // If we receive None here, iteration is complete.
-                    let buffer = self.inner.next()?;
-                    let buffer = buffer.expect("RawTableIter::next: Failed to get buffer!");
-                    self.reader = Some(Cursor::new(buffer));
-                    break;
-                }
+            // If we currently have some bytes in the buffer to still decode, do that.
+            if (&self.reader).remaining() > 0 {
+                let row = self.deserializer.deserialize(&self.reader);
+                return Some(row);
             }
+            // Otherwise, try to fetch the next chunk while reusing the buffer.
+            let buffer = self.inner.next()?;
+            let buffer = buffer.expect("RawTableIter::next: Failed to get buffer!");
+            self.reader.pos.set(0);
+            buffer.read_into(&mut self.reader.buf);
         }
-
-        let reader = self.reader.as_ref().unwrap();
-        let row = self.deserializer.deserialize(reader);
-        Some(row)
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Reuse buffer when reading new chunks from the iterator, instead of freeing and allocating a new one each time.

This will be mainly useful on large iterations that span over our 64KiB chunks.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
