### PR TITLE
Optimize `drop_table`, `rename_table`, `delete_by_col_eq`, and `clear_table`

### DIFF
--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -552,7 +552,7 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
         tx: &mut Self::MutTxId,
         table_id: TableId,
         relation: R,
-    ) -> Result<Option<u32>>;
+    ) -> Result<u32>;
     fn insert_mut_tx<'a>(
         &'a self,
         tx: &'a mut Self::MutTxId,

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -546,13 +546,18 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
         table_id: TableId,
         row_id: &'a Self::RowId,
     ) -> Result<Option<Self::DataRef<'a>>>;
-    fn delete_mut_tx<'a>(&'a self, tx: &'a mut Self::MutTxId, table_id: TableId, row_id: Self::RowId) -> Result<bool>;
-    fn delete_by_rel_mut_tx<R: IntoIterator<Item = ProductValue>>(
+    fn delete_mut_tx<'a>(
+        &'a self,
+        tx: &'a mut Self::MutTxId,
+        table_id: TableId,
+        row_ids: impl IntoIterator<Item = Self::RowId>,
+    ) -> u32;
+    fn delete_by_rel_mut_tx(
         &self,
         tx: &mut Self::MutTxId,
         table_id: TableId,
-        relation: R,
-    ) -> Result<u32>;
+        relation: impl IntoIterator<Item = ProductValue>,
+    ) -> u32;
     fn insert_mut_tx<'a>(
         &'a self,
         tx: &'a mut Self::MutTxId,

--- a/crates/core/src/host/wasmer/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmer/wasm_instance_env.rs
@@ -355,7 +355,8 @@ impl WasmInstanceEnv {
     ) -> RtResult<u16> {
         Self::cvt_ret(caller, "delete_by_col_eq", out, |caller, mem| {
             let value = mem.read_bytes(&caller, value, value_len)?;
-            Ok(caller.data().instance_env.delete_by_col_eq(table_id, col_id, &value)?)
+            let count = caller.data().instance_env.delete_by_col_eq(table_id, col_id, &value)?;
+            Ok(count.get())
         })
     }
 

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -290,7 +290,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
             // TODO: How do we deal with mutating values?
             Table::MemTable(_) => Err(ErrorVm::Other(anyhow::anyhow!("How deal with mutating values?"))),
             Table::DbTable(t) => {
-                let count = self.db.delete_by_rel(self.tx, t.table_id, rows)?;
+                let count = self.db.delete_by_rel(self.tx, t.table_id, rows);
                 Ok(Code::Value(count.into()))
             }
         }


### PR DESCRIPTION
# Description of Changes

These functions and methods now clone less and collect keys/ids to rename/drop/delete rather than storing a cloned `ProductValue` that is then used to do the work.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

2