### PR TITLE
Fix "identity not yet recieved" intermittent failure in tests

### DIFF
--- a/crates/sdk/src/callbacks.rs
+++ b/crates/sdk/src/callbacks.rs
@@ -863,7 +863,10 @@ impl CredentialStore {
     /// Do not invoke on-connect callbacks.
     pub(crate) fn maybe_set_credentials(&mut self, credentials: Option<Credentials>) {
         if let Some(creds) = &credentials {
-            log::trace!("maybe_set_credentials: Setting stored credentials to Some({:?})", creds.identity);
+            log::trace!(
+                "maybe_set_credentials: Setting stored credentials to Some({:?})",
+                creds.identity,
+            );
         } else {
             log::trace!("maybe_set_credentials: Setting stored credentials to None");
         }

--- a/crates/sdk/src/callbacks.rs
+++ b/crates/sdk/src/callbacks.rs
@@ -862,6 +862,12 @@ impl CredentialStore {
     ///
     /// Do not invoke on-connect callbacks.
     pub(crate) fn maybe_set_credentials(&mut self, credentials: Option<Credentials>) {
+        if let Some(creds) = &credentials {
+            log::trace!("maybe_set_credentials: Setting stored credentials to Some({:?})", creds.identity);
+        } else {
+            log::trace!("maybe_set_credentials: Setting stored credentials to None");
+        }
+
         self.credentials = credentials;
     }
 

--- a/crates/sdk/src/callbacks.rs
+++ b/crates/sdk/src/callbacks.rs
@@ -287,6 +287,10 @@ impl<Args: OwnedArgs> CallbackMap<Args> {
                     // Enter a dynamic context where `CURRENT_STATE`
                     // is the state which caused this callback invocation.
                     let _guard = CurrentStateGuard::with_current_state(db_state);
+                    log::trace!(
+                        "CallbackMap worker: received invoke message for args {} and got state guard",
+                        std::any::type_name::<Args>(),
+                    );
 
                     // We're invoking several callbacks, so none of them may consume `args`.
                     let borrowed = args.borrow();
@@ -408,6 +412,7 @@ impl<Args: OwnedArgs> CallbackMap<Args> {
 
     /// Invoke each currently-registered callback in `self` with `args`.
     fn invoke(&self, args: Args, db_state: ClientCacheView) {
+        log::trace!("CallbackMap: invoking for args type {}", std::any::type_name::<Args>());
         self.send
             .unbounded_send(CallbackMessage::Invoke { args, db_state })
             // TODO: properly handle this error somehow
@@ -915,12 +920,16 @@ impl CredentialStore {
             return;
         }
 
+        let identity = Identity::from_bytes(identity);
+        log::trace!("handle_identity_token: received identity {:?}", identity);
+
         let creds = Credentials {
-            identity: Identity::from_bytes(identity),
+            identity,
             token: Token { string: token },
         };
 
         let address = Address::from_slice(&address);
+        log::trace!("handle_identity_token: received address {:?}", address);
 
         if Some(address) != self.address {
             log::error!(
@@ -929,8 +938,6 @@ impl CredentialStore {
                 self.address,
             );
         }
-
-        self.callbacks.invoke((creds.clone(), address), state);
 
         if let Some(existing_creds) = &self.credentials {
             // If we already have credentials, make sure that they match. Log an error if
@@ -944,10 +951,15 @@ impl CredentialStore {
                     creds,
                     existing_creds,
                 );
+            } else {
+                log::trace!("handle_identity_token: received creds match local record.");
             }
         } else {
-            self.credentials = Some(creds);
+            self.credentials = Some(creds.clone());
+            log::trace!("handle_identity_token: storing new credentials");
         }
+
+        self.callbacks.invoke((creds.clone(), address), state);
     }
 
     /// Return the current connection's `Identity`, if one is stored.

--- a/crates/testing/src/sdk.rs
+++ b/crates/testing/src/sdk.rs
@@ -211,7 +211,7 @@ fn run_client(run_command: &str, client_project: &str, db_name: &str, test_name:
         .dir(client_project)
         .env(TEST_CLIENT_PROJECT_ENV_VAR, client_project)
         .env(TEST_DB_NAME_ENV_VAR, db_name)
-        .env("RUST_LOG", "info")
+        .env("RUST_LOG", "trace")
         .stderr_to_stdout()
         .stdout_capture()
         .unchecked()


### PR DESCRIPTION
# Description of Changes

This error turns out to have been a legitimate, albeit rare, race condition, which could have (but apparently didn't) manifested in user code.

The cause, ultimately, was holding locks for too-short scopes while initializing the connection. It was possible for a new connection to receive and completely process its `IdentityToken` message before calling `maybe_set_credentials`, which would then clobber the received identity.

This is now fixed (hopefully) by holding the `CredentialStore` lock for the duration of `BackgroundDbConnection::connect`.
Two other locks, on `ClientCache` and `ReducerCallbacks`, are also newly held for the duration to avoid similar issues.

In addition, this commit adds a call to `disconnect` to the beginning of `connect`. This will prevent pathological user code
which connects twice in a row without an intervening disconnect from encountering bizarre errors caused by the first connection's background workers staying active.

This commit also bumps the `RUST_LOG` env variable for the SDK test clients to `trace`, and adds several trace-level logs to the SDK, which were instrumental in pinning down the failure. This does mean that log output of failed SDK tests will now be much noisier.

Note that # API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

3; this PR non-trivially alters the SDK's connection logic, changing edge-case interactions with other parts of the SDK not directly edited in the PR.

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
