### PR TITLE
Benchmark: deltas + html

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -121,9 +121,9 @@ jobs:
         working-directory: crates/bench/
         run: |
           if [ -e target/criterion/$NORMALIZED_BRANCH_NAME.json ]; then
-            cargo run --bin summarize markdown-report branch.json $NORMALIZED_BRANCH_NAME.json --report-name report
+            cargo run --bin summarize report branch.json $NORMALIZED_BRANCH_NAME.json --report-name report --markdown
           else
-            cargo run --bin summarize markdown-report branch.json --report-name report
+            cargo run --bin summarize report branch.json --report-name report --markdown
           fi
 
       # this will work for both PR and master

--- a/crates/bench/README.md
+++ b/crates/bench/README.md
@@ -64,7 +64,7 @@ This is used on CI (see [`../../.github/workflows/benchmarks.yml`](../../.github
 To generate a report without comparisons, use:
 ```bash
 cargo bench --bench generic --bench special -- --save-baseline current
-cargo run --bin summarize markdown-report current
+cargo run --bin summarize report current --markdown
 ```
 
 To compare to another branch, do:
@@ -73,9 +73,10 @@ git checkout master
 cargo bench --bench generic --bench special -- --save-baseline base
 git checkout high-octane-feature-branch
 cargo bench --bench generic --bench special -- --save-baseline current
-cargo run --bin summarize markdown-report current base
+cargo run --bin summarize report current base --markdown
 ```
 
+Omit `--markdown` to generate HTML instead.
 Of course, this will take about an hour, so it might be better to let the CI do it for you.
 
 ## Adding more


### PR DESCRIPTION
# Description of Changes

Adds html output + deltas to the custom benchmark reporters.

I spent some time looking at how Criterion does statistically significance comparison; they actually are doing some nontrivial statistical stuff (bootstrapping + best fit against iters:time), which I didn't want to reimplement, so I compute deltas in a dumb interval arithmetic way here.

Because I'm not confident in performing statistical tests here, I don't report largest / most significant changes; I think to do that properly you'd need to do a multiple-comparisons correction of some sort..?
