### PR TITLE
Switch allocator to mimalloc for the DB CLI

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2203,6 +2203,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f7012b1bbb0719e1097c47611d3898568c546d597c2e74d66f6087edd5233ff4"
 
 [[package]]
+name = "libmimalloc-sys"
+version = "0.1.35"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3979b5c37ece694f1f5e51e7ecc871fdb0f517ed04ee45f88d15d6d553cb9664"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
 name = "librocksdb-sys"
 version = "0.8.3+7.4.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2390,6 +2400,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5a634b1c61a95585bd15607c6ab0c4e5b226e695ff2800ba0cdccddf208c406c"
 dependencies = [
  "autocfg",
+]
+
+[[package]]
+name = "mimalloc"
+version = "0.1.39"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fa01922b5ea280a911e323e4d2fd24b7fe5cc4042e0d2cda3c40775cdc4bdc9c"
+dependencies = [
+ "libmimalloc-sys",
 ]
 
 [[package]]
@@ -4139,6 +4158,7 @@ dependencies = [
  "futures",
  "lazy_static",
  "log",
+ "mimalloc",
  "rand 0.8.5",
  "regex",
  "rusqlite",
@@ -4191,6 +4211,7 @@ dependencies = [
  "is-terminal",
  "itertools",
  "jsonwebtoken",
+ "mimalloc",
  "reqwest",
  "rustyline",
  "serde",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -115,6 +115,7 @@ itertools = "0.10.5"
 jsonwebtoken = { version = "8.1.0" }
 lazy_static = "1.4.0"
 log = "0.4.17"
+mimalloc = "0.1.39"
 nonempty = "0.8.1"
 once_cell = "1.16"
 parking_lot = { version = "0.12.1", features = ["send_guard", "arc_lock"] }

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -44,3 +44,4 @@ tracing-subscriber.workspace = true
 lazy_static.workspace = true
 walkdir.workspace = true
 regex.workspace = true
+mimalloc.workspace = true

--- a/crates/bench/benches/generic.rs
+++ b/crates/bench/benches/generic.rs
@@ -3,12 +3,17 @@ use criterion::{
     measurement::{Measurement, WallTime},
     Bencher, BenchmarkGroup, Criterion,
 };
+use mimalloc::MiMalloc;
 use spacetimedb_bench::{
     database::BenchDatabase,
     schemas::{create_sequential, BenchTable, IndexStrategy, Location, Person, RandomTable, BENCH_PKEY_INDEX},
     spacetime_module, spacetime_raw, sqlite, ResultBench,
 };
 use spacetimedb_lib::sats::AlgebraicType;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
+
 fn criterion_benchmark(c: &mut Criterion) {
     bench_suite::<sqlite::SQLite>(c, true).unwrap();
     bench_suite::<spacetime_raw::SpacetimeRaw>(c, true).unwrap();

--- a/crates/bench/benches/special.rs
+++ b/crates/bench/benches/special.rs
@@ -1,4 +1,5 @@
 use criterion::{criterion_group, criterion_main, Criterion};
+use mimalloc::MiMalloc;
 use spacetimedb::db::{Config, Storage};
 use spacetimedb_bench::{
     schemas::{create_sequential, BenchTable, Location, Person, RandomTable},
@@ -6,6 +7,9 @@ use spacetimedb_bench::{
 };
 use spacetimedb_lib::{sats, ProductValue};
 use spacetimedb_testing::modules::start_runtime;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 fn criterion_benchmark(c: &mut Criterion) {
     serialize_benchmarks::<Person>(c);

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -34,6 +34,7 @@ futures.workspace = true
 is-terminal.workspace = true
 itertools.workspace = true
 jsonwebtoken.workspace = true
+mimalloc.workspace = true
 reqwest.workspace = true
 rustyline.workspace = true
 serde = { workspace = true, features = ["derive"] }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,6 +1,10 @@
 use clap::Command;
+use mimalloc::MiMalloc;
 use spacetimedb_cli::*;
 use spacetimedb_lib::util;
+
+#[global_allocator]
+static GLOBAL: MiMalloc = MiMalloc;
 
 #[tokio::main]
 async fn main() -> Result<(), anyhow::Error> {


### PR DESCRIPTION
# Description of Changes

We are doing a lot of allocations / clones, and I figured it might be worth looking into high-performance allocators as an easy win among other things.

mimalloc generally beats other allocators and would make the biggest difference in multi-threaded environment (such as an actual cloud) as it has separate per-thread pools.

However, it makes a noticeable difference even in our single-threaded benchmarks:

<details><summary>Benchmark results</summary>

# Benchmark Report

Legend:

- `load`: number of rows pre-loaded into the database
- `count`: number of rows touched by the transaction
- index types:
    - `unique`: a single index on the `id` column
    - `non_unique`: no indexes
    - `multi_index`: non-unique index on every column
- schemas:
    - `person(id: u32, name: String, age: u64)`
    - `location(id: u32, x: u64, y: u64)`

All throughputs are single-threaded.

    
## Empty transaction

| db          | on disk | new latency   | old latency   | new throughput | old throughput | 
|-------------|---------|---------------|---------------|----------------|----------------|
| sqlite      | 💿       | 437.7±1.19ns  | 458.1±8.77ns  | -              | -              | 
| sqlite      | 🧠       | 429.9±1.77ns  | 457.5±6.57ns  | -              | -              | 
| stdb_module | 💿       | 15.9±0.36µs   | 15.6±0.36µs   | -              | -              | 
| stdb_module | 🧠       | 16.3±0.48µs   | 15.9±0.44µs   | -              | -              | 
| stdb_raw    | 💿       | 104.4±0.21ns  | 103.7±0.12ns  | -              | -              | 
| stdb_raw    | 🧠       | 104.2±0.29ns  | 103.4±0.13ns  | -              | -              | 

## Single-row insertions

| db          | on disk | schema   | index type  | load | new latency     | old latency      | new throughput | old throughput | 
|-------------|---------|----------|-------------|------|-----------------|------------------|----------------|----------------|
| sqlite      | 💿       | location | multi_index | 0    | 14.7±1.15µs     | 14.6±0.07µs      | 66.5 Ktx/sec   | 66.7 Ktx/sec   | 
| sqlite      | 💿       | location | multi_index | 1000 | 15.8±0.11µs     | 16.0±0.13µs      | 62.0 Ktx/sec   | 60.9 Ktx/sec   | 
| sqlite      | 💿       | location | non_unique  | 0    | 7.2±1.26µs      | 7.4±0.04µs       | 135.8 Ktx/sec  | 132.8 Ktx/sec  | 
| sqlite      | 💿       | location | non_unique  | 1000 | 6.9±0.04µs      | 7.2±0.04µs       | 140.9 Ktx/sec  | 135.9 Ktx/sec  | 
| sqlite      | 💿       | location | unique      | 0    | 7.0±0.04µs      | 7.4±0.33µs       | 139.4 Ktx/sec  | 131.5 Ktx/sec  | 
| sqlite      | 💿       | location | unique      | 1000 | 7.0±0.02µs      | 7.2±0.04µs       | 140.0 Ktx/sec  | 135.8 Ktx/sec  | 
| sqlite      | 💿       | person   | multi_index | 0    | 14.2±0.03µs     | 14.7±0.71µs      | 69.0 Ktx/sec   | 66.5 Ktx/sec   | 
| sqlite      | 💿       | person   | multi_index | 1000 | 16.1±0.18µs     | 16.2±0.13µs      | 60.8 Ktx/sec   | 60.3 Ktx/sec   | 
| sqlite      | 💿       | person   | non_unique  | 0    | 7.2±0.02µs      | 7.5±0.35µs       | 135.9 Ktx/sec  | 130.5 Ktx/sec  | 
| sqlite      | 💿       | person   | non_unique  | 1000 | 7.2±0.05µs      | 7.4±0.04µs       | 135.3 Ktx/sec  | 132.2 Ktx/sec  | 
| sqlite      | 💿       | person   | unique      | 0    | 7.2±0.41µs      | 7.4±0.33µs       | 135.2 Ktx/sec  | 131.6 Ktx/sec  | 
| sqlite      | 💿       | person   | unique      | 1000 | 7.2±0.05µs      | 7.4±0.05µs       | 135.2 Ktx/sec  | 132.1 Ktx/sec  | 
| sqlite      | 🧠       | location | multi_index | 0    | 4.0±0.02µs      | 4.0±0.01µs       | 242.7 Ktx/sec  | 241.3 Ktx/sec  | 
| sqlite      | 🧠       | location | multi_index | 1000 | 5.1±0.04µs      | 5.2±0.03µs       | 191.5 Ktx/sec  | 186.5 Ktx/sec  | 
| sqlite      | 🧠       | location | non_unique  | 0    | 1853.8±3.31ns   | 1888.8±7.69ns    | 526.8 Ktx/sec  | 517.0 Ktx/sec  | 
| sqlite      | 🧠       | location | non_unique  | 1000 | 1907.5±11.85ns  | 1910.4±9.81ns    | 512.0 Ktx/sec  | 511.2 Ktx/sec  | 
| sqlite      | 🧠       | location | unique      | 0    | 1840.3±4.62ns   | 1880.8±5.27ns    | 530.7 Ktx/sec  | 519.2 Ktx/sec  | 
| sqlite      | 🧠       | location | unique      | 1000 | 1960.9±10.60ns  | 1951.8±7.85ns    | 498.0 Ktx/sec  | 500.3 Ktx/sec  | 
| sqlite      | 🧠       | person   | multi_index | 0    | 3.6±0.01µs      | 4.0±0.01µs       | 268.2 Ktx/sec  | 243.3 Ktx/sec  | 
| sqlite      | 🧠       | person   | multi_index | 1000 | 5.4±0.02µs      | 5.7±0.03µs       | 179.6 Ktx/sec  | 171.4 Ktx/sec  | 
| sqlite      | 🧠       | person   | non_unique  | 0    | 1947.7±7.26ns   | 1970.5±6.36ns    | 501.4 Ktx/sec  | 495.6 Ktx/sec  | 
| sqlite      | 🧠       | person   | non_unique  | 1000 | 2.0±0.01µs      | 2.1±0.01µs       | 485.0 Ktx/sec  | 465.7 Ktx/sec  | 
| sqlite      | 🧠       | person   | unique      | 0    | 1932.6±5.80ns   | 1951.3±5.15ns    | 505.3 Ktx/sec  | 500.5 Ktx/sec  | 
| sqlite      | 🧠       | person   | unique      | 1000 | 2.1±0.02µs      | 2.1±0.01µs       | 471.3 Ktx/sec  | 456.1 Ktx/sec  | 
| stdb_module | 💿       | location | multi_index | 0    | 40.5±4.36µs     | 35.1±4.62µs      | 24.1 Ktx/sec   | 27.9 Ktx/sec   | 
| stdb_module | 💿       | location | multi_index | 1000 | 124.2±8.34µs    | 136.0±55.50µs    | 7.9 Ktx/sec    | 7.2 Ktx/sec    | 
| stdb_module | 💿       | location | non_unique  | 0    | 29.6±2.73µs     | 35.0±3.03µs      | 33.0 Ktx/sec   | 27.9 Ktx/sec   | 
| stdb_module | 💿       | location | non_unique  | 1000 | 125.8±26.80µs   | 230.7±3.00µs     | 7.8 Ktx/sec    | 4.2 Ktx/sec    | 
| stdb_module | 💿       | location | unique      | 0    | 34.8±3.30µs     | 40.4±4.30µs      | 28.0 Ktx/sec   | 24.2 Ktx/sec   | 
| stdb_module | 💿       | location | unique      | 1000 | 266.2±8.40µs    | 383.8±8.09µs     | 3.7 Ktx/sec    | 2.5 Ktx/sec    | 
| stdb_module | 💿       | person   | multi_index | 0    | 48.6±5.69µs     | 52.7±6.65µs      | 20.1 Ktx/sec   | 18.5 Ktx/sec   | 
| stdb_module | 💿       | person   | multi_index | 1000 | 307.6±11.96µs   | 471.2±109.22µs   | 3.2 Ktx/sec    | 2.1 Ktx/sec    | 
| stdb_module | 💿       | person   | non_unique  | 0    | 35.2±3.55µs     | 35.8±3.54µs      | 27.7 Ktx/sec   | 27.3 Ktx/sec   | 
| stdb_module | 💿       | person   | non_unique  | 1000 | 265.7±60.75µs   | 259.0±113.00µs   | 3.7 Ktx/sec    | 3.8 Ktx/sec    | 
| stdb_module | 💿       | person   | unique      | 0    | 38.7±3.94µs     | 44.0±4.17µs      | 25.2 Ktx/sec   | 22.2 Ktx/sec   | 
| stdb_module | 💿       | person   | unique      | 1000 | 352.7±12.98µs   | 435.2±8.06µs     | 2.8 Ktx/sec    | 2.2 Ktx/sec    | 
| stdb_module | 🧠       | location | multi_index | 0    | 32.7±2.86µs     | 30.1±2.64µs      | 29.8 Ktx/sec   | 32.4 Ktx/sec   | 
| stdb_module | 🧠       | location | multi_index | 1000 | 208.7±82.66µs   | 217.6±15.56µs    | 4.7 Ktx/sec    | 4.5 Ktx/sec    | 
| stdb_module | 🧠       | location | non_unique  | 0    | 27.7±2.06µs     | 26.0±1.45µs      | 35.3 Ktx/sec   | 37.6 Ktx/sec   | 
| stdb_module | 🧠       | location | non_unique  | 1000 | 112.1±3.87µs    | 230.1±18.37µs    | 8.7 Ktx/sec    | 4.2 Ktx/sec    | 
| stdb_module | 🧠       | location | unique      | 0    | 31.3±2.35µs     | 28.9±1.86µs      | 31.2 Ktx/sec   | 33.8 Ktx/sec   | 
| stdb_module | 🧠       | location | unique      | 1000 | 109.9±41.41µs   | 304.6±20.93µs    | 8.9 Ktx/sec    | 3.2 Ktx/sec    | 
| stdb_module | 🧠       | person   | multi_index | 0    | 40.3±3.13µs     | 38.1±3.17µs      | 24.2 Ktx/sec   | 25.6 Ktx/sec   | 
| stdb_module | 🧠       | person   | multi_index | 1000 | 151.5±18.64µs   | 210.5±49.11µs    | 6.4 Ktx/sec    | 4.6 Ktx/sec    | 
| stdb_module | 🧠       | person   | non_unique  | 0    | 30.4±2.98µs     | 28.4±2.90µs      | 32.2 Ktx/sec   | 34.4 Ktx/sec   | 
| stdb_module | 🧠       | person   | non_unique  | 1000 | 152.9±37.22µs   | 247.1±21.15µs    | 6.4 Ktx/sec    | 4.0 Ktx/sec    | 
| stdb_module | 🧠       | person   | unique      | 0    | 31.2±2.42µs     | 34.7±3.07µs      | 31.3 Ktx/sec   | 28.2 Ktx/sec   | 
| stdb_module | 🧠       | person   | unique      | 1000 | 229.6±33.70µs   | 385.1±14.01µs    | 4.3 Ktx/sec    | 2.5 Ktx/sec    | 
| stdb_raw    | 💿       | location | multi_index | 0    | 5.0±0.01µs      | 5.3±0.01µs       | 196.6 Ktx/sec  | 184.3 Ktx/sec  | 
| stdb_raw    | 💿       | location | multi_index | 1000 | 27.9±206.60µs   | 33.8±0.51µs      | 34.9 Ktx/sec   | 28.9 Ktx/sec   | 
| stdb_raw    | 💿       | location | non_unique  | 0    | 3.4±0.01µs      | 3.5±0.01µs       | 290.9 Ktx/sec  | 277.3 Ktx/sec  | 
| stdb_raw    | 💿       | location | non_unique  | 1000 | 4.7±0.29µs      | 29.7±79.92µs     | 207.4 Ktx/sec  | 32.8 Ktx/sec   | 
| stdb_raw    | 💿       | location | unique      | 0    | 4.1±0.01µs      | 4.3±0.01µs       | 239.2 Ktx/sec  | 224.8 Ktx/sec  | 
| stdb_raw    | 💿       | location | unique      | 1000 | 6.2±0.16µs      | 39.9±127.80µs    | 157.3 Ktx/sec  | 24.5 Ktx/sec   | 
| stdb_raw    | 💿       | person   | multi_index | 0    | 8.3±0.01µs      | 9.0±0.01µs       | 117.4 Ktx/sec  | 108.7 Ktx/sec  | 
| stdb_raw    | 💿       | person   | multi_index | 1000 | 53.7±422.91µs   | 59.6±350.92µs    | 18.2 Ktx/sec   | 16.4 Ktx/sec   | 
| stdb_raw    | 💿       | person   | non_unique  | 0    | 3.9±0.01µs      | 4.1±0.04µs       | 248.7 Ktx/sec  | 236.1 Ktx/sec  | 
| stdb_raw    | 💿       | person   | non_unique  | 1000 | 5.5±0.08µs      | 14.2±0.13µs      | 176.9 Ktx/sec  | 68.8 Ktx/sec   | 
| stdb_raw    | 💿       | person   | unique      | 0    | 5.6±0.03µs      | 5.9±0.01µs       | 174.8 Ktx/sec  | 165.5 Ktx/sec  | 
| stdb_raw    | 💿       | person   | unique      | 1000 | 8.2±0.14µs      | 21.7±0.35µs      | 119.6 Ktx/sec  | 45.1 Ktx/sec   | 
| stdb_raw    | 🧠       | location | multi_index | 0    | 3.6±0.01µs      | 4.1±0.01µs       | 273.8 Ktx/sec  | 237.6 Ktx/sec  | 
| stdb_raw    | 🧠       | location | multi_index | 1000 | 5.2±0.06µs      | 29.4±0.79µs      | 188.1 Ktx/sec  | 33.2 Ktx/sec   | 
| stdb_raw    | 🧠       | location | non_unique  | 0    | 2.1±0.01µs      | 2.2±0.01µs       | 475.0 Ktx/sec  | 441.5 Ktx/sec  | 
| stdb_raw    | 🧠       | location | non_unique  | 1000 | 2.7±0.01µs      | 19.4±0.08µs      | 364.4 Ktx/sec  | 50.4 Ktx/sec   | 
| stdb_raw    | 🧠       | location | unique      | 0    | 2.7±0.01µs      | 3.0±0.01µs       | 356.5 Ktx/sec  | 322.7 Ktx/sec  | 
| stdb_raw    | 🧠       | location | unique      | 1000 | 4.0±0.04µs      | 24.5±0.12µs      | 242.8 Ktx/sec  | 39.9 Ktx/sec   | 
| stdb_raw    | 🧠       | person   | multi_index | 0    | 7.0±0.02µs      | 7.6±0.01µs       | 140.0 Ktx/sec  | 128.6 Ktx/sec  | 
| stdb_raw    | 🧠       | person   | multi_index | 1000 | 9.1±0.06µs      | 21.5±1.16µs      | 107.7 Ktx/sec  | 45.4 Ktx/sec   | 
| stdb_raw    | 🧠       | person   | non_unique  | 0    | 2.6±0.00µs      | 2.8±0.01µs       | 374.7 Ktx/sec  | 345.8 Ktx/sec  | 
| stdb_raw    | 🧠       | person   | non_unique  | 1000 | 3.4±0.02µs      | 12.8±0.17µs      | 286.2 Ktx/sec  | 76.2 Ktx/sec   | 
| stdb_raw    | 🧠       | person   | unique      | 0    | 4.3±0.00µs      | 4.7±0.01µs       | 227.7 Ktx/sec  | 209.3 Ktx/sec  | 
| stdb_raw    | 🧠       | person   | unique      | 1000 | 5.7±0.05µs      | 17.0±0.57µs      | 170.3 Ktx/sec  | 57.5 Ktx/sec   | 

## Multi-row insertions

| db          | on disk | schema   | index type  | load | count | new latency       | old latency       | new throughput | old throughput | 
|-------------|---------|----------|-------------|------|-------|-------------------|-------------------|----------------|----------------|
| sqlite      | 💿       | location | multi_index | 0    | 100   | 128.6±3.30µs      | 132.9±2.68µs      | 7.6 Ktx/sec    | 7.3 Ktx/sec    | 
| sqlite      | 💿       | location | multi_index | 1000 | 100   | 200.7±1.20µs      | 205.2±3.24µs      | 4.9 Ktx/sec    | 4.8 Ktx/sec    | 
| sqlite      | 💿       | location | non_unique  | 0    | 100   | 48.6±0.22µs       | 50.2±3.32µs       | 20.1 Ktx/sec   | 19.4 Ktx/sec   | 
| sqlite      | 💿       | location | non_unique  | 1000 | 100   | 52.4±0.21µs       | 52.0±0.25µs       | 18.6 Ktx/sec   | 18.8 Ktx/sec   | 
| sqlite      | 💿       | location | unique      | 0    | 100   | 51.0±7.02µs       | 50.7±2.72µs       | 19.1 Ktx/sec   | 19.2 Ktx/sec   | 
| sqlite      | 💿       | location | unique      | 1000 | 100   | 55.6±0.28µs       | 55.6±0.31µs       | 17.6 Ktx/sec   | 17.6 Ktx/sec   | 
| sqlite      | 💿       | person   | multi_index | 0    | 100   | 117.5±2.21µs      | 121.1±5.76µs      | 8.3 Ktx/sec    | 8.1 Ktx/sec    | 
| sqlite      | 💿       | person   | multi_index | 1000 | 100   | 231.0±1.97µs      | 231.9±0.35µs      | 4.2 Ktx/sec    | 4.2 Ktx/sec    | 
| sqlite      | 💿       | person   | non_unique  | 0    | 100   | 49.5±1.29µs       | 50.6±1.16µs       | 19.7 Ktx/sec   | 19.3 Ktx/sec   | 
| sqlite      | 💿       | person   | non_unique  | 1000 | 100   | 61.2±0.30µs       | 62.0±10.46µs      | 15.9 Ktx/sec   | 15.7 Ktx/sec   | 
| sqlite      | 💿       | person   | unique      | 0    | 100   | 50.2±1.54µs       | 50.7±0.33µs       | 19.5 Ktx/sec   | 19.3 Ktx/sec   | 
| sqlite      | 💿       | person   | unique      | 1000 | 100   | 56.1±0.59µs       | 56.3±0.56µs       | 17.4 Ktx/sec   | 17.3 Ktx/sec   | 
| sqlite      | 🧠       | location | multi_index | 0    | 100   | 117.8±0.28µs      | 120.3±0.27µs      | 8.3 Ktx/sec    | 8.1 Ktx/sec    | 
| sqlite      | 🧠       | location | multi_index | 1000 | 100   | 169.8±0.32µs      | 169.8±0.42µs      | 5.8 Ktx/sec    | 5.8 Ktx/sec    | 
| sqlite      | 🧠       | location | non_unique  | 0    | 100   | 43.3±0.32µs       | 43.2±0.46µs       | 22.6 Ktx/sec   | 22.6 Ktx/sec   | 
| sqlite      | 🧠       | location | non_unique  | 1000 | 100   | 44.8±0.40µs       | 43.4±0.26µs       | 21.8 Ktx/sec   | 22.5 Ktx/sec   | 
| sqlite      | 🧠       | location | unique      | 0    | 100   | 44.4±0.30µs       | 44.3±0.49µs       | 22.0 Ktx/sec   | 22.0 Ktx/sec   | 
| sqlite      | 🧠       | location | unique      | 1000 | 100   | 48.2±0.27µs       | 47.0±0.26µs       | 20.3 Ktx/sec   | 20.8 Ktx/sec   | 
| sqlite      | 🧠       | person   | multi_index | 0    | 100   | 106.6±0.39µs      | 109.7±0.47µs      | 9.2 Ktx/sec    | 8.9 Ktx/sec    | 
| sqlite      | 🧠       | person   | multi_index | 1000 | 100   | 189.2±0.37µs      | 190.9±0.29µs      | 5.2 Ktx/sec    | 5.1 Ktx/sec    | 
| sqlite      | 🧠       | person   | non_unique  | 0    | 100   | 43.8±0.35µs       | 44.1±0.31µs       | 22.3 Ktx/sec   | 22.2 Ktx/sec   | 
| sqlite      | 🧠       | person   | non_unique  | 1000 | 100   | 47.2±0.25µs       | 48.1±0.30µs       | 20.7 Ktx/sec   | 20.3 Ktx/sec   | 
| sqlite      | 🧠       | person   | unique      | 0    | 100   | 44.8±0.26µs       | 44.8±0.31µs       | 21.8 Ktx/sec   | 21.8 Ktx/sec   | 
| sqlite      | 🧠       | person   | unique      | 1000 | 100   | 49.0±0.32µs       | 48.4±0.30µs       | 19.9 Ktx/sec   | 20.2 Ktx/sec   | 
| stdb_module | 💿       | location | multi_index | 0    | 100   | 658.9±73.14µs     | 802.0±33.36µs     | 1517 tx/sec    | 1246 tx/sec    | 
| stdb_module | 💿       | location | multi_index | 1000 | 100   | 804.1±89.84µs     | 1066.7±8.03µs     | 1243 tx/sec    | 937 tx/sec     | 
| stdb_module | 💿       | location | non_unique  | 0    | 100   | 438.9±37.54µs     | 426.9±93.74µs     | 2.2 Ktx/sec    | 2.3 Ktx/sec    | 
| stdb_module | 💿       | location | non_unique  | 1000 | 100   | 537.3±69.30µs     | 762.7±66.37µs     | 1861 tx/sec    | 1311 tx/sec    | 
| stdb_module | 💿       | location | unique      | 0    | 100   | 620.9±10.78µs     | 678.6±8.02µs      | 1610 tx/sec    | 1473 tx/sec    | 
| stdb_module | 💿       | location | unique      | 1000 | 100   | 635.6±93.64µs     | 917.8±93.75µs     | 1573 tx/sec    | 1089 tx/sec    | 
| stdb_module | 💿       | person   | multi_index | 0    | 100   | 811.6±198.57µs    | 1520.0±19.35µs    | 1232 tx/sec    | 657 tx/sec     | 
| stdb_module | 💿       | person   | multi_index | 1000 | 100   | 869.1±19.13µs     | 1493.1±75.06µs    | 1150 tx/sec    | 669 tx/sec     | 
| stdb_module | 💿       | person   | non_unique  | 0    | 100   | 557.5±25.01µs     | 636.6±28.35µs     | 1793 tx/sec    | 1570 tx/sec    | 
| stdb_module | 💿       | person   | non_unique  | 1000 | 100   | 701.5±127.26µs    | 850.9±23.67µs     | 1425 tx/sec    | 1175 tx/sec    | 
| stdb_module | 💿       | person   | unique      | 0    | 100   | 829.1±68.87µs     | 939.8±26.00µs     | 1206 tx/sec    | 1064 tx/sec    | 
| stdb_module | 💿       | person   | unique      | 1000 | 100   | 840.8±71.60µs     | 1398.5±87.23µs    | 1189 tx/sec    | 715 tx/sec     | 
| stdb_module | 🧠       | location | multi_index | 0    | 100   | 683.2±2.19µs      | 718.2±4.41µs      | 1463 tx/sec    | 1392 tx/sec    | 
| stdb_module | 🧠       | location | multi_index | 1000 | 100   | 715.7±13.85µs     | 921.4±5.43µs      | 1397 tx/sec    | 1085 tx/sec    | 
| stdb_module | 🧠       | location | non_unique  | 0    | 100   | 403.9±2.14µs      | 420.1±2.15µs      | 2.4 Ktx/sec    | 2.3 Ktx/sec    | 
| stdb_module | 🧠       | location | non_unique  | 1000 | 100   | 447.4±27.83µs     | 635.7±19.99µs     | 2.2 Ktx/sec    | 1573 tx/sec    | 
| stdb_module | 🧠       | location | unique      | 0    | 100   | 434.1±86.86µs     | 558.2±1.47µs      | 2.2 Ktx/sec    | 1791 tx/sec    | 
| stdb_module | 🧠       | location | unique      | 1000 | 100   | 622.6±6.64µs      | 742.0±19.45µs     | 1606 tx/sec    | 1347 tx/sec    | 
| stdb_module | 🧠       | person   | multi_index | 0    | 100   | 777.7±1.77µs      | 826.2±5.98µs      | 1285 tx/sec    | 1210 tx/sec    | 
| stdb_module | 🧠       | person   | multi_index | 1000 | 100   | 1450.7±110.70µs   | 1141.4±151.91µs   | 689 tx/sec     | 876 tx/sec     | 
| stdb_module | 🧠       | person   | non_unique  | 0    | 100   | 538.6±8.41µs      | 420.1±98.20µs     | 1856 tx/sec    | 2.3 Ktx/sec    | 
| stdb_module | 🧠       | person   | non_unique  | 1000 | 100   | 793.3±12.66µs     | 790.0±12.72µs     | 1260 tx/sec    | 1265 tx/sec    | 
| stdb_module | 🧠       | person   | unique      | 0    | 100   | 727.2±68.25µs     | 845.3±74.40µs     | 1375 tx/sec    | 1183 tx/sec    | 
| stdb_module | 🧠       | person   | unique      | 1000 | 100   | 1097.1±23.77µs    | 1152.4±14.87µs    | 911 tx/sec     | 867 tx/sec     | 
| stdb_raw    | 💿       | location | multi_index | 0    | 100   | 277.4±1.03µs      | 304.8±0.38µs      | 3.5 Ktx/sec    | 3.2 Ktx/sec    | 
| stdb_raw    | 💿       | location | multi_index | 1000 | 100   | 332.9±238.34µs    | 366.9±82.40µs     | 2.9 Ktx/sec    | 2.7 Ktx/sec    | 
| stdb_raw    | 💿       | location | non_unique  | 0    | 100   | 129.8±0.12µs      | 136.9±0.17µs      | 7.5 Ktx/sec    | 7.1 Ktx/sec    | 
| stdb_raw    | 💿       | location | non_unique  | 1000 | 100   | 136.4±0.96µs      | 171.2±110.79µs    | 7.2 Ktx/sec    | 5.7 Ktx/sec    | 
| stdb_raw    | 💿       | location | unique      | 0    | 100   | 201.3±10.79µs     | 214.4±0.33µs      | 4.9 Ktx/sec    | 4.6 Ktx/sec    | 
| stdb_raw    | 💿       | location | unique      | 1000 | 100   | 243.8±164.83µs    | 267.2±58.35µs     | 4.0 Ktx/sec    | 3.7 Ktx/sec    | 
| stdb_raw    | 💿       | person   | multi_index | 0    | 100   | 576.4±0.86µs      | 645.3±0.37µs      | 1734 tx/sec    | 1549 tx/sec    | 
| stdb_raw    | 💿       | person   | multi_index | 1000 | 100   | 615.2±0.88µs      | 698.6±2.60µs      | 1625 tx/sec    | 1431 tx/sec    | 
| stdb_raw    | 💿       | person   | non_unique  | 0    | 100   | 181.5±11.55µs     | 195.0±0.24µs      | 5.4 Ktx/sec    | 5.0 Ktx/sec    | 
| stdb_raw    | 💿       | person   | non_unique  | 1000 | 100   | 208.7±166.01µs    | 233.8±161.81µs    | 4.7 Ktx/sec    | 4.2 Ktx/sec    | 
| stdb_raw    | 💿       | person   | unique      | 0    | 100   | 330.6±17.62µs     | 360.0±1.82µs      | 3.0 Ktx/sec    | 2.7 Ktx/sec    | 
| stdb_raw    | 💿       | person   | unique      | 1000 | 100   | 386.1±254.08µs    | 426.5±258.75µs    | 2.5 Ktx/sec    | 2.3 Ktx/sec    | 
| stdb_raw    | 🧠       | location | multi_index | 0    | 100   | 273.3±0.37µs      | 306.8±0.55µs      | 3.6 Ktx/sec    | 3.2 Ktx/sec    | 
| stdb_raw    | 🧠       | location | multi_index | 1000 | 100   | 304.5±0.99µs      | 357.0±0.67µs      | 3.2 Ktx/sec    | 2.7 Ktx/sec    | 
| stdb_raw    | 🧠       | location | non_unique  | 0    | 100   | 126.4±1.11µs      | 135.4±0.10µs      | 7.7 Ktx/sec    | 7.2 Ktx/sec    | 
| stdb_raw    | 🧠       | location | non_unique  | 1000 | 100   | 132.2±0.38µs      | 156.8±0.46µs      | 7.4 Ktx/sec    | 6.2 Ktx/sec    | 
| stdb_raw    | 🧠       | location | unique      | 0    | 100   | 195.9±0.15µs      | 210.1±0.20µs      | 5.0 Ktx/sec    | 4.6 Ktx/sec    | 
| stdb_raw    | 🧠       | location | unique      | 1000 | 100   | 221.3±0.95µs      | 258.7±0.88µs      | 4.4 Ktx/sec    | 3.8 Ktx/sec    | 
| stdb_raw    | 🧠       | person   | multi_index | 0    | 100   | 575.3±0.81µs      | 643.1±0.58µs      | 1738 tx/sec    | 1554 tx/sec    | 
| stdb_raw    | 🧠       | person   | multi_index | 1000 | 100   | 612.9±0.63µs      | 685.6±2.01µs      | 1631 tx/sec    | 1458 tx/sec    | 
| stdb_raw    | 🧠       | person   | non_unique  | 0    | 100   | 176.4±0.13µs      | 191.1±0.22µs      | 5.5 Ktx/sec    | 5.1 Ktx/sec    | 
| stdb_raw    | 🧠       | person   | non_unique  | 1000 | 100   | 188.2±0.43µs      | 213.9±0.71µs      | 5.2 Ktx/sec    | 4.6 Ktx/sec    | 
| stdb_raw    | 🧠       | person   | unique      | 0    | 100   | 324.7±0.54µs      | 355.9±0.28µs      | 3.0 Ktx/sec    | 2.7 Ktx/sec    | 
| stdb_raw    | 🧠       | person   | unique      | 1000 | 100   | 355.0±0.48µs      | 397.9±2.29µs      | 2.8 Ktx/sec    | 2.5 Ktx/sec    | 

## Full table iterate

| db          | on disk | schema   | index type | new latency   | old latency    | new throughput | old throughput | 
|-------------|---------|----------|------------|---------------|----------------|----------------|----------------|
| sqlite      | 💿       | location | unique     | 8.8±0.09µs    | 9.0±0.12µs     | 111.3 Ktx/sec  | 108.6 Ktx/sec  | 
| sqlite      | 💿       | person   | unique     | 9.4±0.11µs    | 9.3±0.10µs     | 104.2 Ktx/sec  | 105.5 Ktx/sec  | 
| sqlite      | 🧠       | location | unique     | 7.7±0.18µs    | 7.7±0.14µs     | 126.4 Ktx/sec  | 126.9 Ktx/sec  | 
| sqlite      | 🧠       | person   | unique     | 8.2±0.10µs    | 8.2±0.12µs     | 119.8 Ktx/sec  | 119.7 Ktx/sec  | 
| stdb_module | 💿       | location | unique     | 47.2±4.59µs   | 44.9±4.67µs    | 20.7 Ktx/sec   | 21.7 Ktx/sec   | 
| stdb_module | 💿       | person   | unique     | 57.2±9.38µs   | 55.0±10.15µs   | 17.1 Ktx/sec   | 17.8 Ktx/sec   | 
| stdb_module | 🧠       | location | unique     | 43.0±4.64µs   | 46.0±3.32µs    | 22.7 Ktx/sec   | 21.2 Ktx/sec   | 
| stdb_module | 🧠       | person   | unique     | 57.9±9.29µs   | 60.1±7.36µs    | 16.9 Ktx/sec   | 16.3 Ktx/sec   | 
| stdb_raw    | 💿       | location | unique     | 8.0±0.02µs    | 10.5±0.09µs    | 122.3 Ktx/sec  | 93.2 Ktx/sec   | 
| stdb_raw    | 💿       | person   | unique     | 9.8±0.01µs    | 12.2±0.01µs    | 99.6 Ktx/sec   | 80.3 Ktx/sec   | 
| stdb_raw    | 🧠       | location | unique     | 8.0±0.10µs    | 10.4±0.05µs    | 121.6 Ktx/sec  | 93.5 Ktx/sec   | 
| stdb_raw    | 🧠       | person   | unique     | 9.8±0.02µs    | 12.2±0.02µs    | 99.6 Ktx/sec   | 80.3 Ktx/sec   | 

## Find unique key

| db          | on disk | key type | load | new latency    | old latency    | new throughput | old throughput | 
|-------------|---------|----------|------|----------------|----------------|----------------|----------------|
| sqlite      | 💿       | u32      | 1000 | 2.4±0.01µs     | 2.4±0.01µs     | 414.9 Ktx/sec  | 405.5 Ktx/sec  | 
| sqlite      | 🧠       | u32      | 1000 | 1153.9±4.96ns  | 1176.1±9.94ns  | 846.3 Ktx/sec  | 830.4 Ktx/sec  | 
| stdb_module | 💿       | u32      | 1000 | 18.4±0.63µs    | 18.8±1.42µs    | 53.1 Ktx/sec   | 52.0 Ktx/sec   | 
| stdb_module | 🧠       | u32      | 1000 | 18.3±0.61µs    | 18.5±1.10µs    | 53.5 Ktx/sec   | 52.9 Ktx/sec   | 
| stdb_raw    | 💿       | u32      | 1000 | 481.1±1.23ns   | 491.2±1.21ns   | 2030.0 Ktx/sec | 1988.1 Ktx/sec | 
| stdb_raw    | 🧠       | u32      | 1000 | 478.9±1.02ns   | 485.1±1.01ns   | 2039.1 Ktx/sec | 2013.1 Ktx/sec | 

## Filter

| db          | on disk | key type | index strategy | load | count | new latency    | old latency    | new throughput | old throughput | 
|-------------|---------|----------|----------------|------|-------|----------------|----------------|----------------|----------------|
| sqlite      | 💿       | string   | indexed        | 1000 | 10    | 5.6±0.06µs     | 5.7±0.02µs     | 174.3 Ktx/sec  | 172.1 Ktx/sec  | 
| sqlite      | 💿       | string   | non_indexed    | 1000 | 10    | 49.0±0.29µs    | 49.9±0.61µs    | 19.9 Ktx/sec   | 19.6 Ktx/sec   | 
| sqlite      | 💿       | u64      | indexed        | 1000 | 10    | 5.4±0.01µs     | 5.5±0.01µs     | 180.2 Ktx/sec  | 178.3 Ktx/sec  | 
| sqlite      | 💿       | u64      | non_indexed    | 1000 | 10    | 32.9±0.27µs    | 34.1±0.09µs    | 29.7 Ktx/sec   | 28.6 Ktx/sec   | 
| sqlite      | 🧠       | string   | indexed        | 1000 | 10    | 4.2±0.01µs     | 4.2±0.01µs     | 231.4 Ktx/sec  | 231.4 Ktx/sec  | 
| sqlite      | 🧠       | string   | non_indexed    | 1000 | 10    | 47.0±0.29µs    | 48.3±0.42µs    | 20.8 Ktx/sec   | 20.2 Ktx/sec   | 
| sqlite      | 🧠       | u64      | indexed        | 1000 | 10    | 4.1±0.01µs     | 4.1±0.02µs     | 241.0 Ktx/sec  | 240.9 Ktx/sec  | 
| sqlite      | 🧠       | u64      | non_indexed    | 1000 | 10    | 31.5±0.07µs    | 31.8±0.09µs    | 31.0 Ktx/sec   | 30.7 Ktx/sec   | 
| stdb_module | 💿       | string   | indexed        | 1000 | 10    | 24.5±1.67µs    | 26.4±2.70µs    | 39.8 Ktx/sec   | 37.0 Ktx/sec   | 
| stdb_module | 💿       | string   | non_indexed    | 1000 | 10    | 191.6±3.94µs   | 190.1±2.91µs   | 5.1 Ktx/sec    | 5.1 Ktx/sec    | 
| stdb_module | 💿       | u64      | indexed        | 1000 | 10    | 20.7±1.16µs    | 21.1±0.98µs    | 47.2 Ktx/sec   | 46.2 Ktx/sec   | 
| stdb_module | 💿       | u64      | non_indexed    | 1000 | 10    | 151.8±4.57µs   | 165.6±6.51µs   | 6.4 Ktx/sec    | 5.9 Ktx/sec    | 
| stdb_module | 🧠       | string   | indexed        | 1000 | 10    | 24.7±2.19µs    | 25.9±2.46µs    | 39.6 Ktx/sec   | 37.8 Ktx/sec   | 
| stdb_module | 🧠       | string   | non_indexed    | 1000 | 10    | 190.5±3.12µs   | 187.4±4.32µs   | 5.1 Ktx/sec    | 5.2 Ktx/sec    | 
| stdb_module | 🧠       | u64      | indexed        | 1000 | 10    | 20.8±0.96µs    | 21.1±1.04µs    | 46.9 Ktx/sec   | 46.2 Ktx/sec   | 
| stdb_module | 🧠       | u64      | non_indexed    | 1000 | 10    | 150.9±4.91µs   | 158.1±4.72µs   | 6.5 Ktx/sec    | 6.2 Ktx/sec    | 
| stdb_raw    | 💿       | string   | indexed        | 1000 | 10    | 2.5±0.00µs     | 2.6±0.00µs     | 389.5 Ktx/sec  | 371.5 Ktx/sec  | 
| stdb_raw    | 💿       | string   | non_indexed    | 1000 | 10    | 153.2±0.34µs   | 173.2±0.73µs   | 6.4 Ktx/sec    | 5.6 Ktx/sec    | 
| stdb_raw    | 💿       | u64      | indexed        | 1000 | 10    | 2.1±0.00µs     | 2.2±0.01µs     | 469.1 Ktx/sec  | 439.0 Ktx/sec  | 
| stdb_raw    | 💿       | u64      | non_indexed    | 1000 | 10    | 128.1±1.14µs   | 135.7±1.88µs   | 7.6 Ktx/sec    | 7.2 Ktx/sec    | 
| stdb_raw    | 🧠       | string   | indexed        | 1000 | 10    | 2.5±0.01µs     | 2.6±0.00µs     | 392.3 Ktx/sec  | 372.0 Ktx/sec  | 
| stdb_raw    | 🧠       | string   | non_indexed    | 1000 | 10    | 150.2±0.33µs   | 172.8±0.56µs   | 6.5 Ktx/sec    | 5.7 Ktx/sec    | 
| stdb_raw    | 🧠       | u64      | indexed        | 1000 | 10    | 2.1±0.00µs     | 2.2±0.00µs     | 459.8 Ktx/sec  | 437.9 Ktx/sec  | 
| stdb_raw    | 🧠       | u64      | non_indexed    | 1000 | 10    | 127.3±1.23µs   | 135.0±0.35µs   | 7.7 Ktx/sec    | 7.2 Ktx/sec    | 

## Serialize

| schema   | format        | count | new latency     | old latency      | new throughput | old throughput | 
|----------|---------------|-------|-----------------|------------------|----------------|----------------|
| location | bsatn         | 100   | 1681.2±33.21ns  | 1659.9±116.77ns  | 56.7 Mtx/sec   | 57.5 Mtx/sec   | 
| location | json          | 100   | 3.1±0.01µs      | 3.2±0.09µs       | 30.5 Mtx/sec   | 29.5 Mtx/sec   | 
| location | product_value | 100   | 1124.0±0.62ns   | 2.5±0.01µs       | 84.8 Mtx/sec   | 38.4 Mtx/sec   | 
| person   | bsatn         | 100   | 2.4±0.01µs      | 2.4±0.01µs       | 39.3 Mtx/sec   | 38.9 Mtx/sec   | 
| person   | json          | 100   | 5.1±0.08µs      | 4.9±0.04µs       | 18.7 Mtx/sec   | 19.4 Mtx/sec   | 
| person   | product_value | 100   | 1117.3±1.58ns   | 1615.2±6.59ns    | 85.4 Mtx/sec   | 59.0 Mtx/sec   | 

## Module: invoke with large arguments

| arg size | new latency   | old latency   | new throughput | old throughput | 
|----------|---------------|---------------|----------------|----------------|
| 64KiB    | 74.4±6.19µs   | 92.2±9.90µs   | -              | -              | 

## Module: print bulk

| line count | new latency       | old latency     | new throughput | old throughput | 
|------------|-------------------|-----------------|----------------|----------------|
| 1          | 19.5±0.77µs       | 20.7±1.30µs     | -              | -              | 
| 100        | 191.6±1.25µs      | 200.8±1.68µs    | -              | -              | 
| 1000       | 1794.2±111.25µs   | 1815.2±7.83µs   | -              | -              | 

## Remaining benchmarks

| name | new latency | old latency | new throughput | old throughput | 
|------|-------------|-------------|----------------|----------------|



</details>

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

1

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
