### PR TITLE
Switch rows to IndexMap

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/table.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/table.rs
@@ -3,21 +3,28 @@ use super::{
     RowId,
 };
 use crate::db::datastore::traits::{ColId, TableSchema};
+use indexmap::IndexMap;
 use nonempty::NonEmpty;
 use spacetimedb_sats::{AlgebraicValue, ProductType, ProductValue};
-use std::{
-    collections::{BTreeMap, HashMap},
-    ops::RangeBounds,
-};
+use std::{collections::HashMap, ops::RangeBounds};
 
 pub(crate) struct Table {
     pub(crate) row_type: ProductType,
     pub(crate) schema: TableSchema,
     pub(crate) indexes: HashMap<NonEmpty<ColId>, BTreeIndex>,
-    pub(crate) rows: BTreeMap<RowId, ProductValue>,
+    pub(crate) rows: IndexMap<RowId, ProductValue>,
 }
 
 impl Table {
+    pub(crate) fn new(row_type: ProductType, schema: TableSchema) -> Self {
+        Self {
+            row_type,
+            schema,
+            indexes: Default::default(),
+            rows: Default::default(),
+        }
+    }
+
     pub(crate) fn insert_index(&mut self, mut index: BTreeIndex) {
         index.build_from_rows(self.scan_rows()).unwrap();
         self.indexes.insert(index.cols.clone().map(ColId), index);


### PR DESCRIPTION
We don't need row ranges, we only (loosely) care about stable iteration order, so we can switch to cheaper IndexMap (HashMap) instead of using a B-Tree.

This small change shows noticeable improvement to both iteration and insertion ops across the board as they all use `rows` (only extracted results for raw in-memory DB as the module ones are currently way too noisy even on CI):

## Single-row insertions

| schema   | index type  | load | new latency      | old latency      | new throughput | old throughput | 
|----------|-------------|------|------------------|------------------|----------------|----------------|
| location | multi_index | 1000 | 24.7±0.81µs      | 29.4±0.79µs      | 39.6 Ktx/sec   | 33.2 Ktx/sec   | 
| location | non_unique  | 1000 | 16.4±0.04µs      | 19.4±0.08µs      | 59.5 Ktx/sec   | 50.4 Ktx/sec   | 
| location | unique      | 1000 | 21.2±0.11µs      | 24.5±0.12µs      | 46.1 Ktx/sec   | 39.9 Ktx/sec   | 
| person   | multi_index | 1000 | 19.8±0.87µs      | 21.5±1.16µs      | 49.4 Ktx/sec   | 45.4 Ktx/sec   | 
| person   | non_unique  | 1000 | 9.8±0.15µs       | 12.8±0.17µs      | 100.0 Ktx/sec  | 76.2 Ktx/sec   | 
| person   | unique      | 1000 | 15.4±0.28µs      | 17.0±0.57µs      | 63.5 Ktx/sec   | 57.5 Ktx/sec   | 

## Full table iterate

| schema   | index type | new latency   | old latency    | new throughput | old throughput | 
|----------|------------|---------------|----------------|----------------|----------------|
| location | unique     | 9.1±0.00µs    | 10.4±0.05µs    | 107.1 Ktx/sec  | 93.5 Ktx/sec   | 
| person   | unique     | 10.3±0.15µs   | 12.2±0.02µs    | 94.8 Ktx/sec   | 80.3 Ktx/sec   | 

# Description of Changes


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

2

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
