### PR TITLE
lib: Don't panic in RelValueRef::get

### DIFF
--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -112,16 +112,16 @@ fn join_inner<'a>(
         rhs,
         header,
         move |row| {
-            let f = row.get(&key_lhs, &key_lhs_header);
+            let f = row.get(&key_lhs, &key_lhs_header)?;
             Ok(f.into())
         },
         move |row| {
-            let f = row.get(&key_rhs, &key_rhs_header);
+            let f = row.get(&key_rhs, &key_rhs_header)?;
             Ok(f.into())
         },
         move |l, r| {
-            let l = l.get(&col_lhs, &col_lhs_header);
-            let r = r.get(&col_rhs, &col_rhs_header);
+            let l = l.get(&col_lhs, &col_lhs_header)?;
+            let r = r.get(&col_rhs, &col_rhs_header)?;
             Ok(l == r)
         },
         move |l, r| {

--- a/crates/lib/src/error.rs
+++ b/crates/lib/src/error.rs
@@ -120,6 +120,8 @@ pub enum AuthError {
 pub enum RelationError {
     #[error("Field `{1}` not found. Must be one of {0}")]
     FieldNotFound(Header, FieldName),
+    #[error("Field `{1}` not found at position {0}")]
+    FieldNotFoundAtPos(usize, FieldName),
     #[error("Field `{0}` fail to infer the type: {1}")]
     TypeInference(FieldName, TypeError),
     #[error("Field declaration only support `table.field` or `field`. It gets instead `{0}`")]

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -458,16 +458,16 @@ pub fn build_query(mut result: Box<IterRows>, query: Vec<Query>) -> Result<Box<I
                     rhs,
                     col_lhs_header.extend(&col_rhs_header),
                     move |row| {
-                        let f = row.get(&key_lhs, &key_lhs_header);
+                        let f = row.get(&key_lhs, &key_lhs_header)?;
                         Ok(f.into())
                     },
                     move |row| {
-                        let f = row.get(&key_rhs, &key_rhs_header);
+                        let f = row.get(&key_rhs, &key_rhs_header)?;
                         Ok(f.into())
                     },
                     move |l, r| {
-                        let l = l.get(&col_lhs, &col_lhs_header);
-                        let r = r.get(&col_rhs, &col_rhs_header);
+                        let l = l.get(&col_lhs, &col_lhs_header)?;
+                        let r = r.get(&col_rhs, &col_rhs_header)?;
                         Ok(l == r)
                     },
                     move |l, r| l.extend(r),

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -100,7 +100,7 @@ impl ColumnOp {
 
     fn reduce(&self, row: RelValueRef, value: &ColumnOp, header: &Header) -> Result<AlgebraicValue, ErrorLang> {
         match value {
-            ColumnOp::Field(field) => Ok(row.get(field, header).clone()),
+            ColumnOp::Field(field) => Ok(row.get(field, header)?.clone()),
             ColumnOp::Cmp { op, lhs, rhs } => Ok(self.compare_bin_op(row, *op, lhs, rhs, header)?.into()),
         }
     }
@@ -108,7 +108,7 @@ impl ColumnOp {
     fn reduce_bool(&self, row: RelValueRef, value: &ColumnOp, header: &Header) -> Result<bool, ErrorLang> {
         match value {
             ColumnOp::Field(field) => {
-                let field = row.get(field, header);
+                let field = row.get(field, header)?;
 
                 match field.as_bool() {
                     Some(b) => Ok(*b),
@@ -156,7 +156,7 @@ impl ColumnOp {
     pub fn compare(&self, row: RelValueRef, header: &Header) -> Result<bool, ErrorVm> {
         match self {
             ColumnOp::Field(field) => {
-                let lhs = row.get(field, header);
+                let lhs = row.get(field, header)?;
                 Ok(*lhs.as_bool().unwrap())
             }
             ColumnOp::Cmp { op, lhs, rhs } => self.compare_bin_op(row, *op, lhs, rhs, header),


### PR DESCRIPTION
# Description of Changes

There is no guarantee that a named field is in the supplied table header, nor that it is in the row. Panicking at this location can be disastrous, while all call sites are inside Result already. So, return Result.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

1
