### PR TITLE
Fix C# generics support

### DIFF
--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -7,7 +7,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>SpacetimeDB.Codegen</AssemblyName>
-    <AssemblyVersion>0.7.2</AssemblyVersion>
+    <AssemblyVersion>0.7.3</AssemblyVersion>
   </PropertyGroup>
 
   <PropertyGroup>

--- a/crates/bindings-csharp/Codegen/Utils.cs
+++ b/crates/bindings-csharp/Codegen/Utils.cs
@@ -15,7 +15,7 @@ static class Utils
         return symbol.ToDisplayString(
             SymbolDisplayFormat.FullyQualifiedFormat
                 .WithMemberOptions(SymbolDisplayMemberOptions.IncludeContainingType)
-                .WithGenericsOptions(SymbolDisplayGenericsOptions.None)
+                .WithGenericsOptions(SymbolDisplayGenericsOptions.IncludeTypeParameters)
                 .WithGlobalNamespaceStyle(SymbolDisplayGlobalNamespaceStyle.Omitted)
         );
     }

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -15,14 +15,17 @@ fn test_calling_a_reducer_in_module(module_name: &'static str) {
             module.send(json).await.unwrap();
 
             let lines = module.read_log(Some(10)).await;
-            let lines: Vec<&str> = lines.trim().split('\n').collect();
+            let lines: Vec<Value> = lines.trim().split('\n').map(serde_json::from_str).collect::<serde_json::Result<_>>().unwrap();
 
-            assert_eq!(lines.len(), 4);
+            assert!(lines.len() >= 4);
 
-            let json: Value = serde_json::from_str(lines[2]).unwrap();
-            assert_eq!(json["message"], Value::String("Hello, Tyrion!".to_string()));
-            let json: Value = serde_json::from_str(lines[3]).unwrap();
-            assert_eq!(json["message"], Value::String("Hello, World!".to_string()));
+            assert_eq!(lines[0], serde_json::json!({"level":"Info","filename":"spacetimedb","message":"Creating table `Person`"}));
+
+            assert_eq!(lines[lines.len() - 2]["level"], "Info");
+            assert_eq!(lines[lines.len() - 2]["message"], "Hello, Tyrion!");
+
+            assert_eq!(lines[lines.len() - 1]["level"], "Info");
+            assert_eq!(lines[lines.len() - 1]["message"], "Hello, World!");
         },
     );
 }

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -14,8 +14,14 @@ fn test_calling_a_reducer_in_module(module_name: &'static str) {
             let json = r#"{"call": {"fn": "say_hello", "args": []}}"#.to_string();
             module.send(json).await.unwrap();
 
-            let lines = module.read_log(Some(10)).await;
-            let lines: Vec<Value> = lines.trim().split('\n').map(serde_json::from_str).collect::<serde_json::Result<_>>().unwrap();
+            let lines: Vec<Value> = module
+                .read_log(Some(10))
+                .await
+                .trim()
+                .split('\n')
+                .map(serde_json::from_str)
+                .collect::<serde_json::Result<_>>()
+                .unwrap();
 
             assert!(lines.len() >= 4);
 

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -19,8 +19,6 @@ fn test_calling_a_reducer_in_module(module_name: &'static str) {
 
             assert!(lines.len() >= 4);
 
-            assert_eq!(lines[0], serde_json::json!({"level":"Info","filename":"spacetimedb","message":"Creating table `Person`"}));
-
             assert_eq!(lines[lines.len() - 2]["level"], "Info");
             assert_eq!(lines[lines.len() - 2]["message"], "Hello, Tyrion!");
 

--- a/modules/spacetimedb-quickstart-cs/Lib.cs
+++ b/modules/spacetimedb-quickstart-cs/Lib.cs
@@ -9,6 +9,31 @@ static partial class Module
         public string Name;
     }
 
+    // Verify that all types compile via codegen successfully.
+    // TODO: port actual SDK tests from Rust.
+    [SpacetimeDB.Table]
+    public partial struct Typecheck
+    {
+        bool BoolField;
+        byte ByteField;
+        sbyte SbyteField;
+        short ShortField;
+        ushort UshortField;
+        int IntField;
+        uint UintField;
+        long LongField;
+        ulong UlongField;
+        float FloatField;
+        double DoubleField;
+        string StringField;
+        Int128 Int128Field;
+        UInt128 Uint128Field;
+        Person NestedTableField;
+        Person[] NestedTableArrayField;
+        List<Person> NestedTableListField;
+        Dictionary<string, Person> NestedTableDictionaryField;
+    }
+
     [SpacetimeDB.Reducer("add")]
     public static void Add(string name)
     {


### PR DESCRIPTION
# Description of Changes

At some point the code was switched to use the full type name helper to resolve types regardless of if they're in scope. The helper didn't include generic params which broke things like `List<...>` as reported in the chat.

This fixes the issue by... well, including generic params.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

1

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
