### PR TITLE
Created a route to check what emails are already connected to an identity

### DIFF
--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,0 +1,7 @@
+{
+  "workbench.colorCustomizations": {
+    "[Material Theme Darker]": {},
+    "minimap.background": "#00000000",
+    "scrollbar.shadow": "#00000000"
+  }
+}

--- a/.vscode/settings.json
+++ b/.vscode/settings.json
@@ -1,7 +1,0 @@
-{
-  "workbench.colorCustomizations": {
-    "[Material Theme Darker]": {},
-    "minimap.background": "#00000000",
-    "scrollbar.shadow": "#00000000"
-  }
-}

--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -147,7 +147,7 @@ pub trait ControlStateWriteAccess: Send + Sync {
     // Identities
     async fn create_identity(&self) -> spacetimedb::control_db::Result<Identity>;
     async fn add_email(&self, identity: &Identity, email: &str) -> spacetimedb::control_db::Result<()>;
-    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<String>>;
+    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<IdentityEmail>>;
     async fn insert_recovery_code(
         &self,
         identity: &Identity,
@@ -260,7 +260,7 @@ impl<T: ControlStateWriteAccess + ?Sized> ControlStateWriteAccess for ArcEnv<T> 
         self.0.add_email(identity, email).await
     }
 
-    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<String>> {
+    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<IdentityEmail>> {
         self.0.get_emails(identity).await
     }
 
@@ -417,7 +417,7 @@ impl<T: ControlStateWriteAccess + ?Sized> ControlStateWriteAccess for Arc<T> {
         (**self).add_email(identity, email).await
     }
 
-    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<String>> {
+    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<IdentityEmail>> {
         (**self).get_emails(identity).await
     }
 

--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -111,6 +111,7 @@ pub trait ControlStateReadAccess {
 
     // Identities
     fn get_identities_for_email(&self, email: &str) -> spacetimedb::control_db::Result<Vec<IdentityEmail>>;
+    fn get_emails_for_identity(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<IdentityEmail>>;
     fn get_recovery_codes(&self, email: &str) -> spacetimedb::control_db::Result<Vec<RecoveryCode>>;
 
     // Energy
@@ -147,7 +148,6 @@ pub trait ControlStateWriteAccess: Send + Sync {
     // Identities
     async fn create_identity(&self) -> spacetimedb::control_db::Result<Identity>;
     async fn add_email(&self, identity: &Identity, email: &str) -> spacetimedb::control_db::Result<()>;
-    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<IdentityEmail>>;
     async fn insert_recovery_code(
         &self,
         identity: &Identity,
@@ -214,6 +214,9 @@ impl<T: ControlStateReadAccess + ?Sized> ControlStateReadAccess for ArcEnv<T> {
     fn get_identities_for_email(&self, email: &str) -> spacetimedb::control_db::Result<Vec<IdentityEmail>> {
         self.0.get_identities_for_email(email)
     }
+    fn get_emails_for_identity(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<IdentityEmail>> {
+        self.0.get_emails_for_identity(identity)
+    }
     fn get_recovery_codes(&self, email: &str) -> spacetimedb::control_db::Result<Vec<RecoveryCode>> {
         self.0.get_recovery_codes(email)
     }
@@ -258,10 +261,6 @@ impl<T: ControlStateWriteAccess + ?Sized> ControlStateWriteAccess for ArcEnv<T> 
 
     async fn add_email(&self, identity: &Identity, email: &str) -> spacetimedb::control_db::Result<()> {
         self.0.add_email(identity, email).await
-    }
-
-    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<IdentityEmail>> {
-        self.0.get_emails(identity).await
     }
 
     async fn insert_recovery_code(
@@ -371,6 +370,9 @@ impl<T: ControlStateReadAccess + ?Sized> ControlStateReadAccess for Arc<T> {
     fn get_identities_for_email(&self, email: &str) -> spacetimedb::control_db::Result<Vec<IdentityEmail>> {
         (**self).get_identities_for_email(email)
     }
+    fn get_emails_for_identity(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<IdentityEmail>> {
+        (**self).get_emails_for_identity(identity)
+    }
     fn get_recovery_codes(&self, email: &str) -> spacetimedb::control_db::Result<Vec<RecoveryCode>> {
         (**self).get_recovery_codes(email)
     }
@@ -415,10 +417,6 @@ impl<T: ControlStateWriteAccess + ?Sized> ControlStateWriteAccess for Arc<T> {
 
     async fn add_email(&self, identity: &Identity, email: &str) -> spacetimedb::control_db::Result<()> {
         (**self).add_email(identity, email).await
-    }
-
-    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<IdentityEmail>> {
-        (**self).get_emails(identity).await
     }
 
     async fn insert_recovery_code(

--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -147,6 +147,7 @@ pub trait ControlStateWriteAccess: Send + Sync {
     // Identities
     async fn create_identity(&self) -> spacetimedb::control_db::Result<Identity>;
     async fn add_email(&self, identity: &Identity, email: &str) -> spacetimedb::control_db::Result<()>;
+    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<String>>;
     async fn insert_recovery_code(
         &self,
         identity: &Identity,
@@ -257,6 +258,10 @@ impl<T: ControlStateWriteAccess + ?Sized> ControlStateWriteAccess for ArcEnv<T> 
 
     async fn add_email(&self, identity: &Identity, email: &str) -> spacetimedb::control_db::Result<()> {
         self.0.add_email(identity, email).await
+    }
+
+    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<String>> {
+        self.0.get_emails(identity).await
     }
 
     async fn insert_recovery_code(
@@ -410,6 +415,10 @@ impl<T: ControlStateWriteAccess + ?Sized> ControlStateWriteAccess for Arc<T> {
 
     async fn add_email(&self, identity: &Identity, email: &str) -> spacetimedb::control_db::Result<()> {
         (**self).add_email(identity, email).await
+    }
+
+    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<String>> {
+        (**self).get_emails(identity).await
     }
 
     async fn insert_recovery_code(

--- a/crates/client-api/src/routes/identity.rs
+++ b/crates/client-api/src/routes/identity.rs
@@ -4,11 +4,12 @@ use http::StatusCode;
 use serde::{Deserialize, Serialize};
 
 use spacetimedb::auth::identity::encode_token_with_expiry;
+use spacetimedb::messages::control_db::IdentityEmail;
 use spacetimedb_lib::de::serde::DeserializeWrapper;
 use spacetimedb_lib::{Address, Identity};
 
 use crate::auth::{SpacetimeAuth, SpacetimeAuthHeader};
-use crate::{log_and_500, ControlStateDelegate, ControlStateWriteAccess, NodeDelegate};
+use crate::{log_and_500, ControlStateDelegate, ControlStateReadAccess, ControlStateWriteAccess, NodeDelegate};
 
 #[derive(Deserialize)]
 pub struct CreateIdentityQueryParams {
@@ -130,7 +131,7 @@ pub async fn set_email<S: ControlStateWriteAccess>(
     Ok(())
 }
 
-pub async fn check_email<S: ControlStateWriteAccess>(
+pub async fn check_email<S: ControlStateReadAccess>(
     State(ctx): State<S>,
     Path(SetEmailParams { identity }): Path<SetEmailParams>,
     auth: SpacetimeAuthHeader,

--- a/crates/client-api/src/routes/identity.rs
+++ b/crates/client-api/src/routes/identity.rs
@@ -143,13 +143,12 @@ pub async fn check_email<S: ControlStateReadAccess>(
         return Err(StatusCode::UNAUTHORIZED.into());
     }
 
-    let emails_raw = ctx.get_emails(&identity).await.map_err(log_and_500)?;
-
-    let mut emails = Vec::new();
-
-    for email in emails_raw {
-        emails.push(email.email);
-    }
+    let emails = ctx
+        .get_emails_for_identity(&identity)
+        .map_err(log_and_500)?
+        .into_iter()
+        .map(|IdentityEmail { email, .. }| email)
+        .collect::<Vec<_>>();
 
     Ok(axum::Json(emails))
 }

--- a/crates/client-api/src/routes/identity.rs
+++ b/crates/client-api/src/routes/identity.rs
@@ -142,7 +142,13 @@ pub async fn check_email<S: ControlStateWriteAccess>(
         return Err(StatusCode::UNAUTHORIZED.into());
     }
 
-    let emails = ctx.get_emails(&identity).await.map_err(log_and_500)?;
+    let emails_raw = ctx.get_emails(&identity).await.map_err(log_and_500)?;
+
+    let mut emails = Vec::new();
+
+    for email in emails_raw {
+        emails.push(email.email);
+    }
 
     Ok(axum::Json(emails))
 }

--- a/crates/client-api/src/routes/identity.rs
+++ b/crates/client-api/src/routes/identity.rs
@@ -141,10 +141,10 @@ pub async fn check_email<S: ControlStateWriteAccess>(
     if auth.identity != identity {
         return Err(StatusCode::UNAUTHORIZED.into());
     }
-    
+
     let emails = ctx.get_emails(&identity).await.map_err(log_and_500)?;
 
-    Ok(emails)
+    Ok(axum::Json(emails))
 }
 
 #[derive(Deserialize)]
@@ -233,6 +233,6 @@ where
         .route("/websocket_token", post(create_websocket_token::<S>))
         .route("/:identity/verify", get(validate_token))
         .route("/:identity/set-email", post(set_email::<S>))
-        .route("/:identity/email", get(check_email::<S>))
+        .route("/:identity/emails", get(check_email::<S>))
         .route("/:identity/databases", get(get_databases::<S>))
 }

--- a/crates/core/src/control_db.rs
+++ b/crates/core/src/control_db.rs
@@ -291,6 +291,19 @@ impl ControlDb {
         Ok(result)
     }
 
+    pub fn get_emails_for_identity(&self, identity: Identity) -> Result<Vec<IdentityEmail>> {
+        let mut result = Vec::<IdentityEmail>::new();
+        let tree = self.db.open_tree("email")?;
+        for i in tree.iter() {
+            let (_, value) = i?;
+            let iemail: IdentityEmail = bsatn::from_slice(&value)?;
+            if iemail.identity == identity {
+                result.push(iemail);
+            }
+        }
+        Ok(result)
+    }
+
     pub fn get_databases(&self) -> Result<Vec<Database>> {
         let tree = self.db.open_tree("database")?;
         let mut databases = Vec::new();

--- a/crates/core/src/control_db.rs
+++ b/crates/core/src/control_db.rs
@@ -291,13 +291,13 @@ impl ControlDb {
         Ok(result)
     }
 
-    pub fn get_emails_for_identity(&self, identity: Identity) -> Result<Vec<IdentityEmail>> {
+    pub fn get_emails_for_identity(&self, identity: &Identity) -> Result<Vec<IdentityEmail>> {
         let mut result = Vec::<IdentityEmail>::new();
         let tree = self.db.open_tree("email")?;
         for i in tree.iter() {
             let (_, value) = i?;
             let iemail: IdentityEmail = bsatn::from_slice(&value)?;
-            if iemail.identity == identity {
+            if &iemail.identity == identity {
                 result.push(iemail);
             }
         }

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -368,6 +368,10 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
             .await
     }
 
+    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<String>> {
+        self.control_db.get_emails_for_identity(*identity).await
+    }
+
     async fn insert_recovery_code(
         &self,
         _identity: &Identity,

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -368,8 +368,8 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
             .await
     }
 
-    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<String>> {
-        self.control_db.get_emails_for_identity(*identity).await
+    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<IdentityEmail>> {
+        self.control_db.get_emails_for_identity(*identity)
     }
 
     async fn insert_recovery_code(

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -253,6 +253,10 @@ impl spacetimedb_client_api::ControlStateReadAccess for StandaloneEnv {
         self.control_db.get_identities_for_email(email)
     }
 
+    fn get_emails_for_identity(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<IdentityEmail>> {
+        self.control_db.get_emails_for_identity(identity)
+    }
+
     fn get_recovery_codes(&self, email: &str) -> spacetimedb::control_db::Result<Vec<RecoveryCode>> {
         self.control_db.spacetime_get_recovery_codes(email)
     }
@@ -366,10 +370,6 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
         self.control_db
             .associate_email_spacetime_identity(*identity, email)
             .await
-    }
-
-    async fn get_emails(&self, identity: &Identity) -> spacetimedb::control_db::Result<Vec<IdentityEmail>> {
-        self.control_db.get_emails_for_identity(*identity)
     }
 
     async fn insert_recovery_code(


### PR DESCRIPTION
# Description of Changes

Created a route to check what emails are already connected to an identity. Mainly for the web to not continue to prompt users to connect an email.

Example: GET /:identity/emails

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [x] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

Rating: 1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
