### PR TITLE
perf(468): Add metric counters for committed transactions and rollbacks

### DIFF
--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -446,15 +446,21 @@ pub trait Tx {
     type TxId;
 
     fn begin_tx(&self) -> Self::TxId;
-    fn release_tx(&self, tx: Self::TxId);
+    fn release_tx(&self, ctx: &ExecutionContext, tx: Self::TxId);
 }
 
 pub trait MutTx {
     type MutTxId;
 
     fn begin_mut_tx(&self) -> Self::MutTxId;
-    fn rollback_mut_tx(&self, tx: Self::MutTxId);
-    fn commit_mut_tx(&self, tx: Self::MutTxId) -> Result<Option<TxData>>;
+    fn commit_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTxId) -> Result<Option<TxData>>;
+    fn rollback_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTxId);
+
+    #[cfg(test)]
+    fn commit_mut_tx_for_test(&self, tx: Self::MutTxId) -> Result<Option<TxData>>;
+
+    #[cfg(test)]
+    fn rollback_mut_tx_for_test(&self, tx: Self::MutTxId);
 }
 
 pub trait TxDatastore: DataRow + Tx {

--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -65,6 +65,16 @@ metrics_group!(
         #[help = "The cumulative number of rows fetched from a table"]
         #[labels(txn_type: TransactionType, db: Address, reducer: str, table_id: u32)]
         pub rdb_num_rows_fetched: IntCounterVec,
+
+        #[name = spacetime_num_txns_committed_cumulative]
+        #[help = "The cumulative number of committed transactions"]
+        #[labels(txn_type: TransactionType, db: Address, reducer: str)]
+        pub rdb_num_txns_committed: IntCounterVec,
+
+        #[name = spacetime_num_txns_rolledback_cumulative]
+        #[help = "The cumulative number of rolled back transactions"]
+        #[labels(txn_type: TransactionType, db: Address, reducer: str)]
+        pub rdb_num_txns_rolledback: IntCounterVec,
     }
 );
 

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -84,7 +84,7 @@ impl DatabaseUpdate {
                 ops: table_row_operations,
             });
         }
-        stdb.rollback_tx(tx);
+        stdb.rollback_tx(&ctx, tx);
 
         DatabaseUpdate { tables: table_updates }
     }

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -629,7 +629,7 @@ pub(crate) mod tests {
 
         assert_eq!(result.data, input.data, "Inventory");
 
-        stdb.rollback_tx(tx);
+        stdb.rollback_tx(&ctx, tx);
 
         Ok(())
     }
@@ -670,7 +670,7 @@ pub(crate) mod tests {
             DbTable::from(&st_table_schema()),
         );
 
-        stdb.rollback_tx(tx);
+        stdb.rollback_tx(&ctx, tx);
 
         Ok(())
     }
@@ -709,7 +709,7 @@ pub(crate) mod tests {
             (&st_columns_schema()).into(),
         );
 
-        stdb.rollback_tx(tx);
+        stdb.rollback_tx(&ctx, tx);
 
         Ok(())
     }
@@ -752,7 +752,7 @@ pub(crate) mod tests {
             (&st_indexes_schema()).into(),
         );
 
-        db.rollback_tx(tx);
+        db.rollback_tx(&ctx, tx);
 
         Ok(())
     }
@@ -789,7 +789,7 @@ pub(crate) mod tests {
             (&st_sequences_schema()).into(),
         );
 
-        db.rollback_tx(tx);
+        db.rollback_tx(&ctx, tx);
 
         Ok(())
     }

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -506,17 +506,18 @@ impl StandaloneEnv {
             })?;
         let ctx = self.load_module_host_context(database.clone(), instance.id).await?;
         let stdb = &ctx.dbic.relational_db;
+        let cx = ExecutionContext::internal(stdb.address());
         let tx = stdb.begin_tx();
         match stdb.program_hash(&tx) {
             Err(e) => {
-                stdb.rollback_tx(tx);
+                stdb.rollback_tx(&cx, tx);
                 Err(e.into())
             }
 
             Ok(maybe_hash) => {
                 // Release tx due to locking semantics and acquire a control db
                 // lock instead.
-                stdb.commit_tx(&ExecutionContext::internal(stdb.address()), tx)?;
+                stdb.commit_tx(&cx, tx)?;
                 let lock = self.lock_database_instance_for_update(instance.id)?;
 
                 if let Some(hash) = maybe_hash {
@@ -558,18 +559,19 @@ impl StandaloneEnv {
 
         let ctx = self.load_module_host_context(database.clone(), instance.id).await?;
         let stdb = &ctx.dbic.relational_db;
+        let cx = ExecutionContext::internal(stdb.address());
         let tx = stdb.begin_tx();
 
         match stdb.program_hash(&tx) {
             Err(e) => {
-                stdb.rollback_tx(tx);
+                stdb.rollback_tx(&cx, tx);
                 Err(e.into())
             }
 
             Ok(maybe_hash) => {
                 // Release tx due to locking semantics and acquire a control db
                 // lock instead.
-                stdb.commit_tx(&ExecutionContext::internal(stdb.address()), tx)?;
+                stdb.commit_tx(&cx, tx)?;
                 let lock = self.lock_database_instance_for_update(instance.id)?;
 
                 match maybe_hash {


### PR DESCRIPTION
Closes #468.

# Description of Changes


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
