### PR TITLE
Fix wasm-opt for C# modules

### DIFF
--- a/crates/cli/src/tasks/mod.rs
+++ b/crates/cli/src/tasks/mod.rs
@@ -14,17 +14,24 @@ pub fn build(project_path: &Path, skip_clippy: bool, build_debug: bool) -> anyho
         ModuleLanguage::Csharp => build_csharp(project_path, build_debug),
     }?;
     if !build_debug {
+        eprintln!("Optimising module with wasm-opt...");
         let wasm_path_opt = wasm_path.with_extension("opt.wasm");
-        match cmd!("wasm-opt", "-O2", &wasm_path, "-o", &wasm_path_opt).run() {
+        match cmd!("wasm-opt", "-all", "-O2", &wasm_path, "-o", &wasm_path_opt).run() {
             Ok(_) => wasm_path = wasm_path_opt,
             // Non-critical error for backward compatibility with users who don't have wasm-opt.
-            Err(err) if err.kind() == std::io::ErrorKind::NotFound => {
-                eprintln!("Could not find wasm-opt to optimise the module.");
-                eprintln!(
-                    "For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases."
-                );
+            Err(err) => {
+                if err.kind() == std::io::ErrorKind::NotFound {
+                    eprintln!("Could not find wasm-opt to optimise the module.");
+                    eprintln!(
+                        "For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases."
+                    );
+                } else {
+                    // If wasm-opt exists but failed for some reason, print the error but continue with unoptimised module.
+                    // This is to reduce disruption in case we produce a module that wasm-opt can't handle like happened before.
+                    eprintln!("Failed to optimise module with wasm-opt: {err}");
+                }
+                eprintln!("Continuing with unoptimised module.");
             }
-            Err(err) => return Err(err.into()),
         }
     }
     Ok(wasm_path)


### PR DESCRIPTION
# Description of Changes

C# generates Wasm code that uses some of the newer performance features (notably, bulk memory ops) and wasm-opt rejects any such instructions by default (there were talks about changing this behavious upstream but that never went anywhere).

Activate all features so that wasm-opt works on anything produced by our compilers, as well as make any future failures a non-critical error just in case.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
