### PR TITLE
refactor(485): Label metrics with database address and reducer name

### DIFF
--- a/crates/core/src/database_instance_context.rs
+++ b/crates/core/src/database_instance_context.rs
@@ -84,15 +84,7 @@ impl DatabaseInstanceContext {
             address,
             logger: Arc::new(DatabaseLogger::open(log_path)),
             relational_db: Arc::new(
-                RelationalDB::open(
-                    db_path,
-                    message_log,
-                    odb,
-                    database_id,
-                    address,
-                    config.fsync != FsyncPolicy::Never,
-                )
-                .unwrap(),
+                RelationalDB::open(db_path, message_log, odb, address, config.fsync != FsyncPolicy::Never).unwrap(),
             ),
             publisher_address,
         })

--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -122,8 +122,8 @@ impl CommitLog {
                     // Increment rows inserted metric
                     let metric = rows_inserted.with_label_values(
                         &ctx.txn_type(),
-                        &ctx.database_id(),
-                        &ctx.reducer_id().unwrap_or_default(),
+                        &ctx.database(),
+                        ctx.reducer_name().unwrap_or_default(),
                         &table_id,
                     );
                     metric.inc();
@@ -133,8 +133,8 @@ impl CommitLog {
                     // Increment rows deleted metric
                     let metric = rows_deleted.with_label_values(
                         &ctx.txn_type(),
-                        &ctx.database_id(),
-                        &ctx.reducer_id().unwrap_or_default(),
+                        &ctx.database(),
+                        ctx.reducer_name().unwrap_or_default(),
                         &table_id,
                     );
                     metric.inc();

--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -1,7 +1,7 @@
-use crate::host::ReducerId;
 use crate::{execution_context::TransactionType, util::typed_prometheus::metrics_group};
 use once_cell::sync::Lazy;
 use prometheus::{Histogram, HistogramVec, IntCounterVec};
+use spacetimedb_lib::Address;
 
 metrics_group!(
     #[non_exhaustive]
@@ -53,17 +53,17 @@ metrics_group!(
 
         #[name = spacetime_num_rows_inserted_cumulative]
         #[help = "The cumulative number of rows inserted into a table"]
-        #[labels(txn_type: TransactionType, database_id: u64, reducer_id: ReducerId, table_id: u32)]
+        #[labels(txn_type: TransactionType, db: Address, reducer: str, table_id: u32)]
         pub rdb_num_rows_inserted: IntCounterVec,
 
         #[name = spacetime_num_rows_deleted_cumulative]
         #[help = "The cumulative number of rows deleted from a table"]
-        #[labels(txn_type: TransactionType, database_id: u64, reducer_id: ReducerId, table_id: u32)]
+        #[labels(txn_type: TransactionType, db: Address, reducer: str, table_id: u32)]
         pub rdb_num_rows_deleted: IntCounterVec,
 
         #[name = spacetime_num_rows_fetched_cumulative]
         #[help = "The cumulative number of rows fetched from a table"]
-        #[labels(txn_type: TransactionType, database_id: u64, reducer_id: ReducerId, table_id: u32)]
+        #[labels(txn_type: TransactionType, db: Address, reducer: str, table_id: u32)]
         pub rdb_num_rows_fetched: IntCounterVec,
     }
 );

--- a/crates/core/src/execution_context.rs
+++ b/crates/core/src/execution_context.rs
@@ -1,15 +1,15 @@
-use crate::host::ReducerId;
 use derive_more::Display;
+use spacetimedb_lib::Address;
 
 /// Represents the context under which a database runtime method is executed.
 /// In particular it provides details about the currently executing txn to runtime operations.
 /// More generally it acts as a container for information that database operations may require to function correctly.
 #[derive(Default)]
-pub struct ExecutionContext {
+pub struct ExecutionContext<'a> {
     // The database on which a transaction is being executed.
-    database_id: u64,
+    database: Address,
     // The reducer from which the current transaction originated.
-    reducer_id: Option<ReducerId>,
+    reducer: Option<&'a str>,
     // The type of transaction that is being executed.
     txn_type: TransactionType,
 }
@@ -31,45 +31,45 @@ impl Default for TransactionType {
     }
 }
 
-impl ExecutionContext {
+impl<'a> ExecutionContext<'a> {
     /// Returns an [ExecutionContext] for a reducer transaction.
-    pub fn reducer(database_id: u64, reducer_id: ReducerId) -> Self {
+    pub fn reducer(database: Address, name: &'a str) -> Self {
         Self {
-            database_id,
-            reducer_id: Some(reducer_id),
+            database,
+            reducer: Some(name),
             txn_type: TransactionType::Reducer,
         }
     }
 
     /// Returns an [ExecutionContext] for a sql or subscription transaction.
-    pub fn sql(database_id: u64) -> Self {
+    pub fn sql(database: Address) -> Self {
         Self {
-            database_id,
-            reducer_id: None,
+            database,
+            reducer: None,
             txn_type: TransactionType::Sql,
         }
     }
 
     /// Returns an [ExecutionContext] for an internal database operation.
-    pub fn internal(database_id: u64) -> Self {
+    pub fn internal(database: Address) -> Self {
         Self {
-            database_id,
-            reducer_id: None,
+            database,
+            reducer: None,
             txn_type: TransactionType::Internal,
         }
     }
 
-    /// Returns the id of the database on which we are operating.
+    /// Returns the address of the database on which we are operating.
     #[inline]
-    pub fn database_id(&self) -> u64 {
-        self.database_id
+    pub fn database(&self) -> Address {
+        self.database
     }
 
-    /// Returns the id of the reducer that is being executed.
+    /// Returns the name of the reducer that is being executed.
     /// Returns [None] if this is not a reducer context.
     #[inline]
-    pub fn reducer_id(&self) -> Option<ReducerId> {
-        self.reducer_id
+    pub fn reducer_name(&self) -> Option<&str> {
+        self.reducer
     }
 
     /// Returns the type of transaction that is being executed.

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -119,7 +119,7 @@ impl InstanceEnv {
     pub fn insert(&self, table_id: TableId, buffer: &[u8]) -> Result<ProductValue, NodesError> {
         let stdb = &*self.dbic.relational_db;
         let tx = &mut *self.get_tx()?;
-        let ctx = ExecutionContext::internal(stdb.id());
+        let ctx = ExecutionContext::internal(stdb.address());
         let ret = stdb
             .insert_bytes_as_row(tx, table_id, buffer)
             .inspect_err_(|e| match e {

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -67,7 +67,7 @@ impl DatabaseUpdate {
             });
         }
 
-        let ctx = ExecutionContext::internal(stdb.id());
+        let ctx = ExecutionContext::internal(stdb.address());
         let mut table_name_map: HashMap<TableId, _> = HashMap::new();
         let mut table_updates = Vec::new();
         for (table_id, table_row_operations) in map.drain() {

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -32,7 +32,7 @@ pub fn execute(
     info!(sql = sql_text);
     if let Some((database_instance_context, _)) = db_inst_ctx_controller.get(database_instance_id) {
         let db = &database_instance_context.relational_db;
-        let ctx = ExecutionContext::sql(db.id());
+        let ctx = ExecutionContext::sql(db.address());
         db.with_auto_commit(&ctx, |tx| {
             run(&database_instance_context.relational_db, tx, &sql_text, auth)
         })
@@ -64,7 +64,7 @@ pub fn execute_single_sql(
     ast: CrudExpr,
     auth: AuthCtx,
 ) -> Result<Vec<MemTable>, DBError> {
-    let ctx = ExecutionContext::sql(db.id());
+    let ctx = ExecutionContext::sql(db.address());
     let p = &mut DbProgram::new(&ctx, db, tx, auth);
     let q = Expr::Crud(Box::new(ast));
 
@@ -82,7 +82,7 @@ pub fn execute_sql(
     auth: AuthCtx,
 ) -> Result<Vec<MemTable>, DBError> {
     let total = ast.len();
-    let ctx = ExecutionContext::sql(db.id());
+    let ctx = ExecutionContext::sql(db.address());
     let p = &mut DbProgram::new(&ctx, db, tx, auth);
     let q = Expr::Block(ast.into_iter().map(|x| Expr::Crud(Box::new(x))).collect());
 

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -184,7 +184,7 @@ impl ModuleSubscriptionActor {
         //Split logic to properly handle `Error` + `Tx`
         let mut tx = self.relational_db.begin_tx();
         let result = self._add_subscription(sender, subscription, &mut tx).await;
-        let ctx = ExecutionContext::sql(self.relational_db.id());
+        let ctx = ExecutionContext::sql(self.relational_db.address());
         self.relational_db.finish_tx(&ctx, tx, result)
     }
 
@@ -232,7 +232,7 @@ impl ModuleSubscriptionActor {
         //Split logic to properly handle `Error` + `Tx`
         let mut tx = self.relational_db.begin_tx();
         let result = self._broadcast_commit_event(event, &mut tx).await;
-        let ctx = ExecutionContext::sql(self.relational_db.id());
+        let ctx = ExecutionContext::sql(self.relational_db.address());
         self.relational_db.finish_tx(&ctx, tx, result)
     }
 }

--- a/crates/core/src/util/typed_prometheus.rs
+++ b/crates/core/src/util/typed_prometheus.rs
@@ -121,7 +121,6 @@ impl_prometheusvalue_string!(
     Identity,
     Address,
     TransactionType,
-    crate::host::ReducerId,
     u8,
     u16,
     u32,

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -198,7 +198,7 @@ pub struct IndexSemiJoin<'a, Rhs: RelOps> {
     // A reference to the current transaction.
     pub tx: &'a MutTxId,
     // The execution context for the current transaction.
-    ctx: &'a ExecutionContext,
+    ctx: &'a ExecutionContext<'a>,
 }
 
 impl<'a, Rhs: RelOps> RelOps for IndexSemiJoin<'a, Rhs> {
@@ -238,7 +238,7 @@ impl<'a, Rhs: RelOps> RelOps for IndexSemiJoin<'a, Rhs> {
 /// A [ProgramVm] implementation that carry a [RelationalDB] for it
 /// query execution
 pub struct DbProgram<'db, 'tx> {
-    ctx: &'tx ExecutionContext,
+    ctx: &'tx ExecutionContext<'tx>,
     pub(crate) env: EnvDb,
     pub(crate) stats: HashMap<String, u64>,
     pub(crate) db: &'db RelationalDB,

--- a/crates/lib/src/address.rs
+++ b/crates/lib/src/address.rs
@@ -23,6 +23,12 @@ pub struct Address {
 
 impl_st!([] Address, _ts => AlgebraicType::product([("__address_bytes", AlgebraicType::bytes())]));
 
+impl Default for Address {
+    fn default() -> Self {
+        Self::ZERO
+    }
+}
+
 impl fmt::Display for Address {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         f.pad(&self.to_hex())

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -516,7 +516,7 @@ impl StandaloneEnv {
             Ok(maybe_hash) => {
                 // Release tx due to locking semantics and acquire a control db
                 // lock instead.
-                stdb.commit_tx(&ExecutionContext::internal(stdb.id()), tx)?;
+                stdb.commit_tx(&ExecutionContext::internal(stdb.address()), tx)?;
                 let lock = self.lock_database_instance_for_update(instance.id)?;
 
                 if let Some(hash) = maybe_hash {
@@ -569,7 +569,7 @@ impl StandaloneEnv {
             Ok(maybe_hash) => {
                 // Release tx due to locking semantics and acquire a control db
                 // lock instead.
-                stdb.commit_tx(&ExecutionContext::internal(stdb.id()), tx)?;
+                stdb.commit_tx(&ExecutionContext::internal(stdb.address()), tx)?;
                 let lock = self.lock_database_instance_for_update(instance.id)?;
 
                 match maybe_hash {


### PR DESCRIPTION
Fixes #485.

Also label metrics with reducer name instead of internal reducer id.


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
