### PR TITLE
perf(469): Add metric for delayed transaction execution

### DIFF
--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -51,6 +51,11 @@ metrics_group!(
         #[labels(table_id: u32)]
         pub rdb_delete_by_rel_time: HistogramVec,
 
+        #[name = spacetime_scheduled_reducer_delay_ns]
+        #[help = "The amount of time (nanoseconds) a reducer has been delayed past its scheduled execution time"]
+        #[labels(db: Address, reducer: str)]
+        pub scheduled_reducer_delay_ns: HistogramVec,
+
         #[name = spacetime_num_rows_inserted_cumulative]
         #[help = "The cumulative number of rows inserted into a table"]
         #[labels(txn_type: TransactionType, db: Address, reducer: str, table_id: u32)]


### PR DESCRIPTION
Closes #469.

This metric tracks the amount of time a reducer spends in the wait queue,
past its scheduled execution time.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
