### PR TITLE
Create multi-column indexes defined in modules

### DIFF
--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -284,6 +284,14 @@ impl TableDef {
     }
 }
 
+/// The magic table id zero, for use in [`IndexDef`]s.
+///
+/// The actual table id is usually not yet known when constructing an
+/// [`IndexDef`]. [`AUTO_TABLE_ID`] can be used instead, which the storage
+/// engine will replace with the actual table id upon creation of the table
+/// respectively index.
+pub const AUTO_TABLE_ID: TableId = TableId(0);
+
 /// This type is just the [TableSchema] without the autoinc fields
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableDef {
@@ -345,7 +353,7 @@ impl TableDef {
                 }
                 indexes.push(IndexDef::new(
                     name,
-                    TableId(0), // Will be ignored
+                    AUTO_TABLE_ID,
                     ColId(col_id as u32),
                     col_attr.is_unique(),
                 ))
@@ -357,7 +365,7 @@ impl TableDef {
         let multi_col_indexes = table.indexes.iter().filter_map(|index| {
             if let [a, b, rest @ ..] = &index.col_ids[..] {
                 Some(IndexDef {
-                    table_id: TableId(0), // Will be ignored
+                    table_id: AUTO_TABLE_ID,
                     cols: NonEmpty {
                         head: ColId::from(*a),
                         tail: iter::once(ColId::from(*b))
@@ -665,4 +673,102 @@ pub trait MutProgrammable: MutTxDatastore {
     /// token `fence` must be verified to be greater than in any previous
     /// invocations of this method.
     fn set_program_hash(&self, tx: &mut Self::MutTxId, fence: Self::FencingToken, hash: Hash) -> Result<()>;
+}
+
+#[cfg(test)]
+mod tests {
+    use nonempty::NonEmpty;
+    use spacetimedb_lib::{
+        auth::{StAccess, StTableType},
+        ColumnIndexAttribute,
+    };
+    use spacetimedb_primitives::ColId;
+    use spacetimedb_sats::{AlgebraicType, AlgebraicTypeRef, ProductType, ProductTypeElement, Typespace};
+
+    use super::{ColumnDef, IndexDef, TableDef, AUTO_TABLE_ID};
+
+    #[test]
+    fn test_tabledef_from_lib_tabledef() -> anyhow::Result<()> {
+        let lib_table_def = spacetimedb_lib::TableDef {
+            name: "Person".into(),
+            data: AlgebraicTypeRef(0),
+            column_attrs: vec![ColumnIndexAttribute::IDENTITY, ColumnIndexAttribute::UNSET],
+            indexes: vec![
+                spacetimedb_lib::IndexDef {
+                    name: "id_and_name".into(),
+                    ty: spacetimedb_lib::IndexType::BTree,
+                    col_ids: vec![0, 1],
+                },
+                spacetimedb_lib::IndexDef {
+                    name: "just_name".into(),
+                    ty: spacetimedb_lib::IndexType::BTree,
+                    col_ids: vec![1],
+                },
+            ],
+            table_type: StTableType::User,
+            table_access: StAccess::Public,
+        };
+        let row_type = ProductType::new(vec![
+            ProductTypeElement {
+                name: Some("id".into()),
+                algebraic_type: AlgebraicType::U32,
+            },
+            ProductTypeElement {
+                name: Some("name".into()),
+                algebraic_type: AlgebraicType::String,
+            },
+        ]);
+
+        let mut datastore_schema =
+            TableDef::from_lib_tabledef(Typespace::new(vec![row_type.into()]).with_type(&lib_table_def))?;
+        let mut expected_schema = TableDef {
+            table_name: "Person".into(),
+            columns: vec![
+                ColumnDef {
+                    col_name: "id".into(),
+                    col_type: AlgebraicType::U32,
+                    is_autoinc: true,
+                },
+                ColumnDef {
+                    col_name: "name".into(),
+                    col_type: AlgebraicType::String,
+                    is_autoinc: false,
+                },
+            ],
+            indexes: vec![
+                IndexDef {
+                    table_id: AUTO_TABLE_ID,
+                    cols: NonEmpty::new(ColId(0)),
+                    name: "Person_id_unique".into(),
+                    is_unique: true,
+                },
+                IndexDef {
+                    table_id: AUTO_TABLE_ID,
+                    cols: NonEmpty {
+                        head: ColId(0),
+                        tail: vec![ColId(1)],
+                    },
+                    name: "id_and_name".into(),
+                    is_unique: false,
+                },
+                IndexDef {
+                    table_id: AUTO_TABLE_ID,
+                    cols: NonEmpty::new(ColId(1)),
+                    name: "just_name".into(),
+                    is_unique: false,
+                },
+            ],
+            table_type: StTableType::User,
+            table_access: StAccess::Public,
+        };
+
+        for schema in [&mut datastore_schema, &mut expected_schema] {
+            schema.columns.sort_by(|a, b| a.col_name.cmp(&b.col_name));
+            schema.indexes.sort_by(|a, b| a.name.cmp(&b.name));
+        }
+
+        assert_eq!(expected_schema, datastore_schema);
+
+        Ok(())
+    }
 }

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -1,3 +1,4 @@
+use core::fmt;
 use std::borrow::Cow;
 use std::collections::{BTreeMap, HashMap};
 
@@ -21,6 +22,11 @@ pub enum UpdateDatabaseError {
     Database(#[from] DBError),
 }
 
+// TODO: Post #267, it will no longer be possible to modify indexes on existing
+// tables. Below must thus be simplified to reject _any_ change to existing
+// tables, and only accept updates which introduce new tables (beware of
+// ordering when comparing definition types!).
+
 pub fn update_database(
     stdb: &RelationalDB,
     tx: MutTxId,
@@ -32,29 +38,38 @@ pub fn update_database(
     let ctx = ExecutionContext::internal(stdb.address());
     let (tx, res) = stdb.with_auto_rollback::<_, _, anyhow::Error>(&ctx, tx, |tx| {
         let existing_tables = stdb.get_all_tables(tx)?;
-        let updates = crate::db::update::schema_updates(existing_tables, proposed_tables, system_logger)?;
+        match schema_updates(existing_tables, proposed_tables)? {
+            SchemaUpdates::Updates {
+                new_tables,
+                indexes_to_drop,
+                indexes_to_create,
+            } => {
+                for (name, schema) in new_tables {
+                    system_logger.info(&format!("Creating table `{}`", name));
+                    stdb.create_table(tx, schema)
+                        .with_context(|| format!("failed to create table {}", name))?;
+                }
 
-        if updates.tainted_tables.is_empty() {
-            for (name, schema) in updates.new_tables {
-                system_logger.info(&format!("creating table `{}`", name));
-                stdb.create_table(tx, schema)
-                    .with_context(|| format!("failed to create table {}", name))?;
+                for index_id in indexes_to_drop {
+                    system_logger.info(&format!("Dropping index with id {}", index_id.0));
+                    stdb.drop_index(tx, index_id)?;
+                }
+
+                for index_def in indexes_to_create {
+                    system_logger.info(&format!("Creating index `{}`", index_def.name));
+                    stdb.create_index(tx, index_def)?;
+                }
             }
 
-            for index_id in updates.indexes_to_drop {
-                system_logger.info(&format!("dropping index with id {}", index_id.0));
-                stdb.drop_index(tx, index_id)?;
+            SchemaUpdates::Tainted(tainted) => {
+                system_logger.error("Module update rejected due to schema mismatch");
+                let mut tables = Vec::with_capacity(tainted.len());
+                for t in tainted {
+                    system_logger.warn(&format!("{}: {}", t.table_name, t.reason));
+                    tables.push(t.table_name);
+                }
+                return Ok(Err(UpdateDatabaseError::IncompatibleSchema { tables }));
             }
-
-            for index_def in updates.indexes_to_create {
-                system_logger.info(&format!("creating index `{}`", index_def.name));
-                stdb.create_index(tx, index_def)?;
-            }
-        } else {
-            system_logger.error("module update rejected due to schema mismatch");
-            return Ok(Err(UpdateDatabaseError::IncompatibleSchema {
-                tables: updates.tainted_tables,
-            }));
         }
 
         // Update the module hash. Morally, this should be done _after_ calling
@@ -66,113 +81,431 @@ pub fn update_database(
     Ok(stdb.rollback_on_err(&ctx, tx, res).map(|(tx, ())| tx))
 }
 
+/// The reasons a table can become [`Tainted`].
+#[derive(Debug, Eq, PartialEq)]
+pub enum TaintReason {
+    /// The (row) schema changed, and we don't know how to go from A to B.
+    IncompatibleSchema,
+    /// The table is no longer present in the new schema.
+    Orphaned,
+}
+
+impl fmt::Display for TaintReason {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str(match self {
+            Self::IncompatibleSchema => "incompatible schema",
+            Self::Orphaned => "orphaned",
+        })
+    }
+}
+
+/// A table with name `table_name` marked tainted for reason [`TaintReason`].
+#[derive(Debug, PartialEq)]
+pub struct Tainted {
+    pub table_name: String,
+    pub reason: TaintReason,
+}
+
+#[derive(Debug)]
+pub enum SchemaUpdates {
+    /// The schema cannot be updated due to conflicts.
+    Tainted(Vec<Tainted>),
+    /// The schema can be updates.
+    Updates {
+        /// Tables to create.
+        new_tables: HashMap<String, TableDef>,
+        /// Indexes to drop.
+        ///
+        /// Should be processed _before_ `indexes_to_create`, as we might be
+        /// updating (i.e. drop then create with different parameters).
+        indexes_to_drop: Vec<IndexId>,
+        /// Indexes to create.
+        ///
+        /// Should be processed _after_ `indexes_to_drop`.
+        indexes_to_create: Vec<IndexDef>,
+    },
+}
+
 /// Compute the diff between the current and proposed schema.
-fn schema_updates(
+///
+/// Compares all `existing_tables` loaded from the [`RelationalDB`] against the
+/// proposed [`TableDef`]s. The proposed schemas are assumed to represent the
+/// full schema information extracted from an STDB module.
+///
+/// Tables in the latter whose schema differs from the former are returned as
+/// [`SchemaUpdates::Tainted`]. Tables also become tainted if they are
+/// no longer present in the proposed schema (they are said to be "orphaned"),
+/// although this restriction may be lifted in the future.
+///
+/// If no tables become tainted, the database may safely be updated using the
+/// information in [`SchemaUpdates::Updates`].
+pub fn schema_updates(
     existing_tables: Vec<Cow<'_, TableSchema>>,
     proposed_tables: Vec<TableDef>,
-    system_logger: &SystemLogger,
 ) -> anyhow::Result<SchemaUpdates> {
-    // Until we know how to migrate schemas, we only accept `TableDef`s for
-    // existing tables which are equal sans their indexes.
-    fn tables_equiv(a: &TableDef, b: &TableDef) -> bool {
-        let TableDef {
-            table_name,
-            columns,
-            indexes: _,
-            table_type,
-            table_access,
-        } = a;
-        table_name == &b.table_name
-            && table_type == &b.table_type
-            && table_access == &b.table_access
-            && columns == &b.columns
-    }
-
     let mut new_tables = HashMap::new();
     let mut tainted_tables = Vec::new();
     let mut indexes_to_create = Vec::new();
     let mut indexes_to_drop = Vec::new();
 
-    let mut known_tables: BTreeMap<_, _> = existing_tables
+    let mut known_tables: BTreeMap<String, Cow<TableSchema>> = existing_tables
         .into_iter()
         .map(|schema| (schema.table_name.clone(), schema))
         .collect();
 
     for proposed_schema_def in proposed_tables {
-        let table_name = &proposed_schema_def.table_name;
-        let Some(known_schema) = known_tables.remove(table_name) else {
-            new_tables.insert(table_name.to_owned(), proposed_schema_def);
-            continue;
-        };
-        let table_id = known_schema.table_id;
-        let known_schema_def = TableDef::from(&*known_schema);
+        let proposed_table_name = &proposed_schema_def.table_name;
+        if let Some(known_schema) = known_tables.remove(proposed_table_name) {
+            let table_id = known_schema.table_id;
+            let known_schema_def = TableDef::from(known_schema.as_ref());
+            // If the schemas differ the update should be rejected.
+            if !equiv(&known_schema_def, &proposed_schema_def) {
+                tainted_tables.push(Tainted {
+                    table_name: proposed_table_name.to_owned(),
+                    reason: TaintReason::IncompatibleSchema,
+                });
+            } else {
+                // The schema is unchanged, but maybe the indexes are.
+                let mut known_indexes = known_schema
+                    .indexes
+                    .iter()
+                    .map(|idx| (idx.index_name.clone(), idx))
+                    .collect::<BTreeMap<_, _>>();
 
-        // If the schemas differ acc. to `tables_equiv`, the update should be rejected.
-        if !tables_equiv(&known_schema_def, &proposed_schema_def) {
-            system_logger.warn(&format!("stored and proposed schema of `{table_name}` differ"));
-            tainted_tables.push(table_name.to_owned());
-            continue;
-        }
+                for mut index_def in proposed_schema_def.indexes {
+                    // This is zero in the proposed schema, as the table id
+                    // is not known at proposal time.
+                    index_def.table_id = table_id;
 
-        // The schema is unchanged, but maybe the indexes are.
-        let mut known_indexes = known_schema
-            .indexes
-            .iter()
-            .map(|idx| (&idx.index_name, idx))
-            .collect::<BTreeMap<_, _>>();
-
-        for mut index_def in proposed_schema_def.indexes {
-            // This is zero in the proposed schema, as the table id
-            // is not known at proposal time.
-            index_def.table_id = table_id;
-
-            match known_indexes.remove(&index_def.name) {
-                None => indexes_to_create.push(index_def),
-                Some(known_index) => {
-                    let known_id = known_index.index_id;
-                    let known_index_def = IndexDef::from(known_index.clone());
-                    if known_index_def != index_def {
-                        indexes_to_drop.push(known_id);
-                        indexes_to_create.push(index_def);
+                    match known_indexes.remove(&index_def.name) {
+                        None => indexes_to_create.push(index_def),
+                        Some(known_index) => {
+                            let known_id = known_index.index_id;
+                            let known_index_def = IndexDef::from(known_index.clone());
+                            if known_index_def != index_def {
+                                indexes_to_drop.push(known_id);
+                                indexes_to_create.push(index_def);
+                            }
+                        }
                     }
                 }
-            }
-        }
 
-        // Indexes not in the proposed schema shall be dropped.
-        for index in known_indexes.into_values() {
-            indexes_to_drop.push(index.index_id);
+                // Indexes not in the proposed schema shall be dropped.
+                for index in known_indexes.into_values() {
+                    indexes_to_drop.push(index.index_id);
+                }
+            }
+        } else {
+            new_tables.insert(proposed_table_name.to_owned(), proposed_schema_def);
         }
     }
     // We may at some point decide to drop orphaned tables automatically,
     // but for now it's an incompatible schema change
     for orphan in known_tables.into_keys() {
         if !orphan.starts_with("st_") {
-            system_logger.warn(format!("Orphaned table: {}", orphan).as_str());
-            tainted_tables.push(orphan);
+            tainted_tables.push(Tainted {
+                table_name: orphan,
+                reason: TaintReason::Orphaned,
+            });
         }
     }
 
-    Ok(SchemaUpdates {
-        new_tables,
-        tainted_tables,
-        indexes_to_drop,
-        indexes_to_create,
-    })
+    let res = if tainted_tables.is_empty() {
+        SchemaUpdates::Updates {
+            new_tables,
+            indexes_to_drop,
+            indexes_to_create,
+        }
+    } else {
+        SchemaUpdates::Tainted(tainted_tables)
+    };
+
+    Ok(res)
 }
 
-struct SchemaUpdates {
-    /// Tables to create.
-    new_tables: HashMap<String, TableDef>,
-    /// Names of tables with incompatible schema updates.
-    tainted_tables: Vec<String>,
-    /// Indexes to drop.
-    ///
-    /// Should be processed _before_ `indexes_to_create`, as we might be
-    /// updating (i.e. drop then create with different parameters).
-    indexes_to_drop: Vec<IndexId>,
-    /// Indexes to create.
-    ///
-    /// Should be processed _after_ `indexes_to_drop`.
-    indexes_to_create: Vec<IndexDef>,
+/// Two [`datastore::traits::TableDef`]s are equivalent if, and only if, all
+/// their fields _except_ for `indexes` are equal.
+///
+/// This allows to reject schema changes in [`schema_updates`] but allow
+/// changes to only the indexes. We don't have support for full schema
+/// migrations yet, but creating and dropping indexes is trivial.
+fn equiv(a: &TableDef, b: &TableDef) -> bool {
+    let TableDef {
+        table_name,
+        columns,
+        indexes: _,
+        table_type,
+        table_access,
+    } = a;
+    table_name == &b.table_name
+        && table_type == &b.table_type
+        && table_access == &b.table_access
+        && columns == &b.columns
+}
+
+#[cfg(test)]
+mod tests {
+    use anyhow::bail;
+    use nonempty::NonEmpty;
+    use spacetimedb_lib::auth::{StAccess, StTableType};
+    use spacetimedb_primitives::{ColId, TableId};
+    use spacetimedb_sats::AlgebraicType;
+
+    use crate::db::datastore::traits::{ColumnDef, ColumnSchema, IndexSchema, AUTO_TABLE_ID};
+
+    use super::*;
+
+    #[test]
+    fn test_updates_new_table() -> anyhow::Result<()> {
+        let current = vec![Cow::Owned(TableSchema {
+            table_id: TableId(42),
+            table_name: "Person".into(),
+            columns: vec![ColumnSchema {
+                table_id: TableId(42),
+                col_id: ColId(0),
+                col_name: "name".into(),
+                col_type: AlgebraicType::String,
+                is_autoinc: false,
+            }],
+            indexes: vec![],
+            constraints: vec![],
+            table_type: StTableType::User,
+            table_access: StAccess::Public,
+        })];
+        let proposed = vec![
+            TableDef {
+                table_name: "Person".into(),
+                columns: vec![ColumnDef {
+                    col_name: "name".into(),
+                    col_type: AlgebraicType::String,
+                    is_autoinc: false,
+                }],
+                indexes: vec![],
+                table_type: StTableType::User,
+                table_access: StAccess::Public,
+            },
+            TableDef {
+                table_name: "Pet".into(),
+                columns: vec![ColumnDef {
+                    col_name: "furry".into(),
+                    col_type: AlgebraicType::Bool,
+                    is_autoinc: false,
+                }],
+                indexes: vec![],
+                table_type: StTableType::User,
+                table_access: StAccess::Public,
+            },
+        ];
+
+        match schema_updates(current, proposed.clone())? {
+            SchemaUpdates::Tainted(tainted) => bail!("unexpectedly tainted: {tainted:#?}"),
+            SchemaUpdates::Updates {
+                new_tables,
+                indexes_to_drop,
+                indexes_to_create,
+            } => {
+                assert!(indexes_to_drop.is_empty());
+                assert!(indexes_to_create.is_empty());
+                assert_eq!(new_tables.len(), 1);
+                assert_eq!(new_tables.get("Pet"), proposed.last());
+
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn test_updates_alter_indexes() -> anyhow::Result<()> {
+        let current = vec![Cow::Owned(TableSchema {
+            table_id: TableId(42),
+            table_name: "Person".into(),
+            columns: vec![
+                ColumnSchema {
+                    table_id: TableId(42),
+                    col_id: ColId(0),
+                    col_name: "id".into(),
+                    col_type: AlgebraicType::U32,
+                    is_autoinc: true,
+                },
+                ColumnSchema {
+                    table_id: TableId(42),
+                    col_id: ColId(1),
+                    col_name: "name".into(),
+                    col_type: AlgebraicType::String,
+                    is_autoinc: false,
+                },
+            ],
+            indexes: vec![IndexSchema {
+                index_id: IndexId(0),
+                table_id: TableId(42),
+                index_name: "Person_id_unique".into(),
+                is_unique: true,
+                cols: NonEmpty::new(ColId(0)),
+            }],
+            // Constraints are possibly not empty when loaded from an actual
+            // database, but not inspected by `schema_updates`.
+            constraints: vec![],
+            table_type: StTableType::User,
+            table_access: StAccess::Public,
+        })];
+        let mut proposed = vec![TableDef {
+            table_name: "Person".into(),
+            columns: vec![
+                ColumnDef {
+                    col_name: "id".into(),
+                    col_type: AlgebraicType::U32,
+                    is_autoinc: true,
+                },
+                ColumnDef {
+                    col_name: "name".into(),
+                    col_type: AlgebraicType::String,
+                    is_autoinc: false,
+                },
+            ],
+            indexes: vec![IndexDef {
+                table_id: AUTO_TABLE_ID,
+                cols: NonEmpty {
+                    head: ColId(0),
+                    tail: vec![ColId(1)],
+                },
+                name: "Person_id_and_name".into(),
+                is_unique: false,
+            }],
+            table_type: StTableType::User,
+            table_access: StAccess::Public,
+        }];
+
+        match schema_updates(current, proposed.clone())? {
+            SchemaUpdates::Tainted(tainted) => bail!("unexpectedly tainted: {tainted:#?}"),
+            SchemaUpdates::Updates {
+                new_tables,
+                indexes_to_drop,
+                indexes_to_create,
+            } => {
+                assert!(new_tables.is_empty());
+                assert_eq!(indexes_to_drop.len(), 1);
+                assert_eq!(indexes_to_create.len(), 1);
+
+                assert_eq!(indexes_to_drop[0].0, 0);
+                assert_eq!(
+                    indexes_to_create.last(),
+                    proposed[0]
+                        .indexes
+                        .pop()
+                        .map(|mut idx| {
+                            idx.table_id = TableId(42);
+                            idx
+                        })
+                        .as_ref()
+                );
+
+                Ok(())
+            }
+        }
+    }
+
+    #[test]
+    fn test_updates_schema_mismatch() -> anyhow::Result<()> {
+        let current = vec![Cow::Owned(TableSchema {
+            table_id: TableId(42),
+            table_name: "Person".into(),
+            columns: vec![ColumnSchema {
+                table_id: TableId(42),
+                col_id: ColId(0),
+                col_name: "name".into(),
+                col_type: AlgebraicType::String,
+                is_autoinc: false,
+            }],
+            indexes: vec![],
+            constraints: vec![],
+            table_type: StTableType::User,
+            table_access: StAccess::Public,
+        })];
+        let proposed = vec![TableDef {
+            table_name: "Person".into(),
+            columns: vec![
+                ColumnDef {
+                    col_name: "id".into(),
+                    col_type: AlgebraicType::U32,
+                    is_autoinc: true,
+                },
+                ColumnDef {
+                    col_name: "name".into(),
+                    col_type: AlgebraicType::String,
+                    is_autoinc: false,
+                },
+            ],
+            indexes: vec![],
+            table_type: StTableType::User,
+            table_access: StAccess::Public,
+        }];
+
+        match schema_updates(current, proposed)? {
+            SchemaUpdates::Tainted(tainted) => {
+                assert_eq!(tainted.len(), 1);
+                assert_eq!(
+                    tainted[0],
+                    Tainted {
+                        table_name: "Person".into(),
+                        reason: TaintReason::IncompatibleSchema,
+                    }
+                );
+
+                Ok(())
+            }
+
+            up @ SchemaUpdates::Updates { .. } => {
+                bail!("unexpectedly not tainted: {up:#?}");
+            }
+        }
+    }
+
+    #[test]
+    fn test_updates_orphaned_table() -> anyhow::Result<()> {
+        let current = vec![Cow::Owned(TableSchema {
+            table_id: TableId(42),
+            table_name: "Person".into(),
+            columns: vec![ColumnSchema {
+                table_id: TableId(42),
+                col_id: ColId(0),
+                col_name: "name".into(),
+                col_type: AlgebraicType::String,
+                is_autoinc: false,
+            }],
+            indexes: vec![],
+            constraints: vec![],
+            table_type: StTableType::User,
+            table_access: StAccess::Public,
+        })];
+        let proposed = vec![TableDef {
+            table_name: "Pet".into(),
+            columns: vec![ColumnDef {
+                col_name: "furry".into(),
+                col_type: AlgebraicType::Bool,
+                is_autoinc: false,
+            }],
+            indexes: vec![],
+            table_type: StTableType::User,
+            table_access: StAccess::Public,
+        }];
+
+        match schema_updates(current, proposed)? {
+            SchemaUpdates::Tainted(tainted) => {
+                assert_eq!(tainted.len(), 1);
+                assert_eq!(
+                    tainted[0],
+                    Tainted {
+                        table_name: "Person".into(),
+                        reason: TaintReason::Orphaned,
+                    }
+                );
+
+                Ok(())
+            }
+
+            up @ SchemaUpdates::Updates { .. } => {
+                bail!("unexpectedly not tainted: {up:#?}")
+            }
+        }
+    }
 }


### PR DESCRIPTION
# Description of Changes

Reroll of #368 on top of #416

Mainly changes the database update logic to consider multi-column indexes defined in the module (previously, we would only create single-column indexes). Even though multi-column indexes are not fully landed yet, _some_ queries can utilize them.

Also adds tests.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

1.5
