### PR TITLE
Refactor commit encoding / decoding

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3103,6 +3103,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "proptest-derive"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9cf16337405ca084e9c78985114633b6827711d22b9e6ef6c6c0d665eb3f0b6e"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
+
+[[package]]
 name = "prost"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4277,6 +4288,8 @@ dependencies = [
  "paste",
  "pin-project-lite",
  "prometheus",
+ "proptest",
+ "proptest-derive",
  "prost",
  "prost-build",
  "rand",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -122,6 +122,7 @@ postgres-types = "0.2.5"
 proc-macro2 = "1.0"
 prometheus = "0.13.0"
 proptest = "1.2.0"
+proptest-derive = "0.4.0"
 prost = "0.10"
 prost-build = { version = "0.10" }
 quick-junit = { version = "0.3.2" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -101,6 +101,8 @@ default = ["odb_sled"]
 [dev-dependencies]
 rusqlite.workspace = true
 criterion.workspace = true
+proptest.workspace = true
+proptest-derive.workspace = true
 rand.workspace = true
 
 [build-dependencies]

--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -167,7 +167,7 @@ impl CommitLog {
                 }
             }
 
-            let mut bytes = Vec::new();
+            let mut bytes = Vec::with_capacity(unwritten_commit.encoded_len());
             unwritten_commit.encode(&mut bytes);
 
             unwritten_commit.parent_commit_hash = Some(hash_bytes(&bytes));

--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -279,11 +279,8 @@ impl Iterator for IterSegment {
 
     fn next(&mut self) -> Option<Self::Item> {
         let next = self.inner.next()?;
-        Some(next.map(|bytes| {
-            // It seems very improbable that `decode` is infallible...
-            let (commit, _) = Commit::decode(bytes);
-            commit
-        }))
+        let io = |e| io::Error::new(io::ErrorKind::InvalidData, e);
+        Some(next.and_then(|bytes| Commit::decode(&mut bytes.as_slice()).map_err(io)))
     }
 }
 

--- a/crates/core/src/db/messages/commit.rs
+++ b/crates/core/src/db/messages/commit.rs
@@ -40,13 +40,17 @@ pub struct Commit {
 mod arbitrary {
     use super::*;
 
+    // [`Hash`] is defined in `lib`, so we can't have an [`Arbitrary`] impl for
+    // it just yet due to orphan rules.
     pub fn parent_commit_hash() -> impl Strategy<Value = Option<Hash>> {
         any::<Option<[u8; 32]>>().prop_map(|maybe_hash| maybe_hash.map(|data| Hash { data }))
     }
 
+    // Custom strategy to apply an upper bound on the number of [`Transaction`]s
+    // generated.
+    //
+    // We only ever commit a single transaction in practice.
     pub fn transactions() -> impl Strategy<Value = Vec<Arc<Transaction>>> {
-        // We only ever commit a single transaction, but for the sake of test
-        // coverage let's generate like two handful.
         prop::collection::vec(any::<Arc<Transaction>>(), 1..8)
     }
 }

--- a/crates/core/src/db/messages/commit.rs
+++ b/crates/core/src/db/messages/commit.rs
@@ -111,9 +111,7 @@ impl Commit {
     }
 
     pub fn encoded_len(&self) -> usize {
-        let mut count = 0;
-
-        count += 1; // tag for option
+        let mut count = 1; // tag for option
         if let Some(hash) = self.parent_commit_hash {
             count += hash.data.len();
         }

--- a/crates/core/src/db/messages/commit.rs
+++ b/crates/core/src/db/messages/commit.rs
@@ -152,15 +152,27 @@ mod tests {
     use super::*;
 
     proptest! {
-        // Generating arbitrary commits is quite slow, so limit this test to
-        // just a few cases.
+        // Generating arbitrary commits is quite slow, so limit to just a few
+        // cases.
+        //
+        // Note that this config applies to all `#[test]`s within the enclosing
+        // `proptest!`.
         #![proptest_config(ProptestConfig::with_cases(64))]
+
+
         #[test]
         fn prop_commit_encoding_roundtrip(commit in any::<Commit>()) {
             let mut buf = Vec::new();
             commit.encode(&mut buf);
             let decoded = Commit::decode(&mut buf.as_slice()).unwrap();
             prop_assert_eq!(commit, decoded)
+        }
+
+        #[test]
+        fn prop_encoded_len_is_encoded_len(commit in any::<Commit>()) {
+            let mut buf = Vec::new();
+            commit.encode(&mut buf);
+            prop_assert_eq!(buf.len(), commit.encoded_len())
         }
     }
 }

--- a/crates/core/src/db/messages/transaction.rs
+++ b/crates/core/src/db/messages/transaction.rs
@@ -4,6 +4,11 @@ use std::fmt;
 
 use super::write::Write;
 
+#[cfg(test)]
+use proptest::prelude::*;
+#[cfg(test)]
+use proptest_derive::Arbitrary;
+
 /// A transaction, consisting of one or more [`Write`]s.
 ///
 /// Encoding:
@@ -11,9 +16,21 @@ use super::write::Write;
 /// ```text
 /// <n(4)>[<write_0(6-38)...<write_n(6-38)>]
 /// ```
-#[derive(Debug, Clone, Default)]
+#[derive(Debug, Clone, Default, PartialEq)]
+#[cfg_attr(test, derive(Arbitrary))]
 pub struct Transaction {
+    #[cfg_attr(test, proptest(strategy = "arbitrary::writes()"))]
     pub writes: Vec<Write>,
+}
+
+#[cfg(test)]
+mod arbitrary {
+    use super::*;
+
+    pub fn writes() -> impl Strategy<Value = Vec<Write>> {
+        // Limit to 64 for performance reasons.
+        prop::collection::vec(any::<Write>(), 1..64)
+    }
 }
 
 /// Error context for [`Transaction::decode`].

--- a/crates/core/src/db/messages/transaction.rs
+++ b/crates/core/src/db/messages/transaction.rs
@@ -1,38 +1,52 @@
+use anyhow::Context as _;
+use spacetimedb_sats::buffer::{BufReader, BufWriter};
+use std::fmt;
+
 use super::write::Write;
 
-// aka Record
-// Must be atomically, durably written to disk
-#[derive(Debug, Clone)]
+/// A transaction, consisting of one or more [`Write`]s.
+///
+/// Encoding:
+///
+/// ```text
+/// <n(4)>[<write_0(6-38)...<write_n(6-38)>]
+/// ```
+#[derive(Debug, Clone, Default)]
 pub struct Transaction {
     pub writes: Vec<Write>,
 }
 
+/// Error context for [`Transaction::decode`].
+enum Context {
+    Len,
+    Write(u32),
+}
+
+impl fmt::Display for Context {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("Failed to decode `Transaction`: ")?;
+        match self {
+            Self::Len => f.write_str("number of writes"),
+            Self::Write(n) => f.write_str(&format!("write {n}")),
+        }
+    }
+}
+
 // tx: [<write>...(dedupped and sorted_numerically)]*
 impl Transaction {
-    pub fn decode(bytes: impl AsRef<[u8]>) -> (Self, usize) {
-        let bytes = &mut bytes.as_ref();
-        if bytes.is_empty() {
-            return (Transaction { writes: Vec::new() }, 0);
+    pub fn decode<'a>(reader: &mut impl BufReader<'a>) -> anyhow::Result<Self> {
+        if reader.remaining() == 0 {
+            return Ok(Self::default());
         }
 
-        let mut bytes_read = 0;
-
-        let mut dst = [0u8; 4];
-        dst.copy_from_slice(&bytes[bytes_read..bytes_read + 4]);
-        let writes_count = u32::from_le_bytes(dst);
-        bytes_read += 4;
-
-        let mut writes: Vec<Write> = Vec::with_capacity(writes_count as usize);
-
-        let mut count = 0;
-        while bytes_read < bytes.len() && count < writes_count {
-            let (write, read) = Write::decode(&bytes[bytes_read..]);
-            bytes_read += read;
+        let n = reader.get_u32().context(Context::Len)?;
+        let mut writes = Vec::with_capacity(n as usize);
+        for i in 0..n {
+            let write = Write::decode(reader).with_context(|| Context::Write(i))?;
             writes.push(write);
-            count += 1;
         }
 
-        (Transaction { writes }, bytes_read)
+        Ok(Self { writes })
     }
 
     pub fn encoded_len(&self) -> usize {
@@ -43,11 +57,10 @@ impl Transaction {
         count
     }
 
-    pub fn encode(&self, bytes: &mut Vec<u8>) {
-        bytes.extend((self.writes.len() as u32).to_le_bytes());
-
+    pub fn encode(&self, writer: &mut impl BufWriter) {
+        writer.put_u32(self.writes.len() as u32);
         for write in &self.writes {
-            write.encode(bytes);
+            write.encode(writer);
         }
     }
 }

--- a/crates/core/src/db/messages/transaction.rs
+++ b/crates/core/src/db/messages/transaction.rs
@@ -27,8 +27,8 @@ pub struct Transaction {
 mod arbitrary {
     use super::*;
 
+    // Limit to 64 for performance reasons.
     pub fn writes() -> impl Strategy<Value = Vec<Write>> {
-        // Limit to 64 for performance reasons.
         prop::collection::vec(any::<Write>(), 1..64)
     }
 }

--- a/crates/core/src/db/messages/write.rs
+++ b/crates/core/src/db/messages/write.rs
@@ -29,7 +29,12 @@ pub struct Write {
 mod arbitrary {
     use super::*;
 
+    // [`DataKey`] is defined in `lib`, so we can't have an [`Arbitrary`] impl
+    // for it just yet due to orphan rules.
     pub fn datakey() -> impl Strategy<Value = DataKey> {
+        // Create [`DataKey::Inline`] and [`DataKey::Hash`] with the same
+        // probability. [`DataKey::from_data`] will take care of choosing the
+        // variant based in the input length.
         prop_oneof![
             prop::collection::vec(any::<u8>(), 0..31).prop_map(DataKey::from_data),
             prop::collection::vec(any::<u8>(), 31..255).prop_map(DataKey::from_data)


### PR DESCRIPTION
# Description of Changes

Use `sats::{BufReader, BufWriter}` for decoding / encoding of `Commit`
and associated types. This makes `decode` fallible (which is quite
desirable, instead of panicking).

As the `DecodeError` from sats is fairly sparse, also add some context
about where exactly decoding failed.

Also add documentation and property test.


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

1