### PR TITLE
Add `delete_by_{non-unique column}` method to `#[spacetimedb(table)]` macro

### DIFF
--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -469,30 +469,35 @@ pub mod query {
         }
     }
 
-    /// Deletes the row of `Table` where the column at `COL_IDX` matches `val`,
+    /// Deletes the rows of `Table` where the column at `COL_IDX` matches `val`,
     /// as defined by decoding to an `AlgebraicValue`
     /// according to the column's schema and then `Ord for AlgebraicValue`.
     ///
-    /// Returns whether any rows were deleted.
+    /// Returns the number of rows were deleted.
     ///
     /// **NOTE:** Do not use directly.
     /// This is exposed as `delete_by_{$field_name}` on types with `#[spacetimedb(table)]`.
     #[doc(hidden)]
-    pub fn delete_by_field<Table: TableType, T: UniqueValue, const COL_IDX: u8>(val: &T) -> bool {
-        let result = delete_by_col_eq(Table::table_id(), COL_IDX, val);
-        match result {
-            Err(_) => {
-                // TODO: Returning here was supposed to signify an error,
-                //       but it can also return `Err(_)` when there is nothing to delete.
-                //spacetimedb::println!("Internal server error on equatable type: {}", #primary_key_tuple_type_str);
-                false
-            }
-            // Should never be `> 1`.
-            Ok(count) => {
-                debug_assert!(count <= 1);
-                count > 0
-            }
-        }
+    pub fn delete_by_field<Table: TableType, T: FilterableValue, const COL_IDX: u8>(val: &T) -> u32 {
+        // TODO: Returning here was supposed to signify an error,
+        //       but it can also return `Err(_)` when there is nothing to delete.
+        delete_by_col_eq(Table::table_id(), COL_IDX, val).unwrap_or(0)
+    }
+
+    /// Deletes the row of `Table` where the column at `COL_IDX` matches `val`,
+    /// as defined by decoding to an `AlgebraicValue`
+    /// according to the column's schema and then `Ord for AlgebraicValue`.
+    ///
+    /// Returns true if and only if a row was deleted.
+    ///
+    /// **NOTE:** Do not use directly.
+    /// This is exposed as `delete_by_{$field_name}` on types with `#[spacetimedb(table)]`
+    /// where `$field_name` is annotated `#[unique]` or `#[primarykey]`.
+    #[doc(hidden)]
+    pub fn delete_by_unique_field<Table: TableType, T: UniqueValue, const COL_IDX: u8>(val: &T) -> bool {
+        let count = delete_by_field::<Table, T, COL_IDX>(val);
+        debug_assert!(count <= 1);
+        count > 0
     }
 
     /// Updates the row of `Table`, where the column at `COL_IDX` matches `old`, to be `new` instead.


### PR DESCRIPTION
Macro generation of `filter_by_column` on non-unique columns is currently broken; this will stay in draft until that's fixed, as it depends on the same code path.

# Description of Changes

- Refactor `bindings::query::delete_by_field` to require `FilterableValue` and return `u32` count of deleted rows.
- Add `bindings::query::delete_by_unique_field` with the previous behavior of `delete_by_field`, i.e. requiring `UniqueValue` and returning `bool` with true = deleted. This is implemented in terms of `delete_by_field`.
- Macro-generated unique filter funcs call `delete_by_unique_field` rather than `delete_by_field`.
- The macro now generates non-unique delete functions alongside the existing non-unique filter functions for non-unique fields with primitive types.

Note that this PR does not include any host-side changes; the diff is localized to the `bindings` and `bindings-macro` crates.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

This is an additive-only change to the module API, and leaves the module ABI untouched.

# Expected complexity level and risk

2 - a reviewer should be prepared to verify that the host-side implementation of `delete_by_col_eq` correctly handles the existence of multiple matching rows.

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
