### PR TITLE
Add OptIn serialization attribute for C# generated types

### DIFF
--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -589,7 +589,11 @@ fn autogen_csharp_product_table_common(
     writeln!(output, "{{").unwrap();
     {
         indent_scope!(output);
-        writeln!(output, "[Newtonsoft.Json.JsonObject(Newtonsoft.Json.MemberSerialization.OptIn)]").unwrap();
+        writeln!(
+            output,
+            "[Newtonsoft.Json.JsonObject(Newtonsoft.Json.MemberSerialization.OptIn)]"
+        )
+        .unwrap();
         writeln!(output, "public partial class {name} : IDatabaseTable").unwrap();
         writeln!(output, "{{").unwrap();
         {

--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -589,6 +589,7 @@ fn autogen_csharp_product_table_common(
     writeln!(output, "{{").unwrap();
     {
         indent_scope!(output);
+        writeln!(output, "[Newtonsoft.Json.JsonObject(Newtonsoft.Json.MemberSerialization.OptIn)]").unwrap();
         writeln!(output, "public partial class {name} : IDatabaseTable").unwrap();
         writeln!(output, "{{").unwrap();
         {


### PR DESCRIPTION
# Description of Changes

Generate the OptIn Json.NET attribute (https://www.newtonsoft.com/json/help/html/JsonObjectAttributeOptIn.htm) for autogenerated C# types.
This fixes a bug where user generated properties in partial classes get serialized to json as well. This caused a deserialization issue on the server, when a user generated property was the last one, resulting in the following error:
![image](https://github.com/clockworklabs/SpacetimeDB/assets/8077248/58af0b7a-0729-4f65-9477-1a01dd25239b)


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*
1

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
