### PR TITLE
lib: Provide `Arbitrary` impls for `Hash` and `DataKey`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4388,6 +4388,7 @@ dependencies = [
  "insta",
  "itertools 0.11.0",
  "proptest",
+ "proptest-derive",
  "rand",
  "serde",
  "serde_json",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -99,6 +99,8 @@ odb_sled = []
 default = ["odb_sled"]
 
 [dev-dependencies]
+spacetimedb-lib = { path = "../lib", features = ["proptest"] }
+
 rusqlite.workspace = true
 criterion.workspace = true
 proptest.workspace = true

--- a/crates/core/src/db/messages/commit.rs
+++ b/crates/core/src/db/messages/commit.rs
@@ -22,7 +22,6 @@ use proptest_derive::Arbitrary;
 pub struct Commit {
     /// The [`Hash`] over the encoded bytes of the previous commit, or `None` if
     /// it is the very first commit.
-    #[cfg_attr(test, proptest(strategy = "arbitrary::parent_commit_hash()"))]
     pub parent_commit_hash: Option<Hash>,
     /// Counter of all commits in a log.
     pub commit_offset: u64,
@@ -39,13 +38,6 @@ pub struct Commit {
 #[cfg(test)]
 mod arbitrary {
     use super::*;
-
-    // [`Hash`] is defined in `lib`, so we can't have an [`Arbitrary`] impl for
-    // it just yet due to orphan rules.
-    pub fn parent_commit_hash() -> impl Strategy<Value = Option<Hash>> {
-        any::<Option<[u8; 32]>>().prop_map(|maybe_hash| maybe_hash.map(|data| Hash { data }))
-    }
-
     // Custom strategy to apply an upper bound on the number of [`Transaction`]s
     // generated.
     //

--- a/crates/core/src/db/messages/write.rs
+++ b/crates/core/src/db/messages/write.rs
@@ -5,8 +5,6 @@ pub use spacetimedb_lib::DataKey;
 use spacetimedb_sats::buffer::{BufReader, BufWriter, DecodeError};
 
 #[cfg(test)]
-use proptest::prelude::*;
-#[cfg(test)]
 use proptest_derive::Arbitrary;
 
 /// A single write operation within a [`super::transaction::Transaction`].
@@ -21,25 +19,7 @@ use proptest_derive::Arbitrary;
 pub struct Write {
     pub operation: Operation,
     pub set_id: u32, // aka table id
-    #[cfg_attr(test, proptest(strategy = "arbitrary::datakey()"))]
     pub data_key: DataKey,
-}
-
-#[cfg(test)]
-mod arbitrary {
-    use super::*;
-
-    // [`DataKey`] is defined in `lib`, so we can't have an [`Arbitrary`] impl
-    // for it just yet due to orphan rules.
-    pub fn datakey() -> impl Strategy<Value = DataKey> {
-        // Create [`DataKey::Inline`] and [`DataKey::Hash`] with the same
-        // probability. [`DataKey::from_data`] will take care of choosing the
-        // variant based in the input length.
-        prop_oneof![
-            prop::collection::vec(any::<u8>(), 0..31).prop_map(DataKey::from_data),
-            prop::collection::vec(any::<u8>(), 31..255).prop_map(DataKey::from_data)
-        ]
-    }
 }
 
 /// The operation of a [`Write`], either insert or delete.

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -17,6 +17,8 @@ required-features = ["serde"]
 default = ["serde"]
 serde = ["dep:serde", "spacetimedb-sats/serde", "dep:serde_with", "chrono/serde"]
 cli = ["clap"]
+# Allows using `Arbitrary` impls defined in this crate.
+proptest = ["dep:proptest", "dep:proptest-derive"]
 
 [dependencies]
 spacetimedb-bindings-macro = { path = "../bindings-macro", version = "0.7.2" }
@@ -37,9 +39,16 @@ sha3.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
+# For the 'proptest' feature.
+proptest = { workspace = true, optional = true }
+proptest-derive = { workspace = true, optional = true }
+
 [dev-dependencies]
 rand.workspace = true
 bytes.workspace = true
 serde_json.workspace = true
 insta.workspace = true
+
+# Also as dev-dependencies for use in _this_ crate's tests.
 proptest.workspace = true
+proptest-derive.workspace = true

--- a/crates/lib/src/hash.rs
+++ b/crates/lib/src/hash.rs
@@ -7,6 +7,7 @@ use crate::hex::HexString;
 pub const HASH_SIZE: usize = 32;
 
 #[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Copy, Hash)]
+#[cfg_attr(any(test, feature = "proptest"), derive(proptest_derive::Arbitrary))]
 pub struct Hash {
     pub data: [u8; HASH_SIZE],
 }


### PR DESCRIPTION
# Description of Changes

Allows to remove custom strategies for the commit log types (in core), and may become useful for future property testing efforts.


**This is stacked on top of #495. Do not merge until after #495 is landed.**


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

1