### PR TITLE
refactor(520): Change histogram units from nanos to fractional secs

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -2080,13 +2080,13 @@ impl traits::MutTx for Locking {
             .with_label_values(&ctx.txn_type(), &ctx.database(), ctx.reducer_name().unwrap_or(""))
             .inc();
         DB_METRICS
-            .rdb_txn_cpu_time_ns
+            .rdb_txn_cpu_time_sec
             .with_label_values(&ctx.txn_type(), &ctx.database(), ctx.reducer_name().unwrap_or(""))
-            .observe(cpu_time.as_nanos() as f64);
+            .observe(cpu_time.as_secs_f64());
         DB_METRICS
-            .rdb_txn_elapsed_time_ns
+            .rdb_txn_elapsed_time_sec
             .with_label_values(&ctx.txn_type(), &ctx.database(), ctx.reducer_name().unwrap_or(""))
-            .observe(elapsed_time.as_nanos() as f64);
+            .observe(elapsed_time.as_secs_f64());
         tx.lock.rollback();
     }
 
@@ -2100,13 +2100,13 @@ impl traits::MutTx for Locking {
             .with_label_values(&ctx.txn_type(), &ctx.database(), ctx.reducer_name().unwrap_or(""))
             .inc();
         DB_METRICS
-            .rdb_txn_cpu_time_ns
+            .rdb_txn_cpu_time_sec
             .with_label_values(&ctx.txn_type(), &ctx.database(), ctx.reducer_name().unwrap_or(""))
-            .observe(cpu_time.as_nanos() as f64);
+            .observe(cpu_time.as_secs_f64());
         DB_METRICS
-            .rdb_txn_elapsed_time_ns
+            .rdb_txn_elapsed_time_sec
             .with_label_values(&ctx.txn_type(), &ctx.database(), ctx.reducer_name().unwrap_or(""))
-            .observe(elapsed_time.as_nanos() as f64);
+            .observe(elapsed_time.as_secs_f64());
         tx.lock.commit()
     }
 

--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -51,10 +51,10 @@ metrics_group!(
         #[labels(table_id: u32)]
         pub rdb_delete_by_rel_time: HistogramVec,
 
-        #[name = spacetime_scheduled_reducer_delay_ns]
-        #[help = "The amount of time (nanoseconds) a reducer has been delayed past its scheduled execution time"]
+        #[name = spacetime_scheduled_reducer_delay_sec]
+        #[help = "The amount of time (in seconds) a reducer has been delayed past its scheduled execution time"]
         #[labels(db: Address, reducer: str)]
-        pub scheduled_reducer_delay_ns: HistogramVec,
+        pub scheduled_reducer_delay_sec: HistogramVec,
 
         #[name = spacetime_num_rows_inserted_cumulative]
         #[help = "The cumulative number of rows inserted into a table"]
@@ -91,20 +91,20 @@ metrics_group!(
         #[labels(txn_type: TransactionType, db: Address, reducer: str)]
         pub rdb_num_txns_rolledback: IntCounterVec,
 
-        #[name = spacetime_txn_elapsed_time_ns]
-        #[help = "The total elapsed (wall) time of a transaction (nanoseconds)"]
+        #[name = spacetime_txn_elapsed_time_sec]
+        #[help = "The total elapsed (wall) time of a transaction (in seconds)"]
         #[labels(txn_type: TransactionType, db: Address, reducer: str)]
-        pub rdb_txn_elapsed_time_ns: HistogramVec,
+        pub rdb_txn_elapsed_time_sec: HistogramVec,
 
-        #[name = spacetime_txn_cpu_time_ns]
-        #[help = "The time spent executing a transaction (nanoseconds), excluding time spent waiting to acquire database locks"]
+        #[name = spacetime_txn_cpu_time_sec]
+        #[help = "The time spent executing a transaction (in seconds), excluding time spent waiting to acquire database locks"]
         #[labels(txn_type: TransactionType, db: Address, reducer: str)]
-        pub rdb_txn_cpu_time_ns: HistogramVec,
+        pub rdb_txn_cpu_time_sec: HistogramVec,
 
-        #[name = spacetime_wasm_abi_call_duration_ns]
-        #[help = "The total duration of a spacetime wasm abi call (nanoseconds); includes row serialization and copying into wasm memory"]
+        #[name = spacetime_wasm_abi_call_duration_sec]
+        #[help = "The total duration of a spacetime wasm abi call (in seconds); includes row serialization and copying into wasm memory"]
         #[labels(txn_type: TransactionType, db: Address, reducer: str, call: AbiCall)]
-        pub wasm_abi_call_duration_ns: HistogramVec,
+        pub wasm_abi_call_duration_sec: HistogramVec,
     }
 );
 

--- a/crates/core/src/host/scheduler.rs
+++ b/crates/core/src/host/scheduler.rs
@@ -273,9 +273,9 @@ impl SchedulerActor {
         // Note, we are only tracking the time a reducer spends delayed in the queue.
         // This does not account for any time the executing thread spends blocked by the os.
         DB_METRICS
-            .scheduled_reducer_delay_ns
+            .scheduled_reducer_delay_sec
             .with_label_values(&module_host.info().address, &scheduled.reducer)
-            .observe(delay.as_nanos() as f64);
+            .observe(delay.as_secs_f64());
         let db = self.db.clone();
         tokio::spawn(async move {
             let info = module_host.info();


### PR DESCRIPTION
Fixes #520.

The default prometheus histogram buckets are meant to be interpreted as f64 seconds. Because previously we were using nanosecond units, all observations were being placed in the last (+inf) bucket. This change was made to avoid modifying the default bucket specification.

# Description of Changes


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
