### PR TITLE
refactor(531): Label transaction count metric with boolean flag

### DIFF
--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -86,15 +86,10 @@ metrics_group!(
         #[labels(txn_type: TransactionType, db: Address, reducer: str, table_id: u32)]
         pub rdb_num_index_seeks: IntCounterVec,
 
-        #[name = spacetime_num_txns_committed_cumulative]
-        #[help = "The cumulative number of committed transactions"]
-        #[labels(txn_type: TransactionType, db: Address, reducer: str)]
-        pub rdb_num_txns_committed: IntCounterVec,
-
-        #[name = spacetime_num_txns_rolledback_cumulative]
-        #[help = "The cumulative number of rolled back transactions"]
-        #[labels(txn_type: TransactionType, db: Address, reducer: str)]
-        pub rdb_num_txns_rolledback: IntCounterVec,
+        #[name = spacetime_num_txns_cumulative]
+        #[help = "The cumulative number of transactions, including both commits and rollbacks"]
+        #[labels(txn_type: TransactionType, db: Address, reducer: str, committed: bool)]
+        pub rdb_num_txns: IntCounterVec,
 
         #[name = spacetime_txn_elapsed_time_sec]
         #[help = "The total elapsed (wall) time of a transaction (in seconds)"]

--- a/crates/core/src/util/typed_prometheus.rs
+++ b/crates/core/src/util/typed_prometheus.rs
@@ -122,6 +122,7 @@ impl_prometheusvalue_string!(
     Address,
     TransactionType,
     AbiCall,
+    bool,
     u8,
     u16,
     u32,


### PR DESCRIPTION
Fixes #531.

Instead of having two distinct metrics for commits and rollbacks, this patch replaces them with a single metric plus a boolean label representing whether the transaction was committed or rolled back.

# Description of Changes


# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
