### PR TITLE
Add integration test for the query macro

### DIFF
--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -115,7 +115,7 @@ impl From<usize> for ReducerId {
 }
 
 #[derive(thiserror::Error, Debug)]
-#[error("invalid arguments for reducer {reducer}")]
+#[error("invalid arguments for reducer {reducer}: {err}")]
 pub struct InvalidReducerArguments {
     #[source]
     err: anyhow::Error,

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -102,7 +102,7 @@ fn test_call_query_macro() {
             let json: Value = serde_json::from_str(lines[11]).unwrap();
             assert_eq!(
                 json["message"],
-                Value::String("Row count filtered by multi-column condition: 201".to_string())
+                Value::String("Row count filtered by multi-column condition: 199".to_string())
             );
         },
     );

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -69,3 +69,42 @@ fn test_calling_a_reducer_with_private_table() {
         },
     );
 }
+
+#[test]
+#[serial]
+fn test_call_query_macro() {
+    CompiledModule::compile("rust-wasm-test", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            let json = r#"{"call": {"fn": "test_query", "args": []}}"#.to_string();
+            module.send(json).await.unwrap();
+
+            let lines = module.read_log(Some(13)).await;
+            let lines: Vec<&str> = lines.trim().split('\n').collect();
+            dbg!(&lines);
+
+            assert_eq!(lines.len(), 13);
+
+            let json: Value = serde_json::from_str(lines[6]).unwrap();
+            assert_eq!(
+                json["message"],
+                Value::String("Row count before delete: 1000".to_string())
+            );
+            let json: Value = serde_json::from_str(lines[8]).unwrap();
+            assert_eq!(
+                json["message"],
+                Value::String("Row count after delete: 995".to_string())
+            );
+            let json: Value = serde_json::from_str(lines[9]).unwrap();
+            assert_eq!(
+                json["message"],
+                Value::String("Row count filtered by condition: 995".to_string())
+            );
+            let json: Value = serde_json::from_str(lines[11]).unwrap();
+            assert_eq!(
+                json["message"],
+                Value::String("Row count filtered by multi-column condition: 201".to_string())
+            );
+        },
+    );
+}

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -76,7 +76,13 @@ fn test_call_query_macro() {
     CompiledModule::compile("rust-wasm-test", CompilationMode::Debug).with_module_async(
         DEFAULT_CONFIG,
         |module| async move {
-            let json = r#"{"call": {"fn": "test_query", "args": []}}"#.to_string();
+            let json = r#"
+{"call": {"fn": "test", "args":[            
+    {"x":0, "y":2, "z":"Macro"},
+    {"foo":"Foo"},
+    {"Foo": {} }
+]}}"#
+                .to_string();
             module.send(json).await.unwrap();
 
             let lines = module.read_log(Some(13)).await;

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -81,7 +81,6 @@ fn test_call_query_macro() {
 
             let lines = module.read_log(Some(13)).await;
             let lines: Vec<&str> = lines.trim().split('\n').collect();
-            dbg!(&lines);
 
             assert_eq!(lines.len(), 13);
 

--- a/modules/rust-wasm-test/src/lib.rs
+++ b/modules/rust-wasm-test/src/lib.rs
@@ -127,7 +127,7 @@ pub fn test(ctx: ReducerContext, arg: TestAlias, arg2: TestB, arg3: TestC) -> an
         });
     }
 
-    let multi_row_count = query!(|row: Point| row.x >= 0 && row.x <= 200).count();
+    let multi_row_count = query!(|row: Point| row.x >= 0 && row.y <= 200).count();
 
     log::info!("Row count filtered by multi-column condition: {:?}", multi_row_count);
 

--- a/modules/rust-wasm-test/src/lib.rs
+++ b/modules/rust-wasm-test/src/lib.rs
@@ -1,6 +1,7 @@
 #![allow(clippy::disallowed_names)]
 use spacetimedb::{
-    delete_by_col_eq, query, spacetimedb, AlgebraicValue, Deserialize, ReducerContext, SpacetimeType, Timestamp,
+    delete_by_col_eq, query, spacetimedb, AlgebraicValue, Deserialize, ReducerContext, SpacetimeType, TableType,
+    Timestamp,
 };
 use spacetimedb_lib::bsatn;
 
@@ -84,8 +85,8 @@ pub fn test(ctx: ReducerContext, arg: TestAlias, arg2: TestB, arg3: TestC) -> an
         TestC::Foo => log::info!("Foo"),
         TestC::Bar => log::info!("Bar"),
     }
-
-    for i in 0..10 {
+    let table_id = TestA::table_id();
+    for i in 0..1000 {
         TestA::insert(TestA {
             x: i + arg.x,
             y: i + arg.y,
@@ -98,7 +99,7 @@ pub fn test(ctx: ReducerContext, arg: TestAlias, arg2: TestB, arg3: TestC) -> an
     log::info!("Row count before delete: {:?}", row_count);
 
     for row in 5..10 {
-        delete_by_col_eq(1.into(), 0, &AlgebraicValue::U32(row))?;
+        delete_by_col_eq(table_id, 0, &AlgebraicValue::U32(row))?;
     }
 
     let row_count = TestA::iter().count();
@@ -117,8 +118,35 @@ pub fn test(ctx: ReducerContext, arg: TestAlias, arg2: TestB, arg3: TestC) -> an
 
     log::info!("Row count filtered by condition: {:?}", other_row_count);
 
+    log::info!("MultiColumn");
+
+    for i in 0i64..1000 {
+        Point::insert(Point {
+            x: i + arg.x as i64,
+            y: i + arg.y as i64,
+        });
+    }
+
+    let multi_row_count = query!(|row: Point| row.x >= 0 && row.x <= 200).count();
+
+    log::info!("Row count filtered by multi-column condition: {:?}", multi_row_count);
+
     log::info!("END");
     Ok(())
+}
+
+#[spacetimedb(reducer)]
+pub fn test_query(ctx: ReducerContext) -> anyhow::Result<()> {
+    test(
+        ctx,
+        TestAlias {
+            x: 0,
+            y: 2,
+            z: "Macro".into(),
+        },
+        TestB { foo: "Foo".into() },
+        TestC::Bar,
+    )
 }
 
 #[spacetimedb(reducer)]

--- a/modules/rust-wasm-test/src/lib.rs
+++ b/modules/rust-wasm-test/src/lib.rs
@@ -136,20 +136,6 @@ pub fn test(ctx: ReducerContext, arg: TestAlias, arg2: TestB, arg3: TestC) -> an
 }
 
 #[spacetimedb(reducer)]
-pub fn test_query(ctx: ReducerContext) -> anyhow::Result<()> {
-    test(
-        ctx,
-        TestAlias {
-            x: 0,
-            y: 2,
-            z: "Macro".into(),
-        },
-        TestB { foo: "Foo".into() },
-        TestC::Bar,
-    )
-}
-
-#[spacetimedb(reducer)]
 pub fn add_player(name: String) -> Result<(), String> {
     TestE::insert(TestE { id: 0, name })?;
     Ok(())


### PR DESCRIPTION
# Description of Changes

The integration test for `rust-wasm-test` contains the use of the `query!` macro but was not called anywhere.

This later will be used to verify the use of `multi-column` indexes on this macro when https://github.com/clockworklabs/SpacetimeDB/pull/267 lands.

# API and ABI

 - [ ] This is a breaking change to the module ABI
 - [ ] This is a breaking change to the module API
 - [ ] This is a breaking change to the ClientAPI
 - [ ] This is a breaking change to the SDK API

*If the API is breaking, please state below what will break*

# Expected complexity level and risk

1
