### PR TITLE
`InstanceEnv::delete_by_col_eq`: return `u32` instead of `NonZeroU32`

### DIFF
--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -1,7 +1,6 @@
 use nonempty::NonEmpty;
 use parking_lot::{Mutex, MutexGuard};
 use spacetimedb_lib::{bsatn, ProductValue};
-use std::num::NonZeroU32;
 use std::ops::DerefMut;
 use std::sync::Arc;
 
@@ -152,7 +151,7 @@ impl InstanceEnv {
         table_id: TableId,
         col_id: ColId,
         value: &[u8],
-    ) -> Result<NonZeroU32, NodesError> {
+    ) -> Result<u32, NodesError> {
         let stdb = &*self.dbic.relational_db;
         let tx = &mut *self.get_tx()?;
 
@@ -165,9 +164,8 @@ impl InstanceEnv {
             .map(|x| RowId(*x.id()))
             .collect::<Vec<_>>();
 
-        // Delete them and count how many we deleted and error if none.
-        let count = stdb.delete(tx, table_id, rows_to_delete);
-        NonZeroU32::new(count).ok_or(NodesError::ColumnValueNotFound)
+        // Delete them and count how many we deleted.
+        Ok(stdb.delete(tx, table_id, rows_to_delete))
     }
 
     /// Deletes all rows in the table identified by `table_id`

--- a/crates/core/src/host/wasmer/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmer/wasm_instance_env.rs
@@ -481,7 +481,7 @@ impl WasmInstanceEnv {
                         .data()
                         .instance_env
                         .delete_by_col_eq(&ctx, table_id.into(), col_id.into(), &value)?;
-                Ok(count.get())
+                Ok(count)
             },
         )
     }


### PR DESCRIPTION
# Description of Changes

Fixes an issue that BitCraft were having (spamming INFO messages).

# API and ABI

No breakage as the ABI of u32 and the non-zero variant are the same.

# Expected complexity level and risk

1 - trivial simple diff with low risk.