### PR TITLE
Disable latest docker tag

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -27,7 +27,8 @@ jobs:
             type=ref,event=branch,prefix=branch-
             type=sha,prefix=commit-
             type=ref,event=tag
-            type=raw,value=latest,enable=false
+          flavor: |
+            latest=false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Cache Docker layers
@@ -79,7 +80,8 @@ jobs:
             type=ref,event=branch,prefix=branch-
             type=sha,prefix=commit-
             type=ref,event=tag
-            type=raw,value=latest,enable=false
+          flavor: |
+            latest=false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Cache Docker layers


### PR DESCRIPTION
# Description of Changes

This PR disables tagging with `latest` tag

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
