### PR TITLE
delete_by_col_eq: optimize with smallvec for 1 row case

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4342,6 +4342,7 @@ dependencies = [
  "sha1",
  "slab",
  "sled",
+ "smallvec",
  "spacetimedb-client-api-messages",
  "spacetimedb-lib",
  "spacetimedb-primitives",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -60,6 +60,7 @@ rayon-core.workspace = true
 regex.workspace = true
 rustc-demangle.workspace = true
 rustc-hash.workspace = true
+smallvec.workspace = true
 scopeguard.workspace = true
 sendgrid.workspace = true
 serde.workspace = true

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -1,5 +1,6 @@
 use nonempty::NonEmpty;
 use parking_lot::{Mutex, MutexGuard};
+use smallvec::SmallVec;
 use spacetimedb_lib::{bsatn, ProductValue};
 use std::ops::DerefMut;
 use std::sync::Arc;
@@ -162,7 +163,9 @@ impl InstanceEnv {
         let rows_to_delete = stdb
             .iter_by_col_eq(ctx, tx, table_id, col_id, eq_value)?
             .map(|x| RowId(*x.id()))
-            .collect::<Vec<_>>();
+            // `delete_by_field` only cares about 1 element,
+            // so optimize for that.
+            .collect::<SmallVec<[_; 1]>>();
 
         // Delete them and count how many we deleted.
         Ok(stdb.delete(tx, table_id, rows_to_delete))


### PR DESCRIPTION
# Description of Changes

I noticed that `delete_by_col_eq` is mostly called by `delete_by_field` which has `debug_assert!(count <= 1);`.
This suggests that we do an unnecessary allocation in most cases.
We can get rid of that by using a `SmallVec<[RowId; 1]>` so that in the `count = 1` case, we don't need to allocate.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1
