### PR TITLE
core: Move replay + error correction logic to commit log

### DIFF
--- a/crates/core/src/database_instance_context.rs
+++ b/crates/core/src/database_instance_context.rs
@@ -97,12 +97,24 @@ impl DatabaseInstanceContext {
 
     /// The number of bytes on disk occupied by the [MessageLog].
     pub fn message_log_size_on_disk(&self) -> Result<u64, DBError> {
-        self.relational_db.commit_log().message_log_size_on_disk()
+        let size = self
+            .relational_db
+            .commit_log()
+            .map(|commit_log| commit_log.message_log_size_on_disk())
+            .transpose()?;
+
+        Ok(size.unwrap_or_default())
     }
 
     /// The number of bytes on disk occupied by the [ObjectDB].
     pub fn object_db_size_on_disk(&self) -> Result<u64, DBError> {
-        self.relational_db.commit_log().object_db_size_on_disk()
+        let size = self
+            .relational_db
+            .commit_log()
+            .map(|commit_log| commit_log.object_db_size_on_disk())
+            .transpose()?;
+
+        Ok(size.unwrap_or_default())
     }
 
     /// The size of the log file.

--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -13,7 +13,7 @@ use crate::{
             write::{Operation, Write},
         },
     },
-    error::DBError,
+    error::{DBError, LogReplayError},
     execution_context::ExecutionContext,
 };
 use anyhow::Context;
@@ -22,27 +22,239 @@ use spacetimedb_sats::DataKey;
 use std::io;
 use std::sync::{Arc, Mutex, MutexGuard};
 
+/// A read-only handle to the commit log.
 #[derive(Clone)]
 pub struct CommitLog {
-    mlog: Option<Arc<Mutex<MessageLog>>>,
+    mlog: Arc<Mutex<MessageLog>>,
     odb: Arc<Mutex<Box<dyn ObjectDB + Send>>>,
-    unwritten_commit: Arc<Mutex<Commit>>,
-    fsync: bool,
 }
 
 impl CommitLog {
-    pub fn new(
-        mlog: Option<Arc<Mutex<MessageLog>>>,
-        odb: Arc<Mutex<Box<dyn ObjectDB + Send>>>,
-        unwritten_commit: Commit,
-        fsync: bool,
-    ) -> Self {
-        Self {
-            mlog,
-            odb,
+    pub const fn new(mlog: Arc<Mutex<MessageLog>>, odb: Arc<Mutex<Box<dyn ObjectDB + Send>>>) -> Self {
+        Self { mlog, odb }
+    }
+
+    pub fn max_commit_offset(&self) -> u64 {
+        self.mlog.lock().unwrap().open_segment_max_offset
+    }
+
+    /// Obtain a [`CommitLogMut`], which permits write access.
+    ///
+    /// Like [`Self::replay`], this traverses the log from the start and ensures
+    /// the resulting [`CommitLogMut`] can safely be written to.
+    ///
+    /// Equivalent to `self.replay(|_, _| Ok(()))`.
+    pub fn to_mut(&self) -> Result<CommitLogMut, DBError> {
+        self.replay(|_, _| Ok(()))
+    }
+
+    /// Traverse the log from the start, calling `F` with each [`Commit`]
+    /// encountered.
+    ///
+    /// The traversal performs some consistency checks, and _may_ perform error
+    /// correction on the persistent log before returning.
+    ///
+    /// **NOTE**: Error correction modifies the on-disk state and may thus
+    /// interfere with concurrent readers. External synchronization is required
+    /// to avoid this.
+    ///
+    /// Currently, this method is the only way to ensure the log is consistent,
+    /// and can thus safely be written to via the resulting [`CommitLogMut`].
+    pub fn replay<F>(&self, mut f: F) -> Result<CommitLogMut, DBError>
+    where
+        // TODO(kim): `&dyn ObjectDB` should suffice
+        F: FnMut(Commit, Arc<Mutex<Box<dyn ObjectDB + Send>>>) -> Result<(), DBError>,
+    {
+        let unwritten_commit = {
+            let mut mlog = self.mlog.lock().unwrap();
+            let total_segments = mlog.total_segments();
+            let segments = mlog.segments();
+            let mut iter = Replay {
+                tx_offset: 0,
+                last_commit_offset: None,
+                last_hash: None,
+
+                segments,
+                segment_offset: 0,
+                current_segment: None,
+            };
+
+            for commit in &mut iter {
+                match commit {
+                    Ok(commit) => f(commit, self.odb.clone())?,
+                    Err(ReplayError::Other { source }) => return Err(source.into()),
+
+                    // We expect that partial writes can occur at the end of a
+                    // segment. Trimming the log is, however, only safe if we're
+                    // at the end of the _log_.
+                    Err(ReplayError::OutOfOrder {
+                        segment_offset,
+                        last_commit_offset,
+                        decoded_commit_offset,
+                        expected,
+                    }) if segment_offset < total_segments - 1 => {
+                        log::warn!("Out-of-order commit {}, expected {}", decoded_commit_offset, expected);
+                        return Err(LogReplayError::TrailingSegments {
+                            segment_offset,
+                            total_segments,
+                            commit_offset: last_commit_offset,
+                            source: io::Error::new(io::ErrorKind::Other, "Out-of-order commit"),
+                        }
+                        .into());
+                    }
+                    Err(ReplayError::CorruptedData {
+                        segment_offset,
+                        last_commit_offset: commit_offset,
+                        source,
+                    }) if segment_offset < total_segments - 1 => {
+                        log::warn!("Corrupt commit after offset {}", commit_offset);
+                        return Err(LogReplayError::TrailingSegments {
+                            segment_offset,
+                            total_segments,
+                            commit_offset,
+                            source,
+                        }
+                        .into());
+                    }
+
+                    // We are near the end of the log, so trim it to the known-
+                    // good prefix.
+                    Err(
+                        ReplayError::OutOfOrder { last_commit_offset, .. }
+                        | ReplayError::CorruptedData { last_commit_offset, .. },
+                    ) => {
+                        mlog.reset_to(last_commit_offset)
+                            .map_err(|source| LogReplayError::Reset {
+                                offset: last_commit_offset,
+                                source,
+                            })?;
+                        break;
+                    }
+                }
+            }
+
+            Commit {
+                parent_commit_hash: iter.last_hash,
+                commit_offset: iter.last_commit_offset.map(|off| off + 1).unwrap_or_default(),
+                min_tx_offset: iter.tx_offset,
+                transactions: Vec::new(),
+            }
+        };
+
+        Ok(CommitLogMut {
+            mlog: self.mlog.clone(),
+            odb: self.odb.clone(),
             unwritten_commit: Arc::new(Mutex::new(unwritten_commit)),
-            fsync,
+            fsync: false,
+        })
+    }
+
+    /// The number of bytes on disk occupied by the [MessageLog].
+    pub fn message_log_size_on_disk(&self) -> Result<u64, DBError> {
+        let guard = self.mlog.lock().unwrap();
+        Ok(guard.size())
+    }
+
+    /// The number of bytes on disk occupied by the [ObjectDB].
+    pub fn object_db_size_on_disk(&self) -> Result<u64, DBError> {
+        let guard = self.odb.lock().unwrap();
+        guard.size_on_disk()
+    }
+
+    /// Obtain an iterator over a snapshot of the raw message log segments.
+    ///
+    /// See also: [`MessageLog::segments`]
+    pub fn message_log_segments(&self) -> message_log::Segments {
+        self.message_log_segments_from(0)
+    }
+
+    /// Obtain an iterator over a snapshot of the raw message log segments
+    /// containing messages equal to or newer than `offset`.
+    ///
+    /// See [`MessageLog::segments_from`] for more information.
+    pub fn message_log_segments_from(&self, offset: u64) -> message_log::Segments {
+        let mlog = self.mlog.lock().unwrap();
+        mlog.segments_from(offset)
+    }
+
+    /// Obtain an iterator over the [`Commit`]s in the log.
+    ///
+    /// The iterator represents a snapshot of the log.
+    pub fn iter(&self) -> Iter {
+        self.iter_from(0)
+    }
+
+    /// Obtain an iterator over the [`Commit`]s in the log, starting at `offset`.
+    ///
+    /// The iterator represents a snapshot of the log.
+    ///
+    /// Note that [`Commit`]s with an offset _smaller_ than `offset` may be
+    /// yielded if the offset doesn't fall on a segment boundary, due to the
+    /// lack of slicing support.
+    ///
+    /// See [`MessageLog::segments_from`] for more information.
+    pub fn iter_from(&self, offset: u64) -> Iter {
+        self.message_log_segments_from(offset).into()
+    }
+
+    /// Obtain an iterator over the large objects in [`Commit`], if any.
+    ///
+    /// Large objects are stored in the [`ObjectDB`], and are referenced from
+    /// the transactions in a [`Commit`].
+    ///
+    /// The iterator attempts to read each large object in turn, yielding an
+    /// [`io::Error`] with kind [`io::ErrorKind::NotFound`] if the object was
+    /// not found.
+    //
+    // TODO(kim): We probably want a more efficient way to stream the contents
+    // of the ODB over the network for replication purposes.
+    pub fn commit_objects<'a>(&self, commit: &'a Commit) -> impl Iterator<Item = io::Result<bytes::Bytes>> + 'a {
+        fn hashes(tx: &Arc<Transaction>) -> impl Iterator<Item = Hash> + '_ {
+            tx.writes.iter().filter_map(|write| {
+                if let DataKey::Hash(h) = write.data_key {
+                    Some(h)
+                } else {
+                    None
+                }
+            })
         }
+
+        let odb = self.odb.clone();
+        commit.transactions.iter().flat_map(hashes).map(move |hash| {
+            let odb = odb.lock().unwrap();
+            odb.get(hash)
+                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, format!("Missing object: {hash}")))
+        })
+    }
+}
+
+/// A mutable handle to the commit log.
+///
+/// "Mutable" specifically means that new commits can be appended to the log
+/// via [`CommitLogMut::append_tx`].
+///
+/// A [`CommitLog`] can by obtained from [`CommitLogMut`] via the [`From`] impl.
+#[derive(Clone)]
+pub struct CommitLogMut {
+    mlog: Arc<Mutex<MessageLog>>,
+    odb: Arc<Mutex<Box<dyn ObjectDB + Send>>>,
+    unwritten_commit: Arc<Mutex<Commit>>,
+    // TODO(kim): Use FsyncPolicy instead of bool.
+    fsync: bool,
+}
+
+impl CommitLogMut {
+    pub fn set_fsync(&mut self, fsync: bool) {
+        self.fsync = fsync
+    }
+
+    pub fn with_fsync(mut self, fsync: bool) -> Self {
+        self.fsync = fsync;
+        self
+    }
+
+    pub fn commit_offset(&self) -> u64 {
+        self.mlog.lock().unwrap().open_segment_max_offset
     }
 
     /// Persist to disk the [Tx] result into the [MessageLog].
@@ -58,15 +270,11 @@ impl CommitLog {
     where
         D: MutTxDatastore<RowId = RowId>,
     {
-        if let Some(mlog) = &self.mlog {
-            let mut mlog = mlog.lock().unwrap();
-            self.generate_commit(ctx, tx_data, datastore)
-                .as_deref()
-                .map(|bytes| self.append_commit_bytes(&mut mlog, bytes))
-                .transpose()
-        } else {
-            Ok(None)
-        }
+        let mut mlog = self.mlog.lock().unwrap();
+        self.generate_commit(ctx, tx_data, datastore)
+            .as_deref()
+            .map(|bytes| self.append_commit_bytes(&mut mlog, bytes))
+            .transpose()
     }
 
     // For testing -- doesn't require a `MutTxDatastore`, which is currently
@@ -176,102 +384,8 @@ impl CommitLog {
     }
 }
 
-/// A read-only view of a [`CommitLog`].
-pub struct CommitLogView {
-    mlog: Option<Arc<Mutex<MessageLog>>>,
-    odb: Arc<Mutex<Box<dyn ObjectDB + Send>>>,
-}
-
-impl CommitLogView {
-    /// The number of bytes on disk occupied by the [MessageLog].
-    pub fn message_log_size_on_disk(&self) -> Result<u64, DBError> {
-        if let Some(ref mlog) = self.mlog {
-            let guard = mlog.lock().unwrap();
-            Ok(guard.size())
-        } else {
-            Ok(0)
-        }
-    }
-
-    /// The number of bytes on disk occupied by the [ObjectDB].
-    pub fn object_db_size_on_disk(&self) -> Result<u64, DBError> {
-        let guard = self.odb.lock().unwrap();
-        guard.size_on_disk()
-    }
-
-    /// Obtain an iterator over a snapshot of the raw message log segments.
-    ///
-    /// See also: [`MessageLog::segments`]
-    pub fn message_log_segments(&self) -> message_log::Segments {
-        self.message_log_segments_from(0)
-    }
-
-    /// Obtain an iterator over a snapshot of the raw message log segments
-    /// containing messages equal to or newer than `offset`.
-    ///
-    /// See [`MessageLog::segments_from`] for more information.
-    pub fn message_log_segments_from(&self, offset: u64) -> message_log::Segments {
-        if let Some(mlog) = &self.mlog {
-            let mlog = mlog.lock().unwrap();
-            mlog.segments_from(offset)
-        } else {
-            message_log::Segments::empty()
-        }
-    }
-
-    /// Obtain an iterator over the [`Commit`]s in the log.
-    ///
-    /// The iterator represents a snapshot of the log.
-    pub fn iter(&self) -> Iter {
-        self.iter_from(0)
-    }
-
-    /// Obtain an iterator over the [`Commit`]s in the log, starting at `offset`.
-    ///
-    /// The iterator represents a snapshot of the log.
-    ///
-    /// Note that [`Commit`]s with an offset _smaller_ than `offset` may be
-    /// yielded if the offset doesn't fall on a segment boundary, due to the
-    /// lack of slicing support.
-    ///
-    /// See [`MessageLog::segments_from`] for more information.
-    pub fn iter_from(&self, offset: u64) -> Iter {
-        self.message_log_segments_from(offset).into()
-    }
-
-    /// Obtain an iterator over the large objects in [`Commit`], if any.
-    ///
-    /// Large objects are stored in the [`ObjectDB`], and are referenced from
-    /// the transactions in a [`Commit`].
-    ///
-    /// The iterator attempts to read each large object in turn, yielding an
-    /// [`io::Error`] with kind [`io::ErrorKind::NotFound`] if the object was
-    /// not found.
-    //
-    // TODO(kim): We probably want a more efficient way to stream the contents
-    // of the ODB over the network for replication purposes.
-    pub fn commit_objects<'a>(&self, commit: &'a Commit) -> impl Iterator<Item = io::Result<bytes::Bytes>> + 'a {
-        fn hashes(tx: &Arc<Transaction>) -> impl Iterator<Item = Hash> + '_ {
-            tx.writes.iter().filter_map(|write| {
-                if let DataKey::Hash(h) = write.data_key {
-                    Some(h)
-                } else {
-                    None
-                }
-            })
-        }
-
-        let odb = self.odb.clone();
-        commit.transactions.iter().flat_map(hashes).map(move |hash| {
-            let odb = odb.lock().unwrap();
-            odb.get(hash)
-                .ok_or_else(|| io::Error::new(io::ErrorKind::NotFound, format!("Missing object: {hash}")))
-        })
-    }
-}
-
-impl From<&CommitLog> for CommitLogView {
-    fn from(log: &CommitLog) -> Self {
+impl From<&CommitLogMut> for CommitLog {
+    fn from(log: &CommitLogMut) -> Self {
         Self {
             mlog: log.mlog.clone(),
             odb: log.odb.clone(),
@@ -315,10 +429,9 @@ impl From<message_log::IterSegment> for IterSegment {
     }
 }
 
-/// Iterator over a [`CommitLogView`], yielding [`Commit`]s.
+/// Iterator over a [`CommitLog`], yielding [`Commit`]s.
 ///
-/// Created by [`CommitLogView::iter`] and [`CommitLogView::iter_from`]
-/// respectively.
+/// Created by [`CommitLog::iter`] and [`CommitLog::iter_from`] respectively.
 #[must_use = "iterators are lazy and do nothing unless consumed"]
 pub struct Iter {
     commits: Option<IterSegment>,
@@ -352,6 +465,127 @@ impl From<message_log::Segments> for Iter {
         Self {
             commits: None,
             segments,
+        }
+    }
+}
+
+/// Iterator created by [`CommitLog::replay`].
+///
+/// Similar to [`Iter`], but performs integrity checking and maintains
+/// additional state.
+#[must_use = "iterators are lazy and do nothing unless consumed"]
+struct Replay {
+    tx_offset: u64,
+    last_commit_offset: Option<u64>,
+    last_hash: Option<Hash>,
+
+    segments: message_log::Segments,
+    segment_offset: usize,
+
+    current_segment: Option<IterSegment>,
+}
+
+enum ReplayError {
+    /// A [`Commit`] was decoded successfully, but is not contiguous.
+    ///
+    /// The current format permits successful decoding even if the slice of data
+    /// being decoded from is slightly off. This usually causes the commit
+    /// offset to be wrong with respect to the preceding commit.
+    ///
+    /// This error may also arise if appending to a [`CommitLogMut`] is not
+    /// properly synchronized, i.e. a regression of [`#465`][465].
+    ///
+    /// We may in the future verify the commit hash, and include expected and
+    /// actual value in this variant.
+    ///
+    /// [465]: https://github.com/clockworklabs/SpacetimeDB/pull/465
+    OutOfOrder {
+        segment_offset: usize,
+        last_commit_offset: u64,
+        decoded_commit_offset: u64,
+        expected: u64,
+    },
+    /// A [`Commit`] could not be decoded.
+    ///
+    /// Either the input was malformed, or we reached EOF unexpectedly. In
+    /// either case, the segment is most definitely irrecoverably corrupted
+    /// after `last_commit_offset`.
+    CorruptedData {
+        segment_offset: usize,
+        last_commit_offset: u64,
+        source: io::Error,
+    },
+    /// Some other error occurred.
+    ///
+    /// May be a transient error. Processing should be aborted, and potentially
+    /// retried later.
+    Other { source: io::Error },
+}
+
+impl Iterator for Replay {
+    type Item = Result<Commit, ReplayError>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(cur) = self.current_segment.as_mut() {
+            if let Some(commit) = cur.next() {
+                // We may be able to recover from a corrupt suffix of the log.
+                // For this, we need to consider three cases:
+                //
+                //   1. The `Commit` was decoded successfully, but is invalid
+                //   2. The `Commit` failed to decode
+                //   3. The underlying `MessageLog` reported an unexpected EOF
+                //
+                // Case 1. can occur because the on-disk format does not
+                // currently have any consistency checks built in. To detect it,
+                // we check that the `commit_offset` sequence is contiguous.
+                //
+                // TODO(kim): We should probably check the `parent_commit_hash`
+                // instead, but only after measuring the performance overhead.
+                let res = match commit {
+                    Ok(commit) => {
+                        let expected = self.last_commit_offset.map(|last| last + 1).unwrap_or_default();
+                        if commit.commit_offset != expected {
+                            Err(ReplayError::OutOfOrder {
+                                segment_offset: self.segment_offset,
+                                last_commit_offset: self.last_commit_offset.unwrap_or_default(),
+                                decoded_commit_offset: commit.commit_offset,
+                                expected,
+                            })
+                        } else {
+                            self.last_commit_offset = Some(commit.commit_offset);
+                            self.last_hash = commit.parent_commit_hash;
+                            self.tx_offset += commit.transactions.len() as u64;
+
+                            Ok(commit)
+                        }
+                    }
+
+                    Err(e) => {
+                        let err = match e.kind() {
+                            io::ErrorKind::InvalidData | io::ErrorKind::UnexpectedEof => ReplayError::CorruptedData {
+                                segment_offset: self.segment_offset,
+                                last_commit_offset: self.last_commit_offset.unwrap_or_default(),
+                                source: e,
+                            },
+                            _ => ReplayError::Other { source: e },
+                        };
+                        Err(err)
+                    }
+                };
+
+                return Some(res);
+            }
+        }
+
+        // Pop the next segment, if available.
+        let next_segment = self.segments.next()?;
+        self.segment_offset += 1;
+        match next_segment.try_into_iter().map(IterSegment::from) {
+            Ok(current_segment) => {
+                self.current_segment = Some(current_segment);
+                self.next()
+            }
+            Err(e) => Some(Err(ReplayError::Other { source: e })),
         }
     }
 }
@@ -405,26 +639,19 @@ mod tests {
             .unwrap();
         let odb = MemoryObjectDB::default();
 
-        let log = CommitLog::new(
-            Some(Arc::new(Mutex::new(mlog))),
-            Arc::new(Mutex::new(Box::new(odb))),
-            Commit {
-                parent_commit_hash: None,
-                commit_offset: 0,
-                min_tx_offset: 0,
-                transactions: Vec::new(),
-            },
-            true, // fsync
-        );
+        let log = CommitLog::new(Arc::new(Mutex::new(mlog)), Arc::new(Mutex::new(Box::new(odb))))
+            .to_mut()
+            .unwrap()
+            .with_fsync(true);
 
         {
-            let mut guard = log.mlog.as_ref().unwrap().lock().unwrap();
+            let mut guard = log.mlog.lock().unwrap();
             for _ in 0..TOTAL_MESSAGES {
                 log.append_commit_bytes(&mut guard, &commit_bytes).unwrap();
             }
         }
 
-        let view = CommitLogView::from(&log);
+        let view = CommitLog::from(&log);
         let commits = view.iter().map(Result::unwrap).count();
         assert_eq!(TOTAL_MESSAGES, commits);
 

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -18,6 +18,7 @@ use crate::db::datastore::traits::DataRow;
 use crate::db::db_metrics::DB_METRICS;
 use crate::db::ostorage::hashmap_object_db::HashMapObjectDB;
 use crate::db::ostorage::ObjectDB;
+use crate::db::FsyncPolicy;
 use crate::error::{DBError, DatabaseError, IndexError, TableError};
 use crate::execution_context::ExecutionContext;
 use crate::hash::Hash;
@@ -105,6 +106,12 @@ impl RelationalDB {
 
                     Ok(())
                 })?;
+
+                let fsync = if fsync {
+                    FsyncPolicy::EveryTx
+                } else {
+                    FsyncPolicy::Never
+                };
 
                 Ok::<_, DBError>(commit_log.with_fsync(fsync))
             })


### PR DESCRIPTION
# Description of Changes

Makes `CommitLog` a read-only handle and introduces `CommitLogMut`,
allowing to append. This better encapsulates the error detection and
trimming logic, and enforces it to be executed before being able to
mutate the log.

~~**Stacked on top of #527**~~
~~[Compare](https://github.com/clockworklabs/SpacetimeDB/compare/kim/truncate-log-in-replay...kim/move-replay-to-commit-log)~~

# API and ABI breaking changes

-

# Expected complexity level and risk

2
