### PR TITLE
Nix `impl TryFrom<&str> for IndexType`

### DIFF
--- a/crates/sats/src/db/def.rs
+++ b/crates/sats/src/db/def.rs
@@ -230,17 +230,6 @@ impl TryFrom<u8> for IndexType {
     }
 }
 
-impl TryFrom<&str> for IndexType {
-    type Error = ();
-    fn try_from(v: &str) -> Result<Self, Self::Error> {
-        match v {
-            "BTree" => Ok(IndexType::BTree),
-            "Hash" => Ok(IndexType::Hash),
-            _ => Err(()),
-        }
-    }
-}
-
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SequenceSchema {
     pub sequence_id: SequenceId,


### PR DESCRIPTION
# Description of Changes

Remove `impl TryFrom<&str> for IndexType` which should be unused.

# API and ABI breaking changes

None

# Expected complexity level and risk

Minus one.