### PR TITLE
core: Refine panic message when decoding fails during replay

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -1681,15 +1681,21 @@ impl Locking {
                 }
                 Operation::Insert => {
                     let product_value = match write.data_key {
-                        DataKey::Data(data) => ProductValue::decode(&row_type, &mut &data[..]).unwrap_or_else(|_| {
-                            panic!("Couldn't decode product value to {:?} from message log", row_type)
+                        DataKey::Data(data) => ProductValue::decode(&row_type, &mut &data[..]).unwrap_or_else(|e| {
+                            panic!(
+                                "Couldn't decode product value from message log: `{}`. Expected row type: {:?}",
+                                e, row_type
+                            )
                         }),
                         DataKey::Hash(hash) => {
                             let data = odb.lock().unwrap().get(hash).unwrap_or_else(|| {
                                 panic!("Object {hash} referenced from transaction not present in object DB");
                             });
-                            ProductValue::decode(&row_type, &mut &data[..]).unwrap_or_else(|_| {
-                                panic!("Couldn't decode product value to {:?} from message log", row_type)
+                            ProductValue::decode(&row_type, &mut &data[..]).unwrap_or_else(|e| {
+                                panic!(
+                                    "Couldn't decode product value {} from object DB: `{}`. Expected row type: {:?}",
+                                    hash, e, row_type
+                                )
                             })
                         }
                     };


### PR DESCRIPTION
# Description of Changes

It is significant for forensics to differentiate the source of the row data being decoded. Change the error messages to that end.

# Expected complexity level and risk

1