### PR TITLE
`system_tables`: fix `st_indexes_schema` inconsistency

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -2701,9 +2701,9 @@ mod tests {
             ColRow { table: 3, pos: 0, name: "index_id", ty: AlgebraicType::U32, autoinc: true },
             ColRow { table: 3, pos: 1, name: "table_id", ty: AlgebraicType::U32, autoinc: false },
             ColRow { table: 3, pos: 2, name: "index_name", ty: AlgebraicType::String, autoinc: false },
-            ColRow { table: 3, pos: 3, name: "columns", ty: AlgebraicType::array(AlgebraicType::U32), autoinc: false },
-            ColRow { table: 3, pos: 4, name: "is_unique", ty: AlgebraicType::Bool, autoinc: false },
-            ColRow { table: 3, pos: 5, name: "index_type", ty: AlgebraicType::U8, autoinc: false },
+            ColRow { table: 3, pos: 3, name: "index_type", ty: AlgebraicType::U8, autoinc: false },
+            ColRow { table: 3, pos: 4, name: "columns", ty: AlgebraicType::array(AlgebraicType::U32), autoinc: false },
+            ColRow { table: 3, pos: 5, name: "is_unique", ty: AlgebraicType::Bool, autoinc: false },
 
             ColRow { table: 4, pos: 0, name: "constraint_id", ty: AlgebraicType::U32, autoinc: true },
             ColRow { table: 4, pos: 1, name: "constraint_name", ty: AlgebraicType::String, autoinc: false },

--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -341,6 +341,13 @@ pub fn st_indexes_schema() -> TableSchema {
             },
             ColumnSchema {
                 table_id: ST_INDEXES_ID,
+                col_id: StIndexFields::IndexType.col_id(),
+                col_name: StIndexFields::IndexType.col_name(),
+                col_type: AlgebraicType::U8,
+                is_autoinc: false,
+            },
+            ColumnSchema {
+                table_id: ST_INDEXES_ID,
                 col_id: StIndexFields::Columns.col_id(),
                 col_name: StIndexFields::Columns.col_name(),
                 col_type: AlgebraicType::array(AlgebraicType::U32),
@@ -351,13 +358,6 @@ pub fn st_indexes_schema() -> TableSchema {
                 col_id: StIndexFields::IsUnique.col_id(),
                 col_name: StIndexFields::IsUnique.col_name(),
                 col_type: AlgebraicType::Bool,
-                is_autoinc: false,
-            },
-            ColumnSchema {
-                table_id: ST_INDEXES_ID,
-                col_id: StIndexFields::IndexType.col_id(),
-                col_name: StIndexFields::IndexType.col_name(),
-                col_type: AlgebraicType::U8,
                 is_autoinc: false,
             },
         ],


### PR DESCRIPTION
# Description of Changes

The order did not correspond to the one in `st_fields_enum!(enum StIndexFields {` and the `TryFrom`/`From` impls.

Possibly breaks ABI of the `ST_INDEXES_NAME` table.

# Expected complexity level and risk

1