### PR TITLE
core: Only write actual large objects to odb

### DIFF
--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -374,11 +374,8 @@ impl CommitLogMut {
             {
                 let mut guard = self.odb.lock().unwrap();
                 for record in &tx_data.records {
-                    match &record.op {
-                        TxOp::Insert(bytes) => {
-                            guard.add(Vec::clone(bytes));
-                        }
-                        TxOp::Delete => continue,
+                    if let (DataKey::Hash(_), TxOp::Insert(bytes)) = (&record.key, &record.op) {
+                        guard.add(Vec::clone(bytes));
                     }
                 }
             }


### PR DESCRIPTION
# Description of Changes

Prevent writing `DataKey::Inline` data to the odb redundantly. _May_ reduce memory pressure, and will help with keyspace traversals.

# Expected complexity level and risk

2