### PR TITLE
Support arbitrary RHS in C# Query

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4350,6 +4350,7 @@ dependencies = [
  "log",
  "prost",
  "rand 0.8.5",
+ "serde",
  "serde_json",
  "serial_test",
  "spacetimedb-cli",

--- a/crates/bench/src/spacetime_module.rs
+++ b/crates/bench/src/spacetime_module.rs
@@ -3,7 +3,7 @@ use spacetimedb_lib::{
     sats::{product, ArrayValue},
     AlgebraicValue, ProductValue,
 };
-use spacetimedb_testing::modules::{start_runtime, CompilationMode, CompiledModule, ModuleHandle};
+use spacetimedb_testing::modules::{start_runtime, CompilationMode, CompiledModule, LoggerRecord, ModuleHandle};
 use tokio::runtime::Runtime;
 
 use crate::{
@@ -205,18 +205,4 @@ impl BenchDatabase for SpacetimeModule {
 pub struct TableId {
     pascal_case: String,
     snake_case: String,
-}
-
-#[allow(unused)]
-/// Used to parse output from module logs.
-///
-/// Sync with: `core::database_logger::Record`. We can't use it
-/// directly because the types are wrong for deserialization.
-/// (Rust!)
-#[derive(serde::Deserialize)]
-struct LoggerRecord {
-    target: Option<String>,
-    filename: Option<String>,
-    line_number: Option<u32>,
-    message: String,
 }

--- a/crates/core/src/database_logger.rs
+++ b/crates/core/src/database_logger.rs
@@ -12,7 +12,7 @@ pub struct DatabaseLogger {
     pub tx: broadcast::Sender<bytes::Bytes>,
 }
 
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, Debug, serde::Deserialize)]
 pub enum LogLevel {
     Error,
     Warn,

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -22,6 +22,7 @@ lazy_static.workspace = true
 rand.workspace = true
 prost.workspace = true
 tempfile.workspace = true
+serde.workspace = true
 
 [dev-dependencies]
 serial_test.workspace = true

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -16,6 +16,8 @@ use spacetimedb::protobuf::client_api;
 use spacetimedb_client_api::{ControlStateReadAccess, ControlStateWriteAccess, DatabaseDef, NodeDelegate};
 use spacetimedb_lib::sats;
 
+pub use spacetimedb::database_logger::LogLevel;
+
 use spacetimedb_standalone::StandaloneEnv;
 
 pub fn start_runtime() -> Runtime {
@@ -180,3 +182,17 @@ pub static DEFAULT_CONFIG: Config = Config {
     storage: Storage::Disk,
     fsync: FsyncPolicy::Never,
 };
+
+/// Used to parse output from module logs.
+///
+/// Sync with: `core::database_logger::Record`. We can't use it
+/// directly because the types are wrong for deserialization.
+/// (Rust!)
+#[derive(serde::Deserialize)]
+pub struct LoggerRecord {
+    pub level: LogLevel,
+    pub target: Option<String>,
+    pub filename: Option<String>,
+    pub line_number: Option<u32>,
+    pub message: String,
+}

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -1,6 +1,7 @@
-use serde_json::Value;
 use serial_test::serial;
-use spacetimedb_testing::modules::{CompilationMode, CompiledModule, DEFAULT_CONFIG};
+use spacetimedb_testing::modules::{
+    CompilationMode, CompiledModule, LogLevel, LoggerRecord, ModuleHandle, DEFAULT_CONFIG,
+};
 
 fn init() {
     let _ = env_logger::builder()
@@ -13,6 +14,24 @@ fn init() {
         .try_init();
 }
 
+async fn read_logs(module: &ModuleHandle) -> Vec<String> {
+    module
+        .read_log(None)
+        .await
+        .trim()
+        .split('\n')
+        .map(|line| {
+            let record: LoggerRecord = serde_json::from_str(line).unwrap();
+            if matches!(record.level, LogLevel::Panic | LogLevel::Error | LogLevel::Warn) {
+                panic!("Found an error-like log line: {line}");
+            }
+            record.message
+        })
+        .skip_while(|line| line != "Database initialized")
+        .skip(1)
+        .collect::<Vec<_>>()
+}
+
 // The tests MUST be run in sequence because they read the OS environment
 // and can cause a race when run in parallel.
 
@@ -22,27 +41,28 @@ fn test_calling_a_reducer_in_module(module_name: &'static str) {
     CompiledModule::compile(module_name, CompilationMode::Debug).with_module_async(
         DEFAULT_CONFIG,
         |module| async move {
-            let json = r#"{"call": {"fn": "add", "args": ["Tyrion"]}}"#.to_string();
+            let json = r#"{"call": {"fn": "add", "args": ["Tyrion", 24]}}"#.to_string();
             module.send(json).await.unwrap();
+
+            let json = r#"{"call": {"fn": "add", "args": ["Cersei", 31]}}"#.to_string();
+            module.send(json).await.unwrap();
+
             let json = r#"{"call": {"fn": "say_hello", "args": []}}"#.to_string();
             module.send(json).await.unwrap();
 
-            let lines: Vec<Value> = module
-                .read_log(Some(10))
-                .await
-                .trim()
-                .split('\n')
-                .map(serde_json::from_str)
-                .collect::<serde_json::Result<_>>()
-                .unwrap();
+            let json = r#"{"call": {"fn": "list_over_age", "args": [30]}}"#.to_string();
+            module.send(json).await.unwrap();
 
-            assert!(lines.len() >= 4);
-
-            assert_eq!(lines[lines.len() - 2]["level"], "Info");
-            assert_eq!(lines[lines.len() - 2]["message"], "Hello, Tyrion!");
-
-            assert_eq!(lines[lines.len() - 1]["level"], "Info");
-            assert_eq!(lines[lines.len() - 1]["message"], "Hello, World!");
+            assert_eq!(
+                read_logs(&module).await,
+                [
+                    "Hello, Tyrion!",
+                    "Hello, Cersei!",
+                    "Hello, World!",
+                    "Cersei has age 31 >= 30",
+                ]
+                .map(String::from)
+            );
         },
     );
 }
@@ -72,15 +92,10 @@ fn test_calling_a_reducer_with_private_table() {
             let json = r#"{"call": {"fn": "query_private", "args": []}}"#.to_string();
             module.send(json).await.unwrap();
 
-            let lines = module.read_log(Some(11)).await;
-            let lines: Vec<&str> = lines.trim().split('\n').collect();
-
-            assert_eq!(lines.len(), 10);
-
-            let json: Value = serde_json::from_str(lines[8]).unwrap();
-            assert_eq!(json["message"], Value::String("Private, Tyrion!".to_string()));
-            let json: Value = serde_json::from_str(lines[9]).unwrap();
-            assert_eq!(json["message"], Value::String("Private, World!".to_string()));
+            assert_eq!(
+                read_logs(&module).await,
+                ["Private, Tyrion!", "Private, World!",].map(String::from)
+            );
         },
     );
 }
@@ -92,7 +107,7 @@ fn test_call_query_macro() {
         DEFAULT_CONFIG,
         |module| async move {
             let json = r#"
-{"call": {"fn": "test", "args":[            
+{"call": {"fn": "test", "args":[
     {"x":0, "y":2, "z":"Macro"},
     {"foo":"Foo"},
     {"Foo": {} }
@@ -100,30 +115,26 @@ fn test_call_query_macro() {
                 .to_string();
             module.send(json).await.unwrap();
 
-            let lines = module.read_log(Some(13)).await;
-            let lines: Vec<&str> = lines.trim().split('\n').collect();
+            let logs = read_logs(&module).await;
 
-            assert_eq!(lines.len(), 13);
+            assert_eq!(logs[0], "BEGIN");
+            assert!(logs[1].starts_with("sender: "));
+            assert!(logs[2].starts_with("timestamp: "));
 
-            let json: Value = serde_json::from_str(lines[6]).unwrap();
             assert_eq!(
-                json["message"],
-                Value::String("Row count before delete: 1000".to_string())
-            );
-            let json: Value = serde_json::from_str(lines[8]).unwrap();
-            assert_eq!(
-                json["message"],
-                Value::String("Row count after delete: 995".to_string())
-            );
-            let json: Value = serde_json::from_str(lines[9]).unwrap();
-            assert_eq!(
-                json["message"],
-                Value::String("Row count filtered by condition: 995".to_string())
-            );
-            let json: Value = serde_json::from_str(lines[11]).unwrap();
-            assert_eq!(
-                json["message"],
-                Value::String("Row count filtered by multi-column condition: 199".to_string())
+                logs[3..],
+                [
+                    r#"bar: "Foo""#,
+                    "Foo",
+                    "Row count before delete: 1000",
+                    r#"Inserted: TestE { id: 1, name: "Tyler" }"#,
+                    "Row count after delete: 995",
+                    "Row count filtered by condition: 995",
+                    "MultiColumn",
+                    "Row count filtered by multi-column condition: 199",
+                    "END",
+                ]
+                .map(String::from)
             );
         },
     );

--- a/modules/spacetimedb-quickstart-cs/Lib.cs
+++ b/modules/spacetimedb-quickstart-cs/Lib.cs
@@ -7,6 +7,7 @@ static partial class Module
     public partial struct Person
     {
         public string Name;
+        public byte Age;
     }
 
     // Verify that all types compile via codegen successfully.
@@ -35,9 +36,9 @@ static partial class Module
     }
 
     [SpacetimeDB.Reducer("add")]
-    public static void Add(string name)
+    public static void Add(string name, byte age)
     {
-        new Person { Name = name }.Insert();
+        new Person { Name = name, Age = age }.Insert();
     }
 
     [SpacetimeDB.Reducer("say_hello")]
@@ -48,5 +49,14 @@ static partial class Module
             Log($"Hello, {person.Name}!");
         }
         Log("Hello, World!");
+    }
+
+    [SpacetimeDB.Reducer("list_over_age")]
+    public static void ListOverAge(byte age)
+    {
+        foreach (var person in Person.Query(person => person.Age >= age))
+        {
+            Log($"{person.Name} has age {person.Age} >= {age}");
+        }
     }
 }

--- a/modules/spacetimedb-quickstart/src/lib.rs
+++ b/modules/spacetimedb-quickstart/src/lib.rs
@@ -1,13 +1,14 @@
-use spacetimedb::{println, spacetimedb};
+use spacetimedb::{println, query, spacetimedb};
 
 #[spacetimedb(table)]
 pub struct Person {
     name: String,
+    age: u8,
 }
 
 #[spacetimedb(reducer)]
-pub fn add(name: String) {
-    Person::insert(Person { name });
+pub fn add(name: String, age: u8) {
+    Person::insert(Person { name, age });
 }
 
 #[spacetimedb(reducer)]
@@ -16,4 +17,11 @@ pub fn say_hello() {
         println!("Hello, {}!", person.name);
     }
     println!("Hello, World!");
+}
+
+#[spacetimedb(reducer)]
+pub fn list_over_age(age: u8) {
+    for person in query!(|person: Person| person.age >= age) {
+        println!("{} has age {} >= {}", person.name, person.age, age);
+    }
 }


### PR DESCRIPTION
# Description of Changes

Unlike Rust, previously this would only accept literal constants and not field captures.

Unlike Rust, this will now accept not only constants and captures, but arbitrary expressions - we can either do the same in Rust or limit this similarly in the future.

Some of the changes here are just to add queries to primary integration tests too and make checking logs a bit easier, feel free to review on per-commit basis.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

2 - this is using special C# dynamic evaluation API to evaluate non-constant RHS expressions, but tests show it works as expected in practice.

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
