### PR TITLE
fix(CommitLog): Do not truncate the log on out of order errors

### DIFF
--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -111,11 +111,10 @@ impl CommitLog {
                         expected,
                     }) => {
                         log::warn!("Out-of-order commit {}, expected {}", decoded_commit_offset, expected);
-                        return Err(LogReplayError::TrailingSegments {
+                        return Err(LogReplayError::OutOfOrderCommit {
+                            commit_offset: decoded_commit_offset,
                             segment_offset,
-                            total_segments,
-                            commit_offset: last_commit_offset,
-                            source: io::Error::new(io::ErrorKind::Other, "Out-of-order commit"),
+                            last_commit_offset,
                         }
                         .into());
                     }

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1520,7 +1520,11 @@ mod tests {
 
         // The state must be the same after reopening the db.
         let db = reopen_db()?;
-        assert_eq!(NUM_TRANSACTIONS as u64, balance(&ctx, &db, table_id)?);
+        assert_eq!(
+            NUM_TRANSACTIONS as u64,
+            balance(&ctx, &db, table_id)?,
+            "the state should be the same as before reopening the db"
+        );
 
         let total_segments = mlog.lock().unwrap().total_segments();
         assert!(total_segments > 3, "expected more than 3 segments");
@@ -1532,7 +1536,11 @@ mod tests {
 
         // Assert that the final tx is lost.
         let db = reopen_db()?;
-        assert_eq!((NUM_TRANSACTIONS - 1) as u64, balance(&ctx, &db, table_id)?);
+        assert_eq!(
+            (NUM_TRANSACTIONS - 1) as u64,
+            balance(&ctx, &db, table_id)?,
+            "the last transaction should have been dropped"
+        );
         assert_eq!(
             total_segments,
             mlog.lock().unwrap().total_segments(),
@@ -1541,11 +1549,23 @@ mod tests {
 
         // Overwrite some portion of the last segment.
         drop(db);
+        let last_segment = mlog.lock().unwrap().segments().last().unwrap();
+        invalidate_overwrite(&mlog_path, last_segment)?;
+        let res = reopen_db();
+        if !matches!(res, Err(DBError::LogReplay(LogReplayError::OutOfOrderCommit { .. }))) {
+            panic!("Expected replay error but got: {res:?}");
+        }
+        // We can't recover from this, so drop the last segment.
+        let mut mlog_guard = mlog.lock().unwrap();
+        let drop_segment = mlog_guard.segments().last().unwrap();
+        mlog_guard.reset_to(drop_segment.offset() - 1)?;
+        let last_segment = mlog_guard.segments().last().unwrap();
+        drop(mlog_guard);
+
         let segment_range = Range {
             start: last_segment.offset(),
-            end: (NUM_TRANSACTIONS - 1) as u64,
+            end: drop_segment.offset() - 1,
         };
-        invalidate_overwrite(&mlog_path, last_segment)?;
         let db = reopen_db()?;
         let balance = balance(&ctx, &db, table_id)?;
         assert!(
@@ -1553,9 +1573,9 @@ mod tests {
             "balance {balance} should fall within {segment_range:?}"
         );
         assert_eq!(
-            total_segments,
+            total_segments - 1,
             mlog.lock().unwrap().total_segments(),
-            "no segment should have beeen removed"
+            "one segment should have beeen removed"
         );
 
         // Now, let's poke a segment somewhere in the middle of the log.
@@ -1565,7 +1585,7 @@ mod tests {
 
         let res = reopen_db();
         if !matches!(res, Err(DBError::LogReplay(LogReplayError::TrailingSegments { .. }))) {
-            panic!("Expected replay error but got: {res:?}")
+            panic!("Expected `LogReplayError::TrailingSegments` but got: {res:?}")
         }
 
         // The same should happen if we overwrite instead of shrink.
@@ -1573,8 +1593,8 @@ mod tests {
         invalidate_overwrite(&mlog_path, segment)?;
 
         let res = reopen_db();
-        if !matches!(res, Err(DBError::LogReplay(LogReplayError::TrailingSegments { .. }))) {
-            panic!("Expected replay error but got: {res:?}")
+        if !matches!(res, Err(DBError::LogReplay(LogReplayError::OutOfOrderCommit { .. }))) {
+            panic!("Expected `LogReplayError::OutOfOrderCommit` but got: {res:?}")
         }
 
         Ok(())

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -219,6 +219,17 @@ impl<'a, T: ?Sized + 'a> From<PoisonError<std::sync::MutexGuard<'a, T>>> for DBE
 #[derive(Debug, Error)]
 pub enum LogReplayError {
     #[error(
+        "Out-of-order commit detected: {} in segment {} after offset {}",
+        .commit_offset,
+        .segment_offset,
+        .last_commit_offset
+    )]
+    OutOfOrderCommit {
+        commit_offset: u64,
+        segment_offset: usize,
+        last_commit_offset: u64,
+    },
+    #[error(
         "Error reading segment {}/{} at commit {}: {}",
         .segment_offset,
         .total_segments,


### PR DESCRIPTION
# Description of Changes

See the main code comment.
I think until we have a better log format, or at the very least, better diagnostic tooling, we shouldn't ignore OutOfOrder errors.
It's not apparent that we'll see such errors in practice due to the the more lenient fsync policy.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
