### PR TITLE
Rename HostType::Wasmtime to just Wasm

### DIFF
--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -19,8 +19,8 @@ pub fn cli() -> clap::Command {
             Arg::new("host_type")
                 .long("host-type")
                 .short('t')
-                .value_parser(["wasmtime"])
-                .default_value("wasmtime")
+                .value_parser(["wasm"])
+                .default_value("wasm")
                 .help("The type of host that should be for hosting this module"),
         )
         .arg(

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -265,7 +265,7 @@ impl HostController {
         let module_hash = hash_bytes(&mhc.program_bytes);
         let (threadpool, energy_monitor) = (self.threadpool.clone(), self.energy_monitor.clone());
         let module_host = match mhc.host_type {
-            HostType::Wasmtime => {
+            HostType::Wasm => {
                 // make_actor with block_in_place since it's going to take some time to compute.
                 let start = Instant::now();
                 let actor = tokio::task::block_in_place(|| {

--- a/crates/core/src/messages/control_db.rs
+++ b/crates/core/src/messages/control_db.rs
@@ -68,5 +68,5 @@ pub struct NodeStatus {
 #[strum(serialize_all = "lowercase")]
 #[repr(i32)]
 pub enum HostType {
-    Wasmtime = 0,
+    Wasm = 0,
 }

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -314,7 +314,7 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
                 id: 0,
                 address: spec.address,
                 identity: *identity,
-                host_type: HostType::Wasmtime,
+                host_type: HostType::Wasm,
                 num_replicas: spec.num_replicas,
                 program_bytes_address,
                 publisher_address,


### PR DESCRIPTION
# Description of Changes

Per @kim's comment:

> I’d prefer if we just named the host type Wasm — it seems very unlikely that we’ll support multiple runtime implementations ever. That is, if we gain another variant it will be Csharp or whatever.

That does make sense to me - the decision to name the host type Wasmer/Wasmtime was made about a year ago, in case we wanted to have both at the same time, and we never took advantage of that and I don't think we ever will (and I think we've pretty conclusively settled on wasmtime as our runtime). I was more or less content having it be like that but if other people feel it's worth changing I'm happy for it.

# Expected complexity level and risk

2 - in a similar way to #457 this is sorta theoretically an http API breaking change to the `/publish` route, but that doesn't actually ever get exercised anyway. And it'd be in the same release cycle.
