### PR TITLE
core: Fully consume input when decoding `Commit`

### DIFF
--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -430,7 +430,11 @@ impl Iterator for IterSegment {
             )
         };
         let io = |e| io::Error::new(io::ErrorKind::InvalidData, e);
-        Some(next.and_then(|bytes| Commit::decode(&mut bytes.as_slice()).with_context(ctx).map_err(io)))
+        Some(next.and_then(|bytes| {
+            Commit::decode_exact(&mut bytes.as_slice())
+                .with_context(ctx)
+                .map_err(io)
+        }))
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Ensures that message- and commit log agree on record boundaries, minimizing "false positive" decodings.

# API and ABI breaking changes

nada 

# Expected complexity level and risk

1