### PR TITLE
EXPERIMENTAL: Add a crc32 checksum to message log records

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4141,6 +4141,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "clap",
+ "crc32fast",
  "criterion",
  "crossbeam-channel",
  "derive_more",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -80,6 +80,7 @@ clap = { version = "4.2.4", features = ["derive"] }
 colored = "2.0.0"
 console = { version = "0.15.6" }
 convert_case = "0.6.0"
+crc32fast = "1.3.2"
 criterion = { version = "0.5.1", features = ["async", "async_tokio", "html_reports"] }
 crossbeam-channel = "0.5"
 cursive = { version = "0.20", default-features = false, features = ["crossterm-backend"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -31,6 +31,7 @@ base64.workspace = true
 bytes.workspace = true
 bytestring.workspace = true
 clap.workspace = true
+crc32fast.workspace = true
 crossbeam-channel.workspace = true
 derive_more.workspace = true
 dirs.workspace = true

--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -642,7 +642,7 @@ mod tests {
 
         const COMMITS_PER_SEGMENT: usize = 10_000;
         const TOTAL_MESSAGES: usize = (COMMITS_PER_SEGMENT * 3) - 1;
-        let segment_size: usize = COMMITS_PER_SEGMENT * (commit_bytes.len() + 4);
+        let segment_size: usize = COMMITS_PER_SEGMENT * MessageLog::message_size(&commit_bytes) as usize;
 
         let mlog = message_log::MessageLog::options()
             .max_segment_size(segment_size as u64)


### PR DESCRIPTION
# Description of Changes

Cost is > 0, but would improve confidence in suffix trimming not deleting data inadvertently.

It seems somewhat unlikely that the low-level message log format is subject to change (soon), so perhaps after quantifying the performance impact this could be deployed until it does.

# API and ABI breaking changes

Changes the on-disk format in an incompatible way.

# Expected complexity level and risk

2