### PR TITLE
Fix id semantics of `DatabaseInstance`

### DIFF
--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -105,9 +105,10 @@ pub trait ControlStateReadAccess {
     fn get_databases(&self) -> spacetimedb::control_db::Result<Vec<Database>>;
 
     // Database instances
-    fn get_database_instance_by_id(&self, id: u64) -> spacetimedb::control_db::Result<Option<DatabaseInstance>>;
-    fn get_database_instances(&self) -> spacetimedb::control_db::Result<Vec<DatabaseInstance>>;
-    fn get_leader_database_instance_by_database(&self, database_id: u64) -> Option<DatabaseInstance>;
+    fn get_leader_database_instance_by_database(
+        &self,
+        database: &Database,
+    ) -> spacetimedb::control_db::Result<Option<DatabaseInstance>>;
 
     // Identities
     fn get_identities_for_email(&self, email: &str) -> spacetimedb::control_db::Result<Vec<IdentityEmail>>;
@@ -200,14 +201,11 @@ impl<T: ControlStateReadAccess + ?Sized> ControlStateReadAccess for ArcEnv<T> {
     }
 
     // Database instances
-    fn get_database_instance_by_id(&self, id: u64) -> spacetimedb::control_db::Result<Option<DatabaseInstance>> {
-        self.0.get_database_instance_by_id(id)
-    }
-    fn get_database_instances(&self) -> spacetimedb::control_db::Result<Vec<DatabaseInstance>> {
-        self.0.get_database_instances()
-    }
-    fn get_leader_database_instance_by_database(&self, database_id: u64) -> Option<DatabaseInstance> {
-        self.0.get_leader_database_instance_by_database(database_id)
+    fn get_leader_database_instance_by_database(
+        &self,
+        database: &Database,
+    ) -> spacetimedb::control_db::Result<Option<DatabaseInstance>> {
+        self.0.get_leader_database_instance_by_database(database)
     }
 
     // Identities
@@ -356,14 +354,11 @@ impl<T: ControlStateReadAccess + ?Sized> ControlStateReadAccess for Arc<T> {
     }
 
     // Database instances
-    fn get_database_instance_by_id(&self, id: u64) -> spacetimedb::control_db::Result<Option<DatabaseInstance>> {
-        (**self).get_database_instance_by_id(id)
-    }
-    fn get_database_instances(&self) -> spacetimedb::control_db::Result<Vec<DatabaseInstance>> {
-        (**self).get_database_instances()
-    }
-    fn get_leader_database_instance_by_database(&self, database_id: u64) -> Option<DatabaseInstance> {
-        (**self).get_leader_database_instance_by_database(database_id)
+    fn get_leader_database_instance_by_database(
+        &self,
+        database: &Database,
+    ) -> spacetimedb::control_db::Result<Option<DatabaseInstance>> {
+        (**self).get_leader_database_instance_by_database(database)
     }
 
     // Identities

--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -82,7 +82,8 @@ pub async fn call<S: ControlStateDelegate + NodeDelegate>(
     })?;
     let identity = database.identity;
     let database_instance = worker_ctx
-        .get_leader_database_instance_by_database(database.id)
+        .get_leader_database_instance_by_database(&database)
+        .map_err(log_and_500)?
         .ok_or((
             StatusCode::NOT_FOUND,
             "Database instance not scheduled to this node yet.",
@@ -209,10 +210,13 @@ async fn extract_db_call_info(
         (StatusCode::NOT_FOUND, "No such database.")
     })?;
 
-    let database_instance = ctx.get_leader_database_instance_by_database(database.id).ok_or((
-        StatusCode::NOT_FOUND,
-        "Database instance not scheduled to this node yet.",
-    ))?;
+    let database_instance = ctx
+        .get_leader_database_instance_by_database(&database)
+        .map_err(log_and_500)?
+        .ok_or((
+            StatusCode::NOT_FOUND,
+            "Database instance not scheduled to this node yet.",
+        ))?;
 
     Ok(DatabaseInformation {
         database_instance,
@@ -449,7 +453,8 @@ where
     }
 
     let database_instance = worker_ctx
-        .get_leader_database_instance_by_database(database.id)
+        .get_leader_database_instance_by_database(&database)
+        .map_err(log_and_500)?
         .ok_or((
             StatusCode::NOT_FOUND,
             "Database instance not scheduled to this node yet.",
@@ -541,7 +546,8 @@ where
     let auth = AuthCtx::new(database.identity, auth.identity);
     log::debug!("auth: {auth:?}");
     let database_instance = worker_ctx
-        .get_leader_database_instance_by_database(database.id)
+        .get_leader_database_instance_by_database(&database)
+        .map_err(log_and_500)?
         .ok_or((
             StatusCode::NOT_FOUND,
             "Database instance not scheduled to this node yet.",

--- a/crates/client-api/src/routes/subscribe.rs
+++ b/crates/client-api/src/routes/subscribe.rs
@@ -84,7 +84,8 @@ where
         .unwrap()
         .ok_or(StatusCode::BAD_REQUEST)?;
     let database_instance = ctx
-        .get_leader_database_instance_by_database(database.id)
+        .get_leader_database_instance_by_database(&database)
+        .map_err(log_and_500)?
         .ok_or(StatusCode::BAD_REQUEST)?;
     let instance_id = database_instance.id;
 

--- a/crates/core/src/control_db.rs
+++ b/crates/core/src/control_db.rs
@@ -1,7 +1,3 @@
-use std::borrow::Cow;
-
-use anyhow::{anyhow, Context};
-
 use crate::address::Address;
 
 use crate::hash::hash_bytes;
@@ -37,6 +33,8 @@ pub enum Error {
     DomainRegistrationFailure(DomainName),
     #[error("failed to decode data")]
     DecodingError(#[from] bsatn::DecodeError),
+    #[error("permission denied: `{identity}` not allowed to modify database `{address}`")]
+    PermissionDenied { identity: Identity, address: Address },
     #[error(transparent)]
     DomainParsingError(#[from] DomainParsingError),
     #[error("connection error")]
@@ -418,11 +416,17 @@ impl ControlDb {
         Ok(None)
     }
 
-    pub fn get_leader_database_instance_by_database(&self, database_id: u64) -> Option<DatabaseInstance> {
-        self.get_database_instances()
-            .unwrap()
-            .into_iter()
-            .find(|instance| instance.database_id == database_id && instance.leader)
+    pub fn get_leader_database_instance_by_database(&self, database: &Database) -> Result<Option<DatabaseInstance>> {
+        self.get_database_instances().map(|instances| {
+            instances.into_iter().find(
+                |&DatabaseInstance {
+                     database_id,
+                     database_rev,
+                     leader,
+                     ..
+                 }| leader && database_id == database.id && database_rev == database.rev,
+            )
+        })
     }
 
     pub fn get_database_instances_by_database(&self, database_id: u64) -> Result<Vec<DatabaseInstance>> {
@@ -577,81 +581,4 @@ impl ControlDb {
 
         Ok(())
     }
-
-    /// Acquire a lock on `key`.
-    ///
-    /// If the lock can not be acquired immediately, an error is returned.
-    ///
-    /// This method is essentially simulating locking in the distributed version
-    /// of SpacetimeDB. It does not, however, provide time-based expiration of
-    /// a lock.
-    pub fn lock<'a, S>(&self, key: S) -> Result<Lock<'a>>
-    where
-        S: Into<Cow<'a, str>>,
-    {
-        let tree = self.db.open_tree("locks")?;
-        let token = self.db.generate_id().map(Some)?;
-        let key = key.into();
-        match cas_u64(&tree, &key, None, token)? {
-            Ok(()) => Ok(Lock { key, token, tree }),
-            Err(_) => Err(anyhow!("Lock on `{key}` taken").into()),
-        }
-    }
-}
-
-/// A keyed lock acquired by [`ControlDb::lock`].
-///
-/// The lock is released on drop, or by calling [`Lock::release`].
-pub struct Lock<'a> {
-    key: Cow<'a, str>,
-    token: Option<u64>,
-    tree: sled::Tree,
-}
-
-impl Lock<'_> {
-    /// Return the [fencing token] associated with this lock.
-    ///
-    /// [fencing token]: https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html
-    pub fn token(&self) -> u64 {
-        self.token.expect("fencing token must be set unless self was dropped")
-    }
-
-    /// Release this lock, consuming `self`.
-    ///
-    /// A [`Lock`] is automatically released when it goes out of scope, however
-    /// any errors are lost in this case. Use [`Self::release`] to observe those
-    /// errors.
-    pub fn release(mut self) -> Result<()> {
-        let this = &mut self;
-        this.release_internal()
-    }
-
-    fn release_internal(&mut self) -> Result<()> {
-        if let Some(tok) = self.token.take() {
-            cas_u64(&self.tree, &self.key, Some(tok), None)?.context("lock token changed while held")?
-        }
-        Ok(())
-    }
-}
-
-impl Drop for Lock<'_> {
-    fn drop(&mut self) {
-        if let Err(e) = self.release_internal() {
-            log::error!("Failed to release lock on `{}`: {}", self.key, e);
-        }
-    }
-}
-
-/// [`sled::Tree::compare_and_swap`] specialized to `&str` keys and `u64` values.
-fn cas_u64(
-    tree: &sled::Tree,
-    key: &str,
-    old: Option<u64>,
-    new: Option<u64>,
-) -> sled::Result<std::result::Result<(), sled::CompareAndSwapError>> {
-    tree.compare_and_swap(
-        key,
-        old.map(|x| x.to_be_bytes()).as_ref(),
-        new.map(|x| x.to_be_bytes()).as_ref(),
-    )
 }

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -27,6 +27,21 @@ pub enum UpdateDatabaseError {
 // tables, and only accept updates which introduce new tables (beware of
 // ordering when comparing definition types!).
 
+/// Update the schema of database `stdb` in transaction `tx`.
+///
+/// The schema is updated to the [`TableDef`]s given in `proposed_tables`, as
+/// extracted from the stdb module with [`Hash`] `hash`. If this succeeds, the
+/// `__init__` reducer of the module is invoked, if one is defined. Lastly,
+/// the module hash is recorded in the system tables of `stdb` (see
+/// [`RelationalDB::set_program_hash`].
+///
+/// If any of the above fails, the transaction is rolled back.
+///
+/// NOTE: Only trivial schema transformations are supported currently, namely
+/// adding new tables and modifying indexes.
+///
+/// The `fence` parameter is used to order concurrent updates -- the transaction
+/// only commits successfully if the value is greater than the stored value.
 pub fn update_database(
     stdb: &RelationalDB,
     tx: MutTxId,

--- a/crates/core/src/messages/control_db.rs
+++ b/crates/core/src/messages/control_db.rs
@@ -21,14 +21,30 @@ pub struct EnergyBalance {
     pub balance: i128,
 }
 
+/// Represents a logical database.
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Database {
+    /// The unique identity of the database.
     pub id: u64,
+    /// The revision of the database.
+    ///
+    /// Incremented whenever the database is updated -- either by updating the
+    /// associated stdb module, or by clearing its state while preserving the
+    /// `address`.
+    ///
+    /// See also: [`DatabaseInstance::database_rev`]
+    pub rev: u64,
+    /// The stable address of the database.
     pub address: Address,
+    /// The owner of the database, usually the publisher.
     pub identity: Identity,
+    /// The runtime type of the associated stdb module.
     pub host_type: HostType,
+    /// The desired number of replica [`DatabaseInstance`]s.
     pub num_replicas: u32,
+    /// Content address of the associated stdb module.
     pub program_bytes_address: Hash,
+    /// The client address used when publishing the database.
     pub publisher_address: Option<Address>,
 }
 
@@ -36,13 +52,34 @@ pub struct Database {
 pub struct DatabaseStatus {
     pub state: String,
 }
+
+/// Represents a scheduled instance of a [`Database`].
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct DatabaseInstance {
+    /// The unique identity of the instance.
     pub id: u64,
+    /// The `id` of the logical [`Database`] this instance represents.
     pub database_id: u64,
+    /// The revision of the logical [`Database`] this instance corresponds to.
+    ///
+    /// Note that, at any point in time, [`DatabaseInstance`]s representing
+    /// different revisions may remain scheduled, possibly in different
+    /// lifecycle states. This field thus allows to determine which revision the
+    /// instance represents, even if the revision of the corresponding database
+    /// has changed meanwhile.
+    ///
+    /// See also: [`Database::rev`].
+    pub database_rev: u64,
+    /// The [`Node`] this instance is scheduled on.
+    ///
+    /// Note that this represents the _desired state_, the [`Node`] may not yet
+    /// have scheduled the instance.
     pub node_id: u64,
+    /// When there are multiple replicas of `(database_id, database_rev)`, this
+    /// instance is the designated leader.
     pub leader: bool,
 }
+
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct DatabaseInstanceStatus {
     pub state: String,

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -152,7 +152,10 @@ impl CompiledModule {
         .unwrap();
 
         let database = env.get_database_by_address(&db_address).unwrap().unwrap();
-        let instance = env.get_leader_database_instance_by_database(database.id).unwrap();
+        let instance = env
+            .get_leader_database_instance_by_database(&database)
+            .unwrap()
+            .unwrap();
 
         let client_id = ClientActorId {
             identity,


### PR DESCRIPTION
# Description of Changes

The `id` field of `DatabaseInstance` was used both as an (auto-inc) identity column and a revision of the corresponding `Database`. The latter mainly to support publishing with the `--clear` flag while preserving the stable address of the logical database.

However, with a replica count > 1 this made it impossible to determine which replicas are supposed to hold the same prefix, assuming scheduling is asynchronous.

Thus, we introduce new fields on both `DatabaseInstance` and `Database` which designate the _revision_ of either entity. The database revision is incremented on every update (regardless of `--clear` flag), and the instances point to the revision they where scheduled with.

As a side effect, this allows to retire the (distributed) locking scheme used to order schema/module updates.

Also add some commentary and remove unused methods from the `ControlStateReadAccess` trait.

# API and ABI breaking changes

Breaks the internal `client-api` (traits) and control db "schema".

# Expected complexity level and risk

2