### PR TITLE
Removed the tx_state lock from the MutTxId, since it's no longer needed

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -130,8 +130,8 @@ type SharedMutexGuard<T> = ArcMutexGuard<RawMutex, T>;
 /// `tx_state_lock` should remain `Some` throughout the transaction's lifecycle, until `commit()` or `rollback()` is called.
 
 pub struct MutTxId {
+    tx_state: TxState,
     committed_state_write_lock: SharedWriteGuard<CommittedState>,
-    tx_state_lock: SharedMutexGuard<Option<TxState>>,
     sequence_state_lock: SharedMutexGuard<SequencesState>,
     memory_lock: SharedMutexGuard<BTreeMap<DataKey, Arc<Vec<u8>>>>,
     lock_wait_time: Duration,
@@ -962,9 +962,7 @@ impl MutTxId {
         row_type: ProductType,
         schema: TableSchema,
     ) -> super::Result<()> {
-        self.tx_state_lock
-            .as_mut()
-            .unwrap()
+        self.tx_state
             .insert_tables
             .insert(table_id, Table::new(row_type, schema));
         Ok(())
@@ -1200,24 +1198,18 @@ impl MutTxId {
         database_address: Address,
     ) -> super::Result<()> {
         let insert_table = if let Some(insert_table) = self
-            .tx_state_lock
-            .as_mut()
-            .unwrap()
+            .tx_state
             .get_insert_table_mut(&index.table_id)
         {
             insert_table
         } else {
             let row_type = self.row_type_for_table(index.table_id, database_address)?.into_owned();
             let schema = self.schema_for_table(index.table_id, database_address)?.into_owned();
-            self.tx_state_lock
-                .as_mut()
-                .unwrap()
+            self.tx_state
                 .insert_tables
                 .insert(index.table_id, Table::new(row_type, schema));
 
-            self.tx_state_lock
-                .as_mut()
-                .unwrap()
+            self.tx_state
                 .get_insert_table_mut(&index.table_id)
                 .unwrap()
         };
@@ -1282,9 +1274,7 @@ impl MutTxId {
             }
         }
         if let Some(insert_table) = self
-            .tx_state_lock
-            .as_mut()
-            .unwrap()
+            .tx_state
             .get_insert_table_mut(&TableId(index_id.0))
         {
             let mut cols = vec![];
@@ -1314,7 +1304,7 @@ impl MutTxId {
     }
 
     fn contains_row(&mut self, table_id: &TableId, row_id: &RowId) -> RowState<'_> {
-        match self.tx_state_lock.as_ref().unwrap().get_row_op(table_id, row_id) {
+        match self.tx_state.get_row_op(table_id, row_id) {
             RowState::Committed(_) => unreachable!("a row cannot be committed in a tx state"),
             RowState::Insert(pv) => return RowState::Insert(pv),
             RowState::Delete => return RowState::Delete,
@@ -1332,10 +1322,8 @@ impl MutTxId {
     }
 
     fn table_exists(&self, table_id: &TableId) -> bool {
-        self.tx_state_lock
-            .as_ref()
-            .map(|tx_state| tx_state.insert_tables.contains_key(table_id))
-            .unwrap_or(false)
+        self.tx_state
+            .insert_tables.contains_key(table_id)
             || self.committed_state_write_lock.tables.contains_key(table_id)
     }
 
@@ -1428,12 +1416,11 @@ impl MutTxId {
         row.encode(&mut bytes);
         let data_key = DataKey::from_data(&bytes);
         let row_id = RowId(data_key);
-        let tx_state = self.tx_state_lock.as_mut().unwrap();
 
         // If the table does exist in the tx state, we need to create it based on the table in the
         // committed state. If the table does not exist in the committed state, it doesn't exist
         // in the database.
-        let insert_table = if let Some(table) = tx_state.get_insert_table(&table_id) {
+        let insert_table = if let Some(table) = self.tx_state.get_insert_table(&table_id) {
             table
         } else {
             let Some(committed_table) = self.committed_state_write_lock.tables.get(&table_id) else {
@@ -1460,8 +1447,8 @@ impl MutTxId {
                     .collect(),
                 rows: Default::default(),
             };
-            tx_state.insert_tables.insert(table_id, table);
-            tx_state.get_insert_table(&table_id).unwrap()
+            self.tx_state.insert_tables.insert(table_id, table);
+            self.tx_state.get_insert_table(&table_id).unwrap()
         };
 
         // Check unique constraints
@@ -1478,7 +1465,7 @@ impl MutTxId {
                     continue;
                 };
                 for row_id in violators {
-                    if let Some(delete_table) = tx_state.delete_tables.get(&table_id) {
+                    if let Some(delete_table) = self.tx_state.delete_tables.get(&table_id) {
                         if !delete_table.contains(row_id) {
                             let value = row.project_not_empty(&index.cols).unwrap();
                             return Err(index.build_error_unique(table, value).into());
@@ -1503,7 +1490,7 @@ impl MutTxId {
             //    by this transaction, we will remove it from `delete_tables`, and the
             //    cummulative effect will be to leave the row in place in the committed state.
 
-            let delete_table = tx_state.get_or_create_delete_table(table_id);
+            let delete_table = self.tx_state.get_or_create_delete_table(table_id);
             let row_was_previously_deleted = delete_table.remove(&row_id);
 
             // If the row was just deleted in this transaction and we are re-inserting it now,
@@ -1512,7 +1499,7 @@ impl MutTxId {
                 return Ok(());
             }
 
-            let insert_table = tx_state.get_insert_table_mut(&table_id).unwrap();
+            let insert_table = self.tx_state.get_insert_table_mut(&table_id).unwrap();
 
             // TODO(cloutiertyler): should probably also check that all the columns are correct? Perf considerations.
             if insert_table.row_type.elements.len() != row.elements.len() {
@@ -1536,7 +1523,7 @@ impl MutTxId {
         if !self.table_exists(table_id) {
             return Err(TableError::IdNotFound(ST_TABLES_ID, table_id.0).into());
         }
-        match self.tx_state_lock.as_ref().unwrap().get_row_op(table_id, row_id) {
+        match self.tx_state.get_row_op(table_id, row_id) {
             RowState::Committed(_) => unreachable!("a row cannot be committed in a tx state"),
             RowState::Insert(row) => {
                 return Ok(Some(DataRef::new(row_id, row)));
@@ -1556,9 +1543,8 @@ impl MutTxId {
 
     fn get_row_type(&self, table_id: &TableId) -> Option<&ProductType> {
         if let Some(row_type) = self
-            .tx_state_lock
-            .as_ref()
-            .and_then(|tx_state| tx_state.insert_tables.get(table_id))
+            .tx_state
+            .insert_tables.get(table_id)
             .map(|table| table.get_row_type())
         {
             return Some(row_type);
@@ -1571,9 +1557,8 @@ impl MutTxId {
 
     fn get_schema(&self, table_id: &TableId) -> Option<&TableSchema> {
         if let Some(schema) = self
-            .tx_state_lock
-            .as_ref()
-            .and_then(|tx_state| tx_state.insert_tables.get(table_id))
+            .tx_state
+            .insert_tables.get(table_id)
             .map(|table| table.get_schema())
         {
             return Some(schema);
@@ -1596,9 +1581,7 @@ impl MutTxId {
             RowState::Committed(_) => {
                 // If the row is present because of a previously committed transaction,
                 // we need to add it to the appropriate delete_table.
-                self.tx_state_lock
-                    .as_mut()
-                    .unwrap()
+                self.tx_state
                     .get_or_create_delete_table(*table_id)
                     .insert(*row_id);
                 // True because we did delete the row.
@@ -1608,9 +1591,7 @@ impl MutTxId {
                 // If the row is present because of a an insertion in this transaction,
                 // we need to remove it from the appropriate insert_table.
                 let insert_table = self
-                    .tx_state_lock
-                    .as_mut()
-                    .unwrap()
+                    .tx_state
                     .get_insert_table_mut(table_id)
                     .unwrap();
                 insert_table.delete(row_id);
@@ -1670,16 +1651,14 @@ impl MutTxId {
         // yet. In particular, I don't know if creating an index in a transaction and
         // rolling it back will leave the index in place.
         if let Some(inserted_rows) = self
-            .tx_state_lock
-            .as_ref()
-            .and_then(|tx_state| tx_state.index_seek(table_id, &cols, &range))
+            .tx_state
+            .index_seek(table_id, &cols, &range)
         {
             // The current transaction has modified this table, and the table is indexed.
-            let tx_state = self.tx_state_lock.as_ref().unwrap();
             Ok(IterByColRange::Index(IndexSeekIterMutTxId {
                 ctx,
                 table_id: *table_id,
-                tx_state,
+                tx_state: &self.tx_state,
                 inserted_rows,
                 committed_rows: self.committed_state_write_lock.index_seek(table_id, &cols, &range),
                 committed_state: &self.committed_state_write_lock,
@@ -1689,22 +1668,14 @@ impl MutTxId {
             // Either the current transaction has not modified this table, or the table is not
             // indexed.
             match self.committed_state_write_lock.index_seek(table_id, &cols, &range) {
-                //If we don't have `self.tx_state_lock` yet is likely we are running the bootstrap process
-                Some(committed_rows) => match self.tx_state_lock.as_ref() {
-                    None => Ok(IterByColRange::Scan(ScanIterByColRange {
-                        range,
-                        cols,
-                        scan_iter: self.iter(ctx, table_id)?,
-                    })),
-                    Some(tx_state) => Ok(IterByColRange::CommittedIndex(CommittedIndexIter {
-                        ctx,
-                        table_id: *table_id,
-                        tx_state,
-                        committed_state: &self.committed_state_write_lock,
-                        committed_rows,
-                        num_committed_rows_fetched: 0,
-                    })),
-                },
+                Some(committed_rows) =>  Ok(IterByColRange::CommittedIndex(CommittedIndexIter {
+                    ctx,
+                    table_id: *table_id,
+                    tx_state: &self.tx_state,
+                    committed_state: &self.committed_state_write_lock,
+                    committed_rows,
+                    num_committed_rows_fetched: 0,
+                })),
                 None => Ok(IterByColRange::Scan(ScanIterByColRange {
                     range,
                     cols,
@@ -1714,15 +1685,13 @@ impl MutTxId {
         }
     }
 
-    fn commit(&mut self) -> super::Result<Option<TxData>> {
-        let tx_state = self.tx_state_lock.take().unwrap();
+    fn commit(mut self) -> super::Result<Option<TxData>> {
         let memory: BTreeMap<DataKey, Arc<Vec<u8>>> = std::mem::take(&mut self.memory_lock);
-        let tx_data = self.committed_state_write_lock.merge(tx_state, memory);
+        let tx_data = self.committed_state_write_lock.merge(self.tx_state, memory);
         Ok(Some(tx_data))
     }
 
-    fn rollback(&mut self) {
-        *self.tx_state_lock = None;
+    fn rollback(self) {
         // TODO: Check that no sequences exceed their allocation after the rollback.
     }
 }
@@ -1744,8 +1713,6 @@ pub struct Locking {
     memory: Arc<Mutex<BTreeMap<DataKey, Arc<Vec<u8>>>>>,
     /// The state of the database up to the point of the last committed transaction.
     committed_state: Arc<RwLock<CommittedState>>,
-    /// The state of all insertions and deletions in this transaction.
-    tx_state: Arc<Mutex<Option<TxState>>>,
     /// The state of sequence generation in this database.
     sequence_state: Arc<Mutex<SequencesState>>,
     /// The address of this database.
@@ -1757,7 +1724,6 @@ impl Locking {
         Self {
             memory: Arc::new(Mutex::new(BTreeMap::new())),
             committed_state: Arc::new(RwLock::new(CommittedState::new())),
-            tx_state: Arc::new(Mutex::new(None)),
             sequence_state: Arc::new(Mutex::new(SequencesState::new())),
             database_address,
         }
@@ -1953,7 +1919,7 @@ impl<'a> Iterator for Iter<'a> {
         // Moves the current scan stage to the current tx if rows were inserted in it.
         // Returns `None` otherwise.
         let maybe_stage_current_tx_inserts = |this: &mut Self| {
-            let table = this.tx.tx_state_lock.as_ref()?;
+            let table = &this.tx.tx_state;
             let insert_table = table.insert_tables.get(&table_id)?;
             this.stage = ScanStage::CurrentTx {
                 iter: insert_table.rows.iter(),
@@ -1988,18 +1954,18 @@ impl<'a> Iterator for Iter<'a> {
                         // Increment metric for number of committed rows scanned.
                         self.num_committed_rows_fetched += 1;
                         // Check the committed row's state in the current tx.
-                        match self.tx.tx_state_lock.as_ref().map(|tx_state| tx_state.get_row_op(&table_id, row_id)) {
-                            Some(RowState::Committed(_)) => unreachable!("a row cannot be committed in a tx state"),
+                        match self.tx.tx_state.get_row_op(&table_id, row_id) {
+                            RowState::Committed(_) => unreachable!("a row cannot be committed in a tx state"),
                             // Do nothing, via (3), we'll get it in the next stage (2).
-                            Some(RowState::Insert(_)) |
+                            RowState::Insert(_) |
                             // Skip it, it's been deleted.
-                            Some(RowState::Delete) => {}
+                            RowState::Delete => {}
                             // There either are no state changes for the current tx (`None`),
                             // or there are, but `row_id` specifically has not been changed.
                             // Either way, the row is in the committed state
                             // and hasn't been removed in the current tx,
                             // so it exists and can be returned.
-                            Some(RowState::Absent) | None => return Some(DataRef::new(row_id, row)),
+                            RowState::Absent => return Some(DataRef::new(row_id, row)),
                         }
                     }
                     // (3) We got here, so we must've exhausted the committed changes.
@@ -2275,22 +2241,17 @@ impl traits::MutTx for Locking {
         let sequence_state_lock = self.sequence_state.lock_arc();
         let memory_lock = self.memory.lock_arc();
         let lock_wait_time = timer.elapsed();
-        let mut tx_state_lock = self.tx_state.lock_arc();
-        if tx_state_lock.is_some() {
-            panic!("The previous transaction was not properly rolled back or committed.");
-        }
-        tx_state_lock.replace(TxState::new());
         MutTxId {
             committed_state_write_lock,
             sequence_state_lock,
-            tx_state_lock,
+            tx_state: TxState::new(),
             memory_lock,
             lock_wait_time,
             timer,
         }
     }
 
-    fn rollback_mut_tx(&self, ctx: &ExecutionContext, mut tx: Self::MutTxId) {
+    fn rollback_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTxId) {
         let workload = &ctx.workload();
         let db = &ctx.database();
         let reducer = ctx.reducer_name().unwrap_or_default();
@@ -2311,7 +2272,7 @@ impl traits::MutTx for Locking {
         tx.rollback();
     }
 
-    fn commit_mut_tx(&self, ctx: &ExecutionContext, mut tx: Self::MutTxId) -> super::Result<Option<TxData>> {
+    fn commit_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTxId) -> super::Result<Option<TxData>> {
         let workload = &ctx.workload();
         let db = &ctx.database();
         let reducer = ctx.reducer_name().unwrap_or_default();
@@ -2364,12 +2325,12 @@ impl traits::MutTx for Locking {
     }
 
     #[cfg(test)]
-    fn rollback_mut_tx_for_test(&self, mut tx: Self::MutTxId) {
+    fn rollback_mut_tx_for_test(&self, tx: Self::MutTxId) {
         tx.rollback();
     }
 
     #[cfg(test)]
-    fn commit_mut_tx_for_test(&self, mut tx: Self::MutTxId) -> super::Result<Option<TxData>> {
+    fn commit_mut_tx_for_test(&self, tx: Self::MutTxId) -> super::Result<Option<TxData>> {
         tx.commit()
     }
 }


### PR DESCRIPTION
# Description of Changes

I am trying to see if we can remove the optional `MutTxId` since it's stored inside the `MutTxId` and it never really makes sense for it to be `None`, if my understanding is correct. I'm 90% sure it is.

# API and ABI breaking changes

It is not.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

2
