### PR TITLE
refactor: Remove global disk and memory tracking

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4172,7 +4172,6 @@ dependencies = [
  "spacetimedb-vm",
  "sqlparser",
  "strum",
- "sys-info",
  "tempfile",
  "thiserror",
  "tokio",
@@ -4578,16 +4577,6 @@ dependencies = [
  "thiserror",
  "walkdir",
  "yaml-rust",
-]
-
-[[package]]
-name = "sys-info"
-version = "0.9.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0b3a0d0aba8bf96a0e1ddfdc352fc53b3df7f39318c71854910c3c4b024ae52c"
-dependencies = [
- "cc",
- "libc",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -157,7 +157,6 @@ sqllogictest = "0.17"
 strum = { version = "0.25.0", features = ["derive"] }
 syn = { version = "2", features = ["full", "extra-traits"] }
 syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"] }
-sys-info = "0.9.1"
 tabled = "0.14.0"
 tar = "0.4"
 tempdir = "0.3.7"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -72,7 +72,6 @@ slab.workspace = true
 sled.workspace = true
 sqlparser.workspace = true
 strum.workspace = true
-sys-info.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
 tokio-util.workspace = true

--- a/crates/core/src/database_instance_context_controller.rs
+++ b/crates/core/src/database_instance_context_controller.rs
@@ -3,7 +3,6 @@ use std::{collections::HashMap, sync::Mutex};
 
 use crate::db::db_metrics::DB_METRICS;
 use crate::host::scheduler::Scheduler;
-use crate::worker_metrics::WORKER_METRICS;
 
 use super::database_instance_context::DatabaseInstanceContext;
 
@@ -38,16 +37,6 @@ impl DatabaseInstanceContextController {
 
     #[tracing::instrument(skip_all)]
     pub fn update_metrics(&self) {
-        // Update global disk usage metrics
-        if let Ok(info) = sys_info::disk_info() {
-            WORKER_METRICS.system_disk_space_free.set(info.free as i64);
-            WORKER_METRICS.system_disk_space_total.set(info.total as i64);
-        }
-        // Update memory usage metrics
-        if let Ok(info) = sys_info::mem_info() {
-            WORKER_METRICS.system_memory_free.set(info.free as i64);
-            WORKER_METRICS.system_memory_total.set(info.total as i64);
-        }
         for (db, _) in self.contexts.lock().unwrap().values() {
             // Use the previous gauge value if there is an issue getting the file size.
             if let Ok(num_bytes) = db.message_log_size_on_disk() {

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Mutex};
 use crate::hash::Hash;
 use crate::util::typed_prometheus::metrics_group;
 use once_cell::sync::Lazy;
-use prometheus::{Gauge, GaugeVec, HistogramVec, IntCounterVec, IntGauge, IntGaugeVec};
+use prometheus::{Gauge, GaugeVec, HistogramVec, IntCounterVec, IntGaugeVec};
 use spacetimedb_lib::{Address, Identity};
 
 metrics_group!(
@@ -100,22 +100,6 @@ metrics_group!(
         #[help = "The number of fatal WASM instance errors, such as reducer panics."]
         #[labels(identity: Identity, module_hash: Hash, database_address: Address, reducer_symbol: str)]
         pub wasm_instance_errors: IntCounterVec,
-
-        #[name = spacetime_system_disk_space_total_bytes]
-        #[help = "A node's total disk space (in bytes)"]
-        pub system_disk_space_total: IntGauge,
-
-        #[name = spacetime_system_disk_space_free_bytes]
-        #[help = "A node's free (unused) disk space (in bytes)"]
-        pub system_disk_space_free: IntGauge,
-
-        #[name = spacetime_system_memory_total_bytes]
-        #[help = "A node's total available memory (in bytes)"]
-        pub system_memory_total: IntGauge,
-
-        #[name = spacetime_system_memory_free_bytes]
-        #[help = "A node's current available (free) memory (in bytes)"]
-        pub system_memory_free: IntGauge,
     }
 );
 


### PR DESCRIPTION
# Description of Changes

These metrics are already tracked via kubernetes.
And sys-info does not appear to be accurate on virtual systems anyway.

Furthermore what we really want are disk and memory usage metrics per database.
We already track disk usage for the wal, objectdb, and module logs.
Tracking memory usage per database requires a custom allocator.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
