### PR TITLE
Allow to see the context of a Unsupported query for a subscription

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -7,6 +7,7 @@ use hex::FromHexError;
 use thiserror::Error;
 
 use crate::client::ClientActorId;
+use crate::sql::query_debug_info::QueryDebugInfo;
 use spacetimedb_lib::buffer::DecodeError;
 use spacetimedb_lib::{PrimaryKey, ProductValue};
 use spacetimedb_primitives::{ColId, IndexId, TableId};
@@ -92,6 +93,8 @@ pub enum SubscriptionError {
     Empty,
     #[error("Queries with side effects not allowed: {0:?}")]
     SideEffect(Crud),
+    #[error("Unsupported query on subscription: {0:?}")]
+    Unsupported(QueryDebugInfo),
 }
 
 #[derive(Error, Debug)]

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -1094,7 +1094,10 @@ mod tests {
             "SELECT * FROM lhs JOIN rhs ON lhs.id = rhs.id WHERE lhs.x < 10",
         ];
         for join in joins {
-            assert!(compile_read_only_query(&db, &tx, &auth, join).is_err(), "{join}");
+            match compile_read_only_query(&db, &tx, &auth, join) {
+                Err(DBError::Subscription(SubscriptionError::Unsupported(_))) => (),
+                x => panic!("Unexpected: {x:?}"),
+            }
         }
 
         Ok(())


### PR DESCRIPTION
# Description of Changes

When an unsupported query was executed in subscriptions it does not show which query failed. Now it does.

# Expected complexity level and risk

1
