### PR TITLE
refactor(metrics): Remove dependencies of metric builder macros

### DIFF
--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -1,9 +1,19 @@
 use std::{collections::HashMap, sync::Mutex};
 
-use crate::{execution_context::WorkloadType, host::AbiCall, util::typed_prometheus::metrics_group};
+use crate::execution_context::WorkloadType;
+use crate::host::AbiCall;
+use crate::util::typed_prometheus::impl_prometheusvalue_string;
+use crate::util::typed_prometheus::metrics_group;
+use crate::util::typed_prometheus::AsPrometheusLabel;
 use once_cell::sync::Lazy;
 use prometheus::{GaugeVec, Histogram, HistogramVec, IntCounterVec, IntGaugeVec};
 use spacetimedb_lib::Address;
+
+impl_prometheusvalue_string! {
+    Address,
+    AbiCall,
+    WorkloadType
+}
 
 metrics_group!(
     #[non_exhaustive]

--- a/crates/core/src/util/typed_prometheus.rs
+++ b/crates/core/src/util/typed_prometheus.rs
@@ -1,6 +1,4 @@
-use crate::hash::Hash;
 use prometheus::core::{Metric, MetricVec, MetricVecBuilder};
-use spacetimedb_lib::{Address, Identity};
 
 #[macro_export]
 macro_rules! metrics_group {
@@ -128,8 +126,6 @@ macro_rules! metrics_vec {
 }
 pub use metrics_vec;
 
-use crate::{execution_context::WorkloadType, host::AbiCall};
-
 pub trait AsPrometheusLabel {
     type Str<'a>: AsRef<str> + 'a
     where
@@ -142,6 +138,7 @@ impl<T: AsRef<str> + ?Sized> AsPrometheusLabel for &T {
         self.as_ref()
     }
 }
+#[macro_export]
 macro_rules! impl_prometheusvalue_string {
     ($($x:ty),*) => {
         $(impl AsPrometheusLabel for $x {
@@ -152,22 +149,9 @@ macro_rules! impl_prometheusvalue_string {
         })*
     }
 }
-impl_prometheusvalue_string!(
-    Hash,
-    Identity,
-    Address,
-    WorkloadType,
-    AbiCall,
-    bool,
-    u8,
-    u16,
-    u32,
-    u64,
-    i8,
-    i16,
-    i32,
-    i64
-);
+pub use impl_prometheusvalue_string;
+
+impl_prometheusvalue_string!(bool, u8, u16, u32, u64, i8, i16, i32, i64);
 
 #[doc(hidden)]
 pub trait ExtractMetricVecT {

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -1,10 +1,17 @@
 use std::{collections::HashMap, sync::Mutex};
 
 use crate::hash::Hash;
+use crate::util::typed_prometheus::impl_prometheusvalue_string;
 use crate::util::typed_prometheus::metrics_group;
+use crate::util::typed_prometheus::AsPrometheusLabel;
 use once_cell::sync::Lazy;
 use prometheus::{Gauge, GaugeVec, HistogramVec, IntCounterVec, IntGaugeVec};
 use spacetimedb_lib::{Address, Identity};
+
+impl_prometheusvalue_string! {
+    Hash,
+    Identity
+}
 
 metrics_group!(
     pub struct WorkerMetrics {


### PR DESCRIPTION
Prometheus metric builders should not have any outside dependencies, other than prometheus.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
