### PR TITLE
C#: don't show "Extracting..." message if already unpacked

### DIFF
--- a/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
+++ b/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
@@ -19,11 +19,11 @@
   <!-- Adapted from https://github.com/dotnet/dotnet-wasi-sdk/blob/2dbb00c779180873d3ed985e59e431f56404d8da/src/Wasi.Sdk/build/Wasi.Sdk.targets#L245-L262 -->
   <!-- Executes before the errors in https://github.com/dotnet/runtime/blob/57fd56a99d4c97ac2f95fe84640f2a3f653f4dd7/src/mono/wasi/build/WasiApp.Native.targets#L41-L50. -->
   <!-- TODO: remove when https://github.com/dotnet/runtime/issues/82788 is resolved. -->
-	<Target Name="ObtainWasiSdk" BeforeTargets="_SetupWasiSdk">
-		<PropertyGroup>
+  <Target Name="ObtainWasiSdk" BeforeTargets="_SetupWasiSdk">
+    <PropertyGroup>
       <WasiSdkVersion>20</WasiSdkVersion>
 
-			<WasiSdkDownloadTempFile>$([System.IO.Path]::Combine($(IntermediateOutputPath), "wasi-sdk.$(WasiSdkVersion).tar.gz"))</WasiSdkDownloadTempFile>
+      <WasiSdkDownloadTempFile>$([System.IO.Path]::Combine($(IntermediateOutputPath), "wasi-sdk.$(WasiSdkVersion).tar.gz"))</WasiSdkDownloadTempFile>
 
       <WasiSdkFilenameSuffix Condition="$([MSBuild]::IsOSPlatform('Windows'))">.m-mingw</WasiSdkFilenameSuffix>
       <WasiSdkFilenameSuffix Condition="$([MSBuild]::IsOSPlatform('Linux'))">-linux</WasiSdkFilenameSuffix>
@@ -35,7 +35,7 @@
       <WasiSysRoot>$([System.IO.Path]::Combine($(WasiSdkRoot), 'share', 'wasi-sysroot'))</WasiSysRoot>
       <WasiClang>$([System.IO.Path]::Combine($(WasiSdkRoot), 'bin', 'clang'))</WasiClang>
       <WasiClang Condition="$([MSBuild]::IsOSPlatform('Windows'))">$(WasiClang).exe</WasiClang>
-		</PropertyGroup>
+    </PropertyGroup>
 
     <DownloadFile
             SourceUrl="$(WasiSdkUrl)"
@@ -43,10 +43,10 @@
             DestinationFileName="$([System.IO.Path]::GetFileName('$(WasiSdkDownloadTempFile)'))"
             Condition="!Exists('$(WasiSdkDownloadTempFile)')" />
 
-    <Message Importance="high" Text="Extracting $(WasiSdkDownloadTempFile) to $(WasiSdkRoot)..." />
+    <Message Importance="high" Text="Extracting $(WasiSdkDownloadTempFile) to $(WasiSdkRoot)..." Condition="!Exists('$(WasiClang)')" />
     <MakeDir Directories="$(WasiSdkRoot)" />
     <!-- Windows 10+ has tar built in, so this should work cross-platform -->
     <Exec Command="tar -xf &quot;$(WasiSdkDownloadTempFile)&quot; -C &quot;$(WasiSdkRoot)&quot; --strip-components=1" Condition="!Exists('$(WasiClang)')" />
-	</Target>
+  </Target>
 
 </Project>


### PR DESCRIPTION
# Description of Changes

Follow-up to #587. I noticed the message was being printed even if WASI SDK is already unpacked because it was lacking the condition, which was slightly annoying. This fixes it.

Also fixed up inconsistent indentations, not sure where that came from.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
