### PR TITLE
refactor(metrics): Move table size metric into lib

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4215,6 +4215,8 @@ dependencies = [
  "hex",
  "insta",
  "itertools 0.11.0",
+ "once_cell",
+ "prometheus",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",

--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -18,6 +18,7 @@ use crate::{
     execution_context::ExecutionContext,
 };
 use anyhow::Context;
+use spacetimedb_lib::metrics::METRICS;
 use spacetimedb_sats::hash::{hash_bytes, Hash};
 use spacetimedb_sats::DataKey;
 use std::{
@@ -380,7 +381,7 @@ impl CommitLogMut {
                         .with_label_values(workload, db, reducer_or_query, &table_id)
                         .inc();
                     // Increment table rows gauge
-                    DB_METRICS.rdb_num_table_rows.with_label_values(db, &table_id).inc();
+                    METRICS.rdb_num_table_rows.with_label_values(db, &table_id).inc();
                     Operation::Insert
                 }
                 TxOp::Delete => {
@@ -390,7 +391,7 @@ impl CommitLogMut {
                         .with_label_values(workload, db, reducer_or_query, &table_id)
                         .inc();
                     // Decrement table rows gauge
-                    DB_METRICS.rdb_num_table_rows.with_label_values(db, &table_id).dec();
+                    METRICS.rdb_num_table_rows.with_label_values(db, &table_id).dec();
                     Operation::Delete
                 }
             };

--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -48,7 +48,7 @@ use crate::{
 };
 use anyhow::anyhow;
 use parking_lot::{lock_api::ArcRwLockWriteGuard, RawRwLock, RwLock};
-use spacetimedb_lib::Address;
+use spacetimedb_lib::{metrics::METRICS, Address};
 use spacetimedb_primitives::*;
 use spacetimedb_sats::data_key::{DataKey, ToDataKey};
 use spacetimedb_sats::db::def::*;
@@ -250,7 +250,7 @@ impl CommittedState {
         for schema in system_tables() {
             let table_id = schema.table_id;
             // Reset the row count metric for this system table
-            DB_METRICS
+            METRICS
                 .rdb_num_table_rows
                 .with_label_values(&database_address, &table_id.0)
                 .set(0);
@@ -283,7 +283,7 @@ impl CommittedState {
 
             st_columns.rows.insert(RowId(data_key), row);
             // Increment row count for st_columns
-            DB_METRICS
+            METRICS
                 .rdb_num_table_rows
                 .with_label_values(&database_address, &ST_COLUMNS_ID.into())
                 .inc();
@@ -311,7 +311,7 @@ impl CommittedState {
             let data_key = row.to_data_key();
             st_constraints.rows.insert(RowId(data_key), row);
             // Increment row count for st_constraints
-            DB_METRICS
+            METRICS
                 .rdb_num_table_rows
                 .with_label_values(&database_address, &ST_CONSTRAINTS_ID.into())
                 .inc();
@@ -340,7 +340,7 @@ impl CommittedState {
             let data_key = row.to_data_key();
             st_indexes.rows.insert(RowId(data_key), row);
             // Increment row count for st_indexes
-            DB_METRICS
+            METRICS
                 .rdb_num_table_rows
                 .with_label_values(&database_address, &ST_INDEXES_ID.into())
                 .inc();
@@ -375,7 +375,7 @@ impl CommittedState {
             let data_key = row.to_data_key();
             st_sequences.rows.insert(RowId(data_key), row);
             // Increment row count for st_sequences
-            DB_METRICS
+            METRICS
                 .rdb_num_table_rows
                 .with_label_values(&database_address, &ST_SEQUENCES_ID.into())
                 .inc();
@@ -1885,7 +1885,7 @@ impl Locking {
                     committed_state
                         .table_rows(table_id, schema)
                         .remove(&RowId(write.data_key));
-                    DB_METRICS
+                    METRICS
                         .rdb_num_table_rows
                         .with_label_values(&self.database_address, &table_id.into())
                         .dec();
@@ -1914,7 +1914,7 @@ impl Locking {
                     committed_state
                         .table_rows(table_id, schema)
                         .insert(RowId(write.data_key), product_value);
-                    DB_METRICS
+                    METRICS
                         .rdb_num_table_rows
                         .with_label_values(&self.database_address, &table_id.into())
                         .inc();

--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -55,11 +55,6 @@ metrics_group!(
         #[labels(table_id: u32)]
         pub rdb_delete_by_rel_time: HistogramVec,
 
-        #[name = spacetime_num_table_rows]
-        #[help = "The number of rows in a table"]
-        #[labels(db: Address, table_id: u32)]
-        pub rdb_num_table_rows: IntGaugeVec,
-
         #[name = spacetime_num_rows_inserted_cumulative]
         #[help = "The cumulative number of rows inserted into a table"]
         #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32)]

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1,5 +1,6 @@
 use fs2::FileExt;
 use nonempty::NonEmpty;
+use spacetimedb_lib::metrics::METRICS;
 use std::borrow::Cow;
 use std::fs::{create_dir_all, File};
 use std::ops::RangeBounds;
@@ -376,7 +377,7 @@ impl RelationalDB {
             .with_label_values(&table_id.0)
             .start_timer();
         self.inner.drop_table_mut_tx(tx, table_id).map(|_| {
-            DB_METRICS
+            METRICS
                 .rdb_num_table_rows
                 .with_label_values(&self.address, &table_id.into())
                 .set(0)

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -34,6 +34,8 @@ derive_more.workspace = true
 enum-as-inner.workspace = true
 hex.workspace = true
 itertools.workspace = true
+once_cell.workspace = true
+prometheus.workspace = true
 serde = { workspace = true, optional = true }
 serde_with = {workspace = true, optional = true }
 thiserror.workspace = true

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -5,6 +5,7 @@ use spacetimedb_sats::{impl_serialize, WithTypespace};
 pub mod address;
 pub mod filter;
 pub mod identity;
+pub mod metrics;
 pub mod name;
 pub mod operator;
 pub mod primary_key;

--- a/crates/lib/src/metrics.rs
+++ b/crates/lib/src/metrics.rs
@@ -1,0 +1,16 @@
+use once_cell::sync::Lazy;
+use prometheus::IntGaugeVec;
+use spacetimedb_lib::Address;
+use spacetimedb_metrics::metrics_group;
+
+metrics_group!(
+    #[non_exhaustive]
+    pub struct Metrics {
+        #[name = spacetime_num_table_rows]
+        #[help = "The number of rows in a table"]
+        #[labels(db: Address, table_id: u32)]
+        pub rdb_num_table_rows: IntGaugeVec,
+    }
+);
+
+pub static METRICS: Lazy<Metrics> = Lazy::new(Metrics::new);


### PR DESCRIPTION
Query optimization will soon need this metric.
Therefore it must be moved out of core and into lib. Eventually we might want to move all metrics into lib.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
