### PR TITLE
refactor(subscriptions): Support returning either side of a join

### DIFF
--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -279,15 +279,13 @@ mod tests {
     use std::ops::Bound;
 
     use crate::db::relational_db::tests_utils::make_test_db;
-    use crate::host::module_host::{DatabaseTableUpdate, TableOp};
-    use crate::subscription::query;
     use spacetimedb_lib::error::ResultTest;
     use spacetimedb_lib::operator::OpQuery;
     use spacetimedb_primitives::{ColId, TableId};
     use spacetimedb_sats::db::auth::StTableType;
     use spacetimedb_sats::db::def::{ColumnDef, IndexDef, TableDef};
-    use spacetimedb_sats::relation::{MemTable, Table};
-    use spacetimedb_sats::{product, AlgebraicType, ToDataKey};
+    use spacetimedb_sats::relation::Table;
+    use spacetimedb_sats::AlgebraicType;
     use spacetimedb_vm::expr::{IndexJoin, IndexScan, JoinExpr, Query};
 
     fn create_table(
@@ -1008,99 +1006,6 @@ mod tests {
         let ColumnOp::Field(FieldExpr::Value(AlgebraicValue::U64(3))) = **value else {
             panic!("unexpected right hand side {:#?}", value);
         };
-        Ok(())
-    }
-
-    #[test]
-    fn compile_incremental_index_join() -> ResultTest<()> {
-        let (db, _) = make_test_db()?;
-        let mut tx = db.begin_tx();
-
-        // Create table [lhs] with index on [b]
-        let schema = &[("a", AlgebraicType::U64), ("b", AlgebraicType::U64)];
-        let indexes = &[(1.into(), "b")];
-        let lhs_id = create_table(&db, &mut tx, "lhs", schema, indexes)?;
-
-        // Create table [rhs] with index on [b, c]
-        let schema = &[
-            ("b", AlgebraicType::U64),
-            ("c", AlgebraicType::U64),
-            ("d", AlgebraicType::U64),
-        ];
-        let indexes = &[(0.into(), "b"), (1.into(), "c")];
-        let rhs_id = create_table(&db, &mut tx, "rhs", schema, indexes)?;
-
-        // Should generate an index join since there is an index on `lhs.b`.
-        // Should push the sargable range condition into the index join's probe side.
-        let sql = "select lhs.* from lhs join rhs on lhs.b = rhs.b where rhs.c > 2 and rhs.c < 4 and rhs.d = 3";
-        let exp = compile_sql(&db, &tx, sql)?.remove(0);
-
-        let CrudExpr::Query(expr) = exp else {
-            panic!("unexpected result from compilation: {:#?}", exp);
-        };
-
-        // Create an insert for an incremental update.
-        let row = product!(0u64, 0u64);
-        let insert = TableOp {
-            op_type: 1,
-            row_pk: row.to_data_key().to_bytes(),
-            row,
-        };
-        let insert = DatabaseTableUpdate {
-            table_id: lhs_id,
-            table_name: String::from("lhs"),
-            ops: vec![insert],
-        };
-
-        // Optimize the query plan for the incremental update.
-        let expr = query::to_mem_table(expr, &insert);
-        let expr = expr.optimize(Some(db.address()));
-
-        let QueryExpr {
-            source:
-                SourceExpr::MemTable(MemTable {
-                    head: Header { table_name, .. },
-                    ..
-                }),
-            query,
-            ..
-        } = expr
-        else {
-            panic!("unexpected result after optimization: {:#?}", expr);
-        };
-
-        assert_eq!(table_name, "lhs");
-        assert_eq!(query.len(), 1);
-
-        let Query::IndexJoin(IndexJoin {
-            probe_side:
-                QueryExpr {
-                    source: SourceExpr::MemTable(_),
-                    query: ref lhs,
-                },
-            probe_field:
-                FieldName::Name {
-                    table: ref probe_table,
-                    field: ref probe_field,
-                },
-            index_side: Table::DbTable(DbTable {
-                table_id: index_table, ..
-            }),
-            index_select: Some(_),
-            index_col,
-            return_index_rows: false,
-        }) = query[0]
-        else {
-            panic!("unexpected operator {:#?}", query[0]);
-        };
-
-        assert!(lhs.is_empty());
-
-        // Assert that original index and probe tables have been swapped.
-        assert_eq!(index_table, rhs_id);
-        assert_eq!(index_col, 0.into());
-        assert_eq!(probe_field, "b");
-        assert_eq!(probe_table, "lhs");
         Ok(())
     }
 }

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -286,7 +286,7 @@ mod tests {
     use spacetimedb_primitives::{ColId, TableId};
     use spacetimedb_sats::db::auth::StTableType;
     use spacetimedb_sats::db::def::{ColumnDef, IndexDef, TableDef};
-    use spacetimedb_sats::relation::MemTable;
+    use spacetimedb_sats::relation::{MemTable, Table};
     use spacetimedb_sats::{product, AlgebraicType, ToDataKey};
     use spacetimedb_vm::expr::{IndexJoin, IndexScan, JoinExpr, Query};
 
@@ -960,7 +960,9 @@ mod tests {
                     table: ref probe_table,
                     field: ref probe_field,
                 },
-            index_table,
+            index_side: Table::DbTable(DbTable {
+                table_id: index_table, ..
+            }),
             index_col,
             ..
         }) = query[0]
@@ -1081,9 +1083,10 @@ mod tests {
                     table: ref probe_table,
                     field: ref probe_field,
                 },
-            index_header: _,
+            index_side: Table::DbTable(DbTable {
+                table_id: index_table, ..
+            }),
             index_select: Some(_),
-            index_table,
             index_col,
             return_index_rows: false,
         }) = query[0]

--- a/crates/sats/src/relation.rs
+++ b/crates/sats/src/relation.rs
@@ -649,7 +649,7 @@ impl Relation for DbTable {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, From)]
+#[derive(Debug, Clone, Eq, PartialEq, From, PartialOrd, Ord)]
 pub enum Table {
     MemTable(MemTable),
     DbTable(DbTable),
@@ -674,6 +674,13 @@ impl Table {
         match self {
             Self::MemTable(x) => x.table_access,
             Self::DbTable(x) => x.table_access,
+        }
+    }
+
+    pub fn get_db_table(&self) -> Option<&DbTable> {
+        match self {
+            Self::DbTable(t) => Some(t),
+            _ => None,
         }
     }
 }


### PR DESCRIPTION
Before this patch we made reference to the "lhs" and the "rhs" of an index join, in the context of incremental evaluation.
This patch further generalizes the incremental evaluation of index joins, by replacing such references with either the probe side or the index side. This is in preparation for adding more types of incremental evaluation plans.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
