### PR TITLE
[CI] Merge docker images from multiple platforms

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -9,12 +9,13 @@ on:
     tags:
       - 'v*'
 
-
 jobs:
   docker-amd64:
     runs-on: bare-metal
     name: Build DockerHub AMD64 Container
     steps:
+      - name: Install jq
+        run: sudo apt-get install jq -y
       - name: Checkout
         uses: actions/checkout@v3
       - name: Docker meta
@@ -27,6 +28,7 @@ jobs:
             type=ref,event=branch,prefix=branch-
             type=sha,prefix=commit-
             type=ref,event=tag
+            type=sha,suffix=-amd64
           flavor: |
             latest=false
       - name: Set up Docker Buildx
@@ -54,6 +56,11 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
           platforms: linux/amd64
+
+      - name: Merge images
+        run: |
+          ./tools/merge-docker-images.sh $GITHUB_SHA
+
         # This ugly bit is necessary if you don't want your cache to grow forever
         # until it hits GitHub's limit of 5GB.
         # Temp fix
@@ -68,6 +75,8 @@ jobs:
     runs-on: arm-runner
     name: Build DockerHub ARM64 Container
     steps:
+      - name: Install jq
+        run: sudo apt-get install jq -y
       - name: Checkout
         uses: actions/checkout@v3
       - name: Docker meta
@@ -80,6 +89,7 @@ jobs:
             type=ref,event=branch,prefix=branch-
             type=sha,prefix=commit-
             type=ref,event=tag
+            type=sha,suffix=-arm64
           flavor: |
             latest=false
       - name: Set up Docker Buildx
@@ -107,6 +117,11 @@ jobs:
           cache-from: type=local,src=/tmp/.buildx-cache
           cache-to: type=local,dest=/tmp/.buildx-cache-new
           platforms: linux/arm64/v8
+
+      - name: Merge images
+        run: |
+          ./tools/merge-docker-images.sh $GITHUB_SHA
+
         # This ugly bit is necessary if you don't want your cache to grow forever
         # until it hits GitHub's limit of 5GB.
         # Temp fix

--- a/tools/merge-docker-images.sh
+++ b/tools/merge-docker-images.sh
@@ -1,0 +1,34 @@
+#!/bin/bash
+set -e
+
+# Shorten the first argument (commit sha) to 7 chars
+SHORT_SHA=${1:0:7}
+TAG="sha-$SHORT_SHA"
+
+# Check if images for both amd64 and arm64 exist
+if docker pull clockworklabs/spacetimedb:$TAG-amd64 --platform amd64 >/dev/null 2>&1 && docker pull clockworklabs/spacetimedb:$TAG-arm64 --platform arm64 >/dev/null 2>&1; then
+    echo "Both images exist, preparing the merged manifest"
+else
+    echo "One or both images do not exist. Exiting"
+    exit 0
+fi
+
+# Extract digests
+AMD64_DIGEST=$(docker manifest inspect clockworklabs/spacetimedb:$TAG-amd64 | jq -r '.manifests[0].digest')
+ARM64_DIGEST=$(docker manifest inspect clockworklabs/spacetimedb:$TAG-arm64 | jq -r '.manifests[0].digest')
+
+FULL_TAG="$SHORT_SHA-full"
+
+# Create a new manifest using extracted digests
+docker manifest create clockworklabs/spacetimedb:$FULL_TAG \
+  clockworklabs/spacetimedb@$AMD64_DIGEST \
+  clockworklabs/spacetimedb@$ARM64_DIGEST
+
+# Annotate the manifest with with proper platforms
+docker manifest annotate clockworklabs/spacetimedb:$FULL_TAG \
+  clockworklabs/spacetimedb@$ARM64_DIGEST --os linux --arch arm64
+docker manifest annotate clockworklabs/spacetimedb:$FULL_TAG \
+  clockworklabs/spacetimedb@$AMD64_DIGEST --os linux --arch amd64
+
+# Push the manifest
+docker manifest push clockworklabs/spacetimedb:$FULL_TAG


### PR DESCRIPTION
# Description of Changes

Because we build our docker images in more than one job, they are also pushed as separate images. This commit adds a script that will merge the images into a multiplatform manifest