### PR TITLE
Fixes for performance drop related to missing index selection

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -499,7 +499,7 @@ impl CommittedState {
         let mut constraints = Vec::new();
         for data_ref in self.iter_by_col_eq(
             &ST_CONSTRAINTS_ID,
-            &NonEmpty::new(StIndexFields::TableId.col_id()),
+            &NonEmpty::new(StConstraintFields::TableId.col_id()),
             &table_id.into(),
         )? {
             let row = data_ref.view();
@@ -1137,7 +1137,7 @@ impl MutTxId {
 
         // Look up the constraints for the table in question.
         let mut constraints = Vec::new();
-        for data_ref in self.iter_by_col_eq(&ctx, &ST_CONSTRAINTS_ID, StIndexFields::TableId, table_id.into())? {
+        for data_ref in self.iter_by_col_eq(&ctx, &ST_CONSTRAINTS_ID, StConstraintFields::TableId, table_id.into())? {
             let row = data_ref.view();
 
             let el = StConstraintRow::try_from(row)?;
@@ -2984,11 +2984,10 @@ mod tests {
             map_array(basic_table_schema_cols()),
              map_array([
                 IdxSchema { id: 6, table: 6, col: 0, name: "id_idx", unique: true },
-                IdxSchema { id: 7, table: 6, col: 1, name: "name_idx", unique: true },
+                IdxSchema { id: 7, table: 6, col: 1, name: "name_idx", unique: false },
             ]),
-            
             map_array([
-                ConstraintRow { constraint_id: 6, table_id: 6, columns: col(0), constraints: Constraints::indexed(), constraint_name: "ct_Foo_id_idx_indexed" },
+                ConstraintRow { constraint_id: 6, table_id: 6, columns: col(0), constraints: Constraints::unique(), constraint_name: "ct_Foo_id_idx_unique" },
                 ConstraintRow { constraint_id: 7, table_id: 6, columns: col(1), constraints: Constraints::indexed(), constraint_name: "ct_Foo_name_idx_indexed" }
             ]),
              map_array([
@@ -3088,7 +3087,7 @@ mod tests {
         #[rustfmt::skip]
         assert_eq!(query.scan_st_constraints()?, map_array([
             ConstraintRow { constraint_id: 0, table_id: 0, columns: col(0), constraints: Constraints::primary_key_auto(), constraint_name: "ct_st_table_table_id_primary_key_auto" },
-            ConstraintRow { constraint_id: 1, table_id: 0, columns: col(1), constraints: Constraints::indexed(), constraint_name: "ct_st_table_table_name_unique_indexed" },
+            ConstraintRow { constraint_id: 1, table_id: 0, columns: col(1), constraints: Constraints::unique(), constraint_name: "ct_st_table_table_name_unique" },
             ConstraintRow { constraint_id: 2, table_id: 1, columns: cols(0, vec![1]), constraints: Constraints::unique(), constraint_name: "ct_st_columns_table_id_col_pos_unique" },
             ConstraintRow { constraint_id: 3, table_id: 2, columns: col(0), constraints: Constraints::primary_key_auto(), constraint_name: "ct_st_sequence_sequence_id_primary_key_auto" },
             ConstraintRow { constraint_id: 4, table_id: 3, columns: col(0), constraints: Constraints::primary_key_auto(), constraint_name: "ct_st_indexes_index_id_primary_key_auto" },

--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -2968,7 +2968,7 @@ mod tests {
                 IndexDef {
                     columns: NonEmpty::new(1.into()),
                     index_name: "name_idx".into(),
-                    is_unique: true,
+                    is_unique: false,
                     index_type: IndexType::BTree,
                 },
             ])

--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -164,9 +164,7 @@ pub fn st_table_schema() -> TableSchema {
     )
     .with_type(StTableType::System)
     .with_column_constraint(Constraints::primary_key_auto(), StTableFields::TableId.col_id())
-    .unwrap()
     .with_column_index(StTableFields::TableName.col_id(), true)
-    .unwrap()
     .into_schema(ST_TABLES_ID)
 }
 
@@ -190,7 +188,6 @@ pub fn st_columns_schema() -> TableSchema {
         Constraints::unique(),
         (StColumnFields::TableId.col_id(), vec![StColumnFields::ColPos.col_id()]),
     )
-    .unwrap()
     .into_schema(ST_COLUMNS_ID)
 }
 
@@ -214,7 +211,6 @@ pub fn st_indexes_schema() -> TableSchema {
     .with_type(StTableType::System)
     // TODO: Unique constraint on index name?
     .with_column_constraint(Constraints::primary_key_auto(), StIndexFields::IndexId.col_id())
-    .unwrap()
     .into_schema(ST_INDEXES_ID)
 }
 
@@ -241,7 +237,6 @@ pub(crate) fn st_sequences_schema() -> TableSchema {
     .with_type(StTableType::System)
     // TODO: Unique constraint on sequence name?
     .with_column_constraint(Constraints::primary_key_auto(), StSequenceFields::SequenceId.col_id())
-    .unwrap()
     .into_schema(ST_SEQUENCES_ID)
 }
 
@@ -269,7 +264,6 @@ pub(crate) fn st_constraints_schema() -> TableSchema {
         Constraints::primary_key_auto(),
         StConstraintFields::ConstraintId.col_id(),
     )
-    .unwrap()
     .into_schema(ST_CONSTRAINTS_ID)
 }
 

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -946,7 +946,6 @@ mod tests {
             }],
         )
         .with_column_constraint(Constraints::primary_key_auto(), ColId(0))
-        .unwrap()
     }
 
     #[test]
@@ -1039,8 +1038,7 @@ mod tests {
                 col_type: AlgebraicType::I64,
             }],
         )
-        .with_column_sequence(ColId(0))
-        .unwrap();
+        .with_column_sequence(ColId(0));
 
         let table_id = stdb.create_table(&mut tx, schema)?;
 
@@ -1174,8 +1172,7 @@ mod tests {
             is_unique: true,
             index_type: IndexType::BTree,
         }])
-        .with_column_constraint(Constraints::identity(), ColId(0))
-        .unwrap();
+        .with_column_constraint(Constraints::identity(), ColId(0));
 
         let table_id = stdb.create_table(&mut tx, schema)?;
 

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -323,7 +323,6 @@ mod tests {
                 ],
             )
             .with_column_constraint(Constraints::identity(), ColId(0))
-            .unwrap()
             .with_indexes(vec![IndexDef::btree(
                 "Person_id_unique".into(),
                 (ColId(0), vec![ColId(1)]),
@@ -346,7 +345,6 @@ mod tests {
             ],
         )
         .with_column_constraint(Constraints::identity(), ColId(0))
-        .unwrap()
         .with_indexes(vec![IndexDef::btree(
             "Person_id_and_name".into(),
             (ColId(0), vec![ColId(1)]),
@@ -401,8 +399,7 @@ mod tests {
                 },
             ],
         )
-        .with_column_constraint(Constraints::identity(), ColId(0))
-        .unwrap()];
+        .with_column_constraint(Constraints::identity(), ColId(0))];
 
         match schema_updates(current, proposed)? {
             SchemaUpdates::Tainted(tainted) => {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -13,7 +13,7 @@ use spacetimedb_lib::buffer::DecodeError;
 use spacetimedb_lib::{PrimaryKey, ProductValue};
 use spacetimedb_primitives::*;
 use spacetimedb_sats::db::def::IndexDef;
-use spacetimedb_sats::db::error::{LibError, RelationError, SchemaError};
+use spacetimedb_sats::db::error::{LibError, RelationError, SchemaErrors};
 use spacetimedb_sats::hash::Hash;
 use spacetimedb_sats::product_value::InvalidFieldError;
 use spacetimedb_sats::relation::FieldName;
@@ -146,7 +146,7 @@ pub enum DBError {
     #[error("IndexError: {0}")]
     Index(#[from] IndexError),
     #[error("SchemaError: {0}")]
-    Schema(#[from] SchemaError),
+    Schema(SchemaErrors),
     #[error("IOError: {0}.")]
     IoError(#[from] std::io::Error),
     #[error("ParseIntError: {0}.")]

--- a/crates/core/src/sql/ast.rs
+++ b/crates/core/src/sql/ast.rs
@@ -175,14 +175,14 @@ impl From {
 
     /// Returns all the fields matching `f` as a `Vec<FromField>`,
     /// including the ones inside the joins.
-    pub fn find_field(&self, f: &str) -> Result<Vec<FieldDef>, RelationError> {
+    pub fn find_field<'a>(&'a self, f: &'a str) -> Result<Vec<FieldDef>, RelationError> {
         let field = extract_table_field(f)?;
         let fields = self.iter_tables().flat_map(|t| {
             t.columns().iter().filter_map(|column| {
                 if column.col_name == field.field {
                     Some(FieldDef {
-                        column: column.clone(),
-                        table_name: field.table.unwrap_or(&t.table_name).to_string(),
+                        column,
+                        table_name: field.table.unwrap_or(&t.table_name),
                     })
                 } else {
                     None
@@ -195,7 +195,7 @@ impl From {
 
     /// Checks if the field `named` matches exactly once in all the tables
     /// including the ones inside the joins
-    pub fn resolve_field(&self, named: &str) -> Result<FieldDef, PlanError> {
+    pub fn resolve_field<'a>(&'a self, named: &'a str) -> Result<FieldDef, PlanError> {
         let fields = self.find_field(named)?;
 
         match fields.len() {

--- a/crates/sats/src/db/def.rs
+++ b/crates/sats/src/db/def.rs
@@ -279,27 +279,20 @@ impl From<&ColumnSchema> for ProductTypeElement {
 
 /// For get the original `table_name` for where a [ColumnSchema] belongs.
 #[derive(Debug, Clone)]
-pub struct FieldDef {
-    pub column: ColumnSchema,
-    pub table_name: String,
+pub struct FieldDef<'a> {
+    pub column: &'a ColumnSchema,
+    pub table_name: &'a str,
 }
 
-impl From<FieldDef> for FieldName {
+impl From<FieldDef<'_>> for FieldName {
     fn from(value: FieldDef) -> Self {
-        FieldName::named(&value.table_name, &value.column.col_name)
+        FieldName::named(value.table_name, &value.column.col_name)
     }
 }
 
-impl From<&FieldDef> for FieldName {
-    fn from(value: &FieldDef) -> Self {
-        FieldName::named(&value.table_name, &value.column.col_name)
-    }
-}
-
-impl From<FieldDef> for ProductTypeElement {
+impl From<FieldDef<'_>> for ProductTypeElement {
     fn from(value: FieldDef) -> Self {
-        let f: FieldName = (&value).into();
-        ProductTypeElement::new(value.column.col_type, Some(f.to_string()))
+        ProductTypeElement::new(value.column.col_type.clone(), Some(value.column.col_name.clone()))
     }
 }
 
@@ -479,7 +472,7 @@ pub struct TableSchema {
     pub table_type: StTableType,
     pub table_access: StAccess,
     /// Cache for `row_type_for_table` in the data store.
-    pub row_type: ProductType,
+    row_type: ProductType,
 }
 
 impl TableSchema {

--- a/crates/sats/src/db/error.rs
+++ b/crates/sats/src/db/error.rs
@@ -3,6 +3,9 @@ use crate::product_value::InvalidFieldError;
 use crate::relation::{FieldName, Header};
 use crate::{buffer, AlgebraicType, AlgebraicValue};
 use derive_more::Display;
+use nonempty::NonEmpty;
+use spacetimedb_primitives::{ColId, TableId};
+use std::fmt;
 use std::string::FromUtf8Error;
 use thiserror::Error;
 
@@ -111,21 +114,33 @@ pub enum RelationError {
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, PartialOrd, Ord, Display)]
 pub enum DefType {
-    Table,
     Column,
     Index,
     Sequence,
     Constraint,
 }
 
-#[derive(thiserror::Error, Debug)]
+#[derive(thiserror::Error, Debug, PartialEq)]
 pub enum SchemaError {
-    #[error("Multiple primary columns defined for table: {0}")]
-    MultiplePrimaryKeys(String),
+    #[error("Multiple primary columns defined for table: {table} columns: {pks:?}")]
+    MultiplePrimaryKeys { table: String, pks: Vec<String> },
     #[error("table id `{table_id}` should have name")]
-    EmptyTableName { table_id: u32 },
+    EmptyTableName { table_id: TableId },
+    #[error("{ty} {name} columns `{columns:?}` not found  in table `{table}`")]
+    ColumnsNotFound {
+        name: String,
+        table: String,
+        columns: Vec<ColId>,
+        ty: DefType,
+    },
     #[error("table `{table}` {ty} should have name. {ty} id: {id}")]
     EmptyName { table: String, ty: DefType, id: u32 },
+    #[error("table `{table}` have `Constraints::unset()` for columns: {columns:?}")]
+    ConstraintUnset {
+        table: String,
+        name: String,
+        columns: NonEmpty<ColId>,
+    },
     #[error("Attempt to define a column with more than 1 auto_inc sequence: Table: `{table}`, Field: `{field}`")]
     OneAutoInc { table: String, field: String },
     #[error("Only Btree Indexes are supported: Table: `{table}`, Index: `{index}` is a `{index_type}`")]
@@ -134,4 +149,13 @@ pub enum SchemaError {
         index: String,
         index_type: IndexType,
     },
+}
+
+#[derive(thiserror::Error, Debug, PartialEq)]
+pub struct SchemaErrors(pub Vec<SchemaError>);
+
+impl fmt::Display for SchemaErrors {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.0.iter()).finish()
+    }
 }


### PR DESCRIPTION
# Description of Changes

This PR fixes the issues that cause the query optimizations to miss the opportunity to use indexes.

This is caused by several problems introduced in https://github.com/clockworklabs/SpacetimeDB/pull/596:

- The `constraints` information was not read correctly
- When a module passes the `TableDef` information it generates `Constraints::unset()` for all the columns without attributes. This causes the index information to skip them despite having indexes available


# API and ABI breaking changes

This requires a database wipe

# Expected complexity level and risk

1