### PR TITLE
Fixes for SpacetimeDB.Runtime package

### DIFF
--- a/crates/bindings-csharp/Runtime/Runtime.csproj
+++ b/crates/bindings-csharp/Runtime/Runtime.csproj
@@ -5,7 +5,7 @@
     <LangVersion>latest</LangVersion>
     <Nullable>enable</Nullable>
     <AssemblyName>SpacetimeDB.Runtime</AssemblyName>
-    <AssemblyVersion>0.8.1</AssemblyVersion>
+    <AssemblyVersion>0.8.2</AssemblyVersion>
     <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
   </PropertyGroup>
@@ -40,10 +40,12 @@
     <None Include="../LICENSE" Pack="true" PackagePath="" />
     <None Include="build/" Pack="true" PackagePath="build" />
     <None Include="bindings.c" Pack="true" PackagePath="" />
+    <None Include="driver.h" Pack="true" PackagePath="" />
   </ItemGroup>
 
   <ItemGroup>
     <UpToDateCheckInput Include="bindings.c" />
+    <UpToDateCheckInput Include="driver.h" />
   </ItemGroup>
 
 </Project>

--- a/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.props
+++ b/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.props
@@ -1,2 +1,13 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+
+  <PropertyGroup>
+    <WasmSingleFileBundle>true</WasmSingleFileBundle>
+    <TrimMode>full</TrimMode>
+    <InvariantGlobalization>true</InvariantGlobalization>
+    <DebuggerSupport>false</DebuggerSupport>
+    <EventSourceSupport>false</EventSourceSupport>
+    <UseSystemResourceKeys>true</UseSystemResourceKeys>
+    <EnableUnsafeBinaryFormatterSerialization>false</EnableUnsafeBinaryFormatterSerialization>
+  </PropertyGroup>
+
 </Project>

--- a/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
+++ b/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
@@ -1,15 +1,5 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
 
-  <PropertyGroup>
-    <WasmSingleFileBundle>true</WasmSingleFileBundle>
-    <TrimMode>full</TrimMode>
-    <InvariantGlobalization>true</InvariantGlobalization>
-    <DebuggerSupport>false</DebuggerSupport>
-    <EventSourceSupport>false</EventSourceSupport>
-    <UseSystemResourceKeys>true</UseSystemResourceKeys>
-    <EnableUnsafeBinaryFormatterSerialization>false</EnableUnsafeBinaryFormatterSerialization>
-  </PropertyGroup>
-
   <ItemGroup>
     <NativeFileReference Include="$(MSBuildThisFileDirectory)..\bindings.c" />
     <_WasmNativeFileForLinking Include="@(NativeFileReference)" />

--- a/modules/Directory.Build.props
+++ b/modules/Directory.Build.props
@@ -1,0 +1,4 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Only needed when referencing local dependencies as projects. For published packages, these are imported automatically. -->
+  <Import Project="../crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.props" />
+</Project>

--- a/modules/Directory.Build.targets
+++ b/modules/Directory.Build.targets
@@ -1,0 +1,4 @@
+<Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
+  <!-- Only needed when referencing local dependencies as projects. For published packages, these are imported automatically. -->
+  <Import Project="../crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets" />
+</Project>

--- a/modules/sdk-test-connect-disconnect-cs/StdbModule.csproj
+++ b/modules/sdk-test-connect-disconnect-cs/StdbModule.csproj
@@ -18,7 +18,5 @@
     <ProjectReference Include="../../crates/bindings-csharp/Codegen/Codegen.csproj" OutputItemType="Analyzer" />
     <ProjectReference Include="../../crates/bindings-csharp/Runtime/Runtime.csproj" />
   </ItemGroup>
-  <!-- Only needed when referencing local dependencies as projects. For published packages, these are imported automatically. -->
-  <Import Project="../../crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets" />
 
 </Project>

--- a/modules/spacetimedb-quickstart-cs/StdbModule.csproj
+++ b/modules/spacetimedb-quickstart-cs/StdbModule.csproj
@@ -21,7 +21,4 @@
     <ProjectReference Include="../../crates/bindings-csharp/Runtime/Runtime.csproj" />
   </ItemGroup>
 
-  <!-- Only needed when referencing local dependencies as projects. For published packages, these are imported automatically. -->
-  <Import Project="../../crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets" />
-
 </Project>


### PR DESCRIPTION
# Description of Changes

As usual, NuGet / MSBuild behaving differently for local projects vs published ones causes build issues that are not revealed by testing...

This is published to NuGet now and verified to work on an empty project.

Also changed the way `SpacetimeDB.Runtime.{props,targets}` are referenced locally by test projects by moving them to `Directory.Build.{props,targets}` at the top level of `modules/` directory.

This should simulate behaviour of published NuGet packages a bit more closely - in particular, I verified that it can reproduce the bug in question before the fix, while the previous `<Import />` approach succeeded regardless - and also makes it easier to share the same configs between multiple projects.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
