### PR TITLE
core: Initialize the database context only once

### DIFF
--- a/crates/core/src/database_instance_context.rs
+++ b/crates/core/src/database_instance_context.rs
@@ -26,12 +26,7 @@ pub struct DatabaseInstanceContext {
 }
 
 impl DatabaseInstanceContext {
-    pub fn from_database(
-        config: Config,
-        database: &Database,
-        instance_id: u64,
-        root_db_path: PathBuf,
-    ) -> Result<Arc<Self>> {
+    pub fn from_database(config: Config, database: &Database, instance_id: u64, root_db_path: PathBuf) -> Result<Self> {
         let mut db_path = root_db_path;
         db_path.extend([&*database.address.to_hex(), &*instance_id.to_string()]);
         db_path.push("database");
@@ -67,7 +62,7 @@ impl DatabaseInstanceContext {
         db_path: PathBuf,
         log_path: &Path,
         publisher_address: Option<Address>,
-    ) -> Result<Arc<Self>> {
+    ) -> Result<Self> {
         let message_log = match config.storage {
             Storage::Memory => None,
             Storage::Disk => {
@@ -86,7 +81,7 @@ impl DatabaseInstanceContext {
         let odb = Arc::new(Mutex::new(odb));
         let relational_db = RelationalDB::open(db_path, message_log, odb, address, config.fsync != FsyncPolicy::Never)?;
 
-        Ok(Arc::new(Self {
+        Ok(Self {
             database_instance_id,
             database_id,
             identity,
@@ -94,7 +89,7 @@ impl DatabaseInstanceContext {
             logger: Arc::new(DatabaseLogger::open(log_path)),
             relational_db: Arc::new(relational_db),
             publisher_address,
-        }))
+        })
     }
 
     pub(crate) fn make_default_ostorage(path: impl AsRef<Path>) -> Result<Box<dyn ObjectDB + Send>> {

--- a/crates/core/src/database_instance_context_controller.rs
+++ b/crates/core/src/database_instance_context_controller.rs
@@ -1,14 +1,34 @@
 use std::sync::Arc;
 use std::{collections::HashMap, sync::Mutex};
 
+use once_cell::sync::OnceCell;
+
 use crate::db::db_metrics::DB_METRICS;
 use crate::host::scheduler::Scheduler;
 
 use super::database_instance_context::DatabaseInstanceContext;
 
+/// The database state managed by [`DatabaseInstanceContextController`].
+///
+/// Morally, this holds a pair of [`DatabaseInstanceContext`] and [`Scheduler`].
+/// The former holds metadata and state of a running database instance, while
+/// the latter manages scheduled reducers.
+///
+/// Operationally, this pair is wrapped in a [`OnceCell`], which ensures that
+/// the same physical database instance is not initialized multiple times due
+/// to concurrent access to the controller. Note that this is not primarily for
+/// safety -- databases acquire filesystem locks which ensure singleton access --
+/// but to prevent unhelpful errors from propagating up, and potential retries
+/// from consuming resources.
+///
+/// Lastly, the [`OnceCell`] is wrapped in an [`Arc`] pointer, which allows
+/// initialization to proceed without holding the lock on the controller's
+/// internal map.
+type Context = Arc<OnceCell<(Arc<DatabaseInstanceContext>, Scheduler)>>;
+
 #[derive(Default)]
 pub struct DatabaseInstanceContextController {
-    contexts: Mutex<HashMap<u64, (Arc<DatabaseInstanceContext>, Scheduler)>>,
+    contexts: Mutex<HashMap<u64, Context>>,
 }
 
 impl DatabaseInstanceContextController {
@@ -16,48 +36,104 @@ impl DatabaseInstanceContextController {
         Self::default()
     }
 
+    /// Get the database instance state if it is already initialized.
+    ///
+    /// Returns `None` if [`Self::get_or_try_init`] has not been called for the
+    /// given instance id before, or the state was explicitly [`Self::remove`]d.
     #[tracing::instrument(skip_all)]
     pub fn get(&self, database_instance_id: u64) -> Option<(Arc<DatabaseInstanceContext>, Scheduler)> {
         let contexts = self.contexts.lock().unwrap();
-        contexts.get(&database_instance_id).cloned()
+        contexts
+            .get(&database_instance_id)
+            .and_then(|cell| cell.get())
+            .map(|(dbic, scheduler)| (dbic.clone(), scheduler.clone()))
     }
 
+    /// Get the database instance state, or initialize it if it is not present.
+    ///
+    /// If the instance is not initialized yet, this method will block until
+    /// `F` returns. It will, however, release internal locks so calls to other
+    /// methods will not block.
+    ///
+    /// After this method returns, the instance state becomes managed by the
+    /// controller until it is removed by calling [`Self::remove`].
+    ///
+    /// Note that [`Self::remove`] must be called eventually, even if this
+    /// method returns an `Err` result: in this case, [`Self::get`] returns
+    /// `None` (as one would expect), but the given `database_instance_id` is
+    /// nevertheless known to the controller.
     #[tracing::instrument(skip_all)]
-    pub fn insert(&self, database_instance_context: Arc<DatabaseInstanceContext>, scheduler: Scheduler) {
-        let database_instance_id = database_instance_context.database_instance_id;
-        let mut contexts = self.contexts.lock().unwrap();
-        contexts.insert(database_instance_id, (database_instance_context, scheduler));
+    pub fn get_or_try_init<F, E>(
+        &self,
+        database_instance_id: u64,
+        f: F,
+    ) -> Result<(Arc<DatabaseInstanceContext>, Scheduler), E>
+    where
+        F: FnOnce() -> Result<(DatabaseInstanceContext, Scheduler), E>,
+    {
+        let cell = {
+            let mut guard = self.contexts.lock().unwrap();
+            let cell = guard
+                .entry(database_instance_id)
+                .or_insert_with(|| Arc::new(OnceCell::new()));
+            Arc::clone(cell)
+        };
+        cell.get_or_try_init(|| {
+            let (dbic, scheduler) = f()?;
+            Ok((Arc::new(dbic), scheduler))
+        })
+        .map(|(dbic, scheduler)| (dbic.clone(), scheduler.clone()))
     }
 
+    /// Remove and return the state corresponding to `database_instance_id`.
+    ///
+    /// Returns `None` if either the state is not known, or was not properly
+    /// initialized (i.e. [`Self::get_or_try_init`] returned an error).
+    ///
+    /// This method may block if the instance state is currently being
+    /// initialized via [`Self::get_or_try_init`].
     #[tracing::instrument(skip_all)]
     pub fn remove(&self, database_instance_id: u64) -> Option<(Arc<DatabaseInstanceContext>, Scheduler)> {
         let mut contexts = self.contexts.lock().unwrap();
-        contexts.remove(&database_instance_id)
+        let arc = contexts.remove(&database_instance_id)?;
+        match Arc::try_unwrap(arc) {
+            Ok(cell) => cell.into_inner(),
+            Err(arc) => {
+                // If the `Arc`'s refcount is > 1, another thread is currently
+                // executing the `get_or_try_init` closure. Wait until it
+                // completes (instead of returning `None`), as callers rely on
+                // calling `scheduler.clear()`.
+                let (dbic, scheduler) = arc.wait();
+                Some((dbic.clone(), scheduler.clone()))
+            }
+        }
     }
 
     #[tracing::instrument(skip_all)]
     pub fn update_metrics(&self) {
-        for (db, _) in self.contexts.lock().unwrap().values() {
-            // Use the previous gauge value if there is an issue getting the file size.
-            if let Ok(num_bytes) = db.message_log_size_on_disk() {
-                DB_METRICS
-                    .message_log_size
-                    .with_label_values(&db.address)
-                    .set(num_bytes as i64);
-            }
-            // Use the previous gauge value if there is an issue getting the file size.
-            if let Ok(num_bytes) = db.object_db_size_on_disk() {
-                DB_METRICS
-                    .object_db_disk_usage
-                    .with_label_values(&db.address)
-                    .set(num_bytes as i64);
-            }
-            // Use the previous gauge value if there is an issue getting the file size.
-            if let Ok(num_bytes) = db.log_file_size() {
-                DB_METRICS
-                    .module_log_file_size
-                    .with_label_values(&db.address)
-                    .set(num_bytes as i64);
+        for cell in self.contexts.lock().unwrap().values() {
+            if let Some((db, _)) = cell.get() {
+                // Use the previous gauge value if there is an issue getting the file size.
+                if let Ok(num_bytes) = db.message_log_size_on_disk() {
+                    DB_METRICS
+                        .message_log_size
+                        .with_label_values(&db.address)
+                        .set(num_bytes as i64);
+                }
+                // Use the previous gauge value if there is an issue getting the file size.
+                if let Ok(num_bytes) = db.object_db_size_on_disk() {
+                    DB_METRICS
+                        .object_db_disk_usage
+                        .with_label_values(&db.address)
+                        .set(num_bytes as i64);
+                }
+                // Use the previous gauge value if there is an issue getting the file size.
+                if let Ok(num_bytes) = db.log_file_size() {
+                    DB_METRICS
+                        .module_log_file_size
+                        .with_label_values(&db.address)
+                        .set(num_bytes as i64);
+                }
             }
         }
     }


### PR DESCRIPTION
Access to the DatabaseInstanceContextController is racy, as another `get` may occur while a new DatabaseInstanceContext is initializing. Because the database acquires filesystem locks, this will lead to errors.

To fix this, the context value is wrapped in a OnceCell.
