### PR TITLE
perf(623): Use row counts in query optimization

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -36,6 +36,7 @@ pub struct RelationalDB {
     commit_log: Option<CommitLogMut>,
     _lock: Arc<File>,
     address: Address,
+    row_count_fn: Arc<dyn Fn(TableId) -> i64 + Send + Sync>,
 }
 
 impl DataRow for RelationalDB {
@@ -139,10 +140,28 @@ impl RelationalDB {
             commit_log,
             _lock: Arc::new(lock),
             address: db_address,
+            row_count_fn: Arc::new(move |table| {
+                METRICS
+                    .rdb_num_table_rows
+                    .with_label_values(&db_address, &table.into())
+                    .get()
+            }),
         };
 
         log::info!("[{}] DATABASE: OPENED", address);
         Ok(db)
+    }
+
+    /// Returns an approximate row count for a particular table.
+    /// TODO: Unify this with `Relation::row_count` when more statistics are added.
+    pub fn row_count(&self, table: TableId) -> i64 {
+        (self.row_count_fn)(table)
+    }
+
+    /// Update this `RelationalDB` with an approximate row count function.
+    pub fn with_row_count(mut self, row_count: Arc<dyn Fn(TableId) -> i64 + Send + Sync>) -> Self {
+        self.row_count_fn = row_count;
+        self
     }
 
     /// Returns the address for this database
@@ -654,7 +673,7 @@ pub(crate) mod tests_utils {
         let tmp_dir = TempDir::with_prefix("stdb_test")?;
         let in_memory = false;
         let fsync = false;
-        let stdb = open_db(&tmp_dir, in_memory, fsync)?;
+        let stdb = open_db(&tmp_dir, in_memory, fsync)?.with_row_count(Arc::new(|_| i64::MAX));
         Ok((stdb, tmp_dir))
     }
 }

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -270,7 +270,7 @@ fn compile_statement(db: &RelationalDB, statement: SqlAst) -> Result<CrudExpr, P
         } => compile_drop(name, kind, table_access)?,
     };
 
-    Ok(q.optimize(Some(db.address())))
+    Ok(q.optimize(&|table| db.row_count(table)))
 }
 
 #[cfg(test)]

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -214,6 +214,8 @@ pub fn classify(expr: &QueryExpr) -> Option<Supported> {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::db::relational_db::tests_utils::make_test_db;
     use crate::host::module_host::{DatabaseUpdate, TableOp};
@@ -544,6 +546,14 @@ mod tests {
     #[test]
     fn test_eval_incr_for_index_join() -> ResultTest<()> {
         let (db, _) = make_test_db()?;
+        run_eval_incr_for_index_join(db)?;
+
+        let (db, _) = make_test_db()?;
+        run_eval_incr_for_index_join(db.with_row_count(Arc::new(|_| 5)))?;
+        Ok(())
+    }
+
+    fn run_eval_incr_for_index_join(db: RelationalDB) -> ResultTest<()> {
         let mut tx = db.begin_tx();
 
         // Create table [lhs] with index on [id]

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -657,7 +657,7 @@ impl<'a> IncrementalJoin<'a> {
             // Replan query after replacing the indexed table with a virtual table,
             // since join order may need to be reversed.
             let join_a = with_delta_table(self.join.clone(), true, self.index_side.inserts());
-            let join_a = QueryExpr::from(join_a).optimize(Some(db.address()));
+            let join_a = QueryExpr::from(join_a).optimize(&|table| db.row_count(table));
 
             // No need to replan after replacing the probe side with a virtual table,
             // since no new constraints have been added.
@@ -685,7 +685,7 @@ impl<'a> IncrementalJoin<'a> {
             // Replan query after replacing the indexed table with a virtual table,
             // since join order may need to be reversed.
             let join_a = with_delta_table(self.join.clone(), true, self.index_side.deletes());
-            let join_a = QueryExpr::from(join_a).optimize(Some(db.address()));
+            let join_a = QueryExpr::from(join_a).optimize(&|table| db.row_count(table));
 
             // No need to replan after replacing the probe side with a virtual table,
             // since no new constraints have been added.
@@ -880,7 +880,7 @@ mod tests {
 
         // Optimize the query plan for the incremental update.
         let expr: QueryExpr = with_delta_table(join, true, delta).into();
-        let mut expr = expr.optimize(Some(db.address()));
+        let mut expr = expr.optimize(&|_| i64::MAX);
 
         assert_eq!(expr.source.table_name(), "lhs");
         assert_eq!(expr.query.len(), 1);
@@ -975,7 +975,7 @@ mod tests {
 
         // Optimize the query plan for the incremental update.
         let expr: QueryExpr = with_delta_table(join, false, delta).into();
-        let mut expr = expr.optimize(Some(db.address()));
+        let mut expr = expr.optimize(&|_| i64::MAX);
 
         assert_eq!(expr.source.table_name(), "lhs");
         assert_eq!(expr.query.len(), 1);

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -77,7 +77,7 @@ fn build_typed<P: ProgramVm>(p: &mut P, node: Expr) -> ExprOpt {
             }
         }
         Expr::Crud(q) => {
-            let q = q.optimize(p.address());
+            let q = q.optimize(&|_| i64::MAX);
             match q {
                 CrudExpr::Query(q) => {
                     let source = build_query_opt(q);


### PR DESCRIPTION
Closes #623.

Before this patch query optimization was entirely syntax driven. Now that we keep table size metrics we can be somewhat data driven.

This patch improves index joins,
by using row counts to determine the index side and the probe side.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
