### PR TITLE
Use associate type for tx

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -2490,12 +2490,7 @@ impl MutTxDatastore for Locking {
         tx.table_name_from_id(ctx, table_id)
     }
 
-    fn create_index_mut_tx(
-        &self,
-        tx: &mut Self::MutTx,
-        table_id: TableId,
-        index: IndexDef,
-    ) -> super::Result<IndexId> {
+    fn create_index_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, index: IndexDef) -> super::Result<IndexId> {
         tx.create_index(table_id, index, self.database_address)
     }
 
@@ -2524,11 +2519,7 @@ impl MutTxDatastore for Locking {
         tx.drop_sequence(seq_id, self.database_address)
     }
 
-    fn sequence_id_from_name_mut_tx(
-        &self,
-        tx: &Self::MutTx,
-        sequence_name: &str,
-    ) -> super::Result<Option<SequenceId>> {
+    fn sequence_id_from_name_mut_tx(&self, tx: &Self::MutTx, sequence_name: &str) -> super::Result<Option<SequenceId>> {
         tx.sequence_id_from_name(sequence_name, self.database_address)
     }
 
@@ -2536,11 +2527,7 @@ impl MutTxDatastore for Locking {
         tx.drop_constraint(constraint_id, self.database_address)
     }
 
-    fn constraint_id_from_name(
-        &self,
-        tx: &Self::MutTx,
-        constraint_name: &str,
-    ) -> super::Result<Option<ConstraintId>> {
+    fn constraint_id_from_name(&self, tx: &Self::MutTx, constraint_name: &str) -> super::Result<Option<ConstraintId>> {
         tx.constraint_id_from_name(constraint_name, self.database_address)
     }
 

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -83,12 +83,7 @@ pub trait TxDatastore: DataRow + Tx {
     where
         Self: 'a;
 
-    fn iter_tx<'a>(
-        &'a self,
-        ctx: &'a ExecutionContext,
-        tx: &'a Self::Tx,
-        table_id: TableId,
-    ) -> Result<Self::Iter<'a>>;
+    fn iter_tx<'a>(&'a self, ctx: &'a ExecutionContext, tx: &'a Self::Tx, table_id: TableId) -> Result<Self::Iter<'a>>;
 
     fn iter_by_col_range_tx<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
@@ -122,11 +117,7 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     // In these methods, we use `'tx` because the return type must borrow data
     // from `Inner` in the `Locking` implementation,
     // and `Inner` lives in `tx: &MutTxId`.
-    fn row_type_for_table_mut_tx<'tx>(
-        &self,
-        tx: &'tx Self::MutTx,
-        table_id: TableId,
-    ) -> Result<Cow<'tx, ProductType>>;
+    fn row_type_for_table_mut_tx<'tx>(&self, tx: &'tx Self::MutTx, table_id: TableId) -> Result<Cow<'tx, ProductType>>;
     fn schema_for_table_mut_tx<'tx>(&self, tx: &'tx Self::MutTx, table_id: TableId) -> Result<Cow<'tx, TableSchema>>;
     fn drop_table_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId) -> Result<()>;
     fn rename_table_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, new_name: &str) -> Result<()>;
@@ -165,19 +156,13 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
 
     // Sequences
     fn get_next_sequence_value_mut_tx(&self, tx: &mut Self::MutTx, seq_id: SequenceId) -> Result<i128>;
-    fn create_sequence_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, seq: SequenceDef)
-        -> Result<SequenceId>;
+    fn create_sequence_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, seq: SequenceDef) -> Result<SequenceId>;
     fn drop_sequence_mut_tx(&self, tx: &mut Self::MutTx, seq_id: SequenceId) -> Result<()>;
-    fn sequence_id_from_name_mut_tx(
-        &self,
-        tx: &Self::MutTx,
-        sequence_name: &str,
-    ) -> super::Result<Option<SequenceId>>;
+    fn sequence_id_from_name_mut_tx(&self, tx: &Self::MutTx, sequence_name: &str) -> super::Result<Option<SequenceId>>;
 
     // Constraints
     fn drop_constraint_mut_tx(&self, tx: &mut Self::MutTx, constraint_id: ConstraintId) -> super::Result<()>;
-    fn constraint_id_from_name(&self, tx: &Self::MutTx, constraint_name: &str)
-        -> super::Result<Option<ConstraintId>>;
+    fn constraint_id_from_name(&self, tx: &Self::MutTx, constraint_name: &str) -> super::Result<Option<ConstraintId>>;
 
     // Data
     fn iter_mut_tx<'a>(

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -50,24 +50,24 @@ pub trait DataRow: Send + Sync {
 }
 
 pub trait Tx {
-    type TxId;
+    type Tx;
 
-    fn begin_tx(&self) -> Self::TxId;
-    fn release_tx(&self, ctx: &ExecutionContext, tx: Self::TxId);
+    fn begin_tx(&self) -> Self::Tx;
+    fn release_tx(&self, ctx: &ExecutionContext, tx: Self::Tx);
 }
 
 pub trait MutTx {
-    type MutTxId;
+    type MutTx;
 
-    fn begin_mut_tx(&self) -> Self::MutTxId;
-    fn commit_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTxId) -> Result<Option<TxData>>;
-    fn rollback_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTxId);
-
-    #[cfg(test)]
-    fn commit_mut_tx_for_test(&self, tx: Self::MutTxId) -> Result<Option<TxData>>;
+    fn begin_mut_tx(&self) -> Self::MutTx;
+    fn commit_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTx) -> Result<Option<TxData>>;
+    fn rollback_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTx);
 
     #[cfg(test)]
-    fn rollback_mut_tx_for_test(&self, tx: Self::MutTxId);
+    fn commit_mut_tx_for_test(&self, tx: Self::MutTx) -> Result<Option<TxData>>;
+
+    #[cfg(test)]
+    fn rollback_mut_tx_for_test(&self, tx: Self::MutTx);
 }
 
 pub trait TxDatastore: DataRow + Tx {
@@ -86,14 +86,14 @@ pub trait TxDatastore: DataRow + Tx {
     fn iter_tx<'a>(
         &'a self,
         ctx: &'a ExecutionContext,
-        tx: &'a Self::TxId,
+        tx: &'a Self::Tx,
         table_id: TableId,
     ) -> Result<Self::Iter<'a>>;
 
     fn iter_by_col_range_tx<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
         ctx: &'a ExecutionContext,
-        tx: &'a Self::TxId,
+        tx: &'a Self::Tx,
         table_id: TableId,
         cols: NonEmpty<ColId>,
         range: R,
@@ -102,7 +102,7 @@ pub trait TxDatastore: DataRow + Tx {
     fn iter_by_col_eq_tx<'a>(
         &'a self,
         ctx: &'a ExecutionContext,
-        tx: &'a Self::TxId,
+        tx: &'a Self::Tx,
         table_id: TableId,
         cols: NonEmpty<ColId>,
         value: AlgebraicValue,
@@ -110,7 +110,7 @@ pub trait TxDatastore: DataRow + Tx {
 
     fn get_tx<'a>(
         &self,
-        tx: &'a Self::TxId,
+        tx: &'a Self::Tx,
         table_id: TableId,
         row_id: &'a Self::RowId,
     ) -> Result<Option<Self::DataRef<'a>>>;
@@ -118,30 +118,30 @@ pub trait TxDatastore: DataRow + Tx {
 
 pub trait MutTxDatastore: TxDatastore + MutTx {
     // Tables
-    fn create_table_mut_tx(&self, tx: &mut Self::MutTxId, schema: TableDef) -> Result<TableId>;
+    fn create_table_mut_tx(&self, tx: &mut Self::MutTx, schema: TableDef) -> Result<TableId>;
     // In these methods, we use `'tx` because the return type must borrow data
     // from `Inner` in the `Locking` implementation,
     // and `Inner` lives in `tx: &MutTxId`.
     fn row_type_for_table_mut_tx<'tx>(
         &self,
-        tx: &'tx Self::MutTxId,
+        tx: &'tx Self::MutTx,
         table_id: TableId,
     ) -> Result<Cow<'tx, ProductType>>;
-    fn schema_for_table_mut_tx<'tx>(&self, tx: &'tx Self::MutTxId, table_id: TableId) -> Result<Cow<'tx, TableSchema>>;
-    fn drop_table_mut_tx(&self, tx: &mut Self::MutTxId, table_id: TableId) -> Result<()>;
-    fn rename_table_mut_tx(&self, tx: &mut Self::MutTxId, table_id: TableId, new_name: &str) -> Result<()>;
-    fn table_id_exists(&self, tx: &Self::MutTxId, table_id: &TableId) -> bool;
-    fn table_id_from_name_mut_tx(&self, tx: &Self::MutTxId, table_name: &str) -> Result<Option<TableId>>;
+    fn schema_for_table_mut_tx<'tx>(&self, tx: &'tx Self::MutTx, table_id: TableId) -> Result<Cow<'tx, TableSchema>>;
+    fn drop_table_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId) -> Result<()>;
+    fn rename_table_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, new_name: &str) -> Result<()>;
+    fn table_id_exists(&self, tx: &Self::MutTx, table_id: &TableId) -> bool;
+    fn table_id_from_name_mut_tx(&self, tx: &Self::MutTx, table_name: &str) -> Result<Option<TableId>>;
     fn table_name_from_id_mut_tx<'a>(
         &'a self,
         ctx: &'a ExecutionContext,
-        tx: &'a Self::MutTxId,
+        tx: &'a Self::MutTx,
         table_id: TableId,
     ) -> Result<Option<&'a str>>;
     fn get_all_tables_mut_tx<'tx>(
         &self,
         ctx: &ExecutionContext,
-        tx: &'tx Self::MutTxId,
+        tx: &'tx Self::MutTx,
     ) -> super::Result<Vec<Cow<'tx, TableSchema>>> {
         let mut tables = Vec::new();
         let table_rows = self.iter_mut_tx(ctx, tx, ST_TABLES_ID)?.collect::<Vec<_>>();
@@ -154,9 +154,9 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     }
 
     // Indexes
-    fn create_index_mut_tx(&self, tx: &mut Self::MutTxId, table_id: TableId, index: IndexDef) -> Result<IndexId>;
-    fn drop_index_mut_tx(&self, tx: &mut Self::MutTxId, index_id: IndexId) -> Result<()>;
-    fn index_id_from_name_mut_tx(&self, tx: &Self::MutTxId, index_name: &str) -> super::Result<Option<IndexId>>;
+    fn create_index_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, index: IndexDef) -> Result<IndexId>;
+    fn drop_index_mut_tx(&self, tx: &mut Self::MutTx, index_id: IndexId) -> Result<()>;
+    fn index_id_from_name_mut_tx(&self, tx: &Self::MutTx, index_name: &str) -> super::Result<Option<IndexId>>;
 
     // TODO: Index data
     // - index_scan_mut_tx
@@ -164,32 +164,32 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     // - index_seek_mut_tx
 
     // Sequences
-    fn get_next_sequence_value_mut_tx(&self, tx: &mut Self::MutTxId, seq_id: SequenceId) -> Result<i128>;
-    fn create_sequence_mut_tx(&self, tx: &mut Self::MutTxId, table_id: TableId, seq: SequenceDef)
+    fn get_next_sequence_value_mut_tx(&self, tx: &mut Self::MutTx, seq_id: SequenceId) -> Result<i128>;
+    fn create_sequence_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, seq: SequenceDef)
         -> Result<SequenceId>;
-    fn drop_sequence_mut_tx(&self, tx: &mut Self::MutTxId, seq_id: SequenceId) -> Result<()>;
+    fn drop_sequence_mut_tx(&self, tx: &mut Self::MutTx, seq_id: SequenceId) -> Result<()>;
     fn sequence_id_from_name_mut_tx(
         &self,
-        tx: &Self::MutTxId,
+        tx: &Self::MutTx,
         sequence_name: &str,
     ) -> super::Result<Option<SequenceId>>;
 
     // Constraints
-    fn drop_constraint_mut_tx(&self, tx: &mut Self::MutTxId, constraint_id: ConstraintId) -> super::Result<()>;
-    fn constraint_id_from_name(&self, tx: &Self::MutTxId, constraint_name: &str)
+    fn drop_constraint_mut_tx(&self, tx: &mut Self::MutTx, constraint_id: ConstraintId) -> super::Result<()>;
+    fn constraint_id_from_name(&self, tx: &Self::MutTx, constraint_name: &str)
         -> super::Result<Option<ConstraintId>>;
 
     // Data
     fn iter_mut_tx<'a>(
         &'a self,
         ctx: &'a ExecutionContext,
-        tx: &'a Self::MutTxId,
+        tx: &'a Self::MutTx,
         table_id: TableId,
     ) -> Result<Self::Iter<'a>>;
     fn iter_by_col_range_mut_tx<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
         ctx: &'a ExecutionContext,
-        tx: &'a Self::MutTxId,
+        tx: &'a Self::MutTx,
         table_id: TableId,
         cols: impl Into<NonEmpty<ColId>>,
         range: R,
@@ -197,32 +197,32 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     fn iter_by_col_eq_mut_tx<'a>(
         &'a self,
         ctx: &'a ExecutionContext,
-        tx: &'a Self::MutTxId,
+        tx: &'a Self::MutTx,
         table_id: TableId,
         cols: impl Into<NonEmpty<ColId>>,
         value: AlgebraicValue,
     ) -> Result<Self::IterByColEq<'a>>;
     fn get_mut_tx<'a>(
         &self,
-        tx: &'a Self::MutTxId,
+        tx: &'a Self::MutTx,
         table_id: TableId,
         row_id: &'a Self::RowId,
     ) -> Result<Option<Self::DataRef<'a>>>;
     fn delete_mut_tx<'a>(
         &'a self,
-        tx: &'a mut Self::MutTxId,
+        tx: &'a mut Self::MutTx,
         table_id: TableId,
         row_ids: impl IntoIterator<Item = Self::RowId>,
     ) -> u32;
     fn delete_by_rel_mut_tx(
         &self,
-        tx: &mut Self::MutTxId,
+        tx: &mut Self::MutTx,
         table_id: TableId,
         relation: impl IntoIterator<Item = ProductValue>,
     ) -> u32;
     fn insert_mut_tx<'a>(
         &'a self,
-        tx: &'a mut Self::MutTxId,
+        tx: &'a mut Self::MutTx,
         table_id: TableId,
         row: ProductValue,
     ) -> Result<ProductValue>;
@@ -238,7 +238,7 @@ pub trait Programmable: TxDatastore {
     ///
     /// A `None` result means that no program is currently associated, e.g.
     /// because the datastore has not been fully initialized yet.
-    fn program_hash(&self, tx: &Self::TxId) -> Result<Option<Hash>>;
+    fn program_hash(&self, tx: &Self::Tx) -> Result<Option<Hash>>;
 }
 
 /// Describes a [`Programmable`] datastore which allows to update the program
@@ -254,7 +254,7 @@ pub trait MutProgrammable: MutTxDatastore {
     /// The operation runs within the transactional context `tx`. The fencing
     /// token `fence` must be verified to be greater than in any previous
     /// invocations of this method.
-    fn set_program_hash(&self, tx: &mut Self::MutTxId, fence: Self::FencingToken, hash: Hash) -> Result<()>;
+    fn set_program_hash(&self, tx: &mut Self::MutTx, fence: Self::FencingToken, hash: Hash) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -1,11 +1,7 @@
-use nonempty::NonEmpty;
-use std::collections::HashMap;
-use tracing::info;
-
-use crate::db::datastore::locking_tx_datastore::MutTxId;
-use crate::db::relational_db::RelationalDB;
+use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::{DBError, PlanError};
 use crate::sql::ast::{compile_to_ast, Column, From, Join, Selection, SqlAst};
+use nonempty::NonEmpty;
 use spacetimedb_primitives::*;
 use spacetimedb_sats::db::auth::StAccess;
 use spacetimedb_sats::db::def::{TableDef, TableSchema};
@@ -14,10 +10,12 @@ use spacetimedb_sats::AlgebraicValue;
 use spacetimedb_vm::dsl::{db_table, db_table_raw, query};
 use spacetimedb_vm::expr::{ColumnOp, CrudExpr, DbType, Expr, QueryExpr, SourceExpr};
 use spacetimedb_vm::operator::OpCmp;
+use std::collections::HashMap;
+use tracing::info;
 
 /// Compile the `SQL` expression into a `ast`
 #[tracing::instrument(skip_all)]
-pub fn compile_sql(db: &RelationalDB, tx: &MutTxId, sql_text: &str) -> Result<Vec<CrudExpr>, DBError> {
+pub fn compile_sql(db: &RelationalDB, tx: &Tx, sql_text: &str) -> Result<Vec<CrudExpr>, DBError> {
     info!(sql = sql_text);
     let ast = compile_to_ast(db, tx, sql_text)?;
 
@@ -278,7 +276,7 @@ mod tests {
     use super::*;
     use std::ops::Bound;
 
-    use crate::db::relational_db::tests_utils::make_test_db;
+    use crate::db::relational_db::{tests_utils::make_test_db, MutTx};
     use crate::host::module_host::{DatabaseTableUpdate, TableOp};
     use crate::subscription::query;
     use spacetimedb_lib::error::ResultTest;
@@ -292,7 +290,7 @@ mod tests {
 
     fn create_table(
         db: &RelationalDB,
-        tx: &mut MutTxId,
+        tx: &mut MutTx,
         name: &str,
         schema: &[(&str, AlgebraicType)],
         indexes: &[(ColId, &str)],

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -7,8 +7,8 @@ use spacetimedb_lib::Address;
 use tracing::debug;
 
 use crate::db::cursor::{CatalogCursor, IndexCursor, TableCursor};
-use crate::db::datastore::locking_tx_datastore::{IterByColEq, MutTxId};
-use crate::db::relational_db::RelationalDB;
+use crate::db::datastore::locking_tx_datastore::IterByColEq;
+use crate::db::relational_db::{MutTx, RelationalDB};
 use crate::execution_context::ExecutionContext;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_primitives::*;
@@ -29,7 +29,7 @@ use spacetimedb_vm::rel_ops::RelOps;
 pub fn build_query<'a>(
     ctx: &'a ExecutionContext,
     stdb: &'a RelationalDB,
-    tx: &'a MutTxId,
+    tx: &'a MutTx,
     query: QueryCode,
 ) -> Result<Box<IterRows<'a>>, ErrorVm> {
     let db_table = matches!(&query.table, Table::DbTable(_));
@@ -119,7 +119,7 @@ pub fn build_query<'a>(
 fn join_inner<'a>(
     ctx: &'a ExecutionContext,
     db: &'a RelationalDB,
-    tx: &'a MutTxId,
+    tx: &'a MutTx,
     lhs: impl RelOps + 'a,
     rhs: JoinExpr,
     semi: bool,
@@ -170,7 +170,7 @@ fn join_inner<'a>(
 fn get_table<'a>(
     ctx: &'a ExecutionContext,
     stdb: &'a RelationalDB,
-    tx: &'a MutTxId,
+    tx: &'a MutTx,
     query: SourceExpr,
 ) -> Result<Box<dyn RelOps + 'a>, ErrorVm> {
     let head = query.head().clone();
@@ -187,7 +187,7 @@ fn get_table<'a>(
 fn iter_by_col_range<'a>(
     ctx: &'a ExecutionContext,
     db: &'a RelationalDB,
-    tx: &'a MutTxId,
+    tx: &'a MutTx,
     table: DbTable,
     col_id: ColId,
     range: impl RangeBounds<AlgebraicValue> + 'a,
@@ -219,7 +219,7 @@ pub struct IndexSemiJoin<'a, Rhs: RelOps> {
     // A reference to the database.
     pub db: &'a RelationalDB,
     // A reference to the current transaction.
-    pub tx: &'a MutTxId,
+    pub tx: &'a MutTx,
     // The execution context for the current transaction.
     ctx: &'a ExecutionContext<'a>,
 }
@@ -291,17 +291,17 @@ impl<'a, Rhs: RelOps> RelOps for IndexSemiJoin<'a, Rhs> {
 
 /// A [ProgramVm] implementation that carry a [RelationalDB] for it
 /// query execution
-pub struct DbProgram<'db, 'tx> {
+pub struct DbProgram<'db, 'tx, T> {
     ctx: &'tx ExecutionContext<'tx>,
     pub(crate) env: EnvDb,
     pub(crate) stats: HashMap<String, u64>,
     pub(crate) db: &'db RelationalDB,
-    pub(crate) tx: &'tx mut MutTxId,
+    pub(crate) tx: &'tx mut T,
     pub(crate) auth: AuthCtx,
 }
 
-impl<'db, 'tx> DbProgram<'db, 'tx> {
-    pub fn new(ctx: &'tx ExecutionContext, db: &'db RelationalDB, tx: &'tx mut MutTxId, auth: AuthCtx) -> Self {
+impl<'db, 'tx> DbProgram<'db, 'tx, MutTx> {
+    pub fn new(ctx: &'tx ExecutionContext, db: &'db RelationalDB, tx: &'tx mut MutTx, auth: AuthCtx) -> Self {
         let mut env = EnvDb::new();
         Self::load_ops(&mut env);
         Self {
@@ -395,7 +395,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
     }
 }
 
-impl ProgramVm for DbProgram<'_, '_> {
+impl ProgramVm for DbProgram<'_, '_, MutTx> {
     fn address(&self) -> Option<Address> {
         Some(self.db.address())
     }
@@ -572,7 +572,7 @@ pub(crate) mod tests {
 
     pub(crate) fn create_table_with_rows(
         db: &RelationalDB,
-        tx: &mut MutTxId,
+        tx: &mut MutTx,
         table_name: &str,
         schema: ProductType,
         rows: &[ProductValue],
@@ -601,7 +601,7 @@ pub(crate) mod tests {
     }
 
     pub(crate) fn create_table_from_program(
-        p: &mut DbProgram,
+        p: &mut DbProgram<MutTx>,
         table_name: &str,
         schema: ProductType,
         rows: &[ProductValue],
@@ -656,7 +656,7 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    fn check_catalog(p: &mut DbProgram, name: &str, row: ProductValue, q: QueryExpr, schema: DbTable) {
+    fn check_catalog(p: &mut DbProgram<MutTx>, name: &str, row: ProductValue, q: QueryExpr, schema: DbTable) {
         let result = run_ast(p, q.into());
 
         //The expected result


### PR DESCRIPTION
# Description of Changes
1. moving from concrete type to use of associate type for tx, this wil help to adapt different type of transaction later
  i.e to use   `relational_db::MutTx` instead of MutTxId, and `realtional_db::Tx` for `compiler.rs` as that is suppose to work with read only tx.
2. changed `traits::MutTxId` -> `traits::MutTx`, similarly for `traits::TxId` as none of them mean to refer to any id.


*How complicated do you think these changes are? Grade on a scale from 1 to 5,
1

