### PR TITLE
core: Remove index update when updating a database

### DIFF
--- a/test/tests/update-module.sh
+++ b/test/tests/update-module.sh
@@ -48,7 +48,7 @@ run_test cargo run logs "$IDENT" 100
 [ ' Hello, Robert!' == "$(grep 'Robert' "$TEST_OUT" | tail -n 4 | cut -d: -f6-)" ]
 [ ' Hello, World!' == "$(grep 'World' "$TEST_OUT" | tail -n 4 | cut -d: -f6-)" ]
 
-# Unchanged module is ok
+: Unchanged module is ok
 run_test cargo run publish --skip_clippy --project-path "$PROJECT_PATH" "$IDENT"
 [ "1" == "$(grep -c "Updated database" "$TEST_OUT")" ]
 
@@ -69,31 +69,7 @@ EOF
 run_test cargo run publish --skip_clippy --project-path "$PROJECT_PATH" "$IDENT" || true
 [ "1" == "$(grep -c "Error: Database update rejected" "$TEST_OUT")" ]
 
-# Adding an index is fine, too, and invokes update
-cat > "${PROJECT_PATH}/src/lib.rs" <<EOF
-use spacetimedb::{println, spacetimedb};
-
-#[spacetimedb(table)]
-#[spacetimedb(index(btree, name = "name", name))]
-pub struct Person {
-    #[primarykey]
-    #[autoinc]
-    id: u64,
-    name: String,
-}
-
-#[spacetimedb(update)]
-pub fn on_module_update() {
-    println!("INDEX ADDED");
-}
-EOF
-
-run_test cargo run publish --skip_clippy --project-path "$PROJECT_PATH" "$IDENT"
-[ "1" == "$(grep -c "Updated database" "$TEST_OUT")" ]
-run_test cargo run logs "$IDENT" 2
-[ ' INDEX ADDED' == "$(grep 'INDEX ADDED' "$TEST_OUT" | tail -n 1 | cut -d: -f6-)" ]
-
-# Adding a table is ok, and invokes update
+: Adding a table is ok, and invokes update
 cat > "${PROJECT_PATH}/src/lib.rs" <<EOF
 use spacetimedb::{println, spacetimedb};
 


### PR DESCRIPTION
The `TableDef` type is nominally the same for the database schema and
the schema description from a module, but only the former contains
information about indexes and sequences. This would cause all indexes to
be dropped when updating a database, because none of the existing
indexes would ever be present in the module's schema definition.

It is unclear if the functionality could be recovered, but it does not
seem to be robust without a dedicated schema manipulation language
either way.

We still want to allow module updates which do not change the schema at
all, or only introduce new tables, as otherwise users may be forced to
re-run expensive initialisation steps even though they only introduced
debugging code or somesuch.

To make this work, a somewhat dubious equivalence comparison is made,
comparing the constraint definitions in a way deemed correct in post-hoc
analysis.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
