### PR TITLE
Move `build_error_unique` to `locking_tx_datastore/mod.rs`

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/btree_index.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/btree_index.rs
@@ -1,6 +1,5 @@
 use super::RowId;
-use crate::db::datastore::locking_tx_datastore::table::Table;
-use crate::error::{DBError, IndexError};
+use crate::error::DBError;
 use nonempty::NonEmpty;
 use spacetimedb_primitives::*;
 use spacetimedb_sats::data_key::ToDataKey;
@@ -186,18 +185,5 @@ impl BTreeIndex {
             self.insert(row)?;
         }
         Ok(())
-    }
-
-    pub(crate) fn build_error_unique(&self, table: &Table, value: AlgebraicValue) -> IndexError {
-        IndexError::UniqueConstraintViolation {
-            constraint_name: self.name.clone(),
-            table_name: table.schema.table_name.clone(),
-            cols: self
-                .cols
-                .iter()
-                .map(|&x| table.schema.columns()[usize::from(x)].col_name.clone())
-                .collect(),
-            value,
-        }
     }
 }

--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -30,13 +30,13 @@ use super::{
     },
     traits::{self, DataRow, MutTx, MutTxDatastore, TxData, TxDatastore},
 };
-use crate::db::datastore::system_tables;
 use crate::db::datastore::system_tables::{
     st_constraints_schema, st_module_schema, table_name_is_system, StColumnFields, StConstraintFields, StConstraintRow,
     StIndexFields, StModuleRow, StSequenceFields, StTableFields, ST_CONSTRAINTS_ID, ST_MODULE_ID, WASM_MODULE,
 };
 use crate::db::db_metrics::{DB_METRICS, MAX_TX_CPU_TIME};
 use crate::execution_context::{ExecutionContext, WorkloadType};
+use crate::{db::datastore::system_tables, error::IndexError};
 use crate::{
     db::datastore::traits::{TxOp, TxRecord},
     db::{
@@ -1568,7 +1568,7 @@ impl MutTxId {
         for index in insert_table.indexes.values() {
             if index.violates_unique_constraint(&row) {
                 let value = row.project_not_empty(&index.cols).unwrap();
-                return Err(index.build_error_unique(insert_table, value).into());
+                return Err(Self::build_error_unique(index, insert_table, value).into());
             }
         }
         if let Some(table) = self.committed_state_write_lock.tables.get_mut(&table_id) {
@@ -1581,11 +1581,11 @@ impl MutTxId {
                     if let Some(delete_table) = self.tx_state.delete_tables.get(&table_id) {
                         if !delete_table.contains(row_id) {
                             let value = row.project_not_empty(&index.cols).unwrap();
-                            return Err(index.build_error_unique(table, value).into());
+                            return Err(Self::build_error_unique(index, table, value).into());
                         }
                     } else {
                         let value = row.project_not_empty(&index.cols)?;
-                        return Err(index.build_error_unique(table, value).into());
+                        return Err(Self::build_error_unique(index, table, value).into());
                     }
                 }
             }
@@ -1630,6 +1630,19 @@ impl MutTxId {
         }
 
         Ok(())
+    }
+
+    fn build_error_unique(index: &BTreeIndex, table: &Table, value: AlgebraicValue) -> IndexError {
+        IndexError::UniqueConstraintViolation {
+            constraint_name: index.name.clone(),
+            table_name: table.schema.table_name.clone(),
+            cols: index
+                .cols
+                .iter()
+                .map(|&x| table.schema.columns()[usize::from(x)].col_name.clone())
+                .collect(),
+            value,
+        }
     }
 
     fn get<'a>(&'a self, table_id: &TableId, row_id: &'a RowId) -> super::Result<Option<DataRef<'a>>> {


### PR DESCRIPTION
# Description of Changes

Moves some code. This removes a dependency on `Table` and reflects a change I'm making in mem-arch.

# API and ABI breaking changes

None

# Expected complexity level and risk

1, trivial