### PR TITLE
`BTreeIndex`: optimize with `BTreeMap<AV, SmallVec<[RowId; 1]>>`

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/btree_index.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/btree_index.rs
@@ -1,12 +1,12 @@
 use super::RowId;
 use crate::error::DBError;
+use core::ops::RangeBounds;
+use core::slice;
+use smallvec::SmallVec;
 use spacetimedb_primitives::*;
 use spacetimedb_sats::data_key::ToDataKey;
-use spacetimedb_sats::{AlgebraicValue, DataKey, ProductValue};
-use std::{
-    collections::{btree_set, BTreeSet},
-    ops::{Bound, RangeBounds},
-};
+use spacetimedb_sats::{AlgebraicValue, ProductValue};
+use std::collections::btree_map::{BTreeMap, Range};
 
 /// ## Index Key Composition
 ///
@@ -28,39 +28,19 @@ use std::{
 /// [AlgebraicValue::I32(0)] = Row(ProductValue(...))
 /// [AlgebraicValue::Product(AlgebraicValue::I32(0), AlgebraicValue::I32(1))] = Row(ProductValue(...))
 /// ```
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
-struct IndexKey {
-    value: AlgebraicValue,
-    row_id: RowId,
-}
+type IndexKey = AlgebraicValue;
 
-impl IndexKey {
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn from_row(value: &AlgebraicValue, row_id: DataKey) -> Self {
-        Self {
-            value: value.clone(),
-            row_id: RowId(row_id),
-        }
-    }
-}
-
-pub struct BTreeIndexIter<'a> {
-    iter: btree_set::Iter<'a, IndexKey>,
-}
-
-impl Iterator for BTreeIndexIter<'_> {
-    type Item = RowId;
-
-    #[tracing::instrument(skip_all)]
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().map(|key| key.row_id)
-    }
-}
+/// A sorted collection of row ids.
+///
+/// This is `Vec<_>` but we allow a single element to be stored inline
+/// to improve performance for the common case of one element.
+type RowIds = SmallVec<[RowId; 1]>;
 
 /// An iterator for the rows that match a value [AlgebraicValue] on the
 /// [BTreeIndex]
 pub struct BTreeIndexRangeIter<'a> {
-    range_iter: btree_set::Range<'a, IndexKey>,
+    outer: Range<'a, AlgebraicValue, RowIds>,
+    inner: Option<slice::Iter<'a, RowId>>,
     num_keys_scanned: u64,
 }
 
@@ -69,11 +49,17 @@ impl<'a> Iterator for BTreeIndexRangeIter<'a> {
 
     #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(key) = self.range_iter.next() {
-            self.num_keys_scanned += 1;
-            Some(&key.row_id)
-        } else {
-            None
+        loop {
+            if let Some(inner) = self.inner.as_mut() {
+                if let Some(ptr) = inner.next() {
+                    self.num_keys_scanned += 1;
+                    return Some(ptr);
+                }
+            }
+
+            self.inner = None;
+            let (_, next) = self.outer.next()?;
+            self.inner = Some(next.iter());
         }
     }
 }
@@ -91,7 +77,7 @@ pub(crate) struct BTreeIndex {
     pub(crate) cols: ColList,
     pub(crate) name: String,
     pub(crate) is_unique: bool,
-    idx: BTreeSet<IndexKey>,
+    idx: BTreeMap<IndexKey, RowIds>,
 }
 
 impl BTreeIndex {
@@ -102,7 +88,7 @@ impl BTreeIndex {
             cols,
             name,
             is_unique,
-            idx: BTreeSet::new(),
+            idx: BTreeMap::new(),
         }
     }
 
@@ -112,17 +98,31 @@ impl BTreeIndex {
     }
 
     #[tracing::instrument(skip_all)]
-    pub(crate) fn insert(&mut self, row: &ProductValue) -> Result<(), DBError> {
+    pub(crate) fn insert(&mut self, row: &ProductValue) -> Result<bool, DBError> {
+        let row_id = RowId(row.to_data_key());
+
         let col_value = self.get_fields(row)?;
-        let key = IndexKey::from_row(&col_value, row.to_data_key());
-        self.idx.insert(key);
-        Ok(())
+        let entry = self.idx.entry(col_value).or_default();
+        // Use binary search to maintain the sort order.
+        // This is used to determine in `O(log(entry.len()))` whether `row_id` was already present.
+        let Err(idx) = entry.binary_search(&row_id) else {
+            return Ok(false);
+        };
+        entry.insert(idx, row_id);
+        Ok(true)
     }
 
     #[tracing::instrument(skip_all)]
-    pub(crate) fn delete(&mut self, col_value: &AlgebraicValue, row_id: &RowId) {
-        let key = IndexKey::from_row(col_value, row_id.0);
-        self.idx.remove(&key);
+    pub(crate) fn delete(&mut self, col_value: &AlgebraicValue, row_id: &RowId) -> bool {
+        if let Some(entry) = self.idx.get_mut(col_value) {
+            // The `entry` is sorted so we can binary search.
+            if let Ok(pos) = entry.binary_search(row_id) {
+                // Maintain the sorted order. Don't use `swap_remove`!
+                entry.remove(pos);
+                return true;
+            }
+        }
+        false
     }
 
     #[tracing::instrument(skip_all)]
@@ -148,35 +148,27 @@ impl BTreeIndex {
         self.seek(value).next().is_some()
     }
 
-    /// Returns an iterator over the `RowId`s in the [BTreeIndex]
-    #[tracing::instrument(skip_all)]
-    pub(crate) fn scan(&self) -> BTreeIndexIter<'_> {
-        BTreeIndexIter { iter: self.idx.iter() }
-    }
-
     /// Returns an iterator over the [BTreeIndex] that yields all the `RowId`s
     /// that fall within the specified `range`.
     #[tracing::instrument(skip_all)]
     pub(crate) fn seek(&self, range: &impl RangeBounds<AlgebraicValue>) -> BTreeIndexRangeIter<'_> {
-        let map = |bound, datakey| match bound {
-            Bound::Included(x) => Bound::Included(IndexKey::from_row(x, datakey)),
-            Bound::Excluded(x) => Bound::Excluded(IndexKey::from_row(x, datakey)),
-            Bound::Unbounded => Bound::Unbounded,
-        };
-        let start = map(range.start_bound(), DataKey::min_datakey());
-        let end = map(range.end_bound(), DataKey::max_datakey());
         BTreeIndexRangeIter {
-            range_iter: self.idx.range((start, end)),
+            outer: self.idx.range((range.start_bound(), range.end_bound())),
+            inner: None,
             num_keys_scanned: 0,
         }
     }
 
     /// Construct the [BTreeIndex] from the rows.
     #[tracing::instrument(skip_all)]
-    pub(crate) fn build_from_rows<'a>(&mut self, rows: impl Iterator<Item = &'a ProductValue>) -> Result<(), DBError> {
+    pub(crate) fn build_from_rows<'a>(
+        &mut self,
+        rows: impl Iterator<Item = &'a ProductValue>,
+    ) -> Result<bool, DBError> {
+        let mut all_inserted = true;
         for row in rows {
-            self.insert(row)?;
+            all_inserted &= self.insert(row)?;
         }
-        Ok(())
+        Ok(all_inserted)
     }
 }

--- a/crates/core/src/db/datastore/locking_tx_datastore/table.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/table.rs
@@ -39,7 +39,7 @@ impl Table {
         let row = self.rows.remove(row_id)?;
         for (cols, index) in self.indexes.iter_mut() {
             let col_value = row.project_not_empty(cols).unwrap();
-            index.delete(&col_value, row_id)
+            index.delete(&col_value, row_id);
         }
         Some(row)
     }


### PR DESCRIPTION
# Description of Changes

Optimizes `BTreeIndex` using `BTreeMap<AV, SmallVec<[RowId; 1]>>` as the backing implementation where the `SmallVec` is sorted.
This was found to improve performance of inserts, deletes, and most importantly, seeks, in the mem-arch-prototype.
Numbers can be found in https://github.com/clockworklabs/SpacetimeDBPrivate/pull/671#issue-2051086035 morally does the same for the prototype. However, it is likely that the performance improvements are even greater here, as `IndexKey` only shrunk from 40 to 32 bytes in the prototype, but shrinks from 72 to 32 bytes here. Moreover, this implementation here uses a more direct and inlined implementation than using `flat_map`, avoiding paying for overhead associated with `DoubleEndedIterator` that the latter has.

# API and ABI breaking changes

None

# Expected complexity level and risk

2, limited to this module and fairly easy to review.