### PR TITLE
Print Remote Server During Publish

### DIFF
--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -107,6 +107,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let anon_identity = args.get_flag("anon_identity");
     let skip_clippy = args.get_flag("skip_clippy");
     let build_debug = args.get_flag("debug");
+    let database_host = config.get_host_url(server)?;
 
     let mut query_params = Vec::<(&str, &str)>::new();
     query_params.push(("host_type", host_type.as_str()));
@@ -138,9 +139,14 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
 
     let path_to_wasm = crate::tasks::build(path_to_project, skip_clippy, build_debug)?;
     let program_bytes = fs::read(path_to_wasm)?;
+    println!(
+        "Uploading to host {} => {}",
+        server.unwrap_or(config.default_server_name().unwrap_or("<default>")),
+        database_host
+    );
 
     let mut builder = reqwest::Client::new().post(Url::parse_with_params(
-        format!("{}/database/publish", config.get_host_url(server)?).as_str(),
+        format!("{}/database/publish", database_host).as_str(),
         query_params,
     )?);
 

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -140,7 +140,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let path_to_wasm = crate::tasks::build(path_to_project, skip_clippy, build_debug)?;
     let program_bytes = fs::read(path_to_wasm)?;
     println!(
-        "Uploading to host {} => {}",
+        "Uploading to {} => {}",
         server.unwrap_or(config.default_server_name().unwrap_or("<default>")),
         database_host
     );


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

 - We've gotten feedback, both internally from the BitCraft team and externally, that we should be printing this information when publshing.

New example output:

```
boppy@boppy-macbook my_rust_module % spacetime publish
info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
checking crate with spacetimedb's clippy configuration
    Checking spacetime-module v0.1.0 (/Users/boppy/clockwork/my_rust_module)
    Finished release [optimized] target(s) in 0.16s
    Finished release [optimized] target(s) in 0.08s
Optimising module with wasm-opt...
Uploading to local => http://127.0.0.1:3000
Created new database with address: fc67c3981db589cafc29bfbb94a5c181
...
boppy@boppy-macbook my_rust_module % spacetime publish -s testnet
info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
checking crate with spacetimedb's clippy configuration
    Checking spacetime-module v0.1.0 (/Users/boppy/clockwork/my_rust_module)
    Finished release [optimized] target(s) in 0.23s
    Finished release [optimized] target(s) in 0.09s
Optimising module with wasm-opt...
Uploading to testnet => https://testnet.spacetimedb.com
Created new database with address: 6150300e3bfbc9aab5cf03c8b0de4321
```

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

- None

# Expected complexity level and risk

0

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
