### PR TITLE
Added Testnet to Default Configs

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -144,13 +144,22 @@ impl RawConfig {
         RawConfig {
             default_server: Some(DEFAULT_HOST_NICKNAME.to_string()),
             identity_configs: Vec::new(),
-            server_configs: vec![ServerConfig {
-                default_identity: None,
-                host: DEFAULT_HOST.to_string(),
-                protocol: DEFAULT_PROTOCOL.to_string(),
-                nickname: Some(DEFAULT_HOST_NICKNAME.to_string()),
-                ecdsa_public_key: None,
-            }],
+            server_configs: vec![
+                ServerConfig {
+                    default_identity: None,
+                    host: DEFAULT_HOST.to_string(),
+                    protocol: DEFAULT_PROTOCOL.to_string(),
+                    nickname: Some(DEFAULT_HOST_NICKNAME.to_string()),
+                    ecdsa_public_key: None,
+                },
+                ServerConfig {
+                    default_identity: None,
+                    host: "testnet.spacetimedb.com".to_string(),
+                    protocol: "https".to_string(),
+                    nickname: Some("testnet".to_string()),
+                    ecdsa_public_key: None,
+                },
+            ],
         }
     }
 


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

- I added testnet to the list of default server configs so that when someone creates a new config file it will include `testnet` in the list of server configs. **Important: The default is still localhost.** We are just including `testnet` in the list of default configs so that we can improve the user experience.

## Testing

This is basically what this does:
```
boppy@boppy-macbook SpacetimeDB % rm -rf ~/.spacetime
boppy@boppy-macbook SpacetimeDB % spacetime server list
 DEFAULT  HOSTNAME                 PROTOCOL  NICKNAME 
     ***  127.0.0.1:3000           http      local    
          testnet.spacetimedb.com  https     testnet
```

If you create a new configuration, you'll see that you also get `testnet` now by default. You can then use testnet immediately in other commands like publish:

```
boppy@boppy-macbook my_rust_module % spacetime publish my_module -s testnet
info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
checking crate with spacetimedb's clippy configuration
    Checking spacetime-module v0.1.0 (/Users/boppy/clockwork/my_rust_module)
    Finished release [optimized] target(s) in 0.16s
    Finished release [optimized] target(s) in 0.09s
Optimising module with wasm-opt...
Created new database with domain: my_module, address: 5be6e4eba8d2ea8fd2c552d358a86b4e
```

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

- None

# Expected complexity level and risk

0

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
