### PR TITLE
Datastore: `Cow<'tx, ProductValue>` rather than `&'tx ProductValue`.

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -1938,8 +1938,8 @@ impl DataRow for Locking {
     type RowId = RowId;
     type DataRef<'a> = DataRef<'a>;
 
-    fn view_product_value<'a>(&self, data_ref: Self::DataRef<'a>) -> &'a ProductValue {
-        data_ref.data
+    fn view_product_value<'a>(&self, data_ref: Self::DataRef<'a>) -> Cow<'a, ProductValue> {
+        Cow::Borrowed(data_ref.data)
     }
 }
 

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -46,8 +46,8 @@ impl DataRow for RelationalDB {
     type RowId = RowId;
     type DataRef<'a> = DataRef<'a>;
 
-    fn view_product_value<'a>(&self, data_ref: Self::DataRef<'a>) -> &'a ProductValue {
-        data_ref.view()
+    fn view_product_value<'a>(&self, data_ref: Self::DataRef<'a>) -> Cow<'a, ProductValue> {
+        Cow::Borrowed(data_ref.view())
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Our current datastore stores `ProductValue`s, and thus can return references to them, but the prototype new mem-arch stores a new flattened representation, and so cannot return `&'tx ProductValue`.

In preparation for the new storage format, this commit changes the datastore traits to return `Cow<'tx, ProductValue>`, so that the new implementation will be able to perform conversion and return Cow::Owned(ProductValue::from(internal_repr))`.

# API and ABI breaking changes

None; this is a strictly internal change.

# Expected complexity level and risk

1; this is a tiny diff which does not change the datastore's semantics. It may (or may not) introduce some performance regressions, as `Cow<T>` is larger than `&T`, but I expect the LLVM to inline and eliminate the `Cow::Owned` branches in most cases.
