### PR TITLE
`MutTxDatastore::table_name_from_id_mut_tx`: return `Cow<str>`

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -2499,8 +2499,8 @@ impl MutTxDatastore for Locking {
         ctx: &'a ExecutionContext,
         tx: &'a Self::MutTx,
         table_id: TableId,
-    ) -> super::Result<Option<&'a str>> {
-        tx.table_name_from_id(ctx, table_id)
+    ) -> super::Result<Option<Cow<'a, str>>> {
+        tx.table_name_from_id(ctx, table_id).map(|opt| opt.map(Cow::Borrowed))
     }
 
     fn create_index_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, index: IndexDef) -> super::Result<IndexId> {

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -135,7 +135,7 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
         ctx: &'a ExecutionContext,
         tx: &'a Self::MutTx,
         table_id: TableId,
-    ) -> Result<Option<&'a str>>;
+    ) -> Result<Option<Cow<'a, str>>>;
     fn get_all_tables_mut_tx<'tx>(
         &self,
         ctx: &ExecutionContext,

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -422,7 +422,7 @@ impl RelationalDB {
         ctx: &'a ExecutionContext,
         tx: &'a MutTx,
         table_id: TableId,
-    ) -> Result<Option<&'a str>, DBError> {
+    ) -> Result<Option<Cow<'a, str>>, DBError> {
         self.inner.table_name_from_id_mut_tx(ctx, tx, table_id)
     }
 
@@ -1331,7 +1331,7 @@ mod tests {
         stdb.rename_table(&mut tx, table_id, "YourTable")?;
         let table_name = stdb.table_name_from_id(&ctx, &tx, table_id)?;
 
-        assert_eq!(Some("YourTable"), table_name);
+        assert_eq!(Some("YourTable"), table_name.as_ref().map(Cow::as_ref));
         // Also make sure we've removed the old ST_TABLES_ID row
         let mut n = 0;
         for row in stdb.iter(&ctx, &tx, ST_TABLES_ID)? {

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -1,3 +1,4 @@
+use std::borrow::Cow;
 use std::collections::HashMap;
 use std::fmt;
 use std::sync::{Arc, Weak};
@@ -69,15 +70,15 @@ impl DatabaseUpdate {
         }
 
         let ctx = ExecutionContext::internal(stdb.address());
-        let mut table_name_map: HashMap<TableId, _> = HashMap::new();
+        let mut table_name_map: HashMap<TableId, Cow<'_, str>> = HashMap::new();
         let mut table_updates = Vec::new();
         for (table_id, table_row_operations) in map.drain() {
-            let table_name = if let Some(name) = table_name_map.get(&table_id) {
-                name
+            let table_name: &str = if let Some(name) = table_name_map.get(&table_id) {
+                name.as_ref()
             } else {
                 let table_name = stdb.table_name_from_id(&ctx, &tx, table_id).unwrap().unwrap();
                 table_name_map.insert(table_id, table_name);
-                table_name
+                table_name_map.get(&table_id).unwrap().as_ref()
             };
             table_updates.push(DatabaseTableUpdate {
                 table_id,

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -73,13 +73,10 @@ impl DatabaseUpdate {
         let mut table_name_map: HashMap<TableId, Cow<'_, str>> = HashMap::new();
         let mut table_updates = Vec::new();
         for (table_id, table_row_operations) in map.drain() {
-            let table_name: &str = if let Some(name) = table_name_map.get(&table_id) {
-                name.as_ref()
-            } else {
-                let table_name = stdb.table_name_from_id(&ctx, &tx, table_id).unwrap().unwrap();
-                table_name_map.insert(table_id, table_name);
-                table_name_map.get(&table_id).unwrap().as_ref()
-            };
+            let table_name = table_name_map
+                .entry(table_id)
+                .or_insert_with(|| stdb.table_name_from_id(&ctx, &tx, table_id).unwrap().unwrap());
+            let table_name: &str = table_name.as_ref();
             table_updates.push(DatabaseTableUpdate {
                 table_id,
                 table_name: table_name.to_owned(),


### PR DESCRIPTION
# Description of Changes

This commit changes the `MutTxDatastore` trait's method `table_name_from_id_mut_tx` method to return a `Cow<str>` rather than an `&str`, abstracting away whether the underlying datastore stores a contiguous `str` table name.

As with PR #691, our current datastore has a `String` to which it can return an `&str`, but the mem-arch-prototype stores a new representation where strings are not necessarily contiguous, so it must extract the table name and return an owned `String` rather than an `&str`.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
