### PR TITLE
Print logs to stdout instead of stderr

### DIFF
--- a/crates/cli/src/subcommands/logs.rs
+++ b/crates/cli/src/subcommands/logs.rs
@@ -116,7 +116,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     } else {
         termcolor::ColorChoice::Never
     };
-    let out = termcolor::StandardStream::stderr(term_color);
+    let out = termcolor::StandardStream::stdout(term_color);
     let mut out = out.lock();
 
     let mut rdr = res


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

- We've been printing the output of `spacetime logs ...` to stderr. This isn't correct because the purpose of the `spacetime logs ...` command is to print logs to the console, so the logs themselves are considered normal/expected output which shouldn't go to stderr. Also printing the logs to stderr is terrible UX because then if you want to search for something in the logs using grep then you have to pipe stderr into stdout which is a huge pain.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

- This is technically an API break because people may have assumed up to this point that we're printing the logs to stderr so this change could technically break CI scripts and such.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

1
