### PR TITLE
Create output directory in `generate` if it doesn't exist

### DIFF
--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -123,12 +123,7 @@ Failed to compile module {:?}. See cargo errors above for more details.",
         },
     };
 
-    if !out_dir.exists() {
-        return Err(anyhow::anyhow!(
-            "Output directory '{}' does not exist. Please create the directory and rerun this command.",
-            out_dir.to_str().unwrap()
-        ));
-    }
+    fs::create_dir_all(&out_dir)?;
 
     let mut paths = vec![];
     for (fname, code) in generate(&wasm_file, lang, namespace.as_str())?.into_iter() {

--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -123,7 +123,7 @@ Failed to compile module {:?}. See cargo errors above for more details.",
         },
     };
 
-    fs::create_dir_all(&out_dir)?;
+    fs::create_dir_all(out_dir)?;
 
     let mut paths = vec![];
     for (fname, code) in generate(&wasm_file, lang, namespace.as_str())?.into_iter() {


### PR DESCRIPTION
# Description of Changes

This is a minor change but has bothered me for as long as I remember - I believe there is no reason to error out if directory doesn't exist; most users will expect the tool to create the output dir, so we can do just that.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
