### PR TITLE
fix(707): Collect table size metrics again

### DIFF
--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -33,6 +33,7 @@ use spacetimedb::object_db::ObjectDb;
 use spacetimedb::sendgrid_controller::SendGridController;
 use spacetimedb::worker_metrics::WORKER_METRICS;
 use spacetimedb::{stdb_path, worker_metrics};
+use spacetimedb_lib::metrics::METRICS;
 use spacetimedb_lib::name::{DomainName, InsertDomainResult, RegisterTldResult, Tld};
 use spacetimedb_lib::recovery::RecoveryCode;
 use std::fs::File;
@@ -68,6 +69,7 @@ impl StandaloneEnv {
         let metrics_registry = prometheus::Registry::new();
         metrics_registry.register(Box::new(&*WORKER_METRICS)).unwrap();
         metrics_registry.register(Box::new(&*DB_METRICS)).unwrap();
+        metrics_registry.register(Box::new(&*METRICS)).unwrap();
 
         let this = Arc::new(Self {
             control_db,


### PR DESCRIPTION
Fixes #707.

Previously the table size metric definition was moved to a different crate. This was to facilitate its use in query optimization. However as part of that change it was never added back into the prometheus registry. This resulted in the metric no longer being collected by prometheus. This patch reintroduces it back into the registry, forcing its collection, again.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
