### PR TITLE
fix(684): Reset max value metrics

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -11,8 +11,6 @@ use self::{
     sequence::Sequence,
     table::Table,
 };
-use std::collections::hash_map::DefaultHasher;
-use std::hash::Hasher;
 use std::ops::Deref;
 use std::time::{Duration, Instant};
 use std::{
@@ -35,7 +33,7 @@ use crate::db::datastore::system_tables::{
     StIndexFields, StModuleRow, StSequenceFields, StTableFields, ST_CONSTRAINTS_ID, ST_MODULE_ID, WASM_MODULE,
 };
 use crate::db::db_metrics::{DB_METRICS, MAX_TX_CPU_TIME};
-use crate::execution_context::{ExecutionContext, WorkloadType};
+use crate::execution_context::ExecutionContext;
 use crate::{db::datastore::system_tables, error::IndexError};
 use crate::{
     db::datastore::traits::{TxOp, TxRecord},
@@ -2399,18 +2397,9 @@ impl traits::MutTx for Locking {
             .with_label_values(workload, db, reducer)
             .observe(elapsed_time);
 
-        fn hash(a: &WorkloadType, b: &Address, c: &str) -> u64 {
-            use std::hash::Hash;
-            let mut hasher = DefaultHasher::new();
-            a.hash(&mut hasher);
-            b.hash(&mut hasher);
-            c.hash(&mut hasher);
-            hasher.finish()
-        }
-
         let mut guard = MAX_TX_CPU_TIME.lock().unwrap();
         let max_cpu_time = *guard
-            .entry(hash(workload, db, reducer))
+            .entry((*db, *workload, reducer.to_owned()))
             .and_modify(|max| {
                 if cpu_time > *max {
                     *max = cpu_time;

--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -157,13 +157,21 @@ metrics_group!(
     }
 );
 
-pub static MAX_TX_CPU_TIME: Lazy<Mutex<HashMap<u64, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
-pub static MAX_QUERY_CPU_TIME: Lazy<Mutex<HashMap<u64, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
-pub static MAX_QUERY_COMPILE_TIME: Lazy<Mutex<HashMap<u64, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+type Triple = (Address, WorkloadType, String);
+
+pub static MAX_TX_CPU_TIME: Lazy<Mutex<HashMap<Triple, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+pub static MAX_QUERY_CPU_TIME: Lazy<Mutex<HashMap<Triple, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+pub static MAX_QUERY_COMPILE_TIME: Lazy<Mutex<HashMap<Triple, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 pub static DB_METRICS: Lazy<DbMetrics> = Lazy::new(DbMetrics::new);
 
 pub fn reset_counters() {
+    // Reset max reducer durations
+    DB_METRICS.rdb_txn_cpu_time_sec_max.0.reset();
     MAX_TX_CPU_TIME.lock().unwrap().clear();
+    // Reset max query durations
+    DB_METRICS.rdb_query_cpu_time_sec_max.0.reset();
     MAX_QUERY_CPU_TIME.lock().unwrap().clear();
+    // Reset max query compile durations
+    DB_METRICS.rdb_query_compile_time_sec_max.0.reset();
     MAX_QUERY_COMPILE_TIME.lock().unwrap().clear();
 }


### PR DESCRIPTION
Fixes #684.

Prometheus does not reset metrics.
It only updates them with new values that it collects. If it does not receive a new value for a metric, it will keep the old value.

Therefore it is important to periodically reset certain metrics. Namely gauge metrics that only receive updates occasionally.

Maximum reducer duration is one such example,
since some reducers run much more infrequently than others.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
