### PR TITLE
fix(683): Label table metrics with table name

### DIFF
--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -372,26 +372,33 @@ impl CommitLogMut {
 
         for record in &tx_data.records {
             let table_id: u32 = record.table_id.into();
+            let table_name = record.table_name.as_str();
 
             let operation = match record.op {
                 TxOp::Insert(_) => {
                     // Increment rows inserted metric
                     DB_METRICS
                         .rdb_num_rows_inserted
-                        .with_label_values(workload, db, reducer_or_query, &table_id)
+                        .with_label_values(workload, db, reducer_or_query, &table_id, table_name)
                         .inc();
                     // Increment table rows gauge
-                    METRICS.rdb_num_table_rows.with_label_values(db, &table_id).inc();
+                    METRICS
+                        .rdb_num_table_rows
+                        .with_label_values(db, &table_id, table_name)
+                        .inc();
                     Operation::Insert
                 }
                 TxOp::Delete => {
                     // Increment rows deleted metric
                     DB_METRICS
                         .rdb_num_rows_deleted
-                        .with_label_values(workload, db, reducer_or_query, &table_id)
+                        .with_label_values(workload, db, reducer_or_query, &table_id, table_name)
                         .inc();
                     // Decrement table rows gauge
-                    METRICS.rdb_num_table_rows.with_label_values(db, &table_id).dec();
+                    METRICS
+                        .rdb_num_table_rows
+                        .with_label_values(db, &table_id, table_name)
+                        .dec();
                     Operation::Delete
                 }
             };

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -30,6 +30,8 @@ pub struct TxRecord {
     pub(crate) key: DataKey,
     /// The table that was modified.
     pub(crate) table_id: TableId,
+    /// The table that was modified.
+    pub(crate) table_name: String,
 }
 
 /// A record of all the operations within a transaction.

--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -57,27 +57,27 @@ metrics_group!(
 
         #[name = spacetime_num_rows_inserted_cumulative]
         #[help = "The cumulative number of rows inserted into a table"]
-        #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32)]
+        #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32, table_name: str)]
         pub rdb_num_rows_inserted: IntCounterVec,
 
         #[name = spacetime_num_rows_deleted_cumulative]
         #[help = "The cumulative number of rows deleted from a table"]
-        #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32)]
+        #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32, table_name: str)]
         pub rdb_num_rows_deleted: IntCounterVec,
 
         #[name = spacetime_num_rows_fetched_cumulative]
         #[help = "The cumulative number of rows fetched from a table"]
-        #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32)]
+        #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32, table_name: str)]
         pub rdb_num_rows_fetched: IntCounterVec,
 
         #[name = spacetime_num_index_keys_scanned_cumulative]
         #[help = "The cumulative number of keys scanned from an index"]
-        #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32)]
+        #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32, table_name: str)]
         pub rdb_num_keys_scanned: IntCounterVec,
 
         #[name = spacetime_num_index_seeks_cumulative]
         #[help = "The cumulative number of index seeks"]
-        #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32)]
+        #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32, table_name: str)]
         pub rdb_num_index_seeks: IntCounterVec,
 
         #[name = spacetime_num_txns_cumulative]

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -32,6 +32,8 @@ use spacetimedb_sats::{AlgebraicType, AlgebraicValue, ProductType, ProductValue}
 pub type MutTx = <Locking as super::datastore::traits::MutTx>::MutTx;
 pub type Tx = <Locking as super::datastore::traits::Tx>::Tx;
 
+type RowCountFn = Arc<dyn Fn(TableId, &str) -> i64 + Send + Sync>;
+
 #[derive(Clone)]
 pub struct RelationalDB {
     // TODO(cloutiertyler): This should not be public
@@ -39,7 +41,7 @@ pub struct RelationalDB {
     commit_log: Option<CommitLogMut>,
     _lock: Arc<File>,
     address: Address,
-    row_count_fn: Arc<dyn Fn(TableId) -> i64 + Send + Sync>,
+    row_count_fn: RowCountFn,
 }
 
 impl DataRow for RelationalDB {
@@ -143,10 +145,10 @@ impl RelationalDB {
             commit_log,
             _lock: Arc::new(lock),
             address: db_address,
-            row_count_fn: Arc::new(move |table| {
+            row_count_fn: Arc::new(move |table_id, table_name| {
                 METRICS
                     .rdb_num_table_rows
-                    .with_label_values(&db_address, &table.into())
+                    .with_label_values(&db_address, &table_id.into(), table_name)
                     .get()
             }),
         };
@@ -157,12 +159,12 @@ impl RelationalDB {
 
     /// Returns an approximate row count for a particular table.
     /// TODO: Unify this with `Relation::row_count` when more statistics are added.
-    pub fn row_count(&self, table: TableId) -> i64 {
-        (self.row_count_fn)(table)
+    pub fn row_count(&self, table_id: TableId, table_name: &str) -> i64 {
+        (self.row_count_fn)(table_id, table_name)
     }
 
     /// Update this `RelationalDB` with an approximate row count function.
-    pub fn with_row_count(mut self, row_count: Arc<dyn Fn(TableId) -> i64 + Send + Sync>) -> Self {
+    pub fn with_row_count(mut self, row_count: RowCountFn) -> Self {
         self.row_count_fn = row_count;
         self
     }
@@ -388,15 +390,19 @@ impl RelationalDB {
         self.inner.create_table_mut_tx(tx, schema.into())
     }
 
-    pub fn drop_table(&self, tx: &mut MutTx, table_id: TableId) -> Result<(), DBError> {
+    pub fn drop_table(&self, ctx: &ExecutionContext, tx: &mut MutTx, table_id: TableId) -> Result<(), DBError> {
         let _guard = DB_METRICS
             .rdb_drop_table_time
             .with_label_values(&table_id.0)
             .start_timer();
+        let table_name = self
+            .table_name_from_id(ctx, tx, table_id)?
+            .map(|name| name.to_string())
+            .unwrap_or_default();
         self.inner.drop_table_mut_tx(tx, table_id).map(|_| {
             METRICS
                 .rdb_num_table_rows
-                .with_label_values(&self.address, &table_id.into())
+                .with_label_values(&self.address, &table_id.into(), &table_name)
                 .set(0)
         })
     }
@@ -667,7 +673,7 @@ pub(crate) mod tests_utils {
         let tmp_dir = TempDir::with_prefix("stdb_test")?;
         let in_memory = false;
         let fsync = false;
-        let stdb = open_db(&tmp_dir, in_memory, fsync)?.with_row_count(Arc::new(|_| i64::MAX));
+        let stdb = open_db(&tmp_dir, in_memory, fsync)?.with_row_count(Arc::new(|_, _| i64::MAX));
         Ok((stdb, tmp_dir))
     }
 }
@@ -916,7 +922,7 @@ mod tests {
         stdb.rollback_tx(&ExecutionContext::default(), tx);
 
         let mut tx = stdb.begin_tx();
-        let result = stdb.drop_table(&mut tx, table_id);
+        let result = stdb.drop_table(&ExecutionContext::default(), &mut tx, table_id);
         result.expect_err("drop_table should fail");
         Ok(())
     }
@@ -1280,7 +1286,7 @@ mod tests {
             .collect::<Vec<_>>();
         assert_eq!(constraints.len(), 4, "Wrong number of constraints");
 
-        stdb.drop_table(&mut tx, table_id)?;
+        stdb.drop_table(&ctx, &mut tx, table_id)?;
 
         let indexes = stdb
             .iter(&ctx, &tx, ST_INDEXES_ID)?

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -267,7 +267,7 @@ fn compile_statement(db: &RelationalDB, statement: SqlAst) -> Result<CrudExpr, P
         } => compile_drop(name, kind, table_access)?,
     };
 
-    Ok(q.optimize(&|table| db.row_count(table)))
+    Ok(q.optimize(&|table_id, table_name| db.row_count(table_id, table_name)))
 }
 
 #[cfg(test)]

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -538,7 +538,7 @@ mod tests {
         run_eval_incr_for_index_join(db)?;
 
         let (db, _) = make_test_db()?;
-        run_eval_incr_for_index_join(db.with_row_count(Arc::new(|_| 5)))?;
+        run_eval_incr_for_index_join(db.with_row_count(Arc::new(|_, _| 5)))?;
         Ok(())
     }
 

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -646,7 +646,7 @@ impl<'a> IncrementalJoin<'a> {
             // Replan query after replacing the indexed table with a virtual table,
             // since join order may need to be reversed.
             let join_a = with_delta_table(self.join.clone(), true, self.index_side.inserts());
-            let join_a = QueryExpr::from(join_a).optimize(&|table| db.row_count(table));
+            let join_a = QueryExpr::from(join_a).optimize(&|table_id, table_name| db.row_count(table_id, table_name));
 
             // No need to replan after replacing the probe side with a virtual table,
             // since no new constraints have been added.
@@ -674,7 +674,7 @@ impl<'a> IncrementalJoin<'a> {
             // Replan query after replacing the indexed table with a virtual table,
             // since join order may need to be reversed.
             let join_a = with_delta_table(self.join.clone(), true, self.index_side.deletes());
-            let join_a = QueryExpr::from(join_a).optimize(&|table| db.row_count(table));
+            let join_a = QueryExpr::from(join_a).optimize(&|table_id, table_name| db.row_count(table_id, table_name));
 
             // No need to replan after replacing the probe side with a virtual table,
             // since no new constraints have been added.
@@ -869,8 +869,7 @@ mod tests {
 
         // Optimize the query plan for the incremental update.
         let expr: QueryExpr = with_delta_table(join, true, delta).into();
-        let mut expr = expr.optimize(&|_| i64::MAX);
-
+        let mut expr = expr.optimize(&|_, _| i64::MAX);
         assert_eq!(expr.source.table_name(), "lhs");
         assert_eq!(expr.query.len(), 1);
 
@@ -964,7 +963,7 @@ mod tests {
 
         // Optimize the query plan for the incremental update.
         let expr: QueryExpr = with_delta_table(join, false, delta).into();
-        let mut expr = expr.optimize(&|_| i64::MAX);
+        let mut expr = expr.optimize(&|_, _| i64::MAX);
 
         assert_eq!(expr.source.table_name(), "lhs");
         assert_eq!(expr.query.len(), 1);

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -371,7 +371,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx, MutTx> {
         match kind {
             DbType::Table => {
                 if let Some(id) = self.db.table_id_from_name(self.tx, name)? {
-                    self.db.drop_table(self.tx, id)?;
+                    self.db.drop_table(self.ctx, self.tx, id)?;
                 }
             }
             DbType::Index => {

--- a/crates/lib/src/metrics.rs
+++ b/crates/lib/src/metrics.rs
@@ -8,7 +8,7 @@ metrics_group!(
     pub struct Metrics {
         #[name = spacetime_num_table_rows]
         #[help = "The number of rows in a table"]
-        #[labels(db: Address, table_id: u32)]
+        #[labels(db: Address, table_id: u32, table_name: str)]
         pub rdb_num_table_rows: IntGaugeVec,
     }
 );

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -77,7 +77,7 @@ fn build_typed<P: ProgramVm>(p: &mut P, node: Expr) -> ExprOpt {
             }
         }
         Expr::Crud(q) => {
-            let q = q.optimize(&|_| i64::MAX);
+            let q = q.optimize(&|_, _| i64::MAX);
             match q {
                 CrudExpr::Query(q) => {
                     let source = build_query_opt(q);

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -426,7 +426,7 @@ impl IndexJoin {
     // Reorder the index and probe sides of an index join.
     // This is necessary if the indexed table has been replaced by a delta table.
     // A delta table is a virtual table consisting of changes or updates to a physical table.
-    pub fn reorder(self, row_count: impl Fn(TableId) -> i64) -> Self {
+    pub fn reorder(self, row_count: impl Fn(TableId, &str) -> i64) -> Self {
         // The probe table must be a physical table.
         if matches!(self.probe_side.source, SourceExpr::MemTable(_)) {
             return self;
@@ -455,7 +455,7 @@ impl IndexJoin {
         let probe_column = self.probe_side.source.head().column(&self.probe_field).unwrap().col_id;
         match self.index_side {
             // If the size of the indexed table is sufficiently large, do not reorder.
-            Table::DbTable(DbTable { table_id, .. }) if row_count(table_id) > 1000 => self,
+            Table::DbTable(DbTable { table_id, ref head, .. }) if row_count(table_id, &head.table_name) > 1000 => self,
             // If this is a delta table, we must reorder.
             // If this is a sufficiently small physical table, we should reorder.
             table => {
@@ -622,7 +622,7 @@ pub enum CrudExpr {
 }
 
 impl CrudExpr {
-    pub fn optimize(self, row_count: &impl Fn(TableId) -> i64) -> Self {
+    pub fn optimize(self, row_count: &impl Fn(TableId, &str) -> i64) -> Self {
         match self {
             CrudExpr::Query(x) => CrudExpr::Query(x.optimize(row_count)),
             _ => self,
@@ -1390,7 +1390,7 @@ impl QueryExpr {
         q
     }
 
-    pub fn optimize(mut self, row_count: &impl Fn(TableId) -> i64) -> Self {
+    pub fn optimize(mut self, row_count: &impl Fn(TableId, &str) -> i64) -> Self {
         let mut q = Self {
             source: self.source.clone(),
             query: Vec::with_capacity(self.query.len()),


### PR DESCRIPTION
Fixes #683.

Previously we were labeling metrics with the table id only. However the table name is almost always desired for diagnostics.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
