### PR TITLE
Fix benchmark actions

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -127,12 +127,6 @@ jobs:
       #        })
       #      }
 
-      - name: PR; compare benchmarks
-        if: ${{ env.PR_NUMBER }}
-        working-directory: crates/bench/
-        run: |
-          cargo run --bin summarize markdown-report branch.json --report-name report
-
       # this will work for both PR and master
       - name: Upload criterion results to DO spaces
         uses: shallwefootball/s3-upload-action@master

--- a/.github/workflows/callgrind_benchmarks.yml
+++ b/.github/workflows/callgrind_benchmarks.yml
@@ -149,6 +149,7 @@ jobs:
           destination_dir: callgrind-benchmarks
 
       - name: Fetch markdown summary PR
+        shell: bash
         run: |
           if [[ $PR_NUMBER ]]; then
             OLD=master
@@ -160,6 +161,7 @@ jobs:
           curl -sS https://benchmarks.spacetimedb.com/compare_callgrind/$OLD/$NEW > report.md
 
       - name: Post comment
+        shell: bash
         run: |
           BODY="<details><summary>Benchmark results</summary>
           $(cat report.md)

--- a/.github/workflows/callgrind_benchmarks.yml
+++ b/.github/workflows/callgrind_benchmarks.yml
@@ -71,6 +71,13 @@ jobs:
           # summary PR" step). otherwise, we can use a fully shallow checkout
           fetch-depth: ${{ env.PR_NUMBER && 1 || 2 }}
 
+      - name: Unbork Github Actions state
+        shell: bash
+        run: |
+          echo "Letting anybody touch our git repo, in order to avoid breaking other jobs"
+          echo "This is necessary because we are running as root inside a docker image"
+          chmod -R a+rw .
+
       - name: Post initial comment
         shell: bash
         run: |
@@ -178,3 +185,7 @@ jobs:
         shell: bash
         run: |
           rm -fr /stdb/*
+          echo "Letting anybody touch our git repo, in order to avoid breaking other jobs"
+          echo "This is necessary because we are running as root inside a docker image"
+          chmod -R a+rw .
+

--- a/.github/workflows/callgrind_benchmarks.yml
+++ b/.github/workflows/callgrind_benchmarks.yml
@@ -137,13 +137,6 @@ jobs:
           [[ ! $PR_NUMBER ]] && cp target/iai/$BASELINE_NAME.json callgrind-results/
           cp target/iai/$BASELINE_NAME.json callgrind-results/$RESULTS_NAME.json
 
-      - name: PR; compare benchmarks
-        if: ${{ env.PR_NUMBER }}
-        working-directory: crates/bench/
-        shell: bash
-        run: |
-          cargo run --bin summarize markdown-report-callgrind branch.json --report-name report
-
       # this will work for both PR and master
       - name: Upload callgrind results to DO spaces
         uses: shallwefootball/s3-upload-action@master


### PR DESCRIPTION
# Description of Changes


This fixes two things:

### Let other people use the actions runner after we're done with it
Specifically, we chmod the git repo directory to a+rw after we touch it in the callgrind benchmarks action.
This is needed because the callgrind benchmarks run as root in a docker container. Github Actions tries to reuse the resulting directory (and I guess stores it on the host?) afterwards, but now the git repo is owned by root and can't be modified, which causes other benchmarks to break.
This issue was pointed out by @coolreader18.

(Note: we can't just chown the git repo, because we're inside a docker image, so who would we chown to?)

### Remove residual references to moved code in the benchmarks & callgrind benchmarks actions.
I pulled out the `markdown-report[-callgrind]` commands from the `benches/summarize` bin in my last callgrind PR -- they've moved to another repo -- but there were residual references to them in these ymls, despite the resulting reports not being used. I'm not sure why that didn't cause errors for that PR, but the residual references are gone now.

This issue was pointed out by @cloutiertyler.