### PR TITLE
chore: Disable query compilation metrics

### DIFF
--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -146,7 +146,4 @@ pub fn reset_counters() {
     // Reset max query durations
     DB_METRICS.rdb_query_cpu_time_sec_max.0.reset();
     MAX_QUERY_CPU_TIME.lock().unwrap().clear();
-    // Reset max query compile durations
-    DB_METRICS.rdb_query_compile_time_sec_max.0.reset();
-    MAX_QUERY_COMPILE_TIME.lock().unwrap().clear();
 }

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -117,11 +117,7 @@ pub fn compile_read_only_query(
         return QuerySet::get_all(relational_db, tx, auth);
     }
 
-    let start = Instant::now();
-    let compiled = compile_sql(relational_db, tx, &input).map(|expr| {
-        record_query_compilation_metrics(WorkloadType::Subscribe, &relational_db.address(), &input, start);
-        expr
-    })?;
+    let compiled = compile_sql(relational_db, tx, &input)?;
     let mut queries = Vec::with_capacity(compiled.len());
     for q in compiled {
         match q {
@@ -150,6 +146,8 @@ pub fn compile_read_only_query(
     }
 }
 
+// TODO: Enable query compilation metrics once cardinality has been addressed.
+#[allow(unused)]
 fn record_query_compilation_metrics(workload: WorkloadType, db: &Address, query: &str, start: Instant) {
     let compile_duration = start.elapsed().as_secs_f64();
 


### PR DESCRIPTION
Query metrics have very high cardinality.
The current metrics store does not handle high cardinality particulary well. Query compilation contributes very little to overall resource consumption. Therefore they have been disabled until the cardinality issue has been addressed.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
