### PR TITLE
fix: Reset max queue length and reducer wait time metrics

### DIFF
--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -84,11 +84,17 @@ metrics_group!(
     }
 );
 
+type ReducerLabel = (Address, String);
+
 pub static MAX_QUEUE_LEN: Lazy<Mutex<HashMap<Address, i64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
-pub static MAX_REDUCER_DELAY: Lazy<Mutex<HashMap<u64, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
+pub static MAX_REDUCER_DELAY: Lazy<Mutex<HashMap<ReducerLabel, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 pub static WORKER_METRICS: Lazy<WorkerMetrics> = Lazy::new(WorkerMetrics::new);
 
 pub fn reset_counters() {
+    // Reset max queue length
+    WORKER_METRICS.instance_queue_length_max.0.reset();
     MAX_QUEUE_LEN.lock().unwrap().clear();
+    // Reset max reducer wait time
+    WORKER_METRICS.scheduled_reducer_delay_sec_max.0.reset();
     MAX_REDUCER_DELAY.lock().unwrap().clear();
 }


### PR DESCRIPTION
Max value metrics are currently reset to zero after each collection period. However this won't be reflected in the metrics store immediately.

Once the database records new values for said metrics, only then will the reset be reflected in the metrics store.

This subtlety is imperceptible for metrics that are frequently updated. But if a metric is not frequently updated,
or for periods of reduced load in general,
the metrics store may present stale max value metrics.

This anomaly was thought to have been fixed by #709. However it only fixed it for DB_METRICS.
This patch removes the anomaly for WORKER_METRICS as well.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
