### PR TITLE
Add `ColList`: a compact replacement of `NonEmpty<ColId>`, 8 vs 32 bytes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2606,12 +2606,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "nonempty"
-version = "0.8.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "aeaf4ad7403de93e699c191202f017118df734d3850b01e13a3a8b2e6953d3c9"
-
-[[package]]
 name = "nu-ansi-term"
 version = "0.46.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4238,7 +4232,6 @@ dependencies = [
  "bytes",
  "derive_more",
  "log",
- "nonempty",
  "once_cell",
  "rand 0.8.5",
  "scoped-tls",
@@ -4266,7 +4259,6 @@ dependencies = [
  "lazy_static",
  "log",
  "mimalloc",
- "nonempty",
  "rand 0.8.5",
  "regex",
  "rusqlite",
@@ -4327,7 +4319,6 @@ dependencies = [
  "itertools 0.11.0",
  "jsonwebtoken",
  "mimalloc",
- "nonempty",
  "regex",
  "reqwest",
  "rustyline",
@@ -4337,6 +4328,7 @@ dependencies = [
  "slab",
  "spacetimedb-core",
  "spacetimedb-lib",
+ "spacetimedb-primitives",
  "spacetimedb-standalone",
  "syntect",
  "tabled",
@@ -4423,7 +4415,6 @@ dependencies = [
  "jsonwebtoken",
  "lazy_static",
  "log",
- "nonempty",
  "once_cell",
  "openssl",
  "parking_lot 0.12.1",
@@ -4481,7 +4472,6 @@ dependencies = [
 name = "spacetimedb-data-structures"
 version = "0.8.1"
 dependencies = [
- "nonempty",
  "serde",
  "thiserror",
 ]
@@ -4530,7 +4520,8 @@ name = "spacetimedb-primitives"
 version = "0.8.1"
 dependencies = [
  "bitflags 2.4.1",
- "nonempty",
+ "either",
+ "proptest",
 ]
 
 [[package]]
@@ -4552,7 +4543,6 @@ dependencies = [
  "enum-as-inner",
  "hex",
  "itertools 0.11.0",
- "nonempty",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
@@ -4647,7 +4637,6 @@ version = "0.8.1"
 dependencies = [
  "anyhow",
  "derive_more",
- "nonempty",
  "spacetimedb-lib",
  "spacetimedb-primitives",
  "spacetimedb-sats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,6 +89,7 @@ decorum = { version = "0.3.1", default-features = false, features = ["std"] }
 derive_more = "0.99.17"
 dirs = "5.0.1"
 duct = "0.13.5"
+either = "1.9"
 email_address = "0.2.4"
 enum-as-inner = "0.6"
 enum-map = "2.6.3"
@@ -119,7 +120,6 @@ jsonwebtoken = { version = "8.1.0" }
 lazy_static = "1.4.0"
 log = "0.4.17"
 mimalloc = "0.1.39"
-nonempty = "0.8.1"
 once_cell = "1.16"
 parking_lot = { version = "0.12.1", features = ["send_guard", "arc_lock"] }
 paste = "1.0"

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -42,7 +42,6 @@ futures.workspace = true
 lazy_static.workspace = true
 log.workspace = true
 mimalloc.workspace = true
-nonempty.workspace = true
 rand.workspace = true
 regex.workspace = true
 rusqlite.workspace = true

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -23,7 +23,6 @@ spacetimedb-primitives = { path = "../primitives", version = "0.8.1" }
 
 derive_more.workspace = true
 log.workspace = true
-nonempty.workspace = true
 once_cell.workspace = true
 scoped-tls.workspace = true
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -17,6 +17,7 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
+spacetimedb-primitives = { path = "../primitives", version = "0.8.1" }
 spacetimedb-core = { path = "../core", version = "0.8.1" }
 spacetimedb-lib = { path = "../lib", version = "0.8.1", features = ["cli"] }
 spacetimedb-standalone = { path = "../standalone", version = "0.8.1", optional = true }
@@ -37,7 +38,6 @@ is-terminal.workspace = true
 itertools.workspace = true
 indicatif.workspace = true
 jsonwebtoken.workspace = true
-nonempty.workspace = true
 mimalloc.workspace = true
 regex.workspace = true
 reqwest.workspace = true

--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -3,12 +3,12 @@ use super::util::fmt_fn;
 use std::fmt::{self, Write};
 
 use convert_case::{Case, Casing};
-use nonempty::NonEmpty;
 use spacetimedb_lib::sats::db::def::TableSchema;
 use spacetimedb_lib::sats::{
     AlgebraicType, AlgebraicType::Builtin, AlgebraicTypeRef, ArrayType, BuiltinType, MapType, ProductType, SumType,
 };
 use spacetimedb_lib::{ReducerDef, TableDesc};
+use spacetimedb_primitives::ColList;
 
 use super::code_indenter::CodeIndenter;
 use super::{GenCtx, GenItem, INDENT};
@@ -668,7 +668,7 @@ fn autogen_csharp_product_table_common(
                 // Declare custom index dictionaries
                 for col in schema.columns() {
                     let field_name = col.col_name.replace("r#", "").to_case(Case::Pascal);
-                    if !constraints[&NonEmpty::new(col.col_pos)].has_unique() {
+                    if !constraints[&ColList::new(col.col_pos)].has_unique() {
                         continue;
                     }
                     let type_name = ty_fmt(ctx, &col.col_type, namespace);
@@ -696,7 +696,7 @@ fn autogen_csharp_product_table_common(
                     writeln!(output, "var val = ({name})insertedValue;").unwrap();
                     for col in schema.columns() {
                         let field_name = col.col_name.replace("r#", "").to_case(Case::Pascal);
-                        if !constraints[&NonEmpty::new(col.col_pos)].has_unique() {
+                        if !constraints[&ColList::new(col.col_pos)].has_unique() {
                             continue;
                         }
                         writeln!(output, "{field_name}_Index[val.{field_name}] = val;").unwrap();
@@ -716,7 +716,7 @@ fn autogen_csharp_product_table_common(
                     writeln!(output, "var val = ({name})deletedValue;").unwrap();
                     for col in schema.columns() {
                         let field_name = col.col_name.replace("r#", "").to_case(Case::Pascal);
-                        if !constraints[&NonEmpty::new(col.col_pos)].has_unique() {
+                        if !constraints[&ColList::new(col.col_pos)].has_unique() {
                             continue;
                         }
                         writeln!(output, "{field_name}_Index.Remove(val.{field_name});").unwrap();
@@ -971,7 +971,7 @@ fn autogen_csharp_access_funcs_for_struct(
 
     let constraints = schema.column_constraints();
     for col in schema.columns() {
-        let is_unique = constraints[&NonEmpty::new(col.col_pos)].has_unique();
+        let is_unique = constraints[&ColList::new(col.col_pos)].has_unique();
 
         let col_i: usize = col.col_pos.into();
 

--- a/crates/cli/src/subcommands/generate/python.rs
+++ b/crates/cli/src/subcommands/generate/python.rs
@@ -1,12 +1,12 @@
 use super::util::fmt_fn;
 
 use convert_case::{Case, Casing};
-use nonempty::NonEmpty;
 use spacetimedb_lib::sats::db::def::TableSchema;
 use spacetimedb_lib::{
     sats::{AlgebraicTypeRef, ArrayType, BuiltinType, MapType},
     AlgebraicType, ProductType, ProductTypeElement, ReducerDef, SumType, TableDesc,
 };
+use spacetimedb_primitives::ColList;
 use std::fmt::{self, Write};
 
 use super::{code_indenter::CodeIndenter, csharp::is_enum, GenCtx, GenItem};
@@ -285,7 +285,7 @@ fn autogen_python_product_table_common(
 
             let constraints = schema.column_constraints();
             for (idx, field) in product_type.elements.iter().enumerate() {
-                let attr = constraints[&NonEmpty::new(idx.into())];
+                let attr = constraints[&ColList::new(idx.into())];
 
                 let field_type = &field.algebraic_type;
 

--- a/crates/cli/src/subcommands/generate/rust.rs
+++ b/crates/cli/src/subcommands/generate/rust.rs
@@ -1,13 +1,13 @@
 use super::code_indenter::CodeIndenter;
 use super::{GenCtx, GenItem};
 use convert_case::{Case, Casing};
-use nonempty::NonEmpty;
 use spacetimedb_lib::sats::db::def::TableSchema;
 use spacetimedb_lib::sats::{
     AlgebraicType, AlgebraicTypeRef, ArrayType, BuiltinType, MapType, ProductType, ProductTypeElement, SumType,
     SumTypeVariant,
 };
 use spacetimedb_lib::{ReducerDef, TableDesc};
+use spacetimedb_primitives::ColList;
 use std::collections::HashSet;
 use std::fmt::Write;
 
@@ -472,7 +472,7 @@ fn print_table_filter_methods(ctx: &GenCtx, out: &mut Indenter, table_type_name:
                 //       Look at `Borrow` or Deref or AsRef?
                 write_type_ctx(ctx, out, &field.col_type);
                 write!(out, ") -> ").unwrap();
-                let ct = constraints[&NonEmpty::new(field.col_pos)];
+                let ct = constraints[&ColList::new(field.col_pos)];
 
                 if ct.has_unique() {
                     write!(out, "Option<Self>").unwrap();

--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -3,13 +3,13 @@ use super::util::fmt_fn;
 use std::fmt::{self, Write};
 
 use convert_case::{Case, Casing};
-use nonempty::NonEmpty;
 use spacetimedb_lib::sats::db::def::TableSchema;
 use spacetimedb_lib::sats::{
     AlgebraicType, AlgebraicTypeRef, ArrayType, BuiltinType, MapType, ProductType, ProductTypeElement, SumType,
     SumTypeVariant,
 };
 use spacetimedb_lib::{ReducerDef, TableDesc};
+use spacetimedb_primitives::ColList;
 
 use super::code_indenter::CodeIndenter;
 use super::{GenCtx, GenItem, INDENT};
@@ -874,7 +874,7 @@ fn autogen_typescript_access_funcs_for_struct(
 ) {
     let constraints = table.column_constraints();
     for col in table.columns() {
-        let is_unique = constraints[&NonEmpty::new(col.col_pos)].has_unique();
+        let is_unique = constraints[&ColList::new(col.col_pos)].has_unique();
         let field = &product_type.elements[usize::from(col.col_pos)];
         let field_name = field.name.as_ref().expect("autogen'd tuples should have field names");
         let field_type = &field.algebraic_type;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -50,7 +50,6 @@ itertools.workspace = true
 jsonwebtoken.workspace = true
 lazy_static.workspace = true
 log.workspace = true
-nonempty.workspace = true
 once_cell.workspace = true
 openssl.workspace = true
 parking_lot.workspace = true

--- a/crates/core/src/db/datastore/locking_tx_datastore/btree_index.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/btree_index.rs
@@ -1,6 +1,5 @@
 use super::RowId;
 use crate::error::DBError;
-use nonempty::NonEmpty;
 use spacetimedb_primitives::*;
 use spacetimedb_sats::data_key::ToDataKey;
 use spacetimedb_sats::{AlgebraicValue, DataKey, ProductValue};
@@ -89,20 +88,14 @@ impl BTreeIndexRangeIter<'_> {
 pub(crate) struct BTreeIndex {
     pub(crate) index_id: IndexId,
     pub(crate) table_id: TableId,
-    pub(crate) cols: NonEmpty<ColId>,
+    pub(crate) cols: ColList,
     pub(crate) name: String,
     pub(crate) is_unique: bool,
     idx: BTreeSet<IndexKey>,
 }
 
 impl BTreeIndex {
-    pub(crate) fn new(
-        index_id: IndexId,
-        table_id: TableId,
-        cols: NonEmpty<ColId>,
-        name: String,
-        is_unique: bool,
-    ) -> Self {
+    pub(crate) fn new(index_id: IndexId, table_id: TableId, cols: ColList, name: String, is_unique: bool) -> Self {
         Self {
             index_id,
             table_id,

--- a/crates/core/src/db/datastore/locking_tx_datastore/table.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/table.rs
@@ -3,15 +3,14 @@ use super::{
     RowId,
 };
 use indexmap::IndexMap;
-use nonempty::NonEmpty;
-use spacetimedb_primitives::ColId;
+use spacetimedb_primitives::ColList;
 use spacetimedb_sats::db::def::TableSchema;
 use spacetimedb_sats::{AlgebraicValue, ProductType, ProductValue};
 use std::{collections::HashMap, ops::RangeBounds};
 
 pub(crate) struct Table {
     pub(crate) schema: TableSchema,
-    pub(crate) indexes: HashMap<NonEmpty<ColId>, BTreeIndex>,
+    pub(crate) indexes: HashMap<ColList, BTreeIndex>,
     pub(crate) rows: IndexMap<RowId, ProductValue>,
 }
 
@@ -69,7 +68,7 @@ impl Table {
     /// Matching is defined by `Ord for AlgebraicValue`.
     pub(crate) fn index_seek(
         &self,
-        cols: &NonEmpty<ColId>,
+        cols: &ColList,
         range: &impl RangeBounds<AlgebraicValue>,
     ) -> Option<BTreeIndexRangeIter<'_>> {
         self.indexes.get(cols).map(|index| index.seek(range))

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -1,4 +1,3 @@
-use nonempty::NonEmpty;
 use std::borrow::Cow;
 use std::{ops::RangeBounds, sync::Arc};
 
@@ -99,7 +98,7 @@ pub trait TxDatastore: DataRow + Tx {
         ctx: &'a ExecutionContext,
         tx: &'a Self::Tx,
         table_id: TableId,
-        cols: impl Into<NonEmpty<ColId>>,
+        cols: impl Into<ColList>,
         range: R,
     ) -> Result<Self::IterByColRange<'a, R>>;
 
@@ -108,7 +107,7 @@ pub trait TxDatastore: DataRow + Tx {
         ctx: &'a ExecutionContext,
         tx: &'a Self::Tx,
         table_id: TableId,
-        cols: impl Into<NonEmpty<ColId>>,
+        cols: impl Into<ColList>,
         value: AlgebraicValue,
     ) -> Result<Self::IterByColEq<'a>>;
 
@@ -186,7 +185,7 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
         ctx: &'a ExecutionContext,
         tx: &'a Self::MutTx,
         table_id: TableId,
-        cols: impl Into<NonEmpty<ColId>>,
+        cols: impl Into<ColList>,
         range: R,
     ) -> Result<Self::IterByColRange<'a, R>>;
     fn iter_by_col_eq_mut_tx<'a>(
@@ -194,7 +193,7 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
         ctx: &'a ExecutionContext,
         tx: &'a Self::MutTx,
         table_id: TableId,
-        cols: impl Into<NonEmpty<ColId>>,
+        cols: impl Into<ColList>,
         value: AlgebraicValue,
     ) -> Result<Self::IterByColEq<'a>>;
     fn get_mut_tx<'a>(
@@ -254,7 +253,7 @@ pub trait MutProgrammable: MutTxDatastore {
 
 #[cfg(test)]
 mod tests {
-    use spacetimedb_primitives::{ColId, Constraints};
+    use spacetimedb_primitives::{col_list, ColId, Constraints};
     use spacetimedb_sats::db::def::ConstraintDef;
     use spacetimedb_sats::{AlgebraicType, AlgebraicTypeRef, ProductType, ProductTypeElement, Typespace};
 
@@ -276,7 +275,7 @@ mod tests {
             ],
         )
         .with_indexes(vec![
-            IndexDef::btree("id_and_name".into(), (0.into(), vec![1.into()]), false),
+            IndexDef::btree("id_and_name".into(), col_list![0, 1], false),
             IndexDef::btree("just_name".into(), ColId(1), false),
         ])
         .with_constraints(vec![ConstraintDef::new(

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -1,4 +1,3 @@
-use nonempty::NonEmpty;
 use parking_lot::{Mutex, MutexGuard};
 use smallvec::SmallVec;
 use std::ops::DerefMut;
@@ -17,7 +16,7 @@ use spacetimedb_lib::filter::CmpArgs;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::operator::OpQuery;
 use spacetimedb_lib::{bsatn, ProductValue};
-use spacetimedb_primitives::{ColId, TableId};
+use spacetimedb_primitives::{ColId, ColListBuilder, TableId};
 use spacetimedb_sats::buffer::BufWriter;
 use spacetimedb_sats::db::def::{IndexDef, IndexType};
 use spacetimedb_sats::relation::{FieldExpr, FieldName};
@@ -238,9 +237,12 @@ impl InstanceEnv {
             }
         };
 
-        let columns = NonEmpty::from_vec(col_ids)
-            .expect("Attempt to create an index with zero columns")
-            .map(Into::into);
+        let columns = col_ids
+            .into_iter()
+            .map(Into::into)
+            .collect::<ColListBuilder>()
+            .build()
+            .expect("Attempt to create an index with zero columns");
 
         let is_unique = stdb.column_constraints(tx, table_id, &columns)?.has_unique();
 

--- a/crates/core/src/sql/ast.rs
+++ b/crates/core/src/sql/ast.rs
@@ -1,11 +1,10 @@
-use nonempty::NonEmpty;
 use std::borrow::Cow;
 use std::collections::HashMap;
 
 use crate::db::datastore::traits::TxDatastore;
 use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::{DBError, PlanError};
-use spacetimedb_primitives::{ConstraintKind, Constraints};
+use spacetimedb_primitives::{ColList, ConstraintKind, Constraints};
 use spacetimedb_sats::db::auth::StAccess;
 use spacetimedb_sats::db::def::{ColumnDef, ConstraintDef, FieldDef, TableDef, TableSchema};
 use spacetimedb_sats::db::error::RelationError;
@@ -814,7 +813,7 @@ fn compile_create_table(table: Table, cols: Vec<SqlColumnDef>) -> Result<SqlAst,
                 &table.name,
                 &name,
                 attr,
-                NonEmpty::new(col_pos.into()),
+                ColList::new(col_pos.into()),
             ));
         }
 

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -1,7 +1,6 @@
 use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::{DBError, PlanError};
 use crate::sql::ast::{compile_to_ast, Column, From, Join, Selection, SqlAst};
-use nonempty::NonEmpty;
 use spacetimedb_primitives::*;
 use spacetimedb_sats::db::auth::StAccess;
 use spacetimedb_sats::db::def::{TableDef, TableSchema};
@@ -82,16 +81,16 @@ fn compile_where(mut q: QueryExpr, table: &From, filter: Selection) -> Result<Qu
 // using an index.
 pub enum IndexArgument {
     Eq {
-        columns: NonEmpty<ColId>,
+        columns: ColList,
         value: AlgebraicValue,
     },
     LowerBound {
-        columns: NonEmpty<ColId>,
+        columns: ColList,
         value: AlgebraicValue,
         inclusive: bool,
     },
     UpperBound {
-        columns: NonEmpty<ColId>,
+        columns: ColList,
         value: AlgebraicValue,
         inclusive: bool,
     },

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -43,7 +43,7 @@ pub fn build_query<'a>(
                 upper_bound,
             }) if db_table => {
                 assert_eq!(columns.len(), 1, "Only support single column IndexScan");
-                let col_id = columns.head;
+                let col_id = columns.head();
                 iter_by_col_range(ctx, stdb, tx, table, col_id, (lower_bound, upper_bound))?
             }
             Query::IndexScan(index_scan) => {
@@ -560,7 +560,6 @@ pub(crate) mod tests {
     };
     use crate::db::relational_db::tests_utils::make_test_db;
     use crate::execution_context::ExecutionContext;
-    use nonempty::NonEmpty;
     use spacetimedb_lib::error::ResultTest;
     use spacetimedb_sats::db::auth::{StAccess, StTableType};
     use spacetimedb_sats::db::def::{ColumnDef, IndexDef, IndexType};
@@ -765,7 +764,7 @@ pub(crate) mod tests {
                 index_id,
                 index_name: "idx_1".to_owned(),
                 table_id,
-                columns: NonEmpty::new(0.into()),
+                columns: ColList::new(0.into()),
                 is_unique: true,
                 index_type: IndexType::BTree,
             }

--- a/crates/data-structures/Cargo.toml
+++ b/crates/data-structures/Cargo.toml
@@ -9,6 +9,5 @@ description = "Assorted data structures used in spacetimedb"
 serde = ["dep:serde"]
 
 [dependencies]
-nonempty.workspace = true
 serde = { workspace = true, optional = true }
 thiserror.workspace = true

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -6,5 +6,8 @@ license-file = "LICENSE"
 description = "Primitives such as TableId and ColumnIndexAttribute"
 
 [dependencies]
-nonempty.workspace = true
+either.workspace = true
 bitflags.workspace = true
+
+[dev-dependencies]
+proptest.workspace = true

--- a/crates/primitives/proptest-regressions/col_list.txt
+++ b/crates/primitives/proptest-regressions/col_list.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 70b4e531ebb215f2a8efd7d316970aa75d0ec8d555411bd73d1c63c33d8ea1ed # shrinks to cols = [ColId(19), ColId(0)]

--- a/crates/primitives/src/col_list.rs
+++ b/crates/primitives/src/col_list.rs
@@ -1,0 +1,554 @@
+#![forbid(unsafe_op_in_unsafe_fn)]
+
+extern crate alloc;
+
+use crate::ColId;
+use alloc::alloc::{alloc, dealloc, handle_alloc_error, realloc};
+use core::{
+    alloc::Layout,
+    cmp::Ordering,
+    fmt,
+    hash::{Hash, Hasher},
+    iter,
+    mem::{size_of, ManuallyDrop},
+    ops::Deref,
+    ptr::NonNull,
+    slice::from_raw_parts,
+};
+use either::Either;
+
+/// Constructs a `ColList` like so `col_list![0, 2]`.
+///
+/// A head element is required.
+/// Mostly provided for testing.
+#[macro_export]
+macro_rules! col_list {
+    ($head:expr $(, $elem:expr)* $(,)?) => {{
+        let mut list = $crate::ColList::new($head.into());
+        $(list.push($elem.into());)*
+        list
+    }};
+}
+
+/// An error signalling that a `ColList` was empty.
+#[derive(Debug)]
+pub struct EmptyColListError;
+
+/// A builder for a [`ColList`] making sure a non-empty one is built.
+pub struct ColListBuilder {
+    /// The in-progress list.
+    list: ColList,
+}
+
+impl Default for ColListBuilder {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+impl ColListBuilder {
+    /// Returns an empty builder.
+    pub fn new() -> Self {
+        Self {
+            list: ColList::from_inline(0),
+        }
+    }
+
+    /// Push a [`ColId`] to the list.
+    pub fn push(&mut self, col: ColId) {
+        self.list.push(col);
+    }
+
+    /// Build the [`ColList`] or error if it would have been empty.
+    pub fn build(self) -> Result<ColList, EmptyColListError> {
+        if self.list.is_empty() {
+            Err(EmptyColListError)
+        } else {
+            Ok(self.list)
+        }
+    }
+}
+
+impl FromIterator<ColId> for ColListBuilder {
+    fn from_iter<T: IntoIterator<Item = ColId>>(iter: T) -> Self {
+        let mut builder = Self::new();
+        for col in iter {
+            builder.push(col);
+        }
+        builder
+    }
+}
+
+/// This represents a non-empty list of [`ColId`]
+/// but packed into a `u64` in a way that takes advantage of the fact that
+/// in almost all cases, we won't store a `ColId` larger than 62.
+/// In the rare case that we store larger ids, we fall back to a thin vec approach.
+///
+/// The list does not guarantee a stable order.
+#[repr(C)]
+pub union ColList {
+    /// Used to determine whether the list is stored inline or not.
+    check: usize,
+    /// The list is stored inline as a bitset.
+    inline: ColListInline,
+    /// A heap allocated version of the list.
+    heap: ManuallyDrop<ColListVec>,
+}
+
+// SAFETY: The data is owned by `ColList` so this is OK.
+unsafe impl Sync for ColList {}
+// SAFETY: The data is owned by `ColList` so this is OK.
+unsafe impl Send for ColList {}
+
+impl From<u32> for ColList {
+    fn from(value: u32) -> Self {
+        ColId(value).into()
+    }
+}
+
+impl From<ColId> for ColList {
+    fn from(value: ColId) -> Self {
+        Self::new(value)
+    }
+}
+
+impl ColList {
+    /// Returns a list with a single column.
+    /// As long `col` is below `62`, this will not allocate.
+    pub fn new(col: ColId) -> Self {
+        let mut list = Self::from_inline(0);
+        list.push(col);
+        list
+    }
+
+    /// Constructs a list from a `u64` bitset
+    /// where the highest bit is unset.
+    ///
+    /// Panics if the highest bit is set.
+    fn from_inline(list: u64) -> Self {
+        debug_assert_eq!(list & (1 << Self::FIRST_HEAP_COL), 0);
+        // (1) Move the whole inline bitset by one bit to the left.
+        // Mark the now-zero lowest bit so we know the list is inline.
+        let inline = ColListInline(list << 1 | 1);
+        // SAFETY: Lowest bit is set, so this will be interpreted as inline and not a pointer.
+        let ret = Self { inline };
+        debug_assert!(ret.is_inline());
+        ret
+    }
+
+    /// Returns the head of the list.
+    pub fn head(&self) -> ColId {
+        // SAFETY: There's always at least one element in the list when this is called.
+        // Notably, `from_inline(0)` is followed by at least one `.push(col)` before
+        // a safe `ColList` is exposed outside this module.
+        unsafe { self.iter().next().unwrap_unchecked() }
+    }
+
+    /// Returns an iterator over all the columns in this list.
+    pub fn iter(&self) -> impl '_ + Iterator<Item = ColId> {
+        match self.as_inline() {
+            Ok(inline) => Either::Left(inline.iter()),
+            Err(heap) => Either::Right(heap.iter().copied()),
+        }
+    }
+
+    /// Convert to a `Vec<u32>`.
+    pub fn to_u32_vec(&self) -> alloc::vec::Vec<u32> {
+        self.iter().map(u32::from).collect()
+    }
+
+    /// Returns the length of the list.
+    pub fn len(&self) -> u32 {
+        match self.as_inline() {
+            Ok(inline) => inline.len(),
+            Err(heap) => heap.len(),
+        }
+    }
+
+    /// Returns false. A `ColList` is never empty.
+    pub fn is_empty(&self) -> bool {
+        false
+    }
+
+    /// Push `col` onto the list.
+    ///
+    /// If `col >= 63` or if this list was already heap allocated, it will now be heap allocated.
+    pub fn push(&mut self, col: ColId) {
+        let val = u32::from(col) as u64;
+        match (val < Self::FIRST_HEAP_COL, self.as_inline_mut()) {
+            (true, Ok(inline)) => inline.0 |= 1 << (val + 1),
+            (false, Ok(_)) => self.convert_to_heap(col),
+            (_, Err(heap)) => heap.push_cold(col),
+        }
+    }
+
+    /// The first `ColId` that would make the list heap allocated.
+    const FIRST_HEAP_COL: u64 = size_of::<u64>() as u64 * 8 - 1;
+
+    /// Converts the list to its non-inline heap form.
+    ///
+    /// This is unlikely to be called.
+    fn convert_to_heap(&mut self, col: ColId) {
+        let mut vec = ColListVec::with_capacity(2 * (self.len() + 1));
+        for col in self.iter() {
+            vec.push(col)
+        }
+        vec.push(col);
+        self.heap = ManuallyDrop::new(vec);
+    }
+
+    /// Returns the list either as inline or heap based.
+    #[inline]
+    fn as_inline(&self) -> Result<&ColListInline, &ManuallyDrop<ColListVec>> {
+        if self.is_inline() {
+            // SAFETY: confirmed that it is inline so this field is active.
+            Ok(unsafe { &self.inline })
+        } else {
+            // SAFETY: confirmed it's not, so `heap` is active instead.
+            Err(unsafe { &self.heap })
+        }
+    }
+
+    /// Returns the list either as inline or heap based.
+    #[inline]
+    fn as_inline_mut(&mut self) -> Result<&mut ColListInline, &mut ManuallyDrop<ColListVec>> {
+        if self.is_inline() {
+            // SAFETY: confirmed that it is inline so this field is active.
+            Ok(unsafe { &mut self.inline })
+        } else {
+            // SAFETY: confirmed it's not, so `heap` is active instead.
+            Err(unsafe { &mut self.heap })
+        }
+    }
+
+    #[inline]
+    fn is_inline(&self) -> bool {
+        // Check whether the lowest bit has been marked.
+        // This bit is unused by the heap case as the pointer must be aligned for `u32`.
+        // SAFETY: Even when `inline`, and on a < 64-bit target,
+        // we can treat the union as a `usize` to check the lowest bit.
+        let addr = unsafe { self.check };
+        addr & 1 != 0
+    }
+}
+
+impl Drop for ColList {
+    fn drop(&mut self) {
+        if let Err(heap) = self.as_inline_mut() {
+            // SAFETY: Only called once, so we will not have use-after-free or double-free.
+            unsafe { ManuallyDrop::drop(heap) };
+        }
+    }
+}
+
+impl Clone for ColList {
+    fn clone(&self) -> Self {
+        match self.as_inline() {
+            Ok(inline) => Self { inline: *inline },
+            Err(heap) => Self { heap: heap.clone() },
+        }
+    }
+}
+
+impl Eq for ColList {}
+impl PartialEq for ColList {
+    fn eq(&self, other: &Self) -> bool {
+        match (self.as_inline(), other.as_inline()) {
+            (Ok(lhs), Ok(rhs)) => lhs == rhs,
+            (Err(lhs), Err(rhs)) => ***lhs == ***rhs,
+            _ => false,
+        }
+    }
+}
+
+impl Ord for ColList {
+    fn cmp(&self, other: &Self) -> Ordering {
+        self.iter().cmp(other.iter())
+    }
+}
+impl PartialOrd for ColList {
+    fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+        Some(self.cmp(other))
+    }
+}
+
+impl Hash for ColList {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self.as_inline() {
+            Ok(inline) => inline.0.hash(state),
+            Err(heap) => heap.hash(state),
+        }
+    }
+}
+
+impl fmt::Debug for ColList {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.debug_list().entries(self.iter()).finish()
+    }
+}
+
+/// The inline version of a [`ColList`].
+#[derive(Clone, Copy, PartialEq)]
+struct ColListInline(u64);
+
+impl ColListInline {
+    /// Returns an iterator over the [`ColId`]s stored by this list.
+    fn iter(&self) -> impl '_ + Iterator<Item = ColId> {
+        let mut value = self.undo_mark();
+        iter::from_fn(move || {
+            if value == 0 {
+                // No set bits; quit!
+                None
+            } else {
+                // Count trailing zeros and then zero out the first set bit.
+                // For e.g., `0b11001`, this would yield `[0, 3, 4]` as expected.
+                let id = ColId(value.trailing_zeros());
+                value &= value.wrapping_sub(1);
+                Some(id)
+            }
+        })
+    }
+
+    /// Returns the length of the list.
+    fn len(&self) -> u32 {
+        self.undo_mark().count_ones()
+    }
+
+    /// Undoes the shift in (1).
+    #[inline]
+    fn undo_mark(&self) -> u64 {
+        self.0 >> 1
+    }
+}
+
+/// The thin-vec heap based version of a [`ColList`].
+struct ColListVec(NonNull<u32>);
+
+impl ColListVec {
+    /// Returns an empty vector with `capacity`.
+    fn with_capacity(capacity: u32) -> Self {
+        // Allocate the vector using the global allocator.
+        let layout = Self::layout(capacity);
+        // SAFETY: the size of `[u32; 2 + capacity]` is always non-zero.
+        let ptr = unsafe { alloc(layout) }.cast::<u32>();
+        let Some(ptr_non_null) = NonNull::new(ptr) else {
+            handle_alloc_error(layout)
+        };
+
+        let mut this = Self(ptr_non_null);
+        // SAFETY: `0 <= capacity` and claiming no elements are init trivially holds.
+        unsafe {
+            this.set_len(0);
+        }
+        // SAFETY: `capacity` matches that of the allocation.
+        unsafe { this.set_capacity(capacity) };
+        this
+    }
+
+    /// Returns the length of the list.
+    fn len(&self) -> u32 {
+        let ptr = self.0.as_ptr();
+        // SAFETY: `ptr` is properly aligned for `u32` and is valid for reads.
+        unsafe { *ptr }
+    }
+
+    /// SAFETY: `new_len <= self.capacity()` and `new_len` <= number of initialized elements.
+    unsafe fn set_len(&mut self, new_len: u32) {
+        let ptr = self.0.as_ptr();
+        // SAFETY:
+        // - `ptr` is valid for writes as we have exclusive access.
+        // - It's also properly aligned for `u32`.
+        unsafe {
+            *ptr = new_len;
+        }
+    }
+
+    /// Returns the capacity of the allocation in terms of elements.
+    fn capacity(&self) -> u32 {
+        let ptr = self.0.as_ptr();
+        // SAFETY: `ptr + 1 u32` is in bounds of the allocation and it doesn't overflow isize.
+        let capacity_ptr = unsafe { ptr.add(1) };
+        // SAFETY: `capacity_ptr` is properly aligned for `u32` and is valid for reads.
+        unsafe { *capacity_ptr }
+    }
+
+    /// Sets the capacity of the allocation in terms of elements.
+    ///
+    /// SAFETY: `cap` must match the actual capacity of the allocation.
+    unsafe fn set_capacity(&mut self, cap: u32) {
+        let ptr = self.0.as_ptr();
+        // SAFETY: `ptr + 1 u32` is in bounds of the allocation and it doesn't overflow isize.
+        let cap_ptr = unsafe { ptr.add(1) };
+        // SAFETY: `cap_ptr` is valid for writes as we have ownership of the allocation.
+        // It's also properly aligned for `u32`.
+        unsafe {
+            *cap_ptr = cap;
+        }
+    }
+
+    fn push_cold(&mut self, val: ColId) {
+        self.push(val);
+    }
+
+    /// Push an element to the list.
+    fn push(&mut self, val: ColId) {
+        let len = self.len();
+        let cap = self.capacity();
+
+        if len == cap {
+            // We're at capacity, reallocate using standard * 2 exponential factor.
+            let new_cap = cap.checked_mul(2).expect("capacity overflow");
+            let new_layout = Self::layout(new_cap);
+            // Reallocation will will move the data as well.
+            let old_layout = Self::layout(cap);
+            let old_ptr = self.0.as_ptr().cast();
+            // SAFETY:
+            // - `base_ptr` came from the global allocator
+            // - `old_layout` is the same layout used for the original allocation.
+            // - `new_layout.size()` is non-zero and <= `isize::MAX`.
+            let new_ptr = unsafe { realloc(old_ptr, old_layout, new_layout.size()) }.cast();
+            let Some(ptr_non_null) = NonNull::new(new_ptr) else {
+                handle_alloc_error(new_layout);
+            };
+            // Use new pointer and set capacity.
+            self.0 = ptr_non_null;
+            // SAFETY: `new_cap` matches that of the allocation.
+            unsafe { self.set_capacity(new_cap) };
+        }
+
+        // Write the element and increase the length.
+        let base_ptr = self.0.as_ptr();
+        let elem_offset = 2 + len as usize;
+        // SAFETY: Allocated for `2 + capacity` `u32`s and `len <= capacity`, so we're in bounds.
+        let elem_ptr = unsafe { base_ptr.add(elem_offset) }.cast();
+        // SAFETY: `elem_ptr` is valid for writes and is properly aligned for `ColId`.
+        unsafe {
+            *elem_ptr = val;
+        }
+        // SAFETY: the length <= the capacity and we just init the `len + 1`th element.
+        unsafe {
+            self.set_len(len + 1);
+        }
+    }
+
+    /// Computes a layout for the following struct:
+    /// ```rust,ignore
+    /// struct ColListVecData {
+    ///     len: u32,
+    ///     capacity: u32,
+    ///     data: [ColId],
+    /// }
+    /// ```
+    ///
+    /// Panics if `cap` would result in an allocation larger than `isize::MAX`.
+    fn layout(cap: u32) -> Layout {
+        Layout::array::<u32>(cap.checked_add(2).expect("capacity overflow") as usize).unwrap()
+    }
+}
+
+impl Deref for ColListVec {
+    type Target = [ColId];
+
+    fn deref(&self) -> &Self::Target {
+        let len = self.len() as usize;
+        let ptr = self.0.as_ptr();
+        // SAFETY: `ptr + 2` is always in bounds of the allocation and `ptr <= isize::MAX`.
+        let ptr = unsafe { ptr.add(2) }.cast::<ColId>();
+        // SAFETY:
+        // - `ptr` is valid for reads for `len * size_of::<ColId>` and it is properly aligned.
+        // - `len`  elements are initialized.
+        // - For the lifetime of `'0`, the memory won't be mutated.
+        // - `len * size_of::<ColId> <= isize::MAX` holds.
+        unsafe { from_raw_parts(ptr, len) }
+    }
+}
+
+impl Drop for ColListVec {
+    fn drop(&mut self) {
+        let capacity = self.capacity();
+        let layout = Self::layout(capacity);
+        let ptr = self.0.as_ptr().cast();
+        // SAFETY: `ptr` was allocated by the global allocator
+        // and `layout` was the one the memory was allocated with.
+        unsafe { dealloc(ptr, layout) };
+    }
+}
+
+impl Clone for ColListVec {
+    fn clone(&self) -> Self {
+        let mut vec = ColListVec::with_capacity(self.len());
+        for col in self.iter().copied() {
+            vec.push(col);
+        }
+        vec
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::collection::vec;
+    use proptest::prelude::*;
+
+    fn contains(list: &ColList, x: &ColId) -> bool {
+        list.iter().any(|y| y == *x)
+    }
+
+    proptest! {
+        #[test]
+        fn test_inline(cols in vec((0..ColList::FIRST_HEAP_COL as u32).prop_map_into(), 1..100)) {
+            let [head, tail @ ..] = &*cols else { unreachable!() };
+
+            let mut list = ColList::new(*head);
+            prop_assert!(list.is_inline());
+            prop_assert!(!list.is_empty());
+            prop_assert_eq!(list.len(), 1);
+            prop_assert_eq!(list.head(), *head);
+            prop_assert_eq!(list.iter().collect::<Vec<_>>(), [*head]);
+
+            for col in tail {
+                let new_head = list.head().min(*col);
+                list.push(*col);
+
+                prop_assert!(list.is_inline());
+                prop_assert!(!list.is_empty());
+                prop_assert_eq!(list.head(), new_head);
+                prop_assert!(contains(&list, col));
+            }
+
+            prop_assert_eq!(&list.clone(), &list);
+
+            let mut cols = cols;
+            cols.sort();
+            cols.dedup();
+            prop_assert_eq!(list.iter().collect::<Vec<_>>(), cols);
+        }
+
+        #[test]
+        fn test_heap(cols in vec((ColList::FIRST_HEAP_COL as u32.. ).prop_map_into(), 1..100)) {
+            let contains = |list: &ColList, x| list.iter().collect::<Vec<_>>().contains(x);
+
+            let head = ColId(0);
+            let mut list = ColList::new(head);
+            prop_assert!(list.is_inline());
+            prop_assert_eq!(list.len(), 1);
+
+            for (idx, col) in cols.iter().enumerate() {
+                list.push(*col);
+                prop_assert!(!list.is_inline());
+                prop_assert!(!list.is_empty());
+                prop_assert_eq!(list.len() as usize, idx + 2);
+                prop_assert_eq!(list.head(), head);
+
+
+                prop_assert!(contains(&list, col));
+            }
+
+            prop_assert_eq!(&list.clone(), &list);
+
+            let mut cols = cols;
+            cols.insert(0, head);
+            prop_assert_eq!(list.iter().collect::<Vec<_>>(), cols);
+        }
+    }
+}

--- a/crates/primitives/src/ids.rs
+++ b/crates/primitives/src/ids.rs
@@ -1,6 +1,5 @@
 //! Provides identifiers such as `TableId`.
 use core::fmt;
-use nonempty::NonEmpty;
 
 #[derive(Debug, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(transparent)]
@@ -58,11 +57,6 @@ macro_rules! system_id {
         impl From<u8> for $name {
             fn from(value: u8) -> Self {
                 Self(value as u32)
-            }
-        }
-        impl From<$name> for NonEmpty<$name> {
-            fn from(value: $name) -> Self {
-                NonEmpty::new(value)
             }
         }
         impl fmt::Display for $name {

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -1,7 +1,9 @@
-#![no_std]
+#![cfg_attr(not(test), no_std)]
 
 mod attr;
+mod col_list;
 mod ids;
 
 pub use attr::{AttributeKind, ColumnAttribute, ConstraintKind, Constraints};
+pub use col_list::{ColList, ColListBuilder};
 pub use ids::{ColId, ConstraintId, IndexId, SequenceId, TableId};

--- a/crates/sats/Cargo.toml
+++ b/crates/sats/Cargo.toml
@@ -24,7 +24,6 @@ derive_more.workspace = true
 enum-as-inner.workspace = true
 hex.workspace = true
 itertools.workspace = true
-nonempty.workspace = true
 # For the 'proptest' feature.
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }

--- a/crates/sats/src/array_value.rs
+++ b/crates/sats/src/array_value.rs
@@ -1,5 +1,4 @@
 use crate::{AlgebraicType, AlgebraicValue, ArrayType, MapValue, ProductValue, SumValue, F32, F64};
-use nonempty::NonEmpty;
 use std::fmt;
 
 /// An array value in "monomorphized form".
@@ -188,15 +187,6 @@ impl_from_array!(F64, F64);
 impl_from_array!(String, String);
 impl_from_array!(ArrayValue, Array);
 impl_from_array!(MapValue, Map);
-
-impl<T> From<NonEmpty<T>> for ArrayValue
-where
-    ArrayValue: From<Vec<T>>,
-{
-    fn from(value: NonEmpty<T>) -> Self {
-        Vec::from(value).into()
-    }
-}
 
 impl ArrayValue {
     /// Returns `self` as `&dyn Debug`.

--- a/crates/sats/src/db/error.rs
+++ b/crates/sats/src/db/error.rs
@@ -3,8 +3,7 @@ use crate::product_value::InvalidFieldError;
 use crate::relation::{FieldName, Header};
 use crate::{buffer, AlgebraicType, AlgebraicValue};
 use derive_more::Display;
-use nonempty::NonEmpty;
-use spacetimedb_primitives::{ColId, TableId};
+use spacetimedb_primitives::{ColId, ColList, TableId};
 use std::fmt;
 use std::string::FromUtf8Error;
 use thiserror::Error;
@@ -139,7 +138,7 @@ pub enum SchemaError {
     ConstraintUnset {
         table: String,
         name: String,
-        columns: NonEmpty<ColId>,
+        columns: ColList,
     },
     #[error("Attempt to define a column with more than 1 auto_inc sequence: Table: `{table}`, Field: `{field}`")]
     OneAutoInc { table: String, field: String },

--- a/crates/sats/src/ser/impls.rs
+++ b/crates/sats/src/ser/impls.rs
@@ -1,4 +1,4 @@
-use nonempty::NonEmpty;
+use spacetimedb_primitives::ColList;
 use std::collections::BTreeMap;
 
 use crate::{
@@ -231,10 +231,10 @@ impl_serialize!([] spacetimedb_primitives::TableId, (self, ser) => ser.serialize
 impl_serialize!([] spacetimedb_primitives::IndexId, (self, ser) => ser.serialize_u32(self.0));
 impl_serialize!([] spacetimedb_primitives::SequenceId, (self, ser) => ser.serialize_u32(self.0));
 
-impl_serialize!([T: crate::ser::Serialize + Clone] NonEmpty<T>, (self, ser) => {
-     let mut arr = ser.serialize_array(self.len())?;
-        for x in self {
-            arr.serialize_element(x)?;
-        }
-        arr.end()
+impl_serialize!([] ColList, (self, ser) => {
+    let mut arr = ser.serialize_array(self.len() as usize)?;
+       for x in self.iter() {
+           arr.serialize_element(&x)?;
+       }
+       arr.end()
 });

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -12,7 +12,6 @@ spacetimedb-primitives = { path = "../primitives", version = "0.8.1" }
 
 anyhow.workspace = true
 derive_more.workspace = true
-nonempty.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 


### PR DESCRIPTION
# Description of Changes

Adds `ColList`, a compact 8 byte replacement for `NonEmpty<ColId>` which was 32 bytes.
The former takes advantage of the fact that `ColId`s tend to be very low numbers for any practical table.
This allows us to represent `[ColId(2)]` as `0b1001` where the first bit is a sentinel to signal that we use a bitset and 1 marks the 2-index bit. For `ColList`s of up to the 62 columns, we can represent this inline. In the unlikely even that we need to represent `ColId(63)` or beyond, we fall back to a version of a `TinyVec` which is 8 byte sized.

The benefit of this is that we avoid more heap allocations, reduce sizes + memory footprint, and in my local version of mem-arch-prototype, this turned out to be a win for insertions into a table with an index.

This also gets rid of `nonempty` as a dependency and the unnecessary slim_slice version of it.

Proptests are provided which have been run under miri.

# API and ABI breaking changes

None; this does not cross from/to the WASM boundary.

# Expected complexity level and risk

2 - the `ColList` changes contain some unsafe; the rest is localized or mechanical changes.