### PR TITLE
Fix for reducer queue metric

### DIFF
--- a/crates/core/src/util/lending_pool.rs
+++ b/crates/core/src/util/lending_pool.rs
@@ -80,9 +80,10 @@ impl<T> LendingPool<T> {
         queue_len_max.set(max_queue_len);
 
         async move {
-            let permit = acq.await.map_err(|_| PoolClosed)?;
+            let permit_result = acq.await.map_err(|_| PoolClosed);
             queue_len.dec();
             queue_len_histogram.observe(queue_len.get() as f64);
+            let permit = permit_result?;
             let resource = pool_inner
                 .vec
                 .lock()


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

- Fixes an issue where the reducer queue metric wouldn't get decremented, which would leave a baseline count which would never reach 0 even if the queue was empty.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

Not ABI/API breaking

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

1
