### PR TITLE
Fix --delete-files command without using --force

### DIFF
--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -164,6 +164,7 @@ Failed to compile module {:?}. See cargo errors above for more details.",
 
             if !force {
                 print!("Are you sure you want to delete these files? [y/N] ");
+                input = "".to_string();
                 std::io::stdout().flush()?;
                 std::io::stdin().read_line(&mut input)?;
             } else {


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

- Chippy in the public Discord discovered this unfortunate issue. When not using the `--force` it was impossible for the flag to function correctly. I've fixed the issue here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
