### PR TITLE
Fix row count for the 'sql' command

### DIFF
--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -112,7 +112,8 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool
         .map(|stmt_result| {
             let mut table = stmt_result_to_table(stmt_result)?;
             if with_stats {
-                let row_count = print_row_count(table.count_rows());
+                // The `tabled::count_rows` add the header as a row, so subtract it.
+                let row_count = print_row_count(table.count_rows().wrapping_sub(1));
                 table.with(tabled::settings::panel::Footer::new(row_count));
             }
             anyhow::Ok(table)


### PR DESCRIPTION
# Description of Changes

The `tabled` library add the header as part of the number of rows...

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1
