### PR TITLE
Use a version label for tag builds

### DIFF
--- a/tools/merge-docker-images.sh
+++ b/tools/merge-docker-images.sh
@@ -32,3 +32,8 @@ docker manifest annotate clockworklabs/spacetimedb:$FULL_TAG \
 
 # Push the manifest
 docker manifest push clockworklabs/spacetimedb:$FULL_TAG
+
+# re-tag the manifeast with a tag
+VERSION=${GITHUB_REF#refs/*/}
+docker buildx imagetools create clockworklabs/spacetimedb:$FULL_TAG --tag clockworklabs/spacetimedb:$VERSION
+


### PR DESCRIPTION
# Description of Changes

When building a release for a tag we have to build a multi arch image ourselves. So far we tagged it with a tag `<short-sha>-full`. This is nice to keep the history of all the tagged commits, but it's not very usable as usually we just want the latest build for a given tag. This commit introduces tagging the build with a git tag

# Expected complexity level and risk

Very low, only a CI change