### PR TITLE
Add workflow to tag latest docker image on release

### DIFF
--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -1,0 +1,22 @@
+on:
+  release:
+    types: [published]
+
+jobs:
+  on-release:
+    name: Re-tag latest
+    runs-on: ubuntu-latest
+    steps:
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v2
+
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+ 
+      - name: Retag the image 
+        run: |
+          VERSION=${GITHUB_REF#refs/*/}
+          docker buildx imagetools create clockworklabs/spacetimedb:$VERSION --tag clockworklabs/spacetimedb:latest


### PR DESCRIPTION
# Description of Changes

This PR adds a workflow to tag a docker image linked to the release as `latest`

# Expected complexity level and risk

Low, just a workflow change