### PR TITLE
Fixed broken quickstart links in readme

### DIFF
--- a/README.md
+++ b/README.md
@@ -179,10 +179,10 @@ You can write SpacetimeDB modules in a bunch of popular languages, with many mor
 
 #### Client Libraries
 
-- [Rust](https://spacetimedb.com/docs/client-languages/rust/rust-sdk-quickstart-guide)
-- [C#](https://spacetimedb.com/docs/client-languages/csharp/csharp-sdk-quickstart-guide)
-- [Typescript](https://spacetimedb.com/docs/client-languages/typescript/typescript-sdk-quickstart-guide)
-- [Python](https://spacetimedb.com/docs/client-languages/python/python-sdk-quickstart-guide)
+- [Rust](https://spacetimedb.com/docs/sdks/rust/quickstart)
+- [C#](https://spacetimedb.com/docs/sdks/c-sharp/quickstart)
+- [Typescript](https://spacetimedb.com/docs/sdks/typescript/quickstart)
+- [Python](https://spacetimedb.com/docs/sdks/python/quickstart)
 - C++ (planned)
 - Lua (planned)
 


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

- User Rory in the discord reported this as an issue. All of the quickstart links were returning 404, so I've updated them to be the correct links.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

No ABI/API break

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

0