### PR TITLE
table_name: use Arc<str>

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -150,7 +150,7 @@ rustyline = { version = "12.0.0", features = [] }
 scoped-tls = "1.0.1"
 scopeguard = "1.1.0"
 sendgrid = { version = "0.19.2", features = ["async"] }
-serde = "1.0.136"
+serde = { version = "1.0.136", features = ["rc"] }
 serde_json = { version = "1.0.87", features = ["raw_value"] }
 serde_path_to_error = "0.1.9"
 serde_with = { version = "3.3.0", features = ["base64", "hex"] }

--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -518,7 +518,7 @@ impl TypespaceBuilder for ModuleBuilder {
                 // Alias provided? Relate `name -> slot_ref`.
                 if let Some(name) = name {
                     self.module.misc_exports.push(MiscModuleExport::TypeAlias(TypeAlias {
-                        name: name.to_owned(),
+                        name: name.into(),
                         ty: slot_ref,
                     }));
                 }

--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -1,6 +1,7 @@
 use super::util::fmt_fn;
 
 use std::fmt::{self, Write};
+use std::ops::Deref;
 
 use convert_case::{Case, Casing};
 use spacetimedb_lib::sats::db::def::TableSchema;
@@ -1357,7 +1358,7 @@ pub fn autogen_csharp_reducer(ctx: &GenCtx, reducer: &ReducerDef, namespace: &st
             writeln!(output, "var _message = new SpacetimeDBClient.ReducerCallRequest {{").unwrap();
             {
                 indent_scope!(output);
-                writeln!(output, "fn = \"{}\",", reducer.name).unwrap();
+                writeln!(output, "fn = \"{}\",", func_name).unwrap();
                 writeln!(output, "args = _argArray,").unwrap();
             }
             writeln!(output, "}};").unwrap();
@@ -1503,7 +1504,7 @@ pub fn autogen_csharp_globals(items: &[GenItem], namespace: &str) -> Vec<Vec<(St
         .collect();
     let reducer_names: Vec<String> = reducers
         .iter()
-        .map(|reducer| reducer.name.to_case(Case::Pascal))
+        .map(|reducer| reducer.name.deref().to_case(Case::Pascal))
         .collect();
 
     let use_namespace = true;
@@ -1570,7 +1571,7 @@ pub fn autogen_csharp_globals(items: &[GenItem], namespace: &str) -> Vec<Vec<(St
         writeln!(output).unwrap();
         // Properties for reducer args
         for reducer in &reducers {
-            let reducer_name = reducer.name.to_case(Case::Pascal);
+            let reducer_name = reducer.name.deref().to_case(Case::Pascal);
             writeln!(output, "public {reducer_name}ArgsStruct {reducer_name}Args").unwrap();
             writeln!(output, "{{").unwrap();
             {
@@ -1598,7 +1599,7 @@ pub fn autogen_csharp_globals(items: &[GenItem], namespace: &str) -> Vec<Vec<(St
             {
                 indent_scope!(output);
                 for reducer in &reducers {
-                    let reducer_name = reducer.name.to_case(Case::Pascal);
+                    let reducer_name = reducer.name.deref().to_case(Case::Pascal);
                     writeln!(output, "case ReducerType.{reducer_name}:").unwrap();
                     writeln!(output, "{{").unwrap();
                     {

--- a/crates/cli/src/subcommands/generate/python.rs
+++ b/crates/cli/src/subcommands/generate/python.rs
@@ -526,6 +526,8 @@ pub fn encode_type<'a>(
 }
 
 pub fn autogen_python_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String {
+    let reducer_name = &*reducer.name;
+
     let mut output = CodeIndenter::new(String::new());
 
     writeln!(
@@ -561,7 +563,7 @@ pub fn autogen_python_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String {
     }
     writeln!(output).unwrap();
 
-    writeln!(output, "reducer_name = \"{}\"", reducer.name).unwrap();
+    writeln!(output, "reducer_name = \"{}\"", reducer_name).unwrap();
     writeln!(output).unwrap();
 
     let mut func_call = Vec::new();
@@ -571,7 +573,7 @@ pub fn autogen_python_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String {
         let arg_name = arg
             .name
             .as_deref()
-            .unwrap_or_else(|| panic!("reducer args should have names: {}", reducer.name));
+            .unwrap_or_else(|| panic!("reducer args should have names: {}", reducer_name));
 
         let arg_type = ty_fmt(ctx, &arg.algebraic_type, "");
 
@@ -596,7 +598,7 @@ pub fn autogen_python_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String {
     writeln!(
         output,
         "def {}({}):",
-        reducer.name.to_case(Case::Snake),
+        reducer_name.to_case(Case::Snake),
         func_arguments_str
     )
     .unwrap();
@@ -607,7 +609,7 @@ pub fn autogen_python_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String {
             let field_name = arg
                 .name
                 .as_deref()
-                .unwrap_or_else(|| panic!("reducer args should have names: {}", reducer.name));
+                .unwrap_or_else(|| panic!("reducer args should have names: {}", reducer_name));
 
             let field_type = &arg.algebraic_type;
             let python_field_name = field_name.to_string().replace("r#", "");
@@ -622,7 +624,7 @@ pub fn autogen_python_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String {
         writeln!(
             output,
             "SpacetimeDBClient.instance._reducer_call(\"{}\"{})",
-            reducer.name, func_call_str
+            reducer_name, func_call_str
         )
         .unwrap();
     }
@@ -631,7 +633,7 @@ pub fn autogen_python_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String {
     writeln!(
         output,
         "def register_on_{}(callback: Callable[[Identity, Optional[Address], str, str{}], None]):",
-        reducer.name.to_case(Case::Snake),
+        reducer_name.to_case(Case::Snake),
         callback_sig_str
     )
     .unwrap();
@@ -641,7 +643,7 @@ pub fn autogen_python_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String {
         writeln!(
             output,
             "SpacetimeDBClient.instance._register_reducer(\"{}\", callback)",
-            reducer.name
+            reducer_name
         )
         .unwrap();
     }

--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -221,7 +221,7 @@ impl ServerMessage for OneOffQueryResponseMessage {
                     .results
                     .into_iter()
                     .map(|table| OneOffTable {
-                        table_name: table.head.table_name,
+                        table_name: table.head.table_name.to_string(),
                         row: table
                             .data
                             .into_iter()

--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -372,7 +372,7 @@ impl CommitLogMut {
 
         for record in &tx_data.records {
             let table_id: u32 = record.table_id.into();
-            let table_name = record.table_name.as_str();
+            let table_name = &*record.table_name;
 
             let operation = match record.op {
                 TxOp::Insert(_) => {

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -170,15 +170,16 @@ impl CommittedState {
         // Insert the table row into `st_tables` for all system tables
         for schema in system_tables() {
             let table_id = schema.table_id;
+            let table_name = &*schema.table_name;
             // Reset the row count metric for this system table
             DB_METRICS
                 .rdb_num_table_rows
-                .with_label_values(&database_address, &table_id.0, &schema.table_name)
+                .with_label_values(&database_address, &table_id.0, table_name)
                 .set(0);
 
             let row = StTableRow {
                 table_id,
-                table_name: schema.table_name,
+                table_name,
                 table_type: StTableType::System,
                 table_access: StAccess::Public,
             };
@@ -391,7 +392,7 @@ impl Drop for CommittedIndexIter<'_> {
         let table_name = self
             .committed_state
             .get_schema(&self.table_id)
-            .map(|table| table.table_name.as_str())
+            .map(|table| &*table.table_name)
             .unwrap_or_default();
 
         DB_METRICS

--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -85,7 +85,7 @@ pub trait StateView {
             .first()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_table, table_id.into()))?;
         let el = StTableRow::try_from(row.view())?;
-        let table_name = el.table_name.to_owned();
+        let table_name = el.table_name.into();
         let table_id = el.table_id;
 
         // Look up the columns for the table in question.
@@ -340,7 +340,7 @@ impl Drop for IndexSeekIterMutTxId<'_> {
         let table_name = self
             .committed_state
             .get_schema(&self.table_id)
-            .map(|table| table.table_name.as_str())
+            .map(|table| &*table.table_name)
             .unwrap_or_default();
 
         // Increment number of index seeks

--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -353,11 +353,11 @@ impl StTableRow<&str> {
     }
 }
 
-impl From<StTableRow<String>> for ProductValue {
-    fn from(x: StTableRow<String>) -> Self {
+impl From<StTableRow<&str>> for ProductValue {
+    fn from(x: StTableRow<&str>) -> Self {
         product![
             x.table_id,
-            x.table_name,
+            x.table_name.to_owned(),
             x.table_type.as_str().to_owned(),
             x.table_access.as_str().to_owned()
         ]

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -30,7 +30,7 @@ pub struct TxRecord {
     /// The table that was modified.
     pub(crate) table_id: TableId,
     /// The table that was modified.
-    pub(crate) table_name: String,
+    pub(crate) table_name: Arc<str>,
 }
 
 /// A record of all the operations within a transaction.

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -1,7 +1,7 @@
 use std::io;
 use std::num::ParseIntError;
 use std::path::PathBuf;
-use std::sync::{MutexGuard, PoisonError};
+use std::sync::{Arc, MutexGuard, PoisonError};
 
 use hex::FromHexError;
 use spacetimedb_sats::AlgebraicType;
@@ -25,11 +25,11 @@ use spacetimedb_vm::expr::Crud;
 #[derive(Error, Debug)]
 pub enum TableError {
     #[error("Table with name `{0}` start with 'st_' and that is reserved for internal system tables.")]
-    System(String),
+    System(Arc<str>),
     #[error("Table with name `{0}` already exists.")]
-    Exist(String),
+    Exist(Arc<str>),
     #[error("Table with name `{0}` not found.")]
-    NotFound(String),
+    NotFound(Arc<str>),
     #[error("Table with ID `{1}` not found in `{0}`.")]
     IdNotFound(SystemTable, u32),
     #[error("Table with ID `{0}` not found in `TxState`.")]
@@ -54,7 +54,7 @@ pub enum TableError {
         found
     )]
     DecodeField {
-        table: String,
+        table: Arc<str>,
         field: String,
         expect: String,
         found: String,
@@ -98,15 +98,15 @@ pub enum PlanError {
     #[error("Unsupported feature: `{feature}`")]
     Unsupported { feature: String },
     #[error("Unknown table: `{table}`")]
-    UnknownTable { table: String },
+    UnknownTable { table: Arc<str> },
     #[error("Qualified Table `{expect}` not found")]
-    TableNotFoundQualified { expect: String },
+    TableNotFoundQualified { expect: Arc<str> },
     #[error("Unknown field: `{field}` not found in the table(s): `{tables:?}`")]
-    UnknownField { field: FieldName, tables: Vec<String> },
+    UnknownField { field: FieldName, tables: Vec<Arc<str>> },
     #[error("Field(s): `{fields:?}` not found in the table(s): `{tables:?}`")]
     UnknownFields {
         fields: Vec<FieldName>,
-        tables: Vec<String>,
+        tables: Vec<Arc<str>>,
     },
     #[error("Ambiguous field: `{field}`. Also found in {found:?}")]
     AmbiguousField { field: String, found: Vec<FieldName> },
@@ -313,9 +313,9 @@ pub enum NodesError {
     #[error("can't perform operation; not inside transaction")]
     NotInTransaction,
     #[error("table with name {0:?} already exists")]
-    AlreadyExists(String),
+    AlreadyExists(Arc<str>),
     #[error("table with name `{0}` start with 'st_' and that is reserved for internal system tables.")]
-    SystemName(String),
+    SystemName(Arc<str>),
     #[error("internal db error: {0}")]
     Internal(#[source] Box<DBError>),
     #[error("invalid index type: {0}")]

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -10,6 +10,7 @@ use spacetimedb_lib::{ProductValue, ReducerDef};
 use spacetimedb_metrics::impl_prometheusvalue_string;
 use spacetimedb_metrics::typed_prometheus::AsPrometheusLabel;
 use spacetimedb_sats::WithTypespace;
+use std::sync::Arc;
 
 mod host_controller;
 pub(crate) mod module_host;
@@ -118,7 +119,7 @@ impl From<usize> for ReducerId {
 pub struct InvalidReducerArguments {
     #[source]
     err: anyhow::Error,
-    reducer: String,
+    reducer: Arc<str>,
 }
 
 fn from_json_seed<'de, T: serde::de::DeserializeSeed<'de>>(s: &'de str, seed: T) -> anyhow::Result<T::Value> {

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -77,10 +77,10 @@ impl DatabaseUpdate {
             let table_name = table_name_map
                 .entry(table_id)
                 .or_insert_with(|| stdb.table_name_from_id(&ctx, &tx, table_id).unwrap().unwrap());
-            let table_name: &str = table_name.as_ref();
+            let table_name: &str = table_name;
             table_updates.push(DatabaseTableUpdate {
                 table_id,
-                table_name: table_name.to_owned(),
+                table_name: table_name.into(),
                 ops: table_row_operations,
             });
         }
@@ -96,7 +96,7 @@ impl DatabaseUpdate {
                 .into_iter()
                 .map(|table| TableUpdate {
                     table_id: table.table_id.into(),
-                    table_name: table.table_name,
+                    table_name: table.table_name.to_string(),
                     table_row_operations: table
                         .ops
                         .into_iter()
@@ -154,7 +154,7 @@ impl DatabaseUpdate {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct DatabaseTableUpdate {
     pub table_id: TableId,
-    pub table_name: String,
+    pub table_name: Arc<str>,
     pub ops: Vec<TableOp>,
 }
 
@@ -205,12 +205,12 @@ pub struct ModuleInfo {
     pub module_hash: Hash,
     pub typespace: Typespace,
     pub reducers: ReducersMap,
-    pub catalog: HashMap<String, EntityDef>,
+    pub catalog: HashMap<Arc<str>, EntityDef>,
     pub log_tx: tokio::sync::broadcast::Sender<bytes::Bytes>,
     pub subscription: ModuleSubscriptionManager,
 }
 
-pub struct ReducersMap(pub IndexMap<String, ReducerDef>);
+pub struct ReducersMap(pub IndexMap<Arc<str>, ReducerDef>);
 
 impl fmt::Debug for ReducersMap {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -290,7 +290,7 @@ impl<T: WasmModule> Module for WasmModuleHostActor<T> {
             // so we can assume there's only one table to clear.
             if let Some(table_id) = tables
                 .iter()
-                .find_map(|t| (t.table_name == table_name).then_some(t.table_id))
+                .find_map(|t| (*t.table_name == *table_name).then_some(t.table_id))
             {
                 db.clear_table(tx, table_id)?;
             }

--- a/crates/core/src/json/client_api.rs
+++ b/crates/core/src/json/client_api.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use bytestring::ByteString;
 use serde::Serialize;
 use spacetimedb_lib::Address;
@@ -61,7 +63,7 @@ pub struct FunctionCallJson {
 #[derive(Debug, Clone, Serialize)]
 pub struct TableUpdateJson {
     pub table_id: u32,
-    pub table_name: String,
+    pub table_name: Arc<str>,
     pub table_row_operations: Vec<TableRowOperationJson>,
 }
 
@@ -113,6 +115,6 @@ pub struct OneOffQueryResponseJson {
 
 #[derive(Debug, Clone, Serialize)]
 pub struct OneOffTableJson {
-    pub table_name: String,
+    pub table_name: Arc<str>,
     pub rows: Vec<Vec<AlgebraicValue>>,
 }

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -114,7 +114,7 @@ fn compile_select(table: From, project: Vec<Column>, selection: Option<Selection
             Column::QualifiedWildcard { table: name } => {
                 if let Some(t) = table.iter_tables().find(|x| x.table_name == name) {
                     for c in t.columns().iter() {
-                        col_ids.push(FieldName::named(&t.table_name, &c.col_name).into());
+                        col_ids.push(FieldName::named(t.table_name.clone(), &c.col_name).into());
                     }
                     qualified_wildcards.push(t.table_id);
                 } else {
@@ -177,7 +177,7 @@ fn compile_columns(table: &TableSchema, columns: Vec<FieldName>) -> DbTable {
 
     for col in columns.into_iter() {
         if let Some(x) = table.get_column_by_field(&col) {
-            let field = FieldName::named(&table.table_name, &x.col_name);
+            let field = FieldName::named(table.table_name.clone(), &x.col_name);
             new.push(relation::Column::new(field, x.col_type.clone(), x.col_pos));
         }
     }
@@ -294,7 +294,7 @@ mod tests {
         schema: &[(&str, AlgebraicType)],
         indexes: &[(ColId, &str)],
     ) -> ResultTest<TableId> {
-        let table_name = name.to_string();
+        let table_name = name.into();
         let table_type = StTableType::User;
         let table_access = StAccess::Public;
 
@@ -678,8 +678,8 @@ mod tests {
         assert_eq!(table_id, rhs_id);
         assert_eq!(lhs_field, "b");
         assert_eq!(rhs_field, "b");
-        assert_eq!(lhs_table, "lhs");
-        assert_eq!(rhs_table, "rhs");
+        assert_eq!(&**lhs_table, "lhs");
+        assert_eq!(&**rhs_table, "rhs");
         Ok(())
     }
 
@@ -728,7 +728,7 @@ mod tests {
             panic!("unexpected left hand side {:#?}", **lhs);
         };
 
-        assert_eq!(table, "lhs");
+        assert_eq!(&**table, "lhs");
         assert_eq!(field, "a");
 
         let ColumnOp::Field(FieldExpr::Value(AlgebraicValue::U64(3))) = **rhs else {
@@ -760,8 +760,8 @@ mod tests {
         assert_eq!(table_id, rhs_id);
         assert_eq!(lhs_field, "b");
         assert_eq!(rhs_field, "b");
-        assert_eq!(lhs_table, "lhs");
-        assert_eq!(rhs_table, "rhs");
+        assert_eq!(&**lhs_table, "lhs");
+        assert_eq!(&**rhs_table, "rhs");
         assert!(rhs.is_empty());
         Ok(())
     }
@@ -822,8 +822,8 @@ mod tests {
         assert_eq!(table_id, rhs_id);
         assert_eq!(lhs_field, "b");
         assert_eq!(rhs_field, "b");
-        assert_eq!(lhs_table, "lhs");
-        assert_eq!(rhs_table, "rhs");
+        assert_eq!(&**lhs_table, "lhs");
+        assert_eq!(&**rhs_table, "rhs");
 
         // The selection should be pushed onto the rhs of the join
         let Query::Select(ColumnOp::Cmp {
@@ -839,7 +839,7 @@ mod tests {
             panic!("unexpected left hand side {:#?}", **lhs);
         };
 
-        assert_eq!(table, "rhs");
+        assert_eq!(&**table, "rhs");
         assert_eq!(field, "c");
 
         let ColumnOp::Field(FieldExpr::Value(AlgebraicValue::U64(3))) = **rhs else {
@@ -917,8 +917,8 @@ mod tests {
         assert_eq!(table_id, rhs_id);
         assert_eq!(lhs_field, "b");
         assert_eq!(rhs_field, "b");
-        assert_eq!(lhs_table, "lhs");
-        assert_eq!(rhs_table, "rhs");
+        assert_eq!(&**lhs_table, "lhs");
+        assert_eq!(&**rhs_table, "rhs");
 
         assert_eq!(1, rhs.len());
 
@@ -997,7 +997,7 @@ mod tests {
         assert_eq!(index_table, lhs_id);
         assert_eq!(index_col, 1.into());
         assert_eq!(probe_field, "b");
-        assert_eq!(probe_table, "rhs");
+        assert_eq!(&**probe_table, "rhs");
 
         assert_eq!(2, rhs.len());
 
@@ -1025,7 +1025,7 @@ mod tests {
             panic!("unexpected left hand side {:#?}", field);
         };
 
-        assert_eq!(table, "rhs");
+        assert_eq!(&**table, "rhs");
         assert_eq!(field, "d");
 
         let ColumnOp::Field(FieldExpr::Value(AlgebraicValue::U64(3))) = **value else {

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -44,7 +44,7 @@ pub fn to_mem_table_with_op_type(head: Header, table_access: StAccess, data: &Da
         }));
     } else {
         t.head.fields.push(Column::new(
-            FieldName::named(&t.head.table_name, OP_TYPE_FIELD_NAME),
+            FieldName::named(t.head.table_name.clone(), OP_TYPE_FIELD_NAME),
             AlgebraicType::U8,
             t.head.fields.len().into(),
         ));
@@ -224,7 +224,7 @@ mod tests {
         schema: &[(&str, AlgebraicType)],
         indexes: &[(ColId, &str)],
     ) -> ResultTest<TableId> {
-        let table_name = name.to_string();
+        let table_name = name.into();
         let table_type = StTableType::User;
         let table_access = StAccess::Public;
 
@@ -253,7 +253,7 @@ mod tests {
         let row_pk = row.to_data_key().to_bytes();
         DatabaseTableUpdate {
             table_id,
-            table_name: table_name.to_string(),
+            table_name: table_name.into(),
             ops: vec![TableOp {
                 op_type: 1,
                 row,
@@ -266,7 +266,7 @@ mod tests {
         let row_pk = row.to_data_key().to_bytes();
         DatabaseTableUpdate {
             table_id,
-            table_name: table_name.to_string(),
+            table_name: table_name.into(),
             ops: vec![TableOp {
                 op_type: 0,
                 row,
@@ -304,7 +304,7 @@ mod tests {
 
         let data = DatabaseTableUpdate {
             table_id,
-            table_name: table_name.to_string(),
+            table_name: table_name.into(),
             ops: vec![op],
         };
 
@@ -331,8 +331,8 @@ mod tests {
 
         // For filtering out the hidden field `OP_TYPE_FIELD_NAME`
         let fields = &[
-            FieldName::named(table_name, "inventory_id").into(),
-            FieldName::named(table_name, "name").into(),
+            FieldName::named(table_name.into(), "inventory_id").into(),
+            FieldName::named(table_name.into(), "name").into(),
         ];
 
         let q = q.with_project(fields, None);
@@ -352,8 +352,8 @@ mod tests {
 
         // For filtering out the hidden field `OP_TYPE_FIELD_NAME`
         let fields = &[
-            FieldName::named(table_name, "player_id").into(),
-            FieldName::named(table_name, "name").into(),
+            FieldName::named(table_name.into(), "player_id").into(),
+            FieldName::named(table_name.into(), "name").into(),
         ];
 
         let q = q.with_project(fields, None);
@@ -825,7 +825,11 @@ mod tests {
         let q_1 = q.clone();
         check_query(&db, &table, &mut tx, &q_1, &data)?;
 
-        let q_2 = q.with_select_cmp(OpCmp::Eq, FieldName::named("inventory", "inventory_id"), scalar(1u64));
+        let q_2 = q.with_select_cmp(
+            OpCmp::Eq,
+            FieldName::named("inventory".into(), "inventory_id"),
+            scalar(1u64),
+        );
         check_query(&db, &table, &mut tx, &q_2, &data)?;
 
         Ok(())
@@ -849,10 +853,11 @@ mod tests {
         //SELECT * FROM inventory
         let q_all = QueryExpr::new(db_table(&schema, schema.table_id));
         //SELECT * FROM inventory WHERE inventory_id = 1
-        let q_id =
-            q_all
-                .clone()
-                .with_select_cmp(OpCmp::Eq, FieldName::named("_inventory", "inventory_id"), scalar(1u64));
+        let q_id = q_all.clone().with_select_cmp(
+            OpCmp::Eq,
+            FieldName::named("_inventory".into(), "inventory_id"),
+            scalar(1u64),
+        );
 
         let s = [q_all, q_id]
             .into_iter()
@@ -873,7 +878,7 @@ mod tests {
 
         let data = DatabaseTableUpdate {
             table_id: schema.table_id,
-            table_name: "_inventory".to_string(),
+            table_name: "_inventory".into(),
             ops: vec![row1, row2],
         };
 
@@ -923,10 +928,11 @@ mod tests {
         //SELECT * FROM inventory
         let q_all = QueryExpr::new(db_table(&schema, schema.table_id));
         //SELECT * FROM inventory WHERE inventory_id = 1
-        let q_id =
-            q_all
-                .clone()
-                .with_select_cmp(OpCmp::Eq, FieldName::named("_inventory", "inventory_id"), scalar(1u64));
+        let q_id = q_all.clone().with_select_cmp(
+            OpCmp::Eq,
+            FieldName::named("_inventory".into(), "inventory_id"),
+            scalar(1u64),
+        );
 
         let s = [q_all, q_id]
             .into_iter()
@@ -953,7 +959,7 @@ mod tests {
 
         let data = DatabaseTableUpdate {
             table_id: schema.table_id,
-            table_name: "inventory".to_string(),
+            table_name: "inventory".into(),
             ops: vec![row1, row2],
         };
 
@@ -1060,13 +1066,13 @@ mod tests {
 
         let data1 = DatabaseTableUpdate {
             table_id: schema_1.table_id,
-            table_name: "inventory".to_string(),
+            table_name: "inventory".into(),
             ops: vec![row1],
         };
 
         let data2 = DatabaseTableUpdate {
             table_id: schema_2.table_id,
-            table_name: "player".to_string(),
+            table_name: "player".into(),
             ops: vec![row2],
         };
 

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -766,7 +766,7 @@ mod tests {
         schema: &[(&str, AlgebraicType)],
         indexes: &[(ColId, &str)],
     ) -> Result<TableId, DBError> {
-        let table_name = name.to_string();
+        let table_name = name.into();
         let table_type = StTableType::User;
         let table_access = StAccess::Public;
 
@@ -840,7 +840,7 @@ mod tests {
         };
         let delta = DatabaseTableUpdate {
             table_id: lhs_id,
-            table_name: String::from("lhs"),
+            table_name: "lhs".into(),
             ops: vec![insert],
         };
 
@@ -883,7 +883,7 @@ mod tests {
         assert_eq!(index_table, rhs_id);
         assert_eq!(index_col, 0.into());
         assert_eq!(probe_field, "b");
-        assert_eq!(probe_table, "lhs");
+        assert_eq!(&**probe_table, "lhs");
         Ok(())
     }
 
@@ -936,7 +936,7 @@ mod tests {
         };
         let delta = DatabaseTableUpdate {
             table_id: rhs_id,
-            table_name: String::from("rhs"),
+            table_name: "rhs".into(),
             ops: vec![insert],
         };
 
@@ -980,7 +980,7 @@ mod tests {
         assert_eq!(index_table, lhs_id);
         assert_eq!(index_col, 1.into());
         assert_eq!(probe_field, "b");
-        assert_eq!(probe_table, "rhs");
+        assert_eq!(&**probe_table, "rhs");
         Ok(())
     }
 }

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -678,7 +678,7 @@ pub(crate) mod tests {
         let data = MemTable::from_value(scalar(1u64));
         let rhs = data.get_field_pos(0).unwrap().clone();
 
-        let q = query(inv).with_join_inner(data, FieldName::positional("inventory", 0), rhs);
+        let q = query(inv).with_join_inner(data, FieldName::positional("inventory".into(), 0), rhs);
 
         let result = match run_ast(p, q.into()) {
             Code::Table(x) => x,
@@ -721,7 +721,7 @@ pub(crate) mod tests {
 
         let q = query(&st_table_schema()).with_select_cmp(
             OpCmp::Eq,
-            FieldName::named(ST_TABLES_NAME, StTableFields::TableName.name()),
+            FieldName::named(ST_TABLES_NAME.into(), StTableFields::TableName.name()),
             scalar(ST_TABLES_NAME),
         );
         check_catalog(
@@ -729,7 +729,7 @@ pub(crate) mod tests {
             ST_TABLES_NAME,
             StTableRow {
                 table_id: ST_TABLES_ID,
-                table_name: ST_TABLES_NAME.to_string(),
+                table_name: ST_TABLES_NAME,
                 table_type: StTableType::System,
                 table_access: StAccess::Public,
             }
@@ -755,12 +755,12 @@ pub(crate) mod tests {
         let q = query(&st_columns_schema())
             .with_select_cmp(
                 OpCmp::Eq,
-                FieldName::named(ST_COLUMNS_NAME, StColumnFields::TableId.name()),
+                FieldName::named(ST_COLUMNS_NAME.into(), StColumnFields::TableId.name()),
                 scalar(ST_COLUMNS_ID),
             )
             .with_select_cmp(
                 OpCmp::Eq,
-                FieldName::named(ST_COLUMNS_NAME, StColumnFields::ColPos.name()),
+                FieldName::named(ST_COLUMNS_NAME.into(), StColumnFields::ColPos.name()),
                 scalar(StColumnFields::TableId as u32),
             );
         check_catalog(
@@ -802,7 +802,7 @@ pub(crate) mod tests {
 
         let q = query(&st_indexes_schema()).with_select_cmp(
             OpCmp::Eq,
-            FieldName::named(ST_INDEXES_NAME, StIndexFields::IndexName.name()),
+            FieldName::named(ST_INDEXES_NAME.into(), StIndexFields::IndexName.name()),
             scalar("idx_1"),
         );
         check_catalog(
@@ -837,7 +837,7 @@ pub(crate) mod tests {
 
         let q = query(&st_sequences_schema()).with_select_cmp(
             OpCmp::Eq,
-            FieldName::named(ST_SEQUENCES_NAME, StSequenceFields::TableId.name()),
+            FieldName::named(ST_SEQUENCES_NAME.into(), StSequenceFields::TableId.name()),
             scalar(ST_SEQUENCES_ID),
         );
         check_catalog(

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::Context;
 use spacetimedb_sats::db::def::TableDef;
 use spacetimedb_sats::{impl_serialize, WithTypespace};
@@ -109,7 +111,7 @@ impl TableDesc {
 
 #[derive(Debug, Clone, de::Deserialize, ser::Serialize)]
 pub struct ReducerDef {
-    pub name: String,
+    pub name: Arc<str>,
     pub args: Vec<ProductTypeElement>,
 }
 
@@ -192,6 +194,6 @@ pub enum MiscModuleExport {
 
 #[derive(Debug, Clone, de::Deserialize, ser::Serialize)]
 pub struct TypeAlias {
-    pub name: String,
+    pub name: Arc<str>,
     pub ty: sats::AlgebraicTypeRef,
 }

--- a/crates/sats/src/db/error.rs
+++ b/crates/sats/src/db/error.rs
@@ -6,6 +6,7 @@ use derive_more::Display;
 use spacetimedb_primitives::{ColId, ColList, TableId};
 use std::fmt;
 use std::string::FromUtf8Error;
+use std::sync::Arc;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -122,29 +123,29 @@ pub enum DefType {
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum SchemaError {
     #[error("Multiple primary columns defined for table: {table} columns: {pks:?}")]
-    MultiplePrimaryKeys { table: String, pks: Vec<String> },
+    MultiplePrimaryKeys { table: Arc<str>, pks: Vec<String> },
     #[error("table id `{table_id}` should have name")]
     EmptyTableName { table_id: TableId },
     #[error("{ty} {name} columns `{columns:?}` not found  in table `{table}`")]
     ColumnsNotFound {
         name: String,
-        table: String,
+        table: Arc<str>,
         columns: Vec<ColId>,
         ty: DefType,
     },
     #[error("table `{table}` {ty} should have name. {ty} id: {id}")]
-    EmptyName { table: String, ty: DefType, id: u32 },
+    EmptyName { table: Arc<str>, ty: DefType, id: u32 },
     #[error("table `{table}` have `Constraints::unset()` for columns: {columns:?}")]
     ConstraintUnset {
-        table: String,
+        table: Arc<str>,
         name: String,
         columns: ColList,
     },
     #[error("Attempt to define a column with more than 1 auto_inc sequence: Table: `{table}`, Field: `{field}`")]
-    OneAutoInc { table: String, field: String },
+    OneAutoInc { table: Arc<str>, field: String },
     #[error("Only Btree Indexes are supported: Table: `{table}`, Index: `{index}` is a `{index_type}`")]
     OnlyBtree {
-        table: String,
+        table: Arc<str>,
         index: String,
         index_type: IndexType,
     },

--- a/crates/sats/src/de/impls.rs
+++ b/crates/sats/src/de/impls.rs
@@ -1,6 +1,7 @@
-use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::marker::PhantomData;
+use std::sync::Arc;
+use std::{borrow::Cow, rc::Rc};
 
 // use crate::type_value::{ElementValue, EnumValue};
 // use crate::{ProductTypeElement, SumType, PrimitiveType, ReducerDef, ProductType, ProductValue, AlgebraicType, AlgebraicValue};
@@ -104,7 +105,11 @@ impl_deserialize!([] String, de => de.deserialize_str(OwnedSliceVisitor));
 impl_deserialize!([T: Deserialize<'de>] Vec<T>, de => T::__deserialize_vec(de));
 impl_deserialize!([T: Deserialize<'de>, const N: usize] [T; N], de => T::__deserialize_array(de));
 impl_deserialize!([] Box<str>, de => String::deserialize(de).map(|s| s.into_boxed_str()));
+impl_deserialize!([] Rc<str>, de => String::deserialize(de).map(|s| s.into()));
+impl_deserialize!([] Arc<str>, de => String::deserialize(de).map(|s| s.into()));
 impl_deserialize!([T: Deserialize<'de>] Box<[T]>, de => Vec::deserialize(de).map(|s| s.into_boxed_slice()));
+impl_deserialize!([T: Deserialize<'de>] Rc<[T]>, de => Vec::deserialize(de).map(|s| s.into()));
+impl_deserialize!([T: Deserialize<'de>] Arc<[T]>, de => Vec::deserialize(de).map(|s| s.into()));
 
 /// The visitor converts the slice to its owned version.
 struct OwnedSliceVisitor;

--- a/crates/sats/src/ser/impls.rs
+++ b/crates/sats/src/ser/impls.rs
@@ -1,5 +1,5 @@
 use spacetimedb_primitives::ColList;
-use std::collections::BTreeMap;
+use std::{collections::BTreeMap, rc::Rc, sync::Arc};
 
 use crate::{
     AlgebraicType, AlgebraicValue, ArrayValue, MapType, MapValue, ProductValue, SumValue, ValueWithType, F32, F64,
@@ -72,6 +72,8 @@ impl_serialize!([T: Serialize] Vec<T>, (self, ser)  => (**self).serialize(ser));
 impl_serialize!([T: Serialize] [T], (self, ser) => T::__serialize_array(self, ser));
 impl_serialize!([T: Serialize, const N: usize] [T; N], (self, ser) => T::__serialize_array(self, ser));
 impl_serialize!([T: Serialize + ?Sized] Box<T>, (self, ser) => (**self).serialize(ser));
+impl_serialize!([T: Serialize + ?Sized] Rc<T>, (self, ser) => (**self).serialize(ser));
+impl_serialize!([T: Serialize + ?Sized] Arc<T>, (self, ser) => (**self).serialize(ser));
 impl_serialize!([T: Serialize + ?Sized] &T, (self, ser) => (**self).serialize(ser));
 impl_serialize!([] String, (self, ser) => ser.serialize_str(self));
 impl_serialize!([T: Serialize] Option<T>, (self, ser) => match self {

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -25,6 +25,7 @@ use spacetimedb_sats::{
     ser::{Serialize, Serializer},
     AlgebraicValue, ProductType, ProductValue,
 };
+use std::sync::Arc;
 use thiserror::Error;
 
 /// A database table containing the row schema, the rows, and indices.
@@ -619,7 +620,7 @@ impl IndexScanIter<'_> {
 #[error("Unique constraint violation '{}' in table '{}': column(s): '{:?}' value: {}", constraint_name, table_name, cols, value.to_satn())]
 pub struct UniqueConstraintViolation {
     pub constraint_name: String,
-    pub table_name: String,
+    pub table_name: Arc<str>,
     pub cols: Vec<String>,
     pub value: AlgebraicValue,
 }
@@ -788,7 +789,7 @@ mod test {
                 value,
             })) => {
                 assert_eq!(constraint_name, index_name);
-                assert_eq!(table_name, "UniqueIndexed");
+                assert_eq!(table_name, "UniqueIndexed".into());
                 assert_eq!(cols, &["unique_col"]);
                 assert_eq!(value, AlgebraicValue::I32(0));
             }

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -745,7 +745,7 @@ mod tests {
             "Project"
         );
 
-        let field = FieldName::positional(&table.head.table_name, 1);
+        let field = FieldName::positional(table.head.table_name, 1);
         let q = source.with_project(&[field.clone().into()], None);
 
         let result = run_ast(p, q.into());

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -1879,6 +1879,8 @@ impl From<Code> for CodeResult {
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::*;
 
     const ALICE: Identity = Identity::from_byte_array([1; 32]);
@@ -1986,12 +1988,13 @@ mod tests {
     fn mem_table(name: &str, fields: &[(&str, AlgebraicType, bool)]) -> MemTable {
         let table_access = StAccess::Public;
         let data = Vec::new();
+        let name: Arc<str> = name.into();
         let head = Header::new(
-            name.into(),
+            name.clone(),
             fields
                 .iter()
                 .enumerate()
-                .map(|(i, (field, ty, _))| Column::new(FieldName::named(name, field), ty.clone(), i.into()))
+                .map(|(i, (field, ty, _))| Column::new(FieldName::named(name.clone(), field), ty.clone(), i.into()))
                 .collect(),
             fields
                 .iter()
@@ -2042,8 +2045,8 @@ mod tests {
             panic!("expected an inner join, but got {:#?}", expr.query[0]);
         };
 
-        assert_eq!(join.col_lhs, FieldName::named("probe", "b"));
-        assert_eq!(join.col_rhs, FieldName::named("index", "b"));
+        assert_eq!(join.col_lhs, FieldName::named("probe".into(), "b"));
+        assert_eq!(join.col_rhs, FieldName::named("index".into(), "b"));
         assert_eq!(
             join.rhs,
             QueryExpr {
@@ -2059,8 +2062,8 @@ mod tests {
         assert_eq!(
             fields,
             &vec![
-                FieldName::named("probe", "c").into(),
-                FieldName::named("probe", "b").into()
+                FieldName::named("probe".into(), "c").into(),
+                FieldName::named("probe".into(), "b").into()
             ]
         );
     }


### PR DESCRIPTION
# Description of Changes

Switches most cases where a table / reducer name is stored to an `Arc<str>` rather than `String`.

# API and ABI breaking changes

None

# Expected complexity level and risk

1