### PR TITLE
Implement 'sql' parsing for 'Identity, Address' in hex format

### DIFF
--- a/crates/core/src/sql/ast.rs
+++ b/crates/core/src/sql/ast.rs
@@ -331,6 +331,7 @@ fn compile_expr_value(table: &From, field: Option<&ProductTypeElement>, of: SqlE
             Value::Number(value, is_long) => infer_number(field, &value, is_long)?,
             Value::SingleQuotedString(s) => infer_str_or_enum(field, s)?,
             Value::DoubleQuotedString(s) => AlgebraicValue::String(s),
+            Value::HexStringLiteral(s) => infer_number(field, &s, false)?,
             Value::Boolean(x) => AlgebraicValue::Bool(x),
             Value::Null => AlgebraicValue::OptionNone(),
             x => {

--- a/crates/lib/src/address.rs
+++ b/crates/lib/src/address.rs
@@ -2,6 +2,7 @@ use anyhow::Context as _;
 use hex::FromHex as _;
 use sats::{impl_deserialize, impl_serialize, impl_st, AlgebraicType};
 use spacetimedb_bindings_macro::{Deserialize, Serialize};
+use spacetimedb_sats::{AlgebraicValue, ProductValue};
 use std::{fmt, net::Ipv6Addr};
 
 use crate::sats;
@@ -51,6 +52,10 @@ impl Address {
     pub const ZERO: Self = Self {
         __address_bytes: [0; 16],
     };
+
+    pub fn get_type() -> AlgebraicType {
+        AlgebraicType::product([("__address_bytes", AlgebraicType::bytes())])
+    }
 
     pub fn from_arr(arr: &[u8; 16]) -> Self {
         Self { __address_bytes: *arr }
@@ -113,6 +118,14 @@ impl Address {
 impl From<u128> for Address {
     fn from(value: u128) -> Self {
         Self::from_u128(value)
+    }
+}
+
+impl From<Address> for AlgebraicValue {
+    fn from(value: Address) -> Self {
+        AlgebraicValue::Product(ProductValue::from(AlgebraicValue::Bytes(
+            value.__address_bytes.to_vec(),
+        )))
     }
 }
 

--- a/crates/lib/src/identity.rs
+++ b/crates/lib/src/identity.rs
@@ -1,6 +1,6 @@
 use spacetimedb_bindings_macro::{Deserialize, Serialize};
 use spacetimedb_sats::hex::HexString;
-use spacetimedb_sats::{hash, impl_st, AlgebraicType};
+use spacetimedb_sats::{hash, impl_st, AlgebraicType, AlgebraicValue, ProductValue};
 use std::{fmt, str::FromStr};
 
 pub type RequestId = u32;
@@ -123,6 +123,12 @@ impl FromStr for Identity {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         Self::from_hex(s)
+    }
+}
+
+impl From<Identity> for AlgebraicValue {
+    fn from(value: Identity) -> Self {
+        AlgebraicValue::Product(ProductValue::from(AlgebraicValue::Bytes(value.to_vec())))
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Allow to execute 

```sql
select * from test where 
identity = 0x0000000000000000000000000000000000000000000000000000000000000000 AND 
identity = x'93dda09db9a56d8fa6c024d843e805D8262191db3b4bA84c5efcd1ad451fed4e' AND 
identity = x'91DDA09DB9A56D8FA6C024D843E805D8262191DB3B4BA84C5EFCD1AD451FED4E' AND 
address = 0x00000000000000000000000000000000 AND 
address = x'00000000000000000000000000000000'
```

for `Identity` and `Address` new types.

NOTE: Only full hex are supported. This fails:

```rust
 Address::to_abbreviated_hex()
```
This requires a breaking change in how the `hex` are parsed:

```rust
pub fn from_hex(hex: &str) -> Result<Self, anyhow::Error> {
        <[u8; 16]>::from_hex(hex)
            .context("Addresses must be 32 hex characters (16 bytes) in length.")
            .map(|arr| Self::from_arr(&arr))
}
```

# Expected complexity level and risk

1