### PR TITLE
Add a RwLock around module subscriptions to prevent a race condition

### DIFF
--- a/crates/client-api/src/routes/subscribe.rs
+++ b/crates/client-api/src/routes/subscribe.rs
@@ -306,12 +306,7 @@ async fn ws_client_actor(client: ClientConnection, mut ws: WebSocketStream, mut 
     // https://rust-lang.github.io/wg-async/vision/submitted_stories/status_quo/aws_engineer/solving_a_deadlock.html
     handle_queue.clear();
 
-    // ignore NoSuchModule; if the module's already closed, that's fine
-    let _ = client.module.subscription().remove_subscriber(client.id);
-    let _ = client
-        .module
-        .call_identity_connected_disconnected(client.id.identity, client.id.address, false)
-        .await;
+    client.module.disconnect_client(client.id).await;
 }
 
 enum ClientMessage {

--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -1,6 +1,7 @@
 use std::ops::Deref;
 
-use crate::host::{ModuleHost, NoSuchModule, ReducerArgs, ReducerCallError, ReducerCallResult};
+use crate::error::DBError;
+use crate::host::{ModuleHost, ReducerArgs, ReducerCallError, ReducerCallResult};
 use crate::protobuf::client_api::Subscribe;
 use crate::util::prometheus_handle::IntGaugeExt;
 use crate::worker_metrics::WORKER_METRICS;
@@ -161,8 +162,16 @@ impl ClientConnection {
             .await
     }
 
-    pub fn subscribe(&self, subscription: Subscribe) -> Result<(), NoSuchModule> {
-        self.module.subscription().add_subscriber(self.sender(), subscription)
+    pub async fn subscribe(&self, subscription: Subscribe) -> Result<(), DBError> {
+        let me = self.clone();
+        tokio::task::spawn_blocking(move || {
+            me.module
+                .subscriptions()
+                .blocking_write()
+                .add_subscriber(me.sender, subscription)
+        })
+        .await
+        .unwrap()
     }
 
     pub async fn one_off_query(&self, query: &str, message_id: &[u8]) -> Result<(), anyhow::Error> {

--- a/crates/core/src/client/message_handlers.rs
+++ b/crates/core/src/client/message_handlers.rs
@@ -142,7 +142,9 @@ impl DecodedMessage<'_> {
                 let res = client.call_reducer(reducer, args).await;
                 res.map(drop).map_err(|e| (Some(reducer), e.into()))
             }
-            DecodedMessage::Subscribe(subscription) => client.subscribe(subscription).map_err(|e| (None, e.into())),
+            DecodedMessage::Subscribe(subscription) => {
+                client.subscribe(subscription).await.map_err(|e| (None, e.into()))
+            }
             DecodedMessage::OneOffQuery {
                 query_string: query,
                 message_id,

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -121,7 +121,7 @@ impl ModuleSubscriptions {
 
     /// A blocking version of [`broadcast_event`][Self::broadcast_event].
     pub fn blocking_broadcast_event(&self, client: Option<&ClientConnectionSender>, event: &ModuleEvent) {
-        tokio::runtime::Handle::current().block_on(self.broadcast_event(client, &event))
+        tokio::runtime::Handle::current().block_on(self.broadcast_event(client, event))
     }
 
     /// Broadcast the commit event to all interested subscribers.

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -50,6 +50,7 @@ use super::query;
 
 /// A subscription is a [`QuerySet`], along with a set of subscribers all
 /// interested in the same set of queries.
+#[derive(Debug)]
 pub struct Subscription {
     pub queries: QuerySet,
     subscribers: Vec<ClientConnectionSender>,


### PR DESCRIPTION
# Description of Changes

Fixes that issue. From a comment I added in module_subscription_actor:

> Take a lock on our subscriptions [before we commit the tx]. Otherwise, we could have a race condition where we commit the tx, someone adds a subscription and receives this tx as an update, and then receives the update again when we broadcast_event.

# Expected complexity level and risk

2
