### PR TITLE
BTreeIndex: use `ReadColumn` instead of `ProductValue` fields

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -312,7 +312,7 @@ impl CommittedState {
             };
             let mut index = BTreeIndex::new(
                 index_row.index_id,
-                &table.row_layout(),
+                table.row_layout(),
                 &index_row.columns,
                 index_row.is_unique,
                 index_row.index_name,

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -312,7 +312,7 @@ impl CommittedState {
             };
             let mut index = BTreeIndex::new(
                 index_row.index_id,
-                &table.row_layout,
+                &table.row_layout(),
                 &index_row.columns,
                 index_row.is_unique,
                 index_row.index_name,

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -310,7 +310,13 @@ impl CommittedState {
             let Some((table, blob_store)) = self.get_table_and_blob_store(index_row.table_id) else {
                 panic!("Cannot create index for table which doesn't exist in committed state");
             };
-            let mut index = BTreeIndex::new(index_row.index_id, index_row.is_unique, index_row.index_name);
+            let mut index = BTreeIndex::new(
+                index_row.index_id,
+                &table.row_layout,
+                &index_row.columns,
+                index_row.is_unique,
+                index_row.index_name,
+            )?;
             index.build_from_rows(&index_row.columns, table.scan_rows(blob_store))?;
             table.indexes.insert(index_row.columns, index);
         }

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -343,7 +343,13 @@ impl MutTxId {
             self.tx_state.get_table_and_blob_store(table_id).unwrap()
         };
 
-        let mut insert_index = BTreeIndex::new(index.index_id, index.is_unique, index.index_name.clone());
+        let mut insert_index = BTreeIndex::new(
+            index.index_id,
+            &table.row_layout,
+            &index.columns,
+            index.is_unique,
+            index.index_name.clone(),
+        )?;
         insert_index.build_from_rows(&index.columns, table.scan_rows(blob_store))?;
 
         // NOTE: Also add all the rows in the already committed table to the index.

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -345,7 +345,7 @@ impl MutTxId {
 
         let mut insert_index = BTreeIndex::new(
             index.index_id,
-            &table.row_layout(),
+            table.row_layout(),
             &index.columns,
             index.is_unique,
             index.index_name.clone(),

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -345,7 +345,7 @@ impl MutTxId {
 
         let mut insert_index = BTreeIndex::new(
             index.index_id,
-            &table.row_layout,
+            &table.row_layout(),
             &index.columns,
             index.is_unique,
             index.index_name.clone(),

--- a/crates/primitives/src/col_list.rs
+++ b/crates/primitives/src/col_list.rs
@@ -203,6 +203,11 @@ impl ColList {
         false
     }
 
+    /// Is this a list of a single column?
+    pub fn is_singleton(&self) -> bool {
+        self.len() == 1
+    }
+
     /// Push `col` onto the list.
     ///
     /// If `col >= 63` or if this list was already heap allocated, it will now be heap allocated.

--- a/crates/table/src/btree_index.rs
+++ b/crates/table/src/btree_index.rs
@@ -1,6 +1,32 @@
+//! BTree indexes with specialized key types.
+//!
+//! Indexes could be implemented as `MultiMap<AlgebraicValue, RowPointer>` (and once were),
+//! but that results in wasted memory and spurious comparisons and branches
+//! because the keys must always be homogeneous at a more specific type than `AlgebraicValue`.
+//!
+//! As an optimization, we hoist the enum out of the keys to the index itself.
+//! This is a sizeable improvement for integer keys,
+//! as e.g. `u64::cmp` is much faster than `AlgebraicValue::cmp`.
+//!
+//! This results in some pretty ugly code, where types that would be structs
+//! are instead enums with similar-looking variants for each specialized key type,
+//! and methods that interact with those enums have matches with similar-looking arms.
+//! Some day we may devise a better solution, but this is good enough for now.
+//
+// I (pgoldman 2024-02-05) suspect, but have not measured, that there's no real reason
+// to have a `ProductType` variant, which would apply to multi-column indexes.
+// I believe `ProductValue::cmp` to not be meaningfully faster than `AlgebraicValue::cmp`.
+// Eventually, we will likely want to compile comparison functions and representations
+// for `ProductValue`-keyed indexes which take advantage of type information,
+// since we know when creating the index the number and type of all the indexed columns.
+// This may involve a bytecode compiler, a tree of closures, or a native JIT.
+
 use super::indexes::RowPointer;
 use super::table::RowRef;
-use crate::static_assert_size;
+use crate::{
+    layout::{AlgebraicTypeLayout, RowTypeLayout},
+    static_assert_size,
+};
 use core::ops::RangeBounds;
 use multimap::{MultiMap, MultiMapRangeIter};
 use spacetimedb_primitives::{ColList, IndexId};
@@ -8,35 +34,51 @@ use spacetimedb_sats::{product_value::InvalidFieldError, AlgebraicValue, Product
 
 mod multimap;
 
-/// An index key storing a mapping to rows via `RowPointer`s
-/// as well as the value the rows have for the relevant [`ColId`]s.
+/// An iterator over a [`TypedMultiMap`], with a specialized key type.
 ///
-/// ## Index Key Composition
-///
-/// `IndexKey` uses an [`AlgebraicValue`] to optimize for the common case of *single columns* as key.
-///
-/// See [`ProductValue::project`] for the logic.
-///
-/// ### SQL Examples
-///
-/// To illustrate the concept of single and multiple column indexes, consider the following SQL examples:
-///
-/// ```sql
-/// CREATE INDEX a ON t1 (column_i32); -- Creating a single column index, a common case.
-/// CREATE INDEX b ON t1 (column_i32, column_i32); -- Creating a multiple column index for more complex requirements.
-/// ```
-/// Will be on memory:
-///
-/// ```rust,ignore
-/// [AlgebraicValue::I32(0)] = Row(ProductValue(...))
-/// [AlgebraicValue::Product(AlgebraicValue::I32(0), AlgebraicValue::I32(1))] = Row(ProductValue(...))
-/// ```
-type IndexKey = AlgebraicValue;
+/// See module docs for info about specialization.
+enum TypedMultiMapRangeIter<'a> {
+    Bool(MultiMapRangeIter<'a, bool, RowPointer>),
+    U8(MultiMapRangeIter<'a, u8, RowPointer>),
+    I8(MultiMapRangeIter<'a, i8, RowPointer>),
+    U16(MultiMapRangeIter<'a, u16, RowPointer>),
+    I16(MultiMapRangeIter<'a, i16, RowPointer>),
+    U32(MultiMapRangeIter<'a, u32, RowPointer>),
+    I32(MultiMapRangeIter<'a, i32, RowPointer>),
+    U64(MultiMapRangeIter<'a, u64, RowPointer>),
+    I64(MultiMapRangeIter<'a, i64, RowPointer>),
+    U128(MultiMapRangeIter<'a, u128, RowPointer>),
+    I128(MultiMapRangeIter<'a, i128, RowPointer>),
+    String(MultiMapRangeIter<'a, String, RowPointer>),
+    AlgebraicValue(MultiMapRangeIter<'a, AlgebraicValue, RowPointer>),
+}
+
+impl<'a> Iterator for TypedMultiMapRangeIter<'a> {
+    type Item = RowPointer;
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            TypedMultiMapRangeIter::Bool(ref mut this) => this.next(),
+            TypedMultiMapRangeIter::U8(ref mut this) => this.next(),
+            TypedMultiMapRangeIter::I8(ref mut this) => this.next(),
+            TypedMultiMapRangeIter::U16(ref mut this) => this.next(),
+            TypedMultiMapRangeIter::I16(ref mut this) => this.next(),
+            TypedMultiMapRangeIter::U32(ref mut this) => this.next(),
+            TypedMultiMapRangeIter::I32(ref mut this) => this.next(),
+            TypedMultiMapRangeIter::U64(ref mut this) => this.next(),
+            TypedMultiMapRangeIter::I64(ref mut this) => this.next(),
+            TypedMultiMapRangeIter::U128(ref mut this) => this.next(),
+            TypedMultiMapRangeIter::I128(ref mut this) => this.next(),
+            TypedMultiMapRangeIter::String(ref mut this) => this.next(),
+            TypedMultiMapRangeIter::AlgebraicValue(ref mut this) => this.next(),
+        }
+        .copied()
+    }
+}
 
 /// An iterator over rows matching a certain [`AlgebraicValue`] on the [`BTreeIndex`].
 pub struct BTreeIndexRangeIter<'a> {
     /// The iterator seeking for matching values.
-    iter: MultiMapRangeIter<'a, AlgebraicValue, RowPointer>,
+    iter: TypedMultiMapRangeIter<'a>,
     /// The number of pointers yielded thus far.
     num_pointers_yielded: u64,
 }
@@ -47,7 +89,7 @@ impl Iterator for BTreeIndexRangeIter<'_> {
     fn next(&mut self) -> Option<Self::Item> {
         self.iter.next().map(|ptr| {
             self.num_pointers_yielded += 1;
-            *ptr
+            ptr
         })
     }
 }
@@ -59,29 +101,285 @@ impl BTreeIndexRangeIter<'_> {
     }
 }
 
+/// A `MultiMap` from a key type determined at runtime to `RowPointer`.
+///
+/// See module docs for info about specialization.
+enum TypedIndex {
+    Bool(MultiMap<bool, RowPointer>),
+    U8(MultiMap<u8, RowPointer>),
+    I8(MultiMap<i8, RowPointer>),
+    U16(MultiMap<u16, RowPointer>),
+    I16(MultiMap<i16, RowPointer>),
+    U32(MultiMap<u32, RowPointer>),
+    I32(MultiMap<i32, RowPointer>),
+    U64(MultiMap<u64, RowPointer>),
+    I64(MultiMap<i64, RowPointer>),
+    U128(MultiMap<u128, RowPointer>),
+    I128(MultiMap<i128, RowPointer>),
+    String(MultiMap<String, RowPointer>),
+    AlgebraicValue(MultiMap<AlgebraicValue, RowPointer>),
+}
+
+impl TypedIndex {
+    // NOTE(pgoldman 2024-02-05): this method is structured the way it is,
+    // taking the `cols` and `row` rather than the new key,
+    // so that it will be amenable to rewriting in terms of `ReadColumn::read_column`,
+    // once that PR lands.
+    fn insert(&mut self, cols: &ColList, row: &ProductValue, ptr: RowPointer) -> Result<bool, InvalidFieldError> {
+        fn insert_at_type<T: Clone + Ord>(
+            this: &mut MultiMap<T, RowPointer>,
+            cols: &ColList,
+            row: &ProductValue,
+            ptr: RowPointer,
+            av_as_t: impl FnOnce(&AlgebraicValue) -> Option<&T>,
+        ) -> Result<bool, InvalidFieldError> {
+            debug_assert!(cols.is_singleton());
+            let col_pos = cols.head();
+            let key = row
+                .elements
+                .get(col_pos.idx())
+                .and_then(av_as_t)
+                .ok_or(InvalidFieldError { col_pos, name: None })?;
+            Ok(this.insert(key.clone(), ptr))
+        }
+        match self {
+            TypedIndex::Bool(ref mut this) => insert_at_type(this, cols, row, ptr, AlgebraicValue::as_bool),
+
+            TypedIndex::U8(ref mut this) => insert_at_type(this, cols, row, ptr, AlgebraicValue::as_u8),
+            TypedIndex::I8(ref mut this) => insert_at_type(this, cols, row, ptr, AlgebraicValue::as_i8),
+            TypedIndex::U16(ref mut this) => insert_at_type(this, cols, row, ptr, AlgebraicValue::as_u16),
+            TypedIndex::I16(ref mut this) => insert_at_type(this, cols, row, ptr, AlgebraicValue::as_i16),
+            TypedIndex::U32(ref mut this) => insert_at_type(this, cols, row, ptr, AlgebraicValue::as_u32),
+            TypedIndex::I32(ref mut this) => insert_at_type(this, cols, row, ptr, AlgebraicValue::as_i32),
+            TypedIndex::U64(ref mut this) => insert_at_type(this, cols, row, ptr, AlgebraicValue::as_u64),
+            TypedIndex::I64(ref mut this) => insert_at_type(this, cols, row, ptr, AlgebraicValue::as_i64),
+            TypedIndex::U128(ref mut this) => insert_at_type(this, cols, row, ptr, AlgebraicValue::as_u128),
+            TypedIndex::I128(ref mut this) => insert_at_type(this, cols, row, ptr, AlgebraicValue::as_i128),
+            TypedIndex::String(ref mut this) => insert_at_type(this, cols, row, ptr, AlgebraicValue::as_string),
+
+            TypedIndex::AlgebraicValue(ref mut this) => {
+                let key = row.project_not_empty(cols)?;
+                Ok(this.insert(key, ptr))
+            }
+        }
+    }
+
+    // NOTE(pgoldman 2024-02-05): this method is structured the way it is,
+    // taking the `cols` and `row` rather than the sought key,
+    // so that it will be amenable to rewriting in terms of `ReadColumn::read_column`,
+    // once that PR lands.
+    fn delete(&mut self, cols: &ColList, row: &ProductValue, ptr: RowPointer) -> Result<bool, InvalidFieldError> {
+        fn delete_at_type<T: Ord>(
+            this: &mut MultiMap<T, RowPointer>,
+
+            cols: &ColList,
+            row: &ProductValue,
+            ptr: RowPointer,
+            av_as_t: impl FnOnce(&AlgebraicValue) -> Option<&T>,
+        ) -> Result<bool, InvalidFieldError> {
+            debug_assert!(cols.is_singleton());
+            let col_pos = cols.head();
+            let key = row
+                .elements
+                .get(col_pos.idx())
+                .and_then(av_as_t)
+                .ok_or(InvalidFieldError { col_pos, name: None })?;
+            Ok(this.delete(key, &ptr))
+        }
+
+        match self {
+            TypedIndex::Bool(ref mut this) => delete_at_type(this, cols, row, ptr, AlgebraicValue::as_bool),
+
+            TypedIndex::U8(ref mut this) => delete_at_type(this, cols, row, ptr, AlgebraicValue::as_u8),
+            TypedIndex::I8(ref mut this) => delete_at_type(this, cols, row, ptr, AlgebraicValue::as_i8),
+            TypedIndex::U16(ref mut this) => delete_at_type(this, cols, row, ptr, AlgebraicValue::as_u16),
+            TypedIndex::I16(ref mut this) => delete_at_type(this, cols, row, ptr, AlgebraicValue::as_i16),
+            TypedIndex::U32(ref mut this) => delete_at_type(this, cols, row, ptr, AlgebraicValue::as_u32),
+            TypedIndex::I32(ref mut this) => delete_at_type(this, cols, row, ptr, AlgebraicValue::as_i32),
+            TypedIndex::U64(ref mut this) => delete_at_type(this, cols, row, ptr, AlgebraicValue::as_u64),
+            TypedIndex::I64(ref mut this) => delete_at_type(this, cols, row, ptr, AlgebraicValue::as_i64),
+            TypedIndex::U128(ref mut this) => delete_at_type(this, cols, row, ptr, AlgebraicValue::as_u128),
+            TypedIndex::I128(ref mut this) => delete_at_type(this, cols, row, ptr, AlgebraicValue::as_i128),
+            TypedIndex::String(ref mut this) => delete_at_type(this, cols, row, ptr, AlgebraicValue::as_string),
+
+            TypedIndex::AlgebraicValue(ref mut this) => {
+                let key = row.project_not_empty(cols)?;
+                Ok(this.delete(&key, &ptr))
+            }
+        }
+    }
+
+    fn values_in_range(&self, range: &impl RangeBounds<AlgebraicValue>) -> TypedMultiMapRangeIter<'_> {
+        fn iter_at_type<'a, T: Ord>(
+            this: &'a MultiMap<T, RowPointer>,
+            range: &impl RangeBounds<AlgebraicValue>,
+            av_as_t: impl Fn(&AlgebraicValue) -> Option<&T>,
+        ) -> MultiMapRangeIter<'a, T, RowPointer> {
+            use std::ops::Bound;
+            let start = match range.start_bound() {
+                Bound::Included(v) => {
+                    Bound::Included(av_as_t(v).expect("Start bound of range does not conform to key type of index"))
+                }
+                Bound::Excluded(v) => {
+                    Bound::Excluded(av_as_t(v).expect("Start bound of range does not conform to key type of index"))
+                }
+                Bound::Unbounded => Bound::Unbounded,
+            };
+            let end = match range.end_bound() {
+                Bound::Included(v) => {
+                    Bound::Included(av_as_t(v).expect("End bound of range does not conform to key type of index"))
+                }
+                Bound::Excluded(v) => {
+                    Bound::Excluded(av_as_t(v).expect("End bound of range does not conform to key type of index"))
+                }
+                Bound::Unbounded => Bound::Unbounded,
+            };
+            this.values_in_range(&(start, end))
+        }
+        match self {
+            TypedIndex::Bool(ref this) => {
+                TypedMultiMapRangeIter::Bool(iter_at_type(this, range, AlgebraicValue::as_bool))
+            }
+
+            TypedIndex::U8(ref this) => TypedMultiMapRangeIter::U8(iter_at_type(this, range, AlgebraicValue::as_u8)),
+            TypedIndex::I8(ref this) => TypedMultiMapRangeIter::I8(iter_at_type(this, range, AlgebraicValue::as_i8)),
+            TypedIndex::U16(ref this) => TypedMultiMapRangeIter::U16(iter_at_type(this, range, AlgebraicValue::as_u16)),
+            TypedIndex::I16(ref this) => TypedMultiMapRangeIter::I16(iter_at_type(this, range, AlgebraicValue::as_i16)),
+            TypedIndex::U32(ref this) => TypedMultiMapRangeIter::U32(iter_at_type(this, range, AlgebraicValue::as_u32)),
+            TypedIndex::I32(ref this) => TypedMultiMapRangeIter::I32(iter_at_type(this, range, AlgebraicValue::as_i32)),
+            TypedIndex::U64(ref this) => TypedMultiMapRangeIter::U64(iter_at_type(this, range, AlgebraicValue::as_u64)),
+            TypedIndex::I64(ref this) => TypedMultiMapRangeIter::I64(iter_at_type(this, range, AlgebraicValue::as_i64)),
+            TypedIndex::U128(ref this) => {
+                TypedMultiMapRangeIter::U128(iter_at_type(this, range, AlgebraicValue::as_u128))
+            }
+            TypedIndex::I128(ref this) => {
+                TypedMultiMapRangeIter::I128(iter_at_type(this, range, AlgebraicValue::as_i128))
+            }
+            TypedIndex::String(ref this) => {
+                TypedMultiMapRangeIter::String(iter_at_type(this, range, AlgebraicValue::as_string))
+            }
+
+            TypedIndex::AlgebraicValue(ref this) => TypedMultiMapRangeIter::AlgebraicValue(this.values_in_range(range)),
+        }
+    }
+
+    fn clear(&mut self) {
+        match self {
+            TypedIndex::Bool(ref mut this) => this.clear(),
+            TypedIndex::U8(ref mut this) => this.clear(),
+            TypedIndex::I8(ref mut this) => this.clear(),
+            TypedIndex::U16(ref mut this) => this.clear(),
+            TypedIndex::I16(ref mut this) => this.clear(),
+            TypedIndex::U32(ref mut this) => this.clear(),
+            TypedIndex::I32(ref mut this) => this.clear(),
+            TypedIndex::U64(ref mut this) => this.clear(),
+            TypedIndex::I64(ref mut this) => this.clear(),
+            TypedIndex::U128(ref mut this) => this.clear(),
+            TypedIndex::I128(ref mut this) => this.clear(),
+            TypedIndex::String(ref mut this) => this.clear(),
+            TypedIndex::AlgebraicValue(ref mut this) => this.clear(),
+        }
+    }
+
+    #[allow(unused)] // used only by tests
+    fn is_empty(&self) -> bool {
+        match self {
+            TypedIndex::Bool(ref this) => this.is_empty(),
+            TypedIndex::U8(ref this) => this.is_empty(),
+            TypedIndex::I8(ref this) => this.is_empty(),
+            TypedIndex::U16(ref this) => this.is_empty(),
+            TypedIndex::I16(ref this) => this.is_empty(),
+            TypedIndex::U32(ref this) => this.is_empty(),
+            TypedIndex::I32(ref this) => this.is_empty(),
+            TypedIndex::U64(ref this) => this.is_empty(),
+            TypedIndex::I64(ref this) => this.is_empty(),
+            TypedIndex::U128(ref this) => this.is_empty(),
+            TypedIndex::I128(ref this) => this.is_empty(),
+            TypedIndex::String(ref this) => this.is_empty(),
+            TypedIndex::AlgebraicValue(ref this) => this.is_empty(),
+        }
+    }
+
+    #[allow(unused)] // used only by tests
+    fn len(&self) -> usize {
+        match self {
+            TypedIndex::Bool(ref this) => this.len(),
+            TypedIndex::U8(ref this) => this.len(),
+            TypedIndex::I8(ref this) => this.len(),
+            TypedIndex::U16(ref this) => this.len(),
+            TypedIndex::I16(ref this) => this.len(),
+            TypedIndex::U32(ref this) => this.len(),
+            TypedIndex::I32(ref this) => this.len(),
+            TypedIndex::U64(ref this) => this.len(),
+            TypedIndex::I64(ref this) => this.len(),
+            TypedIndex::U128(ref this) => this.len(),
+            TypedIndex::I128(ref this) => this.len(),
+            TypedIndex::String(ref this) => this.len(),
+            TypedIndex::AlgebraicValue(ref this) => this.len(),
+        }
+    }
+}
+
 /// A B-Tree based index on a set of [`ColId`]s of a table.
 pub struct BTreeIndex {
     /// The ID of this index.
     pub index_id: IndexId,
     /// Whether this index is also a unique constraint.
     pub(crate) is_unique: bool,
-    /// The actual index.
-    idx: MultiMap<IndexKey, RowPointer>,
+    /// The actual index, specialized for the appropriate key type.
+    idx: TypedIndex,
     /// The index name, used for reporting unique constraint violations.
     pub(crate) name: Box<str>,
 }
 
-static_assert_size!(BTreeIndex, 48);
+static_assert_size!(BTreeIndex, 56);
 
 impl BTreeIndex {
     /// Returns a new possibly unique index, with `index_id` for a set of columns.
-    pub fn new(index_id: IndexId, is_unique: bool, name: impl Into<Box<str>>) -> Self {
-        Self {
+    pub fn new(
+        index_id: IndexId,
+        row_type: &RowTypeLayout,
+        indexed_columns: &ColList,
+        is_unique: bool,
+        name: impl Into<Box<str>>,
+    ) -> Result<Self, InvalidFieldError> {
+        // If the index is on a single column of a primitive type,
+        // use a homogeneous map with a native key type.
+        let typed_index = if indexed_columns.is_singleton() {
+            let col_pos = indexed_columns.head().idx();
+            let col = row_type.product().elements.get(col_pos).ok_or(InvalidFieldError {
+                col_pos: col_pos.into(),
+                name: None,
+            })?;
+
+            match col.ty {
+                AlgebraicTypeLayout::Bool => TypedIndex::Bool(MultiMap::new()),
+                AlgebraicTypeLayout::I8 => TypedIndex::I8(MultiMap::new()),
+                AlgebraicTypeLayout::U8 => TypedIndex::U8(MultiMap::new()),
+                AlgebraicTypeLayout::I16 => TypedIndex::I16(MultiMap::new()),
+                AlgebraicTypeLayout::U16 => TypedIndex::U16(MultiMap::new()),
+                AlgebraicTypeLayout::I32 => TypedIndex::I32(MultiMap::new()),
+                AlgebraicTypeLayout::U32 => TypedIndex::U32(MultiMap::new()),
+                AlgebraicTypeLayout::I64 => TypedIndex::I64(MultiMap::new()),
+                AlgebraicTypeLayout::U64 => TypedIndex::U64(MultiMap::new()),
+                AlgebraicTypeLayout::I128 => TypedIndex::I128(MultiMap::new()),
+                AlgebraicTypeLayout::U128 => TypedIndex::U128(MultiMap::new()),
+                AlgebraicTypeLayout::String => TypedIndex::String(MultiMap::new()),
+
+                // If we don't specialize on the key type, use a map keyed on `AlgebraicValue`.
+                _ => TypedIndex::AlgebraicValue(MultiMap::new()),
+            }
+        } else {
+            // If the index is on multiple columns, use a map keyed on `AlgebraicValue`,
+            // as the keys will be `ProductValue`s.
+            TypedIndex::AlgebraicValue(MultiMap::new())
+        };
+        Ok(Self {
             index_id,
             is_unique,
-            idx: MultiMap::new(),
+            idx: typed_index,
             name: name.into(),
-        }
+        })
     }
 
     /// Extracts from `row` the relevant column values according to what columns are indexed.
@@ -94,15 +392,14 @@ impl BTreeIndex {
     ///
     /// Return false if `ptr` was already indexed prior to this call.
     pub fn insert(&mut self, cols: &ColList, row: &ProductValue, ptr: RowPointer) -> Result<bool, InvalidFieldError> {
-        let col_value = self.get_fields(cols, row)?;
-        Ok(self.idx.insert(col_value, ptr))
+        self.idx.insert(cols, row, ptr)
     }
 
     /// Deletes `ptr` with its indexed value `col_value` from this index.
     ///
     /// Returns whether `ptr` was present.
-    pub fn delete(&mut self, col_value: &AlgebraicValue, ptr: RowPointer) -> bool {
-        self.idx.delete(col_value, &ptr)
+    pub fn delete(&mut self, cols: &ColList, row: &ProductValue, ptr: RowPointer) -> Result<bool, InvalidFieldError> {
+        self.idx.delete(cols, row, ptr)
     }
 
     /// Returns whether indexing `row` again would violate a unique constraint, if any.
@@ -174,7 +471,7 @@ mod test {
     use proptest::prelude::*;
     use proptest::{collection::vec, test_runner::TestCaseResult};
     use spacetimedb_primitives::ColListBuilder;
-    use spacetimedb_sats::product;
+    use spacetimedb_sats::{product, AlgebraicType, ProductType};
 
     fn gen_row_pointer() -> impl Strategy<Value = RowPointer> {
         (any::<PageOffset>(), any::<PageIndex>()).prop_map(|(po, pi)| RowPointer::new(false, pi, po, SquashedOffset(0)))
@@ -185,26 +482,32 @@ mod test {
             .prop_map(|cols| cols.into_iter().collect::<ColListBuilder>().build().unwrap())
     }
 
-    fn gen_row_and_cols() -> impl Strategy<Value = (ColList, ProductValue)> {
-        generate_row_type(1..16).prop_flat_map(|ty| (gen_cols(ty.elements.len()), generate_product_value(ty)))
+    fn gen_row_and_cols() -> impl Strategy<Value = (ProductType, ColList, ProductValue)> {
+        generate_row_type(1..16).prop_flat_map(|ty| {
+            (
+                Just(ty.clone()),
+                gen_cols(ty.elements.len()),
+                generate_product_value(ty),
+            )
+        })
     }
 
-    fn new_index(is_unique: bool) -> BTreeIndex {
-        BTreeIndex::new(0.into(), is_unique, "test_index")
+    fn new_index(row_type: &ProductType, cols: &ColList, is_unique: bool) -> BTreeIndex {
+        let row_layout: RowTypeLayout = row_type.clone().into();
+        BTreeIndex::new(0.into(), &row_layout, cols, is_unique, "test_index").unwrap()
     }
 
     proptest! {
         #[test]
-        fn remove_nonexistent_noop(((cols, pv), ptr, is_unique) in (gen_row_and_cols(), gen_row_pointer(), any::<bool>())) {
-            let mut index = new_index(is_unique);
-            let value = index.get_fields(&cols, &pv).unwrap();
-            prop_assert_eq!(index.delete(&value, ptr), false);
+        fn remove_nonexistent_noop(((ty, cols, pv), ptr, is_unique) in (gen_row_and_cols(), gen_row_pointer(), any::<bool>())) {
+            let mut index = new_index(&ty, &cols, is_unique);
+            prop_assert_eq!(index.delete(&cols, &pv, ptr).unwrap(), false);
             prop_assert!(index.idx.is_empty());
         }
 
         #[test]
-        fn insert_delete_noop(((cols, pv), ptr, is_unique) in (gen_row_and_cols(), gen_row_pointer(), any::<bool>())) {
-            let mut index = new_index(is_unique);
+        fn insert_delete_noop(((ty, cols, pv), ptr, is_unique) in (gen_row_and_cols(), gen_row_pointer(), any::<bool>())) {
+            let mut index = new_index(&ty, &cols, is_unique);
             let value = index.get_fields(&cols, &pv).unwrap();
             prop_assert_eq!(index.idx.len(), 0);
             prop_assert_eq!(index.contains_any(&value), false);
@@ -217,14 +520,14 @@ mod test {
             prop_assert_eq!(index.insert(&cols, &pv, ptr).unwrap(), false);
             prop_assert_eq!(index.idx.len(), 1);
 
-            prop_assert_eq!(index.delete(&value, ptr), true);
+            prop_assert_eq!(index.delete(&cols, &pv, ptr).unwrap(), true);
             prop_assert_eq!(index.idx.len(), 0);
             prop_assert_eq!(index.contains_any(&value), false);
         }
 
         #[test]
-        fn insert_again_violates_unique_constraint(((cols, pv), ptr) in (gen_row_and_cols(), gen_row_pointer())) {
-            let mut index = new_index(true);
+        fn insert_again_violates_unique_constraint(((ty, cols, pv), ptr) in (gen_row_and_cols(), gen_row_pointer())) {
+            let mut index = new_index(&ty, &cols, true);
             let value = index.get_fields(&cols, &pv).unwrap();
 
             // Nothing in the index yet.
@@ -252,7 +555,7 @@ mod test {
             use AlgebraicValue::U64 as V;
 
             let cols = 0.into();
-            let mut index = new_index(true);
+            let mut index = new_index(&ProductType::from_iter([AlgebraicType::U64]), &cols, true);
 
             let prev = needle - 1;
             let next = needle + 1;

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -12,7 +12,10 @@ use super::{
     row_hash::hash_row_in_page,
     row_type_visitor::{row_type_visitor, VarLenVisitorProgram},
 };
-use crate::static_assert_size;
+use crate::{
+    read_column::{ReadColumn, TypeError},
+    static_assert_size,
+};
 use ahash::AHashMap;
 use core::fmt;
 use core::hash::{BuildHasher, Hasher};
@@ -21,6 +24,7 @@ use spacetimedb_primitives::ColList;
 use spacetimedb_sats::{
     algebraic_value::ser::ValueSerializer,
     db::def::TableSchema,
+    product_value::InvalidFieldError,
     satn::Satn,
     ser::{Serialize, Serializer},
     AlgebraicValue, ProductType, ProductValue,
@@ -32,27 +36,78 @@ use thiserror::Error;
 /// The table stores the rows into a page manager
 /// and uses an internal map to ensure that no identical row is stored more than once.
 pub struct Table {
-    /// The type of rows this table stores, with layout information included.
-    //
-    // Public because it's used in the `locking_tx_datastore` (in `core`)
-    // when constructing indexes.
-    pub row_layout: RowTypeLayout,
+    /// Page manager and row layout grouped together, for `RowRef` purposes.
+    inner: TableInner,
     /// The visitor program for `row_layout`.
     visitor_prog: VarLenVisitorProgram,
-    /// The page manager that holds rows
-    /// including both their fixed and variable components.
-    pub pages: Pages,
     /// Maps `RowHash -> [RowPointer]` where a [`RowPointer`] points into `pages`.
     pointer_map: PointerMap,
     /// The indices associated with a set of columns of the table.
     pub indexes: AHashMap<ColList, BTreeIndex>,
     /// The schema of the table, from which the type, and other details are derived.
     pub schema: Box<TableSchema>,
-
     /// `SquashedOffset::TX_STATE` or `SquashedOffset::COMMITTED_STATE`
     /// depending on whether this is a tx scratchpad table
     /// or a committed table.
     squashed_offset: SquashedOffset,
+}
+
+impl Table {
+    pub fn row_layout(&self) -> &RowTypeLayout {
+        &self.inner.row_layout
+    }
+    pub fn pages(&self) -> &Pages {
+        &self.inner.pages
+    }
+}
+
+/// The part of a `Table` concerned only with storing rows.
+///
+/// Separated from the "outer" parts of `Table`, especially the `indexes`,
+/// so that `RowRef` can borrow only the `TableInner`,
+/// while other mutable references to the `indexes` exist.
+/// This is necessary because index insertions and deletions take a `RowRef` as an argument,
+/// from which they [`ReadColumn::read_column`] their keys.
+pub(crate) struct TableInner {
+    /// The type of rows this table stores, with layout information included.
+    row_layout: RowTypeLayout,
+    /// The page manager that holds rows
+    /// including both their fixed and variable components.
+    pages: Pages,
+}
+
+impl TableInner {
+    /// Assumes `ptr` is a present row in `self` and returns a [`RowRef`] to it.
+    ///
+    /// # Safety
+    ///
+    /// The requirement is that `table.is_row_present(ptr)` must hold,
+    /// where `table` is the `Table` which contains this `TableInner`.
+    /// That is, `ptr` must refer to a row within `self`
+    /// which was previously inserted and has not been deleted since.
+    ///
+    /// This means:
+    /// - The `PageIndex` of `ptr` must be in-bounds for `self.pages`.
+    /// - The `PageOffset` of `ptr` must be properly aligned for the row type of `self`,
+    ///   and must refer to a valid, live row in that page.
+    /// - The `SquashedOffset` of `ptr` must match the enclosing table's `table.squashed_offset`.
+    ///
+    /// Showing that `ptr` was the result of a call to [`Table::insert(table, ..)`]
+    /// and has not been passed to [`Table::delete(table, ..)`]
+    /// is sufficient to demonstrate all of these properties.
+    pub(crate) unsafe fn get_row_ref_unchecked<'a>(
+        &'a self,
+        blob_store: &'a dyn BlobStore,
+        ptr: RowPointer,
+    ) -> RowRef<'a> {
+        // SAFETY: Forward caller requirements.
+        unsafe { RowRef::new(self, blob_store, ptr) }
+    }
+
+    /// Returns the page and page offset that `ptr` points to.
+    pub(crate) fn page_and_offset(&self, ptr: RowPointer) -> (&Page, PageOffset) {
+        (&self.pages[ptr.page_index()], ptr.page_offset())
+    }
 }
 
 static_assert_size!(Table, 248);
@@ -147,7 +202,8 @@ impl Table {
 
             // SAFETY: we just inserted `ptr`, so it must be valid.
             unsafe {
-                self.pages
+                self.inner
+                    .pages
                     .delete_row(&self.visitor_prog, self.row_size(), ptr, blob_store)
             };
             return Err(InsertError::Duplicate(existing_row));
@@ -158,9 +214,12 @@ impl Table {
         // add it to the `pointer_map`.
         self.pointer_map.insert(hash, ptr);
 
+        // SAFETY: We just inserted `ptr`, so it must be present.
+        let row_ref = unsafe { self.inner.get_row_ref_unchecked(blob_store, ptr) };
+
         // Insert row into indices.
         for (cols, index) in self.indexes.iter_mut() {
-            index.insert(cols, row, ptr).unwrap();
+            index.insert(cols, row_ref).unwrap();
         }
 
         Ok((hash, ptr))
@@ -180,10 +239,10 @@ impl Table {
         // as `self.pages` was constructed from `self.row_layout` in `Table::new`.
         unsafe {
             write_row_to_pages(
-                &mut self.pages,
+                &mut self.inner.pages,
                 &self.visitor_prog,
                 blob_store,
-                &self.row_layout,
+                &self.inner.row_layout,
                 row,
                 self.squashed_offset,
             )
@@ -219,8 +278,8 @@ impl Table {
             .iter()
             .copied()
             .find(|committed_ptr| {
-                let (committed_page, committed_offset) = committed_table.page_and_offset(*committed_ptr);
-                let (tx_page, tx_offset) = tx_table.page_and_offset(tx_ptr);
+                let (committed_page, committed_offset) = committed_table.inner.page_and_offset(*committed_ptr);
+                let (tx_page, tx_offset) = tx_table.inner.page_and_offset(tx_ptr);
 
                 // SAFETY:
                 // Our invariants mean `tx_ptr` is valid, so `tx_page` and `tx_offset` are both valid.
@@ -233,7 +292,7 @@ impl Table {
                         tx_page,
                         committed_offset,
                         tx_offset,
-                        &committed_table.row_layout,
+                        &committed_table.inner.row_layout,
                     )
                 }
             })
@@ -266,7 +325,7 @@ impl Table {
     pub unsafe fn get_row_ref_unchecked<'a>(&'a self, blob_store: &'a dyn BlobStore, ptr: RowPointer) -> RowRef<'a> {
         debug_assert!(self.is_row_present(ptr));
         // SAFETY: Caller promised that ^-- holds.
-        unsafe { RowRef::new(self, blob_store, ptr) }
+        unsafe { RowRef::new(&self.inner, blob_store, ptr) }
     }
 
     /// Deletes a row in the page manager
@@ -283,14 +342,17 @@ impl Table {
         // - `self.row_size` known to be consistent with `self.pages`,
         //    as the two are tied together in `Table::new`.
         unsafe {
-            self.pages
+            self.inner
+                .pages
                 .delete_row(&self.visitor_prog, self.row_size(), ptr, blob_store)
         };
     }
 
     /// Deletes the row identified by `ptr` from the table.
-    // TODO: Make this `unsafe` and trust `ptr`; remove `Option` from return.
-    //       See TODO comment on `Table::is_row_present`.
+    // TODO(perf,bikeshedding): Make this `unsafe` and trust `ptr`; remove `Option` from return.
+    //     See TODO comment on `Table::is_row_present`.
+    // TODO(perf): Remove returned `ProductValue`.
+    //     Require callers who want the row to read it out explicitly before deleting.
     pub fn delete(&mut self, blob_store: &mut dyn BlobStore, ptr: RowPointer) -> Option<ProductValue> {
         // TODO(bikeshedding,integration): Do we want to make this method unsafe?
         // We currently use `ptr` to ask the page if `is_row_present` which checks alignment.
@@ -305,6 +367,17 @@ impl Table {
         // the method can be safe.
         let row_value = self.get_row_ref(blob_store, ptr)?.to_product_value();
 
+        // SAFETY: `ptr` points to a valid row in this table as we extracted `row_value`.
+        let row_ref = unsafe { self.inner.get_row_ref_unchecked(blob_store, ptr) };
+
+        // Delete row from indices.
+        // Do this before the actual deletion, as `index.delete` needs a `RowRef`
+        // so it can extract the appropriate value.
+        for (cols, index) in self.indexes.iter_mut() {
+            let deleted = index.delete(cols, row_ref).unwrap();
+            debug_assert!(deleted);
+        }
+
         // Remove the set semantic association.
         // SAFETY: `ptr` points to a valid row in this table as we extracted `row_value`.
         let hash = unsafe { self.row_hash_for(ptr) };
@@ -316,12 +389,6 @@ impl Table {
         unsafe {
             self.delete_internal_skip_pointer_map(blob_store, ptr);
         };
-
-        // Delete row from indices.
-        for (cols, index) in self.indexes.iter_mut() {
-            let deleted = index.delete(cols, &row_value, ptr).unwrap();
-            debug_assert!(deleted);
-        }
 
         Some(row_value)
     }
@@ -439,7 +506,7 @@ impl Table {
                 cols.clone(),
                 BTreeIndex::new(
                     index.index_id,
-                    &self.row_layout,
+                    &self.inner.row_layout,
                     cols,
                     index.is_unique,
                     index.name.clone(),
@@ -459,13 +526,13 @@ impl Table {
     /// and not deleted since.
     pub unsafe fn row_hash_for(&self, ptr: RowPointer) -> RowHash {
         let mut hasher = RowHash::hasher_builder().build_hasher();
-        let (page, offset) = self.page_and_offset(ptr);
+        let (page, offset) = self.inner.page_and_offset(ptr);
         // SAFETY: Caller promised that `ptr` refers to a live fixed row in this table, so:
         // 1. `offset` points at a row in `page` lasting `self.row_fixed_size` bytes.
         // 2. the row must be valid for `self.row_layout`.
         // 3. for any `vlr: VarLenRef` stored in the row,
         //    `vlr.first_offset` is either `NULL` or points to a valid granule in `page`.
-        unsafe { hash_row_in_page(&mut hasher, page, offset, &self.row_layout) };
+        unsafe { hash_row_in_page(&mut hasher, page, offset, &self.inner.row_layout) };
         RowHash(hasher.finish())
     }
 }
@@ -479,7 +546,7 @@ impl Table {
 #[derive(Copy, Clone)]
 pub struct RowRef<'a> {
     /// The table that has the row at `self.pointer`.
-    table: &'a Table,
+    table: &'a TableInner,
     /// The blob store used in case there are blob hashes to resolve.
     blob_store: &'a dyn BlobStore,
     /// The pointer to the row in `self.table`.
@@ -511,7 +578,7 @@ impl<'a> RowRef<'a> {
     /// Showing that `pointer` was the result of a call to `table.insert`
     /// and has not been passed to `table.delete`
     /// is sufficient to demonstrate all of these properties.
-    unsafe fn new(table: &'a Table, blob_store: &'a dyn BlobStore, pointer: RowPointer) -> Self {
+    unsafe fn new(table: &'a TableInner, blob_store: &'a dyn BlobStore, pointer: RowPointer) -> Self {
         Self {
             table,
             blob_store,
@@ -534,17 +601,53 @@ impl<'a> RowRef<'a> {
         unsafe { res.unwrap_unchecked() }
     }
 
+    /// Construct a projection of the row at `self` by extracting the `cols`.
+    ///
+    /// Returns an error if `cols` specifies an index which is out-of-bounds for the row at `self`.
+    ///
+    /// If `cols` contains more than one column, the values of the projected columns are wrapped in a [`ProductValue`].
+    /// If `cols` is a single column, the value of that column is returned without wrapping in a `ProductValue`.
+    pub fn project_not_empty(self, cols: &ColList) -> Result<AlgebraicValue, InvalidFieldError> {
+        match cols.len() {
+            0 => unreachable!("A `ColList` can never be empty"),
+            1 => AlgebraicValue::read_column(self, cols.head().idx()).map_err(|_| InvalidFieldError {
+                col_pos: cols.head(),
+                name: None,
+            }),
+            len => {
+                let mut elements = Vec::with_capacity(len as usize);
+                for col in cols.iter() {
+                    let col_val = AlgebraicValue::read_column(self, col.idx()).map_err(|err| match err {
+                        TypeError::WrongType { .. } => {
+                            unreachable!("AlgebraicValue::read_column never returns a `TypeError::WrongType`")
+                        }
+                        TypeError::IndexOutOfBounds { .. } => InvalidFieldError {
+                            col_pos: col,
+                            name: None,
+                        },
+                    })?;
+                    elements.push(col_val);
+                }
+                Ok(AlgebraicValue::Product(ProductValue { elements }))
+            }
+        }
+    }
+
     /// Returns the raw row pointer for this row reference.
     pub fn pointer(&self) -> RowPointer {
         self.pointer
     }
 
-    pub(crate) fn table(&self) -> &Table {
-        self.table
-    }
-
     pub(crate) fn blob_store(&self) -> &dyn BlobStore {
         self.blob_store
+    }
+
+    pub(crate) fn row_layout(&self) -> &RowTypeLayout {
+        &self.table.row_layout
+    }
+
+    pub(crate) fn page_and_offset(&self) -> (&Page, PageOffset) {
+        self.table.page_and_offset(self.pointer())
     }
 }
 
@@ -605,7 +708,7 @@ impl<'a> Iterator for TableScanIter<'a> {
                 None => {
                     // If there's another page, set `self.current_page` to it,
                     // and go to the `Some` case in the match.
-                    let next_page = self.table.pages.get(self.current_page_idx.idx())?;
+                    let next_page = self.table.pages().get(self.current_page_idx.idx())?;
                     let iter = next_page.iter_fixed_len(self.table.row_size());
                     self.current_page = Some(iter);
                 }
@@ -695,19 +798,16 @@ impl Table {
         let row_layout: RowTypeLayout = schema.get_row_type().clone().into();
         let visitor_prog = row_type_visitor(&row_layout);
         Self {
-            row_layout,
+            inner: TableInner {
+                row_layout,
+                pages: Pages::default(),
+            },
             visitor_prog,
             schema: Box::new(schema),
             indexes: AHashMap::with_capacity(indexes_capacity),
-            pages: Pages::default(),
             pointer_map: PointerMap::default(),
             squashed_offset,
         }
-    }
-
-    /// Returns the page and page offset that `ptr` points to.
-    pub(crate) fn page_and_offset(&self, ptr: RowPointer) -> (&Page, PageOffset) {
-        (&self.pages[ptr.page_index()], ptr.page_offset())
     }
 
     /// Returns whether the row at `ptr` is present or not.
@@ -730,19 +830,19 @@ impl Table {
     //       As such, our `delete` and `insert` methods can be `unsafe`
     //       and trust that the `RowPointer` is valid.
     fn is_row_present(&self, ptr: RowPointer) -> bool {
-        let (page, offset) = self.page_and_offset(ptr);
+        let (page, offset) = self.inner.page_and_offset(ptr);
         self.squashed_offset == ptr.squashed_offset() && page.has_row_offset(self.row_size(), offset)
     }
 
     /// Returns the row size for a row in the table.
     fn row_size(&self) -> Size {
-        self.row_layout.size()
+        self.inner.row_layout.size()
     }
 
     /// Returns the fixed-len portion of the row at `ptr`.
     #[allow(unused)]
     fn get_fixed_row(&self, ptr: RowPointer) -> &Bytes {
-        let (page, offset) = self.page_and_offset(ptr);
+        let (page, offset) = self.inner.page_and_offset(ptr);
         page.get_row_data(offset, self.row_size())
     }
 }
@@ -788,7 +888,7 @@ mod test {
         let index_schema = schema.indexes[0].clone();
         let mut table = Table::new(schema, SquashedOffset::COMMITTED_STATE);
         let cols = ColList::new(0.into());
-        let index = BTreeIndex::new(index_schema.index_id, &table.row_layout, &cols, true, index_name).unwrap();
+        let index = BTreeIndex::new(index_schema.index_id, &table.inner.row_layout, &cols, true, index_name).unwrap();
         table.insert_index(&NullBlobStore, cols, index);
 
         // Insert the row (0, 0).
@@ -821,8 +921,8 @@ mod test {
         let (hash, ptr) = table.insert(&mut blob_store, &val).unwrap();
         prop_assert_eq!(table.pointer_map.pointers_for(hash), &[ptr]);
 
-        prop_assert_eq!(table.pages.len(), 1);
-        prop_assert_eq!(table.pages[PageIndex(0)].num_rows(), 1);
+        prop_assert_eq!(table.inner.pages.len(), 1);
+        prop_assert_eq!(table.inner.pages[PageIndex(0)].num_rows(), 1);
 
         prop_assert_eq!(unsafe { table.row_hash_for(ptr) }, hash);
 
@@ -869,16 +969,16 @@ mod test {
 
             prop_assert_eq!(unsafe { table.row_hash_for(ptr) }, hash);
 
-            prop_assert_eq!(table.pages.len(), 1);
-            prop_assert_eq!(table.pages[PageIndex(0)].num_rows(), 1);
+            prop_assert_eq!(table.inner.pages.len(), 1);
+            prop_assert_eq!(table.inner.pages[PageIndex(0)].num_rows(), 1);
             prop_assert_eq!(&table.scan_rows(&blob_store).map(|r| r.pointer()).collect::<Vec<_>>(), &[ptr]);
 
             table.delete(&mut blob_store, ptr);
 
             prop_assert_eq!(table.pointer_map.pointers_for(hash), &[]);
 
-            prop_assert_eq!(table.pages.len(), 1);
-            prop_assert_eq!(table.pages[PageIndex(0)].num_rows(), 0);
+            prop_assert_eq!(table.inner.pages.len(), 1);
+            prop_assert_eq!(table.inner.pages[PageIndex(0)].num_rows(), 0);
 
             prop_assert!(&table.scan_rows(&blob_store).next().is_none());
         }
@@ -889,7 +989,7 @@ mod test {
             let mut table = table(ty);
 
             let (hash, ptr) = table.insert(&mut blob_store, &val).unwrap();
-            prop_assert_eq!(table.pages.len(), 1);
+            prop_assert_eq!(table.inner.pages.len(), 1);
             prop_assert_eq!(table.pointer_map.pointers_for(hash), &[ptr]);
             prop_assert_eq!(unsafe { table.row_hash_for(ptr) }, hash);
             prop_assert_eq!(&table.scan_rows(&blob_store).map(|r| r.pointer()).collect::<Vec<_>>(), &[ptr]);
@@ -897,13 +997,13 @@ mod test {
             let blob_uses = blob_store.usage_counter();
 
             prop_assert!(table.insert(&mut blob_store, &val).is_err());
-            prop_assert_eq!(table.pages.len(), 1);
+            prop_assert_eq!(table.inner.pages.len(), 1);
             prop_assert_eq!(table.pointer_map.pointers_for(hash), &[ptr]);
 
             let blob_uses_after = blob_store.usage_counter();
 
             prop_assert_eq!(blob_uses_after, blob_uses);
-            prop_assert_eq!(table.pages[PageIndex(0)].num_rows(), 1);
+            prop_assert_eq!(table.inner.pages[PageIndex(0)].num_rows(), 1);
             prop_assert_eq!(&table.scan_rows(&blob_store).map(|r| r.pointer()).collect::<Vec<_>>(), &[ptr]);
         }
     }
@@ -918,10 +1018,15 @@ mod test {
         }
 
         let complex = table.scan_rows(&blob_store).map(|r| r.pointer());
-        let simple = table.pages.iter().zip((0..).map(PageIndex)).flat_map(|(page, pi)| {
-            page.iter_fixed_len(table.row_size())
-                .map(move |po| RowPointer::new(false, pi, po, table.squashed_offset))
-        });
+        let simple = table
+            .inner
+            .pages
+            .iter()
+            .zip((0..).map(PageIndex))
+            .flat_map(|(page, pi)| {
+                page.iter_fixed_len(table.row_size())
+                    .map(move |po| RowPointer::new(false, pi, po, table.squashed_offset))
+            });
         assert!(complex.eq(simple));
     }
 


### PR DESCRIPTION
# Description of Changes

Prior to this commit, `BTreeIndex::insert` and `BTreeIndex::delete` took a `&ProductValue`, the row to be inserted or deleted, as an argument, and extracted the indexed column value(s) from it.

With this commit, we instead take a `RowRef` referring to the row to be inserted or deleted, and access the indexed column value(s) using `ReadColumn`. For specialized indexes, we extract them directly as native types, rather than as `AlgebraicValue`.

Making this change involved a nasty split borrow problem, as we now need to have a `RowRef` to the inserted/deleted row coexisting with a mutable borrow of the index to be modified. This required introducing a `TableInner` struct,
which is the referent of `RowRef`.

# API and ABI breaking changes

No external interfaces broken.

# Expected complexity level and risk

2 - minimal `unsafe`, semantics of `Table`, `RowRef` and `BTreeIndex` preserved.