### PR TITLE
Fix private not building with latest master

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -3,7 +3,7 @@
 pub(crate) mod committed_state;
 pub(crate) mod datastore;
 pub(crate) mod mut_tx;
-pub(crate) use mut_tx::MutTxId;
+pub use mut_tx::MutTxId;
 pub(crate) mod sequence;
 pub(crate) mod state_view;
 pub use state_view::{Iter, IterByColEq, IterByColRange};


### PR DESCRIPTION
# Description of Changes
Exposes `MutTxId` more than crate-local, which was causing SpacetimeDBPrivate to fail.

# API and ABI breaking changes
This is an unbreaking change :upside_down_face: 

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
