### PR TITLE
Add rust-version to Cargo.toml

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -64,10 +64,27 @@ rpath = false
 debug = true
 
 [workspace.package]
+version = "0.8.1"
+edition = "2021"
 # update rust-toolchain.toml too!
 rust-version = "1.74.0"
 
 [workspace.dependencies]
+spacetimedb = { path = "crates/bindings", version = "0.8.1" }
+spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "0.8.1" }
+spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "0.8.1" }
+spacetimedb-cli = { path = "crates/cli", version = "0.8.1" }
+spacetimedb-client-api = { path = "crates/client-api", version = "0.8.1" }
+spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "0.8.1" }
+spacetimedb-core = { path = "crates/core", version = "0.8.1" }
+spacetimedb-lib = { path = "crates/lib", default-features = false, version = "0.8.1" }
+spacetimedb-metrics = { path = "crates/metrics", version = "0.8.1" }
+spacetimedb-primitives = { path = "crates/primitives", version = "0.8.1" }
+spacetimedb-sats = { path = "crates/sats", version = "0.8.1" }
+spacetimedb-standalone = { path = "crates/standalone", version = "0.8.1" }
+spacetimedb-table = { path = "crates/table", version = "0.8.1" }
+spacetimedb-vm = { path = "crates/vm", version = "0.8.1" }
+
 ahash = "0.8"
 anyhow = { version = "1.0.68", features = ["backtrace"] }
 anymap = "0.12"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -63,6 +63,10 @@ rpath = false
 [profile.bench]
 debug = true
 
+[workspace.package]
+# update rust-toolchain.toml too!
+rust-version = "1.74.0"
+
 [workspace.dependencies]
 ahash = "0.8"
 anyhow = { version = "1.0.68", features = ["backtrace"] }

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-bench"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "Bench library/utility for SpacetimeDB"
 

--- a/crates/bindings-macro/Cargo.toml
+++ b/crates/bindings-macro/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-bindings-macro"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "Easy support for interacting between SpacetimeDB and Rust."
 rust-version.workspace = true
@@ -12,7 +12,7 @@ proc-macro = true
 bench = false
 
 [dependencies]
-spacetimedb-primitives = { path = "../primitives", version = "0.8.1" }
+spacetimedb-primitives.workspace = true
 
 bitflags.workspace = true
 humantime.workspace = true

--- a/crates/bindings-macro/Cargo.toml
+++ b/crates/bindings-macro/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.1"
 edition = "2021"
 license-file = "LICENSE"
 description = "Easy support for interacting between SpacetimeDB and Rust."
+rust-version.workspace = true
 
 [lib]
 proc-macro = true

--- a/crates/bindings-sys/Cargo.toml
+++ b/crates/bindings-sys/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.1"
 edition = "2021"
 license-file = "LICENSE"
 description = "Easy support for interacting between SpacetimeDB and Rust."
+rust-version.workspace = true
 
 [lib]
 # Benching off, because of https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/crates/bindings-sys/Cargo.toml
+++ b/crates/bindings-sys/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-bindings-sys"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "Easy support for interacting between SpacetimeDB and Rust."
 rust-version.workspace = true
@@ -12,4 +12,4 @@ bench = false
 
 [dependencies]
 getrandom = {workspace = true, optional = true}
-spacetimedb-primitives = { path = "../primitives", version = "0.8.1" }
+spacetimedb-primitives.workspace = true

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "Easy support for interacting between SpacetimeDB and Rust."
 rust-version.workspace = true
@@ -17,10 +17,10 @@ bench = false
 getrandom = ["spacetimedb-bindings-sys/getrandom"]
 
 [dependencies]
-spacetimedb-bindings-sys = { path = "../bindings-sys", version = "0.8.1" }
-spacetimedb-lib = { path = "../lib", default-features = false, version = "0.8.1"}
-spacetimedb-bindings-macro = { path = "../bindings-macro", version = "0.8.1"}
-spacetimedb-primitives = { path = "../primitives", version = "0.8.1" }
+spacetimedb-bindings-sys.workspace = true
+spacetimedb-lib.workspace = true
+spacetimedb-bindings-macro.workspace = true
+spacetimedb-primitives.workspace = true
 
 derive_more.workspace = true
 log.workspace = true

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.1"
 edition = "2021"
 license-file = "LICENSE"
 description = "Easy support for interacting between SpacetimeDB and Rust."
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.1"
 edition = "2021"
 license-file = "LICENSE"
 description = "A command line interface for SpacetimeDB"
+rust-version.workspace = true
 
 [lib]
 bench = false

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-cli"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "A command line interface for SpacetimeDB"
 rust-version.workspace = true
@@ -18,10 +18,10 @@ bench = false
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-spacetimedb-primitives = { path = "../primitives", version = "0.8.1" }
-spacetimedb-core = { path = "../core", version = "0.8.1" }
-spacetimedb-lib = { path = "../lib", version = "0.8.1", features = ["cli"] }
-spacetimedb-standalone = { path = "../standalone", version = "0.8.1", optional = true }
+spacetimedb-primitives.workspace = true
+spacetimedb-core.workspace = true
+spacetimedb-lib = { workspace = true, features = ["cli"] }
+spacetimedb-standalone = { workspace = true, optional = true }
 
 anyhow.workspace = true
 base64.workspace = true

--- a/crates/client-api-messages/Cargo.toml
+++ b/crates/client-api-messages/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-client-api-messages"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "Types for the SpacetimeDB client API messages"
 

--- a/crates/client-api/Cargo.toml
+++ b/crates/client-api/Cargo.toml
@@ -1,15 +1,16 @@
 [package]
 name = "spacetimedb-client-api"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "The HTTP API for SpacetimeDB"
 
 [dependencies]
-spacetimedb-core = { path = "../core", version = "0.8.1" }
+spacetimedb-core.workspace = true
+spacetimedb-lib = { workspace = true, features = ["serde"] }
+
 tokio = { version = "1.2", features = ["full"] }
 lazy_static = "1.4.0"
-spacetimedb-lib = { path = "../lib", version = "0.8.1" }
 log = "0.4.4"
 serde = "1.0.136"
 serde_json = { version = "1.0", features = ["raw_value"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-core"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "The core library for SpacetimeDB"
 rust-version.workspace = true
@@ -19,13 +19,13 @@ name = "odb_flavor_bench"
 harness = false
 
 [dependencies]
-spacetimedb-lib = { path = "../lib", version = "0.8.1" }
-spacetimedb-client-api-messages = { path = "../client-api-messages", version = "0.8.1" }
-spacetimedb-metrics = { path = "../metrics", version = "0.8.1" }
-spacetimedb-primitives = { path = "../primitives", version = "0.8.1" }
-spacetimedb-sats = { path = "../sats", version = "0.8.1" }
-spacetimedb-table = { path = "../table", version = "0.8.1" }
-spacetimedb-vm = { path = "../vm", version = "0.8.1" }
+spacetimedb-lib.workspace = true
+spacetimedb-client-api-messages.workspace = true
+spacetimedb-metrics.workspace = true
+spacetimedb-primitives.workspace = true
+spacetimedb-sats.workspace = true
+spacetimedb-table.workspace = true
+spacetimedb-vm.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.1"
 edition = "2021"
 license-file = "LICENSE"
 description = "The core library for SpacetimeDB"
+rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/crates/data-structures/Cargo.toml
+++ b/crates/data-structures/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-data-structures"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "Assorted data structures used in spacetimedb"
 

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-lib"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "A common library for SpacetimeDB"
 rust-version.workspace = true
@@ -22,10 +22,10 @@ cli = ["clap"]
 proptest = ["dep:proptest", "dep:proptest-derive"]
 
 [dependencies]
-spacetimedb-bindings-macro = { path = "../bindings-macro", version = "0.8.1" }
-spacetimedb-sats = { path = "../sats", version = "0.8.1" }
-spacetimedb-primitives = { path = "../primitives", version = "0.8.1" }
-spacetimedb-metrics = { path = "../metrics", version = "0.8.1" }
+spacetimedb-bindings-macro.workspace = true
+spacetimedb-sats.workspace = true
+spacetimedb-primitives.workspace = true
+spacetimedb-metrics.workspace = true
 
 anyhow.workspace = true
 bitflags.workspace = true

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -4,6 +4,7 @@ version = "0.8.1"
 edition = "2021"
 license-file = "LICENSE"
 description = "A common library for SpacetimeDB"
+rust-version.workspace = true
 
 [lib]
 # Benching off, because of https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-metrics"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "Prometheus utilities for SpacetimeDB"
 

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-primitives"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "Primitives such as TableId and ColumnIndexAttribute"
 

--- a/crates/sats/Cargo.toml
+++ b/crates/sats/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-sats"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "Spacetime Algebraic Type Notation"
 
@@ -13,9 +13,9 @@ serde = ["dep:serde"]
 proptest = ["dep:proptest", "dep:proptest-derive"]
 
 [dependencies]
-spacetimedb-bindings-macro = { path = "../bindings-macro", version = "0.8.1" }
-spacetimedb-primitives = { path = "../primitives", version = "0.8.1" }
-spacetimedb-metrics = { path = "../metrics", version = "0.8.1" }
+spacetimedb-bindings-macro.workspace = true
+spacetimedb-primitives.workspace = true
+spacetimedb-metrics.workspace = true
 
 arrayvec.workspace = true
 bitflags.workspace = true

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -1,16 +1,16 @@
 [package]
 name = "spacetimedb-sdk"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "A Rust SDK for clients to interface with SpacetimeDB"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-spacetimedb-sats = { path = "../sats", version = "0.8.1" }
-spacetimedb-lib = { path = "../lib", version = "0.8.1" }
-spacetimedb-client-api-messages = { path = "../client-api-messages", version = "0.8.1" }
+spacetimedb-sats.workspace = true
+spacetimedb-lib = { workspace = true, features = ["serde"]}
+spacetimedb-client-api-messages.workspace = true
 
 anyhow.workspace = true
 anymap.workspace = true

--- a/crates/sdk/tests/connect_disconnect_client/Cargo.toml
+++ b/crates/sdk/tests/connect_disconnect_client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "connect_disconnect_client"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/sdk/tests/test-client/Cargo.toml
+++ b/crates/sdk/tests/test-client/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-client"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/sdk/tests/test-counter/Cargo.toml
+++ b/crates/sdk/tests/test-counter/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "test-counter"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/sqltest/Cargo.toml
+++ b/crates/sqltest/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sqltest"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 description = "Sql integration test for SpacetimeDB"
 
 [dependencies]

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-standalone"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "An executable for running a single SpacetimeDB standalone instance"
 
@@ -17,9 +17,9 @@ harness = true         # Use libtest harness.
 required-features = [] # Features required to build this target (N/A for lib)
 
 [dependencies]
-spacetimedb-core = { path = "../core", version = "0.8.1" }
-spacetimedb-lib = { path = "../lib", version = "0.8.1", features = ["cli"] }
-spacetimedb-client-api = { path = "../client-api", version = "0.8.1" }
+spacetimedb-core.workspace = true
+spacetimedb-lib = { workspace = true, features = ["cli"] }
+spacetimedb-client-api.workspace = true
 
 anyhow.workspace = true
 async-trait.workspace = true

--- a/crates/table/Cargo.toml
+++ b/crates/table/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-table"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "A database Table implementation and friends"
 

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "spacetimedb-testing"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 
 [dependencies]
-spacetimedb-cli = { path = "../cli", version = "0.8.1" }
-spacetimedb-lib = { path = "../lib", version = "0.8.1" }
-spacetimedb-core = { path = "../core", version = "0.8.1" }
-spacetimedb-standalone = { path = "../standalone", version = "0.8.1" }
-spacetimedb-client-api = { path = "../client-api", version = "0.8.1" }
+spacetimedb-cli.workspace = true
+spacetimedb-lib.workspace = true
+spacetimedb-core.workspace = true
+spacetimedb-standalone.workspace = true
+spacetimedb-client-api.workspace = true
 
 anyhow.workspace = true
 env_logger.workspace = true

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -1,14 +1,14 @@
 [package]
 name = "spacetimedb-vm"
-version = "0.8.1"
-edition = "2021"
+version.workspace = true
+edition.workspace = true
 license-file = "LICENSE"
 description = "A VM for SpacetimeDB"
 
 [dependencies]
-spacetimedb-sats= { path = "../sats", version = "0.8.1" }
-spacetimedb-lib = { path = "../lib", version = "0.8.1" }
-spacetimedb-primitives = { path = "../primitives", version = "0.8.1" }
+spacetimedb-sats.workspace = true
+spacetimedb-lib.workspace = true
+spacetimedb-primitives.workspace = true
 
 anyhow.workspace = true
 derive_more.workspace = true

--- a/modules/benchmarks/Cargo.toml
+++ b/modules/benchmarks/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "benchmarks-module"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/modules/quickstart-chat/Cargo.toml
+++ b/modules/quickstart-chat/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "quickstart-chat-module"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/modules/rust-wasm-test/Cargo.toml
+++ b/modules/rust-wasm-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "rust-wasm-test-module"
 version = "0.0.0"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html\
 

--- a/modules/sdk-test-connect-disconnect/Cargo.toml
+++ b/modules/sdk-test-connect-disconnect/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetime-module"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = { path = "../../crates/bindings", version = "0.8.1" }
+spacetimedb.workspace = true
 log = "0.4"

--- a/modules/sdk-test/Cargo.toml
+++ b/modules/sdk-test/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "sdk-test-module"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
@@ -9,6 +9,6 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = { path = "../../crates/bindings", version = "0.8.1" }
+spacetimedb.workspace = true
 log.workspace = true
 anyhow.workspace = true

--- a/modules/spacetimedb-quickstart/Cargo.toml
+++ b/modules/spacetimedb-quickstart/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "spacetimedb-quickstart-module"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 [lib]
 crate-type = ["cdylib"]

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,5 +1,5 @@
 [toolchain]
-# change crates/standalone/Dockerfile too!
+# change crates/standalone/Dockerfile and rust-version in Cargo.toml too!
 channel = "1.74.0"
 profile = "default"
 targets = ["wasm32-unknown-unknown"]

--- a/tools/upgrade-version/Cargo.toml
+++ b/tools/upgrade-version/Cargo.toml
@@ -1,7 +1,7 @@
 [package]
 name = "upgrade-version"
 version = "0.1.0"
-edition = "2021"
+edition.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 


### PR DESCRIPTION
# Description of Changes

The second change is technically unrelated but it occurred to me when I saw that we didn't have a workspace package field - it should make bumping the version much easier, since all mentions of e.g. 0.8.1 are all in just the root Cargo.toml now.

# Expected complexity level and risk

1