### PR TITLE
Rename types in benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,6 +2,7 @@ on:
   push:
     branches:
       - master
+      - kazimuth/bench_cleanup
 
   workflow_dispatch:
     inputs:
@@ -96,36 +97,24 @@ jobs:
           if [[ $PR_NUMBER ]]; then
             BASELINE_NAME=branch
             RESULTS_NAME=pr-$PR_NUMBER
-            BENCH_FILTER='(special|stdb_module|stdb_raw)'
+            BENCH_FILTER='stdb_raw'
             echo "Running benchmarks without sqlite"
           else
             BASELINE_NAME=master
             RESULTS_NAME=$GITHUB_SHA
-            BENCH_FILTER='.*'
+            BENCH_FILTER='(stdb_raw|sqlite)'
             echo "Running benchmarks with sqlite"
           fi
           pushd crates/bench
-          cargo bench --bench generic --bench special -- --save-baseline "$BASELINE_NAME" "$BENCH_FILTER"
+          cargo bench --bench generic -- --save-baseline "$BASELINE_NAME" "$BENCH_FILTER"
+          # sticker price benchmark
+          cargo bench --bench generic -- --save-baseline "$BASELINE_NAME" 'stdb_module/disk/update_bulk'
+          cargo bench --bench special -- --save-baseline "$BASELINE_NAME"
           cargo run --bin summarize pack "$BASELINE_NAME"
           popd
           mkdir criterion-results
           [[ ! $PR_NUMBER ]] && cp target/criterion/$BASELINE_NAME.json criterion-results/
           cp target/criterion/$BASELINE_NAME.json criterion-results/$RESULTS_NAME.json
-
-      # TODO: can we optionally download if it only might fail?
-      #- name: PR; download bench results for compare
-      #  if: env.PR_NUMBER
-      #  uses: actions/github-script@v6  
-      #  with:
-      #    github-token: ${{secrets.GITHUB_TOKEN}}
-      #    script: |
-      #      try {
-      #        let artifact = github.rest.actions.getArtifact({
-      #          owner: "clockwork",
-      #          repo: "SpacetimeDB",
-      #          
-      #        })
-      #      }
 
       # this will work for both PR and master
       - name: Upload criterion results to DO spaces
@@ -147,6 +136,7 @@ jobs:
             OLD=$(git rev-parse HEAD~1)
             NEW=$GITHUB_SHA
           fi
+          echo "fetching https://benchmarks.spacetimedb.com/compare/$OLD/$NEW"
           curl -sS https://benchmarks.spacetimedb.com/compare/$OLD/$NEW > report.md
 
       - name: Post comment
@@ -314,6 +304,7 @@ jobs:
             OLD=$(git rev-parse HEAD~1)
             NEW=$GITHUB_SHA
           fi
+          echo "fetching https://benchmarks.spacetimedb.com/compare/$OLD/$NEW"
           curl -sS https://benchmarks.spacetimedb.com/compare_callgrind/$OLD/$NEW > report.md
 
       - name: Post comment

--- a/crates/bench/benches/special.rs
+++ b/crates/bench/benches/special.rs
@@ -2,7 +2,7 @@ use criterion::{criterion_group, criterion_main, Criterion};
 use mimalloc::MiMalloc;
 use spacetimedb::db::{Config, Storage};
 use spacetimedb_bench::{
-    schemas::{create_sequential, BenchTable, Location, Person, RandomTable},
+    schemas::{create_sequential, u32_u64_str, u32_u64_u64, BenchTable, RandomTable},
     spacetime_module::BENCHMARKS_MODULE,
 };
 use spacetimedb_lib::{sats, ProductValue};
@@ -12,8 +12,8 @@ use spacetimedb_testing::modules::start_runtime;
 static GLOBAL: MiMalloc = MiMalloc;
 
 fn criterion_benchmark(c: &mut Criterion) {
-    serialize_benchmarks::<Person>(c);
-    serialize_benchmarks::<Location>(c);
+    serialize_benchmarks::<u32_u64_str>(c);
+    serialize_benchmarks::<u32_u64_u64>(c);
 
     custom_module_benchmarks(c);
 }
@@ -28,7 +28,7 @@ fn custom_module_benchmarks(c: &mut Criterion) {
     let module = runtime.block_on(async { BENCHMARKS_MODULE.load_module(config, None).await });
 
     let args = sats::product!["0".repeat(65536)];
-    c.bench_function("stdb_module/large_arguments/64KiB", |b| {
+    c.bench_function("special/stdb_module/large_arguments/64KiB", |b| {
         b.iter_batched(
             || args.clone(),
             |args| runtime.block_on(async { module.call_reducer_binary("fn_with_1_args", args).await.unwrap() }),
@@ -38,7 +38,7 @@ fn custom_module_benchmarks(c: &mut Criterion) {
 
     for n in [1u32, 100, 1000] {
         let args = sats::product![n];
-        c.bench_function(&format!("stdb_module/print_bulk/lines={n}"), |b| {
+        c.bench_function(&format!("special/stdb_module/print_bulk/lines={n}"), |b| {
             b.iter_batched(
                 || args.clone(),
                 |args| runtime.block_on(async { module.call_reducer_binary("print_many_things", args).await.unwrap() }),
@@ -49,7 +49,7 @@ fn custom_module_benchmarks(c: &mut Criterion) {
 }
 
 fn serialize_benchmarks<T: BenchTable + RandomTable>(c: &mut Criterion) {
-    let name = T::name_snake_case();
+    let name = T::name();
     let count = 100;
     let mut group = c.benchmark_group("special/serialize");
     group.throughput(criterion::Throughput::Elements(count));

--- a/crates/bench/src/database.rs
+++ b/crates/bench/src/database.rs
@@ -28,9 +28,6 @@ pub trait BenchDatabase: Sized {
     /// Perform an empty transaction.
     fn empty_transaction(&mut self) -> ResultBench<()>;
 
-    /// Perform a transaction that commits a single row.
-    fn insert<T: BenchTable>(&mut self, table_id: &Self::TableId, row: T) -> ResultBench<()>;
-
     /// Perform a transaction that commits many rows.
     fn insert_bulk<T: BenchTable>(&mut self, table_id: &Self::TableId, rows: Vec<T>) -> ResultBench<()>;
 

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -10,7 +10,7 @@ pub type ResultBench<T> = Result<T, anyhow::Error>;
 mod tests {
     use crate::{
         database::BenchDatabase,
-        schemas::{create_sequential, BenchTable, IndexStrategy, Location, Person, RandomTable},
+        schemas::{create_sequential, u32_u64_str, u32_u64_u64, BenchTable, IndexStrategy, RandomTable},
         spacetime_module::SpacetimeModule,
         spacetime_raw::SpacetimeRaw,
         sqlite::SQLite,
@@ -57,9 +57,7 @@ mod tests {
 
         let sample_data = create_sequential::<T>(0xdeadbeef, count, 100);
 
-        for row in sample_data.clone() {
-            db.insert::<T>(&table_id, row)?;
-        }
+        db.insert_bulk(&table_id, sample_data.clone())?;
         assert_eq!(db.count_table(&table_id)?, count, "inserted rows should be inserted");
 
         db.clear_table(&table_id)?;
@@ -76,7 +74,7 @@ mod tests {
             "bulk inserted rows should be bulk inserted"
         );
 
-        if index_strategy == IndexStrategy::Unique {
+        if index_strategy == IndexStrategy::Unique0 {
             db.update_bulk::<T>(&table_id, count)?;
             assert_eq!(
                 db.count_table(&table_id)?,
@@ -96,20 +94,18 @@ mod tests {
 
     #[test]
     fn test_basic_invariants_sqlite() {
-        basic_invariants::<SQLite, Person>(IndexStrategy::Unique, true).unwrap();
-        basic_invariants::<SQLite, Location>(IndexStrategy::Unique, true).unwrap();
-    }
-
-    #[test]
-    fn test_basic_invariants_sqlite_multi_index() {
-        basic_invariants::<SQLite, Person>(IndexStrategy::MultiIndex, true).unwrap();
-        basic_invariants::<SQLite, Location>(IndexStrategy::MultiIndex, true).unwrap();
+        basic_invariants::<SQLite, u32_u64_str>(IndexStrategy::Unique0, true).unwrap();
+        basic_invariants::<SQLite, u32_u64_u64>(IndexStrategy::Unique0, true).unwrap();
+        basic_invariants::<SQLite, u32_u64_str>(IndexStrategy::BTreeEachColumn, true).unwrap();
+        basic_invariants::<SQLite, u32_u64_u64>(IndexStrategy::BTreeEachColumn, true).unwrap();
     }
 
     #[test]
     fn test_basic_invariants_spacetime_raw() {
-        basic_invariants::<SpacetimeRaw, Person>(IndexStrategy::Unique, true).unwrap();
-        basic_invariants::<SpacetimeRaw, Location>(IndexStrategy::Unique, true).unwrap();
+        basic_invariants::<SpacetimeRaw, u32_u64_str>(IndexStrategy::Unique0, true).unwrap();
+        basic_invariants::<SpacetimeRaw, u32_u64_u64>(IndexStrategy::Unique0, true).unwrap();
+        basic_invariants::<SpacetimeRaw, u32_u64_str>(IndexStrategy::BTreeEachColumn, true).unwrap();
+        basic_invariants::<SpacetimeRaw, u32_u64_u64>(IndexStrategy::BTreeEachColumn, true).unwrap();
     }
 
     #[test]
@@ -117,7 +113,9 @@ mod tests {
         // note: there can only be one #[test] invoking spacetime module stuff.
         // #[test]s run concurrently and they fight over lockfiles.
         // so, run the sub-tests here in sequence.
-        basic_invariants::<SpacetimeModule, Person>(IndexStrategy::Unique, true).unwrap();
-        basic_invariants::<SpacetimeModule, Location>(IndexStrategy::Unique, true).unwrap();
+        basic_invariants::<SpacetimeModule, u32_u64_str>(IndexStrategy::Unique0, true).unwrap();
+        basic_invariants::<SpacetimeModule, u32_u64_u64>(IndexStrategy::Unique0, true).unwrap();
+        basic_invariants::<SpacetimeModule, u32_u64_str>(IndexStrategy::BTreeEachColumn, true).unwrap();
+        basic_invariants::<SpacetimeModule, u32_u64_u64>(IndexStrategy::BTreeEachColumn, true).unwrap();
     }
 }

--- a/crates/bench/src/spacetime_module.rs
+++ b/crates/bench/src/spacetime_module.rs
@@ -10,7 +10,7 @@ use tokio::runtime::Runtime;
 
 use crate::{
     database::BenchDatabase,
-    schemas::{snake_case_table_name, table_name, BenchTable},
+    schemas::{table_name, BenchTable},
     ResultBench,
 };
 
@@ -98,7 +98,7 @@ impl BenchDatabase for SpacetimeModule {
         // Noop. All tables are built into the "benchmarks" module.
         Ok(TableId {
             pascal_case: table_name::<T>(table_style),
-            snake_case: snake_case_table_name::<T>(table_style),
+            snake_case: table_name::<T>(table_style),
         })
     }
 
@@ -145,19 +145,6 @@ impl BenchDatabase for SpacetimeModule {
 
         runtime.block_on(async move {
             module.call_reducer_binary("empty", [].into()).await?;
-            Ok(())
-        })
-    }
-
-    fn insert<T: BenchTable>(&mut self, table_id: &Self::TableId, row: T) -> ResultBench<()> {
-        let SpacetimeModule { runtime, module } = self;
-        let module = module.as_mut().unwrap();
-        let reducer_name = format!("insert_{}", table_id.snake_case);
-
-        runtime.block_on(async move {
-            module
-                .call_reducer_binary(&reducer_name, row.into_product_value())
-                .await?;
             Ok(())
         })
     }

--- a/crates/bench/src/spacetime_raw.rs
+++ b/crates/bench/src/spacetime_raw.rs
@@ -44,12 +44,12 @@ impl BenchDatabase for SpacetimeRaw {
             let table_id = self.db.create_table(tx, table_def)?;
             self.db.rename_table(tx, table_id, &name)?;
             match index_strategy {
-                IndexStrategy::Unique => {
+                IndexStrategy::Unique0 => {
                     self.db
                         .create_index(tx, table_id, IndexDef::btree("id".into(), ColId(0), true))?;
                 }
-                IndexStrategy::NonUnique => (),
-                IndexStrategy::MultiIndex => {
+                IndexStrategy::NoIndex => (),
+                IndexStrategy::BTreeEachColumn => {
                     for (i, column) in T::product_type().elements.iter().enumerate() {
                         self.db.create_index(
                             tx,
@@ -80,13 +80,6 @@ impl BenchDatabase for SpacetimeRaw {
 
     fn empty_transaction(&mut self) -> ResultBench<()> {
         self.db.with_auto_commit(&ExecutionContext::default(), |_tx| Ok(()))
-    }
-
-    fn insert<T: BenchTable>(&mut self, table_id: &Self::TableId, row: T) -> ResultBench<()> {
-        self.db.with_auto_commit(&ExecutionContext::default(), |tx| {
-            self.db.insert(tx, *table_id, row.into_product_value())?;
-            Ok(())
-        })
     }
 
     fn insert_bulk<T: BenchTable>(&mut self, table_id: &Self::TableId, rows: Vec<T>) -> ResultBench<()> {

--- a/modules/benchmarks/src/lib.rs
+++ b/modules/benchmarks/src/lib.rs
@@ -16,13 +16,13 @@
 //! `{operation}_{index_strategy}_{table_name}`, in snake_case.
 //!
 //! The three index strategies are:
-//! - `Unique` / `unique`: a single unique key, declared first in the struct.
-//! - `NonUnique` / `non_unique`: no indexes.
-//! - `MultiIndex` / `multi_index`: one index for each row.
+//! - `unique`: a single unique key, declared first in the struct.
+//! - `no_index`: no indexes.
+//! - `btree_each_column`: one index for each column.
 //!
 //! Obviously more could be added...
 
-#![allow(clippy::too_many_arguments, unused_variables)]
+#![allow(clippy::too_many_arguments, unused_variables, non_camel_case_types)]
 
 use spacetimedb::{println, spacetimedb};
 use std::hint::black_box;
@@ -30,7 +30,7 @@ use std::hint::black_box;
 // ---------- schemas ----------
 
 #[spacetimedb(table)]
-pub struct UniquePerson {
+pub struct unique_0_u32_u64_str {
     #[unique]
     id: u32,
     age: u64,
@@ -38,7 +38,7 @@ pub struct UniquePerson {
 }
 
 #[spacetimedb(table)]
-pub struct NonUniquePerson {
+pub struct no_index_u32_u64_str {
     id: u32,
     age: u64,
     name: String,
@@ -48,14 +48,14 @@ pub struct NonUniquePerson {
 #[spacetimedb(index(btree, name = "id", id))]
 #[spacetimedb(index(btree, name = "name", name))]
 #[spacetimedb(index(btree, name = "age", age))]
-pub struct MultiIndexPerson {
+pub struct btree_each_column_u32_u64_str {
     id: u32,
     age: u64,
     name: String,
 }
 
 #[spacetimedb(table)]
-pub struct UniqueLocation {
+pub struct unique_0_u32_u64_u64 {
     #[unique]
     id: u32,
     x: u64,
@@ -63,7 +63,7 @@ pub struct UniqueLocation {
 }
 
 #[spacetimedb(table)]
-pub struct NonUniqueLocation {
+pub struct no_index_u32_u64_u64 {
     id: u32,
     x: u64,
     y: u64,
@@ -73,7 +73,7 @@ pub struct NonUniqueLocation {
 #[spacetimedb(index(btree, name = "id", id))]
 #[spacetimedb(index(btree, name = "x", x))]
 #[spacetimedb(index(btree, name = "y", y))]
-pub struct MultiIndexLocation {
+pub struct btree_each_column_u32_u64_u64 {
     id: u32,
     x: u64,
     y: u64,
@@ -86,116 +86,116 @@ pub fn empty() {}
 
 // ---------- insert ----------
 #[spacetimedb(reducer)]
-pub fn insert_unique_person(id: u32, age: u64, name: String) {
-    UniquePerson::insert(UniquePerson { id, name, age }).unwrap();
+pub fn insert_unique_0_u32_u64_str(id: u32, age: u64, name: String) {
+    unique_0_u32_u64_str::insert(unique_0_u32_u64_str { id, name, age }).unwrap();
 }
 
 #[spacetimedb(reducer)]
-pub fn insert_non_unique_person(id: u32, age: u64, name: String) {
-    NonUniquePerson::insert(NonUniquePerson { id, name, age });
+pub fn insert_no_index_u32_u64_str(id: u32, age: u64, name: String) {
+    no_index_u32_u64_str::insert(no_index_u32_u64_str { id, name, age });
 }
 
 #[spacetimedb(reducer)]
-pub fn insert_multi_index_person(id: u32, age: u64, name: String) {
-    MultiIndexPerson::insert(MultiIndexPerson { id, name, age });
+pub fn insert_btree_each_column_u32_u64_str(id: u32, age: u64, name: String) {
+    btree_each_column_u32_u64_str::insert(btree_each_column_u32_u64_str { id, name, age });
 }
 
 #[spacetimedb(reducer)]
-pub fn insert_unique_location(id: u32, x: u64, y: u64) {
-    UniqueLocation::insert(UniqueLocation { id, x, y }).unwrap();
+pub fn insert_unique_0_u32_u64_u64(id: u32, x: u64, y: u64) {
+    unique_0_u32_u64_u64::insert(unique_0_u32_u64_u64 { id, x, y }).unwrap();
 }
 
 #[spacetimedb(reducer)]
-pub fn insert_non_unique_location(id: u32, x: u64, y: u64) {
-    NonUniqueLocation::insert(NonUniqueLocation { id, x, y });
+pub fn insert_no_index_u32_u64_u64(id: u32, x: u64, y: u64) {
+    no_index_u32_u64_u64::insert(no_index_u32_u64_u64 { id, x, y });
 }
 
 #[spacetimedb(reducer)]
-pub fn insert_multi_index_location(id: u32, x: u64, y: u64) {
-    MultiIndexLocation::insert(MultiIndexLocation { id, x, y });
+pub fn insert_btree_each_column_u32_u64_u64(id: u32, x: u64, y: u64) {
+    btree_each_column_u32_u64_u64::insert(btree_each_column_u32_u64_u64 { id, x, y });
 }
 
 // ---------- insert bulk ----------
 
 #[spacetimedb(reducer)]
-pub fn insert_bulk_unique_location(locs: Vec<UniqueLocation>) {
+pub fn insert_bulk_unique_0_u32_u64_u64(locs: Vec<unique_0_u32_u64_u64>) {
     for loc in locs {
-        UniqueLocation::insert(loc).unwrap();
+        unique_0_u32_u64_u64::insert(loc).unwrap();
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn insert_bulk_non_unique_location(locs: Vec<NonUniqueLocation>) {
+pub fn insert_bulk_no_index_u32_u64_u64(locs: Vec<no_index_u32_u64_u64>) {
     for loc in locs {
-        NonUniqueLocation::insert(loc);
+        no_index_u32_u64_u64::insert(loc);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn insert_bulk_multi_index_location(locs: Vec<MultiIndexLocation>) {
+pub fn insert_bulk_btree_each_column_u32_u64_u64(locs: Vec<btree_each_column_u32_u64_u64>) {
     for loc in locs {
-        MultiIndexLocation::insert(loc);
+        btree_each_column_u32_u64_u64::insert(loc);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn insert_bulk_unique_person(people: Vec<UniquePerson>) {
-    for person in people {
-        UniquePerson::insert(person).unwrap();
+pub fn insert_bulk_unique_0_u32_u64_str(people: Vec<unique_0_u32_u64_str>) {
+    for u32_u64_str in people {
+        unique_0_u32_u64_str::insert(u32_u64_str).unwrap();
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn insert_bulk_non_unique_person(people: Vec<NonUniquePerson>) {
-    for person in people {
-        NonUniquePerson::insert(person);
+pub fn insert_bulk_no_index_u32_u64_str(people: Vec<no_index_u32_u64_str>) {
+    for u32_u64_str in people {
+        no_index_u32_u64_str::insert(u32_u64_str);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn insert_bulk_multi_index_person(people: Vec<MultiIndexPerson>) {
-    for person in people {
-        MultiIndexPerson::insert(person);
+pub fn insert_bulk_btree_each_column_u32_u64_str(people: Vec<btree_each_column_u32_u64_str>) {
+    for u32_u64_str in people {
+        btree_each_column_u32_u64_str::insert(u32_u64_str);
     }
 }
 
 // ---------- update ----------
 
 #[spacetimedb(reducer)]
-pub fn update_bulk_unique_location(row_count: u32) {
+pub fn update_bulk_unique_0_u32_u64_u64(row_count: u32) {
     let mut hit: u32 = 0;
-    for loc in UniqueLocation::iter().take(row_count as usize) {
+    for loc in unique_0_u32_u64_u64::iter().take(row_count as usize) {
         hit += 1;
         assert!(
-            UniqueLocation::update_by_id(
+            unique_0_u32_u64_u64::update_by_id(
                 &loc.id,
-                UniqueLocation {
+                unique_0_u32_u64_u64 {
                     id: loc.id,
                     x: loc.x.wrapping_add(1),
                     y: loc.y,
                 },
             ),
-            "failed to update location"
+            "failed to update u32_u64_u64"
         );
     }
     assert_eq!(hit, row_count, "not enough rows to perform requested amount of updates");
 }
 
 #[spacetimedb(reducer)]
-pub fn update_bulk_unique_person(row_count: u32) {
+pub fn update_bulk_unique_0_u32_u64_str(row_count: u32) {
     let mut hit: u32 = 0;
-    for person in UniquePerson::iter().take(row_count as usize) {
+    for u32_u64_str in unique_0_u32_u64_str::iter().take(row_count as usize) {
         hit += 1;
         assert!(
-            UniquePerson::update_by_id(
-                &person.id,
-                UniquePerson {
-                    id: person.id,
-                    name: person.name,
-                    age: person.age.wrapping_add(1),
+            unique_0_u32_u64_str::update_by_id(
+                &u32_u64_str.id,
+                unique_0_u32_u64_str {
+                    id: u32_u64_str.id,
+                    name: u32_u64_str.name,
+                    age: u32_u64_str.age.wrapping_add(1),
                 },
             ),
-            "failed to update person"
+            "failed to update u32_u64_str"
         );
     }
     assert_eq!(hit, row_count, "not enough rows to perform requested amount of updates");
@@ -204,121 +204,121 @@ pub fn update_bulk_unique_person(row_count: u32) {
 // ---------- iterate ----------
 
 #[spacetimedb(reducer)]
-pub fn iterate_unique_person() {
-    for person in UniquePerson::iter() {
-        black_box(person);
+pub fn iterate_unique_0_u32_u64_str() {
+    for u32_u64_str in unique_0_u32_u64_str::iter() {
+        black_box(u32_u64_str);
     }
 }
 #[spacetimedb(reducer)]
-pub fn iterate_unique_location() {
-    for location in UniqueLocation::iter() {
-        black_box(location);
+pub fn iterate_unique_0_u32_u64_u64() {
+    for u32_u64_u64 in unique_0_u32_u64_u64::iter() {
+        black_box(u32_u64_u64);
     }
 }
 
 // ---------- filtering ----------
 
 #[spacetimedb(reducer)]
-pub fn filter_unique_person_by_id(id: u32) {
-    if let Some(p) = UniquePerson::filter_by_id(&id) {
+pub fn filter_unique_0_u32_u64_str_by_id(id: u32) {
+    if let Some(p) = unique_0_u32_u64_str::filter_by_id(&id) {
         black_box(p);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_non_unique_person_by_id(id: u32) {
-    for p in NonUniquePerson::filter_by_id(&id) {
+pub fn filter_no_index_u32_u64_str_by_id(id: u32) {
+    for p in no_index_u32_u64_str::filter_by_id(&id) {
         black_box(p);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_multi_index_person_by_id(id: u32) {
-    for p in MultiIndexPerson::filter_by_id(&id) {
+pub fn filter_btree_each_column_u32_u64_str_by_id(id: u32) {
+    for p in btree_each_column_u32_u64_str::filter_by_id(&id) {
         black_box(p);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_unique_person_by_name(name: String) {
-    for p in UniquePerson::filter_by_name(&name) {
+pub fn filter_unique_0_u32_u64_str_by_name(name: String) {
+    for p in unique_0_u32_u64_str::filter_by_name(&name) {
         black_box(p);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_non_unique_person_by_name(name: String) {
-    for p in NonUniquePerson::filter_by_name(&name) {
+pub fn filter_no_index_u32_u64_str_by_name(name: String) {
+    for p in no_index_u32_u64_str::filter_by_name(&name) {
         black_box(p);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_multi_index_person_by_name(name: String) {
-    for p in MultiIndexPerson::filter_by_name(&name) {
+pub fn filter_btree_each_column_u32_u64_str_by_name(name: String) {
+    for p in btree_each_column_u32_u64_str::filter_by_name(&name) {
         black_box(p);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_unique_location_by_id(id: u32) {
-    if let Some(loc) = UniqueLocation::filter_by_id(&id) {
+pub fn filter_unique_0_u32_u64_u64_by_id(id: u32) {
+    if let Some(loc) = unique_0_u32_u64_u64::filter_by_id(&id) {
         black_box(loc);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_non_unique_location_by_id(id: u32) {
-    for loc in NonUniqueLocation::filter_by_id(&id) {
+pub fn filter_no_index_u32_u64_u64_by_id(id: u32) {
+    for loc in no_index_u32_u64_u64::filter_by_id(&id) {
         black_box(loc);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_multi_index_location_by_id(id: u32) {
-    for loc in MultiIndexLocation::filter_by_id(&id) {
+pub fn filter_btree_each_column_u32_u64_u64_by_id(id: u32) {
+    for loc in btree_each_column_u32_u64_u64::filter_by_id(&id) {
         black_box(loc);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_unique_location_by_x(x: u64) {
-    for loc in UniqueLocation::filter_by_x(&x) {
+pub fn filter_unique_0_u32_u64_u64_by_x(x: u64) {
+    for loc in unique_0_u32_u64_u64::filter_by_x(&x) {
         black_box(loc);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_non_unique_location_by_x(x: u64) {
-    for loc in NonUniqueLocation::filter_by_x(&x) {
+pub fn filter_no_index_u32_u64_u64_by_x(x: u64) {
+    for loc in no_index_u32_u64_u64::filter_by_x(&x) {
         black_box(loc);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_multi_index_location_by_x(x: u64) {
-    for loc in MultiIndexLocation::filter_by_x(&x) {
+pub fn filter_btree_each_column_u32_u64_u64_by_x(x: u64) {
+    for loc in btree_each_column_u32_u64_u64::filter_by_x(&x) {
         black_box(loc);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_unique_location_by_y(x: u64) {
-    for loc in UniqueLocation::filter_by_y(&x) {
+pub fn filter_unique_0_u32_u64_u64_by_y(x: u64) {
+    for loc in unique_0_u32_u64_u64::filter_by_y(&x) {
         black_box(loc);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_non_unique_location_by_y(x: u64) {
-    for loc in NonUniqueLocation::filter_by_y(&x) {
+pub fn filter_no_index_u32_u64_u64_by_y(x: u64) {
+    for loc in no_index_u32_u64_u64::filter_by_y(&x) {
         black_box(loc);
     }
 }
 
 #[spacetimedb(reducer)]
-pub fn filter_multi_index_location_by_y(x: u64) {
-    for loc in MultiIndexLocation::filter_by_y(&x) {
+pub fn filter_btree_each_column_u32_u64_u64_by_y(x: u64) {
+    for loc in btree_each_column_u32_u64_u64::filter_by_y(&x) {
         black_box(loc);
     }
 }
@@ -328,43 +328,43 @@ pub fn filter_multi_index_location_by_y(x: u64) {
 // FIXME: current nonunique delete interface is UNUSABLE!!!!
 
 #[spacetimedb(reducer)]
-pub fn delete_unique_person_by_id(id: u32) {
-    UniquePerson::delete_by_id(&id);
+pub fn delete_unique_0_u32_u64_str_by_id(id: u32) {
+    unique_0_u32_u64_str::delete_by_id(&id);
 }
 
 #[spacetimedb(reducer)]
-pub fn delete_unique_location_by_id(id: u32) {
-    UniqueLocation::delete_by_id(&id);
+pub fn delete_unique_0_u32_u64_u64_by_id(id: u32) {
+    unique_0_u32_u64_u64::delete_by_id(&id);
 }
 
 // ---------- clear table ----------
 #[spacetimedb(reducer)]
-pub fn clear_table_unique_person() {
+pub fn clear_table_unique_0_u32_u64_str() {
     unimplemented!("Modules currently have no interface to clear a table");
 }
 
 #[spacetimedb(reducer)]
-pub fn clear_table_non_unique_person() {
+pub fn clear_table_no_index_u32_u64_str() {
     unimplemented!("Modules currently have no interface to clear a table");
 }
 
 #[spacetimedb(reducer)]
-pub fn clear_table_multi_index_person() {
+pub fn clear_table_btree_each_column_u32_u64_str() {
     unimplemented!("Modules currently have no interface to clear a table");
 }
 
 #[spacetimedb(reducer)]
-pub fn clear_table_unique_location() {
+pub fn clear_table_unique_0_u32_u64_u64() {
     unimplemented!("Modules currently have no interface to clear a table");
 }
 
 #[spacetimedb(reducer)]
-pub fn clear_table_non_unique_location() {
+pub fn clear_table_no_index_u32_u64_u64() {
     unimplemented!("Modules currently have no interface to clear a table");
 }
 
 #[spacetimedb(reducer)]
-pub fn clear_table_multi_index_location() {
+pub fn clear_table_btree_each_column_u32_u64_u64() {
     unimplemented!("Modules currently have no interface to clear a table");
 }
 // ---------- count ----------
@@ -372,33 +372,33 @@ pub fn clear_table_multi_index_location() {
 // You need to inspect the module outputs to actually read the result from these.
 
 #[spacetimedb(reducer)]
-pub fn count_unique_person() {
-    println!("COUNT: {}", UniquePerson::iter().count());
+pub fn count_unique_0_u32_u64_str() {
+    println!("COUNT: {}", unique_0_u32_u64_str::iter().count());
 }
 
 #[spacetimedb(reducer)]
-pub fn count_non_unique_person() {
-    println!("COUNT: {}", NonUniquePerson::iter().count());
+pub fn count_no_index_u32_u64_str() {
+    println!("COUNT: {}", no_index_u32_u64_str::iter().count());
 }
 
 #[spacetimedb(reducer)]
-pub fn count_multi_index_person() {
-    println!("COUNT: {}", MultiIndexPerson::iter().count());
+pub fn count_btree_each_column_u32_u64_str() {
+    println!("COUNT: {}", btree_each_column_u32_u64_str::iter().count());
 }
 
 #[spacetimedb(reducer)]
-pub fn count_unique_location() {
-    println!("COUNT: {}", UniqueLocation::iter().count());
+pub fn count_unique_0_u32_u64_u64() {
+    println!("COUNT: {}", unique_0_u32_u64_u64::iter().count());
 }
 
 #[spacetimedb(reducer)]
-pub fn count_non_unique_location() {
-    println!("COUNT: {}", NonUniqueLocation::iter().count());
+pub fn count_no_index_u32_u64_u64() {
+    println!("COUNT: {}", no_index_u32_u64_u64::iter().count());
 }
 
 #[spacetimedb(reducer)]
-pub fn count_multi_index_location() {
-    println!("COUNT: {}", MultiIndexLocation::iter().count());
+pub fn count_btree_each_column_u32_u64_u64() {
+    println!("COUNT: {}", btree_each_column_u32_u64_u64::iter().count());
 }
 // ---------- module-specific stuff ----------
 


### PR DESCRIPTION
# Description of Changes

- Rename tables in benchmarks to describe their contents
- Make parameter names uniform between callgrind and criterion
- Disable stdb_module benchmarks on CI (too noisy)

This wants to be paired with https://github.com/clockworklabs/benchmarks-viewer/pull/2, which reworks some things about benchmark reports.

I'm considering disabling the in memory benchmarks entirely on CI, but haven't done that yet. Changing the benchmark report format may make them easier to read, so that that isn't necessary.

# Expected complexity level and risk

1
