### PR TITLE
`ScanIterByColRange`: Avoid unnecessary `ProductValue` allocations

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -493,8 +493,7 @@ impl<'a, R: RangeBounds<AlgebraicValue>> Iterator for ScanIterByColRange<'a, R> 
     #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Option<Self::Item> {
         for row_ref in &mut self.scan_iter {
-            let row = row_ref.to_product_value();
-            let value = row.project_not_empty(&self.cols).unwrap();
+            let value = row_ref.project_not_empty(&self.cols).unwrap();
             if self.range.contains(&value) {
                 return Some(row_ref);
             }


### PR DESCRIPTION
# Description of Changes

Prior to this commit, `ScanIterByColRange::next` called `RowRef::to_product_value` and then `ProductValue::project_not_empty` on every row in the table to get a key, which it compared to the sought range. This always allocated at least a `ProductValue`, even when seeking a range of primitive type like `u64`. It also unnecessarily deserialized (and potentially allocated) columns not relevant to the search for rows which did not match the range.

With this commit, we call `RowRef::project_not_empty` directly. When the sought range is a single column, this avoids allocating a `ProductValue`. Even when seeking a multi-column range, this avoids deserializing unrelated columns of non-matching rows.

Non-indexed `IterByColEq` is always going to be slow, so this probably doesn't matter, but it's a trivial change.

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1 - +1/-2 diff that preserves semantics.
