### PR TITLE
perf(query): Moves Code::Block instead of cloning during eval

### DIFF
--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -361,7 +361,7 @@ pub fn eval<P: ProgramVm>(p: &mut P, code: Code) -> Code {
 
             match result.len() {
                 0 => Code::Pass,
-                1 => result[0].clone(),
+                1 => result.pop().unwrap(),
                 _ => Code::Block(result),
             }
         }


### PR DESCRIPTION
For a table scan of 1M rows, this clone was over 30% of the total execution time.

<img width="1512" alt="Screenshot 2024-02-07 at 6 18 20 PM" src="https://github.com/clockworklabs/SpacetimeDB/assets/141075564/ec90e4cc-09dc-4b62-84eb-b0508f53aed1">


