### PR TITLE
To make eval subscription concurrent

### DIFF
--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -164,14 +164,9 @@ impl ClientConnection {
 
     pub async fn subscribe(&self, subscription: Subscribe) -> Result<(), DBError> {
         let me = self.clone();
-        tokio::task::spawn_blocking(move || {
-            me.module
-                .subscriptions()
-                .blocking_write()
-                .add_subscriber(me.sender, subscription)
-        })
-        .await
-        .unwrap()
+        tokio::task::spawn_blocking(move || me.module.subscriptions().add_subscriber(me.sender, subscription))
+            .await
+            .unwrap()
     }
 
     pub async fn one_off_query(&self, query: &str, message_id: &[u8]) -> Result<(), anyhow::Error> {


### PR DESCRIPTION
# Description of Changes
Moves RwLock from `SubscriptionManager` to its specific field `subscriptions` so that most of the heavy lifting part i.e `eval` of `add_susbcription` can be done concurrently.

# Expected complexity level and risk
3, It has potential to introduce concurrency bugs.