### PR TITLE
Fix replay: Phoebe's version

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -138,7 +138,7 @@ impl Locking {
     /// context of the commit log.
     ///
     /// Not caring about the order in the log, however, requires that we **do
-    /// not** check index constraints during replay of transaction operatoins.
+    /// not** check index constraints during replay of transaction operations.
     /// We **could** check them in between transactions if we wanted to update
     /// the indexes and constraints as they changed during replay, but that is
     /// unnecessary.
@@ -195,7 +195,7 @@ impl Locking {
                     let (table, blob_store) =
                         committed_state.get_table_and_blob_store_or_create_ref_schema(table_id, &schema);
                     table
-                        .insert_internal_allow_duplicate(blob_store, &row)
+                        .insert_replay_ignore_unique_constraints(blob_store, &row)
                         .unwrap_or_else(|e| {
                             panic!(
                                 "Failed to insert row {:?} during transaction {:?} playback: {:?}",


### PR DESCRIPTION
# Description of Changes

Modifications to #806 based on comments I made there.

- Inserts while replaying must still update the pointer map, maintain set semantics and
  insert into indexes, they just get to skip unique constraints.
- We should not swallow errors when replaying a delete.

# Testing

- Built SpacetimeDB v0.8.1 (pre-mem-arch), published BitCraft, uploaded world.
- Killed SpacetimeDB.
- Built SpacetimeDB from this branch, restarted BitCraft, signed in, walked around.
- Success!

# API and ABI breaking changes

None

# Expected complexity level and risk

4 - replay is, as evidenced by this PR's necessity, fiddly and complex.
