### PR TITLE
Fix: Publish fails if rustup not present

### DIFF
--- a/crates/cli/src/subcommands/project/rust/pre-publish.duck
+++ b/crates/cli/src/subcommands/project/rust/pre-publish.duck
@@ -1,9 +1,0 @@
-#!@duckscript
-
-# Make sure that we have the wasm target installed (ok to run if its already installed)
-exec --fail-on-error rustup target add wasm32-unknown-unknown
-exec --fail-on-error cargo --config net.git-fetch-with-cli=true build --target wasm32-unknown-unknown --release
-
-# Update the running module
-exec --fail-on-error spacetime identity init-default --quiet
-exec --fail-on-error spacetime energy set-balance 5000000000000000 --quiet

--- a/crates/cli/src/subcommands/project/rust/pre-publish.duck
+++ b/crates/cli/src/subcommands/project/rust/pre-publish.duck
@@ -1,0 +1,9 @@
+#!@duckscript
+
+# Make sure that we have the wasm target installed (ok to run if its already installed)
+exec --fail-on-error rustup target add wasm32-unknown-unknown
+exec --fail-on-error cargo --config net.git-fetch-with-cli=true build --target wasm32-unknown-unknown --release
+
+# Update the running module
+exec --fail-on-error spacetime identity init-default --quiet
+exec --fail-on-error spacetime energy set-balance 5000000000000000 --quiet

--- a/crates/cli/src/tasks/rust.rs
+++ b/crates/cli/src/tasks/rust.rs
@@ -21,14 +21,11 @@ fn cargo_cmd(subcommand: &str, build_debug: bool, args: &[&str]) -> duct::Expres
 
 pub(crate) fn build_rust(project_path: &Path, skip_clippy: bool, build_debug: bool) -> anyhow::Result<PathBuf> {
     // Make sure that we have the wasm target installed (ok to run if its already installed)
-    match cmd!("rustup", "target", "add", "wasm32-unknown-unknown").run() {
-        Ok(_) => {}
-        Err(err) => {
-            println!(
-                "Warning: Failed to install wasm32-unknown-unknown target: {}. Is `rustup` installed?",
-                err
-            );
-        }
+    if let Err(err) = cmd!("rustup", "target", "add", "wasm32-unknown-unknown").run() {
+        println!(
+            "Warning: Failed to install wasm32-unknown-unknown target: {}. Is `rustup` installed?",
+            err
+        );
     }
 
     // Note: Clippy has to run first so that it can build & cache deps for actual build while checking in parallel.

--- a/crates/cli/src/tasks/rust.rs
+++ b/crates/cli/src/tasks/rust.rs
@@ -24,7 +24,7 @@ pub(crate) fn build_rust(project_path: &Path, skip_clippy: bool, build_debug: bo
     match cmd!("rustup", "target", "add", "wasm32-unknown-unknown").run() {
         Ok(_) => {}
         Err(err) => {
-            warn!("Failed to install wasm32-unknown-unknown target: {}. Is `rustup` installed?", err);
+            println!("Warning: Failed to install wasm32-unknown-unknown target: {}. Is `rustup` installed?", err);
         }
     }
 

--- a/crates/cli/src/tasks/rust.rs
+++ b/crates/cli/src/tasks/rust.rs
@@ -21,7 +21,12 @@ fn cargo_cmd(subcommand: &str, build_debug: bool, args: &[&str]) -> duct::Expres
 
 pub(crate) fn build_rust(project_path: &Path, skip_clippy: bool, build_debug: bool) -> anyhow::Result<PathBuf> {
     // Make sure that we have the wasm target installed (ok to run if its already installed)
-    cmd!("rustup", "target", "add", "wasm32-unknown-unknown").run()?;
+    match cmd!("rustup", "target", "add", "wasm32-unknown-unknown").run() {
+        Ok(_) => {}
+        Err(err) => {
+            warn!("Failed to install wasm32-unknown-unknown target: {}", err);
+        }
+    }
 
     // Note: Clippy has to run first so that it can build & cache deps for actual build while checking in parallel.
     if !skip_clippy {

--- a/crates/cli/src/tasks/rust.rs
+++ b/crates/cli/src/tasks/rust.rs
@@ -24,7 +24,10 @@ pub(crate) fn build_rust(project_path: &Path, skip_clippy: bool, build_debug: bo
     match cmd!("rustup", "target", "add", "wasm32-unknown-unknown").run() {
         Ok(_) => {}
         Err(err) => {
-            println!("Warning: Failed to install wasm32-unknown-unknown target: {}. Is `rustup` installed?", err);
+            println!(
+                "Warning: Failed to install wasm32-unknown-unknown target: {}. Is `rustup` installed?",
+                err
+            );
         }
     }
 

--- a/crates/cli/src/tasks/rust.rs
+++ b/crates/cli/src/tasks/rust.rs
@@ -24,7 +24,7 @@ pub(crate) fn build_rust(project_path: &Path, skip_clippy: bool, build_debug: bo
     match cmd!("rustup", "target", "add", "wasm32-unknown-unknown").run() {
         Ok(_) => {}
         Err(err) => {
-            warn!("Failed to install wasm32-unknown-unknown target: {}", err);
+            warn!("Failed to install wasm32-unknown-unknown target: {}. Is `rustup` installed?", err);
         }
     }
 


### PR DESCRIPTION
# Description of Changes
Allow users to run `spacetime publish` even if `rustup` is not present on their system. Typically we use it to install the `wasm32-unknown-unknown` target.

Addresses https://github.com/clockworklabs/SpacetimeDB/issues/799

# API and ABI breaking changes
These are CLI-only changes that don't affect our ABI.

# Expected complexity level and risk
1