### PR TITLE
ResultInspectExt is obsolete

### DIFF
--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -11,7 +11,6 @@ use crate::database_logger::{BacktraceProvider, LogLevel, Record};
 use crate::db::datastore::locking_tx_datastore::MutTxId;
 use crate::error::{IndexError, NodesError};
 use crate::execution_context::ExecutionContext;
-use crate::util::ResultInspectExt;
 use crate::vm::{DbProgram, TxMode};
 use spacetimedb_lib::filter::CmpArgs;
 use spacetimedb_lib::identity::AuthCtx;
@@ -126,7 +125,7 @@ impl InstanceEnv {
         let tx = &mut *self.get_tx()?;
         let ret = stdb
             .insert_bytes_as_row(tx, table_id, buffer)
-            .inspect_err_(|e| match e {
+            .inspect_err(|e| match e {
                 crate::error::DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation {
                     constraint_name: _,
                     table_name: _,

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -26,7 +26,7 @@ use crate::identity::Identity;
 use crate::messages::control_db::Database;
 use crate::sql;
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
-use crate::util::{const_unwrap, ResultInspectExt};
+use crate::util::const_unwrap;
 use crate::worker_metrics::WORKER_METRICS;
 use spacetimedb_sats::db::def::TableDef;
 
@@ -353,7 +353,7 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
                 stdb.set_program_hash(tx, fence, self.info.module_hash)?;
                 anyhow::Ok(())
             })
-            .inspect_err_(|e| log::error!("{e:?}"))?;
+            .inspect_err(|e| log::error!("{e:?}"))?;
 
         let rcr = match self.info.reducers.lookup_id(INIT_DUNDER) {
             None => {

--- a/crates/core/src/host/wasmtime/wasmtime_module.rs
+++ b/crates/core/src/host/wasmtime/wasmtime_module.rs
@@ -4,7 +4,6 @@ use crate::energy::ReducerBudget;
 use crate::host::instance_env::InstanceEnv;
 use crate::host::wasm_common::module_host_actor::{DescribeError, InitializationError, ReducerOp};
 use crate::host::wasm_common::*;
-use crate::util::ResultInspectExt;
 use anyhow::anyhow;
 use bytes::Bytes;
 use wasmtime::{AsContext, AsContextMut, ExternType, Instance, InstancePre, Linker, Store, TypedFunc, WasmBacktrace};
@@ -173,7 +172,7 @@ impl module_host_actor::WasmInstance for WasmtimeInstance {
         let duration = start.elapsed();
         log::trace!("Describer \"{}\" ran: {} us", describer_func_name, duration.as_micros(),);
         let buf = result
-            .inspect_err_(|err| log_traceback("describer", describer_func_name, err))
+            .inspect_err(|err| log_traceback("describer", describer_func_name, err))
             .map_err(DescribeError::RuntimeError)?;
         let bytes = store.data_mut().take_buffer(buf).ok_or(DescribeError::BadBuffer)?;
 

--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -9,19 +9,6 @@ pub mod notify_once;
 
 pub use future_queue::{future_queue, FutureQueue};
 
-pub trait ResultInspectExt<T, E> {
-    fn inspect_err_(self, f: impl FnOnce(&E)) -> Self;
-}
-impl<T, E> ResultInspectExt<T, E> for Result<T, E> {
-    #[inline]
-    fn inspect_err_(self, f: impl FnOnce(&E)) -> Self {
-        if let Err(e) = &self {
-            f(e)
-        }
-        self
-    }
-}
-
 pub(crate) fn string_from_utf8_lossy_owned(v: Vec<u8>) -> String {
     match String::from_utf8_lossy(&v) {
         // SAFETY: from_utf8_lossy() returned Borrowed, which means the original buffer is valid utf8


### PR DESCRIPTION
# Description of Changes

This was one of the main reasons I was excited for 1.76 and I forgot lol.

