### PR TITLE
Update upgrade-version tool

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5411,14 +5411,14 @@ dependencies = [
  "serde",
  "serde_spanned",
  "toml_datetime",
- "toml_edit",
+ "toml_edit 0.20.2",
 ]
 
 [[package]]
 name = "toml_datetime"
-version = "0.6.3"
+version = "0.6.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7cda73e2f1397b1262d6dfdcef8aafae14d1de7748d66822d3bfeeb6d03e5e4b"
+checksum = "3550f4e9685620ac18a50ed434eb3aec30db8ba93b0287467bca5826ea25baf1"
 dependencies = [
  "serde",
 ]
@@ -5432,6 +5432,17 @@ dependencies = [
  "indexmap 2.0.2",
  "serde",
  "serde_spanned",
+ "toml_datetime",
+ "winnow",
+]
+
+[[package]]
+name = "toml_edit"
+version = "0.22.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
+dependencies = [
+ "indexmap 2.0.2",
  "toml_datetime",
  "winnow",
 ]
@@ -5693,11 +5704,11 @@ checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 name = "upgrade-version"
 version = "0.1.0"
 dependencies = [
+ "anyhow",
  "clap 4.4.6",
  "duct",
  "regex",
- "tempfile",
- "walkdir",
+ "toml_edit 0.22.4",
 ]
 
 [[package]]

--- a/tools/upgrade-version/Cargo.toml
+++ b/tools/upgrade-version/Cargo.toml
@@ -6,8 +6,8 @@ edition.workspace = true
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 
 [dependencies]
-walkdir = "2"
-tempfile.workspace = true
+toml_edit = "0.22.4"
+anyhow.workspace = true
 clap.workspace = true
 regex.workspace = true
 duct.workspace = true

--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -49,7 +49,7 @@ fn main() -> anyhow::Result<()> {
 
     let current_dir = env::current_dir().expect("No current directory!");
     let dir_name = current_dir.file_name().expect("No current directory!");
-    if dir_name != "SpacetimeDB" {
+    if dir_name != "SpacetimeDB" && dir_name != "public" {
         anyhow::bail!("You must execute this binary from inside of the SpacetimeDB directory, or use --spacetime-path");
     }
 

--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -1,127 +1,32 @@
 #![allow(clippy::disallowed_macros)]
 
-extern crate clap;
-extern crate walkdir;
-
 use clap::{Arg, Command};
 use duct::cmd;
 use regex::Regex;
 use std::env;
-use std::ffi::OsStr;
 use std::fs;
-use std::fs::File;
-use std::io::BufRead;
-use std::io::BufReader;
-use std::io::Write;
+use std::path::Path;
 use std::path::PathBuf;
-use tempfile::NamedTempFile;
-use walkdir::WalkDir;
-
-static IGNORE_FILES: [&str; 5] = [
-    "crates/sdk/tests/connect_disconnect_client/Cargo.toml",
-    "crates/sdk/tests/test-client/Cargo.toml",
-    "crates/sdk/tests/test-counter/Cargo.toml",
-    "crates/sqltest/Cargo.toml",
-    "crates/testing/Cargo.toml",
-];
-
-fn find_files(start_dir: &str, name: &str) -> Vec<String> {
-    let mut files = Vec::new();
-    for entry in WalkDir::new(start_dir).into_iter().filter_map(|e| e.ok()) {
-        if entry.file_type().is_file() && entry.path().file_name() == Some(OsStr::new(name)) {
-            if IGNORE_FILES.contains(&entry.path().to_string_lossy().as_ref()) {
-                continue;
-            }
-            files.push(entry.path().to_string_lossy().to_string());
-        }
-    }
-    files
-}
-
-enum FileProcessState {
-    Package,
-    Dependencies,
-}
-
-fn process_crate_toml(path: &PathBuf, upgrade_version: &str, upgrade_package_version: bool) {
-    println!("Processing file: {}", path.to_string_lossy());
-
-    let file = File::open(path).unwrap_or_else(|_| panic!("File not found: {}", path.to_string_lossy()));
-    let reader = BufReader::new(file);
-    let mut temp_file = NamedTempFile::new().expect("Failed to create temporary file!");
-    let mut state = FileProcessState::Package;
-    let re = Regex::new(r#"(version = ")([^"]+)"#).unwrap();
-
-    for line_result in reader.lines() {
-        match line_result {
-            Ok(line) => {
-                let new_line = match state {
-                    FileProcessState::Package => {
-                        if line.contains("version = ") && upgrade_package_version {
-                            re.replace(&line, format!("version = \"{}", upgrade_version).as_str())
-                                .into()
-                        } else if line.contains("[dependencies]") {
-                            state = FileProcessState::Dependencies;
-                            line
-                        } else {
-                            line
-                        }
-                    }
-                    FileProcessState::Dependencies => {
-                        if line.starts_with("spacetimedb") {
-                            if !line.contains('{') {
-                                format!("spacetimedb = \"{}\"", upgrade_version)
-                            } else {
-                                // Match the version number and capture it
-                                re.replace(&line, format!("version = \"{}", upgrade_version).as_str())
-                                    .into()
-                            }
-                        } else {
-                            line
-                        }
-                    }
-                };
-
-                writeln!(temp_file, "{}", new_line).unwrap();
-            }
-            Err(e) => eprintln!("Error reading line: {}", e),
-        }
-    }
-
-    // Rename the temporary file to replace the original file
-    fs::rename(temp_file.path(), path).expect("Failed to overwrite source file.");
-}
 
 fn process_license_file(upgrade_version: &str) {
     let path = "LICENSE.txt";
-    let file = File::open(path).unwrap_or_else(|_| panic!("File not found: {}", path));
-    let reader = BufReader::new(file);
-    let mut temp_file = NamedTempFile::new().expect("Failed to create temporary file!");
-    let re = Regex::new(r"(^Licensed Work:\s+SpacetimeDB )([\d\.]+)").unwrap();
-
-    for line_result in reader.lines() {
-        match line_result {
-            Ok(line) => {
-                let new_line = if line.starts_with("Licensed Work") {
-                    re.replace(
-                        &line,
-                        format!("{}{}", &re.captures(&line).unwrap()[1], upgrade_version).as_str(),
-                    )
-                    .into()
-                } else {
-                    line
-                };
-                writeln!(temp_file, "{}", new_line).unwrap();
-            }
-            Err(e) => eprintln!("Error reading line: {}", e),
-        }
-    }
-
-    // Rename the temporary file to replace the original file
-    fs::rename(temp_file.path(), path).expect("Failed to overwrite source file.");
+    let file = fs::read_to_string(path).unwrap();
+    let re = Regex::new(r"(?m)^(Licensed Work:\s+SpacetimeDB )([\d\.]+)$").unwrap();
+    let file = re.replace_all(&file, |caps: &regex::Captures| {
+        format!("{}{}", &caps[1], upgrade_version)
+    });
+    fs::write(path, &*file).unwrap();
 }
 
-fn main() {
+fn edit_toml(path: impl AsRef<Path>, f: impl FnOnce(&mut toml_edit::Document)) -> anyhow::Result<()> {
+    let path = path.as_ref();
+    let mut doc = fs::read_to_string(path)?.parse::<toml_edit::Document>()?;
+    f(&mut doc);
+    fs::write(path, doc.to_string())?;
+    Ok(())
+}
+
+fn main() -> anyhow::Result<()> {
     let matches = Command::new("upgrade-version")
         .version("1.0")
         .about("Upgrades the version of the SpacetimeDB repository")
@@ -145,21 +50,29 @@ fn main() {
     let current_dir = env::current_dir().expect("No current directory!");
     let dir_name = current_dir.file_name().expect("No current directory!");
     if dir_name != "SpacetimeDB" {
-        println!("You must execute this binary from inside of the SpacetimeDB directory, or use --spacetime-path");
-        return;
+        anyhow::bail!("You must execute this binary from inside of the SpacetimeDB directory, or use --spacetime-path");
     }
 
-    for file in find_files("crates", "Cargo.toml") {
-        process_crate_toml(&PathBuf::from(file), version, true);
-    }
-    for file in find_files("modules", "Cargo.toml") {
-        process_crate_toml(&PathBuf::from(file), version, false);
-    }
-    for file in find_files("crates", "Cargo._toml") {
-        process_crate_toml(&PathBuf::from(file), version, false);
-    }
+    // root Cargo.toml
+    edit_toml("Cargo.toml", |doc| {
+        doc["workspace"]["package"]["version"] = toml_edit::value(version);
+        for (key, dep) in doc["workspace"]["dependencies"]
+            .as_table_like_mut()
+            .expect("workspace.dependencies is not a table")
+            .iter_mut()
+        {
+            if key.get().starts_with("spacetime") {
+                dep["version"] = toml_edit::value(version)
+            }
+        }
+    })?;
 
-    process_crate_toml(&PathBuf::from("crates/testing/Cargo.toml"), version, false);
+    edit_toml("crates/cli/src/subcommands/project/rust/Cargo._toml", |doc| {
+        doc["dependencies"]["spacetimedb"] = toml_edit::value(version);
+    })?;
+
     process_license_file(version);
     cmd!("cargo", "check").run().expect("Cargo check failed!");
+
+    Ok(())
 }


### PR DESCRIPTION
# Description of Changes

Fixing after #802. Please let me know if there's anything you'd like me to change about this; I didn't wanna try extending the custom toml parsing going on so I just pulled in `toml_edit`; it does the right thing and the code is clearer. (also made `process_license_file` use regex replace_all, cause while testing the file renaming was failing for me. lemme know if I should revert that). I also, instead of doing the walkdir for `Cargo._toml`, just specify `crates/cli/src/subcommands/project/rust/Cargo._toml`, since that's gonna be the only ever one afaik.