### PR TITLE
chore(836): Remove tracing instrumentation from database iterators

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -650,7 +650,6 @@ impl Drop for CommittedIndexIter<'_> {
 impl<'a> Iterator for CommittedIndexIter<'a> {
     type Item = RowRef<'a>;
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(row_ref) = self.committed_rows.find(|row_ref| {
             !self

--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -244,7 +244,6 @@ enum ScanStage<'a> {
 impl<'a> Iterator for Iter<'a> {
     type Item = RowRef<'a>;
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Option<Self::Item> {
         let table_id = self.table_id;
 
@@ -401,7 +400,6 @@ impl Drop for IndexSeekIterMutTxId<'_> {
 impl<'a> Iterator for IndexSeekIterMutTxId<'a> {
     type Item = RowRef<'a>;
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Option<Self::Item> {
         if let Some(row_ref) = self.inserted_rows.next() {
             return Some(row_ref);
@@ -462,7 +460,6 @@ pub enum IterByColRange<'a, R: RangeBounds<AlgebraicValue>> {
 impl<'a, R: RangeBounds<AlgebraicValue>> Iterator for IterByColRange<'a, R> {
     type Item = RowRef<'a>;
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Option<Self::Item> {
         match self {
             IterByColRange::Scan(range) => range.next(),
@@ -487,7 +484,6 @@ impl<'a, R: RangeBounds<AlgebraicValue>> ScanIterByColRange<'a, R> {
 impl<'a, R: RangeBounds<AlgebraicValue>> Iterator for ScanIterByColRange<'a, R> {
     type Item = RowRef<'a>;
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Option<Self::Item> {
         for row_ref in &mut self.scan_iter {
             let row = row_ref.to_product_value();

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -279,7 +279,6 @@ impl<'a, Rhs: RelOps> RelOps for IndexSemiJoin<'a, Rhs> {
         RowCount::unknown()
     }
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Result<Option<RelValue>, ErrorVm> {
         // Return a value from the current index iterator, if not exhausted.
         if self.return_index_rows {
@@ -550,7 +549,6 @@ impl RelOps for TableCursor<'_> {
         RowCount::unknown()
     }
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Result<Option<RelValue>, ErrorVm> {
         Ok(self.iter.next().map(|row| RelValue::new(row.to_product_value(), None)))
     }
@@ -565,7 +563,6 @@ impl<R: RangeBounds<AlgebraicValue>> RelOps for IndexCursor<'_, R> {
         RowCount::unknown()
     }
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Result<Option<RelValue>, ErrorVm> {
         Ok(self.iter.next().map(|row| RelValue::new(row.to_product_value(), None)))
     }
@@ -583,7 +580,6 @@ where
         self.row_count
     }
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Result<Option<RelValue>, ErrorVm> {
         if let Some(row) = self.iter.next() {
             return Ok(Some(RelValue::new(row, None)));

--- a/crates/vm/src/iterators.rs
+++ b/crates/vm/src/iterators.rs
@@ -12,7 +12,6 @@ impl RelOps for RelIter<ProductValue> {
         self.row_count
     }
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Result<Option<RelValue>, ErrorVm> {
         Ok(if self.pos == 0 {
             self.pos += 1;
@@ -32,7 +31,6 @@ impl RelOps for RelIter<MemTable> {
         self.row_count
     }
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Result<Option<RelValue>, ErrorVm> {
         if self.pos < self.of.data.len() {
             let row = &self.of.data[self.pos];

--- a/crates/vm/src/rel_ops.rs
+++ b/crates/vm/src/rel_ops.rs
@@ -164,7 +164,6 @@ where
         self.count
     }
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Result<Option<RelValue>, ErrorVm> {
         let filter = &mut self.predicate;
         while let Some(v) = self.iter.next()? {
@@ -208,7 +207,6 @@ where
         self.count
     }
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Result<Option<RelValue>, ErrorVm> {
         let extract = &mut self.extractor;
         if let Some(v) = self.iter.next()? {
@@ -277,7 +275,6 @@ where
         self.count
     }
 
-    #[tracing::instrument(skip_all)]
     fn next(&mut self) -> Result<Option<RelValue>, ErrorVm> {
         if !self.filled {
             self.map = HashMap::with_capacity(self.rhs.row_count().min);


### PR DESCRIPTION
Closes #836.

The tracing library does not fully remove all instrumentation at compile time. And since tracing is not zero cost,
it must be removed from the hot path of query execution.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
