### PR TITLE
Remove unused pre-publish.duck file

### DIFF
--- a/crates/cli/src/subcommands/project/rust/pre-publish.duck
+++ b/crates/cli/src/subcommands/project/rust/pre-publish.duck
@@ -1,9 +1,0 @@
-#!@duckscript
-
-# Make sure that we have the wasm target installed (ok to run if its already installed)
-exec --fail-on-error rustup target add wasm32-unknown-unknown
-exec --fail-on-error cargo --config net.git-fetch-with-cli=true build --target wasm32-unknown-unknown --release
-
-# Update the running module
-exec --fail-on-error spacetime identity init-default --quiet
-exec --fail-on-error spacetime energy set-balance 5000000000000000 --quiet


### PR DESCRIPTION
# Description of Changes
Just removing the long-unused `pre-publish.duck` file.

# API and ABI breaking changes
Nope

# Expected complexity level and risk
1