### PR TITLE
Revert "Add a RwLock around module subscriptions to prevent a race condition (#792)"

### DIFF
--- a/crates/client-api/src/routes/subscribe.rs
+++ b/crates/client-api/src/routes/subscribe.rs
@@ -306,7 +306,12 @@ async fn ws_client_actor(client: ClientConnection, mut ws: WebSocketStream, mut 
     // https://rust-lang.github.io/wg-async/vision/submitted_stories/status_quo/aws_engineer/solving_a_deadlock.html
     handle_queue.clear();
 
-    client.module.disconnect_client(client.id).await;
+    // ignore NoSuchModule; if the module's already closed, that's fine
+    let _ = client.module.subscription().remove_subscriber(client.id);
+    let _ = client
+        .module
+        .call_identity_connected_disconnected(client.id.identity, client.id.address, false)
+        .await;
 }
 
 enum ClientMessage {

--- a/crates/core/src/client/message_handlers.rs
+++ b/crates/core/src/client/message_handlers.rs
@@ -142,9 +142,7 @@ impl DecodedMessage<'_> {
                 let res = client.call_reducer(reducer, args).await;
                 res.map(drop).map_err(|e| (Some(reducer), e.into()))
             }
-            DecodedMessage::Subscribe(subscription) => {
-                client.subscribe(subscription).await.map_err(|e| (None, e.into()))
-            }
+            DecodedMessage::Subscribe(subscription) => client.subscribe(subscription).map_err(|e| (None, e.into())),
             DecodedMessage::OneOffQuery {
                 query_string: query,
                 message_id,

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -7,11 +7,11 @@ use std::time::Duration;
 use base64::{engine::general_purpose::STANDARD as BASE_64_STD, Engine as _};
 use futures::{Future, FutureExt};
 use indexmap::IndexMap;
-use tokio::sync::{oneshot, RwLock};
+use tokio::sync::oneshot;
 
 use super::host_controller::HostThreadpool;
 use super::{ArgsTuple, InvalidReducerArguments, ReducerArgs, ReducerCallResult, ReducerId, Timestamp};
-use crate::client::{ClientActorId, ClientConnectionSender};
+use crate::client::ClientConnectionSender;
 use crate::database_logger::LogLevel;
 use crate::db::datastore::traits::{TxData, TxOp};
 use crate::db::relational_db::RelationalDB;
@@ -23,7 +23,7 @@ use crate::hash::Hash;
 use crate::identity::Identity;
 use crate::json::client_api::{SubscriptionUpdateJson, TableRowOperationJson, TableUpdateJson};
 use crate::protobuf::client_api::{table_row_operation, SubscriptionUpdate, TableRowOperation, TableUpdate};
-use crate::subscription::module_subscription_actor::ModuleSubscriptions;
+use crate::subscription::module_subscription_actor::ModuleSubscriptionManager;
 use crate::util::lending_pool::{Closed, LendingPool, LentResource, PoolClosed};
 use crate::util::notify_once::NotifyOnce;
 use spacetimedb_lib::{Address, ReducerDef, TableDesc};
@@ -207,7 +207,7 @@ pub struct ModuleInfo {
     pub reducers: ReducersMap,
     pub catalog: HashMap<String, EntityDef>,
     pub log_tx: tokio::sync::broadcast::Sender<bytes::Bytes>,
-    pub subscriptions: Arc<RwLock<ModuleSubscriptions>>,
+    pub subscription: ModuleSubscriptionManager,
 }
 
 pub struct ReducersMap(pub IndexMap<String, ReducerDef>);
@@ -499,8 +499,8 @@ impl ModuleHost {
     }
 
     #[inline]
-    pub fn subscriptions(&self) -> &RwLock<ModuleSubscriptions> {
-        &self.info.subscriptions
+    pub fn subscription(&self) -> &ModuleSubscriptionManager {
+        &self.info.subscription
     }
 
     async fn call<F, R>(&self, _reducer_name: &str, f: F) -> Result<R, NoSuchModule>
@@ -515,15 +515,6 @@ impl ModuleHost {
             let _ = tx.send(f(&mut *inst));
         });
         Ok(rx.await.expect("instance panicked"))
-    }
-
-    pub async fn disconnect_client(&self, client_id: ClientActorId) {
-        tokio::join!(
-            async { self.subscriptions().write().await.remove_subscriber(client_id) },
-            self.call_identity_connected_disconnected(client_id.identity, client_id.address, false)
-                // ignore NoSuchModule; if the module's already closed, that's fine
-                .map(drop)
-        );
     }
 
     pub async fn call_identity_connected_disconnected(

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -2,7 +2,6 @@ use anyhow::{anyhow, Context};
 use bytes::Bytes;
 use std::sync::Arc;
 use std::time::Duration;
-use tokio::sync::RwLock;
 
 use spacetimedb_lib::buffer::DecodeError;
 use spacetimedb_lib::identity::AuthCtx;
@@ -25,7 +24,7 @@ use crate::host::{ArgsTuple, EntityDef, ReducerCallResult, ReducerId, ReducerOut
 use crate::identity::Identity;
 use crate::messages::control_db::Database;
 use crate::sql;
-use crate::subscription::module_subscription_actor::ModuleSubscriptions;
+use crate::subscription::module_subscription_actor::ModuleSubscriptionManager;
 use crate::util::{const_unwrap, ResultInspectExt};
 use crate::worker_metrics::WORKER_METRICS;
 use spacetimedb_sats::db::def::TableDef;
@@ -143,7 +142,7 @@ impl<T: WasmModule> WasmModuleHostActor<T> {
 
         let owner_identity = database_instance_context.identity;
         let relational_db = database_instance_context.relational_db.clone();
-        let subscriptions = Arc::new(RwLock::new(ModuleSubscriptions::new(relational_db, owner_identity)));
+        let subscription = ModuleSubscriptionManager::spawn(relational_db, owner_identity);
 
         let uninit_instance = module.instantiate_pre()?;
         let mut instance = uninit_instance.instantiate(
@@ -185,7 +184,7 @@ impl<T: WasmModule> WasmModuleHostActor<T> {
             reducers,
             catalog,
             log_tx,
-            subscriptions,
+            subscription,
         });
 
         let func_names = Arc::new(func_names);
@@ -564,11 +563,6 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
             .with_label_values(&address, reducer_name)
             .observe(timings.total_duration.as_secs_f64());
 
-        // Take a lock on our subscriptions now. Otherwise, we could have a race condition where we commit
-        // the tx, someone adds a subscription and receives this tx as an update, and then receives the
-        // update again when we broadcast_event.
-        let subscriptions = self.info.subscriptions.blocking_read();
-
         let ctx = ExecutionContext::reducer(address, reducer_name);
         let status = match call_result {
             Err(err) => {
@@ -629,7 +623,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
             energy_quanta_used: energy.used,
             host_execution_duration: timings.total_duration,
         };
-        subscriptions.blocking_broadcast_event(client.as_ref(), &event);
+        self.info.subscription.broadcast_event_blocking(client.as_ref(), event);
 
         ReducerCallResult {
             outcome,

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -4,30 +4,116 @@ use super::{
     query::compile_read_only_query,
     subscription::{QuerySet, Subscription},
 };
-use crate::client::{
-    messages::{CachedMessage, SubscriptionUpdateMessage, TransactionUpdateMessage},
-    ClientActorId, ClientConnectionSender,
-};
-use crate::db::relational_db::RelationalDB;
-use crate::error::DBError;
 use crate::execution_context::ExecutionContext;
-use crate::host::module_host::{EventStatus, ModuleEvent};
 use crate::protobuf::client_api::Subscribe;
 use crate::worker_metrics::WORKER_METRICS;
+use crate::{
+    client::{
+        messages::{CachedMessage, SubscriptionUpdateMessage, TransactionUpdateMessage},
+        ClientActorId, ClientConnectionSender,
+    },
+    host::NoSuchModule,
+};
+use crate::{db::relational_db::RelationalDB, error::DBError};
+use crate::{
+    db::relational_db::Tx,
+    host::module_host::{EventStatus, ModuleEvent},
+};
 use futures::Future;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::Identity;
+use tokio::sync::{mpsc, oneshot};
 
+/// All of these commands (and likely any future ones) should all be in the same enum with the
+/// same queue so that e.g. db updates from commit events and db updates from subscription
+/// modifications don't get sent to the client out of order.
 #[derive(Debug)]
-pub struct ModuleSubscriptions {
+enum Command {
+    AddSubscriber {
+        sender: ClientConnectionSender,
+        subscription: Subscribe,
+    },
+    RemoveSubscriber {
+        client_id: ClientActorId,
+    },
+    BroadcastCommitEvent {
+        event: ModuleEvent,
+        // channel for signaling that all subscriptions have been evaluated.
+        feedback_tx: oneshot::Sender<()>,
+    },
+}
+
+#[derive(Clone, Debug)]
+pub struct ModuleSubscriptionManager {
+    tx: mpsc::UnboundedSender<Command>,
+}
+
+impl ModuleSubscriptionManager {
+    pub fn spawn(relational_db: Arc<RelationalDB>, owner_identity: Identity) -> Self {
+        let (tx, mut rx) = mpsc::unbounded_channel();
+        tokio::spawn(async move {
+            let mut actor = ModuleSubscriptionActor::new(relational_db, owner_identity);
+            while let Some(command) = rx.recv().await {
+                if let Err(e) = actor.handle_message(command).await {
+                    log::error!("error occurred in ModuleSubscriptionActor: {e}")
+                }
+            }
+        });
+        Self { tx }
+    }
+
+    pub fn add_subscriber(&self, sender: ClientConnectionSender, subscription: Subscribe) -> Result<(), NoSuchModule> {
+        self.tx
+            .send(Command::AddSubscriber { sender, subscription })
+            .map_err(|_| NoSuchModule)
+    }
+
+    pub fn remove_subscriber(&self, client_id: ClientActorId) -> Result<(), NoSuchModule> {
+        self.tx
+            .send(Command::RemoveSubscriber { client_id })
+            .map_err(|_| NoSuchModule)
+    }
+
+    pub async fn broadcast_event(&self, client: Option<&ClientConnectionSender>, mut event: ModuleEvent) {
+        match event.status {
+            EventStatus::Committed(_) => {
+                let (tx, rx) = oneshot::channel();
+                self.tx
+                    .send(Command::BroadcastCommitEvent { event, feedback_tx: tx })
+                    .expect("subscription actor panicked");
+                if (rx.await).is_err() {
+                    log::error!("failed to receive acknowledgement of successful evaluation from subscription actor")
+                }
+            }
+            EventStatus::Failed(_) => {
+                if let Some(client) = client {
+                    let message = TransactionUpdateMessage {
+                        event: &mut event,
+                        database_update: Default::default(),
+                    };
+                    let _ = client.send_message(message).await;
+                } else {
+                    log::trace!("Reducer failed but there is no client to send the failure to!")
+                }
+            }
+            EventStatus::OutOfEnergy => {} // ?
+        }
+    }
+
+    pub fn broadcast_event_blocking(&self, client: Option<&ClientConnectionSender>, event: ModuleEvent) {
+        tokio::runtime::Handle::current().block_on(self.broadcast_event(client, event))
+    }
+}
+
+struct ModuleSubscriptionActor {
     relational_db: Arc<RelationalDB>,
     subscriptions: Vec<Subscription>,
     owner_identity: Identity,
 }
 
-impl ModuleSubscriptions {
-    pub fn new(relational_db: Arc<RelationalDB>, owner_identity: Identity) -> Self {
+impl ModuleSubscriptionActor {
+    fn new(relational_db: Arc<RelationalDB>, owner_identity: Identity) -> Self {
         Self {
             relational_db,
             subscriptions: Vec::new(),
@@ -35,15 +121,25 @@ impl ModuleSubscriptions {
         }
     }
 
-    /// Add a subscriber to the module. NOTE: this function is blocking.
-    pub fn add_subscriber(&mut self, sender: ClientConnectionSender, subscription: Subscribe) -> Result<(), DBError> {
+    async fn handle_message(&mut self, command: Command) -> Result<(), DBError> {
+        match command {
+            Command::AddSubscriber { sender, subscription } => self.add_subscription(sender, subscription).await?,
+            Command::RemoveSubscriber { client_id } => self.remove_subscriber(client_id),
+            Command::BroadcastCommitEvent { event, feedback_tx } => {
+                tokio::task::block_in_place(|| self.broadcast_commit_event(event)).await;
+                let _ = feedback_tx.send(());
+            }
+        }
+        Ok(())
+    }
+
+    async fn _add_subscription(
+        &mut self,
+        sender: ClientConnectionSender,
+        subscription: Subscribe,
+        tx: &mut Tx,
+    ) -> Result<(), DBError> {
         self.remove_subscriber(sender.id);
-
-        let tx = &mut *scopeguard::guard(self.relational_db.begin_tx(), |tx| {
-            let ctx = ExecutionContext::subscribe(self.relational_db.address());
-            self.relational_db.release_tx(&ctx, tx);
-        });
-
         let auth = AuthCtx::new(self.owner_identity, sender.id.identity);
         let mut queries = QuerySet::new();
         for sql in subscription.query_strings {
@@ -67,7 +163,7 @@ impl ModuleSubscriptions {
             }
         };
 
-        let database_update = tokio::task::block_in_place(|| subscription.queries.eval(&self.relational_db, tx, auth))?;
+        let database_update = subscription.queries.eval(&self.relational_db, tx, auth)?;
 
         let sender = subscription.subscribers().last().unwrap();
 
@@ -75,13 +171,29 @@ impl ModuleSubscriptions {
         // thread it's possible for messages to get sent to the client out of order. If you do
         // spawn in another thread messages will need to be buffered until the state is sent out
         // on the wire
-        let fut = sender.send_message(SubscriptionUpdateMessage { database_update });
-        let _ = tokio::runtime::Handle::current().block_on(fut);
+        let _ = sender.send_message(SubscriptionUpdateMessage { database_update }).await;
 
         Ok(())
     }
 
-    pub fn remove_subscriber(&mut self, client_id: ClientActorId) {
+    async fn add_subscription(
+        &mut self,
+        sender: ClientConnectionSender,
+        subscription: Subscribe,
+    ) -> Result<(), DBError> {
+        // Split logic to properly handle `Error` + `Tx`
+        let mut tx = self.relational_db.begin_tx();
+
+        let result = self._add_subscription(sender, subscription, &mut tx).await;
+
+        // Note: the missing QueryDebugInfo here is only used for finishing the transaction;
+        // all of the relevant queries already executed, with debug info, in _add_subscription
+        let ctx = ExecutionContext::subscribe(self.relational_db.address());
+        self.relational_db.release_tx(&ctx, tx);
+        result
+    }
+
+    fn remove_subscriber(&mut self, client_id: ClientActorId) {
         self.subscriptions.retain_mut(|subscription| {
             subscription.remove_subscriber(client_id);
             if subscription.subscribers().is_empty() {
@@ -94,43 +206,13 @@ impl ModuleSubscriptions {
         })
     }
 
-    /// Broadcast a ModuleEvent to all interested subscribers.
-    ///
-    /// It's recommended to take a read lock on `ModuleSubscriptions` *before* you commit
-    /// the transaction that will give you the event you pass here, to prevent a race condition
-    /// where a just-added subscriber receives the same update twice.
-    pub async fn broadcast_event(&self, client: Option<&ClientConnectionSender>, event: &ModuleEvent) {
-        match event.status {
-            EventStatus::Committed(_) => {
-                tokio::task::block_in_place(|| self.broadcast_commit_event(event)).await;
-            }
-            EventStatus::Failed(_) => {
-                if let Some(client) = client {
-                    let message = TransactionUpdateMessage {
-                        event,
-                        database_update: Default::default(),
-                    };
-                    let _ = client.send_message(message).await;
-                } else {
-                    log::trace!("Reducer failed but there is no client to send the failure to!")
-                }
-            }
-            EventStatus::OutOfEnergy => {} // ?
-        }
-    }
-
-    /// A blocking version of [`broadcast_event`][Self::broadcast_event].
-    pub fn blocking_broadcast_event(&self, client: Option<&ClientConnectionSender>, event: &ModuleEvent) {
-        tokio::runtime::Handle::current().block_on(self.broadcast_event(client, event))
-    }
-
     /// Broadcast the commit event to all interested subscribers.
     ///
     /// This function is blocking, even though it returns a future. The returned future resolves
     /// once all updates have been successfully added to the subscribers' send queues (i.e. after
     /// it resolves, it's guaranteed that if you call `subscriber.send(x)` the client will receive
     /// x after they receive this subscription update).
-    fn broadcast_commit_event(&self, event: &ModuleEvent) -> impl Future<Output = ()> + '_ {
+    fn broadcast_commit_event(&self, event: ModuleEvent) -> impl Future<Output = ()> + '_ {
         let database_update = event.status.database_update().unwrap();
 
         let auth = AuthCtx::new(self.owner_identity, event.caller_identity);
@@ -159,8 +241,11 @@ impl ModuleSubscriptions {
                     }
                 }
             })
-            .flat_map_iter(|(subscription, database_update)| {
-                let message = TransactionUpdateMessage { event, database_update };
+            .flat_map_iter(|(subscription, incr)| {
+                let message = TransactionUpdateMessage {
+                    event: &event,
+                    database_update: incr,
+                };
                 let mut message = CachedMessage::new(message);
 
                 subscription.subscribers().iter().cloned().map(move |subscriber| {

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -50,7 +50,6 @@ use super::query;
 
 /// A subscription is a [`QuerySet`], along with a set of subscribers all
 /// interested in the same set of queries.
-#[derive(Debug)]
 pub struct Subscription {
     pub queries: QuerySet,
     subscribers: Vec<ClientConnectionSender>,


### PR DESCRIPTION
This reverts https://github.com/clockworklabs/SpacetimeDB/pull/792.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
