### PR TITLE
Core: depend on "serde" from lib

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,7 +19,7 @@ name = "odb_flavor_bench"
 harness = false
 
 [dependencies]
-spacetimedb-lib.workspace = true
+spacetimedb-lib = { workspace = true, features = ["serde"] }
 spacetimedb-client-api-messages.workspace = true
 spacetimedb-metrics.workspace = true
 spacetimedb-primitives.workspace = true


### PR DESCRIPTION
# Description of Changes

I seem to be unable to build `core` directly on master, though building the workspace root, i.e. `cli`, works. This is caused by `core` depending on `spacetimedb-lib.workspace`, which has `default-features = false`, excluding serde support.

This commit correctly specifies the `"serde"` feature for core's dependency on lib, so it is now possible to `cd crates/core && cargo check`.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
