### PR TITLE
chore: Remove instrumentation from DataKey deserializers

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -195,7 +195,6 @@ impl RelationalDB {
             .map_or(Ok(0), |commit_log| commit_log.object_db_size_on_disk())
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn pk_for_row(row: &ProductValue) -> PrimaryKey {
         PrimaryKey {
             data_key: row.to_data_key(),

--- a/crates/sats/src/bsatn.rs
+++ b/crates/sats/src/bsatn.rs
@@ -13,7 +13,6 @@ pub use ser::Serializer;
 pub use crate::buffer::DecodeError;
 
 /// Serialize `value` into the buffered writer `w` in the BSATN format.
-#[tracing::instrument(skip_all)]
 pub fn to_writer<W: BufWriter, T: Serialize + ?Sized>(w: &mut W, value: &T) -> Result<(), ser::BsatnError> {
     value.serialize(Serializer::new(w))
 }
@@ -33,7 +32,6 @@ pub fn to_len<T: Serialize + ?Sized>(value: &T) -> Result<usize, ser::BsatnError
 }
 
 /// Deserialize a `T` from the BSATN format in the buffered `reader`.
-#[tracing::instrument(skip_all)]
 pub fn from_reader<'de, T: Deserialize<'de>>(reader: &mut impl BufReader<'de>) -> Result<T, DecodeError> {
     T::deserialize(Deserializer::new(reader))
 }

--- a/crates/sats/src/hash.rs
+++ b/crates/sats/src/hash.rs
@@ -59,7 +59,6 @@ impl Hash {
     }
 }
 
-#[tracing::instrument(skip_all)]
 pub fn hash_bytes(bytes: impl AsRef<[u8]>) -> Hash {
     let data: [u8; HASH_SIZE] = Keccak256::digest(bytes).into();
     Hash { data }


### PR DESCRIPTION
```
cargo bench --bench=subscription --profile=profiling -- full-scan --exact

full-scan               time:   [418.07 ms 418.83 ms 419.62 ms]
                        change: [-8.7500% -8.2453% -7.7598%] (p = 0.00 < 0.05)
                        Performance has improved.
```
