### PR TITLE
Fix deadlock

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -282,6 +282,10 @@ impl TxDatastore for Locking {
         tx.table_id_from_name(table_name, self.database_address)
     }
 
+    fn table_name_from_id_tx<'a>(&'a self, tx: &'a Self::Tx, table_id: TableId) -> Result<Option<Cow<'a, str>>> {
+        Ok(tx.table_exists(&table_id).map(Cow::Borrowed))
+    }
+
     fn schema_for_table_tx<'tx>(&self, tx: &'tx Self::Tx, table_id: TableId) -> Result<Cow<'tx, TableSchema>> {
         tx.schema_for_table(&ExecutionContext::internal(self.database_address), table_id)
     }

--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -42,6 +42,7 @@ pub(crate) trait StateView {
 
     fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: &TableId) -> Result<Iter<'a>>;
 
+    // TODO(noa): rename to table_name, and TableId doesn't need to be a reference
     fn table_exists(&self, table_id: &TableId) -> Option<&str>;
 
     /// Returns an iterator,

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -113,6 +113,7 @@ pub trait TxDatastore: DataRow + Tx {
 
     fn table_id_exists_tx(&self, tx: &Self::Tx, table_id: &TableId) -> bool;
     fn table_id_from_name_tx(&self, tx: &Self::Tx, table_name: &str) -> Result<Option<TableId>>;
+    fn table_name_from_id_tx<'a>(&'a self, tx: &'a Self::Tx, table_id: TableId) -> Result<Option<Cow<'a, str>>>;
     fn schema_for_table_tx<'tx>(&self, tx: &'tx Self::Tx, table_id: TableId) -> super::Result<Cow<'tx, TableSchema>>;
     fn get_all_tables_tx<'tx>(
         &self,

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -133,7 +133,7 @@ impl InstanceEnv {
                     value: _,
                 })) => {}
                 _ => {
-                    let res = stdb.table_name_from_id(ctx, tx, table_id);
+                    let res = stdb.table_name_from_id_mut(ctx, tx, table_id);
                     if let Ok(Some(table_name)) = res {
                         log::debug!("insert(table: {table_name}, table_id: {table_id}): {e}")
                     } else {

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -78,7 +78,8 @@ impl ModuleSubscriptions {
             .with_label_values(&self.relational_db.address())
             .inc();
 
-        let sender = subscription.subscribers().last().unwrap();
+        let sender = subscription.subscribers().last().unwrap().clone();
+        drop(subscriptions);
         // NOTE: It is important to send the state in this thread because if you spawn a new
         // thread it's possible for messages to get sent to the client out of order. If you do
         // spawn in another thread messages will need to be buffered until the state is sent out


### PR DESCRIPTION
# Description of Changes

Call order that would lead to deadlock:
```
module host: read-lock subscriptions
module host: commit tx, release lock on db
add_subscriber: take read lock on db
module host: call DatabaseUpdate::from_writes. tries to take write lock on db. cannot, add_subscriber has a read lock
add_subscriber: tries to take write lock on subscriptions. cannot, module host still holds it
deadlock
```

This fixes by making from_writes not take a write-lock on the db