### PR TITLE
Fix bench errors and include in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -38,7 +38,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: '8.x'
+          dotnet-version: "8.x"
 
       - name: Create /stdb dir
         run: |
@@ -62,10 +62,7 @@ jobs:
         run: cargo fmt --all -- --check
 
       - name: Run cargo clippy
-        run: cargo clippy --all --tests --features odb_rocksdb,odb_sled,metrics -- -D warnings
-
-      - name: Check benchmarks
-        run: cd crates/bench && cargo check --benches
+        run: cargo clippy --all --tests --benches --features odb_rocksdb,odb_sled,metrics -- -D warnings
 
   wasm_bindings:
     name: Build and test wasm bindings

--- a/crates/table/benches/page_manager.rs
+++ b/crates/table/benches/page_manager.rs
@@ -5,10 +5,8 @@ use criterion::measurement::{Measurement, WallTime};
 use criterion::{
     black_box, criterion_group, criterion_main, Bencher, BenchmarkGroup, BenchmarkId, Criterion, Throughput,
 };
-use rand::distributions::OpenClosed01;
-use rand::prelude::Distribution;
 use rand::rngs::StdRng;
-use rand::SeedableRng;
+use rand::{Rng, SeedableRng};
 use spacetimedb_primitives::{ColList, IndexId, TableId};
 use spacetimedb_sats::db::def::{TableDef, TableSchema};
 use spacetimedb_sats::{AlgebraicType, AlgebraicValue, ProductType, ProductValue};
@@ -386,8 +384,7 @@ fn insert_with_holes_fixed_len(c: &mut Criterion) {
                         }
                         .unwrap();
 
-                        let should_delete = <OpenClosed01 as Distribution<f64>>::sample(&OpenClosed01, &mut rng);
-                        if should_delete < delete_ratio {
+                        if rng.gen_bool(delete_ratio) {
                             ptrs_to_delete.push(RowPointer::new(
                                 false,
                                 page_idx,
@@ -454,13 +451,7 @@ fn copy_filter_fixed_len(c: &mut Criterion) {
 
             // To avoid advancing RNG in the benchmark,
             // precompute a big vec of bools, with one bool for each value that we may or may not keep.
-            let keep_seq: Vec<bool> = (0..total_num_rows)
-                .into_iter()
-                .map(|_| {
-                    let should_keep = <OpenClosed01 as Distribution<f64>>::sample(&OpenClosed01, &mut rng);
-                    should_keep < keep_ratio
-                })
-                .collect();
+            let keep_seq: Vec<bool> = (0..total_num_rows).map(|_| rng.gen_bool(keep_ratio)).collect();
 
             group.bench_function(keep_ratio.to_string(), |b| {
                 b.iter_with_large_drop(|| unsafe {
@@ -629,7 +620,7 @@ fn table_extract_one_row(c: &mut Criterion) {
             b.iter_with_large_drop(|| {
                 black_box(
                     black_box(&table)
-                        .get_row_ref(&mut NullBlobStore, black_box(ptr))
+                        .get_row_ref(&NullBlobStore, black_box(ptr))
                         .unwrap()
                         .to_product_value(),
                 )
@@ -731,8 +722,9 @@ fn make_table_with_indexes<R: IndexedRow>() -> Table {
     let schema = R::make_schema();
     let mut tbl = Table::new(schema, SquashedOffset::COMMITTED_STATE);
 
-    let idx = BTreeIndex::new(IndexId(0), false, "idx");
-    tbl.insert_index(&mut NullBlobStore, R::indexed_columns(), idx);
+    let cols = R::indexed_columns();
+    let idx = BTreeIndex::new(IndexId(0), &R::row_type().into(), &cols, false, "idx").unwrap();
+    tbl.insert_index(&NullBlobStore, cols, idx);
 
     tbl
 }
@@ -767,7 +759,7 @@ fn insert_num_same<R: IndexedRow>(
 fn clear_all_same<R: IndexedRow>(tbl: &mut Table, val_same: u64) {
     let ptrs = tbl
         .index_seek(
-            &mut NullBlobStore,
+            &NullBlobStore,
             &R::indexed_columns(),
             &R::column_value_from_u64(val_same),
         )

--- a/crates/table/benches/var_len_visitor.rs
+++ b/crates/table/benches/var_len_visitor.rs
@@ -10,6 +10,7 @@ fn visit_count(row: &[MaybeUninit<u8>], visitor: &impl VarLenMembers) {
     black_box(unsafe { visitor.visit_var_len(row) }.count());
 }
 
+#[allow(clippy::disallowed_macros)]
 fn visitor_program(row_ty: impl Into<ProductType>) -> VarLenVisitorProgram {
     let row_ty: ProductType = row_ty.into();
     let visitor = row_type_visitor(&row_ty.into());


### PR DESCRIPTION
# Description of Changes

This doesn't affect much in practice, but rust-analyzer checks all crate targets by default and it's annoying to see errors in the status bar from something unrelated to what I'm working on.

# Expected complexity level and risk

1
