### PR TITLE
Add `delete_by_{nonunique_column}` method to `#[spacetimedb(table)]`

### DIFF
--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -633,7 +633,7 @@ fn spacetimedb_tabletype_impl(item: syn::DeriveInput) -> syn::Result<TokenStream
 
         unique_delete_funcs.push(quote! {
             #vis fn #delete_func_ident(#column_ident: &#column_type) -> bool {
-                spacetimedb::query::delete_by_field::<Self, #column_type, #column_index>(#column_ident)
+                spacetimedb::query::delete_by_unique_field::<Self, #column_type, #column_index>(#column_ident)
             }
         });
     }
@@ -645,6 +645,7 @@ fn spacetimedb_tabletype_impl(item: syn::DeriveInput) -> syn::Result<TokenStream
         let column_index = column.index;
 
         let filter_func_ident = format_ident!("filter_by_{}", column_ident);
+        let delete_func_ident = format_ident!("delete_by_{}", column_ident);
 
         let skip = if let syn::Type::Path(p) = column_type {
             // TODO: this is janky as heck
@@ -664,6 +665,9 @@ fn spacetimedb_tabletype_impl(item: syn::DeriveInput) -> syn::Result<TokenStream
             // TODO: should we expose spacetimedb::query::FilterByIter ?
             #vis fn #filter_func_ident<'a>(#column_ident: &#column_type) -> impl Iterator<Item = Self> {
                 spacetimedb::query::filter_by_field::<Self, #column_type, #column_index>(#column_ident)
+            }
+            #vis fn #delete_func_ident(#column_ident: &#column_type) -> u32 {
+                spacetimedb::query::delete_by_field::<Self, #column_type, #column_index>(#column_ident)
             }
         })
     });


### PR DESCRIPTION

# Description of Changes

- Refactor `bindings::query::delete_by_field` to require `FilterableValue` and return `u32` count of deleted rows.
- Add `bindings::query::delete_by_unique_field` with the previous behavior of `delete_by_field`, i.e. requiring `UniqueValue` and returning `bool` with `true = deleted`. This is implemented in terms of `delete_by_field`.
- Macro-generated unique filter funcs call `delete_by_unique_field` rather than `delete_by_field`.
- The table macro now generates non-unique delete functions alongside the existing non-unique filter functions for non-unique fields with primitive types.
- Add uses of `::delete_by_{field}` for both unique and non-unique columns to the `rust-wasm-test` module, so we can see that they compile as expected.

Note that this PR does not include any host-side changes; the diff is localized to the `bindings` and `bindings-macro` crates.

Something to think about: it's possible we should not be emitting `filter_by_{field}` or `delete_by_{field}` methods for columns/fields which do not have an index, on the grounds that table scans for filtering are very slow and bad, and a performing such a filter is almost certainly a bug in the module. This PR does not change our existing behavior, which is to generate the methods for any field/column with a filterable type, even if unindexed.

# API and ABI breaking changes

N/A - `bindings::query` is for internal use only and is marked `#[doc(hidden)]`.

# Expected complexity level and risk

1.
