### PR TITLE
Add GitHub workflow to check for PRs with merge-blocking labels

### DIFF
--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -1,0 +1,29 @@
+name: Check merge labels
+
+on:
+  pull_request:
+    types: [labeled, unlabeled]
+  merge_group:
+permissions: read-all
+
+jobs:
+  check_merge_block_label:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'Do not merge') }}
+    runs-on: ubuntu-latest
+    steps:
+    - run: exit 1
+
+  check_future_release_label:
+    if: ${{ contains(github.event.pull_request.labels.*.name, 'release-0.9') }}
+    runs-on: ubuntu-latest
+    steps:
+    - run: exit 1
+
+  check_breaking_change_labels:
+    if: | ${{
+        contains(github.event.pull_request.labels.*.name, 'abi-break') ||
+        contains(github.event.pull_request.labels.*.name, 'breaking change')
+      }}
+    runs-on: ubuntu-latest
+    steps:
+    - run: exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -20,10 +20,11 @@ jobs:
     - run: exit 1
 
   check_breaking_change_labels:
-    if: | ${{
-        contains(github.event.pull_request.labels.*.name, 'abi-break') ||
-        contains(github.event.pull_request.labels.*.name, 'breaking change')
-      }}
+    if: |
+        ${{
+          contains(github.event.pull_request.labels.*.name, 'abi-break') ||
+          contains(github.event.pull_request.labels.*.name, 'breaking change')
+        }}
     runs-on: ubuntu-latest
     steps:
     - run: exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -20,7 +20,8 @@ jobs:
     - run: exit 1
 
   check_breaking_change_labels:
-    if: | ${{
+    if: |
+      ${{
         contains(github.event.pull_request.labels.*.name, 'abi-break') ||
         contains(github.event.pull_request.labels.*.name, 'breaking change')
       }}

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -13,17 +13,21 @@ jobs:
       - id: explicitly_disallowed
         if: |
           contains(github.event.pull_request.labels.*.name, 'do not merge')
-        run: echo "::error::This is labeled \"Do not merge\"." && exit 1
+        run: |
+          echo "This is labeled \"Do not merge\"."
+          exit 1
+
       - id: future_release
         if: |
           contains(github.event.pull_request.labels.*.name, 'release-0.9')
         run: |
-          echo "::error ::This is targeted for a future release." >/dev/stderr
+          echo "This is targeted for a future release."
           exit 1
+
       - id: breaking_change
         if: |
           contains(github.event.pull_request.labels.*.name, 'abi-break') ||
           contains(github.event.pull_request.labels.*.name, 'breaking change')
         run: |
-          echo "::error ::This is a breaking change." >/dev/stderr
+          echo "This is a breaking change."
           exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -7,7 +7,7 @@ on:
 permissions: read-all
 
 jobs:
-  checks:
+  label_checks:
     runs-on: ubuntu-latest
     steps:
       - id: explicitly_disallowed

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -21,7 +21,8 @@ jobs:
 
   check_breaking_change_labels:
     if: |
-      contains(github.event.pull_request.labels.*.name, 'abi-break')
+      contains(github.event.pull_request.labels.*.name, 'abi-break') ||
+      contains(github.event.pull_request.labels.*.name, 'breaking change')
     runs-on: ubuntu-latest
     steps:
     - run: exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -7,22 +7,12 @@ on:
 permissions: read-all
 
 jobs:
-  Check merge labels:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'Do not merge') }}
-    runs-on: ubuntu-latest
-    steps:
-    - run: exit 1
-
-  check_future_release_label:
-    if: ${{ contains(github.event.pull_request.labels.*.name, 'release-0.9') }}
-    runs-on: ubuntu-latest
-    steps:
-    - run: exit 1
-
-  check_breaking_change_labels:
+  check:
     if: |
       contains(github.event.pull_request.labels.*.name, 'abi-break') ||
-      contains(github.event.pull_request.labels.*.name, 'breaking change')
+      contains(github.event.pull_request.labels.*.name, 'breaking change') ||
+      contains(github.event.pull_request.labels.*.name, 'Do not merge') ||
+      contains(github.event.pull_request.labels.*.name, 'release-0.9')
     runs-on: ubuntu-latest
     steps:
     - run: exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -10,24 +10,9 @@ jobs:
   label_checks:
     runs-on: ubuntu-latest
     steps:
-      - id: explicitly_disallowed
+      - id: manually_blocked
         if: |
           contains(github.event.pull_request.labels.*.name, 'do not merge')
         run: |
           echo "This is labeled \"Do not merge\"."
-          exit 1
-
-      - id: future_release
-        if: |
-          contains(github.event.pull_request.labels.*.name, 'release-0.9')
-        run: |
-          echo "This is targeted for a future release."
-          exit 1
-
-      - id: breaking_change
-        if: |
-          contains(github.event.pull_request.labels.*.name, 'abi-break') ||
-          contains(github.event.pull_request.labels.*.name, 'breaking change')
-        run: |
-          echo "This is a breaking change."
           exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -7,7 +7,7 @@ on:
 permissions: read-all
 
 jobs:
-  check_merge_block_label:
+  Check merge labels:
     if: ${{ contains(github.event.pull_request.labels.*.name, 'Do not merge') }}
     runs-on: ubuntu-latest
     steps:

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -7,16 +7,19 @@ on:
 permissions: read-all
 
 jobs:
-  check:
+  checks:
     runs-on: ubuntu-latest
     steps:
-      - if: |
+      - id: explicitly_disallowed
+        if: |
           contains(github.event.pull_request.labels.*.name, 'do not merge')
         run: echo "::error::This is labeled \"Do not merge\"." && exit 1
-      - if: |
+      - id: future_release
+        if: |
           contains(github.event.pull_request.labels.*.name, 'release-0.9')
         run: echo "::error::This is targeted for a future release." && exit 1
-      - if: |
+      - id: breaking_change
+        if: |
           contains(github.event.pull_request.labels.*.name, 'abi-break') ||
           contains(github.event.pull_request.labels.*.name, 'breaking change')
         run: echo "::error::This is a breaking change." && exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -21,10 +21,7 @@ jobs:
 
   check_breaking_change_labels:
     if: |
-        ${{
-          contains(github.event.pull_request.labels.*.name, 'abi-break') ||
-          contains(github.event.pull_request.labels.*.name, 'breaking change')
-        }}
+        ${{ contains(github.event.pull_request.labels.*.name, 'abi-break') }}
     runs-on: ubuntu-latest
     steps:
     - run: exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -20,9 +20,10 @@ jobs:
     - run: exit 1
 
   check_breaking_change_labels:
-    if: |
-      ${{ contains(github.event.pull_request.labels.*.name, 'abi-break') ||
-        contains(github.event.pull_request.labels.*.name, 'breaking change') }}
+    if: | ${{
+        contains(github.event.pull_request.labels.*.name, 'abi-break') ||
+        contains(github.event.pull_request.labels.*.name, 'breaking change')
+      }}
     runs-on: ubuntu-latest
     steps:
     - run: exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -8,11 +8,15 @@ permissions: read-all
 
 jobs:
   check:
-    if: |
-      contains(github.event.pull_request.labels.*.name, 'abi-break') ||
-      contains(github.event.pull_request.labels.*.name, 'breaking change') ||
-      contains(github.event.pull_request.labels.*.name, 'Do not merge') ||
-      contains(github.event.pull_request.labels.*.name, 'release-0.9')
     runs-on: ubuntu-latest
     steps:
-    - run: exit 1
+      - if: |
+          contains(github.event.pull_request.labels.*.name, 'do not merge')
+        run: echo "::error::This is labeled \"Do not merge\"." && exit 1
+      - if: |
+          contains(github.event.pull_request.labels.*.name, 'release-0.9')
+        run: echo "::error::This is targeted for a future release." && exit 1
+      - if: |
+          contains(github.event.pull_request.labels.*.name, 'abi-break') ||
+          contains(github.event.pull_request.labels.*.name, 'breaking change')
+        run: echo "::error::This is a breaking change." && exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -22,4 +22,6 @@ jobs:
         if: |
           contains(github.event.pull_request.labels.*.name, 'abi-break') ||
           contains(github.event.pull_request.labels.*.name, 'breaking change')
-        run: echo "::error::This is a breaking change." && exit 1
+        run: |
+          echo "::error ::This is a breaking change." >/dev/stderr
+          exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -21,7 +21,7 @@ jobs:
 
   check_breaking_change_labels:
     if: |
-        ${{ contains(github.event.pull_request.labels.*.name, 'abi-break') }}
+      contains(github.event.pull_request.labels.*.name, 'abi-break')
     runs-on: ubuntu-latest
     steps:
     - run: exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -17,7 +17,9 @@ jobs:
       - id: future_release
         if: |
           contains(github.event.pull_request.labels.*.name, 'release-0.9')
-        run: echo "::error::This is targeted for a future release." && exit 1
+        run: |
+          echo "::error ::This is targeted for a future release." >/dev/stderr
+          exit 1
       - id: breaking_change
         if: |
           contains(github.event.pull_request.labels.*.name, 'abi-break') ||

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -21,10 +21,8 @@ jobs:
 
   check_breaking_change_labels:
     if: |
-      ${{
-        contains(github.event.pull_request.labels.*.name, 'abi-break') ||
-        contains(github.event.pull_request.labels.*.name, 'breaking change')
-      }}
+      ${{ contains(github.event.pull_request.labels.*.name, 'abi-break') ||
+        contains(github.event.pull_request.labels.*.name, 'breaking change') }}
     runs-on: ubuntu-latest
     steps:
     - run: exit 1


### PR DESCRIPTION
# Description of Changes
Added a GitHub workflow to check for PRs with a `Do not merge` label, for ad-hoc PR blocking.

**Note:** A repo admin must [make this](https://github.com/clockworklabs/SpacetimeDB/settings/branches) a merge-blocking check!

# API and ABI breaking changes
No runtime changes.

# Expected complexity level and risk
1