### PR TITLE
Adds an isolation_level argument to begin_mut_tx calls

### DIFF
--- a/crates/client-api/src/routes/tracelog.rs
+++ b/crates/client-api/src/routes/tracelog.rs
@@ -86,7 +86,7 @@ pub async fn perform_tracelog_replay(body: Bytes) -> axum::response::Result<impl
     );
     let iv = InstanceEnv::new(dbic, Scheduler::dummy(&tmp_dir.path().join("scheduler")), None);
 
-    let tx = iv.dbic.relational_db.begin_mut_tx();
+    let tx = iv.dbic.relational_db.begin_mut_tx(IsolationLevel::Serializable);
 
     let (_, resp_body) = iv.tx.set(tx, || replay_report(&iv, &mut &body[..]));
 

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -125,6 +125,7 @@ pub fn run(db: &RelationalDB, sql_text: &str, auth: AuthCtx) -> Result<Vec<MemTa
 pub(crate) mod tests {
     use super::*;
     use crate::db::datastore::system_tables::{ST_TABLES_ID, ST_TABLES_NAME};
+    use crate::db::datastore::traits::IsolationLevel;
     use crate::db::relational_db::tests_utils::make_test_db;
     use crate::vm::tests::create_table_with_rows;
     use itertools::Itertools;
@@ -144,7 +145,7 @@ pub(crate) mod tests {
     fn create_data(total_rows: u64) -> ResultTest<(RelationalDB, MemTable, TempDir)> {
         let (db, tmp_dir) = make_test_db()?;
 
-        let mut tx = db.begin_mut_tx();
+        let mut tx = db.begin_mut_tx(IsolationLevel::Serializable);
         let head = ProductType::from([("inventory_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
         let rows: Vec<_> = (1..=total_rows).map(|i| product!(i, format!("health{i}"))).collect();
         create_table_with_rows(&db, &mut tx, "inventory", head.clone(), &rows)?;
@@ -368,7 +369,7 @@ pub(crate) mod tests {
 
         let (db, _tmp_dir) = make_test_db()?;
 
-        let mut tx = db.begin_mut_tx();
+        let mut tx = db.begin_mut_tx(IsolationLevel::Serializable);
         create_table_with_rows(
             &db,
             &mut tx,

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -596,6 +596,7 @@ pub(crate) mod tests {
         StIndexFields, StIndexRow, StSequenceFields, StSequenceRow, StTableFields, StTableRow, ST_COLUMNS_ID,
         ST_COLUMNS_NAME, ST_INDEXES_NAME, ST_SEQUENCES_ID, ST_SEQUENCES_NAME, ST_TABLES_ID, ST_TABLES_NAME,
     };
+    use crate::db::datastore::traits::IsolationLevel;
     use crate::db::relational_db::tests_utils::make_test_db;
     use crate::execution_context::ExecutionContext;
     use spacetimedb_lib::error::ResultTest;
@@ -660,7 +661,7 @@ pub(crate) mod tests {
     fn test_db_query() -> ResultTest<()> {
         let (stdb, _tmp_dir) = make_test_db()?;
 
-        let mut tx = stdb.begin_mut_tx();
+        let mut tx = stdb.begin_mut_tx(IsolationLevel::Serializable);
         let ctx = ExecutionContext::default();
         let tx_mode = &mut TxMode::MutTx(&mut tx);
         let p = &mut DbProgram::new(&ctx, &stdb, tx_mode, AuthCtx::for_testing());
@@ -710,7 +711,7 @@ pub(crate) mod tests {
     fn test_query_catalog_tables() -> ResultTest<()> {
         let (stdb, _tmp_dir) = make_test_db()?;
 
-        let mut tx = stdb.begin_mut_tx();
+        let mut tx = stdb.begin_mut_tx(IsolationLevel::Serializable);
         let ctx = ExecutionContext::default();
         let tx_mode = &mut TxMode::MutTx(&mut tx);
         let p = &mut DbProgram::new(&ctx, &stdb, tx_mode, AuthCtx::for_testing());
@@ -743,7 +744,7 @@ pub(crate) mod tests {
     fn test_query_catalog_columns() -> ResultTest<()> {
         let (stdb, _tmp_dir) = make_test_db()?;
 
-        let mut tx = stdb.begin_mut_tx();
+        let mut tx = stdb.begin_mut_tx(IsolationLevel::Serializable);
         let ctx = ExecutionContext::default();
         let tx_mode = &mut TxMode::MutTx(&mut tx);
         let p = &mut DbProgram::new(&ctx, &stdb, tx_mode, AuthCtx::for_testing());
@@ -785,12 +786,12 @@ pub(crate) mod tests {
         let head = ProductType::from([("inventory_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
         let row = product!(1u64, "health");
 
-        let mut tx = db.begin_mut_tx();
+        let mut tx = db.begin_mut_tx(IsolationLevel::Serializable);
         let ctx = ExecutionContext::default();
         let table_id = create_table_with_rows(&db, &mut tx, "inventory", head, &[row])?;
         db.commit_tx(&ctx, tx)?;
 
-        let mut tx = db.begin_mut_tx();
+        let mut tx = db.begin_mut_tx(IsolationLevel::Serializable);
         let index = IndexDef::btree("idx_1".into(), ColId(0), true);
         let index_id = db.create_index(&mut tx, table_id, index)?;
         let tx_mode = &mut TxMode::MutTx(&mut tx);
@@ -826,7 +827,7 @@ pub(crate) mod tests {
     fn test_query_catalog_sequences() -> ResultTest<()> {
         let (db, _tmp_dir) = make_test_db()?;
 
-        let mut tx = db.begin_mut_tx();
+        let mut tx = db.begin_mut_tx(IsolationLevel::Serializable);
         let ctx = ExecutionContext::default();
         let tx_mode = &mut TxMode::MutTx(&mut tx);
         let p = &mut DbProgram::new(&ctx, &db, tx_mode, AuthCtx::for_testing());


### PR DESCRIPTION
# Description of Changes

This adds an `isolation_level` argument to mutable transactions. This is currently unused and ignored by our datastore implementation as it already guarantees the highest isolation level, serializability. However, I am adding this in in preparation for introducing an implementation for a slightly weaker `Snapshot` isolation implementation that will allow for parallel execution of queries.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

2
