### PR TITLE
Adds a test to ensure that dropping a table is transactional

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -1565,6 +1565,27 @@ mod tests {
         Ok(())
     }
 
+    #[test]
+    fn test_drop_table_is_transactional() -> ResultTest<()> {
+        let (datastore, mut tx, table_id) = setup_table()?;
+
+        let row = u32_str_u32(0, "Foo", 18); // 0 will be ignored.
+        datastore.insert_mut_tx(&mut tx, table_id, row)?;
+        datastore.commit_mut_tx_for_test(tx)?;
+
+        let mut tx = datastore.begin_mut_tx();
+        let result = datastore.drop_table_mut_tx(&mut tx, table_id);
+        assert!(result.is_ok());
+
+        let ctx = ExecutionContext::default();
+        datastore.rollback_mut_tx(&ctx, tx);
+
+        let tx = datastore.begin_mut_tx();
+        assert_eq!(datastore.table_id_exists_mut_tx(&tx, &table_id), true, "Table should still exist");
+
+        Ok(())
+    }
+
     // TODO: Add the following tests
     // - Create index with unique constraint and immediately insert a row that violates the constraint before committing.
     // - Create a tx that inserts 2000 rows with an autoinc column


### PR DESCRIPTION
# Description of Changes

This adds a test to ensure that dropping a table is transactional and can be rolled back.

This is currently failing and should be made to pass.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

1
