### PR TITLE
Set name for Rayon threads

### DIFF
--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -29,6 +29,7 @@ impl HostThreadpool {
     fn new() -> Self {
         let rt = tokio::runtime::Handle::current();
         let inner = rayon_core::ThreadPoolBuilder::new()
+            .thread_name(|_idx| "rayon-worker".to_string())
             .num_threads(std::thread::available_parallelism().unwrap().get() * 2)
             .spawn_handler(move |thread| {
                 rt.spawn_blocking(|| thread.run());


### PR DESCRIPTION
# Description of Changes

Set a name for Rayon threads, so that they don't inherit their thread names from the parent, i.e. `tokio-runtime-w`.

Use the same name for all Rayon threads, i.e. ignore the thread-index, so that tools like `perf` can merge all the Rayon threads into a single backtrace.


# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
