### PR TITLE
auth.rs changes from #735

### DIFF
--- a/crates/client-api/src/auth.rs
+++ b/crates/client-api/src/auth.rs
@@ -1,11 +1,9 @@
-use std::fmt::Write;
 use std::time::Duration;
 
 use axum::extract::Query;
 use axum::response::IntoResponse;
-use axum_extra::typed_header::{TypedHeader, TypedHeaderRejection, TypedHeaderRejectionReason};
-use bytes::BytesMut;
-use headers::authorization::{self, Credentials};
+use axum_extra::typed_header::TypedHeader;
+use headers::{authorization, HeaderMapExt};
 use http::{request, HeaderValue, StatusCode};
 use serde::Deserialize;
 use spacetimedb::auth::identity::{
@@ -27,7 +25,10 @@ use crate::{log_and_500, ControlStateDelegate, NodeDelegate};
 // For now, the basic auth header must be in this form:
 // Basic base64(token:$token_str)
 // where $token_str is the JWT that is aquired from SpacetimeDB when creating a new identity.
-pub struct SpacetimeCreds(authorization::Basic);
+#[derive(Clone, Deserialize)]
+pub struct SpacetimeCreds {
+    token: String,
+}
 
 const TOKEN_USERNAME: &str = "token";
 impl authorization::Credentials for SpacetimeCreds {
@@ -37,128 +38,47 @@ impl authorization::Credentials for SpacetimeCreds {
         if basic.username() != TOKEN_USERNAME {
             return None;
         }
-        Some(Self(basic))
+        let token = basic.password().to_owned();
+        Some(Self { token })
     }
     fn encode(&self) -> HeaderValue {
-        self.0.encode()
+        headers::Authorization::basic(TOKEN_USERNAME, &self.token).0.encode()
     }
 }
 
 impl SpacetimeCreds {
     pub fn token(&self) -> &str {
-        self.0.password()
+        &self.token
     }
     pub fn decode_token(&self, public_key: &DecodingKey) -> Result<SpacetimeIdentityClaims, JwtError> {
         decode_token(public_key, self.token()).map(|x| x.claims)
     }
     pub fn encode_token(private_key: &EncodingKey, identity: Identity) -> Result<Self, JwtError> {
         let token = encode_token(private_key, identity)?;
-        let headers::Authorization(basic) = headers::Authorization::basic(TOKEN_USERNAME, &token);
-        Ok(Self(basic))
+        Ok(Self { token })
+    }
+
+    fn from_request_parts(parts: &request::Parts) -> Result<Option<Self>, headers::Error> {
+        let res = match parts.headers.typed_try_get::<headers::Authorization<Self>>() {
+            Ok(Some(headers::Authorization(creds))) => return Ok(Some(creds)),
+            Ok(None) => Ok(()),
+            Err(e) => Err(e),
+        };
+        if let Ok(Query(creds)) = Query::<Self>::try_from_uri(&parts.uri) {
+            return Ok(Some(creds));
+        }
+        res.map(|()| None)
     }
 }
 
+/// The auth information in a request.
+///
+/// This is inserted as an extension by [`auth_middleware`]; make sure that's applied if you're making expecting
+/// this to be present.
+#[derive(Clone)]
 pub struct SpacetimeAuth {
     pub creds: SpacetimeCreds,
     pub identity: Identity,
-}
-
-pub struct SpacetimeAuthHeader {
-    pub auth: Option<SpacetimeAuth>,
-}
-
-#[derive(Deserialize)]
-pub struct TokenQueryParam {
-    token: String,
-}
-
-#[async_trait::async_trait]
-impl<S: NodeDelegate + Send + Sync> axum::extract::FromRequestParts<S> for SpacetimeAuthHeader {
-    type Rejection = AuthorizationRejection;
-    async fn from_request_parts(parts: &mut request::Parts, state: &S) -> Result<Self, Self::Rejection> {
-        match (
-            TypedHeader::from_request_parts(parts, state).await,
-            Query::<TokenQueryParam>::from_request_parts(parts, state).await,
-        ) {
-            (Ok(TypedHeader(headers::Authorization(creds @ SpacetimeCreds { .. }))), _) => {
-                let claims = creds
-                    .decode_token(state.public_key())
-                    .map_err(|e| AuthorizationRejection {
-                        reason: AuthorizationRejectionReason::Jwt(e.into_kind()),
-                    })?;
-                let auth = SpacetimeAuth {
-                    creds,
-                    identity: claims.identity,
-                };
-                Ok(Self { auth: Some(auth) })
-            }
-            (_, Ok(Query(query))) => {
-                let header =
-                    HeaderValue::from_str(&format!("Basic {}", query.token)).map_err(|_| AuthorizationRejection {
-                        reason: AuthorizationRejectionReason::MalformedTokenQueryString,
-                    })?;
-                let creds = SpacetimeCreds(authorization::Basic::decode(&header).ok_or(AuthorizationRejection {
-                    reason: AuthorizationRejectionReason::CantDecodeAuthorizationToken,
-                })?);
-                let claims = creds
-                    .decode_token(state.public_key())
-                    .map_err(|e| AuthorizationRejection {
-                        reason: AuthorizationRejectionReason::Jwt(e.into_kind()),
-                    })?;
-                let auth = SpacetimeAuth {
-                    creds,
-                    identity: claims.identity,
-                };
-                Ok(Self { auth: Some(auth) })
-            }
-            (Err(e), Err(_)) => match e.reason() {
-                // Leave it to handlers to decide on unauthorized requests.
-                TypedHeaderRejectionReason::Missing => Ok(Self { auth: None }),
-                _ => Err(AuthorizationRejection {
-                    reason: AuthorizationRejectionReason::Header(e),
-                }),
-            },
-        }
-    }
-}
-
-/// A response by the API signifying that an authorization was rejected with the `reason` for this.
-pub struct AuthorizationRejection {
-    /// The reason the authorization was rejected.
-    reason: AuthorizationRejectionReason,
-}
-
-impl IntoResponse for AuthorizationRejection {
-    fn into_response(self) -> axum::response::Response {
-        // Most likely, the server key was rotated.
-        const ROTATED: (StatusCode, &str) = (
-            StatusCode::UNAUTHORIZED,
-            "Authorization failed: token not signed by this instance",
-        );
-        // The JWT is malformed, see SpacetimeCreds for specifics on the format.
-        const INVALID: (StatusCode, &str) = (StatusCode::BAD_REQUEST, "Authorization is invalid: malformed token");
-        // Sensible fallback if no auth header is present.
-        const REQUIRED: (StatusCode, &str) = (StatusCode::UNAUTHORIZED, "Authorization required");
-
-        log::trace!("Authorization rejection: {:?}", self.reason);
-
-        match self.reason {
-            AuthorizationRejectionReason::Jwt(JwtErrorKind::InvalidSignature) => ROTATED.into_response(),
-            AuthorizationRejectionReason::Header(rejection) => match rejection.reason() {
-                TypedHeaderRejectionReason::Missing => REQUIRED.into_response(),
-                _ => rejection.into_response(),
-            },
-            _ => INVALID.into_response(),
-        }
-    }
-}
-
-#[derive(Debug)]
-enum AuthorizationRejectionReason {
-    Jwt(JwtErrorKind),
-    Header(TypedHeaderRejection),
-    MalformedTokenQueryString,
-    CantDecodeAuthorizationToken,
 }
 
 impl SpacetimeAuth {
@@ -177,6 +97,56 @@ impl SpacetimeAuth {
     }
 }
 
+pub struct SpacetimeAuthHeader {
+    pub auth: Option<SpacetimeAuth>,
+}
+
+#[async_trait::async_trait]
+impl<S: NodeDelegate + Send + Sync> axum::extract::FromRequestParts<S> for SpacetimeAuthHeader {
+    type Rejection = AuthorizationRejection;
+    async fn from_request_parts(parts: &mut request::Parts, state: &S) -> Result<Self, Self::Rejection> {
+        let Some(creds) = SpacetimeCreds::from_request_parts(parts)? else {
+            return Ok(Self { auth: None });
+        };
+        let claims = creds.decode_token(state.public_key())?;
+        let auth = SpacetimeAuth {
+            creds,
+            identity: claims.identity,
+        };
+        Ok(Self { auth: Some(auth) })
+    }
+}
+
+/// A response by the API signifying that an authorization was rejected with the `reason` for this.
+#[derive(Debug, derive_more::From)]
+pub enum AuthorizationRejection {
+    Jwt(JwtError),
+    Header(headers::Error),
+    Required,
+}
+
+impl IntoResponse for AuthorizationRejection {
+    fn into_response(self) -> axum::response::Response {
+        // Most likely, the server key was rotated.
+        const ROTATED: (StatusCode, &str) = (
+            StatusCode::UNAUTHORIZED,
+            "Authorization failed: token not signed by this instance",
+        );
+        // The JWT is malformed, see SpacetimeCreds for specifics on the format.
+        const INVALID: (StatusCode, &str) = (StatusCode::BAD_REQUEST, "Authorization is invalid: malformed token");
+        // Sensible fallback if no auth header is present.
+        const REQUIRED: (StatusCode, &str) = (StatusCode::UNAUTHORIZED, "Authorization required");
+
+        log::trace!("Authorization rejection: {:?}", self);
+
+        match self {
+            AuthorizationRejection::Jwt(e) if *e.kind() == JwtErrorKind::InvalidSignature => ROTATED.into_response(),
+            AuthorizationRejection::Jwt(_) | AuthorizationRejection::Header(_) => INVALID.into_response(),
+            AuthorizationRejection::Required => REQUIRED.into_response(),
+        }
+    }
+}
+
 impl SpacetimeAuthHeader {
     pub fn get(self) -> Option<SpacetimeAuth> {
         self.auth
@@ -188,7 +158,7 @@ impl SpacetimeAuthHeader {
         self,
         ctx: &(impl NodeDelegate + ControlStateDelegate + ?Sized),
     ) -> axum::response::Result<SpacetimeAuth> {
-        match self.get() {
+        match self.auth {
             Some(auth) => Ok(auth),
             None => SpacetimeAuth::alloc(ctx).await,
         }
@@ -239,9 +209,9 @@ impl headers::Header for SpacetimeEnergyUsed {
     }
 
     fn encode<E: Extend<HeaderValue>>(&self, values: &mut E) {
-        let mut buf = BytesMut::new();
-        let _ = buf.write_str(itoa::Buffer::new().format(self.0.get()));
-        values.extend([HeaderValue::from_bytes(&buf).unwrap()]);
+        let mut buf = itoa::Buffer::new();
+        let value = buf.format(self.0.get());
+        values.extend([value.try_into().unwrap()]);
     }
 }
 


### PR DESCRIPTION
# Description of Changes
Splitting apart PRs, i.e. shamelessly stealing [Noa's `auth.rs` changes](https://github.com/clockworklabs/SpacetimeDB/pull/735/files#diff-23546b6cfa82e6d6b9c2a74081ce1d77dbf7fa0cd512532c3fe3fc50417707e6)) from #735.

# API and ABI breaking changes
No. **This is expected to not change any user-facing behavior**.

# Expected complexity level and risk
2?