### PR TITLE
Revert "Run initial subscriptions evals on rayon"

### DIFF
--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -166,10 +166,9 @@ impl ClientConnection {
 
     pub async fn subscribe(&self, subscription: Subscribe) -> Result<(), DBError> {
         let me = self.clone();
-        self.module
-            .threadpool()
-            .spawn_task(move || me.module.subscriptions().add_subscriber(me.sender, subscription))
+        tokio::task::spawn_blocking(move || me.module.subscriptions().add_subscriber(me.sender, subscription))
             .await
+            .unwrap()
     }
 
     pub async fn one_off_query(&self, query: &str, message_id: &[u8]) -> Result<(), anyhow::Error> {

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -39,7 +39,7 @@ impl ModuleSubscriptions {
 
     /// Add a subscriber to the module. NOTE: this function is blocking.
     pub fn add_subscriber(&self, sender: ClientConnectionSender, subscription: Subscribe) -> Result<(), DBError> {
-        let tx = scopeguard::guard(self.relational_db.begin_tx(), |tx| {
+        let tx = &mut *scopeguard::guard(self.relational_db.begin_tx(), |tx| {
             let ctx = ExecutionContext::subscribe(self.relational_db.address());
             self.relational_db.release_tx(&ctx, tx);
         });
@@ -47,16 +47,15 @@ impl ModuleSubscriptions {
         let auth = AuthCtx::new(self.owner_identity, sender.id.identity);
         let mut queries = QuerySet::new();
         for sql in subscription.query_strings {
-            let qset = compile_read_only_query(&self.relational_db, &tx, &auth, &sql)?;
+            let qset = compile_read_only_query(&self.relational_db, tx, &auth, &sql)?;
             queries.extend(qset);
         }
 
-        let database_update = queries.eval(&self.relational_db, &tx, auth)?;
+        let database_update = tokio::task::block_in_place(|| queries.eval(&self.relational_db, tx, auth))?;
         // It acquires the subscription lock after `eval`, allowing `add_subscription` to run concurrently.
         // This also makes it possible for `broadcast_event` to get scheduled before the subsequent part here
         // but that should not pose an issue.
         let mut subscriptions = self.subscriptions.write();
-        drop(tx);
         self._remove_subscriber(sender.id, &mut subscriptions);
         let subscription = match subscriptions.iter_mut().find(|s| s.queries == queries) {
             Some(sub) => {


### PR DESCRIPTION
Reverts clockworklabs/SpacetimeDB#888 due to a deadlocking issue with multiple clients connected.