### PR TITLE
VM: Wrap `Header` in `Arc` to avoid cloning

### DIFF
--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -205,7 +205,7 @@ impl ServerMessage for OneOffQueryResponseMessage {
                 .results
                 .into_iter()
                 .map(|table| OneOffTableJson {
-                    table_name: table.head.table_name,
+                    table_name: table.head.table_name.clone(),
                     rows: table.data,
                 })
                 .collect(),
@@ -221,7 +221,7 @@ impl ServerMessage for OneOffQueryResponseMessage {
                     .results
                     .into_iter()
                     .map(|table| OneOffTable {
-                        table_name: table.head.table_name,
+                        table_name: table.head.table_name.clone(),
                         row: table
                             .data
                             .into_iter()

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -10,6 +10,7 @@ use spacetimedb_vm::dsl::{db_table, db_table_raw, query};
 use spacetimedb_vm::expr::{ColumnOp, CrudExpr, DbType, Expr, QueryExpr, SourceExpr};
 use spacetimedb_vm::operator::OpCmp;
 use std::collections::HashMap;
+use std::sync::Arc;
 
 use super::ast::TableSchemaView;
 
@@ -182,7 +183,7 @@ fn compile_columns(table: &TableSchema, columns: Vec<FieldName>) -> DbTable {
         }
     }
     DbTable::new(
-        Header::new(table.table_name.clone(), new, table.get_constraints()),
+        Arc::new(Header::new(table.table_name.clone(), new, table.get_constraints())),
         table.table_id,
         table.table_type,
         table.table_access,

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -133,7 +133,7 @@ pub(crate) mod tests {
     use spacetimedb_sats::relation::Header;
     use spacetimedb_sats::{product, AlgebraicType, ProductType};
     use spacetimedb_vm::dsl::{mem_table, scalar};
-    use spacetimedb_vm::eval::create_game_data;
+    use spacetimedb_vm::eval::test_data::create_game_data;
     use tempfile::TempDir;
 
     /// Short-cut for simplify test execution
@@ -369,9 +369,27 @@ pub(crate) mod tests {
         let (db, _tmp_dir) = make_test_db()?;
 
         let mut tx = db.begin_mut_tx(IsolationLevel::Serializable);
-        create_table_with_rows(&db, &mut tx, "Inventory", data.inv.head.into(), &data.inv.data)?;
-        create_table_with_rows(&db, &mut tx, "Player", data.player.head.into(), &data.player.data)?;
-        create_table_with_rows(&db, &mut tx, "Location", data.location.head.into(), &data.location.data)?;
+        create_table_with_rows(
+            &db,
+            &mut tx,
+            "Inventory",
+            data.inv.head.to_product_type(),
+            &data.inv.data,
+        )?;
+        create_table_with_rows(
+            &db,
+            &mut tx,
+            "Player",
+            data.player.head.to_product_type(),
+            &data.player.data,
+        )?;
+        create_table_with_rows(
+            &db,
+            &mut tx,
+            "Location",
+            data.location.head.to_product_type(),
+            &data.location.data,
+        )?;
         db.commit_tx(&ExecutionContext::default(), tx)?;
 
         let result = &run_for_testing(

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -27,6 +27,7 @@ use anyhow::Context;
 use derive_more::{Deref, DerefMut, From, IntoIterator};
 use std::collections::{btree_set, BTreeSet, HashMap, HashSet};
 use std::ops::Deref;
+use std::sync::Arc;
 use std::time::Instant;
 
 use crate::db::db_metrics::{DB_METRICS, MAX_QUERY_CPU_TIME};
@@ -681,7 +682,7 @@ impl<'a> IncrementalJoin<'a> {
 /// Replace an [IndexJoin]'s scan or fetch operation with a delta table.
 /// A delta table consists purely of updates or changes to the base table.
 fn with_delta_table(mut join: IndexJoin, index_side: bool, delta: DatabaseTableUpdate) -> IndexJoin {
-    fn to_mem_table(head: Header, table_access: StAccess, delta: DatabaseTableUpdate) -> MemTable {
+    fn to_mem_table(head: Arc<Header>, table_access: StAccess, delta: DatabaseTableUpdate) -> MemTable {
         MemTable::new(
             head,
             table_access,

--- a/crates/sats/src/db/def.rs
+++ b/crates/sats/src/db/def.rs
@@ -1,6 +1,7 @@
 use derive_more::Display;
 use itertools::Itertools;
 use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
 
 use crate::db::auth::{StAccess, StTableType};
 use crate::db::error::{DefType, SchemaError};
@@ -938,7 +939,12 @@ impl From<&TableSchema> for ProductType {
 
 impl From<&TableSchema> for DbTable {
     fn from(value: &TableSchema) -> Self {
-        DbTable::new(value.into(), value.table_id, value.table_type, value.table_access)
+        DbTable::new(
+            Arc::new(value.into()),
+            value.table_id,
+            value.table_type,
+            value.table_access,
+        )
     }
 }
 

--- a/crates/sats/src/relation.rs
+++ b/crates/sats/src/relation.rs
@@ -8,6 +8,7 @@ use spacetimedb_primitives::{ColId, ColList, ColListBuilder, Constraints, TableI
 use std::collections::hash_map::DefaultHasher;
 use std::fmt;
 use std::hash::{Hash, Hasher};
+use std::sync::Arc;
 
 pub fn calculate_hash<T: Hash>(t: &T) -> u64 {
     let mut s = DefaultHasher::new();
@@ -15,7 +16,7 @@ pub fn calculate_hash<T: Hash>(t: &T) -> u64 {
     s.finish()
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub struct TableField<'a> {
     pub table: Option<&'a str>,
     pub field: &'a str,
@@ -34,7 +35,7 @@ pub fn extract_table_field(ident: &str) -> Result<TableField, RelationError> {
     }
 }
 
-#[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
+#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum FieldOnly<'a> {
     Name(&'a str),
     Pos(usize),
@@ -53,6 +54,7 @@ impl fmt::Display for FieldOnly<'_> {
     }
 }
 
+// TODO(perf): Remove `Clone` derivation.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum FieldName {
     Name { table: String, field: String },
@@ -101,6 +103,7 @@ impl FieldName {
     }
 }
 
+// TODO(perf): Remove `Clone` derivation.
 #[derive(Debug, Clone, PartialEq, PartialOrd, Eq, Ord, Hash, From)]
 pub enum FieldExpr {
     Name(FieldName),
@@ -135,12 +138,13 @@ impl fmt::Display for FieldExpr {
     }
 }
 
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ColumnOnlyField<'a> {
     pub field: FieldOnly<'a>,
     pub algebraic_type: &'a AlgebraicType,
 }
 
+// TODO(perf): Remove `Clone` derivation.
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Column {
     pub field: FieldName,
@@ -165,12 +169,13 @@ impl Column {
     }
 }
 
+// TODO(perf): Remove `Clone` impl.
 #[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord)]
 pub struct HeaderOnlyField<'a> {
     pub fields: Vec<ColumnOnlyField<'a>>,
 }
 
-#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord, Hash)]
 pub struct Header {
     pub table_name: String,
     pub fields: Vec<Column>,
@@ -183,6 +188,20 @@ impl Header {
             table_name,
             fields,
             constraints,
+        }
+    }
+
+    /// Equivalent to what [`Clone::clone`] would do.
+    ///
+    /// `Header` intentionally does not implement `Clone`,
+    /// as we can't afford to clone it in normal execution paths.
+    /// However, we don't care about performance in error paths,
+    /// and we need to embed owned `Header`s in error objects to report useful messages.
+    pub fn clone_for_error(&self) -> Self {
+        Header {
+            table_name: self.table_name.clone(),
+            fields: self.fields.clone(),
+            constraints: self.constraints.clone(),
         }
     }
 
@@ -207,6 +226,14 @@ impl Header {
             .collect();
 
         Self::new(table_name, cols, Default::default())
+    }
+
+    pub fn to_product_type(&self) -> ProductType {
+        ProductType::from_iter(
+            self.fields.iter().map(|x| {
+                ProductTypeElement::new(x.algebraic_type.clone(), x.field.field_name().map(ToString::to_string))
+            }),
+        )
     }
 
     pub fn for_mem_table(fields: ProductType) -> Self {
@@ -246,7 +273,7 @@ impl Header {
 
     pub fn column_pos_or_err<'a>(&'a self, col: &'a FieldName) -> Result<ColId, RelationError> {
         self.column_pos(col)
-            .ok_or_else(|| RelationError::FieldNotFound(self.clone(), col.clone()))
+            .ok_or_else(|| RelationError::FieldNotFound(self.clone_for_error(), col.clone()))
     }
 
     /// Finds the position of a field with `name`.
@@ -419,7 +446,7 @@ impl RowCount {
 /// A [Relation] is anything that could be represented as a [Header] of `[ColumnName:ColumnType]` that
 /// generates rows/tuples of [AlgebraicValue] that exactly match that [Header].
 pub trait Relation {
-    fn head(&self) -> &Header;
+    fn head(&self) -> &Arc<Header>;
     /// Specify the size in rows of the [Relation].
     ///
     /// Warning: It should at least be precise in the lower-bound estimate.
@@ -429,14 +456,14 @@ pub trait Relation {
 /// A stored table from [RelationalDB]
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, Hash)]
 pub struct DbTable {
-    pub head: Header,
+    pub head: Arc<Header>,
     pub table_id: TableId,
     pub table_type: StTableType,
     pub table_access: StAccess,
 }
 
 impl DbTable {
-    pub fn new(head: Header, table_id: TableId, table_type: StTableType, table_access: StAccess) -> Self {
+    pub fn new(head: Arc<Header>, table_id: TableId, table_type: StTableType, table_access: StAccess) -> Self {
         Self {
             head,
             table_id,
@@ -447,7 +474,7 @@ impl DbTable {
 }
 
 impl Relation for DbTable {
-    fn head(&self) -> &Header {
+    fn head(&self) -> &Arc<Header> {
         &self.head
     }
 
@@ -489,20 +516,20 @@ mod tests {
         let head = head("t1", ("a", "b"), 0);
         let new = head.project(&[] as &[FieldName]).unwrap();
 
-        let mut empty = head.clone();
+        let mut empty = head.clone_for_error();
         empty.fields.clear();
         empty.constraints.clear();
 
         assert_eq!(empty, new);
 
-        let all = head.clone();
+        let all = head.clone_for_error();
         let new = head
             .project(&[FieldName::named("t1", "a"), FieldName::named("t1", "b")])
             .unwrap();
 
         assert_eq!(all, new);
 
-        let mut first = head.clone();
+        let mut first = head.clone_for_error();
         first.fields.pop();
         first.constraints = first.retain_constraints(&0.into());
 
@@ -510,7 +537,7 @@ mod tests {
 
         assert_eq!(first, new);
 
-        let mut second = head.clone();
+        let mut second = head.clone_for_error();
         second.fields.remove(0);
         second.constraints = second.retain_constraints(&1.into());
 

--- a/crates/vm/src/dsl.rs
+++ b/crates/vm/src/dsl.rs
@@ -7,6 +7,7 @@ use spacetimedb_sats::algebraic_value::AlgebraicValue;
 use spacetimedb_sats::db::auth::{StAccess, StTableType};
 use spacetimedb_sats::product_value::ProductValue;
 use spacetimedb_sats::relation::{DbTable, Header};
+use std::sync::Arc;
 
 pub fn scalar<T: Into<AlgebraicValue>>(of: T) -> AlgebraicValue {
     of.into()
@@ -23,7 +24,7 @@ where
     I: IntoIterator<Item = T>,
     T: Into<ProductValue>,
 {
-    MemTable::from_iter(head.into(), iter.into_iter().map(Into::into))
+    MemTable::from_iter(Arc::new(head.into()), iter.into_iter().map(Into::into))
 }
 
 pub fn db_table_raw<T: Into<Header>>(
@@ -32,7 +33,7 @@ pub fn db_table_raw<T: Into<Header>>(
     table_type: StTableType,
     table_access: StAccess,
 ) -> DbTable {
-    DbTable::new(head.into(), table_id, table_type, table_access)
+    DbTable::new(Arc::new(head.into()), table_id, table_type, table_access)
 }
 
 /// Create a [DbTable] of type [StTableType::User] and derive `StAccess::for_name(name)`.

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -17,6 +17,7 @@ use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Bound;
+use std::sync::Arc;
 
 /// Trait for checking if the `caller` have access to `Self`
 pub trait AuthAccess {
@@ -297,7 +298,7 @@ impl SourceExpr {
         }
     }
 
-    pub fn head(&self) -> &Header {
+    pub fn head(&self) -> &Arc<Header> {
         match self {
             SourceExpr::MemTable(x) => &x.head,
             SourceExpr::DbTable(x) => &x.head,
@@ -313,7 +314,7 @@ impl SourceExpr {
 }
 
 impl Relation for SourceExpr {
-    fn head(&self) -> &Header {
+    fn head(&self) -> &Arc<Header> {
         match self {
             SourceExpr::MemTable(x) => x.head(),
             SourceExpr::DbTable(x) => x.head(),
@@ -349,7 +350,7 @@ impl From<SourceExpr> for Table {
 impl From<&TableSchema> for SourceExpr {
     fn from(value: &TableSchema) -> Self {
         SourceExpr::DbTable(DbTable::new(
-            value.into(),
+            Arc::new(value.into()),
             value.table_id,
             value.table_type,
             value.table_access,
@@ -1561,7 +1562,7 @@ impl AuthAccess for QueryCode {
 }
 
 impl Relation for QueryCode {
-    fn head(&self) -> &Header {
+    fn head(&self) -> &Arc<Header> {
         self.table.head()
     }
 
@@ -1677,20 +1678,20 @@ mod tests {
     fn tables() -> [Table; 2] {
         [
             Table::MemTable(MemTable {
-                head: Header {
+                head: Arc::new(Header {
                     table_name: "foo".into(),
                     fields: vec![],
                     constraints: Default::default(),
-                },
+                }),
                 data: vec![],
                 table_access: StAccess::Private,
             }),
             Table::DbTable(DbTable {
-                head: Header {
+                head: Arc::new(Header {
                     table_name: "foo".into(),
                     fields: vec![],
                     constraints: vec![(ColId(42).into(), Constraints::indexed())],
-                },
+                }),
                 table_id: 42.into(),
                 table_type: StTableType::User,
                 table_access: StAccess::Private,
@@ -1718,11 +1719,11 @@ mod tests {
                     field: "bar".into(),
                 },
                 index_side: Table::DbTable(DbTable {
-                    head: Header {
+                    head: Arc::new(Header {
                         table_name: "bar".into(),
                         fields: vec![],
                         constraints: Default::default(),
-                    },
+                    }),
                     table_id: 42.into(),
                     table_type: StTableType::User,
                     table_access: StAccess::Public,
@@ -1788,7 +1789,7 @@ mod tests {
                 .collect(),
         );
         MemTable {
-            head,
+            head: Arc::new(head),
             data,
             table_access,
         }

--- a/crates/vm/src/iterators.rs
+++ b/crates/vm/src/iterators.rs
@@ -3,18 +3,19 @@ use crate::rel_ops::RelOps;
 use crate::relation::{MemTable, RelValue};
 use core::mem;
 use spacetimedb_sats::relation::{Header, RowCount};
+use std::sync::Arc;
 
 /// Common wrapper for relational iterators that work like cursors.
 #[derive(Debug)]
 pub struct RelIter<T> {
-    pub head: Header,
+    pub head: Arc<Header>,
     pub row_count: RowCount,
     pub pos: usize,
     pub of: T,
 }
 
 impl<T> RelIter<T> {
-    pub fn new(head: Header, row_count: RowCount, of: T) -> Self {
+    pub fn new(head: Arc<Header>, row_count: RowCount, of: T) -> Self {
         Self {
             head,
             row_count,
@@ -25,7 +26,7 @@ impl<T> RelIter<T> {
 }
 
 impl<'a> RelOps<'a> for RelIter<MemTable> {
-    fn head(&self) -> &Header {
+    fn head(&self) -> &Arc<Header> {
         &self.head
     }
 


### PR DESCRIPTION
# Description of Changes

Re: #834 . In the VM, wrap `Header` in `Arc` everywhere it's held by a relational operator, so we can `Arc::clone` instead of `Header::clone`.

In support of this change, remove the `Clone` impl on `Header`. For slow paths where cloning is acceptable, define a method `Header::clone_for_error`, which behaves the same as the derived `Clone` would, but better communicates intent.

# API and ABI breaking changes

N/a.

# Expected complexity level and risk

2 - Internal changes to the VM whose performance impacts must be verified, but no (intentional) semantic changes.

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
