### PR TITLE
Fixed an issue which caused metrics to only be recorded for on-disk databases

### DIFF
--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -390,12 +390,8 @@ impl CommitLogMut {
             let table_id: u32 = record.table_id.into();
 
             let operation = match record.op {
-                TxOp::Insert(_) => {
-                    Operation::Insert
-                }
-                TxOp::Delete => {
-                    Operation::Delete
-                }
+                TxOp::Insert(_) => Operation::Insert,
+                TxOp::Delete => Operation::Delete,
             };
 
             writes.push(Write {

--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -8,7 +8,6 @@ use super::{
 use crate::{
     db::{
         datastore::traits::TxOp,
-        db_metrics::DB_METRICS,
         messages::{
             transaction::Transaction,
             write::{Operation, Write},
@@ -373,7 +372,7 @@ impl CommitLogMut {
 
     fn generate_commit(
         &self,
-        ctx: &ExecutionContext,
+        _ctx: &ExecutionContext,
         unwritten_commit: &mut MutexGuard<'_, Commit>,
         tx_data: &TxData,
     ) -> Option<Vec<u8>> {

--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -386,41 +386,14 @@ impl CommitLogMut {
 
         let mut writes = Vec::with_capacity(tx_data.records.len());
 
-        let workload = &ctx.workload();
-        let db = &ctx.database();
-        let reducer = &ctx.reducer_name();
-
         for record in &tx_data.records {
             let table_id: u32 = record.table_id.into();
-            let table_name = record.table_name.as_str();
 
             let operation = match record.op {
                 TxOp::Insert(_) => {
-                    // Increment rows inserted metric
-                    #[cfg(feature = "metrics")]
-                    DB_METRICS
-                        .rdb_num_rows_inserted
-                        .with_label_values(workload, db, reducer, &table_id, table_name)
-                        .inc();
-                    // Increment table rows gauge
-                    DB_METRICS
-                        .rdb_num_table_rows
-                        .with_label_values(db, &table_id, table_name)
-                        .inc();
                     Operation::Insert
                 }
                 TxOp::Delete => {
-                    // Increment rows deleted metric
-                    #[cfg(feature = "metrics")]
-                    DB_METRICS
-                        .rdb_num_rows_deleted
-                        .with_label_values(workload, db, reducer, &table_id, table_name)
-                        .inc();
-                    // Decrement table rows gauge
-                    DB_METRICS
-                        .rdb_num_table_rows
-                        .with_label_values(db, &table_id, table_name)
-                        .dec();
                     Operation::Delete
                 }
             };

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -376,24 +376,24 @@ impl CommittedState {
         table.get_row_ref(&self.blob_store, row_ptr).unwrap()
     }
 
-    pub fn merge(&mut self, tx_state: TxState) -> TxData {
+    pub fn merge(&mut self, tx_state: TxState, ctx: &ExecutionContext) -> TxData {
         // TODO(perf): pre-allocate `Vec::with_capacity`?
         let mut tx_data = TxData { records: vec![] };
 
         self.next_tx_offset += 1;
 
         // First, apply deletes. This will free up space in the committed tables.
-        self.merge_apply_deletes(&mut tx_data, tx_state.delete_tables);
+        self.merge_apply_deletes(&mut tx_data, tx_state.delete_tables, ctx);
 
         // Then, apply inserts. This will re-fill the holes freed by deletions
         // before allocating new pages.
 
-        self.merge_apply_inserts(&mut tx_data, tx_state.insert_tables, tx_state.blob_store);
+        self.merge_apply_inserts(&mut tx_data, tx_state.insert_tables, tx_state.blob_store, ctx);
 
         tx_data
     }
 
-    fn merge_apply_deletes(&mut self, tx_data: &mut TxData, delete_tables: BTreeMap<TableId, BTreeSet<RowPointer>>) {
+    fn merge_apply_deletes(&mut self, tx_data: &mut TxData, delete_tables: BTreeMap<TableId, BTreeSet<RowPointer>>, ctx: &ExecutionContext) {
         for (table_id, row_ptrs) in delete_tables {
             if let Some((table, blob_store)) = self.get_table_and_blob_store(table_id) {
                 // Note: we maintain the invariant that the delete_tables
@@ -414,9 +414,27 @@ impl CommittedState {
                         product_value: pv,
                     });
                 }
+
+                let workload = &ctx.workload();
+                let db = &ctx.database();
+                let reducer = ctx.reducer_name();
+                let table_id: u32 = table_id.into();
+                let table_name = table.get_schema().table_name.as_str();
+                // Increment rows deleted metric
+                #[cfg(feature = "metrics")]
+                DB_METRICS
+                    .rdb_num_rows_deleted
+                    .with_label_values(workload, db, reducer, &table_id, table_name)
+                    .inc();
+                // Decrement table rows gauge
+                DB_METRICS
+                    .rdb_num_table_rows
+                    .with_label_values(db, &table_id, table_name)
+                    .dec();
             } else if !row_ptrs.is_empty() {
                 panic!("Deletion for non-existent table {:?}... huh?", table_id);
             }
+
         }
     }
 
@@ -425,6 +443,7 @@ impl CommittedState {
         tx_data: &mut TxData,
         insert_tables: BTreeMap<TableId, Table>,
         tx_blob_store: impl BlobStore,
+        ctx: &ExecutionContext,
     ) {
         // TODO(perf): Consider moving whole pages from the `insert_tables` into the committed state,
         //             rather than copying individual rows out of them.
@@ -465,11 +484,33 @@ impl CommittedState {
                 }
             }
 
+            // NOTE: if there is a schema change the table id will not change
+            // and that is what is important here so it doesn't matter if we
+            // do this before or after the schema update below.
+            let workload = &ctx.workload();
+            let db = &ctx.database();
+            let reducer = ctx.reducer_name();
+            let table_id: u32 = table_id.into();
+            let table_name = commit_table.get_schema().table_name.as_str();
+            // Increment rows inserted metric
+            #[cfg(feature = "metrics")]
+            DB_METRICS
+                .rdb_num_rows_inserted
+                .with_label_values(workload, db, reducer, &table_id, table_name)
+                .inc();
+            // Increment table rows gauge
+            DB_METRICS
+                .rdb_num_table_rows
+                .with_label_values(db, &table_id, table_name)
+                .inc();
+
             // The schema may have been modified in the transaction.
             // Update this last to placate borrowck and avoid a clone.
             // None of the above operations will inspect the schema.
             commit_table.schema = tx_table.schema;
         }
+
+
     }
 
     pub fn get_table(&self, table_id: TableId) -> Option<&Table> {

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -413,7 +413,6 @@ impl CommittedState {
                     let data_key = pv.to_data_key();
                     tx_data.records.push(TxRecord {
                         op: TxOp::Delete,
-                        table_name: table.schema.table_name.clone(),
                         table_id,
                         key: data_key,
                         product_value: pv,
@@ -475,7 +474,6 @@ impl CommittedState {
                     op: TxOp::Insert(Arc::new(bytes)),
                     product_value: pv,
                     key: data_key,
-                    table_name: commit_table.schema.table_name.clone(),
                     table_id,
                 });
             }

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -393,7 +393,12 @@ impl CommittedState {
         tx_data
     }
 
-    fn merge_apply_deletes(&mut self, tx_data: &mut TxData, delete_tables: BTreeMap<TableId, BTreeSet<RowPointer>>, ctx: &ExecutionContext) {
+    fn merge_apply_deletes(
+        &mut self,
+        tx_data: &mut TxData,
+        delete_tables: BTreeMap<TableId, BTreeSet<RowPointer>>,
+        ctx: &ExecutionContext,
+    ) {
         for (table_id, row_ptrs) in delete_tables {
             if let Some((table, blob_store)) = self.get_table_and_blob_store(table_id) {
                 // Note: we maintain the invariant that the delete_tables
@@ -434,7 +439,6 @@ impl CommittedState {
             } else if !row_ptrs.is_empty() {
                 panic!("Deletion for non-existent table {:?}... huh?", table_id);
             }
-
         }
     }
 
@@ -509,8 +513,6 @@ impl CommittedState {
             // None of the above operations will inspect the schema.
             commit_table.schema = tx_table.schema;
         }
-
-
     }
 
     pub fn get_table(&self, table_id: TableId) -> Option<&Table> {

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -552,7 +552,7 @@ impl MutTx for Locking {
     fn commit_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTx) -> Result<Option<TxData>> {
         #[cfg(feature = "metrics")]
         record_metrics(ctx, tx.timer, tx.lock_wait_time, true);
-        Ok(Some(tx.commit()))
+        Ok(Some(tx.commit(ctx)))
     }
 
     #[cfg(test)]

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -683,13 +683,13 @@ impl MutTxId {
         })
     }
 
-    pub fn commit(self) -> TxData {
+    pub fn commit(self, ctx: &ExecutionContext) -> TxData {
         let Self {
             mut committed_state_write_lock,
             tx_state,
             ..
         } = self;
-        committed_state_write_lock.merge(tx_state)
+        committed_state_write_lock.merge(tx_state, ctx)
     }
 
     pub fn rollback(self) {

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -177,8 +177,6 @@ pub struct TxRecord {
     pub(crate) key: DataKey,
     /// The table that was modified.
     pub(crate) table_id: TableId,
-    /// The table that was modified.
-    pub(crate) table_name: String,
 }
 
 /// A record of all the operations within a transaction.


### PR DESCRIPTION
# Description of Changes

Fixed an issue which caused metrics to only be recorded for on-disk databases.

Note to reviewer: I'm not sure that it makes sense to pass the ExecutionContext so deep, but this works.

# API and ABI breaking changes
None

# Expected complexity level and risk
2
