### PR TITLE
core: Fix host controller to not replace module if lifecyle hooks failed

### DIFF
--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -179,6 +179,9 @@ impl HostController {
     /// reducer scheduler is started.
     ///
     /// Otherwise, if `F` returns an `Err` result, the module is discarded.
+    ///
+    /// In the `Err` case, `F` **MUST** roll back any modifications it has made
+    /// to the database passed in the [`ModuleHostContext`].
     async fn setup_module_host<F, Fut, T>(&self, mhc: ModuleHostContext, f: F) -> anyhow::Result<T>
     where
         F: FnOnce(ModuleHost) -> Fut,
@@ -250,6 +253,9 @@ impl HostController {
     ///
     /// This is a fairly expensive operation and should not be run on the async
     /// task threadpool.
+    ///
+    /// Note that this function **MUST NOT** make any modifications to the
+    /// database passed in as part of the [`ModuleCreationContext`].
     fn make_module_host(host_type: HostType, mcc: ModuleCreationContext) -> anyhow::Result<ModuleHost> {
         let module_host = match host_type {
             HostType::Wasm => {

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -19,7 +19,7 @@ pub mod instance_env;
 mod timestamp;
 mod wasm_common;
 
-pub use host_controller::{DescribedEntityType, HostController, ReducerCallResult, ReducerOutcome, UpdateOutcome};
+pub use host_controller::{DescribedEntityType, HostController, ReducerCallResult, ReducerOutcome};
 pub use module_host::{
     EntityDef, ModuleHost, NoSuchModule, ReducerCallError, UpdateDatabaseResult, UpdateDatabaseSuccess,
 };

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -24,7 +24,7 @@ use spacetimedb::db::db_metrics;
 use spacetimedb::db::{db_metrics::DB_METRICS, Config};
 use spacetimedb::energy::{EnergyBalance, EnergyQuanta};
 use spacetimedb::execution_context::ExecutionContext;
-use spacetimedb::host::{HostController, Scheduler, UpdateDatabaseResult, UpdateOutcome};
+use spacetimedb::host::{HostController, Scheduler, UpdateDatabaseResult};
 use spacetimedb::identity::Identity;
 use spacetimedb::messages::control_db::{Database, DatabaseInstance, HostType, IdentityEmail, Node};
 use spacetimedb::module_host_context::ModuleHostContext;
@@ -587,10 +587,7 @@ impl StandaloneEnv {
                     }
                     Some(hash) => {
                         log::info!("Updating database from {} to {}", hash, database.program_bytes_address);
-                        let UpdateOutcome {
-                            module_host: _,
-                            update_result,
-                        } = self
+                        let update_result = self
                             .host_controller
                             .update_module_host(lock.token() as u128, ctx)
                             .await?;

--- a/test/tests/update-module.sh
+++ b/test/tests/update-module.sh
@@ -48,7 +48,7 @@ run_test cargo run logs "$IDENT" 100
 [ ' Hello, Robert!' == "$(grep 'Robert' "$TEST_OUT" | tail -n 4 | cut -d: -f6-)" ]
 [ ' Hello, World!' == "$(grep 'World' "$TEST_OUT" | tail -n 4 | cut -d: -f6-)" ]
 
-: Unchanged module is ok
+# Unchanged module is ok
 run_test cargo run publish --skip_clippy --project-path "$PROJECT_PATH" "$IDENT"
 [ "1" == "$(grep -c "Updated database" "$TEST_OUT")" ]
 
@@ -68,8 +68,10 @@ EOF
 
 run_test cargo run publish --skip_clippy --project-path "$PROJECT_PATH" "$IDENT" || true
 [ "1" == "$(grep -c "Error: Database update rejected" "$TEST_OUT")" ]
+# Check that the old module is still running by calling say_hello
+run_test cargo run call "$IDENT" say_hello
 
-: Adding a table is ok, and invokes update
+# Adding a table is ok, and invokes update
 cat > "${PROJECT_PATH}/src/lib.rs" <<EOF
 use spacetimedb::{println, spacetimedb};
 


### PR DESCRIPTION
Previously, `spawn_module_host` would unconditionally insert the new module into the controller state, and not remove it if the lifecycle hooks (`init_database` / `update_database`) returned an error.

This would mean that the module code was replaced with the new one, even if it should be rejected because the schema was not updated or the init / update reducer failed.

Fix this by starting the module, and later "committing" it to the controller state in two phases.