### PR TITLE
Revert 694

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4831,8 +4831,6 @@ version = "0.8.2"
 dependencies = [
  "anyhow",
  "derive_more",
- "itertools 0.12.0",
- "smallvec",
  "spacetimedb-lib",
  "spacetimedb-primitives",
  "spacetimedb-sats",
@@ -4840,7 +4838,6 @@ dependencies = [
  "tempfile",
  "thiserror",
  "tracing",
- "typed-arena",
 ]
 
 [[package]]
@@ -5649,12 +5646,6 @@ dependencies = [
  "url",
  "utf-8",
 ]
-
-[[package]]
-name = "typed-arena"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6af6ae20167a9ece4bcb41af5b80f8a1f1df981f6391189ce00fd257af04126a"
 
 [[package]]
 name = "typenum"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -210,7 +210,6 @@ tracing-core = "0.1.31"
 tracing-flame = "0.2.0"
 tracing-log = "0.1.3"
 tracing-subscriber = { version = "0.3.17", features = ["env-filter"] }
-typed-arena = "2.0"
 url = "2.3.1"
 urlencoding = "2.1.2"
 uuid = { version = "1.2.1", features = ["v4"] }

--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -6,7 +6,7 @@ use spacetimedb::host::module_host::{DatabaseTableUpdate, DatabaseUpdate, TableO
 use spacetimedb::subscription::query::compile_read_only_query;
 use spacetimedb::subscription::subscription::ExecutionSet;
 use spacetimedb_lib::identity::AuthCtx;
-use spacetimedb_primitives::{col_list, TableId};
+use spacetimedb_primitives::TableId;
 use spacetimedb_sats::{product, AlgebraicType, AlgebraicValue, ProductValue};
 use tempdir::TempDir;
 
@@ -18,7 +18,8 @@ fn create_table_location(db: &RelationalDB) -> Result<TableId, DBError> {
         ("z", AlgebraicType::I32),
         ("dimension", AlgebraicType::U32),
     ];
-    db.create_table_for_test_multi_column("location", schema, col_list![2, 3, 4])
+    let indexes = &[(0.into(), "entity_id"), (1.into(), "chunk_index"), (2.into(), "x")];
+    db.create_table_for_test("location", schema, indexes)
 }
 
 fn create_table_footprint(db: &RelationalDB) -> Result<TableId, DBError> {
@@ -69,7 +70,7 @@ fn eval(c: &mut Criterion) {
             for i in 0u64..1200 {
                 let entity_id = chunk_index * 1200 + i;
                 let x = 0i32;
-                let z = entity_id as i32;
+                let z = 0i32;
                 let dimension = 0u32;
                 let row = product!(entity_id, chunk_index, x, z, dimension);
                 let _ = db.insert(tx, rhs, row)?;
@@ -97,34 +98,43 @@ fn eval(c: &mut Criterion) {
         ],
     };
 
-    let bench_eval = |c: &mut Criterion, name, sql| {
-        c.bench_function(name, |b| {
-            let auth = AuthCtx::for_testing();
-            let tx = db.begin_tx();
-            let query = compile_read_only_query(&db, &tx, &auth, sql).unwrap();
-            let query: ExecutionSet = query.into();
-
-            b.iter(|| drop(black_box(query.eval(&db, &tx, auth).unwrap())))
-        });
-    };
-
     // To profile this benchmark for 30s
     // samply record -r 10000000 cargo bench --bench=subscription --profile=profiling -- full-scan --exact --profile-time=30
-    // Iterate 1M rows.
-    bench_eval(c, "full-scan", "select * from footprint");
+    c.bench_function("full-scan", |b| {
+        // Iterate 1M rows.
+        let scan = "select * from footprint";
+        let auth = AuthCtx::for_testing();
+        let tx = db.begin_tx();
+        let query = compile_read_only_query(&db, &tx, &auth, scan).unwrap();
+        let query: ExecutionSet = query.into();
+
+        b.iter(|| {
+            let out = query.eval(&db, &tx, auth).unwrap();
+            black_box(out);
+        })
+    });
 
     // To profile this benchmark for 30s
     // samply record -r 10000000 cargo bench --bench=subscription --profile=profiling -- full-join --exact --profile-time=30
-    // Join 1M rows on the left with 12K rows on the right.
-    // Note, this should use an index join so as not to read the entire lhs table.
-    let name = format!(
-        r#"
-        select footprint.*
-        from footprint join location on footprint.entity_id = location.entity_id
-        where location.chunk_index = {chunk_index}
-        "#
-    );
-    bench_eval(c, "full-join", &name);
+    c.bench_function("full-join", |b| {
+        // Join 1M rows on the left with 12K rows on the right.
+        // Note, this should use an index join so as not to read the entire lhs table.
+        let join = format!(
+            "\
+            select footprint.* \
+            from footprint join location on footprint.entity_id = location.entity_id \
+            where location.chunk_index = {chunk_index}"
+        );
+        let auth = AuthCtx::for_testing();
+        let tx = db.begin_tx();
+        let query = compile_read_only_query(&db, &tx, &auth, &join).unwrap();
+        let query: ExecutionSet = query.into();
+
+        b.iter(|| {
+            let out = query.eval(&db, &tx, AuthCtx::for_testing()).unwrap();
+            black_box(out);
+        })
+    });
 
     // To profile this benchmark for 30s
     // samply record -r 10000000 cargo bench --bench=subscription --profile=profiling -- incr-select --exact --profile-time=30
@@ -164,15 +174,6 @@ fn eval(c: &mut Criterion) {
             black_box(out);
         })
     });
-
-    // To profile this benchmark for 30s
-    // samply record -r 10000000 cargo bench --bench=subscription --profile=profiling -- query-indexes-multi --exact --profile-time=30
-    // Iterate 1M rows.
-    bench_eval(
-        c,
-        "query-indexes-multi",
-        "select * from location WHERE x = 0 AND z = 10000 AND dimension = 0",
-    );
 }
 
 criterion_group!(benches, eval);

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -18,6 +18,7 @@ use crate::error::{DBError, DatabaseError, TableError};
 use crate::execution_context::ExecutionContext;
 use crate::hash::Hash;
 use fs2::FileExt;
+use itertools::Itertools;
 use spacetimedb_primitives::*;
 use spacetimedb_sats::db::auth::{StAccess, StTableType};
 use spacetimedb_sats::db::def::{ColumnDef, IndexDef, SequenceDef, TableDef, TableSchema};
@@ -411,47 +412,33 @@ impl RelationalDB {
         self.inner.create_table_mut_tx(tx, schema.into())
     }
 
-    fn col_def_for_test(schema: &[(&str, AlgebraicType)]) -> Vec<ColumnDef> {
-        schema
-            .iter()
-            .cloned()
-            .map(|(col_name, col_type)| ColumnDef {
-                col_name: col_name.into(),
-                col_type,
-            })
-            .collect()
-    }
-
     pub fn create_table_for_test(
         &self,
         name: &str,
         schema: &[(&str, AlgebraicType)],
         indexes: &[(ColId, &str)],
     ) -> Result<TableId, DBError> {
+        let table_name = name.to_string();
+        let table_type = StTableType::User;
+        let table_access = StAccess::Public;
+
+        let columns = schema
+            .iter()
+            .map(|(col_name, col_type)| ColumnDef {
+                col_name: col_name.to_string(),
+                col_type: col_type.clone(),
+            })
+            .collect_vec();
+
         let indexes = indexes
             .iter()
-            .copied()
-            .map(|(col_id, index_name)| IndexDef::btree(index_name.into(), col_id, false))
-            .collect();
+            .map(|(col_id, index_name)| IndexDef::btree(index_name.to_string(), *col_id, false))
+            .collect_vec();
 
-        let schema = TableDef::new(name.into(), Self::col_def_for_test(schema))
+        let schema = TableDef::new(table_name, columns)
             .with_indexes(indexes)
-            .with_type(StTableType::User)
-            .with_access(StAccess::Public);
-
-        self.with_auto_commit(&ExecutionContext::default(), |tx| self.create_table(tx, schema))
-    }
-
-    pub fn create_table_for_test_multi_column(
-        &self,
-        name: &str,
-        schema: &[(&str, AlgebraicType)],
-        idx_cols: ColList,
-    ) -> Result<TableId, DBError> {
-        let schema = TableDef::new(name.into(), Self::col_def_for_test(schema))
-            .with_column_index(idx_cols, false)
-            .with_type(StTableType::User)
-            .with_access(StAccess::Public);
+            .with_type(table_type)
+            .with_access(table_access);
 
         self.with_auto_commit(&ExecutionContext::default(), |tx| self.create_table(tx, schema))
     }
@@ -561,7 +548,7 @@ impl RelationalDB {
     /// Returns the `index_id`
     ///
     /// NOTE: It loads the data from the table into it before returning
-    #[tracing::instrument(skip(self, tx, index), fields(index = index.index_name))]
+    #[tracing::instrument(skip(self, tx, index), fields(index=index.index_name))]
     pub fn create_index(&self, tx: &mut MutTx, table_id: TableId, index: IndexDef) -> Result<IndexId, DBError> {
         self.inner.create_index_mut_tx(tx, table_id, index)
     }
@@ -704,7 +691,7 @@ impl RelationalDB {
     }
 
     /// Add a [Sequence] into the database instance, generates a stable [SequenceId] for it that will persist on restart.
-    #[tracing::instrument(skip(self, tx, seq), fields(seq = seq.sequence_name))]
+    #[tracing::instrument(skip(self, tx, seq), fields(seq=seq.sequence_name))]
     pub fn create_sequence(
         &mut self,
         tx: &mut MutTx,

--- a/crates/core/src/sql/ast.rs
+++ b/crates/core/src/sql/ast.rs
@@ -1,4 +1,3 @@
-use itertools::Itertools;
 use std::borrow::Cow;
 use std::collections::HashMap;
 
@@ -33,7 +32,6 @@ impl Unsupported for bool {
         *self
     }
 }
-
 impl<T> Unsupported for Option<T> {
     fn unsupported(&self) -> bool {
         self.is_some()
@@ -61,7 +59,7 @@ impl Unsupported for sqlparser::ast::GroupByExpr {
     }
 }
 
-macro_rules! unsupported {
+macro_rules! unsupported{
     ($name:literal,$a:expr)=>{{
         let name = stringify!($name);
         let it = stringify!($a);
@@ -163,13 +161,6 @@ impl From {
                 Join::Inner { rhs, .. } => rhs,
             })
         }))
-    }
-
-    /// Returns all the columns from [Self::iter_tables], removing duplicates by `col_name`
-    pub fn iter_columns_dedup(&self) -> impl Iterator<Item = (&TableSchema, &ColumnSchema)> {
-        self.iter_tables()
-            .flat_map(|t| t.columns().iter().map(move |column| (t, column)))
-            .dedup_by(|(_, x), (_, y)| x.col_name == y.col_name)
     }
 
     /// Returns all the table names as a `Vec<String>`, including the ones inside the joins.
@@ -326,7 +317,7 @@ fn compile_expr_value(table: &From, field: Option<&ProductTypeElement>, of: SqlE
             x => {
                 return Err(PlanError::Unsupported {
                     feature: format!("Unsupported value: {x}."),
-                });
+                })
             }
         }),
         SqlExpr::BinaryOp { left, op, right } => {
@@ -340,7 +331,7 @@ fn compile_expr_value(table: &From, field: Option<&ProductTypeElement>, of: SqlE
         x => {
             return Err(PlanError::Unsupported {
                 feature: format!("Unsupported expression: {x}"),
-            });
+            })
         }
     }))
 }
@@ -394,7 +385,7 @@ fn compile_bin_op(
         x => {
             return Err(PlanError::Unsupported {
                 feature: format!("BinaryOperator not supported in WHERE: {x}."),
-            });
+            })
         }
     };
 
@@ -784,7 +775,7 @@ fn column_def_type(named: &String, is_null: bool, data_type: &DataType) -> Resul
         x => {
             return Err(PlanError::Unsupported {
                 feature: format!("Column {} of type {}", named, x),
-            });
+            })
         }
     };
 
@@ -825,7 +816,7 @@ fn compile_column_option(col: &SqlColumnDef) -> Result<(bool, Constraints), Plan
                     x => {
                         return Err(PlanError::Unsupported {
                             feature: format!("IDENTITY option {x:?}"),
-                        });
+                        })
                     }
                 }
             }
@@ -833,7 +824,7 @@ fn compile_column_option(col: &SqlColumnDef) -> Result<(bool, Constraints), Plan
             x => {
                 return Err(PlanError::Unsupported {
                     feature: format!("Column option {x}"),
-                });
+                })
             }
         }
     }
@@ -884,7 +875,7 @@ fn compile_drop(name: &ObjectName, kind: ObjectType) -> Result<SqlAst, PlanError
         x => {
             return Err(PlanError::Unsupported {
                 feature: format!("DROP {x}"),
-            });
+            })
         }
     };
 
@@ -929,7 +920,7 @@ fn compile_statement<T: TableSchemaView>(db: &RelationalDB, tx: &T, statement: S
                     _ => {
                         return Err(PlanError::Unsupported {
                             feature: "Insert WITHOUT values".into(),
-                        });
+                        })
                     }
                 };
 

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -1,9 +1,11 @@
 use crate::db::relational_db::RelationalDB;
 use crate::error::{DBError, PlanError};
 use crate::sql::ast::{compile_to_ast, Column, From, Join, Selection, SqlAst};
+use spacetimedb_primitives::*;
 use spacetimedb_sats::db::auth::StAccess;
 use spacetimedb_sats::db::def::{TableDef, TableSchema};
 use spacetimedb_sats::relation::{self, DbTable, FieldExpr, FieldName, Header};
+use spacetimedb_sats::AlgebraicValue;
 use spacetimedb_vm::dsl::{db_table, db_table_raw, query};
 use spacetimedb_vm::expr::{ColumnOp, CrudExpr, DbType, Expr, QueryExpr, SourceExpr};
 use spacetimedb_vm::operator::OpCmp;
@@ -72,10 +74,29 @@ fn check_cmp_expr(table: &From, expr: &ColumnOp) -> Result<(), PlanError> {
 /// Compiles a `WHERE ...` clause
 fn compile_where(mut q: QueryExpr, table: &From, filter: Selection) -> Result<QueryExpr, PlanError> {
     check_cmp_expr(table, &filter.clause)?;
-    for op in filter.clause.flatten_ands() {
+    for op in filter.clause.to_vec() {
         q = q.with_select(op);
     }
     Ok(q)
+}
+
+// IndexArgument represents an equality or range predicate that can be answered
+// using an index.
+pub enum IndexArgument {
+    Eq {
+        columns: ColList,
+        value: AlgebraicValue,
+    },
+    LowerBound {
+        columns: ColList,
+        value: AlgebraicValue,
+        inclusive: bool,
+    },
+    UpperBound {
+        columns: ColList,
+        value: AlgebraicValue,
+        inclusive: bool,
+    },
 }
 
 /// Compiles a `SELECT ...` clause
@@ -270,19 +291,19 @@ fn compile_statement(db: &RelationalDB, statement: SqlAst) -> Result<CrudExpr, P
 #[cfg(test)]
 mod tests {
     use super::*;
-    use crate::db::datastore::traits::IsolationLevel;
+    use std::ops::Bound;
+
     use crate::db::relational_db::tests_utils::make_test_db;
     use spacetimedb_lib::error::ResultTest;
     use spacetimedb_lib::operator::OpQuery;
-    use spacetimedb_primitives::{col_list, ColList, TableId};
-    use spacetimedb_sats::{product, AlgebraicType, AlgebraicValue};
+    use spacetimedb_primitives::{ColId, TableId};
+    use spacetimedb_sats::AlgebraicType;
     use spacetimedb_vm::expr::{IndexJoin, IndexScan, JoinExpr, Query};
     use spacetimedb_vm::relation::Table;
-    use std::ops::Bound;
 
     fn assert_index_scan(
         op: Query,
-        cols: impl Into<ColList>,
+        col: ColId,
         low_bound: Bound<AlgebraicValue>,
         up_bound: Bound<AlgebraicValue>,
     ) -> TableId {
@@ -293,18 +314,13 @@ mod tests {
             upper_bound,
         }) = op
         {
-            assert_eq!(columns, cols.into(), "Columns don't match");
+            assert_eq!(columns, col.into(), "Columns don't match");
             assert_eq!(lower_bound, low_bound, "Lower bound don't match");
             assert_eq!(upper_bound, up_bound, "Upper bound don't match");
             table.table_id
         } else {
             panic!("Expected IndexScan, got {op}");
         }
-    }
-
-    fn assert_one_eq_index_scan(op: Query, cols: impl Into<ColList>, val: AlgebraicValue) -> TableId {
-        let val = Bound::Included(val);
-        assert_index_scan(op, cols, val.clone(), val)
     }
 
     #[test]
@@ -348,11 +364,23 @@ mod tests {
         let tx = db.begin_tx();
         //Compile query
         let sql = "select * from test where a = 1";
-        let CrudExpr::Query(QueryExpr { source: _, mut query }) = compile_sql(&db, &tx, sql)?.remove(0) else {
+        let CrudExpr::Query(QueryExpr {
+            source: _,
+            query: mut ops,
+        }) = compile_sql(&db, &tx, sql)?.remove(0)
+        else {
             panic!("Expected QueryExpr");
         };
-        assert_eq!(1, query.len());
-        assert_one_eq_index_scan(query.remove(0), 0, 1u64.into());
+
+        assert_eq!(1, ops.len());
+
+        // Assert index scan.
+        assert_index_scan(
+            ops.swap_remove(0),
+            0.into(),
+            Bound::Included(1u64.into()),
+            Bound::Included(1u64.into()),
+        );
         Ok(())
     }
 
@@ -366,14 +394,23 @@ mod tests {
         db.create_table_for_test("test", schema, indexes)?;
 
         let tx = db.begin_tx();
-        // Note, order does not matter matter.
-        // The sargable predicate occurs last but we can still generate an index scan.
+        // Note, order matters - the sargable predicate occurs last which means
+        // no index scan will be generated.
         let sql = "select * from test where a = 1 and b = 2";
-        let CrudExpr::Query(QueryExpr { source: _, mut query }) = compile_sql(&db, &tx, sql)?.remove(0) else {
+        let CrudExpr::Query(QueryExpr {
+            source: _,
+            query: mut ops,
+        }) = compile_sql(&db, &tx, sql)?.remove(0)
+        else {
             panic!("Expected QueryExpr");
         };
-        assert_eq!(2, query.len());
-        assert_one_eq_index_scan(query.remove(0), 1, 2u64.into());
+
+        assert_eq!(1, ops.len());
+
+        // Assert no index scan
+        let Query::Select(_) = ops.remove(0) else {
+            panic!("Expected Select");
+        };
         Ok(())
     }
 
@@ -387,37 +424,26 @@ mod tests {
         db.create_table_for_test("test", schema, indexes)?;
 
         let tx = db.begin_tx();
-        // Note, order does not matters.
-        // The sargable predicate occurs first adn we can generate an index scan.
+        // Note, order matters - the sargable predicate occurs first which
+        // means an index scan will be generated.
         let sql = "select * from test where b = 2 and a = 1";
-        let CrudExpr::Query(QueryExpr { source: _, mut query }) = compile_sql(&db, &tx, sql)?.remove(0) else {
+        let CrudExpr::Query(QueryExpr {
+            source: _,
+            query: mut ops,
+        }) = compile_sql(&db, &tx, sql)?.remove(0)
+        else {
             panic!("Expected QueryExpr");
         };
-        assert_eq!(2, query.len());
-        assert_one_eq_index_scan(query.remove(0), 1, 2u64.into());
-        Ok(())
-    }
 
-    #[test]
-    fn compile_index_multi_eq_and_eq() -> ResultTest<()> {
-        let (db, _tmp) = make_test_db()?;
+        assert_eq!(2, ops.len());
 
-        // Create table [test] with index on [b]
-        let schema = &[
-            ("a", AlgebraicType::U64),
-            ("b", AlgebraicType::U64),
-            ("c", AlgebraicType::U64),
-            ("d", AlgebraicType::U64),
-        ];
-        db.create_table_for_test_multi_column("test", schema, col_list![0, 1])?;
-
-        let tx = db.begin_mut_tx(IsolationLevel::Serializable);
-        let sql = "select * from test where b = 2 and a = 1";
-        let CrudExpr::Query(QueryExpr { source: _, mut query }) = compile_sql(&db, &tx, sql)?.remove(0) else {
-            panic!("Expected QueryExpr");
-        };
-        assert_eq!(1, query.len());
-        assert_one_eq_index_scan(query.remove(0), col_list![0, 1], product![1u64, 2u64].into());
+        // Assert index scan.
+        assert_index_scan(
+            ops.swap_remove(0),
+            1.into(),
+            Bound::Included(2u64.into()),
+            Bound::Included(2u64.into()),
+        );
         Ok(())
     }
 
@@ -449,7 +475,6 @@ mod tests {
         };
         Ok(())
     }
-
     #[test]
     fn compile_index_range_open() -> ResultTest<()> {
         let (db, _tmp) = make_test_db()?;
@@ -474,7 +499,7 @@ mod tests {
 
         assert_index_scan(
             ops.remove(0),
-            1,
+            1.into(),
             Bound::Excluded(AlgebraicValue::U64(2)),
             Bound::Unbounded,
         );
@@ -506,7 +531,7 @@ mod tests {
 
         assert_index_scan(
             ops.remove(0),
-            1,
+            1.into(),
             Bound::Excluded(AlgebraicValue::U64(2)),
             Bound::Excluded(AlgebraicValue::U64(5)),
         );
@@ -525,16 +550,29 @@ mod tests {
 
         let tx = db.begin_tx();
         // Note, order matters - the equality condition occurs first which
-        // means an index scan will be generated rather than the range condition.
+        // means an index scan will be generated it rather than the range
+        // condition.
         let sql = "select * from test where a = 3 and b > 2 and b < 5";
-        let CrudExpr::Query(QueryExpr { source: _, mut query }) = compile_sql(&db, &tx, sql)?.remove(0) else {
+        let CrudExpr::Query(QueryExpr {
+            source: _,
+            query: mut ops,
+        }) = compile_sql(&db, &tx, sql)?.remove(0)
+        else {
             panic!("Expected QueryExpr");
         };
-        assert_eq!(2, query.len());
-        let Query::Select(_) = query[1] else {
+
+        assert_eq!(2, ops.len());
+
+        assert_index_scan(
+            ops.remove(0),
+            0.into(),
+            Bound::Included(AlgebraicValue::U64(3)),
+            Bound::Included(AlgebraicValue::U64(3)),
+        );
+
+        let Query::Select(_) = ops.remove(0) else {
             panic!("Expected Select");
         };
-        assert_one_eq_index_scan(query.remove(0), 0, 3u64.into());
         Ok(())
     }
 
@@ -570,7 +608,12 @@ mod tests {
         assert_eq!(query.len(), 2);
 
         // First operation in the pipeline should be an index scan
-        let table_id = assert_one_eq_index_scan(query[0].clone(), 0, 3u64.into());
+        let table_id = assert_index_scan(
+            query[0].clone(),
+            0.into(),
+            Bound::Included(AlgebraicValue::U64(3)),
+            Bound::Included(AlgebraicValue::U64(3)),
+        );
 
         assert_eq!(table_id, lhs_id);
 
@@ -629,6 +672,7 @@ mod tests {
         else {
             panic!("unexpected expression: {:#?}", exp);
         };
+
         assert_eq!(table_id, lhs_id);
         assert_eq!(query.len(), 2);
 
@@ -797,7 +841,12 @@ mod tests {
         assert_eq!(query.len(), 2);
 
         // First operation in the pipeline should be an index scan
-        let table_id = assert_one_eq_index_scan(query[0].clone(), 0, 3u64.into());
+        let table_id = assert_index_scan(
+            query[0].clone(),
+            0.into(),
+            Bound::Included(AlgebraicValue::U64(3)),
+            Bound::Included(AlgebraicValue::U64(3)),
+        );
 
         assert_eq!(table_id, lhs_id);
 
@@ -834,7 +883,7 @@ mod tests {
         // The right side of the join should be an index scan
         let table_id = assert_index_scan(
             rhs[0].clone(),
-            1,
+            1.into(),
             Bound::Unbounded,
             Bound::Excluded(AlgebraicValue::U64(4)),
         );
@@ -911,103 +960,10 @@ mod tests {
         // The probe side of the join should be an index scan
         let table_id = assert_index_scan(
             rhs[0].clone(),
-            1,
+            1.into(),
             Bound::Excluded(AlgebraicValue::U64(2)),
             Bound::Excluded(AlgebraicValue::U64(4)),
         );
-
-        assert_eq!(table_id, rhs_id);
-
-        // Followed by a selection
-        let Query::Select(ColumnOp::Cmp {
-            op: OpQuery::Cmp(OpCmp::Eq),
-            lhs: ref field,
-            rhs: ref value,
-        }) = rhs[1]
-        else {
-            panic!("unexpected operator {:#?}", rhs[0]);
-        };
-
-        let ColumnOp::Field(FieldExpr::Name(FieldName::Name { ref table, ref field })) = **field else {
-            panic!("unexpected left hand side {:#?}", field);
-        };
-
-        assert_eq!(table, "rhs");
-        assert_eq!(field, "d");
-
-        let ColumnOp::Field(FieldExpr::Value(AlgebraicValue::U64(3))) = **value else {
-            panic!("unexpected right hand side {:#?}", value);
-        };
-        Ok(())
-    }
-
-    #[test]
-    fn compile_index_multi_join() -> ResultTest<()> {
-        let (db, _tmp) = make_test_db()?;
-
-        // Create table [lhs] with index on [b]
-        let schema = &[("a", AlgebraicType::U64), ("b", AlgebraicType::U64)];
-        let indexes = &[(1.into(), "b")];
-        let lhs_id = db.create_table_for_test("lhs", schema, indexes)?;
-
-        // Create table [rhs] with index on [b, c]
-        let schema = &[
-            ("b", AlgebraicType::U64),
-            ("c", AlgebraicType::U64),
-            ("d", AlgebraicType::U64),
-        ];
-        let indexes = col_list![0, 1];
-        let rhs_id = db.create_table_for_test_multi_column("rhs", schema, indexes)?;
-
-        let tx = db.begin_tx();
-        // Should generate an index join since there is an index on `lhs.b`.
-        // Should push the sargable range condition into the index join's probe side.
-        let sql = "select lhs.* from lhs join rhs on lhs.b = rhs.b where rhs.c = 2 and rhs.b = 4 and rhs.d = 3";
-        let exp = compile_sql(&db, &tx, sql)?.remove(0);
-
-        let CrudExpr::Query(QueryExpr {
-            source: SourceExpr::DbTable(DbTable { table_id, .. }),
-            query,
-            ..
-        }) = exp
-        else {
-            panic!("unexpected result from compilation: {:?}", exp);
-        };
-
-        assert_eq!(table_id, lhs_id);
-        assert_eq!(query.len(), 1);
-
-        let Query::IndexJoin(IndexJoin {
-            probe_side:
-                QueryExpr {
-                    source: SourceExpr::DbTable(DbTable { table_id, .. }),
-                    query: ref rhs,
-                },
-            probe_field:
-                FieldName::Name {
-                    table: ref probe_table,
-                    field: ref probe_field,
-                },
-            index_side: Table::DbTable(DbTable {
-                table_id: index_table, ..
-            }),
-            index_col,
-            ..
-        }) = query[0]
-        else {
-            panic!("unexpected operator {:#?}", query[0]);
-        };
-
-        assert_eq!(table_id, rhs_id);
-        assert_eq!(index_table, lhs_id);
-        assert_eq!(index_col, 1.into());
-        assert_eq!(probe_field, "b");
-        assert_eq!(probe_table, "rhs");
-
-        assert_eq!(2, rhs.len());
-
-        // The probe side of the join should be an index scan
-        let table_id = assert_one_eq_index_scan(rhs[0].clone(), col_list![0, 1], product![4u64, 2u64].into());
 
         assert_eq!(table_id, rhs_id);
 

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -129,7 +129,6 @@ pub(crate) mod tests {
     use crate::db::relational_db::tests_utils::make_test_db;
     use crate::vm::tests::create_table_with_rows;
     use spacetimedb_lib::error::ResultTest;
-    use spacetimedb_primitives::col_list;
     use spacetimedb_sats::db::auth::{StAccess, StTableType};
     use spacetimedb_sats::relation::Header;
     use spacetimedb_sats::{product, AlgebraicType, ProductType};
@@ -669,30 +668,6 @@ SELECT * FROM inventory",
 
         let result = result.first().unwrap().clone();
         assert_eq!(result.data.len(), 4);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_multi_column() -> ResultTest<()> {
-        let (db, _input, _tmp_dir) = create_data(1)?;
-
-        // Create table [test] with index on [a, b]
-        let schema = &[
-            ("a", AlgebraicType::I32),
-            ("b", AlgebraicType::I32),
-            ("c", AlgebraicType::I32),
-            ("d", AlgebraicType::I32),
-        ];
-        let table_id = db.create_table_for_test_multi_column("test", schema, col_list![0, 1])?;
-        db.with_auto_commit(&ExecutionContext::default(), |tx| {
-            db.insert(tx, table_id, product![1, 1, 1, 1])
-        })?;
-
-        let result = run_for_testing(&db, "select * from test where b = 1 and a = 1")?;
-
-        let result = result.first().unwrap().clone();
-        assert_eq!(result.data, vec![product![1, 1, 1, 1]]);
 
         Ok(())
     }

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -24,21 +24,23 @@
 #![doc = include_str!("../../../../docs/incremental-joins.md")]
 
 use super::query;
-use crate::client::{ClientActorId, ClientConnectionSender};
-use crate::db::relational_db::{RelationalDB, Tx};
+use crate::db::relational_db::Tx;
 use crate::error::{DBError, SubscriptionError};
 use crate::execution_context::ExecutionContext;
-use crate::host::module_host::{DatabaseTableUpdate, DatabaseUpdate, TableOp};
 use crate::subscription::query::{run_query, to_mem_table_with_op_type, OP_TYPE_FIELD_NAME};
+use crate::{
+    client::{ClientActorId, ClientConnectionSender},
+    db::relational_db::RelationalDB,
+    host::module_host::{DatabaseTableUpdate, DatabaseUpdate, TableOp},
+};
 use anyhow::Context;
 use itertools::Either;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use spacetimedb_lib::identity::AuthCtx;
+use spacetimedb_lib::ProductValue;
 use spacetimedb_primitives::TableId;
 use spacetimedb_sats::db::auth::{StAccess, StTableType};
-use spacetimedb_sats::relation::Header;
-use spacetimedb_sats::relation::Relation;
-use spacetimedb_sats::ProductValue;
+use spacetimedb_sats::relation::{Header, Relation};
 use spacetimedb_vm::expr::{self, IndexJoin, QueryExpr};
 use spacetimedb_vm::relation::MemTable;
 use std::collections::{hash_map, HashMap, HashSet};

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -57,7 +57,11 @@ pub fn build_query<'a>(
                 columns,
                 lower_bound,
                 upper_bound,
-            }) if db_table => iter_by_col_range(ctx, stdb, tx, table, columns, (lower_bound, upper_bound))?,
+            }) if db_table => {
+                assert_eq!(columns.len(), 1, "Only support single column IndexScan");
+                let col_id = columns.head();
+                iter_by_col_range(ctx, stdb, tx, table, col_id, (lower_bound, upper_bound))?
+            }
             Query::IndexScan(index_scan) => {
                 let header = result.head().clone();
                 let cmp: ColumnOp = index_scan.into();
@@ -200,12 +204,12 @@ fn iter_by_col_range<'a>(
     db: &'a RelationalDB,
     tx: &'a TxMode,
     table: DbTable,
-    columns: ColList,
+    col_id: ColId,
     range: impl RangeBounds<AlgebraicValue> + 'a,
 ) -> Result<Box<dyn RelOps<'a> + 'a>, ErrorVm> {
     let iter = match tx {
-        TxMode::MutTx(tx) => db.iter_by_col_range_mut(ctx, tx, table.table_id, columns, range)?,
-        TxMode::Tx(tx) => db.iter_by_col_range(ctx, tx, table.table_id, columns, range)?,
+        TxMode::MutTx(tx) => db.iter_by_col_range_mut(ctx, tx, table.table_id, col_id, range)?,
+        TxMode::Tx(tx) => db.iter_by_col_range(ctx, tx, table.table_id, col_id, range)?,
     };
     Ok(Box::new(IndexCursor::new(table, iter)?) as Box<IterRows<'_>>)
 }

--- a/crates/sats/src/relation.rs
+++ b/crates/sats/src/relation.rs
@@ -485,8 +485,9 @@ impl Relation for DbTable {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use spacetimedb_primitives::col_list;
+
+    use super::*;
 
     /// Build a [Header] using the initial `start_pos` as the column position for the [Constraints]
     fn head(table: &str, fields: (&str, &str), start_pos: u32) -> Header {

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -13,11 +13,8 @@ spacetimedb-table.workspace = true
 
 anyhow.workspace = true
 derive_more.workspace = true
-itertools.workspace = true
-smallvec.workspace = true
 thiserror.workspace = true
 tracing.workspace = true
 
 [dev-dependencies]
 tempfile.workspace = true
-typed-arena.workspace = true

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -2,7 +2,6 @@ use crate::errors::{ErrorKind, ErrorLang, ErrorType, ErrorVm};
 use crate::operator::{OpCmp, OpLogic, OpQuery};
 use crate::relation::{MemTable, RelValue, Table};
 use derive_more::From;
-use smallvec::{smallvec, SmallVec};
 use spacetimedb_lib::Identity;
 use spacetimedb_primitives::*;
 use spacetimedb_sats::algebraic_type::AlgebraicType;
@@ -13,9 +12,8 @@ use spacetimedb_sats::db::error::AuthError;
 use spacetimedb_sats::relation::{Column, DbTable, FieldExpr, FieldName, Header, Relation, RowCount};
 use spacetimedb_sats::satn::Satn;
 use spacetimedb_sats::{ProductValue, Typespace, WithTypespace};
-use std::cmp::{Ordering, Reverse};
-use std::collections::btree_map::Entry;
-use std::collections::{BTreeMap, HashMap, HashSet, VecDeque};
+use std::cmp::Ordering;
+use std::collections::{HashMap, VecDeque};
 use std::fmt;
 use std::hash::{Hash, Hasher};
 use std::ops::Bound;
@@ -37,9 +35,6 @@ pub enum ColumnOp {
     },
 }
 
-type ColumnOpFlat = SmallVec<[ColumnOp; 1]>;
-type ColumnOpRefFlat<'a> = SmallVec<[&'a ColumnOp; 1]>;
-
 impl ColumnOp {
     pub fn new(op: OpQuery, lhs: ColumnOp, rhs: ColumnOp) -> Self {
         Self::Cmp {
@@ -50,11 +45,11 @@ impl ColumnOp {
     }
 
     pub fn cmp(field: FieldName, op: OpCmp, value: AlgebraicValue) -> Self {
-        Self::new(
-            OpQuery::Cmp(op),
-            ColumnOp::Field(FieldExpr::Name(field)),
-            ColumnOp::Field(FieldExpr::Value(value)),
-        )
+        Self::Cmp {
+            op: OpQuery::Cmp(op),
+            lhs: Box::new(ColumnOp::Field(FieldExpr::Name(field))),
+            rhs: Box::new(ColumnOp::Field(FieldExpr::Value(value))),
+        }
     }
 
     fn reduce(&self, row: &RelValue<'_>, value: &ColumnOp, header: &Header) -> Result<AlgebraicValue, ErrorLang> {
@@ -122,56 +117,21 @@ impl ColumnOp {
         }
     }
 
-    /// Flattens a nested conjunction of AND expressions.
-    ///
-    /// For example, `a = 1 AND b = 2 AND c = 3` becomes `[a = 1, b = 2, c = 3]`.
-    ///
-    /// This helps with splitting the kinds of `queries`,
-    /// that *could* be answered by a `index`,
-    /// from the ones that need to be executed with a `scan`.
-    pub fn flatten_ands(self) -> ColumnOpFlat {
-        fn fill_vec(buf: &mut ColumnOpFlat, op: ColumnOp) {
-            match op {
-                ColumnOp::Cmp {
-                    op: OpQuery::Logic(OpLogic::And),
-                    lhs,
-                    rhs,
-                } => {
-                    fill_vec(buf, *lhs);
-                    fill_vec(buf, *rhs);
-                }
-                op => buf.push(op),
+    // Flattens a nested conjunction of AND expressions.
+    pub fn to_vec(self) -> Vec<ColumnOp> {
+        match self {
+            ColumnOp::Cmp {
+                op: OpQuery::Logic(OpLogic::And),
+                lhs,
+                rhs,
+            } => {
+                let mut lhs = lhs.to_vec();
+                let mut rhs = rhs.to_vec();
+                lhs.append(&mut rhs);
+                lhs
             }
+            op => vec![op],
         }
-        let mut buf = SmallVec::new();
-        fill_vec(&mut buf, self);
-        buf
-    }
-
-    /// Flattens a nested conjunction of AND expressions.
-    ///
-    /// For example, `a = 1 AND b = 2 AND c = 3` becomes `[a = 1, b = 2, c = 3]`.
-    ///
-    /// This helps with splitting the kinds of `queries`,
-    /// that *could* be answered by a `index`,
-    /// from the ones that need to be executed with a `scan`.
-    pub fn flatten_ands_ref(&self) -> ColumnOpRefFlat<'_> {
-        fn fill_vec<'a>(buf: &mut ColumnOpRefFlat<'a>, op: &'a ColumnOp) {
-            match op {
-                ColumnOp::Cmp {
-                    op: OpQuery::Logic(OpLogic::And),
-                    lhs,
-                    rhs,
-                } => {
-                    fill_vec(buf, lhs);
-                    fill_vec(buf, rhs);
-                }
-                op => buf.push(op),
-            }
-        }
-        let mut buf = SmallVec::new();
-        fill_vec(&mut buf, self);
-        buf
     }
 }
 
@@ -222,6 +182,7 @@ impl From<IndexScan> for ColumnOp {
     fn from(value: IndexScan) -> Self {
         let table = value.table;
         let columns = value.columns;
+        assert_eq!(columns.len(), 1, "multi-column predicates are not yet supported");
 
         let field = table.head.fields[usize::from(columns.head())].field.clone();
         match (value.lower_bound, value.upper_bound) {
@@ -263,7 +224,11 @@ impl From<IndexScan> for ColumnOp {
                     lower_bound: Bound::Unbounded,
                     upper_bound,
                 };
-                ColumnOp::new(OpQuery::Logic(OpLogic::And), lhs.into(), rhs.into())
+                ColumnOp::Cmp {
+                    op: OpQuery::Logic(OpLogic::And),
+                    lhs: lhs.into(),
+                    rhs: rhs.into(),
+                }
             }
         }
     }
@@ -313,7 +278,10 @@ impl SourceExpr {
     }
 
     pub fn table_name(&self) -> &str {
-        &self.head().table_name
+        match self {
+            SourceExpr::MemTable(x) => &x.head.table_name,
+            SourceExpr::DbTable(x) => &x.head.table_name,
+        }
     }
 
     pub fn table_type(&self) -> StTableType {
@@ -720,7 +688,7 @@ pub enum Query {
     Select(ColumnOp),
     // Projects a set of columns.
     // The second argument is the table id for a qualified wildcard project.
-    // If present, further optimizations are possible.
+    // If present, further optimzations are possible.
     Project(Vec<FieldExpr>, Option<TableId>),
     // A join of two relations (base or intermediate) based on equality.
     // Equivalent to a Nested Loop Join.
@@ -744,315 +712,80 @@ impl Query {
 
 // IndexArgument represents an equality or range predicate that can be answered
 // using an index.
-#[derive(Debug, PartialEq, Clone)]
-enum IndexArgument<'a> {
+pub enum IndexArgument {
     Eq {
-        columns: &'a ColList,
+        col_id: ColId,
         value: AlgebraicValue,
     },
     LowerBound {
-        columns: &'a ColList,
+        col_id: ColId,
         value: AlgebraicValue,
         inclusive: bool,
     },
     UpperBound {
-        columns: &'a ColList,
+        col_id: ColId,
         value: AlgebraicValue,
         inclusive: bool,
     },
 }
 
-#[derive(Debug, PartialEq, Clone)]
-enum IndexColumnOp<'a> {
-    Index(IndexArgument<'a>),
-    Scan(&'a ColumnOp),
-}
-
-/// Extracts `name = val` when `lhs` is a field that exists and `rhs` is a value.
-fn ext_field_val<'a>(
-    table: &'a SourceExpr,
-    lhs: &'a ColumnOp,
-    rhs: &'a ColumnOp,
-) -> Option<(&'a Column, &'a AlgebraicValue)> {
-    if let (ColumnOp::Field(FieldExpr::Name(name)), ColumnOp::Field(FieldExpr::Value(val))) = (lhs, rhs) {
-        let column = table.get_column_by_field(name)?;
-        return Some((column, val));
-    }
-    None
-}
-
-/// Extracts `name = val` when `op` is `name = val` and `name` exists.
-fn ext_cmp_field_val<'a>(
-    table: &'a SourceExpr,
-    op: &'a ColumnOp,
-) -> Option<(&'a OpCmp, &'a Column, &'a AlgebraicValue)> {
-    match op {
-        ColumnOp::Cmp {
-            op: OpQuery::Cmp(op),
-            lhs,
-            rhs,
-        } => ext_field_val(table, lhs, rhs).map(|(f, v)| (op, f, v)),
-        _ => None,
-    }
-}
-
-fn make_index_arg(cmp: OpCmp, columns: &ColList, value: AlgebraicValue) -> IndexColumnOp<'_> {
-    let arg = match cmp {
-        OpCmp::Eq => IndexArgument::Eq { columns, value },
-        // a < 5 => exclusive upper bound
-        OpCmp::Lt => IndexArgument::UpperBound {
-            columns,
-            value,
-            inclusive: false,
-        },
-        // a > 5 => exclusive lower bound
-        OpCmp::Gt => IndexArgument::LowerBound {
-            columns,
-            value,
-            inclusive: false,
-        },
-        // a <= 5 => inclusive upper bound
-        OpCmp::LtEq => IndexArgument::UpperBound {
-            columns,
-            value,
-            inclusive: true,
-        },
-        // a >= 5 => inclusive lower bound
-        OpCmp::GtEq => IndexArgument::LowerBound {
-            columns,
-            value,
-            inclusive: true,
-        },
-        OpCmp::NotEq => {
-            todo!("Need to implement `NotEq`")
-        }
-    };
-    IndexColumnOp::Index(arg)
-}
-
-#[derive(Debug)]
-struct FieldValue<'a> {
-    parent: &'a ColumnOp,
-    cmp: OpCmp,
-    field: &'a Column,
-    value: &'a AlgebraicValue,
-}
-
-impl<'a> FieldValue<'a> {
-    pub fn new(parent: &'a ColumnOp, cmp: OpCmp, field: &'a Column, value: &'a AlgebraicValue) -> Self {
-        Self {
-            parent,
-            cmp,
-            field,
-            value,
-        }
-    }
-}
-
-type IndexColumnOpSink<'a> = SmallVec<[IndexColumnOp<'a>; 1]>;
-type FieldsIndexed<'a> = HashSet<(&'a FieldName, OpCmp)>;
-
-/// Pick the best indices that can serve the constraints in `fields`
-/// where the indices are taken from `header`.
-///
-/// This function is designed to handle complex scenarios when selecting the optimal index for a query.
-/// The scenarios include:
-///
-/// - Combinations of multi- and single-column indexes that could refer to the same field.
-///   For example, the table could have indexes `[a]` and `[a, b]]`
-///   and a user could query for `WHERE a = 1 AND b = 2 AND a = 3`.
-///
-/// - Query constraints can be supplied in any order;
-///   i.e., both `WHERE a = 1 AND b = 2`
-///   and `WHERE b = 2 AND a = 1` are valid.
-///
-/// - Queries against multi-col indices must use the same operator in their constraints.
-///   Otherwise, the index cannot be used.
-///   That is, for `WHERE a < 1, b < 3`, we can use `ScanOrIndex::Index(Lt, [a, b], (1, 3))`,
-///   whereas for `WHERE a < 1, b != 3`, we cannot.
-///
-/// - The use of multiple tables could generate redundant/duplicate operations like
-///   `[ScanOrIndex::Index(a = 1), ScanOrIndex::Index(a = 1), ScanOrIndex::Scan(a = 1)]`.
-///   This *cannot* be handled here.
-///
-/// # Returns
-///
-/// - A vector of `ScanOrIndex` representing the selected `index` OR `scan` operations.
-///
-/// - A HashSet of `(FieldName, OpCmp)` representing the fields
-///   and operators that can be served by an index.
-///
-///   This is required to remove the redundant operation on e.g.,
-///   `[ScanOrIndex::Index(a = 1), ScanOrIndex::Index(a = 1), ScanOrIndex::Scan(a = 1)]`,
-///   that could be generated by calling this function several times by using multiple `JOINS`.
-///
-/// # Example
-///
-/// If we have a table with `indexes`: `[a], [b], [b, c]` and then try to
-/// optimize `WHERE a = 1 AND d > 2 AND c = 2 AND b = 1` we should return
-///
-/// -`ScanOrIndex::Index([c, b] = [1, 2])`
-/// -`ScanOrIndex::Index(a = 1)`
-/// -`ScanOrIndex::Scan(c = 2)`
-fn select_best_index<'a>(
-    fields_indexed: &mut FieldsIndexed<'a>,
-    found: &mut IndexColumnOpSink<'a>,
-    header: &'a Header,
-    fields: Vec<FieldValue<'a>>,
-) {
-    // Collect and sort indices by their lengths, with longest first.
-    // We do this so that multi-col indices are used first, as they are more efficient.
-    // TODO(Centril): This could be computed when `Header` is constructed.
-    let mut indices = header
-        .constraints
-        .iter()
-        .filter(|(_, c)| c.has_indexed())
-        .map(|(cl, _)| cl)
-        .collect::<SmallVec<[_; 1]>>();
-    indices.sort_unstable_by_key(|cl| Reverse(cl.len()));
-
-    // Collect fields into a multi-map `(col_id, cmp) -> [field]`.
-    // This gives us `log(N)` seek + deletion.
-    // TODO(Centril): Consider https://docs.rs/small-map/0.1.3/small_map/enum.SmallMap.html
-    let mut fields_map = BTreeMap::<_, SmallVec<[_; 1]>>::new();
-    for field in fields {
-        fields_map
-            .entry((field.field.col_id, field.cmp))
-            .or_default()
-            .push(field);
-    }
-
-    // Go through each operator and index,
-    // consuming all field constraints that can be served by an index.
-    for (col_list, cmp) in [OpCmp::Eq, OpCmp::NotEq, OpCmp::Lt, OpCmp::LtEq, OpCmp::Gt, OpCmp::GtEq]
-        .into_iter()
-        .flat_map(|cmp| indices.iter().map(move |cl| (*cl, cmp)))
+// Sargable stands for Search ARGument ABLE.
+// A sargable predicate is one that can be answered using an index.
+fn is_sargable(table: &SourceExpr, op: &ColumnOp) -> Option<IndexArgument> {
+    if let ColumnOp::Cmp {
+        op: OpQuery::Cmp(op),
+        lhs,
+        rhs,
+    } = op
     {
-        // (1) No fields left? We're done.
-        if fields_map.is_empty() {
-            break;
+        // lhs must be a field
+        let ColumnOp::Field(FieldExpr::Name(ref name)) = **lhs else {
+            return None;
+        };
+        // rhs must be a value
+        let ColumnOp::Field(FieldExpr::Value(ref value)) = **rhs else {
+            return None;
+        };
+        // lhs field must exist
+        let column = table.get_column_by_field(name)?;
+        // lhs field must have an index
+        if !table.head().has_constraint(&column.field, Constraints::indexed()) {
+            return None;
         }
 
-        if col_list.is_singleton() {
-            // For a single column index,
-            // we want to avoid the `ProductValue` indirection of below.
-            for FieldValue { cmp, value, field, .. } in fields_map.remove(&(col_list.head(), cmp)).into_iter().flatten()
-            {
-                found.push(make_index_arg(cmp, col_list, value.clone()));
-                fields_indexed.insert((&field.field, cmp));
-            }
-        } else if col_list
-            .iter()
-            // (2) Ensure that every col has a field.
-            .all(|col| fields_map.get(&(col, cmp)).filter(|fs| !fs.is_empty()).is_some())
-        {
-            // We've ensured `col_list ⊆ columns_of(field_map(cmp))`.
-            // Construct the value to compare against.
-            let mut elems = Vec::with_capacity(col_list.len() as usize);
-            for col in col_list.iter() {
-                // Retrieve the field for this (col, cmp) key.
-                // Remove the map entry if the list is empty now.
-                let Entry::Occupied(mut entry) = fields_map.entry((col, cmp)) else {
-                    // We ensured in (2) that the map is occupied for `(col, cmp)`.
-                    unreachable!()
-                };
-                let fields = entry.get_mut();
-                // We ensured in (2) that `fields` is non-empty.
-                let field = fields.pop().unwrap();
-                if fields.is_empty() {
-                    // Remove the entry so that (1) works.
-                    entry.remove();
-                }
-
-                // Add the field value to the product value.
-                elems.push(field.value.clone());
-                fields_indexed.insert((&field.field.field, cmp));
-            }
-            let value = AlgebraicValue::product(elems);
-            found.push(make_index_arg(cmp, col_list, value));
-        }
-    }
-
-    // The remaining constraints must be served by a scan.
-    found.extend(
-        fields_map
-            .into_iter()
-            .flat_map(|(_, fs)| fs)
-            .map(|f| IndexColumnOp::Scan(f.parent)),
-    );
-}
-
-/// Extracts a list of `field = val` constraints that *could* be answered by an index.
-/// The [`ColumnOp`]s that don't fit `field = val` are made into [`IndexColumnOp::Scan`]s immediately.
-fn extract_fields<'a>(
-    ops: &[&'a ColumnOp],
-    table: &'a SourceExpr,
-) -> (Vec<FieldValue<'a>>, SmallVec<[IndexColumnOp<'a>; 1]>) {
-    let mut expr = SmallVec::new();
-    let mut fields = Vec::new();
-    let mut add_field = |parent, op, field, val| fields.push(FieldValue::new(parent, op, field, val));
-
-    for op in ops {
         match op {
-            ColumnOp::Cmp {
-                op: OpQuery::Cmp(cmp),
-                lhs,
-                rhs,
-            } => {
-                if let Some((field, val)) = ext_field_val(table, lhs, rhs) {
-                    // `lhs` must be a field that exists and `rhs` must be a value.
-                    add_field(op, *cmp, field, val);
-                    continue;
-                }
-            }
-            ColumnOp::Cmp {
-                op: OpQuery::Logic(OpLogic::And),
-                lhs,
-                rhs,
-            } => {
-                if let Some((op_lhs, col_lhs, val_lhs)) = ext_cmp_field_val(table, lhs) {
-                    if let Some((op_rhs, col_rhs, val_rhs)) = ext_cmp_field_val(table, rhs) {
-                        // Both lhs and rhs columns must exist.
-                        add_field(op, *op_lhs, col_lhs, val_lhs);
-                        add_field(op, *op_rhs, col_rhs, val_rhs);
-                        continue;
-                    }
-                }
-            }
-            ColumnOp::Cmp {
-                op: OpQuery::Logic(OpLogic::Or),
-                ..
-            }
-            | ColumnOp::Field(_) => {}
-        }
-
-        expr.push(IndexColumnOp::Scan(op));
-    }
-
-    (fields, expr)
-}
-
-/// Sargable stands for Search ARGument ABLE.
-/// A sargable predicate is one that can be answered using an index.
-fn find_sargable_ops<'a>(
-    fields_indexed: &mut FieldsIndexed<'a>,
-    table: &'a SourceExpr,
-    op: &'a ColumnOp,
-) -> SmallVec<[IndexColumnOp<'a>; 1]> {
-    let mut many = |ops: &[&'a ColumnOp]| {
-        let (fields, mut result) = extract_fields(ops, table);
-        select_best_index(fields_indexed, &mut result, table.head(), fields);
-        result
-    };
-    let mut ops_flat = op.flatten_ands_ref();
-    if ops_flat.len() == 1 {
-        match ops_flat.swap_remove(0) {
-            // Special case; fast path for a single field.
-            op @ ColumnOp::Field(_) => smallvec![IndexColumnOp::Scan(op)],
-            op => many(&[op]),
+            OpCmp::Eq => Some(IndexArgument::Eq {
+                col_id: column.col_id,
+                value: value.clone(),
+            }),
+            // a < 5 => exclusive upper bound
+            OpCmp::Lt => Some(IndexArgument::UpperBound {
+                col_id: column.col_id,
+                value: value.clone(),
+                inclusive: false,
+            }),
+            // a > 5 => exclusive lower bound
+            OpCmp::Gt => Some(IndexArgument::LowerBound {
+                col_id: column.col_id,
+                value: value.clone(),
+                inclusive: false,
+            }),
+            // a <= 5 => inclusive upper bound
+            OpCmp::LtEq => Some(IndexArgument::UpperBound {
+                col_id: column.col_id,
+                value: value.clone(),
+                inclusive: true,
+            }),
+            // a >= 5 => inclusive lower bound
+            OpCmp::GtEq => Some(IndexArgument::LowerBound {
+                col_id: column.col_id,
+                value: value.clone(),
+                inclusive: true,
+            }),
+            OpCmp::NotEq => None,
         }
     } else {
-        many(&ops_flat)
+        None
     }
 }
 
@@ -1187,17 +920,17 @@ impl QueryExpr {
             }
             // merge with a preceding select
             Query::Select(filter) => {
-                self.query.push(Query::Select(ColumnOp::new(
-                    OpQuery::Logic(OpLogic::And),
-                    filter,
-                    IndexScan {
+                self.query.push(Query::Select(ColumnOp::Cmp {
+                    op: OpQuery::Logic(OpLogic::And),
+                    lhs: filter.into(),
+                    rhs: IndexScan {
                         table,
                         columns,
                         lower_bound: Bound::Included(value.clone()),
                         upper_bound: Bound::Included(value),
                     }
                     .into(),
-                )));
+                }));
                 self
             }
             // else generate a new select
@@ -1295,17 +1028,17 @@ impl QueryExpr {
             }
             // merge with a preceding select
             Query::Select(filter) => {
-                self.query.push(Query::Select(ColumnOp::new(
-                    OpQuery::Logic(OpLogic::And),
-                    filter,
-                    IndexScan {
+                self.query.push(Query::Select(ColumnOp::Cmp {
+                    op: OpQuery::Logic(OpLogic::And),
+                    lhs: filter.into(),
+                    rhs: IndexScan {
                         table,
                         columns,
                         lower_bound: Self::bound(value, inclusive),
                         upper_bound: Bound::Unbounded,
                     }
                     .into(),
-                )));
+                }));
                 self
             }
             // else generate a new select
@@ -1403,17 +1136,17 @@ impl QueryExpr {
             }
             // merge with a preceding select
             Query::Select(filter) => {
-                self.query.push(Query::Select(ColumnOp::new(
-                    OpQuery::Logic(OpLogic::And),
-                    filter,
-                    IndexScan {
+                self.query.push(Query::Select(ColumnOp::Cmp {
+                    op: OpQuery::Logic(OpLogic::And),
+                    lhs: filter.into(),
+                    rhs: IndexScan {
                         table,
                         columns,
                         lower_bound: Bound::Unbounded,
                         upper_bound: Self::bound(value, inclusive),
                     }
                     .into(),
-                )));
+                }));
                 self
             }
             // else generate a new select
@@ -1452,24 +1185,24 @@ impl QueryExpr {
                 },
             ) => match (*field, *value) {
                 (ColumnOp::Field(FieldExpr::Name(field)), ColumnOp::Field(FieldExpr::Value(value)))
-                // Field is from lhs, so push onto join's left arg
-                if self.source.head().column(&field).is_some() =>
-                    {
-                        self = self.with_select(ColumnOp::cmp(field, cmp, value));
-                        self.query.push(Query::JoinInner(JoinExpr { rhs, col_lhs, col_rhs }));
-                        self
-                    }
+                    // Field is from lhs, so push onto join's left arg
+                    if self.source.head().column(&field).is_some() =>
+                {
+                    self = self.with_select(ColumnOp::cmp(field, cmp, value));
+                    self.query.push(Query::JoinInner(JoinExpr { rhs, col_lhs, col_rhs }));
+                    self
+                }
                 (ColumnOp::Field(FieldExpr::Name(field)), ColumnOp::Field(FieldExpr::Value(value)))
-                // Field is from rhs, so push onto join's right arg
-                if rhs.source.head().column(&field).is_some() =>
-                    {
-                        self.query.push(Query::JoinInner(JoinExpr {
-                            rhs: rhs.with_select(ColumnOp::cmp(field, cmp, value)),
-                            col_lhs,
-                            col_rhs,
-                        }));
-                        self
-                    }
+                    // Field is from rhs, so push onto join's right arg
+                    if rhs.source.head().column(&field).is_some() =>
+                {
+                    self.query.push(Query::JoinInner(JoinExpr {
+                        rhs: rhs.with_select(ColumnOp::cmp(field, cmp, value)),
+                        col_lhs,
+                        col_rhs,
+                    }));
+                    self
+                }
                 (field, value) => {
                     self.query.push(Query::JoinInner(JoinExpr { rhs, col_lhs, col_rhs }));
                     self.query.push(Query::Select(ColumnOp::new(OpQuery::Cmp(cmp), field, value)));
@@ -1598,51 +1331,39 @@ impl QueryExpr {
 
     /// Look for filters that could use indexes
     fn optimize_select(mut q: QueryExpr, op: ColumnOp, tables: &[SourceExpr]) -> QueryExpr {
-        // Go through each table schema referenced in the query.
-        // Find the first sargable condition and short-circuit.
-        let mut fields_found = HashSet::new();
-        for schema in tables {
-            for op in find_sargable_ops(&mut fields_found, schema, &op) {
-                match &op {
-                    IndexColumnOp::Index(_) | IndexColumnOp::Scan(ColumnOp::Field(_)) => {}
-                    // Remove a duplicated/redundant operation on the same `field` and `op`
-                    // like `[ScanOrIndex::Index(a = 1), ScanOrIndex::Index(a = 1), ScanOrIndex::Scan(a = 1)]`
-                    IndexColumnOp::Scan(ColumnOp::Cmp { op, lhs, rhs: _ }) => {
-                        if let (ColumnOp::Field(FieldExpr::Name(col)), OpQuery::Cmp(cmp)) = (&**lhs, op) {
-                            if fields_found.contains(&(col, *cmp)) {
-                                continue;
-                            } else {
-                                fields_found.insert((col, *cmp));
-                            }
-                        }
-                    }
-                }
-
-                match op {
+        'outer: for ref op in op.to_vec() {
+            // Go through each table schema referenced in the query.
+            // Find the first sargable condition and short-circuit.
+            for schema in tables {
+                match is_sargable(schema, op) {
                     // found sargable equality condition for one of the table schemas
-                    IndexColumnOp::Index(idx) => match idx {
-                        IndexArgument::Eq { columns, value } => {
-                            q = q.with_index_eq(schema.into(), columns.clone(), value);
-                        }
-                        IndexArgument::LowerBound {
-                            columns,
-                            value,
-                            inclusive,
-                        } => {
-                            q = q.with_index_lower_bound(schema.into(), columns.clone(), value, inclusive);
-                        }
-                        IndexArgument::UpperBound {
-                            columns,
-                            value,
-                            inclusive,
-                        } => {
-                            q = q.with_index_upper_bound(schema.into(), columns.clone(), value, inclusive);
-                        }
-                    },
-                    // Filter condition cannot be answered using an index.
-                    IndexColumnOp::Scan(scan) => q = q.with_select(scan.clone()),
+                    Some(IndexArgument::Eq { col_id, value }) => {
+                        q = q.with_index_eq(schema.into(), col_id.into(), value);
+                        continue 'outer;
+                    }
+                    // found sargable range condition for one of the table schemas
+                    Some(IndexArgument::LowerBound {
+                        col_id,
+                        value,
+                        inclusive,
+                    }) => {
+                        q = q.with_index_lower_bound(schema.into(), col_id.into(), value, inclusive);
+                        continue 'outer;
+                    }
+                    // found sargable range condition for one of the table schemas
+                    Some(IndexArgument::UpperBound {
+                        col_id,
+                        value,
+                        inclusive,
+                    }) => {
+                        q = q.with_index_upper_bound(schema.into(), col_id.into(), value, inclusive);
+                        continue 'outer;
+                    }
+                    None => {}
                 }
             }
+            // filter condition cannot be answered using an index
+            q = q.with_select(op.clone());
         }
 
         q
@@ -1948,10 +1669,9 @@ impl From<Code> for CodeResult {
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::relation::{MemTable, Table};
-    use spacetimedb_sats::product;
-    use typed_arena::Arena;
+
+    use super::*;
 
     const ALICE: Identity = Identity::from_byte_array([1; 32]);
     const BOB: Identity = Identity::from_byte_array([2; 32]);
@@ -2120,7 +1840,7 @@ mod tests {
             join.rhs,
             QueryExpr {
                 source: SourceExpr::MemTable(index_side),
-                query: vec![index_select.into()],
+                query: vec![index_select.into()]
             }
         );
 
@@ -2132,245 +1852,8 @@ mod tests {
             fields,
             &vec![
                 FieldName::named("probe", "c").into(),
-                FieldName::named("probe", "b").into(),
+                FieldName::named("probe", "b").into()
             ]
-        );
-    }
-
-    fn setup_best_index() -> (Header, [Column; 5], [AlgebraicValue; 5]) {
-        let mut pos = 0;
-        let fields = ["a", "b", "c", "d", "e"].map(|x| {
-            let c = Column::new(FieldName::named("t1", x), AlgebraicType::I8, pos.into());
-            pos += 1;
-            c
-        });
-
-        let [a, b, c, d] = [0, 1, 2, 3].map(ColId);
-        let head1 = Header::new(
-            "t1".into(),
-            fields.to_vec(),
-            vec![
-                //Index a
-                (a.into(), Constraints::primary_key()),
-                //Index b
-                (b.into(), Constraints::indexed()),
-                //Index b + c
-                (col_list![b, c], Constraints::unique()),
-                //Index a + b + c + d
-                (col_list![a, b, c, d], Constraints::indexed()),
-            ],
-        );
-
-        let vals = [1, 2, 3, 4, 5].map(AlgebraicValue::U64);
-
-        (head1, fields, vals)
-    }
-
-    fn make_field_value<'a>(
-        arena: &'a Arena<ColumnOp>,
-        (cmp, col, value): (OpCmp, &'a Column, &'a AlgebraicValue),
-    ) -> FieldValue<'a> {
-        let from_expr = |expr| Box::new(ColumnOp::Field(expr));
-        let op = ColumnOp::Cmp {
-            op: OpQuery::Cmp(cmp),
-            lhs: from_expr(FieldExpr::Name(col.field.clone())),
-            rhs: from_expr(FieldExpr::Value(value.clone())),
-        };
-        let parent = arena.alloc(op);
-        FieldValue::new(parent, cmp, col, value)
-    }
-
-    fn scan_eq<'a>(arena: &'a Arena<ColumnOp>, col: &'a Column, val: &'a AlgebraicValue) -> IndexColumnOp<'a> {
-        scan(arena, OpCmp::Eq, col, val)
-    }
-
-    fn scan<'a>(arena: &'a Arena<ColumnOp>, cmp: OpCmp, col: &'a Column, val: &'a AlgebraicValue) -> IndexColumnOp<'a> {
-        IndexColumnOp::Scan(make_field_value(arena, (cmp, col, val)).parent)
-    }
-
-    #[test]
-    fn best_index() {
-        let (head1, fields, vals) = setup_best_index();
-        let [col_a, col_b, col_c, col_d, col_e] = fields;
-        let [val_a, val_b, val_c, val_d, val_e] = vals;
-
-        let arena = Arena::new();
-        let select_best_index = |fields: &[_]| {
-            let fields = fields
-                .iter()
-                .copied()
-                .map(|(col, val)| make_field_value(&arena, (OpCmp::Eq, col, val)))
-                .collect();
-            let mut result = <_>::default();
-            select_best_index(&mut <_>::default(), &mut result, &head1, fields);
-            result
-        };
-
-        let col_list_arena = Arena::new();
-        let idx_eq = |cols, val| make_index_arg(OpCmp::Eq, col_list_arena.alloc(cols), val);
-
-        // Check for simple scan
-        assert_eq!(
-            select_best_index(&[(&col_d, &val_e)]),
-            [scan_eq(&arena, &col_d, &val_e)].into(),
-        );
-
-        assert_eq!(
-            select_best_index(&[(&col_a, &val_a)]),
-            [idx_eq(col_a.col_id.into(), val_a.clone())].into(),
-        );
-
-        assert_eq!(
-            select_best_index(&[(&col_b, &val_b)]),
-            [idx_eq(col_b.col_id.into(), val_b.clone())].into(),
-        );
-
-        // Check for permutation
-        assert_eq!(
-            select_best_index(&[(&col_b, &val_b), (&col_c, &val_c)]),
-            [idx_eq(
-                col_list![col_b.col_id, col_c.col_id],
-                product![val_b.clone(), val_c.clone()].into()
-            )]
-            .into(),
-        );
-
-        assert_eq!(
-            select_best_index(&[(&col_c, &val_c), (&col_b, &val_b)]),
-            [idx_eq(
-                col_list![col_b.col_id, col_c.col_id],
-                product![val_b.clone(), val_c.clone()].into()
-            )]
-            .into(),
-        );
-
-        // Check for permutation
-        assert_eq!(
-            select_best_index(&[(&col_a, &val_a), (&col_b, &val_b), (&col_c, &val_c), (&col_d, &val_d)]),
-            [idx_eq(
-                col_list![col_a.col_id, col_b.col_id, col_c.col_id, col_d.col_id],
-                product![val_a.clone(), val_b.clone(), val_c.clone(), val_d.clone()].into(),
-            )]
-            .into(),
-        );
-
-        assert_eq!(
-            select_best_index(&[(&col_b, &val_b), (&col_a, &val_a), (&col_d, &val_d), (&col_c, &val_c)]),
-            [idx_eq(
-                col_list![col_a.col_id, col_b.col_id, col_c.col_id, col_d.col_id],
-                product![val_a.clone(), val_b.clone(), val_c.clone(), val_d.clone()].into(),
-            )]
-            .into()
-        );
-
-        // Check mix scan + index
-        assert_eq!(
-            select_best_index(&[(&col_b, &val_b), (&col_a, &val_a), (&col_e, &val_e), (&col_d, &val_d)]),
-            [
-                idx_eq(col_a.col_id.into(), val_a.clone()),
-                idx_eq(col_b.col_id.into(), val_b.clone()),
-                scan_eq(&arena, &col_d, &val_d),
-                scan_eq(&arena, &col_e, &val_e),
-            ]
-            .into()
-        );
-
-        assert_eq!(
-            select_best_index(&[(&col_b, &val_b), (&col_c, &val_c), (&col_d, &val_d)]),
-            [
-                idx_eq(
-                    col_list![col_b.col_id, col_c.col_id],
-                    product![val_b.clone(), val_c.clone()].into(),
-                ),
-                scan_eq(&arena, &col_d, &val_d),
-            ]
-            .into()
-        );
-    }
-
-    #[test]
-    fn best_index_range() {
-        let arena = Arena::new();
-
-        let (head1, fields, vals) = setup_best_index();
-        let [col_a, col_b, col_c, col_d, _] = fields;
-        let [val_a, val_b, val_c, val_d, _] = vals;
-
-        let select_best_index = |fields: &[_]| {
-            let fields = fields.iter().map(|x| make_field_value(&arena, *x)).collect();
-            let mut result = <_>::default();
-            select_best_index(&mut <_>::default(), &mut result, &head1, fields);
-            result
-        };
-
-        let col_list_arena = Arena::new();
-        let idx = |cmp, cols: &[&Column], val: &AlgebraicValue| {
-            let columns = cols
-                .iter()
-                .map(|c| c.col_id)
-                .collect::<ColListBuilder>()
-                .build()
-                .unwrap();
-            let columns = col_list_arena.alloc(columns);
-            make_index_arg(cmp, columns, val.clone())
-        };
-
-        // Same field indexed
-        assert_eq!(
-            select_best_index(&[(OpCmp::Gt, &col_a, &val_a), (OpCmp::Lt, &col_a, &val_b)]),
-            [idx(OpCmp::Lt, &[&col_a], &val_b), idx(OpCmp::Gt, &[&col_a], &val_a)].into()
-        );
-
-        // Same field scan
-        assert_eq!(
-            select_best_index(&[(OpCmp::Gt, &col_d, &val_d), (OpCmp::Lt, &col_d, &val_b)]),
-            [
-                scan(&arena, OpCmp::Lt, &col_d, &val_b),
-                scan(&arena, OpCmp::Gt, &col_d, &val_d)
-            ]
-            .into()
-        );
-        // One indexed other scan
-        assert_eq!(
-            select_best_index(&[(OpCmp::Gt, &col_b, &val_b), (OpCmp::Lt, &col_c, &val_c)]),
-            [
-                idx(OpCmp::Gt, &[&col_b], &val_b),
-                scan(&arena, OpCmp::Lt, &col_c, &val_c)
-            ]
-            .into()
-        );
-
-        // 1 multi-indexed 1 index
-        assert_eq!(
-            select_best_index(&[
-                (OpCmp::Eq, &col_b, &val_b),
-                (OpCmp::GtEq, &col_a, &val_a),
-                (OpCmp::Eq, &col_c, &val_c),
-            ]),
-            [
-                idx(
-                    OpCmp::Eq,
-                    &[&col_b, &col_c],
-                    &product![val_b.clone(), val_c.clone()].into(),
-                ),
-                idx(OpCmp::GtEq, &[&col_a], &val_a),
-            ]
-            .into()
-        );
-
-        // 1 indexed 2 scan
-        assert_eq!(
-            select_best_index(&[
-                (OpCmp::Gt, &col_b, &val_b),
-                (OpCmp::Eq, &col_a, &val_a),
-                (OpCmp::Lt, &col_c, &val_c),
-            ]),
-            [
-                idx(OpCmp::Eq, &[&col_a], &val_a),
-                idx(OpCmp::Gt, &[&col_b], &val_b),
-                scan(&arena, OpCmp::Lt, &col_c, &val_c),
-            ]
-            .into()
         );
     }
 


### PR DESCRIPTION
This reverts commit 726080dadcce3a74f3055937183a037a21f4c221.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

- This broke bitcraft with this error:

```
2024-03-01T19:57:19.479142Z DEBUG crates\client-api\src\routes\subscribe.rs:134: New client connected from unknown ip
thread 'tokio-runtime-worker' panicked at crates\vm\src\expr.rs:827:13:
not yet implemented: Need to implement `NotEq`
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
thread 'tokio-runtime-worker' panicked at C:\Users\Boppy\clockworklabs\SpacetimeDB\crates\core\src\client\client_connection.rs:171:14:
called `Result::unwrap()` on an `Err` value: JoinError::Panic(Id(12680), ...)
```

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

None

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

`
