### PR TITLE
perf(747): Single query execution for multiple subscriptions 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4556,6 +4556,7 @@ dependencies = [
  "async-trait",
  "backtrace",
  "base64 0.21.4",
+ "blake3",
  "bytes",
  "bytestring",
  "chrono",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -31,6 +31,7 @@ anyhow.workspace = true
 async-trait.workspace = true
 backtrace.workspace = true
 base64.workspace = true
+blake3.workspace = true
 bytes.workspace = true
 bytestring.workspace = true
 chrono.workspace = true

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -18,6 +18,17 @@ pub struct ClientActorId {
     pub name: ClientName,
 }
 
+impl ClientActorId {
+    #[cfg(test)]
+    pub fn for_test(identity: Identity) -> Self {
+        ClientActorId {
+            identity,
+            address: Address::ZERO,
+            name: ClientName(0),
+        }
+    }
+}
+
 #[derive(PartialEq, Eq, Clone, Copy, Hash, Debug)]
 pub struct ClientName(pub u64);
 

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -32,6 +32,20 @@ pub struct DatabaseUpdate {
     pub tables: Vec<DatabaseTableUpdate>,
 }
 
+impl FromIterator<DatabaseTableUpdate> for DatabaseUpdate {
+    fn from_iter<T: IntoIterator<Item = DatabaseTableUpdate>>(iter: T) -> Self {
+        DatabaseUpdate {
+            tables: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl From<Vec<DatabaseTableUpdate>> for DatabaseUpdate {
+    fn from(value: Vec<DatabaseTableUpdate>) -> Self {
+        DatabaseUpdate::from_iter(value)
+    }
+}
+
 impl DatabaseUpdate {
     pub fn is_empty(&self) -> bool {
         if self.tables.len() == 0 {

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -634,7 +634,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         };
         self.info
             .subscriptions
-            .blocking_broadcast_event(client.as_ref(), &subscriptions, &event);
+            .blocking_broadcast_event(client.as_ref(), &subscriptions, Arc::new(event));
 
         ReducerCallResult {
             outcome,

--- a/crates/core/src/startup.rs
+++ b/crates/core/src/startup.rs
@@ -151,7 +151,7 @@ fn configure_rayon() {
         // and Rayon threads to the other.
         // Then we should give Tokio and Rayon each a number of worker threads
         // equal to the size of their pool.
-        .num_threads(std::thread::available_parallelism().unwrap().get())
+        .num_threads(std::thread::available_parallelism().unwrap().get() / 2)
         .build_global()
         .unwrap()
 }

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -1,0 +1,161 @@
+use std::hash::Hash;
+
+use spacetimedb_lib::identity::AuthCtx;
+use spacetimedb_primitives::TableId;
+use spacetimedb_vm::expr::SourceSet;
+
+use crate::db::relational_db::{RelationalDB, Tx};
+use crate::error::DBError;
+use crate::execution_context::ExecutionContext;
+use crate::host::module_host::{DatabaseTableUpdate, TableOp};
+
+use super::query::{self, run_query, Supported};
+use super::subscription::{eval_primary_updates, IncrementalJoin, SupportedQuery};
+
+/// A hash for uniquely identifying query execution units,
+/// to avoid recompilation of queries that have an open subscription.
+///
+/// Currently we are using a cryptographic hash,
+/// which is most certainly overkill.
+/// However the benefits include uniqueness by definition,
+/// and a compact representation for equality comparisons.
+///
+/// It also decouples the hash from the physical plan.
+///
+/// Note that we could hash QueryExprs directly,
+/// using the standard library's hasher.
+/// However some execution units are comprised of several query plans,
+/// as is the case for incremental joins.
+/// And we want to associate a hash with the entire unit of execution,
+/// rather than an individual plan.
+#[derive(Debug, Clone, Copy, PartialEq, Eq, Hash)]
+pub struct QueryHash {
+    data: [u8; 32],
+}
+
+impl QueryHash {
+    pub const NONE: Self = Self { data: [0; 32] };
+
+    pub fn from_bytes(bytes: &[u8]) -> Self {
+        Self {
+            data: blake3::hash(bytes).into(),
+        }
+    }
+
+    pub fn from_string(str: &str) -> Self {
+        Self::from_bytes(str.as_bytes())
+    }
+}
+
+/// An atomic unit of execution within a subscription set.
+/// Currently just a single query plan,
+/// however in the future this could be multiple query plans,
+/// such as those of an incremental join.
+#[derive(Debug)]
+pub struct ExecutionUnit {
+    hash: QueryHash,
+    plan: SupportedQuery,
+}
+
+/// An ExecutionUnit is uniquely identified by its QueryHash.
+impl Eq for ExecutionUnit {}
+
+impl PartialEq for ExecutionUnit {
+    fn eq(&self, other: &Self) -> bool {
+        self.hash == other.hash
+    }
+}
+
+impl From<SupportedQuery> for ExecutionUnit {
+    fn from(plan: SupportedQuery) -> Self {
+        ExecutionUnit {
+            hash: QueryHash::NONE,
+            plan,
+        }
+    }
+}
+
+impl ExecutionUnit {
+    pub fn new(plan: SupportedQuery, hash: QueryHash) -> Self {
+        ExecutionUnit { hash, plan }
+    }
+
+    /// Is this a single table select or a semijoin?
+    pub fn kind(&self) -> Supported {
+        self.plan.kind
+    }
+
+    /// The unique query hash for this execution unit.
+    pub fn hash(&self) -> QueryHash {
+        self.hash
+    }
+
+    /// The table from which this query returns rows.
+    pub fn return_table(&self) -> TableId {
+        self.plan.return_table()
+    }
+
+    pub fn return_name(&self) -> String {
+        self.plan.return_name()
+    }
+
+    /// The table on which this query filters rows.
+    /// In the case of a single table select,
+    /// this is the same as the return table.
+    /// In the case of a semijoin,
+    /// it is the auxiliary table against which we are joining.
+    pub fn filter_table(&self) -> TableId {
+        self.plan.filter_table()
+    }
+
+    /// Evaluate this execution unit against the database.
+    #[tracing::instrument(skip_all)]
+    pub fn eval(&self, db: &RelationalDB, tx: &Tx, auth: AuthCtx) -> Result<Option<DatabaseTableUpdate>, DBError> {
+        let ctx = ExecutionContext::subscribe(db.address());
+        let mut ops = vec![];
+        for table in run_query(&ctx, db, tx, &self.plan.expr, auth, SourceSet::default())? {
+            ops.extend(table.data.into_iter().map(TableOp::insert));
+        }
+        Ok((!ops.is_empty()).then(|| DatabaseTableUpdate {
+            table_id: self.return_table(),
+            table_name: self.return_name(),
+            ops,
+        }))
+    }
+
+    /// Evaluate this execution unit against the given delta tables.
+    #[tracing::instrument(skip_all)]
+    pub fn eval_incr<'a>(
+        &'a self,
+        db: &RelationalDB,
+        tx: &Tx,
+        tables: impl Iterator<Item = &'a DatabaseTableUpdate>,
+        auth: AuthCtx,
+    ) -> Result<Option<DatabaseTableUpdate>, DBError> {
+        let ops = match self.plan.kind {
+            Supported::Select => {
+                let mut ops = Vec::new();
+                for table in tables.filter(|table| table.table_id == self.return_table()) {
+                    // Replace table reference in original query plan with virtual MemTable
+                    let (plan, sources) = query::to_mem_table(self.plan.expr.clone(), table);
+                    // Evaluate the new plan and capture the new row operations.
+                    ops.extend(eval_primary_updates(db, auth, tx, &plan, sources)?.map(|r| TableOp::new(r.0, r.1)));
+                }
+                ops
+            }
+            Supported::Semijoin => {
+                if let Some(plan) = IncrementalJoin::new(&self.plan.expr, tables.into_iter())? {
+                    // Evaluate the plan and capture the new row operations
+                    plan.eval(db, tx, &auth)?.collect()
+                } else {
+                    vec![]
+                }
+            }
+        };
+        Ok((!ops.is_empty()).then(|| DatabaseTableUpdate {
+            table_id: self.return_table(),
+            table_name: self.return_name(),
+            ops,
+        }))
+    }
+}

--- a/crates/core/src/subscription/mod.rs
+++ b/crates/core/src/subscription/mod.rs
@@ -1,4 +1,6 @@
+pub mod execution_unit;
 pub mod module_subscription_actor;
+pub mod module_subscription_manager;
 pub mod query;
 #[allow(clippy::module_inception)] // it's right this isn't ideal :/
 pub mod subscription;

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -1,26 +1,22 @@
-use super::{
-    query::compile_read_only_query,
-    subscription::{ExecutionSet, Subscription},
-};
-use crate::client::{
-    messages::{CachedMessage, SubscriptionUpdateMessage, TransactionUpdateMessage},
-    ClientActorId, ClientConnectionSender,
-};
+use super::execution_unit::{ExecutionUnit, QueryHash};
+use super::module_subscription_manager::SubscriptionManager;
+use super::query::compile_read_only_query;
+use super::subscription::ExecutionSet;
+use crate::client::messages::{SubscriptionUpdateMessage, TransactionUpdateMessage};
+use crate::client::{ClientActorId, ClientConnectionSender};
 use crate::db::relational_db::RelationalDB;
-use crate::error::DBError;
+use crate::error::{DBError, SubscriptionError};
 use crate::execution_context::ExecutionContext;
 use crate::host::module_host::{EventStatus, ModuleEvent};
 use crate::protobuf::client_api::Subscribe;
 use crate::worker_metrics::WORKER_METRICS;
-use futures::Future;
-use itertools::Itertools;
 use parking_lot::RwLock;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::Identity;
 use std::sync::Arc;
 
-type Subscriptions = Arc<RwLock<Vec<Subscription>>>;
+type Subscriptions = Arc<RwLock<SubscriptionManager>>;
+
 #[derive(Debug)]
 pub struct ModuleSubscriptions {
     relational_db: Arc<RelationalDB>,
@@ -32,7 +28,7 @@ impl ModuleSubscriptions {
     pub fn new(relational_db: Arc<RelationalDB>, owner_identity: Identity) -> Self {
         Self {
             relational_db,
-            subscriptions: Arc::new(RwLock::new(Vec::new())),
+            subscriptions: Arc::new(RwLock::new(SubscriptionManager::default())),
             owner_identity,
         }
     }
@@ -46,44 +42,52 @@ impl ModuleSubscriptions {
         });
 
         let auth = AuthCtx::new(self.owner_identity, sender.id.identity);
-        let mut n_queries = 0;
-        let queries = subscription
-            .query_strings
-            .iter()
-            .map(|sql| compile_read_only_query(&self.relational_db, &tx, &auth, sql))
-            .flatten_ok()
-            .inspect(|_| n_queries += 1)
-            .collect::<Result<ExecutionSet, _>>()?;
+        let mut queries = vec![];
 
-        let database_update = queries.eval(&self.relational_db, &tx, auth)?;
-        // It acquires the subscription lock after `eval`, allowing `add_subscription` to run concurrently.
-        // This also makes it possible for `broadcast_event` to get scheduled before the subsequent part here
-        // but that should not pose an issue.
-        let mut subscriptions = self.subscriptions.write();
-        drop(tx);
-        self._remove_subscriber(sender.id, &mut subscriptions);
-        let subscription = match subscriptions.iter_mut().find(|s| s.queries == queries) {
-            Some(sub) => {
-                sub.add_subscriber(sender);
-                sub
+        let guard = self.subscriptions.read();
+
+        for sql in subscription.query_strings {
+            let hash = QueryHash::from_string(&sql);
+            if let Some(unit) = guard.query(&hash) {
+                queries.push(unit);
+            } else {
+                let mut compiled = compile_read_only_query(&self.relational_db, &tx, &auth, &sql)?;
+                if compiled.len() > 1 {
+                    return Result::Err(
+                        SubscriptionError::Unsupported(String::from("Multiple statements in subscription query"))
+                            .into(),
+                    );
+                }
+                queries.push(Arc::new(ExecutionUnit::new(compiled.remove(0), hash)));
             }
-            None => {
-                subscriptions.push(Subscription::new(queries, sender));
-                WORKER_METRICS
-                    .subscription_queries
-                    .with_label_values(&self.relational_db.address())
-                    .add(n_queries as i64);
-                subscriptions.last_mut().unwrap()
-            }
-        };
+        }
+
+        drop(guard);
+
+        let execution_set: ExecutionSet = queries.into();
+        let database_update = execution_set.eval(&self.relational_db, &tx, auth)?;
 
         WORKER_METRICS
             .initial_subscription_evals
             .with_label_values(&self.relational_db.address())
             .inc();
 
-        let sender = subscription.subscribers().last().unwrap().clone();
+        // It acquires the subscription lock after `eval`, allowing `add_subscription` to run concurrently.
+        // This also makes it possible for `broadcast_event` to get scheduled before the subsequent part here
+        // but that should not pose an issue.
+        let sender = Arc::new(sender);
+        let mut subscriptions = self.subscriptions.write();
+        drop(tx);
+        subscriptions.remove_subscription(&sender.id.identity);
+        subscriptions.add_subscription(sender.clone(), execution_set.into_iter());
+        let num_queries = subscriptions.num_queries();
         drop(subscriptions);
+
+        WORKER_METRICS
+            .subscription_queries
+            .with_label_values(&self.relational_db.address())
+            .set(num_queries as i64);
+
         // NOTE: It is important to send the state in this thread because if you spawn a new
         // thread it's possible for messages to get sent to the client out of order. If you do
         // spawn in another thread messages will need to be buffered until the state is sent out
@@ -95,20 +99,11 @@ impl ModuleSubscriptions {
 
     pub fn remove_subscriber(&self, client_id: ClientActorId) {
         let mut subscriptions = self.subscriptions.write();
-        self._remove_subscriber(client_id, &mut subscriptions);
-    }
-
-    fn _remove_subscriber(&self, client_id: ClientActorId, subscriptions: &mut Vec<Subscription>) {
-        subscriptions.retain_mut(|subscription| {
-            subscription.remove_subscriber(client_id);
-            if subscription.subscribers().is_empty() {
-                WORKER_METRICS
-                    .subscription_queries
-                    .with_label_values(&self.relational_db.address())
-                    .sub(subscription.queries.num_queries() as i64);
-            }
-            !subscription.subscribers().is_empty()
-        })
+        subscriptions.remove_subscription(&client_id.identity);
+        WORKER_METRICS
+            .subscription_queries
+            .with_label_values(&self.relational_db.address())
+            .set(subscriptions.num_queries() as i64);
     }
 
     /// Broadcast a ModuleEvent to all interested subscribers.
@@ -119,17 +114,22 @@ impl ModuleSubscriptions {
     pub async fn broadcast_event(
         &self,
         client: Option<&ClientConnectionSender>,
-        subscriptions: &[Subscription],
-        event: &ModuleEvent,
+        subscriptions: &SubscriptionManager,
+        event: Arc<ModuleEvent>,
     ) {
         match event.status {
             EventStatus::Committed(_) => {
-                tokio::task::block_in_place(|| self.broadcast_commit_event(subscriptions, event)).await;
+                if let Err(err) =
+                    tokio::task::block_in_place(|| self.broadcast_commit_event(subscriptions, event)).await
+                {
+                    // TODO: log an id for the subscription somehow as well
+                    tracing::error!(err = &err as &dyn std::error::Error, "subscription eval_incr failed");
+                }
             }
             EventStatus::Failed(_) => {
                 if let Some(client) = client {
                     let message = TransactionUpdateMessage {
-                        event,
+                        event: &event,
                         database_update: Default::default(),
                     };
                     let _ = client.send_message(message).await;
@@ -145,8 +145,8 @@ impl ModuleSubscriptions {
     pub fn blocking_broadcast_event(
         &self,
         client: Option<&ClientConnectionSender>,
-        subscriptions: &[Subscription],
-        event: &ModuleEvent,
+        subscriptions: &SubscriptionManager,
+        event: Arc<ModuleEvent>,
     ) {
         tokio::runtime::Handle::current().block_on(self.broadcast_event(client, subscriptions, event))
     }
@@ -157,55 +157,12 @@ impl ModuleSubscriptions {
     /// once all updates have been successfully added to the subscribers' send queues (i.e. after
     /// it resolves, it's guaranteed that if you call `subscriber.send(x)` the client will receive
     /// x after they receive this subscription update).
-    fn broadcast_commit_event(
+    async fn broadcast_commit_event(
         &self,
-        subscriptions: &[Subscription],
-        event: &ModuleEvent,
-    ) -> impl Future<Output = ()> + '_ {
-        let database_update = event.status.database_update().unwrap();
-
+        subscriptions: &SubscriptionManager,
+        event: Arc<ModuleEvent>,
+    ) -> Result<(), DBError> {
         let auth = AuthCtx::new(self.owner_identity, event.caller_identity);
-
-        let tokio_handle = &tokio::runtime::Handle::current();
-
-        let tx = &*scopeguard::guard(self.relational_db.begin_tx(), |tx| {
-            let ctx = ExecutionContext::incremental_update(self.relational_db.address());
-            self.relational_db.release_tx(&ctx, tx);
-        });
-
-        let tasks = subscriptions
-            .par_iter()
-            .filter_map(|subscription| {
-                let incr = subscription
-                    .queries
-                    .eval_incr(&self.relational_db, tx, database_update, auth);
-                match incr {
-                    Ok(incr) if incr.tables.is_empty() => None,
-                    Ok(incr) => Some((subscription, incr)),
-                    Err(err) => {
-                        // TODO: log an id for the subscription somehow as well
-                        tracing::error!(err = &err as &dyn std::error::Error, "subscription eval_incr failed");
-                        None
-                    }
-                }
-            })
-            .flat_map_iter(|(subscription, database_update)| {
-                let message = TransactionUpdateMessage { event, database_update };
-                let mut message = CachedMessage::new(message);
-
-                subscription.subscribers().iter().cloned().map(move |subscriber| {
-                    let message = message.serialize(subscriber.protocol);
-                    tokio_handle.spawn(async move {
-                        let _ = subscriber.send(message).await;
-                    })
-                })
-            })
-            .collect::<Vec<_>>();
-
-        async move {
-            for task in tasks {
-                let _ = task.await;
-            }
-        }
+        subscriptions.eval_updates(&self.relational_db, auth, event).await
     }
 }

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -1,0 +1,433 @@
+use super::execution_unit::{ExecutionUnit, QueryHash};
+use crate::client::messages::{CachedMessage, TransactionUpdateMessage};
+use crate::client::{ClientConnectionSender, DataMessage, Protocol};
+use crate::db::relational_db::RelationalDB;
+use crate::error::DBError;
+use crate::execution_context::ExecutionContext;
+use crate::host::module_host::{DatabaseTableUpdate, DatabaseUpdate, ModuleEvent};
+use rayon::iter::{IntoParallelIterator, ParallelIterator};
+use smallvec::SmallVec;
+use spacetimedb_lib::identity::AuthCtx;
+use spacetimedb_lib::Identity;
+use spacetimedb_primitives::TableId;
+use std::collections::{HashMap, HashSet};
+use std::sync::Arc;
+
+type Query = Arc<ExecutionUnit>;
+type Client = Arc<ClientConnectionSender>;
+
+/// Responsible for the efficient evaluation of subscriptions.
+/// It performs basic multi-query optimization,
+/// in that if a query has N subscribers,
+/// it is only executed once,
+/// with the results copied to the N receivers.
+#[derive(Debug, Default)]
+pub struct SubscriptionManager {
+    // Subscriber identities and their client connections.
+    clients: HashMap<Identity, Client>,
+    // Queries for which there is at least one subscriber.
+    queries: HashMap<QueryHash, Query>,
+    // The subscribers for each query.
+    subscribers: HashMap<QueryHash, HashSet<Identity>>,
+    // Inverted index from tables to queries that read from them.
+    tables: HashMap<TableId, HashSet<QueryHash>>,
+}
+
+impl SubscriptionManager {
+    pub fn client(&self, id: &Identity) -> Client {
+        self.clients[id].clone()
+    }
+
+    pub fn query(&self, hash: &QueryHash) -> Option<Query> {
+        self.queries.get(hash).map(Arc::clone)
+    }
+
+    pub fn num_queries(&self) -> usize {
+        self.queries.len()
+    }
+
+    #[cfg(test)]
+    fn contains_query(&self, hash: &QueryHash) -> bool {
+        self.queries.contains_key(hash)
+    }
+
+    #[cfg(test)]
+    fn contains_subscription(&self, subscriber: &Identity, query: &QueryHash) -> bool {
+        self.subscribers.get(query).is_some_and(|ids| ids.contains(subscriber))
+    }
+
+    #[cfg(test)]
+    fn query_reads_from_table(&self, query: &QueryHash, table: &TableId) -> bool {
+        self.tables.get(table).is_some_and(|queries| queries.contains(query))
+    }
+
+    /// Adds a client and its queries to the subscription manager.
+    /// If a query is not already indexed,
+    /// its table ids added to the inverted index.
+    #[tracing::instrument(skip_all)]
+    pub fn add_subscription(&mut self, client: Client, queries: impl IntoIterator<Item = Query>) {
+        let id = client.id.identity;
+        self.clients.insert(id, client);
+        for unit in queries {
+            let hash = unit.hash();
+            self.tables.entry(unit.return_table()).or_default().insert(hash);
+            self.tables.entry(unit.filter_table()).or_default().insert(hash);
+            self.subscribers.entry(hash).or_default().insert(id);
+            self.queries.insert(hash, unit);
+        }
+    }
+
+    /// Removes a client from the subscriber mapping.
+    /// If a query no longer has any subscribers,
+    /// it is removed from the index along with its table ids.
+    #[tracing::instrument(skip_all)]
+    pub fn remove_subscription(&mut self, client: &Identity) {
+        self.clients.remove(client);
+        self.subscribers.retain(|hash, ids| {
+            ids.remove(client);
+            if ids.is_empty() {
+                if let Some(query) = self.queries.remove(hash) {
+                    if self
+                        .tables
+                        .get_mut(&query.return_table())
+                        .is_some_and(|hashes| hashes.remove(hash) && hashes.is_empty())
+                    {
+                        self.tables.remove(&query.return_table());
+                    }
+                    if self
+                        .tables
+                        .get_mut(&query.filter_table())
+                        .is_some_and(|hashes| hashes.remove(hash) && hashes.is_empty())
+                    {
+                        self.tables.remove(&query.filter_table());
+                    }
+                }
+            }
+            !ids.is_empty()
+        });
+    }
+
+    /// This method takes a set of delta tables,
+    /// evaluates only the necessary queries for those delta tables,
+    /// and then sends the results to each client.
+    #[tracing::instrument(skip_all)]
+    pub async fn eval_updates(&self, db: &RelationalDB, auth: AuthCtx, event: Arc<ModuleEvent>) -> Result<(), DBError> {
+        let tokio_handle = &tokio::runtime::Handle::current();
+        let tables = &event.status.database_update().unwrap().tables;
+        let tx = db.begin_tx();
+
+        // Put the main work on a rayon compute thread.
+        let tasks = rayon::scope(|_| {
+            // Collect the delta tables for each query.
+            // For selects this is just a single table.
+            // For joins it's two tables.
+            let mut units: HashMap<_, SmallVec<[_; 2]>> = HashMap::new();
+            for table @ DatabaseTableUpdate { table_id, .. } in tables {
+                if let Some(hashes) = self.tables.get(table_id) {
+                    for hash in hashes {
+                        units.entry(hash).or_insert_with(SmallVec::new).push(table);
+                    }
+                }
+            }
+
+            units
+                .into_par_iter()
+                .filter_map(|(hash, tables)| self.queries.get(hash).map(|unit| (hash, tables, unit)))
+                .filter_map(|(hash, tables, unit)| {
+                    match unit.eval_incr(db, &tx, tables.into_iter(), auth) {
+                        Ok(None) => None,
+                        Ok(Some(table)) => Some((hash, table)),
+                        Err(err) => {
+                            // TODO: log an id for the subscription somehow as well
+                            tracing::error!(err = &err as &dyn std::error::Error, "subscription eval_incr failed");
+                            None
+                        }
+                    }
+                })
+                // If N clients are subscribed to a query,
+                // we copy the DatabaseTableUpdate N times,
+                // which involves cloning product values.
+                // TODO(perf): In order to reduce heap allocations,
+                // we should serialize and memcpy bsatn directly.
+                .flat_map_iter(|(hash, delta)| {
+                    self.subscribers
+                        .get(hash)
+                        .into_iter()
+                        .flatten()
+                        .map(move |id| (id, delta.table_id, delta.clone()))
+                })
+                .collect::<Vec<_>>()
+                .into_iter()
+                .fold(
+                    HashMap::new(),
+                    |mut tables: HashMap<(&Identity, TableId), DatabaseTableUpdate>, (id, table_id, delta)| {
+                        if let Some(table) = tables.get_mut(&(id, table_id)) {
+                            table.ops.extend(delta.ops);
+                        } else {
+                            tables.insert((id, table_id), delta);
+                        }
+                        tables
+                    },
+                )
+                .into_iter()
+                // Each client receives a single DatabaseUpdate per transaction.
+                // So before sending an update to each client,
+                // we must stitch together the DatabaseTableUpdates into a final DatabaseUpdate.
+                .fold(HashMap::new(), |mut updates, ((id, _), delta)| {
+                    if let Some(DatabaseUpdate { tables }) = updates.get_mut(id) {
+                        tables.push(delta);
+                    } else {
+                        updates.insert(id, vec![delta].into());
+                    }
+                    updates
+                })
+                .into_iter()
+                .map(|(id, update)| {
+                    let client = self.client(id);
+                    let event = event.clone();
+                    tokio_handle.spawn(async move {
+                        let _ = client.send(serialize_updates(update, &event, client.protocol)).await;
+                    })
+                })
+                .collect::<Vec<_>>()
+        });
+
+        tx.release(&ExecutionContext::incremental_update(db.address()));
+
+        for task in tasks {
+            let _ = task.await;
+        }
+        Ok(())
+    }
+}
+
+#[tracing::instrument(skip_all)]
+fn serialize_updates(database_update: DatabaseUpdate, event: &ModuleEvent, protocol: Protocol) -> DataMessage {
+    let message = TransactionUpdateMessage { event, database_update };
+    let mut cached = CachedMessage::new(message);
+    cached.serialize(protocol)
+}
+
+#[cfg(test)]
+mod tests {
+    use std::sync::Arc;
+
+    use spacetimedb_lib::{error::ResultTest, AlgebraicType, Identity};
+    use spacetimedb_primitives::TableId;
+    use spacetimedb_vm::expr::CrudExpr;
+
+    use crate::{
+        client::{ClientActorId, ClientConnectionSender, Protocol},
+        db::relational_db::{tests_utils::make_test_db, RelationalDB},
+        execution_context::ExecutionContext,
+        sql::compiler::compile_sql,
+        subscription::{
+            execution_unit::{ExecutionUnit, QueryHash},
+            subscription::SupportedQuery,
+        },
+    };
+
+    use super::SubscriptionManager;
+
+    fn create_table(db: &RelationalDB, name: &str) -> ResultTest<TableId> {
+        Ok(db.create_table_for_test(name, &[("a", AlgebraicType::U8)], &[])?)
+    }
+
+    fn compile_plan(db: &RelationalDB, sql: &str) -> ResultTest<Arc<ExecutionUnit>> {
+        db.with_read_only(&ExecutionContext::default(), |tx| {
+            let mut exprs = compile_sql(db, tx, sql)?;
+            assert_eq!(1, exprs.len());
+            assert!(matches!(exprs[0], CrudExpr::Query(_)));
+            let CrudExpr::Query(query) = exprs.remove(0) else {
+                unreachable!();
+            };
+            let plan = SupportedQuery::new(query, sql.to_owned())?;
+            let hash = QueryHash::from_string(sql);
+            Ok(Arc::new(ExecutionUnit::new(plan, hash)))
+        })
+    }
+
+    #[test]
+    fn test_subscribe() -> ResultTest<()> {
+        let (db, _) = make_test_db()?;
+
+        let table_id = create_table(&db, "T")?;
+        let sql = "select * from T";
+        let plan = compile_plan(&db, sql)?;
+        let hash = plan.hash();
+
+        let id = Identity::ZERO;
+        let client = ClientActorId::for_test(id);
+        let client = Arc::new(ClientConnectionSender::dummy(client, Protocol::Binary));
+
+        let mut subscriptions = SubscriptionManager::default();
+        subscriptions.add_subscription(client, [plan]);
+
+        assert!(subscriptions.contains_query(&hash));
+        assert!(subscriptions.contains_subscription(&id, &hash));
+        assert!(subscriptions.query_reads_from_table(&hash, &table_id));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_unsubscribe() -> ResultTest<()> {
+        let (db, _) = make_test_db()?;
+
+        let table_id = create_table(&db, "T")?;
+        let sql = "select * from T";
+        let plan = compile_plan(&db, sql)?;
+        let hash = plan.hash();
+
+        let id = Identity::ZERO;
+        let client = ClientActorId::for_test(id);
+        let client = Arc::new(ClientConnectionSender::dummy(client, Protocol::Binary));
+
+        let mut subscriptions = SubscriptionManager::default();
+        subscriptions.add_subscription(client, [plan]);
+        subscriptions.remove_subscription(&id);
+
+        assert!(!subscriptions.contains_query(&hash));
+        assert!(!subscriptions.contains_subscription(&id, &hash));
+        assert!(!subscriptions.query_reads_from_table(&hash, &table_id));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_subscribe_idempotent() -> ResultTest<()> {
+        let (db, _) = make_test_db()?;
+
+        let table_id = create_table(&db, "T")?;
+        let sql = "select * from T";
+        let plan = compile_plan(&db, sql)?;
+        let hash = plan.hash();
+
+        let id = Identity::ZERO;
+        let client = ClientActorId::for_test(id);
+        let client = Arc::new(ClientConnectionSender::dummy(client, Protocol::Binary));
+
+        let mut subscriptions = SubscriptionManager::default();
+        subscriptions.add_subscription(client.clone(), [plan.clone()]);
+        subscriptions.add_subscription(client.clone(), [plan.clone()]);
+
+        assert!(subscriptions.contains_query(&hash));
+        assert!(subscriptions.contains_subscription(&id, &hash));
+        assert!(subscriptions.query_reads_from_table(&hash, &table_id));
+
+        subscriptions.remove_subscription(&id);
+
+        assert!(!subscriptions.contains_query(&hash));
+        assert!(!subscriptions.contains_subscription(&id, &hash));
+        assert!(!subscriptions.query_reads_from_table(&hash, &table_id));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_share_queries_full() -> ResultTest<()> {
+        let (db, _) = make_test_db()?;
+
+        let table_id = create_table(&db, "T")?;
+        let sql = "select * from T";
+        let plan = compile_plan(&db, sql)?;
+        let hash = plan.hash();
+
+        let id0 = Identity::ZERO;
+        let client0 = ClientActorId::for_test(id0);
+        let client0 = Arc::new(ClientConnectionSender::dummy(client0, Protocol::Binary));
+
+        let id1 = Identity::from_byte_array([1; 32]);
+        let client1 = ClientActorId::for_test(id1);
+        let client1 = Arc::new(ClientConnectionSender::dummy(client1, Protocol::Binary));
+
+        let mut subscriptions = SubscriptionManager::default();
+        subscriptions.add_subscription(client0, [plan.clone()]);
+        subscriptions.add_subscription(client1, [plan.clone()]);
+
+        assert!(subscriptions.contains_query(&hash));
+        assert!(subscriptions.contains_subscription(&id0, &hash));
+        assert!(subscriptions.contains_subscription(&id1, &hash));
+        assert!(subscriptions.query_reads_from_table(&hash, &table_id));
+
+        subscriptions.remove_subscription(&id0);
+
+        assert!(subscriptions.contains_query(&hash));
+        assert!(subscriptions.contains_subscription(&id1, &hash));
+        assert!(subscriptions.query_reads_from_table(&hash, &table_id));
+
+        assert!(!subscriptions.contains_subscription(&id0, &hash));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_share_queries_partial() -> ResultTest<()> {
+        let (db, _) = make_test_db()?;
+
+        let t = create_table(&db, "T")?;
+        let s = create_table(&db, "S")?;
+
+        let scan = "select * from T";
+        let select0 = "select * from T where a = 0";
+        let select1 = "select * from S where a = 1";
+
+        let plan_scan = compile_plan(&db, scan)?;
+        let plan_select0 = compile_plan(&db, select0)?;
+        let plan_select1 = compile_plan(&db, select1)?;
+
+        let hash_scan = plan_scan.hash();
+        let hash_select0 = plan_select0.hash();
+        let hash_select1 = plan_select1.hash();
+
+        let id0 = Identity::ZERO;
+        let client0 = ClientActorId::for_test(id0);
+        let client0 = Arc::new(ClientConnectionSender::dummy(client0, Protocol::Binary));
+
+        let id1 = Identity::from_byte_array([1; 32]);
+        let client1 = ClientActorId::for_test(id1);
+        let client1 = Arc::new(ClientConnectionSender::dummy(client1, Protocol::Binary));
+
+        let mut subscriptions = SubscriptionManager::default();
+        subscriptions.add_subscription(client0, [plan_scan.clone(), plan_select0.clone()]);
+        subscriptions.add_subscription(client1, [plan_scan.clone(), plan_select1.clone()]);
+
+        assert!(subscriptions.contains_query(&hash_scan));
+        assert!(subscriptions.contains_query(&hash_select0));
+        assert!(subscriptions.contains_query(&hash_select1));
+
+        assert!(subscriptions.contains_subscription(&id0, &hash_scan));
+        assert!(subscriptions.contains_subscription(&id0, &hash_select0));
+
+        assert!(subscriptions.contains_subscription(&id1, &hash_scan));
+        assert!(subscriptions.contains_subscription(&id1, &hash_select1));
+
+        assert!(subscriptions.query_reads_from_table(&hash_scan, &t));
+        assert!(subscriptions.query_reads_from_table(&hash_select0, &t));
+        assert!(subscriptions.query_reads_from_table(&hash_select1, &s));
+
+        assert!(!subscriptions.query_reads_from_table(&hash_scan, &s));
+        assert!(!subscriptions.query_reads_from_table(&hash_select0, &s));
+        assert!(!subscriptions.query_reads_from_table(&hash_select1, &t));
+
+        subscriptions.remove_subscription(&id0);
+
+        assert!(subscriptions.contains_query(&hash_scan));
+        assert!(subscriptions.contains_query(&hash_select1));
+        assert!(!subscriptions.contains_query(&hash_select0));
+
+        assert!(subscriptions.contains_subscription(&id1, &hash_scan));
+        assert!(subscriptions.contains_subscription(&id1, &hash_select1));
+
+        assert!(!subscriptions.contains_subscription(&id0, &hash_scan));
+        assert!(!subscriptions.contains_subscription(&id0, &hash_select0));
+
+        assert!(subscriptions.query_reads_from_table(&hash_scan, &t));
+        assert!(subscriptions.query_reads_from_table(&hash_select1, &s));
+
+        assert!(!subscriptions.query_reads_from_table(&hash_scan, &s));
+        assert!(!subscriptions.query_reads_from_table(&hash_select1, &t));
+
+        Ok(())
+    }
+}

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -172,7 +172,7 @@ fn record_query_compilation_metrics(workload: WorkloadType, db: &Address, query:
 #[derive(Clone, Copy, Debug, Eq, Ord, PartialEq, PartialOrd, Hash)]
 pub enum Supported {
     /// A scan or [`QueryExpr::Select`] of a single table.
-    Scan,
+    Select,
     /// A semijoin of two tables, restricted to [`QueryExpr::IndexJoin`]s.
     ///
     /// See [`crate::sql::compiler::try_index_join`].
@@ -191,7 +191,7 @@ pub fn classify(expr: &QueryExpr) -> Option<Supported> {
             return None;
         }
     }
-    Some(Supported::Scan)
+    Some(Supported::Select)
 }
 
 #[cfg(test)]
@@ -949,7 +949,7 @@ mod tests {
         ];
         for scan in scans {
             let expr = compile_read_only_query(&db, &tx, &auth, scan)?.pop().unwrap();
-            assert_eq!(expr.kind(), Supported::Scan, "{scan}\n{expr:#?}");
+            assert_eq!(expr.kind(), Supported::Select, "{scan}\n{expr:#?}");
         }
 
         // Only index semijoins are supported

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -23,6 +23,7 @@
 //!
 #![doc = include_str!("../../../../docs/incremental-joins.md")]
 
+use super::execution_unit::ExecutionUnit;
 use super::query;
 use crate::db::relational_db::Tx;
 use crate::error::{DBError, SubscriptionError};
@@ -37,13 +38,13 @@ use anyhow::Context;
 use itertools::Either;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use spacetimedb_lib::identity::AuthCtx;
+use spacetimedb_lib::ProductValue;
 use spacetimedb_primitives::TableId;
 use spacetimedb_sats::db::auth::{StAccess, StTableType};
 use spacetimedb_sats::relation::Header;
-use spacetimedb_sats::ProductValue;
-use spacetimedb_vm::expr::{self, IndexJoin, QueryExpr, SourceSet};
+use spacetimedb_vm::expr::{self, IndexJoin, Query, QueryExpr, SourceSet};
 use spacetimedb_vm::relation::MemTable;
-use std::collections::{hash_map, HashMap, HashSet};
+use std::collections::HashSet;
 use std::ops::Deref;
 use std::sync::Arc;
 
@@ -84,8 +85,8 @@ impl Subscription {
 /// Constructed via `TryFrom`, which rejects unsupported queries.
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct SupportedQuery {
-    kind: query::Supported,
-    expr: QueryExpr,
+    pub kind: query::Supported,
+    pub expr: QueryExpr,
 }
 
 impl SupportedQuery {
@@ -100,6 +101,40 @@ impl SupportedQuery {
 
     pub fn as_expr(&self) -> &QueryExpr {
         self.as_ref()
+    }
+
+    /// The table whose rows are being returned.
+    pub fn return_table(&self) -> TableId {
+        self.expr.source.get_db_table().unwrap().table_id
+    }
+
+    pub fn return_name(&self) -> String {
+        self.expr.source.table_name().to_owned()
+    }
+
+    /// This is the same as the return table unless this is a join.
+    /// For joins this is the table whose rows are not being returned.
+    pub fn filter_table(&self) -> TableId {
+        let return_table = self.return_table();
+        self.expr
+            .query
+            .first()
+            .and_then(|op| {
+                if let Query::IndexJoin(join) = op {
+                    Some(join)
+                } else {
+                    None
+                }
+            })
+            .and_then(|join| {
+                join.index_side
+                    .get_db_table()
+                    .filter(|t| t.table_id != return_table)
+                    .or_else(|| join.probe_side.source.get_db_table())
+                    .filter(|t| t.table_id != return_table)
+                    .map(|t| t.table_id)
+            })
+            .unwrap_or(return_table)
     }
 }
 
@@ -123,7 +158,7 @@ impl AsRef<QueryExpr> for SupportedQuery {
 ///
 /// A secondary table is one whose rows are not directly returned by the query.
 /// An example is the right table of a left semijoin.
-fn eval_secondary_updates<'a>(
+pub fn eval_secondary_updates<'a>(
     db: &RelationalDB,
     auth: AuthCtx,
     tx: &Tx,
@@ -140,7 +175,7 @@ fn eval_secondary_updates<'a>(
 ///
 /// The primary table is the one whose rows are returned by the query.
 /// An example is the left table of a left semijoin.
-fn eval_primary_updates<'a>(
+pub fn eval_primary_updates<'a>(
     db: &RelationalDB,
     auth: AuthCtx,
     tx: &Tx,
@@ -194,7 +229,7 @@ fn eval_updates<'a>(
 }
 
 /// Helper for evaluating a [`query::Supported::Semijoin`].
-struct IncrementalJoin<'a> {
+pub struct IncrementalJoin<'a> {
     join: &'a IndexJoin,
     index_side: JoinSide,
     probe_side: JoinSide,
@@ -461,138 +496,10 @@ fn with_delta_table(
     (join, sources)
 }
 
-/// The atomic unit of execution within a subscription set.
-#[derive(Debug, PartialEq, Eq, Hash)]
-struct ExecutionUnit {
-    table_id: TableId,
-    table_name: String,
-    queries: Vec<SupportedQuery>,
-}
-
-impl ExecutionUnit {
-    #[tracing::instrument(skip_all)]
-    fn eval(&self, db: &RelationalDB, tx: &Tx, auth: AuthCtx) -> Result<Option<DatabaseTableUpdate>, DBError> {
-        let ctx = ExecutionContext::subscribe(db.address());
-        let ops = match &self.queries[..] {
-            // special-case single query - we don't have to deduplicate
-            // Raw SQL queries (not incrementalized) never reference `MemTable`s,
-            // so pass an empty `SourceSet`.
-            [query] => run_query(&ctx, db, tx, &query.expr, auth, SourceSet::default())?
-                .into_iter()
-                .flat_map(|table| table.data)
-                .map(TableOp::insert)
-                .collect(),
-            // this is a case we don't fully support atm
-            queries => {
-                let mut ops = Vec::new();
-
-                for SupportedQuery { kind: _, expr } in queries {
-                    // Raw SQL queries (not incrementalized) never reference `MemTable`s,
-                    // so pass an empty `SourceSet`.
-                    for table in run_query(&ctx, db, tx, expr, auth, SourceSet::default())? {
-                        ops.extend(table.data.into_iter().map(TableOp::insert));
-                    }
-                }
-
-                ops
-            }
-        };
-
-        Ok((!ops.is_empty()).then(|| DatabaseTableUpdate {
-            table_id: self.table_id,
-            table_name: self.table_name.clone(),
-            ops,
-        }))
-    }
-
-    #[tracing::instrument(skip_all)]
-    fn eval_incr(
-        &self,
-        db: &RelationalDB,
-        tx: &Tx,
-        database_update: &DatabaseUpdate,
-        auth: AuthCtx,
-    ) -> Result<Option<DatabaseTableUpdate>, DBError> {
-        use query::Supported::*;
-        let ops = match &self.queries[..] {
-            // special-case single query - we don't have to deduplicate
-            [query] => {
-                match query.kind {
-                    Scan => {
-                        if let Some(rows) = database_update
-                            .tables
-                            .iter()
-                            .find(|update| update.table_id == self.table_id)
-                        {
-                            // Replace table reference in original query plan with virtual MemTable
-                            let (plan, sources) = query::to_mem_table(query.expr.clone(), rows);
-                            // Evaluate the new plan and capture the new row operations.
-                            eval_primary_updates(db, auth, tx, &plan, sources)?
-                                .map(|r| TableOp::new(r.0, r.1))
-                                .collect()
-                        } else {
-                            vec![]
-                        }
-                    }
-                    Semijoin => {
-                        if let Some(plan) = IncrementalJoin::new(&query.expr, &database_update.tables)? {
-                            // Evaluate the plan and capture the new row operations
-                            plan.eval(db, tx, &auth)?.collect()
-                        } else {
-                            vec![]
-                        }
-                    }
-                }
-            }
-            // this is a case we don't fully support atm
-            queries => {
-                let mut ops = Vec::new();
-
-                for query in queries {
-                    match query.kind {
-                        Scan => {
-                            if let Some(rows) = database_update
-                                .tables
-                                .iter()
-                                .find(|update| update.table_id == self.table_id)
-                            {
-                                // Replace table reference in original query plan with virtual MemTable
-                                let (plan, sources) = query::to_mem_table(query.expr.clone(), rows);
-                                // Evaluate the new plan and capture the new row operations.
-                                ops.extend(
-                                    eval_primary_updates(db, auth, tx, &plan, sources)?.map(|r| TableOp::new(r.0, r.1)),
-                                );
-                            }
-                        }
-                        Semijoin => {
-                            for rows in database_update.tables.iter().filter(|table| {
-                                table.table_id == self.table_id || query.expr.reads_from_table(&table.table_id)
-                            }) {
-                                if let Some(plan) = IncrementalJoin::new(&query.expr, [rows])? {
-                                    // Evaluate the plan and capture the new row operations
-                                    ops.extend(plan.eval(db, tx, &auth)?);
-                                }
-                            }
-                        }
-                    }
-                }
-
-                ops
-            }
-        };
-
-        Ok((!ops.is_empty()).then(|| DatabaseTableUpdate {
-            table_id: self.table_id,
-            table_name: self.table_name.clone(),
-            ops,
-        }))
-    }
-}
-
 /// A set of independent single or multi-query execution units.
 #[derive(Debug, PartialEq, Eq)]
 pub struct ExecutionSet {
-    exec_units: Vec<ExecutionUnit>,
+    exec_units: Vec<Arc<ExecutionUnit>>,
 }
 
 impl ExecutionSet {
@@ -620,39 +527,40 @@ impl ExecutionSet {
         let tables = self
             .exec_units
             .iter()
-            .filter_map(|unit| unit.eval_incr(db, tx, database_update, auth).transpose())
+            .filter_map(|unit| unit.eval_incr(db, tx, database_update.tables.iter(), auth).transpose())
             .collect::<Result<_, _>>()?;
         Ok(DatabaseUpdate { tables })
-    }
-
-    pub fn num_queries(&self) -> usize {
-        self.exec_units.iter().map(|unit| unit.queries.len()).sum()
     }
 }
 
 impl FromIterator<SupportedQuery> for ExecutionSet {
     fn from_iter<T: IntoIterator<Item = SupportedQuery>>(iter: T) -> Self {
-        let mut exec_units = Vec::new();
-        // a map from the table id of each execution unit to its index in the vector
-        let mut exec_units_map = HashMap::new();
-        for query in iter {
-            let Some(db_table) = query.expr.source.get_db_table() else {
-                continue;
-            };
-            match exec_units_map.entry(db_table.table_id) {
-                hash_map::Entry::Vacant(v) => {
-                    v.insert(exec_units.len());
-                    exec_units.push(ExecutionUnit {
-                        table_id: db_table.table_id,
-                        table_name: db_table.head.table_name.clone(),
-                        queries: vec![query],
-                    });
-                }
-                hash_map::Entry::Occupied(o) => exec_units[*o.get()].queries.push(query),
-            }
+        ExecutionSet {
+            exec_units: iter.into_iter().map(|plan| Arc::new(plan.into())).collect(),
         }
+    }
+}
 
-        ExecutionSet { exec_units }
+impl IntoIterator for ExecutionSet {
+    type Item = Arc<ExecutionUnit>;
+    type IntoIter = std::vec::IntoIter<Self::Item>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.exec_units.into_iter()
+    }
+}
+
+impl FromIterator<Arc<ExecutionUnit>> for ExecutionSet {
+    fn from_iter<T: IntoIterator<Item = Arc<ExecutionUnit>>>(iter: T) -> Self {
+        ExecutionSet {
+            exec_units: iter.into_iter().collect(),
+        }
+    }
+}
+
+impl From<Vec<Arc<ExecutionUnit>>> for ExecutionSet {
+    fn from(value: Vec<Arc<ExecutionUnit>>) -> Self {
+        ExecutionSet::from_iter(value)
     }
 }
 
@@ -674,7 +582,7 @@ pub(crate) fn get_all(relational_db: &RelationalDB, tx: &Tx, auth: &AuthCtx) -> 
             t.table_type == StTableType::User && (auth.owner == auth.caller || t.table_access == StAccess::Public)
         })
         .map(|src| SupportedQuery {
-            kind: query::Supported::Scan,
+            kind: query::Supported::Select,
             expr: QueryExpr::new(src),
         })
         .collect())

--- a/crates/lib/src/identity.rs
+++ b/crates/lib/src/identity.rs
@@ -27,7 +27,7 @@ impl AuthCtx {
     }
 }
 
-#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Copy, Hash, Serialize, Deserialize)]
+#[derive(Default, Eq, PartialEq, PartialOrd, Ord, Clone, Copy, Hash, Serialize, Deserialize)]
 pub struct Identity {
     __identity_bytes: [u8; 32],
 }
@@ -41,6 +41,10 @@ impl AsPrometheusLabel for Identity {
 }
 
 impl Identity {
+    pub const ZERO: Self = Self {
+        __identity_bytes: [0; 32],
+    };
+
     /// Returns an `Identity` defined as the given `bytes` byte array.
     pub const fn from_byte_array(bytes: [u8; 32]) -> Self {
         Self {


### PR DESCRIPTION
# Description of Changes

Previously we would evaluate each and every subscription on each and every row update.
If N subscriptions had a query Q in common, Q would be evaluated N different times.
With this change, queries are evaluated once, and the results transmitted to each client.
So in the example above, Q would be evaluated once, with the results duplicated to N different clients.

Some things to note:
1. It's currently single threaded
    In principle evaluating row updates should be very fast.
    On the order of microseconds.
    In that case parallelizing eval probably just adds overhead.
    However if we didn't have to aggregate the different table updates before sending to the client, it might be beneficial.
2. It's evaluated on a rayon thread.
    Again, if eval_incr is on the order of microseconds, is this just adding overhead?
3. When sending to clients, we clone `DatabaseTableUpdate`
    This means we clone product values.
    It would be better if we could serialize each DatabaseTableUpdate, so that we could just memcpy, but that would require changes to our protobuf schema.

# API and ABI breaking changes

None

# Expected complexity level and risk

4 Mainly due to subpar test coverage of eval_incr (although we have decent coverage, just not excellent)
