### PR TITLE
(1/3) Commitlog: Base implementation "sans I/O"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -953,6 +953,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "crc32c"
+version = "0.6.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "89254598aa9b9fa608de44b3ae54c810f0f06d755e24c50177f1f8f31ff50ce2"
+dependencies = [
+ "rustc_version",
+]
+
+[[package]]
 name = "crc32fast"
 version = "1.3.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4435,6 +4444,21 @@ dependencies = [
  "prost",
  "prost-build",
  "strum",
+]
+
+[[package]]
+name = "spacetimedb-commitlog"
+version = "0.8.2"
+dependencies = [
+ "bitflags 2.4.1",
+ "crc32c",
+ "env_logger",
+ "itertools 0.12.0",
+ "log",
+ "proptest",
+ "rand 0.8.5",
+ "spacetimedb-sats",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -7,6 +7,7 @@ members = [
   "crates/cli",
   "crates/client-api",
   "crates/client-api-messages",
+  "crates/commitlog",
   "crates/core",
   "crates/data-structures",
   "crates/lib",
@@ -85,6 +86,7 @@ spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "0.8.2" }
 spacetimedb-cli = { path = "crates/cli", version = "0.8.2" }
 spacetimedb-client-api = { path = "crates/client-api", version = "0.8.2" }
 spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "0.8.2" }
+spacetimedb-commitlog = { path = "crates/commitlog", version = "0.8.2" }
 spacetimedb-core = { path = "crates/core", version = "0.8.2" }
 spacetimedb-lib = { path = "crates/lib", default-features = false, version = "0.8.2" }
 spacetimedb-metrics = { path = "crates/metrics", version = "0.8.2" }
@@ -115,6 +117,7 @@ clap = { version = "4.2.4", features = ["derive"] }
 colored = "2.0.0"
 console = { version = "0.15.6" }
 convert_case = "0.6.0"
+crc32c = "0.6.4"
 criterion = { version = "0.5.1", features = ["async", "async_tokio", "html_reports"] }
 crossbeam-channel = "0.5"
 cursive = { version = "0.20", default-features = false, features = ["crossterm-backend"] }

--- a/crates/commitlog/Cargo.toml
+++ b/crates/commitlog/Cargo.toml
@@ -1,0 +1,21 @@
+[package]
+name = "spacetimedb-commitlog"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license-file = "LICENSE"
+
+description = "Implementation of the SpacetimeDB commitlog."
+
+[dependencies]
+bitflags.workspace = true
+crc32c.workspace = true
+itertools.workspace = true
+log.workspace = true
+spacetimedb-sats.workspace = true
+thiserror.workspace = true
+
+[dev-dependencies]
+env_logger.workspace = true
+proptest.workspace = true
+rand.workspace = true

--- a/crates/commitlog/LICENSE
+++ b/crates/commitlog/LICENSE
@@ -1,0 +1,1 @@
+../../LICENSE.txt

--- a/crates/commitlog/src/commit.rs
+++ b/crates/commitlog/src/commit.rs
@@ -1,0 +1,228 @@
+use std::{
+    io::{self, Read, Write},
+    ops::Range,
+};
+
+use crc32c::{Crc32cReader, Crc32cWriter};
+use spacetimedb_sats::buffer::{BufReader, DecodeError};
+
+use crate::{error::ChecksumMismatch, segment::CHECKSUM_ALGORITHM_CRC32C};
+
+pub struct Header {
+    min_tx_offset: u64,
+    n: u16,
+    len: u32,
+}
+
+impl Header {
+    pub const LEN: usize = /* offset */ 8 + /* n */ 2 + /* len */  4;
+
+    /// Read [`Self::LEN`] bytes from `reader` and interpret them as the
+    /// "header" of a [`Commit`].
+    ///
+    /// Returns `None` if:
+    ///
+    /// - The reader cannot provide exactly [`Self::LEN`] bytes
+    ///
+    ///   I.e. it is at EOF
+    ///
+    /// - Or, the read bytes are all zeroes
+    ///
+    ///   This is to allow preallocation of segments.
+    ///
+    pub fn decode<R: Read>(mut reader: R) -> io::Result<Option<Self>> {
+        let mut hdr = [0; Self::LEN];
+        if let Err(e) = reader.read_exact(&mut hdr) {
+            if e.kind() == io::ErrorKind::UnexpectedEof {
+                return Ok(None);
+            }
+
+            return Err(e);
+        }
+        match &mut hdr.as_slice() {
+            [0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0] => Ok(None),
+            buf => {
+                let min_tx_offset = buf.get_u64().map_err(decode_error)?;
+                let n = buf.get_u16().map_err(decode_error)?;
+                let len = buf.get_u32().map_err(decode_error)?;
+
+                Ok(Some(Self { min_tx_offset, n, len }))
+            }
+        }
+    }
+}
+
+/// Entry type of a [`crate::Commitlog`].
+#[derive(Debug, Default, PartialEq)]
+pub struct Commit {
+    /// The offset of the first record in this commit.
+    ///
+    /// The offset starts from zero and is counted from the beginning of the
+    /// entire log.
+    pub min_tx_offset: u64,
+    /// The number of records in the commit.
+    pub n: u16,
+    /// A buffer of all records in the commit in serialized form.
+    ///
+    /// Readers must bring their own [`crate::Decoder`] to interpret this buffer.
+    /// `n` indicates how many records the buffer contains.
+    pub records: Vec<u8>,
+}
+
+impl Commit {
+    pub const FRAMING_LEN: usize = Header::LEN + /* crc32 */ 4;
+    pub const CHECKSUM_ALGORITHM: u8 = CHECKSUM_ALGORITHM_CRC32C;
+
+    /// The range of transaction offsets contained in this commit.
+    pub fn tx_range(&self) -> Range<u64> {
+        self.min_tx_offset..self.min_tx_offset + self.n as u64
+    }
+
+    /// Length in bytes of this commit when written to the log via [`Self::write`].
+    pub fn encoded_len(&self) -> usize {
+        Self::FRAMING_LEN + self.records.len()
+    }
+
+    /// Serialize and write `self` to `out`.
+    pub fn write<W: Write>(&self, out: W) -> io::Result<()> {
+        let mut out = Crc32cWriter::new(out);
+
+        let min_tx_offset = self.min_tx_offset.to_le_bytes();
+        let n = self.n.to_le_bytes();
+        let len = (self.records.len() as u32).to_le_bytes();
+
+        out.write_all(&min_tx_offset)?;
+        out.write_all(&n)?;
+        out.write_all(&len)?;
+        out.write_all(&self.records)?;
+
+        let crc = out.crc32c();
+        let mut out = out.into_inner();
+        out.write_all(&crc.to_le_bytes())?;
+
+        Ok(())
+    }
+
+    /// Attempt to read one [`Commit`] from the given [`Read`]er.
+    ///
+    /// Returns `None` if the reader is already at EOF.
+    ///
+    /// Verifies the checksum of the commit. If it doesn't match, an error of
+    /// kind [`io::ErrorKind::InvalidData`] with an inner error downcastable to
+    /// [`ChecksumMismatch`] is returned.
+    pub fn decode<R: Read>(reader: R) -> io::Result<Option<Self>> {
+        let mut reader = Crc32cReader::new(reader);
+
+        let Some(hdr) = Header::decode(&mut reader)? else {
+            return Ok(None);
+        };
+        let mut records = vec![0; hdr.len as usize];
+        reader.read_exact(&mut records)?;
+
+        let chk = reader.crc32c();
+        let crc = decode_u32(reader.into_inner())?;
+
+        if chk != crc {
+            return Err(invalid_data(ChecksumMismatch));
+        }
+
+        Ok(Some(Self {
+            min_tx_offset: hdr.min_tx_offset,
+            n: hdr.n,
+            records,
+        }))
+    }
+}
+
+/// Numbers needed to compute [`crate::segment::Header`].
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Metadata {
+    pub tx_range: Range<u64>,
+    pub size_in_bytes: u64,
+}
+
+impl Metadata {
+    /// Extract the [`Metadata`] of a single [`Commit`] from the given reader.
+    ///
+    /// Note that this decodes the commit due to checksum verification.
+    /// Like [`Commit::decode`], returns `None` if the reader is at EOF already.
+    pub fn extract<R: io::Read>(reader: R) -> io::Result<Option<Self>> {
+        Commit::decode(reader).map(|maybe_commit| maybe_commit.map(Self::from))
+    }
+}
+
+impl From<Commit> for Metadata {
+    fn from(commit: Commit) -> Self {
+        Self {
+            tx_range: commit.tx_range(),
+            size_in_bytes: commit.encoded_len() as u64,
+        }
+    }
+}
+
+fn decode_u32<R: Read>(mut read: R) -> io::Result<u32> {
+    let mut buf = [0; 4];
+    read.read_exact(&mut buf)?;
+    Ok(u32::from_le_bytes(buf))
+}
+
+fn decode_error(e: DecodeError) -> io::Error {
+    invalid_data(e)
+}
+
+fn invalid_data<E>(e: E) -> io::Error
+where
+    E: Into<Box<dyn std::error::Error + Send + Sync>>,
+{
+    io::Error::new(io::ErrorKind::InvalidData, e)
+}
+
+#[cfg(test)]
+mod tests {
+    use rand::prelude::*;
+
+    use super::*;
+
+    #[test]
+    fn commit_roundtrip() {
+        let records = vec![0; 128];
+        let commit = Commit {
+            min_tx_offset: 0,
+            n: 3,
+            records,
+        };
+
+        let mut buf = Vec::with_capacity(commit.encoded_len());
+        commit.write(&mut buf).unwrap();
+        let commit2 = Commit::decode(&mut buf.as_slice()).unwrap();
+
+        assert_eq!(Some(commit), commit2);
+    }
+
+    #[test]
+    fn bitflip() {
+        let commit = Commit {
+            min_tx_offset: 42,
+            n: 10,
+            records: vec![1; 512],
+        };
+
+        let mut buf = Vec::with_capacity(commit.encoded_len());
+        commit.write(&mut buf).unwrap();
+
+        let mut rng = thread_rng();
+        let b = buf.choose_mut(&mut rng).unwrap();
+        *b ^= rng.gen::<u8>();
+
+        match Commit::decode(&mut buf.as_slice()) {
+            Err(e) => {
+                assert_eq!(e.kind(), io::ErrorKind::InvalidData);
+                e.into_inner()
+                    .unwrap()
+                    .downcast::<ChecksumMismatch>()
+                    .expect("IO inner should be checksum mismatch");
+            }
+            Ok(commit) => panic!("expected checksum mismatch, got valid commit: {commit:?}"),
+        }
+    }
+}

--- a/crates/commitlog/src/commitlog.rs
+++ b/crates/commitlog/src/commitlog.rs
@@ -1,0 +1,569 @@
+use std::{io, marker::PhantomData, mem, ops::Range, vec};
+
+use itertools::Itertools;
+use log::{debug, info, warn};
+
+use crate::{
+    error,
+    payload::Decoder,
+    repo::{self, Repo},
+    segment::{self, FileLike, Transaction, Writer},
+    Commit, Encode, Options,
+};
+
+#[derive(Debug)]
+pub struct Generic<R: Repo, T> {
+    pub(crate) repo: R,
+    pub(crate) head: Writer<R::Segment>,
+    tail: Vec<u64>,
+    opts: Options,
+    _record: PhantomData<T>,
+}
+
+impl<R: Repo, T> Generic<R, T> {
+    pub fn open(repo: R, opts: Options) -> io::Result<Self> {
+        let mut tail = repo.existing_offsets()?;
+        if !tail.is_empty() {
+            debug!("segments: {tail:?}");
+        }
+        let head = if let Some(last) = tail.pop() {
+            debug!("resuming last segment: {last}");
+            repo::resume_segment_writer(&repo, opts, last)?.or_else(|meta| {
+                tail.push(meta.tx_range.start);
+                repo::create_segment_writer(&repo, opts, meta.tx_range.end)
+            })?
+        } else {
+            debug!("starting fresh log");
+            repo::create_segment_writer(&repo, opts, 0)?
+        };
+
+        Ok(Self {
+            repo,
+            head,
+            tail,
+            opts,
+            _record: PhantomData,
+        })
+    }
+
+    /// Write the currently buffered data to disk and rotate segments as
+    /// necessary.
+    ///
+    /// Note that this does not imply that the data is durable, call
+    /// [`Self::sync`] to flush OS buffers.
+    ///
+    /// # Errors
+    ///
+    /// If an error occurs writing the data, the current [`Commit`] buffer is
+    /// retained, but a new segment is created. Retrying in case of an `Err`
+    /// return value thus will write the current data to that new segment.
+    ///
+    /// If this fails, however, the next attempt to create a new segment will
+    /// fail with [`io::ErrorKind::AlreadyExists`]. Encountering this error kind
+    /// this means that something is seriously wrong underlying storage, and the
+    /// caller should stop writing to the log.
+    pub fn commit(&mut self) -> io::Result<usize> {
+        let writer = &mut self.head;
+        let sz = writer.commit.encoded_len();
+        // If the segment is empty, but the commit exceeds the max size,
+        // we got a huge commit which needs to be written even if that
+        // results in a huge segment.
+        let should_rotate = !writer.is_empty() && writer.len() + sz as u64 > self.opts.max_segment_size;
+        let writer = if should_rotate {
+            if let Err(e) = writer.fsync() {
+                warn!("Failed to fsync segment: {e}");
+            }
+            self.start_new_segment()?
+        } else {
+            writer
+        };
+
+        if let Err(e) = writer.commit() {
+            warn!("Commit failed: {e}");
+            self.start_new_segment()?;
+            Err(e)
+        } else {
+            Ok(sz)
+        }
+    }
+
+    pub fn sync(&self) -> io::Result<()> {
+        self.head.fsync()
+    }
+
+    /// The last transaction offset written to disk, or `None` if nothing has
+    /// been written yet.
+    ///
+    /// Note that this does not imply durability: [`Self::sync`] may not have
+    /// been called at this offset.
+    pub fn max_committed_offset(&self) -> Option<u64> {
+        // Naming is hard: the segment's `next_tx_offset` indicates how many
+        // txs are already in the log (it's the next commit's min-tx-offset).
+        // If the value is zero, however, the initial commit hasn't been
+        // committed yet.
+        self.head.next_tx_offset().checked_sub(1)
+    }
+
+    // Helper to obtain a list of the segment offsets which include transaction
+    // offset `offset`.
+    //
+    // The returned `Vec` is sorted in **ascending** order, such that the first
+    // element is the segment which contains `offset`.
+    //
+    // The offset of `self.head` is always included, regardless of how many
+    // entries it actually contains.
+    fn segment_offsets_from(&self, offset: u64) -> Vec<u64> {
+        if offset >= self.head.min_tx_offset {
+            vec![self.head.min_tx_offset]
+        } else {
+            let mut offs = Vec::with_capacity(self.tail.len() + 1);
+            if let Some(pos) = self.tail.iter().rposition(|off| off <= &offset) {
+                offs.extend_from_slice(&self.tail[pos..]);
+                offs.push(self.head.min_tx_offset);
+            }
+
+            offs
+        }
+    }
+
+    pub fn commits_from(&self, offset: u64) -> Commits<R> {
+        let offsets = self.segment_offsets_from(offset);
+        let last_offset = offsets.first().cloned().unwrap_or(offset);
+        let segments = Segments {
+            offs: offsets.into_iter(),
+            repo: self.repo.clone(),
+            max_log_format_version: self.opts.log_format_version,
+        };
+        Commits {
+            inner: None,
+            segments,
+            last_offset,
+            last_error: None,
+        }
+    }
+
+    pub fn reset(mut self) -> io::Result<Self> {
+        info!("hard reset");
+
+        self.tail.reserve(1);
+        self.tail.push(self.head.min_tx_offset);
+        for segment in self.tail.iter().rev() {
+            self.repo.remove_segment(*segment)?;
+        }
+
+        Self::open(self.repo.clone(), self.opts)
+    }
+
+    pub fn reset_to(mut self, offset: u64) -> io::Result<Self> {
+        info!("reset to {offset}");
+
+        self.tail.reserve(1);
+        self.tail.push(self.head.min_tx_offset);
+        for segment in self.tail.iter().rev() {
+            let segment = *segment;
+            if segment > offset {
+                // Segment is outside the offset, so remove it wholesale.
+                self.repo.remove_segment(segment)?;
+            } else {
+                // Read commit-wise until we find the byte offset.
+                let reader = repo::open_segment_reader(&self.repo, self.opts.log_format_version, segment)?;
+                let commits = reader.commits();
+
+                let mut bytes_read = 0;
+                let mut commits_read = 0;
+                for commit in commits {
+                    let commit = commit?;
+                    commits_read += 1;
+                    if commit.min_tx_offset > offset {
+                        break;
+                    }
+                    bytes_read += commit.encoded_len() as u64;
+                }
+
+                if commits_read == 0 {
+                    // Segment is empty, just remove it.
+                    self.repo.remove_segment(segment)?;
+                } else {
+                    let byte_offset = segment::Header::LEN as u64 + bytes_read;
+                    self.repo.open_segment(segment)?.ftruncate(byte_offset)?;
+                }
+            }
+        }
+
+        Self::open(self.repo.clone(), self.opts)
+    }
+
+    fn start_new_segment(&mut self) -> io::Result<&mut Writer<R::Segment>> {
+        debug!(
+            "starting new segment offset={} prev-offset={}",
+            self.head.next_tx_offset(),
+            self.head.min_tx_offset()
+        );
+        let new = repo::create_segment_writer(&self.repo, self.opts, self.head.next_tx_offset())?;
+        let old = mem::replace(&mut self.head, new);
+        self.tail.push(old.min_tx_offset());
+        self.head.commit = old.commit;
+
+        Ok(&mut self.head)
+    }
+}
+
+impl<R: Repo, T: Encode> Generic<R, T> {
+    pub fn append(&mut self, record: T) -> Result<(), T> {
+        self.head.append(record)
+    }
+
+    pub fn transactions_from<D: Decoder<Record = T>>(
+        &self,
+        offset: u64,
+        decoder: D,
+    ) -> impl Iterator<Item = Result<Transaction<T>, error::Traversal>> {
+        self.commits_from(offset)
+            .with_log_format_version()
+            .map_ok(move |(version, commit)| {
+                let buf = &mut commit.records.as_slice();
+                // TODO: Unroll iterator, so we can decode incrementally.
+                let records = (0..commit.n)
+                    .map(|n| {
+                        decoder
+                            .decode_record(version, buf)
+                            .map_err(|e| error::Traversal::Decode {
+                                offset: commit.min_tx_offset + n as u64,
+                                source: e,
+                            })
+                    })
+                    .collect::<Result<Vec<_>, _>>()?;
+                let transactions = (commit.min_tx_offset..)
+                    .zip(records)
+                    .skip_while(move |(ofs, _)| ofs < &offset)
+                    .map(move |(offset, txdata)| Transaction { offset, txdata });
+                Ok::<_, error::Traversal>(transactions)
+            })
+            .flatten_ok()
+            .flatten_ok()
+    }
+}
+
+impl<R: Repo, T> Drop for Generic<R, T> {
+    fn drop(&mut self) {
+        if let Err(e) = self.commit() {
+            warn!("Failed to commit on drop: {e}");
+        }
+        if let Err(e) = self.head.fsync() {
+            warn!("Failed to fsync on drop: {e}");
+        }
+    }
+}
+
+pub struct Segments<R> {
+    repo: R,
+    offs: vec::IntoIter<u64>,
+    max_log_format_version: u8,
+}
+
+impl<R: Repo> Iterator for Segments<R> {
+    type Item = io::Result<segment::Reader<R::Segment>>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let off = self.offs.next()?;
+        debug!("iter segment {off}");
+        Some(repo::open_segment_reader(&self.repo, self.max_log_format_version, off))
+    }
+}
+
+pub struct Commits<R: Repo> {
+    inner: Option<segment::Commits<R::Segment>>,
+    segments: Segments<R>,
+    last_offset: u64,
+    last_error: Option<error::Traversal>,
+}
+
+impl<R: Repo> Commits<R> {
+    fn current_segment_header(&self) -> Option<&segment::Header> {
+        self.inner.as_ref().map(|segment| &segment.header)
+    }
+
+    /// Turn `self` into an iterator which pairs the log format version of the
+    /// current segment with the [`Commit`].
+    pub fn with_log_format_version(self) -> impl Iterator<Item = Result<(u8, Commit), error::Traversal>> {
+        CommitsWithVersion { inner: self }
+    }
+}
+
+impl<R: Repo> Iterator for Commits<R> {
+    type Item = Result<Commit, error::Traversal>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        if let Some(commits) = self.inner.as_mut() {
+            if let Some(commit) = commits.next() {
+                match commit {
+                    Ok(commit) => {
+                        let prev_error = self.last_error.take();
+                        if commit.min_tx_offset != self.last_offset {
+                            warn!("out-of-order: commit={:?} last-error={:?}", commit, self.last_error);
+                            return Some(Err(error::Traversal::OutOfOrder {
+                                expected_offset: self.last_offset,
+                                actual_offset: commit.min_tx_offset,
+                                prev_error: prev_error.map(Box::new),
+                            }));
+                        }
+                        self.last_offset = commit.tx_range().end;
+                        return Some(Ok(commit));
+                    }
+                    Err(e) => {
+                        warn!("error reading next commit: {e}");
+                        // Fall through to peek at next segment.
+                        //
+                        // If this is just a partial write at the end of a
+                        // segment, we may be able to obtain a commit with the
+                        // right offset from the next segment.
+                        //
+                        // However, the error here may be more helpful and would
+                        // be clobbered by `OutOfOrder`, and so we store it
+                        // until we recurse below.
+                        let last_error = if e.kind() == io::ErrorKind::InvalidData && e.get_ref().is_some() {
+                            e.into_inner()
+                                .unwrap()
+                                .downcast::<error::ChecksumMismatch>()
+                                .map(|source| error::Traversal::Checksum {
+                                    offset: self.last_offset,
+                                    source: *source,
+                                })
+                                .unwrap_or_else(|e| io::Error::new(io::ErrorKind::InvalidData, e).into())
+                        } else {
+                            error::Traversal::from(e)
+                        };
+                        self.last_error = Some(last_error);
+                    }
+                }
+            }
+        }
+
+        match self.segments.next() {
+            // When there is no more data, the last commit being bad is an error
+            None => self.last_error.take().map(Err),
+            Some(segment) => segment.map_or_else(
+                |e| Some(Err(e.into())),
+                |segment| {
+                    self.inner = Some(segment.commits());
+                    self.next()
+                },
+            ),
+        }
+    }
+}
+
+struct CommitsWithVersion<R: Repo> {
+    inner: Commits<R>,
+}
+
+impl<R: Repo> Iterator for CommitsWithVersion<R> {
+    type Item = Result<(u8, Commit), error::Traversal>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.inner.next()?;
+        match next {
+            Ok(commit) => {
+                let version = self
+                    .inner
+                    .current_segment_header()
+                    .map(|hdr| hdr.log_format_version)
+                    .expect("segment header none even though segment yielded a commit");
+                Some(Ok((version, commit)))
+            }
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::iter::repeat;
+
+    use super::*;
+    use crate::{
+        payload::ArrayDecoder,
+        tests::helpers::{fill_log, mem_log},
+    };
+
+    #[test]
+    fn rotate_segments_simple() {
+        let mut log = mem_log::<[u8; 32]>(128);
+        for _ in 0..3 {
+            log.append([0; 32]).unwrap();
+            log.commit().unwrap();
+        }
+
+        let offsets = log.repo.existing_offsets().unwrap();
+        assert_eq!(&offsets[..offsets.len() - 1], &log.tail);
+        assert_eq!(offsets[offsets.len() - 1], 2);
+    }
+
+    #[test]
+    fn huge_commit() {
+        let mut log = mem_log::<[u8; 32]>(32);
+
+        log.append([0; 32]).unwrap();
+        log.append([1; 32]).unwrap();
+        log.commit().unwrap();
+        assert!(log.head.len() > log.opts.max_segment_size);
+
+        log.append([2; 32]).unwrap();
+        log.commit().unwrap();
+
+        assert_eq!(&log.tail, &[0]);
+        assert_eq!(&log.repo.existing_offsets().unwrap(), &[0, 2]);
+    }
+
+    #[test]
+    fn traverse_commits() {
+        let mut log = mem_log::<[u8; 32]>(32);
+        fill_log(&mut log, 10, repeat(1));
+
+        for (i, commit) in (0..10).zip(log.commits_from(0)) {
+            assert_eq!(i, commit.unwrap().min_tx_offset);
+        }
+    }
+
+    #[test]
+    fn traverse_commits_with_offset() {
+        let mut log = mem_log::<[u8; 32]>(32);
+        fill_log(&mut log, 10, repeat(1));
+
+        for offset in 0..10 {
+            for commit in log.commits_from(offset) {
+                let commit = commit.unwrap();
+                assert!(commit.min_tx_offset >= offset);
+            }
+        }
+        // Nb.: the head commit is always returned,
+        // because we don't know its offset upper bound
+        assert_eq!(1, log.commits_from(10).count());
+    }
+
+    #[test]
+    fn traverse_transactions() {
+        let mut log = mem_log::<[u8; 32]>(32);
+        let total_txs = fill_log(&mut log, 10, (1..=3).cycle()) as u64;
+
+        for (i, tx) in (0..total_txs).zip(log.transactions_from(0, ArrayDecoder)) {
+            assert_eq!(i, tx.unwrap().offset);
+        }
+    }
+
+    #[test]
+    fn traverse_transactions_with_offset() {
+        let mut log = mem_log::<[u8; 32]>(32);
+        let total_txs = fill_log(&mut log, 10, (1..=3).cycle()) as u64;
+
+        for offset in 0..total_txs {
+            let mut iter = log.transactions_from(offset, ArrayDecoder);
+            assert_eq!(offset, iter.next().expect("at least one tx expected").unwrap().offset);
+            for tx in iter {
+                assert!(tx.unwrap().offset >= offset);
+            }
+        }
+        assert_eq!(0, log.transactions_from(total_txs, ArrayDecoder).count());
+    }
+
+    #[test]
+    fn traverse_empty() {
+        let log = mem_log::<[u8; 32]>(32);
+
+        assert_eq!(0, log.commits_from(0).count());
+        assert_eq!(0, log.commits_from(42).count());
+        assert_eq!(0, log.transactions_from(0, ArrayDecoder).count());
+        assert_eq!(0, log.transactions_from(42, ArrayDecoder).count());
+    }
+
+    #[test]
+    fn reset_hard() {
+        let mut log = mem_log::<[u8; 32]>(128);
+        fill_log(&mut log, 50, (1..=10).cycle());
+
+        log = log.reset().unwrap();
+        assert_eq!(0, log.transactions_from(0, ArrayDecoder).count());
+    }
+
+    #[test]
+    fn reset_to_offset() {
+        let mut log = mem_log::<[u8; 32]>(128);
+        let total_txs = fill_log(&mut log, 50, repeat(1)) as u64;
+
+        for offset in (0..total_txs).rev() {
+            log = log.reset_to(offset).unwrap();
+            assert_eq!(
+                offset,
+                log.transactions_from(0, ArrayDecoder)
+                    .map(Result::unwrap)
+                    .last()
+                    .unwrap()
+                    .offset
+            );
+            // We're counting from zero, so offset + 1 is the # of txs.
+            assert_eq!(
+                offset + 1,
+                log.transactions_from(0, ArrayDecoder).map(Result::unwrap).count() as u64
+            );
+        }
+    }
+
+    #[test]
+    fn reset_to_offset_many_txs_per_commit() {
+        let mut log = mem_log::<[u8; 32]>(128);
+        let total_txs = fill_log(&mut log, 50, (1..=10).cycle()) as u64;
+
+        // No op.
+        log = log.reset_to(total_txs).unwrap();
+        assert_eq!(total_txs, log.transactions_from(0, ArrayDecoder).count() as u64);
+
+        let middle_commit = log.commits_from(0).nth(25).unwrap().unwrap();
+
+        // Both fall into the middle commit, which should be retained.
+        log = log.reset_to(middle_commit.min_tx_offset + 1).unwrap();
+        assert_eq!(
+            middle_commit.tx_range().end,
+            log.transactions_from(0, ArrayDecoder).count() as u64
+        );
+        log = log.reset_to(middle_commit.min_tx_offset).unwrap();
+        assert_eq!(
+            middle_commit.tx_range().end,
+            log.transactions_from(0, ArrayDecoder).count() as u64
+        );
+
+        // Offset falls into 2nd commit.
+        // 1st commit (1 tx) + 2nd commit (2 txs) = 3
+        log = log.reset_to(1).unwrap();
+        assert_eq!(3, log.transactions_from(0, ArrayDecoder).count() as u64);
+
+        // Offset falls into 1st commit.
+        // 1st commit (1 tx) = 1
+        log = log.reset_to(0).unwrap();
+        assert_eq!(1, log.transactions_from(0, ArrayDecoder).count() as u64);
+    }
+
+    #[test]
+    fn reopen() {
+        let mut log = mem_log::<[u8; 32]>(1024);
+        let mut total_txs = fill_log(&mut log, 100, (1..=10).cycle());
+        assert_eq!(
+            total_txs,
+            log.transactions_from(0, ArrayDecoder).map(Result::unwrap).count()
+        );
+
+        let mut log = Generic::<_, [u8; 32]>::open(
+            log.repo.clone(),
+            Options {
+                max_segment_size: 1024,
+                ..Options::default()
+            },
+        )
+        .unwrap();
+        total_txs += fill_log(&mut log, 100, (1..=10).cycle());
+
+        assert_eq!(
+            total_txs,
+            log.transactions_from(0, ArrayDecoder).map(Result::unwrap).count()
+        );
+    }
+}

--- a/crates/commitlog/src/error.rs
+++ b/crates/commitlog/src/error.rs
@@ -1,0 +1,55 @@
+use std::io;
+
+use spacetimedb_sats::buffer::DecodeError;
+use thiserror::Error;
+
+use crate::segment;
+
+/// Error yielded by public commitlog iterators.
+#[derive(Debug, Error)]
+pub enum Traversal {
+    #[error("out-of-order commit: expected-offset={expected_offset} actual-offset={actual_offset}")]
+    OutOfOrder {
+        expected_offset: u64,
+        actual_offset: u64,
+        /// If the next segment starts with a commit with matching offset, a
+        /// previous bad commit will be ignored. If, however, the offset does
+        /// **not** match, `prev_error` contains the error encountered when
+        /// trying to read the previous commit (which was skipped).
+        #[source]
+        prev_error: Option<Box<Self>>,
+    },
+    #[error("failed to decode tx record at offset={offset}")]
+    Decode {
+        offset: u64,
+        #[source]
+        source: DecodeError,
+    },
+    #[error("checksum mismatch at offset={offset}")]
+    Checksum {
+        offset: u64,
+        #[source]
+        source: ChecksumMismatch,
+    },
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}
+
+/// A checksum mismatch was detected.
+///
+/// Usually wrapped in another error, such as [`io::Error`].
+#[derive(Debug, Error)]
+#[error("checksum mismatch")]
+pub struct ChecksumMismatch;
+
+#[derive(Debug, Error)]
+pub(crate) enum SegmentMetadata {
+    #[error("invalid commit encountered")]
+    InvalidCommit {
+        sofar: segment::Metadata,
+        #[source]
+        source: io::Error,
+    },
+    #[error(transparent)]
+    Io(#[from] io::Error),
+}

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -1,0 +1,55 @@
+#![allow(unused)]
+
+use std::num::NonZeroU16;
+
+mod commit;
+mod commitlog;
+mod repo;
+mod segment;
+
+pub use crate::{
+    commit::Commit,
+    payload::{Decoder, Encode},
+    segment::{Transaction, DEFAULT_LOG_FORMAT_VERSION},
+};
+pub mod error;
+pub mod payload;
+
+#[cfg(test)]
+mod tests;
+
+/// [`Commitlog`] options.
+#[derive(Clone, Copy, Debug)]
+pub struct Options {
+    /// Set the log format version to write, and the maximum supported version.
+    ///
+    /// Choosing a payload format `T` of [`Commitlog`] should usually result in
+    /// updating the [`DEFAULT_LOG_FORMAT_VERSION`] of this crate. Sometimes it
+    /// may however be useful to set the version at runtime, e.g. to experiment
+    /// with new or very old versions.
+    ///
+    /// Default: [`DEFAULT_LOG_FORMAT_VERSION`]
+    pub log_format_version: u8,
+    /// The maximum size in bytes to which log segments should be allowed to
+    /// grow.
+    ///
+    /// Default: 1GiB
+    pub max_segment_size: u64,
+    /// The maximum number of records in a commit.
+    ///
+    /// If this number is exceeded, the commit is flushed to disk even without
+    /// explicitly calling [`Commitlog::flush`].
+    ///
+    /// Default: 65,535
+    pub max_records_in_commit: NonZeroU16,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            log_format_version: DEFAULT_LOG_FORMAT_VERSION,
+            max_segment_size: 1024 * 1024 * 1024,
+            max_records_in_commit: NonZeroU16::MAX,
+        }
+    }
+}

--- a/crates/commitlog/src/payload.rs
+++ b/crates/commitlog/src/payload.rs
@@ -1,0 +1,55 @@
+use std::sync::Arc;
+
+use spacetimedb_sats::buffer::{BufReader, BufWriter, DecodeError};
+
+/// A **datatype** which can be encoded.
+///
+/// The transaction payload of the commitlog (i.e. individual records in the log)
+/// must satisfy this trait.
+pub trait Encode {
+    /// Encode `self` to the given buffer.
+    fn encode_record<W: BufWriter>(&self, writer: &mut W);
+}
+
+impl<T: Encode> Encode for Arc<T> {
+    fn encode_record<W: BufWriter>(&self, writer: &mut W) {
+        (**self).encode_record(writer)
+    }
+}
+
+/// A decoder which can decode the transaction (aka record) format of the log.
+///
+/// Unlike [`Encode`], this is not a datatype: the canonical commitlog format
+/// requires to look up row types during log traversal in order to be able to
+/// decode (see also [`RowDecoder`]).
+pub trait Decoder {
+    /// The type of records this decoder can decode.
+    /// This is also the type which can be appended to a commitlog, and so must
+    /// satisfy [`Encode`].
+    type Record: Encode;
+
+    /// Decode one [`Self::Record`] from the given buffer.
+    ///
+    /// The `version` argument corresponds to the log format version of the
+    /// current segment (see [`segment::Header::log_format_version`]).
+    fn decode_record<'a, R: BufReader<'a>>(&self, version: u8, reader: &mut R) -> Result<Self::Record, DecodeError>;
+    // TODO: Assuming `Decoder` is stateful, we could also update the log
+    // format version only when it changes, instead of passing it on every
+    // `decode_record` call.
+}
+
+impl<const N: usize> Encode for [u8; N] {
+    fn encode_record<W: BufWriter>(&self, writer: &mut W) {
+        writer.put_slice(&self[..])
+    }
+}
+
+pub struct ArrayDecoder<const N: usize>;
+
+impl<const N: usize> Decoder for ArrayDecoder<N> {
+    type Record = [u8; N];
+
+    fn decode_record<'a, R: BufReader<'a>>(&self, _version: u8, reader: &mut R) -> Result<Self::Record, DecodeError> {
+        reader.get_array()
+    }
+}

--- a/crates/commitlog/src/repo/mem.rs
+++ b/crates/commitlog/src/repo/mem.rs
@@ -1,0 +1,192 @@
+use std::{
+    collections::{btree_map, BTreeMap},
+    io,
+    ops::DerefMut as _,
+    sync::{Arc, RwLock},
+    u64,
+};
+
+use crate::segment::FileLike;
+
+use super::Repo;
+
+type SharedLock<T> = Arc<RwLock<T>>;
+type SharedBytes = SharedLock<Vec<u8>>;
+
+/// A log segment backed by a `Vec<u8>`.
+///
+/// Note that this is not a faithful model of a file, as safe Rust requires to
+/// protect the buffer with a lock. This means that pathological situations
+/// arising from concurrent read/write access of a file are impossible to occur.
+#[derive(Clone, Debug, Default)]
+pub struct Segment {
+    pos: u64,
+    buf: SharedBytes,
+}
+
+impl Segment {
+    pub fn len(&self) -> usize {
+        self.buf.read().unwrap().len()
+    }
+}
+
+impl From<SharedBytes> for Segment {
+    fn from(buf: SharedBytes) -> Self {
+        Self { pos: 0, buf }
+    }
+}
+
+impl FileLike for Segment {
+    fn fsync(&self) -> io::Result<()> {
+        Ok(())
+    }
+
+    fn ftruncate(&self, size: u64) -> io::Result<()> {
+        let mut inner = self.buf.write().unwrap();
+        inner.resize(size as usize, 0);
+        Ok(())
+    }
+}
+
+impl io::Write for Segment {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut inner = self.buf.write().unwrap();
+        // Piggyback on unsafe code in Cursor
+        let mut cursor = io::Cursor::new(inner.deref_mut());
+        cursor.set_position(self.pos);
+        let sz = cursor.write(buf)?;
+        self.pos = cursor.position();
+
+        Ok(sz)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        Ok(())
+    }
+}
+
+impl io::Read for Segment {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        let inner = self.buf.read().unwrap();
+        let len = self.pos.min(inner.len() as u64);
+        let n = io::Read::read(&mut &inner[(len as usize)..], buf)?;
+        self.pos += n as u64;
+        Ok(n)
+    }
+}
+
+impl io::Seek for Segment {
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        let (base_pos, offset) = match pos {
+            io::SeekFrom::Start(n) => {
+                self.pos = n;
+                return Ok(n);
+            }
+            io::SeekFrom::End(n) => (self.len() as u64, n),
+            io::SeekFrom::Current(n) => (self.pos, n),
+        };
+        match base_pos.checked_add_signed(offset) {
+            Some(n) => {
+                self.pos = n;
+                Ok(n)
+            }
+            None => Err(io::Error::new(
+                io::ErrorKind::InvalidInput,
+                "invalid seek to a negative or overflowing position",
+            )),
+        }
+    }
+}
+
+/// In-memory implementation of [`Repo`].
+#[derive(Clone, Debug, Default)]
+pub struct Memory(SharedLock<BTreeMap<u64, SharedBytes>>);
+
+impl Memory {
+    pub fn new() -> Self {
+        Self::default()
+    }
+}
+
+impl Repo for Memory {
+    type Segment = Segment;
+
+    fn create_segment(&self, offset: u64) -> io::Result<Self::Segment> {
+        let mut inner = self.0.write().unwrap();
+        match inner.entry(offset) {
+            btree_map::Entry::Occupied(entry) => {
+                if entry.get().read().unwrap().len() == 0 {
+                    Ok(Segment::from(Arc::clone(entry.get())))
+                } else {
+                    Err(io::Error::new(
+                        io::ErrorKind::AlreadyExists,
+                        format!("segment {offset} already exists"),
+                    ))
+                }
+            }
+            btree_map::Entry::Vacant(entry) => {
+                let segment = entry.insert(Default::default());
+                Ok(Segment::from(Arc::clone(segment)))
+            }
+        }
+    }
+
+    fn open_segment(&self, offset: u64) -> io::Result<Self::Segment> {
+        let inner = self.0.read().unwrap();
+        let Some(buf) = inner.get(&offset) else {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("segment {offset} does not exist"),
+            ));
+        };
+        Ok(Segment::from(Arc::clone(buf)))
+    }
+
+    fn remove_segment(&self, offset: u64) -> io::Result<()> {
+        let mut inner = self.0.write().unwrap();
+        if inner.remove(&offset).is_none() {
+            return Err(io::Error::new(
+                io::ErrorKind::NotFound,
+                format!("segment {offset} does not exist"),
+            ));
+        }
+
+        Ok(())
+    }
+
+    fn existing_offsets(&self) -> io::Result<Vec<u64>> {
+        Ok(self.0.read().unwrap().keys().copied().collect())
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::{Read, Seek, Write};
+
+    #[test]
+    fn segment_read_write_seek() {
+        let mut segment = Segment::default();
+        segment.write_all(b"alonso").unwrap();
+
+        segment.seek(io::SeekFrom::Start(0)).unwrap();
+        let mut buf = [0; 6];
+        segment.read_exact(&mut buf).unwrap();
+        assert_eq!(&buf, b"alonso");
+
+        segment.seek(io::SeekFrom::Start(2)).unwrap();
+        let n = segment.read(&mut buf).unwrap();
+        assert_eq!(n, 4);
+        assert_eq!(&buf[..4], b"onso");
+
+        segment.seek(io::SeekFrom::Current(-4)).unwrap();
+        let n = segment.read(&mut buf).unwrap();
+        assert_eq!(n, 4);
+        assert_eq!(&buf[..4], b"onso");
+
+        segment.seek(io::SeekFrom::End(-3)).unwrap();
+        let n = segment.read(&mut buf).unwrap();
+        assert_eq!(n, 3);
+        assert_eq!(&buf[0..3], b"nso");
+    }
+}

--- a/crates/commitlog/src/repo/mod.rs
+++ b/crates/commitlog/src/repo/mod.rs
@@ -1,0 +1,152 @@
+use std::{io, u64};
+
+use log::{debug, warn};
+
+use crate::{
+    commit::Commit,
+    error,
+    segment::{FileLike, Header, Metadata, Reader, Writer},
+    Options,
+};
+
+#[cfg(test)]
+pub mod mem;
+
+#[cfg(test)]
+pub use mem::Memory;
+
+/// A repository of log segments.
+///
+/// This is mainly an internal trait to allow testing against an in-memory
+/// representation.
+pub trait Repo: Clone {
+    /// The type of log segments managed by this repo, which must behave like a file.
+    type Segment: io::Read + io::Write + FileLike;
+
+    /// Create a new segment with the minimum transaction offset `offset`.
+    ///
+    /// This **must** create the segment atomically, and return
+    /// [`io::ErrorKind::AlreadyExists`] if the segment already exists.
+    ///
+    /// It is permissible, however, to successfully return the new segment if
+    /// it is completely empty (i.e. [`create_segment_writer`] did not previously
+    /// succeed in writing the segment header).
+    fn create_segment(&self, offset: u64) -> io::Result<Self::Segment>;
+
+    /// Open an existing segment at the minimum transaction offset `offset`.
+    ///
+    /// Must return [`io::ErrorKind::NotFound`] if a segment with the given
+    /// `offset` does not exist.
+    ///
+    /// The method does not guarantee that the segment is non-empty -- this case
+    /// will be caught by [`open_segment_writer`] and [`open_segment_reader`]
+    /// respectively.
+    fn open_segment(&self, offset: u64) -> io::Result<Self::Segment>;
+
+    /// Remove the segment at the minimum transaction offset `offset`.
+    ///
+    /// Return [`io::ErrorKind::NotFound`] if no such segment exists.
+    fn remove_segment(&self, offset: u64) -> io::Result<()>;
+
+    /// Traverse all segments in this repository and return list of their
+    /// offsets, sorted in ascending order.
+    fn existing_offsets(&self) -> io::Result<Vec<u64>>;
+}
+
+/// Create a new segment [`Writer`] with `offset`.
+///
+/// Immediately attempts to write the segment header with the supplied
+/// `log_format_version`.
+///
+/// If the segment already exists, [`io::ErrorKind::AlreadyExists`] is returned.
+pub fn create_segment_writer<R: Repo>(repo: &R, opts: Options, offset: u64) -> io::Result<Writer<R::Segment>> {
+    let mut storage = repo.create_segment(offset)?;
+    Header {
+        log_format_version: opts.log_format_version,
+        checksum_algorithm: Commit::CHECKSUM_ALGORITHM,
+    }
+    .write(&mut storage)?;
+    storage.fsync()?;
+
+    Ok(Writer {
+        commit: Commit {
+            min_tx_offset: offset,
+            n: 0,
+            records: Vec::new(),
+        },
+        inner: io::BufWriter::new(storage),
+
+        min_tx_offset: offset,
+        bytes_written: Header::LEN as u64,
+
+        max_records_in_commit: opts.max_records_in_commit,
+    })
+}
+
+/// Open the existing segment at `offset` for writing.
+///
+/// This will traverse the segment in order to find the offset of the next
+/// commit to write to it, which may fail for various reasons.
+///
+/// If the traversal is successful, the segment header is checked against the
+/// `max_log_format_version`, and [`io::ErrorKind::InvalidData`] is returned if
+/// the segment's log format version is greater than the given value. Likewise
+/// if the checksum algorithm stored in the segment header cannot be handled
+/// by this crate.
+///
+/// If only a (non-empty) prefix of the segment could be read due to a failure
+/// to decode a [`Commit`], the segment [`Metadata`] read up to the faulty
+/// commit is returned in an `Err`. In this case, a new segment should be
+/// created for writing.
+pub fn resume_segment_writer<R: Repo>(
+    repo: &R,
+    opts: Options,
+    offset: u64,
+) -> io::Result<Result<Writer<R::Segment>, Metadata>> {
+    let mut storage = repo.open_segment(offset)?;
+    let Metadata {
+        header,
+        tx_range,
+        size_in_bytes,
+    } = match Metadata::extract(offset, &mut storage) {
+        Err(error::SegmentMetadata::InvalidCommit { sofar, source }) => {
+            warn!("invalid commit in segment {offset}: {source}");
+            debug!("sofar={sofar:?}");
+            return Ok(Err(sofar));
+        }
+        Err(error::SegmentMetadata::Io(e)) => return Err(e),
+        Ok(meta) => meta,
+    };
+    header
+        .ensure_compatible(opts.log_format_version, Commit::CHECKSUM_ALGORITHM)
+        .map_err(|msg| io::Error::new(io::ErrorKind::InvalidData, msg))?;
+
+    Ok(Ok(Writer {
+        commit: Commit {
+            min_tx_offset: tx_range.end,
+            n: 0,
+            records: Vec::new(),
+        },
+        inner: io::BufWriter::new(storage),
+
+        min_tx_offset: tx_range.start,
+        bytes_written: size_in_bytes,
+
+        max_records_in_commit: opts.max_records_in_commit,
+    }))
+}
+
+/// Open the existing segment at `offset` for reading.
+///
+/// Unlike [`open_segment_writer`], this does not traverse the segment. It does,
+/// however, attempt to read the segment header and checks that the log format
+/// version and checksum algorithm are compatible.
+pub fn open_segment_reader<R: Repo>(
+    repo: &R,
+    max_log_format_version: u8,
+    offset: u64,
+) -> io::Result<Reader<R::Segment>> {
+    debug!("open segment reader at {offset}");
+    let storage = repo.open_segment(offset)?;
+    Reader::new(max_log_format_version, offset, storage)
+}

--- a/crates/commitlog/src/segment.rs
+++ b/crates/commitlog/src/segment.rs
@@ -1,0 +1,555 @@
+use std::{
+    fs::File,
+    io::{self, BufWriter, Write as _},
+    num::NonZeroU16,
+    ops::Range,
+};
+
+use log::debug;
+
+use crate::{
+    commit::{self, Commit},
+    error,
+    payload::Encode,
+};
+
+#[cfg(test)]
+use crate::payload::Decoder;
+
+pub const MAGIC: [u8; 6] = [b'(', b'd', b's', b')', b'^', b'2'];
+
+pub const DEFAULT_LOG_FORMAT_VERSION: u8 = 0;
+pub const DEFAULT_CHECKSUM_ALGORITHM: u8 = CHECKSUM_ALGORITHM_CRC32C;
+
+pub const CHECKSUM_ALGORITHM_CRC32C: u8 = 0;
+
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+pub struct Header {
+    pub log_format_version: u8,
+    pub checksum_algorithm: u8,
+}
+
+impl Header {
+    pub const LEN: usize = MAGIC.len() + 4;
+
+    pub fn write<W: io::Write>(&self, mut out: W) -> io::Result<()> {
+        out.write_all(&MAGIC)?;
+        out.write_all(&[self.log_format_version, self.checksum_algorithm, 0, 0])?;
+
+        Ok(())
+    }
+
+    pub fn decode<R: io::Read>(mut read: R) -> io::Result<Self> {
+        let mut buf = [0; Self::LEN];
+        read.read_exact(&mut buf)?;
+
+        if !buf.starts_with(&MAGIC) {
+            return Err(io::Error::new(
+                io::ErrorKind::InvalidData,
+                "segment header does not start with magic",
+            ));
+        }
+
+        Ok(Self {
+            log_format_version: buf[MAGIC.len()],
+            checksum_algorithm: buf[MAGIC.len() + 1],
+        })
+    }
+
+    pub fn ensure_compatible(&self, max_log_format_version: u8, checksum_algorithm: u8) -> Result<(), String> {
+        if self.log_format_version > max_log_format_version {
+            return Err(format!("unsupported log format version: {}", self.log_format_version));
+        }
+        if self.checksum_algorithm != checksum_algorithm {
+            return Err(format!("unsupported checksum algorithm: {}", self.checksum_algorithm));
+        }
+
+        Ok(())
+    }
+}
+
+impl Default for Header {
+    fn default() -> Self {
+        Self {
+            log_format_version: DEFAULT_LOG_FORMAT_VERSION,
+            checksum_algorithm: DEFAULT_CHECKSUM_ALGORITHM,
+        }
+    }
+}
+
+#[derive(Debug)]
+pub struct Writer<W: io::Write> {
+    pub(crate) commit: Commit,
+    pub(crate) inner: BufWriter<W>,
+
+    pub(crate) min_tx_offset: u64,
+    pub(crate) bytes_written: u64,
+
+    pub(crate) max_records_in_commit: NonZeroU16,
+}
+
+impl<W: io::Write> Writer<W> {
+    /// Append the record (aka transaction) `T` to the segment.
+    ///
+    /// If the number of currently buffered records would exceed `max_records_in_commit`
+    /// after the method returns, the argument is returned in an `Err` and not
+    /// appended to this writer's buffer.
+    ///
+    /// Otherwise, the `record` is encoded and and stored in the buffer.
+    ///
+    /// An `Err` result indicates that [`Self::commit`] should be called in
+    /// order to flush the buffered records to persistent storage.
+    pub fn append<T: Encode>(&mut self, record: T) -> Result<(), T> {
+        if self.commit.n == u16::MAX || self.commit.n + 1 > self.max_records_in_commit.get() {
+            Err(record)
+        } else {
+            self.commit.n += 1;
+            record.encode_record(&mut self.commit.records);
+            Ok(())
+        }
+    }
+
+    /// Write the current [`Commit`] to the underlying [`io::Write`].
+    ///
+    /// Will do nothing if the current commit is empty (i.e. `Commit::n` is zero).
+    pub fn commit(&mut self) -> io::Result<()> {
+        if self.commit.n == 0 {
+            return Ok(());
+        }
+        self.commit.write(&mut self.inner)?;
+        self.inner.flush()?;
+
+        self.bytes_written += self.commit.encoded_len() as u64;
+        self.commit.min_tx_offset += self.commit.n as u64;
+        self.commit.n = 0;
+        self.commit.records.clear();
+
+        Ok(())
+    }
+
+    /// The smallest transaction offset in this segment.
+    pub fn min_tx_offset(&self) -> u64 {
+        self.min_tx_offset
+    }
+
+    /// The next transaction offset to be written if [`Self::commit`] was called.
+    pub fn next_tx_offset(&self) -> u64 {
+        self.commit.min_tx_offset
+    }
+
+    /// `true` if the segment contains no commits.
+    ///
+    /// The segment will, however, contain a header. This thus violates the
+    /// convention that `is_empty == (len == 0)`.
+    pub fn is_empty(&self) -> bool {
+        self.bytes_written <= Header::LEN as u64
+    }
+
+    /// Number of bytes written to this segment, including the header.
+    pub fn len(&self) -> u64 {
+        self.bytes_written
+    }
+}
+
+pub trait FileLike {
+    fn fsync(&self) -> io::Result<()>;
+    fn ftruncate(&self, size: u64) -> io::Result<()>;
+}
+
+impl FileLike for File {
+    fn fsync(&self) -> io::Result<()> {
+        self.sync_all()
+    }
+
+    fn ftruncate(&self, size: u64) -> io::Result<()> {
+        self.set_len(size)
+    }
+}
+
+impl<W: io::Write + FileLike> FileLike for BufWriter<W> {
+    fn fsync(&self) -> io::Result<()> {
+        self.get_ref().fsync()
+    }
+
+    fn ftruncate(&self, size: u64) -> io::Result<()> {
+        self.get_ref().ftruncate(size)
+    }
+}
+
+impl<W: io::Write + FileLike> FileLike for Writer<W> {
+    fn fsync(&self) -> io::Result<()> {
+        self.inner.fsync()
+    }
+
+    fn ftruncate(&self, size: u64) -> io::Result<()> {
+        self.inner.ftruncate(size)
+    }
+}
+
+#[derive(Debug)]
+pub struct Reader<R> {
+    pub header: Header,
+    pub min_tx_offset: u64,
+    inner: R,
+}
+
+impl<R: io::Read> Reader<R> {
+    pub fn new(max_log_format_version: u8, min_tx_offset: u64, mut inner: R) -> io::Result<Self> {
+        let header = Header::decode(&mut inner)?;
+        header
+            .ensure_compatible(max_log_format_version, Commit::CHECKSUM_ALGORITHM)
+            .map_err(|msg| io::Error::new(io::ErrorKind::InvalidData, msg))?;
+
+        Ok(Self {
+            header,
+            min_tx_offset,
+            inner,
+        })
+    }
+}
+
+impl<R: io::Read> Reader<R> {
+    pub fn commits(self) -> Commits<R> {
+        Commits {
+            header: self.header,
+            reader: io::BufReader::new(self.inner),
+        }
+    }
+
+    #[cfg(test)]
+    pub fn transactions<D: Decoder>(self, decoder: D) -> impl Iterator<Item = io::Result<Transaction<D::Record>>> {
+        use itertools::Itertools as _;
+
+        self.commits()
+            .with_log_format_version()
+            .map_ok(move |(version, commit)| {
+                let buf = &mut commit.records.as_slice();
+                let records = (0..commit.n)
+                    .map(|_| decoder.decode_record(version, buf))
+                    .collect::<Result<Vec<_>, _>>()
+                    .map_err(|e| io::Error::new(io::ErrorKind::Other, e))?;
+                let transactions = (commit.min_tx_offset..)
+                    .zip(records)
+                    .map(move |(offset, txdata)| Transaction { offset, txdata });
+                Ok::<_, io::Error>(transactions)
+            })
+            .flatten_ok()
+            .flatten_ok()
+    }
+
+    #[cfg(test)]
+    pub fn metadata(self) -> Result<Metadata, error::SegmentMetadata> {
+        Metadata::with_header(self.min_tx_offset, self.header, io::BufReader::new(self.inner))
+    }
+}
+
+/// Pair of transaction offset and payload.
+///
+/// Created by iterators which "flatten" commits into individual transaction
+/// records.
+#[derive(Debug, PartialEq)]
+pub struct Transaction<T> {
+    /// The offset of this transaction relative to the start of the log.
+    pub offset: u64,
+    /// The transaction payload.
+    pub txdata: T,
+}
+
+pub struct Commits<R> {
+    pub header: Header,
+    reader: io::BufReader<R>,
+}
+
+impl<R: io::Read> Iterator for Commits<R> {
+    type Item = io::Result<Commit>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        Commit::decode(&mut self.reader).transpose()
+    }
+}
+
+#[cfg(test)]
+impl<R: io::Read> Commits<R> {
+    pub fn with_log_format_version(self) -> impl Iterator<Item = io::Result<(u8, Commit)>> {
+        CommitsWithVersion { inner: self }
+    }
+}
+
+#[cfg(test)]
+struct CommitsWithVersion<R> {
+    inner: Commits<R>,
+}
+
+#[cfg(test)]
+impl<R: io::Read> Iterator for CommitsWithVersion<R> {
+    type Item = io::Result<(u8, Commit)>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        let next = self.inner.next()?;
+        match next {
+            Ok(commit) => Some(Ok((self.inner.header.log_format_version, commit))),
+            Err(e) => Some(Err(e)),
+        }
+    }
+}
+
+#[derive(Clone, Debug, Eq, PartialEq)]
+pub struct Metadata {
+    pub header: Header,
+    pub tx_range: Range<u64>,
+    pub size_in_bytes: u64,
+}
+
+impl Metadata {
+    /// Read and validate metadata from a segment.
+    ///
+    /// This traverses the entire segment, consuming thre `reader.
+    /// Doing so is necessary to determine the `max_tx_offset` and `size_in_bytes`.
+    pub fn extract<R: io::Read>(min_tx_offset: u64, mut reader: R) -> Result<Self, error::SegmentMetadata> {
+        let header = Header::decode(&mut reader)?;
+        Self::with_header(min_tx_offset, header, reader)
+    }
+
+    fn with_header<R: io::Read>(
+        min_tx_offset: u64,
+        header: Header,
+        mut reader: R,
+    ) -> Result<Self, error::SegmentMetadata> {
+        let mut sofar = Self {
+            header,
+            tx_range: Range {
+                start: min_tx_offset,
+                end: min_tx_offset,
+            },
+            size_in_bytes: Header::LEN as u64,
+        };
+
+        fn commit_meta<R: io::Read>(
+            reader: &mut R,
+            sofar: &Metadata,
+        ) -> Result<Option<commit::Metadata>, error::SegmentMetadata> {
+            commit::Metadata::extract(reader).map_err(|e| {
+                if e.kind() == io::ErrorKind::InvalidData {
+                    error::SegmentMetadata::InvalidCommit {
+                        sofar: sofar.clone(),
+                        source: e,
+                    }
+                } else {
+                    e.into()
+                }
+            })
+        }
+        while let Some(commit) = commit_meta(&mut reader, &sofar)? {
+            debug!("commit::{commit:?}");
+            if commit.tx_range.start != sofar.tx_range.end {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "out-of-order offset: expected={} actual={}",
+                        sofar.tx_range.end, commit.tx_range.start,
+                    ),
+                )
+                .into());
+            }
+            sofar.tx_range.end = commit.tx_range.end;
+            sofar.size_in_bytes += commit.size_in_bytes;
+        }
+
+        Ok(sofar)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use std::num::NonZeroU16;
+
+    use super::*;
+    use crate::{payload::ArrayDecoder, repo, Options};
+    use proptest::prelude::*;
+
+    #[test]
+    fn header_roundtrip() {
+        let hdr = Header {
+            log_format_version: 42,
+            checksum_algorithm: 7,
+        };
+
+        let mut buf = [0u8; Header::LEN];
+        hdr.write(&mut &mut buf[..]).unwrap();
+        let h2 = Header::decode(&buf[..]).unwrap();
+
+        assert_eq!(hdr, h2);
+    }
+
+    #[test]
+    fn write_read_roundtrip() {
+        let repo = repo::Memory::default();
+
+        let mut writer = repo::create_segment_writer(&repo, Options::default(), 0).unwrap();
+        writer.append([0; 32]).unwrap();
+        writer.append([1; 32]).unwrap();
+        writer.append([2; 32]).unwrap();
+        writer.commit().unwrap();
+
+        let reader = repo::open_segment_reader(&repo, DEFAULT_LOG_FORMAT_VERSION, 0).unwrap();
+        let header = reader.header;
+        let commit = reader
+            .commits()
+            .next()
+            .expect("expected one commit")
+            .expect("unexpected IO");
+
+        assert_eq!(
+            header,
+            Header {
+                log_format_version: DEFAULT_LOG_FORMAT_VERSION,
+                checksum_algorithm: DEFAULT_CHECKSUM_ALGORITHM
+            }
+        );
+        assert_eq!(commit.min_tx_offset, 0);
+        assert_eq!(commit.records, [[0; 32], [1; 32], [2; 32]].concat());
+    }
+
+    #[test]
+    fn metadata() {
+        let repo = repo::Memory::default();
+
+        let mut writer = repo::create_segment_writer(&repo, Options::default(), 0).unwrap();
+        writer.append([0; 32]).unwrap();
+        writer.append([0; 32]).unwrap();
+        writer.commit().unwrap();
+        writer.append([1; 32]).unwrap();
+        writer.commit().unwrap();
+        writer.append([2; 32]).unwrap();
+        writer.append([2; 32]).unwrap();
+        writer.commit().unwrap();
+
+        let reader = repo::open_segment_reader(&repo, DEFAULT_LOG_FORMAT_VERSION, 0).unwrap();
+        let Metadata {
+            header: _,
+            tx_range,
+            size_in_bytes,
+        } = reader.metadata().unwrap();
+
+        assert_eq!(tx_range.start, 0);
+        assert_eq!(tx_range.end, 5);
+        assert_eq!(
+            size_in_bytes,
+            (Header::LEN + (5 * 32) + (3 * Commit::FRAMING_LEN)) as u64
+        );
+    }
+
+    #[test]
+    fn commits() {
+        let repo = repo::Memory::default();
+        let commits = vec![vec![[1; 32], [2; 32]], vec![[3; 32]], vec![[4; 32], [5; 32]]];
+
+        let mut writer = repo::create_segment_writer(&repo, Options::default(), 0).unwrap();
+        for commit in &commits {
+            for tx in commit {
+                writer.append(*tx).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        let reader = repo::open_segment_reader(&repo, DEFAULT_LOG_FORMAT_VERSION, 0).unwrap();
+        let mut commits1 = Vec::with_capacity(commits.len());
+        let mut min_tx_offset = 0;
+        for txs in commits {
+            commits1.push(Commit {
+                min_tx_offset,
+                n: txs.len() as u16,
+                records: txs.concat(),
+            });
+            min_tx_offset += txs.len() as u64;
+        }
+        let commits2 = reader.commits().collect::<Result<Vec<_>, _>>().unwrap();
+        assert_eq!(commits1, commits2);
+    }
+
+    #[test]
+    fn transactions() {
+        let repo = repo::Memory::default();
+        let commits = vec![vec![[1; 32], [2; 32]], vec![[3; 32]], vec![[4; 32], [5; 32]]];
+
+        let mut writer = repo::create_segment_writer(&repo, Options::default(), 0).unwrap();
+        for commit in &commits {
+            for tx in commit {
+                writer.append(*tx).unwrap();
+            }
+            writer.commit().unwrap();
+        }
+
+        let reader = repo::open_segment_reader(&repo, DEFAULT_LOG_FORMAT_VERSION, 0).unwrap();
+        let txs = reader
+            .transactions(ArrayDecoder)
+            .collect::<Result<Vec<_>, _>>()
+            .unwrap();
+        assert_eq!(
+            txs,
+            commits
+                .into_iter()
+                .flatten()
+                .enumerate()
+                .map(|(offset, txdata)| Transaction {
+                    offset: offset as u64,
+                    txdata
+                })
+                .collect::<Vec<_>>()
+        );
+    }
+
+    proptest! {
+        #[test]
+        fn max_records_in_commit(max_records_in_commit in any::<NonZeroU16>()) {
+            let mut writer = Writer {
+                commit: Commit::default(),
+                inner: BufWriter::new(Vec::new()),
+
+                min_tx_offset: 0,
+                bytes_written: 0,
+
+                max_records_in_commit,
+            };
+
+            for i in 0..max_records_in_commit.get() {
+                assert!(
+                    writer.append([0; 16]).is_ok(),
+                    "less than {} records written: {}",
+                    max_records_in_commit.get(),
+                    i
+                );
+            }
+            assert!(
+                writer.append([0; 16]).is_err(),
+                "more than {} records written",
+                max_records_in_commit.get()
+            );
+        }
+    }
+
+    #[test]
+    fn next_tx_offset() {
+        let mut writer = Writer {
+            commit: Commit::default(),
+            inner: BufWriter::new(Vec::new()),
+
+            min_tx_offset: 0,
+            bytes_written: 0,
+
+            max_records_in_commit: NonZeroU16::MAX,
+        };
+
+        assert_eq!(0, writer.next_tx_offset());
+        writer.append([0; 16]).unwrap();
+        assert_eq!(0, writer.next_tx_offset());
+        writer.commit().unwrap();
+        assert_eq!(1, writer.next_tx_offset());
+        writer.commit().unwrap();
+        assert_eq!(1, writer.next_tx_offset());
+        writer.append([1; 16]).unwrap();
+        writer.append([1; 16]).unwrap();
+        writer.commit().unwrap();
+        assert_eq!(3, writer.next_tx_offset());
+    }
+}

--- a/crates/commitlog/src/tests.rs
+++ b/crates/commitlog/src/tests.rs
@@ -1,0 +1,4 @@
+mod bitflip;
+mod partial;
+
+pub mod helpers;

--- a/crates/commitlog/src/tests/bitflip.rs
+++ b/crates/commitlog/src/tests/bitflip.rs
@@ -1,0 +1,73 @@
+use std::{
+    cmp,
+    io::{Read, Seek, SeekFrom, Write},
+    iter::{repeat, successors},
+};
+
+use log::debug;
+use proptest::bits::u64;
+use rand::prelude::*;
+
+use crate::{
+    commit, error, payload,
+    repo::Repo,
+    segment,
+    tests::helpers::{enable_logging, fill_log, mem_log},
+    Commit,
+};
+
+#[test]
+fn traversal() {
+    enable_logging();
+
+    const NUM_COMMITS: usize = 100;
+    const TX_SIZE: usize = 32;
+    const TXS_PER_COMMIT: usize = 10;
+    const COMMIT_SIZE: usize = Commit::FRAMING_LEN + (TX_SIZE * TXS_PER_COMMIT);
+
+    let mut log = mem_log::<[u8; TX_SIZE]>(1024);
+    fill_log(&mut log, NUM_COMMITS, repeat(TXS_PER_COMMIT));
+
+    {
+        // TODO: Allow supplying a seed, though env or whatever
+        let mut rng = thread_rng();
+
+        let segments = log.repo.existing_offsets().unwrap();
+        debug!("segments={segments:?}");
+        let segment_offset = segments.choose(&mut rng).copied().unwrap();
+        let mut segment = log.repo.open_segment(segment_offset).unwrap();
+
+        // Make sure we don't touch the commit header, so we're sure that the
+        // error will be a checksum mismatch. If we'd match on any out-of-order
+        // error, we might be missing error conditions we hadn't thought of.
+        let mut pos = rng.gen_range(segment::Header::LEN + commit::Header::LEN..segment.len());
+        for x in successors(Some(0), |n| Some(n * COMMIT_SIZE)).take(NUM_COMMITS) {
+            if pos >= x && pos < x + COMMIT_SIZE {
+                pos = cmp::max(x + commit::Header::LEN + 1, pos);
+            }
+        }
+
+        debug!("flipping {pos} of {} in {segment_offset}", segment.len());
+
+        segment.seek(SeekFrom::Start(pos as u64)).unwrap();
+        let mut buf = [0; 1];
+        segment.read_exact(&mut buf).unwrap();
+        buf[0] ^= rng.gen::<u8>();
+        segment.seek(SeekFrom::Current(-1)).unwrap();
+        segment.write_all(&buf).unwrap();
+    }
+
+    let first_err = log
+        .transactions_from(0, payload::ArrayDecoder)
+        .find_map(Result::err)
+        .expect("unexpected success");
+    let unexpected = match first_err {
+        error::Traversal::OutOfOrder {
+            prev_error: Some(prev_error),
+            ..
+        } if matches!(*prev_error, error::Traversal::Checksum { .. }) => None,
+        error::Traversal::Checksum { .. } => None,
+        e => Some(e),
+    };
+    assert!(unexpected.is_none(), "unexpected error: {unexpected:?}");
+}

--- a/crates/commitlog/src/tests/helpers.rs
+++ b/crates/commitlog/src/tests/helpers.rs
@@ -1,0 +1,47 @@
+use std::fmt::Debug;
+
+use crate::{
+    commitlog,
+    repo::{self, Repo},
+    Encode, Options,
+};
+
+pub fn mem_log<T: Encode>(max_segment_size: u64) -> commitlog::Generic<repo::Memory, T> {
+    commitlog::Generic::open(
+        repo::Memory::new(),
+        Options {
+            max_segment_size,
+            ..Options::default()
+        },
+    )
+    .unwrap()
+}
+
+pub fn fill_log<R, T>(
+    log: &mut commitlog::Generic<R, T>,
+    num_commits: usize,
+    txs_per_commit: impl Iterator<Item = usize>,
+) -> usize
+where
+    R: Repo,
+    T: Debug + Default + Encode,
+{
+    let mut total_txs = 0;
+    for (_, n) in (0..num_commits).zip(txs_per_commit) {
+        for _ in 0..n {
+            log.append(T::default()).unwrap();
+            total_txs += 1;
+        }
+        log.commit().unwrap();
+    }
+
+    total_txs
+}
+
+pub fn enable_logging() {
+    let _ = env_logger::builder()
+        .filter_level(log::LevelFilter::Trace)
+        .format_timestamp(None)
+        .is_test(true)
+        .try_init();
+}

--- a/crates/commitlog/src/tests/partial.rs
+++ b/crates/commitlog/src/tests/partial.rs
@@ -1,0 +1,277 @@
+use std::{
+    cmp,
+    fmt::Debug,
+    io::{self, Seek as _, SeekFrom, Write},
+    iter::repeat,
+};
+
+use log::debug;
+
+use crate::{
+    commitlog, error, payload,
+    repo::{self, Repo},
+    segment::FileLike,
+    tests::helpers::enable_logging,
+    Encode, Options, DEFAULT_LOG_FORMAT_VERSION,
+};
+
+#[test]
+fn traversal() {
+    enable_logging();
+
+    let mut log = open_log::<[u8; 32]>(ShortMem::new(800));
+    let total_commits = 100;
+    let total_txs = fill_log_enospc(&mut log, total_commits, (1..=10).cycle());
+
+    assert_eq!(
+        total_txs,
+        log.transactions_from(0, payload::ArrayDecoder)
+            .map(Result::unwrap)
+            .count()
+    );
+    assert_eq!(total_commits, log.commits_from(0).map(Result::unwrap).count());
+}
+
+// Note: Write errors cause the in-flight commit to be written to a fresh
+// segment. So as long as we write through the public API, partial writes
+// never surface (i.e. the log is contiguous).
+#[test]
+fn reopen() {
+    enable_logging();
+
+    let repo = ShortMem::new(800);
+    let num_commits = 10;
+
+    let mut total_txs = 0;
+    for i in 0..2 {
+        let mut log = open_log::<[u8; 32]>(repo.clone());
+        total_txs += fill_log_enospc(&mut log, num_commits, (1..=10).cycle());
+
+        debug!("fill {} done", i + 1);
+    }
+
+    assert_eq!(
+        total_txs,
+        open_log::<[u8; 32]>(repo.clone())
+            .transactions_from(0, payload::ArrayDecoder)
+            .map(Result::unwrap)
+            .count()
+    );
+
+    // Let's see if we hit a funny case in any of the segments.
+    for offset in repo.existing_offsets().unwrap().into_iter().rev() {
+        let meta = repo::open_segment_reader(&repo, DEFAULT_LOG_FORMAT_VERSION, offset)
+            .unwrap()
+            .metadata()
+            .unwrap();
+        debug!("dropping segment: segment::{meta:?}");
+        repo.remove_segment(offset).unwrap();
+        assert_eq!(
+            meta.tx_range.start,
+            open_log::<[u8; 32]>(repo.clone())
+                .transactions_from(0, payload::ArrayDecoder)
+                .map(Result::unwrap)
+                .count() as u64
+        );
+    }
+}
+
+#[test]
+fn overwrite_reopen() {
+    enable_logging();
+
+    let repo = ShortMem::new(800);
+    let num_commits = 10;
+    let txs_per_commit = 5;
+
+    let mut log = open_log::<[u8; 32]>(repo.clone());
+    let mut total_txs = fill_log_enospc(&mut log, num_commits, repeat(txs_per_commit));
+
+    let last_segment_offset = repo.existing_offsets().unwrap().last().copied().unwrap();
+    let last_commit = repo::open_segment_reader(&repo, DEFAULT_LOG_FORMAT_VERSION, last_segment_offset)
+        .unwrap()
+        .commits()
+        .map(Result::unwrap)
+        .last()
+        .unwrap();
+    debug!("last commit: {last_commit:?}");
+    let mut last_segment = repo.open_segment(last_segment_offset).unwrap();
+    last_segment
+        .seek(SeekFrom::End(-((last_commit.encoded_len() - 1) as i64)))
+        .unwrap();
+    last_segment.write_all(&[255; 1]).unwrap();
+
+    let mut log = open_log::<[u8; 32]>(repo.clone());
+    for (i, commit) in log.commits_from(0).enumerate() {
+        if i < num_commits - 1 {
+            commit.expect("all but last commit should be good");
+        } else {
+            let last_good_offset = txs_per_commit * (num_commits - 1);
+            assert!(
+                matches!(
+                    commit,
+                    Err(error::Traversal::Checksum { offset, .. }) if offset == last_good_offset as u64,
+                ),
+                "expected checksum error with offset={}: {:?}",
+                last_good_offset,
+                commit
+            );
+        }
+    }
+
+    // Write some more data.
+    total_txs += fill_log_enospc(&mut log, num_commits, repeat(txs_per_commit));
+    // Log should be contiguous, but missing one corrupted commit.
+    assert_eq!(
+        total_txs - txs_per_commit,
+        log.transactions_from(0, payload::ArrayDecoder)
+            .map(Result::unwrap)
+            .count()
+    );
+    // Check that this is true if we reopen the log.
+    assert_eq!(
+        total_txs - txs_per_commit,
+        open_log::<[u8; 32]>(repo)
+            .transactions_from(0, payload::ArrayDecoder)
+            .map(Result::unwrap)
+            .count()
+    );
+}
+
+fn open_log<T>(repo: ShortMem) -> commitlog::Generic<ShortMem, T> {
+    commitlog::Generic::open(
+        repo,
+        Options {
+            max_segment_size: 1024,
+            ..Options::default()
+        },
+    )
+    .unwrap()
+}
+
+const ENOSPC: i32 = 28;
+
+/// Wrapper around [`mem::Segment`] which causes a partial [`io::Write::write`]
+/// if and when the size of the underlying buffer exceeds a max length.
+#[derive(Debug)]
+struct ShortSegment {
+    inner: repo::mem::Segment,
+    max_len: u64,
+}
+
+impl FileLike for ShortSegment {
+    fn fsync(&self) -> std::io::Result<()> {
+        self.inner.fsync()
+    }
+
+    fn ftruncate(&self, size: u64) -> std::io::Result<()> {
+        self.inner.ftruncate(size)
+    }
+}
+
+impl io::Write for ShortSegment {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let pos = self.inner.stream_position()?;
+        debug!("pos={} max_len={} buf-len={}", pos, self.max_len, buf.len());
+        if pos + buf.len() as u64 > self.max_len {
+            let max = cmp::min(1, (self.max_len - pos) as usize);
+            let n = self.inner.write(&buf[..max])?;
+            debug!("partial write {}/{}", n, buf.len());
+            return Err(io::Error::from_raw_os_error(ENOSPC));
+        }
+        self.inner.write(buf)
+    }
+
+    fn flush(&mut self) -> io::Result<()> {
+        self.inner.flush()
+    }
+}
+
+impl io::Read for ShortSegment {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        self.inner.read(buf)
+    }
+}
+
+impl io::Seek for ShortSegment {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        self.inner.seek(pos)
+    }
+}
+
+/// Wrapper around [`repo::Memory`] which causes partial (or: short) writes.
+#[derive(Debug, Clone)]
+struct ShortMem {
+    inner: repo::Memory,
+    max_len: u64,
+}
+
+impl ShortMem {
+    pub fn new(max_len: u64) -> Self {
+        Self {
+            inner: repo::Memory::new(),
+            max_len,
+        }
+    }
+}
+
+impl Repo for ShortMem {
+    type Segment = ShortSegment;
+
+    fn create_segment(&self, offset: u64) -> io::Result<Self::Segment> {
+        self.inner.create_segment(offset).map(|inner| ShortSegment {
+            inner,
+            max_len: self.max_len,
+        })
+    }
+
+    fn open_segment(&self, offset: u64) -> io::Result<Self::Segment> {
+        self.inner.open_segment(offset).map(|inner| ShortSegment {
+            inner,
+            max_len: self.max_len,
+        })
+    }
+
+    fn remove_segment(&self, offset: u64) -> io::Result<()> {
+        self.inner.remove_segment(offset)
+    }
+
+    fn existing_offsets(&self) -> io::Result<Vec<u64>> {
+        self.inner.existing_offsets()
+    }
+}
+
+/// Like [`crate::tests::helpers::fill_log`], but expect that ENOSPC happens at
+/// least once.
+fn fill_log_enospc<T>(
+    log: &mut commitlog::Generic<ShortMem, T>,
+    num_commits: usize,
+    txs_per_commit: impl Iterator<Item = usize>,
+) -> usize
+where
+    T: Debug + Default + Encode,
+{
+    let mut seen_enospc = false;
+
+    let mut total_txs = 0;
+    for (_, n) in (0..num_commits).zip(txs_per_commit) {
+        for _ in 0..n {
+            log.append(T::default()).unwrap();
+            total_txs += 1;
+        }
+        let res = log.commit();
+        if let Err(Some(os)) = res.as_ref().map_err(|e| e.raw_os_error()) {
+            if os == ENOSPC {
+                debug!("fill: ignoring ENOSPC");
+                seen_enospc = true;
+                log.commit().unwrap();
+                continue;
+            }
+        }
+        res.unwrap();
+    }
+
+    assert!(seen_enospc, "expected to see ENOSPC");
+
+    total_txs
+}


### PR DESCRIPTION
First in a series of patches to implement the new commitlog format.

This patch implements the base format, leaving the transaction payload generic. Segment handling, writing and reading is implemented based on an in-memory backend, which greatly simplifies testing.

As a notable deviation from the previous implementation, segments are never implicitly trimmed. Instead, faulty commits are ignored if and only if the next commit in the log sequence is valid and has the right offset. On the write path, this entails closing the active segment when an (I/O) error occurs, but retaining the commit in memory such that it is written to the next segment.

Note that this patch does not define the final public API.

# Expected complexity level and risk

5