### PR TITLE
(2/3) Commitlog: Add I/O based on regular files

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4494,7 +4494,9 @@ dependencies = [
  "proptest",
  "rand 0.8.5",
  "spacetimedb-sats",
+ "tempfile",
  "thiserror",
+ "tokio",
 ]
 
 [[package]]

--- a/crates/commitlog/Cargo.toml
+++ b/crates/commitlog/Cargo.toml
@@ -14,8 +14,10 @@ itertools.workspace = true
 log.workspace = true
 spacetimedb-sats.workspace = true
 thiserror.workspace = true
+tokio.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true
 proptest.workspace = true
 rand.workspace = true
+tempfile.workspace = true

--- a/crates/commitlog/src/commitlog.rs
+++ b/crates/commitlog/src/commitlog.rs
@@ -1,4 +1,4 @@
-use std::{io, marker::PhantomData, mem, ops::Range, vec};
+use std::{io, marker::PhantomData, mem, vec};
 
 use itertools::Itertools;
 use log::{debug, info, warn};

--- a/crates/commitlog/src/error.rs
+++ b/crates/commitlog/src/error.rs
@@ -35,6 +35,18 @@ pub enum Traversal {
     Io(#[from] io::Error),
 }
 
+/// Error returned by [`crate::Commitlog::append`].
+#[derive(Debug, Error)]
+#[error("failed to commit during append")]
+pub struct Append<T> {
+    /// The payload which was passed to [`crate::Commitlog::append`], but was
+    /// not retained because flushing the data to the underlying storage failed.
+    pub txdata: T,
+    /// Why flushing to persistent storage failed.
+    #[source]
+    pub source: io::Error,
+}
+
 /// A checksum mismatch was detected.
 ///
 /// Usually wrapped in another error, such as [`io::Error`].

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -1,6 +1,17 @@
-#![allow(unused)]
+use std::{
+    io,
+    num::NonZeroU16,
+    path::PathBuf,
+    sync::{Arc, RwLock},
+    time::Duration,
+};
 
-use std::num::NonZeroU16;
+use log::debug;
+use tokio::{
+    sync::watch,
+    task::spawn_blocking,
+    time::{interval, MissedTickBehavior},
+};
 
 mod commit;
 mod commitlog;
@@ -51,5 +62,260 @@ impl Default for Options {
             max_segment_size: 1024 * 1024 * 1024,
             max_records_in_commit: NonZeroU16::MAX,
         }
+    }
+}
+
+/// The canonical commitlog, backed by on-disk log files.
+///
+/// Records in the log are of type `T`, which canonically is instantiated to
+/// [`Txdata`].
+pub struct Commitlog<T> {
+    inner: RwLock<commitlog::Generic<repo::Fs, T>>,
+}
+
+impl<T> Commitlog<T> {
+    /// Open the log at root directory `root` with [`Options`].
+    ///
+    /// The root directory must already exist.
+    pub fn open(root: impl Into<PathBuf>, opts: Options) -> io::Result<Self> {
+        let inner = commitlog::Generic::open(repo::Fs::new(root), opts)?;
+
+        Ok(Self {
+            inner: RwLock::new(inner),
+        })
+    }
+
+    /// Sync all OS-buffered writes to disk.
+    ///
+    /// Note that this does **not** write outstanding records to disk.
+    /// Use [`Self::flush_and_sync`] or call [`Self::flush`] prior to this
+    /// method to ensure all data is on disk.
+    ///
+    /// Returns the maximum transaction offset which is considered durable after
+    /// this method returns successfully. The offset is `None` if the log hasn't
+    /// been flushed to disk yet.
+    pub fn sync(&self) -> io::Result<Option<u64>> {
+        let inner = self.inner.read().unwrap();
+        debug!("sync commitlog");
+        inner.sync()?;
+
+        Ok(inner.max_committed_offset())
+    }
+
+    /// Write all outstanding transaction records to disk.
+    ///
+    /// Note that this does **not** force the OS to sync the data to disk.
+    /// Use [`Self::flush_and_sync`] or call [`Self::sync`] after this method
+    /// to ensure all data is on disk.
+    ///
+    /// Returns the maximum transaction offset written to disk. The offset is
+    /// `None` if the log is empty and no data was pending to be flushed.
+    ///
+    /// Repeatedly calling this method may return the same value.
+    pub fn flush(&self) -> io::Result<Option<u64>> {
+        let mut inner = self.inner.write().unwrap();
+        debug!("flush commitlog");
+        inner.commit()?;
+
+        Ok(inner.max_committed_offset())
+    }
+
+    /// Write all outstanding transaction records to disk and flush OS buffers.
+    ///
+    /// Equivalent to calling [`Self::flush`] followed by [`Self::sync`], but
+    /// without releasing the write lock in between.
+    pub fn flush_and_sync(&self) -> io::Result<Option<u64>> {
+        let mut inner = self.inner.write().unwrap();
+        debug!("flush and sync commitlog");
+        inner.commit()?;
+        inner.sync()?;
+
+        Ok(inner.max_committed_offset())
+    }
+
+    /// Obtain an iterator which traverses the log from the start, yielding
+    /// [`Commit`]s.
+    ///
+    /// The returned iterator is not aware of segment rotation. That is, if a
+    /// new segment is created after this method returns, the iterator will not
+    /// traverse it.
+    ///
+    /// Commits appended to the log while it is being traversed are generally
+    /// visible to the iterator. Upon encountering [`io::ErrorKind::UnexpectedEof`],
+    /// however, a new iterator should be created using [`Self::commits_from`]
+    /// with the last transaction offset yielded.
+    ///
+    /// Note that the very last [`Commit`] in a commitlog may be corrupt (e.g.
+    /// due to a partial write to disk), but a subsequent `append` will bring
+    /// the log into a consistent state.
+    ///
+    /// This means that, when this iterator yields an `Err` value, the consumer
+    /// may want to check if the iterator is exhausted (by calling `next()`)
+    /// before treating the `Err` value as an application error.
+    pub fn commits(&self) -> impl Iterator<Item = Result<Commit, error::Traversal>> {
+        self.commits_from(0)
+    }
+
+    /// Obtain an iterator starting from transaction offset `offset`, yielding
+    /// [`Commit`]s.
+    ///
+    /// Similar to [`Self::commits`] but will skip until the offset is contained
+    /// in the next [`Commit`] to yield.
+    ///
+    /// Note that the first [`Commit`] yielded is the first commit containing
+    /// the given transaction offset, i.e. its `min_tx_offset` may be smaller
+    /// than `offset`.
+    pub fn commits_from(&self, offset: u64) -> impl Iterator<Item = Result<Commit, error::Traversal>> {
+        self.inner.read().unwrap().commits_from(offset)
+    }
+
+    /// Remove all data from the log and reopen it.
+    ///
+    /// Log segments are deleted starting from the newest. As multiple segments
+    /// cannot be deleted atomically, the log may not be completely empty if
+    /// the method returns an error.
+    ///
+    /// Note that the method consumes `self` to ensure the log is not modified
+    /// while resetting.
+    pub fn reset(self) -> io::Result<Self> {
+        let inner = self.inner.into_inner().unwrap().reset()?;
+        Ok(Self {
+            inner: RwLock::new(inner),
+        })
+    }
+
+    /// Remove all data past the given transaction `offset` from the log and
+    /// reopen it.
+    ///
+    /// Like with [`Self::reset`], it may happen that not all segments newer
+    /// than `offset` can be deleted.
+    ///
+    /// If the method returns successfully, the most recent [`Commit`] in the
+    /// log will contain the transaction at `offset`.
+    ///
+    /// Note that the method consumes `self` to ensure the log is not modified
+    /// while resetting.
+    pub fn reset_to(self, offset: u64) -> io::Result<Self> {
+        let inner = self.inner.into_inner().unwrap().reset_to(offset)?;
+        Ok(Self {
+            inner: RwLock::new(inner),
+        })
+    }
+}
+
+impl<T: Encode> Commitlog<T> {
+    /// Append the record `txdata` to the log.
+    ///
+    /// If the internal buffer exceeds [`Options::max_records_in_commit`], the
+    /// argument is returned in an `Err`. The caller should [`Self::flush`] the
+    /// log and try again.
+    ///
+    /// In case the log is appended to from multiple threads, this may result in
+    /// a busy loop trying to acquire a slot in the buffer. In such scenarios,
+    /// [`Self::append_maybe_flush`] is preferable.
+    pub fn append(&self, txdata: T) -> Result<(), T> {
+        let mut inner = self.inner.write().unwrap();
+        inner.append(txdata)
+    }
+
+    /// Append the record `txdata` to the log.
+    ///
+    /// The `txdata` payload is buffered in memory until either:
+    ///
+    /// - [`Self::flush`] is called explicitly, or
+    /// - [`Options::max_records_in_commit`] is exceeded
+    ///
+    /// In the latter case, [`Self::append`] flushes implicitly, _before_
+    /// appending the `txdata` argument.
+    ///
+    /// I.e. the argument is not guaranteed to be flushed after the method
+    /// returns. If that is desired, [`Self::flush`] must be called explicitly.
+    ///
+    /// # Errors
+    ///
+    /// If the log needs to be flushed, but an I/O error occurs, ownership of
+    /// `txdata` is returned back to the caller alongside the [`io::Error`].
+    ///
+    /// The value can then be used to retry appending.
+    pub fn append_maybe_flush(&self, txdata: T) -> Result<(), error::Append<T>> {
+        let mut inner = self.inner.write().unwrap();
+
+        if let Err(txdata) = inner.append(txdata) {
+            if let Err(source) = inner.commit() {
+                return Err(error::Append { txdata, source });
+            }
+            // `inner.commit.n` must be zero at this point
+            let res = inner.append(txdata);
+            debug_assert!(res.is_ok(), "failed to append while holding write lock");
+        }
+
+        Ok(())
+    }
+
+    /// Obtain an iterator which traverses the log from the start, yielding
+    /// [`Transaction`]s.
+    ///
+    /// The provided `decoder`'s [`Decoder::decode_record`] method will be
+    /// called [`Commit::n`] times per [`Commit`] to obtain the individual
+    /// transaction payloads.
+    ///
+    /// Like [`Self::commits`], the iterator is not aware of segment rotation.
+    /// That is, if a new segment is created after this method returns, the
+    /// iterator will not traverse it.
+    ///
+    /// Transactions appended to the log while it is being traversed are
+    /// generally visible to the iterator. Upon encountering [`io::ErrorKind::UnexpectedEof`],
+    /// however, a new iterator should be created using [`Self::transactions_from`]
+    /// with the last transaction offset yielded.
+    pub fn transactions<D: Decoder<Record = T>>(
+        &self,
+        decoder: D,
+    ) -> impl Iterator<Item = Result<Transaction<T>, error::Traversal>> {
+        self.transactions_from(0, decoder)
+    }
+
+    /// Obtain an iterator starting from transaction offset `offset`, yielding
+    /// [`Transaction`]s.
+    ///
+    /// Similar to [`Self::transactions`] but will skip until the provided
+    /// `offset`, i.e. the first [`Transaction`] yielded will be the transaction
+    /// with offset `offset`.
+    pub fn transactions_from<D: Decoder<Record = T>>(
+        &self,
+        offset: u64,
+        decoder: D,
+    ) -> impl Iterator<Item = Result<Transaction<T>, error::Traversal>> {
+        self.inner.read().unwrap().transactions_from(offset, decoder)
+    }
+}
+
+impl<T: Send + Sync + 'static> Commitlog<T> {
+    /// Call [`Self::flush_and_sync`] periodically.
+    ///
+    /// Returns a [`watch::Receiver`] yielding the maximum durable transaction
+    /// offset after each invocation of [`Self::flush_and_sync`]. The item type
+    /// is a `Result`, so as to allow the caller to be notified of I/O errors.
+    ///
+    /// The interval loop terminates when all receivers have been dropped.
+    /// Note that this does not happen promptly.
+    pub fn flush_and_sync_every(self: Arc<Self>, period: Duration) -> watch::Receiver<io::Result<Option<u64>>> {
+        let (tx, rx) = watch::channel(Ok(None));
+        let mut interval = interval(period);
+        interval.set_missed_tick_behavior(MissedTickBehavior::Delay);
+
+        tokio::spawn(async move {
+            loop {
+                interval.tick().await;
+                let this = self.clone();
+                let offset = spawn_blocking(move || this.flush_and_sync()).await?;
+                if tx.send(offset).is_err() {
+                    break;
+                }
+            }
+
+            Ok::<(), tokio::task::JoinError>(())
+        });
+
+        rx
     }
 }

--- a/crates/commitlog/src/repo/fs.rs
+++ b/crates/commitlog/src/repo/fs.rs
@@ -1,0 +1,108 @@
+use std::io;
+use std::{
+    fs::{self, File},
+    path::PathBuf,
+};
+
+use log::debug;
+
+use super::Repo;
+
+const SEGMENT_FILE_EXT: &str = ".stdb.log";
+
+/// By convention, the file name of a segment consists of the minimum
+/// transaction offset contained in it, left-padded with zeroes to 20 digits,
+/// and the file extension `.stdb.log`.
+pub fn segment_file_name(offset: u64) -> String {
+    format!("{offset:0>20}{SEGMENT_FILE_EXT}")
+}
+
+// TODO
+//
+// - should use advisory locks?
+//
+// Experiment:
+//
+// - O_DIRECT | O_DSYNC
+// - preallocation of disk space
+// - io_uring
+//
+
+/// A commitlog repository [`Repo`] which stores commits in ordinary files on
+/// disk.
+#[derive(Clone, Debug)]
+pub struct Fs {
+    /// The base directory within which segment files will be stored.
+    root: PathBuf,
+}
+
+impl Fs {
+    /// Create a commitlog repository which stores segments in the directory `root`.
+    ///
+    /// `root` must name an extant, accessible, writeable directory.
+    pub fn new(root: impl Into<PathBuf>) -> Self {
+        Self { root: root.into() }
+    }
+
+    /// Get the filename for a segment starting with `offset` within this
+    /// repository.
+    pub fn segment_path(&self, offset: u64) -> PathBuf {
+        self.root.join(segment_file_name(offset))
+    }
+}
+
+impl Repo for Fs {
+    type Segment = File;
+
+    fn create_segment(&self, offset: u64) -> io::Result<Self::Segment> {
+        File::options()
+            .read(true)
+            .append(true)
+            .create_new(true)
+            .open(self.segment_path(offset))
+            .or_else(|e| {
+                if e.kind() == io::ErrorKind::AlreadyExists {
+                    debug!("segment {offset} already exists");
+                    let file = self.open_segment(offset)?;
+                    if file.metadata()?.len() == 0 {
+                        debug!("segment {offset} is empty");
+                        return Ok(file);
+                    }
+                }
+
+                Err(e)
+            })
+    }
+
+    fn open_segment(&self, offset: u64) -> io::Result<Self::Segment> {
+        File::options().read(true).append(true).open(self.segment_path(offset))
+    }
+
+    fn remove_segment(&self, offset: u64) -> io::Result<()> {
+        fs::remove_file(self.segment_path(offset))
+    }
+
+    fn existing_offsets(&self) -> io::Result<Vec<u64>> {
+        let mut segments = Vec::new();
+
+        for entry in fs::read_dir(&self.root)? {
+            let entry = entry?;
+            if entry.file_type()?.is_file() {
+                let path = entry.path();
+                let name = path.file_name().unwrap_or_default().to_string_lossy();
+                let Some(file_name) = name.strip_suffix(SEGMENT_FILE_EXT) else {
+                    continue;
+                };
+                let Ok(offset) = file_name.parse::<u64>() else {
+                    continue;
+                };
+
+                segments.push(offset);
+            }
+        }
+
+        segments.sort_unstable();
+
+        Ok(segments)
+    }
+}

--- a/crates/commitlog/src/repo/mod.rs
+++ b/crates/commitlog/src/repo/mod.rs
@@ -9,9 +9,11 @@ use crate::{
     Options,
 };
 
+mod fs;
 #[cfg(test)]
 pub mod mem;
 
+pub use fs::Fs;
 #[cfg(test)]
 pub use mem::Memory;
 

--- a/crates/commitlog/tests/io.rs
+++ b/crates/commitlog/tests/io.rs
@@ -1,0 +1,1 @@
+mod random_payload;

--- a/crates/commitlog/tests/random_payload/mod.rs
+++ b/crates/commitlog/tests/random_payload/mod.rs
@@ -1,0 +1,78 @@
+use std::num::NonZeroU16;
+
+use rand::Rng;
+use spacetimedb_commitlog::{payload, Commitlog, Options};
+use tempfile::tempdir;
+
+fn gen_payload() -> [u8; 256] {
+    let mut rng = rand::thread_rng();
+    let mut buf = [0u8; 256];
+    rng.fill(&mut buf);
+    buf
+}
+
+#[test]
+fn smoke() {
+    let root = tempdir().unwrap();
+    let clog = Commitlog::open(
+        root.path(),
+        Options {
+            max_segment_size: 8 * 1024,
+            max_records_in_commit: NonZeroU16::MIN,
+            ..Options::default()
+        },
+    )
+    .unwrap();
+
+    let n_txs = 500;
+    let payload = gen_payload();
+    for _ in 0..n_txs {
+        clog.append_maybe_flush(payload).unwrap();
+    }
+    let committed_offset = clog.flush_and_sync().unwrap();
+
+    assert_eq!(n_txs - 1, committed_offset.unwrap() as usize);
+    assert_eq!(
+        n_txs,
+        clog.transactions(payload::ArrayDecoder).map(Result::unwrap).count()
+    );
+    // We set max_records_in_commit to 1, so n_commits == n_txs
+    assert_eq!(n_txs, clog.commits().map(Result::unwrap).count());
+}
+
+#[test]
+fn resets() {
+    let root = tempdir().unwrap();
+    let mut clog = Commitlog::open(
+        root.path(),
+        Options {
+            max_segment_size: 512,
+            max_records_in_commit: NonZeroU16::MIN,
+            ..Options::default()
+        },
+    )
+    .unwrap();
+
+    let payload = gen_payload();
+    for _ in 0..50 {
+        clog.append_maybe_flush(payload).unwrap();
+    }
+    clog.flush_and_sync().unwrap();
+
+    for offset in (0..50).rev() {
+        clog = clog.reset_to(offset).unwrap();
+        assert_eq!(
+            offset,
+            clog.transactions(payload::ArrayDecoder)
+                .map(Result::unwrap)
+                .last()
+                .unwrap()
+                .offset
+        );
+        // We're counting from zero, so offset + 1 is the # of txs.
+        assert_eq!(
+            offset + 1,
+            clog.transactions(payload::ArrayDecoder).map(Result::unwrap).count() as u64
+        );
+    }
+}


### PR DESCRIPTION
Provides a commitlog backing store based on files, and defines the exported `Commitlog` type which fixes the store to the file-based one.

**NOTE: This PR is stacked on top of #919**

# Expected complexity level and risk

1