### PR TITLE
Durability: Traits and implementation in terms of commitlog

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4571,6 +4571,18 @@ dependencies = [
 ]
 
 [[package]]
+name = "spacetimedb-durability"
+version = "0.8.2"
+dependencies = [
+ "anyhow",
+ "log",
+ "spacetimedb-commitlog",
+ "spacetimedb-sats",
+ "tokio",
+ "tracing",
+]
+
+[[package]]
 name = "spacetimedb-lib"
 version = "0.8.2"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -10,6 +10,7 @@ members = [
   "crates/commitlog",
   "crates/core",
   "crates/data-structures",
+  "crates/durability",
   "crates/lib",
   "crates/metrics",
   "crates/primitives",
@@ -89,7 +90,7 @@ spacetimedb-client-api-messages = { path = "crates/client-api-messages", version
 spacetimedb-commitlog = { path = "crates/commitlog", version = "0.8.2" }
 spacetimedb-core = { path = "crates/core", version = "0.8.2" }
 spacetimedb-data-structures = { path = "crates/data-structures", version = "0.8.2" }
-
+spacetimedb-durability = { path = "crates/durability", version = "0.8.2" }
 spacetimedb-lib = { path = "crates/lib", default-features = false, version = "0.8.2" }
 spacetimedb-metrics = { path = "crates/metrics", version = "0.8.2" }
 spacetimedb-primitives = { path = "crates/primitives", version = "0.8.2" }

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -88,6 +88,13 @@ impl<T> Commitlog<T> {
         })
     }
 
+    /// Determine the maximum transaction offset considered durable.
+    ///
+    /// The offset is `None` if the log hasn't been flushed to disk yet.
+    pub fn max_committed_offset(&self) -> Option<u64> {
+        self.inner.read().unwrap().max_committed_offset()
+    }
+
     /// Sync all OS-buffered writes to disk.
     ///
     /// Note that this does **not** write outstanding records to disk.

--- a/crates/commitlog/src/payload.rs
+++ b/crates/commitlog/src/payload.rs
@@ -9,6 +9,7 @@ use spacetimedb_sats::{
 use thiserror::Error;
 
 pub mod txdata;
+pub use txdata::Txdata;
 
 /// A **datatype** which can be encoded.
 ///

--- a/crates/durability/Cargo.toml
+++ b/crates/durability/Cargo.toml
@@ -1,0 +1,16 @@
+[package]
+name = "spacetimedb-durability"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license-file = "LICENSE"
+
+description = "Traits and single-node implementation of durability for SpacetimeDB."
+
+[dependencies]
+anyhow.workspace = true
+log.workspace = true
+spacetimedb-commitlog.workspace = true
+spacetimedb-sats.workspace = true
+tokio.workspace = true
+tracing.workspace = true

--- a/crates/durability/LICENSE
+++ b/crates/durability/LICENSE
@@ -1,0 +1,1 @@
+../../LICENSE.txt

--- a/crates/durability/src/imp/local.rs
+++ b/crates/durability/src/imp/local.rs
@@ -1,0 +1,303 @@
+use std::{
+    io,
+    num::NonZeroU16,
+    panic,
+    path::PathBuf,
+    sync::{
+        atomic::{
+            AtomicI64, AtomicU64,
+            Ordering::{Acquire, Relaxed, Release},
+        },
+        Arc,
+    },
+    time::Duration,
+};
+
+use anyhow::Context as _;
+use log::{info, trace, warn};
+use spacetimedb_commitlog::{error, payload::Txdata, Commit, Commitlog, Decoder, Encode, Transaction};
+use tokio::{
+    sync::mpsc,
+    task::{spawn_blocking, JoinHandle},
+};
+use tracing::instrument;
+
+use crate::{Durability, History, TxOffset};
+
+/// [`Local`] configuration.
+#[derive(Clone, Copy, Debug)]
+pub struct Options {
+    /// Periodically flush and sync the log this often.
+    ///
+    /// Default: 500ms
+    pub sync_interval: Duration,
+    /// [`Commitlog`] configuration.
+    pub commitlog: spacetimedb_commitlog::Options,
+}
+
+impl Default for Options {
+    fn default() -> Self {
+        Self {
+            sync_interval: Duration::from_millis(500),
+            commitlog: Default::default(),
+        }
+    }
+}
+
+/// [`Durability`] implementation backed by a [`Commitlog`] on local storage.
+///
+/// The commitlog is constrained to store the canonical [`Txdata`] payload,
+/// where the generic parameter `T` is the type of the row data stored in
+/// the mutations section.
+///
+/// `T` is left generic in order to allow bypassing the `ProductValue`
+/// intermediate representation in the future.
+///
+/// Note, however, that instantiating `T` to a different type may require to
+/// change the log format version!
+pub struct Local<T> {
+    /// The [`Commitlog`] this [`Durability`] and [`History`] impl wraps.
+    clog: Arc<Commitlog<Txdata<T>>>,
+    /// The durable transaction offset, as reported by the background
+    /// [`FlushAndSyncTask`].
+    ///
+    /// A negative number indicates that we haven't flushed yet, or that the
+    /// number overflowed. In either case, appending new transactions shall panic.
+    ///
+    /// The offset will be used by the datastore to squash durable transactions
+    /// into the committed state, thereby making them visible to durable-only
+    /// readers.
+    ///
+    /// We don't want to hang on to those transactions longer than needed, so
+    /// acquire / release or stronger should be used to prevent stale reads.
+    durable_offset: Arc<AtomicI64>,
+    /// Backlog of transactions to be written to disk by the background
+    /// [`PersisterTask`].
+    ///
+    /// Note that this is unbounded!
+    queue: mpsc::UnboundedSender<Txdata<T>>,
+    /// How many transactions are sitting in the `queue`.
+    ///
+    /// This is mainly for observability purposes, and can thus be updated with
+    /// relaxed memory ordering.
+    queue_depth: Arc<AtomicU64>,
+    /// Handle to the [`PersisterTask`], allowing to drain the `queue` when
+    /// explicitly dropped via [`Self::close`].
+    persister_task: JoinHandle<()>,
+}
+
+impl<T: Encode + Send + Sync + 'static> Local<T> {
+    /// Create a [`Local`] instance at the `root` directory.
+    ///
+    /// The `root` directory must already exist.
+    ///
+    /// Background tasks are spawned onto the provided tokio runtime.
+    pub fn open(root: impl Into<PathBuf>, rt: tokio::runtime::Handle, opts: Options) -> io::Result<Self> {
+        info!("open local durability");
+
+        let clog = Arc::new(Commitlog::open(root, opts.commitlog)?);
+        let (queue, rx) = mpsc::unbounded_channel();
+        let queue_depth = Arc::new(AtomicU64::new(0));
+        let offset = {
+            let offset = clog.max_committed_offset().map(|x| x as i64).unwrap_or(-1);
+            Arc::new(AtomicI64::new(offset))
+        };
+
+        let persister_task = rt.spawn(
+            PersisterTask {
+                clog: clog.clone(),
+                rx,
+                queue_depth: queue_depth.clone(),
+                max_records_in_commit: opts.commitlog.max_records_in_commit,
+            }
+            .run(),
+        );
+        rt.spawn(
+            FlushAndSyncTask {
+                clog: clog.clone(),
+                period: opts.sync_interval,
+                offset: offset.clone(),
+            }
+            .run(),
+        );
+
+        Ok(Self {
+            clog,
+            durable_offset: offset,
+            queue,
+            queue_depth,
+            persister_task,
+        })
+    }
+
+    /// Inspect how many transactions added via [`Self::append_tx`] are pending
+    /// to be applied to the underlying [`Commitlog`].
+    pub fn queue_depth(&self) -> u64 {
+        self.queue_depth.load(Relaxed)
+    }
+
+    /// Obtain an iterator over the [`Commit`]s in the underlying log.
+    pub fn commits_from(&self, offset: TxOffset) -> impl Iterator<Item = Result<Commit, error::Traversal>> {
+        self.clog.commits_from(offset)
+    }
+
+    /// Apply all outstanding transactions to the [`Commitlog`] and flush it
+    /// to disk.
+    ///
+    /// Returns the durable [`TxOffset`], if any.
+    pub async fn close(self) -> anyhow::Result<Option<TxOffset>> {
+        info!("close local durability");
+
+        drop(self.queue);
+        if let Err(e) = self.persister_task.await {
+            if e.is_panic() {
+                return Err(e).context("persister task panicked");
+            }
+        }
+
+        spawn_blocking(move || self.clog.flush_and_sync())
+            .await?
+            .context("failed to sync commitlog")
+    }
+}
+
+struct PersisterTask<T> {
+    clog: Arc<Commitlog<Txdata<T>>>,
+    rx: mpsc::UnboundedReceiver<Txdata<T>>,
+    queue_depth: Arc<AtomicU64>,
+    max_records_in_commit: NonZeroU16,
+}
+
+impl<T: Encode + Send + Sync + 'static> PersisterTask<T> {
+    #[instrument(name = "durability::local::persister_task", skip_all)]
+    async fn run(mut self) {
+        info!("starting persister task");
+
+        while let Some(txdata) = self.rx.recv().await {
+            self.queue_depth.fetch_sub(1, Relaxed);
+            trace!("received txdata");
+
+            // If we are writing one commit per tx, trying to buffer is
+            // fairly pointless. Immediately flush instead.
+            //
+            // Otherwise, try `Commitlog::append` as a fast-path which doesn't
+            // require `spawn_blocking`.
+            if self.max_records_in_commit.get() == 1 {
+                self.flush_append(txdata, true).await;
+            } else if let Err(retry) = self.clog.append(txdata) {
+                self.flush_append(retry, false).await
+            }
+
+            trace!("appended txdata");
+        }
+
+        info!("exiting persister task");
+    }
+
+    #[instrument(skip_all)]
+    async fn flush_append(&self, txdata: Txdata<T>, flush_after: bool) {
+        let clog = self.clog.clone();
+        let task = spawn_blocking(move || {
+            let mut retry = Some(txdata);
+            while let Some(txdata) = retry.take() {
+                if let Err(error::Append { txdata, source }) = clog.append_maybe_flush(txdata) {
+                    flush_error(source);
+                    retry = Some(txdata);
+                }
+            }
+
+            if flush_after {
+                clog.flush().map(drop).unwrap_or_else(flush_error);
+            }
+
+            trace!("flush-append succeeded");
+        })
+        .await;
+        if let Err(e) = task {
+            // Resume panic on the spawned task,
+            // which will drop the channel receiver,
+            // which will cause `append_tx` to panic.
+            if e.is_panic() {
+                panic::resume_unwind(e.into_panic())
+            }
+        }
+    }
+}
+
+/// Handle an error flushing the commitlog.
+///
+/// Panics if the error indicates that the log may be permanently unwritable.
+#[inline]
+fn flush_error(e: io::Error) {
+    warn!("error flushing commitlog: {e:?}");
+    if e.kind() == io::ErrorKind::AlreadyExists {
+        panic!("commitlog unwritable!");
+    }
+}
+
+struct FlushAndSyncTask<T> {
+    clog: Arc<Commitlog<Txdata<T>>>,
+    period: Duration,
+    offset: Arc<AtomicI64>,
+}
+
+impl<T: Send + Sync + 'static> FlushAndSyncTask<T> {
+    #[instrument(name = "durability::local::flush_and_sync_task", skip_all)]
+    async fn run(self) {
+        info!("starting syncer task");
+
+        let mut watch = self.clog.flush_and_sync_every(self.period);
+        while watch.changed().await.is_ok() {
+            match &*watch.borrow_and_update() {
+                Err(e) => warn!("commit log flush/sync error: {e}"),
+                Ok(Some(new_offset)) => {
+                    trace!("synced to offset {new_offset}");
+                    // NOTE: Overflow will make `durable_tx_offset` return `None`
+                    self.offset.store(*new_offset as i64, Release);
+                }
+                Ok(None) => {}
+            }
+        }
+
+        info!("exiting syncer task");
+    }
+}
+
+impl<T: Send + Sync + 'static> Durability for Local<T> {
+    type TxData = Txdata<T>;
+
+    fn append_tx(&self, tx: Self::TxData) {
+        self.queue.send(tx).expect("commitlog persister task vanished");
+        self.queue_depth.fetch_add(1, Relaxed);
+    }
+
+    fn durable_tx_offset(&self) -> Option<TxOffset> {
+        let offset = self.durable_offset.load(Acquire);
+        (offset > -1).then_some(offset as u64)
+    }
+}
+
+impl<T: Encode + 'static> History for Local<T> {
+    type TxData = Txdata<T>;
+
+    fn fold_transactions_from<D>(&self, offset: TxOffset, decoder: D) -> Result<(), D::Error>
+    where
+        D: Decoder,
+        D::Error: From<error::Traversal>,
+    {
+        self.clog.fold_transactions_from(offset, decoder)
+    }
+
+    fn transactions_from<'a, D>(
+        &self,
+        offset: TxOffset,
+        decoder: &'a D,
+    ) -> impl Iterator<Item = Result<Transaction<Self::TxData>, D::Error>>
+    where
+        D: Decoder<Record = Self::TxData>,
+        D::Error: From<error::Traversal>,
+        Self::TxData: 'a,
+    {
+        self.clog.transactions_from(offset, decoder)
+    }
+}

--- a/crates/durability/src/imp/mod.rs
+++ b/crates/durability/src/imp/mod.rs
@@ -1,0 +1,2 @@
+pub mod local;
+pub use local::Local;

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -1,0 +1,101 @@
+use std::sync::Arc;
+
+pub use spacetimedb_commitlog::{error, payload::Txdata, Decoder, Transaction};
+
+mod imp;
+pub use imp::{local, Local};
+
+/// Transaction offset.
+///
+/// The transaction offset is essentially a monotonic counter of all
+/// transactions submitted to the durability layer, starting from zero.
+///
+/// While the implementation may not guarantee that the sequence contains no
+/// gaps, it must guarantee that a higher transaction offset implies durability
+/// of all offsets smaller than it.
+pub type TxOffset = u64;
+
+/// The durability API.
+///
+/// NOTE: This is a preliminary definition, still under consideration.
+///
+/// A durability implementation accepts a payload representing a single database
+/// transaction via [`Durability::append_tx`] in a non-blocking fashion. The
+/// payload _should_ become durable eventually. [`TxOffset`]s reported by
+/// [`Durability::durable_tx_offset`] shall be considered durable to the
+/// extent the implementation can guarantee.
+pub trait Durability: Send + Sync {
+    /// The payload representing a single transaction.
+    type TxData;
+
+    /// Submit the transaction payload to be made durable.
+    ///
+    /// This method must never block, and accept new transactions even if they
+    /// cannot be made durable immediately.
+    ///
+    /// A permanent failure of the durable storage may be signalled by panicking.
+    fn append_tx(&self, tx: Self::TxData);
+
+    /// The [`TxOffset`] considered durable.
+    ///
+    /// A `None` return value indicates that the durable offset is not known,
+    /// either because nothing has been persisted yet, or because the status
+    /// cannot be retrieved.
+    fn durable_tx_offset(&self) -> Option<TxOffset>;
+}
+
+/// Access to the durable history.
+///
+/// The durable history is the sequence of transactions in the order
+/// [`Durability::append_tx`] was called.
+///
+/// Some [`Durability`] implementations will be able to also implement this
+/// trait, but others may not. A database may also use a [`Durability`]
+/// implementation to persist transactions, but a separate [`History`]
+/// implementation to obtain the history.
+pub trait History {
+    type TxData;
+
+    /// Traverse the history of transactions from `offset` and "fold" it into
+    /// the provided [`Decoder`].
+    fn fold_transactions_from<D>(&self, offset: TxOffset, decoder: D) -> Result<(), D::Error>
+    where
+        D: Decoder,
+        D::Error: From<error::Traversal>;
+
+    /// Obtain an iterator over the history of transactions, starting from `offset`.
+    fn transactions_from<'a, D>(
+        &self,
+        offset: TxOffset,
+        decoder: &'a D,
+    ) -> impl Iterator<Item = Result<Transaction<Self::TxData>, D::Error>>
+    where
+        D: Decoder<Record = Self::TxData>,
+        D::Error: From<error::Traversal>,
+        Self::TxData: 'a;
+}
+
+impl<T: History> History for Arc<T> {
+    type TxData = T::TxData;
+
+    fn fold_transactions_from<D>(&self, offset: TxOffset, decoder: D) -> Result<(), D::Error>
+    where
+        D: Decoder,
+        D::Error: From<error::Traversal>,
+    {
+        (**self).fold_transactions_from(offset, decoder)
+    }
+
+    fn transactions_from<'a, D>(
+        &self,
+        offset: TxOffset,
+        decoder: &'a D,
+    ) -> impl Iterator<Item = Result<Transaction<Self::TxData>, D::Error>>
+    where
+        D: Decoder<Record = Self::TxData>,
+        D::Error: From<error::Traversal>,
+        Self::TxData: 'a,
+    {
+        (**self).transactions_from(offset, decoder)
+    }
+}


### PR DESCRIPTION
Defines traits intended to abstract over the kind of persistence a
database utilizes. The only implementation is (host-)local durability in
terms of the new commitlog crate.

The trait definitions may not be considered stable yet, but are in their
tentative form needed for further integration of the new commitlog.

**NOTE: This PR is stacked on top of #921**