### PR TITLE
`iter_by_col_eq`: take AV by ref + impl RangeBounds<..> for &AV

### DIFF
--- a/crates/bench/src/spacetime_raw.rs
+++ b/crates/bench/src/spacetime_raw.rs
@@ -108,7 +108,7 @@ impl BenchDatabase for SpacetimeRaw {
                 // (update_by_{field} -> spacetimedb::query::update_by_field -> (delete_by_col_eq; insert))
                 let id = self
                     .db
-                    .iter_by_col_eq_mut(&ctx, tx, *table_id, ColId(0), row.elements[0].clone())?
+                    .iter_by_col_eq_mut(&ctx, tx, *table_id, ColId(0), &row.elements[0])?
                     .next()
                     .expect("failed to find row during update!")
                     .pointer();
@@ -151,7 +151,7 @@ impl BenchDatabase for SpacetimeRaw {
         let col: ColId = column_index.into();
         let ctx = ExecutionContext::default();
         self.db.with_auto_commit(&ctx, |tx| {
-            for row in self.db.iter_by_col_eq_mut(&ctx, tx, *table_id, col, value)? {
+            for row in self.db.iter_by_col_eq_mut(&ctx, tx, *table_id, col, &value)? {
                 black_box(row);
             }
             Ok(())

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -59,7 +59,7 @@ impl MutTxId {
         &mut self,
         table_id: TableId,
         col_pos: ColId,
-        value: AlgebraicValue,
+        value: &AlgebraicValue,
         database_address: Address,
     ) -> Result<()> {
         let ctx = ExecutionContext::internal(database_address);
@@ -217,13 +217,13 @@ impl MutTxId {
         self.drop_col_eq(
             ST_TABLES_ID,
             StTableFields::TableId.col_id(),
-            table_id.into(),
+            &table_id.into(),
             database_address,
         )?;
         self.drop_col_eq(
             ST_COLUMNS_ID,
             StColumnFields::TableId.col_id(),
-            table_id.into(),
+            &table_id.into(),
             database_address,
         )?;
 
@@ -244,7 +244,7 @@ impl MutTxId {
                 &ctx,
                 &ST_TABLES_ID,
                 StTableFields::TableId.col_id().into(),
-                table_id.into(),
+                &table_id.into(),
             )?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_table, table_id.into()))?;
@@ -260,7 +260,7 @@ impl MutTxId {
 
     pub fn table_id_from_name(&self, table_name: &str, database_address: Address) -> Result<Option<TableId>> {
         let ctx = ExecutionContext::internal(database_address);
-        let table_name = table_name.to_owned().into();
+        let table_name = &table_name.to_owned().into();
         let row = self
             .iter_by_col_eq(&ctx, &ST_TABLES_ID, StTableFields::TableName.into(), table_name)?
             .next();
@@ -268,7 +268,7 @@ impl MutTxId {
     }
 
     pub fn table_name_from_id<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Option<String>> {
-        self.iter_by_col_eq(ctx, &ST_TABLES_ID, StTableFields::TableId.into(), table_id.into())
+        self.iter_by_col_eq(ctx, &ST_TABLES_ID, StTableFields::TableId.into(), &table_id.into())
             .map(|mut iter| iter.next().map(|row| row.read_col(StTableFields::TableName).unwrap()))
     }
 
@@ -370,7 +370,7 @@ impl MutTxId {
                 &ctx,
                 &ST_INDEXES_ID,
                 StIndexFields::IndexId.col_id().into(),
-                index_id.into(),
+                &index_id.into(),
             )?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_indexes, index_id.into()))?;
@@ -407,7 +407,7 @@ impl MutTxId {
 
     pub fn index_id_from_name(&self, index_name: &str, database_address: Address) -> Result<Option<IndexId>> {
         let ctx = ExecutionContext::internal(database_address);
-        let name = index_name.to_owned().into();
+        let name = &index_name.to_owned().into();
         self.iter_by_col_eq(&ctx, &ST_INDEXES_ID, StIndexFields::IndexName.into(), name)
             .map(|mut iter| iter.next().map(|row| row.read_col(StIndexFields::IndexId).unwrap()))
     }
@@ -432,7 +432,7 @@ impl MutTxId {
                 &ctx,
                 &ST_SEQUENCES_ID,
                 StSequenceFields::SequenceId.into(),
-                seq_id.into(),
+                &seq_id.into(),
             )?
             .last()
             .unwrap();
@@ -509,7 +509,7 @@ impl MutTxId {
                 &ctx,
                 &ST_SEQUENCES_ID,
                 StSequenceFields::SequenceId.col_id().into(),
-                sequence_id.into(),
+                &sequence_id.into(),
             )?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_sequence, sequence_id.into()))?;
@@ -530,7 +530,7 @@ impl MutTxId {
 
     pub fn sequence_id_from_name(&self, seq_name: &str, database_address: Address) -> Result<Option<SequenceId>> {
         let ctx = ExecutionContext::internal(database_address);
-        let name = seq_name.to_owned().into();
+        let name = &seq_name.to_owned().into();
         self.iter_by_col_eq(&ctx, &ST_SEQUENCES_ID, StSequenceFields::SequenceName.into(), name)
             .map(|mut iter| {
                 iter.next()
@@ -604,7 +604,7 @@ impl MutTxId {
                 &ctx,
                 &ST_CONSTRAINTS_ID,
                 StConstraintFields::ConstraintId.col_id().into(),
-                constraint_id.into(),
+                &constraint_id.into(),
             )?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_constraints, constraint_id.into()))?;
@@ -629,7 +629,7 @@ impl MutTxId {
             &ExecutionContext::internal(database_address),
             &ST_CONSTRAINTS_ID,
             StConstraintFields::ConstraintName.into(),
-            constraint_name.to_owned().into(),
+            &constraint_name.to_owned().into(),
         )
         .map(|mut iter| {
             iter.next()
@@ -738,7 +738,7 @@ impl MutTxId {
                 &ctx,
                 &ST_SEQUENCES_ID,
                 StSequenceFields::TableId.into(),
-                table_id.into(),
+                &table_id.into(),
             )? {
                 let seq_col_pos: ColId = seq_row.read_col(StSequenceFields::ColPos)?;
                 if seq_col_pos == seq.col_pos {

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -230,7 +230,7 @@ pub trait TxDatastore: DataRow + Tx {
     where
         Self: 'a;
 
-    type IterByColEq<'a>: Iterator<Item = Self::RowRef<'a>>
+    type IterByColEq<'a, 'r>: Iterator<Item = Self::RowRef<'a>>
     where
         Self: 'a;
 
@@ -245,14 +245,14 @@ pub trait TxDatastore: DataRow + Tx {
         range: R,
     ) -> Result<Self::IterByColRange<'a, R>>;
 
-    fn iter_by_col_eq_tx<'a>(
+    fn iter_by_col_eq_tx<'a, 'r>(
         &'a self,
         ctx: &'a ExecutionContext,
         tx: &'a Self::Tx,
         table_id: TableId,
         cols: impl Into<ColList>,
-        value: AlgebraicValue,
-    ) -> Result<Self::IterByColEq<'a>>;
+        value: &'r AlgebraicValue,
+    ) -> Result<Self::IterByColEq<'a, 'r>>;
 
     fn table_id_exists_tx(&self, tx: &Self::Tx, table_id: &TableId) -> bool;
     fn table_id_from_name_tx(&self, tx: &Self::Tx, table_name: &str) -> Result<Option<TableId>>;
@@ -332,14 +332,14 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
         cols: impl Into<ColList>,
         range: R,
     ) -> Result<Self::IterByColRange<'a, R>>;
-    fn iter_by_col_eq_mut_tx<'a>(
+    fn iter_by_col_eq_mut_tx<'a, 'r>(
         &'a self,
         ctx: &'a ExecutionContext,
         tx: &'a Self::MutTx,
         table_id: TableId,
         cols: impl Into<ColList>,
-        value: AlgebraicValue,
-    ) -> Result<Self::IterByColEq<'a>>;
+        value: &'r AlgebraicValue,
+    ) -> Result<Self::IterByColEq<'a, 'r>>;
     fn get_mut_tx<'a>(
         &self,
         tx: &'a Self::MutTx,

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -581,25 +581,25 @@ impl RelationalDB {
     /// where the column data identified by `cols` matches `value`.
     ///
     /// Matching is defined by `Ord for AlgebraicValue`.
-    pub fn iter_by_col_eq_mut<'a>(
+    pub fn iter_by_col_eq_mut<'a, 'r>(
         &'a self,
         ctx: &'a ExecutionContext,
         tx: &'a MutTx,
         table_id: impl Into<TableId>,
         cols: impl Into<ColList>,
-        value: AlgebraicValue,
-    ) -> Result<IterByColEq<'a>, DBError> {
+        value: &'r AlgebraicValue,
+    ) -> Result<IterByColEq<'a, 'r>, DBError> {
         self.inner.iter_by_col_eq_mut_tx(ctx, tx, table_id.into(), cols, value)
     }
 
-    pub fn iter_by_col_eq<'a>(
+    pub fn iter_by_col_eq<'a, 'r>(
         &'a self,
         ctx: &'a ExecutionContext,
         tx: &'a Tx,
         table_id: impl Into<TableId>,
         cols: impl Into<ColList>,
-        value: AlgebraicValue,
-    ) -> Result<IterByColEq<'a>, DBError> {
+        value: &'r AlgebraicValue,
+    ) -> Result<IterByColEq<'a, 'r>, DBError> {
         self.inner.iter_by_col_eq_tx(ctx, tx, table_id.into(), cols, value)
     }
 
@@ -1333,11 +1333,11 @@ mod tests {
         stdb.insert(&mut tx, table_id, product![1u64, 2u64, 2u64])?;
 
         let cols = col_list![0, 1];
-        let value: AlgebraicValue = product![0u64, 1u64].into();
+        let value = product![0u64, 1u64].into();
 
         let ctx = ExecutionContext::default();
 
-        let IterByColEq::Index(mut iter) = stdb.iter_by_col_eq_mut(&ctx, &tx, table_id, cols, value)? else {
+        let IterByColEq::Index(mut iter) = stdb.iter_by_col_eq_mut(&ctx, &tx, table_id, cols, &value)? else {
             panic!("expected index iterator");
         };
 

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -161,7 +161,7 @@ impl InstanceEnv {
         let tx = &mut *self.get_tx()?;
 
         // Interpret the `value` using the schema of the column.
-        let eq_value = stdb.decode_column(tx, table_id, col_id, value)?;
+        let eq_value = &stdb.decode_column(tx, table_id, col_id, value)?;
 
         // Find all rows in the table where the column data equates to `value`.
         let rows_to_delete = stdb
@@ -283,7 +283,7 @@ impl InstanceEnv {
         let tx = &mut *self.get_tx()?;
 
         // Interpret the `value` using the schema of the column.
-        let value = stdb.decode_column(tx, table_id, col_id, value)?;
+        let value = &stdb.decode_column(tx, table_id, col_id, value)?;
 
         // Find all rows in the table where the column data matches `value`.
         // Concatenate and return these rows using bsatn encoding.

--- a/crates/sats/src/algebraic_value.rs
+++ b/crates/sats/src/algebraic_value.rs
@@ -283,8 +283,17 @@ impl<T: Into<AlgebraicValue>> From<Option<T>> for AlgebraicValue {
     }
 }
 
-// An AlgebraicValue can be interpreted as a range containing a only the value itself.
-// This is useful for BTrees where single key scans are still viewed range scans.
+/// An AlgebraicValue can be interpreted as a range containing a only the value itself.
+/// This is useful for BTrees where single key scans are still viewed range scans.
+impl RangeBounds<AlgebraicValue> for &AlgebraicValue {
+    fn start_bound(&self) -> Bound<&AlgebraicValue> {
+        Bound::Included(self)
+    }
+    fn end_bound(&self) -> Bound<&AlgebraicValue> {
+        Bound::Included(self)
+    }
+}
+
 impl RangeBounds<AlgebraicValue> for AlgebraicValue {
     fn start_bound(&self) -> Bound<&AlgebraicValue> {
         Bound::Included(self)


### PR DESCRIPTION
# Description of Changes

- Let `iter_by_col_eq` take `&AlgebraicValue` instead of taking ownership.
- Add `impl RangeBounds<AlgebraicValue> for &AlgebraicValue`.

Together, and with especially the latter, these will facilitate reusing queries.

# API and ABI breaking changes

None

# Expected complexity level and risk

1