### PR TITLE
chore: Remove debug instrumentation from hot path

### DIFF
--- a/crates/core/src/db/commit_log.rs
+++ b/crates/core/src/db/commit_log.rs
@@ -306,7 +306,6 @@ impl CommitLogMut {
     ///
     /// Returns the number of bytes written, or `None` if it was an empty
     /// transaction (i.e. one which did not modify any rows).
-    #[tracing::instrument(skip_all)]
     pub fn append_tx<D>(
         &self,
         ctx: &ExecutionContext,

--- a/crates/core/src/db/message_log.rs
+++ b/crates/core/src/db/message_log.rs
@@ -214,7 +214,6 @@ impl MessageLog {
         OpenOptions::default()
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn append(&mut self, message: impl AsRef<[u8]>) -> io::Result<()> {
         let message = message.as_ref();
         let mess_size = message.len() as u32;
@@ -256,7 +255,6 @@ impl MessageLog {
     // https://www.evanjones.ca/durability-filesystem.html
     // https://stackoverflow.com/questions/42442387/is-write-safe-to-be-called-from-multiple-threads-simultaneously/42442926#42442926
     // https://github.com/facebook/rocksdb/wiki/WAL-Performance
-    #[tracing::instrument]
     pub fn flush(&mut self) -> io::Result<()> {
         self.open_segment_file.flush()?;
         Ok(())
@@ -266,7 +264,6 @@ impl MessageLog {
     // been pushed to the OS. You probably don't need to call this function, unless you need it
     // to be for sure durably written.
     // SEE: https://stackoverflow.com/questions/69819990/whats-the-difference-between-flush-and-sync-all
-    #[tracing::instrument]
     pub fn sync_all(&mut self) -> io::Result<()> {
         log::trace!("fsync log file");
         self.flush()?;

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -182,13 +182,11 @@ impl RelationalDB {
             .map_or(Ok(0), |commit_log| commit_log.object_db_size_on_disk())
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn encode_row(row: &ProductValue, bytes: &mut Vec<u8>) {
         // TODO: large file storage of the row elements
         row.encode(bytes);
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn schema_for_table_mut<'tx>(
         &self,
         tx: &'tx MutTx,
@@ -197,12 +195,10 @@ impl RelationalDB {
         self.inner.schema_for_table_mut_tx(tx, table_id)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn schema_for_table<'tx>(&self, tx: &'tx Tx, table_id: TableId) -> Result<Cow<'tx, TableSchema>, DBError> {
         self.inner.schema_for_table_tx(tx, table_id)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn row_schema_for_table<'tx>(
         &self,
         tx: &'tx MutTx,
@@ -221,7 +217,6 @@ impl RelationalDB {
             .get_all_tables_tx(&ExecutionContext::internal(self.address), tx)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn schema_for_column<'tx>(
         &self,
         tx: &'tx MutTx,
@@ -377,7 +372,6 @@ impl RelationalDB {
     }
 
     /// Perform the transactional logic for the `tx` according to the `res`
-    #[tracing::instrument(skip_all)]
     pub fn finish_tx<A, E>(&self, ctx: &ExecutionContext, tx: MutTx, res: Result<A, E>) -> Result<A, E>
     where
         E: From<DBError>,
@@ -484,32 +478,26 @@ impl RelationalDB {
         self.inner.rename_table_mut_tx(tx, table_id, new_name)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn table_id_from_name_mut(&self, tx: &MutTx, table_name: &str) -> Result<Option<TableId>, DBError> {
         self.inner.table_id_from_name_mut_tx(tx, table_name)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn table_id_from_name(&self, tx: &Tx, table_name: &str) -> Result<Option<TableId>, DBError> {
         self.inner.table_id_from_name_tx(tx, table_name)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn table_id_exists(&self, tx: &Tx, table_id: &TableId) -> bool {
         self.inner.table_id_exists_tx(tx, table_id)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn table_id_exists_mut(&self, tx: &MutTx, table_id: &TableId) -> bool {
         self.inner.table_id_exists_mut_tx(tx, table_id)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn table_name_from_id<'a>(&'a self, tx: &'a Tx, table_id: TableId) -> Result<Option<Cow<'a, str>>, DBError> {
         self.inner.table_name_from_id_tx(tx, table_id)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn table_name_from_id_mut<'a>(
         &'a self,
         ctx: &'a ExecutionContext,
@@ -519,7 +507,6 @@ impl RelationalDB {
         self.inner.table_name_from_id_mut_tx(ctx, tx, table_id)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn column_constraints(
         &self,
         tx: &mut MutTx,
@@ -541,17 +528,14 @@ impl RelationalDB {
         Ok(attr)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn index_id_from_name(&self, tx: &MutTx, index_name: &str) -> Result<Option<IndexId>, DBError> {
         self.inner.index_id_from_name_mut_tx(tx, index_name)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn sequence_id_from_name(&self, tx: &MutTx, sequence_name: &str) -> Result<Option<SequenceId>, DBError> {
         self.inner.sequence_id_from_name_mut_tx(tx, sequence_name)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn constraint_id_from_name(&self, tx: &MutTx, constraint_name: &str) -> Result<Option<ConstraintId>, DBError> {
         self.inner.constraint_id_from_name(tx, constraint_name)
     }
@@ -561,20 +545,17 @@ impl RelationalDB {
     /// Returns the `index_id`
     ///
     /// NOTE: It loads the data from the table into it before returning
-    #[tracing::instrument(skip(self, tx, index), fields(index = index.index_name))]
     pub fn create_index(&self, tx: &mut MutTx, table_id: TableId, index: IndexDef) -> Result<IndexId, DBError> {
         self.inner.create_index_mut_tx(tx, table_id, index)
     }
 
     /// Removes the [index::BTreeIndex] from the database by their `index_id`
-    #[tracing::instrument(skip(self, tx))]
     pub fn drop_index(&self, tx: &mut MutTx, index_id: IndexId) -> Result<(), DBError> {
         self.inner.drop_index_mut_tx(tx, index_id)
     }
 
     /// Returns an iterator,
     /// yielding every row in the table identified by `table_id`.
-    #[tracing::instrument(skip(self, ctx, tx))]
     pub fn iter_mut<'a>(
         &'a self,
         ctx: &'a ExecutionContext,
@@ -584,7 +565,6 @@ impl RelationalDB {
         self.inner.iter_mut_tx(ctx, tx, table_id)
     }
 
-    #[tracing::instrument(skip(self, ctx, tx))]
     pub fn iter<'a>(&'a self, ctx: &'a ExecutionContext, tx: &'a Tx, table_id: TableId) -> Result<Iter<'a>, DBError> {
         self.inner.iter_tx(ctx, tx, table_id)
     }
@@ -649,7 +629,6 @@ impl RelationalDB {
         self.inner.iter_by_col_range_tx(ctx, tx, table_id.into(), cols, range)
     }
 
-    #[tracing::instrument(skip(self, tx, row))]
     pub fn insert(&self, tx: &mut MutTx, table_id: TableId, row: ProductValue) -> Result<ProductValue, DBError> {
         #[cfg(feature = "metrics")]
         let _guard = DB_METRICS
@@ -659,7 +638,6 @@ impl RelationalDB {
         self.inner.insert_mut_tx(tx, table_id, row)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn insert_bytes_as_row(
         &self,
         tx: &mut MutTx,
@@ -675,7 +653,6 @@ impl RelationalDB {
         self.inner.delete_mut_tx(tx, table_id, row_ids)
     }
 
-    #[tracing::instrument(skip_all)]
     pub fn delete_by_rel<R: Relation>(&self, tx: &mut MutTx, table_id: TableId, relation: R) -> u32 {
         #[cfg(feature = "metrics")]
         let _guard = DB_METRICS
@@ -687,7 +664,6 @@ impl RelationalDB {
     }
 
     /// Clear all rows from a table without dropping it.
-    #[tracing::instrument(skip_all)]
     pub fn clear_table(&self, tx: &mut MutTx, table_id: TableId) -> Result<(), DBError> {
         let relation = self
             .iter_mut(&ExecutionContext::internal(self.address), tx, table_id)?
@@ -698,13 +674,11 @@ impl RelationalDB {
     }
 
     /// Generated the next value for the [SequenceId]
-    #[tracing::instrument(skip_all)]
     pub fn next_sequence(&self, tx: &mut MutTx, seq_id: SequenceId) -> Result<i128, DBError> {
         self.inner.get_next_sequence_value_mut_tx(tx, seq_id)
     }
 
     /// Add a [Sequence] into the database instance, generates a stable [SequenceId] for it that will persist on restart.
-    #[tracing::instrument(skip(self, tx, seq), fields(seq = seq.sequence_name))]
     pub fn create_sequence(
         &mut self,
         tx: &mut MutTx,
@@ -715,13 +689,11 @@ impl RelationalDB {
     }
 
     ///Removes the [Sequence] from database instance
-    #[tracing::instrument(skip(self, tx))]
     pub fn drop_sequence(&self, tx: &mut MutTx, seq_id: SequenceId) -> Result<(), DBError> {
         self.inner.drop_sequence_mut_tx(tx, seq_id)
     }
 
     ///Removes the [Constraints] from database instance
-    #[tracing::instrument(skip(self, tx))]
     pub fn drop_constraint(&self, tx: &mut MutTx, constraint_id: ConstraintId) -> Result<(), DBError> {
         self.inner.drop_constraint_mut_tx(tx, constraint_id)
     }

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -259,6 +259,7 @@ impl<T: WasmModule> Module for WasmModuleHostActor<T> {
         self.scheduler.close()
     }
 
+    #[tracing::instrument(skip_all)]
     fn one_off_query(
         &self,
         caller_identity: Identity,

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -626,7 +626,7 @@ impl WasmInstanceEnv {
     /// - a table with the provided `table_id` doesn't exist
     /// - `(filter, filter_len)` doesn't decode to a filter expression
     /// - `filter + filter_len` overflows a 64-bit integer
-    // #[tracing::instrument(skip_all)]
+    #[tracing::instrument(skip_all)]
     pub fn iter_start_filtered(
         caller: Caller<'_, Self>,
         table_id: u32,

--- a/crates/core/src/sql/ast.rs
+++ b/crates/core/src/sql/ast.rs
@@ -431,7 +431,7 @@ fn compile_where(table: &From, filter: Option<SqlExpr>) -> Result<Option<Selecti
     }
 }
 
-pub(crate) trait TableSchemaView {
+pub trait TableSchemaView {
     fn find_table(&self, db: &RelationalDB, t: Table) -> Result<Cow<'_, TableSchema>, PlanError>;
 }
 

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -13,7 +13,6 @@ use std::sync::Arc;
 use super::ast::TableSchemaView;
 
 /// Compile the `SQL` expression into an `ast`
-#[tracing::instrument(skip_all)]
 pub fn compile_sql<T: TableSchemaView>(db: &RelationalDB, tx: &T, sql_text: &str) -> Result<Vec<CrudExpr>, DBError> {
     tracing::trace!(sql = sql_text);
     let ast = compile_to_ast(db, tx, sql_text)?;

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -20,7 +20,6 @@ pub struct StmtResult {
 // we always generate a plan, but it may contain errors
 
 /// Run a `SQL` query/statement in the specified `database_instance_id`.
-#[tracing::instrument(skip_all)]
 pub fn execute(
     db_inst_ctx_controller: &DatabaseInstanceContextController,
     database_instance_id: u64,
@@ -51,7 +50,6 @@ fn collect_result(result: &mut Vec<MemTable>, r: CodeResult) -> Result<(), DBErr
     Ok(())
 }
 
-#[tracing::instrument(skip_all)]
 pub fn execute_single_sql(
     cx: &ExecutionContext,
     db: &RelationalDB,
@@ -69,7 +67,6 @@ pub fn execute_single_sql(
     Ok(result)
 }
 
-#[tracing::instrument(skip_all)]
 pub fn execute_sql_mut_tx(
     db: &RelationalDB,
     tx: &mut MutTx,
@@ -91,7 +88,6 @@ pub fn execute_sql_mut_tx(
 /// Run the compiled `SQL` expression inside the `vm` created by [DbProgram]
 ///
 /// Evaluates `ast` and accordingly triggers mutable or read tx to execute
-#[tracing::instrument(skip_all)]
 pub fn execute_sql(db: &RelationalDB, ast: Vec<CrudExpr>, auth: AuthCtx) -> Result<Vec<MemTable>, DBError> {
     let total = ast.len();
     let ctx = ExecutionContext::sql(db.address());
@@ -117,7 +113,6 @@ pub fn execute_sql(db: &RelationalDB, ast: Vec<CrudExpr>, auth: AuthCtx) -> Resu
 }
 
 /// Run the `SQL` string using the `auth` credentials
-#[tracing::instrument(skip_all)]
 pub fn run(db: &RelationalDB, sql_text: &str, auth: AuthCtx) -> Result<Vec<MemTable>, DBError> {
     let ctx = &ExecutionContext::sql(db.address());
     let ast = db.with_read_only(ctx, |tx| compile_sql(db, tx, sql_text))?;

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -56,7 +56,6 @@ fn find_op_type_col_pos(header: &Header) -> Option<ColId> {
 
 /// Create a virtual table from a sequence of table updates.
 /// Add a special column __op_type to distinguish inserts and deletes.
-#[tracing::instrument(skip_all)]
 pub fn to_mem_table_with_op_type(head: Arc<Header>, table_access: StAccess, data: &DatabaseTableUpdate) -> MemTable {
     let mut t = MemTable::new(head, table_access, vec![]);
 
@@ -119,7 +118,6 @@ pub fn to_mem_table(mut of: QueryExpr, data: &DatabaseTableUpdate) -> (QueryExpr
 }
 
 /// Runs a query that evaluates if the changes made should be reported to the [ModuleSubscriptionManager]
-#[tracing::instrument(skip_all)]
 pub(crate) fn run_query(
     cx: &ExecutionContext,
     db: &RelationalDB,
@@ -141,7 +139,6 @@ pub(crate) fn run_query(
 ///
 /// This is necessary when merging multiple SQL queries into a single query set,
 /// as in [`crate::subscription::module_subscription_actor::ModuleSubscriptions::add_subscriber`].
-#[tracing::instrument(skip(relational_db, auth, tx))]
 pub fn compile_read_only_query(
     relational_db: &RelationalDB,
     tx: &Tx,

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -40,7 +40,6 @@ impl<'a> From<&'a Tx> for TxMode<'a> {
 
 //TODO: This is partially duplicated from the `vm` crate to avoid borrow checker issues
 //and pull all that crate in core. Will be revisited after trait refactor
-#[tracing::instrument(skip_all)]
 pub fn build_query<'a>(
     ctx: &'a ExecutionContext,
     stdb: &'a RelationalDB,
@@ -378,7 +377,6 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
         Self { ctx, db, tx, auth }
     }
 
-    #[tracing::instrument(skip_all)]
     fn _eval_query(&mut self, query: QueryCode, sources: &mut SourceSet) -> Result<Code, ErrorVm> {
         let table_access = query.table.table_access();
         tracing::trace!(table = query.table.table_name());

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -52,7 +52,6 @@ pub type IterRows<'a> = dyn RelOps<'a> + 'a;
 /// While constructing the query, the `sources` will be destructively modified with `Option::take`
 /// to extract the sources,
 /// so the `query` cannot refer to the same `SourceId` multiple times.
-#[tracing::instrument(skip_all)]
 pub fn build_query<'a>(
     mut result: Box<IterRows<'a>>,
     query: Vec<Query>,
@@ -130,13 +129,11 @@ pub fn build_query<'a>(
 }
 
 /// Optimize & compile the [CrudExpr] for late execution
-#[tracing::instrument(skip_all)]
 pub fn build_ast(ast: CrudExpr) -> Code {
     compile_query_expr(ast)
 }
 
 /// Execute the code
-#[tracing::instrument(skip_all)]
 pub fn eval<P: ProgramVm>(p: &mut P, code: Code, sources: &mut SourceSet) -> Code {
     match code {
         Code::Value(_) => code.clone(),
@@ -176,7 +173,6 @@ fn to_vec(of: Vec<Expr>) -> Code {
 }
 
 /// Optimize, compile & run the [Expr]
-#[tracing::instrument(skip_all)]
 pub fn run_ast<P: ProgramVm>(p: &mut P, ast: Expr, mut sources: SourceSet) -> Code {
     let code = match ast {
         Expr::Block(x) => to_vec(x),

--- a/crates/vm/src/program.rs
+++ b/crates/vm/src/program.rs
@@ -63,7 +63,6 @@ impl ProgramVm for Program {
         &self.auth
     }
 
-    #[tracing::instrument(skip_all)]
     fn eval_query(&mut self, query: CrudCode, sources: &mut SourceSet) -> Result<Code, ErrorVm> {
         match query {
             CrudCode::Query(query) => {


### PR DESCRIPTION
Removes most instrumentation from RelationalDB,
but keeps all pre-existing instrumentation of the wasm api.

# API and ABI breaking changes

None

# Expected complexity level and risk

1
