### PR TITLE
fix: Optimize query plan in iter_filtered_chunks

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1126,7 +1126,6 @@ mod tests {
         stdb.commit_tx(&ExecutionContext::default(), tx)?;
         drop(stdb);
 
-        dbg!("reopen...");
         let stdb = open_db(&tmp_dir, false, true)?;
 
         let mut tx = stdb.begin_mut_tx(IsolationLevel::Serializable);

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -367,8 +367,12 @@ impl InstanceEnv {
         .map_err(NodesError::DecodeFilter)?;
 
         // TODO(Centril): consider caching from `filter: &[u8] -> query: QueryExpr`.
-        let query =
-            spacetimedb_vm::dsl::query(schema.as_ref()).with_select(filter_to_column_op(&schema.table_name, filter));
+        let query = spacetimedb_vm::dsl::query(schema.as_ref())
+            .with_select(filter_to_column_op(&schema.table_name, filter))
+            .optimize(&|table_id, table_name| stdb.row_count(table_id, table_name));
+
+        // TODO(Centril): Conditionally dump the `query` to a file and compare against integration test.
+        // Invent a system where we can make these kinds of "optimization path tests".
 
         let tx: TxMode = tx.into();
         // SQL queries can never reference `MemTable`s, so pass in an empty `SourceSet`.

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -688,7 +688,7 @@ pub(crate) mod tests {
         let row = product!(1u64, "health");
         let table_id = create_table_from_program(p, "inventory", head.clone(), &[row])?;
 
-        let schema = TableDef::from_product("test", head).into_schema(table_id);
+        let schema = TableDef::from_product("inventory", head).into_schema(table_id);
 
         let data = MemTable::from_value(scalar(1u64));
         let rhs = data.get_field_pos(0).unwrap().clone();

--- a/crates/sqltest/src/db.rs
+++ b/crates/sqltest/src/db.rs
@@ -17,7 +17,6 @@ impl AsyncDB for DBRunner {
     type ColumnType = Kind;
 
     async fn run(&mut self, sql: &str) -> Result<DBOutput<Self::ColumnType>, Self::Error> {
-        //dbg!("RUNNING", sql);
         let mut last = None;
         for x in sql.split('\n') {
             last = Some(match self {


### PR DESCRIPTION
# Description of Changes

There were two bugs that prevented us from using multi-col indexes in `query!`.
None of these were in `find_sargable`, rather, they were in:
1. `InstanceEnv::iter_filtered_chunks`: it didn't call `q.optimize(...)` (so we may potentially see other improvements now).
2. `Header::column` would not find the `Column` due to `FieldName::Pos` being passed.

I've verified that the query ends up being optimized to a `Query::IndexScan` and that this actually reaches the index with the right name in `BTreeIndex::seek`.

# API and ABI breaking changes

None

# Expected complexity level and risk

2 - There are other users of `Header::column_pos_idx`.