### PR TITLE
Optimize the lookups of fields in the 'Header' and reduce the cost of allocations

### DIFF
--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -253,8 +253,8 @@ pub(crate) mod tests {
         assert_eq!(result.len(), 1, "Not return results");
         let result = result.first().unwrap().clone();
         //The expected result
-        let col = table.head.find_by_name("inventory_id").unwrap();
-        let inv = table.head.project(&[col.field.clone()]).unwrap();
+        let col = table.head.column_by_name("inventory_id").unwrap();
+        let inv = table.head.project(&[col.field.as_ref().clone()]).unwrap();
 
         let row = product!(scalar(1u64));
         let input = mem_table(inv, vec![row]);
@@ -277,8 +277,8 @@ pub(crate) mod tests {
         let result = result.first().unwrap().clone();
 
         //The expected result
-        let col = table.head.find_by_name("inventory_id").unwrap();
-        let inv = table.head.project(&[col.field.clone()]).unwrap();
+        let col = table.head.column_by_name("inventory_id").unwrap();
+        let inv = table.head.project(&[col.field.as_ref().clone()]).unwrap();
 
         let row = product!(scalar(1u64));
         let input = mem_table(inv, vec![row]);
@@ -304,8 +304,8 @@ pub(crate) mod tests {
         let mut result = result.first().unwrap().clone();
         result.data.sort();
         //The expected result
-        let col = table.head.find_by_name("inventory_id").unwrap();
-        let inv = table.head.project(&[col.field.clone()]).unwrap();
+        let col = table.head.column_by_name("inventory_id").unwrap();
+        let inv = table.head.project(&[col.field.as_ref().clone()]).unwrap();
 
         let input = mem_table(inv, vec![product!(scalar(1u64)), product!(scalar(2u64))]);
 
@@ -330,8 +330,8 @@ pub(crate) mod tests {
         let mut result = result.first().unwrap().clone();
         result.data.sort();
         //The expected result
-        let col = table.head.find_by_name("inventory_id").unwrap();
-        let inv = table.head.project(&[col.field.clone()]).unwrap();
+        let col = table.head.column_by_name("inventory_id").unwrap();
+        let inv = table.head.project(&[col.field.as_ref().clone()]).unwrap();
 
         let input = mem_table(inv, vec![product!(scalar(1u64)), product!(scalar(2u64))]);
 

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -324,7 +324,7 @@ impl ExecutionUnit {
             panic!(
                 "Failed to locate `{OP_TYPE_FIELD_NAME}` in `{}`, fields: {:?}",
                 header.table_name,
-                header.fields.iter().map(|x| &x.field).collect::<Vec<_>>()
+                header.fields().iter().map(|x| &x.field).collect::<Vec<_>>()
             )
         });
         let pos_op_type = pos_op_type.idx();

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -45,9 +45,9 @@ pub const OP_TYPE_FIELD_NAME: &str = "__op_type";
 /// header.find_pos_by_name(OP_TYPE_FIELD_NAME)
 /// ```
 pub fn find_op_type_col_pos(header: &Header) -> Option<ColId> {
-    if let Some(last_col) = header.fields.last() {
+    if let Some(last_col) = header.fields().last() {
         if last_col.field.field_name() == Some(OP_TYPE_FIELD_NAME) {
-            return Some(ColId((header.fields.len() - 1) as u32));
+            return Some(ColId((header.fields().len() - 1) as u32));
         }
     }
     None
@@ -90,10 +90,10 @@ pub fn to_mem_table_with_op_type(head: Arc<Header>, table_access: StAccess, data
     } else {
         // TODO(perf): Eliminate this `clone_for_error` call, as we're not in an error path.
         let mut head = t.head.clone_for_error();
-        head.fields.push(Column::new(
+        head.add(Column::new(
             FieldName::named(&t.head.table_name, OP_TYPE_FIELD_NAME),
             AlgebraicType::U8,
-            t.head.fields.len().into(),
+            t.head.fields().len().into(),
         ));
         t.head = Arc::new(head);
         for row in &data.ops {

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -356,7 +356,7 @@ impl<'a, Rhs: RelOps<'a>> RelOps<'a> for IndexSemiJoin<'a, '_, Rhs> {
 
         // Otherwise probe the index with a row from the probe side.
         while let Some(row) = self.probe_side.next()? {
-            if let Some(pos) = self.probe_side.head().column_pos(self.probe_field) {
+            if let Some(pos) = self.probe_side.head().col_id_by_field(self.probe_field) {
                 if let Some(value) = row.read_column(pos.idx()) {
                     let table_id = self.index_table;
                     let col_id = self.index_col;
@@ -530,7 +530,7 @@ impl ProgramVm for DbProgram<'_, '_> {
                 // assignments are consumed.
                 let exprs: Vec<Option<FieldExpr>> = table
                     .head()
-                    .fields
+                    .fields()
                     .iter()
                     .map(|col| assignments.remove(&col.field))
                     .collect();

--- a/crates/sats/src/db/def.rs
+++ b/crates/sats/src/db/def.rs
@@ -951,7 +951,7 @@ impl From<&TableSchema> for DbTable {
 impl From<&TableSchema> for Header {
     fn from(value: &TableSchema) -> Self {
         let constraints = value.get_constraints();
-        let fields = value
+        let fields: Vec<Column> = value
             .columns
             .iter()
             .enumerate()

--- a/crates/sqltest/src/space.rs
+++ b/crates/sqltest/src/space.rs
@@ -110,7 +110,7 @@ impl AsyncDB for SpaceDb {
         }
         let r = r.into_iter().next().unwrap();
 
-        let header = r.head.fields.iter().map(|x| Kind(x.algebraic_type.clone())).collect();
+        let header = r.head.fields().iter().map(|x| Kind(x.algebraic_type.clone())).collect();
 
         let output: Vec<Vec<_>> = r
             .data

--- a/crates/vm/src/relation.rs
+++ b/crates/vm/src/relation.rs
@@ -72,7 +72,7 @@ impl<'a> RelValue<'a> {
     ) -> Result<Cow<'a, AlgebraicValue>, RelationError> {
         let val = match col {
             FieldExprRef::Name(col) => {
-                let pos = header.column_pos_or_err(col)?.idx();
+                let pos = header.col_id_by_field_or_err(col)?.idx();
                 self.read_column(pos)
                     .ok_or_else(|| RelationError::FieldNotFoundAtPos(pos, col.clone()))?
             }
@@ -108,7 +108,7 @@ impl<'a> RelValue<'a> {
         for col in cols {
             let val = match col {
                 FieldExpr::Name(col) => {
-                    let pos = header.column_pos_or_err(col)?.idx();
+                    let pos = header.col_id_by_field_or_err(col)?.idx();
                     self.read_or_take_column(pos)
                         .ok_or_else(|| RelationError::FieldNotFoundAtPos(pos, col.clone()))?
                 }
@@ -139,10 +139,10 @@ pub struct MemTable {
 impl MemTable {
     pub fn new(head: Arc<Header>, table_access: StAccess, data: Vec<ProductValue>) -> Self {
         assert_eq!(
-            head.fields.len(),
+            head.fields().len(),
             data.first()
                 .map(|pv| pv.elements.len())
-                .unwrap_or_else(|| head.fields.len()),
+                .unwrap_or_else(|| head.fields().len()),
             "number of columns in `header.len() != data.len()`"
         );
         Self {
@@ -173,11 +173,11 @@ impl MemTable {
     }
 
     pub fn get_field_pos(&self, pos: usize) -> Option<&FieldName> {
-        self.head.fields.get(pos).map(|x| &x.field)
+        self.head.field_by_pos(pos)
     }
 
     pub fn get_field_named(&self, name: &str) -> Option<&FieldName> {
-        self.head.find_by_name(name).map(|x| &x.field)
+        self.head.field_by_name(name)
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Eliminate the linear scans in lookups for `FieldName`:

```bash
# Before
find_by_name            time:   [13.951 µs 14.554 µs 15.303 µs]
Found 6 outliers among 100 measurements (6.00%)
  6 (6.00%) high severe  

#After
find_by_name            time:   [269.77 ns 270.10 ns 270.51 ns]
                        change: [-98.148% -98.082% -98.027%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
```

Using a map of `FieldsName -> Postions`. 

NOTE: I don't use a regular `HashMap` or `Map<FieldName, Column>` because the order of the fields should be preserved as intended by the user (ie: `select c, a, b, i_want_this_order`).

Also, considering that the header is rarely updated, the `FieldNames` are now under `Arc`.

Closes #932.

# Expected complexity level and risk

1