### PR TITLE
perf: Make op_type special case fast for selections

### DIFF
--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -1,4 +1,4 @@
-use super::query::{self, Supported, OP_TYPE_FIELD_NAME};
+use super::query::{self, find_op_type_col_pos, Supported, OP_TYPE_FIELD_NAME};
 use super::subscription::{IncrementalJoin, SupportedQuery};
 use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::DBError;
@@ -303,7 +303,7 @@ impl ExecutionUnit {
         mut query: Box<IterRows<'_>>,
         header: &Header,
     ) -> Result<(), DBError> {
-        let pos_op_type = header.find_pos_by_name(OP_TYPE_FIELD_NAME).unwrap_or_else(|| {
+        let pos_op_type = find_op_type_col_pos(header).unwrap_or_else(|| {
             panic!(
                 "Failed to locate `{OP_TYPE_FIELD_NAME}` in `{}`, fields: {:?}",
                 header.table_name,

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -547,11 +547,12 @@ impl ExecutionSet {
         tx: &Tx,
         database_update: &DatabaseUpdate,
     ) -> Result<DatabaseUpdate, DBError> {
-        let tables = self
-            .exec_units
-            .iter()
-            .filter_map(|unit| unit.eval_incr(db, tx, database_update.tables.iter()).transpose())
-            .collect::<Result<_, _>>()?;
+        let mut tables = Vec::new();
+        for unit in &self.exec_units {
+            if let Some(table) = unit.eval_incr(db, tx, database_update.tables.iter())? {
+                tables.push(table);
+            }
+        }
         Ok(DatabaseUpdate { tables })
     }
 }


### PR DESCRIPTION
As an optimization,
because we do not support strict projections in subscription queries, selections may always assume that the op_type field is last, when removing it.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
