### PR TITLE
core: More compact TxData

### DIFF
--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -41,8 +41,8 @@ fn insert_op(table_id: TableId, table_name: &str, row: ProductValue) -> Database
     DatabaseTableUpdate {
         table_id,
         table_name: table_name.to_string(),
-        inserts: vec![row],
-        deletes: vec![],
+        inserts: [row].into(),
+        deletes: [].into(),
     }
 }
 

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -14,7 +14,7 @@ use crate::{
                 StTableRow, SystemTable, ST_COLUMNS_ID, ST_COLUMNS_NAME, ST_CONSTRAINTS_ID, ST_CONSTRAINTS_NAME,
                 ST_INDEXES_ID, ST_INDEXES_NAME, ST_MODULE_ID, ST_SEQUENCES_ID, ST_SEQUENCES_NAME, ST_TABLES_ID,
             },
-            traits::{TxData, TxOp, TxRecord},
+            traits::TxData,
         },
         db_metrics::DB_METRICS,
     },
@@ -41,7 +41,6 @@ use spacetimedb_table::{
 use std::{
     collections::{BTreeMap, BTreeSet},
     ops::RangeBounds,
-    sync::Arc,
 };
 
 #[derive(Default)]
@@ -377,8 +376,7 @@ impl CommittedState {
     }
 
     pub fn merge(&mut self, tx_state: TxState, ctx: &ExecutionContext) -> TxData {
-        // TODO(perf): pre-allocate `Vec::with_capacity`?
-        let mut tx_data = TxData { records: vec![] };
+        let mut tx_data = TxData::default();
 
         self.next_tx_offset += 1;
 
@@ -403,6 +401,8 @@ impl CommittedState {
             if let Some((table, blob_store)) = self.get_table_and_blob_store(table_id) {
                 let db = &ctx.database();
 
+                let mut deletes = Vec::with_capacity(row_ptrs.len());
+
                 // Note: we maintain the invariant that the delete_tables
                 // holds only committed rows which should be deleted,
                 // i.e. `RowPointer`s with `SquashedOffset::COMMITTED_STATE`,
@@ -410,14 +410,8 @@ impl CommittedState {
                 for row_ptr in row_ptrs.iter().copied() {
                     debug_assert!(row_ptr.squashed_offset().is_committed_state());
 
-                    // TODO: re-write `TxRecord` to remove `product_value`, or at least `key`.
+                    // TODO: re-write `TxData` to remove `ProductValue`s
                     let pv = table.delete(blob_store, row_ptr).expect("Delete for non-existent row!");
-                    tx_data.records.push(TxRecord {
-                        op: TxOp::Delete,
-                        table_id,
-                        product_value: pv,
-                    });
-
                     let table_name = table.get_schema().table_name.as_str();
                     //Increment rows deleted metric
                     ctx.metrics
@@ -428,6 +422,10 @@ impl CommittedState {
                         .rdb_num_table_rows
                         .with_label_values(db, &table_id.into(), table_name)
                         .dec();
+                    deletes.push(pv);
+                }
+                if !deletes.is_empty() {
+                    tx_data.set_deletes_for_table(table_id, &table.get_schema().table_name, deletes.into());
                 }
             } else if !row_ptrs.is_empty() {
                 panic!("Deletion for non-existent table {:?}... huh?", table_id);
@@ -462,22 +460,14 @@ impl CommittedState {
             // do this before or after the schema update below.
             let db = &ctx.database();
 
+            // TODO(perf): Allocate with capacity?
+            let mut inserts = vec![];
             // For each newly-inserted row, insert it into the committed state.
             for row_ref in tx_table.scan_rows(&tx_blob_store) {
                 let pv = row_ref.to_product_value();
                 commit_table
                     .insert(commit_blob_store, &pv)
                     .expect("Failed to insert when merging commit");
-
-                // Serialize the `row_ref` rather than the `pv`
-                // so we can take advantage of the BFLATN -> BSATN fast path for fixed-sized rows.
-                // TODO(perf): Remove `DataKey` from `TxRecord` and avoid this entirely.
-                let bytes = row_ref.to_bsatn_vec().expect("Failed to BSATN-serialize RowRef");
-                tx_data.records.push(TxRecord {
-                    op: TxOp::Insert(Arc::new(bytes)),
-                    product_value: pv,
-                    table_id,
-                });
 
                 let table_name = commit_table.get_schema().table_name.as_str();
                 // Increment rows inserted metric
@@ -489,6 +479,11 @@ impl CommittedState {
                     .rdb_num_table_rows
                     .with_label_values(db, &table_id.into(), table_name)
                     .inc();
+
+                inserts.push(pv);
+            }
+            if !inserts.is_empty() {
+                tx_data.set_inserts_for_table(table_id, &commit_table.schema.table_name, inserts.into());
             }
 
             // Add all newly created indexes to the committed state.

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -6,12 +6,14 @@ use super::{
     tx_state::TxState,
     SharedMutexGuard, SharedWriteGuard,
 };
-use crate::db::datastore::traits::TxData;
 use crate::db::{
-    datastore::system_tables::{
-        table_name_is_system, StColumnFields, StColumnRow, StConstraintFields, StConstraintRow, StIndexFields,
-        StIndexRow, StSequenceFields, StSequenceRow, StTableFields, StTableRow, SystemTable, ST_COLUMNS_ID,
-        ST_CONSTRAINTS_ID, ST_INDEXES_ID, ST_SEQUENCES_ID, ST_TABLES_ID,
+    datastore::{
+        system_tables::{
+            table_name_is_system, StColumnFields, StColumnRow, StConstraintFields, StConstraintRow, StIndexFields,
+            StIndexRow, StSequenceFields, StSequenceRow, StTableFields, StTableRow, SystemTable, ST_COLUMNS_ID,
+            ST_CONSTRAINTS_ID, ST_INDEXES_ID, ST_SEQUENCES_ID, ST_TABLES_ID,
+        },
+        traits::TxData,
     },
     db_metrics::table_num_rows,
 };

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -1,9 +1,11 @@
 use std::borrow::Cow;
+use std::collections::BTreeMap;
 use std::{ops::RangeBounds, sync::Arc};
 
 use super::Result;
 use crate::db::datastore::system_tables::ST_TABLES_ID;
 use crate::execution_context::ExecutionContext;
+use spacetimedb_data_structures::map::IntMap;
 use spacetimedb_primitives::*;
 use spacetimedb_sats::db::def::*;
 use spacetimedb_sats::hash::Hash;
@@ -158,27 +160,69 @@ pub enum IsolationLevel {
     Serializable,
 }
 
-/// Operations in a transaction are either Inserts or Deletes.
-/// Inserts report the byte objects they inserted, to be persisted
-/// later in an object store.
-pub enum TxOp {
-    Insert(Arc<Vec<u8>>),
-    Delete,
-}
-
-/// A record of a single operation within a transaction.
-pub struct TxRecord {
-    /// Whether the operation was an insert or a delete.
-    pub(crate) op: TxOp,
-    /// The value of the modified row.
-    pub(crate) product_value: ProductValue,
-    /// The table that was modified.
-    pub(crate) table_id: TableId,
-}
-
 /// A record of all the operations within a transaction.
+#[derive(Default)]
 pub struct TxData {
-    pub(crate) records: Vec<TxRecord>,
+    /// The inserted rows per table.
+    inserts: BTreeMap<TableId, Arc<[ProductValue]>>,
+    /// The deleted rows per table.
+    deletes: BTreeMap<TableId, Arc<[ProductValue]>>,
+    /// Map of all `TableId`s in both `inserts` and `deletes` to their
+    /// corresponding table name.
+    tables: IntMap<TableId, String>,
+    // TODO: Store an `Arc<String>` or equivalent instead.
+}
+
+impl TxData {
+    /// Set `rows` as the inserted rows for `(table_id, table_name)`.
+    pub fn set_inserts_for_table(&mut self, table_id: TableId, table_name: &str, rows: Arc<[ProductValue]>) {
+        self.inserts.insert(table_id, rows);
+        self.tables.entry(table_id).or_insert_with(|| table_name.to_owned());
+    }
+
+    /// Set `rows` as the deleted rows for `(table_id, table_name)`.
+    pub fn set_deletes_for_table(&mut self, table_id: TableId, table_name: &str, rows: Arc<[ProductValue]>) {
+        self.deletes.insert(table_id, rows);
+        self.tables.entry(table_id).or_insert_with(|| table_name.to_owned());
+    }
+
+    /// Obtain an iterator over the inserted rows per table.
+    pub fn inserts(&self) -> impl Iterator<Item = (&TableId, &Arc<[ProductValue]>)> + '_ {
+        self.inserts.iter()
+    }
+
+    /// Obtain an iterator over the inserted rows per table.
+    ///
+    /// If you don't need access to the table name, [`Self::inserts`] is
+    /// slightly more efficient.
+    pub fn inserts_with_table_name(&self) -> impl Iterator<Item = (&TableId, &str, &Arc<[ProductValue]>)> + '_ {
+        self.inserts.iter().map(|(table_id, rows)| {
+            let table_name = self
+                .tables
+                .get(table_id)
+                .expect("invalid `TxData`: partial table name mapping");
+            (table_id, table_name.as_str(), rows)
+        })
+    }
+
+    /// Obtain an iterator over the deleted rows per table.
+    pub fn deletes(&self) -> impl Iterator<Item = (&TableId, &Arc<[ProductValue]>)> + '_ {
+        self.deletes.iter()
+    }
+
+    /// Obtain an iterator over the inserted rows per table.
+    ///
+    /// If you don't need access to the table name, [`Self::deletes`] is
+    /// slightly more efficient.
+    pub fn deletes_with_table_name(&self) -> impl Iterator<Item = (&TableId, &str, &Arc<[ProductValue]>)> + '_ {
+        self.deletes.iter().map(|(table_id, rows)| {
+            let table_name = self
+                .tables
+                .get(table_id)
+                .expect("invalid `TxData`: partial table name mapping");
+            (table_id, table_name.as_str(), rows)
+        })
+    }
 }
 
 pub trait Data: Into<ProductValue> {

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1,16 +1,15 @@
 use super::datastore::traits::{
-    IsolationLevel, MutProgrammable, MutTx as _, MutTxDatastore, Programmable, Tx as _, TxData, TxDatastore,
+    IsolationLevel, MutProgrammable, MutTx as _, MutTxDatastore, Programmable, Tx as _, TxDatastore,
 };
 use super::datastore::{
     locking_tx_datastore::{
         datastore::Locking,
         state_view::{Iter, IterByColEq, IterByColRange},
     },
-    traits::TxRecord,
+    traits::TxData,
 };
 use super::relational_operators::Relation;
 use crate::address::Address;
-use crate::db::datastore::traits::TxOp;
 use crate::db::db_metrics::DB_METRICS;
 use crate::error::{DBError, DatabaseError, TableError};
 use crate::execution_context::ExecutionContext;
@@ -24,7 +23,6 @@ use spacetimedb_sats::db::def::{ColumnDef, IndexDef, SequenceDef, TableDef, Tabl
 use spacetimedb_sats::{AlgebraicType, AlgebraicValue, ProductType, ProductValue};
 use spacetimedb_table::indexes::RowPointer;
 use std::borrow::Cow;
-use std::collections::BTreeMap;
 use std::fs::{create_dir_all, File};
 use std::ops::RangeBounds;
 use std::path::Path;
@@ -276,57 +274,41 @@ impl RelationalDB {
 
         log::trace!("COMMIT MUT TX");
 
-        fn fold_ops(
-            records: &[TxRecord],
-        ) -> (
-            BTreeMap<TableId, Vec<ProductValue>>,
-            BTreeMap<TableId, Vec<ProductValue>>,
-        ) {
-            records.iter().fold(
-                (BTreeMap::new(), BTreeMap::new()),
-                |(mut inserts, mut deletes), record| {
-                    let rows = match record.op {
-                        TxOp::Insert(_) => inserts.entry(record.table_id).or_default(),
-                        TxOp::Delete => deletes.entry(record.table_id).or_default(),
-                    };
-                    // TODO: Avoid clone
-                    rows.push(record.product_value.clone());
-                    (inserts, deletes)
-                },
-            )
-        }
+        let Some(tx_data) = self.inner.commit_mut_tx(ctx, tx)? else {
+            return Ok(None);
+        };
 
-        fn into_ops(m: BTreeMap<TableId, Vec<ProductValue>>) -> Box<[Ops<ProductValue>]> {
-            m.into_iter()
+        if let Some(durability) = &self.durability {
+            let inserts = tx_data
+                .inserts()
                 .map(|(table_id, rowdata)| Ops {
-                    table_id,
-                    rowdata: rowdata.into(),
+                    table_id: *table_id,
+                    rowdata: rowdata.clone(),
                 })
-                .collect()
+                .collect();
+            let deletes = tx_data
+                .deletes()
+                .map(|(table_id, rowdata)| Ops {
+                    table_id: *table_id,
+                    rowdata: rowdata.clone(),
+                })
+                .collect();
+
+            let txdata = Txdata {
+                inputs: None,
+                outputs: None,
+                mutations: Some(Mutations {
+                    inserts,
+                    deletes,
+                    truncates: Box::new([]),
+                }),
+            };
+            log::trace!("append {txdata:?}");
+            // TODO: Should measure queuing time + actual write
+            durability.append_tx(txdata);
         }
 
-        // TODO(cloutiertyler): We should measure the time to append a transaction to the commitlog separately in metrics
-        if let Some(tx_data) = self.inner.commit_mut_tx(ctx, tx)? {
-            if let Some(durability) = self.durability.as_ref() {
-                let (inserts, deletes) = fold_ops(&tx_data.records);
-
-                let txdata = Txdata {
-                    inputs: None,
-                    outputs: None,
-                    mutations: Some(Mutations {
-                        inserts: into_ops(inserts),
-                        deletes: into_ops(deletes),
-                        truncates: Box::new([]),
-                    }),
-                };
-                log::trace!("append {txdata:?}");
-                durability.append_tx(txdata);
-            }
-
-            return Ok(Some(tx_data));
-        }
-
-        Ok(None)
+        Ok(Some(tx_data))
     }
 
     /// Run a fallible function in a transaction.

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -604,7 +604,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
             }
             Ok(Ok(())) => {
                 if let Some(tx_data) = stdb.commit_tx(&ctx, tx).unwrap() {
-                    EventStatus::Committed(DatabaseUpdate::from_writes(stdb, &tx_data))
+                    EventStatus::Committed(DatabaseUpdate::from_writes(&tx_data))
                 } else {
                     todo!("Write skew, you need to implement retries my man, T-dawg.");
                 }

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -145,8 +145,8 @@ mod tests {
         DatabaseTableUpdate {
             table_id,
             table_name: table_name.to_string(),
-            deletes: vec![],
-            inserts: vec![row],
+            deletes: [].into(),
+            inserts: [row].into(),
         }
     }
 
@@ -154,8 +154,8 @@ mod tests {
         DatabaseTableUpdate {
             table_id,
             table_name: table_name.to_string(),
-            deletes: vec![row],
-            inserts: vec![],
+            deletes: [row].into(),
+            inserts: [].into(),
         }
     }
 
@@ -181,8 +181,8 @@ mod tests {
         let data = DatabaseTableUpdate {
             table_id,
             table_name: table_name.to_string(),
-            deletes: vec![],
-            inserts: vec![row.clone()],
+            deletes: [].into(),
+            inserts: [row.clone()].into(),
         };
 
         let schema = db.schema_for_table_mut(tx, table_id).unwrap().into_owned();
@@ -359,8 +359,8 @@ mod tests {
             tables: vec![DatabaseTableUpdate {
                 table_id,
                 table_name: "test".into(),
-                deletes,
-                inserts: vec![],
+                deletes: deletes.into(),
+                inserts: [].into(),
             }],
         };
 
@@ -442,8 +442,8 @@ mod tests {
         let data = DatabaseTableUpdate {
             table_id: schema.table_id,
             table_name: "_inventory".to_string(),
-            deletes: vec![],
-            inserts: vec![row.clone()],
+            deletes: [].into(),
+            inserts: [row.clone()].into(),
         };
 
         let update = DatabaseUpdate {
@@ -563,15 +563,15 @@ mod tests {
         let data1 = DatabaseTableUpdate {
             table_id: schema_1.table_id,
             table_name: "inventory".to_string(),
-            deletes: vec![row_1],
-            inserts: vec![],
+            deletes: [row_1].into(),
+            inserts: [].into(),
         };
 
         let data2 = DatabaseTableUpdate {
             table_id: schema_2.table_id,
             table_name: "player".to_string(),
-            deletes: vec![],
-            inserts: vec![row_2],
+            deletes: [].into(),
+            inserts: [row_2].into(),
         };
 
         let update = DatabaseUpdate {
@@ -1025,14 +1025,14 @@ mod tests {
                 DatabaseTableUpdate {
                     table_id: lhs_id,
                     table_name: "lhs".to_string(),
-                    deletes: vec![lhs_old.clone()],
-                    inserts: vec![lhs_new.clone()],
+                    deletes: [lhs_old.clone()].into(),
+                    inserts: [lhs_new.clone()].into(),
                 },
                 DatabaseTableUpdate {
                     table_id: rhs_id,
                     table_name: "rhs".to_string(),
-                    deletes: vec![rhs_old.clone()],
-                    inserts: vec![rhs_new.clone()],
+                    deletes: [rhs_old.clone()].into(),
+                    inserts: [rhs_new.clone()].into(),
                 },
             ],
         )?;
@@ -1044,8 +1044,8 @@ mod tests {
             DatabaseTableUpdate {
                 table_id: lhs_id,
                 table_name: "lhs".to_string(),
-                deletes: vec![lhs_old],
-                inserts: vec![lhs_new],
+                deletes: [lhs_old].into(),
+                inserts: [lhs_new].into(),
             },
         );
         Ok(())

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -378,21 +378,21 @@ impl IncrementalJoin {
         let mut lhs_deletes = updates
             .clone()
             .filter(|u| u.table_id == self.lhs.table_id)
-            .flat_map(|u| &u.deletes)
+            .flat_map(|u| u.deletes.iter())
             .peekable();
         let mut lhs_inserts = updates
             .clone()
             .filter(|u| u.table_id == self.lhs.table_id)
-            .flat_map(|u| &u.inserts)
+            .flat_map(|u| u.inserts.iter())
             .peekable();
         let mut rhs_deletes = updates
             .clone()
             .filter(|u| u.table_id == self.rhs.table_id)
-            .flat_map(|u| &u.deletes)
+            .flat_map(|u| u.deletes.iter())
             .peekable();
         let mut rhs_inserts = updates
             .filter(|u| u.table_id == self.rhs.table_id)
-            .flat_map(|u| &u.inserts)
+            .flat_map(|u| u.inserts.iter())
             .peekable();
 
         // No updates at all? Return `None`.


### PR DESCRIPTION
`TxData` is the representation of a transaction after it was committed,
and is passed around for evaluation of subscription queries and sending
the result to clients.

With the new commitlog, it can be represented more compactly, such that
copies for writing to the log can be avoided.

~~Note that this patch stops short of refactoring `DatabaseUpdate`, which
is another representation of the same information as sent to clients.
This means that `ProductValue`s need to be cloned from `TxData`, just as
before.~~ ProductValues are now `Arc<[ProductValue]>`, eliminating expensive clones.

**NOTE: This PR is stacked on top of #926**