### PR TITLE
perf(933): Clone bsatn instead of product values in incremental update

### DIFF
--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -60,7 +60,7 @@ impl ClientConnectionSender {
         self.send(message.serialize(self.protocol))
     }
 
-    pub fn send(&self, message: DataMessage) -> Result<(), ClientSendError> {
+    fn send(&self, message: DataMessage) -> Result<(), ClientSendError> {
         let bytes_len = message.len();
 
         if self.cancelled.load(Relaxed) {

--- a/crates/core/src/client/message_handlers.rs
+++ b/crates/core/src/client/message_handlers.rs
@@ -2,7 +2,7 @@ use std::time::{Duration, Instant};
 
 use crate::energy::EnergyQuanta;
 use crate::execution_context::WorkloadType;
-use crate::host::module_host::{EventStatus, ModuleEvent, ModuleFunctionCall};
+use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent, ModuleFunctionCall};
 use crate::host::{ReducerArgs, Timestamp};
 use crate::identity::Identity;
 use crate::protobuf::client_api::{message, FunctionCall, Message, Subscribe};
@@ -216,7 +216,7 @@ impl DecodedMessage<'_> {
     }
 }
 
-/// An error that arises from executing a message.  
+/// An error that arises from executing a message.
 #[derive(thiserror::Error, Debug)]
 #[error("error executing message (reducer: {reducer:?}) (err: {err:?})")]
 pub struct MessageExecutionError {
@@ -248,7 +248,7 @@ impl MessageExecutionError {
 
 impl ServerMessage for MessageExecutionError {
     fn serialize_text(self) -> crate::json::client_api::MessageJson {
-        TransactionUpdateMessage {
+        TransactionUpdateMessage::<DatabaseUpdate> {
             event: &mut self.into_event(),
             database_update: Default::default(),
         }
@@ -256,7 +256,7 @@ impl ServerMessage for MessageExecutionError {
     }
 
     fn serialize_binary(self) -> Message {
-        TransactionUpdateMessage {
+        TransactionUpdateMessage::<DatabaseUpdate> {
             event: &mut self.into_event(),
             database_update: Default::default(),
         }

--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -7,10 +7,10 @@ use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent};
 use crate::identity::Identity;
 use crate::json::client_api::{
     EventJson, FunctionCallJson, IdentityTokenJson, MessageJson, OneOffQueryResponseJson, OneOffTableJson,
-    SubscriptionUpdateJson, TransactionUpdateJson,
+    SubscriptionUpdateJson, TableUpdateJson, TransactionUpdateJson,
 };
 use crate::protobuf::client_api::{event, message, Event, FunctionCall, IdentityToken, Message, TransactionUpdate};
-use spacetimedb_client_api_messages::client_api::{OneOffQueryResponse, OneOffTable};
+use spacetimedb_client_api_messages::client_api::{OneOffQueryResponse, OneOffTable, TableUpdate};
 use spacetimedb_lib::Address;
 use spacetimedb_vm::relation::MemTable;
 
@@ -54,12 +54,12 @@ impl ServerMessage for IdentityTokenMessage {
     }
 }
 
-pub struct TransactionUpdateMessage<'a> {
+pub struct TransactionUpdateMessage<'a, U> {
     pub event: &'a ModuleEvent,
-    pub database_update: SubscriptionUpdate,
+    pub database_update: SubscriptionUpdate<U>,
 }
 
-impl ServerMessage for TransactionUpdateMessage<'_> {
+impl<U: Into<Vec<TableUpdate>> + Into<Vec<TableUpdateJson>>> ServerMessage for TransactionUpdateMessage<'_, U> {
     fn serialize_text(self) -> MessageJson {
         let Self { event, database_update } = self;
         let (status_str, errmsg) = match &event.status {
@@ -112,11 +112,9 @@ impl ServerMessage for TransactionUpdateMessage<'_> {
             caller_address: event.caller_address.unwrap_or(Address::zero()).as_slice().to_vec(),
         };
 
-        let subscription_update = database_update.into_protobuf();
-
         let tx_update = TransactionUpdate {
             event: Some(event),
-            subscription_update: Some(subscription_update),
+            subscription_update: Some(database_update.into_protobuf()),
         };
 
         Message {
@@ -125,7 +123,9 @@ impl ServerMessage for TransactionUpdateMessage<'_> {
     }
 }
 
-impl ServerMessage for &mut TransactionUpdateMessage<'_> {
+impl<U: Clone + Into<Vec<TableUpdate>> + Into<Vec<TableUpdateJson>>> ServerMessage
+    for &mut TransactionUpdateMessage<'_, U>
+{
     fn serialize_text(self) -> MessageJson {
         TransactionUpdateMessage {
             event: self.event,
@@ -143,7 +143,7 @@ impl ServerMessage for &mut TransactionUpdateMessage<'_> {
 }
 
 pub struct SubscriptionUpdateMessage {
-    pub subscription_update: SubscriptionUpdate,
+    pub subscription_update: SubscriptionUpdate<DatabaseUpdate>,
 }
 
 impl ServerMessage for SubscriptionUpdateMessage {
@@ -152,33 +152,33 @@ impl ServerMessage for SubscriptionUpdateMessage {
     }
 
     fn serialize_binary(self) -> Message {
-        Message {
-            r#type: Some(message::Type::SubscriptionUpdate(
-                self.subscription_update.into_protobuf(),
-            )),
-        }
+        let msg = self.subscription_update.into_protobuf();
+        let r#type = Some(message::Type::SubscriptionUpdate(msg));
+        Message { r#type }
     }
 }
 
 #[derive(Debug, Default, Clone)]
-pub struct SubscriptionUpdate {
-    pub database_update: DatabaseUpdate,
+pub struct SubscriptionUpdate<U> {
+    pub database_update: U,
     pub request_id: Option<RequestId>,
     pub timer: Option<Instant>,
 }
 
-impl SubscriptionUpdate {
-    fn into_json(self) -> SubscriptionUpdateJson {
-        SubscriptionUpdateJson {
-            table_updates: self.database_update.into_json(),
+impl<T: Into<Vec<TableUpdate>>> SubscriptionUpdate<T> {
+    fn into_protobuf(self) -> spacetimedb_client_api_messages::client_api::SubscriptionUpdate {
+        spacetimedb_client_api_messages::client_api::SubscriptionUpdate {
+            table_updates: self.database_update.into(),
             request_id: self.request_id.unwrap_or(0),
             total_host_execution_duration_micros: self.timer.map_or(0, |t| t.elapsed().as_micros() as u64),
         }
     }
+}
 
-    fn into_protobuf(self) -> spacetimedb_client_api_messages::client_api::SubscriptionUpdate {
-        spacetimedb_client_api_messages::client_api::SubscriptionUpdate {
-            table_updates: self.database_update.into_protobuf(),
+impl<T: Into<Vec<TableUpdateJson>>> SubscriptionUpdate<T> {
+    fn into_json(self) -> SubscriptionUpdateJson {
+        SubscriptionUpdateJson {
+            table_updates: self.database_update.into(),
             request_id: self.request_id.unwrap_or(0),
             total_host_execution_duration_micros: self.timer.map_or(0, |t| t.elapsed().as_micros() as u64),
         }

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -7,7 +7,7 @@ use crate::client::{ClientActorId, ClientConnectionSender};
 use crate::db::relational_db::RelationalDB;
 use crate::error::{DBError, SubscriptionError};
 use crate::execution_context::ExecutionContext;
-use crate::host::module_host::{EventStatus, ModuleEvent};
+use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent};
 use crate::protobuf::client_api::Subscribe;
 use crate::worker_metrics::WORKER_METRICS;
 use parking_lot::RwLock;
@@ -133,9 +133,9 @@ impl ModuleSubscriptions {
             }
             EventStatus::Failed(_) => {
                 if let Some(client) = client {
-                    let message = TransactionUpdateMessage {
+                    let message = TransactionUpdateMessage::<DatabaseUpdate> {
                         event: &event,
-                        database_update: Default::default(),
+                        database_update: <_>::default(),
                     };
                     let _ = client.send_message(message);
                 } else {


### PR DESCRIPTION
# Description of Changes

"Cache" the BSATN serialization in incremental updates for subscribers using the same query.
Unfortunately, we have to deal with JSON as a possibility because of the website, so we have to thread through a bunch of `Either`s.

# API and ABI breaking changes

None

# Expected complexity level and risk

2