### PR TITLE
Increase sdk tests' timeout to 60 seconds

### DIFF
--- a/crates/sdk/tests/test-counter/src/lib.rs
+++ b/crates/sdk/tests/test-counter/src/lib.rs
@@ -56,7 +56,7 @@ impl TestCounter {
         let lock = self.inner.lock().expect("TestCounterInner Mutex is poisoned");
         let (lock, timeout_result) = self
             .wait_until_done
-            .wait_timeout_while(lock, Duration::from_secs(30), |inner| {
+            .wait_timeout_while(lock, Duration::from_secs(60), |inner| {
                 inner.outcomes.len() != inner.registered.len()
             })
             .expect("TestCounterInner Mutex is poisoned");


### PR DESCRIPTION
# Description of Changes

We're seeing intermittent failures of the SDK tests in CI due to timeouts. The timeout is meant only to fail if an expected event never happens; the SDK tests are not interested in measuring performance at all.

This commit doubles the timeout from 30 to 60 seconds, in the hopes that we will see fewer false failures.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*
