### PR TITLE
perf(813): Avoid materialization of product values in subscriptions

### DIFF
--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -1,4 +1,5 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
+use spacetimedb::client::Protocol;
 use spacetimedb::db::relational_db::{open_db, RelationalDB};
 use spacetimedb::error::DBError;
 use spacetimedb::execution_context::ExecutionContext;
@@ -107,7 +108,7 @@ fn eval(c: &mut Criterion) {
             let query = compile_read_only_query(&db, &tx, &auth, sql).unwrap();
             let query: ExecutionSet = query.into();
 
-            b.iter(|| drop(black_box(query.eval(&db, &tx).unwrap())))
+            b.iter(|| drop(black_box(query.eval(Protocol::Binary, &db, &tx).unwrap())))
         });
     };
 

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -5,6 +5,9 @@ use std::time::{Duration, Instant};
 
 use futures::{Future, FutureExt};
 use indexmap::IndexMap;
+use itertools::{Either, Itertools};
+use spacetimedb_client_api_messages::client_api::table_row_operation::OperationType;
+use spacetimedb_lib::bsatn::to_vec;
 use spacetimedb_lib::identity::RequestId;
 
 use super::{ArgsTuple, InvalidReducerArguments, ReducerArgs, ReducerCallResult, ReducerId, Timestamp};
@@ -19,16 +22,34 @@ use crate::execution_context::ExecutionContext;
 use crate::hash::Hash;
 use crate::identity::Identity;
 use crate::json::client_api::{TableRowOperationJson, TableUpdateJson};
-use crate::protobuf::client_api::{table_row_operation, TableRowOperation, TableUpdate};
+use crate::protobuf::client_api::{TableRowOperation, TableUpdate};
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
 use crate::util::lending_pool::{Closed, LendingPool, LentResource, PoolClosed};
 use crate::util::notify_once::NotifyOnce;
+use derive_more::{From, Into};
 use spacetimedb_lib::{Address, ReducerDef, TableDesc};
 use spacetimedb_primitives::TableId;
 use spacetimedb_sats::{ProductValue, Typespace, WithTypespace};
 use spacetimedb_vm::relation::MemTable;
 
-#[derive(Debug, Default, Clone)]
+#[derive(Debug, Clone, From, Into)]
+pub struct ProtocolDatabaseUpdate {
+    pub tables: Either<Vec<TableUpdate>, Vec<TableUpdateJson>>,
+}
+
+impl From<ProtocolDatabaseUpdate> for Vec<TableUpdate> {
+    fn from(update: ProtocolDatabaseUpdate) -> Self {
+        update.tables.unwrap_left()
+    }
+}
+
+impl From<ProtocolDatabaseUpdate> for Vec<TableUpdateJson> {
+    fn from(update: ProtocolDatabaseUpdate) -> Self {
+        update.tables.unwrap_right()
+    }
+}
+
+#[derive(Debug, Default, Clone, From)]
 pub struct DatabaseUpdate {
     pub tables: Vec<DatabaseTableUpdate>,
 }
@@ -38,12 +59,6 @@ impl FromIterator<DatabaseTableUpdate> for DatabaseUpdate {
         DatabaseUpdate {
             tables: iter.into_iter().collect(),
         }
-    }
-}
-
-impl From<Vec<DatabaseTableUpdate>> for DatabaseUpdate {
-    fn from(value: Vec<DatabaseTableUpdate>) -> Self {
-        DatabaseUpdate::from_iter(value)
     }
 }
 
@@ -78,55 +93,17 @@ impl DatabaseUpdate {
 
         DatabaseUpdate { tables: table_updates }
     }
+}
 
-    pub fn into_protobuf(self) -> Vec<TableUpdate> {
-        self.tables
-            .into_iter()
-            .map(|table| TableUpdate {
-                table_id: table.table_id.into(),
-                table_name: table.table_name,
-                table_row_operations: table
-                    .ops
-                    .into_iter()
-                    .map(|op| {
-                        let mut row_bytes = Vec::new();
-                        op.row.encode(&mut row_bytes);
-                        TableRowOperation {
-                            op: if op.op_type == 1 {
-                                table_row_operation::OperationType::Insert.into()
-                            } else {
-                                table_row_operation::OperationType::Delete.into()
-                            },
-                            row: row_bytes,
-                        }
-                    })
-                    .collect(),
-            })
-            .collect()
+impl From<DatabaseUpdate> for Vec<TableUpdate> {
+    fn from(update: DatabaseUpdate) -> Self {
+        update.tables.into_iter().map_into().collect()
     }
+}
 
-    pub fn into_json(self) -> Vec<TableUpdateJson> {
-        // For all tables, push all state
-        // TODO: We need some way to namespace tables so we don't send all the internal tables and stuff
-        self.tables
-            .into_iter()
-            .map(|table| TableUpdateJson {
-                table_id: table.table_id.into(),
-                table_name: table.table_name,
-                table_row_operations: table
-                    .ops
-                    .into_iter()
-                    .map(|op| TableRowOperationJson {
-                        op: if op.op_type == 1 {
-                            "insert".into()
-                        } else {
-                            "delete".into()
-                        },
-                        row: op.row.elements,
-                    })
-                    .collect(),
-            })
-            .collect()
+impl From<DatabaseUpdate> for Vec<TableUpdateJson> {
+    fn from(update: DatabaseUpdate) -> Self {
+        update.tables.into_iter().map_into().collect()
     }
 }
 
@@ -135,6 +112,26 @@ pub struct DatabaseTableUpdate {
     pub table_id: TableId,
     pub table_name: String,
     pub ops: Vec<TableOp>,
+}
+
+impl From<DatabaseTableUpdate> for TableUpdate {
+    fn from(table: DatabaseTableUpdate) -> Self {
+        Self {
+            table_id: table.table_id.into(),
+            table_name: table.table_name,
+            table_row_operations: table.ops.iter().map_into().collect(),
+        }
+    }
+}
+
+impl From<DatabaseTableUpdate> for TableUpdateJson {
+    fn from(table: DatabaseTableUpdate) -> Self {
+        Self {
+            table_id: table.table_id.into(),
+            table_name: table.table_name,
+            table_row_operations: table.ops.into_iter().map_into().collect(),
+        }
+    }
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
@@ -157,6 +154,26 @@ impl TableOp {
     #[inline]
     pub fn delete(row: ProductValue) -> Self {
         Self::new(0, row)
+    }
+}
+
+impl From<&TableOp> for TableRowOperation {
+    fn from(top: &TableOp) -> Self {
+        let row = to_vec(&top.row).unwrap();
+        let op = if top.op_type == 1 {
+            OperationType::Insert.into()
+        } else {
+            OperationType::Delete.into()
+        };
+        Self { op, row }
+    }
+}
+
+impl From<TableOp> for TableRowOperationJson {
+    fn from(top: TableOp) -> Self {
+        let row = top.row.elements;
+        let op = if top.op_type == 1 { "insert" } else { "delete" }.into();
+        Self { op, row }
     }
 }
 

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -4,12 +4,16 @@ use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::DBError;
 use crate::execution_context::ExecutionContext;
 use crate::host::module_host::{DatabaseTableUpdate, TableOp};
+use crate::json::client_api::TableUpdateJson;
 use crate::vm::{build_query, TxMode};
+use spacetimedb_client_api_messages::client_api::{TableRowOperation, TableUpdate};
+use spacetimedb_lib::bsatn::to_writer;
 use spacetimedb_primitives::TableId;
 use spacetimedb_sats::relation::{DbTable, Header};
 use spacetimedb_vm::eval::IterRows;
 use spacetimedb_vm::expr::{Query, QueryExpr, SourceExpr, SourceSet};
 use spacetimedb_vm::rel_ops::RelOps;
+use spacetimedb_vm::relation::RelValue;
 use std::hash::Hash;
 
 /// A hash for uniquely identifying query execution units,
@@ -208,21 +212,46 @@ impl ExecutionUnit {
             .unwrap_or(return_table)
     }
 
-    /// Evaluate this execution unit against the database.
-    pub fn eval(&self, db: &RelationalDB, tx: &Tx) -> Result<Option<DatabaseTableUpdate>, DBError> {
-        let ops = Self::eval_query_code(db, tx, &self.eval_plan)?;
-        Ok((!ops.is_empty()).then(|| DatabaseTableUpdate {
-            table_id: self.return_table(),
+    /// Evaluate this execution unit against the database using the json format.
+    #[tracing::instrument(skip_all)]
+    pub fn eval_json(&self, db: &RelationalDB, tx: &Tx) -> Result<Option<TableUpdateJson>, DBError> {
+        let table_row_operations = Self::eval_query_expr(db, tx, &self.eval_plan, |row| {
+            TableOp::insert(row.into_product_value()).into()
+        })?;
+        Ok((!table_row_operations.is_empty()).then(|| TableUpdateJson {
+            table_id: self.return_table().into(),
             table_name: self.return_name(),
-            ops,
+            table_row_operations,
         }))
     }
 
-    fn eval_query_code(db: &RelationalDB, tx: &Tx, eval_plan: &QueryExpr) -> Result<Vec<TableOp>, DBError> {
+    /// Evaluate this execution unit against the database using the binary format.
+    #[tracing::instrument(skip_all)]
+    pub fn eval_binary(&self, db: &RelationalDB, tx: &Tx) -> Result<Option<TableUpdate>, DBError> {
+        let mut buf = Vec::new();
+        let table_row_operations = Self::eval_query_expr(db, tx, &self.eval_plan, |row| {
+            to_writer(&mut buf, &row).unwrap();
+            let row = buf.clone();
+            buf.clear();
+            TableRowOperation { op: 1, row }
+        })?;
+        Ok((!table_row_operations.is_empty()).then(|| TableUpdate {
+            table_id: self.return_table().into(),
+            table_name: self.return_name(),
+            table_row_operations,
+        }))
+    }
+
+    fn eval_query_expr<T>(
+        db: &RelationalDB,
+        tx: &Tx,
+        eval_plan: &QueryExpr,
+        convert: impl FnMut(RelValue<'_>) -> T,
+    ) -> Result<Vec<T>, DBError> {
         let ctx = ExecutionContext::subscribe(db.address());
         let tx: TxMode = tx.into();
         let query = build_query(&ctx, db, &tx, eval_plan, &mut SourceSet::default())?;
-        let ops = query.collect_vec(|row_ref| TableOp::insert(row_ref.into_product_value()))?;
+        let ops = query.collect_vec(convert)?;
         Ok(ops)
     }
 
@@ -235,7 +264,7 @@ impl ExecutionUnit {
     ) -> Result<Option<DatabaseTableUpdate>, DBError> {
         let ops = match &self.eval_incr_plan {
             EvalIncrPlan::Select(eval_incr_plan) => {
-                Self::eval_incr_query_code(db, tx, tables, eval_incr_plan, self.return_table())?
+                Self::eval_incr_query_expr(db, tx, tables, eval_incr_plan, self.return_table())?
             }
             EvalIncrPlan::Semijoin(eval_incr_plan) => eval_incr_plan
                 .eval(db, tx, tables)?
@@ -249,7 +278,7 @@ impl ExecutionUnit {
         }))
     }
 
-    fn eval_incr_query_code<'a>(
+    fn eval_incr_query_expr<'a>(
         db: &RelationalDB,
         tx: &Tx,
         tables: impl Iterator<Item = &'a DatabaseTableUpdate>,

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -71,7 +71,7 @@ impl ModuleSubscriptions {
         drop(guard);
 
         let execution_set: ExecutionSet = queries.into();
-        let database_update = execution_set.eval(&self.relational_db, &tx)?;
+        let database_update = execution_set.eval(sender.protocol, &self.relational_db, &tx)?;
 
         WORKER_METRICS
             .initial_subscription_evals

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -25,14 +25,17 @@
 
 use super::execution_unit::ExecutionUnit;
 use super::query;
-use crate::client::{ClientActorId, ClientConnectionSender};
+use crate::client::{ClientActorId, ClientConnectionSender, Protocol};
 use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::{DBError, SubscriptionError};
 use crate::execution_context::ExecutionContext;
-use crate::host::module_host::{DatabaseTableUpdate, DatabaseUpdate, TableOp};
+use crate::host::module_host::{DatabaseTableUpdate, DatabaseUpdate, ProtocolDatabaseUpdate, TableOp};
+use crate::json::client_api::TableUpdateJson;
 use crate::vm::{build_query, TxMode};
 use anyhow::Context;
+use itertools::Either;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use spacetimedb_client_api_messages::client_api::TableUpdate;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::ProductValue;
 use spacetimedb_primitives::TableId;
@@ -613,17 +616,32 @@ pub struct ExecutionSet {
 }
 
 impl ExecutionSet {
+    pub fn eval(&self, protocol: Protocol, db: &RelationalDB, tx: &Tx) -> Result<ProtocolDatabaseUpdate, DBError> {
+        let tables = match protocol {
+            Protocol::Binary => Either::Left(self.eval_binary(db, tx)?),
+            Protocol::Text => Either::Right(self.eval_json(db, tx)?),
+        };
+        Ok(ProtocolDatabaseUpdate { tables })
+    }
+
     #[tracing::instrument(skip_all)]
-    pub fn eval(&self, db: &RelationalDB, tx: &Tx) -> Result<DatabaseUpdate, DBError> {
+    fn eval_json(&self, db: &RelationalDB, tx: &Tx) -> Result<Vec<TableUpdateJson>, DBError> {
         // evaluate each of the execution units in this ExecutionSet in parallel
-        let tables = self
-            .exec_units
+        self.exec_units
             // if you need eval to run single-threaded for debugging, change this to .iter()
             .par_iter()
-            .filter_map(|unit| unit.eval(db, tx).transpose())
-            .collect::<Result<Vec<_>, _>>()?;
+            .filter_map(|unit| unit.eval_json(db, tx).transpose())
+            .collect::<Result<Vec<_>, _>>()
+    }
 
-        Ok(DatabaseUpdate { tables })
+    #[tracing::instrument(skip_all)]
+    fn eval_binary(&self, db: &RelationalDB, tx: &Tx) -> Result<Vec<TableUpdate>, DBError> {
+        // evaluate each of the execution units in this ExecutionSet in parallel
+        self.exec_units
+            // if you need eval to run single-threaded for debugging, change this to .iter()
+            .par_iter()
+            .filter_map(|unit| unit.eval_binary(db, tx).transpose())
+            .collect::<Result<Vec<_>, _>>()
     }
 
     #[tracing::instrument(skip_all)]


### PR DESCRIPTION
# Description of Changes

- Fixes https://github.com/clockworklabs/SpacetimeDB/issues/813.

```
Benchmarking full-scan: Collecting 100 samples in estimated 
full-scan               time:   [162.84 ms 164.37 ms 166.88 ms]
                        change: [-47.765% -47.089% -46.260%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking query-indexes-multi: Collecting 100 samples in 
query-indexes-multi     time:   [1.1162 µs 1.1202 µs 1.1274 µs]
                        change: [-6.4601% -5.3782% -4.0002%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# API and ABI breaking changes

None

# Expected complexity level and risk

2