### PR TITLE
Added 'override' keywords to functions and properties extending from …

### DIFF
--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -687,8 +687,16 @@ fn autogen_typescript_product_table_common(
     {
         indent_scope!(output);
 
-        writeln!(output, "public static override db: ClientDB = __SPACETIMEDB__.clientDB;").unwrap();
-        writeln!(output, "public static override tableName = \"{struct_name_pascal_case}\";").unwrap();
+        writeln!(
+            output,
+            "public static override db: ClientDB = __SPACETIMEDB__.clientDB;"
+        )
+        .unwrap();
+        writeln!(
+            output,
+            "public static override tableName = \"{struct_name_pascal_case}\";"
+        )
+        .unwrap();
 
         let mut constructor_signature = Vec::new();
         let mut constructor_assignments = Vec::new();

--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -687,8 +687,8 @@ fn autogen_typescript_product_table_common(
     {
         indent_scope!(output);
 
-        writeln!(output, "public static db: ClientDB = __SPACETIMEDB__.clientDB;").unwrap();
-        writeln!(output, "public static tableName = \"{struct_name_pascal_case}\";").unwrap();
+        writeln!(output, "public static override db: ClientDB = __SPACETIMEDB__.clientDB;").unwrap();
+        writeln!(output, "public static override tableName = \"{struct_name_pascal_case}\";").unwrap();
 
         let mut constructor_signature = Vec::new();
         let mut constructor_assignments = Vec::new();
@@ -1081,10 +1081,10 @@ pub fn autogen_typescript_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String 
 
         writeln!(
             output,
-            "public static reducerName: string = \"{reducer_name_pascal_case}\";"
+            "public static override reducerName: string = \"{reducer_name_pascal_case}\";"
         )
         .unwrap();
-        writeln!(output, "public static call({}) {{", func_arguments.join(", ")).unwrap();
+        writeln!(output, "public static override call({}) {{", func_arguments.join(", ")).unwrap();
         {
             indent_scope!(output);
 
@@ -1092,7 +1092,7 @@ pub fn autogen_typescript_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String 
         }
         writeln!(output, "}}\n").unwrap();
 
-        writeln!(output, "public call({}) {{", func_arguments.join(", ")).unwrap();
+        writeln!(output, "public override call({}) {{", func_arguments.join(", ")).unwrap();
         {
             indent_scope!(output);
 
@@ -1177,7 +1177,7 @@ pub fn autogen_typescript_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String 
         // OnCreatePlayerEvent(dbEvent.Status, Identity.From(dbEvent.CallerIdentity.ToByteArray()), args[0].ToObject<string>());
         writeln!(
             output,
-            "public on(callback: (reducerEvent: ReducerEvent, {}) => void)",
+            "public override on(callback: (reducerEvent: ReducerEvent, {}) => void)",
             func_arguments.join(", ")
         )
         .unwrap();


### PR DESCRIPTION
What version of TypeScript are you targeting?

Since version 4.3 of TypeScript, override keyword has been introduced for properties or functions of classes extending from other classes.

Recent frameworks using Typescript might enforce the presence of the override keyword.

Of course implicit in projects can be disabled with the follow code. But I think it might be better to have it.
```
{
  "compilerOptions": {
    // ...
    "noImplicitOverride": true
  }
}
```