### PR TITLE
perf(828): Compile selections ahead of time for incremental eval

### DIFF
--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -128,8 +128,10 @@ impl ExecutionUnit {
         // at least less specifically inaccurate.
         let (eval_incr_plan, _source_set) = query::to_mem_table(expr.clone(), &table_update);
         debug_assert_eq!(_source_set.len(), 1);
-
-        Self::compile_query_expr_to_query_code(eval_incr_plan)
+        // Our choice of row count function is completely arbitrary,
+        // since it is only used for optimizing joins.
+        // It will be completely ignored for selections.
+        Self::compile_query_expr_to_query_code(eval_incr_plan.optimize(&|_, _| 0))
     }
 
     fn compile_eval(expr: QueryExpr) -> QueryCode {


### PR DESCRIPTION
Specifically index scans which were not handled by #928.

Note this doesn't improve performance significantly by itself.
But it make it possible to remove the cloning of query plans from the execution path,
which is handled by #959.

# Expected complexity level and risk

1
