### PR TITLE
perf(816): Compile inner joins ahead of time for incremental evaluation

### DIFF
--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -328,7 +328,7 @@ impl IncrementalJoin {
             Some(Self::dummy_table_update(&probe_table)),
         );
         debug_assert_eq!(_sources.len(), 2);
-        let virtual_plan = Self::optimize_query(virtual_plan);
+        let virtual_plan = spacetimedb_vm::eval::compile_query(virtual_plan.to_inner_join());
 
         let return_index_rows = join.return_index_rows;
 

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -80,33 +80,10 @@ pub fn build_query<'a>(
                 let iter = result.select(move |row| cmp.compare(row, &header));
                 Box::new(iter)
             }
-            // This type of index join is invalid and needs to be converted to an inner join.
-            // A virtual table cannot be probed as if it were a physical table with an index.
-            // Note that incremental evaluation can produce such a plan.
-            // Specifically when a transaction produces updates to both base tables.
-            //
-            // TODO: This logic should be entirely encapsulated within the query planner.
-            // It should not be possible for the planner to produce an invalid plan.
-            Query::IndexJoin(
-                join @ IndexJoin {
-                    index_side: SourceExpr::MemTable { .. },
-                    ..
-                },
-            ) => {
-                if result.is_some() {
-                    return Err(anyhow::anyhow!("Invalid query: `IndexJoin` must be the first operator").into());
-                }
-                build_query(ctx, stdb, tx, join.to_inner_join().into(), sources)?
-            }
             Query::IndexJoin(IndexJoin {
                 probe_side,
                 probe_field,
-                index_side:
-                    SourceExpr::DbTable(DbTable {
-                        head: index_header,
-                        table_id: index_table,
-                        ..
-                    }),
+                index_side,
                 index_select,
                 index_col,
                 return_index_rows,
@@ -114,6 +91,10 @@ pub fn build_query<'a>(
                 if result.is_some() {
                     return Err(anyhow::anyhow!("Invalid query: `IndexJoin` must be the first operator").into());
                 }
+                // The compiler guarantees that the index side is a db table,
+                // and therefore this unwrap is always safe.
+                let index_table = index_side.table_id().unwrap();
+                let index_header = index_side.head().clone();
                 let probe_side = build_query(ctx, stdb, tx, probe_side.into(), sources)?;
                 Box::new(IndexSemiJoin {
                     ctx,


### PR DESCRIPTION
Joins of two delta tables are compiled to an inner join. Their ahead of time compilation was not handled as part of #938.

# Expected complexity level and risk

1
