### PR TITLE
Fix bench for location, restore single-column indexes

### DIFF
--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -18,7 +18,7 @@ fn create_table_location(db: &RelationalDB) -> Result<TableId, DBError> {
         ("z", AlgebraicType::I32),
         ("dimension", AlgebraicType::U32),
     ];
-    let indexes = &[(0.into(), "entity_id"), (2.into(), "owner_entity_id")];
+    let indexes = &[(0.into(), "entity_id"), (1.into(), "chunk_index")];
 
     // Is necessary to test for both single & multi-column indexes...
     db.create_table_for_test_mix_indexes("location", schema, indexes, col_list![2, 3, 4])

--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -18,7 +18,10 @@ fn create_table_location(db: &RelationalDB) -> Result<TableId, DBError> {
         ("z", AlgebraicType::I32),
         ("dimension", AlgebraicType::U32),
     ];
-    db.create_table_for_test_multi_column("location", schema, col_list![2, 3, 4])
+    let indexes = &[(0.into(), "entity_id"), (2.into(), "owner_entity_id")];
+
+    // Is necessary to test for both single & multi-column indexes...
+    db.create_table_for_test_mix_indexes("location", schema, indexes, col_list![2, 3, 4])
 }
 
 fn create_table_footprint(db: &RelationalDB) -> Result<TableId, DBError> {


### PR DESCRIPTION
# Description of Changes

Revert regression on `bench` for location, restoring the creation of single-column indexes.

Closes [965](https://github.com/clockworklabs/SpacetimeDB/issues/965)

# Expected complexity level and risk

1