### PR TITLE
Set cpu affinity on tokio and rayon threads (thread per core)

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -598,6 +598,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
 
 [[package]]
+name = "cfg_aliases"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fd16c4719339c4530435d38e511904438d07cce7950afa3718a84ac36c10e89e"
+
+[[package]]
 name = "chrono"
 version = "0.4.31"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2335,9 +2341,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
@@ -2626,6 +2632,18 @@ checksum = "598beaf3cc6fdd9a5dfb1630c2800c7acd31df7aaf0f565796fba2b53ca1af1b"
 dependencies = [
  "bitflags 1.3.2",
  "cfg-if",
+ "libc",
+]
+
+[[package]]
+name = "nix"
+version = "0.28.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ab2156c4fce2f8df6c499cc1c763e4394b7482525bf2a9701c9d79d215f519e4"
+dependencies = [
+ "bitflags 2.4.1",
+ "cfg-if",
+ "cfg_aliases",
  "libc",
 ]
 
@@ -3844,7 +3862,7 @@ dependencies = [
  "libc",
  "log",
  "memchr",
- "nix",
+ "nix 0.26.4",
  "radix_trie",
  "scopeguard",
  "unicode-segmentation",
@@ -4458,6 +4476,7 @@ dependencies = [
  "jsonwebtoken",
  "lazy_static",
  "log",
+ "nix 0.28.0",
  "once_cell",
  "openssl",
  "parking_lot 0.12.1",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -148,6 +148,7 @@ jsonwebtoken = { version = "8.1.0" }
 lazy_static = "1.4.0"
 log = "0.4.17"
 mimalloc = "0.1.39"
+nix = "0.28"
 nohash-hasher = "0.2"
 once_cell = "1.16"
 parking_lot = { version = "0.12.1", features = ["send_guard", "arc_lock"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -53,6 +53,7 @@ itertools.workspace = true
 jsonwebtoken.workspace = true
 lazy_static.workspace = true
 log.workspace = true
+nix = { workspace = true, features = ["sched"] }
 once_cell.workspace = true
 openssl.workspace = true
 parking_lot.workspace = true

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -644,7 +644,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         };
         self.info
             .subscriptions
-            .blocking_broadcast_event(client.as_deref(), &subscriptions, Arc::new(event));
+            .broadcast_event(client.as_deref(), &subscriptions, &event);
 
         ReducerCallResult {
             outcome,

--- a/crates/standalone/src/main.rs
+++ b/crates/standalone/src/main.rs
@@ -1,7 +1,5 @@
 use clap::Command;
 
-use tokio::runtime::Builder;
-
 use spacetimedb_lib::util;
 use spacetimedb_standalone::*;
 use std::panic;
@@ -46,9 +44,5 @@ fn main() -> anyhow::Result<()> {
     }));
 
     // Create a multi-threaded run loop
-    Builder::new_multi_thread()
-        .enable_all()
-        .build()
-        .unwrap()
-        .block_on(async_main())
+    spacetimedb::startup::tokio_runtime().unwrap().block_on(async_main())
 }


### PR DESCRIPTION
# Description of Changes

Should help performance by ensuring worker cpu cores aren't context switching (as much).

Maybe for standalone this should be turned off? Unsure.

Also, we don't need tokio block_on for anything inside of rayon anymore - that should make you happy @gefjon

# Expected complexity level and risk

2-3 - theoretically this could mess up thread scheduling and make performance worse, though I don't think that's very likely. We should test it first to be sure.