### PR TITLE
Log a warning when doing `iter_by_col_range` without an index

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -98,12 +98,14 @@ wasmtime.workspace = true
 rocksdb = {workspace = true, optional = true}
 
 [features]
+# Print a warning when doing an unindexed `iter_by_col_range` on a large table.
+unindexed_iter_by_col_range_warn = []
 # Enable metrics in spacetimedb.
 metrics = []
 # Optional storage engines.
 odb_rocksdb = ["dep:rocksdb"]
 odb_sled = []
-default = ["odb_sled", "metrics"]
+default = ["odb_sled", "metrics", "unindexed_iter_by_col_range_warn"]
 
 [dev-dependencies]
 spacetimedb-lib = { path = "../lib", features = ["proptest"] }

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -1047,6 +1047,7 @@ impl StateView for MutTxId {
                     committed_rows,
                 ))),
                 None => {
+                    #[cfg(feature = "unindexed_iter_by_col_range_warn")]
                     match self.schema_for_table(ctx, *table_id) {
                         // TODO(ux): log these warnings to the module logs rather than host logs.
                         Err(e) => log::error!(

--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -6,6 +6,7 @@ use once_cell::sync::Lazy;
 use prometheus::{GaugeVec, HistogramVec, IntCounterVec, IntGaugeVec};
 use spacetimedb_lib::Address;
 use spacetimedb_metrics::metrics_group;
+use spacetimedb_primitives::TableId;
 
 metrics_group!(
     #[non_exhaustive]
@@ -147,4 +148,12 @@ pub fn reset_counters() {
     // Reset max query durations
     DB_METRICS.rdb_query_cpu_time_sec_max.0.reset();
     MAX_QUERY_CPU_TIME.lock().unwrap().clear();
+}
+
+/// Returns the number of committed rows in the table named by `table_name` and identified by `table_id` in the database `db_address`.
+pub fn table_num_rows(db_address: Address, table_id: TableId, table_name: &str) -> u64 {
+    DB_METRICS
+        .rdb_num_table_rows
+        .with_label_values(&db_address, &table_id.0, table_name)
+        .get() as _
 }


### PR DESCRIPTION
# Description of Changes

Adds a warning to `iter_by_col_range` when there is no applicable index and the table has >1000 rows. Should make it easier for us to debug BitCraft performance. This is an obviously suboptimal implementation which is intended as a stopgap until we can properly implement this warning.

### Concerns:
- Warnings go to the host logs, not the module logs. This will clearly need to change before 1.0.

### Possible alternatives:
- Simply don't generate `filter_by_{col}` methods unless there's an index.
  - This won't stop unindexed queries via the `query!` macro, but will catch the vast majority of cases.
  - This will not allow unindexed filters on small tables.
- Generate the above methods, but mark them `#[deprecated]`.
  - The point would not be to actually remove them, but because that's the only mechanism Rust exposes (AFAIK) for warning at a method's callsites.
  - This will warn on unindexed filters on small tables.
- Generate the above methods, but with an ugly name, like `slow_unindexed_filter_by_{col}`.

### Example

Using a modified version of the `spacetimedb-quickstart` module with a `find_named` reducer which does `Person::filter_by_name`. Note that I've snipped some calls; the table count is in fact accurate.

```sh
phoebe@phoebe-framework:~/clockworklabs/SpacetimeDB/modules/spacetimedb-quickstart]$ for i in {1..1000}; do spacetime call demo add "person-$i" 20; done

[phoebe@phoebe-framework:~/clockworklabs/SpacetimeDB/modules/spacetimedb-quickstart]$ spacetime call demo find_named person-1000
2024-03-14T13:56:59.291994Z  WARN iter_by_col_eq:iter_by_col_eq: crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs:1068: iter_by_col_range without index: table Person has 1021 rows; scanning columns ["name"]    
```

TODO:
- [x] Gate this behind a compile-time feature.
  - Should be enabled by default, but possible to disable so we can deploy the alpha without the logs.

# API and ABI breaking changes

N/a.
[phoebe@phoebe-framework:~/clockworklabs/SpacetimeDB/modules/spacetimedb-quickstart]$ spacetime call demo list_over_age 20

# Expected complexity level and risk

2 - social concern that we merge this and then never come back and write the better version.