### PR TITLE
core: Make `init_module_host` consistent with `update_module_host`

### DIFF
--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -6,7 +6,7 @@ use crate::host;
 use crate::messages::control_db::HostType;
 use crate::module_host_context::{ModuleCreationContext, ModuleHostContext};
 use crate::util::spawn_rayon;
-use anyhow::{ensure, Context};
+use anyhow::ensure;
 use futures::TryFutureExt;
 use parking_lot::Mutex;
 use serde::Serialize;
@@ -68,6 +68,12 @@ pub struct ReducerCallResult {
     pub execution_duration: Duration,
 }
 
+impl From<ReducerCallResult> for Result<(), anyhow::Error> {
+    fn from(value: ReducerCallResult) -> Self {
+        value.outcome.into_result()
+    }
+}
+
 #[derive(Clone, Debug)]
 pub enum ReducerOutcome {
     Committed,
@@ -103,24 +109,44 @@ impl HostController {
         }
     }
 
+    /// Initialize a module and underlying database.
+    ///
+    /// This will call the `init` reducer of the supplied program and set the
+    /// program as the database's program if it succeeds (or no `init` reducer
+    /// is defined).
+    ///
+    /// The method is executed in a transaction: if an error occurs (including
+    /// the `init` reducer failing), the module will not be in an initialized
+    /// state and the database will not have a program set..
+    ///
+    /// The result of calling the `init` reducer is returned as `Some` (or `None`
+    /// if the module does not define an `init` reducer).
+    ///
+    /// Note that callers may want to scrutinize the [`ReducerOutcome`] contained
+    /// in the [`ReducerCallResult`] in order to decide if the module was
+    /// indeed initialized successfully.
+    ///
+    /// The reason this error case is nested is that some callers may want to
+    /// report it instead of short-circuiting using `?`, consistent with
+    /// [`Self::update_module_host`].
     pub async fn init_module_host(
         &self,
         fence: u128,
         module_host_context: ModuleHostContext,
-    ) -> Result<ModuleHost, anyhow::Error> {
-        self.setup_module_host(module_host_context, |module_host| async {
+    ) -> Result<Option<ReducerCallResult>, anyhow::Error> {
+        self.setup_module_host(module_host_context, |module_host| async move {
             // TODO(cloutiertyler): Hook this up again
             // let identity = &module_host.info().identity;
             // let max_spend = worker_budget::max_tx_spend(identity);
-            let rcr = module_host.init_database(fence, ReducerArgs::Nullary).await?;
-            // worker_budget::record_tx_spend(identity, rcr.energy_quanta_used);
-            rcr.outcome.into_result().context("init reducer failed")?;
-
-            Ok(module_host)
+            let maybe_init_call_result = module_host.init_database(fence, ReducerArgs::Nullary).await?;
+            Ok(maybe_init_call_result)
         })
         .await
     }
 
+    /// Exit and delete the module corresponding to the provided instance id.
+    ///
+    /// Note that this currently does not delete any physical data.
     pub async fn delete_module_host(
         &self,
         _fence: u128,
@@ -139,6 +165,19 @@ impl HostController {
         Ok(())
     }
 
+    /// Update an existing module and database with the supplied program.
+    ///
+    /// This will call the `update` reducer of the supplied program and set the
+    /// program as the database's program if it succeeds (or no `update` reducer
+    /// is defined).
+    ///
+    /// The method is executed in a transaction: if an error occurs (including
+    /// the `update` reducer failing), the module and database will not be
+    /// updated, and the previous instance will keep running.
+    ///
+    /// The result of calling the `update` reducer is returned in
+    /// [`UpdateDatabaseResult`], which itself is a `Result`. Callers may choose
+    /// to short-circuit it using `?`, or report the outcome in a different way.
     pub async fn update_module_host(
         &self,
         fence: u128,
@@ -157,17 +196,21 @@ impl HostController {
         .or_else(|e| e.downcast::<UpdateDatabaseError>().map(Err))
     }
 
+    /// Spawn the given module host.
+    ///
+    /// The supplied program must match the program stored in the database,
+    /// otherwise an error is returned.
+    ///
     /// NOTE: Currently repeating reducers are only restarted when the [ModuleHost] is spawned.
     /// That means that if SpacetimeDB is restarted, repeating reducers will not be restarted unless
     /// there is a trigger that causes the [ModuleHost] to be spawned (e.g. a reducer is run).
-    ///
-    /// TODO(cloutiertyler): We need to determine what the correct behavior should be. In my mind,
-    /// the repeating reducers for all [ModuleHost]s should be rescheduled on startup, with the overarching
-    /// theory that SpacetimeDB should make a best effort to be as invisible as possible and not
-    /// impact the logic of applications. The idea being that if SpacetimeDB is a distributed operating
-    /// system, the applications will expect to be called when they are scheduled to be called regardless
-    /// of whether the OS has been restarted.
     pub async fn spawn_module_host(&self, mhc: ModuleHostContext) -> Result<ModuleHost, anyhow::Error> {
+        // TODO(cloutiertyler): We need to determine what the correct behavior should be. In my mind,
+        // the repeating reducers for all [ModuleHost]s should be rescheduled on startup, with the overarching
+        // theory that SpacetimeDB should make a best effort to be as invisible as possible and not
+        // impact the logic of applications. The idea being that if SpacetimeDB is a distributed operating
+        // system, the applications will expect to be called when they are scheduled to be called regardless
+        // of whether the OS has been restarted.
         self.setup_module_host(mhc, |mh| async { Ok(mh) }).await
     }
 

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -260,7 +260,7 @@ pub trait ModuleInstance: Send + 'static {
     // should probably be generic over the type of token, but that turns out a
     // bit unpleasant at the moment. So we just use the widest possible integer.
 
-    fn init_database(&mut self, fence: u128, args: ArgsTuple) -> anyhow::Result<ReducerCallResult>;
+    fn init_database(&mut self, fence: u128, args: ArgsTuple) -> anyhow::Result<Option<ReducerCallResult>>;
 
     fn update_database(&mut self, fence: u128) -> anyhow::Result<UpdateDatabaseResult>;
 
@@ -297,7 +297,7 @@ impl<T: Module> ModuleInstance for AutoReplacingModuleInstance<T> {
     fn trapped(&self) -> bool {
         self.inst.trapped()
     }
-    fn init_database(&mut self, fence: u128, args: ArgsTuple) -> anyhow::Result<ReducerCallResult> {
+    fn init_database(&mut self, fence: u128, args: ArgsTuple) -> anyhow::Result<Option<ReducerCallResult>> {
         let ret = self.inst.init_database(fence, args);
         self.check_trap();
         ret
@@ -635,7 +635,11 @@ impl ModuleHost {
         Ok(self.info().log_tx.subscribe())
     }
 
-    pub async fn init_database(&self, fence: u128, args: ReducerArgs) -> Result<ReducerCallResult, InitDatabaseError> {
+    pub async fn init_database(
+        &self,
+        fence: u128,
+        args: ReducerArgs,
+    ) -> Result<Option<ReducerCallResult>, InitDatabaseError> {
         let args = match self.catalog().get_reducer("__init__") {
             Some(schema) => args.into_tuple(schema)?,
             _ => ArgsTuple::default(),

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -532,7 +532,12 @@ impl StandaloneEnv {
                         log::info!("Database already initialized with module {}", hash);
                     }
                 } else {
-                    self.host_controller.init_module_host(lock.token() as u128, ctx).await?;
+                    self.host_controller
+                        .init_module_host(lock.token() as u128, ctx)
+                        .await?
+                        .map(Result::from)
+                        .transpose()
+                        .context("Init reducer failed")?;
                 }
 
                 Ok(())
@@ -578,7 +583,12 @@ impl StandaloneEnv {
                             "Update requested on non-initialized database, initializing with module {}",
                             database.program_bytes_address
                         );
-                        self.host_controller.init_module_host(lock.token() as u128, ctx).await?;
+                        self.host_controller
+                            .init_module_host(lock.token() as u128, ctx)
+                            .await?
+                            .map(Result::from)
+                            .transpose()
+                            .context("Init reducer failed")?;
                         Ok(None)
                     }
                     Some(hash) if hash == database.program_bytes_address => {


### PR DESCRIPTION
`spawn_module_host` was changed in #904 to ensure that the supplied program is indeed the database's current program. There are, however, uses which would call `spawn_module_host`, followed by either `init_database` or `update_database` on the returned `ModuleHost`.

This would fail because the condition is not met.

While we cannot prevent misuse, this patch documents the various lifecycle methods, and adjusts the signature of `init_module_host` to be (somewhat) consistent with `update_module_host`. Namely, it will optionally return the result of the `init` reducer call.

---

It is probably preferable to re-arrange the error types and not use `anyhow`. I will leave that to a follow-up.