### PR TITLE
iter_filtered_chunks: avoid PVs

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -342,3 +342,9 @@ impl From<DBError> for NodesError {
         }
     }
 }
+
+impl From<ErrorVm> for NodesError {
+    fn from(err: ErrorVm) -> Self {
+        DBError::from(err).into()
+    }
+}

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -1,6 +1,6 @@
 use super::compiler::compile_sql;
 use crate::database_instance_context_controller::DatabaseInstanceContextController;
-use crate::db::relational_db::{MutTx, RelationalDB, Tx};
+use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::{DBError, DatabaseError};
 use crate::execution_context::ExecutionContext;
 use crate::vm::{DbProgram, TxMode};
@@ -63,24 +63,6 @@ pub fn execute_single_sql(
     let q = Expr::Crud(Box::new(ast));
 
     let mut result = Vec::with_capacity(1);
-    collect_result(&mut result, run_ast(p, q, sources).into())?;
-    Ok(result)
-}
-
-pub fn execute_sql_mut_tx(
-    db: &RelationalDB,
-    tx: &mut MutTx,
-    ast: Vec<CrudExpr>,
-    auth: AuthCtx,
-    sources: SourceSet,
-) -> Result<Vec<MemTable>, DBError> {
-    let total = ast.len();
-    let mut tx: TxMode = tx.into();
-    let ctx = ExecutionContext::sql(db.address());
-    let p = &mut DbProgram::new(&ctx, db, &mut tx, auth);
-    let q = Expr::Block(ast.into_iter().map(|x| Expr::Crud(Box::new(x))).collect());
-
-    let mut result = Vec::with_capacity(total);
     collect_result(&mut result, run_ast(p, q, sources).into())?;
     Ok(result)
 }

--- a/crates/vm/src/dsl.rs
+++ b/crates/vm/src/dsl.rs
@@ -43,9 +43,6 @@ pub fn db_table<T: Into<Header>>(head: T, table_id: TableId) -> DbTable {
     db_table_raw(head, table_id, StTableType::User, access)
 }
 
-pub fn query<Source>(source: Source) -> QueryExpr
-where
-    Source: Into<SourceExpr>,
-{
+pub fn query(source: impl Into<SourceExpr>) -> QueryExpr {
     QueryExpr::new(source)
 }

--- a/crates/vm/src/relation.rs
+++ b/crates/vm/src/relation.rs
@@ -3,7 +3,7 @@ use spacetimedb_sats::db::auth::{StAccess, StTableType};
 use spacetimedb_sats::db::error::RelationError;
 use spacetimedb_sats::product_value::ProductValue;
 use spacetimedb_sats::relation::{DbTable, FieldExpr, FieldName, Header, HeaderOnlyField, Relation, RowCount};
-use spacetimedb_sats::AlgebraicValue;
+use spacetimedb_sats::{impl_serialize, AlgebraicValue};
 use spacetimedb_table::read_column::ReadColumn;
 use spacetimedb_table::table::RowRef;
 use std::borrow::Cow;
@@ -20,6 +20,11 @@ pub enum RelValue<'a> {
     Row(RowRef<'a>),
     Projection(ProductValue),
 }
+
+impl_serialize!(['a] RelValue<'a>, (self, ser) => match self {
+    Self::Row(row) => row.serialize(ser),
+    Self::Projection(row) => row.serialize(ser),
+});
 
 impl<'a> RelValue<'a> {
     /// Converts `self` into a `ProductValue`


### PR DESCRIPTION
# Description of Changes

Avoid `row.into_product_value()` in `InstanceEnv::iter_filtered_chunks`.

# API and ABI breaking changes

None

# Expected complexity level and risk

1