### PR TITLE
perf(833): Do not clone query plan during execution

### DIFF
--- a/crates/bench/src/spacetime_raw.rs
+++ b/crates/bench/src/spacetime_raw.rs
@@ -108,7 +108,7 @@ impl BenchDatabase for SpacetimeRaw {
                 // (update_by_{field} -> spacetimedb::query::update_by_field -> (delete_by_col_eq; insert))
                 let id = self
                     .db
-                    .iter_by_col_eq_mut(&ctx, tx, *table_id, ColId(0), &row.elements[0])?
+                    .iter_by_col_eq_mut(&ctx, tx, *table_id, 0, &row.elements[0])?
                     .next()
                     .expect("failed to find row during update!")
                     .pointer();
@@ -148,10 +148,9 @@ impl BenchDatabase for SpacetimeRaw {
         column_index: u32,
         value: AlgebraicValue,
     ) -> ResultBench<()> {
-        let col: ColId = column_index.into();
         let ctx = ExecutionContext::default();
         self.db.with_auto_commit(&ctx, |tx| {
-            for row in self.db.iter_by_col_eq_mut(&ctx, tx, *table_id, col, &value)? {
+            for row in self.db.iter_by_col_eq_mut(&ctx, tx, *table_id, column_index, &value)? {
                 black_box(row);
             }
             Ok(())

--- a/crates/core/src/db/cursor.rs
+++ b/crates/core/src/db/cursor.rs
@@ -29,12 +29,12 @@ impl<'a> TableCursor<'a> {
 /// A relational iterator wrapping a storage level index iterator.
 /// A relational iterator returns [RelValue]s whereas storage iterators return [DataRef]s.
 pub struct IndexCursor<'a, R: RangeBounds<AlgebraicValue>> {
-    pub table: DbTable,
+    pub table: &'a DbTable,
     pub iter: IterByColRange<'a, R>,
 }
 
 impl<'a, R: RangeBounds<AlgebraicValue>> IndexCursor<'a, R> {
-    pub fn new(table: DbTable, iter: IterByColRange<'a, R>) -> Result<Self, DBError> {
+    pub fn new(table: &'a DbTable, iter: IterByColRange<'a, R>) -> Result<Self, DBError> {
         Ok(Self { table, iter })
     }
 }

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -275,7 +275,7 @@ impl TxDatastore for Locking {
         cols: impl Into<ColList>,
         value: &'r AlgebraicValue,
     ) -> Result<Self::IterByColEq<'a, 'r>> {
-        tx.iter_by_col_eq(ctx, &table_id, cols.into(), value)
+        tx.iter_by_col_eq(ctx, &table_id, cols, value)
     }
 
     fn table_id_exists_tx(&self, tx: &Self::Tx, table_id: &TableId) -> bool {

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -63,7 +63,7 @@ impl MutTxId {
         database_address: Address,
     ) -> Result<()> {
         let ctx = ExecutionContext::internal(database_address);
-        let rows = self.iter_by_col_eq(&ctx, &table_id, col_pos.into(), value)?;
+        let rows = self.iter_by_col_eq(&ctx, &table_id, col_pos, value)?;
         let ptrs_to_delete = rows.map(|row_ref| row_ref.pointer()).collect::<Vec<_>>();
         if ptrs_to_delete.is_empty() {
             return Err(TableError::IdNotFound(SystemTable::st_columns, col_pos.0).into());
@@ -240,12 +240,7 @@ impl MutTxId {
         let ctx = ExecutionContext::internal(database_address);
 
         let st_table_ref = self
-            .iter_by_col_eq(
-                &ctx,
-                &ST_TABLES_ID,
-                StTableFields::TableId.col_id().into(),
-                &table_id.into(),
-            )?
+            .iter_by_col_eq(&ctx, &ST_TABLES_ID, StTableFields::TableId, &table_id.into())?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_table, table_id.into()))?;
         let mut st = StTableRow::try_from(st_table_ref)?;
@@ -262,13 +257,13 @@ impl MutTxId {
         let ctx = ExecutionContext::internal(database_address);
         let table_name = &table_name.to_owned().into();
         let row = self
-            .iter_by_col_eq(&ctx, &ST_TABLES_ID, StTableFields::TableName.into(), table_name)?
+            .iter_by_col_eq(&ctx, &ST_TABLES_ID, StTableFields::TableName, table_name)?
             .next();
         Ok(row.map(|row| row.read_col(StTableFields::TableId).unwrap()))
     }
 
     pub fn table_name_from_id<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Option<String>> {
-        self.iter_by_col_eq(ctx, &ST_TABLES_ID, StTableFields::TableId.into(), &table_id.into())
+        self.iter_by_col_eq(ctx, &ST_TABLES_ID, StTableFields::TableId, &table_id.into())
             .map(|mut iter| iter.next().map(|row| row.read_col(StTableFields::TableName).unwrap()))
     }
 
@@ -366,12 +361,7 @@ impl MutTxId {
         let ctx = ExecutionContext::internal(database_address);
 
         let st_index_ref = self
-            .iter_by_col_eq(
-                &ctx,
-                &ST_INDEXES_ID,
-                StIndexFields::IndexId.col_id().into(),
-                &index_id.into(),
-            )?
+            .iter_by_col_eq(&ctx, &ST_INDEXES_ID, StIndexFields::IndexId, &index_id.into())?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_indexes, index_id.into()))?;
         let table_id = st_index_ref.read_col(StIndexFields::TableId)?;
@@ -408,7 +398,7 @@ impl MutTxId {
     pub fn index_id_from_name(&self, index_name: &str, database_address: Address) -> Result<Option<IndexId>> {
         let ctx = ExecutionContext::internal(database_address);
         let name = &index_name.to_owned().into();
-        self.iter_by_col_eq(&ctx, &ST_INDEXES_ID, StIndexFields::IndexName.into(), name)
+        self.iter_by_col_eq(&ctx, &ST_INDEXES_ID, StIndexFields::IndexName, name)
             .map(|mut iter| iter.next().map(|row| row.read_col(StIndexFields::IndexId).unwrap()))
     }
 
@@ -428,12 +418,7 @@ impl MutTxId {
         // If we're out of allocations, then update the sequence row in st_sequences to allocate a fresh batch of sequences.
         let ctx = ExecutionContext::internal(database_address);
         let old_seq_row_ref = self
-            .iter_by_col_eq(
-                &ctx,
-                &ST_SEQUENCES_ID,
-                StSequenceFields::SequenceId.into(),
-                &seq_id.into(),
-            )?
+            .iter_by_col_eq(&ctx, &ST_SEQUENCES_ID, StSequenceFields::SequenceId, &seq_id.into())?
             .last()
             .unwrap();
         let old_seq_row_ptr = old_seq_row_ref.pointer();
@@ -508,7 +493,7 @@ impl MutTxId {
             .iter_by_col_eq(
                 &ctx,
                 &ST_SEQUENCES_ID,
-                StSequenceFields::SequenceId.col_id().into(),
+                StSequenceFields::SequenceId,
                 &sequence_id.into(),
             )?
             .next()
@@ -531,7 +516,7 @@ impl MutTxId {
     pub fn sequence_id_from_name(&self, seq_name: &str, database_address: Address) -> Result<Option<SequenceId>> {
         let ctx = ExecutionContext::internal(database_address);
         let name = &seq_name.to_owned().into();
-        self.iter_by_col_eq(&ctx, &ST_SEQUENCES_ID, StSequenceFields::SequenceName.into(), name)
+        self.iter_by_col_eq(&ctx, &ST_SEQUENCES_ID, StSequenceFields::SequenceName, name)
             .map(|mut iter| {
                 iter.next()
                     .map(|row| row.read_col(StSequenceFields::SequenceId).unwrap())
@@ -603,7 +588,7 @@ impl MutTxId {
             .iter_by_col_eq(
                 &ctx,
                 &ST_CONSTRAINTS_ID,
-                StConstraintFields::ConstraintId.col_id().into(),
+                StConstraintFields::ConstraintId,
                 &constraint_id.into(),
             )?
             .next()
@@ -628,7 +613,7 @@ impl MutTxId {
         self.iter_by_col_eq(
             &ExecutionContext::internal(database_address),
             &ST_CONSTRAINTS_ID,
-            StConstraintFields::ConstraintName.into(),
+            StConstraintFields::ConstraintName,
             &constraint_name.to_owned().into(),
         )
         .map(|mut iter| {
@@ -734,12 +719,7 @@ impl MutTxId {
             .iter()
             .filter(|seq| row.elements[usize::from(seq.col_pos)].is_numeric_zero())
         {
-            for seq_row in self.iter_by_col_eq(
-                &ctx,
-                &ST_SEQUENCES_ID,
-                StSequenceFields::TableId.into(),
-                &table_id.into(),
-            )? {
+            for seq_row in self.iter_by_col_eq(&ctx, &ST_SEQUENCES_ID, StSequenceFields::TableId, &table_id.into())? {
                 let seq_col_pos: ColId = seq_row.read_col(StSequenceFields::ColPos)?;
                 if seq_col_pos == seq.col_pos {
                     let seq_id = seq_row.read_col(StSequenceFields::SequenceId)?;

--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -170,8 +170,8 @@ pub fn st_table_schema() -> TableSchema {
         ],
     )
     .with_type(StTableType::System)
-    .with_column_constraint(Constraints::primary_key_auto(), StTableFields::TableId.col_id())
-    .with_column_index(StTableFields::TableName.col_id(), true)
+    .with_column_constraint(Constraints::primary_key_auto(), StTableFields::TableId)
+    .with_column_index(StTableFields::TableName, true)
     .into_schema(ST_TABLES_ID)
 }
 
@@ -218,7 +218,7 @@ pub fn st_indexes_schema() -> TableSchema {
     )
     .with_type(StTableType::System)
     // TODO: Unique constraint on index name?
-    .with_column_constraint(Constraints::primary_key_auto(), StIndexFields::IndexId.col_id())
+    .with_column_constraint(Constraints::primary_key_auto(), StIndexFields::IndexId)
     .into_schema(ST_INDEXES_ID)
 }
 
@@ -244,7 +244,7 @@ pub(crate) fn st_sequences_schema() -> TableSchema {
     )
     .with_type(StTableType::System)
     // TODO: Unique constraint on sequence name?
-    .with_column_constraint(Constraints::primary_key_auto(), StSequenceFields::SequenceId.col_id())
+    .with_column_constraint(Constraints::primary_key_auto(), StSequenceFields::SequenceId)
     .into_schema(ST_SEQUENCES_ID)
 }
 
@@ -268,10 +268,7 @@ pub(crate) fn st_constraints_schema() -> TableSchema {
         ],
     )
     .with_type(StTableType::System)
-    .with_column_constraint(
-        Constraints::primary_key_auto(),
-        StConstraintFields::ConstraintId.col_id(),
-    )
+    .with_column_constraint(Constraints::primary_key_auto(), StConstraintFields::ConstraintId)
     .into_schema(ST_CONSTRAINTS_ID)
 }
 
@@ -552,11 +549,7 @@ impl TryFrom<RowRef<'_>> for StConstraintRow<String> {
     fn try_from(row: RowRef<'_>) -> Result<StConstraintRow<String>, DBError> {
         let constraints = row.read_col::<u8>(StConstraintFields::Constraints)?;
         let constraints = Constraints::try_from(constraints).expect("Fail to decode Constraints");
-        let columns = to_cols(
-            row,
-            StConstraintFields::Columns.col_id(),
-            StConstraintFields::Columns.name(),
-        )?;
+        let columns = to_cols(row, StConstraintFields::Columns, StConstraintFields::Columns.name())?;
         Ok(StConstraintRow {
             table_id: row.read_col(StConstraintFields::TableId)?,
             constraint_id: row.read_col(StConstraintFields::ConstraintId)?,

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -375,7 +375,7 @@ impl InstanceEnv {
 
         let tx: TxMode = tx.into();
         // SQL queries can never reference `MemTable`s, so pass in an empty `SourceSet`.
-        let mut query = build_query(ctx, stdb, &tx, query, &mut SourceSet::default())?;
+        let mut query = build_query(ctx, stdb, &tx, &query, &mut SourceSet::default())?;
 
         // write all rows and flush at row boundaries.
         let mut chunked_writer = ChunkedWriter::default();

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -866,26 +866,26 @@ mod tests {
             probe_side:
                 QueryExpr {
                     source: SourceExpr::DbTable(DbTable { table_id, .. }),
-                    query: ref rhs,
+                    query: rhs,
                 },
             probe_field:
                 FieldName::Name {
-                    table: ref probe_table,
-                    field: ref probe_field,
+                    table: probe_table,
+                    field: probe_field,
                 },
             index_side: SourceExpr::DbTable(DbTable {
                 table_id: index_table, ..
             }),
             index_col,
             ..
-        }) = query[0]
+        }) = &query[0]
         else {
             panic!("unexpected operator {:#?}", query[0]);
         };
 
-        assert_eq!(table_id, rhs_id);
-        assert_eq!(index_table, lhs_id);
-        assert_eq!(index_col, 1.into());
+        assert_eq!(*table_id, rhs_id);
+        assert_eq!(*index_table, lhs_id);
+        assert_eq!(index_col, &1.into());
         assert_eq!(probe_field, "b");
         assert_eq!(probe_table, "rhs");
 
@@ -964,26 +964,26 @@ mod tests {
             probe_side:
                 QueryExpr {
                     source: SourceExpr::DbTable(DbTable { table_id, .. }),
-                    query: ref rhs,
+                    query: rhs,
                 },
             probe_field:
                 FieldName::Name {
-                    table: ref probe_table,
-                    field: ref probe_field,
+                    table: probe_table,
+                    field: probe_field,
                 },
             index_side: SourceExpr::DbTable(DbTable {
                 table_id: index_table, ..
             }),
             index_col,
             ..
-        }) = query[0]
+        }) = &query[0]
         else {
             panic!("unexpected operator {:#?}", query[0]);
         };
 
-        assert_eq!(table_id, rhs_id);
-        assert_eq!(index_table, lhs_id);
-        assert_eq!(index_col, 1.into());
+        assert_eq!(*table_id, rhs_id);
+        assert_eq!(*index_table, lhs_id);
+        assert_eq!(index_col, &1.into());
         assert_eq!(probe_field, "b");
         assert_eq!(probe_table, "rhs");
 

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -221,8 +221,7 @@ impl ExecutionUnit {
     fn eval_query_code(db: &RelationalDB, tx: &Tx, eval_plan: &QueryExpr) -> Result<Vec<TableOp>, DBError> {
         let ctx = ExecutionContext::subscribe(db.address());
         let tx: TxMode = tx.into();
-        // TODO(perf, 833): avoid clone.
-        let query = build_query(&ctx, db, &tx, eval_plan.clone(), &mut SourceSet::default())?;
+        let query = build_query(&ctx, db, &tx, eval_plan, &mut SourceSet::default())?;
         let ops = query.collect_vec(|row_ref| TableOp::insert(row_ref.into_product_value()))?;
         Ok(ops)
     }
@@ -279,8 +278,7 @@ impl ExecutionUnit {
             debug_assert_eq!(_source_expr.source_id(), Some(_source_id));
             // Evaluate the saved plan against the new `SourceSet`
             // and capture the new row operations.
-            // TODO(perf, 833): avoid clone.
-            let query = build_query(&ctx, db, &tx, eval_incr_plan.clone(), &mut sources)?;
+            let query = build_query(&ctx, db, &tx, eval_incr_plan, &mut sources)?;
             Self::collect_rows_remove_table_ops(&mut ops, query, header)?;
         }
         Ok(ops)

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -160,8 +160,7 @@ fn eval_updates(
 ) -> Result<impl Iterator<Item = ProductValue>, DBError> {
     let ctx = ExecutionContext::incremental_update(db.address());
     let tx: TxMode = tx.into();
-    // TODO(perf, 833): avoid clone.
-    let query = build_query(&ctx, db, &tx, query.clone(), &mut sources)?;
+    let query = build_query(&ctx, db, &tx, query, &mut sources)?;
     // TODO(perf): avoid collecting into a vec.
     Ok(query.collect_vec(|row_ref| row_ref.into_product_value())?.into_iter())
 }

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -10,7 +10,7 @@ use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::Address;
 use spacetimedb_primitives::*;
 use spacetimedb_sats::db::def::TableDef;
-use spacetimedb_sats::relation::{DbTable, FieldExpr, FieldName, Header, Relation, RowCount};
+use spacetimedb_sats::relation::{DbTable, FieldExpr, FieldExprRef, FieldName, Header, Relation, RowCount};
 use spacetimedb_sats::{AlgebraicValue, ProductValue};
 use spacetimedb_vm::errors::ErrorVm;
 use spacetimedb_vm::eval::IterRows;
@@ -45,7 +45,7 @@ pub fn build_query<'a>(
     ctx: &'a ExecutionContext,
     stdb: &'a RelationalDB,
     tx: &'a TxMode,
-    query: QueryExpr,
+    query: &'a QueryExpr,
     sources: &mut SourceSet,
 ) -> Result<Box<IterRows<'a>>, ErrorVm> {
     let db_table = query.source.is_db_table();
@@ -66,10 +66,11 @@ pub fn build_query<'a>(
     //   removing the need for this convoluted logic?
     let mut result = None;
 
-    for op in query.query {
+    for op in &query.query {
         result = Some(match op {
             Query::IndexScan(IndexScan { table, columns, bounds }) if db_table => {
-                iter_by_col_range(ctx, stdb, tx, table, columns, bounds)?
+                let bounds = (bounds.start_bound(), bounds.end_bound());
+                iter_by_col_range(ctx, stdb, tx, table, columns.clone(), bounds)?
             }
             Query::IndexScan(index_scan) => {
                 let result = result
@@ -78,7 +79,7 @@ pub fn build_query<'a>(
                     .unwrap_or_else(|| get_table(ctx, stdb, tx, &query.source, sources))?;
 
                 let cols = &index_scan.columns;
-                let bounds = index_scan.bounds;
+                let bounds = &index_scan.bounds;
                 if cols.is_singleton() {
                     // For singleton constraints, we compare the column directly against `bounds`.
                     let head = cols.head().idx();
@@ -96,9 +97,8 @@ pub fn build_query<'a>(
                         }
                     }
                     // Project start/end `Bound<AV>`s to `Bound<Vec<AV>>`s.
-                    let start_bound = map(bounds.0, |av| av.into_product().unwrap().elements);
-                    let end_bound = map(bounds.1, |av| av.into_product().unwrap().elements);
-                    let cols = cols.clone();
+                    let start_bound = map(bounds.0.as_ref(), |av| &av.as_product().unwrap().elements);
+                    let end_bound = map(bounds.1.as_ref(), |av| &av.as_product().unwrap().elements);
                     // Construct the query:
                     let iter = result.select(move |row| {
                         // Go through each column position,
@@ -107,8 +107,8 @@ pub fn build_query<'a>(
                         // All columns must match to include the row,
                         // which is essentially the same as a big `AND` of `ColumnOp`s.
                         Ok(cols.iter().enumerate().all(|(idx, col)| {
-                            let start_bound = map(start_bound.as_ref(), |pv| &pv[idx]);
-                            let end_bound = map(end_bound.as_ref(), |pv| &pv[idx]);
+                            let start_bound = map(start_bound, |pv| &pv[idx]);
+                            let end_bound = map(end_bound, |pv| &pv[idx]);
                             let read_col = row.read_column(col.idx()).unwrap();
                             (start_bound, end_bound).contains(&*read_col)
                         }))
@@ -130,7 +130,7 @@ pub fn build_query<'a>(
                 // The compiler guarantees that the index side is a db table,
                 // and therefore this unwrap is always safe.
                 let index_table = index_side.table_id().unwrap();
-                let index_header = index_side.head().clone();
+                let index_header = index_side.head();
                 let probe_side = build_query(ctx, stdb, tx, probe_side, sources)?;
                 Box::new(IndexSemiJoin {
                     ctx,
@@ -141,9 +141,9 @@ pub fn build_query<'a>(
                     index_header,
                     index_select,
                     index_table,
-                    index_col,
+                    index_col: *index_col,
                     index_iter: None,
-                    return_index_rows,
+                    return_index_rows: *return_index_rows,
                 })
             }
             Query::Select(cmp) => {
@@ -186,21 +186,22 @@ pub fn build_query<'a>(
         .unwrap_or_else(|| get_table(ctx, stdb, tx, &query.source, sources))
 }
 
+#[allow(clippy::too_many_arguments)]
 fn join_inner<'a>(
     ctx: &'a ExecutionContext,
     db: &'a RelationalDB,
     tx: &'a TxMode,
     lhs: impl RelOps<'a> + 'a,
-    rhs: JoinExpr,
+    rhs: &'a JoinExpr,
     semi: bool,
     sources: &mut SourceSet,
 ) -> Result<impl RelOps<'a> + 'a, ErrorVm> {
-    let col_lhs = FieldExpr::Name(rhs.col_lhs);
-    let col_rhs = FieldExpr::Name(rhs.col_rhs);
-    let key_lhs = [col_lhs.clone()];
-    let key_rhs = [col_rhs.clone()];
+    let col_lhs = FieldExprRef::Name(&rhs.col_lhs);
+    let col_rhs = FieldExprRef::Name(&rhs.col_rhs);
+    let key_lhs = [col_lhs];
+    let key_rhs = [col_rhs];
 
-    let rhs = build_query(ctx, db, tx, rhs.rhs, sources)?;
+    let rhs = build_query(ctx, db, tx, &rhs.rhs, sources)?;
     let key_lhs_header = lhs.head().clone();
     let key_rhs_header = rhs.head().clone();
     let col_lhs_header = lhs.head().clone();
@@ -218,8 +219,8 @@ fn join_inner<'a>(
         move |row| Ok(row.project(&key_lhs, &key_lhs_header)?),
         move |row| Ok(row.project(&key_rhs, &key_rhs_header)?),
         move |l, r| {
-            let l = l.get(&col_lhs, &col_lhs_header)?;
-            let r = r.get(&col_rhs, &col_rhs_header)?;
+            let l = l.get(col_lhs, &col_lhs_header)?;
+            let r = r.get(col_rhs, &col_rhs_header)?;
             Ok(l == r)
         },
         move |l, r| {
@@ -271,7 +272,7 @@ fn iter_by_col_range<'a>(
     ctx: &'a ExecutionContext,
     db: &'a RelationalDB,
     tx: &'a TxMode,
-    table: DbTable,
+    table: &'a DbTable,
     columns: ColList,
     range: impl RangeBounds<AlgebraicValue> + 'a,
 ) -> Result<Box<dyn RelOps<'a> + 'a>, ErrorVm> {
@@ -283,16 +284,16 @@ fn iter_by_col_range<'a>(
 }
 
 /// An index join operator that returns matching rows from the index side.
-pub struct IndexSemiJoin<'a, Rhs: RelOps<'a>> {
+pub struct IndexSemiJoin<'a, 'c, Rhs: RelOps<'a>> {
     /// An iterator for the probe side.
     /// The values returned will be used to probe the index.
     pub probe_side: Rhs,
     /// The field whose value will be used to probe the index.
-    pub probe_field: FieldName,
+    pub probe_field: &'c FieldName,
     /// The header for the index side of the join.
-    pub index_header: Arc<Header>,
+    pub index_header: &'c Arc<Header>,
     /// An optional predicate to evaluate over the matching rows of the index.
-    pub index_select: Option<ColumnOp>,
+    pub index_select: &'c Option<ColumnOp>,
     /// The table id on which the index is defined.
     pub index_table: TableId,
     /// The column id for which the index is defined.
@@ -310,10 +311,10 @@ pub struct IndexSemiJoin<'a, Rhs: RelOps<'a>> {
     ctx: &'a ExecutionContext<'a>,
 }
 
-impl<'a, Rhs: RelOps<'a>> IndexSemiJoin<'a, Rhs> {
+impl<'a, Rhs: RelOps<'a>> IndexSemiJoin<'a, '_, Rhs> {
     fn filter(&self, index_row: &RelValue<'_>) -> Result<bool, ErrorVm> {
         Ok(if let Some(op) = &self.index_select {
-            op.compare(index_row, &self.index_header)?
+            op.compare(index_row, self.index_header)?
         } else {
             true
         })
@@ -329,10 +330,10 @@ impl<'a, Rhs: RelOps<'a>> IndexSemiJoin<'a, Rhs> {
     }
 }
 
-impl<'a, Rhs: RelOps<'a>> RelOps<'a> for IndexSemiJoin<'a, Rhs> {
+impl<'a, Rhs: RelOps<'a>> RelOps<'a> for IndexSemiJoin<'a, '_, Rhs> {
     fn head(&self) -> &Arc<Header> {
         if self.return_index_rows {
-            &self.index_header
+            self.index_header
         } else {
             self.probe_side.head()
         }
@@ -355,7 +356,7 @@ impl<'a, Rhs: RelOps<'a>> RelOps<'a> for IndexSemiJoin<'a, Rhs> {
 
         // Otherwise probe the index with a row from the probe side.
         while let Some(row) = self.probe_side.next()? {
-            if let Some(pos) = self.probe_side.head().column_pos(&self.probe_field) {
+            if let Some(pos) = self.probe_side.head().column_pos(self.probe_field) {
                 if let Some(value) = row.read_column(pos.idx()) {
                     let table_id = self.index_table;
                     let col_id = self.index_col;
@@ -394,7 +395,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
         Self { ctx, db, tx, auth }
     }
 
-    fn _eval_query(&mut self, query: QueryExpr, sources: &mut SourceSet) -> Result<Code, ErrorVm> {
+    fn _eval_query(&mut self, query: &QueryExpr, sources: &mut SourceSet) -> Result<Code, ErrorVm> {
         let table_access = query.source.table_access();
         tracing::trace!(table = query.source.table_name());
 
@@ -435,7 +436,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
         }
     }
 
-    fn _delete_query(&mut self, query: QueryExpr, sources: &mut SourceSet) -> Result<Code, ErrorVm> {
+    fn _delete_query(&mut self, query: &QueryExpr, sources: &mut SourceSet) -> Result<Code, ErrorVm> {
         let table = sources
             .take_table(&query.source)
             .expect("Cannot delete from a `MemTable`");
@@ -507,22 +508,21 @@ impl ProgramVm for DbProgram<'_, '_> {
         query.check_auth(self.auth.owner, self.auth.caller)?;
 
         match query {
-            CrudExpr::Query(query) => self._eval_query(query, sources),
-            CrudExpr::Insert { source: table, rows } => {
-                let src = sources.take_table(&table).unwrap();
+            CrudExpr::Query(query) => self._eval_query(&query, sources),
+            CrudExpr::Insert { source, rows } => {
+                let src = sources.take_table(&source).unwrap();
                 self._execute_insert(&src, rows)
             }
             CrudExpr::Update {
                 delete,
                 mut assignments,
             } => {
-                let table = delete.source.clone();
-                let result = self._eval_query(delete, sources)?;
+                let result = self._eval_query(&delete, sources)?;
 
                 let Code::Table(deleted) = result else {
                     return Ok(result);
                 };
-                let table = sources.take_table(&table).unwrap();
+                let table = sources.take_table(&delete.source).unwrap();
                 self._execute_delete(&table, deleted.data.clone())?;
 
                 // Replace the columns in the matched rows with the assigned
@@ -557,7 +557,7 @@ impl ProgramVm for DbProgram<'_, '_> {
 
                 self._execute_insert(&table, insert_rows)
             }
-            CrudExpr::Delete { query } => self._delete_query(query, sources),
+            CrudExpr::Delete { query } => self._delete_query(&query, sources),
             CrudExpr::CreateTable { table } => self._create_table(table),
             CrudExpr::Drop { name, kind, .. } => self._drop(&name, kind),
         }

--- a/crates/sats/src/relation.rs
+++ b/crates/sats/src/relation.rs
@@ -110,6 +110,16 @@ pub enum FieldExpr {
     Value(AlgebraicValue),
 }
 
+impl FieldExpr {
+    /// Returns a borrowed version of `FieldExpr`.
+    pub fn borrowed(&self) -> FieldExprRef<'_> {
+        match self {
+            Self::Name(x) => FieldExprRef::Name(x),
+            Self::Value(x) => FieldExprRef::Value(x),
+        }
+    }
+}
+
 impl fmt::Display for FieldName {
     fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
         match self {
@@ -136,6 +146,13 @@ impl fmt::Display for FieldExpr {
             }
         }
     }
+}
+
+/// A borrowed version of `FieldExpr`.
+#[derive(Clone, Copy)]
+pub enum FieldExprRef<'a> {
+    Name(&'a FieldName),
+    Value(&'a AlgebraicValue),
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq, Ord, PartialOrd, Hash)]

--- a/crates/vm/src/program.rs
+++ b/crates/vm/src/program.rs
@@ -78,7 +78,7 @@ impl ProgramVm for Program {
                     panic!("DB not set")
                 };
 
-                let result = build_query(result, query.query, sources)?;
+                let result = build_query(result, &query.query, sources)?;
 
                 let head = result.head().clone();
                 let rows: Vec<_> = result.collect_vec(|row| row.into_product_value())?;


### PR DESCRIPTION
# Description of Changes

Fixes #833 

Perf numbers on my machine:

```
Benchmarking incr-join: Collecting 100 samples in estimated 5.01
incr-join               time:   [5.0575 µs 5.0914 µs 5.1521 µs]
                        change: [-19.535% -18.714% -17.870%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking query-indexes-multi: Collecting 100 samples in esti
query-indexes-multi     time:   [1.0330 µs 1.0387 µs 1.0457 µs]
                        change: [-13.574% -12.820% -12.213%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

No changes semantically; should be covered by existing tests.