### PR TITLE
Commitlog: panic on fsync failure

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2338,9 +2338,9 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.150"
+version = "0.2.153"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "89d92a4743f9a61002fae18374ed11e7973f530cb3a3255fb354818118b2203c"
+checksum = "9c198f91728a82281a64e1f4f9eeb25d82cb32a5de251c6bd1b5154d63a8e7bd"
 
 [[package]]
 name = "libloading"
@@ -4489,7 +4489,6 @@ dependencies = [
  "spacetimedb-sats",
  "tempfile",
  "thiserror",
- "tokio",
 ]
 
 [[package]]

--- a/crates/commitlog/Cargo.toml
+++ b/crates/commitlog/Cargo.toml
@@ -19,7 +19,6 @@ serde = { workspace = true, optional = true }
 spacetimedb-primitives.workspace = true
 spacetimedb-sats.workspace = true
 thiserror.workspace = true
-tokio.workspace = true
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/crates/commitlog/src/commit.rs
+++ b/crates/commitlog/src/commit.rs
@@ -53,7 +53,7 @@ impl Header {
 }
 
 /// Entry type of a [`crate::Commitlog`].
-#[derive(Debug, Default, PartialEq)]
+#[derive(Clone, Debug, Default, PartialEq)]
 pub struct Commit {
     /// The offset of the first record in this commit.
     ///

--- a/crates/commitlog/src/commit.rs
+++ b/crates/commitlog/src/commit.rs
@@ -110,6 +110,79 @@ impl Commit {
     /// Verifies the checksum of the commit. If it doesn't match, an error of
     /// kind [`io::ErrorKind::InvalidData`] with an inner error downcastable to
     /// [`ChecksumMismatch`] is returned.
+    ///
+    /// To retain access to the checksum, use [`StoredCommit::decode`].
+    pub fn decode<R: Read>(reader: R) -> io::Result<Option<Self>> {
+        let commit = StoredCommit::decode(reader)?;
+        Ok(commit.map(Into::into))
+    }
+
+    /// Convert `self` into an iterator yielding [`Transaction`]s.
+    ///
+    /// The supplied [`Decoder`] is responsible for extracting individual
+    /// transactions from the `records` buffer.
+    pub fn into_transactions<D: Decoder>(
+        self,
+        version: u8,
+        de: &D,
+    ) -> impl Iterator<Item = Result<Transaction<D::Record>, D::Error>> + '_ {
+        let records = Cursor::new(self.records);
+        (self.min_tx_offset..(self.min_tx_offset + self.n as u64)).scan(records, move |recs, offset| {
+            let mut cursor = &*recs;
+            let tx = de
+                .decode_record(version, offset, &mut cursor)
+                .map(|txdata| Transaction { offset, txdata });
+            Some(tx)
+        })
+    }
+}
+
+impl From<StoredCommit> for Commit {
+    fn from(
+        StoredCommit {
+            min_tx_offset,
+            n,
+            records,
+            checksum: _,
+        }: StoredCommit,
+    ) -> Self {
+        Self {
+            min_tx_offset,
+            n,
+            records,
+        }
+    }
+}
+
+/// A [`Commit`] as stored on disk.
+///
+/// Differs from [`Commit`] only in the presence of a `checksum` field, which
+/// is computed when encoding a commit for storage.
+#[derive(Debug, PartialEq)]
+pub struct StoredCommit {
+    /// See [`Commit::min_tx_offset`].
+    pub min_tx_offset: u64,
+    /// See [`Commit::n`].
+    pub n: u16,
+    /// See [`Commit::records`].
+    pub records: Vec<u8>,
+    /// The checksum computed when encoding a [`Commit`] for storage.
+    pub checksum: u32,
+}
+
+impl StoredCommit {
+    /// The range of transaction offsets contained in this commit.
+    pub fn tx_range(&self) -> Range<u64> {
+        self.min_tx_offset..self.min_tx_offset + self.n as u64
+    }
+
+    /// Attempt to read one [`StoredCommit`] from the given [`Read`]er.
+    ///
+    /// Returns `None` if the reader is already at EOF.
+    ///
+    /// Verifies the checksum of the commit. If it doesn't match, an error of
+    /// kind [`io::ErrorKind::InvalidData`] with an inner error downcastable to
+    /// [`ChecksumMismatch`] is returned.
     pub fn decode<R: Read>(reader: R) -> io::Result<Option<Self>> {
         let mut reader = Crc32cReader::new(reader);
 
@@ -130,22 +203,20 @@ impl Commit {
             min_tx_offset: hdr.min_tx_offset,
             n: hdr.n,
             records,
+            checksum: crc,
         }))
     }
 
+    /// Convert `self` into an iterator yielding [`Transaction`]s.
+    ///
+    /// The supplied [`Decoder`] is responsible for extracting individual
+    /// transactions from the `records` buffer.
     pub fn into_transactions<D: Decoder>(
         self,
         version: u8,
         de: &D,
     ) -> impl Iterator<Item = Result<Transaction<D::Record>, D::Error>> + '_ {
-        let records = Cursor::new(self.records);
-        (self.min_tx_offset..(self.min_tx_offset + self.n as u64)).scan(records, move |recs, offset| {
-            let mut cursor = &*recs;
-            let tx = de
-                .decode_record(version, offset, &mut cursor)
-                .map(|txdata| Transaction { offset, txdata });
-            Some(tx)
-        })
+        Commit::from(self).into_transactions(version, de)
     }
 }
 
@@ -209,9 +280,9 @@ mod tests {
 
         let mut buf = Vec::with_capacity(commit.encoded_len());
         commit.write(&mut buf).unwrap();
-        let commit2 = Commit::decode(&mut buf.as_slice()).unwrap();
+        let commit2 = Commit::decode(&mut buf.as_slice()).unwrap().unwrap();
 
-        assert_eq!(Some(commit), commit2);
+        assert_eq!(commit, commit2);
     }
 
     #[test]

--- a/crates/commitlog/src/error.rs
+++ b/crates/commitlog/src/error.rs
@@ -19,6 +19,13 @@ pub enum Traversal {
         #[source]
         prev_error: Option<Box<Self>>,
     },
+    /// The log is considered forked iff a commit with the same `min_tx_offset`
+    /// but a different crc32 than the previous commit is encountered.
+    ///
+    /// This may happen in rare circumstances where a write was considered
+    /// failed (e.g. due to a failed `fsync(2)`), when it was actually successful.
+    #[error("forked history: offset={offset}")]
+    Forked { offset: u64 },
     #[error("failed to decode tx record at offset={offset}")]
     Decode {
         offset: u64,

--- a/crates/commitlog/src/repo/mod.rs
+++ b/crates/commitlog/src/repo/mod.rs
@@ -9,7 +9,7 @@ use crate::{
     Options,
 };
 
-mod fs;
+pub(crate) mod fs;
 #[cfg(test)]
 pub mod mem;
 

--- a/crates/commitlog/src/tests/partial.rs
+++ b/crates/commitlog/src/tests/partial.rs
@@ -12,7 +12,7 @@ use crate::{
     repo::{self, Repo},
     segment::FileLike,
     tests::helpers::enable_logging,
-    Encode, Options, DEFAULT_LOG_FORMAT_VERSION,
+    Commit, Encode, Options, DEFAULT_LOG_FORMAT_VERSION,
 };
 
 #[test]
@@ -88,12 +88,13 @@ fn overwrite_reopen() {
     let mut total_txs = fill_log_enospc(&mut log, num_commits, repeat(txs_per_commit));
 
     let last_segment_offset = repo.existing_offsets().unwrap().last().copied().unwrap();
-    let last_commit = repo::open_segment_reader(&repo, DEFAULT_LOG_FORMAT_VERSION, last_segment_offset)
+    let last_commit: Commit = repo::open_segment_reader(&repo, DEFAULT_LOG_FORMAT_VERSION, last_segment_offset)
         .unwrap()
         .commits()
         .map(Result::unwrap)
         .last()
-        .unwrap();
+        .unwrap()
+        .into();
     debug!("last commit: {last_commit:?}");
     let mut last_segment = repo.open_segment(last_segment_offset).unwrap();
     last_segment


### PR DESCRIPTION
Failure to `fsync(2)` can result in a strange state, in particular if the OS's page cache is used.
The most reasonable thing to do is to crash the application and force it re-read the filesystem state from disk.

Because we sync asynchronously, this means that we need to panic.

Please read the commit messages for more context.
You may also be interested in [this study](https://www.usenix.org/system/files/atc20-rebello.pdf).