### PR TITLE
Remove useless usages of RowCount

### DIFF
--- a/crates/core/src/db/cursor.rs
+++ b/crates/core/src/db/cursor.rs
@@ -1,18 +1,10 @@
 use std::ops::RangeBounds;
 
 use crate::error::DBError;
-use spacetimedb_sats::relation::{DbTable, RowCount};
-use spacetimedb_sats::{AlgebraicValue, ProductValue};
+use spacetimedb_sats::relation::DbTable;
+use spacetimedb_sats::AlgebraicValue;
 
 use super::datastore::locking_tx_datastore::{Iter, IterByColRange};
-
-#[derive(Debug, Clone, Copy)]
-pub enum CatalogKind {
-    Table,
-    Column,
-    Index,
-    Sequence,
-}
 
 /// Common wrapper for relational iterators that work like cursors.
 pub struct TableCursor<'a> {
@@ -36,28 +28,5 @@ pub struct IndexCursor<'a, R: RangeBounds<AlgebraicValue>> {
 impl<'a, R: RangeBounds<AlgebraicValue>> IndexCursor<'a, R> {
     pub fn new(table: &'a DbTable, iter: IterByColRange<'a, R>) -> Result<Self, DBError> {
         Ok(Self { table, iter })
-    }
-}
-
-/// Common wrapper for relational iterators of [Catalog].
-pub struct CatalogCursor<I> {
-    pub(crate) table: DbTable,
-    #[allow(dead_code)]
-    pub(crate) kind: CatalogKind,
-    pub(crate) row_count: RowCount,
-    pub(crate) iter: I,
-}
-
-impl<I> CatalogCursor<I> {
-    pub fn new(table: DbTable, kind: CatalogKind, row_count: RowCount, iter: I) -> Self
-    where
-        I: Iterator<Item = ProductValue>,
-    {
-        Self {
-            table,
-            kind,
-            row_count,
-            iter,
-        }
     }
 }

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -1,6 +1,6 @@
 //! The [DbProgram] that execute arbitrary queries & code against the database.
 
-use crate::db::cursor::{CatalogCursor, IndexCursor, TableCursor};
+use crate::db::cursor::{IndexCursor, TableCursor};
 use crate::db::datastore::locking_tx_datastore::IterByColRange;
 use crate::db::relational_db::{MutTx, RelationalDB, Tx};
 use crate::execution_context::ExecutionContext;
@@ -10,7 +10,7 @@ use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::Address;
 use spacetimedb_primitives::*;
 use spacetimedb_sats::db::def::TableDef;
-use spacetimedb_sats::relation::{DbTable, FieldExpr, FieldExprRef, FieldName, Header, Relation, RowCount};
+use spacetimedb_sats::relation::{DbTable, FieldExpr, FieldExprRef, FieldName, Header, Relation};
 use spacetimedb_sats::{AlgebraicValue, ProductValue};
 use spacetimedb_vm::errors::ErrorVm;
 use spacetimedb_vm::eval::IterRows;
@@ -339,10 +339,6 @@ impl<'a, Rhs: RelOps<'a>> RelOps<'a> for IndexSemiJoin<'a, '_, Rhs> {
         }
     }
 
-    fn row_count(&self) -> RowCount {
-        RowCount::unknown()
-    }
-
     fn next(&mut self) -> Result<Option<RelValue<'a>>, ErrorVm> {
         // Return a value from the current index iterator, if not exhausted.
         if self.return_index_rows {
@@ -569,10 +565,6 @@ impl<'a> RelOps<'a> for TableCursor<'a> {
         &self.table.head
     }
 
-    fn row_count(&self) -> RowCount {
-        RowCount::unknown()
-    }
-
     fn next(&mut self) -> Result<Option<RelValue<'a>>, ErrorVm> {
         Ok(self.iter.next().map(RelValue::Row))
     }
@@ -583,26 +575,8 @@ impl<'a, R: RangeBounds<AlgebraicValue>> RelOps<'a> for IndexCursor<'a, R> {
         &self.table.head
     }
 
-    fn row_count(&self) -> RowCount {
-        RowCount::unknown()
-    }
-
     fn next(&mut self) -> Result<Option<RelValue<'a>>, ErrorVm> {
         Ok(self.iter.next().map(RelValue::Row))
-    }
-}
-
-impl<'a, I: Iterator<Item = ProductValue>> RelOps<'a> for CatalogCursor<I> {
-    fn head(&self) -> &Arc<Header> {
-        &self.table.head
-    }
-
-    fn row_count(&self) -> RowCount {
-        self.row_count
-    }
-
-    fn next(&mut self) -> Result<Option<RelValue<'a>>, ErrorVm> {
-        Ok(self.iter.next().map(RelValue::Projection))
     }
 }
 

--- a/crates/sats/src/relation.rs
+++ b/crates/sats/src/relation.rs
@@ -453,11 +453,6 @@ impl RowCount {
     pub fn unknown() -> Self {
         Self { min: 0, max: None }
     }
-
-    pub fn add_exact(&mut self, count: usize) {
-        self.min += count;
-        self.max = Some(self.min);
-    }
 }
 
 /// A [Relation] is anything that could be represented as a [Header] of `[ColumnName:ColumnType]` that


### PR DESCRIPTION
# Description of Changes

`RowCount` is meant to be used to estimate the rows of a query, but we can't do that yet. Remove their uses in `Select` and others where the calculation is useless because in `collect_vec` is asked before is known the number of rows.

# Expected complexity level and risk

1

