### PR TITLE
Generate TypeScript "bigint" type instead of "BigInt"

### DIFF
--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -31,7 +31,7 @@ fn maybe_primitive(b: &BuiltinType) -> MaybePrimitive {
         | BuiltinType::U32
         | BuiltinType::F32
         | BuiltinType::F64 => "number",
-        BuiltinType::I128 | BuiltinType::U128 | BuiltinType::I64 | BuiltinType::U64 => "BigInt",
+        BuiltinType::I128 | BuiltinType::U128 | BuiltinType::I64 | BuiltinType::U64 => "bigint",
         BuiltinType::String => "string",
         BuiltinType::Array(ty) => return MaybePrimitive::Array(ty),
         BuiltinType::Map(m) => return MaybePrimitive::Map(m),


### PR DESCRIPTION
# Description of Changes

Generate the TypeScript `bigint` type instead of `BigInt` ([context from the TS docs](https://www.typescriptlang.org/docs/handbook/release-notes/typescript-3-2.html#bigint)).

# API and ABI breaking changes

This is probably not a notable API change, although it's technically tweaking a type definition in code generated for client use so I'm calling that out here just in case.

# Expected complexity level and risk

2

I'm only marking this as a 2 and not a 1 because it relates to [another PR](https://github.com/clockworklabs/spacetimedb-typescript-sdk/pull/37) in `clockworklabs/spacetimedb-typescript-sdk`. I don't believe there's a release dependency between these two PRs.

# Testing

`cargo test` still passes. I also tried this change locally and it worked as expected for my `u64` case, where it generated `bigint` types where expected and the code still ran fine in the browser with no TypeScript warnings/errors.

I haven't added any tests to test specifically for `bigint` generation.

- [x] `cargo test` (including `test_typescript_codegen_output`)