### PR TITLE
eval_incr: try to keep references to PVs till bsatn, not owned

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4720,6 +4720,7 @@ name = "spacetimedb-vm"
 version = "0.8.2"
 dependencies = [
  "anyhow",
+ "arrayvec",
  "derive_more",
  "itertools 0.12.0",
  "smallvec",

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -3,7 +3,6 @@ use smallvec::SmallVec;
 use spacetimedb_sats::bsatn::ser::BsatnError;
 use spacetimedb_table::table::{RowRef, UniqueConstraintViolation};
 use spacetimedb_vm::relation::RelValue;
-use std::iter;
 use std::ops::DerefMut;
 use std::sync::Arc;
 
@@ -22,7 +21,7 @@ use spacetimedb_primitives::{ColId, ColListBuilder, TableId};
 use spacetimedb_sats::db::def::{IndexDef, IndexType};
 use spacetimedb_sats::relation::{FieldExpr, FieldName};
 use spacetimedb_sats::{ProductType, Typespace};
-use spacetimedb_vm::expr::ColumnOp;
+use spacetimedb_vm::expr::{ColumnOp, NoInMemUsed};
 
 #[derive(Clone)]
 pub struct InstanceEnv {
@@ -369,7 +368,7 @@ impl InstanceEnv {
 
         let tx: TxMode = tx.into();
         // SQL queries can never reference `MemTable`s, so pass in an empty set.
-        let mut query = build_query::<iter::Empty<_>>(ctx, stdb, &tx, &query, &mut |_| None)?;
+        let mut query = build_query(ctx, stdb, &tx, &query, &mut NoInMemUsed)?;
 
         // write all rows and flush at row boundaries.
         let mut chunked_writer = ChunkedWriter::default();

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -3,6 +3,7 @@ use smallvec::SmallVec;
 use spacetimedb_sats::bsatn::ser::BsatnError;
 use spacetimedb_table::table::{RowRef, UniqueConstraintViolation};
 use spacetimedb_vm::relation::RelValue;
+use std::iter;
 use std::ops::DerefMut;
 use std::sync::Arc;
 
@@ -21,7 +22,7 @@ use spacetimedb_primitives::{ColId, ColListBuilder, TableId};
 use spacetimedb_sats::db::def::{IndexDef, IndexType};
 use spacetimedb_sats::relation::{FieldExpr, FieldName};
 use spacetimedb_sats::{ProductType, Typespace};
-use spacetimedb_vm::expr::{ColumnOp, SourceSet};
+use spacetimedb_vm::expr::ColumnOp;
 
 #[derive(Clone)]
 pub struct InstanceEnv {
@@ -367,8 +368,8 @@ impl InstanceEnv {
         // Invent a system where we can make these kinds of "optimization path tests".
 
         let tx: TxMode = tx.into();
-        // SQL queries can never reference `MemTable`s, so pass in an empty `SourceSet`.
-        let mut query = build_query(ctx, stdb, &tx, &query, &mut SourceSet::default())?;
+        // SQL queries can never reference `MemTable`s, so pass in an empty set.
+        let mut query = build_query::<iter::Empty<_>>(ctx, stdb, &tx, &query, &mut |_| None)?;
 
         // write all rows and flush at row boundaries.
         let mut chunked_writer = ChunkedWriter::default();

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -166,7 +166,7 @@ mod tests {
         tx: &Tx,
         query: &QueryExpr,
         auth: AuthCtx,
-        sources: SourceSet<MemTable, N>,
+        sources: SourceSet<Vec<ProductValue>, N>,
     ) -> Result<Vec<MemTable>, DBError> {
         let mut tx = tx.into();
         let p = &mut DbProgram::new(cx, db, &mut tx, auth);
@@ -275,7 +275,10 @@ mod tests {
 
     /// Replace the primary (ie. `source`) table of the given [`QueryExpr`] with
     /// a virtual [`MemTable`] consisting of the rows in [`DatabaseTableUpdate`].
-    fn query_to_mem_table(mut of: QueryExpr, data: &DatabaseTableUpdate) -> (QueryExpr, SourceSet<MemTable, 1>) {
+    fn query_to_mem_table(
+        mut of: QueryExpr,
+        data: &DatabaseTableUpdate,
+    ) -> (QueryExpr, SourceSet<Vec<ProductValue>, 1>) {
         let data = data.ops.iter().map(|op| op.row.clone()).collect();
         let mem_table = MemTable::new(of.source.head().clone(), of.source.table_access(), data);
         let mut sources = SourceSet::empty();

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -558,7 +558,7 @@ fn with_delta_table(
     mut join: IndexJoin,
     index_side: Option<Vec<ProductValue>>,
     probe_side: Option<Vec<ProductValue>>,
-) -> (IndexJoin, SourceSet<MemTable, 2>) {
+) -> (IndexJoin, SourceSet<Vec<ProductValue>, 2>) {
     let mut sources = SourceSet::empty();
 
     if let Some(index_side) = index_side {

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -750,7 +750,7 @@ mod tests {
         let IndexJoin {
             probe_side:
                 QueryExpr {
-                    source: SourceExpr::MemTable { .. },
+                    source: SourceExpr::InMemory { .. },
                     query: ref lhs,
                 },
             probe_field:
@@ -837,7 +837,7 @@ mod tests {
         let IndexJoin {
             probe_side:
                 QueryExpr {
-                    source: SourceExpr::MemTable { .. },
+                    source: SourceExpr::InMemory { .. },
                     query: ref rhs,
                 },
             probe_field:

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -399,7 +399,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
         tracing::trace!(table = query.source.table_name());
 
         let result = build_query(self.ctx, self.db, self.tx, query, &mut |id| {
-            sources.take(id).map(|mt| mt.data.into_iter().map(RelValue::Projection))
+            sources.take(id).map(|mt| mt.into_iter().map(RelValue::Projection))
         })?;
         let head = result.head().clone();
         let rows = result.collect_vec(|row| row.into_product_value())?;

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -12,6 +12,7 @@ spacetimedb-primitives.workspace = true
 spacetimedb-table.workspace = true
 
 anyhow.workspace = true
+arrayvec.workspace = true
 derive_more.workspace = true
 itertools.workspace = true
 smallvec.workspace = true

--- a/crates/vm/src/dsl.rs
+++ b/crates/vm/src/dsl.rs
@@ -13,7 +13,7 @@ pub fn scalar<T: Into<AlgebraicValue>>(of: T) -> AlgebraicValue {
     of.into()
 }
 
-pub fn value<T: Into<AlgebraicValue>>(of: T) -> Expr {
+pub fn value(of: impl Into<AlgebraicValue>) -> Expr {
     let v: AlgebraicValue = of.into();
     Expr::Value(v)
 }

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -93,7 +93,10 @@ pub fn build_query<'a, const N: usize>(
     Ok(result)
 }
 
-fn build_source_expr_query<'a, const N: usize>(sources: Sources<'_, N>, source: &SourceExpr) -> Box<IterRows<'a>> {
+pub(crate) fn build_source_expr_query<'a, const N: usize>(
+    sources: Sources<'_, N>,
+    source: &SourceExpr,
+) -> Box<IterRows<'a>> {
     let source_id = source.source_id().unwrap_or_else(|| todo!("How pass the db iter?"));
     let head = source.head().clone();
     let rc = source.row_count();

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -1,10 +1,10 @@
 use crate::errors::ErrorVm;
-use crate::expr::{Code, SourceSet};
+use crate::expr::{Code, SourceExpr, SourceSet};
 use crate::expr::{Expr, Query};
 use crate::iterators::RelIter;
-use crate::program::ProgramVm;
+use crate::program::{ProgramVm, Sources};
 use crate::rel_ops::RelOps;
-use crate::relation::RelValue;
+use crate::relation::{MemTable, RelValue};
 use spacetimedb_sats::relation::{FieldExprRef, Relation};
 use std::sync::Arc;
 
@@ -15,10 +15,10 @@ pub type IterRows<'a> = dyn RelOps<'a> + 'a;
 /// While constructing the query, the `sources` will be destructively modified with `Option::take`
 /// to extract the sources,
 /// so the `query` cannot refer to the same `SourceId` multiple times.
-pub fn build_query<'a>(
+pub fn build_query<'a, const N: usize>(
     mut result: Box<IterRows<'a>>,
     query: &'a [Query],
-    sources: &mut SourceSet,
+    sources: Sources<'_, N>,
 ) -> Result<Box<IterRows<'a>>, ErrorVm> {
     for q in query {
         result = match q {
@@ -48,22 +48,8 @@ pub fn build_query<'a>(
                 //Pick the smaller set to be at the left
                 let col_lhs = FieldExprRef::Name(&q.col_lhs);
                 let col_rhs = FieldExprRef::Name(&q.col_rhs);
-                let row_rhs = q.rhs.source.row_count();
 
-                let semi = q.semi;
-
-                let head = q.rhs.source.head().clone();
-                let rhs = if let Some(rhs_source_id) = q.rhs.source.source_id() {
-                    let Some(rhs_table) = sources.take_mem_table(rhs_source_id) else {
-                        panic!(
-                            "Query plan specifies a `MemTable` for {rhs_source_id:?}, but found a `DbTable` or nothing"
-                        );
-                    };
-                    Box::new(RelIter::new(head, row_rhs, rhs_table)) as Box<IterRows<'_>>
-                } else {
-                    todo!("How pass the db iter?")
-                };
-
+                let rhs = build_source_expr_query(sources, &q.rhs.source);
                 let rhs = build_query(rhs, &q.rhs.query, sources)?;
 
                 let lhs = result;
@@ -72,7 +58,7 @@ pub fn build_query<'a>(
                 let col_lhs_header = lhs.head().clone();
                 let col_rhs_header = rhs.head().clone();
 
-                if semi {
+                if q.semi {
                     let iter = lhs.join_inner(
                         rhs,
                         col_lhs_header.clone(),
@@ -107,8 +93,20 @@ pub fn build_query<'a>(
     Ok(result)
 }
 
+fn build_source_expr_query<'a, const N: usize>(sources: Sources<'_, N>, source: &SourceExpr) -> Box<IterRows<'a>> {
+    let source_id = source.source_id().unwrap_or_else(|| todo!("How pass the db iter?"));
+    let head = source.head().clone();
+    let rc = source.row_count();
+    match sources.take(source_id) {
+        None => {
+            panic!("Query plan specifies in-mem table for {source_id:?}, but found a `DbTable` or nothing")
+        }
+        Some(t) => Box::new(RelIter::new(head, rc, t.data.into_iter().map(RelValue::Projection))) as Box<IterRows<'a>>,
+    }
+}
+
 /// Execute the code
-pub fn eval<P: ProgramVm>(p: &mut P, code: Code, sources: &mut SourceSet) -> Code {
+pub fn eval<const N: usize, P: ProgramVm>(p: &mut P, code: Code, sources: Sources<'_, N>) -> Code {
     match code {
         c @ (Code::Value(_) | Code::Halt(_) | Code::Table(_)) => c,
         Code::Block(lines) => {
@@ -145,7 +143,7 @@ fn to_vec(of: Vec<Expr>) -> Code {
 }
 
 /// Optimize, compile & run the [Expr]
-pub fn run_ast<P: ProgramVm>(p: &mut P, ast: Expr, mut sources: SourceSet) -> Code {
+pub fn run_ast<const N: usize, P: ProgramVm>(p: &mut P, ast: Expr, mut sources: SourceSet<MemTable, N>) -> Code {
     let code = match ast {
         Expr::Block(x) => to_vec(x),
         Expr::Crud(x) => Code::Crud(*x),
@@ -202,14 +200,13 @@ pub mod tests {
     use crate::expr::SourceSet;
     use crate::program::Program;
     use crate::relation::MemTable;
-    use spacetimedb_lib::identity::AuthCtx;
     use spacetimedb_lib::operator::{OpCmp, OpLogic};
     use spacetimedb_sats::db::auth::StAccess;
     use spacetimedb_sats::db::error::RelationError;
     use spacetimedb_sats::relation::FieldName;
     use spacetimedb_sats::{product, AlgebraicType, ProductType};
 
-    fn run_query(p: &mut Program, ast: Expr, sources: SourceSet) -> MemTable {
+    fn run_query<const N: usize>(p: &mut Program, ast: Expr, sources: SourceSet<MemTable, N>) -> MemTable {
         match run_ast(p, ast, sources) {
             Code::Table(x) => x,
             x => panic!("Unexpected result on query: {x}"),
@@ -218,10 +215,10 @@ pub mod tests {
 
     #[test]
     fn test_select() {
-        let p = &mut Program::new(AuthCtx::for_testing());
+        let p = &mut Program;
         let input = MemTable::from_value(scalar(1));
         let field = input.get_field_pos(0).unwrap().clone();
-        let mut sources = SourceSet::default();
+        let mut sources = SourceSet::<_, 1>::empty();
         let source_expr = sources.add_mem_table(input);
 
         let q = query(source_expr).with_select_cmp(OpCmp::Eq, field, scalar(1));
@@ -239,11 +236,11 @@ pub mod tests {
 
     #[test]
     fn test_project() {
-        let p = &mut Program::new(AuthCtx::for_testing());
+        let p = &mut Program;
         let input = scalar(1);
         let table = MemTable::from_value(scalar(1));
 
-        let mut sources = SourceSet::default();
+        let mut sources = SourceSet::<_, 1>::empty();
         let source_expr = sources.add_mem_table(table.clone());
 
         let source = query(source_expr);
@@ -259,7 +256,7 @@ pub mod tests {
             "Project"
         );
 
-        let mut sources = SourceSet::default();
+        let mut sources = SourceSet::<_, 1>::empty();
         let source_expr = sources.add_mem_table(table.clone());
 
         let source = query(source_expr);
@@ -276,11 +273,11 @@ pub mod tests {
 
     #[test]
     fn test_join_inner() {
-        let p = &mut Program::new(AuthCtx::for_testing());
+        let p = &mut Program;
         let table = MemTable::from_value(scalar(1));
         let field = table.get_field_pos(0).unwrap().clone();
 
-        let mut sources = SourceSet::default();
+        let mut sources = SourceSet::<_, 2>::empty();
         let source_expr = sources.add_mem_table(table.clone());
         let second_source_expr = sources.add_mem_table(table);
 
@@ -303,11 +300,11 @@ pub mod tests {
 
     #[test]
     fn test_semijoin() {
-        let p = &mut Program::new(AuthCtx::for_testing());
+        let p = &mut Program;
         let table = MemTable::from_value(scalar(1));
         let field = table.get_field_pos(0).unwrap().clone();
 
-        let mut sources = SourceSet::default();
+        let mut sources = SourceSet::<_, 2>::empty();
         let source_expr = sources.add_mem_table(table.clone());
         let second_source_expr = sources.add_mem_table(table);
 
@@ -334,7 +331,7 @@ pub mod tests {
 
     #[test]
     fn test_query_logic() {
-        let p = &mut Program::new(AuthCtx::for_testing());
+        let p = &mut Program;
 
         let inv = ProductType::from([("id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
 
@@ -343,7 +340,7 @@ pub mod tests {
         let input = mem_table(inv, vec![row]);
         let inv = input.clone();
 
-        let mut sources = SourceSet::default();
+        let mut sources = SourceSet::<_, 1>::empty();
         let source_expr = sources.add_mem_table(input.clone());
 
         let q = query(source_expr.clone()).with_select_cmp(OpLogic::And, scalar(true), scalar(true));
@@ -352,7 +349,7 @@ pub mod tests {
 
         assert_eq!(result, Code::Table(inv.clone()), "Query And");
 
-        let mut sources = SourceSet::default();
+        let mut sources = SourceSet::<_, 1>::empty();
         let source_expr = sources.add_mem_table(input);
 
         let q = query(source_expr).with_select_cmp(OpLogic::Or, scalar(true), scalar(false));
@@ -366,7 +363,7 @@ pub mod tests {
     /// Inventory
     /// | id: u64 | name : String |
     fn test_query_inner_join() {
-        let p = &mut Program::new(AuthCtx::for_testing());
+        let p = &mut Program;
 
         let inv = ProductType::from([("id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
 
@@ -375,7 +372,7 @@ pub mod tests {
         let input = mem_table(inv, vec![row]);
         let field = input.get_field_pos(0).unwrap().clone();
 
-        let mut sources = SourceSet::default();
+        let mut sources = SourceSet::<_, 2>::empty();
         let source_expr = sources.add_mem_table(input.clone());
         let second_source_expr = sources.add_mem_table(input);
 
@@ -401,7 +398,7 @@ pub mod tests {
     /// Inventory
     /// | id: u64 | name : String |
     fn test_query_semijoin() {
-        let p = &mut Program::new(AuthCtx::for_testing());
+        let p = &mut Program;
 
         let inv = ProductType::from([("id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
 
@@ -410,7 +407,7 @@ pub mod tests {
         let input = mem_table(inv, vec![row]);
         let field = input.get_field_pos(0).unwrap().clone();
 
-        let mut sources = SourceSet::default();
+        let mut sources = SourceSet::<_, 2>::empty();
         let source_expr = sources.add_mem_table(input.clone());
         let second_source_expr = sources.add_mem_table(input);
 
@@ -436,7 +433,7 @@ pub mod tests {
     /// Location
     /// | entity_id: u64 | x : f32 | z : f32 |
     fn test_query_game() {
-        let p = &mut Program::new(AuthCtx::for_testing());
+        let p = &mut Program;
 
         let data = create_game_data();
 
@@ -449,7 +446,7 @@ pub mod tests {
         let location_x = data.location.get_field_named("x").unwrap().clone();
         let location_z = data.location.get_field_named("z").unwrap().clone();
 
-        let mut sources = SourceSet::default();
+        let mut sources = SourceSet::<_, 2>::empty();
         let player_source_expr = sources.add_mem_table(data.player.clone());
         let location_source_expr = sources.add_mem_table(data.location.clone());
 
@@ -480,7 +477,7 @@ pub mod tests {
 
         assert_eq!(result.as_without_table_name(), input.as_without_table_name(), "Player");
 
-        let mut sources = SourceSet::default();
+        let mut sources = SourceSet::<_, 3>::empty();
         let player_source_expr = sources.add_mem_table(data.player);
         let location_source_expr = sources.add_mem_table(data.location);
         let inventory_source_expr = sources.add_mem_table(data.inv);

--- a/crates/vm/src/program.rs
+++ b/crates/vm/src/program.rs
@@ -24,17 +24,6 @@ pub trait ProgramVm {
 
 pub type Sources<'a, const N: usize> = &'a mut SourceSet<MemTable, N>;
 
-pub struct ProgramStore<P> {
-    pub p: P,
-    pub code: Code,
-}
-
-impl<P> ProgramStore<P> {
-    pub fn new(p: P, code: Code) -> Self {
-        Self { p, code }
-    }
-}
-
 /// A default program that run in-memory without a database
 pub struct Program;
 

--- a/crates/vm/src/relation.rs
+++ b/crates/vm/src/relation.rs
@@ -183,6 +183,7 @@ impl MemTable {
         }
     }
 
+    /// For testing purposes only this provides a single-col header / product value.
     pub fn from_value(of: AlgebraicValue) -> Self {
         let head = Header::for_mem_table(of.type_of().into());
         Self::new(Arc::new(head), StAccess::Public, [of.into()].into())


### PR DESCRIPTION
# Description of Changes

## Changes

Closes https://github.com/clockworklabs/SpacetimeDB/issues/998.

- Add `RelValue::ProjRef(&'a ProductValue)` to avoid cloning PVs. Various cow-like types are added so that we can instead go from a reference to a PV to bsatn in incremental evaluation.
- As a consequence to the above, the way sources are passed is changed to be generic, with the trait `SourceProvider`. An in-memory table is now any `Iterator<Item = RelValue<'a>>`.

```
Benchmarking incr-select: Collecting 100 samples in estimated 5.0000 
incr-select             time:   [238.90 ns 240.17 ns 241.72 ns]
                        change: [-45.577% -45.329% -45.079%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  3 (3.00%) high mild
  10 (10.00%) high severe

Benchmarking incr-join: Collecting 100 samples in estimated 5.0065 s 
incr-join               time:   [1.9816 µs 1.9931 µs 2.0088 µs]
                        change: [-25.185% -24.919% -24.651%] (p = 0.00 < 0.05)
                        Performance has improved.
```

Relative to before 1st commit, on i7-7700K, 64gb ram.

# API and ABI breaking changes

None

# Expected complexity level and risk

2

# Testing

No semantic changes, existing tests should cover this.