### PR TITLE
test: Subscriptions should not drop read lock early

### DIFF
--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -226,9 +226,13 @@ impl ClientConnection {
 
     pub async fn subscribe(&self, subscription: Subscribe, timer: Instant) -> Result<(), DBError> {
         let me = self.clone();
-        tokio::task::spawn_blocking(move || me.module.subscriptions().add_subscriber(me.sender, subscription, timer))
-            .await
-            .unwrap()
+        tokio::task::spawn_blocking(move || {
+            me.module
+                .subscriptions()
+                .add_subscriber(me.sender, subscription, timer, None)
+        })
+        .await
+        .unwrap()
     }
 
     pub async fn one_off_query(&self, query: &str, message_id: &[u8], timer: Instant) -> Result<(), anyhow::Error> {

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -4,7 +4,7 @@ use super::query::compile_read_only_query;
 use super::subscription::ExecutionSet;
 use crate::client::messages::{SubscriptionUpdate, SubscriptionUpdateMessage, TransactionUpdateMessage};
 use crate::client::{ClientActorId, ClientConnectionSender};
-use crate::db::relational_db::RelationalDB;
+use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::{DBError, SubscriptionError};
 use crate::execution_context::ExecutionContext;
 use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent};
@@ -24,6 +24,8 @@ pub struct ModuleSubscriptions {
     owner_identity: Identity,
 }
 
+type AssertTxFn = Arc<dyn Fn(&Tx)>;
+
 impl ModuleSubscriptions {
     pub fn new(relational_db: Arc<RelationalDB>, owner_identity: Identity) -> Self {
         Self {
@@ -40,6 +42,7 @@ impl ModuleSubscriptions {
         sender: Arc<ClientConnectionSender>,
         subscription: Subscribe,
         timer: Instant,
+        _assert: Option<AssertTxFn>,
     ) -> Result<(), DBError> {
         let tx = scopeguard::guard(self.relational_db.begin_tx(), |tx| {
             let ctx = ExecutionContext::subscribe(self.relational_db.address());
@@ -92,6 +95,12 @@ impl ModuleSubscriptions {
             .subscription_queries
             .with_label_values(&self.relational_db.address())
             .set(num_queries as i64);
+
+        #[cfg(test)]
+        if let Some(assert) = _assert {
+            let tx = self.relational_db.begin_tx();
+            assert(&tx);
+        }
 
         // NOTE: It is important to send the state in this thread because if you spawn a new
         // thread it's possible for messages to get sent to the client out of order. If you do
@@ -164,5 +173,76 @@ impl ModuleSubscriptions {
     /// x after they receive this subscription update).
     fn broadcast_commit_event(&self, subscriptions: &SubscriptionManager, event: Arc<ModuleEvent>) {
         subscriptions.eval_updates(&self.relational_db, &event)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::ModuleSubscriptions;
+    use crate::client::{ClientActorId, ClientConnectionSender, Protocol};
+    use crate::db::relational_db::tests_utils::make_test_db;
+    use crate::execution_context::ExecutionContext;
+    use spacetimedb_client_api_messages::client_api::Subscribe;
+    use spacetimedb_lib::{error::ResultTest, AlgebraicType, Identity};
+    use spacetimedb_sats::product;
+    use std::time::Instant;
+    use std::{sync::Arc, time::Duration};
+    use tokio::{runtime::Builder, sync::mpsc};
+
+    #[test]
+    #[ignore = "before #997"]
+    /// Asserts that a subscription holds a tx handle for the entire length of its evaluation.
+    fn test_tx_subscription_ordering() -> ResultTest<()> {
+        let runtime = Builder::new_multi_thread().enable_all().build().unwrap();
+
+        // Create table with one row
+        let db = Arc::new(make_test_db()?.0);
+        let table_id = db.create_table_for_test("T", &[("a", AlgebraicType::U8)], &[])?;
+        db.with_auto_commit(&ExecutionContext::default(), |tx| {
+            db.insert(tx, table_id, product!(1_u8))
+        })?;
+
+        let id = Identity::ZERO;
+        let client = ClientActorId::for_test(id);
+        let sender = Arc::new(ClientConnectionSender::dummy(client, Protocol::Binary));
+        let module_subscriptions = ModuleSubscriptions::new(db.clone(), id);
+
+        let (send, mut recv) = mpsc::unbounded_channel();
+
+        // Subscribing to T should return a single row
+        let query_handle = runtime.spawn_blocking(move || {
+            let db = module_subscriptions.relational_db.clone();
+            // Wake up writer thread after starting the reader thread
+            let _ = send.send(());
+            let query_strings = vec!["select * from T".into()];
+            module_subscriptions.add_subscriber(
+                sender,
+                Subscribe {
+                    query_strings,
+                    request_id: 0,
+                },
+                Instant::now(),
+                Some(Arc::new(move |tx: &_| {
+                    std::thread::sleep(Duration::from_secs(1));
+                    let ctx = ExecutionContext::default();
+                    // Assuming subscription evaluation holds a lock on the db,
+                    // any mutations to T will necessarily occur after,
+                    // and therefore we should only see a single row returned.
+                    assert_eq!(1, db.iter(&ctx, tx, table_id).unwrap().count());
+                })),
+            )
+        });
+
+        // Write a second row to T concurrently with the reader thread
+        let write_handle = runtime.spawn(async move {
+            let _ = recv.recv().await;
+            db.with_auto_commit(&ExecutionContext::default(), |tx| {
+                db.insert(tx, table_id, product!(2_u8))
+            })
+        });
+
+        runtime.block_on(write_handle)??;
+        runtime.block_on(query_handle)??;
+        Ok(())
     }
 }


### PR DESCRIPTION
If a subscription drops its read lock on the database too early, that is before it sends its updates to the client, this test will fail.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
