### PR TITLE
Show the error text of the server when a sql call fails on cli

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4375,6 +4375,7 @@ dependencies = [
  "tar",
  "tempfile",
  "termcolor",
+ "thiserror",
  "tokio",
  "toml 0.8.2",
  "wasmbin",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -52,6 +52,7 @@ tabled.workspace = true
 tar.workspace = true
 tempfile.workspace = true
 termcolor.workspace = true
+thiserror.workspace = true
 tokio.workspace = true
 toml.workspace = true
 wasmbin.workspace = true

--- a/crates/cli/src/errors.rs
+++ b/crates/cli/src/errors.rs
@@ -1,0 +1,35 @@
+use reqwest::{Response, StatusCode};
+use thiserror::Error;
+
+#[derive(Debug)]
+pub enum RequestSource {
+    Client,
+    Server,
+}
+
+#[derive(Error, Debug)]
+pub enum CliError {
+    #[error("HTTP status {kind:?} error ({status}): {msg}")]
+    Request {
+        msg: String,
+        kind: RequestSource,
+        status: StatusCode,
+    },
+    #[error(transparent)]
+    ReqWest(#[from] reqwest::Error),
+}
+
+/// Turn a response into an error if the server returned an error.
+pub async fn error_for_status(response: Response) -> Result<Response, CliError> {
+    let status = response.status();
+    if let Some(kind) = status
+        .is_client_error()
+        .then_some(RequestSource::Client)
+        .or_else(|| status.is_client_error().then_some(RequestSource::Server))
+    {
+        let msg = response.text().await?;
+        return Err(CliError::Request { kind, msg, status });
+    }
+
+    Ok(response)
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,9 +1,11 @@
 pub mod api;
 mod config;
 mod edit_distance;
+mod errors;
 mod subcommands;
 mod tasks;
 pub mod util;
+
 use clap::{ArgMatches, Command};
 
 pub use config::Config;

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -9,6 +9,7 @@ use spacetimedb_lib::sats::{satn, Typespace};
 use tabled::settings::Style;
 
 use crate::config::Config;
+use crate::errors::error_for_status;
 use crate::util::{database_address, get_auth_header_only};
 
 pub fn cli() -> clap::Command {
@@ -88,11 +89,8 @@ fn print_timings(now: Instant) {
 pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool) -> Result<(), anyhow::Error> {
     let now = Instant::now();
 
-    let json = builder
-        .body(sql.to_owned())
-        .send()
+    let json = error_for_status(builder.body(sql.to_owned()).send().await?)
         .await?
-        .error_for_status()?
         .text()
         .await?;
 


### PR DESCRIPTION
# Description of Changes

Now if a `sql` call fails, it shows the error from the server:

Closes [#1003](https://github.com/clockworklabs/SpacetimeDB/issues/1003)

```sql
🪐quickstart>update IdentityRole set role = "Role.Player" where email = 'test@clockworklabs'
HTTP status Client error (400 Bad Request): SqlError: Unknown field: `Role.Player` not found in the table(s): `["IdentityRole"]`, executing: `update IdentityRole set role = "Role.Player" where email = 'test@clockworklabs'`
🪐quickstart>.exit
```

# API and ABI breaking changes

It changes only what is show on the `cli` on error.

# Expected complexity level and risk

1
# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Manual inspection of the cli*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
