### PR TITLE
fix: Consistency test for subscription message ordering

### DIFF
--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -208,8 +208,6 @@ mod tests {
         // Subscribing to T should return a single row
         let query_handle = runtime.spawn_blocking(move || {
             let db = module_subscriptions.relational_db.clone();
-            // Wake up writer thread after starting the reader thread
-            let _ = send.send(());
             let query_strings = vec!["select * from T".into()];
             module_subscriptions.add_subscriber(
                 sender,
@@ -219,6 +217,9 @@ mod tests {
                 },
                 Instant::now(),
                 Some(Arc::new(move |tx: &_| {
+                    // Wake up writer thread after starting the reader tx
+                    let _ = send.send(());
+                    // Then go to sleep
                     std::thread::sleep(Duration::from_secs(1));
                     let ctx = ExecutionContext::default();
                     // Assuming subscription evaluation holds a lock on the db,


### PR DESCRIPTION
Updates a test to wake up a writer tx only after a reader tx has started.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
