### PR TITLE
Preserve debuginfo (e.g. symbols) in wasm-opt

### DIFF
--- a/crates/cli/src/tasks/mod.rs
+++ b/crates/cli/src/tasks/mod.rs
@@ -16,7 +16,7 @@ pub fn build(project_path: &Path, skip_clippy: bool, build_debug: bool) -> anyho
     if !build_debug {
         eprintln!("Optimising module with wasm-opt...");
         let wasm_path_opt = wasm_path.with_extension("opt.wasm");
-        match cmd!("wasm-opt", "-all", "-O2", &wasm_path, "-o", &wasm_path_opt).run() {
+        match cmd!("wasm-opt", "-all", "-g", "-O2", &wasm_path, "-o", &wasm_path_opt).run() {
             Ok(_) => wasm_path = wasm_path_opt,
             // Non-critical error for backward compatibility with users who don't have wasm-opt.
             Err(err) => {


### PR DESCRIPTION
# Description of Changes

This gives much better information for backtraces, and if the user does want to strip all symbols, they can change the `profile.release.strip` option in their `Cargo.toml`.

# Expected complexity level and risk

1