### PR TITLE
Prune deps from bindings dependency tree

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3757,7 +3757,6 @@ dependencies = [
  "anyhow",
  "log",
  "spacetimedb",
- "spacetimedb-lib",
 ]
 
 [[package]]
@@ -4272,7 +4271,6 @@ dependencies = [
  "bytes",
  "derive_more",
  "log",
- "once_cell",
  "rand 0.8.5",
  "scoped-tls",
  "spacetimedb-bindings-macro",
@@ -4537,8 +4535,6 @@ dependencies = [
  "hex",
  "insta",
  "itertools 0.12.0",
- "once_cell",
- "prometheus",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
@@ -4550,7 +4546,6 @@ dependencies = [
  "spacetimedb-primitives",
  "spacetimedb-sats",
  "thiserror",
- "tracing",
 ]
 
 [[package]]
@@ -4601,7 +4596,6 @@ dependencies = [
  "spacetimedb-metrics",
  "spacetimedb-primitives",
  "thiserror",
- "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -90,7 +90,7 @@ spacetimedb-table = { path = "crates/table", version = "0.8.2" }
 spacetimedb-vm = { path = "crates/vm", version = "0.8.2" }
 
 ahash = "0.8"
-anyhow = { version = "1.0.68", features = ["backtrace"] }
+anyhow = "1.0.68"
 anymap = "0.12"
 arrayvec = "0.7.2"
 async-trait = "0.1.68"

--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -514,7 +514,7 @@ fn spacetimedb_tabletype_impl(item: syn::DeriveInput) -> syn::Result<TokenStream
 
     let get_table_id_func = quote! {
         fn table_id() -> spacetimedb::TableId {
-            static TABLE_ID: spacetimedb::rt::OnceCell<spacetimedb::TableId> = spacetimedb::rt::OnceCell::new();
+            static TABLE_ID: std::sync::OnceLock<spacetimedb::TableId> = std::sync::OnceLock::new();
             *TABLE_ID.get_or_init(|| {
                 spacetimedb::get_table_id(<Self as spacetimedb::TableType>::TABLE_NAME)
             })

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -24,7 +24,6 @@ spacetimedb-primitives.workspace = true
 
 derive_more.workspace = true
 log.workspace = true
-once_cell.workspace = true
 scoped-tls.workspace = true
 
 [dev-dependencies]

--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -4,7 +4,7 @@ use std::any::TypeId;
 use std::collections::{btree_map, BTreeMap};
 use std::fmt;
 use std::marker::PhantomData;
-use std::sync::Mutex;
+use std::sync::{Mutex, OnceLock};
 use std::time::Duration;
 use sys::Buffer;
 
@@ -18,8 +18,6 @@ use spacetimedb_lib::sats::{impl_deserialize, impl_serialize, AlgebraicType, Alg
 use spacetimedb_lib::ser::{Serialize, SerializeSeqProduct};
 use spacetimedb_lib::{bsatn, Address, Identity, MiscModuleExport, ModuleDef, ReducerDef, TableDesc, TypeAlias};
 use spacetimedb_primitives::*;
-
-pub use once_cell::sync::{Lazy, OnceCell};
 
 /// The `sender` invokes `reducer` at `timestamp` and provides it with the given `args`.
 ///
@@ -538,7 +536,7 @@ static DESCRIBERS: Mutex<Vec<fn(&mut ModuleBuilder)>> = Mutex::new(Vec::new());
 
 /// A reducer function takes in `(Sender, Timestamp, Args)` and writes to a new `Buffer`.
 pub type ReducerFn = fn(Buffer, Buffer, u64, &[u8]) -> Buffer;
-static REDUCERS: OnceCell<Vec<ReducerFn>> = OnceCell::new();
+static REDUCERS: OnceLock<Vec<ReducerFn>> = OnceLock::new();
 
 /// Describes the module into a serialized form that is returned and writes the set of `REDUCERS`.
 #[no_mangle]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -19,7 +19,7 @@ name = "odb_flavor_bench"
 harness = false
 
 [dependencies]
-spacetimedb-lib = { workspace = true, features = ["serde"] }
+spacetimedb-lib = { workspace = true, features = ["serde", "metrics"] }
 spacetimedb-client-api-messages.workspace = true
 spacetimedb-metrics.workspace = true
 spacetimedb-primitives.workspace = true
@@ -27,7 +27,7 @@ spacetimedb-sats = { workspace = true, features = ["serde"] }
 spacetimedb-table.workspace = true
 spacetimedb-vm.workspace = true
 
-anyhow.workspace = true
+anyhow = { workspace = true, features = ["backtrace"] }
 async-trait.workspace = true
 backtrace.workspace = true
 base64.workspace = true

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -15,17 +15,18 @@ name = "serde"
 required-features = ["serde"]
 
 [features]
-default = ["serde"]
+default = ["serde", "metrics"]
 serde = ["dep:serde", "spacetimedb-sats/serde", "dep:serde_with", "chrono/serde"]
 cli = ["clap"]
 # Allows using `Arbitrary` impls defined in this crate.
 proptest = ["dep:proptest", "dep:proptest-derive"]
+metrics = ["dep:spacetimedb-metrics", "spacetimedb-sats/metrics"]
 
 [dependencies]
 spacetimedb-bindings-macro.workspace = true
 spacetimedb-sats.workspace = true
 spacetimedb-primitives.workspace = true
-spacetimedb-metrics.workspace = true
+spacetimedb-metrics = { workspace = true, optional = true }
 
 anyhow.workspace = true
 bitflags.workspace = true
@@ -35,12 +36,9 @@ derive_more.workspace = true
 enum-as-inner.workspace = true
 hex.workspace = true
 itertools.workspace = true
-once_cell.workspace = true
-prometheus.workspace = true
 serde = { workspace = true, optional = true, features = ["derive"] }
 serde_with = {workspace = true, optional = true }
 thiserror.workspace = true
-tracing.workspace = true
 
 # For the 'proptest' feature.
 proptest = { workspace = true, optional = true }

--- a/crates/lib/src/address.rs
+++ b/crates/lib/src/address.rs
@@ -2,7 +2,6 @@ use anyhow::Context as _;
 use hex::FromHex as _;
 use sats::{impl_deserialize, impl_serialize, impl_st, AlgebraicType};
 use spacetimedb_bindings_macro::{Deserialize, Serialize};
-use spacetimedb_metrics::typed_prometheus::AsPrometheusLabel;
 use std::{fmt, net::Ipv6Addr};
 
 use crate::sats;
@@ -24,7 +23,8 @@ pub struct Address {
 
 impl_st!([] Address, _ts => AlgebraicType::product([("__address_bytes", AlgebraicType::bytes())]));
 
-impl AsPrometheusLabel for Address {
+#[cfg(feature = "metrics")]
+impl spacetimedb_metrics::typed_prometheus::AsPrometheusLabel for Address {
     fn as_prometheus_str(&self) -> impl AsRef<str> + '_ {
         self.to_hex()
     }

--- a/crates/lib/src/identity.rs
+++ b/crates/lib/src/identity.rs
@@ -1,5 +1,4 @@
 use spacetimedb_bindings_macro::{Deserialize, Serialize};
-use spacetimedb_metrics::typed_prometheus::AsPrometheusLabel;
 use spacetimedb_sats::hex::HexString;
 use spacetimedb_sats::{hash, impl_st, AlgebraicType};
 use std::{fmt, str::FromStr};
@@ -36,7 +35,8 @@ pub struct Identity {
 
 impl_st!([] Identity, _ts => Identity::get_type());
 
-impl AsPrometheusLabel for Identity {
+#[cfg(feature = "metrics")]
+impl spacetimedb_metrics::typed_prometheus::AsPrometheusLabel for Identity {
     fn as_prometheus_str(&self) -> impl AsRef<str> + '_ {
         self.to_hex()
     }

--- a/crates/sats/Cargo.toml
+++ b/crates/sats/Cargo.toml
@@ -11,11 +11,12 @@ description = "Spacetime Algebraic Type Notation"
 serde = ["dep:serde"]
 # Allows using `Arbitrary` impls defined in this crate.
 proptest = ["dep:proptest", "dep:proptest-derive"]
+metrics = ["dep:spacetimedb-metrics"]
 
 [dependencies]
 spacetimedb-bindings-macro.workspace = true
 spacetimedb-primitives.workspace = true
-spacetimedb-metrics.workspace = true
+spacetimedb-metrics = { workspace = true, optional = true }
 
 arrayvec.workspace = true
 bitflags.workspace = true
@@ -31,7 +32,6 @@ sha3.workspace = true
 serde = { workspace = true, optional = true }
 smallvec.workspace = true
 thiserror.workspace = true
-tracing.workspace = true
 
 [dev-dependencies]
 bytes.workspace = true

--- a/crates/sats/src/hash.rs
+++ b/crates/sats/src/hash.rs
@@ -2,7 +2,6 @@ use crate::hex::HexString;
 use crate::{impl_deserialize, impl_serialize, impl_st, AlgebraicType};
 use core::fmt;
 use sha3::{Digest, Keccak256};
-use spacetimedb_metrics::typed_prometheus::AsPrometheusLabel;
 
 pub const HASH_SIZE: usize = 32;
 
@@ -16,7 +15,8 @@ impl_st!([] Hash, _ts => AlgebraicType::bytes());
 impl_serialize!([] Hash, (self, ser) => self.data.serialize(ser));
 impl_deserialize!([] Hash, de => Ok(Self { data: <_>::deserialize(de)? }));
 
-impl AsPrometheusLabel for Hash {
+#[cfg(feature = "metrics")]
+impl spacetimedb_metrics::typed_prometheus::AsPrometheusLabel for Hash {
     fn as_prometheus_str(&self) -> impl AsRef<str> + '_ {
         self.to_hex()
     }

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -12,7 +12,7 @@ spacetimedb-sats.workspace = true
 spacetimedb-lib = { workspace = true, features = ["serde"]}
 spacetimedb-client-api-messages.workspace = true
 
-anyhow.workspace = true
+anyhow = { workspace = true, features = ["backtrace"] }
 anymap.workspace = true
 base64.workspace = true
 futures.workspace = true

--- a/modules/rust-wasm-test/Cargo.toml
+++ b/modules/rust-wasm-test/Cargo.toml
@@ -12,7 +12,6 @@ bench = false
 
 [dependencies]
 spacetimedb = { path = "../../crates/bindings" }
-spacetimedb-lib = { path = "../../crates/lib" } # TODO: this should not ever be necessary. `spacetimedb` should provide all module dependencies.
 
 anyhow.workspace = true
 log.workspace = true

--- a/modules/rust-wasm-test/src/lib.rs
+++ b/modules/rust-wasm-test/src/lib.rs
@@ -1,6 +1,6 @@
 #![allow(clippy::disallowed_names)]
+use spacetimedb::spacetimedb_lib::{self, bsatn};
 use spacetimedb::{query, spacetimedb, Deserialize, ReducerContext, SpacetimeType, Timestamp};
-use spacetimedb_lib::bsatn;
 
 #[spacetimedb(table)]
 #[spacetimedb(index(btree, name = "foo", x))]


### PR DESCRIPTION
# Description of Changes

I noticed that somehow `protobuf` got into the transitive dependencies of `spacetimedb-bindings`. This brings the dependency count from 99 back to a respectable 56.

This makes modules compile quicker, which is good for our CI as well as first impressions of SpacetimeDB as a product. Speaking for myself, I know that I do often judge crates on dependency bloat, and I think 56 transitive dependencies is much more reasonable for a bindings crate than 99 (esp. when a lot of those had no need to be in there).

# Expected complexity level and risk

1