### PR TITLE
Bench for eval add serialization steps

### DIFF
--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -19,7 +19,6 @@ pub struct ClientActorId {
 }
 
 impl ClientActorId {
-    #[cfg(test)]
     pub fn for_test(identity: Identity) -> Self {
         ClientActorId {
             identity,


### PR DESCRIPTION
# Description of Changes

Closes #999

NOTE: The purpose of this PR was changed after talks with @joshua-spacetime.


OLD:

Another serialization benches for both protobuf & bsatn, using `select * from footprint` * 1_000_000 rows.

NOW:

Include the steps of serialization on the `eval` benches to have a full picture of the costs.

# Expected complexity level and risk
1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
