### PR TITLE
Shub/remove lifetime from ctx

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -539,7 +539,7 @@ impl CommittedState {
 }
 
 pub struct CommittedIndexIter<'a> {
-    ctx: &'a ExecutionContext<'a>,
+    ctx: &'a ExecutionContext,
     table_id: TableId,
     tx_state: Option<&'a TxState>,
     committed_state: &'a CommittedState,
@@ -569,7 +569,7 @@ impl<'a> CommittedIndexIter<'a> {
 #[cfg(feature = "metrics")]
 impl Drop for CommittedIndexIter<'_> {
     fn drop(&mut self) {
-        let mut metrics = self.ctx.metrics.borrow_mut();
+        let mut metrics = self.ctx.metrics.write();
         let get_table_name = || {
             self.committed_state
                 .get_schema(&self.table_id)

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -649,10 +649,10 @@ mod tests {
     /// Utility to query the system tables and return their concrete table row
     pub struct SystemTableQuery<'a> {
         db: &'a MutTxId,
-        ctx: &'a ExecutionContext<'a>,
+        ctx: &'a ExecutionContext,
     }
 
-    fn query_st_tables<'a>(ctx: &'a ExecutionContext<'a>, tx: &'a MutTxId) -> SystemTableQuery<'a> {
+    fn query_st_tables<'a>(ctx: &'a ExecutionContext, tx: &'a MutTxId) -> SystemTableQuery<'a> {
         SystemTableQuery { db: tx, ctx }
     }
 

--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -173,7 +173,7 @@ pub(crate) trait StateView {
 }
 
 pub struct Iter<'a> {
-    ctx: &'a ExecutionContext<'a>,
+    ctx: &'a ExecutionContext,
     table_id: TableId,
     tx_state: Option<&'a TxState>,
     committed_state: &'a CommittedState,
@@ -320,7 +320,7 @@ impl<'a> Iterator for Iter<'a> {
 }
 
 pub struct IndexSeekIterMutTxId<'a> {
-    pub(crate) ctx: &'a ExecutionContext<'a>,
+    pub(crate) ctx: &'a ExecutionContext,
     pub(crate) table_id: TableId,
     pub(crate) tx_state: &'a TxState,
     pub(crate) committed_state: &'a CommittedState,

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -33,6 +33,7 @@ pub struct InstanceEnv {
 #[derive(Clone, Default)]
 pub struct TxSlot {
     inner: Arc<Mutex<Option<MutTxId>>>,
+    ctx: Arc<Mutex<Option<ExecutionContext>>>,
 }
 
 #[derive(Default)]
@@ -112,6 +113,10 @@ impl InstanceEnv {
 
     fn get_tx(&self) -> Result<impl DerefMut<Target = MutTxId> + '_, GetTxError> {
         self.tx.get()
+    }
+
+    pub fn get_ctx(&self) -> Result<impl DerefMut<Target = ExecutionContext> + '_, GetTxError> {
+        self.tx.get_ctx()
     }
 
     #[tracing::instrument(skip_all)]
@@ -393,20 +398,35 @@ impl InstanceEnv {
 }
 
 impl TxSlot {
-    pub fn set<T>(&self, tx: MutTxId, f: impl FnOnce() -> T) -> (MutTxId, T) {
+    pub fn set<T>(
+        &mut self,
+        ctx: ExecutionContext,
+        tx: MutTxId,
+        f: impl FnOnce() -> T,
+    ) -> (ExecutionContext, MutTxId, T) {
+        self.ctx.lock().replace(ctx);
         let prev = self.inner.lock().replace(tx);
         assert!(prev.is_none(), "reentrant TxSlot::set");
         let remove_tx = || self.inner.lock().take();
+
+        let remove_ctx = || self.ctx.lock().take();
+
         let res = {
-            scopeguard::defer_on_unwind! { remove_tx(); }
+            scopeguard::defer_on_unwind! { remove_ctx(); remove_tx();}
             f()
         };
+
+        let ctx = remove_ctx().expect("ctx was removed during transaction");
         let tx = remove_tx().expect("tx was removed during transaction");
-        (tx, res)
+        (ctx, tx, res)
     }
 
     pub fn get(&self) -> Result<impl DerefMut<Target = MutTxId> + '_, GetTxError> {
         MutexGuard::try_map(self.inner.lock(), |map| map.as_mut()).map_err(|_| GetTxError)
+    }
+
+    pub fn get_ctx(&self) -> Result<impl DerefMut<Target = ExecutionContext> + '_, GetTxError> {
+        MutexGuard::try_map(self.ctx.lock(), |map| map.as_mut()).map_err(|_| GetTxError)
     }
 }
 

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -271,7 +271,7 @@ pub struct IndexSemiJoin<'a, Rhs: RelOps<'a>> {
     /// A reference to the current transaction.
     pub tx: &'a TxMode<'a>,
     /// The execution context for the current transaction.
-    ctx: &'a ExecutionContext<'a>,
+    ctx: &'a ExecutionContext,
 }
 
 impl<'a, Rhs: RelOps<'a>> IndexSemiJoin<'a, Rhs> {
@@ -347,7 +347,7 @@ impl<'a, Rhs: RelOps<'a>> RelOps<'a> for IndexSemiJoin<'a, Rhs> {
 /// A [ProgramVm] implementation that carry a [RelationalDB] for it
 /// query execution
 pub struct DbProgram<'db, 'tx> {
-    ctx: &'tx ExecutionContext<'tx>,
+    ctx: &'tx ExecutionContext,
     pub(crate) db: &'db RelationalDB,
     pub(crate) tx: &'tx mut TxMode<'tx>,
     pub(crate) auth: AuthCtx,


### PR DESCRIPTION
# Description of Changes
- remove lifeitme depency from `ExecutionContext` by making reducer_name from `&str` -> `String` with only one allocation per reducer call.
- Move Context inside TxSlot so it can be re-usable between ABIs & host for same call.
