### PR TITLE
Implement 'sql' parsing for simple 'Enums'

### DIFF
--- a/crates/core/src/sql/ast.rs
+++ b/crates/core/src/sql/ast.rs
@@ -12,7 +12,7 @@ use spacetimedb_sats::{AlgebraicType, AlgebraicValue, ProductTypeElement};
 use spacetimedb_vm::errors::ErrorVm;
 use spacetimedb_vm::expr::{ColumnOp, DbType, Expr};
 use spacetimedb_vm::operator::{OpCmp, OpLogic, OpQuery};
-use spacetimedb_vm::ops::parse::parse;
+use spacetimedb_vm::ops::parse::{parse, parse_simple_enum};
 use sqlparser::ast::{
     Assignment, BinaryOperator, ColumnDef as SqlColumnDef, ColumnOption, DataType, ExactNumberInfo, Expr as SqlExpr,
     GeneratedAs, HiveDistributionStyle, Ident, JoinConstraint, JoinOperator, ObjectName, ObjectType, Query, Select,
@@ -309,6 +309,17 @@ fn infer_number(field: Option<&ProductTypeElement>, value: &str, is_long: bool) 
     }
 }
 
+/// `Enums` in `sql` are simple strings like `Player` that must be inferred by their type.
+///
+/// If `field` is a `simple enum` it looks for the `tag` specified by `value`, else it should be a plain `String`.
+fn infer_str_or_enum(field: Option<&ProductTypeElement>, value: String) -> Result<AlgebraicValue, ErrorVm> {
+    if let Some(sum) = field.and_then(|x| x.algebraic_type.as_sum()) {
+        parse_simple_enum(sum, &value)
+    } else {
+        Ok(AlgebraicValue::String(value))
+    }
+}
+
 /// Compiles a [SqlExpr] expression into a [ColumnOp]
 fn compile_expr_value(table: &From, field: Option<&ProductTypeElement>, of: SqlExpr) -> Result<ColumnOp, PlanError> {
     Ok(ColumnOp::Field(match of {
@@ -319,7 +330,7 @@ fn compile_expr_value(table: &From, field: Option<&ProductTypeElement>, of: SqlE
         }
         SqlExpr::Value(x) => FieldExpr::Value(match x {
             Value::Number(value, is_long) => infer_number(field, &value, is_long)?,
-            Value::SingleQuotedString(s) => AlgebraicValue::String(s),
+            Value::SingleQuotedString(s) => infer_str_or_enum(field, s)?,
             Value::DoubleQuotedString(s) => AlgebraicValue::String(s),
             Value::Boolean(x) => AlgebraicValue::Bool(x),
             Value::Null => AlgebraicValue::OptionNone(),

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -283,11 +283,16 @@ mod tests {
     use super::*;
     use crate::db::datastore::traits::IsolationLevel;
     use crate::db::relational_db::tests_utils::make_test_db;
+    use crate::execution_context::ExecutionContext;
+    use crate::sql::execute::execute_sql;
+    use crate::vm::tests::create_table_with_rows;
     use spacetimedb_lib::error::ResultTest;
+    use spacetimedb_lib::identity::AuthCtx;
     use spacetimedb_lib::operator::OpQuery;
     use spacetimedb_primitives::{col_list, ColList, TableId};
-    use spacetimedb_sats::{product, AlgebraicType, AlgebraicValue};
+    use spacetimedb_sats::{product, AlgebraicType, AlgebraicValue, ProductType};
     use spacetimedb_vm::expr::{IndexJoin, IndexScan, JoinExpr, Query};
+    use std::convert::From;
     use std::ops::Bound;
 
     fn assert_index_scan(
@@ -1069,6 +1074,27 @@ mod tests {
                 panic!("Unexpected")
             }
         }
+        Ok(())
+    }
+
+    #[test]
+    fn compile_enum_field() -> ResultTest<()> {
+        let (db, _tmp) = make_test_db()?;
+
+        // Create table [enum] with enum type on [a]
+        let mut tx = db.begin_mut_tx(IsolationLevel::Serializable);
+        let head = ProductType::from([("a", AlgebraicType::simple_enum(["Player", "Gm"].into_iter()))]);
+        let rows: Vec<_> = (1..=10).map(|_| product!(AlgebraicValue::enum_simple(0))).collect();
+        create_table_with_rows(&db, &mut tx, "enum", head.clone(), &rows)?;
+        db.commit_tx(&ExecutionContext::default(), tx)?;
+
+        let tx = db.begin_tx();
+        // Should work with any qualified field
+        let sql = "select * from enum where a = 'Player'";
+        let q = compile_sql(&db, &tx, sql);
+        assert!(q.is_ok());
+        let result = execute_sql(&db, q.unwrap(), AuthCtx::for_testing())?;
+        assert_eq!(result[0].data, vec![product![AlgebraicValue::enum_simple(0)]]);
         Ok(())
     }
 }

--- a/crates/sats/src/algebraic_value.rs
+++ b/crates/sats/src/algebraic_value.rs
@@ -164,6 +164,13 @@ impl AlgebraicValue {
         Self::Sum(SumValue { tag, value })
     }
 
+    /// Returns an [`AlgebraicValue`] representing a sum value with `tag` and empty [AlgebraicValue::product], that is
+    /// valid for simple enums without payload.
+    pub fn enum_simple(tag: u8) -> Self {
+        let value = Box::new(AlgebraicValue::product(vec![]));
+        Self::Sum(SumValue { tag, value })
+    }
+
     /// Returns an [`AlgebraicValue`] representing a product value with the given `elements`.
     pub const fn product(elements: Vec<Self>) -> Self {
         Self::Product(ProductValue { elements })

--- a/crates/sats/src/sum_type.rs
+++ b/crates/sats/src/sum_type.rs
@@ -70,6 +70,26 @@ impl SumType {
     pub fn is_simple_enum(&self) -> bool {
         self.variants.iter().all(SumTypeVariant::is_unit)
     }
+
+    /// Returns the sum type variant using `tag_name` with their tag position.
+    pub fn get_variant(&self, tag_name: &str) -> Option<(u8, &SumTypeVariant)> {
+        self.variants.iter().enumerate().find_map(|(pos, x)| {
+            if x.name.as_deref() == Some(tag_name) {
+                Some((pos as u8, x))
+            } else {
+                None
+            }
+        })
+    }
+
+    /// Returns the sum type variant using `tag_name` with their tag position, if this is a [Self::is_simple_enum]
+    pub fn get_variant_simple(&self, tag_name: &str) -> Option<(u8, &SumTypeVariant)> {
+        if self.is_simple_enum() {
+            self.get_variant(tag_name)
+        } else {
+            None
+        }
+    }
 }
 
 impl From<Vec<SumTypeVariant>> for SumType {


### PR DESCRIPTION
# Description of Changes

Following the way enums are [used in postgres](https://www.postgresql.org/docs/current/datatype-enum.html), which are simple enums, we can now parse them and query for them:


It means if we have:

```rust
#[derive(spacetimedb::SpacetimeType, Clone, Copy, PartialEq, Debug)]
#[repr(i32)]
pub enum Role {
    Player,
    Admin,
}

#[spacetimedb(table)]
#[derive(Clone, Debug)]
pub struct IdentityRole {
    #[primarykey]
    pub identity: Identity,
    pub email: String,
    pub role: Role,
}
```

Now we can execute:

```sql
select * from IdentityRole where role = 'Player';
update IdentityRole set role =  'Admin' where email = 'test@clockworklabs';
```

Note: We can't use enums for `create table` or anywhere we could use the `type` of the enum on `sql`. It only can match the `value` specified by the enum from a module.

# Expected complexity level and risk
1
# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *compile_enum_field*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
