### PR TITLE
perf(1021): Compress subscription update messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +464,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "brotli"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -4446,6 +4482,7 @@ dependencies = [
  "backtrace",
  "base64 0.21.4",
  "blake3",
+ "brotli",
  "bytes",
  "bytestring",
  "chrono",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ base64 = "0.21.2"
 bitflags = "2.3.3"
 bit-vec = "0.6"
 blake3 = "1.5"
+brotli = "3.5.0"
 byte-unit = "4.0.18"
 bytes = "1.2.1"
 bytestring = { version = "1.2.0", features = ["serde"] }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -32,6 +32,7 @@ async-trait.workspace = true
 backtrace.workspace = true
 base64.workspace = true
 blake3.workspace = true
+brotli.workspace = true
 bytes.workspace = true
 bytestring.workspace = true
 chrono.workspace = true

--- a/crates/core/src/client/message_handlers.rs
+++ b/crates/core/src/client/message_handlers.rs
@@ -247,7 +247,7 @@ impl MessageExecutionError {
 }
 
 impl ServerMessage for MessageExecutionError {
-    fn serialize_text(self) -> crate::json::client_api::MessageJson {
+    fn serialize_text(self) -> String {
         TransactionUpdateMessage::<DatabaseUpdate> {
             event: &mut self.into_event(),
             database_update: Default::default(),
@@ -255,7 +255,7 @@ impl ServerMessage for MessageExecutionError {
         .serialize_text()
     }
 
-    fn serialize_binary(self) -> Message {
+    fn serialize_binary(self) -> Vec<u8> {
         TransactionUpdateMessage::<DatabaseUpdate> {
             event: &mut self.into_event(),
             database_update: Default::default(),


### PR DESCRIPTION
Closes #1021.

Subscription update messages can be quite large.
As such they can benefit a great deal from compression.

Unfortunately tungstenite does not support compression, so we add support for it here separately.

We chose Brotli for its universal support,
and its better compression ration compared to gzip.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
