### PR TITLE
Brotli-compress `SubscriptionUpdate` messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -50,6 +50,21 @@ dependencies = [
 ]
 
 [[package]]
+name = "alloc-no-stdlib"
+version = "2.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cc7bb162ec39d46ab1ca8c77bf72e890535becd1751bb45f64c597edb4c8c6b3"
+
+[[package]]
+name = "alloc-stdlib"
+version = "0.2.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "94fb8275041c72129eb51b7d0322c29b8387a0386127718b096429201a5d6ece"
+dependencies = [
+ "alloc-no-stdlib",
+]
+
+[[package]]
 name = "allocator-api2"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -449,6 +464,27 @@ dependencies = [
  "proc-macro2",
  "quote",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "brotli"
+version = "3.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d640d25bc63c50fb1f0b545ffd80207d2e10a4c965530809b40ba3386825c391"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
+ "brotli-decompressor",
+]
+
+[[package]]
+name = "brotli-decompressor"
+version = "2.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4e2e4afe60d7dd600fdd3de8d0f08c2b7ec039712e3b6137ff98b7004e82de4f"
+dependencies = [
+ "alloc-no-stdlib",
+ "alloc-stdlib",
 ]
 
 [[package]]
@@ -4446,6 +4482,7 @@ dependencies = [
  "backtrace",
  "base64 0.21.4",
  "blake3",
+ "brotli",
  "bytes",
  "bytestring",
  "chrono",
@@ -4621,6 +4658,7 @@ dependencies = [
  "anyhow",
  "anymap",
  "base64 0.21.4",
+ "brotli",
  "cursive",
  "futures",
  "futures-channel",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -106,6 +106,7 @@ base64 = "0.21.2"
 bitflags = "2.3.3"
 bit-vec = "0.6"
 blake3 = "1.5"
+brotli = "3.5"
 byte-unit = "4.0.18"
 bytes = "1.2.1"
 bytestring = { version = "1.2.0", features = ["serde"] }
@@ -222,7 +223,6 @@ urlencoding = "2.1.2"
 uuid = { version = "1.2.1", features = ["v4"] }
 walkdir = "2.2.5"
 wasmbin = "0.6"
-
 
 wasmtime = { version = "15", default-features = false, features = ["cranelift", "demangle", "addr2line", "cache"] }
 

--- a/crates/client-api-messages/protobuf/client_api.proto
+++ b/crates/client-api-messages/protobuf/client_api.proto
@@ -10,8 +10,13 @@ message Message {
     oneof type {
         // client -> database, request a reducer run.
         FunctionCall functionCall = 1;
-        // database -> client, contained in `TransactionUpdate`, informs of changes to
-        // subscribed rows.
+        // database -> client, response to `Subscribe` containing all matching committed rows.
+        // Also contained in `TransactionUpdate`, where it informs of changes to subscribed rows
+        // resulting from a TX.
+        //
+        // Currently (2024-03-26) never sent by the server in this form;
+        // rather, the `SubscriptionUpdate` is encoded as bytes, Brotli compressed,
+        // and sent as a `compressedSubscriptionUpdate`.
         SubscriptionUpdate subscriptionUpdate = 2;
         // database -> client, contained in `TransactionUpdate`, describes a reducer run.
         Event event = 3;
@@ -25,6 +30,12 @@ message Message {
         OneOffQuery oneOffQuery = 7;
         // database -> client, return results to a one off SQL query.
         OneOffQueryResponse oneOffQueryResponse = 8;
+        // database -> client, a `SubscriptionUpdate` message in response to a `Subscribe`,
+        // compressed with Brotli.
+        //
+        // Note that the bytes here are a (Brotli-compressed) `SubscriptionUpdate`,
+        // not a `Message` whose `type` is `subscriptionUpdate`.
+        bytes compressedSubscriptionUpdate = 9;
     }
 }
 

--- a/crates/client-api-messages/protobuf/client_api.proto
+++ b/crates/client-api-messages/protobuf/client_api.proto
@@ -30,13 +30,23 @@ message Message {
         OneOffQuery oneOffQuery = 7;
         // database -> client, return results to a one off SQL query.
         OneOffQueryResponse oneOffQueryResponse = 8;
-        // database -> client, a `SubscriptionUpdate` message in response to a `Subscribe`,
+        // database -> client, a `SubscriptionApplied` message in response to a `Subscribe`,
         // compressed with Brotli.
-        //
-        // Note that the bytes here are a (Brotli-compressed) `SubscriptionUpdate`,
-        // not a `Message` whose `type` is `subscriptionUpdate`.
         bytes compressedSubscriptionUpdate = 9;
     }
+}
+
+message SubscriptionApplied {
+  repeated TableSubResponse tables = 1;
+  uint32 requestId = 2;
+  uint64 total_host_execution_duration_micros = 3;
+}
+
+message TableSubResponse {
+  uint32 tableId = 1;
+  string tableName = 2;
+  // BSATN encoding of all response rows concatenated together.
+  bytes bsatnRows = 3;
 }
 
 /// Received by database from client to inform of user's identity, token and client address.

--- a/crates/client-api-messages/protobuf/client_api.proto
+++ b/crates/client-api-messages/protobuf/client_api.proto
@@ -36,20 +36,35 @@ message Message {
     }
 }
 
+/// Sent by database to client in response to a `Subscribe` message,
+/// compressed within a `compressedSubscriptionUpdate` `Message`.
+///
+/// - `tables` stores a `TableSubResponse` for each queried table,
+///            containing all committed rows which match the subscribed queries.
+/// - `requestId` will be the same id as contained in the `Subscribe` message
+///               which initiated this new subscription.
+/// - `total_host_execution_duration_micros` is what it says.
 message SubscriptionApplied {
   repeated TableSubResponse tables = 1;
   uint32 requestId = 2;
   uint64 total_host_execution_duration_micros = 3;
 }
 
+/// A single table's matching rows within a `SubscriptionApplied` message.
+///
+/// `tableId` and `tableName` identify the table. Clients should use the `tableName`, as
+///                           it is a stable part of a module's API, whereas `tableId` may
+///                           or may not change between runs.
+///
+/// `bsatnRows` are all matching rows in the committed state,
+///             encoded as BSATN and concatenated.
 message TableSubResponse {
   uint32 tableId = 1;
   string tableName = 2;
-  // BSATN encoding of all response rows concatenated together.
   bytes bsatnRows = 3;
 }
 
-/// Received by database from client to inform of user's identity, token and client address.
+/// Sent by database to client to inform of user's identity, token and client address.
 ///
 /// The database will always send an `IdentityToken` message
 /// as the first message for a new WebSocket connection.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -32,6 +32,7 @@ async-trait.workspace = true
 backtrace.workspace = true
 base64.workspace = true
 blake3.workspace = true
+brotli.workspace = true
 bytes.workspace = true
 bytestring.workspace = true
 chrono.workspace = true
@@ -95,6 +96,7 @@ url.workspace = true
 urlencoding.workspace = true
 uuid.workspace = true
 wasmtime.workspace = true
+
 # Rocksdb ostorage backend, linked only if "rocksdb" feature enabled.
 rocksdb = {workspace = true, optional = true}
 

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -15,6 +15,7 @@ spacetimedb-client-api-messages.workspace = true
 anyhow.workspace = true
 anymap.workspace = true
 base64.workspace = true
+brotli.workspace = true
 futures.workspace = true
 futures-channel.workspace = true
 home.workspace = true


### PR DESCRIPTION
# Description of Changes

Re: #1022 .

This PR adds a new message to the client API protobuf schema, `compressedSubscriptionUpdate`, a `bytes` which holds a Brotli-compressed `SubscriptionUpdate`. The `ServerMessage::serialize_binary` implementation for `SubscriptionUpdateMessage` now calls `BrotliCompress` with `quality: 1` (high speed, low compression) and emits a `CompressedSubscriptionUpdate`, where previously it emitted an uncompressed `SubscriptionUpdate`.

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

Unsure whether "abi-break" is the correct label. This PR is a breaking change to the binary WebSocket API. As with all changes to our ProtoBuf schema, this means that a newer client will continue to work with an older server, but an older client will be unable to connect to a newer server.

This means we need to update:

- [x] The Rust SDK (included in this PR).
- [ ] The C# SDK (see https://github.com/clockworklabs/spacetimedb-csharp-sdk/issues/74).
- [ ] The Unity SDK (see https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/issues/25).
- [ ] The Typescript SDK (see https://github.com/clockworklabs/spacetimedb-typescript-sdk/issues/40).

# Expected complexity level and risk

3 - client-api changes are scary; not clear whether I've selected a sensible `BrotliiEncoderParams`.

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Rust SDK tests pass.
- [ ] After updating the C# SDK, run the C# quickstart-chat app and ensure it behaves as expected.
- [ ] After updating the Typescript SDK, run the Typescript quickstart-chat app and ensure it behaves as expected.
- [ ] After updating the Unity SDK, run BitCraft and ensure it behaves as expected.
- [ ] After updating the Unity SDK, bot-test BitCraft and ensure its performance improves as we expect.
  - This should significantly reduce latency of crossing a chunk boundary. 
