### PR TITLE
perf(1024): Remove serialization from tx execution thread

### DIFF
--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -3,7 +3,7 @@ use std::sync::atomic::{AtomicBool, Ordering::Relaxed};
 use std::sync::Arc;
 use std::time::Instant;
 
-use super::messages::{OneOffQueryResponseMessage, ServerMessage};
+use super::messages::{OneOffQueryResponseMessage, SerializableMessage};
 use super::{message_handlers, ClientActorId, MessageHandleError};
 use crate::error::DBError;
 use crate::host::{ModuleHost, ReducerArgs, ReducerCallError, ReducerCallResult};
@@ -26,7 +26,7 @@ pub enum Protocol {
 pub struct ClientConnectionSender {
     pub id: ClientActorId,
     pub protocol: Protocol,
-    sendtx: mpsc::Sender<DataMessage>,
+    sendtx: mpsc::Sender<SerializableMessage>,
     abort_handle: AbortHandle,
     cancelled: AtomicBool,
 }
@@ -56,13 +56,11 @@ impl ClientConnectionSender {
         }
     }
 
-    pub fn send_message(&self, message: impl ServerMessage) -> Result<(), ClientSendError> {
-        self.send(message.serialize(self.protocol))
+    pub fn send_message(&self, message: impl Into<SerializableMessage>) -> Result<(), ClientSendError> {
+        self.send(message.into())
     }
 
-    fn send(&self, message: DataMessage) -> Result<(), ClientSendError> {
-        let bytes_len = message.len();
-
+    fn send(&self, message: SerializableMessage) -> Result<(), ClientSendError> {
         if self.cancelled.load(Relaxed) {
             return Err(ClientSendError::Cancelled);
         }
@@ -76,13 +74,6 @@ impl ClientConnectionSender {
             }
             mpsc::error::TrySendError::Closed(_) => ClientSendError::Disconnected,
         })?;
-
-        WORKER_METRICS.websocket_sent.with_label_values(&self.id.identity).inc();
-
-        WORKER_METRICS
-            .websocket_sent_msg_size
-            .with_label_values(&self.id.identity)
-            .observe(bytes_len as f64);
 
         Ok(())
     }
@@ -137,7 +128,7 @@ impl ClientConnection {
         actor: F,
     ) -> Result<ClientConnection, ReducerCallError>
     where
-        F: FnOnce(ClientConnection, mpsc::Receiver<DataMessage>) -> Fut,
+        F: FnOnce(ClientConnection, mpsc::Receiver<SerializableMessage>) -> Fut,
         Fut: Future<Output = ()> + Send + 'static,
     {
         // Add this client as a subscriber
@@ -148,7 +139,7 @@ impl ClientConnection {
             .call_identity_connected_disconnected(id.identity, id.address, true)
             .await?;
 
-        let (sendtx, sendrx) = mpsc::channel::<DataMessage>(CLIENT_CHANNEL_CAPACITY);
+        let (sendtx, sendrx) = mpsc::channel::<SerializableMessage>(CLIENT_CHANNEL_CAPACITY);
 
         let db = module.info().address;
 

--- a/crates/core/src/client/message_handlers.rs
+++ b/crates/core/src/client/message_handlers.rs
@@ -1,3 +1,4 @@
+use std::sync::Arc;
 use std::time::{Duration, Instant};
 
 use crate::energy::EnergyQuanta;
@@ -249,7 +250,7 @@ impl MessageExecutionError {
 impl ServerMessage for MessageExecutionError {
     fn serialize_text(self) -> crate::json::client_api::MessageJson {
         TransactionUpdateMessage::<DatabaseUpdate> {
-            event: &mut self.into_event(),
+            event: Arc::new(self.into_event()),
             database_update: Default::default(),
         }
         .serialize_text()
@@ -257,7 +258,7 @@ impl ServerMessage for MessageExecutionError {
 
     fn serialize_binary(self) -> Message {
         TransactionUpdateMessage::<DatabaseUpdate> {
-            event: &mut self.into_event(),
+            event: Arc::new(self.into_event()),
             database_update: Default::default(),
         }
         .serialize_binary()

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -140,7 +140,7 @@ impl ModuleSubscriptions {
             EventStatus::Failed(_) => {
                 if let Some(client) = client {
                     let message = TransactionUpdateMessage::<DatabaseUpdate> {
-                        event: &event,
+                        event,
                         database_update: <_>::default(),
                     };
                     let _ = client.send_message(message);
@@ -169,7 +169,7 @@ impl ModuleSubscriptions {
     /// it resolves, it's guaranteed that if you call `subscriber.send(x)` the client will receive
     /// x after they receive this subscription update).
     fn broadcast_commit_event(&self, subscriptions: &SubscriptionManager, event: Arc<ModuleEvent>) {
-        subscriptions.eval_updates(&self.relational_db, &event)
+        subscriptions.eval_updates(&self.relational_db, event)
     }
 }
 


### PR DESCRIPTION
Closes #1024.

Before this change,
we would serialize messages **before** inserting into the send queue.

Because we commit the tx only after inserting into the send queue, this meant we were holding onto the database lock unnecessarily.

After this change,
we serialize messages **after** inserting into the send queue. This means we serialize only after committing the tx.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [ ] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
