### PR TITLE
Detect unsatisfiable range queries; warn and short-circuit.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4761,6 +4761,7 @@ dependencies = [
  "arrayvec",
  "derive_more",
  "itertools 0.12.0",
+ "log",
  "smallvec",
  "spacetimedb-lib",
  "spacetimedb-primitives",

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -93,7 +93,7 @@ pub(crate) mod tests {
     use crate::db::relational_db::tests_utils::make_test_db;
     use crate::vm::tests::create_table_with_rows;
     use spacetimedb_lib::error::ResultTest;
-    use spacetimedb_primitives::col_list;
+    use spacetimedb_primitives::{col_list, ColId};
     use spacetimedb_sats::db::auth::{StAccess, StTableType};
     use spacetimedb_sats::relation::Header;
     use spacetimedb_sats::{product, AlgebraicType, ProductType};
@@ -659,5 +659,38 @@ SELECT * FROM inventory",
         assert_eq!(result.data, vec![product![1, 1, 1, 1]]);
 
         Ok(())
+    }
+
+    #[test]
+    fn test_impossible_bounds_no_panic() {
+        let (db, _tmp_dir) = make_test_db().unwrap();
+
+        let table_id = db
+            .create_table_for_test("test", &[("x", AlgebraicType::I32)], &[(ColId(0), "test_x")])
+            .unwrap();
+
+        db.with_auto_commit(&ExecutionContext::default(), |tx| {
+            for i in 0..1000i32 {
+                db.insert(tx, table_id, product!(i)).unwrap();
+            }
+            Ok::<(), DBError>(())
+        })
+        .unwrap();
+
+        let result = run_for_testing(&db, "select * from test where x > 5 and x < 5").unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0].data.is_empty());
+
+        let result = run_for_testing(&db, "select * from test where x >= 5 and x < 4").unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(
+            result[0].data.is_empty(),
+            "Expected no rows but found {:#?}",
+            result[0].data
+        );
+
+        let result = run_for_testing(&db, "select * from test where x > 5 and x <= 4").unwrap();
+        assert_eq!(result.len(), 1);
+        assert!(result[0].data.is_empty());
     }
 }

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -108,6 +108,11 @@ pub fn build_query<'a>(
                     // return an empty iterator.
                     // Unlike the above case, this is not necessary, as the below `select` will never panic,
                     // but it's still nice to avoid needlessly traversing a bunch of rows.
+                    // TODO: We should change the compiler to not emit an `IndexScan` in this case,
+                    // so that this branch is unreachable.
+                    // The current behavior is a hack
+                    // because this patch was written (2024-04-01 pgoldman) a short time before the BitCraft alpha,
+                    // and a more invasive change was infeasible.
                     Box::new(EmptyRelOps::new(index_scan.table.head.clone())) as Box<IterRows<'a>>
                 } else if cols.is_singleton() {
                     // For singleton constraints, we compare the column directly against `bounds`.

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -17,8 +17,9 @@ use spacetimedb_vm::eval::IterRows;
 use spacetimedb_vm::expr::*;
 use spacetimedb_vm::iterators::RelIter;
 use spacetimedb_vm::program::{ProgramVm, Sources};
-use spacetimedb_vm::rel_ops::RelOps;
+use spacetimedb_vm::rel_ops::{EmptyRelOps, RelOps};
 use spacetimedb_vm::relation::{MemTable, RelValue, Table};
+use std::ops::Bound;
 use std::sync::Arc;
 
 pub enum TxMode<'a> {
@@ -35,6 +36,18 @@ impl<'a> From<&'a mut MutTx> for TxMode<'a> {
 impl<'a> From<&'a Tx> for TxMode<'a> {
     fn from(tx: &'a Tx) -> Self {
         TxMode::Tx(tx)
+    }
+}
+
+fn bound_is_satisfiable(lower: &Bound<AlgebraicValue>, upper: &Bound<AlgebraicValue>) -> bool {
+    match (lower, upper) {
+        (Bound::Excluded(lower), Bound::Excluded(upper)) if lower >= upper => false,
+        (Bound::Included(lower), Bound::Excluded(upper)) | (Bound::Excluded(lower), Bound::Included(upper))
+            if lower > upper =>
+        {
+            false
+        }
+        _ => true,
     }
 }
 
@@ -68,8 +81,17 @@ pub fn build_query<'a>(
     for op in &query.query {
         result = Some(match op {
             Query::IndexScan(IndexScan { table, columns, bounds }) if db_table => {
-                let bounds = (bounds.start_bound(), bounds.end_bound());
-                iter_by_col_range(ctx, stdb, tx, table, columns.clone(), bounds)?
+                if !bound_is_satisfiable(&bounds.0, &bounds.1) {
+                    // If the bound is impossible to satisfy
+                    // because the lower bound is greater than the upper bound, or both bounds are excluded and equal,
+                    // return an empty iterator.
+                    // This avoids a panic in `BTreeMap`'s `NodeRef::search_tree_for_bifurcation`,
+                    // which is very unhappy about unsatisfiable bounds.
+                    Box::new(EmptyRelOps::new(table.head.clone())) as Box<IterRows<'a>>
+                } else {
+                    let bounds = (bounds.start_bound(), bounds.end_bound());
+                    iter_by_col_range(ctx, stdb, tx, table, columns.clone(), bounds)?
+                }
             }
             Query::IndexScan(index_scan) => {
                 let result = result
@@ -79,7 +101,15 @@ pub fn build_query<'a>(
 
                 let cols = &index_scan.columns;
                 let bounds = &index_scan.bounds;
-                if cols.is_singleton() {
+
+                if !bound_is_satisfiable(&bounds.0, &bounds.1) {
+                    // If the bound is impossible to satisfy
+                    // because the lower bound is greater than the upper bound, or both bounds are excluded and equal,
+                    // return an empty iterator.
+                    // Unlike the above case, this is not necessary, as the below `select` will never panic,
+                    // but it's still nice to avoid needlessly traversing a bunch of rows.
+                    Box::new(EmptyRelOps::new(index_scan.table.head.clone())) as Box<IterRows<'a>>
+                } else if cols.is_singleton() {
                     // For singleton constraints, we compare the column directly against `bounds`.
                     let head = cols.head().idx();
                     let iter = result.select(move |row| Ok(bounds.contains(&*row.read_column(head).unwrap())));

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -15,6 +15,7 @@ anyhow.workspace = true
 arrayvec.workspace = true
 derive_more.workspace = true
 itertools.workspace = true
+log.workspace = true
 smallvec.workspace = true
 thiserror.workspace = true
 tracing.workspace = true

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -1359,6 +1359,12 @@ impl QueryExpr {
                 // Queries like `WHERE x < 5 AND x > 5` never return any rows and are likely mistakes.
                 // Detect such queries and log a warning.
                 // Compute this condition early, then compute the resulting query and log it.
+                // TODO: We should not emit an `IndexScan` in this case.
+                // Further design work is necessary to decide whether this should be an error at query compile time,
+                // or whether we should emit a query plan which explicitly says that it will return 0 rows.
+                // The current behavior is a hack
+                // because this patch was written (2024-04-01 pgoldman) a short time before the BitCraft alpha,
+                // and a more invasive change was infeasible.
                 let is_never = !inclusive && value == upper;
 
                 let bounds = (Self::bound(value, inclusive), Bound::Excluded(upper));
@@ -1455,6 +1461,12 @@ impl QueryExpr {
                 // Queries like `WHERE x < 5 AND x > 5` never return any rows and are likely mistakes.
                 // Detect such queries and log a warning.
                 // Compute this condition early, then compute the resulting query and log it.
+                // TODO: We should not emit an `IndexScan` in this case.
+                // Further design work is necessary to decide whether this should be an error at query compile time,
+                // or whether we should emit a query plan which explicitly says that it will return 0 rows.
+                // The current behavior is a hack
+                // because this patch was written (2024-04-01 pgoldman) a short time before the BitCraft alpha,
+                // and a more invasive change was infeasible.
                 let is_never = !inclusive && value == lower;
 
                 let bounds = (Bound::Excluded(lower), Self::bound(value, inclusive));

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -1452,7 +1452,7 @@ impl QueryExpr {
                 self.query.push(Query::IndexScan(IndexScan { table, columns, bounds }));
                 self
             }
-            // merge with a preceding lower bounded index scan (enclusive)
+            // merge with a preceding lower bounded index scan (exclusive)
             Query::IndexScan(IndexScan {
                 columns: lhs_col_id,
                 bounds: (Bound::Excluded(lower), Bound::Unbounded),

--- a/crates/vm/src/rel_ops.rs
+++ b/crates/vm/src/rel_ops.rs
@@ -134,6 +134,30 @@ impl<'a, I: RelOps<'a> + ?Sized> RelOps<'a> for Box<I> {
     }
 }
 
+/// `RelOps` iterator which never returns any rows.
+///
+/// Used to compile queries with unsatisfiable bounds, like `WHERE x < 5 AND x > 5`.
+#[derive(Clone, Debug)]
+pub struct EmptyRelOps {
+    head: Arc<Header>,
+}
+
+impl EmptyRelOps {
+    pub fn new(head: Arc<Header>) -> Self {
+        Self { head }
+    }
+}
+
+impl<'a> RelOps<'a> for EmptyRelOps {
+    fn head(&self) -> &Arc<Header> {
+        &self.head
+    }
+
+    fn next(&mut self) -> Result<Option<RelValue<'a>>, ErrorVm> {
+        Ok(None)
+    }
+}
+
 #[derive(Clone, Debug)]
 pub struct Select<I, P> {
     pub(crate) iter: I,


### PR DESCRIPTION
# Description of Changes

This commit fixes a panic caused by unsatisfiable range bounds on an index query, e.g. `WHERE x < 5 AND x > 5`. These unsatisfiable bounds made Rust's `BTreeMap` angry (See https://doc.rust-lang.org/src/alloc/collections/btree/search.rs.html#106-124), and panicked. They also represent probable bugs, as it's silly to write a query which statically will return no rows.

With this commit, we detect statically unsatisfiable bounds in two cases:
- When compiling queries, we log a message at `WARN` containing the offending query.
- When evaluating queries, we silently construct an `EmptyRelOps` rather than a real query iterator.

This commit also adds a test that the offending queries can be compiled and executed without panicking, and select no rows.

# API and ABI breaking changes

N/a

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Checked that the logs are emitted by enabling `env_logger` and passing `--nocapture` when running the tests.
- [x] Newly-added test `test_impossible_bounds_no_panic` used to panic but doesn't anymore.