### PR TITLE
Reject large SQL queries

### DIFF
--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -660,4 +660,28 @@ SELECT * FROM inventory",
 
         Ok(())
     }
+
+    #[test]
+    fn test_large_query_no_panic() {
+        let (db, _tmp_dir) = make_test_db().unwrap();
+
+        let _table_id = db
+            .create_table_for_test_multi_column(
+                "test",
+                &[("x", AlgebraicType::I32), ("y", AlgebraicType::I32)],
+                col_list![0, 1],
+            )
+            .unwrap();
+
+        let mut query = "select * from test where ".to_string();
+        for x in 0..1_000 {
+            for y in 0..1_000 {
+                let fragment = format!("((x = {x}) and y = {y}) or");
+                query.push_str(&fragment);
+            }
+        }
+        query.push_str("((x = 1000) and (y = 1000))");
+
+        assert!(run_for_testing(&db, &query).is_err());
+    }
 }


### PR DESCRIPTION
# Description of Changes

Return an error rather than attempting to compile queries longer than 50k bytes.

This avoids a stack overflow when compiling deeply-nested `AND` and `OR` expressions.

# API and ABI breaking changes

...Technically a breaking change, in that a case that used to sometimes-maybe-work is now always an error?

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1 - stupid hack, but trivial.

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Added a test which used to fail but now passes.