### PR TITLE
`spacetime publish`: Add confirmation for `-c`

### DIFF
--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -29,7 +29,7 @@ pub fn cli() -> clap::Command {
                 .long("clear-database")
                 .short('c')
                 .action(SetTrue)
-                .requires("name_or_address")
+                .requires("name|address")
                 .help("When publishing to an existing address, first DESTROY all data associated with the module"),
         )
         .arg(

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -109,7 +109,7 @@ pub fn cli() -> clap::Command {
                 .help("DANGEROUS - Proceed with all actions without waiting for user confirmation")
         )
         .arg(
-            Arg::new("clear_database")
+            Arg::new("deprecated_clear_database")
                 .long("clear-database")
                 .requires("name_or_address")
                 .conflicts_with("destroy_previous")
@@ -125,9 +125,9 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let name_or_address = args.get_one::<String>("name|address");
     let path_to_project = args.get_one::<PathBuf>("project_path").unwrap();
     let host_type = args.get_one::<String>("host_type").unwrap();
-    let clear_database = args.get_flag("destroy_previous") || args.get_flag("clear_database");
-    // This is to preserve backwards-compatibility with the (deprecated) --clear-database.
-    let force = args.get_flag("force") || args.get_flag("clear_database");
+    let clear_database = args.get_flag("destroy_previous") || args.get_flag("deprecated_clear_database");
+    // This is to preserve backwards-compatibility with the old --clear-database.
+    let force = args.get_flag("force") || args.get_flag("deprecated_clear_database");
     let trace_log = args.get_flag("trace_log");
     let anon_identity = args.get_flag("anon_identity");
     let skip_clippy = args.get_flag("skip_clippy");

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -126,7 +126,8 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let path_to_project = args.get_one::<PathBuf>("project_path").unwrap();
     let host_type = args.get_one::<String>("host_type").unwrap();
     let clear_database = args.get_flag("destroy_previous") || args.get_flag("clear_database");
-    let force = args.get_flag("force");
+    // This is to preserve backwards-compatibility with the (deprecated) --clear-database.
+    let force = args.get_flag("force") || args.get_flag("clear_database");
     let trace_log = args.get_flag("trace_log");
     let anon_identity = args.get_flag("anon_identity");
     let skip_clippy = args.get_flag("skip_clippy");

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -30,7 +30,7 @@ pub fn cli() -> clap::Command {
                 .short('c')
                 .action(SetTrue)
                 .requires("name_or_address")
-                .help("When publishing to an existing address, first delete all data associated with the database"),
+                .help("When publishing to an existing address, first DESTROY all data associated with the module"),
         )
         .arg(
             Arg::new("project_path")

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -126,8 +126,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let path_to_project = args.get_one::<PathBuf>("project_path").unwrap();
     let host_type = args.get_one::<String>("host_type").unwrap();
     let clear_database = args.get_flag("destroy_previous") || args.get_flag("deprecated_clear_database");
-    // This is to preserve backwards-compatibility with the old --clear-database.
-    let force = args.get_flag("force") || args.get_flag("deprecated_clear_database");
+    let force = args.get_flag("force");
     let trace_log = args.get_flag("trace_log");
     let anon_identity = args.get_flag("anon_identity");
     let skip_clippy = args.get_flag("skip_clippy");
@@ -177,7 +176,8 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     );
 
     if clear_database {
-        if force {
+        // This is to preserve backwards-compatibility with the old --clear-database.
+        if force || args.get_flag("deprecated_clear_database") {
             eprintln!("Skipping confirmation due to --force.");
         } else {
             // Note: `name_or_address` should be set, because it is `required` in the CLI arg config.

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -108,14 +108,6 @@ pub fn cli() -> clap::Command {
                 .action(SetTrue)
                 .help("DANGEROUS - Proceed with all actions without waiting for user confirmation")
         )
-        .arg(
-            Arg::new("deprecated_clear_database")
-                .long("clear-database")
-                .requires("name_or_address")
-                .conflicts_with("destroy_previous")
-                .action(SetTrue)
-                .help("DEPRECATED - Use --destroy-previous"),
-        )
         .after_help("Run `spacetime help publish` for more detailed information.")
 }
 
@@ -125,7 +117,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let name_or_address = args.get_one::<String>("name|address");
     let path_to_project = args.get_one::<PathBuf>("project_path").unwrap();
     let host_type = args.get_one::<String>("host_type").unwrap();
-    let clear_database = args.get_flag("destroy_previous") || args.get_flag("deprecated_clear_database");
+    let clear_database = args.get_flag("destroy_previous");
     let force = args.get_flag("force");
     let trace_log = args.get_flag("trace_log");
     let anon_identity = args.get_flag("anon_identity");
@@ -176,8 +168,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     );
 
     if clear_database {
-        // This is to preserve backwards-compatibility with the old --clear-database.
-        if force || args.get_flag("deprecated_clear_database") {
+        if force {
             eprintln!("Skipping confirmation due to --force.");
         } else {
             // Note: `name_or_address` should be set, because it is `required` in the CLI arg config.

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -117,7 +117,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let name_or_address = args.get_one::<String>("name|address");
     let path_to_project = args.get_one::<PathBuf>("project_path").unwrap();
     let host_type = args.get_one::<String>("host_type").unwrap();
-    let clear_database = args.get_flag("destroy_previous");
+    let destroy_previous = args.get_flag("destroy_previous");
     let force = args.get_flag("force");
     let trace_log = args.get_flag("trace_log");
     let anon_identity = args.get_flag("anon_identity");
@@ -167,7 +167,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
         database_host
     );
 
-    if clear_database {
+    if destroy_previous {
         if force {
             eprintln!("Skipping confirmation due to --force.");
         } else {

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -169,7 +169,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
 
     if clear_database {
         if force {
-            eprintln!("Skipping confirmation due to --force.");
+            println!("Skipping confirmation due to --force.");
         } else {
             // Note: `name_or_address` should be set, because it is `required` in the CLI arg config.
             println!(
@@ -191,7 +191,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
         query_params.push(("clear", "true"));
     }
 
-    eprintln!("Publishing module...");
+    println!("Publishing module...");
 
     let mut builder = reqwest::Client::new().post(Url::parse_with_params(
         format!("{}/database/publish", database_host).as_str(),

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -25,8 +25,8 @@ pub fn cli() -> clap::Command {
                 .help("The type of host that should be for hosting this module"),
         )
         .arg(
-            Arg::new("destroy_previous")
-                .long("destroy-previous")
+            Arg::new("delete_tables")
+                .long("delete-tables")
                 .short('c')
                 .action(SetTrue)
                 .requires("name_or_address")
@@ -117,7 +117,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let name_or_address = args.get_one::<String>("name|address");
     let path_to_project = args.get_one::<PathBuf>("project_path").unwrap();
     let host_type = args.get_one::<String>("host_type").unwrap();
-    let destroy_previous = args.get_flag("destroy_previous");
+    let delete_tables = args.get_flag("delete_tables");
     let force = args.get_flag("force");
     let trace_log = args.get_flag("trace_log");
     let anon_identity = args.get_flag("anon_identity");
@@ -167,7 +167,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
         database_host
     );
 
-    if destroy_previous {
+    if delete_tables {
         if force {
             eprintln!("Skipping confirmation due to --force.");
         } else {

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -25,8 +25,8 @@ pub fn cli() -> clap::Command {
                 .help("The type of host that should be for hosting this module"),
         )
         .arg(
-            Arg::new("delete_tables")
-                .long("delete-tables")
+            Arg::new("clear_database")
+                .long("clear-database")
                 .short('c')
                 .action(SetTrue)
                 .requires("name_or_address")
@@ -117,7 +117,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let name_or_address = args.get_one::<String>("name|address");
     let path_to_project = args.get_one::<PathBuf>("project_path").unwrap();
     let host_type = args.get_one::<String>("host_type").unwrap();
-    let delete_tables = args.get_flag("delete_tables");
+    let clear_database = args.get_flag("clear_database");
     let force = args.get_flag("force");
     let trace_log = args.get_flag("trace_log");
     let anon_identity = args.get_flag("anon_identity");
@@ -167,7 +167,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
         database_host
     );
 
-    if delete_tables {
+    if clear_database {
         if force {
             eprintln!("Skipping confirmation due to --force.");
         } else {

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -129,9 +129,9 @@ class Smoketest(unittest.TestCase):
     def publish_module(self, domain=None, *, clear=True, capture_stderr=True):
         publish_output = self.spacetime(
             "publish",
-            *[domain] if domain is not None else [],
             "--project-path", self.project_path,
-            *(["-c"] if clear else []),
+            *[domain] if domain is not None else [],
+            *["-c"] if clear and domain is not None else [],
             capture_stderr=capture_stderr,
         )
         self.resolved_address = re.search(r"address: ([0-9a-fA-F]+)", publish_output)[1]

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -129,9 +129,9 @@ class Smoketest(unittest.TestCase):
     def publish_module(self, domain=None, *, clear=True, capture_stderr=True):
         publish_output = self.spacetime(
             "publish",
-            "--project-path", self.project_path,
             *[domain] if domain is not None else [],
             *["-c"] if clear and domain is not None else [],
+            "--project-path", self.project_path,
             capture_stderr=capture_stderr,
         )
         self.resolved_address = re.search(r"address: ([0-9a-fA-F]+)", publish_output)[1]

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -130,7 +130,7 @@ class Smoketest(unittest.TestCase):
         publish_output = self.spacetime(
             "publish",
             *[domain] if domain is not None else [],
-            *["-c"] if clear and domain is not None else [],
+            *["-c", "--force"] if clear and domain is not None else [],
             "--project-path", self.project_path,
             capture_stderr=capture_stderr,
         )

--- a/smoketests/tests/permissions.py
+++ b/smoketests/tests/permissions.py
@@ -68,7 +68,7 @@ class Permissions(Smoketest):
         self.reset_config()
 
         with self.assertRaises(Exception): 
-            self.spacetime("publish", self.address, "--project-path", self.project_path, "--clear-database")
+            self.spacetime("publish", self.address, "--project-path", self.project_path, "--clear-database", "--force")
 
     
 class PrivateTablePermissions(Smoketest):


### PR DESCRIPTION
# Description of Changes

Making this change in response to a request from the BitCraft team.

`spacetime publish -c` now asks for confirmation, unless a new `--force` is passed as well.

# API and ABI breaking changes

This **will break** any automation using `spacetime publish -c`.

I think that's an acceptable level of break? @jdetter ?

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

2

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing
```
Basic publish still works fine, with no input:

  $ echo | spacetime publish -s local test-module
  info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
  checking crate with spacetimedb's clippy configuration
      Checking spacetime-module v0.1.0 (/tmp/cramtests-v9blcwxj/publish-test.t/module-test)
      Finished release [optimized] target(s) in 0.15s
      Finished release [optimized] target(s) in 0.06s
  Optimising module with wasm-opt...
  Could not find wasm-opt to optimise the module.
  For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases.
  Continuing with unoptimised module.
  Uploading to local => http://127.0.0.1:3000
  Publishing module...
  Updated database with domain: test-module, address: 0d78dc56e0223a61218791b864064ab5


Publishing with `-c` (now) fails without confirmation:

  $ echo | spacetime publish -s local -c test-module
  info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
  checking crate with spacetimedb's clippy configuration
      Checking spacetime-module v0.1.0 (/tmp/cramtests-v9blcwxj/publish-test.t/module-test)
      Finished release [optimized] target(s) in 0.16s
      Finished release [optimized] target(s) in 0.06s
  Optimising module with wasm-opt...
  Could not find wasm-opt to optimise the module.
  For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases.
  Continuing with unoptimised module.
  Uploading to local => http://127.0.0.1:3000
  This will DESTROY the current test-module module, and ALL corresponding data.
  Are you sure you want to proceed? (y/N) [deleting test-module] Aborting


...and it succeeds when given confirmation:

  $ echo 'y' | spacetime publish -s local -c test-module
  info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
  checking crate with spacetimedb's clippy configuration
      Checking spacetime-module v0.1.0 (/tmp/cramtests-v9blcwxj/publish-test.t/module-test)
      Finished release [optimized] target(s) in 0.14s
      Finished release [optimized] target(s) in 0.06s
  Optimising module with wasm-opt...
  Could not find wasm-opt to optimise the module.
  For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases.
  Continuing with unoptimised module.
  Uploading to local => http://127.0.0.1:3000
  This will DESTROY the current test-module module, and ALL corresponding data.
  Are you sure you want to proceed? (y/N) [deleting test-module] Publishing module...
  Updated database with domain: test-module, address: 0d78dc56e0223a61218791b864064ab5


A "yes-like" answer is not good enough!

  $ echo 'yessir' | spacetime publish -s local -c test-module
  info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
  checking crate with spacetimedb's clippy configuration
      Checking spacetime-module v0.1.0 (/tmp/cramtests-v9blcwxj/publish-test.t/module-test)
      Finished release [optimized] target(s) in 0.15s
      Finished release [optimized] target(s) in 0.06s
  Optimising module with wasm-opt...
  Could not find wasm-opt to optimise the module.
  For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases.
  Continuing with unoptimised module.
  Uploading to local => http://127.0.0.1:3000
  This will DESTROY the current test-module module, and ALL corresponding data.
  Are you sure you want to proceed? (y/N) [deleting test-module] Aborting

The clearly-named long flag works:

  $ echo | spacetime publish -s local --destroy-previous test-module
  info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
  checking crate with spacetimedb's clippy configuration
      Checking spacetime-module v0.1.0 (/tmp/cramtests-v9blcwxj/publish-test.t/module-test)
      Finished release [optimized] target(s) in 0.15s
      Finished release [optimized] target(s) in 0.06s
  Optimising module with wasm-opt...
  Could not find wasm-opt to optimise the module.
  For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases.
  Continuing with unoptimised module.
  Uploading to local => http://127.0.0.1:3000
  This will DESTROY the current test-module module, and ALL corresponding data.
  Are you sure you want to proceed? (y/N) [deleting test-module] Aborting
  $ echo | spacetime publish -s local --destroy-previous --force test-module
  info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
  checking crate with spacetimedb's clippy configuration
      Checking spacetime-module v0.1.0 (/tmp/cramtests-v9blcwxj/publish-test.t/module-test)
      Finished release [optimized] target(s) in 0.15s
      Finished release [optimized] target(s) in 0.06s
  Optimising module with wasm-opt...
  Could not find wasm-opt to optimise the module.
  For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases.
  Continuing with unoptimised module.
  Uploading to local => http://127.0.0.1:3000
  Skipping confirmation due to --force.
  Publishing module...
  Updated database with domain: test-module, address: 0d78dc56e0223a61218791b864064ab5

The deprecated long flag works like before:

  $ echo | spacetime publish -s local --clear-database test-module
  info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
  checking crate with spacetimedb's clippy configuration
      Checking spacetime-module v0.1.0 (/tmp/cramtests-v9blcwxj/publish-test.t/module-test)
      Finished release [optimized] target(s) in 0.14s
      Finished release [optimized] target(s) in 0.06s
  Optimising module with wasm-opt...
  Could not find wasm-opt to optimise the module.
  For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases.
  Continuing with unoptimised module.
  Uploading to local => http://127.0.0.1:3000
  Skipping confirmation due to --force.
  Publishing module...
  Updated database with domain: test-module, address: 0d78dc56e0223a61218791b864064ab5
```