### PR TITLE
Remove dead code in subscription

### DIFF
--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -1,3 +1,4 @@
+use super::subscription::get_all;
 use crate::db::db_metrics::{DB_METRICS, MAX_QUERY_COMPILE_TIME};
 use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::{DBError, SubscriptionError};
@@ -11,15 +12,8 @@ use spacetimedb_lib::Address;
 use spacetimedb_vm::expr::{self, Crud, CrudExpr, DbType, QueryExpr};
 use std::time::Instant;
 
-use super::subscription::get_all;
-
 static WHITESPACE: Lazy<Regex> = Lazy::new(|| Regex::new(r"\s+").unwrap());
 pub const SUBSCRIBE_TO_ALL_QUERY: &str = "SELECT * FROM *";
-
-pub enum QueryDef {
-    Table(String),
-    Sql(String),
-}
 
 // TODO: It's semantically wrong to `SUBSCRIBE_TO_ALL_QUERY`
 // as it can only return back the changes valid for the tables in scope *right now*

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -25,7 +25,7 @@
 
 use super::execution_unit::ExecutionUnit;
 use super::query;
-use crate::client::{ClientActorId, ClientConnectionSender, Protocol};
+use crate::client::Protocol;
 use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::{DBError, SubscriptionError};
 use crate::execution_context::ExecutionContext;
@@ -53,38 +53,6 @@ use std::hash::Hash;
 use std::iter;
 use std::ops::Deref;
 use std::sync::Arc;
-
-/// A subscription is an [`ExecutionSet`], along with a set of subscribers all
-/// interested in the same set of queries.
-#[derive(Debug)]
-pub struct Subscription {
-    pub queries: ExecutionSet,
-    subscribers: Vec<ClientConnectionSender>,
-}
-
-impl Subscription {
-    pub fn new(queries: impl Into<ExecutionSet>, subscriber: ClientConnectionSender) -> Self {
-        Self {
-            queries: queries.into(),
-            subscribers: vec![subscriber],
-        }
-    }
-
-    pub fn subscribers(&self) -> &[ClientConnectionSender] {
-        &self.subscribers
-    }
-
-    pub fn remove_subscriber(&mut self, client_id: ClientActorId) -> Option<ClientConnectionSender> {
-        let i = self.subscribers.iter().position(|sub| sub.id == client_id)?;
-        Some(self.subscribers.swap_remove(i))
-    }
-
-    pub fn add_subscriber(&mut self, sender: ClientConnectionSender) {
-        if !self.subscribers.iter().any(|s| s.id == sender.id) {
-            self.subscribers.push(sender);
-        }
-    }
-}
 
 /// A [`QueryExpr`] tagged with [`query::Supported`].
 ///


### PR DESCRIPTION
# Description of Changes

Removes some dead code.

Note: If we use `pub(crate)` or the least possible visibility, then this would have been caught by the compiler before, so I recommend avoiding needless `pub`s.