### PR TITLE
Consistently use `--identity` `-i` for identity args to CLI

### DIFF
--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -58,7 +58,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), Error> {
     let arguments = args.get_many::<String>("arguments");
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
 
-    let as_identity = args.get_one::<String>("identity");
+    let identity = args.get_one::<String>("identity");
     let anon_identity = args.get_flag("anon_identity");
 
     let address = database_address(&config, database, server).await?;
@@ -69,7 +69,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), Error> {
         address.clone(),
         reducer_name
     ));
-    let auth_header = get_auth_header_only(&mut config, anon_identity, as_identity, server).await?;
+    let auth_header = get_auth_header_only(&mut config, anon_identity, identity, server).await?;
     let builder = add_auth_header_opt(builder, &auth_header);
     let describe_reducer = util::describe_reducer(
         &mut config,
@@ -77,7 +77,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), Error> {
         server.map(|x| x.to_string()),
         reducer_name.clone(),
         anon_identity,
-        as_identity.cloned(),
+        identity.cloned(),
     )
     .await?;
 

--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -35,8 +35,8 @@ pub fn cli() -> clap::Command {
                 .help("The nickname, host name or URL of the server hosting the database"),
         )
         .arg(
-            Arg::new("as_identity")
-                .long("as-identity")
+            Arg::new("identity")
+                .long("identity")
                 .short('i')
                 .conflicts_with("anon_identity")
                 .help("The identity to use for the call"),
@@ -45,7 +45,7 @@ pub fn cli() -> clap::Command {
             Arg::new("anon_identity")
                 .long("anon-identity")
                 .short('a')
-                .conflicts_with("as_identity")
+                .conflicts_with("identity")
                 .action(ArgAction::SetTrue)
                 .help("If this flag is present, the call will be executed with no identity provided"),
         )
@@ -58,7 +58,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), Error> {
     let arguments = args.get_many::<String>("arguments");
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
 
-    let as_identity = args.get_one::<String>("as_identity");
+    let as_identity = args.get_one::<String>("identity");
     let anon_identity = args.get_flag("anon_identity");
 
     let address = database_address(&config, database, server).await?;

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -23,8 +23,8 @@ pub fn cli() -> clap::Command {
         .arg(Arg::new("brief").long("brief").short('b').action(SetTrue)
             .help("If this flag is present, a brief description shall be returned"))
         .arg(
-            Arg::new("as_identity")
-                .long("as-identity")
+            Arg::new("identity")
+                .long("identity")
                 .short('i')
                 .conflicts_with("anon_identity")
                 .help("The identity to use to describe the entity")
@@ -34,7 +34,7 @@ pub fn cli() -> clap::Command {
             Arg::new("anon_identity")
                 .long("anon-identity")
                 .short('a')
-                .conflicts_with("as_identity")
+                .conflicts_with("identity")
                 .action(SetTrue)
                 .help("If this flag is present, no identity will be provided when describing the database"),
         )
@@ -54,7 +54,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let entity_type = args.get_one::<String>("entity_type");
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
 
-    let as_identity = args.get_one::<String>("as_identity");
+    let as_identity = args.get_one::<String>("identity");
     let anon_identity = args.get_flag("anon_identity");
 
     let address = database_address(&config, database, server).await?;

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -54,7 +54,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let entity_type = args.get_one::<String>("entity_type");
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
 
-    let as_identity = args.get_one::<String>("identity");
+    let identity = args.get_one::<String>("identity");
     let anon_identity = args.get_flag("anon_identity");
 
     let address = database_address(&config, database, server).await?;
@@ -69,7 +69,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
             entity_name
         ),
     });
-    let auth_header = get_auth_header_only(&mut config, anon_identity, as_identity, server).await?;
+    let auth_header = get_auth_header_only(&mut config, anon_identity, identity, server).await?;
     let builder = add_auth_header_opt(builder, &auth_header);
 
     let descr = builder

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -53,21 +53,15 @@ pub fn cli() -> clap::Command {
                 .help("Turn on diagnostic/performance tracing for this project")
                 .action(SetTrue),
         )
-        // TODO(tyler): We should be able to pass in either an identity or an alias here
         .arg(
             Arg::new("identity")
                 .long("identity")
-                .short('I')
+                .short('i')
                 .help("The identity that should own the database")
-                .long_help("The identity that should own the database. If no identity is provided, your default identity will be used."))
-        // TODO(jdetter): add this back in when we actually support this
-        // .arg(
-        //     Arg::new("as_identity")
-        //         .long("as-identity")
-        //         .short('i')
-        //         .required(false)
-        //         .conflicts_with("anon_identity"),
-        // )
+                .long_help("The identity that should own the database. If no identity is provided, your default identity will be used.")
+                .required(false)
+                .conflicts_with("anon_identity")
+        )
         .arg(
             Arg::new("anon_identity")
                 .long("anon-identity")

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -65,12 +65,12 @@ pub fn cli() -> clap::Command {
 pub(crate) async fn parse_req(mut config: Config, args: &ArgMatches) -> Result<Connection, anyhow::Error> {
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
     let database = args.get_one::<String>("database").unwrap();
-    let as_identity = args.get_one::<String>("identity");
+    let identity = args.get_one::<String>("identity");
     let anon_identity = args.get_flag("anon_identity");
 
     Ok(Connection {
         host: config.get_host_url(server)?,
-        auth_header: get_auth_header_only(&mut config, anon_identity, as_identity, server).await?,
+        auth_header: get_auth_header_only(&mut config, anon_identity, identity, server).await?,
         address: database_address(&config, database, server).await?,
         database: database.to_string(),
     })

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -39,8 +39,8 @@ pub fn cli() -> clap::Command {
                 .required(true)
         )
         .arg(
-            Arg::new("as_identity")
-                .long("as-identity")
+            Arg::new("identity")
+                .long("identity")
                 .short('i')
                 .conflicts_with("anon_identity")
                 .help("The identity to use for querying the database")
@@ -50,7 +50,7 @@ pub fn cli() -> clap::Command {
             Arg::new("anon_identity")
                 .long("anon-identity")
                 .short('a')
-                .conflicts_with("as_identity")
+                .conflicts_with("identity")
                 .action(ArgAction::SetTrue)
                 .help("If this flag is present, no identity will be provided when querying the database")
         )
@@ -65,7 +65,7 @@ pub fn cli() -> clap::Command {
 pub(crate) async fn parse_req(mut config: Config, args: &ArgMatches) -> Result<Connection, anyhow::Error> {
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
     let database = args.get_one::<String>("database").unwrap();
-    let as_identity = args.get_one::<String>("as_identity");
+    let as_identity = args.get_one::<String>("identity");
     let anon_identity = args.get_flag("anon_identity");
 
     Ok(Connection {


### PR DESCRIPTION
# Description of Changes

Prior to this commit, some subcommands used `--as-identity` as the long, some of them used `-I` as the short, and there was no clear pattern.

With this commit, we just use `--identity` as the long everywhere, and `-i` as the short.

# API and ABI breaking changes

Breaking change to CLI arg parsing.

# Expected complexity level and risk

2 - I may have missed an arg, or some tool which depends on the previous arg format.
