### PR TITLE
Metrics were not measuring the time it took to commit the tx

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -289,6 +289,7 @@ impl RelationalDB {
     pub fn commit_tx(&self, ctx: &ExecutionContext, tx: MutTx) -> Result<Option<(TxData, Option<usize>)>, DBError> {
         log::trace!("COMMIT MUT TX");
         if let Some(tx_data) = self.inner.commit_mut_tx(ctx, tx)? {
+            // TODO(cloutiertyler): We should measure the time to append a transaction to the commitlog separately in metrics
             let bytes_written = self
                 .commit_log
                 .as_ref()


### PR DESCRIPTION
I am now including the time it takes to commit the transaction in the in the transaction duration. Commitlog appending is still not measured but should be measured separately in the future.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk
2

# Testing
None yet.
