### PR TITLE
Shrink AV by 8 bytes and AT by 16

### DIFF
--- a/crates/bench/benches/callgrind.rs
+++ b/crates/bench/benches/callgrind.rs
@@ -528,13 +528,10 @@ mod callgrind_benches {
             assert_eq!(self.format, "bsatn", "provided metadata has incorrect format");
 
             let buckets = 64;
-            let data = create_sequential::<u32_u64_str>(0xdeadbeef, self.count, buckets);
-            let data = ProductValue {
-                elements: data
-                    .into_iter()
-                    .map(|row| spacetimedb_lib::AlgebraicValue::Product(row.into_product_value()))
-                    .collect::<Vec<_>>(),
-            };
+            let data = create_sequential::<u32_u64_str>(0xdeadbeef, self.count, buckets)
+                .into_iter()
+                .map(|row| spacetimedb_lib::AlgebraicValue::Product(row.into_product_value()))
+                .collect::<ProductValue>();
 
             spacetimedb::callgrind_flag::enable_callgrind_globally(|| {
                 // don't time deallocation: return this!
@@ -567,13 +564,10 @@ mod callgrind_benches {
             assert_eq!(self.format, "json", "provided metadata has incorrect format");
 
             let buckets = 64;
-            let data = create_sequential::<u32_u64_str>(0xdeadbeef, self.count, buckets);
-            let data = ProductValue {
-                elements: data
-                    .into_iter()
-                    .map(|row| spacetimedb_lib::AlgebraicValue::Product(row.into_product_value()))
-                    .collect::<Vec<_>>(),
-            };
+            let data = create_sequential::<u32_u64_str>(0xdeadbeef, self.count, buckets)
+                .into_iter()
+                .map(|row| spacetimedb_lib::AlgebraicValue::Product(row.into_product_value()))
+                .collect::<ProductValue>();
 
             spacetimedb::callgrind_flag::enable_callgrind_globally(|| {
                 // don't time deallocation: return this!

--- a/crates/bench/benches/special.rs
+++ b/crates/bench/benches/special.rs
@@ -29,7 +29,7 @@ fn custom_module_benchmarks(c: &mut Criterion) {
     };
     let module = runtime.block_on(async { BENCHMARKS_MODULE.load_module(config, None).await });
 
-    let args = sats::product!["0".repeat(65536)];
+    let args = sats::product!["0".repeat(65536).into_boxed_str()];
     c.bench_function("special/stdb_module/large_arguments/64KiB", |b| {
         b.iter_batched(
             || args.clone(),
@@ -66,12 +66,10 @@ fn serialize_benchmarks<T: BenchTable + RandomTable>(c: &mut Criterion) {
         );
     });
     // this measures serialization from a ProductValue, not directly (as in, from generated code in the Rust SDK.)
-    let data_pv = ProductValue {
-        elements: data
-            .into_iter()
-            .map(|row| spacetimedb_lib::AlgebraicValue::Product(row.into_product_value()))
-            .collect::<Vec<_>>(),
-    };
+    let data_pv = data
+        .into_iter()
+        .map(|row| spacetimedb_lib::AlgebraicValue::Product(row.into_product_value()))
+        .collect::<ProductValue>();
 
     group.bench_function(&format!("{name}/bsatn/count={count}"), |b| {
         b.iter_batched_ref(

--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -40,7 +40,7 @@ fn create_table_footprint(db: &RelationalDB) -> Result<TableId, DBError> {
 fn insert_op(table_id: TableId, table_name: &str, row: ProductValue) -> DatabaseTableUpdate {
     DatabaseTableUpdate {
         table_id,
-        table_name: table_name.to_string(),
+        table_name: table_name.into(),
         inserts: [row].into(),
         deletes: [].into(),
     }

--- a/crates/bench/src/schemas.rs
+++ b/crates/bench/src/schemas.rs
@@ -19,7 +19,7 @@ pub struct u32_u64_str {
     // column 1
     age: u64,
     // column 2
-    name: String,
+    name: Box<str>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq, Hash)]
@@ -82,7 +82,7 @@ impl BenchTable for u32_u64_str {
         sats::product![self.id, self.age, self.name,]
     }
 
-    type SqliteParams = (u32, u64, String);
+    type SqliteParams = (u32, u64, Box<str>);
     fn into_sqlite_params(self) -> Self::SqliteParams {
         (self.id, self.age, self.name)
     }
@@ -192,7 +192,7 @@ pub trait RandomTable {
 
 impl RandomTable for u32_u64_str {
     fn gen(id: u32, rng: &mut XorShiftLite, buckets: u64) -> Self {
-        let name = nth_name(rng.gen() % buckets);
+        let name = nth_name(rng.gen() % buckets).into();
         let age = rng.gen() % buckets;
         u32_u64_str { id, name, age }
     }

--- a/crates/bench/src/spacetime_module.rs
+++ b/crates/bench/src/spacetime_module.rs
@@ -3,7 +3,7 @@ use std::path::Path;
 use spacetimedb::db::{Config, Storage};
 use spacetimedb_lib::{
     sats::{product, ArrayValue},
-    AlgebraicValue, ProductValue,
+    AlgebraicValue,
 };
 use spacetimedb_testing::modules::{start_runtime, CompilationMode, CompiledModule, LoggerRecord, ModuleHandle};
 use tokio::runtime::Runtime;
@@ -107,7 +107,7 @@ impl BenchDatabase for SpacetimeModule {
             module.call_reducer_binary(&name, ProductValue::new(&[])).await?;
             */
             // workaround for now
-            module.client.module.clear_table(table_id.pascal_case.clone()).await?;
+            module.client.module.clear_table(&table_id.pascal_case).await?;
             Ok(())
         })
     }
@@ -194,9 +194,7 @@ impl BenchDatabase for SpacetimeModule {
         let reducer_name = format!("filter_{}_by_{}", table_id.snake_case, column_name);
 
         runtime.block_on(async move {
-            module
-                .call_reducer_binary(&reducer_name, ProductValue { elements: vec![value] })
-                .await?;
+            module.call_reducer_binary(&reducer_name, [value].into()).await?;
             Ok(())
         })
     }

--- a/crates/bench/src/sqlite.rs
+++ b/crates/bench/src/sqlite.rs
@@ -135,8 +135,8 @@ impl BenchDatabase for SQLite {
 
     fn update_bulk<T: BenchTable>(&mut self, table_id: &Self::TableId, row_count: u32) -> ResultBench<()> {
         let mut product = T::product_type();
-        let id_column = product.elements.swap_remove(0).name.unwrap();
-        let update_column = product.elements.swap_remove(1).name.unwrap();
+        let id_column = product.elements[0].name.take().unwrap();
+        let update_column = product.elements[1].name.take().unwrap();
         // this relies on IDs having been generated in order...
         let statement =
             format!("UPDATE {table_id} SET {update_column} = {update_column} + 1 WHERE {id_column} < {row_count}");
@@ -175,11 +175,7 @@ impl BenchDatabase for SQLite {
         value: AlgebraicValue,
     ) -> ResultBench<()> {
         let statement = memo_query(BenchName::Filter, table_id, || {
-            let column: String = T::product_type()
-                .elements
-                .swap_remove(column_index as usize)
-                .name
-                .unwrap();
+            let column: Box<str> = T::product_type().elements[column_index as usize].name.take().unwrap();
             format!("SELECT * FROM {table_id} WHERE {column} = ?")
         });
 

--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -270,7 +270,7 @@ macro_rules! impl_reducer {
                     name: Info::NAME.into(),
                     args: vec![
                         $(ProductTypeElement {
-                            name: $T.map(str::to_owned),
+                            name: $T.map(Into::into),
                             algebraic_type: <$T>::make_type(_typespace),
                         }),*
                     ],
@@ -470,7 +470,7 @@ impl From<crate::IndexDesc<'_>> for IndexDef {
         };
 
         IndexDef {
-            index_name: index.name.to_string(),
+            index_name: index.name.into(),
             is_unique: false,
             index_type: index.ty,
             columns,

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -133,7 +133,7 @@ fn stmt_result_to_table(stmt_result: &StmtResultJson) -> anyhow::Result<tabled::
             .elements
             .iter()
             .enumerate()
-            .map(|(i, e)| e.name.clone().unwrap_or_else(|| format!("column {i}"))),
+            .map(|(i, e)| e.name.clone().unwrap_or_else(|| format!("column {i}").into())),
     );
 
     let ty = Typespace::EMPTY.with_type(schema);

--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -258,7 +258,7 @@ impl ServerMessage for OneOffQueryResponseMessage {
                 .results
                 .into_iter()
                 .map(|table| OneOffTableJson {
-                    table_name: table.head.table_name.clone(),
+                    table_name: table.head.table_name.clone().into(),
                     rows: table.data,
                 })
                 .collect(),
@@ -274,7 +274,7 @@ impl ServerMessage for OneOffQueryResponseMessage {
                     .results
                     .into_iter()
                     .map(|table| OneOffTable {
-                        table_name: table.head.table_name.clone(),
+                        table_name: table.head.table_name.clone().into(),
                         row: table
                             .data
                             .into_iter()

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -412,7 +412,7 @@ impl CommittedState {
 
                     // TODO: re-write `TxData` to remove `ProductValue`s
                     let pv = table.delete(blob_store, row_ptr).expect("Delete for non-existent row!");
-                    let table_name = table.get_schema().table_name.as_str();
+                    let table_name = &*table.get_schema().table_name;
                     //Increment rows deleted metric
                     ctx.metrics
                         .write()
@@ -469,7 +469,7 @@ impl CommittedState {
                     .insert(commit_blob_store, &pv)
                     .expect("Failed to insert when merging commit");
 
-                let table_name = commit_table.get_schema().table_name.as_str();
+                let table_name = &*commit_table.get_schema().table_name;
                 // Increment rows inserted metric
                 ctx.metrics
                     .write()
@@ -603,7 +603,7 @@ impl<'a> CommittedIndexIter<'a> {
 //         let get_table_name = || {
 //             self.committed_state
 //                 .get_schema(&self.table_id)
-//                 .map(|table| table.table_name.as_str())
+//                 .map(|table| &*table.table_name)
 //                 .unwrap_or_default()
 //                 .to_string()
 //         };

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -253,21 +253,21 @@ impl MutTxId {
 
         self.delete(ST_TABLES_ID, st_table_ptr)?;
         // Update the table's name in st_tables.
-        st.table_name = new_name.to_string();
+        st.table_name = new_name.into();
         self.insert(ST_TABLES_ID, &mut st.into(), database_address)?;
         Ok(())
     }
 
     pub fn table_id_from_name(&self, table_name: &str, database_address: Address) -> Result<Option<TableId>> {
         let ctx = ExecutionContext::internal(database_address);
-        let table_name = &table_name.to_owned().into();
+        let table_name = &table_name.into();
         let row = self
             .iter_by_col_eq(&ctx, &ST_TABLES_ID, StTableFields::TableName, table_name)?
             .next();
         Ok(row.map(|row| row.read_col(StTableFields::TableId).unwrap()))
     }
 
-    pub fn table_name_from_id<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Option<String>> {
+    pub fn table_name_from_id<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Option<Box<str>>> {
         self.iter_by_col_eq(ctx, &ST_TABLES_ID, StTableFields::TableId, &table_id.into())
             .map(|mut iter| iter.next().map(|row| row.read_col(StTableFields::TableName).unwrap()))
     }
@@ -402,7 +402,7 @@ impl MutTxId {
 
     pub fn index_id_from_name(&self, index_name: &str, database_address: Address) -> Result<Option<IndexId>> {
         let ctx = ExecutionContext::internal(database_address);
-        let name = &index_name.to_owned().into();
+        let name = &<Box<str>>::from(index_name).into();
         self.iter_by_col_eq(&ctx, &ST_INDEXES_ID, StIndexFields::IndexName, name)
             .map(|mut iter| iter.next().map(|row| row.read_col(StIndexFields::IndexId).unwrap()))
     }
@@ -520,7 +520,7 @@ impl MutTxId {
 
     pub fn sequence_id_from_name(&self, seq_name: &str, database_address: Address) -> Result<Option<SequenceId>> {
         let ctx = ExecutionContext::internal(database_address);
-        let name = &seq_name.to_owned().into();
+        let name = &<Box<str>>::from(seq_name).into();
         self.iter_by_col_eq(&ctx, &ST_SEQUENCES_ID, StSequenceFields::SequenceName, name)
             .map(|mut iter| {
                 iter.next()
@@ -619,7 +619,7 @@ impl MutTxId {
             &ExecutionContext::internal(database_address),
             &ST_CONSTRAINTS_ID,
             StConstraintFields::ConstraintName,
-            &constraint_name.to_owned().into(),
+            &<Box<str>>::from(constraint_name).into(),
         )
         .map(|mut iter| {
             iter.next()

--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -26,7 +26,7 @@ pub(crate) trait StateView {
 
     fn table_id_from_name(&self, table_name: &str, database_address: Address) -> Result<Option<TableId>> {
         let ctx = ExecutionContext::internal(database_address);
-        let name = &table_name.to_owned().into();
+        let name = &<Box<str>>::from(table_name).into();
         let row = self
             .iter_by_col_eq(&ctx, &ST_TABLES_ID, StTableFields::TableName, name)?
             .next();
@@ -68,7 +68,7 @@ pub(crate) trait StateView {
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_table, table_id.into()))?;
         let row = StTableRow::try_from(row)?;
-        let table_name: String = row.table_name;
+        let table_name = row.table_name;
         let table_id: TableId = row.table_id;
         let table_type = row.table_type;
         let table_access = row.table_access;
@@ -326,7 +326,7 @@ pub struct IndexSeekIterMutTxId<'a> {
 //         let get_table_name = || {
 //             self.committed_state
 //                 .get_schema(&self.table_id)
-//                 .map(|table| table.table_name.as_str())
+//                 .map(|table| &*table.table_name)
 //                 .unwrap_or_default()
 //                 .to_string()
 //         };

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -438,7 +438,7 @@ pub trait MutProgrammable: MutTxDatastore {
 mod tests {
     use spacetimedb_primitives::{col_list, ColId, Constraints};
     use spacetimedb_sats::db::def::ConstraintDef;
-    use spacetimedb_sats::{AlgebraicType, AlgebraicTypeRef, ProductType, ProductTypeElement, Typespace};
+    use spacetimedb_sats::{AlgebraicType, AlgebraicTypeRef, ProductType, Typespace};
 
     use super::{ColumnDef, IndexDef, TableDef};
 
@@ -471,16 +471,7 @@ mod tests {
             schema: expected_schema.clone(),
             data: AlgebraicTypeRef(0),
         };
-        let row_type = ProductType::new(vec![
-            ProductTypeElement {
-                name: Some("id".into()),
-                algebraic_type: AlgebraicType::U32,
-            },
-            ProductTypeElement {
-                name: Some("name".into()),
-                algebraic_type: AlgebraicType::String,
-            },
-        ]);
+        let row_type = ProductType::from([("id", AlgebraicType::U32), ("name", AlgebraicType::String)]);
 
         let mut datastore_schema = spacetimedb_lib::TableDesc::into_table_def(
             Typespace::new(vec![row_type.into()]).with_type(&lib_table_def),

--- a/crates/core/src/db/relational_operators.rs
+++ b/crates/core/src/db/relational_operators.rs
@@ -108,11 +108,12 @@ impl<S: Iterator<Item = ProductValue>> Iterator for Project<S> {
     type Item = ProductValue;
 
     fn next(&mut self) -> Option<ProductValue> {
-        self.source.next().map(|mut row| {
+        self.source.next().map(|row| {
+            let mut row: Vec<_> = row.elements.into();
             for &i in self.cols.iter().rev() {
-                row.elements.remove(i as usize);
+                row.remove(i as usize);
             }
-            row
+            row.into()
         })
     }
 }

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -18,7 +18,7 @@ use std::time::Duration;
 #[derive(thiserror::Error, Debug)]
 pub enum UpdateDatabaseError {
     #[error("incompatible schema changes for: {tables:?}. See database log for details.")]
-    IncompatibleSchema { tables: Vec<String> },
+    IncompatibleSchema { tables: Vec<Box<str>> },
     #[error(transparent)]
     Database(#[from] DBError),
 }
@@ -100,7 +100,7 @@ impl fmt::Display for TaintReason {
 /// A table with name `table_name` marked tainted for reason [`TaintReason`].
 #[derive(Debug, PartialEq)]
 pub struct Tainted {
-    pub table_name: String,
+    pub table_name: Box<str>,
     pub reason: TaintReason,
 }
 
@@ -111,7 +111,7 @@ pub enum SchemaUpdates {
     /// The schema can be updates.
     Updates {
         /// Tables to create.
-        new_tables: HashMap<String, TableDef>,
+        new_tables: HashMap<Box<str>, TableDef>,
     },
 }
 
@@ -135,7 +135,7 @@ pub fn schema_updates(
     let mut new_tables = HashMap::new();
     let mut tainted_tables = Vec::new();
 
-    let mut known_tables: BTreeMap<String, Cow<TableSchema>> = existing_tables
+    let mut known_tables: BTreeMap<Box<str>, Cow<TableSchema>> = existing_tables
         .into_iter()
         .map(|schema| (schema.table_name.clone(), schema))
         .collect();
@@ -476,7 +476,7 @@ mod tests {
                         t.table_name,
                         t.reason
                     );
-                    actual_tainted_tables.push(t.table_name);
+                    actual_tainted_tables.push(t.table_name.to_string());
                 }
                 assert_eq!(&actual_tainted_tables, tainted_tables);
             }

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -26,7 +26,7 @@ use spacetimedb_vm::expr::Crud;
 #[derive(Error, Debug)]
 pub enum TableError {
     #[error("Table with name `{0}` start with 'st_' and that is reserved for internal system tables.")]
-    System(String),
+    System(Box<str>),
     #[error("Table with name `{0}` already exists.")]
     Exist(String),
     #[error("Table with name `{0}` not found.")]
@@ -56,7 +56,7 @@ pub enum TableError {
     )]
     DecodeField {
         table: String,
-        field: String,
+        field: Box<str>,
         expect: String,
         found: String,
     },
@@ -103,15 +103,15 @@ pub enum PlanError {
     #[error("Unsupported feature: `{feature}`")]
     Unsupported { feature: String },
     #[error("Unknown table: `{table}`")]
-    UnknownTable { table: String },
+    UnknownTable { table: Box<str> },
     #[error("Qualified Table `{expect}` not found")]
     TableNotFoundQualified { expect: String },
     #[error("Unknown field: `{field}` not found in the table(s): `{tables:?}`")]
-    UnknownField { field: FieldName, tables: Vec<String> },
+    UnknownField { field: FieldName, tables: Vec<Box<str>> },
     #[error("Field(s): `{fields:?}` not found in the table(s): `{tables:?}`")]
     UnknownFields {
         fields: Vec<FieldName>,
-        tables: Vec<String>,
+        tables: Vec<Box<str>>,
     },
     #[error("Ambiguous field: `{field}`. Also found in {found:?}")]
     AmbiguousField { field: String, found: Vec<FieldName> },
@@ -324,7 +324,7 @@ pub enum NodesError {
     #[error("table with name {0:?} already exists")]
     AlreadyExists(String),
     #[error("table with name `{0}` start with 'st_' and that is reserved for internal system tables.")]
-    SystemName(String),
+    SystemName(Box<str>),
     #[error("internal db error: {0}")]
     Internal(#[source] Box<DBError>),
     #[error("invalid index type: {0}")]

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -225,7 +225,7 @@ impl InstanceEnv {
     #[tracing::instrument(skip_all)]
     pub fn create_index(
         &self,
-        index_name: String,
+        index_name: Box<str>,
         table_id: TableId,
         index_type: u8,
         col_ids: Vec<u8>,

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -69,15 +69,12 @@ pub struct ArgsTuple {
 }
 
 impl ArgsTuple {
-    #[allow(clippy::declare_interior_mutable_const)] // false positive on Bytes
-    const NULLARY: Self = ArgsTuple {
-        tuple: spacetimedb_sats::product![],
-        bsatn: OnceCell::with_value(Bytes::new()),
-        json: OnceCell::with_value(ByteString::from_static("[]")),
-    };
-
-    pub const fn nullary() -> Self {
-        Self::NULLARY
+    pub fn nullary() -> Self {
+        ArgsTuple {
+            tuple: spacetimedb_sats::product![],
+            bsatn: OnceCell::with_value(Bytes::new()),
+            json: OnceCell::with_value(ByteString::from_static("[]")),
+        }
     }
 
     pub fn get_bsatn(&self) -> &Bytes {
@@ -117,7 +114,7 @@ impl From<usize> for ReducerId {
 pub struct InvalidReducerArguments {
     #[source]
     err: anyhow::Error,
-    reducer: String,
+    reducer: Box<str>,
 }
 
 fn from_json_seed<'de, T: serde::de::DeserializeSeed<'de>>(s: &'de str, seed: T) -> anyhow::Result<T::Value> {

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -285,7 +285,7 @@ impl<T: WasmModule> Module for WasmModuleHostActor<T> {
         sql::execute::execute_sql(db, compiled, auth)
     }
 
-    fn clear_table(&self, table_name: String) -> Result<(), anyhow::Error> {
+    fn clear_table(&self, table_name: &str) -> Result<(), anyhow::Error> {
         let db = &*self.database_instance_context.relational_db;
         db.with_auto_commit(&ExecutionContext::internal(db.address()), |tx| {
             let tables = db.get_all_tables_mut(tx)?;
@@ -293,7 +293,7 @@ impl<T: WasmModule> Module for WasmModuleHostActor<T> {
             // so we can assume there's only one table to clear.
             if let Some(table_id) = tables
                 .iter()
-                .find_map(|t| (t.table_name == table_name).then_some(t.table_id))
+                .find_map(|t| (&*t.table_name == table_name).then_some(t.table_id))
             {
                 db.clear_table(tx, table_id)?;
             }

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -528,7 +528,7 @@ impl WasmInstanceEnv {
         Self::cvt(caller, AbiCall::CreateIndex, |caller| {
             let (mem, env) = Self::mem_env(caller);
             // Read the index name from WASM memory.
-            let index_name = mem.deref_str(index_name, index_name_len)?.to_owned();
+            let index_name = mem.deref_str(index_name, index_name_len)?.into();
 
             // Read the column ids on which to create an index from WASM memory.
             // This may be one column or an index on several columns.

--- a/crates/core/src/json/client_api.rs
+++ b/crates/core/src/json/client_api.rs
@@ -63,7 +63,7 @@ pub struct FunctionCallJson {
 #[derive(Debug, Clone, Serialize)]
 pub struct TableUpdateJson {
     pub table_id: u32,
-    pub table_name: String,
+    pub table_name: Box<str>,
     pub table_row_operations: Vec<TableRowOperationJson>,
 }
 

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -100,7 +100,7 @@ fn compile_select(table: From, project: Vec<Column>, selection: Option<Selection
                 Err(err) => return Err(err),
             },
             Column::QualifiedWildcard { table: name } => {
-                if let Some(t) = table.iter_tables().find(|x| x.table_name == name) {
+                if let Some(t) = table.iter_tables().find(|x| *x.table_name == name) {
                     for c in t.columns().iter() {
                         col_ids.push(FieldName::named(&t.table_name, &c.col_name).into());
                     }
@@ -672,10 +672,10 @@ mod tests {
         };
 
         assert_eq!(table_id, rhs_id);
-        assert_eq!(lhs_field, "b");
-        assert_eq!(rhs_field, "b");
-        assert_eq!(lhs_table, "lhs");
-        assert_eq!(rhs_table, "rhs");
+        assert_eq!(&**lhs_field, "b");
+        assert_eq!(&**rhs_field, "b");
+        assert_eq!(&**lhs_table, "lhs");
+        assert_eq!(&**rhs_table, "rhs");
         Ok(())
     }
 
@@ -721,8 +721,8 @@ mod tests {
             panic!("unexpected left hand side {:#?}", **lhs);
         };
 
-        assert_eq!(table, "lhs");
-        assert_eq!(field, "a");
+        assert_eq!(&**table, "lhs");
+        assert_eq!(&**field, "a");
 
         let ColumnOp::Field(FieldExpr::Value(AlgebraicValue::U64(3))) = **rhs else {
             panic!("unexpected right hand side {:#?}", **rhs);
@@ -752,10 +752,10 @@ mod tests {
         };
 
         assert_eq!(table_id, rhs_id);
-        assert_eq!(lhs_field, "b");
-        assert_eq!(rhs_field, "b");
-        assert_eq!(lhs_table, "lhs");
-        assert_eq!(rhs_table, "rhs");
+        assert_eq!(&**lhs_field, "b");
+        assert_eq!(&**rhs_field, "b");
+        assert_eq!(&**lhs_table, "lhs");
+        assert_eq!(&**rhs_table, "rhs");
         assert!(rhs.is_empty());
         Ok(())
     }
@@ -813,10 +813,10 @@ mod tests {
         };
 
         assert_eq!(table_id, rhs_id);
-        assert_eq!(lhs_field, "b");
-        assert_eq!(rhs_field, "b");
-        assert_eq!(lhs_table, "lhs");
-        assert_eq!(rhs_table, "rhs");
+        assert_eq!(&**lhs_field, "b");
+        assert_eq!(&**rhs_field, "b");
+        assert_eq!(&**lhs_table, "lhs");
+        assert_eq!(&**rhs_table, "rhs");
 
         // The selection should be pushed onto the rhs of the join
         let Query::Select(ColumnOp::Cmp {
@@ -832,8 +832,8 @@ mod tests {
             panic!("unexpected left hand side {:#?}", **lhs);
         };
 
-        assert_eq!(table, "rhs");
-        assert_eq!(field, "c");
+        assert_eq!(&**table, "rhs");
+        assert_eq!(&**field, "c");
 
         let ColumnOp::Field(FieldExpr::Value(AlgebraicValue::U64(3))) = **rhs else {
             panic!("unexpected right hand side {:#?}", **rhs);
@@ -902,10 +902,10 @@ mod tests {
         };
 
         assert_eq!(table_id, rhs_id);
-        assert_eq!(lhs_field, "b");
-        assert_eq!(rhs_field, "b");
-        assert_eq!(lhs_table, "lhs");
-        assert_eq!(rhs_table, "rhs");
+        assert_eq!(&**lhs_field, "b");
+        assert_eq!(&**rhs_field, "b");
+        assert_eq!(&**lhs_table, "lhs");
+        assert_eq!(&**rhs_table, "rhs");
 
         assert_eq!(1, rhs.len());
 
@@ -976,8 +976,8 @@ mod tests {
         assert_eq!(*table_id, rhs_id);
         assert_eq!(*index_table, lhs_id);
         assert_eq!(index_col, &1.into());
-        assert_eq!(probe_field, "b");
-        assert_eq!(probe_table, "rhs");
+        assert_eq!(&**probe_field, "b");
+        assert_eq!(&**probe_table, "rhs");
 
         assert_eq!(2, rhs.len());
 
@@ -1005,8 +1005,8 @@ mod tests {
             panic!("unexpected left hand side {:#?}", field);
         };
 
-        assert_eq!(table, "rhs");
-        assert_eq!(field, "d");
+        assert_eq!(&**table, "rhs");
+        assert_eq!(&**field, "d");
 
         let ColumnOp::Field(FieldExpr::Value(AlgebraicValue::U64(3))) = **value else {
             panic!("unexpected right hand side {:#?}", value);
@@ -1074,8 +1074,8 @@ mod tests {
         assert_eq!(*table_id, rhs_id);
         assert_eq!(*index_table, lhs_id);
         assert_eq!(index_col, &1.into());
-        assert_eq!(probe_field, "b");
-        assert_eq!(probe_table, "rhs");
+        assert_eq!(&**probe_field, "b");
+        assert_eq!(&**probe_table, "rhs");
 
         assert_eq!(2, rhs.len());
 
@@ -1098,8 +1098,8 @@ mod tests {
             panic!("unexpected left hand side {:#?}", field);
         };
 
-        assert_eq!(table, "rhs");
-        assert_eq!(field, "d");
+        assert_eq!(&**table, "rhs");
+        assert_eq!(&**field, "d");
 
         let ColumnOp::Field(FieldExpr::Value(AlgebraicValue::U64(3))) = **value else {
             panic!("unexpected right hand side {:#?}", value);

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -110,7 +110,9 @@ pub(crate) mod tests {
 
         let mut tx = stdb.begin_mut_tx(IsolationLevel::Serializable);
         let head = ProductType::from([("inventory_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
-        let rows: Vec<_> = (1..=total_rows).map(|i| product!(i, format!("health{i}"))).collect();
+        let rows: Vec<_> = (1..=total_rows)
+            .map(|i| product!(i, format!("health{i}").into_boxed_str()))
+            .collect();
         create_table_with_rows(&stdb, &mut tx, "inventory", head.clone(), &rows)?;
         stdb.commit_tx(&ExecutionContext::default(), tx)?;
 

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -172,7 +172,7 @@ impl ExecutionUnit {
         self.return_db_table().table_id
     }
 
-    pub fn return_name(&self) -> String {
+    pub fn return_name(&self) -> Box<str> {
         self.return_db_table().head.table_name.clone()
     }
 
@@ -239,7 +239,7 @@ impl ExecutionUnit {
         })?;
         Ok((!table_row_operations.is_empty()).then(|| TableUpdate {
             table_id: self.return_table().into(),
-            table_name: self.return_name(),
+            table_name: self.return_name().into(),
             table_row_operations,
         }))
     }

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -202,7 +202,7 @@ impl SubscriptionManager {
                             Entry::Vacant(entry) => drop(entry.insert(match ops {
                                 Either::Left(ops) => Either::Left(TableUpdate {
                                     table_id: table_id.into(),
-                                    table_name,
+                                    table_name: table_name.into(),
                                     table_row_operations: ops,
                                 }),
                                 Either::Right(ops) => Either::Right(TableUpdateJson {

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -144,7 +144,7 @@ mod tests {
     fn insert_op(table_id: TableId, table_name: &str, row: ProductValue) -> DatabaseTableUpdate {
         DatabaseTableUpdate {
             table_id,
-            table_name: table_name.to_string(),
+            table_name: table_name.into(),
             deletes: [].into(),
             inserts: [row].into(),
         }
@@ -153,7 +153,7 @@ mod tests {
     fn delete_op(table_id: TableId, table_name: &str, row: ProductValue) -> DatabaseTableUpdate {
         DatabaseTableUpdate {
             table_id,
-            table_name: table_name.to_string(),
+            table_name: table_name.into(),
             deletes: [row].into(),
             inserts: [].into(),
         }
@@ -180,7 +180,7 @@ mod tests {
 
         let data = DatabaseTableUpdate {
             table_id,
-            table_name: table_name.to_string(),
+            table_name: table_name.into(),
             deletes: [].into(),
             inserts: [row.clone()].into(),
         };
@@ -441,7 +441,7 @@ mod tests {
 
         let data = DatabaseTableUpdate {
             table_id: schema.table_id,
-            table_name: "_inventory".to_string(),
+            table_name: "_inventory".into(),
             deletes: [].into(),
             inserts: [row.clone()].into(),
         };
@@ -562,14 +562,14 @@ mod tests {
 
         let data1 = DatabaseTableUpdate {
             table_id: schema_1.table_id,
-            table_name: "inventory".to_string(),
+            table_name: "inventory".into(),
             deletes: [row_1].into(),
             inserts: [].into(),
         };
 
         let data2 = DatabaseTableUpdate {
             table_id: schema_2.table_id,
-            table_name: "player".to_string(),
+            table_name: "player".into(),
             deletes: [].into(),
             inserts: [row_2].into(),
         };
@@ -1024,13 +1024,13 @@ mod tests {
             vec![
                 DatabaseTableUpdate {
                     table_id: lhs_id,
-                    table_name: "lhs".to_string(),
+                    table_name: "lhs".into(),
                     deletes: [lhs_old.clone()].into(),
                     inserts: [lhs_new.clone()].into(),
                 },
                 DatabaseTableUpdate {
                     table_id: rhs_id,
-                    table_name: "rhs".to_string(),
+                    table_name: "rhs".into(),
                     deletes: [rhs_old.clone()].into(),
                     inserts: [rhs_new.clone()].into(),
                 },
@@ -1043,7 +1043,7 @@ mod tests {
             result.tables[0],
             DatabaseTableUpdate {
                 table_id: lhs_id,
-                table_name: "lhs".to_string(),
+                table_name: "lhs".into(),
                 deletes: [lhs_old].into(),
                 inserts: [lhs_new].into(),
             },

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -730,8 +730,8 @@ mod tests {
         // Assert that original index and probe tables have been swapped.
         assert_eq!(index_table, rhs_id);
         assert_eq!(index_col, 0.into());
-        assert_eq!(probe_field, "b");
-        assert_eq!(probe_table, "lhs");
+        assert_eq!(&**probe_field, "b");
+        assert_eq!(&**probe_table, "lhs");
         Ok(())
     }
 
@@ -817,8 +817,8 @@ mod tests {
         // Assert that original index and probe tables have not been swapped.
         assert_eq!(index_table, lhs_id);
         assert_eq!(index_col, 1.into());
-        assert_eq!(probe_field, "b");
-        assert_eq!(probe_table, "rhs");
+        assert_eq!(&**probe_field, "b");
+        assert_eq!(&**probe_table, "rhs");
         Ok(())
     }
 

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -562,7 +562,6 @@ impl ProgramVm for DbProgram<'_, '_> {
                     .into_iter()
                     .map(|row| {
                         let elements = row
-                            .elements
                             .into_iter()
                             .zip(&exprs)
                             .map(|(val, expr)| {
@@ -634,12 +633,11 @@ pub(crate) mod tests {
         schema: ProductType,
         rows: &[ProductValue],
     ) -> ResultTest<TableId> {
-        let columns: Vec<_> = schema
-            .elements
+        let columns: Vec<_> = Vec::from(schema.elements)
             .into_iter()
             .enumerate()
             .map(|(i, e)| ColumnDef {
-                col_name: e.name.unwrap_or(i.to_string()),
+                col_name: e.name.unwrap_or_else(|| i.to_string().into()),
                 col_type: e.algebraic_type,
             })
             .collect();
@@ -797,7 +795,7 @@ pub(crate) mod tests {
             ST_TABLES_NAME,
             StTableRow {
                 table_id: ST_TABLES_ID,
-                table_name: ST_TABLES_NAME.to_string(),
+                table_name: ST_TABLES_NAME.into(),
                 table_type: StTableType::System,
                 table_access: StAccess::Public,
             }
@@ -878,7 +876,7 @@ pub(crate) mod tests {
             ST_INDEXES_NAME,
             StIndexRow {
                 index_id,
-                index_name: "idx_1".to_owned(),
+                index_name: "idx_1".into(),
                 table_id,
                 columns: ColList::new(0.into()),
                 is_unique: true,
@@ -913,7 +911,7 @@ pub(crate) mod tests {
             ST_SEQUENCES_NAME,
             StSequenceRow {
                 sequence_id: 3.into(),
-                sequence_name: "seq_st_sequence_sequence_id_primary_key_auto".to_string(),
+                sequence_name: "seq_st_sequence_sequence_id_primary_key_auto".into(),
                 table_id: 2.into(),
                 col_pos: 0.into(),
                 increment: 1,

--- a/crates/lib/src/address.rs
+++ b/crates/lib/src/address.rs
@@ -124,7 +124,7 @@ impl From<u128> for Address {
 impl From<Address> for AlgebraicValue {
     fn from(value: Address) -> Self {
         AlgebraicValue::Product(ProductValue::from(AlgebraicValue::Bytes(
-            value.__address_bytes.to_vec(),
+            value.__address_bytes.to_vec().into(),
         )))
     }
 }

--- a/crates/lib/src/identity.rs
+++ b/crates/lib/src/identity.rs
@@ -128,7 +128,7 @@ impl FromStr for Identity {
 
 impl From<Identity> for AlgebraicValue {
     fn from(value: Identity) -> Self {
-        AlgebraicValue::Product(ProductValue::from(AlgebraicValue::Bytes(value.to_vec())))
+        AlgebraicValue::Product(ProductValue::from(AlgebraicValue::Bytes(value.to_vec().into())))
     }
 }
 

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -102,7 +102,7 @@ impl TableDesc {
 
 #[derive(Debug, Clone, de::Deserialize, ser::Serialize)]
 pub struct ReducerDef {
-    pub name: String,
+    pub name: Box<str>,
     pub args: Vec<ProductTypeElement>,
 }
 

--- a/crates/primitives/src/col_list.rs
+++ b/crates/primitives/src/col_list.rs
@@ -185,8 +185,8 @@ impl ColList {
         }
     }
 
-    /// Convert to a `Vec<u32>`.
-    pub fn to_u32_vec(&self) -> alloc::vec::Vec<u32> {
+    /// Convert to a `Box<[u32]>`.
+    pub fn to_u32_vec(&self) -> alloc::boxed::Box<[u32]> {
         self.iter().map(u32::from).collect()
     }
 

--- a/crates/sats/src/algebraic_type.rs
+++ b/crates/sats/src/algebraic_type.rs
@@ -114,6 +114,13 @@ pub enum AlgebraicType {
     Ref(AlgebraicTypeRef),
 }
 
+/// Provided to enable `mem::take`.
+impl Default for AlgebraicType {
+    fn default() -> Self {
+        Self::ZERO_REF
+    }
+}
+
 #[allow(non_upper_case_globals)]
 impl AlgebraicType {
     /// The first type in the typespace.
@@ -243,7 +250,7 @@ impl AlgebraicType {
 
     /// Returns a sum type of unit variants with names taken from `var_names`.
     pub fn simple_enum<'a>(var_names: impl Iterator<Item = &'a str>) -> Self {
-        Self::sum(var_names.into_iter().map(SumTypeVariant::unit).collect::<Vec<_>>())
+        Self::sum(var_names.into_iter().map(SumTypeVariant::unit).collect::<Box<[_]>>())
     }
 
     pub fn as_value(&self) -> AlgebraicValue {

--- a/crates/sats/src/algebraic_value.rs
+++ b/crates/sats/src/algebraic_value.rs
@@ -64,7 +64,7 @@ pub enum AlgebraicValue {
     ///
     /// We box the `MapValue` to reduce size
     /// and because we assume that map values will be uncommon.
-    Map(MapValue),
+    Map(Box<MapValue>),
     /// A [`bool`] value of type [`AlgebraicType::Bool`].
     Bool(bool),
     /// An [`i8`] value of type [`AlgebraicType::I8`].
@@ -86,11 +86,11 @@ pub enum AlgebraicValue {
     /// An [`i128`] value of type [`AlgebraicType::I128`].
     ///
     /// We box these up as they allow us to shrink `AlgebraicValue`.
-    I128(i128),
+    I128(Packed<i128>),
     /// A [`u128`] value of type [`AlgebraicType::U128`].
     ///
     /// We box these up as they allow us to shrink `AlgebraicValue`.
-    U128(u128),
+    U128(Packed<u128>),
     /// A totally ordered [`F32`] value of type [`AlgebraicType::F32`].
     ///
     /// All floating point values defined in IEEE-754 are supported.
@@ -108,7 +108,30 @@ pub enum AlgebraicValue {
     /// A UTF-8 string value of type [`AlgebraicType::String`].
     ///
     /// Uses Rust's standard representation of strings.
-    String(String),
+    String(Box<str>),
+}
+
+/// Wraps `T` making the outer type packed with alignment 1.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+#[repr(packed)]
+pub struct Packed<T>(pub T);
+
+impl From<u128> for AlgebraicValue {
+    fn from(value: u128) -> Self {
+        Self::U128(Packed(value))
+    }
+}
+
+impl From<i128> for AlgebraicValue {
+    fn from(value: i128) -> Self {
+        Self::I128(Packed(value))
+    }
+}
+
+impl<T> From<T> for Packed<T> {
+    fn from(value: T) -> Self {
+        Self(value)
+    }
 }
 
 #[allow(non_snake_case)]
@@ -131,17 +154,17 @@ impl AlgebraicValue {
     ///
     /// The type of `UNIT` is `()`.
     pub fn unit() -> Self {
-        Self::product([].into())
+        Self::product([])
     }
 
-    /// Returns an [`AlgebraicValue`] representing `v: Vec<u8>`.
+    /// Returns an [`AlgebraicValue`] representing `v: Box<[u8]>`.
     #[inline]
-    pub const fn Bytes(v: Vec<u8>) -> Self {
+    pub const fn Bytes(v: Box<[u8]>) -> Self {
         Self::Array(ArrayValue::U8(v))
     }
 
     /// Converts `self` into a byte string, if applicable.
-    pub fn into_bytes(self) -> Result<Vec<u8>, Self> {
+    pub fn into_bytes(self) -> Result<Box<[u8]>, Self> {
         match self {
             Self::Array(ArrayValue::U8(v)) => Ok(v),
             _ => Err(self),
@@ -178,13 +201,13 @@ impl AlgebraicValue {
     }
 
     /// Returns an [`AlgebraicValue`] representing a product value with the given `elements`.
-    pub const fn product(elements: Vec<Self>) -> Self {
-        Self::Product(ProductValue { elements })
+    pub fn product(elements: impl Into<ProductValue>) -> Self {
+        Self::Product(elements.into())
     }
 
     /// Returns an [`AlgebraicValue`] representing a map value defined by the given `map`.
     pub fn map(map: MapValue) -> Self {
-        Self::Map(map)
+        Self::Map(Box::new(map))
     }
 
     /// Returns the [`AlgebraicType`] of the sum value `x`.
@@ -204,7 +227,7 @@ impl AlgebraicValue {
 
     /// Returns the [`AlgebraicType`] of the product value `x`.
     pub(crate) fn type_of_product(x: &ProductValue) -> AlgebraicType {
-        AlgebraicType::product(x.elements.iter().map(|x| x.type_of().into()).collect::<Vec<_>>())
+        AlgebraicType::product(x.elements.iter().map(|x| x.type_of().into()).collect::<Box<[_]>>())
     }
 
     /// Returns the [`AlgebraicType`] of the map with key type `k` and value type `v`.
@@ -258,8 +281,8 @@ impl AlgebraicValue {
             Self::U32(x) => x == 0,
             Self::I64(x) => x == 0,
             Self::U64(x) => x == 0,
-            Self::I128(x) => x == 0,
-            Self::U128(x) => x == 0,
+            Self::I128(x) => x.0 == 0,
+            Self::U128(x) => x.0 == 0,
             Self::F32(x) => x == 0.0,
             Self::F64(x) => x == 0.0,
             _ => false,
@@ -339,7 +362,7 @@ mod tests {
     fn product_value() {
         let product_type = AlgebraicType::product([("foo", AlgebraicType::I32)]);
         let typespace = Typespace::new(vec![]);
-        let product_value = AlgebraicValue::product([AlgebraicValue::I32(42)].into());
+        let product_value = AlgebraicValue::product([AlgebraicValue::I32(42)]);
         assert_eq!(
             "(foo = 42)",
             in_space(&typespace, &product_type, &product_value).to_satn(),
@@ -365,7 +388,7 @@ mod tests {
     #[test]
     fn array() {
         let array = AlgebraicType::array(AlgebraicType::U8);
-        let value = AlgebraicValue::Array(ArrayValue::Sum(Vec::new()));
+        let value = AlgebraicValue::Array(ArrayValue::Sum([].into()));
         let typespace = Typespace::new(vec![]);
         assert_eq!(in_space(&typespace, &array, &value).to_satn(), "[]");
     }

--- a/crates/sats/src/algebraic_value/de.rs
+++ b/crates/sats/src/algebraic_value/de.rs
@@ -54,7 +54,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer {
     type Error = ValueDeserializeError;
 
     fn deserialize_product<V: de::ProductVisitor<'de>>(self, visitor: V) -> Result<V::Output, Self::Error> {
-        let vals = map_err(self.val.into_product())?.elements.into_iter();
+        let vals = map_err(self.val.into_product())?.into_iter();
         visitor.visit_seq_product(ProductAccess { vals })
     }
 
@@ -84,7 +84,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer {
     }
 
     fn deserialize_u128(self) -> Result<u128, Self::Error> {
-        map_err(self.val.into_u128())
+        map_err(self.val.into_u128().map(|x| x.0))
     }
 
     fn deserialize_i8(self) -> Result<i8, Self::Error> {
@@ -104,7 +104,7 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer {
     }
 
     fn deserialize_i128(self) -> Result<i128, Self::Error> {
-        map_err(self.val.into_i128())
+        map_err(self.val.into_i128().map(|x| x.0))
     }
 
     fn deserialize_f32(self) -> Result<f32, Self::Error> {
@@ -116,11 +116,11 @@ impl<'de> de::Deserializer<'de> for ValueDeserializer {
     }
 
     fn deserialize_str<V: de::SliceVisitor<'de, str>>(self, visitor: V) -> Result<V::Output, Self::Error> {
-        visitor.visit_owned(map_err(self.val.into_string())?)
+        visitor.visit_owned(map_err(self.val.into_string().map(Into::into))?)
     }
 
     fn deserialize_bytes<V: de::SliceVisitor<'de, [u8]>>(self, visitor: V) -> Result<V::Output, Self::Error> {
-        visitor.visit_owned(map_err(self.val.into_bytes())?)
+        visitor.visit_owned(map_err(self.val.into_bytes().map(Vec::from))?)
     }
 
     fn deserialize_array_seed<V: de::ArrayVisitor<'de, T::Output>, T: de::DeserializeSeed<'de> + Clone>(
@@ -281,7 +281,7 @@ impl<'de> de::Deserializer<'de> for &'de ValueDeserializer {
         ok_or(self.val.as_u64().copied())
     }
     fn deserialize_u128(self) -> Result<u128, Self::Error> {
-        ok_or(self.val.as_u128().copied())
+        ok_or(self.val.as_u128().copied().map(|x| x.0))
     }
     fn deserialize_i8(self) -> Result<i8, Self::Error> {
         ok_or(self.val.as_i8().copied())
@@ -296,7 +296,7 @@ impl<'de> de::Deserializer<'de> for &'de ValueDeserializer {
         ok_or(self.val.as_i64().copied())
     }
     fn deserialize_i128(self) -> Result<i128, Self::Error> {
-        ok_or(self.val.as_i128().copied())
+        ok_or(self.val.as_i128().copied().map(|x| x.0))
     }
     fn deserialize_f32(self) -> Result<f32, Self::Error> {
         ok_or(self.val.as_f32().copied().map(f32::from))

--- a/crates/sats/src/array_value.rs
+++ b/crates/sats/src/array_value.rs
@@ -10,41 +10,41 @@ use std::fmt;
 #[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub enum ArrayValue {
     /// An array of [`SumValue`](crate::SumValue)s.
-    Sum(Vec<SumValue>),
+    Sum(Box<[SumValue]>),
     /// An array of [`ProductValue`](crate::ProductValue)s.
-    Product(Vec<ProductValue>),
+    Product(Box<[ProductValue]>),
     /// An array of [`bool`]s.
-    Bool(Vec<bool>),
+    Bool(Box<[bool]>),
     /// An array of [`i8`]s.
-    I8(Vec<i8>),
+    I8(Box<[i8]>),
     /// An array of [`u8`]s.
-    U8(Vec<u8>),
+    U8(Box<[u8]>),
     /// An array of [`i16`]s.
-    I16(Vec<i16>),
+    I16(Box<[i16]>),
     /// An array of [`u16`]s.
-    U16(Vec<u16>),
+    U16(Box<[u16]>),
     /// An array of [`i32`]s.
-    I32(Vec<i32>),
+    I32(Box<[i32]>),
     /// An array of [`u32`]s.
-    U32(Vec<u32>),
+    U32(Box<[u32]>),
     /// An array of [`i64`]s.
-    I64(Vec<i64>),
+    I64(Box<[i64]>),
     /// An array of [`u64`]s.
-    U64(Vec<u64>),
+    U64(Box<[u64]>),
     /// An array of [`i128`]s.
-    I128(Vec<i128>),
+    I128(Box<[i128]>),
     /// An array of [`u128`]s.
-    U128(Vec<u128>),
+    U128(Box<[u128]>),
     /// An array of totally ordered [`F32`]s.
-    F32(Vec<F32>),
+    F32(Box<[F32]>),
     /// An array of totally ordered [`F64`]s.
-    F64(Vec<F64>),
+    F64(Box<[F64]>),
     /// An array of UTF-8 strings.
-    String(Vec<String>),
+    String(Box<[Box<str>]>),
     /// An array of arrays.
-    Array(Vec<ArrayValue>),
+    Array(Box<[ArrayValue]>),
     /// An array of maps.
-    Map(Vec<MapValue>),
+    Map(Box<[MapValue]>),
 }
 
 impl crate::Value for ArrayValue {
@@ -155,14 +155,14 @@ macro_rules! impl_from_array {
     ($el:ty, $var:ident) => {
         impl<const N: usize> From<[$el; N]> for ArrayValue {
             fn from(v: [$el; N]) -> Self {
-                let vec: Vec<_> = v.into();
+                let vec: Box<[_]> = v.into();
                 vec.into()
             }
         }
 
         // Exists for convenience.
-        impl From<Vec<$el>> for ArrayValue {
-            fn from(v: Vec<$el>) -> Self {
+        impl From<Box<[$el]>> for ArrayValue {
+            fn from(v: Box<[$el]>) -> Self {
                 Self::$var(v)
             }
         }
@@ -184,7 +184,7 @@ impl_from_array!(i128, I128);
 impl_from_array!(u128, U128);
 impl_from_array!(F32, F32);
 impl_from_array!(F64, F64);
-impl_from_array!(String, String);
+impl_from_array!(Box<str>, String);
 impl_from_array!(ArrayValue, Array);
 impl_from_array!(MapValue, Map);
 
@@ -226,24 +226,24 @@ impl IntoIterator for ArrayValue {
 
     fn into_iter(self) -> Self::IntoIter {
         match self {
-            ArrayValue::Sum(v) => ArrayValueIntoIter::Sum(v.into_iter()),
-            ArrayValue::Product(v) => ArrayValueIntoIter::Product(v.into_iter()),
-            ArrayValue::Bool(v) => ArrayValueIntoIter::Bool(v.into_iter()),
-            ArrayValue::I8(v) => ArrayValueIntoIter::I8(v.into_iter()),
-            ArrayValue::U8(v) => ArrayValueIntoIter::U8(v.into_iter()),
-            ArrayValue::I16(v) => ArrayValueIntoIter::I16(v.into_iter()),
-            ArrayValue::U16(v) => ArrayValueIntoIter::U16(v.into_iter()),
-            ArrayValue::I32(v) => ArrayValueIntoIter::I32(v.into_iter()),
-            ArrayValue::U32(v) => ArrayValueIntoIter::U32(v.into_iter()),
-            ArrayValue::I64(v) => ArrayValueIntoIter::I64(v.into_iter()),
-            ArrayValue::U64(v) => ArrayValueIntoIter::U64(v.into_iter()),
-            ArrayValue::I128(v) => ArrayValueIntoIter::I128(v.into_iter()),
-            ArrayValue::U128(v) => ArrayValueIntoIter::U128(v.into_iter()),
-            ArrayValue::F32(v) => ArrayValueIntoIter::F32(v.into_iter()),
-            ArrayValue::F64(v) => ArrayValueIntoIter::F64(v.into_iter()),
-            ArrayValue::String(v) => ArrayValueIntoIter::String(v.into_iter()),
-            ArrayValue::Array(v) => ArrayValueIntoIter::Array(v.into_iter()),
-            ArrayValue::Map(v) => ArrayValueIntoIter::Map(v.into_iter()),
+            ArrayValue::Sum(v) => ArrayValueIntoIter::Sum(Vec::from(v).into_iter()),
+            ArrayValue::Product(v) => ArrayValueIntoIter::Product(Vec::from(v).into_iter()),
+            ArrayValue::Bool(v) => ArrayValueIntoIter::Bool(Vec::from(v).into_iter()),
+            ArrayValue::I8(v) => ArrayValueIntoIter::I8(Vec::from(v).into_iter()),
+            ArrayValue::U8(v) => ArrayValueIntoIter::U8(Vec::from(v).into_iter()),
+            ArrayValue::I16(v) => ArrayValueIntoIter::I16(Vec::from(v).into_iter()),
+            ArrayValue::U16(v) => ArrayValueIntoIter::U16(Vec::from(v).into_iter()),
+            ArrayValue::I32(v) => ArrayValueIntoIter::I32(Vec::from(v).into_iter()),
+            ArrayValue::U32(v) => ArrayValueIntoIter::U32(Vec::from(v).into_iter()),
+            ArrayValue::I64(v) => ArrayValueIntoIter::I64(Vec::from(v).into_iter()),
+            ArrayValue::U64(v) => ArrayValueIntoIter::U64(Vec::from(v).into_iter()),
+            ArrayValue::I128(v) => ArrayValueIntoIter::I128(Vec::from(v).into_iter()),
+            ArrayValue::U128(v) => ArrayValueIntoIter::U128(Vec::from(v).into_iter()),
+            ArrayValue::F32(v) => ArrayValueIntoIter::F32(Vec::from(v).into_iter()),
+            ArrayValue::F64(v) => ArrayValueIntoIter::F64(Vec::from(v).into_iter()),
+            ArrayValue::String(v) => ArrayValueIntoIter::String(Vec::from(v).into_iter()),
+            ArrayValue::Array(v) => ArrayValueIntoIter::Array(Vec::from(v).into_iter()),
+            ArrayValue::Map(v) => ArrayValueIntoIter::Map(Vec::from(v).into_iter()),
         }
     }
 }
@@ -281,7 +281,7 @@ pub enum ArrayValueIntoIter {
     /// An iterator on a [`F64`] array.
     F64(std::vec::IntoIter<F64>),
     /// An iterator on an array of UTF-8 strings.
-    String(std::vec::IntoIter<String>),
+    String(std::vec::IntoIter<Box<str>>),
     /// An iterator on an array of arrays.
     Array(std::vec::IntoIter<ArrayValue>),
     /// An iterator on an array of maps.
@@ -331,7 +331,7 @@ pub enum ArrayValueIterCloned<'a> {
     U128(std::slice::Iter<'a, u128>),
     F32(std::slice::Iter<'a, F32>),
     F64(std::slice::Iter<'a, F64>),
-    String(std::slice::Iter<'a, String>),
+    String(std::slice::Iter<'a, Box<str>>),
     Array(std::slice::Iter<'a, ArrayValue>),
     Map(std::slice::Iter<'a, MapValue>),
 }

--- a/crates/sats/src/convert.rs
+++ b/crates/sats/src/convert.rs
@@ -1,19 +1,14 @@
-use crate::{AlgebraicType, AlgebraicValue, ArrayType, BuiltinType, MapType, ProductType, ProductValue};
+use crate::{AlgebraicType, AlgebraicValue, ArrayType, BuiltinType, MapType, MapValue, ProductType, ProductValue};
 use spacetimedb_primitives::{ColId, ConstraintId, IndexId, SequenceId, TableId};
 
 impl crate::Value for AlgebraicValue {
     type Type = AlgebraicType;
 }
 
-impl From<Vec<AlgebraicValue>> for ProductValue {
-    fn from(elements: Vec<AlgebraicValue>) -> Self {
+impl<X: Into<Box<[AlgebraicValue]>>> From<X> for ProductValue {
+    fn from(elements: X) -> Self {
+        let elements = elements.into();
         ProductValue { elements }
-    }
-}
-
-impl<const N: usize> From<[AlgebraicValue; N]> for ProductValue {
-    fn from(fields: [AlgebraicValue; N]) -> Self {
-        Vec::from(fields).into()
     }
 }
 
@@ -38,6 +33,12 @@ impl From<ArrayType> for AlgebraicType {
 impl From<MapType> for AlgebraicType {
     fn from(x: MapType) -> Self {
         BuiltinType::Map(Box::new(x)).into()
+    }
+}
+
+impl From<MapValue> for AlgebraicValue {
+    fn from(x: MapValue) -> Self {
+        Box::new(x).into()
     }
 }
 

--- a/crates/sats/src/db/def.rs
+++ b/crates/sats/src/db/def.rs
@@ -22,7 +22,7 @@ impl_serialize!([] Constraints, (self, ser) => ser.serialize_u8(self.bits()));
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct SequenceSchema {
     pub sequence_id: SequenceId,
-    pub sequence_name: String,
+    pub sequence_name: Box<str>,
     pub table_id: TableId,
     /// The position of the column associated with this sequence.
     pub col_pos: ColId,
@@ -49,13 +49,13 @@ impl SequenceSchema {
     /// let sequence_def = SequenceDef::for_column("my_table".into(), "my_sequence".into(), 1.into());
     /// let schema = SequenceSchema::from_def(42.into(), sequence_def);
     ///
-    /// assert_eq!(schema.sequence_name, "seq_my_table_my_sequence");
+    /// assert_eq!(&*schema.sequence_name, "seq_my_table_my_sequence");
     /// assert_eq!(schema.table_id, 42.into());
     /// ```
     pub fn from_def(table_id: TableId, sequence: SequenceDef) -> Self {
         Self {
             sequence_id: SequenceId(0), // Will be replaced later when created
-            sequence_name: sequence.sequence_name.trim().to_string(),
+            sequence_name: sequence.sequence_name.trim().into(),
             table_id,
             col_pos: sequence.col_pos,
             increment: sequence.increment,
@@ -71,7 +71,7 @@ impl SequenceSchema {
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, ser::Serialize, de::Deserialize)]
 #[sats(crate = crate)]
 pub struct SequenceDef {
-    pub sequence_name: String,
+    pub sequence_name: Box<str>,
     /// The position of the column associated with this sequence.
     pub col_pos: ColId,
     pub increment: i128,
@@ -96,14 +96,14 @@ impl SequenceDef {
     /// use spacetimedb_sats::db::def::*;
     ///
     /// let sequence_def = SequenceDef::for_column("my_table", "my_sequence", 1.into());
-    /// assert_eq!(sequence_def.sequence_name, "seq_my_table_my_sequence");
+    /// assert_eq!(&*sequence_def.sequence_name, "seq_my_table_my_sequence");
     /// ```
     pub fn for_column(table: &str, column_or_name: &str, col_pos: ColId) -> Self {
         //removes the auto-generated suffix...
         let seq_name = column_or_name.trim_start_matches(&format!("ct_{}_", table));
 
         SequenceDef {
-            sequence_name: format!("seq_{}_{}", table, seq_name),
+            sequence_name: format!("seq_{}_{}", table, seq_name).into(),
             col_pos,
             increment: 1,
             start: None,
@@ -134,7 +134,7 @@ pub struct IndexSchema {
     pub index_id: IndexId,
     pub table_id: TableId,
     pub index_type: IndexType,
-    pub index_name: String,
+    pub index_name: Box<str>,
     pub is_unique: bool,
     pub columns: ColList,
 }
@@ -146,7 +146,7 @@ impl IndexSchema {
             index_id: IndexId(0), // Set to 0 as it may be assigned later.
             table_id,
             index_type: index.index_type,
-            index_name: index.index_name.trim().to_string(),
+            index_name: index.index_name.trim().into(),
             is_unique: index.is_unique,
             columns: index.columns,
         }
@@ -181,7 +181,7 @@ impl TryFrom<u8> for IndexType {
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, ser::Serialize, de::Deserialize)]
 #[sats(crate = crate)]
 pub struct IndexDef {
-    pub index_name: String,
+    pub index_name: Box<str>,
     pub is_unique: bool,
     pub index_type: IndexType,
     /// List of column positions that compose the index.
@@ -198,7 +198,7 @@ impl IndexDef {
     /// * `index_name`: The name of the index.
     /// * `columns`: List of column positions that compose the index.
     /// * `is_unique`: Indicates whether the index enforces uniqueness.
-    pub fn btree(index_name: String, columns: impl Into<ColList>, is_unique: bool) -> Self {
+    pub fn btree(index_name: Box<str>, columns: impl Into<ColList>, is_unique: bool) -> Self {
         Self {
             columns: columns.into(),
             index_name,
@@ -218,7 +218,7 @@ impl IndexDef {
     /// use spacetimedb_sats::db::def::*;
     ///
     /// let index_def = IndexDef::for_column("my_table", "test", ColList::new(1u32.into()), true);
-    /// assert_eq!(index_def.index_name, "idx_my_table_test_unique");
+    /// assert_eq!(&*index_def.index_name, "idx_my_table_test_unique");
     /// ```
     pub fn for_column(table: &str, index_or_name: &str, columns: impl Into<ColList>, is_unique: bool) -> Self {
         let unique = if is_unique { "unique" } else { "non_unique" };
@@ -228,11 +228,12 @@ impl IndexDef {
 
         // Constructs the index name using a predefined format.
         // No duplicate the `kind_name` that was added by an constraint
-        if name.ends_with(&unique) {
-            Self::btree(format!("idx_{table}_{name}"), columns, is_unique)
+        let name = if name.ends_with(&unique) {
+            format!("idx_{table}_{name}")
         } else {
-            Self::btree(format!("idx_{table}_{name}_{unique}"), columns, is_unique)
-        }
+            format!("idx_{table}_{name}_{unique}")
+        };
+        Self::btree(name.into(), columns, is_unique)
     }
 }
 
@@ -253,7 +254,7 @@ pub struct ColumnSchema {
     pub table_id: TableId,
     /// Position of the column within the table.
     pub col_pos: ColId,
-    pub col_name: String,
+    pub col_name: Box<str>,
     pub col_type: AlgebraicType,
 }
 
@@ -307,21 +308,20 @@ impl From<FieldDef<'_>> for ProductTypeElement {
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, ser::Serialize, de::Deserialize)]
 #[sats(crate = crate)]
 pub struct ColumnDef {
-    pub col_name: String,
+    pub col_name: Box<str>,
     pub col_type: AlgebraicType,
 }
 
 impl From<ProductType> for Vec<ColumnDef> {
     fn from(value: ProductType) -> Self {
-        value
-            .elements
+        Vec::from(value.elements)
             .into_iter()
             .enumerate()
             .map(|(pos, col)| {
                 let col_name = if let Some(name) = col.name {
                     name
                 } else {
-                    format!("col_{pos}")
+                    format!("col_{pos}").into()
                 };
 
                 ColumnDef {
@@ -367,7 +367,7 @@ impl From<ColumnSchema> for ColumnDef {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct ConstraintSchema {
     pub constraint_id: ConstraintId,
-    pub constraint_name: String,
+    pub constraint_name: Box<str>,
     pub constraints: Constraints,
     pub table_id: TableId,
     pub columns: ColList,
@@ -383,7 +383,7 @@ impl ConstraintSchema {
     pub fn from_def(table_id: TableId, constraint: ConstraintDef) -> Self {
         ConstraintSchema {
             constraint_id: ConstraintId(0), // Set to 0 as it may be assigned later.
-            constraint_name: constraint.constraint_name.trim().to_string(),
+            constraint_name: constraint.constraint_name.trim().into(),
             constraints: constraint.constraints,
             table_id,
             columns: constraint.columns,
@@ -395,7 +395,7 @@ impl ConstraintSchema {
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, ser::Serialize, de::Deserialize)]
 #[sats(crate = crate)]
 pub struct ConstraintDef {
-    pub constraint_name: String,
+    pub constraint_name: Box<str>,
     pub constraints: Constraints,
     /// List of column positions associated with the constraint.
     pub columns: ColList,
@@ -409,7 +409,7 @@ impl ConstraintDef {
     /// * `constraint_name`: The name of the constraint.
     /// * `constraints`: The constraints.
     /// * `columns`: List of column positions associated with the constraint.
-    pub fn new(constraint_name: String, constraints: Constraints, columns: impl Into<ColList>) -> Self {
+    pub fn new(constraint_name: Box<str>, constraints: Constraints, columns: impl Into<ColList>) -> Self {
         Self {
             constraint_name,
             constraints,
@@ -435,7 +435,7 @@ impl ConstraintDef {
     /// use spacetimedb_sats::db::def::*;
     ///
     /// let constraint_def = ConstraintDef::for_column("my_table", "test", Constraints::identity(), ColList::new(1u32.into()));
-    /// assert_eq!(constraint_def.constraint_name, "ct_my_table_test_identity");
+    /// assert_eq!(&*constraint_def.constraint_name, "ct_my_table_test_identity");
     /// ```
     pub fn for_column(
         table: &str,
@@ -449,9 +449,9 @@ impl ConstraintDef {
         let kind_name = format!("{:?}", constraints.kind()).to_lowercase();
         // No duplicate the `kind_name` that was added by an index
         if name.ends_with(&kind_name) {
-            Self::new(format!("ct_{table}_{name}"), constraints, columns)
+            Self::new(format!("ct_{table}_{name}").into(), constraints, columns)
         } else {
-            Self::new(format!("ct_{table}_{name}_{kind_name}"), constraints, columns)
+            Self::new(format!("ct_{table}_{name}_{kind_name}").into(), constraints, columns)
         }
     }
 }
@@ -473,7 +473,7 @@ impl From<ConstraintSchema> for ConstraintDef {
 #[derive(Debug, Clone, PartialEq, Eq)]
 pub struct TableSchema {
     pub table_id: TableId,
-    pub table_name: String,
+    pub table_name: Box<str>,
     columns: Vec<ColumnSchema>,
     pub indexes: Vec<IndexSchema>,
     pub constraints: Vec<ConstraintSchema>,
@@ -488,7 +488,7 @@ impl TableSchema {
     #[allow(clippy::too_many_arguments)]
     pub fn new(
         table_id: TableId,
-        table_name: String,
+        table_name: Box<str>,
         columns: Vec<ColumnSchema>,
         indexes: Vec<IndexSchema>,
         constraints: Vec<ConstraintSchema>,
@@ -610,7 +610,7 @@ impl TableSchema {
     ///
     /// Warning: It ignores the `table_name`
     pub fn get_column_by_name(&self, col_name: &str) -> Option<&ColumnSchema> {
-        self.columns.iter().find(|x| x.col_name == col_name)
+        self.columns.iter().find(|x| &*x.col_name == col_name)
     }
 
     /// Check if there is an index for this [FieldName]
@@ -673,7 +673,7 @@ impl TableSchema {
         //testing.
         TableSchema::new(
             table_id,
-            schema.table_name.trim().to_string(),
+            schema.table_name.trim().into(),
             schema
                 .columns
                 .into_iter()
@@ -760,7 +760,7 @@ impl TableSchema {
                                 if let Some(col) = schema {
                                     col.col_name.clone()
                                 } else {
-                                    format!("col_{col}")
+                                    format!("col_{col}").into()
                                 }
                             })
                             .collect(),
@@ -974,7 +974,7 @@ impl From<&TableSchema> for Header {
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, ser::Serialize, de::Deserialize)]
 #[sats(crate = crate)]
 pub struct TableDef {
-    pub table_name: String,
+    pub table_name: Box<str>,
     pub columns: Vec<ColumnDef>,
     pub indexes: Vec<IndexDef>,
     pub constraints: Vec<ConstraintDef>,
@@ -991,7 +991,7 @@ impl TableDef {
     /// - `table_name`: The name of the table.
     /// - `columns`: A `vec` of `ColumnDef` instances representing the columns of the table.
     ///
-    pub fn new(table_name: String, columns: Vec<ColumnDef>) -> Self {
+    pub fn new(table_name: Box<str>, columns: Vec<ColumnDef>) -> Self {
         Self {
             table_name,
             columns,
@@ -1033,7 +1033,7 @@ impl TableDef {
         let mut column_name = Vec::with_capacity(columns.len() as usize);
         for col_pos in columns.iter() {
             if let Some(col) = self.get_column(col_pos.idx()) {
-                column_name.push(col.col_name.as_str())
+                column_name.push(&*col.col_name)
             }
         }
 
@@ -1099,11 +1099,11 @@ impl TableDef {
     pub fn from_product(table_name: &str, row: ProductType) -> Self {
         Self::new(
             table_name.into(),
-            row.elements
+            Vec::from(row.elements)
                 .into_iter()
                 .enumerate()
                 .map(|(col_pos, e)| ColumnDef {
-                    col_name: e.name.unwrap_or_else(|| format!("col_{col_pos}")),
+                    col_name: e.name.unwrap_or_else(|| format!("col_{col_pos}").into()),
                     col_type: e.algebraic_type,
                 })
                 .collect::<Vec<_>>(),
@@ -1212,7 +1212,7 @@ impl TableDef {
     ///
     /// Warning: It ignores the `table_name`
     pub fn get_column_by_name(&self, col_name: &str) -> Option<&ColumnDef> {
-        self.columns.iter().find(|x| x.col_name == col_name)
+        self.columns.iter().find(|x| &*x.col_name == col_name)
     }
 }
 
@@ -1397,7 +1397,7 @@ mod tests {
 
         // Empty names
         let mut t_name = t.clone();
-        t_name.table_name.clear();
+        t_name.table_name = "".into();
         assert_eq!(
             t_name.into_schema(TableId(0)).validated(),
             Err(vec![SchemaError::EmptyTableName { table_id: TableId(0) }])
@@ -1408,7 +1408,7 @@ mod tests {
         assert_eq!(
             t_col.into_schema(TableId(0)).validated(),
             Err(vec![SchemaError::EmptyName {
-                table: "test".to_string(),
+                table: "test".into(),
                 ty: DefType::Column,
                 id: 5
             },])
@@ -1420,7 +1420,7 @@ mod tests {
         assert_eq!(
             t_ct.into_schema(TableId(0)).validated(),
             Err(vec![SchemaError::EmptyName {
-                table: "test".to_string(),
+                table: "test".into(),
                 ty: DefType::Constraint,
                 id: 0,
             },])
@@ -1504,37 +1504,37 @@ mod tests {
             errs,
             vec![
                 SchemaError::ColumnsNotFound {
-                    name: "seq_test_".to_string(),
+                    name: "seq_test_".into(),
                     table: "test".into(),
                     columns: vec![ColId(1001)],
                     ty: DefType::Sequence,
                 },
                 SchemaError::ColumnsNotFound {
-                    name: "ct_test__unique".to_string(),
+                    name: "ct_test__unique".into(),
                     table: "test".into(),
                     columns: vec![ColId(1002)],
                     ty: DefType::Constraint,
                 },
                 SchemaError::ColumnsNotFound {
-                    name: "idx_test__unique".to_string(),
+                    name: "idx_test__unique".into(),
                     table: "test".into(),
                     columns: vec![ColId(1002)],
                     ty: DefType::Index,
                 },
                 SchemaError::ColumnsNotFound {
-                    name: "ct_test__non_unique_indexed".to_string(),
+                    name: "ct_test__non_unique_indexed".into(),
                     table: "test".into(),
                     columns: vec![ColId(1003)],
                     ty: DefType::Constraint,
                 },
                 SchemaError::ColumnsNotFound {
-                    name: "idx_test__non_unique".to_string(),
+                    name: "idx_test__non_unique".into(),
                     table: "test".into(),
                     columns: vec![ColId(1003)],
                     ty: DefType::Index,
                 },
                 SchemaError::ColumnsNotFound {
-                    name: "seq_test_".to_string(),
+                    name: "seq_test_".into(),
                     table: "test".into(),
                     columns: vec![ColId(1004)],
                     ty: DefType::Sequence,
@@ -1563,7 +1563,7 @@ mod tests {
     #[test]
     fn test_validate_btree() {
         let t = table_def().with_indexes(vec![IndexDef {
-            index_name: "bad".to_string(),
+            index_name: "bad".into(),
             is_unique: false,
             index_type: IndexType::Hash,
             columns: ColList::new(0.into()),
@@ -1573,7 +1573,7 @@ mod tests {
             t.into_schema(TableId(0)).validated(),
             Err(vec![SchemaError::OnlyBtree {
                 table: "test".into(),
-                index: "bad".to_string(),
+                index: "bad".into(),
                 index_type: IndexType::Hash,
             }])
         );

--- a/crates/sats/src/db/error.rs
+++ b/crates/sats/src/db/error.rs
@@ -122,30 +122,30 @@ pub enum DefType {
 #[derive(thiserror::Error, Debug, PartialEq)]
 pub enum SchemaError {
     #[error("Multiple primary columns defined for table: {table} columns: {pks:?}")]
-    MultiplePrimaryKeys { table: String, pks: Vec<String> },
+    MultiplePrimaryKeys { table: Box<str>, pks: Vec<String> },
     #[error("table id `{table_id}` should have name")]
     EmptyTableName { table_id: TableId },
     #[error("{ty} {name} columns `{columns:?}` not found  in table `{table}`")]
     ColumnsNotFound {
-        name: String,
-        table: String,
+        name: Box<str>,
+        table: Box<str>,
         columns: Vec<ColId>,
         ty: DefType,
     },
     #[error("table `{table}` {ty} should have name. {ty} id: {id}")]
-    EmptyName { table: String, ty: DefType, id: u32 },
+    EmptyName { table: Box<str>, ty: DefType, id: u32 },
     #[error("table `{table}` have `Constraints::unset()` for columns: {columns:?}")]
     ConstraintUnset {
-        table: String,
-        name: String,
+        table: Box<str>,
+        name: Box<str>,
         columns: ColList,
     },
     #[error("Attempt to define a column with more than 1 auto_inc sequence: Table: `{table}`, Field: `{field}`")]
-    OneAutoInc { table: String, field: String },
+    OneAutoInc { table: Box<str>, field: Box<str> },
     #[error("Only Btree Indexes are supported: Table: `{table}`, Index: `{index}` is a `{index_type}`")]
     OnlyBtree {
-        table: String,
-        index: String,
+        table: Box<str>,
+        index: Box<str>,
         index_type: IndexType,
     },
 }

--- a/crates/sats/src/de/impls.rs
+++ b/crates/sats/src/de/impls.rs
@@ -320,7 +320,7 @@ impl<'de> DeserializeSeed<'de> for WithTypespace<'_, AlgebraicType> {
             &AlgebraicType::U128 => u128::deserialize(de).map(Into::into),
             &AlgebraicType::F32 => f32::deserialize(de).map(Into::into),
             &AlgebraicType::F64 => f64::deserialize(de).map(Into::into),
-            &AlgebraicType::String => String::deserialize(de).map(Into::into),
+            &AlgebraicType::String => <Box<str>>::deserialize(de).map(Into::into),
         }
     }
 }
@@ -417,9 +417,9 @@ impl<'de> DeserializeSeed<'de> for WithTypespace<'_, ArrayType> {
         /// Deserialize a vector and `map` it to the appropriate `ArrayValue` variant.
         fn de_array<'de, D: Deserializer<'de>, T: Deserialize<'de>>(
             de: D,
-            map: impl FnOnce(Vec<T>) -> ArrayValue,
+            map: impl FnOnce(Box<[T]>) -> ArrayValue,
         ) -> Result<ArrayValue, D::Error> {
-            de.deserialize_array(BasicVecVisitor).map(map)
+            de.deserialize_array(BasicVecVisitor).map(<Box<[_]>>::from).map(map)
         }
 
         let mut ty = &*self.ty().elem_ty;
@@ -434,19 +434,26 @@ impl<'de> DeserializeSeed<'de> for WithTypespace<'_, ArrayType> {
                 }
                 AlgebraicType::Sum(ty) => deserializer
                     .deserialize_array_seed(BasicVecVisitor, self.with(ty))
+                    .map(<Box<[_]>>::from)
                     .map(ArrayValue::Sum),
                 AlgebraicType::Product(ty) => deserializer
                     .deserialize_array_seed(BasicVecVisitor, self.with(ty))
+                    .map(<Box<[_]>>::from)
                     .map(ArrayValue::Product),
                 AlgebraicType::Builtin(crate::BuiltinType::Array(ty)) => deserializer
                     .deserialize_array_seed(BasicVecVisitor, self.with(ty))
+                    .map(<Box<[_]>>::from)
                     .map(ArrayValue::Array),
                 AlgebraicType::Builtin(crate::BuiltinType::Map(ty)) => deserializer
                     .deserialize_array_seed(BasicVecVisitor, self.with(&**ty))
+                    .map(<Box<[_]>>::from)
                     .map(ArrayValue::Map),
                 &AlgebraicType::Bool => de_array(deserializer, ArrayValue::Bool),
                 &AlgebraicType::I8 => de_array(deserializer, ArrayValue::I8),
-                &AlgebraicType::U8 => deserializer.deserialize_bytes(OwnedSliceVisitor).map(ArrayValue::U8),
+                &AlgebraicType::U8 => deserializer
+                    .deserialize_bytes(OwnedSliceVisitor)
+                    .map(<Box<[_]>>::from)
+                    .map(ArrayValue::U8),
                 &AlgebraicType::I16 => de_array(deserializer, ArrayValue::I16),
                 &AlgebraicType::U16 => de_array(deserializer, ArrayValue::U16),
                 &AlgebraicType::I32 => de_array(deserializer, ArrayValue::I32),

--- a/crates/sats/src/lib.rs
+++ b/crates/sats/src/lib.rs
@@ -52,7 +52,7 @@ pub trait Value {
     type Type;
 }
 
-impl<T: Value> Value for Vec<T> {
+impl<T: Value> Value for Box<[T]> {
     // TODO(centril/phoebe): This looks weird; shouldn't it be ArrayType?
     type Type = T::Type;
 }
@@ -109,7 +109,7 @@ impl<'a, T: Value> ValueWithType<'a, T> {
     }
 }
 
-impl<'a, T: Value> ValueWithType<'a, Vec<T>> {
+impl<'a, T: Value> ValueWithType<'a, Box<[T]>> {
     pub fn iter(&self) -> impl Iterator<Item = ValueWithType<'_, T>> {
         self.value().iter().map(|val| ValueWithType { ty: self.ty, val })
     }

--- a/crates/sats/src/product_type.rs
+++ b/crates/sats/src/product_type.rs
@@ -34,12 +34,12 @@ pub struct ProductType {
     ///
     /// These factors can either be named or unnamed.
     /// When all the factors are unnamed, we can regard this as a plain tuple type.
-    pub elements: Vec<ProductTypeElement>,
+    pub elements: Box<[ProductTypeElement]>,
 }
 
 impl ProductType {
     /// Returns a product type with the given `elements` as its factors.
-    pub const fn new(elements: Vec<ProductTypeElement>) -> Self {
+    pub const fn new(elements: Box<[ProductTypeElement]>) -> Self {
         Self { elements }
     }
 
@@ -49,7 +49,7 @@ impl ProductType {
             [ProductTypeElement {
                 name: Some(name),
                 algebraic_type,
-            }] => name == check && algebraic_type.is_bytes(),
+            }] => &**name == check && algebraic_type.is_bytes(),
             _ => false,
         }
     }
@@ -86,13 +86,13 @@ impl<'a, I: Into<AlgebraicType>> FromIterator<(&'a str, I)> for ProductType {
 impl<'a, I: Into<AlgebraicType>> FromIterator<(Option<&'a str>, I)> for ProductType {
     fn from_iter<T: IntoIterator<Item = (Option<&'a str>, I)>>(iter: T) -> Self {
         iter.into_iter()
-            .map(|(name, ty)| ProductTypeElement::new(ty.into(), name.map(str::to_string)))
+            .map(|(name, ty)| ProductTypeElement::new(ty.into(), name.map(Into::into)))
             .collect()
     }
 }
 
-impl From<Vec<ProductTypeElement>> for ProductType {
-    fn from(fields: Vec<ProductTypeElement>) -> Self {
+impl From<Box<[ProductTypeElement]>> for ProductType {
+    fn from(fields: Box<[ProductTypeElement]>) -> Self {
         ProductType::new(fields)
     }
 }
@@ -136,7 +136,7 @@ impl ProductType {
 impl<'a> WithTypespace<'a, ProductType> {
     #[inline]
     pub fn elements(&self) -> ElementsWithTypespace<'a> {
-        self.iter_with(&self.ty().elements)
+        self.iter_with(&*self.ty().elements)
     }
 
     #[inline]

--- a/crates/sats/src/product_type_element.rs
+++ b/crates/sats/src/product_type_element.rs
@@ -16,7 +16,7 @@ pub struct ProductTypeElement {
     /// As our type system is structural,
     /// a type like `{ foo: U8 }`, where `foo: U8` is the `ProductTypeElement`,
     /// is inequal to `{ bar: U8 }`, although their `algebraic_type`s (`U8`) match.
-    pub name: Option<String>,
+    pub name: Option<Box<str>>,
     /// The type of the element.
     ///
     /// Only values of this type can be stored in the element.
@@ -25,12 +25,12 @@ pub struct ProductTypeElement {
 
 impl ProductTypeElement {
     /// Returns an element with the given `name` and `algebraic_type`.
-    pub const fn new(algebraic_type: AlgebraicType, name: Option<String>) -> Self {
+    pub const fn new(algebraic_type: AlgebraicType, name: Option<Box<str>>) -> Self {
         Self { algebraic_type, name }
     }
 
     /// Returns a named element with `name` and `algebraic_type`.
-    pub fn new_named(algebraic_type: AlgebraicType, name: impl Into<String>) -> Self {
+    pub fn new_named(algebraic_type: AlgebraicType, name: impl Into<Box<str>>) -> Self {
         Self::new(algebraic_type, Some(name.into()))
     }
 

--- a/crates/sats/src/product_value.rs
+++ b/crates/sats/src/product_value.rs
@@ -10,7 +10,7 @@ use spacetimedb_primitives::{ColId, ColList};
 #[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq, Hash, Default)]
 pub struct ProductValue {
     /// The values that make up this product value.
-    pub elements: Vec<AlgebraicValue>,
+    pub elements: Box<[AlgebraicValue]>,
 }
 
 /// Constructs a product value from a list of fields with syntax `product![v1, v2, ...]`.
@@ -20,7 +20,7 @@ pub struct ProductValue {
 macro_rules! product {
     [$($elems:expr),*$(,)?] => {
         $crate::ProductValue {
-            elements: vec![$($crate::AlgebraicValue::from($elems)),*],
+            elements: [$($crate::AlgebraicValue::from($elems)),*].into(),
         }
     }
 }
@@ -36,7 +36,7 @@ impl IntoIterator for ProductValue {
     type Item = AlgebraicValue;
     type IntoIter = std::vec::IntoIter<AlgebraicValue>;
     fn into_iter(self) -> Self::IntoIter {
-        self.elements.into_iter()
+        Vec::from(self.elements).into_iter()
     }
 }
 
@@ -168,12 +168,12 @@ impl ProductValue {
 
     /// Interprets the value at field of `self` identified by `index` as a `i128`.
     pub fn field_as_i128(&self, index: usize, named: Option<&'static str>) -> Result<i128, InvalidFieldError> {
-        self.extract_field(index, named, |f| f.as_i128().copied())
+        self.extract_field(index, named, |f| f.as_i128().copied().map(|x| x.0))
     }
 
     /// Interprets the value at field of `self` identified by `index` as a `u128`.
     pub fn field_as_u128(&self, index: usize, named: Option<&'static str>) -> Result<u128, InvalidFieldError> {
-        self.extract_field(index, named, |f| f.as_u128().copied())
+        self.extract_field(index, named, |f| f.as_u128().copied().map(|x| x.0))
     }
 
     /// Interprets the value at field of `self` identified by `index` as a string slice.

--- a/crates/sats/src/resolve_refs.rs
+++ b/crates/sats/src/resolve_refs.rs
@@ -126,7 +126,7 @@ impl ResolveRefs for SumType {
             .variants
             .iter()
             .map(|v| this.with(v)._resolve_refs(state))
-            .collect::<Option<Vec<_>>>()?;
+            .collect::<Option<_>>()?;
         Some(Self { variants })
     }
 }

--- a/crates/sats/src/ser/impls.rs
+++ b/crates/sats/src/ser/impls.rs
@@ -103,8 +103,8 @@ impl_serialize!([] AlgebraicValue, (self, ser) => match self {
     Self::U32(v) => ser.serialize_u32(*v),
     Self::I64(v) => ser.serialize_i64(*v),
     Self::U64(v) => ser.serialize_u64(*v),
-    Self::I128(v) => ser.serialize_i128(*v),
-    Self::U128(v) => ser.serialize_u128(*v),
+    Self::I128(v) => ser.serialize_i128(v.0),
+    Self::U128(v) => ser.serialize_u128(v.0),
     Self::F32(v) => ser.serialize_f32((*v).into()),
     Self::F64(v) => ser.serialize_f64((*v).into()),
     // Self::Bytes(v) => ser.serialize_bytes(v),
@@ -149,7 +149,7 @@ impl_serialize!([] ValueWithType<'_, AlgebraicValue>, (self, ser) => {
             (AlgebraicValue::Sum(val), AlgebraicType::Sum(ty)) => self.with(ty, val).serialize(ser),
             (AlgebraicValue::Product(val), AlgebraicType::Product(ty)) => self.with(ty, val).serialize(ser),
             (AlgebraicValue::Array(val), AlgebraicType::Builtin(crate::BuiltinType::Array(ty))) => self.with(ty, val).serialize(ser),
-            (AlgebraicValue::Map(val), AlgebraicType::Builtin(crate::BuiltinType::Map(ty))) => self.with(&**ty, val).serialize(ser),
+            (AlgebraicValue::Map(val), AlgebraicType::Builtin(crate::BuiltinType::Map(ty))) => self.with(&**ty, &**val).serialize(ser),
             (AlgebraicValue::Bool(v), &AlgebraicType::Bool) => ser.serialize_bool(*v),
             (AlgebraicValue::I8(v), &AlgebraicType::I8) => ser.serialize_i8(*v),
             (AlgebraicValue::U8(v), &AlgebraicType::U8) => ser.serialize_u8(*v),
@@ -159,8 +159,8 @@ impl_serialize!([] ValueWithType<'_, AlgebraicValue>, (self, ser) => {
             (AlgebraicValue::U32(v), &AlgebraicType::U32) => ser.serialize_u32(*v),
             (AlgebraicValue::I64(v), &AlgebraicType::I64) => ser.serialize_i64(*v),
             (AlgebraicValue::U64(v), &AlgebraicType::U64) => ser.serialize_u64(*v),
-            (AlgebraicValue::I128(v), &AlgebraicType::I128) => ser.serialize_i128(*v),
-            (AlgebraicValue::U128(v), &AlgebraicType::U128) => ser.serialize_u128(*v),
+            (AlgebraicValue::I128(v), &AlgebraicType::I128) => ser.serialize_i128(v.0),
+            (AlgebraicValue::U128(v), &AlgebraicType::U128) => ser.serialize_u128(v.0),
             (AlgebraicValue::F32(v), &AlgebraicType::F32) => ser.serialize_f32((*v).into()),
             (AlgebraicValue::F64(v), &AlgebraicType::F64) => ser.serialize_f64((*v).into()),
             (AlgebraicValue::String(s), &AlgebraicType::String) => ser.serialize_str(s),
@@ -170,7 +170,7 @@ impl_serialize!([] ValueWithType<'_, AlgebraicValue>, (self, ser) => {
 });
 impl_serialize!(
     [T: crate::Value] where [for<'a> ValueWithType<'a, T>: Serialize]
-    ValueWithType<'_, Vec<T>>,
+    ValueWithType<'_, Box<[T]>>,
     (self, ser) => {
         let mut vec = ser.serialize_array(self.value().len())?;
         for val in self.iter() {

--- a/crates/sats/src/sum_type.rs
+++ b/crates/sats/src/sum_type.rs
@@ -34,18 +34,18 @@ pub struct SumType {
     /// The possible variants of the sum type.
     ///
     /// The order is relevant as it defines the tags of the variants at runtime.
-    pub variants: Vec<SumTypeVariant>,
+    pub variants: Box<[SumTypeVariant]>,
 }
 
 impl SumType {
     /// Returns a sum type with these possible `variants`.
-    pub const fn new(variants: Vec<SumTypeVariant>) -> Self {
+    pub const fn new(variants: Box<[SumTypeVariant]>) -> Self {
         Self { variants }
     }
 
     /// Returns a sum type of unnamed variants taken from `types`.
-    pub fn new_unnamed(types: Vec<AlgebraicType>) -> Self {
-        let variants = types.into_iter().map(|ty| ty.into()).collect::<Vec<_>>();
+    pub fn new_unnamed(types: Box<[AlgebraicType]>) -> Self {
+        let variants = Vec::from(types).into_iter().map(|ty| ty.into()).collect();
         Self { variants }
     }
 
@@ -92,8 +92,8 @@ impl SumType {
     }
 }
 
-impl From<Vec<SumTypeVariant>> for SumType {
-    fn from(fields: Vec<SumTypeVariant>) -> Self {
+impl From<Box<[SumTypeVariant]>> for SumType {
+    fn from(fields: Box<[SumTypeVariant]>) -> Self {
         SumType::new(fields)
     }
 }

--- a/crates/sats/src/sum_type_variant.rs
+++ b/crates/sats/src/sum_type_variant.rs
@@ -10,7 +10,7 @@ use crate::{de::Deserialize, ser::Serialize};
 #[sats(crate = crate)]
 pub struct SumTypeVariant {
     /// The name of the variant, if any.
-    pub name: Option<String>,
+    pub name: Option<Box<str>>,
     /// The type of the variant.
     ///
     /// Unlike a language like Rust,
@@ -23,7 +23,7 @@ pub struct SumTypeVariant {
 
 impl SumTypeVariant {
     /// Returns a sum type variant with an optional `name` and `algebraic_type`.
-    pub const fn new(algebraic_type: AlgebraicType, name: Option<String>) -> Self {
+    pub const fn new(algebraic_type: AlgebraicType, name: Option<Box<str>>) -> Self {
         Self { algebraic_type, name }
     }
 
@@ -31,7 +31,7 @@ impl SumTypeVariant {
     pub fn new_named(algebraic_type: AlgebraicType, name: impl AsRef<str>) -> Self {
         Self {
             algebraic_type,
-            name: Some(name.as_ref().to_owned()),
+            name: Some(name.as_ref().into()),
         }
     }
 

--- a/crates/sats/src/typespace.rs
+++ b/crates/sats/src/typespace.rs
@@ -107,12 +107,12 @@ impl Typespace {
     pub fn inline_typerefs_in_type(&mut self, ty: &mut AlgebraicType) -> Result<(), TypeRefError> {
         match ty {
             AlgebraicType::Sum(sum_ty) => {
-                for variant in &mut sum_ty.variants {
+                for variant in &mut *sum_ty.variants {
                     self.inline_typerefs_in_type(&mut variant.algebraic_type)?;
                 }
             }
             AlgebraicType::Product(product_ty) => {
-                for element in &mut product_ty.elements {
+                for element in &mut *product_ty.elements {
                     self.inline_typerefs_in_type(&mut element.algebraic_type)?;
                 }
             }

--- a/crates/sats/tests/encoding_roundtrip.rs
+++ b/crates/sats/tests/encoding_roundtrip.rs
@@ -30,9 +30,9 @@ fn map_vec<T, U>(vec: Vec<T>, map: impl Fn(T) -> U) -> Vec<U> {
 
 fn array_value<T>(vec: Vec<T>) -> AlgebraicValue
 where
-    ArrayValue: From<Vec<T>>,
+    ArrayValue: From<Box<[T]>>,
 {
-    AlgebraicValue::Array(vec.into())
+    AlgebraicValue::Array(vec.into_boxed_slice().into())
 }
 
 fn array_values() -> impl Strategy<Value = AlgebraicValue> {
@@ -47,7 +47,7 @@ fn array_values() -> impl Strategy<Value = AlgebraicValue> {
         vec(0i128..10, 0..10).prop_map(array_value),
         vec(0u128..10, 0..10).prop_map(array_value),
         vec(0..10, 0..10).prop_map(|v| array_value(map_vec(v, |x| x == 0))),
-        vec(0i32..10, 0..10).prop_map(|v| array_value(map_vec(v, |x| x.to_string()))),
+        vec(0i32..10, 0..10).prop_map(|v| array_value(map_vec(v, |x| x.to_string().into_boxed_str()))),
         vec(0i32..10, 0..10).prop_map(|v| array_value(map_vec(v, |x| F32::from_inner(x as f32)))),
         vec(0i32..10, 0..10).prop_map(|v| array_value(map_vec(v, |x| F64::from_inner(x as f64)))),
     ]
@@ -69,7 +69,7 @@ fn leaf_values() -> impl Strategy<Value = AlgebraicValue> {
         any::<f32>().prop_map(Into::into),
         any::<f64>().prop_map(Into::into),
         "[0-1]+".prop_map(|x| array_value(x.into_bytes())),
-        ".*".prop_map(AlgebraicValue::String),
+        ".*".prop_map_into().prop_map(AlgebraicValue::String),
     ]
 }
 

--- a/crates/sqltest/src/space.rs
+++ b/crates/sqltest/src/space.rs
@@ -6,6 +6,7 @@ use spacetimedb::execution_context::ExecutionContext;
 use spacetimedb::sql::compiler::compile_sql;
 use spacetimedb::sql::execute::execute_sql;
 use spacetimedb_lib::identity::AuthCtx;
+use spacetimedb_sats::algebraic_value::Packed;
 use spacetimedb_sats::meta_type::MetaType;
 use spacetimedb_sats::satn::Satn;
 use spacetimedb_sats::{AlgebraicType, AlgebraicValue, BuiltinType};
@@ -109,8 +110,7 @@ impl AsyncDB for SpaceDb {
             .data
             .into_iter()
             .map(|row| {
-                row.elements
-                    .into_iter()
+                row.into_iter()
                     .map(|value| match value {
                         AlgebraicValue::Bool(x) => if x { "1" } else { "0" }.to_string(),
                         // ^-- For compat with sqlite.
@@ -122,8 +122,8 @@ impl AsyncDB for SpaceDb {
                         AlgebraicValue::U32(x) => x.to_string(),
                         AlgebraicValue::I64(x) => x.to_string(),
                         AlgebraicValue::U64(x) => x.to_string(),
-                        AlgebraicValue::I128(x) => x.to_string(),
-                        AlgebraicValue::U128(x) => x.to_string(),
+                        AlgebraicValue::I128(Packed(x)) => x.to_string(),
+                        AlgebraicValue::U128(Packed(x)) => x.to_string(),
                         AlgebraicValue::F32(x) => format!("{:?}", x.as_ref()),
                         AlgebraicValue::F64(x) => format!("{:?}", x.as_ref()),
                         AlgebraicValue::String(x) => format!("'{}'", x),

--- a/crates/table/benches/page.rs
+++ b/crates/table/benches/page.rs
@@ -507,7 +507,7 @@ fn u32_array_value<const N: usize>(arr: [u32; N]) -> ProductValue {
 
 fn u32_matrix_value<const N: usize, const M: usize>(matrix: [[u32; N]; M]) -> ProductValue {
     let elements = matrix
-        .map(|inner| AlgebraicValue::product(inner.map(AlgebraicValue::U32).into()))
+        .map(|inner| AlgebraicValue::product(inner.map(AlgebraicValue::U32)))
         .into();
     ProductValue { elements }
 }
@@ -567,28 +567,28 @@ fn product_value_test_cases() -> impl Iterator<
         (
             "String/0",
             string_row_type(),
-            product!["".to_string()],
+            product![""],
             None,
             Some(AlignedVarLenOffsets::from_offsets(&[0])),
         ),
         (
             "String/16",
             string_row_type(),
-            product!["0123456789abcdef".to_string()],
+            product!["0123456789abcdef"],
             None,
             Some(AlignedVarLenOffsets::from_offsets(&[0])),
         ),
         (
             "String/128",
             string_row_type(),
-            product!["0123456789abcdef".repeat(8)],
+            product!["0123456789abcdef".repeat(8).into_boxed_str()],
             None,
             Some(AlignedVarLenOffsets::from_offsets(&[0])),
         ),
         (
             "String/512",
             string_row_type(),
-            product!["0123456789abcdef".repeat(32)],
+            product!["0123456789abcdef".repeat(32).into_boxed_str()],
             None,
             Some(AlignedVarLenOffsets::from_offsets(&[0])),
         ),

--- a/crates/table/benches/page_manager.rs
+++ b/crates/table/benches/page_manager.rs
@@ -146,7 +146,6 @@ unsafe impl Row for U32x64 {
 
     fn from_product(prod: ProductValue) -> Self {
         let vals: Vec<u32> = prod
-            .elements
             .into_iter()
             .map(|val| *val.as_u32().expect("Invalid product value for U32x64"))
             .collect();
@@ -165,18 +164,17 @@ unsafe impl FixedLenRow for U32x64 {
     }
 }
 
-unsafe impl Row for String {
+unsafe impl Row for Box<str> {
     fn row_type() -> ProductType {
         [AlgebraicType::String].into()
     }
 
     fn from_product(prod: ProductValue) -> Self {
-        prod.elements
-            .into_iter()
+        prod.into_iter()
             .next()
             .expect("Invalid ProductValue for String: not enough elements")
             .into_string()
-            .expect("Invalid ProductValue for String: not a String")
+            .expect("Invalid ProductValue for String: not a string")
     }
 
     fn to_product(self) -> ProductValue {
@@ -555,15 +553,19 @@ fn table_insert_one_row(c: &mut Criterion) {
     let mut group = c.benchmark_group("table_insert_one_row/String");
 
     group.throughput(Throughput::Elements(1));
-    bench_insert_row(&mut group, "".to_string(), "0");
+    bench_insert_row(&mut group, Box::from(""), "0");
 
     group.throughput(Throughput::Bytes(1));
-    bench_insert_row(&mut group, "a".to_string(), "1");
+    bench_insert_row(&mut group, Box::from("a"), "1");
 
     for num_granules in [1, 2, 4, 8, 16] {
         let num_bytes = VarLenGranule::DATA_SIZE * num_granules;
         group.throughput(Throughput::Bytes(num_bytes as u64));
-        bench_insert_row(&mut group, "a".repeat(num_bytes), &num_bytes.to_string());
+        bench_insert_row(
+            &mut group,
+            "a".repeat(num_bytes).into_boxed_str(),
+            &num_bytes.to_string(),
+        );
     }
 }
 
@@ -598,15 +600,19 @@ fn table_delete_one_row(c: &mut Criterion) {
     let mut group = c.benchmark_group("table_delete_one_row/String");
 
     group.throughput(Throughput::Elements(1));
-    bench_delete_row(&mut group, "".to_string(), "0");
+    bench_delete_row(&mut group, Box::from(""), "0");
 
     group.throughput(Throughput::Bytes(1));
-    bench_delete_row(&mut group, "a".to_string(), "1");
+    bench_delete_row(&mut group, Box::from("a"), "1");
 
     for num_granules in [1, 2, 4, 8, 16] {
         let num_bytes = VarLenGranule::DATA_SIZE * num_granules;
         group.throughput(Throughput::Bytes(num_bytes as u64));
-        bench_delete_row(&mut group, "a".repeat(num_bytes), &num_bytes.to_string());
+        bench_delete_row(
+            &mut group,
+            "a".repeat(num_bytes).into_boxed_str(),
+            &num_bytes.to_string(),
+        );
     }
 }
 
@@ -644,15 +650,19 @@ fn table_extract_one_row(c: &mut Criterion) {
     let mut group = c.benchmark_group("table_extract_one_row/String");
 
     group.throughput(Throughput::Elements(1));
-    bench_extract_row(&mut group, "".to_string(), "0");
+    bench_extract_row(&mut group, Box::from(""), "0");
 
     group.throughput(Throughput::Bytes(1));
-    bench_extract_row(&mut group, "a".to_string(), "1");
+    bench_extract_row(&mut group, Box::from("a"), "1");
 
     for num_granules in [1, 2, 4, 8, 16] {
         let num_bytes = VarLenGranule::DATA_SIZE * num_granules;
         group.throughput(Throughput::Bytes(num_bytes as u64));
-        bench_extract_row(&mut group, "a".repeat(num_bytes), &num_bytes.to_string());
+        bench_extract_row(
+            &mut group,
+            "a".repeat(num_bytes).into_boxed_str(),
+            &num_bytes.to_string(),
+        );
     }
 }
 
@@ -707,9 +717,9 @@ impl IndexedRow for U32x64 {
     }
 }
 
-impl IndexedRow for String {
+impl IndexedRow for Box<str> {
     fn column_value_from_u64(u: u64) -> AlgebraicValue {
-        AlgebraicValue::String(u.to_string())
+        AlgebraicValue::String(u.to_string().into())
     }
     fn throughput() -> Throughput {
         // I'm too lazy to come up with an interface that computes the length of a string
@@ -843,7 +853,7 @@ fn index_insert(c: &mut Criterion) {
     bench_many_table_sizes::<U32x8>(FixedLenRow::from_u64, &mut group, "U32x8", 0.50);
     bench_many_table_sizes::<U32x8>(FixedLenRow::from_u64, &mut group, "U32x8", 1.00);
     bench_many_table_sizes::<U32x64>(FixedLenRow::from_u64, &mut group, "U32x64", 0.0);
-    bench_many_table_sizes::<String>(|i| i.to_string(), &mut group, "String", 0.0);
+    bench_many_table_sizes::<Box<str>>(|i| i.to_string().into(), &mut group, "String", 0.0);
 }
 
 fn index_seek(c: &mut Criterion) {
@@ -908,7 +918,7 @@ fn index_seek(c: &mut Criterion) {
     bench_many_table_sizes::<U32x8>(FixedLenRow::from_u64, &mut group, "U32x8", 0.50);
     bench_many_table_sizes::<U32x8>(FixedLenRow::from_u64, &mut group, "U32x8", 1.00);
     bench_many_table_sizes::<U32x64>(FixedLenRow::from_u64, &mut group, "U32x64", 0.0);
-    bench_many_table_sizes::<String>(|i| i.to_string(), &mut group, "String", 0.0);
+    bench_many_table_sizes::<Box<str>>(|i| i.to_string().into(), &mut group, "String", 0.0);
 }
 
 fn index_delete(c: &mut Criterion) {
@@ -957,7 +967,7 @@ fn index_delete(c: &mut Criterion) {
     bench_many_table_sizes::<U32x8>(FixedLenRow::from_u64, &mut group, "U32x8", 0.50);
     bench_many_table_sizes::<U32x8>(FixedLenRow::from_u64, &mut group, "U32x8", 1.00);
     bench_many_table_sizes::<U32x64>(FixedLenRow::from_u64, &mut group, "U32x64", 0.0);
-    bench_many_table_sizes::<String>(|i| i.to_string(), &mut group, "String", 0.0);
+    bench_many_table_sizes::<Box<str>>(|i| i.to_string().into(), &mut group, "String", 0.0);
 }
 
 criterion_group!(index, index_insert, index_seek, index_delete);

--- a/crates/table/src/bflatn_to.rs
+++ b/crates/table/src/bflatn_to.rs
@@ -201,8 +201,8 @@ impl BflatnSerializedRowBuffer<'_> {
             (&AlgebraicTypeLayout::U32, AlgebraicValue::U32(val)) => self.write_u32(*val),
             (&AlgebraicTypeLayout::I64, AlgebraicValue::I64(val)) => self.write_i64(*val),
             (&AlgebraicTypeLayout::U64, AlgebraicValue::U64(val)) => self.write_u64(*val),
-            (&AlgebraicTypeLayout::I128, AlgebraicValue::I128(val)) => self.write_i128(*val),
-            (&AlgebraicTypeLayout::U128, AlgebraicValue::U128(val)) => self.write_u128(*val),
+            (&AlgebraicTypeLayout::I128, AlgebraicValue::I128(val)) => self.write_i128(val.0),
+            (&AlgebraicTypeLayout::U128, AlgebraicValue::U128(val)) => self.write_u128(val.0),
             // Float types:
             (&AlgebraicTypeLayout::F32, AlgebraicValue::F32(val)) => self.write_f32((*val).into()),
             (&AlgebraicTypeLayout::F64, AlgebraicValue::F64(val)) => self.write_f64((*val).into()),

--- a/crates/table/src/bflatn_to_bsatn_fast_path.rs
+++ b/crates/table/src/bflatn_to_bsatn_fast_path.rs
@@ -321,7 +321,7 @@ mod test {
         }
 
         for (ty, bsatn_length, fields) in [
-            (ProductType::new(vec![]), 0, &[][..]),
+            (ProductType::new([].into()), 0, &[][..]),
             (
                 ProductType::from([AlgebraicType::sum([
                     AlgebraicType::U8,

--- a/crates/table/src/btree_index.rs
+++ b/crates/table/src/btree_index.rs
@@ -31,7 +31,7 @@ use crate::{
 use core::ops::RangeBounds;
 use multimap::{MultiMap, MultiMapRangeIter};
 use spacetimedb_primitives::{ColList, IndexId};
-use spacetimedb_sats::{product_value::InvalidFieldError, AlgebraicValue};
+use spacetimedb_sats::{algebraic_value::Packed, product_value::InvalidFieldError, AlgebraicValue};
 
 mod multimap;
 
@@ -48,9 +48,9 @@ enum TypedMultiMapRangeIter<'a> {
     I32(MultiMapRangeIter<'a, i32, RowPointer>),
     U64(MultiMapRangeIter<'a, u64, RowPointer>),
     I64(MultiMapRangeIter<'a, i64, RowPointer>),
-    U128(MultiMapRangeIter<'a, u128, RowPointer>),
-    I128(MultiMapRangeIter<'a, i128, RowPointer>),
-    String(MultiMapRangeIter<'a, String, RowPointer>),
+    U128(MultiMapRangeIter<'a, Packed<u128>, RowPointer>),
+    I128(MultiMapRangeIter<'a, Packed<i128>, RowPointer>),
+    String(MultiMapRangeIter<'a, Box<str>, RowPointer>),
     AlgebraicValue(MultiMapRangeIter<'a, AlgebraicValue, RowPointer>),
 }
 
@@ -115,9 +115,9 @@ enum TypedIndex {
     I32(MultiMap<i32, RowPointer>),
     U64(MultiMap<u64, RowPointer>),
     I64(MultiMap<i64, RowPointer>),
-    U128(MultiMap<u128, RowPointer>),
-    I128(MultiMap<i128, RowPointer>),
-    String(MultiMap<String, RowPointer>),
+    U128(MultiMap<Packed<u128>, RowPointer>),
+    I128(MultiMap<Packed<i128>, RowPointer>),
+    String(MultiMap<Box<str>, RowPointer>),
     AlgebraicValue(MultiMap<AlgebraicValue, RowPointer>),
 }
 
@@ -142,21 +142,20 @@ impl TypedIndex {
             Ok(this.insert(key, row_ref.pointer()))
         }
         match self {
-            TypedIndex::Bool(ref mut this) => insert_at_type(this, cols, row_ref),
+            TypedIndex::Bool(this) => insert_at_type(this, cols, row_ref),
+            TypedIndex::U8(this) => insert_at_type(this, cols, row_ref),
+            TypedIndex::I8(this) => insert_at_type(this, cols, row_ref),
+            TypedIndex::U16(this) => insert_at_type(this, cols, row_ref),
+            TypedIndex::I16(this) => insert_at_type(this, cols, row_ref),
+            TypedIndex::U32(this) => insert_at_type(this, cols, row_ref),
+            TypedIndex::I32(this) => insert_at_type(this, cols, row_ref),
+            TypedIndex::U64(this) => insert_at_type(this, cols, row_ref),
+            TypedIndex::I64(this) => insert_at_type(this, cols, row_ref),
+            TypedIndex::U128(this) => insert_at_type(this, cols, row_ref),
+            TypedIndex::I128(this) => insert_at_type(this, cols, row_ref),
+            TypedIndex::String(this) => insert_at_type(this, cols, row_ref),
 
-            TypedIndex::U8(ref mut this) => insert_at_type(this, cols, row_ref),
-            TypedIndex::I8(ref mut this) => insert_at_type(this, cols, row_ref),
-            TypedIndex::U16(ref mut this) => insert_at_type(this, cols, row_ref),
-            TypedIndex::I16(ref mut this) => insert_at_type(this, cols, row_ref),
-            TypedIndex::U32(ref mut this) => insert_at_type(this, cols, row_ref),
-            TypedIndex::I32(ref mut this) => insert_at_type(this, cols, row_ref),
-            TypedIndex::U64(ref mut this) => insert_at_type(this, cols, row_ref),
-            TypedIndex::I64(ref mut this) => insert_at_type(this, cols, row_ref),
-            TypedIndex::U128(ref mut this) => insert_at_type(this, cols, row_ref),
-            TypedIndex::I128(ref mut this) => insert_at_type(this, cols, row_ref),
-            TypedIndex::String(ref mut this) => insert_at_type(this, cols, row_ref),
-
-            TypedIndex::AlgebraicValue(ref mut this) => {
+            TypedIndex::AlgebraicValue(this) => {
                 let key = row_ref.project_not_empty(cols)?;
                 Ok(this.insert(key, row_ref.pointer()))
             }

--- a/crates/table/src/proptest_sats.rs
+++ b/crates/table/src/proptest_sats.rs
@@ -55,16 +55,22 @@ pub fn generate_algebraic_type() -> impl Strategy<Value = AlgebraicType> {
 
             // No need to generate units here;
             // we already generate them in `generate_non_compound_algebraic_type`.
-            vec(gen_element.clone().prop_map_into(), 1..=16).prop_map(AlgebraicType::product),
+            vec(gen_element.clone().prop_map_into(), 1..=16)
+                .prop_map(Vec::into_boxed_slice)
+                .prop_map(AlgebraicType::product),
             // Do not generate nevers here; we can't store never in a page.
-            vec(gen_element.clone().prop_map_into(), 1..=16).prop_map(AlgebraicType::sum),
+            vec(gen_element.clone().prop_map_into(), 1..=16)
+                .prop_map(Vec::into_boxed_slice)
+                .prop_map(AlgebraicType::sum),
         ]
     })
 }
 
 /// Generates a `ProductType` that is good as a row type.
 pub fn generate_row_type(range: impl Into<SizeRange>) -> impl Strategy<Value = ProductType> {
-    vec(generate_algebraic_type().prop_map_into(), range).prop_map_into()
+    vec(generate_algebraic_type().prop_map_into(), range)
+        .prop_map(Vec::into_boxed_slice)
+        .prop_map_into()
 }
 
 /// Generates an `AlgebraicValue` for values `Val: Arbitrary`.
@@ -88,7 +94,7 @@ pub fn generate_algebraic_value(ty: AlgebraicType) -> impl Strategy<Value = Alge
         AlgebraicType::U128 => generate_non_compound::<u128>(),
         AlgebraicType::F32 => generate_non_compound::<f32>(),
         AlgebraicType::F64 => generate_non_compound::<f64>(),
-        AlgebraicType::String => generate_non_compound::<String>(),
+        AlgebraicType::String => generate_non_compound::<Box<str>>(),
 
         AlgebraicType::Builtin(BuiltinType::Array(ty)) => generate_array_value(*ty.elem_ty).prop_map_into().boxed(),
 
@@ -104,11 +110,11 @@ pub fn generate_algebraic_value(ty: AlgebraicType) -> impl Strategy<Value = Alge
 
 /// Generates a `ProductValue` typed at `ty`.
 pub fn generate_product_value(ty: ProductType) -> impl Strategy<Value = ProductValue> {
-    ty.elements
+    Vec::from(ty.elements)
         .into_iter()
         .map(|elem| generate_algebraic_value(elem.algebraic_type))
         .collect::<Vec<_>>()
-        .prop_map(|elements| ProductValue { elements })
+        .prop_map_into()
 }
 
 /// Generates a `SumValue` typed at `ty`.
@@ -138,9 +144,12 @@ fn generate_map_value(ty: MapType) -> impl Strategy<Value = MapValue> {
 fn generate_array_of<S>(gen_elem: S) -> BoxedStrategy<ArrayValue>
 where
     S: Strategy + 'static,
-    Vec<S::Value>: 'static + Into<ArrayValue>,
+    Box<[S::Value]>: 'static + Into<ArrayValue>,
 {
-    vec(gen_elem, 0..=16).prop_map_into().boxed()
+    vec(gen_elem, 0..=16)
+        .prop_map(Vec::into_boxed_slice)
+        .prop_map_into()
+        .boxed()
 }
 
 /// Generates an array value with elements typed at `ty`.
@@ -159,7 +168,7 @@ fn generate_array_value(ty: AlgebraicType) -> BoxedStrategy<ArrayValue> {
         AlgebraicType::U128 => generate_array_of(any::<u128>()),
         AlgebraicType::F32 => generate_array_of(any::<f32>().prop_map_into::<F32>()),
         AlgebraicType::F64 => generate_array_of(any::<f64>().prop_map_into::<F64>()),
-        AlgebraicType::String => generate_array_of(any::<String>()),
+        AlgebraicType::String => generate_array_of(any::<Box<str>>()),
         AlgebraicType::Product(ty) => generate_array_of(generate_product_value(ty)),
         AlgebraicType::Sum(ty) => generate_array_of(generate_sum_value(ty)),
         AlgebraicType::Builtin(BuiltinType::Array(ty)) => generate_array_of(generate_array_value(*ty.elem_ty)),

--- a/crates/table/src/read_column.rs
+++ b/crates/table/src/read_column.rs
@@ -11,8 +11,8 @@ use crate::{
     util::slice_assume_init_ref,
 };
 use spacetimedb_sats::{
-    algebraic_value::ser::ValueSerializer, AlgebraicType, AlgebraicValue, ArrayValue, MapValue, ProductType,
-    ProductValue, SumValue,
+    algebraic_value::{ser::ValueSerializer, Packed},
+    AlgebraicType, AlgebraicValue, ArrayValue, MapValue, ProductType, ProductValue, SumValue,
 };
 use std::{cell::Cell, mem};
 use thiserror::Error;
@@ -306,9 +306,9 @@ macro_rules! impl_read_column_via_av {
 }
 
 impl_read_column_via_av! {
-    AlgebraicTypeLayout::VarLen(VarLenType::String) => into_string => String;
+    AlgebraicTypeLayout::VarLen(VarLenType::String) => into_string => Box<str>;
     AlgebraicTypeLayout::VarLen(VarLenType::Array(_)) => into_array => ArrayValue;
-    AlgebraicTypeLayout::VarLen(VarLenType::Map(_)) => into_map => MapValue;
+    AlgebraicTypeLayout::VarLen(VarLenType::Map(_)) => into_map => Box<MapValue>;
     AlgebraicTypeLayout::Sum(_) => into_sum => SumValue;
     AlgebraicTypeLayout::Product(_) => into_product => ProductValue;
 }
@@ -336,6 +336,8 @@ impl_read_column_via_from! {
     u32 => spacetimedb_primitives::IndexId;
     u32 => spacetimedb_primitives::ConstraintId;
     u32 => spacetimedb_primitives::SequenceId;
+    u128 => Packed<u128>;
+    i128 => Packed<i128>;
 }
 
 #[cfg(test)]
@@ -373,7 +375,7 @@ mod test {
 
             let row_ref = table.get_row_ref(&blob_store, ptr).unwrap();
 
-            for (idx, orig_col_value) in val.elements.into_iter().enumerate() {
+            for (idx, orig_col_value) in val.into_iter().enumerate() {
                 let read_col_value = row_ref.read_col::<AlgebraicValue>(idx).unwrap();
                 prop_assert_eq!(orig_col_value, read_col_value);
             }
@@ -391,7 +393,7 @@ mod test {
 
             let row_ref = table.get_row_ref(&blob_store, ptr).unwrap();
 
-            for (idx, col_ty) in ty.elements.into_iter().enumerate() {
+            for (idx, col_ty) in ty.elements.iter().enumerate() {
                 assert_wrong_type_error::<u8>(row_ref, idx, &col_ty.algebraic_type, AlgebraicType::U8)?;
                 assert_wrong_type_error::<i8>(row_ref, idx, &col_ty.algebraic_type, AlgebraicType::I8)?;
                 assert_wrong_type_error::<u16>(row_ref, idx, &col_ty.algebraic_type, AlgebraicType::U16)?;
@@ -405,7 +407,7 @@ mod test {
                 assert_wrong_type_error::<f32>(row_ref, idx, &col_ty.algebraic_type, AlgebraicType::F32)?;
                 assert_wrong_type_error::<f64>(row_ref, idx, &col_ty.algebraic_type, AlgebraicType::F64)?;
                 assert_wrong_type_error::<bool>(row_ref, idx, &col_ty.algebraic_type, AlgebraicType::Bool)?;
-                assert_wrong_type_error::<String>(row_ref, idx, &col_ty.algebraic_type, AlgebraicType::String)?;
+                assert_wrong_type_error::<Box<str>>(row_ref, idx, &col_ty.algebraic_type, AlgebraicType::String)?;
             }
         }
 
@@ -509,15 +511,15 @@ mod test {
 
         read_column_bool { AlgebraicType::Bool => bool = true };
 
-        read_column_empty_string { AlgebraicType::String => String = "".to_string() };
+        read_column_empty_string { AlgebraicType::String => Box<str> = "".into() };
 
         // Use a short string which fits in a single granule.
-        read_column_short_string { AlgebraicType::String => String = "short string".to_string() };
+        read_column_short_string { AlgebraicType::String => Box<str> = "short string".into() };
 
         // Use a medium-sized string which takes multiple granules.
-        read_column_medium_string { AlgebraicType::String => String = "medium string.".repeat(16) };
+        read_column_medium_string { AlgebraicType::String => Box<str> = "medium string.".repeat(16).into() };
 
         // Use a long string which will hit the blob store.
-        read_column_long_string { AlgebraicType::String => String = "long string. ".repeat(2048) };
+        read_column_long_string { AlgebraicType::String => Box<str> = "long string. ".repeat(2048).into() };
     }
 }

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -853,8 +853,8 @@ impl IndexScanIter<'_> {
 #[error("Unique constraint violation '{}' in table '{}': column(s): '{:?}' value: {}", constraint_name, table_name, cols, value.to_satn())]
 pub struct UniqueConstraintViolation {
     pub constraint_name: String,
-    pub table_name: String,
-    pub cols: Vec<String>,
+    pub table_name: Box<str>,
+    pub cols: Vec<Box<str>>,
     pub value: AlgebraicValue,
 }
 
@@ -1004,8 +1004,8 @@ pub(crate) mod test {
                 value,
             })) => {
                 assert_eq!(constraint_name, index_name);
-                assert_eq!(table_name, "UniqueIndexed");
-                assert_eq!(cols, &["unique_col"]);
+                assert_eq!(&*table_name, "UniqueIndexed");
+                assert_eq!(cols.iter().map(|c| c.to_string()).collect::<Vec<_>>(), &["unique_col"]);
                 assert_eq!(value, AlgebraicValue::I32(0));
             }
             Err(e) => panic!("Expected UniqueConstraintViolation but found {:?}", e),
@@ -1041,14 +1041,14 @@ pub(crate) mod test {
     #[test]
     fn repro_serialize_bsatn_empty_array() {
         let ty = AlgebraicType::array(AlgebraicType::U64);
-        let arr = ArrayValue::from(Vec::<u64>::new());
+        let arr = ArrayValue::from(Vec::<u64>::new().into_boxed_slice());
         insert_retrieve_body(ty, AlgebraicValue::from(arr)).unwrap();
     }
 
     #[test]
     fn repro_serialize_bsatn_debug_assert() {
         let ty = AlgebraicType::array(AlgebraicType::U64);
-        let arr = ArrayValue::from((0..130u64).collect::<Vec<_>>());
+        let arr = ArrayValue::from((0..130u64).collect::<Box<_>>());
         insert_retrieve_body(ty, AlgebraicValue::from(arr)).unwrap();
     }
 

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -76,7 +76,7 @@ impl ColumnOp {
 
         // Otherwise, pair column ids and product fields together.
         cols.iter()
-            .zip(value.into_product().unwrap().elements)
+            .zip(value.into_product().unwrap())
             .map(eq)
             .reduce(Self::and)
             .unwrap()

--- a/crates/vm/src/ops/parse.rs
+++ b/crates/vm/src/ops/parse.rs
@@ -77,7 +77,7 @@ pub fn parse(value: &str, ty: &AlgebraicType) -> Result<AlgebraicValue, ErrorVm>
         &AlgebraicType::U128 => _parse::<u128>(value, ty),
         &AlgebraicType::F32 => _parse::<f32>(value, ty),
         &AlgebraicType::F64 => _parse::<f64>(value, ty),
-        &AlgebraicType::String => Ok(AlgebraicValue::String(value.to_string())),
+        &AlgebraicType::String => Ok(AlgebraicValue::String(value.into())),
         AlgebraicType::Sum(sum) => parse_simple_enum(sum, value),
         AlgebraicType::Product(product) => parse_product(product, value),
         x => Err(ErrorVm::Unsupported(format!(

--- a/crates/vm/src/relation.rs
+++ b/crates/vm/src/relation.rs
@@ -67,11 +67,11 @@ impl<'a> RelValue<'a> {
 
     /// Extends `self` with the columns in `other`.
     ///
-    /// This will always cause `RowRef<'_>`s to be read out into
+    /// This will always cause `RowRef<'_>`s to be read out into [`ProductValue`]s.
     pub fn extend(self, other: RelValue<'a>) -> RelValue<'a> {
-        let mut x = self.into_product_value();
-        x.elements.extend(other.into_product_value().elements);
-        RelValue::Projection(x)
+        let mut x: Vec<_> = self.into_product_value().elements.into();
+        x.extend(other.into_product_value());
+        RelValue::Projection(x.into())
     }
 
     /// Read the column at index `col`.


### PR DESCRIPTION
# Description of Changes

This primarily shrinks the size of types `AlgebraicValue` from 32 bytes to 24 and `AlgebraicType` from 32 to 16.
The size of some other types are also shrunk, notably, table, column, index, sequence, etc. definitions are shrunk by moving from `String` to `Box<str>`.  Moreover, `ProductValue` is shrunk to 16 bytes, a type that is used frequently in hot places.

Benchmarks below relative to based master, run on i7-7700K, 64GB.

```
full-scan               time:   [80.111 ms 80.529 ms 80.979 ms]
                        change: [-14.103% -13.427% -12.763%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking full-join: Collecting 100 samples in estimated 6.
full-join               time:   [301.14 µs 302.01 µs 303.25 µs]
                        change: [-9.6948% -9.1117% -8.5214%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking incr-select: Collecting 100 samples in estimated 
incr-select             time:   [183.21 ns 185.12 ns 188.14 ns]
                        change: [-5.7687% -4.8383% -3.6110%] (p = 0.00 < 0.05)
                        Performance has improved.
```

# API and ABI breaking changes

None

# Expected complexity level and risk

2

# Testing

No semantic changes, existing tests should suffice.