### PR TITLE
Slow query log

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -178,9 +178,9 @@ impl ReadConfigOption {
 impl Display for ReadConfigOption {
     fn fmt(&self, f: &mut Formatter<'_>) -> std::fmt::Result {
         let value = match self {
-            ReadConfigOption::SlowQueryThreshold => "slow_query_threshold",
-            ReadConfigOption::SlowIncrementalUpdatesThreshold => "slow_incremental_updates_threshold",
-            ReadConfigOption::SlowSubscriptionsThreshold => "slow_subscriptions_threshold",
+            ReadConfigOption::SlowQueryThreshold => "slow_ad_hoc_query_ms",
+            ReadConfigOption::SlowIncrementalUpdatesThreshold => "slow_tx_update_ms",
+            ReadConfigOption::SlowSubscriptionsThreshold => "slow_subscription_query_ms",
         };
         write!(f, "{value}")
     }
@@ -191,9 +191,9 @@ impl FromStr for ReadConfigOption {
 
     fn from_str(s: &str) -> Result<Self, Self::Err> {
         match s {
-            "slow_query_threshold" => Ok(Self::SlowQueryThreshold),
-            "slow_incremental_updates_threshold" => Ok(Self::SlowIncrementalUpdatesThreshold),
-            "slow_subscriptions_threshold" => Ok(Self::SlowSubscriptionsThreshold),
+            "slow_ad_hoc_query_ms" => Ok(Self::SlowQueryThreshold),
+            "slow_tx_update_ms" => Ok(Self::SlowIncrementalUpdatesThreshold),
+            "slow_subscription_query_ms" => Ok(Self::SlowSubscriptionsThreshold),
             x => Err(ConfigError::NotFound(x.into())),
         }
     }

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -63,7 +63,7 @@ pub struct RelationalDB {
 
     // Release file lock last when dropping.
     _lock: Arc<File>,
-    pub(crate) config: Arc<RwLock<DatabaseConfig>>,
+    config: Arc<RwLock<DatabaseConfig>>,
 }
 
 impl std::fmt::Debug for RelationalDB {
@@ -759,8 +759,13 @@ impl RelationalDB {
         self.inner.set_program_hash(tx, fence, hash)
     }
 
+    /// Set a runtime configurations setting of the database
     pub fn set_config(&self, key: &str, value: AlgebraicValue) -> Result<(), ErrorVm> {
         self.config.write().set_config(key, value)
+    }
+    /// Read the runtime configurations settings of the database
+    pub fn read_config(&self) -> DatabaseConfig {
+        *self.config.read()
     }
 }
 

--- a/crates/core/src/execution_context.rs
+++ b/crates/core/src/execution_context.rs
@@ -161,7 +161,7 @@ impl ExecutionContext {
 
     /// Returns an [ExecutionContext] for a reducer transaction.
     pub fn reducer(database: Address, name: String) -> Self {
-        Self::new(database, Some(name), WorkloadType::Reducer)
+        Self::new(database, Some(name), WorkloadType::Reducer, Default::default())
     }
 
     /// Returns an [ExecutionContext] for a one-off sql query.

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -269,7 +269,7 @@ impl<T: WasmModule> Module for WasmModuleHostActor<T> {
         let auth = AuthCtx::new(self.database_instance_context.identity, caller_identity);
         log::debug!("One-off query: {query}");
         // Don't need the `slow query` logger on compilation
-        let ctx = &ExecutionContext::sql(db.address(), db.config.read().slow_query);
+        let ctx = &ExecutionContext::sql(db.address(), db.read_config().slow_query);
         let compiled: Vec<_> = db.with_read_only(ctx, |tx| {
             let ast = sql::compiler::compile_sql(db, tx, &query)?;
             ast.into_iter()

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -268,7 +268,8 @@ impl<T: WasmModule> Module for WasmModuleHostActor<T> {
         let db = &self.database_instance_context.relational_db;
         let auth = AuthCtx::new(self.database_instance_context.identity, caller_identity);
         log::debug!("One-off query: {query}");
-        let ctx = &ExecutionContext::sql(db.address());
+        // Don't need the `slow query` logger on compilation
+        let ctx = &ExecutionContext::sql(db.address(), db.config.read().slow_query);
         let compiled: Vec<_> = db.with_read_only(ctx, |tx| {
             let ast = sql::compiler::compile_sql(db, tx, &query)?;
             ast.into_iter()
@@ -282,7 +283,7 @@ impl<T: WasmModule> Module for WasmModuleHostActor<T> {
                 .collect::<Result<_, _>>()
         })?;
 
-        sql::execute::execute_sql(db, compiled, auth)
+        sql::execute::execute_sql(db, &query, compiled, auth)
     }
 
     fn clear_table(&self, table_name: &str) -> Result<(), anyhow::Error> {

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -281,6 +281,8 @@ fn compile_statement(db: &RelationalDB, statement: SqlAst) -> Result<CrudExpr, P
             kind,
             table_access,
         } => compile_drop(name, kind, table_access)?,
+        SqlAst::SetVar { name, value } => CrudExpr::SetVar { name, value },
+        SqlAst::ReadVar { name } => CrudExpr::ReadVar { name },
     };
 
     Ok(q.optimize(&|table_id, table_name| db.row_count(table_id, table_name)))
@@ -1165,7 +1167,7 @@ mod tests {
         let sql = "select * from enum where a = 'Player'";
         let q = compile_sql(&db, &tx, sql);
         assert!(q.is_ok());
-        let result = execute_sql(&db, q.unwrap(), AuthCtx::for_testing())?;
+        let result = execute_sql(&db, sql, q.unwrap(), AuthCtx::for_testing())?;
         assert_eq!(result[0].data, vec![product![AlgebraicValue::enum_simple(0)]]);
         Ok(())
     }

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -53,11 +53,15 @@ pub(crate) fn collect_result(result: &mut Vec<MemTable>, r: CodeResult) -> Resul
 /// Run the compiled `SQL` expression inside the `vm` created by [DbProgram]
 ///
 /// Evaluates `ast` and accordingly triggers mutable or read tx to execute
-pub fn execute_sql(db: &RelationalDB, ast: Vec<CrudExpr>, auth: AuthCtx) -> Result<Vec<MemTable>, DBError> {
+///
+/// Also, in case the execution takes more than x, log it as `slow query`
+pub fn execute_sql(db: &RelationalDB, sql: &str, ast: Vec<CrudExpr>, auth: AuthCtx) -> Result<Vec<MemTable>, DBError> {
     let total = ast.len();
-    let ctx = ExecutionContext::sql(db.address());
+    let ctx = ExecutionContext::sql(db.address(), db.config.read().slow_query);
     let mut result = Vec::with_capacity(total);
     let sources = [].into();
+    let slow_logger = ctx.slow_query_config.for_queries(sql);
+
     match CrudExpr::is_reads(&ast) {
         false => db.with_auto_commit(&ctx, |mut_tx| {
             let mut tx: TxMode = mut_tx.into();
@@ -74,15 +78,16 @@ pub fn execute_sql(db: &RelationalDB, ast: Vec<CrudExpr>, auth: AuthCtx) -> Resu
             collect_result(&mut result, run_ast(p, q, sources).into())
         }),
     }?;
+    slow_logger.log();
 
     Ok(result)
 }
 
 /// Run the `SQL` string using the `auth` credentials
 pub fn run(db: &RelationalDB, sql_text: &str, auth: AuthCtx) -> Result<Vec<MemTable>, DBError> {
-    let ctx = &ExecutionContext::sql(db.address());
+    let ctx = &ExecutionContext::sql(db.address(), db.config.read().slow_query);
     let ast = db.with_read_only(ctx, |tx| compile_sql(db, tx, sql_text))?;
-    execute_sql(db, ast, auth)
+    execute_sql(db, sql_text, ast, auth)
 }
 
 #[cfg(test)]

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -3,6 +3,7 @@ use crate::database_instance_context_controller::DatabaseInstanceContextControll
 use crate::db::relational_db::RelationalDB;
 use crate::error::{DBError, DatabaseError};
 use crate::execution_context::ExecutionContext;
+use crate::util::slow::SlowQueryLogger;
 use crate::vm::{DbProgram, TxMode};
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::{ProductType, ProductValue};
@@ -57,10 +58,10 @@ pub(crate) fn collect_result(result: &mut Vec<MemTable>, r: CodeResult) -> Resul
 /// Also, in case the execution takes more than x, log it as `slow query`
 pub fn execute_sql(db: &RelationalDB, sql: &str, ast: Vec<CrudExpr>, auth: AuthCtx) -> Result<Vec<MemTable>, DBError> {
     let total = ast.len();
-    let ctx = ExecutionContext::sql(db.address(), db.config.read().slow_query);
+    let ctx = ExecutionContext::sql(db.address(), db.read_config().slow_query);
     let mut result = Vec::with_capacity(total);
     let sources = [].into();
-    let slow_logger = ctx.slow_query_config.for_queries(sql);
+    let slow_logger = SlowQueryLogger::query(ctx.slow_query_config, sql);
 
     match CrudExpr::is_reads(&ast) {
         false => db.with_auto_commit(&ctx, |mut_tx| {
@@ -85,7 +86,7 @@ pub fn execute_sql(db: &RelationalDB, sql: &str, ast: Vec<CrudExpr>, auth: AuthC
 
 /// Run the `SQL` string using the `auth` credentials
 pub fn run(db: &RelationalDB, sql_text: &str, auth: AuthCtx) -> Result<Vec<MemTable>, DBError> {
-    let ctx = &ExecutionContext::sql(db.address(), db.config.read().slow_query);
+    let ctx = &ExecutionContext::sql(db.address(), db.read_config().slow_query);
     let ast = db.with_read_only(ctx, |tx| compile_sql(db, tx, sql_text))?;
     execute_sql(db, sql_text, ast, auth)
 }

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -71,6 +71,7 @@ enum EvalIncrPlan {
 pub struct ExecutionUnit {
     hash: QueryHash,
 
+    pub(crate) sql: String,
     /// A version of the plan optimized for `eval`,
     /// whose source is a [`DbTable`].
     ///
@@ -133,16 +134,18 @@ impl ExecutionUnit {
             SupportedQuery {
                 kind: query::Supported::Select,
                 expr,
+                ..
             } => EvalIncrPlan::Select(Self::compile_select_eval_incr(expr)),
             SupportedQuery {
                 kind: query::Supported::Semijoin,
                 expr,
+                ..
             } => EvalIncrPlan::Semijoin(IncrementalJoin::new(expr)?),
         };
-        let eval_plan = eval_plan.expr;
         Ok(ExecutionUnit {
             hash,
-            eval_plan,
+            sql: eval_plan.sql,
+            eval_plan: eval_plan.expr,
             eval_incr_plan,
         })
     }
@@ -211,8 +214,9 @@ impl ExecutionUnit {
         ctx: &ExecutionContext,
         db: &RelationalDB,
         tx: &Tx,
+        sql: &str,
     ) -> Result<Option<TableUpdateJson>, DBError> {
-        let table_row_operations = Self::eval_query_expr(ctx, db, tx, &self.eval_plan, |row| {
+        let table_row_operations = Self::eval_query_expr(ctx, db, tx, &self.eval_plan, sql, |row| {
             TableOp::insert(row.into_product_value()).into()
         })?;
         Ok((!table_row_operations.is_empty()).then(|| TableUpdateJson {
@@ -229,9 +233,10 @@ impl ExecutionUnit {
         ctx: &ExecutionContext,
         db: &RelationalDB,
         tx: &Tx,
+        sql: &str,
     ) -> Result<Option<TableUpdate>, DBError> {
         let mut buf = Vec::new();
-        let table_row_operations = Self::eval_query_expr(ctx, db, tx, &self.eval_plan, |row| {
+        let table_row_operations = Self::eval_query_expr(ctx, db, tx, &self.eval_plan, sql, |row| {
             row.to_bsatn_extend(&mut buf).unwrap();
             let row = buf.clone();
             buf.clear();
@@ -249,11 +254,14 @@ impl ExecutionUnit {
         db: &RelationalDB,
         tx: &Tx,
         eval_plan: &QueryExpr,
+        sql: &str,
         convert: impl FnMut(RelValue<'_>) -> T,
     ) -> Result<Vec<T>, DBError> {
         let tx: TxMode = tx.into();
+        let slow_query = ctx.slow_query_config.for_subscriptions(sql);
         let query = build_query(ctx, db, &tx, eval_plan, &mut NoInMemUsed)?;
         let ops = query.collect_vec(convert)?;
+        slow_query.log();
         Ok(ops)
     }
 
@@ -263,12 +271,16 @@ impl ExecutionUnit {
         ctx: &'a ExecutionContext,
         db: &'a RelationalDB,
         tx: &'a TxMode<'a>,
+        sql: &'a str,
         tables: impl 'a + Clone + Iterator<Item = &'a DatabaseTableUpdate>,
     ) -> Result<Option<DatabaseTableUpdateCow<'a>>, DBError> {
+        let slow_query = ctx.slow_query_config.for_incremental_updates(sql);
         let updates = match &self.eval_incr_plan {
             EvalIncrPlan::Select(plan) => Self::eval_incr_query_expr(ctx, db, tx, tables, plan, self.return_table())?,
             EvalIncrPlan::Semijoin(plan) => plan.eval(ctx, db, tx, tables)?,
         };
+        slow_query.log();
+
         Ok(updates.has_updates().then(|| DatabaseTableUpdateCow {
             table_id: self.return_table(),
             table_name: self.return_name(),

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -44,7 +44,10 @@ impl ModuleSubscriptions {
         timer: Instant,
         _assert: Option<AssertTxFn>,
     ) -> Result<(), DBError> {
-        let ctx = ExecutionContext::subscribe(self.relational_db.address());
+        let ctx = ExecutionContext::subscribe(
+            self.relational_db.address(),
+            self.relational_db.config.read().slow_query,
+        );
         let tx = scopeguard::guard(self.relational_db.begin_tx(), |tx| {
             self.relational_db.release_tx(&ctx, tx);
         });

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -46,7 +46,7 @@ impl ModuleSubscriptions {
     ) -> Result<(), DBError> {
         let ctx = ExecutionContext::subscribe(
             self.relational_db.address(),
-            self.relational_db.config.read().slow_query,
+            self.relational_db.read_config().slow_query,
         );
         let tx = scopeguard::guard(self.relational_db.begin_tx(), |tx| {
             self.relational_db.release_tx(&ctx, tx);

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -114,7 +114,7 @@ impl SubscriptionManager {
     #[tracing::instrument(skip_all)]
     pub fn eval_updates(&self, db: &RelationalDB, event: Arc<ModuleEvent>) {
         let tables = &event.status.database_update().unwrap().tables;
-        let slow = db.config.read().slow_query;
+        let slow = db.read_config().slow_query;
         let tx = scopeguard::guard(db.begin_tx(), |tx| {
             tx.release(&ExecutionContext::incremental_update(db.address(), slow));
         });

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -61,12 +61,13 @@ use std::sync::Arc;
 pub struct SupportedQuery {
     pub kind: query::Supported,
     pub expr: QueryExpr,
+    pub sql: String,
 }
 
 impl SupportedQuery {
-    pub fn new(expr: QueryExpr, text: String) -> Result<Self, DBError> {
-        let kind = query::classify(&expr).ok_or(SubscriptionError::Unsupported(text))?;
-        Ok(Self { kind, expr })
+    pub fn new(expr: QueryExpr, sql: String) -> Result<Self, DBError> {
+        let kind = query::classify(&expr).ok_or_else(|| SubscriptionError::Unsupported(sql.clone()))?;
+        Ok(Self { kind, expr, sql })
     }
 
     pub fn kind(&self) -> query::Supported {
@@ -113,12 +114,12 @@ impl SupportedQuery {
 }
 
 #[cfg(test)]
-impl TryFrom<QueryExpr> for SupportedQuery {
+impl TryFrom<(QueryExpr, String)> for SupportedQuery {
     type Error = DBError;
 
-    fn try_from(expr: QueryExpr) -> Result<Self, Self::Error> {
+    fn try_from((expr, sql): (QueryExpr, String)) -> Result<Self, Self::Error> {
         let kind = query::classify(&expr).context("Unsupported query expression")?;
-        Ok(Self { kind, expr })
+        Ok(Self { kind, expr, sql })
     }
 }
 
@@ -553,7 +554,7 @@ impl ExecutionSet {
         self.exec_units
             // if you need eval to run single-threaded for debugging, change this to .iter()
             .par_iter()
-            .filter_map(|unit| unit.eval_json(ctx, db, tx).transpose())
+            .filter_map(|unit| unit.eval_json(ctx, db, tx, &unit.sql).transpose())
             .collect::<Result<Vec<_>, _>>()
     }
 
@@ -563,7 +564,7 @@ impl ExecutionSet {
         self.exec_units
             // if you need eval to run single-threaded for debugging, change this to .iter()
             .par_iter()
-            .filter_map(|unit| unit.eval_binary(ctx, db, tx).transpose())
+            .filter_map(|unit| unit.eval_binary(ctx, db, tx, &unit.sql).transpose())
             .collect::<Result<Vec<_>, _>>()
     }
 
@@ -577,7 +578,7 @@ impl ExecutionSet {
     ) -> Result<DatabaseUpdateCow<'_>, DBError> {
         let mut tables = Vec::new();
         for unit in &self.exec_units {
-            if let Some(table) = unit.eval_incr(ctx, db, tx, database_update.tables.iter())? {
+            if let Some(table) = unit.eval_incr(ctx, db, tx, &unit.sql, database_update.tables.iter())? {
                 tables.push(table);
             }
         }
@@ -636,6 +637,7 @@ pub(crate) fn get_all(relational_db: &RelationalDB, tx: &Tx, auth: &AuthCtx) -> 
         .map(|src| SupportedQuery {
             kind: query::Supported::Select,
             expr: QueryExpr::new(src),
+            sql: format!("SELECT * FROM {}", src.table_name),
         })
         .collect())
 }

--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -9,6 +9,7 @@ pub mod prometheus_handle;
 mod future_queue;
 pub mod lending_pool;
 pub mod notify_once;
+pub mod slow;
 
 pub use future_queue::{future_queue, FutureQueue};
 

--- a/crates/core/src/util/slow.rs
+++ b/crates/core/src/util/slow.rs
@@ -1,0 +1,250 @@
+use std::time::{Duration, Instant};
+
+/// Default threshold for general queries in `ms`.
+const THRESHOLD_QUERIES_MILLIS: u64 = 100;
+
+/// Configuration threshold for detecting slow queries.
+#[derive(Debug, Clone, Copy)]
+pub struct SlowQueryConfig {
+    /// The threshold duration for incremental updates.
+    pub(crate) incremental_updates: Option<Duration>,
+    /// The threshold duration for subscriptions.
+    pub(crate) subscriptions: Option<Duration>,
+    /// The threshold duration for general queries.
+    pub(crate) queries: Option<Duration>,
+}
+
+impl SlowQueryConfig {
+    /// Creates a new `SlowQueryConfig` with all the threshold set to [None].
+    pub fn new() -> Self {
+        Self {
+            incremental_updates: None,
+            subscriptions: None,
+            queries: None,
+        }
+    }
+
+    /// Creates a new `SlowQueryConfig` with [THRESHOLD_QUERIES_MILLIS] for `queries` and the rest set to [None].
+    pub fn with_defaults() -> Self {
+        Self {
+            incremental_updates: None,
+            subscriptions: None,
+            queries: Some(Duration::from_millis(THRESHOLD_QUERIES_MILLIS)),
+        }
+    }
+
+    /// Sets the threshold for incremental updates.
+    pub fn with_incremental_updates(mut self, duration: Duration) -> Self {
+        self.incremental_updates = Some(duration);
+        self
+    }
+    /// Sets the threshold for subscriptions.
+    pub fn with_subscriptions(mut self, duration: Duration) -> Self {
+        self.subscriptions = Some(duration);
+        self
+    }
+    /// Sets the threshold for general queries.
+    pub fn with_queries(mut self, duration: Duration) -> Self {
+        self.queries = Some(duration);
+        self
+    }
+
+    pub fn for_queries(self, sql: &str) -> SlowQuery {
+        SlowQuery::query(self, sql)
+    }
+    pub fn for_subscriptions(self, sql: &str) -> SlowQuery {
+        SlowQuery::query(self, sql)
+    }
+    pub fn for_incremental_updates(self, sql: &str) -> SlowQuery {
+        SlowQuery::incremental_updates(self, sql)
+    }
+}
+
+impl Default for SlowQueryConfig {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
+/// Represents `threshold` for [SlowQuery].
+pub enum Threshold {
+    IncrementalUpdates(Option<Duration>),
+    Subscriptions(Option<Duration>),
+    Queries(Option<Duration>),
+}
+
+/// Start the recording of a `sql` with a specific [Threshold].
+pub struct SlowQuery<'a> {
+    /// The SQL statement of the query.
+    sql: &'a str,
+    /// The start time of the query execution.
+    start: Instant,
+    /// Which [Threshold] to use.
+    threshold: Threshold,
+}
+
+impl<'a> SlowQuery<'a> {
+    pub fn new(sql: &'a str, threshold: Threshold) -> Self {
+        Self {
+            sql,
+            start: Instant::now(),
+            threshold,
+        }
+    }
+
+    /// Creates a new [SlowQuery] instance for general queries.
+    pub fn query(config: SlowQueryConfig, sql: &'a str) -> Self {
+        Self::new(sql, Threshold::Queries(config.queries))
+    }
+
+    /// Creates a new [SlowQuery] instance for subscriptions.
+    pub fn subscription(config: SlowQueryConfig, sql: &'a str) -> Self {
+        Self::new(sql, Threshold::Subscriptions(config.subscriptions))
+    }
+
+    /// Creates a new [SlowQuery] instance for incremental updates.
+    pub fn incremental_updates(config: SlowQueryConfig, sql: &'a str) -> Self {
+        Self::new(sql, Threshold::IncrementalUpdates(config.queries))
+    }
+
+    /// Log as `tracing::warn!` the query if it exceeds the threshold.
+    pub fn log(&self) -> Option<Duration> {
+        let (kind, dur) = match self.threshold {
+            Threshold::IncrementalUpdates(dur) => ("IncrementalUpdates", dur),
+            Threshold::Subscriptions(dur) => ("Subscriptions", dur),
+            Threshold::Queries(dur) => ("Queries", dur),
+        };
+        if let Some(dur) = dur {
+            let elapsed = self.start.elapsed();
+            if elapsed > dur {
+                tracing::warn!(kind = kind, threshold = ?dur, elapsed = ?elapsed, sql = self.sql, "SLOW QUERY");
+                return Some(elapsed);
+            }
+        };
+        None
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    use crate::execution_context::ExecutionContext;
+    use crate::sql::compiler::compile_sql;
+    use crate::sql::execute::execute_sql;
+    use spacetimedb_lib::error::ResultTest;
+    use spacetimedb_lib::identity::AuthCtx;
+
+    use crate::config::ReadConfigOption;
+    use crate::db::relational_db::tests_utils::TestDB;
+    use crate::db::relational_db::RelationalDB;
+    use spacetimedb_sats::{product, AlgebraicType};
+    use spacetimedb_vm::relation::MemTable;
+
+    fn run_query(db: &RelationalDB, sql: String) -> ResultTest<MemTable> {
+        let tx = db.begin_tx();
+        let q = compile_sql(db, &tx, &sql)?;
+        Ok(execute_sql(db, &sql, q, AuthCtx::for_testing())?.pop().unwrap())
+    }
+
+    fn run_query_write(db: &RelationalDB, sql: String) -> ResultTest<()> {
+        let tx = db.begin_tx();
+        let q = compile_sql(db, &tx, &sql)?;
+        drop(tx);
+
+        execute_sql(db, &sql, q, AuthCtx::for_testing())?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_slow_queries() -> ResultTest<()> {
+        let db = TestDB::in_memory()?.db;
+
+        let table_id =
+            db.create_table_for_test("test", &[("x", AlgebraicType::I32), ("y", AlgebraicType::I32)], &[])?;
+
+        db.with_auto_commit(&ExecutionContext::default(), |tx| -> ResultTest<_> {
+            for i in 0..100_000 {
+                db.insert(tx, table_id, product![i, i * 2])?;
+            }
+            Ok(())
+        })?;
+        let tx = db.begin_tx();
+
+        let sql = "select * from test where x > 0";
+        let q = compile_sql(&db, &tx, sql)?;
+
+        let slow = SlowQueryConfig::default()
+            .with_queries(Duration::from_millis(1))
+            .for_queries(sql);
+
+        let result = execute_sql(&db, sql, q, AuthCtx::for_testing())?;
+        assert_eq!(result[0].data[0], product![1, 2]);
+        assert!(slow.log().is_some());
+
+        Ok(())
+    }
+
+    // Verify we can change the threshold at runtime
+    #[test]
+    fn test_runtime_config() -> ResultTest<()> {
+        let db = TestDB::in_memory()?.db;
+
+        let config = *db.config.read();
+
+        let check = |table: MemTable, x: Option<Duration>| {
+            assert_eq!(
+                table.data[0].field_as_sum(0, None).unwrap().value.as_u128().copied(),
+                x.map(|x| x.as_millis())
+            );
+        };
+
+        // Check we can read the default config
+        let result = run_query(&db, format!("SHOW {}", ReadConfigOption::SlowQueryThreshold))?;
+        check(result, config.slow_query.queries);
+        let result = run_query(&db, format!("SHOW {}", ReadConfigOption::SlowSubscriptionsThreshold))?;
+        check(result, config.slow_query.subscriptions);
+        let result = run_query(
+            &db,
+            format!("SHOW {}", ReadConfigOption::SlowIncrementalUpdatesThreshold),
+        )?;
+        check(result, config.slow_query.incremental_updates);
+        // Check we can write a new config
+        run_query_write(&db, format!("SET {} TO 1", ReadConfigOption::SlowQueryThreshold))?;
+        run_query_write(
+            &db,
+            format!("SET {} TO 1", ReadConfigOption::SlowSubscriptionsThreshold),
+        )?;
+        run_query_write(
+            &db,
+            format!("SET {} TO 1", ReadConfigOption::SlowIncrementalUpdatesThreshold),
+        )?;
+
+        let config = *db.config.read();
+
+        assert_eq!(config.slow_query.queries, Some(Duration::from_millis(1)));
+        assert_eq!(config.slow_query.subscriptions, Some(Duration::from_millis(1)));
+        assert_eq!(config.slow_query.incremental_updates, Some(Duration::from_millis(1)));
+
+        // And the new config
+        let result = run_query(&db, format!("SHOW {}", ReadConfigOption::SlowQueryThreshold))?;
+        check(result, config.slow_query.queries);
+        let result = run_query(&db, format!("SHOW {}", ReadConfigOption::SlowSubscriptionsThreshold))?;
+        check(result, config.slow_query.subscriptions);
+        let result = run_query(
+            &db,
+            format!("SHOW {}", ReadConfigOption::SlowIncrementalUpdatesThreshold),
+        )?;
+        check(result, config.slow_query.incremental_updates);
+
+        // And disable the config
+        run_query_write(&db, format!("SET {} TO 0", ReadConfigOption::SlowQueryThreshold))?;
+
+        let config = *db.config.read();
+
+        let result = run_query(&db, format!("SHOW {}", ReadConfigOption::SlowQueryThreshold))?;
+        check(result, config.slow_query.queries);
+        Ok(())
+    }
+}

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -523,6 +523,17 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
             TxMode::Tx(_) => unreachable!("mutable operation is invalid with read tx"),
         }
     }
+
+    fn _set_config(&mut self, name: String, value: AlgebraicValue) -> Result<Code, ErrorVm> {
+        self.db.set_config(&name, value)?;
+        Ok(Code::Pass)
+    }
+
+    fn _read_config(&self, name: String) -> Result<Code, ErrorVm> {
+        let config = self.db.config.read();
+
+        Ok(Code::Table(config.read_key_into_table(&name)?))
+    }
 }
 
 impl ProgramVm for DbProgram<'_, '_> {
@@ -582,6 +593,8 @@ impl ProgramVm for DbProgram<'_, '_> {
             CrudExpr::Delete { query } => self._delete_query(&query, sources),
             CrudExpr::CreateTable { table } => self._create_table(table),
             CrudExpr::Drop { name, kind, .. } => self._drop(&name, kind),
+            CrudExpr::SetVar { name, value } => self._set_config(name, value),
+            CrudExpr::ReadVar { name } => self._read_config(name),
         }
     }
 }

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -530,7 +530,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
     }
 
     fn _read_config(&self, name: String) -> Result<Code, ErrorVm> {
-        let config = self.db.config.read();
+        let config = self.db.read_config();
 
         Ok(Code::Table(config.read_key_into_table(&name)?))
     }

--- a/crates/sqltest/src/space.rs
+++ b/crates/sqltest/src/space.rs
@@ -76,7 +76,7 @@ impl SpaceDb {
     pub(crate) fn run_sql(&self, sql: &str) -> anyhow::Result<Vec<MemTable>> {
         self.conn.with_read_only(&ExecutionContext::default(), |tx| {
             let ast = compile_sql(&self.conn, tx, sql)?;
-            let result = execute_sql(&self.conn, ast, self.auth)?;
+            let result = execute_sql(&self.conn, sql, ast, self.auth)?;
             //remove comments to see which SQL worked. Can't collect it outside from lack of a hook in the external `sqllogictest` crate... :(
             //append_file(&std::path::PathBuf::from(".ok.sql"), sql)?;
             Ok(result)

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -768,6 +768,7 @@ pub enum Crud {
     Delete,
     Create(DbType),
     Drop(DbType),
+    Config,
 }
 
 #[derive(Debug, Eq, PartialEq)]
@@ -792,6 +793,13 @@ pub enum CrudExpr {
         kind: DbType,
         table_access: StAccess,
     },
+    SetVar {
+        name: String,
+        value: AlgebraicValue,
+    },
+    ReadVar {
+        name: String,
+    },
 }
 
 impl CrudExpr {
@@ -803,7 +811,9 @@ impl CrudExpr {
     }
 
     pub fn is_reads<'a>(exprs: impl IntoIterator<Item = &'a CrudExpr>) -> bool {
-        exprs.into_iter().all(|expr| matches!(expr, CrudExpr::Query(_)))
+        exprs
+            .into_iter()
+            .all(|expr| matches!(expr, CrudExpr::Query(_) | CrudExpr::ReadVar { .. }))
     }
 }
 

--- a/crates/vm/src/program.rs
+++ b/crates/vm/src/program.rs
@@ -53,6 +53,12 @@ impl ProgramVm for Program {
             CrudExpr::Drop { .. } => {
                 todo!()
             }
+            CrudExpr::SetVar { .. } => {
+                todo!()
+            }
+            CrudExpr::ReadVar { .. } => {
+                todo!()
+            }
         }
     }
 }


### PR DESCRIPTION
# Description of Changes

Closes [#1071](https://github.com/clockworklabs/SpacetimeDB/issues/1071)

Log as `tracing::warn!` a query if it exceeds the threshold.

Note: Currently the default is burned [here](https://github.com/clockworklabs/SpacetimeDB/blob/11fb6fb65e92e9bb76cab193ecbc43ead42d9a58/crates/core/src/util/slow.rs#L4).

Note: The settings are not persited neither are transactional.

Is possible to query and set it at runtime:

```sql
🪐quickstart>SHOW slow_query_threshold;
 slow_query_threshold
----------------------
 100
 (1 row)
Time: 12.11ms

🪐quickstart>SET slow_query_threshold = 1
Time: 6.59ms
OK
```

The current settings:

```
slow_query_threshold = 100 ms
slow_incremental_updates_threshold = None
slow_subscriptions_threshold = None
```

# Expected complexity level and risk
1
# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *test_slow_queries*
- [x] *test_runtime_config*
- [x] *Check with the `sql cli` that  `SET slow_query_threshold TO 1` and running a query print the warning*

Don't have a way to check for `stdout`.