### PR TITLE
fix(1051): Reset queue length metrics on module restart

### DIFF
--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -14,6 +14,7 @@ use crate::protobuf::client_api::{TableRowOperation, TableUpdate};
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
 use crate::util::lending_pool::{Closed, LendingPool, LentResource, PoolClosed};
 use crate::util::notify_once::NotifyOnce;
+use crate::worker_metrics::WORKER_METRICS;
 use derive_more::{From, Into};
 use futures::{Future, FutureExt};
 use indexmap::IndexMap;
@@ -509,6 +510,16 @@ async fn select_first<A: Future, B: Future<Output = ()>>(fut_a: A, fut_b: B) -> 
 #[async_trait::async_trait]
 impl<T: Module> DynModuleHost for HostControllerActor<T> {
     async fn get_instance(&self, db: Address) -> Result<Box<dyn ModuleInstance>, NoSuchModule> {
+        // In the event of a PoolClosed error,
+        // we need to reset the queue length metrics.
+        fn no_such_module(db: &Address) -> NoSuchModule {
+            WORKER_METRICS.instance_queue_length.with_label_values(db).set(0);
+            WORKER_METRICS
+                .instance_queue_length_histogram
+                .with_label_values(db)
+                .observe(0 as f64);
+            NoSuchModule
+        }
         self.start.notified().await;
         // in the future we should do something like in the else branch here -- add more instances based on load.
         // we need to do write-skew retries first - right now there's only ever once instance per module.
@@ -516,7 +527,7 @@ impl<T: Module> DynModuleHost for HostControllerActor<T> {
             self.instance_pool
                 .request_with_context(db)
                 .await
-                .map_err(|_| NoSuchModule)?
+                .map_err(|_| no_such_module(&db))?
         } else {
             const GET_INSTANCE_TIMEOUT: Duration = Duration::from_millis(500);
             select_first(
@@ -524,7 +535,7 @@ impl<T: Module> DynModuleHost for HostControllerActor<T> {
                 tokio::time::sleep(GET_INSTANCE_TIMEOUT).map(|()| self.spinup_new_instance()),
             )
             .await
-            .map_err(|_| NoSuchModule)?
+            .map_err(|_| no_such_module(&db))?
         };
         Ok(Box::new(AutoReplacingModuleInstance {
             inst,

--- a/crates/core/src/util/lending_pool.rs
+++ b/crates/core/src/util/lending_pool.rs
@@ -80,10 +80,9 @@ impl<T> LendingPool<T> {
         queue_len_max.set(max_queue_len);
 
         async move {
-            let permit_result = acq.await.map_err(|_| PoolClosed);
+            let permit = acq.await.map_err(|_| PoolClosed)?;
             queue_len.dec();
             queue_len_histogram.observe(queue_len.get() as f64);
-            let permit = permit_result?;
             let resource = pool_inner
                 .vec
                 .lock()


### PR DESCRIPTION
Fixes #1051.

Queue length metrics were not being reset in all cases for module restarts.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
