### PR TITLE
fix: Disable unused metrics

### DIFF
--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -16,16 +16,6 @@ metrics_group!(
         #[labels(table_id: u32)]
         pub rdb_drop_table_time: HistogramVec,
 
-        #[name = spacetime_rdb_insert_row_time]
-        #[help = "The time spent inserting into a table"]
-        #[labels(table_id: u32)]
-        pub rdb_insert_row_time: HistogramVec,
-
-        #[name = spacetime_rdb_delete_in_time]
-        #[help = "The time spent deleting values in a set from a table"]
-        #[labels(table_id: u32)]
-        pub rdb_delete_by_rel_time: HistogramVec,
-
         #[name = spacetime_num_table_rows]
         #[help = "The number of rows in a table"]
         #[labels(db: Address, table_id: u32, table_name: str)]
@@ -82,32 +72,6 @@ metrics_group!(
         #[labels(txn_type: WorkloadType, db: Address, reducer: str)]
         pub rdb_txn_cpu_time_sec_max: GaugeVec,
 
-        #[name = spacetime_query_cpu_time_sec]
-        #[help = "The time spent executing a query (in seconds)"]
-        #[labels(txn_type: WorkloadType, db: Address)]
-        #[buckets(
-            1e-6, 5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0
-        )]
-        pub rdb_query_cpu_time_sec: HistogramVec,
-
-        #[name = spacetime_query_cpu_time_sec_max]
-        #[help = "The cpu time of the longest running query (in seconds)"]
-        #[labels(txn_type: WorkloadType, db: Address)]
-        pub rdb_query_cpu_time_sec_max: GaugeVec,
-
-        #[name = spacetime_query_compile_time_sec]
-        #[help = "The time spent compiling a query (in seconds)"]
-        #[labels(txn_type: WorkloadType, db: Address)]
-        #[buckets(
-            1e-6, 5e-6, 1e-5, 5e-5, 1e-4, 5e-4, 1e-3, 0.005, 0.01, 0.025, 0.05, 0.1, 0.25, 0.5, 1.0, 2.5, 5.0, 10.0
-        )]
-        pub rdb_query_compile_time_sec: HistogramVec,
-
-        #[name = spacetime_query_compile_time_sec_max]
-        #[help = "The maximum query compilation time (in seconds)"]
-        #[labels(txn_type: WorkloadType, db: Address)]
-        pub rdb_query_compile_time_sec_max: GaugeVec,
-
         #[name = spacetime_wasm_abi_call_duration_sec]
         #[help = "The total duration of a spacetime wasm abi call (in seconds); includes row serialization and copying into wasm memory"]
         #[labels(db: Address, reducer: str, call: AbiCall)]
@@ -137,7 +101,6 @@ type ReducerLabel = (Address, WorkloadType, String);
 type AddressLabel = (Address, WorkloadType);
 
 pub static MAX_TX_CPU_TIME: Lazy<Mutex<HashMap<ReducerLabel, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
-pub static MAX_QUERY_CPU_TIME: Lazy<Mutex<HashMap<AddressLabel, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 pub static MAX_QUERY_COMPILE_TIME: Lazy<Mutex<HashMap<AddressLabel, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 pub static DB_METRICS: Lazy<DbMetrics> = Lazy::new(DbMetrics::new);
 
@@ -145,9 +108,6 @@ pub fn reset_counters() {
     // Reset max reducer durations
     DB_METRICS.rdb_txn_cpu_time_sec_max.0.reset();
     MAX_TX_CPU_TIME.lock().unwrap().clear();
-    // Reset max query durations
-    DB_METRICS.rdb_query_cpu_time_sec_max.0.reset();
-    MAX_QUERY_CPU_TIME.lock().unwrap().clear();
 }
 
 /// Returns the number of committed rows in the table named by `table_name` and identified by `table_id` in the database `db_address`.

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -653,11 +653,6 @@ impl RelationalDB {
     }
 
     pub fn insert(&self, tx: &mut MutTx, table_id: TableId, row: ProductValue) -> Result<ProductValue, DBError> {
-        #[cfg(feature = "metrics")]
-        let _guard = DB_METRICS
-            .rdb_insert_row_time
-            .with_label_values(&table_id.0)
-            .start_timer();
         self.inner.insert_mut_tx(tx, table_id, row)
     }
 
@@ -677,12 +672,6 @@ impl RelationalDB {
     }
 
     pub fn delete_by_rel<R: Relation>(&self, tx: &mut MutTx, table_id: TableId, relation: R) -> u32 {
-        #[cfg(feature = "metrics")]
-        let _guard = DB_METRICS
-            .rdb_delete_by_rel_time
-            .with_label_values(&table_id.0)
-            .start_timer();
-
         self.inner.delete_by_rel_mut_tx(tx, table_id, relation)
     }
 

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -160,7 +160,7 @@ impl WasmInstanceEnv {
 
     // TODO: make this part of cvt(), maybe?
     /// Gather the appropriate metadata and log a wasm_abi_call_duration_ns with the given AbiCall & duration
-    #[cfg(feature = "metrics")]
+    #[allow(unused)]
     fn start_abi_call_timer(&self, call: AbiCall) -> prometheus::HistogramTimer {
         let db = self.instance_env().dbic.address;
 
@@ -382,8 +382,7 @@ impl WasmInstanceEnv {
     pub fn insert(caller: Caller<'_, Self>, table_id: u32, row: WasmPtr<u8>, row_len: u32) -> RtResult<u32> {
         // TODO: Instead of writing this metric on every insert call,
         // we should aggregate and write at the end of the transaction.
-        #[cfg(feature = "metrics")]
-        let _guard = caller.data().start_abi_call_timer(AbiCall::Insert);
+        // let _guard = caller.data().start_abi_call_timer(AbiCall::Insert);
 
         Self::cvt(caller, AbiCall::Insert, |caller| {
             let (mem, env) = Self::mem_env(caller);
@@ -426,8 +425,9 @@ impl WasmInstanceEnv {
         value_len: u32,
         out: WasmPtr<u32>,
     ) -> RtResult<u32> {
-        #[cfg(feature = "metrics")]
-        let _guard = caller.data().start_abi_call_timer(AbiCall::DeleteByColEq);
+        // TODO: Instead of writing this metric on every insert call,
+        // we should aggregate and write at the end of the transaction.
+        // let _guard = caller.data().start_abi_call_timer(AbiCall::DeleteByColEq);
 
         Self::cvt_ret(caller, AbiCall::DeleteByColEq, out, |caller| {
             let (mem, env) = Self::mem_env(caller);
@@ -565,8 +565,9 @@ impl WasmInstanceEnv {
         val_len: u32,
         out: WasmPtr<BufferIdx>,
     ) -> RtResult<u32> {
-        #[cfg(feature = "metrics")]
-        let _guard = caller.data().start_abi_call_timer(AbiCall::IterByColEq);
+        // TODO: Instead of writing this metric on every insert call,
+        // we should aggregate and write at the end of the transaction.
+        // let _guard = caller.data().start_abi_call_timer(AbiCall::IterByColEq);
 
         Self::cvt_ret(caller, AbiCall::IterByColEq, out, |caller| {
             let (mem, env) = Self::mem_env(caller);
@@ -598,8 +599,9 @@ impl WasmInstanceEnv {
     /// - a table with the provided `table_id` doesn't exist
     // #[tracing::instrument(skip_all)]
     pub fn iter_start(caller: Caller<'_, Self>, table_id: u32, out: WasmPtr<BufferIterIdx>) -> RtResult<u32> {
-        #[cfg(feature = "metrics")]
-        let _guard = caller.data().start_abi_call_timer(AbiCall::IterStart);
+        // TODO: Instead of writing this metric on every insert call,
+        // we should aggregate and write at the end of the transaction.
+        // let _guard = caller.data().start_abi_call_timer(AbiCall::IterStart);
 
         Self::cvt_ret(caller, AbiCall::IterStart, out, |caller| {
             let env = caller.data_mut();
@@ -634,8 +636,9 @@ impl WasmInstanceEnv {
         filter_len: u32,
         out: WasmPtr<BufferIterIdx>,
     ) -> RtResult<u32> {
-        #[cfg(feature = "metrics")]
-        let _guard = caller.data().start_abi_call_timer(AbiCall::IterStartFiltered);
+        // TODO: Instead of writing this metric on every insert call,
+        // we should aggregate and write at the end of the transaction.
+        // let _guard = caller.data().start_abi_call_timer(AbiCall::IterStartFiltered);
 
         Self::cvt_ret(caller, AbiCall::IterStartFiltered, out, |caller| {
             let (mem, env) = Self::mem_env(caller);


### PR DESCRIPTION
This patch:

(1) Disables unused WasmInstanceEnv metrics,
(2) Removes unused query compilation metrics,
(3) Removes unused RelationalDB metrics

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
