### PR TITLE
Ignore discriminants in `Hash for AV + ArrayValue` + nix len-prefix for PV

### DIFF
--- a/crates/sats/src/algebraic_value.rs
+++ b/crates/sats/src/algebraic_value.rs
@@ -22,7 +22,7 @@ pub type F64 = decorum::Total<f64>;
 /// These are only values and not expressions.
 /// That is, they are canonical and cannot be simplified further by some evaluation.
 /// So forms like `42 + 24` are not represented in an `AlgebraicValue`.
-#[derive(EnumAsInner, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, From)]
+#[derive(EnumAsInner, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, From)]
 pub enum AlgebraicValue {
     /// A structural sum value.
     ///

--- a/crates/sats/src/algebraic_value_hash.rs
+++ b/crates/sats/src/algebraic_value_hash.rs
@@ -1,0 +1,87 @@
+//! Defines hash functions for `AlgebraicValue` and friends.
+
+use crate::{AlgebraicValue, ArrayValue, ProductValue};
+use core::hash::{Hash, Hasher};
+
+// We only manually implement those hash functions that cannot be `#[derive(Hash)]`ed.
+// Those that can be are:
+//
+// - `sum: SumValue`: The generated impl will first write the `sum.tag: u8`,
+//   and then proceed to write the `sum.value`, which delegates to our custom impl below.
+//   The tag is hashed so that e.g., `Result<u32, u32>` represented as an AV
+//   results in different hashes for `Ok(x)` and `Err(x)`.
+//
+// - `map: MapValue`: Uses the hash function for `BTreeMap<AV, AV>`,
+//   which is length prefixed and then writes each `(key, value)` sequentially.
+//   Eventually, this delegates to our custom impl below.
+//
+// - `str: Box<str>`: Uses the standard hash function for `str`.
+//
+// - Primitive types: Trivially what we want.
+
+/// The hash function for an [`AlgebraicValue`] only hashes its domain types
+/// and avoids length prefixing for product values.
+/// This avoids the hashing `Discriminant<AlgebraicValue>`
+/// which is OK as a table column will only ever have the same type (and so the same discriminant).
+impl Hash for AlgebraicValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            AlgebraicValue::Sum(x) => x.hash(state),
+            AlgebraicValue::Product(x) => x.hash(state),
+            AlgebraicValue::Array(x) => x.hash(state),
+            AlgebraicValue::Map(x) => x.hash(state),
+            AlgebraicValue::Bool(x) => x.hash(state),
+            AlgebraicValue::I8(x) => x.hash(state),
+            AlgebraicValue::U8(x) => x.hash(state),
+            AlgebraicValue::I16(x) => x.hash(state),
+            AlgebraicValue::U16(x) => x.hash(state),
+            AlgebraicValue::I32(x) => x.hash(state),
+            AlgebraicValue::U32(x) => x.hash(state),
+            AlgebraicValue::I64(x) => x.hash(state),
+            AlgebraicValue::U64(x) => x.hash(state),
+            AlgebraicValue::I128(x) => x.hash(state),
+            AlgebraicValue::U128(x) => x.hash(state),
+            AlgebraicValue::F32(x) => x.hash(state),
+            AlgebraicValue::F64(x) => x.hash(state),
+            AlgebraicValue::String(s) => s.hash(state),
+        }
+    }
+}
+
+/// The hash function for `ProductValue` does *not* length prefix.
+impl Hash for ProductValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        for field in self.elements.iter() {
+            field.hash(state);
+        }
+    }
+}
+
+/// The hash function for an [`ArrayValue`] only hashes its domain types.
+/// This avoids the hashing `Discriminant<ArrayValue>`
+/// which is OK as a table column will only ever have the same type (and so the same discriminant).
+/// The hash function will however length-prefix as the value is of variable length.
+impl Hash for ArrayValue {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            ArrayValue::Sum(es) => es.hash(state),
+            ArrayValue::Product(es) => es.hash(state),
+            ArrayValue::Bool(es) => es.hash(state),
+            ArrayValue::I8(es) => es.hash(state),
+            ArrayValue::U8(es) => es.hash(state),
+            ArrayValue::I16(es) => es.hash(state),
+            ArrayValue::U16(es) => es.hash(state),
+            ArrayValue::I32(es) => es.hash(state),
+            ArrayValue::U32(es) => es.hash(state),
+            ArrayValue::I64(es) => es.hash(state),
+            ArrayValue::U64(es) => es.hash(state),
+            ArrayValue::I128(es) => es.hash(state),
+            ArrayValue::U128(es) => es.hash(state),
+            ArrayValue::F32(es) => es.hash(state),
+            ArrayValue::F64(es) => es.hash(state),
+            ArrayValue::String(es) => es.hash(state),
+            ArrayValue::Array(es) => es.hash(state),
+            ArrayValue::Map(es) => es.hash(state),
+        }
+    }
+}

--- a/crates/sats/src/array_value.rs
+++ b/crates/sats/src/array_value.rs
@@ -7,7 +7,7 @@ use std::fmt;
 /// rather than unnecessary indirections and tags of `AlgebraicValue`.
 /// We can do this as we know statically that the type of each element is the same
 /// as arrays are homogenous dynamically sized product types.
-#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd)]
 pub enum ArrayValue {
     /// An array of [`SumValue`](crate::SumValue)s.
     Sum(Box<[SumValue]>),

--- a/crates/sats/src/lib.rs
+++ b/crates/sats/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod algebraic_type;
 mod algebraic_type_ref;
 pub mod algebraic_value;
+mod algebraic_value_hash;
 pub mod array_type;
 pub mod array_value;
 pub mod bsatn;

--- a/crates/sats/src/product_value.rs
+++ b/crates/sats/src/product_value.rs
@@ -7,7 +7,7 @@ use spacetimedb_primitives::{ColId, ColList};
 /// "elements" / "fields" / "factors" of other `AlgebraicValue`s.
 ///
 /// The type of a product value is a [product type](`ProductType`).
-#[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq, Hash, Default)]
+#[derive(Debug, Clone, Ord, PartialOrd, PartialEq, Eq, Default)]
 pub struct ProductValue {
     /// The values that make up this product value.
     pub elements: Box<[AlgebraicValue]>,


### PR DESCRIPTION
# Description of Changes

Fixes https://github.com/clockworklabs/SpacetimeDB/issues/1048.

- `Hash for AV` does not include `Discriminant<AV>` anymore.
- `Hash for PV ` is no longer length-prefixed.
- `Hash for ArrayValue` does not include `Discriminant<ArrayValue>` anymore.

In spacetimedb, we only compare hashes between homogeneously-typed values. Therefore, this PR does less work and does in fact not weaken the hash function. Rather, by avoiding to feed in known-equal data into the hasher, we can reduce the rate of conflicts, as we're now packing the same number of "interesting" bits alongside fewer "boring" bits into a hash.

# API and ABI breaking changes

Semantics in the APIs above are broken by this PR.

# Expected complexity level and risk

2