### PR TITLE
Swap the location of tags in the BFLATN encoding

### DIFF
--- a/crates/table/src/bflatn_to_bsatn_fast_path.rs
+++ b/crates/table/src/bflatn_to_bsatn_fast_path.rs
@@ -341,8 +341,8 @@ mod test {
                     AlgebraicType::Bool,
                 ])]),
                 2,
-                // in bflatn, sums have padding after the tag to the max alignment of any variant payload
-                // in this case, 0 bytes of padding, because all payloads are aligned to 1
+                // In BFLATN, sums have padding after the tag to the max alignment of any variant payload.
+                // In this case, 0 bytes of padding, because all payloads are aligned to 1.
                 &[(0, 0, 1), (1, 1, 1)][..],
             ),
             (
@@ -357,8 +357,8 @@ mod test {
                     AlgebraicType::U32,
                 ])]),
                 5,
-                // in bflatn, sums have padding after the tag to the max alignment of any variant payload
-                // in this case, 3 bytes of padding
+                // In BFLATN, sums have padding after the tag to the max alignment of any variant payload.
+                // In this case, 3 bytes of padding.
                 &[(0, 0, 1), (4, 1, 4)][..],
             ),
             (
@@ -367,8 +367,8 @@ mod test {
                     AlgebraicType::U32,
                 ]),
                 21,
-                // in bflatn, sums have padding after the tag to the max alignment of any variant payload
-                // in this case, 15 bytes of padding
+                // In BFLATN, sums have padding after the tag to the max alignment of any variant payload.
+                // In this case, 15 bytes of padding.
                 &[(0, 0, 1), (16, 1, 16), (32, 17, 4)][..],
             ),
             (
@@ -393,7 +393,7 @@ mod test {
                 31,
                 &[(0, 0, 1), (2, 1, 30)][..],
             ),
-            // make sure sums with no variant data are handled correctly
+            // Make sure sums with no variant data are handled correctly.
             (
                 ProductType::from([AlgebraicType::sum([AlgebraicType::product::<[AlgebraicType; 0]>([])])]),
                 1,

--- a/crates/table/src/bflatn_to_bsatn_fast_path.rs
+++ b/crates/table/src/bflatn_to_bsatn_fast_path.rs
@@ -257,9 +257,7 @@ impl LayoutBuilder {
                 bsatn_offset: payload_bsatn_offset,
                 length: 0,
             });
-        } else if sum.payload_offset == 1 {
-            // Nothing to do.
-        }
+        } // Otherwise, nothing to do.
 
         // Lay out the variants.
         // Since all variants have the same layout, we just use the first one.

--- a/crates/table/src/layout.rs
+++ b/crates/table/src/layout.rs
@@ -244,7 +244,8 @@ pub struct SumTypeLayout {
     pub layout: Layout,
     /// The variants of the sum type.
     pub variants: Collection<SumTypeVariantLayout>,
-    /// The relative offset of a sum value's tag for sums of this type.
+    /// The relative offset of a sum value's payload for sums of this type.
+    /// Sum value tags are always at offset 0.
     pub payload_offset: u16,
 }
 

--- a/crates/table/src/row_type_visitor.rs
+++ b/crates/table/src/row_type_visitor.rs
@@ -95,6 +95,9 @@ fn product_type_to_rose_tree(ty: &ProductTypeLayout, current_offset: &mut usize)
 ///
 /// See [`algebraic_type_to_rose_tree`] for more details.
 fn sum_type_to_rose_tree(ty: &SumTypeLayout, current_offset: &mut usize) -> VarLenRoseTree {
+    // The tag goes before the variant data.
+    let tag_offset = *current_offset + ty.offset_of_tag();
+
     // For each variant, collect that variant's sub-tree.
     let mut variants = ty
         .variants
@@ -116,9 +119,6 @@ fn sum_type_to_rose_tree(ty: &SumTypeLayout, current_offset: &mut usize) -> VarL
             algebraic_type_to_rose_tree(var_ty, &mut child_offset)
         })
         .collect::<Vec<_>>();
-
-    // The tag goes after the variant data.
-    let tag_offset = ty.offset_of_tag() + *current_offset;
 
     // Store the new offset after the sum.
     *current_offset += ty.size();
@@ -548,7 +548,7 @@ mod test {
     #[test]
     fn visit_var_len_bare_enum() {
         let ty = row_type([AlgebraicType::option(
-            AlgebraicType::String, // tag 0
+            AlgebraicType::String, // tag 0, size 4, align 2
         )]);
         assert_eq!(ty.size(), Size(6));
         assert_eq!(ty.align(), 2);
@@ -562,7 +562,7 @@ mod test {
         let program = row_type_visitor(&ty);
         // Variant 1 (String) is live
         row[outer_tag].write(0);
-        check_addrs(&program, row, [0]);
+        check_addrs(&program, row, [2]);
 
         // Variant 1 (none) is live
         row[outer_tag].write(1);
@@ -574,13 +574,13 @@ mod test {
         // Tables are always product types.
         let ty = row_type([AlgebraicType::sum([
             AlgebraicType::U32,                                                  // tag 0, size 4, align 4
-            AlgebraicType::String,                                               // tag 1, size 4, align 4
+            AlgebraicType::String,                                               // tag 1, size 4, align 2
             AlgebraicType::product([AlgebraicType::U32, AlgebraicType::String]), // tag 2, size 8, align 4
             AlgebraicType::sum(
-                // tag 3, size 8, align 4, inner tag at +4
+                // tag 3, size 8, align 4
                 [
-                    AlgebraicType::U32,    // 3, 0
-                    AlgebraicType::String, // 3, 1
+                    AlgebraicType::U32,    // tag (3, 0), size 4, align 4
+                    AlgebraicType::String, // tag (3, 1), size 4, align 2
                 ],
             ),
         ])]);
@@ -588,9 +588,9 @@ mod test {
         assert_eq!(ty.align(), 4);
         let outer_sum = &ty[0].as_sum().unwrap();
         let outer_tag = outer_sum.offset_of_tag();
-        assert_eq!(outer_tag, 8);
+        assert_eq!(outer_tag, 0);
         let inner_sum = outer_sum.variants[3].ty.as_sum().unwrap();
-        let inner_tag = inner_sum.offset_of_tag();
+        let inner_tag = outer_sum.offset_of_variant_data(3) + inner_sum.offset_of_tag();
         assert_eq!(inner_tag, 4);
 
         let row = &mut uninit_array::<u32, 3>();
@@ -605,11 +605,11 @@ mod test {
 
         // Variant 1 (String) is live
         row[outer_tag].write(1);
-        check_addrs(&program, row, [0]);
+        check_addrs(&program, row, [4]);
 
         // Variant 2 (Product) is live
         row[outer_tag].write(2);
-        check_addrs(&program, row, [4]);
+        check_addrs(&program, row, [8]);
 
         // Variant 3 (Sum) is live but its tag is not init yet.
         row[outer_tag].write(3);
@@ -620,6 +620,6 @@ mod test {
 
         // Variant 3, 1 (Sum, String) is live.
         row[inner_tag].write(1);
-        check_addrs(&program, row, [0]);
+        check_addrs(&program, row, [8]);
     }
 }

--- a/crates/table/src/row_type_visitor.rs
+++ b/crates/table/src/row_type_visitor.rs
@@ -96,6 +96,7 @@ fn product_type_to_rose_tree(ty: &ProductTypeLayout, current_offset: &mut usize)
 /// See [`algebraic_type_to_rose_tree`] for more details.
 fn sum_type_to_rose_tree(ty: &SumTypeLayout, current_offset: &mut usize) -> VarLenRoseTree {
     // The tag goes before the variant data.
+    // Currently, this is the same as `*current_offset`.
     let tag_offset = *current_offset + ty.offset_of_tag();
 
     // For each variant, collect that variant's sub-tree.


### PR DESCRIPTION
# Description of Changes

Partially implements #1006. I haven't ensured we're actually doing the relevant memcpy optimizations yet.

# API and ABI breaking changes

Is BFLATN public ABI yet? It will be once we have snapshots I suppose. 
So, a breaking change on the BFLATN ABI.

# Expected complexity level and risk

3

# Testing

I want to run this under miri but haven't done so yet.