### PR TITLE
Make spacetime list <identity> CLI command also show db_name associated with database

### DIFF
--- a/crates/cli/src/subcommands/list.rs
+++ b/crates/cli/src/subcommands/list.rs
@@ -1,9 +1,14 @@
-use crate::Config;
+use crate::{config::IdentityConfig, Config};
 use anyhow::Context;
 use clap::{Arg, ArgMatches, Command};
+use futures::future::join_all;
 use reqwest::StatusCode;
 use serde::Deserialize;
-use spacetimedb_lib::Address;
+
+use spacetimedb_lib::{
+    name::{DomainName, ReverseDNSResponse},
+    Address,
+};
 use tabled::{
     settings::{object::Columns, Alignment, Modify, Style},
     Table, Tabled,
@@ -33,6 +38,12 @@ struct DatabasesResult {
 #[derive(Tabled, Deserialize)]
 #[serde(transparent)]
 struct AddressRow {
+    pub db_address: Address,
+}
+
+#[derive(Tabled, Deserialize)]
+struct DatabaseRow {
+    pub db_name: DomainName,
     pub db_address: Address,
 }
 
@@ -69,15 +80,81 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error
 
     let identity = identity_config.nick_or_identity();
     if !result.addresses.is_empty() {
-        let mut table = Table::new(result.addresses);
-        table
-            .with(Style::psql())
-            .with(Modify::new(Columns::first()).with(Alignment::left()));
-        println!("Associated database addresses for {}:\n", identity);
-        println!("{}", table);
+        let databases_dns =
+            get_dns_for_database_addresses(config.clone(), server, identity_config, &result.addresses).await;
+
+        let combined_dns_address_rows: Vec<DatabaseRow> = result
+            .addresses
+            .iter()
+            .enumerate()
+            .map(|(index, address)| DatabaseRow {
+                db_name: databases_dns.as_ref().unwrap().get(index).unwrap().clone(),
+                db_address: address.db_address,
+            })
+            .collect();
+
+        if !combined_dns_address_rows.is_empty() {
+            let mut table = Table::new(combined_dns_address_rows);
+            table
+                .with(Style::psql())
+                .with(Modify::new(Columns::first()).with(Alignment::left()));
+            println!("Associated databases for {}:\n", identity);
+            println!("{}", table);
+        } else {
+            println!("No databases found for {}.", identity);
+        }
+
+        Ok(())
     } else {
-        println!("No databases found for {}.", identity);
+        return Err(anyhow::anyhow!(format!(
+            "Unable to retrieve databases for identity: {}",
+            identity
+        )));
+    }
+}
+
+async fn get_dns_for_database_addresses(
+    config: Config,
+    server: Option<&str>,
+    identity_config: &IdentityConfig,
+    addresses: &Vec<AddressRow>,
+) -> Result<Vec<DomainName>, anyhow::Error> {
+    let client = reqwest::Client::new();
+    let mut database_names: Vec<DomainName> = vec![];
+    let futures = addresses.iter().map(|address| async {
+        let res = client
+            .get(format!(
+                "{}/database/reverse_dns/{}",
+                config.get_host_url(server)?,
+                address.db_address
+            ))
+            .basic_auth("token", Some(&identity_config.token))
+            .send()
+            .await?;
+
+        if res.status() != StatusCode::OK {
+            return Err(anyhow::anyhow!(format!(
+                "Unable to retrieve database name for database {}: {}",
+                address.db_address,
+                res.status()
+            )));
+        }
+
+        let result: ReverseDNSResponse = res.json().await?;
+        if result.names.get(0).is_some() {
+            return Ok(result.names.get(0).unwrap().clone());
+        } else {
+            return Err(anyhow::anyhow!(format!(
+                "Unable to retrieve database name for database {}",
+                address.db_address,
+            )));
+        }
+    });
+
+    let result = join_all(futures).await;
+    for domain in result {
+        database_names.push(domain.unwrap());
     }
 
-    Ok(())
+    return Ok(database_names);
 }


### PR DESCRIPTION
# Description of Changes

#1046 Mentions a need to see the database name when listing databases for an identity. I agree with this being useful so here is an implementation supporting that. There may be better ways that the StDB team could do this, but here is what I use locally when developing if I want to easily get a database name.

Updated the `spacetime list <identity>` to also display a `db_name` column in the response. This `db_name` column is populated by making a request to the `/database/reverse_dns/<db_address>` endpoint for each db_address returned for the identity.

# API and ABI breaking changes
 N/A ?

# Expected complexity level and risk

I believe the complexity and risk of this change to be a 1/5.

# Testing

I tested this by making multiple databases, then running the `spacetime list <identity>` command. This should show a response in the CLI as a table with two columns: `db_name` and `db_address`. You can verify the db_address' all match the db_names via spacetime profile dashboard, as well as by creating new databases, and renaming databases. After that, the command should reflect new database names correctly, as well as updated database names.

**Test 1**

- Create a new identity if you do not already have one
- Create a new database (or even multiple)
- Use the `spacetime list <identity>` command
- Verify the db_name is present, and that it matches the correct db_address
- Verify in the SpacetimeDB Profile page that they match as well if applicable

**Test 2**

- Follow test 1 if you do not already have an identity that owns at least one database
- Use the `spacetime list <identity>` command
- Verify the db_name is present, and that it matches the correct db_address
- Verify in the SpacetimeDB Profile page that they match as well if applicable
- Rename the database
- Use the `spacetime list <identity>` command
- Verify the db_address matches the new db_name you set for it