### PR TITLE
Drop various logs to `trace` for less noise

### DIFF
--- a/crates/commitlog/src/commitlog.rs
+++ b/crates/commitlog/src/commitlog.rs
@@ -290,7 +290,7 @@ impl<R: Repo> Iterator for Segments<R> {
 
     fn next(&mut self) -> Option<Self::Item> {
         let off = self.offs.next()?;
-        debug!("iter segment {off}");
+        trace!("iter segment {off}");
         Some(repo::open_segment_reader(&self.repo, self.max_log_format_version, off))
     }
 }

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -6,7 +6,7 @@ use std::{
     time::Duration,
 };
 
-use log::debug;
+use log::trace;
 use tokio::{
     sync::watch,
     task::spawn_blocking,
@@ -106,7 +106,7 @@ impl<T> Commitlog<T> {
     /// been flushed to disk yet.
     pub fn sync(&self) -> io::Result<Option<u64>> {
         let inner = self.inner.read().unwrap();
-        debug!("sync commitlog");
+        trace!("sync commitlog");
         inner.sync()?;
 
         Ok(inner.max_committed_offset())
@@ -124,7 +124,7 @@ impl<T> Commitlog<T> {
     /// Repeatedly calling this method may return the same value.
     pub fn flush(&self) -> io::Result<Option<u64>> {
         let mut inner = self.inner.write().unwrap();
-        debug!("flush commitlog");
+        trace!("flush commitlog");
         inner.commit()?;
 
         Ok(inner.max_committed_offset())
@@ -136,7 +136,7 @@ impl<T> Commitlog<T> {
     /// without releasing the write lock in between.
     pub fn flush_and_sync(&self) -> io::Result<Option<u64>> {
         let mut inner = self.inner.write().unwrap();
-        debug!("flush and sync commitlog");
+        trace!("flush and sync commitlog");
         inner.commit()?;
         inner.sync()?;
 

--- a/crates/commitlog/src/segment.rs
+++ b/crates/commitlog/src/segment.rs
@@ -5,7 +5,7 @@ use std::{
     ops::Range,
 };
 
-use log::debug;
+use log::trace;
 
 use crate::{
     commit::{self, Commit},
@@ -333,7 +333,7 @@ impl Metadata {
             })
         }
         while let Some(commit) = commit_meta(&mut reader, &sofar)? {
-            debug!("commit::{commit:?}");
+            trace!("commit::{commit:?}");
             if commit.tx_range.start != sofar.tx_range.end {
                 return Err(io::Error::new(
                     io::ErrorKind::InvalidData,

--- a/crates/durability/src/imp/local.rs
+++ b/crates/durability/src/imp/local.rs
@@ -14,7 +14,7 @@ use std::{
 };
 
 use anyhow::Context as _;
-use log::{debug, info, trace, warn};
+use log::{info, trace, warn};
 use spacetimedb_commitlog::{error, payload::Txdata, Commit, Commitlog, Decoder, Encode, Transaction};
 use tokio::{
     sync::mpsc,
@@ -215,7 +215,7 @@ impl<T: Encode + Send + Sync + 'static> PersisterTask<T> {
                 clog.flush().map(drop).unwrap_or_else(flush_error);
             }
 
-            debug!("flush-append succeeded");
+            trace!("flush-append succeeded");
         })
         .await;
         if let Err(e) = task {


### PR DESCRIPTION
# Description of Changes

Does what it says in the title.

# API and ABI breaking changes

N/a.

# Expected complexity level and risk

1

# Testing

Completely untested.