### PR TITLE
Table: skip alignment checks in eq_row_in_page and hash_row_in_page

### DIFF
--- a/crates/table/src/eq.rs
+++ b/crates/table/src/eq.rs
@@ -96,7 +96,8 @@ unsafe fn eq_product(ctx: &mut EqCtx<'_, '_>, ty: &ProductTypeLayout) -> bool {
 }
 
 /// For `value_a/b = &ctx.a/b.bytes[range_move(0..ty.size(), *ctx.curr_offset)]` typed at `ty`,
-/// equates `value_a == value_b`, including any var-len objects.
+/// equates `value_a == value_b`, including any var-len objects,
+/// and advances the `ctx.curr_offset`.
 ///
 /// SAFETY:
 /// 1. `value_a/b` must both be valid at type `ty` and properly aligned for `ty`.

--- a/crates/table/src/row_hash.rs
+++ b/crates/table/src/row_hash.rs
@@ -63,7 +63,8 @@ unsafe fn hash_product(
     }
 }
 
-/// Hashes `value = &bytes[range_move(0..ty.size(), *curr_offset)]` typed at `ty`.
+/// Hashes `value = &bytes[range_move(0..ty.size(), *curr_offset)]` typed at `ty`
+/// and advances the `curr_offset`.
 ///
 /// SAFETY:
 /// 1. the `value` must be valid at type `ty` and properly aligned for `ty`.


### PR DESCRIPTION
# Description of Changes

Fixes #1050

# Expected complexity level and risk

3, this is unsafe code but a pretty small change.

# Testing

I ran the table tests and benchmarks, they all succeeded.

I'm not sure how much these bits of code are exercised by the tests, maybe I should add some?

<details>
<summary>Benchmark improvements for eq_row_in_page</summary>

```
eq_in_page/U32          time:   [8.3954 ns 8.4318 ns 8.4806 ns]
                        change: [-12.902% -12.415% -11.887%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high severe
eq_in_page/Option<U32>/None
                        time:   [11.904 ns 11.952 ns 12.004 ns]
                        change: [-15.750% -15.285% -14.801%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 13 outliers among 100 measurements (13.00%)
  5 (5.00%) high mild
  8 (8.00%) high severe
eq_in_page/Option<U32>/Some
                        time:   [15.532 ns 15.566 ns 15.610 ns]
                        change: [-4.9379% -4.6162% -4.3162%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 9 outliers among 100 measurements (9.00%)
  1 (1.00%) high mild
  8 (8.00%) high severe
eq_in_page/U32x2        time:   [13.034 ns 13.079 ns 13.131 ns]
                        change: [-16.605% -16.362% -16.092%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 20 outliers among 100 measurements (20.00%)
  8 (8.00%) low mild
  6 (6.00%) high mild
  6 (6.00%) high severe
eq_in_page/U32x4        time:   [22.661 ns 22.729 ns 22.806 ns]
                        change: [-20.179% -19.895% -19.582%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 3 outliers among 100 measurements (3.00%)
  3 (3.00%) high mild
eq_in_page/U32x8        time:   [42.571 ns 42.717 ns 42.884 ns]
                        change: [-26.443% -26.167% -25.859%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 8 outliers among 100 measurements (8.00%)
  5 (5.00%) high mild
  3 (3.00%) high severe
eq_in_page/String/0     time:   [7.1651 ns 7.1857 ns 7.2106 ns]
                        change: [-7.2275% -6.4587% -5.4438%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  4 (4.00%) high mild
  12 (12.00%) high severe
eq_in_page/String/16    time:   [9.5632 ns 9.5886 ns 9.6150 ns]
                        change: [-9.1528% -8.7062% -8.2822%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 25 outliers among 100 measurements (25.00%)
  14 (14.00%) low mild
  5 (5.00%) high mild
  6 (6.00%) high severe
eq_in_page/String/128   time:   [16.343 ns 16.374 ns 16.409 ns]
                        change: [-6.6474% -6.2948% -5.9437%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  2 (2.00%) high mild
eq_in_page/String/512   time:   [29.778 ns 29.887 ns 30.002 ns]
                        change: [-9.9883% -9.5701% -9.0735%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 4 outliers among 100 measurements (4.00%)
  3 (3.00%) high mild
  1 (1.00%) high severe
eq_in_page/Array<U32>/0 time:   [9.4957 ns 9.5265 ns 9.5595 ns]
                        change: [-9.6671% -9.3211% -8.9672%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  5 (5.00%) high mild
eq_in_page/Array<U32>/1 time:   [9.5172 ns 9.5487 ns 9.5810 ns]
                        change: [-10.617% -10.061% -9.5460%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  5 (5.00%) high mild
  2 (2.00%) high severe
eq_in_page/Array<U32>/2 time:   [9.4762 ns 9.5047 ns 9.5365 ns]
                        change: [-9.6844% -9.3517% -9.0119%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 16 outliers among 100 measurements (16.00%)
  10 (10.00%) high mild
  6 (6.00%) high severe
eq_in_page/Array<U32>/4 time:   [9.4780 ns 9.5053 ns 9.5387 ns]
                        change: [-9.0774% -8.7185% -8.3335%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 5 outliers among 100 measurements (5.00%)
  3 (3.00%) high mild
  2 (2.00%) high severe
eq_in_page/Array<U32>/8 time:   [9.8320 ns 9.8680 ns 9.9057 ns]
                        change: [-7.8644% -7.4503% -7.0667%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 2 outliers among 100 measurements (2.00%)
  1 (1.00%) high mild
  1 (1.00%) high severe
eq_in_page/U32x2x2      time:   [28.679 ns 28.733 ns 28.797 ns]
                        change: [-33.703% -32.948% -32.333%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  1 (1.00%) low mild
  4 (4.00%) high mild
  6 (6.00%) high severe
eq_in_page/U32x4x2      time:   [49.292 ns 49.497 ns 49.743 ns]
                        change: [-31.550% -31.182% -30.735%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 7 outliers among 100 measurements (7.00%)
  2 (2.00%) high mild
  5 (5.00%) high severe
eq_in_page/U32x2x4      time:   [54.701 ns 54.833 ns 54.985 ns]
                        change: [-35.960% -35.768% -35.569%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 12 outliers among 100 measurements (12.00%)
  7 (7.00%) low mild
  1 (1.00%) high mild
  4 (4.00%) high severe
eq_in_page/Option<U32x2>/None
                        time:   [11.762 ns 11.802 ns 11.850 ns]
                        change: [-16.271% -15.890% -15.537%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 10 outliers among 100 measurements (10.00%)
  7 (7.00%) high mild
  3 (3.00%) high severe
eq_in_page/Option<U32x2>/Some
                        time:   [21.571 ns 21.623 ns 21.690 ns]
                        change: [-24.230% -23.868% -23.542%] (p = 0.00 < 0.05)
                        Performance has improved.
Found 11 outliers among 100 measurements (11.00%)
  7 (7.00%) high mild
  4 (4.00%) high severe
```

</details>
