### PR TITLE
core: Don't persist empty transactions

### DIFF
--- a/crates/commitlog/src/payload/txdata.rs
+++ b/crates/commitlog/src/payload/txdata.rs
@@ -99,6 +99,15 @@ pub struct Txdata<T> {
     pub mutations: Option<Mutations<T>>,
 }
 
+impl<T> Txdata<T> {
+    /// `true` if `self` contains neither inputs, outputs nor mutations.
+    pub fn is_empty(&self) -> bool {
+        self.inputs.is_none()
+            && self.outputs.is_none()
+            && self.mutations.as_ref().map(Mutations::is_empty).unwrap_or(true)
+    }
+}
+
 impl<T: Encode> Txdata<T> {
     pub const VERSION: u8 = 0;
 
@@ -244,6 +253,13 @@ pub struct Mutations<T> {
     pub deletes: Box<[Ops<T>]>,
     /// Truncated tables.
     pub truncates: Box<[TableId]>,
+}
+
+impl<T> Mutations<T> {
+    /// `true` if `self` contains no mutations at all.
+    pub fn is_empty(&self) -> bool {
+        self.inserts.is_empty() && self.deletes.is_empty() && self.truncates.is_empty()
+    }
 }
 
 impl<T: Encode> Mutations<T> {

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -327,9 +327,12 @@ impl RelationalDB {
                     truncates: Box::new([]),
                 }),
             };
-            log::trace!("append {txdata:?}");
-            // TODO: Should measure queuing time + actual write
-            durability.append_tx(txdata);
+
+            if !txdata.is_empty() {
+                log::trace!("append {txdata:?}");
+                // TODO: Should measure queuing time + actual write
+                durability.append_tx(txdata);
+            }
         }
 
         Ok(Some(tx_data))


### PR DESCRIPTION
Fix a minor bug where completely empty transactions would still be
written to the commitlog. The bug is minor because, once we start
logging inputs, all transactions will be non-empty.

The check is done in relational DB rather than the durability crate,
because in principle empty transactions are permissible, and may be used
in the future (e.g. to confirm a certain offset).

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Test suite passes
- [x] Log output is absent as expected when calling a reducer which doesn't
      modify rows (where previously it was present).
