### PR TITLE
perf: optimize `Table::clone_structure` by avoiding clones

### DIFF
--- a/crates/bench/benches/special.rs
+++ b/crates/bench/benches/special.rs
@@ -87,7 +87,9 @@ fn serialize_benchmarks<T: BenchTable + RandomTable>(c: &mut Criterion) {
     });
 
     let mut table = spacetimedb_table::table::Table::new(
-        TableDef::from_product(name, T::product_type().clone()).into_schema(TableId(0)),
+        TableDef::from_product(name, T::product_type().clone())
+            .into_schema(TableId(0))
+            .into(),
         spacetimedb_table::indexes::SquashedOffset::COMMITTED_STATE,
     );
     let mut blob_store = spacetimedb_table::blob_store::HashMapBlobStore::default();

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -38,6 +38,7 @@ use spacetimedb_table::{
     indexes::{RowPointer, SquashedOffset},
     table::{IndexScanIter, InsertError, RowRef, Table},
 };
+use std::sync::Arc;
 use std::{
     collections::{BTreeMap, BTreeSet},
     ops::RangeBounds,
@@ -51,7 +52,7 @@ pub(crate) struct CommittedState {
 }
 
 impl StateView for CommittedState {
-    fn get_schema(&self, table_id: &TableId) -> Option<&TableSchema> {
+    fn get_schema(&self, table_id: &TableId) -> Option<&Arc<TableSchema>> {
         self.tables.get(table_id).map(|table| table.get_schema())
     }
     fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: &TableId) -> Result<Iter<'a>> {
@@ -61,11 +62,7 @@ impl StateView for CommittedState {
         Err(TableError::IdNotFound(SystemTable::st_table, table_id.0).into())
     }
     fn table_exists(&self, table_id: &TableId) -> Option<&str> {
-        if let Some(table) = self.tables.get(table_id) {
-            Some(&table.schema.table_name)
-        } else {
-            None
-        }
+        self.tables.get(table_id).map(|t| &*t.schema.table_name)
     }
     /// Returns an iterator,
     /// yielding every row in the table identified by `table_id`,
@@ -117,7 +114,7 @@ impl CommittedState {
         };
 
         // Insert the table row into st_tables, creating st_tables if it's missing
-        let (st_tables, blob_store) = self.get_table_and_blob_store_or_create(ST_TABLES_ID, st_table_schema());
+        let (st_tables, blob_store) = self.get_table_and_blob_store_or_create(ST_TABLES_ID, st_table_schema().into());
         // Insert the table row into `st_tables` for all system tables
         for schema in system_tables() {
             let table_id = schema.table_id;
@@ -139,7 +136,8 @@ impl CommittedState {
         }
 
         // Insert the columns into `st_columns`
-        let (st_columns, blob_store) = self.get_table_and_blob_store_or_create(ST_COLUMNS_ID, st_columns_schema());
+        let (st_columns, blob_store) =
+            self.get_table_and_blob_store_or_create(ST_COLUMNS_ID, st_columns_schema().into());
         for col in system_tables().into_iter().flat_map(|x| x.into_columns()) {
             let row = StColumnRow {
                 table_id: col.table_id,
@@ -159,7 +157,7 @@ impl CommittedState {
 
         // Insert constraints into `st_constraints`
         let (st_constraints, blob_store) =
-            self.get_table_and_blob_store_or_create(ST_CONSTRAINTS_ID, st_constraints_schema());
+            self.get_table_and_blob_store_or_create(ST_CONSTRAINTS_ID, st_constraints_schema().into());
         for (i, constraint) in system_tables()
             .into_iter()
             .flat_map(|x| x.constraints)
@@ -184,7 +182,8 @@ impl CommittedState {
         }
 
         // Insert the indexes into `st_indexes`
-        let (st_indexes, blob_store) = self.get_table_and_blob_store_or_create(ST_INDEXES_ID, st_indexes_schema());
+        let (st_indexes, blob_store) =
+            self.get_table_and_blob_store_or_create(ST_INDEXES_ID, st_indexes_schema().into());
         for (i, index) in system_tables()
             .into_iter()
             .flat_map(|x| x.indexes)
@@ -215,7 +214,7 @@ impl CommittedState {
 
         // Insert the sequences into `st_sequences`
         let (st_sequences, blob_store) =
-            self.get_table_and_blob_store_or_create(ST_SEQUENCES_ID, st_sequences_schema());
+            self.get_table_and_blob_store_or_create(ST_SEQUENCES_ID, st_sequences_schema().into());
         // We create sequences last to get right the starting number
         // so, we don't sort here
         for (i, col) in system_tables().into_iter().flat_map(|x| x.sequences).enumerate() {
@@ -244,8 +243,8 @@ impl CommittedState {
         // Re-read the schema with the correct ids...
         let ctx = ExecutionContext::internal(database_address);
         for schema in system_tables() {
-            *self.tables.get_mut(&schema.table_id).unwrap().schema =
-                self.schema_for_table_raw(&ctx, schema.table_id)?;
+            self.tables.get_mut(&schema.table_id).unwrap().schema =
+                Arc::new(self.schema_for_table_raw(&ctx, schema.table_id)?);
         }
 
         Ok(())
@@ -265,7 +264,7 @@ impl CommittedState {
         Ok(())
     }
 
-    pub fn replay_insert(&mut self, table_id: TableId, schema: &TableSchema, row: &ProductValue) -> Result<()> {
+    pub fn replay_insert(&mut self, table_id: TableId, schema: &Arc<TableSchema>, row: &ProductValue) -> Result<()> {
         let (table, blob_store) = self.get_table_and_blob_store_or_create_ref_schema(table_id, schema);
         table.insert_internal(blob_store, row).map_err(TableError::Insert)?;
         Ok(())
@@ -331,9 +330,7 @@ impl CommittedState {
 
         // Construct their schemas and insert tables for them.
         for table_id in table_ids {
-            let schema = self
-                .schema_for_table(&ExecutionContext::default(), table_id)?
-                .into_owned();
+            let schema = self.schema_for_table(&ExecutionContext::default(), table_id)?;
             self.tables
                 .insert(table_id, Table::new(schema, SquashedOffset::COMMITTED_STATE));
         }
@@ -449,11 +446,8 @@ impl CommittedState {
         //             and the fullness of the page.
 
         for (table_id, mut tx_table) in insert_tables {
-            let (commit_table, commit_blob_store) = self.get_table_and_blob_store_or_create(
-                table_id,
-                // TODO(perf): avoid cloning here.
-                *tx_table.schema.clone(),
-            );
+            let (commit_table, commit_blob_store) =
+                self.get_table_and_blob_store_or_create(table_id, tx_table.schema.clone());
 
             // NOTE: if there is a schema change the table id will not change
             // and that is what is important here so it doesn't matter if we
@@ -517,13 +511,13 @@ impl CommittedState {
 
     fn create_table(&mut self, table_id: TableId, schema: TableSchema) {
         self.tables
-            .insert(table_id, Table::new(schema, SquashedOffset::COMMITTED_STATE));
+            .insert(table_id, Table::new(Arc::new(schema), SquashedOffset::COMMITTED_STATE));
     }
 
     pub fn get_table_and_blob_store_or_create_ref_schema<'this>(
         &'this mut self,
         table_id: TableId,
-        schema: &'_ TableSchema,
+        schema: &Arc<TableSchema>,
     ) -> (&'this mut Table, &'this mut dyn BlobStore) {
         let table = self
             .tables
@@ -536,7 +530,7 @@ impl CommittedState {
     pub fn get_table_and_blob_store_or_create(
         &mut self,
         table_id: TableId,
-        schema: TableSchema,
+        schema: Arc<TableSchema>,
     ) -> (&mut Table, &mut dyn BlobStore) {
         let table = self
             .tables

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -8,6 +8,7 @@ use super::{
 use crate::execution_context::ExecutionContext;
 use spacetimedb_primitives::{ColList, TableId};
 use spacetimedb_sats::{db::def::TableSchema, AlgebraicValue};
+use std::sync::Arc;
 use std::{
     ops::RangeBounds,
     time::{Duration, Instant},
@@ -20,7 +21,7 @@ pub struct TxId {
 }
 
 impl StateView for TxId {
-    fn get_schema(&self, table_id: &TableId) -> Option<&TableSchema> {
+    fn get_schema(&self, table_id: &TableId) -> Option<&Arc<TableSchema>> {
         self.committed_state_shared_lock.get_schema(table_id)
     }
 

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -1,3 +1,4 @@
+use core::ops::Deref;
 use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::{ops::RangeBounds, sync::Arc};
@@ -225,6 +226,26 @@ impl TxData {
     }
 }
 
+/// The result of [`MutTxDatastore::row_type_for_table_mut_tx`] and friends.
+/// This is a smart pointer returning a `&ProductType`.
+pub enum RowTypeForTable<'a> {
+    /// A reference can be stored to the type.
+    Ref(&'a ProductType),
+    /// The type is within the schema.
+    Arc(Arc<TableSchema>),
+}
+
+impl Deref for RowTypeForTable<'_> {
+    type Target = ProductType;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Ref(x) => x,
+            Self::Arc(x) => x.get_row_type(),
+        }
+    }
+}
+
 pub trait Data: Into<ProductValue> {
     fn view(&self) -> Cow<'_, ProductValue>;
 }
@@ -296,12 +317,8 @@ pub trait TxDatastore: DataRow + Tx {
     fn table_id_exists_tx(&self, tx: &Self::Tx, table_id: &TableId) -> bool;
     fn table_id_from_name_tx(&self, tx: &Self::Tx, table_name: &str) -> Result<Option<TableId>>;
     fn table_name_from_id_tx<'a>(&'a self, tx: &'a Self::Tx, table_id: TableId) -> Result<Option<Cow<'a, str>>>;
-    fn schema_for_table_tx<'tx>(&self, tx: &'tx Self::Tx, table_id: TableId) -> super::Result<Cow<'tx, TableSchema>>;
-    fn get_all_tables_tx<'tx>(
-        &self,
-        ctx: &ExecutionContext,
-        tx: &'tx Self::Tx,
-    ) -> super::Result<Vec<Cow<'tx, TableSchema>>>;
+    fn schema_for_table_tx(&self, tx: &Self::Tx, table_id: TableId) -> super::Result<Arc<TableSchema>>;
+    fn get_all_tables_tx(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> super::Result<Vec<Arc<TableSchema>>>;
 }
 
 pub trait MutTxDatastore: TxDatastore + MutTx {
@@ -310,8 +327,8 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     // In these methods, we use `'tx` because the return type must borrow data
     // from `Inner` in the `Locking` implementation,
     // and `Inner` lives in `tx: &MutTxId`.
-    fn row_type_for_table_mut_tx<'tx>(&self, tx: &'tx Self::MutTx, table_id: TableId) -> Result<Cow<'tx, ProductType>>;
-    fn schema_for_table_mut_tx<'tx>(&self, tx: &'tx Self::MutTx, table_id: TableId) -> Result<Cow<'tx, TableSchema>>;
+    fn row_type_for_table_mut_tx<'tx>(&self, tx: &'tx Self::MutTx, table_id: TableId) -> Result<RowTypeForTable<'tx>>;
+    fn schema_for_table_mut_tx(&self, tx: &Self::MutTx, table_id: TableId) -> Result<Arc<TableSchema>>;
     fn drop_table_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId) -> Result<()>;
     fn rename_table_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, new_name: &str) -> Result<()>;
     fn table_id_from_name_mut_tx(&self, tx: &Self::MutTx, table_name: &str) -> Result<Option<TableId>>;
@@ -322,11 +339,7 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
         tx: &'a Self::MutTx,
         table_id: TableId,
     ) -> Result<Option<Cow<'a, str>>>;
-    fn get_all_tables_mut_tx<'tx>(
-        &self,
-        ctx: &ExecutionContext,
-        tx: &'tx Self::MutTx,
-    ) -> super::Result<Vec<Cow<'tx, TableSchema>>> {
+    fn get_all_tables_mut_tx(&self, ctx: &ExecutionContext, tx: &Self::MutTx) -> super::Result<Vec<Arc<TableSchema>>> {
         let mut tables = Vec::new();
         let table_rows = self.iter_mut_tx(ctx, tx, ST_TABLES_ID)?.collect::<Vec<_>>();
         for row in table_rows {

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -11,8 +11,8 @@ use spacetimedb_data_structures::map::HashMap;
 use spacetimedb_primitives::ConstraintKind;
 use spacetimedb_sats::db::def::{ConstraintSchema, IndexSchema, SequenceSchema, TableDef, TableSchema};
 use spacetimedb_sats::hash::Hash;
-use std::borrow::Cow;
 use std::collections::BTreeMap;
+use std::sync::Arc;
 use std::time::Duration;
 
 #[derive(thiserror::Error, Debug)]
@@ -129,13 +129,13 @@ pub enum SchemaUpdates {
 /// If no tables become tainted, the database may safely be updated using the
 /// information in [`SchemaUpdates::Updates`].
 pub fn schema_updates(
-    existing_tables: Vec<Cow<'_, TableSchema>>,
+    existing_tables: impl IntoIterator<Item = Arc<TableSchema>>,
     proposed_tables: Vec<TableDef>,
 ) -> anyhow::Result<SchemaUpdates> {
     let mut new_tables = HashMap::new();
     let mut tainted_tables = Vec::new();
 
-    let mut known_tables: BTreeMap<Box<str>, Cow<TableSchema>> = existing_tables
+    let mut known_tables: BTreeMap<Box<str>, Arc<TableSchema>> = existing_tables
         .into_iter()
         .map(|schema| (schema.table_name.clone(), schema))
         .collect();
@@ -151,50 +151,50 @@ pub fn schema_updates(
             // Also, there is no guarantee that the constituents of the schema
             // are sorted. They will be, however, when converting the proposed
             // `TableDef` into `TableSchema` (via `from_def`).
-            let known_schema = known_schema.into_owned();
             let columns = known_schema
                 .columns()
                 .iter()
                 .cloned()
                 .sorted_by_key(|x| x.col_pos)
                 .collect();
-            let known_schema = {
-                TableSchema::new(
-                    known_schema.table_id,
-                    known_schema.table_name,
-                    columns,
-                    known_schema
-                        .indexes
-                        .into_iter()
-                        .map(|x| IndexSchema {
-                            index_id: 0.into(),
-                            ..x
-                        })
-                        .sorted_by_key(|x| x.columns.clone())
-                        .collect(),
-                    known_schema
-                        .constraints
-                        .into_iter()
-                        .map(|x| ConstraintSchema {
-                            constraint_id: 0.into(),
-                            ..x
-                        })
-                        .filter(|x| x.constraints.kind() != ConstraintKind::UNSET)
-                        .sorted_by_key(|x| x.columns.clone())
-                        .collect(),
-                    known_schema
-                        .sequences
-                        .into_iter()
-                        .map(|x| SequenceSchema {
-                            sequence_id: 0.into(),
-                            ..x
-                        })
-                        .sorted_by_key(|x| x.col_pos)
-                        .collect(),
-                    known_schema.table_type,
-                    known_schema.table_access,
-                )
-            };
+            let known_schema = TableSchema::new(
+                known_schema.table_id,
+                known_schema.table_name.clone(),
+                columns,
+                known_schema
+                    .indexes
+                    .iter()
+                    .cloned()
+                    .map(|x| IndexSchema {
+                        index_id: 0.into(),
+                        ..x
+                    })
+                    .sorted_by_key(|x| x.columns.clone())
+                    .collect(),
+                known_schema
+                    .constraints
+                    .iter()
+                    .cloned()
+                    .map(|x| ConstraintSchema {
+                        constraint_id: 0.into(),
+                        ..x
+                    })
+                    .filter(|x| x.constraints.kind() != ConstraintKind::UNSET)
+                    .sorted_by_key(|x| x.columns.clone())
+                    .collect(),
+                known_schema
+                    .sequences
+                    .iter()
+                    .cloned()
+                    .map(|x| SequenceSchema {
+                        sequence_id: 0.into(),
+                        ..x
+                    })
+                    .sorted_by_key(|x| x.col_pos)
+                    .collect(),
+                known_schema.table_type,
+                known_schema.table_access,
+            );
             let proposed_schema = TableSchema::from_def(known_schema.table_id, proposed_schema_def);
 
             if proposed_schema != known_schema {
@@ -245,7 +245,7 @@ mod tests {
 
     #[test]
     fn test_updates_new_table() -> anyhow::Result<()> {
-        let current = vec![Cow::Owned(TableSchema::new(
+        let current = [Arc::new(TableSchema::new(
             TableId(42),
             "Person".into(),
             vec![ColumnSchema {
@@ -290,7 +290,7 @@ mod tests {
 
     #[test]
     fn test_updates_schema_mismatch() {
-        let current: Vec<Cow<TableSchema>> = vec![Cow::Owned(
+        let current = [Arc::new(
             TableDef::new(
                 "Person".into(),
                 vec![ColumnDef {
@@ -320,7 +320,7 @@ mod tests {
 
     #[test]
     fn test_updates_orphaned_table() {
-        let current = vec![Cow::Owned(
+        let current = [Arc::new(
             TableDef::new(
                 "Person".into(),
                 vec![ColumnDef {
@@ -343,7 +343,7 @@ mod tests {
 
     #[test]
     fn test_updates_add_index() {
-        let current: Vec<Cow<TableSchema>> = vec![Cow::Owned(
+        let current = [Arc::new(
             TableDef::new(
                 "Person".into(),
                 vec![ColumnDef {
@@ -367,7 +367,7 @@ mod tests {
 
     #[test]
     fn test_updates_drop_index() {
-        let current: Vec<Cow<TableSchema>> = vec![Cow::Owned(TableSchema::new(
+        let current = [Arc::new(TableSchema::new(
             TableId(42),
             "Person".into(),
             vec![ColumnSchema {
@@ -402,7 +402,7 @@ mod tests {
 
     #[test]
     fn test_updates_add_constraint() {
-        let current: Vec<Cow<TableSchema>> = vec![Cow::Owned(
+        let current = [Arc::new(
             TableDef::new(
                 "Person".into(),
                 vec![ColumnDef {
@@ -426,7 +426,7 @@ mod tests {
 
     #[test]
     fn test_updates_drop_constraint() {
-        let current: Vec<Cow<TableSchema>> = vec![Cow::Owned(
+        let current = [Arc::new(
             TableDef::new(
                 "Person".into(),
                 vec![ColumnDef {

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -121,7 +121,7 @@ fn compile_select(table: From, project: Vec<Column>, selection: Option<Selection
     }
 
     let source_expr = SourceExpr::DbTable(db_table_raw(
-        &table.root,
+        &*table.root,
         table.root.table_id,
         table.root.table_type,
         table.root.table_access,
@@ -133,7 +133,7 @@ fn compile_select(table: From, project: Vec<Column>, selection: Option<Selection
         for join in joins {
             match join {
                 Join::Inner { rhs, on } => {
-                    let rhs_source_expr = SourceExpr::DbTable(db_table(rhs, rhs.table_id));
+                    let rhs_source_expr = SourceExpr::DbTable(db_table(&**rhs, rhs.table_id));
                     match on.op {
                         OpCmp::Eq => {}
                         x => unreachable!("Unsupported operator `{x}` for joins"),
@@ -190,11 +190,11 @@ fn compile_columns(table: &TableSchema, columns: Vec<FieldName>) -> DbTable {
 
 /// Compiles a `INSERT ...` clause
 fn compile_insert(
-    table: TableSchema,
+    table: &TableSchema,
     columns: Vec<FieldName>,
     values: Vec<Vec<FieldExpr>>,
 ) -> Result<CrudExpr, PlanError> {
-    let source_expr = SourceExpr::DbTable(compile_columns(&table, columns));
+    let source_expr = SourceExpr::DbTable(compile_columns(table, columns));
 
     let mut rows = Vec::with_capacity(values.len());
     for x in values {
@@ -219,28 +219,28 @@ fn compile_insert(
 }
 
 /// Compiles a `DELETE ...` clause
-fn compile_delete(table: TableSchema, selection: Option<Selection>) -> Result<CrudExpr, PlanError> {
+fn compile_delete(table: Arc<TableSchema>, selection: Option<Selection>) -> Result<CrudExpr, PlanError> {
     let query = if let Some(filter) = selection {
-        let query = QueryExpr::new(&table);
+        let query = QueryExpr::new(&*table);
         compile_where(query, &From::new(table), filter)?
     } else {
-        QueryExpr::new(&table)
+        QueryExpr::new(&*table)
     };
     Ok(CrudExpr::Delete { query })
 }
 
 /// Compiles a `UPDATE ...` clause
 fn compile_update(
-    table: TableSchema,
+    table: Arc<TableSchema>,
     assignments: HashMap<FieldName, FieldExpr>,
     selection: Option<Selection>,
 ) -> Result<CrudExpr, PlanError> {
     let table = From::new(table);
     let delete = if let Some(filter) = selection.clone() {
-        let query = QueryExpr::new(&table.root);
+        let query = QueryExpr::new(&*table.root);
         compile_where(query, &table, filter)?
     } else {
-        QueryExpr::new(&table.root)
+        QueryExpr::new(&*table.root)
     };
 
     Ok(CrudExpr::Update { delete, assignments })
@@ -268,7 +268,7 @@ fn compile_statement(db: &RelationalDB, statement: SqlAst) -> Result<CrudExpr, P
             project,
             selection,
         } => CrudExpr::Query(compile_select(from, project, selection)?),
-        SqlAst::Insert { table, columns, values } => compile_insert(table, columns, values)?,
+        SqlAst::Insert { table, columns, values } => compile_insert(&table, columns, values)?,
         SqlAst::Update {
             table,
             assignments,

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -205,7 +205,7 @@ pub(crate) mod tests {
         let (db, _) = create_data(1)?;
 
         let tx = db.begin_tx();
-        let schema = db.schema_for_table(&tx, ST_TABLES_ID).unwrap().into_owned();
+        let schema = db.schema_for_table(&tx, ST_TABLES_ID).unwrap();
         db.release_tx(&ExecutionContext::internal(db.address()), tx);
         let result = run_for_testing(
             &db,
@@ -220,7 +220,7 @@ pub(crate) mod tests {
             scalar(StTableType::System.as_str()),
             scalar(StAccess::Public.as_str()),
         );
-        let input = mem_table(Header::from(&schema), vec![row]);
+        let input = mem_table(Header::from(&*schema), vec![row]);
 
         assert_eq!(
             result.as_without_table_name(),

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -174,7 +174,7 @@ mod tests {
         table_name: &str,
         head: &ProductType,
         row: &ProductValue,
-    ) -> ResultTest<(TableSchema, MemTable, DatabaseTableUpdate, QueryExpr)> {
+    ) -> ResultTest<(Arc<TableSchema>, MemTable, DatabaseTableUpdate, QueryExpr)> {
         let table = mem_table(head.clone(), [row.clone()]);
         let table_id = create_table_with_rows(db, tx, table_name, head.clone(), &[row.clone()])?;
 
@@ -185,9 +185,9 @@ mod tests {
             inserts: [row.clone()].into(),
         };
 
-        let schema = db.schema_for_table_mut(tx, table_id).unwrap().into_owned();
+        let schema = db.schema_for_table_mut(tx, table_id).unwrap();
 
-        let q = QueryExpr::new(&schema);
+        let q = QueryExpr::new(&*schema);
 
         Ok((schema, table, data, q))
     }
@@ -196,7 +196,7 @@ mod tests {
         db: &RelationalDB,
         tx: &mut MutTx,
         access: StAccess,
-    ) -> ResultTest<(TableSchema, MemTable, DatabaseTableUpdate, QueryExpr)> {
+    ) -> ResultTest<(Arc<TableSchema>, MemTable, DatabaseTableUpdate, QueryExpr)> {
         let table_name = if access == StAccess::Public {
             "inventory"
         } else {
@@ -222,7 +222,7 @@ mod tests {
     fn make_player(
         db: &RelationalDB,
         tx: &mut MutTx,
-    ) -> ResultTest<(TableSchema, MemTable, DatabaseTableUpdate, QueryExpr)> {
+    ) -> ResultTest<(Arc<TableSchema>, MemTable, DatabaseTableUpdate, QueryExpr)> {
         let table_name = "player";
         let head = ProductType::from([("player_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
         let row = product!(2u64, "jhon doe");
@@ -431,7 +431,7 @@ mod tests {
         check_query(&db, &table, &tx, &q, &data)?;
 
         //SELECT * FROM inventory WHERE inventory_id = 1
-        let q_id = QueryExpr::new(&schema).with_select_cmp(
+        let q_id = QueryExpr::new(&*schema).with_select_cmp(
             OpCmp::Eq,
             FieldName::named("_inventory", "inventory_id"),
             scalar(1u64),
@@ -452,7 +452,7 @@ mod tests {
 
         check_query_incr(&db, &tx, &s, &update, 1, &[row])?;
 
-        let q = QueryExpr::new(&schema);
+        let q = QueryExpr::new(&*schema);
 
         let (q, sources) = query_to_mem_table(q, &data);
         //Try access the private table

--- a/crates/table/benches/page_manager.rs
+++ b/crates/table/benches/page_manager.rs
@@ -496,7 +496,7 @@ fn make_table(c: &mut Criterion) {
                 let mut tables = Vec::with_capacity(num_iters as usize);
                 let start = WallTime.start();
                 for schema in schemas {
-                    tables.push(Table::new(schema, SquashedOffset::COMMITTED_STATE));
+                    tables.push(Table::new(schema.into(), SquashedOffset::COMMITTED_STATE));
                 }
                 let elapsed = WallTime.end(start);
                 black_box(tables);
@@ -515,7 +515,7 @@ fn make_table(c: &mut Criterion) {
 fn make_table_for_row_type<R: Row>(name: &str) -> Table {
     let ty = R::row_type();
     let schema = schema_from_ty(ty.clone(), name);
-    Table::new(schema, SquashedOffset::COMMITTED_STATE)
+    Table::new(schema.into(), SquashedOffset::COMMITTED_STATE)
 }
 
 fn use_type_throughput<T>(group: &mut BenchmarkGroup<'_, impl Measurement>) {
@@ -730,7 +730,7 @@ impl IndexedRow for Box<str> {
 
 fn make_table_with_indexes<R: IndexedRow>() -> Table {
     let schema = R::make_schema();
-    let mut tbl = Table::new(schema, SquashedOffset::COMMITTED_STATE);
+    let mut tbl = Table::new(schema.into(), SquashedOffset::COMMITTED_STATE);
 
     let cols = R::indexed_columns();
     let idx = BTreeIndex::new(IndexId(0), &R::row_type().into(), &cols, false, "idx").unwrap();

--- a/crates/table/src/bflatn_to_bsatn_fast_path.rs
+++ b/crates/table/src/bflatn_to_bsatn_fast_path.rs
@@ -31,7 +31,7 @@ use crate::{
 
 /// A precomputed BSATN layout for a type whose encoded length is a known constant,
 /// enabling fast BFLATN -> BSATN conversion.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, Clone)]
 pub struct StaticBsatnLayout {
     /// The length of the encoded BSATN representation of a row of this type,
     /// in bytes.

--- a/crates/table/src/btree_index.rs
+++ b/crates/table/src/btree_index.rs
@@ -479,7 +479,7 @@ mod test {
     fn table(ty: ProductType) -> Table {
         let def = TableDef::from_product("", ty);
         let schema = TableSchema::from_def(0.into(), def);
-        Table::new(schema, SquashedOffset::COMMITTED_STATE)
+        Table::new(schema.into(), SquashedOffset::COMMITTED_STATE)
     }
 
     /// Extracts from `row` the relevant column values according to what columns are indexed.

--- a/crates/table/src/layout.rs
+++ b/crates/table/src/layout.rs
@@ -95,7 +95,7 @@ pub trait HasLayout {
 ///   where `VarLenType` returns a static ref to [`VAR_LEN_REF_LAYOUT`],
 ///   and `PrimitiveType` dispatches on its variant to return a static ref
 ///   to a type-specific `Layout`.
-#[derive(Debug, PartialEq, Eq, EnumAsInner)]
+#[derive(Debug, PartialEq, Eq, Clone, EnumAsInner)]
 pub enum AlgebraicTypeLayout {
     /// A sum type, annotated with its layout.
     Sum(SumTypeLayout),
@@ -165,7 +165,7 @@ pub const fn row_size_for_type<T>() -> Size {
 /// The type of a row, annotated with a [`Layout`].
 ///
 /// This type ensures that the minimum row size is adhered to.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct RowTypeLayout(ProductTypeLayout);
 
 impl RowTypeLayout {
@@ -207,7 +207,7 @@ impl Index<usize> for RowTypeLayout {
 }
 
 /// A mirror of [`ProductType`] annotated with a [`Layout`].
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ProductTypeLayout {
     /// The memoized layout of the product type.
     pub layout: Layout,
@@ -222,7 +222,7 @@ impl HasLayout for ProductTypeLayout {
 }
 
 /// A mirrior of [`ProductTypeElement`] annotated with a [`Layout`].
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct ProductTypeElementLayout {
     /// The relative offset of a field's value to its parent product value.
     pub offset: u16,
@@ -238,7 +238,7 @@ pub struct ProductTypeElementLayout {
 }
 
 /// A mirrior of [`SumType`] annotated with a [`Layout`].
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SumTypeLayout {
     /// The layout of a sum value of this sum type.
     pub layout: Layout,
@@ -256,7 +256,7 @@ impl HasLayout for SumTypeLayout {
 }
 
 /// A mirrior of [`SumTypeVariant`] annotated with a [`Layout`].
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub struct SumTypeVariantLayout {
     /// The type of the variant.
     pub ty: AlgebraicTypeLayout,
@@ -270,7 +270,7 @@ pub struct SumTypeVariantLayout {
 
 /// Variants of [`BuiltinType`] which do not require a `VarLenRef` indirection,
 /// i.e. bools, integers and floats.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone, Copy)]
 pub enum PrimitiveType {
     Bool,
     I8,
@@ -301,7 +301,7 @@ impl HasLayout for PrimitiveType {
 
 /// [`BuiltinType`] variants which require a `VarLenRef` indirection,
 /// i.e. strings, arrays and maps.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, PartialEq, Eq, Clone)]
 pub enum VarLenType {
     /// The string type corresponds to `AlgebraicType::String`.
     String,

--- a/crates/table/src/read_column.rs
+++ b/crates/table/src/read_column.rs
@@ -355,7 +355,7 @@ mod test {
     fn table(ty: ProductType) -> Table {
         let def = TableDef::from_product("", ty);
         let schema = TableSchema::from_def(0.into(), def);
-        Table::new(schema, SquashedOffset::COMMITTED_STATE)
+        Table::new(schema.into(), SquashedOffset::COMMITTED_STATE)
     }
 
     proptest! {

--- a/crates/table/src/row_type_visitor.rs
+++ b/crates/table/src/row_type_visitor.rs
@@ -37,6 +37,7 @@ use core::fmt;
 use core::marker::PhantomData;
 use core::mem::MaybeUninit;
 use itertools::Itertools;
+use std::sync::Arc;
 
 /// Construct an implementor of `VarLenMembers`,
 /// which visits the var-len members in a row of `ty`.
@@ -269,7 +270,7 @@ fn remove_trailing_gotos(program: &mut Vec<Insn>) -> bool {
 }
 
 /// The instruction set of a [`VarLenVisitorProgram`].
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 enum Insn {
     // TODO(perf): consider boxing this variant (or making it a variable-width instruction)
     //             to minimize sizeof(insn),
@@ -348,9 +349,10 @@ impl fmt::Display for Insn {
 /// Forward progress, and thus termination,
 /// during interpretation is guaranteed when evaluating a program,
 /// as all jumps (`SwitchOnTag` and `Goto`) will set `new_instr_ptr > old_instr_ptr`.
+#[derive(Clone)]
 pub struct VarLenVisitorProgram {
     /// The list of instructions that make up this program.
-    insns: Box<[Insn]>,
+    insns: Arc<[Insn]>,
 }
 
 /// Evalutes the `program`,


### PR DESCRIPTION
# Description of Changes

Fixes #1082 
Fixes #1084 

Make Table::clone_structure cheaper by:
- Arcing `TableSchema`, and this has benefits elsewhere too.
- Arc<[_]>ing the visitor program instructions.

The data behind the Arcs very rarely change,
which is the perfect case for an Arc.

# API and ABI breaking changes

None

# Expected complexity level and risk

2

# Testing

No semantic changes nor anything that is very interesting, so existing tests should suffice.
