### PR TITLE
core: Store inputs (reducer info + args) in commitlog

### DIFF
--- a/crates/commitlog/src/varchar.rs
+++ b/crates/commitlog/src/varchar.rs
@@ -3,7 +3,7 @@ use std::ops::Deref;
 /// An owned string with a max length of `N`, like the venerable VARCHAR.
 ///
 /// The length is in bytes, not characters.
-#[derive(Clone, Debug, PartialEq)]
+#[derive(Clone, Debug, Eq, Hash, PartialEq)]
 #[repr(transparent)]
 pub struct Varchar<const N: usize> {
     // TODO: Depending on `core` usage, we may want a SSO string type, a pointer

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -13,7 +13,7 @@ use crate::address::Address;
 use crate::config::DatabaseConfig;
 use crate::db::db_metrics::DB_METRICS;
 use crate::error::{DBError, DatabaseError, TableError};
-use crate::execution_context::ExecutionContext;
+use crate::execution_context::{ExecutionContext, ReducerContext};
 use crate::hash::Hash;
 use crate::util::slow::SlowQueryConfig;
 use fs2::FileExt;
@@ -158,14 +158,14 @@ impl RelationalDB {
     where
         T: durability::History<TxData = Txdata>,
     {
-        log::debug!("DATABASE: applying transaction history...");
+        log::debug!("[{}] DATABASE: applying transaction history...", self.address);
         // TODO: Output progress
         history
             .fold_transactions_from(0, self.inner.replay())
             .map_err(anyhow::Error::from)?;
-        log::debug!("DATABASE: applied transaction history");
+        log::debug!("[{}] DATABASE: applied transaction history", self.address);
         self.inner.rebuild_state_after_replay()?;
-        log::debug!("DATABASE: rebuilt state after replay");
+        log::debug!("[{}] DATABASE: rebuilt state after replay", self.address);
 
         Ok(self)
     }
@@ -291,14 +291,14 @@ impl RelationalDB {
         };
 
         if let Some(durability) = &self.durability {
-            let inserts = tx_data
+            let inserts: Box<_> = tx_data
                 .inserts()
                 .map(|(table_id, rowdata)| Ops {
                     table_id: *table_id,
                     rowdata: rowdata.clone(),
                 })
                 .collect();
-            let deletes = tx_data
+            let deletes: Box<_> = tx_data
                 .deletes()
                 .map(|(table_id, rowdata)| Ops {
                     table_id: *table_id,
@@ -306,13 +306,35 @@ impl RelationalDB {
                 })
                 .collect();
 
+            // Avoid appending transactions to the commitlog which don't modify
+            // any tables.
+            //
+            // An exception ar connect / disconnect calls, which we always want
+            // paired in the log, so as to be able to disconnect clients
+            // automatically after a server crash. See:
+            // [`crate::host::ModuleHost::call_identity_connected_disconnected`]
+            //
+            // Note that this may change in the future: some analytics and/or
+            // timetravel queries may benefit from seeing all inputs, even if
+            // the database state did not change.
+            let is_noop = || inserts.is_empty() && deletes.is_empty();
+            let is_connect_disconnect = |ctx: &ReducerContext| {
+                matches!(
+                    ctx.name.strip_prefix("__identity_"),
+                    Some("connected__" | "disconnected__")
+                )
+            };
+            let inputs = ctx
+                .reducer_context()
+                .and_then(|rcx| (!is_noop() || is_connect_disconnect(rcx)).then(|| rcx.into()));
+
             let txdata = Txdata {
-                inputs: None,
+                inputs,
                 outputs: None,
                 mutations: Some(Mutations {
                     inserts,
                     deletes,
-                    truncates: Box::new([]),
+                    truncates: [].into(),
                 }),
             };
 
@@ -968,14 +990,27 @@ pub mod tests_utils {
 mod tests {
     #![allow(clippy::disallowed_macros)]
 
+    use std::cell::RefCell;
+    use std::rc::Rc;
+
     use super::*;
     use crate::db::datastore::system_tables::{
-        StConstraintRow, StIndexRow, StSequenceRow, StTableRow, ST_CONSTRAINTS_ID, ST_INDEXES_ID, ST_SEQUENCES_ID,
-        ST_TABLES_ID,
+        system_tables, StConstraintRow, StIndexRow, StSequenceRow, StTableRow, ST_CONSTRAINTS_ID, ST_INDEXES_ID,
+        ST_SEQUENCES_ID, ST_TABLES_ID,
     };
     use crate::db::relational_db::tests_utils::TestDB;
     use crate::error::IndexError;
+    use crate::execution_context::ReducerContext;
+    use crate::host::Timestamp;
+    use anyhow::bail;
+    use bytes::Bytes;
+    use commitlog::payload::txdata;
+    use commitlog::Commitlog;
+    use spacetimedb_data_structures::map::IntMap;
     use spacetimedb_lib::error::ResultTest;
+    use spacetimedb_lib::Identity;
+    use spacetimedb_sats::bsatn;
+    use spacetimedb_sats::buffer::BufReader;
     use spacetimedb_sats::db::def::{ColumnDef, ConstraintDef};
     use spacetimedb_sats::product;
     use spacetimedb_table::read_column::ReadColumn;
@@ -1584,5 +1619,213 @@ mod tests {
         );
 
         stdb.rollback_mut_tx(&ctx, delete_insert_tx);
+    }
+
+    #[test]
+    fn test_tx_inputs_are_in_the_commitlog() {
+        let _ = env_logger::builder()
+            .filter_level(log::LevelFilter::Trace)
+            .format_timestamp(None)
+            .is_test(true)
+            .try_init();
+
+        let stdb = TestDB::durable().expect("failed to create TestDB");
+
+        let timestamp = Timestamp::now();
+        let ctx = ExecutionContext::reducer(
+            stdb.address(),
+            ReducerContext {
+                name: "abstract_concrete_proxy_factory_impl".into(),
+                caller_identity: Identity::__dummy(),
+                caller_address: Address::__DUMMY,
+                timestamp,
+                arg_bsatn: Bytes::new(),
+            },
+        );
+
+        let row_ty = ProductType::from([("le_boeuf", AlgebraicType::I32)]);
+        let schema = TableDef::from_product("test_table", row_ty.clone());
+
+        // Create an empty transaction
+        {
+            let tx = stdb.begin_mut_tx(IsolationLevel::Serializable);
+            stdb.commit_tx(&ctx, tx).expect("failed to commit empty transaction");
+        }
+
+        // Create an empty transaction pretending to be an
+        // `__identity_connected__` call.
+        {
+            let tx = stdb.begin_mut_tx(IsolationLevel::Serializable);
+            stdb.commit_tx(
+                &ExecutionContext::reducer(
+                    stdb.address(),
+                    ReducerContext {
+                        name: "__identity_connected__".into(),
+                        caller_identity: Identity::__dummy(),
+                        caller_address: Address::__DUMMY,
+                        timestamp,
+                        arg_bsatn: Bytes::new(),
+                    },
+                ),
+                tx,
+            )
+            .expect("failed to commit empty __identity_connected__ transaction");
+        }
+
+        // Create a non-empty transaction including reducer info
+        let table_id = {
+            let mut tx = stdb.begin_mut_tx(IsolationLevel::Serializable);
+            let table_id = stdb.create_table(&mut tx, schema).expect("failed to create table");
+            stdb.insert(&mut tx, table_id, product!(AlgebraicValue::I32(0)))
+                .expect("failed to insert row");
+            stdb.commit_tx(&ctx, tx).expect("failed to commit tx");
+
+            table_id
+        };
+
+        // Create a non-empty transaction without reducer info, as it would be
+        // created by a mutable SQL transaction
+        {
+            let mut tx = stdb.begin_mut_tx(IsolationLevel::Serializable);
+            stdb.insert(&mut tx, table_id, product!(AlgebraicValue::I32(-42)))
+                .expect("failed to insert row");
+            stdb.commit_tx(&ExecutionContext::sql(stdb.address(), Default::default()), tx)
+                .expect("failed to commit tx");
+        }
+
+        // `txdata::Visitor` which only collects `txdata::Inputs`.
+        struct Inputs {
+            // The inputs collected during traversal of the log.
+            inputs: Vec<txdata::Inputs>,
+            // The number of transactions seen during traversal of the log.
+            num_txs: usize,
+            // System tables, needed to be able to consume transaction records.
+            sys: IntMap<TableId, ProductType>,
+            // The table created above, needed to be able to consume transaction
+            // records.
+            row_ty: ProductType,
+        }
+
+        impl txdata::Visitor for Inputs {
+            type Row = ();
+            type Error = anyhow::Error;
+
+            fn visit_insert<'a, R: BufReader<'a>>(
+                &mut self,
+                table_id: TableId,
+                reader: &mut R,
+            ) -> Result<Self::Row, Self::Error> {
+                let ty = self.sys.get(&table_id).unwrap_or(&self.row_ty);
+                let row = ProductValue::decode(ty, reader)?;
+                log::debug!("insert: {table_id} {row:?}");
+                Ok(())
+            }
+
+            fn visit_delete<'a, R: BufReader<'a>>(
+                &mut self,
+                table_id: TableId,
+                _reader: &mut R,
+            ) -> Result<Self::Row, Self::Error> {
+                bail!("unexpected delete for table: {table_id}")
+            }
+
+            fn visit_inputs(&mut self, inputs: &txdata::Inputs) -> Result<(), Self::Error> {
+                log::debug!("visit_inputs: {inputs:?}");
+                self.inputs.push(inputs.clone());
+                Ok(())
+            }
+
+            fn visit_tx_start(&mut self, offset: u64) -> Result<(), Self::Error> {
+                log::debug!("tx start: {offset}");
+                self.num_txs += 1;
+                Ok(())
+            }
+
+            fn visit_tx_end(&mut self) -> Result<(), Self::Error> {
+                log::debug!("tx end");
+                Ok(())
+            }
+        }
+
+        struct Decoder(Rc<RefCell<Inputs>>);
+
+        impl spacetimedb_commitlog::Decoder for Decoder {
+            type Record = txdata::Txdata<()>;
+            type Error = txdata::DecoderError<anyhow::Error>;
+
+            #[inline]
+            fn decode_record<'a, R: BufReader<'a>>(
+                &self,
+                version: u8,
+                tx_offset: u64,
+                reader: &mut R,
+            ) -> Result<Self::Record, Self::Error> {
+                txdata::decode_record_fn(&mut *self.0.borrow_mut(), version, tx_offset, reader)
+            }
+        }
+
+        let (db, durablity, rt, dir) = stdb.into_parts();
+        // Free reference to durability.
+        drop(db);
+        // Ensure everything is flushed to disk.
+        rt.expect("Durable TestDB must have a runtime")
+            .block_on(
+                Arc::into_inner(durablity.expect("Durable TestDB must have a durability"))
+                    .expect("failed to unwrap Arc")
+                    .close(),
+            )
+            .expect("failed to close local durabilility");
+
+        // Re-open commitlog and collect inputs.
+        let inputs = Rc::new(RefCell::new(Inputs {
+            inputs: Vec::new(),
+            num_txs: 0,
+            sys: system_tables()
+                .into_iter()
+                .map(|schema| (schema.table_id, schema.into_row_type()))
+                .collect(),
+            row_ty,
+        }));
+        {
+            let clog =
+                Commitlog::<()>::open(dir.path().join("clog"), Default::default()).expect("failed to open commitlog");
+            let decoder = Decoder(Rc::clone(&inputs));
+            clog.fold_transactions(decoder).unwrap();
+        }
+        // Just a safeguard so we don't drop the temp dir before this point.
+        drop(dir);
+
+        let inputs = Rc::into_inner(inputs).unwrap().into_inner();
+        log::debug!("collected inputs: {:?}", inputs.inputs);
+
+        // We should've seen three transactions --
+        // the empty one should've been ignored/
+        assert_eq!(inputs.num_txs, 3);
+        // Two of the transactions should yield inputs.
+        assert_eq!(inputs.inputs.len(), 2);
+
+        // Also assert that we got what we put in.
+        for (i, input) in inputs.inputs.into_iter().enumerate() {
+            let reducer_name = input.reducer_name.as_str();
+            if i == 0 {
+                assert_eq!(reducer_name, "__identity_connected__");
+            } else {
+                assert_eq!(reducer_name, "abstract_concrete_proxy_factory_impl");
+            }
+            let mut args = input.reducer_args.as_ref();
+            let identity: Identity =
+                bsatn::from_reader(&mut args).expect("failed to decode caller identity from reducer args");
+            let address: Address =
+                bsatn::from_reader(&mut args).expect("failed to decode caller address from reducer args");
+            let timestamp1: Timestamp =
+                bsatn::from_reader(&mut args).expect("failed to decode timestamp from reducer args");
+            assert!(
+                args.is_empty(),
+                "expected args to be exhausted because nullary args were given"
+            );
+            assert_eq!(identity, Identity::ZERO);
+            assert_eq!(address, Address::ZERO);
+            assert_eq!(timestamp1, timestamp);
+        }
     }
 }

--- a/crates/core/src/execution_context.rs
+++ b/crates/core/src/execution_context.rs
@@ -1,12 +1,15 @@
 use std::sync::Arc;
 
+use bytes::Bytes;
 use derive_more::Display;
 use parking_lot::RwLock;
-use spacetimedb_lib::Address;
+use spacetimedb_commitlog::{payload::txdata, Varchar};
+use spacetimedb_lib::{Address, Identity};
 use spacetimedb_primitives::TableId;
+use spacetimedb_sats::bsatn;
 
-use crate::db::db_metrics::DB_METRICS;
 use crate::util::slow::SlowQueryConfig;
+use crate::{db::db_metrics::DB_METRICS, host::Timestamp};
 
 pub enum MetricType {
     IndexSeeks,
@@ -114,13 +117,64 @@ pub struct ExecutionContext {
     /// The database on which a transaction is being executed.
     database: Address,
     /// The reducer from which the current transaction originated.
-    reducer: Option<String>,
+    reducer: Option<ReducerContext>,
     /// The type of workload that is being executed.
     workload: WorkloadType,
     /// The Metrics to be reported for this transaction.
     pub metrics: Arc<RwLock<Metrics>>,
     /// Configuration threshold for detecting slow queries.
     pub slow_query_config: SlowQueryConfig,
+}
+
+/// If an [`ExecutionContext`] is a reducer context, describes the reducer.
+///
+/// Note that this information is written to persistent storage.
+#[derive(Clone)]
+pub struct ReducerContext {
+    /// The name of the reducer.
+    pub name: String,
+    /// The [`Identity`] of the caller.
+    pub caller_identity: Identity,
+    /// The [`Address`] of the caller.
+    pub caller_address: Address,
+    /// The timestamp of the reducer invocation.
+    pub timestamp: Timestamp,
+    /// The BSATN-encoded arguments given to the reducer.
+    ///
+    /// Note that [`Bytes`] is a refcounted value, but the memory it points to
+    /// can be large-ish. The reference should be freed as soon as possible.
+    pub arg_bsatn: Bytes,
+}
+
+impl From<&ReducerContext> for txdata::Inputs {
+    fn from(
+        ReducerContext {
+            name,
+            caller_identity,
+            caller_address,
+            timestamp,
+            arg_bsatn,
+        }: &ReducerContext,
+    ) -> Self {
+        let reducer_name = Arc::new(Varchar::from_str_truncate(name));
+        let cap = arg_bsatn.len()
+        /* caller_identity */
+        + 32
+        /* caller_address */
+        + 16
+        /* timestamp */
+        + 8;
+        let mut buf = Vec::with_capacity(cap);
+        bsatn::to_writer(&mut buf, caller_identity).unwrap();
+        bsatn::to_writer(&mut buf, caller_address).unwrap();
+        bsatn::to_writer(&mut buf, timestamp).unwrap();
+        buf.extend_from_slice(arg_bsatn);
+
+        txdata::Inputs {
+            reducer_name,
+            reducer_args: buf.into(),
+        }
+    }
 }
 
 /// Classifies a transaction according to its workload.
@@ -146,7 +200,7 @@ impl ExecutionContext {
     /// Returns an [ExecutionContext] with the provided parameters and empty metrics.
     fn new(
         database: Address,
-        reducer: Option<String>,
+        reducer: Option<ReducerContext>,
         workload: WorkloadType,
         slow_query_config: SlowQueryConfig,
     ) -> Self {
@@ -160,8 +214,8 @@ impl ExecutionContext {
     }
 
     /// Returns an [ExecutionContext] for a reducer transaction.
-    pub fn reducer(database: Address, name: String) -> Self {
-        Self::new(database, Some(name), WorkloadType::Reducer, Default::default())
+    pub fn reducer(database: Address, ctx: ReducerContext) -> Self {
+        Self::new(database, Some(ctx), WorkloadType::Reducer, Default::default())
     }
 
     /// Returns an [ExecutionContext] for a one-off sql query.
@@ -193,7 +247,13 @@ impl ExecutionContext {
     /// If this is a reducer context, returns the name of the reducer.
     #[inline]
     pub fn reducer_name(&self) -> &str {
-        self.reducer.as_deref().unwrap_or_default()
+        self.reducer.as_ref().map(|ctx| ctx.name.as_str()).unwrap_or_default()
+    }
+
+    /// If this is a reducer context, returns the full reducer metadata.
+    #[inline]
+    pub fn reducer_context(&self) -> Option<&ReducerContext> {
+        self.reducer.as_ref()
     }
 
     /// Returns the type of workload that is being executed.
@@ -207,7 +267,7 @@ impl Drop for ExecutionContext {
     fn drop(&mut self) {
         let workload = self.workload;
         let database = self.database;
-        let reducer = self.reducer.as_deref().unwrap_or_default();
+        let reducer = self.reducer_name();
         self.metrics.write().flush(&workload, &database, reducer);
     }
 }

--- a/crates/core/src/host/wasmtime/wasmtime_module.rs
+++ b/crates/core/src/host/wasmtime/wasmtime_module.rs
@@ -1,8 +1,10 @@
+use self::module_host_actor::ReducerOp;
+
 use super::wasm_instance_env::WasmInstanceEnv;
 use super::{Mem, WasmtimeFuel};
 use crate::energy::ReducerBudget;
 use crate::host::instance_env::InstanceEnv;
-use crate::host::wasm_common::module_host_actor::{DescribeError, InitializationError, ReducerOp};
+use crate::host::wasm_common::module_host_actor::{DescribeError, InitializationError};
 use crate::host::wasm_common::*;
 use anyhow::anyhow;
 use bytes::Bytes;


### PR DESCRIPTION
Prerequisite for auto-disconnect after a database crash, requested for analytics purposes.


# Expected complexity level and risk

2

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] I wrote a test
