### PR TITLE
Nuke `#[spacetimedb(reducer, repeat = _)]`

### DIFF
--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -21,8 +21,6 @@ use spacetimedb_primitives::*;
 
 /// The `sender` invokes `reducer` at `timestamp` and provides it with the given `args`.
 ///
-/// The `epilogue` is executed after `reducer` has finished.
-///
 /// Returns an invalid buffer on success
 /// and otherwise the error is written into the fresh one returned.
 pub fn invoke_reducer<'a, A: Args<'a>, T>(
@@ -31,7 +29,6 @@ pub fn invoke_reducer<'a, A: Args<'a>, T>(
     client_address: Buffer,
     timestamp: u64,
     args: &'a [u8],
-    epilogue: impl FnOnce(Result<(), &str>),
 ) -> Buffer {
     let ctx = assemble_context(sender, timestamp, client_address);
 
@@ -39,12 +36,7 @@ pub fn invoke_reducer<'a, A: Args<'a>, T>(
     let SerDeArgs(args) = bsatn::from_slice(args).expect("unable to decode args");
 
     // Run the reducer with the timestamp set.
-    let res = with_timestamp_set(ctx.timestamp, || {
-        let res: Result<(), Box<str>> = reducer.invoke(ctx, args);
-        // Then run the epilogue.
-        epilogue(res.as_ref().copied().map_err(|e| &**e));
-        res
-    });
+    let res = with_timestamp_set(ctx.timestamp, || reducer.invoke(ctx, args));
 
     // Any error is pushed into a `Buffer`.
     cvt_result(res)

--- a/modules/rust-wasm-test/src/lib.rs
+++ b/modules/rust-wasm-test/src/lib.rs
@@ -73,10 +73,13 @@ pub fn update() {
     log::info!("Update called!");
 }
 
-#[spacetimedb(reducer, repeat = 1000ms)]
+#[spacetimedb(reducer)]
 pub fn repeating_test(ctx: ReducerContext, prev_time: Timestamp) {
     let delta_time = prev_time.elapsed();
     log::trace!("Timestamp: {:?}, Delta time: {:?}", ctx.timestamp, delta_time);
+
+    // Reschedule ourselves.
+    spacetimedb::schedule!("1000ms", repeating_test(_, Timestamp::now()));
 }
 
 #[spacetimedb(reducer)]


### PR DESCRIPTION
# Description of Changes

Get rid of the `repeat` modifier now that its unused in BitCraft and because it is a trap.

# API and ABI breaking changes

Breaks the module API/ABI.

# Expected complexity level and risk

3, someone (not BitCraft) might depend on this?