### PR TITLE
Re-instantiate replay progress reporting

### DIFF
--- a/crates/durability/src/imp/local.rs
+++ b/crates/durability/src/imp/local.rs
@@ -305,4 +305,8 @@ impl<T: Encode + 'static> History for Local<T> {
     {
         self.clog.transactions_from(offset, decoder)
     }
+
+    fn max_tx_offset(&self) -> Option<TxOffset> {
+        self.clog.max_committed_offset()
+    }
 }

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -73,6 +73,20 @@ pub trait History {
         D: Decoder<Record = Self::TxData>,
         D::Error: From<error::Traversal>,
         Self::TxData: 'a;
+
+    /// Get the maximum transaction offset contained in this history.
+    ///
+    /// Similar to [`std::iter::Iterator::size_hint`], this is considered an
+    /// estimation: the upper bound may not be known, or it may change after
+    /// this method was called because more data was added to the log.
+    ///
+    /// Callers should thus only rely on it for informational purposes.
+    ///
+    /// The default implementation returns `None`, which is correct for any
+    /// history implementation.
+    fn max_tx_offset(&self) -> Option<TxOffset> {
+        None
+    }
 }
 
 impl<T: History> History for Arc<T> {
@@ -97,5 +111,9 @@ impl<T: History> History for Arc<T> {
         Self::TxData: 'a,
     {
         (**self).transactions_from(offset, decoder)
+    }
+
+    fn max_tx_offset(&self) -> Option<TxOffset> {
+        (**self).max_tx_offset()
     }
 }


### PR DESCRIPTION
# Description of Changes

Output was wrongly logged at `debug`, and percentage reporting was missing a way to obtain the max offset to expect.

Note that this may need some reconsideration once we apply history _suffixes_. Do not rely on the output as is.

# API and ABI breaking changes

Nada

# Expected complexity level and risk

1

# Testing

- [ ] Manual testing: spin up an existing database and observe the log output
