### PR TITLE
Dylan/doc: Link directly to cargo install on missing

### DIFF
--- a/crates/cli/src/subcommands/init.rs
+++ b/crates/cli/src/subcommands/init.rs
@@ -36,7 +36,7 @@ fn check_for_cargo() -> bool {
             if find_executable("cargo.exe").is_some() {
                 return true;
             }
-            println!("{}", "Warning: You have created a rust project, but you are missing cargo. Visit the rust-lang official website for the latest instructions on install cargo on Windows:\n\n\tYou have created a rust project, but you are missing cargo.\n".yellow());
+            println!("{}", "Warning: You have created a rust project, but you are missing `cargo`. Visit https://www.rust-lang.org/tools/install for installation instructions:\n\n\tYou have created a rust project, but you are missing cargo.\n".yellow());
         }
         unsupported_os => {
             println!("{}", format!("This OS may be unsupported: {}", unsupported_os).yellow());


### PR DESCRIPTION
# Description of Changes

* doc: Link directly to cargo install on missing
![image](https://github.com/clockworklabs/SpacetimeDB/assets/8840024/0ae2d7ae-7009-4610-8cc3-add24f7a11f9)

## Why?

Most modern terminals parse links for you -- let's skip redundant research for the user.