### PR TITLE
Add repository field to crates

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,6 +77,7 @@ debug = true
 [workspace.package]
 version = "0.8.2"
 edition = "2021"
+repository = "https://github.com/clockworklabs/SpacetimeDB"
 # update rust-toolchain.toml too!
 rust-version = "1.77.0"
 

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-bench"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "Bench library/utility for SpacetimeDB"
 
 [[bench]]

--- a/crates/bindings-macro/Cargo.toml
+++ b/crates/bindings-macro/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-bindings-macro"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "Easy support for interacting between SpacetimeDB and Rust."
 rust-version.workspace = true
 

--- a/crates/bindings-sys/Cargo.toml
+++ b/crates/bindings-sys/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-bindings-sys"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "Easy support for interacting between SpacetimeDB and Rust."
 rust-version.workspace = true
 

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "Easy support for interacting between SpacetimeDB and Rust."
 rust-version.workspace = true
 

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-cli"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "A command line interface for SpacetimeDB"
 rust-version.workspace = true
 

--- a/crates/client-api-messages/Cargo.toml
+++ b/crates/client-api-messages/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-client-api-messages"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "Types for the SpacetimeDB client API messages"
 
 [dependencies]

--- a/crates/client-api/Cargo.toml
+++ b/crates/client-api/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-client-api"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "The HTTP API for SpacetimeDB"
 
 [dependencies]

--- a/crates/commitlog/Cargo.toml
+++ b/crates/commitlog/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 
 description = "Implementation of the SpacetimeDB commitlog."
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-core"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "The core library for SpacetimeDB"
 rust-version.workspace = true
 

--- a/crates/data-structures/Cargo.toml
+++ b/crates/data-structures/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-data-structures"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "Assorted data structures used in spacetimedb"
 
 [features]

--- a/crates/durability/Cargo.toml
+++ b/crates/durability/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spacetimedb-durability"
 version.workspace = true
 edition.workspace = true
+repository.workspace = true
 rust-version.workspace = true
 license-file = "LICENSE"
 

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-lib"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "A common library for SpacetimeDB"
 rust-version.workspace = true
 

--- a/crates/metrics/Cargo.toml
+++ b/crates/metrics/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-metrics"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "Prometheus utilities for SpacetimeDB"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-primitives"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "Primitives such as TableId and ColumnIndexAttribute"
 
 [dependencies]

--- a/crates/sats/Cargo.toml
+++ b/crates/sats/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-sats"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "Spacetime Algebraic Type Notation"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/sdk/Cargo.toml
+++ b/crates/sdk/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-sdk"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "A Rust SDK for clients to interface with SpacetimeDB"
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html

--- a/crates/sdk/tests/connect_disconnect_client/Cargo.toml
+++ b/crates/sdk/tests/connect_disconnect_client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "connect_disconnect_client"
 version.workspace = true
 edition.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/sdk/tests/test-client/Cargo.toml
+++ b/crates/sdk/tests/test-client/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test-client"
 version.workspace = true
 edition.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/sdk/tests/test-counter/Cargo.toml
+++ b/crates/sdk/tests/test-counter/Cargo.toml
@@ -2,6 +2,7 @@
 name = "test-counter"
 version.workspace = true
 edition.workspace = true
+repository.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 

--- a/crates/sqltest/Cargo.toml
+++ b/crates/sqltest/Cargo.toml
@@ -2,6 +2,7 @@
 name = "sqltest"
 version.workspace = true
 edition.workspace = true
+repository.workspace = true
 description = "Sql integration test for SpacetimeDB"
 
 [dependencies]

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-standalone"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "An executable for running a single SpacetimeDB standalone instance"
 
 [[bin]]

--- a/crates/table/Cargo.toml
+++ b/crates/table/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-table"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "A database Table implementation and friends"
 
 [[bench]]

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spacetimedb-testing"
 version.workspace = true
 edition.workspace = true
+repository.workspace = true
 
 [dependencies]
 spacetimedb-cli.workspace = true

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-vm"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+repository.workspace = true
 description = "A VM for SpacetimeDB"
 
 [dependencies]


### PR DESCRIPTION
# Description of Changes

Adds the `repository` field to `Cargo.toml`, making it easier for the link to the repository to be found by crates.io, lib.rs users and automated tools

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None