### PR TITLE
cli: Suggest to make new identity the default for server

### DIFF
--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -361,7 +361,7 @@ Has the server rotated its keys?
 Remove the outdated identity with:
 \tspacetime identity remove {identity}
 Generate a new identity with:
-\tspacetime identity new --no-email --server {server}"
+\tspacetime identity new --no-email --server {server} --default"
         )
     })
 }


### PR DESCRIPTION
When a server key rotation is suspected, suggest to make the new identity the default.

This usually happens during development using an ephemeral instance. If one follows the instructions, the `default_identity` is not set for the existing server, which makes the CLI generate a fresh identity every time.

See also: #333

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- Spin up an ephemeral stdb
- Try to do something using the CLI
- Observe that it complains about a rotated key 
- Run `spacetime identity new --no-email --server <the server>` (**without** `--default`)
- Try more things using the CLI
- Observe that a fresh identity is created every time
- Run `spacetime identity new --no-email --server <the server> --default` (as suggested)
- Observe that this identity is used subsequently
