### PR TITLE
Default commitlog output to info instead of debug

### DIFF
--- a/crates/standalone/log.conf
+++ b/crates/standalone/log.conf
@@ -5,6 +5,8 @@ spacetimedb=debug
 spacetimedb_client_api=debug
 spacetimedb_lib=debug
 spacetimedb_standalone=debug
+spacetimedb_commitlog=info
+spacetimedb_durability=info
 axum::rejection=trace
 
 # vim: set nowritebackup: << otherwise triggers cargo-watch


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

Right now the default log level for the commitlog is debug which is pretty noisy when loading a database from disk:

![image](https://github.com/clockworklabs/SpacetimeDB/assets/4099508/9d9fde28-28d2-43c1-8bae-9d1712c41770)

After defaulting it to info its much more reasonable:

![image](https://github.com/clockworklabs/SpacetimeDB/assets/4099508/9a9fb9fd-27af-4ff7-b67b-418b37883c0c)

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

No API/ABI break

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

0 - this is just changing log levels

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Try loading a database before this change, the log is pretty spammy, try with this change and its much better. See screenshots.
