### PR TITLE
Build uses -S for skip clippy

### DIFF
--- a/crates/cli/src/subcommands/build.rs
+++ b/crates/cli/src/subcommands/build.rs
@@ -15,7 +15,7 @@ pub fn cli() -> clap::Command {
         .arg(
             Arg::new("skip_clippy")
                 .long("skip_clippy")
-                .short('s')
+                .short('S')
                 .action(SetTrue)
                 .env("SPACETIME_SKIP_CLIPPY")
                 .value_parser(clap::builder::FalseyValueParser::new())


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

Everywhere else we're using `-S` for skipping clippy, this is the only remaining place where it is the lagacy flag `-s`.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

Technically yes - only a CLI change.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

0

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [x] `spacetime build -S` works
