### PR TITLE
Use -s to specify server for spacetime identity list -s <server>

### DIFF
--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -85,6 +85,8 @@ fn get_subcommands() -> Vec<Command> {
         Command::new("list").about("List saved identities which apply to a server")
             .arg(
                 Arg::new("server")
+                    .short('s')
+                    .long("server")
                     .help("The nickname, host name or URL of the server to list identities for")
                     .conflicts_with("all")
             )


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

Previous command was:
```
spacetime identity list <server>
```

New command is:
```
spacetime identity list -s <server>
```

The new command is more consistent with all of the other `spacetime` CLI commands which take a server argument.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

Technically yes, just a CLI change.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

0

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] Do `spacetime identity list -s <server>` or leave `-s <server>` unset to list identities for the default server.
