### PR TITLE
Fix an inconsistency with spacetime server fingerprint

### DIFF
--- a/crates/cli/src/subcommands/server.rs
+++ b/crates/cli/src/subcommands/server.rs
@@ -67,7 +67,12 @@ fn get_subcommands() -> Vec<Command> {
             ),
         Command::new("fingerprint")
             .about("Show or update a saved server's fingerprint")
-            .arg(Arg::new("server").help("The nickname, host name or URL of the server"))
+            .arg(
+                Arg::new("server")
+                    .short('s')
+                    .long("server")
+                    .help("The nickname, host name or URL of the server"),
+            )
             .arg(
                 Arg::new("force")
                     .help("Save changes to the server's configuration without confirming")


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

Previous command:
```
spacetime server fingerprint <server>
```

New command:
```
spacetime server fingerprint -s <server>
```

if no `-s <server>` is supplied, the default server will be fingerprinted.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

Technically yes, just a CLI change

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

0

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [x] Try `spacetime server fingerprint` and `spacetime server fingerprint -s <server>`
