### PR TITLE
Disconnect dangling clients

### DIFF
--- a/crates/core/src/database_instance_context.rs
+++ b/crates/core/src/database_instance_context.rs
@@ -1,5 +1,5 @@
 use super::database_logger::DatabaseLogger;
-use crate::db::relational_db::RelationalDB;
+use crate::db::relational_db::{ConnectedClients, RelationalDB};
 use crate::db::{Config, Storage};
 use crate::error::DBError;
 use crate::messages::control_db::Database;
@@ -11,6 +11,7 @@ use std::sync::Arc;
 
 pub type Result<T> = anyhow::Result<T>;
 
+/// A "live" database.
 #[derive(Clone)]
 pub struct DatabaseInstanceContext {
     pub database: Database,
@@ -21,31 +22,47 @@ pub struct DatabaseInstanceContext {
 }
 
 impl DatabaseInstanceContext {
+    /// Construct a [`DatabaseInstanceContext`] from a [`Database`] and
+    /// additional configuration.
+    ///
+    /// Alongside `Self`, the set of clients who were connected as of the most
+    /// recent transaction is returned as a [`ConnectedClients`]. If the value
+    /// `Some`, the set is non-empty. `__disconnect__` should be called for
+    /// each entry.
     pub fn from_database(
         config: Config,
         database: Database,
         instance_id: u64,
         root_db_path: PathBuf,
         rt: tokio::runtime::Handle,
-    ) -> Result<Self> {
+    ) -> Result<(Self, Option<ConnectedClients>)> {
         let mut db_path = root_db_path;
         db_path.extend([&*database.address.to_hex(), &*instance_id.to_string()]);
         db_path.push("database");
 
         let log_path = DatabaseLogger::filepath(&database.address, instance_id);
-        let relational_db = Arc::new(match config.storage {
-            Storage::Memory => RelationalDB::open(db_path, database.address, None)?,
-            Storage::Disk => RelationalDB::local(db_path, rt, database.address)?,
-        });
+        let (relational_db, dangling_connections) = match config.storage {
+            Storage::Memory => {
+                let db = RelationalDB::open(db_path, database.address, None)?;
+                (Arc::new(db), None)
+            }
+            Storage::Disk => {
+                let (db, connected_clients) = RelationalDB::local(db_path, rt, database.address)?;
+                let connected_clients = (!connected_clients.is_empty()).then_some(connected_clients);
+                (Arc::new(db), connected_clients)
+            }
+        };
         let subscriptions = ModuleSubscriptions::new(relational_db.clone(), database.identity);
 
-        Ok(Self {
+        let dbic = Self {
             database,
             database_instance_id: instance_id,
             logger: Arc::new(DatabaseLogger::open(log_path)),
             subscriptions,
             relational_db,
-        })
+        };
+
+        Ok((dbic, dangling_connections))
     }
 
     pub fn scheduler_db_path(&self, root_db_path: PathBuf) -> PathBuf {

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -26,6 +26,7 @@ use crate::{
 use anyhow::{anyhow, Context};
 use parking_lot::{Mutex, RwLock};
 use spacetimedb_commitlog::payload::{txdata, Txdata};
+use spacetimedb_lib::Identity;
 use spacetimedb_primitives::{ColList, ConstraintId, IndexId, SequenceId, TableId};
 use spacetimedb_sats::db::def::{IndexDef, SequenceDef, TableDef, TableSchema};
 use spacetimedb_sats::{bsatn, buffer::BufReader, hash::Hash, AlgebraicValue, ProductValue};
@@ -33,7 +34,7 @@ use spacetimedb_table::{indexes::RowPointer, table::RowRef};
 use std::sync::Arc;
 use std::time::Instant;
 use std::{borrow::Cow, time::Duration};
-use std::{cell::RefCell, ops::RangeBounds};
+use std::{cell::RefCell, collections::HashSet, ops::RangeBounds};
 use thiserror::Error;
 
 pub type Result<T> = std::result::Result<T, DBError>;
@@ -123,6 +124,7 @@ impl Locking {
             database_address: self.database_address,
             committed_state: self.committed_state.clone(),
             progress: RefCell::new(progress),
+            connected_clients: RefCell::new(HashSet::new()),
         }
     }
 }
@@ -589,6 +591,17 @@ pub struct Replay<F> {
     database_address: Address,
     committed_state: Arc<RwLock<CommittedState>>,
     progress: RefCell<F>,
+    /// Tracks the connect / disconnect calls recorded in the transaction history.
+    ///
+    /// If non-empty after a replay, the remaining entries were not gracefully
+    /// disconnected. A disconnect call should be performed for each.
+    connected_clients: RefCell<HashSet<(Identity, Address)>>,
+}
+
+impl<F> Replay<F> {
+    pub fn into_connected_clients(self) -> HashSet<(Identity, Address)> {
+        self.connected_clients.into_inner()
+    }
 }
 
 impl<F> Replay<F> {
@@ -598,6 +611,7 @@ impl<F> Replay<F> {
             database_address: &self.database_address,
             committed_state: &mut committed_state,
             progress: &mut *self.progress.borrow_mut(),
+            connected_clients: &mut self.connected_clients.borrow_mut(),
         };
         f(&mut visitor)
     }
@@ -623,6 +637,21 @@ impl<F: FnMut(u64)> spacetimedb_commitlog::Decoder for Replay<F> {
         reader: &mut R,
     ) -> std::result::Result<(), Self::Error> {
         self.using_visitor(|visitor| txdata::consume_record_fn(visitor, version, tx_offset, reader))
+    }
+}
+
+impl<F: FnMut(u64)> spacetimedb_commitlog::Decoder for &mut Replay<F> {
+    type Record = txdata::Txdata<ProductValue>;
+    type Error = txdata::DecoderError<ReplayError>;
+
+    #[inline]
+    fn decode_record<'a, R: BufReader<'a>>(
+        &self,
+        version: u8,
+        tx_offset: u64,
+        reader: &mut R,
+    ) -> std::result::Result<Self::Record, Self::Error> {
+        spacetimedb_commitlog::Decoder::decode_record(&**self, version, tx_offset, reader)
     }
 }
 
@@ -666,6 +695,7 @@ struct ReplayVisitor<'a, F> {
     database_address: &'a Address,
     committed_state: &'a mut CommittedState,
     progress: &'a mut F,
+    connected_clients: &'a mut HashSet<(Identity, Address)>,
 }
 
 impl<F: FnMut(u64)> spacetimedb_commitlog::payload::txdata::Visitor for ReplayVisitor<'_, F> {
@@ -759,8 +789,31 @@ impl<F: FnMut(u64)> spacetimedb_commitlog::payload::txdata::Visitor for ReplayVi
         Ok(())
     }
 
-    fn visit_tx_end(&mut self) -> std::prelude::v1::Result<(), Self::Error> {
+    fn visit_tx_end(&mut self) -> std::result::Result<(), Self::Error> {
         self.committed_state.next_tx_offset += 1;
+
+        Ok(())
+    }
+
+    fn visit_inputs(&mut self, inputs: &txdata::Inputs) -> std::result::Result<(), Self::Error> {
+        let decode_caller = || {
+            let buf = &mut inputs.reducer_args.as_ref();
+            let caller_identity: Identity = bsatn::from_reader(buf).context("Could not decode caller identity")?;
+            let caller_address: Address = bsatn::from_reader(buf).context("Could not decode caller address")?;
+            anyhow::Ok((caller_identity, caller_address))
+        };
+        if let Some(action) = inputs.reducer_name.strip_prefix("__identity_") {
+            let caller = decode_caller()?;
+            match action {
+                "connected__" => {
+                    self.connected_clients.insert(caller);
+                }
+                "disconnected__" => {
+                    self.connected_clients.remove(&caller);
+                }
+                _ => {}
+            }
+        }
 
         Ok(())
     }

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -1,3 +1,4 @@
+use super::wasm_common::{CLIENT_CONNECTED_DUNDER, CLIENT_DISCONNECTED_DUNDER};
 use super::{ArgsTuple, InvalidReducerArguments, ReducerArgs, ReducerCallResult, ReducerId, Timestamp};
 use crate::client::{ClientActorId, ClientConnectionSender};
 use crate::database_instance_context::DatabaseInstanceContext;
@@ -661,12 +662,10 @@ impl ModuleHost {
         caller_address: Address,
         connected: bool,
     ) -> Result<(), ReducerCallError> {
-        // TODO: DUNDER consts are in wasm_common, so seems weird to use them
-        // here. But maybe there should be dunders for this?
         let reducer_name = if connected {
-            "__identity_connected__"
+            CLIENT_CONNECTED_DUNDER
         } else {
-            "__identity_disconnected__"
+            CLIENT_DISCONNECTED_DUNDER
         };
 
         self.call_reducer_inner(

--- a/crates/core/src/host/wasm_common.rs
+++ b/crates/core/src/host/wasm_common.rs
@@ -21,6 +21,10 @@ pub const SETUP_DUNDER: &str = "__setup__";
 pub const INIT_DUNDER: &str = "__init__";
 /// the reducer with this name is invoked when updating the database
 pub const UPDATE_DUNDER: &str = "__update__";
+/// The reducer with this name is invoked when a client connects.
+pub const CLIENT_CONNECTED_DUNDER: &str = "__identity_connected__";
+/// The reducer with this name is invoked when a client disconnects.
+pub const CLIENT_DISCONNECTED_DUNDER: &str = "__identity_disconnected__";
 
 #[derive(Debug, Copy, Clone, PartialEq, Eq)]
 #[allow(unused)]


### PR DESCRIPTION
When replaying the commitlog, keep track of unpaired connect/disconnect calls and call disconnect when instantiating the module.

# Expected complexity level and risk

2

# Testing

- [x] Tested with `quickstart-chat` like so:

  - edit `quickstart-chat` to log connect / disconnect calls
  - publish `quickstart-chat` module
  - start client
  - shutdown server
  - start server
  - start client (to force module to be loaded)
  - stop client
  - examine module logs to convince thyself that connect is always paired with disconnect
