### PR TITLE
core: AnyBytes from boxed slice

### DIFF
--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -33,6 +33,12 @@ impl From<Vec<u8>> for AnyBytes {
     }
 }
 
+impl From<Box<[u8]>> for AnyBytes {
+    fn from(b: Box<[u8]>) -> Self {
+        Self::Bytes(b.into())
+    }
+}
+
 impl AsRef<[u8]> for AnyBytes {
     fn as_ref(&self) -> &[u8] {
         self


### PR DESCRIPTION
Avoids an unnecessarity roundtrip through `Vec<u8>` in private#731.

# Expected complexity level and risk

0
