### PR TITLE
Move `extract_table_field` to its only use

### DIFF
--- a/crates/sats/src/db/def.rs
+++ b/crates/sats/src/db/def.rs
@@ -1,7 +1,7 @@
 use crate::db::auth::{StAccess, StTableType};
 use crate::db::error::{DefType, SchemaError};
 use crate::product_value::InvalidFieldError;
-use crate::relation::{Column, DbTable, FieldName, FieldOnly, Header, TableField};
+use crate::relation::{Column, DbTable, FieldName, FieldOnly, Header};
 use crate::{de, impl_deserialize, impl_serialize, ser};
 use crate::{AlgebraicType, ProductType, ProductTypeElement};
 use derive_more::Display;
@@ -611,22 +611,6 @@ impl TableSchema {
     /// Warning: It ignores the `table_name`
     pub fn get_column_by_name(&self, col_name: &str) -> Option<&ColumnSchema> {
         self.columns.iter().find(|x| &*x.col_name == col_name)
-    }
-
-    /// Check if there is an index for this [FieldName]
-    ///
-    /// Warning: It ignores the `table_name`
-    pub fn get_index_by_field(&self, field: &FieldName) -> Option<&IndexSchema> {
-        let ColumnSchema { col_pos, .. } = self.get_column_by_field(field)?;
-        self.indexes.iter().find(|IndexSchema { columns, .. }| {
-            let mut cols = columns.iter();
-            cols.next() == Some(*col_pos) && cols.next().is_none()
-        })
-    }
-
-    /// Turn a [TableField] that could be an unqualified field `id` into `table.id`
-    pub fn normalize_field(&self, or_use: &TableField) -> FieldName {
-        FieldName::named(or_use.table.unwrap_or(&self.table_name), or_use.field)
     }
 
     /// Project the fields from the supplied `indexes`.

--- a/crates/sats/src/relation.rs
+++ b/crates/sats/src/relation.rs
@@ -11,25 +11,6 @@ use spacetimedb_primitives::{ColId, ColList, ColListBuilder, Constraints, TableI
 use std::sync::Arc;
 
 #[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
-pub struct TableField<'a> {
-    pub table: Option<&'a str>,
-    pub field: &'a str,
-}
-
-pub fn extract_table_field(ident: &str) -> Result<TableField, RelationError> {
-    let parts: Vec<_> = ident.split('.').take(3).collect();
-
-    match parts[..] {
-        [table, field] => Ok(TableField {
-            table: Some(table),
-            field,
-        }),
-        [field] => Ok(TableField { table: None, field }),
-        _ => Err(RelationError::FieldPathInvalid(ident.to_string())),
-    }
-}
-
-#[derive(Debug, Clone, Copy, PartialEq, PartialOrd, Eq, Ord, Hash)]
 pub enum FieldOnly<'a> {
     Name(&'a str),
     Pos(usize),


### PR DESCRIPTION
# Description of Changes

Working towards https://github.com/clockworklabs/SpacetimeDB/issues/1117 and  https://github.com/clockworklabs/SpacetimeDB/issues/1118.

Also remove `Header::get_index_by_field`, which is dead code.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Pure refactoring.