### PR TITLE
Prevent importing an identity with a name that already exists in the config

### DIFF
--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -455,7 +455,7 @@ async fn exec_import(mut config: Config, args: &ArgMatches) -> Result<(), anyhow
     //optional
     let nickname = args.get_one::<String>("name").cloned();
     if let Some(ref name) = nickname {
-        if config.get_identity_config_by_name(&name).is_some() {
+        if config.get_identity_config_by_name(name).is_some() {
             return Err(anyhow::anyhow!(
                 "An identity with that name already exists. Please import using a different name."
             ));

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -454,6 +454,13 @@ async fn exec_import(mut config: Config, args: &ArgMatches) -> Result<(), anyhow
 
     //optional
     let nickname = args.get_one::<String>("name").cloned();
+    if let Some(ref name) = nickname {
+        if config.get_identity_config_by_name(&name).is_some() {
+            return Err(anyhow::anyhow!(
+                "An identity with that name already exists. Please import using a different name."
+            ));
+        }
+    }
 
     config.identity_configs_mut().push(IdentityConfig {
         identity,


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

Reported in the discord by `halu`. If you have an identity in your config with some name, like `admin`, you can still import another identity with this same name. This PR changes the behavior so that an error is printed telling the user to select another name.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

No

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

0

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [x] Create a new identity with the name `admin`. Then create another identity with no name. Export this new identity. Delete the identity. Now import this identity with the name `admin`, you will get an error.
