### PR TITLE
Make identity naming more consistent + fix bugs

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -978,22 +978,27 @@ Import an existing identity with:
         })
     }
 
-    pub fn name_exists(&self, name: &str) -> bool {
-        self.get_identity_config_by_name(name).is_some()
-    }
+    pub fn can_set_name(&self, new_nickname: Option<&str>) -> Result<(), anyhow::Error> {
+        if let Some(new_nickname) = new_nickname {
+            if self.name_exists(new_nickname) {
+                return Err(anyhow::anyhow!("An identity with that name already exists."));
+            }
 
-    pub fn identity_exists(&self, identity: &Identity) -> bool {
-        self.get_identity_config_by_identity(identity).is_some()
-    }
+            if is_hex_identity(new_nickname) {
+                return Err(anyhow::anyhow!("An identity name cannot be an identity."));
+            }
+        }
 
-    pub fn can_set_name(&self, new_nickname: &str) -> Result<(), anyhow::Error> {
-        if self.name_exists(new_nickname) {
-            return Err(anyhow::anyhow!("An identity with that name already exists."));
-        }
-        if is_hex_identity(new_nickname) {
-            return Err(anyhow::anyhow!("An identity name cannot be an identity."));
-        }
         Ok(())
+    }
+
+    pub fn name_exists(&self, nickname: &str) -> bool {
+        for name in self.identity_configs().iter().map(|c| &c.nickname) {
+            if name.as_ref() == Some(&nickname.to_string()) {
+                return true;
+            }
+        }
+        false
     }
 
     pub fn get_identity_config_by_name(&self, name: &str) -> Option<&IdentityConfig> {

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -978,17 +978,13 @@ Import an existing identity with:
         })
     }
 
-    pub fn can_set_name(&self, new_nickname: Option<&str>) -> Result<(), anyhow::Error> {
-        if let Some(new_nickname) = new_nickname {
-            if self.name_exists(new_nickname) {
-                return Err(anyhow::anyhow!("An identity with that name already exists."));
-            }
-
-            if is_hex_identity(new_nickname) {
-                return Err(anyhow::anyhow!("An identity name cannot be an identity."));
-            }
+    pub fn can_set_name(&self, new_nickname: &str) -> Result<(), anyhow::Error> {
+        if self.name_exists(new_nickname) {
+            return Err(anyhow::anyhow!("An identity with that name already exists."));
         }
-
+        if is_hex_identity(new_nickname) {
+            return Err(anyhow::anyhow!("An identity name cannot be an identity."));
+        }
         Ok(())
     }
 

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -988,13 +988,12 @@ Import an existing identity with:
         Ok(())
     }
 
-    pub fn name_exists(&self, nickname: &str) -> bool {
-        for name in self.identity_configs().iter().map(|c| &c.nickname) {
-            if name.as_ref() == Some(&nickname.to_string()) {
-                return true;
-            }
-        }
-        false
+    pub fn name_exists(&self, name: &str) -> bool {
+        self.get_identity_config_by_name(name).is_some()
+    }
+
+    pub fn identity_exists(&self, identity: &Identity) -> bool {
+        self.get_identity_config_by_identity(identity).is_some()
     }
 
     pub fn get_identity_config_by_name(&self, name: &str) -> Option<&IdentityConfig> {

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -978,6 +978,14 @@ Import an existing identity with:
         })
     }
 
+    pub fn name_exists(&self, name: &str) -> bool {
+        self.get_identity_config_by_name(name).is_some()
+    }
+
+    pub fn identity_exists(&self, identity: &Identity) -> bool {
+        self.get_identity_config_by_identity(identity).is_some()
+    }
+
     pub fn can_set_name(&self, new_nickname: &str) -> Result<(), anyhow::Error> {
         if self.name_exists(new_nickname) {
             return Err(anyhow::anyhow!("An identity with that name already exists."));
@@ -986,14 +994,6 @@ Import an existing identity with:
             return Err(anyhow::anyhow!("An identity name cannot be an identity."));
         }
         Ok(())
-    }
-
-    pub fn name_exists(&self, name: &str) -> bool {
-        self.get_identity_config_by_name(name).is_some()
-    }
-
-    pub fn identity_exists(&self, identity: &Identity) -> bool {
-        self.get_identity_config_by_identity(identity).is_some()
     }
 
     pub fn get_identity_config_by_name(&self, name: &str) -> Option<&IdentityConfig> {

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -388,7 +388,9 @@ async fn exec_new(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let alias = args.get_one::<String>("name");
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
     let default = *args.get_one::<bool>("default").unwrap();
-    config.can_set_name(alias.map(|x| x.as_str()))?;
+    if let Some(x) = alias {
+        config.can_set_name(x.as_str())?;
+    }
 
     let email = args.get_one::<String>("email");
     let no_email = args.get_flag("no-email");
@@ -445,10 +447,12 @@ async fn exec_import(mut config: Config, args: &ArgMatches) -> Result<(), anyhow
 
     //optional
     let nickname = args.get_one::<String>("name").cloned();
-    config.can_set_name(nickname.as_deref())?;
+    if let Some(x) = nickname.as_deref() {
+        config.can_set_name(x)?;
+    }
 
     if config.identity_configs().iter().any(|ic| ic.identity == identity) {
-        return Err(anyhow::anyhow!("Identity already exists in config"));
+        return Err(anyhow::anyhow!("Identity \"{}\" already exists in config", identity));
     };
 
     config.identity_configs_mut().push(IdentityConfig {
@@ -581,7 +585,7 @@ async fn exec_token(config: Config, args: &ArgMatches) -> Result<(), anyhow::Err
 async fn exec_set_name(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let new_name = args.get_one::<String>("name").unwrap();
     let identity = args.get_one::<String>("identity").unwrap();
-    config.can_set_name(Some(new_name.as_str()))?;
+    config.can_set_name(new_name.as_str())?;
     let ic = config
         .get_identity_config_mut(identity)
         .ok_or_else(|| anyhow::anyhow!("Missing identity credentials for identity: {identity}"))?;

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -447,6 +447,13 @@ async fn exec_import(mut config: Config, args: &ArgMatches) -> Result<(), anyhow
 
     //optional
     let nickname = args.get_one::<String>("name").cloned();
+    if let Some(ref name) = nickname {
+        if config.get_identity_config_by_name(&name).is_some() {
+            return Err(anyhow::anyhow!(
+                "An identity with that name already exists. Please import using a different name."
+            ));
+        }
+    }
 
     config.identity_configs_mut().push(IdentityConfig {
         identity,

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -388,9 +388,7 @@ async fn exec_new(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let alias = args.get_one::<String>("name");
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
     let default = *args.get_one::<bool>("default").unwrap();
-    if let Some(x) = alias {
-        config.can_set_name(x)?;
-    }
+    config.can_set_name(alias.map(|x| x.as_str()))?;
 
     let email = args.get_one::<String>("email");
     let no_email = args.get_flag("no-email");
@@ -447,13 +445,7 @@ async fn exec_import(mut config: Config, args: &ArgMatches) -> Result<(), anyhow
 
     //optional
     let nickname = args.get_one::<String>("name").cloned();
-    if let Some(ref name) = nickname {
-        if config.get_identity_config_by_name(&name).is_some() {
-            return Err(anyhow::anyhow!(
-                "An identity with that name already exists. Please import using a different name."
-            ));
-        }
-    }
+    config.can_set_name(nickname.as_ref().map(|x| x.as_str()))?;
 
     config.identity_configs_mut().push(IdentityConfig {
         identity,
@@ -585,6 +577,7 @@ async fn exec_token(config: Config, args: &ArgMatches) -> Result<(), anyhow::Err
 async fn exec_set_name(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let new_name = args.get_one::<String>("name").unwrap();
     let identity = args.get_one::<String>("identity").unwrap();
+    config.can_set_name(Some(identity.as_str()))?;
     let ic = config
         .get_identity_config_mut(identity)
         .ok_or_else(|| anyhow::anyhow!("Missing identity credentials for identity: {identity}"))?;

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -388,7 +388,7 @@ async fn exec_new(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let alias = args.get_one::<String>("name");
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
     let default = *args.get_one::<bool>("default").unwrap();
-    if let Some(x) = alias.as_deref() {
+    if let Some(x) = alias {
         config.can_set_name(x)?;
     }
 
@@ -451,7 +451,7 @@ async fn exec_import(mut config: Config, args: &ArgMatches) -> Result<(), anyhow
         config.can_set_name(x)?;
     }
 
-    if config.identity_configs().iter().any(|ic| ic.identity == identity) {
+    if config.identity_exists(&identity) {
         return Err(anyhow::anyhow!("Identity \"{}\" already exists in config", identity));
     };
 

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -577,7 +577,7 @@ async fn exec_token(config: Config, args: &ArgMatches) -> Result<(), anyhow::Err
 async fn exec_set_name(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let new_name = args.get_one::<String>("name").unwrap();
     let identity = args.get_one::<String>("identity").unwrap();
-    config.can_set_name(Some(identity.as_str()))?;
+    config.can_set_name(Some(new_name.as_str()))?;
     let ic = config
         .get_identity_config_mut(identity)
         .ok_or_else(|| anyhow::anyhow!("Missing identity credentials for identity: {identity}"))?;

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -445,7 +445,7 @@ async fn exec_import(mut config: Config, args: &ArgMatches) -> Result<(), anyhow
 
     //optional
     let nickname = args.get_one::<String>("name").cloned();
-    config.can_set_name(nickname.as_ref().map(|x| x.as_str()))?;
+    config.can_set_name(nickname.as_deref())?;
 
     config.identity_configs_mut().push(IdentityConfig {
         identity,

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -447,6 +447,10 @@ async fn exec_import(mut config: Config, args: &ArgMatches) -> Result<(), anyhow
     let nickname = args.get_one::<String>("name").cloned();
     config.can_set_name(nickname.as_deref())?;
 
+    if config.identity_configs().iter().any(|ic| ic.identity == identity) {
+        return Err(anyhow::anyhow!("Identity already exists in config"));
+    };
+
     config.identity_configs_mut().push(IdentityConfig {
         identity,
         token,

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -388,8 +388,8 @@ async fn exec_new(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let alias = args.get_one::<String>("name");
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
     let default = *args.get_one::<bool>("default").unwrap();
-    if let Some(x) = alias {
-        config.can_set_name(x.as_str())?;
+    if let Some(x) = alias.as_deref() {
+        config.can_set_name(x)?;
     }
 
     let email = args.get_one::<String>("email");

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::path::PathBuf;
 
 use crate::config::Config;
+use crate::util;
 use crate::util::unauth_error_context;
 use crate::util::{add_auth_header_opt, get_auth_header};
 
@@ -111,6 +112,8 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let build_debug = args.get_flag("debug");
     let wasm_file = args.get_one::<PathBuf>("wasm_file");
     let database_host = config.get_host_url(server)?;
+    // Validate the identity first to provide an early error message
+    util::select_identity_config(&mut config, identity, server).await?;
 
     let mut query_params = Vec::<(&str, &str)>::new();
     query_params.push(("host_type", host_type.as_str()));

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -149,6 +149,10 @@ pub async fn select_identity_config(
     server: Option<&str>,
 ) -> Result<IdentityConfig, anyhow::Error> {
     if let Some(identity_or_name) = identity_or_name {
+        if identity_or_name == "" {
+            return Err(anyhow::anyhow!("Identity value cannot be empty."));
+        }
+
         config
             .get_identity_config(identity_or_name)
             .cloned()

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -149,14 +149,10 @@ pub async fn select_identity_config(
     server: Option<&str>,
 ) -> Result<IdentityConfig, anyhow::Error> {
     if let Some(identity_or_name) = identity_or_name {
-        if identity_or_name.is_empty() {
-            return Err(anyhow::anyhow!("Identity value cannot be empty."));
-        }
-
         config
             .get_identity_config(identity_or_name)
             .cloned()
-            .ok_or_else(|| anyhow::anyhow!("No such identity credentials for identity: {}", identity_or_name))
+            .ok_or_else(|| anyhow::anyhow!("No identity credentials for identity \"{}\"", identity_or_name))
     } else {
         Ok(init_default(config, None, server).await?.identity_config)
     }

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -149,7 +149,7 @@ pub async fn select_identity_config(
     server: Option<&str>,
 ) -> Result<IdentityConfig, anyhow::Error> {
     if let Some(identity_or_name) = identity_or_name {
-        if identity_or_name == "" {
+        if identity_or_name.is_empty() {
             return Err(anyhow::anyhow!("Identity value cannot be empty."));
         }
 


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

- There are several places in the CLI where you can set the name of an identity:
  - `spacetime identity new --name <name> --no-email`
  - `spacetime identity set-name <identity> <name>`
  - `spacetime identity import <identity> <token> --name <name>`
 
In these places we had slightly different logic for validating that an identity name looks okay. I've made the logic in these places more consistent. This will prevent people from accidentally adding identities with the same name or with an invalid name (identity names cannot look like identities).

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

Not breaking

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

0

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [x] Create a new identity with the name admin. Then create another identity with no name. Export this new identity. Delete the identity. Now import this identity with the name admin, you will get an error.
