### PR TITLE
Use a custom `FixedBitSet` + optimize `Page::iter_fixed_len`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -30,14 +30,15 @@ dependencies = [
 
 [[package]]
 name = "ahash"
-version = "0.8.3"
+version = "0.8.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2c99f64d1e06488f620f932677e24bc6e2897582980441ae90a671415bd7ec2f"
+checksum = "e89da841a80418a9b391ebaea17f5c112ffaaa96f621d2c285b5174da76b9011"
 dependencies = [
  "cfg-if",
  "getrandom",
  "once_cell",
  "version_check",
+ "zerocopy",
 ]
 
 [[package]]
@@ -1128,7 +1129,7 @@ version = "0.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5438eb16bdd8af51b31e74764fef5d0a9260227a5ec82ba75c9d11ce46595839"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.11",
  "cfg-if",
  "crossbeam-channel",
  "crossterm",
@@ -1147,7 +1148,7 @@ version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4db3b58161228d0dcb45c7968c5e74c3f03ad39e8983e58ad7d57061aa2cd94d"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.11",
  "crossbeam-channel",
  "enum-map",
  "enumset",
@@ -1812,7 +1813,7 @@ version = "0.13.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "43a3c133739dddd0d2990f9a4bdf8eb4b21ef50e4851ca85ab661199821d510e"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.11",
 ]
 
 [[package]]
@@ -1821,7 +1822,7 @@ version = "0.14.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7dfda62a12f55daeae5015f81b0baea145391cb4520f86c248fc615d72640d12"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.11",
  "allocator-api2",
  "rayon",
  "serde",
@@ -2130,7 +2131,7 @@ version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e98c1d0ad70fc91b8b9654b1f33db55e59579d3b3de2bffdced0fdb810570cb8"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.11",
  "hashbrown 0.12.3",
 ]
 
@@ -2174,7 +2175,7 @@ version = "0.11.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "321f0f839cd44a4686e9504b0a62b4d69a50b62072144c71c68f5873c167b8d9"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.11",
  "crossbeam-channel",
  "crossbeam-utils",
  "dashmap",
@@ -4647,7 +4648,7 @@ dependencies = [
 name = "spacetimedb-sats"
 version = "0.8.2"
 dependencies = [
- "ahash 0.8.3",
+ "ahash 0.8.11",
  "arrayvec",
  "bitflags 2.4.1",
  "bytes",
@@ -4731,8 +4732,7 @@ dependencies = [
 name = "spacetimedb-table"
 version = "0.8.2"
 dependencies = [
- "ahash 0.8.3",
- "bit-vec",
+ "ahash 0.8.11",
  "blake3",
  "criterion",
  "decorum",
@@ -6448,6 +6448,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
+]
+
+[[package]]
+name = "zerocopy"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "74d4d3961e53fa4c9a25a8637fc2bfaf2595b3d3ae34875568a5cf64787716be"
+dependencies = [
+ "zerocopy-derive",
+]
+
+[[package]]
+name = "zerocopy-derive"
+version = "0.7.32"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.39",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -109,7 +109,6 @@ axum-extra = { version = "0.9", features = ["typed-header"] }
 backtrace = "0.3.66"
 base64 = "0.21.2"
 bitflags = "2.3.3"
-bit-vec = "0.6"
 blake3 = "1.5"
 brotli = "3.5"
 byte-unit = "4.0.18"

--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -38,7 +38,6 @@ use spacetimedb_lib::address::AddressForUrl;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::sats::WithTypespace;
 use spacetimedb_lib::ProductTypeElement;
-use std::convert::From;
 
 pub(crate) struct DomainParsingRejection;
 

--- a/crates/client-api/src/util/flat_csv.rs
+++ b/crates/client-api/src/util/flat_csv.rs
@@ -22,7 +22,6 @@
 
 #![allow(clippy::all)]
 
-use std::iter::FromIterator;
 use std::marker::PhantomData;
 
 use bytes::BytesMut;

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -816,10 +816,8 @@ impl RelationalDB {
 
 #[cfg(any(test, feature = "test"))]
 pub mod tests_utils {
-    use std::fs::create_dir_all;
-    use std::ops::Deref;
-
     use super::*;
+    use core::ops::Deref;
     use tempfile::TempDir;
 
     /// A [`RelationalDB`] in a temporary directory.

--- a/crates/sats/src/de/impls.rs
+++ b/crates/sats/src/de/impls.rs
@@ -602,16 +602,15 @@ impl_deserialize!([] spacetimedb_primitives::TableId, de => u32::deserialize(de)
 impl_deserialize!([] spacetimedb_primitives::IndexId, de => u32::deserialize(de).map(Self));
 impl_deserialize!([] spacetimedb_primitives::SequenceId, de => u32::deserialize(de).map(Self));
 
-impl_deserialize!([] spacetimedb_primitives::ColList, de => {
-    impl GrowingVec<ColId> for ColListBuilder {
-        fn with_capacity(_: usize) -> Self {
-            Self::new()
-        }
-        fn push(&mut self, elem: ColId) {
-            self.push(elem);
-        }
+impl GrowingVec<ColId> for ColListBuilder {
+    fn with_capacity(_: usize) -> Self {
+        Self::new()
     }
-
+    fn push(&mut self, elem: ColId) {
+        self.push(elem);
+    }
+}
+impl_deserialize!([] spacetimedb_primitives::ColList, de => {
     struct ColListVisitor;
     impl<'de> ArrayVisitor<'de, ColId> for ColListVisitor {
         type Output = ColListBuilder;

--- a/crates/sats/src/proptest.rs
+++ b/crates/sats/src/proptest.rs
@@ -10,8 +10,6 @@ use proptest::{
     collection::{vec, SizeRange},
     prelude::*,
     prop_oneof,
-    strategy::Just,
-    strategy::{BoxedStrategy, Strategy},
 };
 
 const SIZE: usize = 16;

--- a/crates/table/Cargo.toml
+++ b/crates/table/Cargo.toml
@@ -34,7 +34,6 @@ spacetimedb-primitives.workspace = true
 spacetimedb-sats.workspace = true
 
 ahash.workspace = true
-bit-vec.workspace = true
 blake3.workspace = true
 decorum.workspace = true
 derive_more.workspace = true

--- a/crates/table/src/fixed_bit_set.rs
+++ b/crates/table/src/fixed_bit_set.rs
@@ -1,0 +1,370 @@
+use core::{
+    ops::{BitAnd, BitAndAssign, BitOr, Not, Shl},
+    slice::Iter,
+};
+pub use internal_unsafe::FixedBitSet;
+use internal_unsafe::Len;
+
+/// A type used to represent blocks in a bit set.
+/// A smaller type, compared to usize,
+/// means taking less advantage of native operations.
+/// A larger type means we might over-allocate more.
+pub trait BitBlock:
+    Copy
+    + Eq
+    + Not<Output = Self>
+    + BitAnd<Self, Output = Self>
+    + BitAndAssign
+    + BitOr<Self, Output = Self>
+    + Shl<usize, Output = Self>
+{
+    /// The number of bits that [`Self`] can represent.
+    const BITS: u32;
+
+    /// The first bit is set.
+    const ONE: Self;
+
+    /// No bits are set.
+    const ZERO: Self;
+
+    fn wrapping_sub(self, rhs: Self) -> Self;
+    fn trailing_zeros(self) -> u32;
+}
+
+type DefaultBitBlock = u64;
+
+impl BitBlock for DefaultBitBlock {
+    const BITS: u32 = Self::BITS;
+    const ONE: Self = 1;
+    const ZERO: Self = 0;
+
+    #[inline]
+    fn wrapping_sub(self, rhs: Self) -> Self {
+        self.wrapping_sub(rhs)
+    }
+
+    #[inline]
+    fn trailing_zeros(self) -> u32 {
+        self.trailing_zeros()
+    }
+}
+
+/// The internals of `FixedBitSet`.
+/// Separated from the higher level APIs to contain the safety boundary.
+mod internal_unsafe {
+    use super::{BitBlock, DefaultBitBlock};
+    use crate::{static_assert_align, static_assert_size};
+    use core::{
+        mem,
+        ptr::NonNull,
+        slice::{from_raw_parts, from_raw_parts_mut},
+    };
+
+    /// Computes how many blocks are needed to store that many bits.
+    fn blocks_for_bits<B: BitBlock>(bits: usize) -> usize {
+        // Must round e.g., 31 / 32 to 1 and 32 / 32 to 1 as well.
+        bits.div_ceil(B::BITS as usize)
+    }
+
+    /// The type used to represent the number of bits the set can hold.
+    ///
+    /// Currently `u16` to keep `mem::size_of::<FixedBitSet>()` small.
+    pub(super) type Len = u16;
+
+    /// A bit set that, once created, has a fixed size over time.
+    ///
+    /// The set can store at most `u16::MAX` number of bits.
+    #[repr(C, packed)]
+    pub struct FixedBitSet<B = DefaultBitBlock> {
+        /// The size of the heap allocation in number of elements.
+        len: Len,
+        /// A pointer to a heap allocation of `[B]` of `self.len`.
+        ptr: NonNull<B>,
+    }
+
+    static_assert_align!(FixedBitSet, 1);
+    static_assert_size!(FixedBitSet, mem::size_of::<usize>() + mem::size_of::<Len>());
+
+    // SAFETY: `FixedBitSet` owns its data.
+    unsafe impl<B> Send for FixedBitSet<B> {}
+    // SAFETY: `FixedBitSet` owns its data.
+    unsafe impl<B> Sync for FixedBitSet<B> {}
+
+    impl<B> Drop for FixedBitSet<B> {
+        fn drop(&mut self) {
+            let blocks = self.storage_mut();
+            // SAFETY: We own the memory region pointed to by `blocks`,
+            // and as we have `&'0 mut self`, we also have exclusive access to it.
+            // So, and since we are in `drop`,
+            // we can deallocate the memory as we are the last referent to it.
+            // Moreover, the memory was allocated in `Self::new(..)` using `vec![..]`,
+            // which will allocate using `Global`, so we can convert it back to a `Box`.
+            let _ = unsafe { Box::from_raw(blocks) };
+        }
+    }
+
+    impl<B: BitBlock> FixedBitSet<B> {
+        /// Allocates a new bit set capable of holding `bits` number of bits.
+        pub fn new(bits: usize) -> Self {
+            // Compute the number of blocks needed.
+            let nblocks = blocks_for_bits::<B>(bits);
+            // SAFETY: required for the soundness of `Drop` as
+            // `dealloc` must receive the same layout as it was `alloc`ated with.
+            assert!(nblocks <= Len::MAX as usize);
+            let len = nblocks as Len;
+
+            // Allocate the blocks and extract the pointer to the heap region.
+            let blocks: Box<[B]> = vec![B::ZERO; nblocks].into_boxed_slice();
+            let ptr = NonNull::from(Box::leak(blocks)).cast();
+
+            Self { ptr, len }
+        }
+    }
+
+    impl<B> FixedBitSet<B> {
+        /// Returns the backing `[B]` slice for shared access.
+        pub(super) const fn storage(&self) -> &[B] {
+            let ptr = self.ptr.as_ptr();
+            let len = self.len as usize;
+            // SAFETY:
+            // - `self.ptr` is a `NonNull` so `ptr` cannot be null.
+            // - `self.ptr` is properly aligned for `BitBlock`s.
+            // - `self.ptr` is valid for reads as we have `&self` and we own the memory
+            //   which we know is `blocks` elements long.
+            // - As we have `&'0 self`, elsewhere cannot mutate the memory during `'0`
+            //   except through an `UnsafeCell`.
+            unsafe { from_raw_parts(ptr, len) }
+        }
+
+        /// Returns the backing `[B]` slice for mutation.
+        pub(super) fn storage_mut(&mut self) -> &mut [B] {
+            let ptr = self.ptr.as_ptr();
+            let len = self.len as usize;
+            // SAFETY:
+            // - `self.ptr` is a `NonNull` so `ptr` cannot be null.
+            // - `self.ptr` is properly aligned for `BitBlock`s.
+            // - `self.ptr` is valid for reads and writes as we have `&mut self` and we own the memory
+            //   which we know is `blocks` elements long.
+            // - As we have `&'0 mut self`, we have exclusive access for `'0`
+            //   so the memory cannot be accessed elsewhere during `'0`.
+            unsafe { from_raw_parts_mut(ptr, len) }
+        }
+    }
+}
+
+impl<B: BitBlock> FixedBitSet<B> {
+    /// Converts `idx` to its block index and the index within the block.
+    const fn idx_to_pos(idx: usize) -> (usize, usize) {
+        let bits = B::BITS as usize;
+        (idx / bits, idx % bits)
+    }
+
+    /// Returns whether `idx` is set or not.
+    pub fn get(&self, idx: usize) -> bool {
+        let (block_idx, pos_in_block) = Self::idx_to_pos(idx);
+        let block = self.storage()[block_idx];
+        (block & (B::ONE << pos_in_block)) != B::ZERO
+    }
+
+    /// Sets bit at position `idx` to `val`.
+    pub fn set(&mut self, idx: usize, val: bool) {
+        let (block_idx, pos_in_block) = Self::idx_to_pos(idx);
+        let block = &mut self.storage_mut()[block_idx];
+
+        // Update the block.
+        let flag = B::ONE << pos_in_block;
+        *block = if val { *block | flag } else { *block & !flag };
+    }
+
+    /// Clears every bit in the vec.
+    pub fn clear(&mut self) {
+        self.storage_mut().fill(B::ZERO);
+    }
+
+    /// Returns all the set indices.
+    pub fn iter_set(&self) -> IterSet<'_, B> {
+        let mut inner = self.storage().iter();
+
+        // Fetch the first block; if it isn't there, use an all-zero one.
+        // This will cause the iterator to terminate immediately.
+        let curr = inner.next().copied().unwrap_or(B::ZERO);
+
+        IterSet {
+            inner,
+            curr,
+            block_idx: 0,
+        }
+    }
+
+    /// Returns all the set indices from `start_idx` inclusive.
+    pub fn iter_set_from(&self, start_idx: usize) -> IterSet<'_, B> {
+        // Translate the index to its block and position within it.
+        let (block_idx, pos_in_block) = Self::idx_to_pos(start_idx);
+
+        // We want our iteration to start from the block that includes `start_idx`.
+        let mut inner = self.storage()[block_idx..].iter();
+
+        // Fetch the first block; if it isn't there, use an all-zero one.
+        // This will cause the iterator to terminate immediately.
+        let curr = inner.next().copied().unwrap_or(B::ZERO);
+
+        // Our `start_idx` might be in the middle of the `curr` block.
+        // To resolve this, we must zero out any preceding bits.
+        // So e.g., for `B = u8`,
+        // we must transform `0000_1011` to `0000_1000` for `start_idx = 3`.
+        let zero_preceding_mask = B::ZERO.wrapping_sub(B::ONE << pos_in_block);
+        let curr = curr & zero_preceding_mask;
+
+        IterSet {
+            inner,
+            curr,
+            block_idx: block_idx as Len,
+        }
+    }
+}
+
+/// An iterator that yields the set indices of a [`FixedBitSet`].
+pub struct IterSet<'a, B = DefaultBitBlock> {
+    /// The block iterator.
+    inner: Iter<'a, B>,
+    /// The current block being processed, taken from `self.inner`.
+    curr: B,
+    /// What the index of `self.curr` is.
+    block_idx: Len,
+}
+
+impl<B: BitBlock> Iterator for IterSet<'_, B> {
+    type Item = usize;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            let tz = self.curr.trailing_zeros();
+            if tz < B::BITS {
+                // Some bit was set; so yield the index of that
+                // and zero the bit out so we don't yield it again.
+                self.curr &= self.curr.wrapping_sub(B::ONE);
+                let idx = self.block_idx as u32 * B::BITS + tz;
+                return Some(idx as usize);
+            } else {
+                // No bit is set; advance to the next block, or quit if none left.
+                self.curr = *self.inner.next()?;
+                self.block_idx += 1;
+            }
+        }
+    }
+}
+
+#[cfg(test)]
+pub(crate) mod test {
+    use super::*;
+    use proptest::bits::bitset::between;
+    use proptest::prelude::*;
+    use spacetimedb_data_structures::map::HashSet;
+
+    #[test]
+    #[should_panic]
+    fn zero_sized_is_ok() {
+        let mut set = FixedBitSet::<DefaultBitBlock>::new(0);
+        set.clear();
+        set.iter_set_from(0).count();
+        set.iter_set().count();
+        set.get(0);
+    }
+
+    const MAX_NBITS: usize = 1000;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2048))]
+
+        #[test]
+        fn after_new_there_are_no_bits_set(nbits in 0..MAX_NBITS) {
+            let set = FixedBitSet::<DefaultBitBlock>::new(nbits);
+            for idx in 0..nbits {
+                prop_assert!(!set.get(idx));
+            }
+        }
+
+        #[test]
+        fn after_clear_there_are_no_bits_set(choices in between(0, MAX_NBITS)) {
+            let nbits = choices.get_ref().len();
+
+            let mut set = FixedBitSet::<DefaultBitBlock>::new(nbits);
+
+            // Set all the bits chosen.
+            for idx in &choices {
+                prop_assert!(!set.get(idx));
+                set.set(idx, true);
+                prop_assert!(set.get(idx));
+            }
+
+            // Clear!
+            set.clear();
+
+            // After clearing, all bits should be unset.
+            for idx in 0..nbits {
+                prop_assert!(!set.get(idx));
+            }
+        }
+
+        #[test]
+        fn get_set_consistency(choices in between(0, MAX_NBITS)) {
+            let nbits = choices.get_ref().len();
+            let mut set = FixedBitSet::<DefaultBitBlock>::new(nbits);
+
+            // Set all the bits chosen.
+            for idx in &choices {
+                prop_assert!(!set.get(idx));
+
+                // After setting, it's true.
+                set.set(idx, true);
+                prop_assert!(set.get(idx));
+                // And this is idempotent.
+                set.set(idx, true);
+                prop_assert!(set.get(idx));
+            }
+
+            // Build the "complement" of `choices`.
+            let choices: HashSet<_> = choices.into_iter().collect();
+            let universe: HashSet<_> = (0..nbits).collect();
+            for idx in universe.difference(&choices) {
+                prop_assert!(!set.get(*idx));
+            }
+
+            // Unset all the bits chosen.
+            for idx in &choices {
+                // After unsetting, it's false.
+                set.set(*idx, false);
+                prop_assert!(!set.get(*idx));
+                // And this is idempotent.
+                set.set(*idx, false);
+                prop_assert!(!set.get(*idx));
+            }
+        }
+
+        #[test]
+        fn iter_set_preserves_order_of_original_choices(choices in between(0, MAX_NBITS)) {
+            let nbits = choices.get_ref().len();
+
+            // Set all the bits chosen.
+            let mut set = FixedBitSet::<DefaultBitBlock>::new(nbits);
+            for idx in &choices {
+                set.set(idx, true);
+            }
+
+            // `iter_set` produces the same list `choices`.
+            let collected = set.iter_set().collect::<Vec<_>>();
+            let original = choices.iter().collect::<Vec<_>>();
+            prop_assert_eq!(&original, &collected);
+
+            if let [_, second, ..] = &*original {
+                // Starting from the second yields the same list as `choices[1..]`.
+                let collected = set.iter_set_from(*second).collect::<Vec<_>>();
+                prop_assert_eq!(&original[1..], &collected);
+            }
+
+            // `iter_set_from` and `iter_set` produce the same list.
+            prop_assert_eq!(collected, set.iter_set_from(0).collect::<Vec<_>>());
+        }
+
+    }
+}

--- a/crates/table/src/layout.rs
+++ b/crates/table/src/layout.rs
@@ -620,7 +620,7 @@ pub fn bsatn_len(val: &AlgebraicValue) -> usize {
 #[cfg(test)]
 mod test {
     use super::*;
-    use itertools::Itertools;
+    use itertools::Itertools as _;
     use proptest::collection::vec;
     use proptest::prelude::*;
     use spacetimedb_sats::proptest::generate_algebraic_type;

--- a/crates/table/src/lib.rs
+++ b/crates/table/src/lib.rs
@@ -13,6 +13,7 @@ pub mod blob_store;
 pub mod btree_index;
 pub mod eq;
 pub mod eq_to_pv;
+mod fixed_bit_set;
 pub mod indexes;
 pub mod layout;
 pub mod page;

--- a/crates/table/src/page.rs
+++ b/crates/table/src/page.rs
@@ -20,6 +20,7 @@
 
 use super::{
     blob_store::BlobStore,
+    fixed_bit_set::FixedBitSet,
     indexes::{Byte, Bytes, PageOffset, Size, PAGE_HEADER_SIZE, PAGE_SIZE},
     layout::MIN_ROW_SIZE,
     util::maybe_uninit_write_slice,
@@ -28,7 +29,7 @@ use super::{
         VarLenRef,
     },
 };
-use crate::static_assert_size;
+use crate::{fixed_bit_set::IterSet, static_assert_size};
 use core::{
     mem::{self, MaybeUninit},
     ops::ControlFlow,
@@ -118,7 +119,6 @@ impl FreeCellRef {
 
 /// All the fixed size header information.
 #[repr(C)] // Required for a stable ABI.
-#[derive(Debug)]
 struct FixedHeader {
     /// A pointer to the head of the freelist which stores
     /// all the unused (freed) fixed row cells.
@@ -141,17 +141,17 @@ struct FixedHeader {
     // TODO(stable-module-abi): should this be inlined into the page?
     /// For each fixed-length row slot, true if a row is stored there,
     /// false if the slot is uninit.
-    present_rows: bit_vec::BitVec,
+    present_rows: FixedBitSet,
 
     #[cfg(debug_assertions)]
     fixed_row_size: Size,
 }
 
 #[cfg(debug_assertions)]
-static_assert_size!(FixedHeader, 48);
+static_assert_size!(FixedHeader, 18);
 
 #[cfg(not(debug_assertions))]
-static_assert_size!(FixedHeader, 40);
+static_assert_size!(FixedHeader, 16);
 
 impl FixedHeader {
     /// Returns a new `FixedHeader`
@@ -163,7 +163,7 @@ impl FixedHeader {
             // Points one after the last allocated fixed-length row, or `NULL` for an empty page.
             last: PageOffset::VAR_LEN_NULL,
             num_rows: 0,
-            present_rows: bit_vec::BitVec::from_elem(PageOffset::PAGE_END.idx().div_ceil(fixed_row_size.len()), false),
+            present_rows: FixedBitSet::new(PageOffset::PAGE_END.idx().div_ceil(fixed_row_size.len())),
             #[cfg(debug_assertions)]
             fixed_row_size,
         }
@@ -198,7 +198,7 @@ impl FixedHeader {
     #[inline]
     fn is_row_present(&self, offset: PageOffset, fixed_row_size: Size) -> bool {
         self.debug_check_fixed_row_size(fixed_row_size);
-        self.present_rows.get(offset / fixed_row_size).unwrap()
+        self.present_rows.get(offset / fixed_row_size)
     }
 
     /// Resets the header information to its state
@@ -216,7 +216,6 @@ impl FixedHeader {
 
 /// All the var-len header information.
 #[repr(C)] // Required for a stable ABI.
-#[derive(Debug)]
 struct VarHeader {
     /// A pointer to the head of the freelist which stores
     /// all the unused (freed) var-len granules.
@@ -1245,11 +1244,10 @@ impl Page {
     /// this iterator are valid when used to do anything `unsafe`.
     fn iter_fixed_len_from(&self, fixed_row_size: Size, starting_from: PageOffset) -> FixedLenRowsIter<'_> {
         self.header.fixed.debug_check_fixed_row_size(fixed_row_size);
+        let idx = starting_from / fixed_row_size;
         FixedLenRowsIter {
-            next_row: starting_from,
-            header: &self.header.fixed,
+            idx_iter: self.header.fixed.present_rows.iter_set_from(idx),
             fixed_row_size,
-            rows_traversed_so_far: 0,
         }
     }
 
@@ -1262,7 +1260,11 @@ impl Page {
     /// It is the caller's responsibility to ensure that `PageOffset`s derived from
     /// this iterator are valid when used to do anything `unsafe`.
     pub fn iter_fixed_len(&self, fixed_row_size: Size) -> FixedLenRowsIter<'_> {
-        self.iter_fixed_len_from(fixed_row_size, PageOffset::VAR_LEN_NULL)
+        self.header.fixed.debug_check_fixed_row_size(fixed_row_size);
+        FixedLenRowsIter {
+            idx_iter: self.header.fixed.present_rows.iter_set(),
+            fixed_row_size,
+        }
     }
 
     /// Returns an iterator over all the `VarLenGranule`s of the var-len object
@@ -1604,52 +1606,18 @@ pub struct FixedLenRowsIter<'page> {
     /// The fixed header of the page,
     /// used to determine where the last fixed row is
     /// and whether the fixed row slot is actually a fixed row.
-    header: &'page FixedHeader,
-    /// Location of the next fixed row slot, not necessarily the next row.
-    next_row: PageOffset,
+    idx_iter: IterSet<'page>,
     /// The size of a row in bytes.
     fixed_row_size: Size,
-    /// Stored so we can implement `Iterator::size_hint` efficiently.
-    rows_traversed_so_far: usize,
 }
 
 impl Iterator for FixedLenRowsIter<'_> {
     type Item = PageOffset;
 
     fn next(&mut self) -> Option<Self::Item> {
-        // TODO(perf): can we use the bitmap with count leading zeros (or similar)
-        //       to skip ahead to the next present row?
-        //       `BitVec` does not provide this interface,
-        //       so we'd have to consider alternative crates or roll our own.
-        //
-        //       If `next_row` points to a zero bit in the present? bitvec,
-        //       it should be possible to do some masks and CLZs
-        //       to determine that the next N bits in the bitvec are also zero,
-        //       and thus to skip ahead to the next present row.
-        //
-        //       First step: determine overhead.
-
-        // As long as we haven't reached the high water mark,
-        while self.next_row != self.header.last {
-            // Wish we could do `self.next_row.post_increment(1)`...
-            let this_row = self.next_row;
-            self.next_row += self.fixed_row_size;
-            // If `this_row` is present, i.e. has not been deleted,
-            // return it.
-            // Otherwise, continue the loop to search the next row.
-            if self.header.is_row_present(this_row, self.fixed_row_size) {
-                self.rows_traversed_so_far += 1;
-                return Some(this_row);
-            }
-        }
-
-        // When we reach the high water mark, there are no more rows.
-        None
-    }
-
-    fn size_hint(&self) -> (usize, Option<usize>) {
-        let num_remaining = self.header.num_rows as usize - self.rows_traversed_so_far;
-        (num_remaining, Some(num_remaining))
+        self.idx_iter
+            .next()
+            .map(|idx| PageOffset(idx as u16 * self.fixed_row_size.0))
     }
 }
 

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -996,7 +996,6 @@ impl Table {
 pub(crate) mod test {
     use super::*;
     use crate::blob_store::HashMapBlobStore;
-    use crate::indexes::{PageIndex, PageOffset};
     use proptest::prelude::*;
     use proptest::test_runner::TestCaseResult;
     use spacetimedb_sats::bsatn::to_vec;

--- a/crates/vm/src/rel_ops.rs
+++ b/crates/vm/src/rel_ops.rs
@@ -5,10 +5,6 @@ use spacetimedb_sats::product_value::ProductValue;
 use spacetimedb_sats::relation::{FieldExpr, Header, RowCount};
 use std::sync::Arc;
 
-pub(crate) trait ResultExt<T> {
-    fn unpack_fold(self) -> Result<T, ErrorVm>;
-}
-
 /// A trait for dealing with fallible iterators for the database.
 pub trait RelOps<'a> {
     fn head(&self) -> &Arc<Header>;


### PR DESCRIPTION
# Description of Changes

- Shrinks `present_rows` to only take up 10 bytes. Fixes #1152.
- Drops the `bit-vec` dependency in favor of `FixedBitSet` so we can achieve the above.
- Changes the algorithm of `Page::iter_fixed_len` to use a `trailing_zeros` approach.
  This improves performance of the `iter_read_fixed_len` for all cases significantly (see results below).
- Removes some dead code and addresses lints to make the nightly compiler happier (to pacify `miri`).

Benchmarks as compared to `HEAD~1` (branched master) on i7-7700K, 64GB RAM.

```
iter_read_fixed_len 8_byte/iter_read_fixed_len 8_byte/0.1
                        time:   [1.2453 µs 1.2476 µs 1.2504 µs]
                        thrpt:  [4.9933 GiB/s 5.0044 GiB/s 5.0138 GiB/s]
                 change:
                        time:   [-90.640% -90.594% -90.557%] (p = 0.00 < 0.05)
                        thrpt:  [+958.94% +963.11% +968.42%]
                        Performance has improved.

iter_read_fixed_len 8_byte/iter_read_fixed_len 8_byte/0.25
                        time:   [3.1358 µs 3.1572 µs 3.1847 µs]
                        thrpt:  [4.8825 GiB/s 4.9251 GiB/s 4.9586 GiB/s]
                 change:
                        time:   [-84.648% -84.560% -84.426%] (p = 0.00 < 0.05)
                        thrpt:  [+542.11% +547.68% +551.37%]
                        Performance has improved.

iter_read_fixed_len 8_byte/iter_read_fixed_len 8_byte/0.5
                        time:   [5.4504 µs 5.4618 µs 5.4775 µs]
                        thrpt:  [5.6068 GiB/s 5.6230 GiB/s 5.6347 GiB/s]
                 change:
                        time:   [-84.835% -84.755% -84.652%] (p = 0.00 < 0.05)
                        thrpt:  [+551.56% +555.96% +559.43%]
                        Performance has improved.

iter_read_fixed_len 8_byte/iter_read_fixed_len 8_byte/0.75
                        time:   [7.6559 µs 7.6630 µs 7.6772 µs]
                        thrpt:  [5.9500 GiB/s 5.9610 GiB/s 5.9666 GiB/s]
                 change:
                        time:   [-71.593% -71.571% -71.540%] (p = 0.00 < 0.05)
                        thrpt:  [+251.37% +251.75% +252.03%]
                        Performance has improved.

iter_read_fixed_len 8_byte/iter_read_fixed_len 8_byte/0.9
                        time:   [9.0964 µs 9.1057 µs 9.1182 µs]
                        thrpt:  [6.0172 GiB/s 6.0255 GiB/s 6.0316 GiB/s]
                 change:
                        time:   [-61.702% -61.475% -61.299%] (p = 0.00 < 0.05)
                        thrpt:  [+158.39% +159.57% +161.11%]
                        Performance has improved.

iter_read_fixed_len 8_byte/iter_read_fixed_len 8_byte/1
                        time:   [10.002 µs 10.007 µs 10.012 µs]
                        thrpt:  [6.0903 GiB/s 6.0932 GiB/s 6.0960 GiB/s]
                 change:
                        time:   [-54.012% -53.966% -53.916%] (p = 0.00 < 0.05)
                        thrpt:  [+116.99% +117.23% +117.45%]
                        Performance has improved.

iter_read_fixed_len 32_byte/iter_read_fixed_len 32_byte/0.1
                        time:   [261.06 ns 261.42 ns 261.80 ns]
                        thrpt:  [24.816 GiB/s 24.853 GiB/s 24.887 GiB/s]
                 change:
                        time:   [-90.917% -90.870% -90.838%] (p = 0.00 < 0.05)
                        thrpt:  [+991.51% +995.34% +1001.0%]
                        Performance has improved.

iter_read_fixed_len 32_byte/iter_read_fixed_len 32_byte/0.25
                        time:   [757.95 ns 758.98 ns 760.35 ns]
                        thrpt:  [20.813 GiB/s 20.850 GiB/s 20.879 GiB/s]
                 change:
                        time:   [-74.311% -74.261% -74.208%] (p = 0.00 < 0.05)
                        thrpt:  [+287.72% +288.51% +289.27%]
                        Performance has improved.

iter_read_fixed_len 32_byte/iter_read_fixed_len 32_byte/0.5
                        time:   [1.3360 µs 1.3364 µs 1.3368 µs]
                        thrpt:  [22.628 GiB/s 22.636 GiB/s 22.642 GiB/s]
                 change:
                        time:   [-61.588% -61.510% -61.409%] (p = 0.00 < 0.05)
                        thrpt:  [+159.13% +159.81% +160.33%]
                        Performance has improved.
                        
iter_read_fixed_len 32_byte/iter_read_fixed_len 32_byte/0.75
                        time:   [1.9166 µs 1.9174 µs 1.9183 µs]
                        thrpt:  [23.800 GiB/s 23.812 GiB/s 23.822 GiB/s]
                 change:
                        time:   [-50.428% -50.281% -50.131%] (p = 0.00 < 0.05)
                        thrpt:  [+100.53% +101.13% +101.73%]
                        Performance has improved.
                        
iter_read_fixed_len 32_byte/iter_read_fixed_len 32_byte/0.9
                        time:   [2.2676 µs 2.2698 µs 2.2735 µs]
                        thrpt:  [24.133 GiB/s 24.173 GiB/s 24.196 GiB/s]
                 change:
                        time:   [-46.345% -46.272% -46.199%] (p = 0.00 < 0.05)
                        thrpt:  [+85.870% +86.123% +86.375%]
                        Performance has improved.
                        
iter_read_fixed_len 32_byte/iter_read_fixed_len 32_byte/1
                        time:   [2.4979 µs 2.4998 µs 2.5028 µs]
                        thrpt:  [24.363 GiB/s 24.392 GiB/s 24.410 GiB/s]
                 change:
                        time:   [-39.172% -39.109% -39.052%] (p = 0.00 < 0.05)
                        thrpt:  [+64.074% +64.227% +64.397%]
                        Performance has improved.
                        

iter_read_fixed_len 256_byte/iter_read_fixed_len 256_byte/0.1
                        time:   [31.214 ns 31.237 ns 31.264 ns]
                        thrpt:  [175.40 GiB/s 175.55 GiB/s 175.68 GiB/s]
                 change:
                        time:   [-89.765% -89.756% -89.747%] (p = 0.00 < 0.05)
                        thrpt:  [+875.28% +876.16% +877.00%]
                        Performance has improved.
                        
iter_read_fixed_len 256_byte/iter_read_fixed_len 256_byte/0.25
                        time:   [67.296 ns 67.340 ns 67.424 ns]
                        thrpt:  [194.49 GiB/s 194.73 GiB/s 194.85 GiB/s]
                 change:
                        time:   [-79.814% -79.798% -79.777%] (p = 0.00 < 0.05)
                        thrpt:  [+394.50% +395.00% +395.38%]
                        Performance has improved.
                        
iter_read_fixed_len 256_byte/iter_read_fixed_len 256_byte/0.5
                        time:   [163.99 ns 164.26 ns 164.56 ns]
                        thrpt:  [188.35 GiB/s 188.69 GiB/s 189.00 GiB/s]
                 change:
                        time:   [-58.921% -58.858% -58.791%] (p = 0.00 < 0.05)
                        thrpt:  [+142.66% +143.06% +143.44%]
                        Performance has improved.
iter_read_fixed_len 256_byte/iter_read_fixed_len 256_byte/0.75
                        time:   [247.31 ns 247.47 ns 247.78 ns]
                        thrpt:  [189.56 GiB/s 189.80 GiB/s 189.92 GiB/s]
                 change:
                        time:   [-46.170% -46.134% -46.080%] (p = 0.00 < 0.05)
                        thrpt:  [+85.460% +85.645% +85.770%]
                        Performance has improved.
                        
iter_read_fixed_len 256_byte/iter_read_fixed_len 256_byte/0.9
                        time:   [293.82 ns 294.04 ns 294.30 ns]
                        thrpt:  [187.95 GiB/s 188.11 GiB/s 188.25 GiB/s]
                 change:
                        time:   [-40.039% -39.889% -39.644%] (p = 0.00 < 0.05)
                        thrpt:  [+65.685% +66.358% +66.776%]
                        Performance has improved.
                        
iter_read_fixed_len 256_byte/iter_read_fixed_len 256_byte/1
                        time:   [318.79 ns 319.17 ns 319.92 ns]
                        thrpt:  [190.04 GiB/s 190.49 GiB/s 190.71 GiB/s]
                 change:
                        time:   [-38.455% -38.353% -38.268%] (p = 0.00 < 0.05)
                        thrpt:  [+61.991% +62.213% +62.482%]
                        Performance has improved.
```

# API and ABI breaking changes

None

# Expected complexity level and risk

2, contained changes, but some unsafe included.

# Testing

Proptests are included and they have been run in miri