### PR TITLE
Add `Hash for RowRef` + make it consistent with `Hash for PV`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3929,6 +3929,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
 
 [[package]]
+name = "second-stack"
+version = "0.3.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4904c83c6e51f1b9b08bfa5a86f35a51798e8307186e6f5513852210a219c0bb"
+
+[[package]]
 name = "security-framework"
 version = "2.9.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4653,6 +4659,7 @@ dependencies = [
  "proptest",
  "proptest-derive",
  "rand 0.8.5",
+ "second-stack",
  "serde",
  "sha3",
  "smallvec",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -187,6 +187,7 @@ rustc-hash = "1.1.0"
 rustyline = { version = "12.0.0", features = [] }
 scoped-tls = "1.0.1"
 scopeguard = "1.1.0"
+second-stack = "0.3"
 sendgrid = "0.21"
 serde = "1.0.136"
 serde_json = { version = "1.0.87", features = ["raw_value"] }

--- a/crates/bench/benches/special.rs
+++ b/crates/bench/benches/special.rs
@@ -97,7 +97,13 @@ fn serialize_benchmarks<T: BenchTable + RandomTable>(c: &mut Criterion) {
     let ptrs = data_pv
         .elements
         .iter()
-        .map(|row| table.insert(&mut blob_store, row.as_product().unwrap()).unwrap().1)
+        .map(|row| {
+            table
+                .insert(&mut blob_store, row.as_product().unwrap())
+                .unwrap()
+                .1
+                .pointer()
+        })
         .collect::<Vec<_>>();
     let refs = ptrs
         .into_iter()

--- a/crates/sats/Cargo.toml
+++ b/crates/sats/Cargo.toml
@@ -29,6 +29,7 @@ itertools.workspace = true
 proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 sha3.workspace = true
+second-stack.workspace = true
 serde = { workspace = true, optional = true }
 smallvec.workspace = true
 thiserror.workspace = true

--- a/crates/table/Cargo.toml
+++ b/crates/table/Cargo.toml
@@ -48,6 +48,7 @@ proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
+spacetimedb-sats = { workspace = true, features = ["proptest"] }
 criterion.workspace = true
 proptest.workspace = true
 proptest-derive.workspace = true

--- a/crates/table/benches/page.rs
+++ b/crates/table/benches/page.rs
@@ -770,7 +770,15 @@ fn hash_in_page(c: &mut Criterion) {
         group.bench_function(name, |b| {
             let mut hasher = RowHash::hasher_builder().build_hasher();
             b.iter(|| {
-                unsafe { hash_row_in_page(&mut hasher, black_box(&page), black_box(offset), black_box(&ty)) };
+                unsafe {
+                    hash_row_in_page(
+                        &mut hasher,
+                        black_box(&page),
+                        black_box(&NullBlobStore),
+                        black_box(offset),
+                        black_box(&ty),
+                    )
+                };
                 black_box(&mut hasher);
             });
         });

--- a/crates/table/proptest-regressions/row_hash.txt
+++ b/crates/table/proptest-regressions/row_hash.txt
@@ -1,0 +1,8 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 3e55b94365a0ae7698bb9e89259f3f5b84227b1c5ba2f0737be0360f55256c26 # shrinks to (ty, val) = (ProductType { elements: [ProductTypeElement { name: None, algebraic_type: Sum(SumType { variants: [SumTypeVariant { name: None, algebraic_type: Builtin(Bool) }] }) }] }, ProductValue { elements: [Sum(SumValue { tag: 0, value: Bool(false) })] })
+cc aedcfc0fa45005cb11fa8b47f668a8b68c99adadfb50fdc6219840aa8ffd83f6 # shrinks to (ty, val) = (ProductType { elements: [ProductTypeElement { name: None, algebraic_type: Sum(SumType { variants: [SumTypeVariant { name: None, algebraic_type: Builtin(I32) }, SumTypeVariant { name: None, algebraic_type: Builtin(F64) }, SumTypeVariant { name: None, algebraic_type: Builtin(String) }, SumTypeVariant { name: None, algebraic_type: Builtin(U16) }, SumTypeVariant { name: None, algebraic_type: Builtin(U16) }, SumTypeVariant { name: None, algebraic_type: Builtin(String) }, SumTypeVariant { name: None, algebraic_type: Builtin(Bool) }, SumTypeVariant { name: None, algebraic_type: Builtin(I16) }, SumTypeVariant { name: None, algebraic_type: Builtin(I16) }, SumTypeVariant { name: None, algebraic_type: Builtin(I64) }, SumTypeVariant { name: None, algebraic_type: Builtin(I128) }, SumTypeVariant { name: None, algebraic_type: Builtin(U64) }] }) }] }, ProductValue { elements: [Sum(SumValue { tag: 2, value: String("יּ/Ⱥ🂠છrÔ") })] })

--- a/crates/table/src/bflatn_from.rs
+++ b/crates/table/src/bflatn_from.rs
@@ -305,7 +305,7 @@ unsafe fn serialize_bsatn<S: Serializer>(
     let vlr = unsafe { read_from_bytes::<VarLenRef>(bytes, curr_offset) };
 
     if vlr.is_large_blob() {
-        // SAFETY: As `vlr` a blob, `vlr.first_granule` always points to a valid granule.
+        // SAFETY: As `vlr` is a blob, `vlr.first_granule` always points to a valid granule.
         let blob = unsafe { vlr_blob_bytes(page, blob_store, vlr) };
         // SAFETY: The BSATN in `blob` is encoded from an `AlgebraicValue`.
         unsafe { ser.serialize_bsatn(ty, blob) }

--- a/crates/table/src/bflatn_to_bsatn_fast_path.rs
+++ b/crates/table/src/bflatn_to_bsatn_fast_path.rs
@@ -26,8 +26,9 @@ use crate::{
         AlgebraicTypeLayout, HasLayout, PrimitiveType, ProductTypeElementLayout, ProductTypeLayout, RowTypeLayout,
         SumTypeLayout, SumTypeVariantLayout,
     },
-    util::{range_move, slice_assume_init_ref},
+    util::range_move,
 };
+use spacetimedb_sats::algebraic_value::ser::slice_assume_init_ref;
 
 /// A precomputed BSATN layout for a type whose encoded length is a known constant,
 /// enabling fast BFLATN -> BSATN conversion.
@@ -482,13 +483,13 @@ mod test {
                 return Err(TestCaseError::reject("Var-length type"));
             };
 
-            let (_, ptr) = table.insert(&mut blob_store, &val).unwrap();
+            let size = table.row_layout().size();
+            let (_, row_ref) = table.insert(&mut blob_store, &val).unwrap();
 
-            let row_ref = table.get_row_ref(&blob_store, ptr).unwrap();
             let slow_path = bsatn::to_vec(&row_ref).unwrap();
 
             let (page, offset) = row_ref.page_and_offset();
-            let bytes = page.get_row_data(offset, table.row_layout().size());
+            let bytes = page.get_row_data(offset, size);
 
             let mut fast_path = vec![0u8; bsatn_layout.bsatn_length as usize];
             unsafe {

--- a/crates/table/src/btree_index.rs
+++ b/crates/table/src/btree_index.rs
@@ -496,8 +496,7 @@ mod test {
             let mut index = new_index(&ty, &cols, is_unique);
             let mut table = table(ty);
             let mut blob_store = HashMapBlobStore::default();
-            let ptr = table.insert(&mut blob_store, &pv).unwrap().1;
-            let row_ref = table.get_row_ref(&blob_store, ptr).unwrap();
+            let row_ref = table.insert(&mut blob_store, &pv).unwrap().1;
             prop_assert_eq!(index.delete(&cols, row_ref).unwrap(), false);
             prop_assert!(index.idx.is_empty());
         }
@@ -507,8 +506,7 @@ mod test {
             let mut index = new_index(&ty, &cols, is_unique);
             let mut table = table(ty);
             let mut blob_store = HashMapBlobStore::default();
-            let ptr = table.insert(&mut blob_store, &pv).unwrap().1;
-            let row_ref = table.get_row_ref(&blob_store, ptr).unwrap();
+            let row_ref = table.insert(&mut blob_store, &pv).unwrap().1;
             let value = get_fields(&cols, &pv);
 
             prop_assert_eq!(index.idx.len(), 0);
@@ -528,8 +526,7 @@ mod test {
             let mut index = new_index(&ty, &cols, true);
             let mut table = table(ty);
             let mut blob_store = HashMapBlobStore::default();
-            let ptr = table.insert(&mut blob_store, &pv).unwrap().1;
-            let row_ref = table.get_row_ref(&blob_store, ptr).unwrap();
+            let row_ref = table.insert(&mut blob_store, &pv).unwrap().1;
             let value = get_fields(&cols, &pv);
 
             // Nothing in the index yet.
@@ -548,7 +545,7 @@ mod test {
             prop_assert_eq!(violates_unique_constraint(&index, &cols, &pv), true);
             prop_assert_eq!(
                 index.get_rows_that_violate_unique_constraint(&value).unwrap().collect::<Vec<_>>(),
-                [ptr]
+                [row_ref.pointer()]
             );
         }
 
@@ -571,9 +568,8 @@ mod test {
             // Insert `prev`, `needle`, and `next`.
             for x in range.clone() {
                 let row = product![x];
-                let ptr = table.insert(&mut blob_store, &row).unwrap().1;
-                val_to_ptr.insert(x, ptr);
-                let row_ref = table.get_row_ref(&blob_store, ptr).unwrap();
+                let row_ref = table.insert(&mut blob_store, &row).unwrap().1;
+                val_to_ptr.insert(x, row_ref.pointer());
                 index.insert(&cols, row_ref).unwrap();
             }
 

--- a/crates/table/src/eq.rs
+++ b/crates/table/src/eq.rs
@@ -8,9 +8,10 @@ use super::{
     layout::{align_to, AlgebraicTypeLayout, HasLayout, ProductTypeLayout, RowTypeLayout},
     page::Page,
     row_hash::read_from_bytes,
-    util::{range_move, slice_assume_init_ref},
+    util::range_move,
     var_len::VarLenRef,
 };
+use spacetimedb_sats::algebraic_value::ser::slice_assume_init_ref;
 
 /// Equates row `a` in `page_a` with its fixed part starting at `fixed_offset_a`
 /// to row `b` in `page_b` with its fixed part starting at `fixed_offset_b`.

--- a/crates/table/src/page.rs
+++ b/crates/table/src/page.rs
@@ -1693,12 +1693,10 @@ impl<'page> Iterator for VarLenGranulesIter<'page> {
 mod tests {
     use super::*;
     use crate::{
-        blob_store::NullBlobStore,
-        layout::row_size_for_type,
-        util::{slice_assume_init_ref, uninit_array},
-        var_len::AlignedVarLenOffsets,
+        blob_store::NullBlobStore, layout::row_size_for_type, util::uninit_array, var_len::AlignedVarLenOffsets,
     };
     use proptest::{collection::vec, prelude::*};
+    use spacetimedb_sats::algebraic_value::ser::slice_assume_init_ref;
     use std::slice::from_raw_parts;
 
     fn as_uninit(slice: &[u8]) -> &Bytes {

--- a/crates/table/src/read_column.rs
+++ b/crates/table/src/read_column.rs
@@ -8,10 +8,12 @@ use crate::{
     indexes::{PageOffset, Size},
     layout::{AlgebraicTypeLayout, PrimitiveType, ProductTypeElementLayout, VarLenType},
     table::RowRef,
-    util::slice_assume_init_ref,
 };
 use spacetimedb_sats::{
-    algebraic_value::{ser::ValueSerializer, Packed},
+    algebraic_value::{
+        ser::{slice_assume_init_ref, ValueSerializer},
+        Packed,
+    },
     AlgebraicType, AlgebraicValue, ArrayValue, MapValue, ProductType, ProductValue, SumValue,
 };
 use std::{cell::Cell, mem};
@@ -370,9 +372,7 @@ mod test {
             let mut blob_store = HashMapBlobStore::default();
             let mut table = table(ty);
 
-            let (_, ptr) = table.insert(&mut blob_store, &val).unwrap();
-
-            let row_ref = table.get_row_ref(&blob_store, ptr).unwrap();
+            let (_, row_ref) = table.insert(&mut blob_store, &val).unwrap();
 
             for (idx, orig_col_value) in val.into_iter().enumerate() {
                 let read_col_value = row_ref.read_col::<AlgebraicValue>(idx).unwrap();
@@ -388,9 +388,7 @@ mod test {
             let mut blob_store = HashMapBlobStore::default();
             let mut table = table(ty.clone());
 
-            let (_, ptr) = table.insert(&mut blob_store, &val).unwrap();
-
-            let row_ref = table.get_row_ref(&blob_store, ptr).unwrap();
+            let (_, row_ref) = table.insert(&mut blob_store, &val).unwrap();
 
             for (idx, col_ty) in ty.elements.iter().enumerate() {
                 assert_wrong_type_error::<u8>(row_ref, idx, &col_ty.algebraic_type, AlgebraicType::U8)?;
@@ -418,9 +416,7 @@ mod test {
             let mut blob_store = HashMapBlobStore::default();
             let mut table = table(ty.clone());
 
-            let (_, ptr) = table.insert(&mut blob_store, &val).unwrap();
-
-            let row_ref = table.get_row_ref(&blob_store, ptr).unwrap();
+            let (_, row_ref) = table.insert(&mut blob_store, &val).unwrap();
 
             let oob = ty.elements.len();
 
@@ -478,8 +474,7 @@ mod test {
                 let mut table = table(ProductType::from_iter([$algebraic_type]));
 
                 let val: $rust_type = $val;
-                let (_, ptr) = table.insert(&mut blob_store, &product![val.clone()]).unwrap();
-                let row_ref = table.get_row_ref(&blob_store, ptr).unwrap();
+                let (_, row_ref) = table.insert(&mut blob_store, &product![val.clone()]).unwrap();
 
                 assert_eq!(val, row_ref.read_col::<$rust_type>(0).unwrap());
             }

--- a/crates/table/src/row_hash.rs
+++ b/crates/table/src/row_hash.rs
@@ -9,9 +9,11 @@ use super::{
     page::Page,
     var_len::VarLenRef,
 };
+use crate::{bflatn_from::vlr_blob_bytes, blob_store::BlobStore, layout::VarLenType};
 use core::hash::{Hash as _, Hasher};
 use core::mem;
-use spacetimedb_sats::{F32, F64};
+use core::str;
+use spacetimedb_sats::{algebraic_value::ser::concat_byte_chunks_buf, bsatn::Deserializer, F32, F64};
 
 /// Hashes the row in `page` where the fixed part starts at `fixed_offset`
 /// and lasts `ty.size()` bytes. This region is typed at `ty`.
@@ -25,14 +27,20 @@ use spacetimedb_sats::{F32, F64};
 /// 2. the row must be a valid `ty`.
 /// 3. for any `vlr: VarLenRef` stored in the row,
 ///   `vlr.first_offset` must either be `NULL` or point to a valid granule in `page`.
-pub unsafe fn hash_row_in_page(hasher: &mut impl Hasher, page: &Page, fixed_offset: PageOffset, ty: &RowTypeLayout) {
+pub unsafe fn hash_row_in_page(
+    hasher: &mut impl Hasher,
+    page: &Page,
+    blob_store: &dyn BlobStore,
+    fixed_offset: PageOffset,
+    ty: &RowTypeLayout,
+) {
     let fixed_bytes = page.get_row_data(fixed_offset, ty.size());
 
     // SAFETY:
     // - Per 1. and 2., `fixed_bytes` points at a row in `page` valid for `ty`.
     // - Per 3., for any `vlr: VarLenRef` stored in `fixed_bytes`,
     //   `vlr.first_offset` is either `NULL` or points to a valid granule in `page`.
-    unsafe { hash_product(hasher, fixed_bytes, page, &mut 0, ty.product()) };
+    unsafe { hash_product(hasher, fixed_bytes, page, blob_store, &mut 0, ty.product()) };
 }
 
 /// Hashes every product field in `value = &bytes[range_move(0..ty.size(), *curr_offset)]`
@@ -46,6 +54,7 @@ unsafe fn hash_product(
     hasher: &mut impl Hasher,
     bytes: &Bytes,
     page: &Page,
+    blob_store: &dyn BlobStore,
     curr_offset: &mut usize,
     ty: &ProductTypeLayout,
 ) {
@@ -58,7 +67,7 @@ unsafe fn hash_product(
         // are valid `elem_ty.ty`s.
         // By 2., and the above, it follows that sub-`value`s won't have dangling `VarLenRef`s.
         unsafe {
-            hash_value(hasher, bytes, page, curr_offset, &elem_ty.ty);
+            hash_value(hasher, bytes, page, blob_store, curr_offset, &elem_ty.ty);
         }
     }
 }
@@ -74,6 +83,7 @@ unsafe fn hash_value(
     hasher: &mut impl Hasher,
     bytes: &Bytes,
     page: &Page,
+    blob_store: &dyn BlobStore,
     curr_offset: &mut usize,
     ty: &AlgebraicTypeLayout,
 ) {
@@ -87,9 +97,10 @@ unsafe fn hash_value(
 
     match ty {
         AlgebraicTypeLayout::Sum(ty) => {
-            // Read the tag of the sum value.
+            // Read and hash the tag of the sum value.
             // SAFETY: `bytes[curr_offset..]` hold a sum value at `ty`.
             let (tag, data_ty) = unsafe { read_tag(bytes, ty, *curr_offset) };
+            tag.hash(hasher);
 
             // Hash the variant data value.
             let mut data_offset = *curr_offset + ty.offset_of_variant_data(tag);
@@ -97,12 +108,12 @@ unsafe fn hash_value(
             // we know `data_value = &bytes[range_move(0..data_ty.size(), data_offset))`
             // is valid at `data_ty`.
             // By 2., and the above, we also know that `data_value` won't have dangling `VarLenRef`s.
-            unsafe { hash_value(hasher, bytes, page, &mut data_offset, data_ty) };
+            unsafe { hash_value(hasher, bytes, page, blob_store, &mut data_offset, data_ty) };
             *curr_offset += ty.size();
         }
         AlgebraicTypeLayout::Product(ty) => {
             // SAFETY: `value` was valid at `ty` and `VarLenRef`s won't be dangling.
-            unsafe { hash_product(hasher, bytes, page, curr_offset, ty) }
+            unsafe { hash_product(hasher, bytes, page, blob_store, curr_offset, ty) }
         }
 
         // The primitive types:
@@ -147,35 +158,67 @@ unsafe fn hash_value(
         }
 
         // The var-len cases.
-        &AlgebraicTypeLayout::String | AlgebraicTypeLayout::VarLen(_) => {
+        &AlgebraicTypeLayout::String => {
             // SAFETY: `value` was valid at and aligned for `ty`.
             // These `ty` store a `vlr: VarLenRef` as their value,
             // so the range is valid and properly aligned for `VarLenRef`.
             // Moreover, `vlr.first_granule` was promised by the caller
             // to either be `NULL` or point to a valid granule in `page`.
-            unsafe { hash_vlo(hasher, page, bytes, curr_offset) }
+            unsafe {
+                run_vlo_bytes(page, bytes, blob_store, curr_offset, |bytes| {
+                    // SAFETY: For `::String`, the blob will always be valid UTF-8.
+                    let string = str::from_utf8_unchecked(bytes);
+                    string.hash(hasher)
+                });
+            }
+        }
+        AlgebraicTypeLayout::VarLen(VarLenType::Array(ty) | VarLenType::Map(ty)) => {
+            // SAFETY: `value` was valid at and aligned for `ty`.
+            // These `ty` store a `vlr: VarLenRef` as their value,
+            // so the range is valid and properly aligned for `VarLenRef`.
+            // Moreover, `vlr.first_granule` was promised by the caller
+            // to either be `NULL` or point to a valid granule in `page`.
+            unsafe {
+                run_vlo_bytes(page, bytes, blob_store, curr_offset, |mut bsatn| {
+                    let de = Deserializer::new(&mut bsatn);
+                    spacetimedb_sats::hash_bsatn(hasher, ty, de).unwrap();
+                });
+            }
         }
     }
 }
 
-/// Hashes the bytes of a var-len object
+/// Runs the function `run` on the concatenated bytes of a var-len object,
 /// referred to at by the var-len reference at `curr_offset`
 /// which is then advanced.
-///
-/// The function does not care about large-blob-ness.
-/// Rather, the blob hash is implicitly hashed.
 ///
 /// SAFETY: `data = bytes[range_move(0..size_of::<VarLenRef>(), *curr_offset)]`
 /// must be a valid `vlr = VarLenRef` and `&data` must be properly aligned for a `VarLenRef`.
 /// The `vlr.first_granule` must be `NULL` or must point to a valid granule in `page`.
-unsafe fn hash_vlo(hasher: &mut impl Hasher, page: &Page, bytes: &Bytes, curr_offset: &mut usize) {
-    // SAFETY: We have a valid `VarLenRef` at `&data`.
+unsafe fn run_vlo_bytes(
+    page: &Page,
+    bytes: &Bytes,
+    blob_store: &dyn BlobStore,
+    curr_offset: &mut usize,
+    run: impl FnOnce(&[u8]),
+) {
+    // SAFETY: `value` was valid at and aligned for `ty`.
+    // These `ty` store a `vlr: VarLenRef` as their fixed value.
+    // The range thus is valid and properly aligned for `VarLenRef`.
     let vlr = unsafe { read_from_bytes::<VarLenRef>(bytes, curr_offset) };
-    // SAFETY: ^-- got valid `VarLenRef` where `vlr.first_granule` was `NULL`
-    // or a pointer to a valid starting granule, as required.
-    for data in unsafe { page.iter_vlo_data(vlr.first_granule) } {
-        hasher.write(data);
-    }
+
+    if vlr.is_large_blob() {
+        // SAFETY: As `vlr` is a blob, `vlr.first_granule` always points to a valid granule.
+        let bytes = unsafe { vlr_blob_bytes(page, blob_store, vlr) };
+        run(bytes)
+    } else {
+        // SAFETY: `vlr.first_granule` is either NULL or points to a valid granule.
+        let var_iter = unsafe { page.iter_vlo_data(vlr.first_granule) };
+        let total_len = vlr.length_in_bytes as usize;
+
+        // SAFETY: `total_len == var_iter.map(|c| c.len()).sum()`.
+        unsafe { concat_byte_chunks_buf(total_len, var_iter, run) };
+    };
 }
 
 /// Read a `T` from `bytes` at the `curr_offset` and advance by `size` bytes.
@@ -192,4 +235,39 @@ pub unsafe fn read_from_bytes<T: Copy>(bytes: &Bytes, curr_offset: &mut usize) -
     // SAFETY: Caller promised that `ptr` points to a `T`.
     // Moreover, `ptr` is derived from a shared reference with permission to read this range.
     unsafe { *ptr }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::blob_store::HashMapBlobStore;
+    use core::hash::BuildHasher;
+    use proptest::prelude::*;
+    use spacetimedb_sats::proptest::generate_typed_row;
+
+    proptest! {
+        #![proptest_config(ProptestConfig::with_cases(2048))]
+        #[test]
+        fn pv_row_ref_hash_same_std_random_state((ty, val) in generate_typed_row()) {
+            // Turn `val` into a `RowRef`.
+            let mut table = crate::table::test::table(ty);
+            let blob_store = &mut HashMapBlobStore::default();
+            let (_, row) = table.insert(blob_store, &val).unwrap();
+
+            // Check hashing algos.
+            let rs = std::hash::RandomState::new();
+            prop_assert_eq!(rs.hash_one(&val), rs.hash_one(row));
+        }
+
+        #[test]
+        fn pv_row_ref_hash_same_ahash((ty, val) in generate_typed_row()) {
+            // Turn `val` into a `RowRef`.
+            let blob_store = &mut HashMapBlobStore::default();
+            let mut table = crate::table::test::table(ty);
+            let (_, row) = table.insert(blob_store, &val).unwrap();
+
+            // Check hashing algos.
+            let rs = std::hash::RandomState::new();
+            prop_assert_eq!(rs.hash_one(&val), rs.hash_one(row));
+        }
+    }
 }

--- a/crates/table/src/util.rs
+++ b/crates/table/src/util.rs
@@ -24,20 +24,6 @@ pub fn maybe_uninit_write_slice<T: Copy>(this: &mut [MaybeUninit<T>], src: &[T])
     this[0..uninit_src.len()].copy_from_slice(uninit_src);
 }
 
-/// Convert a `[MaybeUninit<T>]` into a `[T]` by asserting all elements are initialized.
-///
-/// Identitcal copy of the source of `MaybeUninit::slice_assume_init_ref`, but that's not stabilized.
-/// https://doc.rust-lang.org/std/mem/union.MaybeUninit.html#method.slice_assume_init_ref
-///
-/// SAFETY: all elements of `slice` must be initialized.
-pub const unsafe fn slice_assume_init_ref<T>(slice: &[MaybeUninit<T>]) -> &[T] {
-    // SAFETY: casting `slice` to a `*const [T]` is safe since the caller guarantees that
-    // `slice` is initialized, and `MaybeUninit` is guaranteed to have the same layout as `T`.
-    // The pointer obtained is valid since it refers to memory owned by `slice` which is a
-    // reference and thus guaranteed to be valid for reads.
-    unsafe { &*(slice as *const [MaybeUninit<T>] as *const [T]) }
-}
-
 /// Asserts that `$ty` is `$size` bytes in `static_assert_size($ty, $size)`.
 ///
 /// Example:

--- a/crates/table/src/var_len.rs
+++ b/crates/table/src/var_len.rs
@@ -33,12 +33,12 @@
 use super::{
     blob_store::BlobHash,
     indexes::{Byte, Bytes, PageOffset, Size},
-    util::slice_assume_init_ref,
 };
 use crate::{static_assert_align, static_assert_size};
 use core::iter;
 use core::marker::PhantomData;
 use core::mem::{self, MaybeUninit};
+use spacetimedb_sats::algebraic_value::ser::slice_assume_init_ref;
 
 /// Reference to var-len object within a page.
 // TODO: make this larger and do short-string optimization?


### PR DESCRIPTION
# Description of Changes
1. Add `Hash for RowRef` + make it consistent with `Hash for ProductValue`. 
2. Make `RowRef::row_hash` use the above.
3. Make `Table::insert` return a `RowRef`.
4. Use less unsafe because of 1-3.
5. Use `second-stack` to reuse temporary allocations in hashing and serialization.

Fixes https://github.com/clockworklabs/SpacetimeDB/pull/1107.

# API and ABI breaking changes

None

# Expected complexity level and risk

3, some unsafe involved and we need to ensure consistency in the eq/hash functions.
Some unsafe code is also removed.

# Testing

Proptests are added for the new code.