### PR TITLE
CLI - Small refactors to identity code

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -1,4 +1,4 @@
-use crate::util::{contains_protocol, host_or_url_to_host_and_protocol};
+use crate::util::{contains_protocol, host_or_url_to_host_and_protocol, is_hex_identity};
 use anyhow::Context;
 use jsonwebtoken::DecodingKey;
 use serde::{Deserialize, Serialize};
@@ -884,13 +884,22 @@ Import an existing identity with:
         })
     }
 
-    pub fn name_exists(&self, nickname: &str) -> bool {
-        for name in self.identity_configs().iter().map(|c| &c.nickname) {
-            if name.as_ref() == Some(&nickname.to_string()) {
-                return true;
-            }
+    pub fn name_exists(&self, name: &str) -> bool {
+        self.get_identity_config_by_name(name).is_some()
+    }
+
+    pub fn identity_exists(&self, identity: &Identity) -> bool {
+        self.get_identity_config_by_identity(identity).is_some()
+    }
+
+    pub fn can_set_name(&self, new_nickname: &str) -> Result<(), anyhow::Error> {
+        if self.name_exists(new_nickname) {
+            return Err(anyhow::anyhow!("An identity with that name already exists."));
         }
-        false
+        if is_hex_identity(new_nickname) {
+            return Err(anyhow::anyhow!("An identity name cannot be an identity."));
+        }
+        Ok(())
     }
 
     pub fn get_identity_config_by_name(&self, name: &str) -> Option<&IdentityConfig> {


### PR DESCRIPTION
# Description of Changes

Small refactors to some CLI code around identity management, to make review for https://github.com/clockworklabs/SpacetimeDB/pull/1140 easier.

These changes **do not change any behavior**.

- `Config.name_exists` now just uses `Config.get_identity_config_by_name`
- Added `Config.identity_exists` for parity (currently unused, used in https://github.com/clockworklabs/SpacetimeDB/pull/1140)
- Added `Config.can_set_name` (just used in one place, used more in https://github.com/clockworklabs/SpacetimeDB/pull/1140)

# API and ABI breaking changes
No

# Expected complexity level and risk
1

# Testing
- [x] Existing CLI tests