### PR TITLE
fix(1170): Use scope guard to decrement reducer queue length

### DIFF
--- a/crates/core/src/util/lending_pool.rs
+++ b/crates/core/src/util/lending_pool.rs
@@ -12,7 +12,7 @@ use parking_lot::Mutex;
 use spacetimedb_lib::Address;
 use tokio::sync::{OwnedSemaphorePermit, Semaphore};
 
-use crate::worker_metrics::{MAX_QUEUE_LEN, WORKER_METRICS};
+use crate::worker_metrics::WORKER_METRICS;
 
 use super::notify_once::{NotifiedOnce, NotifyOnce};
 
@@ -49,6 +49,35 @@ struct PoolVec<T> {
 #[derive(Debug)]
 pub struct PoolClosed;
 
+/// A scope guard for the reducer queue length metric,
+/// ensuring an increment is always be paired with one and only one decrement.
+struct QueueMetric {
+    db: Address,
+}
+
+impl Drop for QueueMetric {
+    fn drop(&mut self) {
+        WORKER_METRICS.instance_queue_length.with_label_values(&self.db).dec();
+        let queue_length = WORKER_METRICS.instance_queue_length.with_label_values(&self.db).get();
+        WORKER_METRICS
+            .instance_queue_length_histogram
+            .with_label_values(&self.db)
+            .observe(queue_length as f64);
+    }
+}
+
+impl QueueMetric {
+    fn inc(db: Address) -> Self {
+        WORKER_METRICS.instance_queue_length.with_label_values(&db).inc();
+        let queue_length = WORKER_METRICS.instance_queue_length.with_label_values(&db).get();
+        WORKER_METRICS
+            .instance_queue_length_histogram
+            .with_label_values(&db)
+            .observe(queue_length as f64);
+        Self { db }
+    }
+}
+
 impl<T> LendingPool<T> {
     pub fn new() -> Self {
         Self::from_iter(std::iter::empty())
@@ -58,31 +87,9 @@ impl<T> LendingPool<T> {
         let acq = self.sem.clone().acquire_owned();
         let pool_inner = self.inner.clone();
 
-        let queue_len = WORKER_METRICS.instance_queue_length.with_label_values(&db);
-        let queue_len_max = WORKER_METRICS.instance_queue_length_max.with_label_values(&db);
-        let queue_len_histogram = WORKER_METRICS.instance_queue_length_histogram.with_label_values(&db);
-
-        queue_len.inc();
-        let new_queue_len = queue_len.get();
-        queue_len_histogram.observe(new_queue_len as f64);
-
-        let mut guard = MAX_QUEUE_LEN.lock().unwrap();
-        let max_queue_len = *guard
-            .entry(db)
-            .and_modify(|max| {
-                if new_queue_len > *max {
-                    *max = new_queue_len;
-                }
-            })
-            .or_insert_with(|| new_queue_len);
-
-        drop(guard);
-        queue_len_max.set(max_queue_len);
-
         async move {
+            let _guard = QueueMetric::inc(db);
             let permit = acq.await.map_err(|_| PoolClosed)?;
-            queue_len.dec();
-            queue_len_histogram.observe(queue_len.get() as f64);
             let resource = pool_inner
                 .vec
                 .lock()

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -54,15 +54,10 @@ metrics_group!(
         #[labels(database_address: Address)]
         pub instance_queue_length: IntGaugeVec,
 
-        #[name = spacetime_worker_instance_operation_queue_length_max]
-        #[help = "Max length of the wait queue for access to a module instance."]
-        #[labels(database_address: Address)]
-        pub instance_queue_length_max: IntGaugeVec,
-
         #[name = spacetime_worker_instance_operation_queue_length_histogram]
         #[help = "Length of the wait queue for access to a module instance."]
         #[labels(database_address: Address)]
-        #[buckets(0, 1, 2, 3, 4, 5, 6, 7, 8, 9, 10, 15, 25, 50)]
+        #[buckets(0, 10, 25, 50, 75, 100, 150, 200, 250, 300, 350, 400, 450, 500, 1000)]
         pub instance_queue_length_histogram: HistogramVec,
 
         #[name = spacetime_scheduled_reducer_delay_sec]
@@ -102,14 +97,10 @@ metrics_group!(
 
 type ReducerLabel = (Address, String);
 
-pub static MAX_QUEUE_LEN: Lazy<Mutex<HashMap<Address, i64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 pub static MAX_REDUCER_DELAY: Lazy<Mutex<HashMap<ReducerLabel, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 pub static WORKER_METRICS: Lazy<WorkerMetrics> = Lazy::new(WorkerMetrics::new);
 
 pub fn reset_counters() {
-    // Reset max queue length
-    WORKER_METRICS.instance_queue_length_max.0.reset();
-    MAX_QUEUE_LEN.lock().unwrap().clear();
     // Reset max reducer wait time
     WORKER_METRICS.scheduled_reducer_delay_sec_max.0.reset();
     MAX_REDUCER_DELAY.lock().unwrap().clear();


### PR DESCRIPTION
Fixes #1170.

Also updates the bucket values for the queue length histogram. Also removes the max queue length metric, since the histogram should suffice.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
