### PR TITLE
fix(1173): Record wait time for all reducers

### DIFF
--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -30,8 +30,8 @@ use spacetimedb::messages::control_db::{Database, DatabaseInstance, HostType, Id
 use spacetimedb::module_host_context::ModuleHostContext;
 use spacetimedb::object_db::ObjectDb;
 use spacetimedb::sendgrid_controller::SendGridController;
+use spacetimedb::stdb_path;
 use spacetimedb::worker_metrics::WORKER_METRICS;
-use spacetimedb::{stdb_path, worker_metrics};
 use spacetimedb_client_api_messages::name::{DomainName, InsertDomainResult, RegisterTldResult, Tld};
 use spacetimedb_client_api_messages::recovery::RecoveryCode;
 use std::fs::File;
@@ -160,7 +160,6 @@ impl spacetimedb_client_api::NodeDelegate for StandaloneEnv {
     fn gather_metrics(&self) -> Vec<prometheus::proto::MetricFamily> {
         defer_on_success! {
             db_metrics::reset_counters();
-            worker_metrics::reset_counters();
         }
         // Note, we update certain metrics such as disk usage on demand.
         self.db_inst_ctx_controller.update_metrics();


### PR DESCRIPTION
Fixes #1173.

Previously we were only recording this metric for scheduled reducers. We were also recording it before we acquired access to the module instance. Now we record it for all reducers after we acquire access to the module instance.

This patch also removes max wait time since the histogram should suffice.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
