### PR TITLE
Ignore const members in C# types

### DIFF
--- a/crates/bindings-csharp/Codegen/Type.cs
+++ b/crates/bindings-csharp/Codegen/Type.cs
@@ -57,7 +57,7 @@ public class Type : IIncrementalGenerator
         WithAttrAndPredicate(context, "SpacetimeDB.TableAttribute", (_node) => true);
     }
 
-    public void WithAttrAndPredicate(
+    public static void WithAttrAndPredicate(
         IncrementalGeneratorInitializationContext context,
         string fullyQualifiedMetadataName,
         Func<SyntaxNode, bool> predicate
@@ -86,7 +86,12 @@ public class Type : IIncrementalGenerator
                         .FirstOrDefault();
 
                     var fields = type.Members.OfType<FieldDeclarationSyntax>()
-                        .Where(f => !f.Modifiers.Any(m => m.IsKind(SyntaxKind.StaticKeyword)))
+                        .Where(f =>
+                            !f.Modifiers.Any(m =>
+                                m.IsKind(SyntaxKind.StaticKeyword)
+                                || m.IsKind(SyntaxKind.ConstKeyword)
+                            )
+                        )
                         .SelectMany(f =>
                         {
                             var typeSymbol = context


### PR DESCRIPTION
# Description of Changes

Const members shouldn't count as table or type fields in `[SpacetimeDB.Type]`.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
