### PR TITLE
Switch to a better API for tagged enums for C#

### DIFF
--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -128,7 +128,7 @@ public class Module : IIncrementalGenerator
                                         )
                                     "))} }}
                                 ),
-                                {t.Name}.GetSatsTypeInfo().AlgebraicType.TypeRef
+                                (SpacetimeDB.SATS.AlgebraicType.Ref){t.Name}.GetSatsTypeInfo().AlgebraicType
                             );
 
                             public static IEnumerable<{t.Name}> Query(System.Linq.Expressions.Expression<Func<{t.Name}, bool>> filter) =>
@@ -244,7 +244,7 @@ public class Module : IIncrementalGenerator
                                 SpacetimeDB.Module.ReducerDef IReducer.MakeReducerDef() {{
                                     return new (
                                         ""{r.ExportName}""
-                                        {string.Join("", r.Args.Where(a => !a.IsContextArg).Select(a => $",\nnew SpacetimeDB.SATS.ProductTypeElement(nameof({a.Name}), {a.Name}.AlgebraicType)"))}
+                                        {string.Join("", r.Args.Where(a => !a.IsContextArg).Select(a => $",\nnew SpacetimeDB.SATS.AggregateElement(nameof({a.Name}), {a.Name}.AlgebraicType)"))}
                                     );
                                 }}
 

--- a/crates/bindings-csharp/Codegen/README.md
+++ b/crates/bindings-csharp/Codegen/README.md
@@ -12,14 +12,12 @@ This project contains Roslyn [incremental source generators](https://github.com/
 
   ```csharp
   [SpacetimeDB.Type]
-  partial struct Option<T> : SpacetimeDB.TaggedEnum<(T Some, Unit None)> { }
+  partial record Option<T> : SpacetimeDB.TaggedEnum<(T Some, Unit None)>;
   ```
 
-  will generate properties `bool IsSome`, `bool IsNone`, `T Some`, and `Unit None` for the `Option<T>` type.
-
-  The `Some` and `None` accessors will throw an exception if the type is not in the corresponding state, so you must use `Is*` checks if you don't know which variant is currently active.
-
-  All of those properties are stored in a compact `byte` + `object` pair representation.
+  will generate inherited records `Option.Some(T Some_)` and `Option.None(Unit None_)`. It allows
+  you to use tagged enums in C# in a similar way to Rust enums by leveraging C# pattern-matching
+  on any instance of `Option<T>`.
 
 - `[SpacetimeDB.Table]` - generates code to register this table in the `FFI` upon startup so that they can be enumerated by the `__describe_module__` FFI API. It implies `[SpacetimeDB.Type]`, so you must not specify both attributes on the same struct.
 

--- a/crates/bindings-csharp/Codegen/Type.cs
+++ b/crates/bindings-csharp/Codegen/Type.cs
@@ -9,10 +9,11 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Utils;
 
-struct VariableDeclaration
+struct VariableDeclaration(string name, ITypeSymbol typeSymbol)
 {
-    public string Name;
-    public ITypeSymbol TypeSymbol;
+    public string Name = name;
+    public string Type = SymbolToName(typeSymbol);
+    public string TypeInfo = GetTypeInfo(typeSymbol);
 }
 
 [Generator]
@@ -26,7 +27,7 @@ public class Type : IIncrementalGenerator
             (node) =>
             {
                 // structs and classes should be always processed
-                if (!(node is EnumDeclarationSyntax enumType))
+                if (node is not EnumDeclarationSyntax enumType)
                     return true;
 
                 // Ensure variants are contiguous as SATS enums don't support explicit tags.
@@ -103,11 +104,10 @@ public class Type : IIncrementalGenerator
                                     NullableAnnotation.Annotated
                                 );
                             }
-                            return f.Declaration.Variables.Select(v => new VariableDeclaration
-                            {
-                                Name = v.Identifier.Text,
-                                TypeSymbol = typeSymbol,
-                            });
+                            return f.Declaration.Variables.Select(v => new VariableDeclaration(
+                                v.Identifier.Text,
+                                typeSymbol
+                            ));
                         });
 
                     if (taggedEnumVariants is not null)
@@ -116,106 +116,92 @@ public class Type : IIncrementalGenerator
                         {
                             throw new InvalidOperationException("Tagged enums cannot have fields.");
                         }
-                        fields = taggedEnumVariants
-                            .Value.Select(v => new VariableDeclaration
-                            {
-                                Name = v.Name,
-                                TypeSymbol = v.Type,
-                            })
-                            .ToArray();
+                        fields = taggedEnumVariants.Value.Select(v => new VariableDeclaration(
+                            v.Name,
+                            v.Type
+                        ));
                     }
 
                     return new
                     {
                         Scope = new Scope(type),
+                        ShortName = type.Identifier.Text,
                         FullName = SymbolToName(context.SemanticModel.GetDeclaredSymbol(type, ct)!),
                         GenericName = $"{type.Identifier}{type.TypeParameterList}",
                         IsTaggedEnum = taggedEnumVariants is not null,
                         TypeParams = type.TypeParameterList?.Parameters
                             .Select(p => p.Identifier.Text)
                             .ToArray() ?? [],
-                        Members = fields,
+                        Members = fields.ToArray(),
                     };
                 }
             )
             .Select(
                 (type, ct) =>
                 {
-                    var typeKind = type.IsTaggedEnum ? "Sum" : "Product";
-
-                    string read,
+                    string typeKind,
+                        read,
                         write;
 
                     var typeDesc = "";
 
-                    var fieldIO = type.Members.Select(m => new
-                    {
-                        m.Name,
-                        Read = $"{m.Name} = fieldTypeInfo.{m.Name}.Read(reader),",
-                        Write = $"fieldTypeInfo.{m.Name}.Write(writer, value.{m.Name});"
-                    });
+                    var fieldNames = type.Members.Select(m => m.Name);
 
                     if (type.IsTaggedEnum)
                     {
+                        typeKind = "Sum";
+
                         typeDesc +=
                             $@"
-                            public enum TagKind: byte
-                            {{
-                                {string.Join(", ", type.Members.Select(m => m.Name))}
-                            }}
+                            private {type.ShortName}() {{ }}
 
-                            public TagKind Tag {{ get; private set; }}
-                            private object? boxedValue;
+                            public enum @enum: byte
+                            {{
+                                {string.Join(",\n", fieldNames)}
+                            }}
                         ";
 
                         typeDesc += string.Join(
                             "\n",
                             type.Members.Select(m =>
-                            {
-                                var name = m.Name;
-                                var type = m.TypeSymbol.ToDisplayString();
-
-                                return $@"
-                                public bool Is{name} => Tag == TagKind.{name};
-
-                                public {type} {name} {{
-                                    get => Is{name} ? ({type})boxedValue! : throw new System.InvalidOperationException($""Expected {name} but got {{Tag}}"");
-                                    set {{
-                                        Tag = TagKind.{name};
-                                        boxedValue = value;
-                                    }}
-                                }}
-                                ";
-                            })
+                                // C# puts field names in the same namespace as records themselves, and will complain about clashes if they match.
+                                // To avoid this, we append an underscore to the field name.
+                                // In most cases the field name shouldn't matter anyway as you'll idiomatically use pattern matching to extract the value.
+                                $@"public sealed record {m.Name}({m.Type} {m.Name}_) : {type.ShortName};"
+                            )
                         );
 
                         read =
-                            $@"(TagKind)reader.ReadByte() switch {{
-                                {string.Join("\n", fieldIO.Select(m => $"TagKind.{m.Name} => new {type.GenericName} {{ {m.Read} }},"))}
-                                var tag => throw new System.InvalidOperationException($""Unknown tag {{tag}}"")
+                            $@"(@enum)reader.ReadByte() switch {{
+                                {string.Join("\n", fieldNames.Select(name => $"@enum.{name} => new {name}(fieldTypeInfo.{name}.Read(reader)),"))}
+                                _ => throw new System.InvalidOperationException(""Invalid tag value, this state should be unreachable."")
                             }}";
 
                         write =
-                            $@"writer.Write((byte)value.Tag);
-                            switch (value.Tag) {{
-                                {string.Join("\n", fieldIO.Select(m => $@"
-                                    case TagKind.{m.Name}:
-                                        {m.Write};
+                            $@"switch (value) {{
+                                {string.Join("\n", fieldNames.Select(name => $@"
+                                    case {name}(var inner):
+                                        writer.Write((byte)@enum.{name});
+                                        fieldTypeInfo.{name}.Write(writer, inner);
                                         break;
                                 "))}
-                                default:
-                                    throw new System.InvalidOperationException($""Tagged enum is corrupted and has an unsupported tag {{value.Tag}}"");
-                            }}
-                        ";
+                            }}";
                     }
                     else
                     {
+                        typeKind = "Product";
+
                         read =
                             $@"new {type.GenericName} {{
-                                {string.Join("\n", fieldIO.Select(m => m.Read))}
+                                {string.Join(",\n", fieldNames.Select(name => $"{name} = fieldTypeInfo.{name}.Read(reader)"))}
                             }}";
 
-                        write = string.Join("\n", fieldIO.Select(m => m.Write));
+                        write = string.Join(
+                            "\n",
+                            fieldNames.Select(name =>
+                                $"fieldTypeInfo.{name}.Write(writer, value.{name});"
+                            )
+                        );
                     }
 
                     typeDesc +=
@@ -237,13 +223,13 @@ public static SpacetimeDB.SATS.TypeInfo<{type.GenericName}> GetSatsTypeInfo({str
         (writer, value) => write(writer, value)
     );
     var fieldTypeInfo = new {{
-        {string.Join("\n", type.Members.Select(m => $"{m.Name} = {GetTypeInfo(m.TypeSymbol)},"))}
+        {string.Join("\n", type.Members.Select(m => $"{m.Name} = {m.TypeInfo},"))}
     }};
     SpacetimeDB.Module.FFI.SetTypeRef<{type.GenericName}>(
         typeRef,
-        new SpacetimeDB.SATS.{typeKind}Type {{
-            {string.Join("\n", type.Members.Select(m => $"{{ nameof({m.Name}), fieldTypeInfo.{m.Name}.AlgebraicType }},"))}
-        }},
+        new SpacetimeDB.SATS.AlgebraicType.{typeKind}(new SpacetimeDB.SATS.AggregateElement[] {{
+            {string.Join("\n", type.Members.Select(m => $"new(nameof({m.Name}), fieldTypeInfo.{m.Name}.AlgebraicType),"))}
+        }}),
         {(
             fullyQualifiedMetadataName == "SpacetimeDB.TableAttribute"
             // anonymous (don't register type alias) if it's a table that will register its own name in a different way

--- a/crates/bindings-csharp/Codegen/Utils.cs
+++ b/crates/bindings-csharp/Codegen/Utils.cs
@@ -56,7 +56,7 @@ static class Utils
         )
         {
             // if we're here, then this is a nullable reference type like `string?`.
-            return $"SpacetimeDB.SATS.SumType.MakeRefOption({GetTypeInfo(type.WithNullableAnnotation(NullableAnnotation.None))})";
+            return $"SpacetimeDB.SATS.AlgebraicType.MakeRefOption({GetTypeInfo(type.WithNullableAnnotation(NullableAnnotation.None))})";
         }
         return type switch
         {
@@ -97,7 +97,7 @@ static class Utils
                             "System.Collections.Generic.List<T>" => "SpacetimeDB.SATS.BuiltinType.MakeList",
                             "System.Collections.Generic.Dictionary<TKey, TValue>" => "SpacetimeDB.SATS.BuiltinType.MakeMap",
                             // If we're here, then this is nullable value type like `int?`.
-                            "System.Nullable<T>" => $"SpacetimeDB.SATS.SumType.MakeValueOption",
+                            "System.Nullable<T>" => $"SpacetimeDB.SATS.AlgebraicType.MakeValueOption",
                             var name when name.StartsWith("System.") => throw new InvalidOperationException(
                                 $"Unsupported system type {name}"
                             ),

--- a/crates/bindings-csharp/Runtime/AlgebraicType.cs
+++ b/crates/bindings-csharp/Runtime/AlgebraicType.cs
@@ -11,7 +11,7 @@ namespace SpacetimeDB.SATS
     public partial struct Unit
     {
         private static readonly TypeInfo<Unit> satsTypeInfo =
-            new(new ProductType(), reader => default, (writer, value) => { });
+            new(AlgebraicType.Unit, reader => default, (writer, value) => { });
 
         public static TypeInfo<Unit> GetSatsTypeInfo() => satsTypeInfo;
     }
@@ -55,34 +55,265 @@ namespace SpacetimeDB.SATS
     }
 
     [SpacetimeDB.Type]
-    public partial struct SumType : IEnumerable<SumTypeVariant>
+    public partial struct AggregateElement(string? name, AlgebraicType algebraicType)
     {
-        public List<SumTypeVariant> Variants = [];
+        public string? Name = name;
+        public AlgebraicType AlgebraicType = algebraicType;
+    }
 
-        public SumType() { }
+    [SpacetimeDB.Type]
+    public partial struct MapElement(AlgebraicType key, AlgebraicType value)
+    {
+        public AlgebraicType Key = key;
+        public AlgebraicType Value = value;
+    }
 
-        public IEnumerator<SumTypeVariant> GetEnumerator()
+    [SpacetimeDB.Type]
+    public partial record BuiltinType
+        : SpacetimeDB.TaggedEnum<(
+            Unit Bool,
+            Unit I8,
+            Unit U8,
+            Unit I16,
+            Unit U16,
+            Unit I32,
+            Unit U32,
+            Unit I64,
+            Unit U64,
+            Unit I128,
+            Unit U128,
+            Unit F32,
+            Unit F64,
+            Unit String,
+            AlgebraicType Array,
+            MapElement Map
+        )>
+    {
+        public static readonly TypeInfo<bool> BoolTypeInfo = new TypeInfo<bool>(
+            new Bool(default),
+            (reader) => reader.ReadBoolean(),
+            (writer, value) => writer.Write(value)
+        );
+
+        public static readonly TypeInfo<sbyte> I8TypeInfo = new TypeInfo<sbyte>(
+            new I8(default),
+            (reader) => reader.ReadSByte(),
+            (writer, value) => writer.Write(value)
+        );
+
+        public static readonly TypeInfo<byte> U8TypeInfo = new TypeInfo<byte>(
+            new U8(default),
+            (reader) => reader.ReadByte(),
+            (writer, value) => writer.Write(value)
+        );
+
+        public static readonly TypeInfo<short> I16TypeInfo = new TypeInfo<short>(
+            new I16(default),
+            (reader) => reader.ReadInt16(),
+            (writer, value) => writer.Write(value)
+        );
+
+        public static readonly TypeInfo<ushort> U16TypeInfo = new TypeInfo<ushort>(
+            new U16(default),
+            (reader) => reader.ReadUInt16(),
+            (writer, value) => writer.Write(value)
+        );
+
+        public static readonly TypeInfo<int> I32TypeInfo = new TypeInfo<int>(
+            new I32(default),
+            (reader) => reader.ReadInt32(),
+            (writer, value) => writer.Write(value)
+        );
+
+        public static readonly TypeInfo<uint> U32TypeInfo = new TypeInfo<uint>(
+            new U32(default),
+            (reader) => reader.ReadUInt32(),
+            (writer, value) => writer.Write(value)
+        );
+
+        public static readonly TypeInfo<long> I64TypeInfo = new TypeInfo<long>(
+            new I64(default),
+            (reader) => reader.ReadInt64(),
+            (writer, value) => writer.Write(value)
+        );
+
+        public static readonly TypeInfo<ulong> U64TypeInfo = new TypeInfo<ulong>(
+            new U64(default),
+            (reader) => reader.ReadUInt64(),
+            (writer, value) => writer.Write(value)
+        );
+
+#if NET7_0_OR_GREATER
+        public static readonly TypeInfo<Int128> I128TypeInfo = new TypeInfo<Int128>(
+            new I128(default),
+            (reader) => new Int128(reader.ReadUInt64(), reader.ReadUInt64()),
+            (writer, value) =>
+            {
+                writer.Write((ulong)(value >> 64));
+                writer.Write((ulong)value);
+            }
+        );
+
+        public static readonly TypeInfo<UInt128> U128TypeInfo = new TypeInfo<UInt128>(
+            new U128(default),
+            (reader) => new UInt128(reader.ReadUInt64(), reader.ReadUInt64()),
+            (writer, value) =>
+            {
+                writer.Write((ulong)(value >> 64));
+                writer.Write((ulong)value);
+            }
+        );
+#endif
+
+        public static readonly TypeInfo<float> F32TypeInfo = new TypeInfo<float>(
+            new F32(default),
+            (reader) => reader.ReadSingle(),
+            (writer, value) => writer.Write(value)
+        );
+
+        public static readonly TypeInfo<double> F64TypeInfo = new TypeInfo<double>(
+            new F64(default),
+            (reader) => reader.ReadDouble(),
+            (writer, value) => writer.Write(value)
+        );
+
+        public static readonly TypeInfo<byte[]> BytesTypeInfo = new TypeInfo<byte[]>(
+            new Array(U8TypeInfo.AlgebraicType),
+            (reader) =>
+            {
+                var length = reader.ReadInt32();
+                return reader.ReadBytes(length);
+            },
+            (writer, value) =>
+            {
+                writer.Write(value.Length);
+                writer.Write(value);
+            }
+        );
+
+        public static readonly TypeInfo<string> StringTypeInfo = new TypeInfo<string>(
+            new String(default),
+            (reader) => Encoding.UTF8.GetString(BytesTypeInfo.Read(reader)),
+            (writer, value) => BytesTypeInfo.Write(writer, Encoding.UTF8.GetBytes(value))
+        );
+
+        private static IEnumerable<T> ReadEnumerable<T>(
+            BinaryReader reader,
+            Func<BinaryReader, T> readElement
+        )
         {
-            return Variants.AsEnumerable().GetEnumerator();
+            var length = reader.ReadInt32();
+            return Enumerable.Range(0, length).Select((_) => readElement(reader));
         }
 
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
+        private static void WriteEnumerable<T>(
+            BinaryWriter writer,
+            ICollection<T> enumerable,
+            Action<BinaryWriter, T> writeElement
+        )
         {
-            return GetEnumerator();
+            writer.Write(enumerable.Count);
+            foreach (var element in enumerable)
+            {
+                writeElement(writer, element);
+            }
         }
 
-        public void Add(string name, AlgebraicType algebraicType)
+        public static TypeInfo<A> MakeArrayLike<T, A>(
+            Func<IEnumerable<T>, A> create,
+            TypeInfo<T> elementTypeInfo
+        )
+            where A : ICollection<T>
         {
-            Variants.Add(new SumTypeVariant(name, algebraicType));
+            return new TypeInfo<A>(
+                new Array(elementTypeInfo.AlgebraicType),
+                (reader) => create(ReadEnumerable(reader, elementTypeInfo.Read)),
+                (writer, array) => WriteEnumerable(writer, array, elementTypeInfo.Write)
+            );
         }
+
+        public static TypeInfo<T[]> MakeArray<T>(TypeInfo<T> elementTypeInfo) =>
+            MakeArrayLike(Enumerable.ToArray, elementTypeInfo);
+
+        public static TypeInfo<List<T>> MakeList<T>(TypeInfo<T> elementTypeInfo) =>
+            MakeArrayLike(Enumerable.ToList, elementTypeInfo);
+
+        public static TypeInfo<Dictionary<K, V>> MakeMap<K, V>(TypeInfo<K> key, TypeInfo<V> value)
+            where K : notnull
+        {
+            return new TypeInfo<Dictionary<K, V>>(
+                new Map(new MapElement(key.AlgebraicType, value.AlgebraicType)),
+                (reader) =>
+                    ReadEnumerable(
+                            reader,
+                            (reader) => (Key: key.Read(reader), Value: value.Read(reader))
+                        )
+                        .ToDictionary((pair) => pair.Key, (pair) => pair.Value),
+                (writer, map) =>
+                    WriteEnumerable(
+                        writer,
+                        map,
+                        (w, pair) =>
+                        {
+                            key.Write(w, pair.Key);
+                            value.Write(w, pair.Value);
+                        }
+                    )
+            );
+        }
+
+        private static Dictionary<Type, object> enumTypeInfoCache = [];
+
+        public static TypeInfo<T> MakeEnum<T>()
+            where T : struct, Enum, IConvertible
+        {
+            if (enumTypeInfoCache.TryGetValue(typeof(T), out var cached))
+            {
+                return (TypeInfo<T>)cached;
+            }
+
+            // plain enums are never recursive, so it should be fine to alloc & set typeref at once
+            var typeRef = Module.FFI.AllocTypeRef();
+
+            Module.FFI.SetTypeRef<T>(
+                typeRef,
+                new AlgebraicType.Sum(
+                    Enum.GetNames(typeof(T))
+                        .Select(name => new AggregateElement(name, AlgebraicType.Unit))
+                        .ToArray()
+                )
+            );
+
+            var typeInfo = new TypeInfo<T>(
+                typeRef,
+                (reader) => (T)Enum.ToObject(typeof(T), reader.ReadByte()),
+                (writer, value) => writer.Write(Convert.ToByte(value))
+            );
+
+            enumTypeInfoCache[typeof(T)] = typeInfo;
+
+            return typeInfo;
+        }
+    }
+
+    [SpacetimeDB.Type]
+    public partial record AlgebraicType
+        : SpacetimeDB.TaggedEnum<(
+            AggregateElement[] Sum,
+            AggregateElement[] Product,
+            BuiltinType Builtin,
+            int Ref
+        )>
+    {
+        public static implicit operator AlgebraicType(BuiltinType builtin) => new Builtin(builtin);
+
+        public static readonly AlgebraicType Unit = new Product([]);
+
+        public static readonly AlgebraicType Uninhabited = new Sum([]);
 
         // Special AlgebraicType that can be recognised by the SpacetimeDB `generate` CLI as an Option<T>.
         private static AlgebraicType MakeOptionAlgebraicType(AlgebraicType algebraicType) =>
-            new SumType
-            {
-                { "some", algebraicType },
-                { "none", Unit.GetSatsTypeInfo().AlgebraicType }
-            };
+            new Sum([new("some", algebraicType), new("none", Unit)]);
 
         public static TypeInfo<T?> MakeRefOption<T>(TypeInfo<T> typeInfo)
             where T : class
@@ -121,315 +352,5 @@ namespace SpacetimeDB.SATS
                 }
             );
         }
-    }
-
-    [SpacetimeDB.Type]
-    public partial struct SumTypeVariant(string? name, AlgebraicType algebraicType)
-    {
-        public string? Name = name;
-        public AlgebraicType AlgebraicType = algebraicType;
-    }
-
-    [SpacetimeDB.Type]
-    public partial struct ProductType : IEnumerable<ProductTypeElement>
-    {
-        public List<ProductTypeElement> Elements = [];
-
-        public ProductType() { }
-
-        public IEnumerator<ProductTypeElement> GetEnumerator()
-        {
-            return Elements.AsEnumerable().GetEnumerator();
-        }
-
-        System.Collections.IEnumerator System.Collections.IEnumerable.GetEnumerator()
-        {
-            return GetEnumerator();
-        }
-
-        public void Add(string name, AlgebraicType algebraicType)
-        {
-            Elements.Add(new ProductTypeElement(name, algebraicType));
-        }
-    }
-
-    [SpacetimeDB.Type]
-    public partial struct ProductTypeElement(string? name, AlgebraicType algebraicType)
-    {
-        public string? Name = name;
-        public AlgebraicType AlgebraicType = algebraicType;
-    }
-
-    [SpacetimeDB.Type]
-    public partial struct MapType(AlgebraicType key, AlgebraicType value)
-    {
-        public AlgebraicType Key = key;
-        public AlgebraicType Value = value;
-    }
-
-    [SpacetimeDB.Type]
-    public partial struct BuiltinType
-        : SpacetimeDB.TaggedEnum<(
-            Unit Bool,
-            Unit I8,
-            Unit U8,
-            Unit I16,
-            Unit U16,
-            Unit I32,
-            Unit U32,
-            Unit I64,
-            Unit U64,
-            Unit I128,
-            Unit U128,
-            Unit F32,
-            Unit F64,
-            Unit String,
-            AlgebraicType Array,
-            MapType Map
-        )>
-    {
-        public static readonly TypeInfo<bool> BoolTypeInfo = new TypeInfo<bool>(
-            new BuiltinType { Bool = default },
-            (reader) => reader.ReadBoolean(),
-            (writer, value) => writer.Write(value)
-        );
-
-        public static readonly TypeInfo<sbyte> I8TypeInfo = new TypeInfo<sbyte>(
-            new BuiltinType { I8 = default },
-            (reader) => reader.ReadSByte(),
-            (writer, value) => writer.Write(value)
-        );
-
-        public static readonly TypeInfo<byte> U8TypeInfo = new TypeInfo<byte>(
-            new BuiltinType { U8 = default },
-            (reader) => reader.ReadByte(),
-            (writer, value) => writer.Write(value)
-        );
-
-        public static readonly TypeInfo<short> I16TypeInfo = new TypeInfo<short>(
-            new BuiltinType { I16 = default },
-            (reader) => reader.ReadInt16(),
-            (writer, value) => writer.Write(value)
-        );
-
-        public static readonly TypeInfo<ushort> U16TypeInfo = new TypeInfo<ushort>(
-            new BuiltinType { U16 = default },
-            (reader) => reader.ReadUInt16(),
-            (writer, value) => writer.Write(value)
-        );
-
-        public static readonly TypeInfo<int> I32TypeInfo = new TypeInfo<int>(
-            new BuiltinType { I32 = default },
-            (reader) => reader.ReadInt32(),
-            (writer, value) => writer.Write(value)
-        );
-
-        public static readonly TypeInfo<uint> U32TypeInfo = new TypeInfo<uint>(
-            new BuiltinType { U32 = default },
-            (reader) => reader.ReadUInt32(),
-            (writer, value) => writer.Write(value)
-        );
-
-        public static readonly TypeInfo<long> I64TypeInfo = new TypeInfo<long>(
-            new BuiltinType { I64 = default },
-            (reader) => reader.ReadInt64(),
-            (writer, value) => writer.Write(value)
-        );
-
-        public static readonly TypeInfo<ulong> U64TypeInfo = new TypeInfo<ulong>(
-            new BuiltinType { U64 = default },
-            (reader) => reader.ReadUInt64(),
-            (writer, value) => writer.Write(value)
-        );
-
-#if NET7_0_OR_GREATER
-        public static readonly TypeInfo<Int128> I128TypeInfo = new TypeInfo<Int128>(
-            new BuiltinType { I128 = default },
-            (reader) => new Int128(reader.ReadUInt64(), reader.ReadUInt64()),
-            (writer, value) =>
-            {
-                writer.Write((ulong)(value >> 64));
-                writer.Write((ulong)value);
-            }
-        );
-
-        public static readonly TypeInfo<UInt128> U128TypeInfo = new TypeInfo<UInt128>(
-            new BuiltinType { U128 = default },
-            (reader) => new UInt128(reader.ReadUInt64(), reader.ReadUInt64()),
-            (writer, value) =>
-            {
-                writer.Write((ulong)(value >> 64));
-                writer.Write((ulong)value);
-            }
-        );
-#endif
-
-        public static readonly TypeInfo<float> F32TypeInfo = new TypeInfo<float>(
-            new BuiltinType { F32 = default },
-            (reader) => reader.ReadSingle(),
-            (writer, value) => writer.Write(value)
-        );
-
-        public static readonly TypeInfo<double> F64TypeInfo = new TypeInfo<double>(
-            new BuiltinType { F64 = default },
-            (reader) => reader.ReadDouble(),
-            (writer, value) => writer.Write(value)
-        );
-
-        public static readonly TypeInfo<byte[]> BytesTypeInfo = new TypeInfo<byte[]>(
-            new BuiltinType { Array = U8TypeInfo.AlgebraicType },
-            (reader) =>
-            {
-                var length = reader.ReadInt32();
-                return reader.ReadBytes(length);
-            },
-            (writer, value) =>
-            {
-                writer.Write(value.Length);
-                writer.Write(value);
-            }
-        );
-
-        public static readonly TypeInfo<string> StringTypeInfo = new TypeInfo<string>(
-            new BuiltinType { String = default },
-            (reader) => Encoding.UTF8.GetString(BytesTypeInfo.Read(reader)),
-            (writer, value) => BytesTypeInfo.Write(writer, Encoding.UTF8.GetBytes(value))
-        );
-
-        private static IEnumerable<T> ReadEnumerable<T>(
-            BinaryReader reader,
-            Func<BinaryReader, T> readElement
-        )
-        {
-            var length = reader.ReadInt32();
-            return Enumerable.Range(0, length).Select((_) => readElement(reader));
-        }
-
-        private static void WriteEnumerable<T>(
-            BinaryWriter writer,
-            ICollection<T> enumerable,
-            Action<BinaryWriter, T> writeElement
-        )
-        {
-            writer.Write(enumerable.Count);
-            foreach (var element in enumerable)
-            {
-                writeElement(writer, element);
-            }
-        }
-
-        public static TypeInfo<A> MakeArrayLike<T, A>(
-            Func<IEnumerable<T>, A> create,
-            TypeInfo<T> elementTypeInfo
-        )
-            where A : ICollection<T>
-        {
-            return new TypeInfo<A>(
-                new BuiltinType { Array = elementTypeInfo.AlgebraicType },
-                (reader) => create(ReadEnumerable(reader, elementTypeInfo.Read)),
-                (writer, array) => WriteEnumerable(writer, array, elementTypeInfo.Write)
-            );
-        }
-
-        public static TypeInfo<T[]> MakeArray<T>(TypeInfo<T> elementTypeInfo) =>
-            MakeArrayLike(Enumerable.ToArray, elementTypeInfo);
-
-        public static TypeInfo<List<T>> MakeList<T>(TypeInfo<T> elementTypeInfo) =>
-            MakeArrayLike(Enumerable.ToList, elementTypeInfo);
-
-        public static TypeInfo<Dictionary<K, V>> MakeMap<K, V>(TypeInfo<K> key, TypeInfo<V> value)
-            where K : notnull
-        {
-            return new TypeInfo<Dictionary<K, V>>(
-                new BuiltinType { Map = new MapType(key.AlgebraicType, value.AlgebraicType) },
-                (reader) =>
-                    ReadEnumerable(
-                            reader,
-                            (reader) => (Key: key.Read(reader), Value: value.Read(reader))
-                        )
-                        .ToDictionary((pair) => pair.Key, (pair) => pair.Value),
-                (writer, map) =>
-                    WriteEnumerable(
-                        writer,
-                        map,
-                        (w, pair) =>
-                        {
-                            key.Write(w, pair.Key);
-                            value.Write(w, pair.Value);
-                        }
-                    )
-            );
-        }
-
-        private static Dictionary<Type, object> enumTypeInfoCache = [];
-        private static readonly AlgebraicType unitType = Unit.GetSatsTypeInfo().AlgebraicType;
-
-        public static TypeInfo<T> MakeEnum<T>()
-            where T : struct, Enum, IConvertible
-        {
-            if (enumTypeInfoCache.TryGetValue(typeof(T), out var cached))
-            {
-                return (TypeInfo<T>)cached;
-            }
-
-            // plain enums are never recursive, so it should be fine to alloc & set typeref at once
-            var typeRef = Module.FFI.AllocTypeRef();
-
-            Module.FFI.SetTypeRef<T>(
-                typeRef,
-                new SumType
-                {
-                    Variants = Enum.GetNames(typeof(T))
-                        .Select(name => new SumTypeVariant(name, unitType))
-                        .ToList()
-                }
-            );
-
-            var typeInfo = new TypeInfo<T>(
-                typeRef,
-                (reader) => (T)Enum.ToObject(typeof(T), reader.ReadByte()),
-                (writer, value) => writer.Write(Convert.ToByte(value))
-            );
-
-            enumTypeInfoCache[typeof(T)] = typeInfo;
-
-            return typeInfo;
-        }
-    }
-
-    [SpacetimeDB.Type]
-    public partial struct AlgebraicType
-        : SpacetimeDB.TaggedEnum<(
-            SumType Sum,
-            ProductType Product,
-            BuiltinType Builtin,
-            AlgebraicTypeRef TypeRef
-        )>
-    {
-        public static implicit operator AlgebraicType(SumType sum)
-        {
-            return new AlgebraicType { Sum = sum };
-        }
-
-        public static implicit operator AlgebraicType(ProductType product)
-        {
-            return new AlgebraicType { Product = product };
-        }
-
-        public static implicit operator AlgebraicType(BuiltinType builtin)
-        {
-            return new AlgebraicType { Builtin = builtin };
-        }
-
-        public static implicit operator AlgebraicType(AlgebraicTypeRef typeRef)
-        {
-            return new AlgebraicType { TypeRef = typeRef };
-        }
-    }
-
-    [SpacetimeDB.Type]
-    public partial struct AlgebraicTypeRef(int typeRef)
-    {
-        public int TypeRef = typeRef;
     }
 }

--- a/crates/bindings-csharp/Runtime/Attrs.cs
+++ b/crates/bindings-csharp/Runtime/Attrs.cs
@@ -1,6 +1,7 @@
 ﻿namespace SpacetimeDB;
 
 using System;
+using System.Runtime.CompilerServices;
 using SpacetimeDB.Module;
 
 [AttributeUsage(AttributeTargets.Method, Inherited = false, AllowMultiple = false)]
@@ -23,8 +24,10 @@ public sealed class TableAttribute : Attribute { }
 )]
 public sealed class TypeAttribute : Attribute { }
 
-public interface TaggedEnum<Variants>
-    where Variants : struct { }
+// This could be an interface, but using `record` forces C# to check that it can
+// only be applied on types that are records themselves.
+public record TaggedEnum<Variants>
+    where Variants : struct, ITuple { }
 
 [AttributeUsage(AttributeTargets.Field, Inherited = false, AllowMultiple = false)]
 public sealed class ColumnAttribute(ColumnAttrs type) : Attribute

--- a/crates/bindings-csharp/Runtime/Module.cs
+++ b/crates/bindings-csharp/Runtime/Module.cs
@@ -90,28 +90,28 @@ public partial struct TableDef(string tableName, ColumnDefWithAttrs[] columns)
 }
 
 [SpacetimeDB.Type]
-public partial struct TableDesc(TableDef schema, AlgebraicTypeRef data)
+public partial struct TableDesc(TableDef schema, AlgebraicType.Ref typeRef)
 {
     TableDef Schema = schema;
-    AlgebraicTypeRef Data = data;
+    int TypeRef = typeRef.Ref_;
 }
 
 [SpacetimeDB.Type]
-public partial struct ReducerDef(string name, params ProductTypeElement[] args)
+public partial struct ReducerDef(string name, params AggregateElement[] args)
 {
     string Name = name;
-    ProductTypeElement[] Args = args;
+    AggregateElement[] Args = args;
 }
 
 [SpacetimeDB.Type]
-partial struct TypeAlias
+partial struct TypeAlias(string name, AlgebraicType.Ref typeRef)
 {
-    internal string Name;
-    internal AlgebraicTypeRef Type;
+    string Name = name;
+    int TypeRef = typeRef.Ref_;
 }
 
 [SpacetimeDB.Type]
-partial struct MiscModuleExport : SpacetimeDB.TaggedEnum<(TypeAlias TypeAlias, Unit _Reserved)> { }
+partial record MiscModuleExport : SpacetimeDB.TaggedEnum<(TypeAlias TypeAlias, Unit _Reserved)>;
 
 [SpacetimeDB.Type]
 public partial struct ModuleDef
@@ -123,12 +123,12 @@ public partial struct ModuleDef
 
     public ModuleDef() { }
 
-    public AlgebraicTypeRef AllocTypeRef()
+    public AlgebraicType.Ref AllocTypeRef()
     {
         var index = Types.Count;
-        var typeRef = new AlgebraicTypeRef(index);
-        // uninhabited type, to be replaced by a real type
-        Types.Add(new SumType());
+        var typeRef = new AlgebraicType.Ref(index);
+        // to be replaced by a real type
+        Types.Add(AlgebraicType.Uninhabited);
         return typeRef;
     }
 
@@ -139,16 +139,13 @@ public partial struct ModuleDef
             ? $"{type.Name.Remove(type.Name.IndexOf('`'))}_{string.Join("_", type.GetGenericArguments().Select(GetFriendlyName))}"
             : type.Name;
 
-    public void SetTypeRef<T>(AlgebraicTypeRef typeRef, AlgebraicType type, bool anonymous = false)
+    public void SetTypeRef<T>(AlgebraicType.Ref typeRef, AlgebraicType type, bool anonymous = false)
     {
-        Types[typeRef.TypeRef] = type;
+        Types[typeRef.Ref_] = type;
         if (!anonymous)
         {
             MiscExports.Add(
-                new MiscModuleExport
-                {
-                    TypeAlias = new TypeAlias { Name = GetFriendlyName(typeof(T)), Type = typeRef }
-                }
+                new MiscModuleExport.TypeAlias(new TypeAlias(GetFriendlyName(typeof(T)), typeRef))
             );
         }
     }
@@ -204,10 +201,10 @@ public static class FFI
 
     public static void RegisterTable(TableDesc table) => module.Add(table);
 
-    public static AlgebraicTypeRef AllocTypeRef() => module.AllocTypeRef();
+    public static AlgebraicType.Ref AllocTypeRef() => module.AllocTypeRef();
 
     public static void SetTypeRef<T>(
-        AlgebraicTypeRef typeRef,
+        AlgebraicType.Ref typeRef,
         AlgebraicType type,
         bool anonymous = false
     ) => module.SetTypeRef<T>(typeRef, type, anonymous);

--- a/crates/bindings-csharp/Runtime/Runtime.cs
+++ b/crates/bindings-csharp/Runtime/Runtime.cs
@@ -4,6 +4,7 @@ using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Runtime.CompilerServices;
+using SpacetimeDB.SATS;
 using static System.Text.Encoding;
 
 public static class Runtime
@@ -154,10 +155,14 @@ public static class Runtime
         private static SpacetimeDB.SATS.TypeInfo<Identity> satsTypeInfo =
             new(
                 // We need to set type info to inlined identity type as `generate` CLI currently can't recognise type references for built-ins.
-                new SpacetimeDB.SATS.ProductType
-                {
-                    { "__identity_bytes", SpacetimeDB.SATS.BuiltinType.BytesTypeInfo.AlgebraicType }
-                },
+                new SpacetimeDB.SATS.AlgebraicType.Product(
+                    [
+                        new(
+                            "__identity_bytes",
+                            SpacetimeDB.SATS.BuiltinType.BytesTypeInfo.AlgebraicType
+                        )
+                    ]
+                ),
                 reader => new(SpacetimeDB.SATS.BuiltinType.BytesTypeInfo.Read(reader)),
                 (writer, value) =>
                     SpacetimeDB.SATS.BuiltinType.BytesTypeInfo.Write(writer, value.bytes)
@@ -188,10 +193,14 @@ public static class Runtime
         private static SpacetimeDB.SATS.TypeInfo<Address> satsTypeInfo =
             new(
                 // We need to set type info to inlined address type as `generate` CLI currently can't recognise type references for built-ins.
-                new SpacetimeDB.SATS.ProductType
-                {
-                    { "__address_bytes", SpacetimeDB.SATS.BuiltinType.BytesTypeInfo.AlgebraicType }
-                },
+                new SpacetimeDB.SATS.AlgebraicType.Product(
+                    [
+                        new(
+                            "__address_bytes",
+                            SpacetimeDB.SATS.BuiltinType.BytesTypeInfo.AlgebraicType
+                        )
+                    ]
+                ),
                 // Concern: We use this "packed" representation (as Bytes)
                 //          in the caller_id field of reducer arguments,
                 //          but in table rows,

--- a/modules/sdk-test-cs/Lib.cs
+++ b/modules/sdk-test-cs/Lib.cs
@@ -12,7 +12,7 @@ static partial class Module
     }
 
     [SpacetimeDB.Type]
-    public partial struct EnumWithPayload
+    public partial record EnumWithPayload
         : SpacetimeDB.TaggedEnum<(
             byte U8,
             ushort U16,
@@ -34,7 +34,7 @@ static partial class Module
             List<int> Ints,
             List<string> Strings,
             List<SimpleEnum> SimpleEnums
-        )> { }
+        )>;
 
     [SpacetimeDB.Type]
     public partial struct UnitStruct { }


### PR DESCRIPTION
# Description of Changes

With C# records - which are available since C# 9, so covers Unity requirements as well - we can use subclassing and pattern matching to get sum types that look a lot more like Rust tagged enums than my previous approach.

For example, the following Rust code:

```rust
let foo = match some_tagged_value {
  MyEnum::A(x) => ...,
  MyEnum::B(y) => ...
};
```

can now be expressed via almost equivalent C# code

```cs
var foo = someTaggedValue switch {
  MyEnum.A(var x) => ...,
  MyEnum.B(var y) => ...,
  // main difference is that, unlike in Rust, they're not exhaustive so you need to handle edge cases yourself
  _ => throw new ArgumentException(...)
};
```

This is a breaking change but IMO worth it for the better API going forward.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

2

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Checked that C# SDK tests are still working.
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
