### PR TITLE
Add PR status check that fails unless based on `master`

### DIFF
--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -16,9 +16,3 @@ jobs:
         run: |
           echo "This is labeled \"Do not merge\"."
           exit 1
-      - id: not_based_on_master
-        if: |
-          github.event.pull_request.base.ref != 'master'
-        run: |
-          echo "This PR is not based on master. Please wait until the base PR merges."
-          exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -16,3 +16,9 @@ jobs:
         run: |
           echo "This is labeled \"Do not merge\"."
           exit 1
+      - id: not_based_on_master
+        if: |
+          github.event.pull_request.base.ref == 'master'
+        run: |
+          echo "This PR is not based on master. Please wait until the base PR merges."
+          exit 1

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -18,7 +18,7 @@ jobs:
           exit 1
       - id: not_based_on_master
         if: |
-          github.event.pull_request.base.ref == 'master'
+          github.event.pull_request.base.ref != 'master'
         run: |
           echo "This PR is not based on master. Please wait until the base PR merges."
           exit 1

--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -1,0 +1,18 @@
+name: Check PR base
+
+on:
+  pull_request:
+    types: [opened, edited]
+  merge_group:
+permissions: read-all
+
+jobs:
+  check_base_ref:
+    runs-on: ubuntu-latest
+    steps:
+      - id: not_based_on_master
+        if: |
+          github.event.pull_request.base.ref != 'master'
+        run: |
+          echo "This PR is not based on master. Please wait until the base PR merges."
+          exit 1

--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -1,4 +1,4 @@
-name: Check PR base
+name: Git tree checks
 
 on:
   pull_request:
@@ -8,6 +8,7 @@ permissions: read-all
 
 jobs:
   check_base_ref:
+    name: Based on `master`
     runs-on: ubuntu-latest
     steps:
       - id: not_based_on_master


### PR DESCRIPTION
# Description of Changes

CI change - block PRs from merging if not based on `master`

# API and ABI breaking changes

No

# Testing

In a test repo:
- [x] Check that PRs merge if based on `master`
  - https://github.com/clockworklabs/SpacetimeDB/pull/1184
- [x] Check that PRs don't merge if not based on `master`
  - https://github.com/clockworklabs/SpacetimeDB/pull/1185
