### PR TITLE
C#: rename DbEventArgs to ReducerContext

### DIFF
--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -222,7 +222,8 @@ public class Module : IIncrementalGenerator
                             (
                                 p.Name,
                                 p.Type,
-                                IsDbEvent: p.Type.ToString() == "SpacetimeDB.Runtime.ReducerContext"
+                                IsContextArg: p.Type.ToString()
+                                    == "SpacetimeDB.Runtime.ReducerContext"
                             )
                         )
                         .ToArray(),
@@ -238,17 +239,17 @@ public class Module : IIncrementalGenerator
                         r.Name,
                         Class: $@"
                             class {r.Name}: IReducer {{
-                                {string.Join("\n", r.Args.Where(a => !a.IsDbEvent).Select(a => $"SpacetimeDB.SATS.TypeInfo<{a.Type}> {a.Name} = {GetTypeInfo(a.Type)};"))}
+                                {string.Join("\n", r.Args.Where(a => !a.IsContextArg).Select(a => $"SpacetimeDB.SATS.TypeInfo<{a.Type}> {a.Name} = {GetTypeInfo(a.Type)};"))}
 
                                 SpacetimeDB.Module.ReducerDef IReducer.MakeReducerDef() {{
                                     return new (
                                         ""{r.ExportName}""
-                                        {string.Join("", r.Args.Where(a => !a.IsDbEvent).Select(a => $",\nnew SpacetimeDB.SATS.ProductTypeElement(nameof({a.Name}), {a.Name}.AlgebraicType)"))}
+                                        {string.Join("", r.Args.Where(a => !a.IsContextArg).Select(a => $",\nnew SpacetimeDB.SATS.ProductTypeElement(nameof({a.Name}), {a.Name}.AlgebraicType)"))}
                                     );
                                 }}
 
-                                void IReducer.Invoke(BinaryReader reader, SpacetimeDB.Runtime.ReducerContext dbEvent) {{
-                                    {r.FullName}({string.Join(", ", r.Args.Select(a => a.IsDbEvent ? "dbEvent" : $"{a.Name}.Read(reader)"))});
+                                void IReducer.Invoke(BinaryReader reader, SpacetimeDB.Runtime.ReducerContext ctx) {{
+                                    {r.FullName}({string.Join(", ", r.Args.Select(a => a.IsContextArg ? "ctx" : $"{a.Name}.Read(reader)"))});
                                 }}
                             }}
                         "
@@ -327,10 +328,10 @@ public class Module : IIncrementalGenerator
                         r.FullName,
                         r.Scope.GenerateExtensions(
                             $@"
-                            public static SpacetimeDB.Runtime.ScheduleToken Schedule{r.Name}(DateTimeOffset time{string.Join("", r.Args.Where(a => !a.IsDbEvent).Select(a => $", {a.Type} {a.Name}"))}) {{
+                            public static SpacetimeDB.Runtime.ScheduleToken Schedule{r.Name}(DateTimeOffset time{string.Join("", r.Args.Where(a => !a.IsContextArg).Select(a => $", {a.Type} {a.Name}"))}) {{
                                 using var stream = new MemoryStream();
                                 using var writer = new BinaryWriter(stream);
-                                {string.Join("\n", r.Args.Where(a => !a.IsDbEvent).Select(a => $"{GetTypeInfo(a.Type)}.Write(writer, {a.Name});"))}
+                                {string.Join("\n", r.Args.Where(a => !a.IsContextArg).Select(a => $"{GetTypeInfo(a.Type)}.Write(writer, {a.Name});"))}
                                 return new(nameof({r.Name}), stream.ToArray(), time);
                             }}
                         "

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -222,7 +222,7 @@ public class Module : IIncrementalGenerator
                             (
                                 p.Name,
                                 p.Type,
-                                IsDbEvent: p.Type.ToString() == "SpacetimeDB.Runtime.DbEventArgs"
+                                IsDbEvent: p.Type.ToString() == "SpacetimeDB.Runtime.ReducerContext"
                             )
                         )
                         .ToArray(),
@@ -247,7 +247,7 @@ public class Module : IIncrementalGenerator
                                     );
                                 }}
 
-                                void IReducer.Invoke(BinaryReader reader, SpacetimeDB.Runtime.DbEventArgs dbEvent) {{
+                                void IReducer.Invoke(BinaryReader reader, SpacetimeDB.Runtime.ReducerContext dbEvent) {{
                                     {r.FullName}({string.Join(", ", r.Args.Select(a => a.IsDbEvent ? "dbEvent" : $"{a.Name}.Read(reader)"))});
                                 }}
                             }}

--- a/crates/bindings-csharp/Runtime/Module.cs
+++ b/crates/bindings-csharp/Runtime/Module.cs
@@ -188,7 +188,7 @@ public static class ReducerKind
 public interface IReducer
 {
     SpacetimeDB.Module.ReducerDef MakeReducerDef();
-    void Invoke(System.IO.BinaryReader reader, Runtime.DbEventArgs args);
+    void Invoke(System.IO.BinaryReader reader, Runtime.ReducerContext args);
 }
 
 public static class FFI

--- a/crates/bindings-csharp/Runtime/Runtime.cs
+++ b/crates/bindings-csharp/Runtime/Runtime.cs
@@ -207,13 +207,13 @@ public static class Runtime
         public static SpacetimeDB.SATS.TypeInfo<Address> GetSatsTypeInfo() => satsTypeInfo;
     }
 
-    public class DbEventArgs : EventArgs
+    public class ReducerContext
     {
         public readonly Identity Sender;
         public readonly DateTimeOffset Time;
         public readonly Address? Address;
 
-        public DbEventArgs(byte[] senderIdentity, byte[] senderAddress, ulong timestamp_us)
+        public ReducerContext(byte[] senderIdentity, byte[] senderAddress, ulong timestamp_us)
         {
             Sender = new Identity(senderIdentity);
             var addr = new Address(senderAddress);

--- a/modules/sdk-test-connect-disconnect-cs/Lib.cs
+++ b/modules/sdk-test-connect-disconnect-cs/Lib.cs
@@ -16,13 +16,13 @@ static partial class Module
     }
 
     [SpacetimeDB.Reducer(ReducerKind.Connect)]
-    public static void OnConnect(DbEventArgs e)
+    public static void OnConnect(ReducerContext e)
     {
         new Connected { identity = e.Sender }.Insert();
     }
 
     [SpacetimeDB.Reducer(ReducerKind.Disconnect)]
-    public static void OnDisconnect(DbEventArgs e)
+    public static void OnDisconnect(ReducerContext e)
     {
         new Disconnected { identity = e.Sender }.Insert();
     }

--- a/modules/sdk-test-cs/Lib.cs
+++ b/modules/sdk-test-cs/Lib.cs
@@ -1372,37 +1372,37 @@ static partial class Module
     }
 
     [SpacetimeDB.Reducer]
-    public static void insert_caller_one_identity(DbEventArgs ctx)
+    public static void insert_caller_one_identity(ReducerContext ctx)
     {
         new OneIdentity { i = ctx.Sender }.Insert();
     }
 
     [SpacetimeDB.Reducer]
-    public static void insert_caller_vec_identity(DbEventArgs ctx)
+    public static void insert_caller_vec_identity(ReducerContext ctx)
     {
         new VecIdentity { i = new List<Identity> { ctx.Sender } }.Insert();
     }
 
     [SpacetimeDB.Reducer]
-    public static void insert_caller_unique_identity(DbEventArgs ctx, int data)
+    public static void insert_caller_unique_identity(ReducerContext ctx, int data)
     {
         new UniqueIdentity { i = ctx.Sender, data = data }.Insert();
     }
 
     [SpacetimeDB.Reducer]
-    public static void insert_caller_pk_identity(DbEventArgs ctx, int data)
+    public static void insert_caller_pk_identity(ReducerContext ctx, int data)
     {
         new PkIdentity { i = ctx.Sender, data = data }.Insert();
     }
 
     [SpacetimeDB.Reducer]
-    public static void insert_caller_one_address(DbEventArgs ctx)
+    public static void insert_caller_one_address(ReducerContext ctx)
     {
         new OneAddress { a = (Address)ctx.Address!, }.Insert();
     }
 
     [SpacetimeDB.Reducer]
-    public static void insert_caller_vec_address(DbEventArgs ctx)
+    public static void insert_caller_vec_address(ReducerContext ctx)
     {
         // VecAddress::insert(VecAddress {
         //     < a[_]>::into_vec(
@@ -1413,13 +1413,13 @@ static partial class Module
     }
 
     [SpacetimeDB.Reducer]
-    public static void insert_caller_unique_address(DbEventArgs ctx, int data)
+    public static void insert_caller_unique_address(ReducerContext ctx, int data)
     {
         new UniqueAddress { a = (Address)ctx.Address!, data = data }.Insert();
     }
 
     [SpacetimeDB.Reducer]
-    public static void insert_caller_pk_address(DbEventArgs ctx, int data)
+    public static void insert_caller_pk_address(ReducerContext ctx, int data)
     {
         new PkAddress { a = (Address)ctx.Address!, data = data }.Insert();
     }


### PR DESCRIPTION
# Description of Changes

This is no longer an event type, so remove subclassing and rename to match the Rust API.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

1

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Checked that C# SDK tests still build.
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*