### PR TITLE
Create a lockfile when opening config files

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -653,6 +653,20 @@ Fetch the server's fingerprint with:
 }
 
 impl Config {
+    /// Release the system configuration `Lockfile` contained in `self`, if it exists,
+    /// allowing other processes to access the configuration.
+    ///
+    /// This is equivalent to dropping `self`, but more explicit in purpose.
+    pub fn release_lock(self) {
+        // Just drop `self`, cleaning up its lockfile.
+        //
+        // If we had CLI subcommands which wanted to read a `Config` but never `Config::save` it,
+        // we could have this message take `&mut self` and set the `home_lock` to `None`.
+        // This seems unlikely to be useful,
+        // as many accesses to the `Config` will implicitly mutate and `save`,
+        // e.g. by creating a new identity if none exists.
+    }
+
     pub fn default_server_name(&self) -> Option<&str> {
         self.proj
             .default_server

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -52,15 +52,19 @@ pub async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Re
         "logs" => logs::exec(config, args).await,
         "sql" => sql::exec(config, args).await,
         "dns" => dns::exec(config, args).await,
-        "generate" => generate::exec(args),
+        "generate" => generate::exec(config, args),
         "list" => list::exec(config, args).await,
         "local" => local::exec(config, args).await,
         "init" => init::exec(config, args).await,
         "build" => build::exec(config, args).await,
         "server" => server::exec(config, args).await,
         #[cfg(feature = "standalone")]
-        "start" => start::exec(args).await,
-        "upgrade" => upgrade::exec(args).await,
+        "start" => {
+            // Release the lockfile on the config, since we don't need it.
+            drop(config);
+            start::exec(args).await
+        }
+        "upgrade" => upgrade::exec(config, args).await,
         unknown => Err(anyhow::anyhow!("Invalid subcommand: {}", unknown)),
     }
 }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -61,7 +61,7 @@ pub async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Re
         #[cfg(feature = "standalone")]
         "start" => {
             // Release the lockfile on the config, since we don't need it.
-            drop(config);
+            config.release_lock();
             start::exec(args).await
         }
         "upgrade" => upgrade::exec(config, args).await,

--- a/crates/cli/src/subcommands/build.rs
+++ b/crates/cli/src/subcommands/build.rs
@@ -32,7 +32,7 @@ pub fn cli() -> clap::Command {
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     // Release the lockfile on the config, since we don't need it.
-    drop(config);
+    config.release_lock();
 
     let project_path = args.get_one::<PathBuf>("project_path").unwrap();
     let skip_clippy = args.get_flag("skip_clippy");

--- a/crates/cli/src/subcommands/build.rs
+++ b/crates/cli/src/subcommands/build.rs
@@ -30,7 +30,10 @@ pub fn cli() -> clap::Command {
         )
 }
 
-pub async fn exec(_: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+    // Release the lockfile on the config, since we don't need it.
+    drop(config);
+
     let project_path = args.get_one::<PathBuf>("project_path").unwrap();
     let skip_clippy = args.get_flag("skip_clippy");
     let build_debug = args.get_flag("debug");

--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -14,6 +14,8 @@ use spacetimedb_lib::MODULE_ABI_MAJOR_VERSION;
 use spacetimedb_lib::{bsatn, MiscModuleExport, ModuleDef, ReducerDef, TableDesc, TypeAlias};
 use wasmtime::{AsContext, Caller};
 
+use crate::Config;
+
 mod code_indenter;
 pub mod csharp;
 pub mod python;
@@ -98,7 +100,10 @@ pub fn cli() -> clap::Command {
         .after_help("Run `spacetime help publish` for more detailed information.")
 }
 
-pub fn exec(args: &clap::ArgMatches) -> anyhow::Result<()> {
+pub fn exec(config: Config, args: &clap::ArgMatches) -> anyhow::Result<()> {
+    // Release the lockfile on the config, since we don't need it.
+    drop(config);
+
     let project_path = args.get_one::<PathBuf>("project_path").unwrap();
     let wasm_file = args.get_one::<PathBuf>("wasm_file").cloned();
     let out_dir = args.get_one::<PathBuf>("out_dir").unwrap();

--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -102,7 +102,7 @@ pub fn cli() -> clap::Command {
 
 pub fn exec(config: Config, args: &clap::ArgMatches) -> anyhow::Result<()> {
     // Release the lockfile on the config, since we don't need it.
-    drop(config);
+    config.release_lock();
 
     let project_path = args.get_one::<PathBuf>("project_path").unwrap();
     let wasm_file = args.get_one::<PathBuf>("wasm_file").cloned();

--- a/crates/cli/src/subcommands/init.rs
+++ b/crates/cli/src/subcommands/init.rs
@@ -112,7 +112,10 @@ fn check_for_git() -> bool {
     false
 }
 
-pub async fn exec(_: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+    // Release the lockfile on the config, since we don't need it.
+    drop(config);
+
     let project_path = args.get_one::<PathBuf>("project-path").unwrap();
     let project_lang = *args.get_one::<ModuleLanguage>("lang").unwrap();
 

--- a/crates/cli/src/subcommands/init.rs
+++ b/crates/cli/src/subcommands/init.rs
@@ -114,7 +114,7 @@ fn check_for_git() -> bool {
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     // Release the lockfile on the config, since we don't need it.
-    drop(config);
+    config.release_lock();
 
     let project_path = args.get_one::<PathBuf>("project-path").unwrap();
     let project_lang = *args.get_one::<ModuleLanguage>("lang").unwrap();

--- a/crates/cli/src/subcommands/local.rs
+++ b/crates/cli/src/subcommands/local.rs
@@ -37,7 +37,10 @@ async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Result
     }
 }
 
-async fn exec_clear(_config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+async fn exec_clear(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+    // Release the lockfile on the config, since we don't need it.
+    drop(config);
+
     let force = args.get_flag("force");
     if std::env::var_os("STDB_PATH").map(PathBuf::from).is_none() {
         let mut path = dirs::home_dir().unwrap_or_default();

--- a/crates/cli/src/subcommands/local.rs
+++ b/crates/cli/src/subcommands/local.rs
@@ -39,7 +39,7 @@ async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Result
 
 async fn exec_clear(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     // Release the lockfile on the config, since we don't need it.
-    drop(config);
+    config.release_lock();
 
     let force = args.get_flag("force");
     if std::env::var_os("STDB_PATH").map(PathBuf::from).is_none() {

--- a/crates/cli/src/subcommands/upgrade.rs
+++ b/crates/cli/src/subcommands/upgrade.rs
@@ -3,7 +3,7 @@ use std::{env, fs};
 
 extern crate regex;
 
-use crate::version;
+use crate::{version, Config};
 use clap::{Arg, ArgMatches};
 use flate2::read::GzDecoder;
 use futures::stream::StreamExt;
@@ -121,7 +121,10 @@ async fn download_with_progress(client: &reqwest::Client, url: &str, temp_path: 
     Ok(())
 }
 
-pub async fn exec(args: &ArgMatches) -> Result<(), anyhow::Error> {
+pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+    // Release the lockfile on the config, since we don't need it.
+    drop(config);
+
     let version = args.get_one::<String>("version");
     let current_exe_path = env::current_exe()?;
     let force = args.get_flag("force");

--- a/crates/cli/src/subcommands/upgrade.rs
+++ b/crates/cli/src/subcommands/upgrade.rs
@@ -123,7 +123,7 @@ async fn download_with_progress(client: &reqwest::Client, url: &str, temp_path: 
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     // Release the lockfile on the config, since we don't need it.
-    drop(config);
+    config.release_lock();
 
     let version = args.get_one::<String>("version");
     let current_exe_path = env::current_exe()?;

--- a/crates/cli/src/subcommands/version.rs
+++ b/crates/cli/src/subcommands/version.rs
@@ -19,7 +19,7 @@ pub fn cli() -> clap::Command {
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     // Release the lockfile on the config, since we don't need it.
-    drop(config);
+    config.release_lock();
 
     if args.get_flag("cli") {
         println!("{}", CLI_VERSION);

--- a/crates/cli/src/subcommands/version.rs
+++ b/crates/cli/src/subcommands/version.rs
@@ -17,7 +17,10 @@ pub fn cli() -> clap::Command {
         )
 }
 
-pub async fn exec(_config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+    // Release the lockfile on the config, since we don't need it.
+    drop(config);
+
     if args.get_flag("cli") {
         println!("{}", CLI_VERSION);
         return Ok(());

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -34,6 +34,6 @@ pub fn invoke_cli(args: &[&str]) {
     let (cmd, args) = args.subcommand().expect("Could not split subcommand and args");
 
     RUNTIME
-        .block_on(spacetimedb_cli::exec_subcommand((*CONFIG).clone(), cmd, args))
+        .block_on(spacetimedb_cli::exec_subcommand((*CONFIG).clone_for_test(), cmd, args))
         .unwrap()
 }


### PR DESCRIPTION
# Description of Changes

In the past, we've had issues where multiple concurrent CLI processes would race to read and write the CLI config file,
leading to data loss.

We considered using `flock`/`LockFileEx` and blocking until the file became available, but unfortunately it's not possible to atomically create and lock a nonexistent file, which we need to do in the case where the configuration doesn't yet exist.

Instead, we opt for a classic lockfile-based scheme: Before opening a config file `foo.conf`, attempt to exclusively create `foo.lock`, and panic if the exclusive creation fails. Once it becomes clear that we will not write the config any more, i.e. in `Config::drop`, delete the lockfile, allowing another process to operate.

This means that attempting to run multiple concurrent Spacetime CLI processes with the same config file is now a hard error.

# API and ABI breaking changes

Arguably this is a CLI interface break, in the sense that running multiple concurrent CLI processes with the same config file is now a hard error, where before it sometimes worked.

# Expected complexity level and risk

3 - CLI stuff is finicky and requires manual testing.

# Testing

- [x] Using the new CLI:
  - Create an identity.
  - List identities for a particular server, a non-default server, and all servers.
  - Publish a database.
  - Fingerprint a server.
  - Add a server configuration.
  - Delete an identity.
  - Access a module's logs.
  - Run a SQL query against a module.
- [x] Create a file `~/.spacetime/config.lock`, then attempt the above, and observe the error.
- [x] Delete `~/.spacetime/config.lock`, try again, and see that it works again.
- [x] Invoke the CLI with invalid arguments to trigger a Clap parse error (e.g. `spacetime lsit`), then run again with a valid parse (e.g. `spacetime identity list`), and verify that there is no stale lockfile preventing the corrected command.
- [x] Delete the `~/.spacetime` directory, then run a CLI command and verify that the lockfile can be created despite the directory not existing.
- [ ] Do whatever cursed concurrent invocations were exhibiting the bug before, and observe that they now show an error rather than silently corrupting or losing data.
