### PR TITLE
Jeremie/notify sql

### DIFF
--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -523,20 +523,25 @@ where
     let instance_id = database_instance.id;
 
     let host = worker_ctx.host_controller();
-    let module_host = host.get_or_launch_module_host(database.clone(), instance_id).await.map_err(log_and_500)?;
-    let json = host.using_database(
-        database,
-        instance_id,
-        move |db| -> axum::response::Result<_, (StatusCode, String)> {
-            tracing::info!(sql = body);
-            let results = sql::execute::run(db, &body, auth, Some(&module_host.info().subscriptions)).map_err(|e| {
-                log::warn!("{}", e);
-                if let Some(auth_err) = e.get_auth_error() {
-                    (StatusCode::UNAUTHORIZED, auth_err.to_string())
-                } else {
-                    (StatusCode::BAD_REQUEST, e.to_string())
-                }
-            })?;
+    let module_host = host
+        .get_or_launch_module_host(database.clone(), instance_id)
+        .await
+        .map_err(log_and_500)?;
+    let json = host
+        .using_database(
+            database,
+            instance_id,
+            move |db| -> axum::response::Result<_, (StatusCode, String)> {
+                tracing::info!(sql = body);
+                let results =
+                    sql::execute::run(db, &body, auth, Some(&module_host.info().subscriptions)).map_err(|e| {
+                        log::warn!("{}", e);
+                        if let Some(auth_err) = e.get_auth_error() {
+                            (StatusCode::UNAUTHORIZED, auth_err.to_string())
+                        } else {
+                            (StatusCode::BAD_REQUEST, e.to_string())
+                        }
+                    })?;
 
                 let json = db.with_read_only(&ctx_sql(db), |tx| {
                     results

--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -538,28 +538,29 @@ where
                 }
             })?;
 
-            let json = db.with_read_only(&ctx_sql(db), |tx| {
-                results
-                    .into_iter()
-                    .map(|result| {
-                        let rows = result.data;
-                        let schema = result
-                            .head
-                            .fields
-                            .iter()
-                            .map(|x| {
-                                let ty = x.algebraic_type.clone();
-                                let name = translate_col(tx, x.field);
-                                ProductTypeElement::new(ty, name)
-                            })
-                            .collect();
-                        StmtResultJson { schema, rows }
-                    })
-                    .collect::<Vec<_>>()
-            });
+                let json = db.with_read_only(&ctx_sql(db), |tx| {
+                    results
+                        .into_iter()
+                        .map(|result| {
+                            let rows = result.data;
+                            let schema = result
+                                .head
+                                .fields
+                                .iter()
+                                .map(|x| {
+                                    let ty = x.algebraic_type.clone();
+                                    let name = translate_col(tx, x.field);
+                                    ProductTypeElement::new(ty, name)
+                                })
+                                .collect();
+                            StmtResultJson { schema, rows }
+                        })
+                        .collect::<Vec<_>>()
+                });
 
-            Ok(json)
-        })
+                Ok(json)
+            },
+        )
         .await
         .map_err(log_and_500)??;
 

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -177,7 +177,6 @@ pub fn translate_col(tx: &Tx, field: FieldName) -> Option<Box<str>> {
 #[cfg(test)]
 pub(crate) mod tests {
     use std::sync::Arc;
-
     use super::*;
     use crate::db::datastore::system_tables::{ST_TABLES_ID, ST_TABLES_NAME};
     use crate::db::relational_db::tests_utils::TestDB;

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -191,6 +191,11 @@ pub(crate) mod tests {
     use spacetimedb_sats::{product, AlgebraicType, ProductType};
     use spacetimedb_vm::eval::test_helpers::{create_game_data, mem_table, mem_table_without_table_name};
 
+    pub(crate) fn execute_for_testing(db: &RelationalDB, sql_text: &str, q: Vec<CrudExpr>) -> Result<Vec<MemTable>, DBError> {
+        let subs = ModuleSubscriptions::new(Arc::new(db.clone()), Identity::ZERO);
+        execute_sql(db, sql_text, q, AuthCtx::for_testing(), Some(&subs))
+    }
+
     /// Short-cut for simplify test execution
     pub(crate) fn run_for_testing(db: &RelationalDB, sql_text: &str) -> Result<Vec<MemTable>, DBError> {
         let subs = ModuleSubscriptions::new(Arc::new(db.clone()), Identity::ZERO);

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -28,7 +28,11 @@ pub struct StmtResult {
 // TODO(cloutiertyler): we could do this the swift parsing way in which
 // we always generate a plan, but it may contain errors
 
-pub(crate) fn collect_result(result: &mut Vec<MemTable>, updates: &mut Vec<DatabaseTableUpdate>, r: CodeResult) -> Result<(), DBError> {
+pub(crate) fn collect_result(
+    result: &mut Vec<MemTable>,
+    updates: &mut Vec<DatabaseTableUpdate>,
+    r: CodeResult,
+) -> Result<(), DBError> {
     match r {
         CodeResult::Value(_) => {}
         CodeResult::Table(x) => result.push(x),
@@ -39,16 +43,16 @@ pub(crate) fn collect_result(result: &mut Vec<MemTable>, updates: &mut Vec<Datab
         }
         CodeResult::Halt(err) => return Err(DBError::VmUser(err)),
         CodeResult::Pass(x) => match x {
-            None => {},
+            None => {}
             Some(update) => {
                 updates.push(DatabaseTableUpdate {
                     table_name: update.table_name,
                     table_id: update.table_id,
                     inserts: update.inserts.into(),
-                    deletes: update.deletes.into()
+                    deletes: update.deletes.into(),
                 });
             }
-        }
+        },
     }
 
     Ok(())
@@ -95,13 +99,13 @@ pub fn execute_sql(db: &RelationalDB, sql: &str, ast: Vec<CrudExpr>, auth: AuthC
                 caller_address: None,
                 function_call: ModuleFunctionCall {
                     reducer: String::new(),
-                    args: ArgsTuple::default()
+                    args: ArgsTuple::default(),
                 },
                 status: EventStatus::Committed(DatabaseUpdate { tables: updates }),
                 energy_quanta_used: EnergyQuanta::ZERO,
                 host_execution_duration: Duration::ZERO,
                 request_id: None,
-                timer: None
+                timer: None,
             };
             match subs.unwrap().commit_and_broadcast_event(None, event, &ctx, tx).unwrap() {
                 Ok(_) => res,
@@ -176,7 +180,6 @@ pub fn translate_col(tx: &Tx, field: FieldName) -> Option<Box<str>> {
 
 #[cfg(test)]
 pub(crate) mod tests {
-    use std::sync::Arc;
     use super::*;
     use crate::db::datastore::system_tables::{ST_TABLES_ID, ST_TABLES_NAME};
     use crate::db::relational_db::tests_utils::TestDB;
@@ -189,8 +192,13 @@ pub(crate) mod tests {
     use spacetimedb_sats::relation::Header;
     use spacetimedb_sats::{product, AlgebraicType, ProductType};
     use spacetimedb_vm::eval::test_helpers::{create_game_data, mem_table, mem_table_without_table_name};
+    use std::sync::Arc;
 
-    pub(crate) fn execute_for_testing(db: &RelationalDB, sql_text: &str, q: Vec<CrudExpr>) -> Result<Vec<MemTable>, DBError> {
+    pub(crate) fn execute_for_testing(
+        db: &RelationalDB,
+        sql_text: &str,
+        q: Vec<CrudExpr>,
+    ) -> Result<Vec<MemTable>, DBError> {
         let subs = ModuleSubscriptions::new(Arc::new(db.clone()), Identity::ZERO);
         execute_sql(db, sql_text, q, AuthCtx::for_testing(), Some(&subs))
     }

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -191,7 +191,7 @@ pub fn run(
         //       and figure out if we can detect the mutablility of the query before we take
         //       the tx? once we have migrations we probably don't want to have stale
         //       sql queries after a database schema have been updated.
-        Either::Right(ast) => execute_sql(db, sql_text, ast, auth, subs)
+        Either::Right(ast) => execute_sql(db, sql_text, ast, auth, subs),
     }
 }
 

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -1,16 +1,15 @@
-use std::sync::Arc;
 use std::time::Duration;
 
 use super::compiler::compile_sql;
 use crate::db::datastore::locking_tx_datastore::state_view::StateView;
-use crate::db::datastore::locking_tx_datastore::tx::TxId;
+use crate::db::datastore::traits::IsolationLevel;
 use crate::db::relational_db::{RelationalDB, Tx};
 use crate::energy::EnergyQuanta;
 use crate::error::DBError;
 use crate::execution_context::ExecutionContext;
 use crate::host::module_host::{DatabaseTableUpdate, DatabaseUpdate, EventStatus, ModuleEvent, ModuleFunctionCall};
 use crate::host::{ArgsTuple, Timestamp};
-use crate::subscription::module_subscription_actor::ModuleSubscriptions;
+use crate::subscription::module_subscription_actor::{ModuleSubscriptions, WriteConflict};
 use crate::util::slow::SlowQueryLogger;
 use crate::vm::{DbProgram, TxMode};
 use itertools::Either;
@@ -59,11 +58,11 @@ pub fn ctx_sql(db: &RelationalDB) -> ExecutionContext {
     ExecutionContext::sql(db.address(), db.read_config().slow_query)
 }
 
-fn execute(p: &mut DbProgram<'_, '_>, ast: Vec<CrudExpr>) -> Result<Vec<MemTable>, DBError> {
+fn execute(p: &mut DbProgram<'_, '_>, ast: Vec<CrudExpr>, updates: &mut Vec<DatabaseTableUpdate>) -> Result<Vec<MemTable>, DBError> {
     let mut result = Vec::with_capacity(ast.len());
     let query = Expr::Block(ast.into_iter().map(|x| Expr::Crud(Box::new(x))).collect());
     // SQL queries can never reference `MemTable`s, so pass an empty `SourceSet`.
-    collect_result(&mut result, run_ast(p, query, [].into()).into())?;
+    collect_result(&mut result, updates, run_ast(p, query, [].into()).into())?;
     Ok(result)
 }
 
@@ -72,17 +71,46 @@ fn execute(p: &mut DbProgram<'_, '_>, ast: Vec<CrudExpr>) -> Result<Vec<MemTable
 /// Evaluates `ast` and accordingly triggers mutable or read tx to execute
 ///
 /// Also, in case the execution takes more than x, log it as `slow query`
-pub fn execute_sql(db: &RelationalDB, sql: &str, ast: Vec<CrudExpr>, auth: AuthCtx) -> Result<Vec<MemTable>, DBError> {
+pub fn execute_sql(db: &RelationalDB, sql: &str, ast: Vec<CrudExpr>, auth: AuthCtx, subs: Option<&ModuleSubscriptions>) -> Result<Vec<MemTable>, DBError> {
     let ctx = ctx_sql(db);
     let _slow_logger = SlowQueryLogger::query(&ctx, sql).log_guard();
     if CrudExpr::is_reads(&ast) {
+        let mut updates = Vec::new();
         db.with_read_only(&ctx, |tx| {
-            execute(&mut DbProgram::new(&ctx, db, &mut TxMode::Tx(tx), auth), ast)
+            execute(&mut DbProgram::new(&ctx, db, &mut TxMode::Tx(tx), auth), ast, &mut updates)
+        })
+    } else if subs.is_none() {
+        let mut updates = Vec::new();
+        db.with_auto_commit(&ctx, |mut_tx| {
+            execute(&mut DbProgram::new(&ctx, db, &mut mut_tx.into(), auth), ast, &mut updates)
         })
     } else {
-        db.with_auto_commit(&ctx, |mut_tx| {
-            execute(&mut DbProgram::new(&ctx, db, &mut mut_tx.into(), auth), ast)
-        })
+        let mut tx = db.begin_mut_tx(IsolationLevel::Serializable);
+        let mut updates = Vec::with_capacity(ast.len());
+        let res = execute(&mut DbProgram::new(&ctx, db, &mut (&mut tx).into(), auth), ast, &mut updates);
+        if res.is_ok() && !updates.is_empty() {
+            let event = ModuleEvent {
+                timestamp: Timestamp::now(),
+                caller_identity: auth.caller,
+                caller_address: None,
+                function_call: ModuleFunctionCall {
+                    reducer: String::new(),
+                    args: ArgsTuple::default()
+                },
+                status: EventStatus::Committed(DatabaseUpdate { tables: updates }),
+                energy_quanta_used: EnergyQuanta::ZERO,
+                host_execution_duration: Duration::ZERO,
+                request_id: None,
+                timer: None
+            };
+            match subs.unwrap().commit_and_broadcast_event(None, event, &ctx, tx).unwrap() {
+                Ok(_) => res,
+                Err(WriteConflict) => todo!("See module_host_actor::call_reducer_with_tx"),
+            }
+        }
+        else {
+            db.finish_tx(&ctx, tx, res)
+        }
     }
 }
 
@@ -104,17 +132,19 @@ pub fn execute_sql_tx<'a>(
 
     let ctx = ctx_sql(db);
     let _slow_logger = SlowQueryLogger::query(&ctx, sql).log_guard();
-    execute(&mut DbProgram::new(&ctx, db, &mut tx, auth), ast).map(Some)
+    let mut updates = Vec::new(); // No subscription updates in this path, because it requires owning the tx.
+    execute(&mut DbProgram::new(&ctx, db, &mut tx, auth), ast, &mut updates).map(Some)
 }
 
 /// Run the `SQL` string using the `auth` credentials
-pub fn run(db: &RelationalDB, sql_text: &str, auth: AuthCtx) -> Result<Vec<MemTable>, DBError> {
+pub fn run(db: &RelationalDB, sql_text: &str, auth: AuthCtx, subs: Option<&ModuleSubscriptions>) -> Result<Vec<MemTable>, DBError> {
     let ctx = ctx_sql(db);
     let _slow_logger = SlowQueryLogger::query(&ctx, sql_text).log_guard();
     let result = db.with_read_only(&ctx, |tx| {
         let ast = compile_sql(db, tx, sql_text)?;
         if CrudExpr::is_reads(&ast) {
-            let result = execute(&mut DbProgram::new(&ctx, db, &mut TxMode::Tx(tx), auth), ast)?;
+            let mut updates = Vec::new();
+            let result = execute(&mut DbProgram::new(&ctx, db, &mut TxMode::Tx(tx), auth), ast, &mut updates)?;
             Ok::<_, DBError>(Either::Left(result))
         } else {
             // hehe. right. write.
@@ -127,9 +157,10 @@ pub fn run(db: &RelationalDB, sql_text: &str, auth: AuthCtx) -> Result<Vec<MemTa
         //       and figure out if we can detect the mutablility of the query before we take
         //       the tx? once we have migrations we probably don't want to have stale
         //       sql queries after a database schema have been updated.
-        Either::Right(ast) => db.with_auto_commit(&ctx, |tx| {
-            execute(&mut DbProgram::new(&ctx, db, &mut tx.into(), auth), ast)
-        }),
+        Either::Right(ast) => //db.with_auto_commit(&ctx, |tx| {
+            //execute(&mut DbProgram::new(&ctx, db, &mut tx.into(), auth), ast)
+        //}),
+        execute_sql(db, sql_text, ast, auth, subs)
     }
 }
 
@@ -145,6 +176,8 @@ pub fn translate_col(tx: &Tx, field: FieldName) -> Option<Box<str>> {
 
 #[cfg(test)]
 pub(crate) mod tests {
+    use std::sync::Arc;
+
     use super::*;
     use crate::db::datastore::system_tables::{ST_TABLES_ID, ST_TABLES_NAME};
     use crate::db::relational_db::tests_utils::TestDB;
@@ -161,7 +194,7 @@ pub(crate) mod tests {
     /// Short-cut for simplify test execution
     pub(crate) fn run_for_testing(db: &RelationalDB, sql_text: &str) -> Result<Vec<MemTable>, DBError> {
         let subs = ModuleSubscriptions::new(Arc::new(db.clone()), Identity::ZERO);
-        run(db, sql_text, AuthCtx::for_testing(), &subs)
+        run(db, sql_text, AuthCtx::for_testing(), Some(&subs))
     }
 
     fn create_data(total_rows: u64) -> ResultTest<(TestDB, MemTable)> {

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -133,7 +133,8 @@ mod tests {
         let q = Expr::Crud(Box::new(CrudExpr::Query(query.clone())));
 
         let mut result = Vec::with_capacity(1);
-        collect_result(&mut result, run_ast(p, q, sources).into())?;
+        let mut updates = Vec::new();
+        collect_result(&mut result, &mut updates, run_ast(p, q, sources).into())?;
         Ok(result)
     }
 

--- a/crates/core/src/util/slow.rs
+++ b/crates/core/src/util/slow.rs
@@ -123,7 +123,7 @@ mod tests {
         let tx = db.begin_tx();
         let q = compile_sql(db, &tx, &sql)?;
         let subs = ModuleSubscriptions::new(Arc::new(db.clone()), Identity::ZERO);
-        Ok(execute_sql(db, &sql, q, AuthCtx::for_testing(), &subs)?.pop().unwrap())
+        Ok(execute_sql(db, &sql, q, AuthCtx::for_testing(), Some(&subs))?.pop().unwrap())
     }
 
     fn run_query_write(db: &RelationalDB, sql: String) -> ResultTest<()> {
@@ -132,7 +132,7 @@ mod tests {
         drop(tx);
 
         let subs = ModuleSubscriptions::new(Arc::new(db.clone()), Identity::ZERO);
-        execute_sql(db, &sql, q, AuthCtx::for_testing(), &subs)?;
+        execute_sql(db, &sql, q, AuthCtx::for_testing(), Some(&subs))?;
 
         Ok(())
     }
@@ -161,7 +161,7 @@ mod tests {
         let slow = SlowQueryLogger::query(&ctx, sql);
 
         let subs = ModuleSubscriptions::new(Arc::new(db.clone()), Identity::ZERO);
-        let result = execute_sql(&db, sql, q, AuthCtx::for_testing(), &subs)?;
+        let result = execute_sql(&db, sql, q, AuthCtx::for_testing(), Some(&subs))?;
         assert_eq!(result[0].data[0], product![1, 2]);
         assert!(slow.log().is_some());
 

--- a/crates/core/src/util/slow.rs
+++ b/crates/core/src/util/slow.rs
@@ -104,9 +104,9 @@ impl<'a> SlowQueryLogger<'a> {
 mod tests {
     use super::*;
 
-    use crate::sql::execute::tests::execute_for_testing;
     use crate::execution_context::ExecutionContext;
     use crate::sql::compiler::compile_sql;
+    use crate::sql::execute::tests::execute_for_testing;
     use spacetimedb_lib::error::ResultTest;
 
     use crate::config::ReadConfigOption;

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -450,14 +450,13 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
 
     fn _execute_insert(&mut self, table: &DbTable, rows: Vec<ProductValue>) -> Result<Code, ErrorVm> {
         let tx = self.tx.unwrap_mut();
-        let inserts = rows.clone();
+        let inserts = rows.clone(); // TODO code shouldn't be hot, let's remove later
         for row in rows {
             self.db.insert(tx, table.table_id, row)?;
         }
         Ok(Code::Pass(Some(Update {
-            affected_rows: inserts.len() as u32,
-            table_id: table.table_id,
-            table_name: table.head.table_name.clone(),
+            table_id: table.get_db_table().unwrap().table_id,
+            table_name: table.table_name().into(),
             inserts,
             deletes: Vec::default()
         })))
@@ -523,7 +522,6 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
         let count = self.db.delete_by_rel(self.tx.unwrap_mut(), table.table_id, rows);
 
         Ok(Code::Pass(Some(Update {
-            affected_rows: count.into(),
             table_id: table.table_id,
             table_name: table.head.table_name.clone(),
             inserts: Vec::default(),
@@ -573,7 +571,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
 
     fn _set_config(&mut self, name: String, value: AlgebraicValue) -> Result<Code, ErrorVm> {
         self.db.set_config(&name, value)?;
-        Ok(Code::Pass(None)) // TODO can subscriptions watch config values?
+        Ok(Code::Pass(None))
     }
 
     fn _read_config(&self, name: String) -> Result<Code, ErrorVm> {

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -450,10 +450,17 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
 
     fn _execute_insert(&mut self, table: &DbTable, rows: Vec<ProductValue>) -> Result<Code, ErrorVm> {
         let tx = self.tx.unwrap_mut();
+        let inserts = rows.clone();
         for row in rows {
             self.db.insert(tx, table.table_id, row)?;
         }
-        Ok(Code::Pass)
+        Ok(Code::Pass(Some(Update {
+            affected_rows: inserts.len() as u32,
+            table_id: table.table_id,
+            table_name: table.head.table_name.clone(),
+            inserts,
+            deletes: Vec::default()
+        })))
     }
 
     fn _execute_update<const N: usize>(
@@ -472,11 +479,12 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
             .get_db_table()
             .expect("source for Update should be a DbTable");
 
-        self._execute_delete(table.table_id, deleted.data.clone());
+        self._execute_delete(table, deleted.data.clone());
 
         // Replace the columns in the matched rows with the assigned
         // values. No typechecking is performed here, nor that all
         // assignments are consumed.
+        let deletes = deleted.data.clone();
         let exprs: Vec<Option<ColExpr>> = (0..table.head.fields.len())
             .map(ColId::from)
             .map(|c| assigns.remove(&c))
@@ -502,26 +510,37 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
             })
             .collect_vec();
 
-        self._execute_insert(table, insert_rows)
+        let result = self._execute_insert(table, insert_rows);
+        let Ok(Code::Pass(Some(insert))) = result else {
+            return result;
+        };
+
+        Ok(Code::Pass(Some(Update { deletes, ..insert })))
     }
 
-    fn _execute_delete(&mut self, table: TableId, rows: Vec<ProductValue>) -> u32 {
-        self.db.delete_by_rel(self.tx.unwrap_mut(), table, rows)
+    fn _execute_delete(&mut self, table: &DbTable, rows: Vec<ProductValue>) -> Result<Code, ErrorVm> {
+        let deletes = rows.clone();
+        let count = self.db.delete_by_rel(self.tx.unwrap_mut(), table.table_id, rows);
+
+        Ok(Code::Pass(Some(Update {
+            affected_rows: count.into(),
+            table_id: table.table_id,
+            table_name: table.head.table_name.clone(),
+            inserts: Vec::default(),
+            deletes
+        })))
     }
 
     fn _delete_query<const N: usize>(&mut self, query: &QueryExpr, sources: Sources<'_, N>) -> Result<Code, ErrorVm> {
         match self._eval_query(query, sources)? {
-            Code::Table(result) => Ok(Code::Value(
-                self._execute_delete(query.source.table_id().unwrap(), result.data)
-                    .into(),
-            )),
+            Code::Table(result) => self._execute_delete(query.source.get_db_table().unwrap(), result.data),
             r => Ok(r),
         }
     }
 
     fn _create_table(&mut self, table: TableDef) -> Result<Code, ErrorVm> {
         self.db.create_table(self.tx.unwrap_mut(), table)?;
-        Ok(Code::Pass)
+        Ok(Code::Pass(None))
     }
 
     fn _drop(&mut self, name: &str, kind: DbType) -> Result<Code, ErrorVm> {
@@ -549,12 +568,12 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
                 }
             }
         }
-        Ok(Code::Pass)
+        Ok(Code::Pass(None))
     }
 
     fn _set_config(&mut self, name: String, value: AlgebraicValue) -> Result<Code, ErrorVm> {
         self.db.set_config(&name, value)?;
-        Ok(Code::Pass)
+        Ok(Code::Pass(None)) // TODO can subscriptions watch config values?
     }
 
     fn _read_config(&self, name: String) -> Result<Code, ErrorVm> {

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -455,8 +455,8 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
             self.db.insert(tx, table.table_id, row)?;
         }
         Ok(Code::Pass(Some(Update {
-            table_id: table.get_db_table().unwrap().table_id,
-            table_name: table.table_name().into(),
+            table_id: table.table_id,
+            table_name: table.head.table_name.clone(),
             inserts,
             deletes: Vec::default()
         })))
@@ -519,7 +519,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
 
     fn _execute_delete(&mut self, table: &DbTable, rows: Vec<ProductValue>) -> Result<Code, ErrorVm> {
         let deletes = rows.clone();
-        let count = self.db.delete_by_rel(self.tx.unwrap_mut(), table.table_id, rows);
+        self.db.delete_by_rel(self.tx.unwrap_mut(), table.table_id, rows);
 
         Ok(Code::Pass(Some(Update {
             table_id: table.table_id,

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -458,7 +458,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
             table_id: table.table_id,
             table_name: table.head.table_name.clone(),
             inserts,
-            deletes: Vec::default()
+            deletes: Vec::default(),
         })))
     }
 
@@ -525,7 +525,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
             table_id: table.table_id,
             table_name: table.head.table_name.clone(),
             inserts: Vec::default(),
-            deletes
+            deletes,
         })))
     }
 

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -479,7 +479,7 @@ impl<'db, 'tx> DbProgram<'db, 'tx> {
             .get_db_table()
             .expect("source for Update should be a DbTable");
 
-        self._execute_delete(table, deleted.data.clone());
+        self._execute_delete(table, deleted.data.clone())?;
 
         // Replace the columns in the matched rows with the assigned
         // values. No typechecking is performed here, nor that all

--- a/crates/sqltest/src/space.rs
+++ b/crates/sqltest/src/space.rs
@@ -80,7 +80,7 @@ impl SpaceDb {
         self.conn.with_read_only(&ExecutionContext::default(), |tx| {
             let ast = compile_sql(&self.conn, tx, sql)?;
             let subs = ModuleSubscriptions::new(Arc::new(self.conn.db.clone()), Identity::ZERO);
-            let result = execute_sql(&self.conn, sql, ast, self.auth, &subs)?;
+            let result = execute_sql(&self.conn, sql, ast, self.auth, Some(&subs))?;
             //remove comments to see which SQL worked. Can't collect it outside from lack of a hook in the external `sqllogictest` crate... :(
             //append_file(&std::path::PathBuf::from(".ok.sql"), sql)?;
             Ok(result)

--- a/crates/sqltest/src/space.rs
+++ b/crates/sqltest/src/space.rs
@@ -5,6 +5,8 @@ use spacetimedb::error::DBError;
 use spacetimedb::execution_context::ExecutionContext;
 use spacetimedb::sql::compiler::compile_sql;
 use spacetimedb::sql::execute::execute_sql;
+use spacetimedb::subscription::module_subscription_actor::ModuleSubscriptions;
+use spacetimedb::Identity;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_sats::algebraic_value::Packed;
 use spacetimedb_sats::meta_type::MetaType;
@@ -14,6 +16,7 @@ use spacetimedb_vm::relation::MemTable;
 use sqllogictest::{AsyncDB, ColumnType, DBOutput};
 use std::fs;
 use std::io::Write;
+use std::sync::Arc;
 
 #[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct Kind(pub(crate) AlgebraicType);
@@ -76,7 +79,8 @@ impl SpaceDb {
     pub(crate) fn run_sql(&self, sql: &str) -> anyhow::Result<Vec<MemTable>> {
         self.conn.with_read_only(&ExecutionContext::default(), |tx| {
             let ast = compile_sql(&self.conn, tx, sql)?;
-            let result = execute_sql(&self.conn, sql, ast, self.auth)?;
+            let subs = ModuleSubscriptions::new(Arc::new(self.conn.db.clone()), Identity::ZERO);
+            let result = execute_sql(&self.conn, sql, ast, self.auth, &subs)?;
             //remove comments to see which SQL worked. Can't collect it outside from lack of a hook in the external `sqllogictest` crate... :(
             //append_file(&std::path::PathBuf::from(".ok.sql"), sql)?;
             Ok(result)

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -39,8 +39,8 @@ pub fn eval<const N: usize, P: ProgramVm>(p: &mut P, code: Code, sources: Source
             let mut result = Vec::with_capacity(lines.len());
             for x in lines {
                 match eval(p, x, sources) {
-                    Code::Pass(None) => {},
-                    r => result.push(r)
+                    Code::Pass(None) => {}
+                    r => result.push(r),
                 };
             }
 

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -38,20 +38,20 @@ pub fn eval<const N: usize, P: ProgramVm>(p: &mut P, code: Code, sources: Source
         Code::Block(lines) => {
             let mut result = Vec::with_capacity(lines.len());
             for x in lines {
-                let r = eval(p, x, sources);
-                if r != Code::Pass {
-                    result.push(r);
-                }
+                match eval(p, x, sources) {
+                    Code::Pass(None) => {},
+                    r => result.push(r)
+                };
             }
 
             match result.len() {
-                0 => Code::Pass,
+                0 => Code::Pass(None),
                 1 => result.pop().unwrap(),
                 _ => Code::Block(result),
             }
         }
         Code::Crud(q) => p.eval_query(q, sources).unwrap_or_else(|err| Code::Halt(err.into())),
-        Code::Pass => Code::Pass,
+        Code::Pass(x) => Code::Pass(x),
     }
 }
 

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -2062,7 +2062,6 @@ impl AuthAccess for CrudExpr {
 
 #[derive(Debug, PartialEq)]
 pub struct Update {
-    pub affected_rows: u32,
     pub table_id: TableId,
     pub table_name: Box<str>,
     pub inserts: Vec<ProductValue>,

--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -2061,13 +2061,22 @@ impl AuthAccess for CrudExpr {
 }
 
 #[derive(Debug, PartialEq)]
+pub struct Update {
+    pub affected_rows: u32,
+    pub table_id: TableId,
+    pub table_name: Box<str>,
+    pub inserts: Vec<ProductValue>,
+    pub deletes: Vec<ProductValue>,
+}
+
+#[derive(Debug, PartialEq)]
 pub enum Code {
     Value(AlgebraicValue),
     Table(MemTable),
     Halt(ErrorLang),
     Block(Vec<Code>),
     Crud(CrudExpr),
-    Pass,
+    Pass(Option<Update>),
 }
 
 impl fmt::Display for Code {
@@ -2088,7 +2097,7 @@ pub enum CodeResult {
     Table(MemTable),
     Block(Vec<CodeResult>),
     Halt(ErrorLang),
-    Pass,
+    Pass(Option<Update>),
 }
 
 impl From<Code> for CodeResult {
@@ -2099,12 +2108,12 @@ impl From<Code> for CodeResult {
             Code::Halt(x) => Self::Halt(x),
             Code::Block(x) => {
                 if x.is_empty() {
-                    Self::Pass
+                    Self::Pass(None)
                 } else {
                     Self::Block(x.into_iter().map(CodeResult::from).collect())
                 }
             }
-            Code::Pass => Self::Pass,
+            Code::Pass(x) => Self::Pass(x),
             x => Self::Halt(ErrorLang::new(
                 ErrorKind::Compiler,
                 Some(&format!("Invalid result: {x}")),


### PR DESCRIPTION
# Description of Changes

- Added a new parameter on execute_sql to bring ModuleSubscriptions into scope.
- Augmented Code::Pass with an optional Update structure to thread inserts/deletes back into execute_sql where they can be broadcast as an event to subscribers.
- Updated tests to reflect these changes.

# Expected complexity level and risk

2? Still a few things I'm unsure of:
- Changed the return from evaluating delete from a count to an Update structure holding the count, but (afaik) the count wasn't used.
- The new Update structure is almost identical to the one from core it then converts into, would it be preferable to move that one instead?
- Moved ast transform and collect_result outside the transaction scope in execute_sql. Assuming these changes are safe.

# Testing

Still need to add tests to validate that changes broadcast correctly.
