### PR TITLE
[EXPERIMENT]: Subscriptions: Fuse BSATN for all table row ops in one allocation

### DIFF
--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -106,7 +106,7 @@ fn eval(c: &mut Criterion) {
             let query = compile_read_only_query(&raw.db, &tx, &auth, sql).unwrap();
             let query: ExecutionSet = query.into();
             let ctx = &ExecutionContext::subscribe(raw.db.address(), SlowQueryConfig::default());
-            b.iter(|| drop(black_box(query.eval(ctx, Protocol::Binary, &raw.db, &tx).unwrap())))
+            b.iter(|| drop(black_box(query.eval_bench(ctx, Protocol::Binary, &raw.db, &tx).unwrap())))
         });
     };
 

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -254,6 +254,17 @@ pub(crate) fn rel_value_to_table_row_op_json(row: RelValue<'_>, op: OpType) -> T
 }
 
 /// Annotate `row` BSATN-encoded with `op` as a `TableRowOperation`.
+pub(crate) fn rel_value_to_table_row_op_binary_bench(
+    scratch: &mut Vec<u8>,
+    row: &RelValue<'_>,
+    op: OpType,
+) {
+    scratch.push(op as u8);
+
+    row.to_bsatn_extend(scratch).unwrap();
+}
+
+/// Annotate `row` BSATN-encoded with `op` as a `TableRowOperation`.
 pub(crate) fn rel_value_to_table_row_op_binary(
     scratch: &mut Vec<u8>,
     row: &RelValue<'_>,


### PR DESCRIPTION
# Description of Changes

Making a combined combined "ticket plus code experiment" that demonstrates the issue.
Here in this PR, instead of creating one `Vec<u8>` of BSATN per row, we put all the BSATN of all rows in a single `Vec<u8>`.
(In a real PR we'd need to add the number of elements as well and other changes, but this is just a perf demonstration.)

In a sample benchmark run on my i7-7700K, 64GB RAM, this result in the following improvements compared to HEAD~1:
```
Benchmarking full-scan: Collecting 100 samples in estimated 5.5034 s (200 iteration
full-scan               time:   [27.010 ms 27.122 ms 27.300 ms]
                        change: [-71.553% -71.319% -71.037%] (p = 0.00 < 0.05)
                        Performance has improved.

Benchmarking full-join: Collecting 100 samples in estimated 5.2570 s (25k iteration
full-join               time:   [216.69 µs 218.12 µs 220.19 µs]
                        change: [-25.202% -24.271% -23.234%] (p = 0.00 < 0.05)
                        Performance has improved.
```

For full-scan, this is about a 3.5x improvement to runtime (was about 96ms before).
For full-join, this is about a 1.3x improvement (full-join does more additional interesting work, explaining the difference).

Here is a picture of the flamegraph before:

![image](https://github.com/clockworklabs/SpacetimeDB/assets/855702/d265f670-76ae-4e71-a82c-7c61cbdd167b)

And here is one after:

![image](https://github.com/clockworklabs/SpacetimeDB/assets/855702/dc087508-d4db-44ff-a27b-9fe24744261c)

The big `malloc` bar is gone and instead, `TableCursor` + and `to_bsatn_extend` are taking up the remaining time.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
