### PR TITLE
Bump to Rust 1.78

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -170,7 +170,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20 # on a successful run, runs in 8 minutes
     container:
-      image: rust:1.77
+      image: rust:1.78
       options: --privileged
     # filter for a comment containing 'benchmarks please'
     if: ${{ github.event_name != 'issue_comment' || (github.event.issue.pull_request && contains(github.event.comment.body, 'benchmarks please')) }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,7 +78,7 @@ debug = true
 version = "0.8.2"
 edition = "2021"
 # update rust-toolchain.toml too!
-rust-version = "1.77.0"
+rust-version = "1.78.0"
 
 [workspace.dependencies]
 spacetimedb = { path = "crates/bindings", version = "0.8.2" }

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -129,7 +129,7 @@ impl WasmInstanceEnv {
     /// Signal to this `WasmInstanceEnv` that a reducer call is beginning.
     pub fn start_reducer(&mut self, name: &str) {
         self.reducer_start = Instant::now();
-        self.reducer_name = name.to_owned();
+        name.clone_into(&mut self.reducer_name);
     }
 
     /// Signal to this `WasmInstanceEnv` that a reducer call is over.

--- a/crates/core/src/util/notify_once.rs
+++ b/crates/core/src/util/notify_once.rs
@@ -32,6 +32,12 @@ impl NotifyOnce {
     }
 }
 
+impl Default for NotifyOnce {
+    fn default() -> Self {
+        Self::new()
+    }
+}
+
 pin_project_lite::pin_project! {
     pub struct NotifiedOnce<'a> {
         #[pin]

--- a/crates/data-structures/src/slim_slice.rs
+++ b/crates/data-structures/src/slim_slice.rs
@@ -1538,7 +1538,7 @@ mod tests {
         assert_ne!(hash_of(a), hash_of(b));
     }
 
-    fn ord_properties<T: Ord>(a: &T, b: &T, a_deref: &T::Target, b_deref: &T::Target)
+    fn ord_properties<T>(a: &T, b: &T, a_deref: &T::Target, b_deref: &T::Target)
     where
         T: Ord + Debug + Deref + PartialOrd<<T as Deref>::Target>,
     {

--- a/crates/sdk/tests/test-client/src/pk_test_table.rs
+++ b/crates/sdk/tests/test-client/src/pk_test_table.rs
@@ -7,8 +7,6 @@ use test_counter::TestCounter;
 pub trait PkTestTable: TableWithPrimaryKey {
     fn as_value(&self) -> i32;
 
-    fn from_key_value(k: Self::PrimaryKey, v: i32) -> Self;
-
     fn is_insert_reducer_event(event: &Self::ReducerEvent) -> bool;
     fn is_update_reducer_event(event: &Self::ReducerEvent) -> bool;
     fn is_delete_reducer_event(event: &Self::ReducerEvent) -> bool;
@@ -138,13 +136,6 @@ macro_rules! impl_pk_test_table {
         impl PkTestTable for $table {
             fn as_value(&self) -> i32 {
                 self.data
-            }
-
-            fn from_key_value(key: Self::PrimaryKey, value: i32) -> Self {
-                Self {
-                    $field_name: key,
-                    data: value,
-                }
             }
 
             fn is_insert_reducer_event(event: &Self::ReducerEvent) -> bool {

--- a/crates/sdk/tests/test-client/src/simple_test_table.rs
+++ b/crates/sdk/tests/test-client/src/simple_test_table.rs
@@ -8,7 +8,6 @@ pub trait SimpleTestTable: TableType {
     type Contents: Clone + Send + Sync + PartialEq + std::fmt::Debug + 'static;
 
     fn as_contents(&self) -> &Self::Contents;
-    fn from_contents(contents: Self::Contents) -> Self;
 
     fn is_insert_reducer_event(event: &Self::ReducerEvent) -> bool;
 
@@ -27,12 +26,6 @@ macro_rules! impl_simple_test_table {
 
             fn as_contents(&self) -> &Self::Contents {
                 &self.$field_name
-            }
-
-            fn from_contents(contents: Self::Contents) -> Self {
-                Self {
-                    $field_name: contents,
-                }
             }
 
             fn is_insert_reducer_event(event: &Self::ReducerEvent) -> bool {

--- a/crates/sdk/tests/test-client/src/unique_test_table.rs
+++ b/crates/sdk/tests/test-client/src/unique_test_table.rs
@@ -10,8 +10,6 @@ pub trait UniqueTestTable: TableType {
     fn as_key(&self) -> &Self::Key;
     fn as_value(&self) -> i32;
 
-    fn from_key_value(k: Self::Key, v: i32) -> Self;
-
     fn is_insert_reducer_event(event: &Self::ReducerEvent) -> bool;
     fn is_delete_reducer_event(event: &Self::ReducerEvent) -> bool;
 
@@ -97,13 +95,6 @@ macro_rules! impl_unique_test_table {
             }
             fn as_value(&self) -> i32 {
                 self.data
-            }
-
-            fn from_key_value(key: Self::Key, value: i32) -> Self {
-                Self {
-                    $field_name: key,
-                    data: value,
-                }
             }
 
             fn is_insert_reducer_event(event: &Self::ReducerEvent) -> bool {

--- a/crates/standalone/Dockerfile
+++ b/crates/standalone/Dockerfile
@@ -1,9 +1,7 @@
-# Warning: we removed binstall recently because they added a dependency on the QUIC protocol.
-
 ARG CARGO_PROFILE=release
 
 
-FROM rust:1.77.0 AS chef
+FROM rust:1.78.0 AS chef
 RUN rust_target=$(rustc -vV | awk '/^host:/{ print $2 }') && \
   curl https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$rust_target.tgz -fL | tar xz -C $CARGO_HOME/bin
 RUN cargo binstall -y cargo-chef@0.1.56

--- a/crates/testing/src/sdk.rs
+++ b/crates/testing/src/sdk.rs
@@ -201,7 +201,7 @@ fn generate_bindings(language: &str, wasm_file: &str, client_project: &str, gene
             "--wasm-file",
             wasm_file,
             "--out-dir",
-            &generate_dir,
+            generate_dir,
         ]);
     })
 }

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,6 @@
 [toolchain]
 # change crates/standalone/Dockerfile and rust-version in Cargo.toml too!
 # also the docker image tag in .github/workflows/benchmarks.yml:jobs/callgrind_benchmark/container/image
-channel = "1.77.0"
+channel = "1.78.0"
 profile = "default"
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
# Description of Changes

1.78 brings `#[diagnostic::on_unimplemented]`, which lets you customize error messages when a type doesn't implement a trait. I have a branch that uses it to improve reducer & table type errors.

# API and ABI breaking changes

MSRV bump, but that's usually not a big deal. understandable if we wanna hold off on it for a bit.

# Expected complexity level and risk

1