### PR TITLE
subscription benches: reorder footprint fields

### DIFF
--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -31,10 +31,10 @@ fn create_table_footprint(db: &RelationalDB) -> Result<TableId, DBError> {
     let footprint = AlgebraicType::sum(["A", "B", "C", "D"].map(|n| (n, AlgebraicType::unit())));
     let schema = &[
         ("entity_id", AlgebraicType::U64),
-        ("type", footprint),
         ("owner_entity_id", AlgebraicType::U64),
+        ("type", footprint),
     ];
-    let indexes = &[(0.into(), "entity_id"), (2.into(), "owner_entity_id")];
+    let indexes = &[(0.into(), "entity_id"), (1.into(), "owner_entity_id")];
     db.create_table_for_test("footprint", schema, indexes)
 }
 
@@ -60,7 +60,7 @@ fn eval(c: &mut Criterion) {
             for entity_id in 0u64..1_000_000 {
                 let owner = entity_id % 1_000;
                 let footprint = AlgebraicValue::sum(entity_id as u8 % 4, AlgebraicValue::unit());
-                let row = product!(entity_id, footprint, owner);
+                let row = product!(entity_id, owner, footprint);
                 let _ = raw.db.insert(tx, lhs, row)?;
             }
             Ok(())
@@ -92,7 +92,7 @@ fn eval(c: &mut Criterion) {
     let footprint = AlgebraicValue::sum(1, AlgebraicValue::unit());
     let owner = 6u64;
 
-    let new_lhs_row = product!(entity_id, footprint, owner);
+    let new_lhs_row = product!(entity_id, owner, footprint);
     let new_rhs_row = product!(entity_id, chunk_index, x, z, dimension);
 
     let ins_lhs = insert_op(lhs, "footprint", new_lhs_row);


### PR DESCRIPTION
# Description of Changes

Reorder `footprint` table in subscription benchmarks to be more optimal wrt. layout such that there is less padding and so to-bsatn serialization uses fewer memcpy fields. This does not improve the performance of spacetimedb but represents better what spacetimedb is capable of when a table is optimized.

Extracted from https://github.com/clockworklabs/SpacetimeDB/pull/1207 in the interest of smaller PRs.

# API and ABI breaking changes

None

# Expected complexity level and risk

1