### PR TITLE
Remove some impls that were dead code

### DIFF
--- a/crates/vm/src/expr.rs
+++ b/crates/vm/src/expr.rs
@@ -246,21 +246,9 @@ impl From<FieldName> for ColumnOp {
     }
 }
 
-impl From<FieldName> for Box<ColumnOp> {
-    fn from(value: FieldName) -> Self {
-        Box::new(ColumnOp::Field(value.into()))
-    }
-}
-
 impl From<AlgebraicValue> for ColumnOp {
     fn from(value: AlgebraicValue) -> Self {
         ColumnOp::Field(value.into())
-    }
-}
-
-impl From<AlgebraicValue> for Box<ColumnOp> {
-    fn from(value: AlgebraicValue) -> Self {
-        Box::new(ColumnOp::Field(value.into()))
     }
 }
 


### PR DESCRIPTION
# Description of Changes

- Remove `impl From<FieldName> for Box<ColumnOp>`
- Remove `impl From<AlgebraicValue> for Box<ColumnOp>`

Both are dead code.