### PR TITLE
`spacetime build` uses `--project-path` param

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,7 +74,7 @@ jobs:
       - run: echo ::add-matcher::.github/workflows/rust_matcher.json
 
       - name: Build rust-wasm-test
-        run: cargo run -p spacetimedb-cli -- build modules/rust-wasm-test
+        run: cargo run -p spacetimedb-cli -- build --project-path modules/rust-wasm-test
 
       - name: Run bindgen tests
         run: cargo test -p spacetimedb-cli

--- a/crates/cli/src/subcommands/build.rs
+++ b/crates/cli/src/subcommands/build.rs
@@ -8,6 +8,8 @@ pub fn cli() -> clap::Command {
         .about("Builds a spacetime module.")
         .arg(
             Arg::new("project_path")
+                .long("project-path")
+                .short('p')
                 .value_parser(clap::value_parser!(PathBuf))
                 .default_value(".")
                 .help("The system path (absolute or relative) to the project you would like to build")

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -48,7 +48,7 @@ def build_template_target():
 
         BuildModule.setUpClass()
         env = { **os.environ, "CARGO_TARGET_DIR": str(TEMPLATE_TARGET_DIR) }
-        spacetime("build", BuildModule.project_path, env=env, capture_stderr=False)
+        spacetime("build", "--project-path", BuildModule.project_path, env=env, capture_stderr=False)
         BuildModule.tearDownClass()
         BuildModule.doClassCleanups()
 
@@ -99,7 +99,7 @@ def run_cmd(*args, capture_stderr=True, check=True, full_output=False, cmd_name=
             output.args[0] = "spacetime"
         output.check_returncode()
     return output if full_output else output.stdout
-    
+
 
 def spacetime(*args, **kwargs):
     return run_cmd(SPACETIME_BIN, *args, cmd_name="spacetime", **kwargs)
@@ -139,14 +139,14 @@ class Smoketest(unittest.TestCase):
     def _check_published(self):
         if not hasattr(self, "address"):
             raise Exception("Cannot use this function without publishing a module")
-    
+
     def call(self, reducer, *args):
         self._check_published()
         self.spacetime("call", "--", self.address, reducer, *map(json.dumps, args))
-    
+
     def logs(self, n):
         return [log["message"] for log in self.log_records(n)]
-        
+
     def log_records(self, n):
         self._check_published()
         logs = self.spacetime("logs", "--json", "--", self.address, str(n))
@@ -162,7 +162,7 @@ class Smoketest(unittest.TestCase):
         )
         self.resolved_address = re.search(r"address: ([0-9a-fA-F]+)", publish_output)[1]
         self.address = domain if domain is not None else self.resolved_address
-    
+
     @classmethod
     def reset_config(cls):
         shutil.copy(STDB_CONFIG, cls.config_path)
@@ -170,17 +170,17 @@ class Smoketest(unittest.TestCase):
     def fingerprint(self):
         # Fetch the server's fingerprint; required for `identity list`.
         self.spacetime("server", "fingerprint", "-s", "localhost", "-f")
-    
+
     def new_identity(self, *, email, default=False):
         output = self.spacetime("identity", "new", "--no-email" if email is None else f"--email={email}")
         identity = extract_field(output, "IDENTITY")
         if default:
             self.spacetime("identity", "set-default", identity)
         return identity
-    
+
     def token(self, identity):
         return self.spacetime("identity", "token", identity).strip()
-    
+
     def import_identity(self, identity, token, *, default=False):
         self.spacetime("identity", "import", identity, token)
         if default:
@@ -191,8 +191,8 @@ class Smoketest(unittest.TestCase):
         open(cls.project_path / "src/lib.rs", "w").write(module_code)
 
     # testcase initialization
-    
-    
+
+
     @classmethod
     def setUpClass(cls):
         cls.project_path = Path(cls.enterClassContext(tempfile.TemporaryDirectory()))
@@ -208,7 +208,7 @@ class Smoketest(unittest.TestCase):
         if cls.AUTOPUBLISH:
             print(f"Compiling module for {cls.__qualname__}...", file=sys.__stderr__)
             cls.publish_module(cls, capture_stderr=False)
-    
+
     def tearDown(self):
         # if this single test method published a database, clean it up now
         if "address" in self.__dict__:
@@ -230,7 +230,7 @@ class Smoketest(unittest.TestCase):
     # def setUp(self):
     #     if self.AUTOPUBLISH:
     #         self.spacetime("publish", "-S", "--project-path", self.project_path)
-    
+
     if sys.version_info < (3, 11):
         # polyfill; python 3.11 defines this classmethod on TestCase
         @classmethod

--- a/smoketests/tests/detect_wasm_bindgen.py
+++ b/smoketests/tests/detect_wasm_bindgen.py
@@ -20,6 +20,6 @@ extern "C" {
     def test_detect_wasm_bindgen(self):
         """Ensure that spacetime build properly catches wasm_bindgen imports"""
 
-        output = self.spacetime("build", self.project_path, full_output=True, check=False)
+        output = self.spacetime("build", "--project-path", self.project_path, full_output=True, check=False)
         self.assertTrue(output.returncode)
         self.assertIn("wasm-bindgen detected", output.stderr)


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

- `spacetime publish` and `spacetime generate` both use `--project-path <path>`, so `spacetime build` should use the same.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

Breaks the CLI params

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] `spacetime build --project-path <path>` works as expected.
