### PR TITLE
Fix #1180: Add PR status check that fails unless based on master

### DIFF
--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -13,6 +13,7 @@ jobs:
     steps:
       - id: not_based_on_master
         if: |
+          github.event_name == 'pull_request' &&
           github.event.pull_request.base.ref != 'master'
         run: |
           echo "This PR is not based on master. Please wait until the base PR merges."


### PR DESCRIPTION
# Description of Changes

#1180 added a GitHub status check for PRs; this check fails if a PR is based on any branch besides `master`.

It turns out that this check runs, and fails, on commits that are not part of a PR at all.

I believe this PR fixes that.

# API and ABI breaking changes

No runtime changes.

# Expected complexity level and risk
1

# Testing
Not super satisfying, but the check currently passes on this PR :shrug: 