### PR TITLE
commitlog: Allow folds to not allocate `Mutations` values

### DIFF
--- a/crates/commitlog/src/commitlog.rs
+++ b/crates/commitlog/src/commitlog.rs
@@ -342,7 +342,7 @@ where
         let records = &mut commit.records.as_slice();
         for n in 0..commit.n {
             let tx_offset = commit.min_tx_offset + n as u64;
-            de.decode_record(version, tx_offset, records)?;
+            de.consume_record(version, tx_offset, records)?;
         }
     }
 

--- a/crates/commitlog/src/payload.rs
+++ b/crates/commitlog/src/payload.rs
@@ -63,6 +63,23 @@ pub trait Decoder {
         tx_offset: u64,
         reader: &mut R,
     ) -> Result<Self::Record, Self::Error>;
+
+    /// Variant of [`Self::decode_record`] which discards the decoded
+    /// [`Self::Record`].
+    ///
+    /// Useful for folds which don't need to yield or collect record values.
+    ///
+    /// The default implementation just drops the record returned from
+    /// [`Self::decode_record`]. Implementations may want to override this, such
+    /// that the record is not allocated in the first place.
+    fn consume_record<'a, R: BufReader<'a>>(
+        &self,
+        version: u8,
+        tx_offset: u64,
+        reader: &mut R,
+    ) -> Result<(), Self::Error> {
+        self.decode_record(version, tx_offset, reader).map(drop)
+    }
 }
 
 impl<const N: usize> Encode for [u8; N] {


### PR DESCRIPTION
The documentation promised to not collect payload values during folds (i.e. replaying), but the code did so anyway. This patch makes it so only values required to satisfy the `Visitor` trait are allocated when folding.

# Expected complexity level and risk

1