### PR TITLE
Add CODEOWNERS for `rust-toolchain.toml`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,1 +1,2 @@
 /crates/core/src/db/datastore/traits.rs @cloutiertyler
+/rust-toolchain.toml @jdetter @cloutiertyler


### PR DESCRIPTION
# Description of Changes

Adds a `CODEOWNERS` entry for `rust-toolchain.toml`.

This is to prevent surprise changes to the Rust version, which may have adverse downstream impacts.

# API and ABI breaking changes

No.

# Expected complexity level and risk

0

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] See https://github.com/clockworklabs/SpacetimeDB/pull/1222
