### PR TITLE
Add CODEOWNERS for `LICENSE.txt`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,2 +1,3 @@
 /crates/core/src/db/datastore/traits.rs @cloutiertyler
 /rust-toolchain.toml @jdetter @cloutiertyler
+LICENSE.txt @cloutiertyler


### PR DESCRIPTION
# Description of Changes

Adds a `CODEOWNERS` entry for all `LICENSE.txt` files.

This also makes sure that @cloutiertyler signs off on any **version bumps**, which update the root `LICENSE.txt`.

This means that @cloutiertyler is the signoff on every release.

# API and ABI breaking changes

No.

# Expected complexity level and risk

0

# Testing

- [x] See https://github.com/clockworklabs/SpacetimeDB/pull/1228