### PR TITLE
Add Jenkinsfile to run internal automation

### DIFF
--- a/.jenkins/Jenkinsfile.internal
+++ b/.jenkins/Jenkinsfile.internal
@@ -1,0 +1,55 @@
+//
+// This function is used to manually specify a name for the check. In this case, its "Internal Tests".
+// Source: https://stackoverflow.com/a/47162309
+//
+void setBuildStatus(String message, String state) {
+  step([
+      $class: "GitHubCommitStatusSetter",
+	reposSource: [$class: "ManuallyEnteredRepositorySource", url: "https://github.com/clockworklabs/SpacetimeDB"],
+      contextSource: [$class: "ManuallyEnteredCommitContextSource", context: "Internal Tests"],
+      errorHandlers: [[$class: "ChangingBuildStatusErrorHandler", result: "UNSTABLE"]],
+      statusResultSource: [ $class: "ConditionalStatusResultSource", results: [[$class: "AnyBuildResult", message: message, state: state]] ]
+  ]);
+}
+
+pipeline {
+    agent any
+    
+    stages {
+	
+	stage('Git Checkout') {
+	    steps {
+		setBuildStatus("Build pending", "PENDING")
+		checkout scm
+	    }
+	}
+
+	stage('Public-Private Tests') {
+	    steps {
+	    	script {
+		    
+		    def jobName = 'Internal Tests'
+		    def branchName = 'master' // branch to trigger
+
+		    // call the internal Jenkins job
+		    build job: "/${jobName}/${branchName}", propagate: true, wait: true, parameters: [
+			string(
+			    name: 'SPACETIMEDB_PUBLIC_BRANCH',
+			    value: "${env.BRANCH_NAME}"
+			)
+		    ]
+		}
+	    }
+	}
+    }
+
+    post {
+	success {
+            setBuildStatus("Build succeeded", "SUCCESS");
+	}
+	failure {
+            setBuildStatus("Build failed", "FAILURE");
+	}
+    }
+}
+    


### PR DESCRIPTION
# Description of Changes

Adds a Jenkinsfile which is used to kick-off internal automation.

For those who do not have experience with Jenkins, the new Jenkinsfile automatically performs the following functions:

1. Sets a Github Status Check to `Pending`
2. Starts internal automation within Jenkins
3. Waits for the internal automation to finish executing
4. Updates the Github Status Check with a `Success` or `Failure` message depending on the results.

# API and ABI breaking changes

n/a

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

1 - Trivial and should not impact the source code at all.

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [X] Verified that changes to this Pull Request automatically kick off the appropriate pipelines in Jenkins.
