### PR TITLE
Renamed RelationalDB to DatabaseEngine

### DIFF
--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use spacetimedb::client::Protocol;
-use spacetimedb::db::relational_db::RelationalDB;
+use spacetimedb::db::engine::DatabaseEngine;
 use spacetimedb::error::DBError;
 use spacetimedb::execution_context::ExecutionContext;
 use spacetimedb::host::module_host::DatabaseTableUpdate;
@@ -12,7 +12,7 @@ use spacetimedb_bench::spacetime_raw::SpacetimeRaw;
 use spacetimedb_primitives::{col_list, TableId};
 use spacetimedb_sats::{product, AlgebraicType, AlgebraicValue, ProductValue};
 
-fn create_table_location(db: &RelationalDB) -> Result<TableId, DBError> {
+fn create_table_location(db: &DatabaseEngine) -> Result<TableId, DBError> {
     let schema = &[
         ("entity_id", AlgebraicType::U64),
         ("chunk_index", AlgebraicType::U64),
@@ -26,7 +26,7 @@ fn create_table_location(db: &RelationalDB) -> Result<TableId, DBError> {
     db.create_table_for_test_mix_indexes("location", schema, indexes, col_list![2, 3, 4])
 }
 
-fn create_table_footprint(db: &RelationalDB) -> Result<TableId, DBError> {
+fn create_table_footprint(db: &DatabaseEngine) -> Result<TableId, DBError> {
     let footprint = AlgebraicType::sum(["A", "B", "C", "D"].map(|n| (n, AlgebraicType::unit())));
     let schema = &[
         ("entity_id", AlgebraicType::U64),

--- a/crates/bench/src/database.rs
+++ b/crates/bench/src/database.rs
@@ -5,7 +5,7 @@ use crate::ResultBench;
 
 /// A database we can execute a standard benchmark suite against.
 /// Currently implemented for SQLite, raw Spacetime outside a module boundary
-/// (RelationalDB), and Spacetime through the module boundary.
+/// (DatabaseEngine), and Spacetime through the module boundary.
 ///
 /// Not all benchmarks have to go through this trait.
 pub trait BenchDatabase: Sized {

--- a/crates/bench/src/spacetime_raw.rs
+++ b/crates/bench/src/spacetime_raw.rs
@@ -3,7 +3,7 @@ use crate::{
     schemas::{table_name, BenchTable, IndexStrategy},
     ResultBench,
 };
-use spacetimedb::db::relational_db::{tests_utils::TestDB, RelationalDB};
+use spacetimedb::db::engine::{tests_utils::TestDB, DatabaseEngine};
 use spacetimedb::execution_context::ExecutionContext;
 use spacetimedb_lib::sats::AlgebraicValue;
 use spacetimedb_primitives::{ColId, TableId};
@@ -11,7 +11,7 @@ use spacetimedb_sats::db::def::{IndexDef, TableDef};
 use std::hint::black_box;
 use tempdir::TempDir;
 
-pub type DbResult = (RelationalDB, TempDir, u32);
+pub type DbResult = (DatabaseEngine, TempDir, u32);
 
 pub struct SpacetimeRaw {
     pub db: TestDB,

--- a/crates/bench/src/sqlite.rs
+++ b/crates/bench/src/sqlite.rs
@@ -37,7 +37,7 @@ impl BenchDatabase for SQLite {
             Connection::open(temp_dir.path().join("test.db"))?
         };
         // For sqlite benchmarks we should set synchronous to either full or off which more
-        // closely aligns with wal_fsync=true and wal_fsync=false respectively in stdb.
+        // closely aligns with wal_fsync=true and wal_fsync=false respectively in db_engine.
         db.execute_batch(if fsync {
             "PRAGMA journal_mode = WAL; PRAGMA synchronous = full;"
         } else {

--- a/crates/bindings-csharp/Runtime/bindings.c
+++ b/crates/bindings-csharp/Runtime/bindings.c
@@ -190,7 +190,7 @@ WASI_SHIM(sock_shutdown, (int32_t, int32_t));
 // Mono retrieves executable name via argv[0], so we need to shim it with
 // some dummy name instead of returning an empty argv[] array to avoid
 // assertion failures.
-const char executable_name[] = "stdb.wasm";
+const char executable_name[] = "db_engine.wasm";
 
 int32_t WASI_NAME(args_sizes_get)(__wasi_size_t* argc,
                                   __wasi_size_t* argv_buf_size) {

--- a/crates/cli/src/subcommands/repl.rs
+++ b/crates/cli/src/subcommands/repl.rs
@@ -41,7 +41,7 @@ sort by
 pub async fn exec(con: Connection) -> Result<(), anyhow::Error> {
     let database = con.database.clone();
     let mut rl = Editor::<ReplHelper, DefaultHistory>::new().unwrap();
-    let history = home_dir().unwrap_or_else(temp_dir).join(".stdb.history.txt");
+    let history = home_dir().unwrap_or_else(temp_dir).join(".db_engine.history.txt");
     if rl.load_history(&history).is_err() {
         eprintln!("No previous history.");
     }

--- a/crates/client-api/src/routes/tracelog.rs
+++ b/crates/client-api/src/routes/tracelog.rs
@@ -86,7 +86,7 @@ pub async fn perform_tracelog_replay(body: Bytes) -> axum::response::Result<impl
     );
     let iv = InstanceEnv::new(dbic, Scheduler::dummy(&tmp_dir.path().join("scheduler")), None);
 
-    let tx = iv.dbic.relational_db.begin_mut_tx(IsolationLevel::Serializable);
+    let tx = iv.dbic.db_engine.begin_mut_tx(IsolationLevel::Serializable);
 
     let (_, resp_body) = iv.tx.set(tx, || replay_report(&iv, &mut &body[..]));
 

--- a/crates/commitlog/src/repo/fs.rs
+++ b/crates/commitlog/src/repo/fs.rs
@@ -8,11 +8,11 @@ use log::debug;
 
 use super::Repo;
 
-const SEGMENT_FILE_EXT: &str = ".stdb.log";
+const SEGMENT_FILE_EXT: &str = ".db_engine.log";
 
 /// By convention, the file name of a segment consists of the minimum
 /// transaction offset contained in it, left-padded with zeroes to 20 digits,
-/// and the file extension `.stdb.log`.
+/// and the file extension `.db_engine.log`.
 pub fn segment_file_name(offset: u64) -> String {
     format!("{offset:0>20}{SEGMENT_FILE_EXT}")
 }

--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -156,7 +156,7 @@ st_fields_enum!(enum StIndexFields {
 });
 // WARNING: For a stable schema, don't change the field names and discriminants.
 st_fields_enum!(
-    /// The fields that define the internal table [crate::db::relational_db::ST_SEQUENCES_NAME].
+    /// The fields that define the internal table [crate::db::engine::ST_SEQUENCES_NAME].
     enum StSequenceFields {
     "sequence_id", SequenceId = 0,
     "sequence_name", SequenceName = 1,

--- a/crates/core/src/db/engine.rs
+++ b/crates/core/src/db/engine.rs
@@ -77,7 +77,9 @@ pub struct DatabaseEngine {
 
 impl std::fmt::Debug for DatabaseEngine {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        f.debug_struct("DatabaseEngine").field("address", &self.address).finish()
+        f.debug_struct("DatabaseEngine")
+            .field("address", &self.address)
+            .finish()
     }
 }
 
@@ -1207,8 +1209,12 @@ mod tests {
         row.read_col(0).unwrap()
     }
 
-    fn collect_sorted<T: ReadColumn + Ord>(db_engine: &DatabaseEngine, tx: &MutTx, table_id: TableId) -> ResultTest<Vec<T>> {
-        let mut rows = db_engine 
+    fn collect_sorted<T: ReadColumn + Ord>(
+        db_engine: &DatabaseEngine,
+        tx: &MutTx,
+        table_id: TableId,
+    ) -> ResultTest<Vec<T>> {
+        let mut rows = db_engine
             .iter_mut(&ExecutionContext::default(), tx, table_id)?
             .map(read_first_col)
             .collect::<Vec<T>>();
@@ -1460,16 +1466,20 @@ mod tests {
         let mut tx = test_db.begin_mut_tx(IsolationLevel::Serializable);
 
         let schema = table_indexed(true);
-        let table_id = test_db.create_table(&mut tx, schema).expect("test_db.create_table failed");
+        let table_id = test_db
+            .create_table(&mut tx, schema)
+            .expect("test_db.create_table failed");
 
         assert!(
-            test_db.index_id_from_name(&tx, "MyTable_my_col_idx")
+            test_db
+                .index_id_from_name(&tx, "MyTable_my_col_idx")
                 .expect("index_id_from_name failed")
                 .is_some(),
             "Index not created"
         );
 
-        test_db.insert(&mut tx, table_id, product![1i64])
+        test_db
+            .insert(&mut tx, table_id, product![1i64])
             .expect("test_db.insert failed");
         match test_db.insert(&mut tx, table_id, product![1i64]) {
             Ok(_) => {
@@ -1682,13 +1692,16 @@ mod tests {
 
         let mut initial_tx = test_db.begin_mut_tx(IsolationLevel::Serializable);
         let schema = TableDef::from_product("test_table", ProductType::from_iter([("my_col", AlgebraicType::I32)]));
-        let table_id = test_db.create_table(&mut initial_tx, schema).expect("create_table failed");
+        let table_id = test_db
+            .create_table(&mut initial_tx, schema)
+            .expect("create_table failed");
 
         test_db.commit_tx(&ctx, initial_tx).expect("Commit initial_tx failed");
 
         // Insert a row and commit it, so the row is in the committed_state.
         let mut insert_tx = test_db.begin_mut_tx(IsolationLevel::Serializable);
-        test_db.insert(&mut insert_tx, table_id, product!(AlgebraicValue::I32(0)))
+        test_db
+            .insert(&mut insert_tx, table_id, product!(AlgebraicValue::I32(0)))
             .expect("Insert insert_tx failed");
         test_db.commit_tx(&ctx, insert_tx).expect("Commit insert_tx failed");
 
@@ -1702,7 +1715,8 @@ mod tests {
         // Insert the row again, so that depending on the datastore internals,
         // it may now be only in the committed_state,
         // or in all three of the committed_state, delete_tables and insert_tables.
-        test_db.insert(&mut delete_insert_tx, table_id, product!(AlgebraicValue::I32(0)))
+        test_db
+            .insert(&mut delete_insert_tx, table_id, product!(AlgebraicValue::I32(0)))
             .expect("Insert delete_insert_tx failed");
 
         // Iterate over the table and assert that we see the committed-deleted-inserted row only once.
@@ -1753,27 +1767,29 @@ mod tests {
         // `__identity_connected__` call.
         {
             let tx = test_db.begin_mut_tx(IsolationLevel::Serializable);
-            test_db.commit_tx(
-                &ExecutionContext::reducer(
-                    test_db.address(),
-                    ReducerContext {
-                        name: "__identity_connected__".into(),
-                        caller_identity: Identity::__dummy(),
-                        caller_address: Address::__DUMMY,
-                        timestamp,
-                        arg_bsatn: Bytes::new(),
-                    },
-                ),
-                tx,
-            )
-            .expect("failed to commit empty __identity_connected__ transaction");
+            test_db
+                .commit_tx(
+                    &ExecutionContext::reducer(
+                        test_db.address(),
+                        ReducerContext {
+                            name: "__identity_connected__".into(),
+                            caller_identity: Identity::__dummy(),
+                            caller_address: Address::__DUMMY,
+                            timestamp,
+                            arg_bsatn: Bytes::new(),
+                        },
+                    ),
+                    tx,
+                )
+                .expect("failed to commit empty __identity_connected__ transaction");
         }
 
         // Create a non-empty transaction including reducer info
         let table_id = {
             let mut tx = test_db.begin_mut_tx(IsolationLevel::Serializable);
             let table_id = test_db.create_table(&mut tx, schema).expect("failed to create table");
-            test_db.insert(&mut tx, table_id, product!(AlgebraicValue::I32(0)))
+            test_db
+                .insert(&mut tx, table_id, product!(AlgebraicValue::I32(0)))
                 .expect("failed to insert row");
             test_db.commit_tx(&ctx, tx).expect("failed to commit tx");
 
@@ -1784,9 +1800,11 @@ mod tests {
         // created by a mutable SQL transaction
         {
             let mut tx = test_db.begin_mut_tx(IsolationLevel::Serializable);
-            test_db.insert(&mut tx, table_id, product!(AlgebraicValue::I32(-42)))
+            test_db
+                .insert(&mut tx, table_id, product!(AlgebraicValue::I32(-42)))
                 .expect("failed to insert row");
-            test_db.commit_tx(&ExecutionContext::sql(test_db.address(), Default::default()), tx)
+            test_db
+                .commit_tx(&ExecutionContext::sql(test_db.address(), Default::default()), tx)
                 .expect("failed to commit tx");
         }
 

--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -1,7 +1,7 @@
 pub mod cursor;
 pub mod datastore;
 pub mod db_metrics;
-pub mod relational_db;
+pub mod engine;
 mod relational_operators;
 pub mod update;
 

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -38,7 +38,8 @@ pub fn update_database(
             SchemaUpdates::Updates { new_tables } => {
                 for (name, schema) in new_tables {
                     system_logger.info(&format!("Creating table `{}`", name));
-                    db_engine.create_table(tx, schema)
+                    db_engine
+                        .create_table(tx, schema)
                         .with_context(|| format!("failed to create table {}", name))?;
                 }
             }

--- a/crates/core/src/estimation.rs
+++ b/crates/core/src/estimation.rs
@@ -1,4 +1,4 @@
-use crate::db::relational_db::Tx;
+use crate::db::engine::Tx;
 use spacetimedb_primitives::{ColList, TableId};
 use spacetimedb_vm::expr::{Query, QueryExpr, SourceExpr};
 
@@ -67,7 +67,7 @@ fn index_row_est(tx: &Tx, table_id: TableId, cols: &ColList) -> u64 {
 #[cfg(test)]
 mod tests {
     use crate::{
-        db::relational_db::{tests_utils::TestDB, RelationalDB},
+        db::engine::{tests_utils::TestDB, DatabaseEngine},
         error::DBError,
         estimation::num_rows,
         execution_context::ExecutionContext,
@@ -81,7 +81,7 @@ mod tests {
         TestDB::in_memory().expect("failed to make test db")
     }
 
-    fn num_rows_for(db: &RelationalDB, sql: &str) -> u64 {
+    fn num_rows_for(db: &DatabaseEngine, sql: &str) -> u64 {
         let tx = db.begin_tx();
         match &*compile_sql(db, &tx, sql).expect("Failed to compile sql") {
             [CrudExpr::Query(expr)] => num_rows(&tx, expr),
@@ -94,7 +94,7 @@ mod tests {
     const NUM_S_ROWS: u64 = 2;
     const NDV_S: u64 = 2;
 
-    fn create_table_t(db: &RelationalDB, indexed: bool) {
+    fn create_table_t(db: &DatabaseEngine, indexed: bool) {
         let indexes = &[(0.into(), "a")];
         let indexes = if indexed { indexes } else { &[] as &[_] };
         let table_id = db
@@ -111,7 +111,7 @@ mod tests {
         .expect("failed to insert into table");
     }
 
-    fn create_table_s(db: &RelationalDB, indexed: bool) {
+    fn create_table_s(db: &DatabaseEngine, indexed: bool) {
         let indexes = &[(0.into(), "a"), (1.into(), "c")];
         let indexes = if indexed { indexes } else { &[] as &[_] };
         let rhs = db

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -797,10 +797,7 @@ impl Host {
     ) -> anyhow::Result<UpdateDatabaseResult> {
         let dbic = &self.dbic;
         let (scheduler, scheduler_starter) = self.scheduler.new_with_same_db();
-        let program_bytes = self
-            .program_storage
-            .load_program(&dbic.db_engine, program_hash)
-            .await?;
+        let program_bytes = self.program_storage.load_program(&dbic.db_engine, program_hash).await?;
         let module = make_module_host(
             host_type,
             ModuleCreationContext {

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -178,7 +178,7 @@ impl InstanceEnv {
         let eq_value = &db_engine.decode_column(tx, table_id, col_id, value)?;
 
         // Find all rows in the table where the column data equates to `value`.
-        let rows_to_delete = db_engine 
+        let rows_to_delete = db_engine
             .iter_by_col_eq_mut(ctx, tx, table_id, col_id, eq_value)?
             .map(|row_ref| row_ref.pointer())
             // `delete_by_field` only cares about 1 element,

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -676,7 +676,7 @@ impl ModuleHost {
             CLIENT_DISCONNECTED_DUNDER
         };
 
-        let db = &self.inner.dbic().relational_db;
+        let db = &self.inner.dbic().db_engine;
         let ctx = || {
             ExecutionContext::reducer(
                 db.address(),
@@ -747,7 +747,7 @@ impl ModuleHost {
         caller_address: Address,
         connected: bool,
     ) -> Result<(), DBError> {
-        let db = &*self.inner.dbic().relational_db;
+        let db = &*self.inner.dbic().db_engine;
         let ctx = &ExecutionContext::internal(db.address());
         let row = &StClientsRow {
             identity: caller_identity,

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -346,7 +346,8 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
                     let schema = schema?;
                     let table_name = schema.table_name.clone();
                     self.system_logger().info(&format!("Creating table `{table_name}`"));
-                    db_engine.create_table(tx, schema)
+                    db_engine
+                        .create_table(tx, schema)
                         .with_context(|| format!("failed to create table {table_name}"))?;
                 }
                 // Set the module hash. Morally, this should be done _after_ calling

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -337,7 +337,7 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
     #[tracing::instrument(skip(self, args), fields(db_id = self.instance.instance_env().dbic.id))]
     fn init_database(&mut self, fence: u128, args: ArgsTuple) -> anyhow::Result<Option<ReducerCallResult>> {
         let timestamp = Timestamp::now();
-        let db_engine: &crate::db::engine::DatabaseEngine = &*self.database_instance_context().db_engine;
+        let db_engine: &crate::db::engine::DatabaseEngine = &self.database_instance_context().db_engine;
         let ctx = ExecutionContext::internal(db_engine.address());
         let tx = db_engine.begin_mut_tx(IsolationLevel::Serializable);
         let (tx, ()) = db_engine

--- a/crates/core/src/sql/ast.rs
+++ b/crates/core/src/sql/ast.rs
@@ -1,5 +1,5 @@
 use crate::config::ReadConfigOption;
-use crate::db::engine::{MutTx, DatabaseEngine, Tx};
+use crate::db::engine::{DatabaseEngine, MutTx, Tx};
 use crate::error::{DBError, PlanError};
 use spacetimedb_data_structures::map::HashMap;
 use spacetimedb_primitives::{ColList, ConstraintKind, Constraints};
@@ -983,7 +983,11 @@ fn compile_read_config(name: Vec<Ident>) -> Result<SqlAst, PlanError> {
 }
 
 /// Compiles a `SQL` clause
-fn compile_statement<T: TableSchemaView>(db: &DatabaseEngine, tx: &T, statement: Statement) -> Result<SqlAst, PlanError> {
+fn compile_statement<T: TableSchemaView>(
+    db: &DatabaseEngine,
+    tx: &T,
+    statement: Statement,
+) -> Result<SqlAst, PlanError> {
     match statement {
         Statement::Query(query) => Ok(compile_query(db, tx, *query)?),
         Statement::Insert {

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -1,4 +1,4 @@
-use crate::db::relational_db::RelationalDB;
+use crate::db::engine::DatabaseEngine;
 use crate::error::{DBError, PlanError};
 use crate::sql::ast::{compile_to_ast, Column, From, Join, Selection, SqlAst};
 use core::ops::Deref;
@@ -17,7 +17,7 @@ use super::ast::TableSchemaView;
 const MAX_SQL_LENGTH: usize = 50_000;
 
 /// Compile the `SQL` expression into an `ast`
-pub fn compile_sql<T: TableSchemaView>(db: &RelationalDB, tx: &T, sql_text: &str) -> Result<Vec<CrudExpr>, DBError> {
+pub fn compile_sql<T: TableSchemaView>(db: &DatabaseEngine, tx: &T, sql_text: &str) -> Result<Vec<CrudExpr>, DBError> {
     if sql_text.len() > MAX_SQL_LENGTH {
         return Err(anyhow::anyhow!("SQL query exceeds maximum allowed length: \"{sql_text:.120}...\"").into());
     }
@@ -203,7 +203,7 @@ fn compile_create_table(table: TableDef) -> CrudExpr {
 }
 
 /// Compiles a `SQL` clause
-fn compile_statement(db: &RelationalDB, statement: SqlAst) -> Result<CrudExpr, PlanError> {
+fn compile_statement(db: &DatabaseEngine, statement: SqlAst) -> Result<CrudExpr, PlanError> {
     let q = match statement {
         SqlAst::Select {
             from,
@@ -230,7 +230,7 @@ fn compile_statement(db: &RelationalDB, statement: SqlAst) -> Result<CrudExpr, P
 mod tests {
     use super::*;
     use crate::db::datastore::traits::IsolationLevel;
-    use crate::db::relational_db::tests_utils::TestDB;
+    use crate::db::engine::tests_utils::TestDB;
     use crate::execution_context::ExecutionContext;
     use crate::sql::execute::tests::run_for_testing;
     use crate::vm::tests::create_table_with_rows;

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -54,7 +54,12 @@ fn execute(p: &mut DbProgram<'_, '_>, ast: Vec<CrudExpr>) -> Result<Vec<MemTable
 /// Evaluates `ast` and accordingly triggers mutable or read tx to execute
 ///
 /// Also, in case the execution takes more than x, log it as `slow query`
-pub fn execute_sql(db: &DatabaseEngine, sql: &str, ast: Vec<CrudExpr>, auth: AuthCtx) -> Result<Vec<MemTable>, DBError> {
+pub fn execute_sql(
+    db: &DatabaseEngine,
+    sql: &str,
+    ast: Vec<CrudExpr>,
+    auth: AuthCtx,
+) -> Result<Vec<MemTable>, DBError> {
     let ctx = ctx_sql(db);
     let _slow_logger = SlowQueryLogger::query(&ctx, sql).log_guard();
     if CrudExpr::is_reads(&ast) {

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -1,7 +1,7 @@
 use super::query::{self, Supported};
 use super::subscription::{IncrementalJoin, SupportedQuery};
 use crate::db::datastore::locking_tx_datastore::tx::TxId;
-use crate::db::relational_db::{RelationalDB, Tx};
+use crate::db::engine::{DatabaseEngine, Tx};
 use crate::error::DBError;
 use crate::estimation;
 use crate::execution_context::ExecutionContext;
@@ -218,7 +218,7 @@ impl ExecutionUnit {
     pub fn eval_json(
         &self,
         ctx: &ExecutionContext,
-        db: &RelationalDB,
+        db: &DatabaseEngine,
         tx: &Tx,
         sql: &str,
     ) -> Result<Option<TableUpdateJson>, DBError> {
@@ -237,7 +237,7 @@ impl ExecutionUnit {
     pub fn eval_binary(
         &self,
         ctx: &ExecutionContext,
-        db: &RelationalDB,
+        db: &DatabaseEngine,
         tx: &Tx,
         sql: &str,
     ) -> Result<Option<TableUpdate>, DBError> {
@@ -254,7 +254,7 @@ impl ExecutionUnit {
 
     fn eval_query_expr<T>(
         ctx: &ExecutionContext,
-        db: &RelationalDB,
+        db: &DatabaseEngine,
         tx: &Tx,
         eval_plan: &QueryExpr,
         sql: &str,
@@ -271,7 +271,7 @@ impl ExecutionUnit {
     pub fn eval_incr<'a>(
         &'a self,
         ctx: &'a ExecutionContext,
-        db: &'a RelationalDB,
+        db: &'a DatabaseEngine,
         tx: &'a TxMode<'a>,
         sql: &'a str,
         tables: impl 'a + Clone + Iterator<Item = &'a DatabaseTableUpdate>,
@@ -291,7 +291,7 @@ impl ExecutionUnit {
 
     fn eval_query_expr_against_memtable<'a>(
         ctx: &'a ExecutionContext,
-        db: &'a RelationalDB,
+        db: &'a DatabaseEngine,
         tx: &'a TxMode,
         mem_table: &'a [ProductValue],
         eval_incr_plan: &'a QueryExpr,
@@ -305,7 +305,7 @@ impl ExecutionUnit {
 
     fn eval_incr_query_expr<'a>(
         ctx: &'a ExecutionContext,
-        db: &'a RelationalDB,
+        db: &'a DatabaseEngine,
         tx: &'a TxMode<'a>,
         tables: impl Iterator<Item = &'a DatabaseTableUpdate>,
         eval_incr_plan: &'a QueryExpr,

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -4,7 +4,7 @@ use super::query::compile_read_only_query;
 use super::subscription::ExecutionSet;
 use crate::client::messages::{SubscriptionUpdate, SubscriptionUpdateMessage, TransactionUpdateMessage};
 use crate::client::{ClientActorId, ClientConnectionSender};
-use crate::db::engine::{MutTx, DatabaseEngine, Tx};
+use crate::db::engine::{DatabaseEngine, MutTx, Tx};
 use crate::error::{DBError, SubscriptionError};
 use crate::execution_context::ExecutionContext;
 use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent};

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -1,7 +1,7 @@
 use super::execution_unit::{ExecutionUnit, QueryHash};
 use crate::client::messages::{SerializableMessage, SubscriptionUpdate, TransactionUpdateMessage};
 use crate::client::{ClientConnectionSender, Protocol};
-use crate::db::relational_db::{RelationalDB, Tx};
+use crate::db::engine::{DatabaseEngine, Tx};
 use crate::execution_context::ExecutionContext;
 use crate::host::module_host::{DatabaseTableUpdate, DatabaseUpdate, ModuleEvent, ProtocolDatabaseUpdate};
 use crate::json::client_api::{TableRowOperationJson, TableUpdateJson};
@@ -117,7 +117,7 @@ impl SubscriptionManager {
     #[tracing::instrument(skip_all)]
     pub fn eval_updates(
         &self,
-        db: &RelationalDB,
+        db: &DatabaseEngine,
         tx: &Tx,
         event: Arc<ModuleEvent>,
         sender_client: Option<&ClientConnectionSender>,
@@ -289,7 +289,7 @@ mod tests {
 
     use crate::{
         client::{ClientActorId, ClientConnectionSender, ClientName, Protocol},
-        db::relational_db::{tests_utils::TestDB, RelationalDB},
+        db::engine::{tests_utils::TestDB, DatabaseEngine},
         energy::EnergyQuanta,
         execution_context::ExecutionContext,
         host::{
@@ -305,11 +305,11 @@ mod tests {
 
     use super::SubscriptionManager;
 
-    fn create_table(db: &RelationalDB, name: &str) -> ResultTest<TableId> {
+    fn create_table(db: &DatabaseEngine, name: &str) -> ResultTest<TableId> {
         Ok(db.create_table_for_test(name, &[("a", AlgebraicType::U8)], &[])?)
     }
 
-    fn compile_plan(db: &RelationalDB, sql: &str) -> ResultTest<Arc<ExecutionUnit>> {
+    fn compile_plan(db: &DatabaseEngine, sql: &str) -> ResultTest<Arc<ExecutionUnit>> {
         db.with_read_only(&ExecutionContext::default(), |tx| {
             let mut exprs = compile_sql(db, tx, sql)?;
             assert_eq!(1, exprs.len());

--- a/crates/core/src/util/slow.rs
+++ b/crates/core/src/util/slow.rs
@@ -111,18 +111,18 @@ mod tests {
     use spacetimedb_lib::identity::AuthCtx;
 
     use crate::config::ReadConfigOption;
-    use crate::db::relational_db::tests_utils::TestDB;
-    use crate::db::relational_db::RelationalDB;
+    use crate::db::engine::tests_utils::TestDB;
+    use crate::db::engine::DatabaseEngine;
     use spacetimedb_sats::{product, AlgebraicType};
     use spacetimedb_vm::relation::MemTable;
 
-    fn run_query(db: &RelationalDB, sql: String) -> ResultTest<MemTable> {
+    fn run_query(db: &DatabaseEngine, sql: String) -> ResultTest<MemTable> {
         let tx = db.begin_tx();
         let q = compile_sql(db, &tx, &sql)?;
         Ok(execute_sql(db, &sql, q, AuthCtx::for_testing())?.pop().unwrap())
     }
 
-    fn run_query_write(db: &RelationalDB, sql: String) -> ResultTest<()> {
+    fn run_query_write(db: &DatabaseEngine, sql: String) -> ResultTest<()> {
         let tx = db.begin_tx();
         let q = compile_sql(db, &tx, &sql)?;
         drop(tx);

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -4,7 +4,7 @@ use crate::config::DatabaseConfig;
 use crate::db::cursor::{IndexCursor, TableCursor};
 use crate::db::datastore::locking_tx_datastore::tx::TxId;
 use crate::db::datastore::locking_tx_datastore::IterByColRange;
-use crate::db::engine::{MutTx, DatabaseEngine, Tx};
+use crate::db::engine::{DatabaseEngine, MutTx, Tx};
 use crate::error::DBError;
 use crate::estimation;
 use crate::execution_context::ExecutionContext;
@@ -647,7 +647,8 @@ pub(crate) mod tests {
     fn test_db_query_inner_join() -> ResultTest<()> {
         let test_db = TestDB::durable()?;
 
-        let (schema, _) = test_db.with_auto_commit(&ExecutionContext::default(), |tx| create_inv_table(&test_db, tx))?;
+        let (schema, _) =
+            test_db.with_auto_commit(&ExecutionContext::default(), |tx| create_inv_table(&test_db, tx))?;
         let table_id = schema.table_id;
 
         let data = mem_table_one_u64(u32::MAX.into());

--- a/crates/sats/src/relation.rs
+++ b/crates/sats/src/relation.rs
@@ -255,7 +255,7 @@ pub trait Relation {
     fn row_count(&self) -> RowCount;
 }
 
-/// A stored table from [RelationalDB]
+/// A stored table from [DatabaseEngine]
 #[derive(Debug, Clone, Eq, PartialEq, Hash)]
 pub struct DbTable {
     pub head: Arc<Header>,

--- a/crates/sqltest/src/space.rs
+++ b/crates/sqltest/src/space.rs
@@ -1,6 +1,6 @@
 use crate::db::DBRunner;
 use async_trait::async_trait;
-use spacetimedb::db::relational_db::tests_utils::TestDB;
+use spacetimedb::db::engine::tests_utils::TestDB;
 use spacetimedb::error::DBError;
 use spacetimedb::execution_context::ExecutionContext;
 use spacetimedb::sql::compiler::compile_sql;


### PR DESCRIPTION
# Description of Changes

This renames `RelationalDB` to `DatabaseEngine`. No other changes are made.

# Expected complexity level and risk

1.5

# Testing

I have done no additional testing.
