### PR TITLE
Remove unreachable branches from C# generate

### DIFF
--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -976,27 +976,15 @@ fn autogen_csharp_access_funcs_for_struct(
                         writeln!(output);
                         writeln!(output, "if (ByteArrayCompare(compareValue, value))");
                         indented_block(output, |output| {
-                            if is_unique {
-                                writeln!(output, "return ({struct_name_pascal_case})entry.Item2;");
-                            } else {
-                                writeln!(output, "yield return ({struct_name_pascal_case})entry.Item2;");
-                            }
+                            writeln!(output, "yield return ({struct_name_pascal_case})entry.Item2;");
                         });
                     } else {
                         writeln!(output, "if (compareValue == value)");
                         indented_block(output, |output| {
-                            if is_unique {
-                                writeln!(output, "return ({struct_name_pascal_case})entry.Item2;");
-                            } else {
-                                writeln!(output, "yield return ({struct_name_pascal_case})entry.Item2;");
-                            }
+                            writeln!(output, "yield return ({struct_name_pascal_case})entry.Item2;");
                         });
                     }
                 });
-
-                if is_unique {
-                    writeln!(output, "return null;");
-                }
             }
         });
         writeln!(output);


### PR DESCRIPTION
# Description of Changes

These branches are already inside of `if is_unique {} else { ... }` branch, so `is_unique` can never be `true`.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
