### PR TITLE
Remove `BTreeIndex::name` again

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -307,7 +307,6 @@ impl CommittedState {
                 table.row_layout(),
                 &index_row.columns,
                 index_row.is_unique,
-                index_row.index_name,
             )?;
             index.build_from_rows(&index_row.columns, table.scan_rows(blob_store))?;
             table.indexes.insert(index_row.columns, index);

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -324,13 +324,7 @@ impl MutTxId {
             self.tx_state.get_table_and_blob_store(table_id).unwrap()
         };
 
-        let mut insert_index = BTreeIndex::new(
-            index.index_id,
-            table.row_layout(),
-            &index.columns,
-            index.is_unique,
-            index.index_name.clone(),
-        )?;
+        let mut insert_index = BTreeIndex::new(index.index_id, table.row_layout(), &index.columns, index.is_unique)?;
         insert_index.build_from_rows(&index.columns, table.scan_rows(blob_store))?;
 
         // NOTE: Also add all the rows in the already committed table to the index.

--- a/crates/table/benches/page_manager.rs
+++ b/crates/table/benches/page_manager.rs
@@ -693,7 +693,7 @@ fn make_table_with_indexes<R: IndexedRow>() -> Table {
     let mut tbl = Table::new(schema.into(), SquashedOffset::COMMITTED_STATE);
 
     let cols = R::indexed_columns();
-    let idx = BTreeIndex::new(IndexId(0), &R::row_type().into(), &cols, false, "idx").unwrap();
+    let idx = BTreeIndex::new(IndexId(0), &R::row_type().into(), &cols, false).unwrap();
     tbl.insert_index(&NullBlobStore, cols, idx);
 
     tbl

--- a/crates/table/src/btree_index.rs
+++ b/crates/table/src/btree_index.rs
@@ -325,11 +325,9 @@ pub struct BTreeIndex {
     pub(crate) is_unique: bool,
     /// The actual index, specialized for the appropriate key type.
     idx: TypedIndex,
-    /// The index name, used for reporting unique constraint violations.
-    pub(crate) name: Box<str>,
 }
 
-static_assert_size!(BTreeIndex, 56);
+static_assert_size!(BTreeIndex, 40);
 
 impl BTreeIndex {
     /// Returns a new possibly unique index, with `index_id` for a set of columns.
@@ -338,7 +336,6 @@ impl BTreeIndex {
         row_type: &RowTypeLayout,
         indexed_columns: &ColList,
         is_unique: bool,
-        name: impl Into<Box<str>>,
     ) -> Result<Self, InvalidFieldError> {
         // If the index is on a single column of a primitive type,
         // use a homogeneous map with a native key type.
@@ -372,7 +369,6 @@ impl BTreeIndex {
             index_id,
             is_unique,
             idx: typed_index,
-            name: name.into(),
         })
     }
 
@@ -471,7 +467,7 @@ mod test {
 
     fn new_index(row_type: &ProductType, cols: &ColList, is_unique: bool) -> BTreeIndex {
         let row_layout: RowTypeLayout = row_type.clone().into();
-        BTreeIndex::new(0.into(), &row_layout, cols, is_unique, "test_index").unwrap()
+        BTreeIndex::new(0.into(), &row_layout, cols, is_unique).unwrap()
     }
 
     fn table(ty: ProductType) -> Table {

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -576,14 +576,7 @@ impl Table {
             new.insert_index(
                 &NullBlobStore,
                 cols.clone(),
-                BTreeIndex::new(
-                    index.index_id,
-                    &self.inner.row_layout,
-                    cols,
-                    index.is_unique,
-                    index.name.clone(),
-                )
-                .unwrap(),
+                BTreeIndex::new(index.index_id, &self.inner.row_layout, cols, index.is_unique).unwrap(),
             );
         }
         new
@@ -936,7 +929,7 @@ impl IndexScanIter<'_> {
 #[derive(Error, Debug, PartialEq, Eq)]
 #[error("Unique constraint violation '{}' in table '{}': column(s): '{:?}' value: {}", constraint_name, table_name, cols, value.to_satn())]
 pub struct UniqueConstraintViolation {
-    pub constraint_name: String,
+    pub constraint_name: Box<str>,
     pub table_name: Box<str>,
     pub cols: Vec<Box<str>>,
     pub value: AlgebraicValue,
@@ -954,14 +947,27 @@ impl Table {
     ) -> UniqueConstraintViolation {
         let schema = self.get_schema();
 
+        // Fetch the table name.
+        let table_name = schema.table_name.clone();
+
+        // Fetch the names of the columns used in the index.
         let cols = cols
             .iter()
             .map(|x| schema.columns()[x.idx()].col_name.clone())
             .collect();
 
+        // Fetch the name of the index.
+        let constraint_name = schema
+            .indexes
+            .iter()
+            .find(|i| i.index_id == index.index_id)
+            .unwrap()
+            .index_name
+            .clone();
+
         UniqueConstraintViolation {
-            constraint_name: index.name.clone().into(),
-            table_name: schema.table_name.clone(),
+            constraint_name,
+            table_name,
             cols,
             value,
         }
@@ -1070,7 +1076,7 @@ pub(crate) mod test {
         let mut table = Table::new(schema.into(), SquashedOffset::COMMITTED_STATE);
         let cols = ColList::new(0.into());
 
-        let index = BTreeIndex::new(index_schema.index_id, &table.inner.row_layout, &cols, true, index_name).unwrap();
+        let index = BTreeIndex::new(index_schema.index_id, &table.inner.row_layout, &cols, true).unwrap();
         table.insert_index(&NullBlobStore, cols, index);
 
         // Insert the row (0, 0).
@@ -1087,7 +1093,7 @@ pub(crate) mod test {
                 cols,
                 value,
             })) => {
-                assert_eq!(constraint_name, index_name);
+                assert_eq!(&*constraint_name, index_name);
                 assert_eq!(&*table_name, "UniqueIndexed");
                 assert_eq!(cols.iter().map(|c| c.to_string()).collect::<Vec<_>>(), &["unique_col"]);
                 assert_eq!(value, AlgebraicValue::I32(0));


### PR DESCRIPTION
# Description of Changes

Small change that we can do now that the IDs are right for system tables.
Removes `BTreeIndex::name` and recovers the name from the `TableSchema` when used in error messages,
where we don't care about perf as much.

# API and ABI breaking changes

None

# Expected complexity level and risk

1