### PR TITLE
Atomically downgrade lock when committing tx to prevent deadlock

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -486,6 +486,33 @@ impl MutTx for Locking {
     }
 }
 
+impl Locking {
+    pub fn rollback_mut_tx_downgrade(&self, ctx: &ExecutionContext, tx: MutTxId) -> TxId {
+        let lock_wait_time = tx.lock_wait_time;
+        let timer = tx.timer;
+        // TODO(cloutiertyler): We should probably track the tx.rollback() time separately.
+        let tx = tx.rollback_downgrade();
+
+        // Record metrics for the transaction at the very end right before we drop
+        // the MutTx and release the lock.
+        record_metrics(ctx, timer, lock_wait_time, false);
+
+        tx
+    }
+
+    pub fn commit_mut_tx_downgrade(&self, ctx: &ExecutionContext, tx: MutTxId) -> Result<Option<(TxData, TxId)>> {
+        let lock_wait_time = tx.lock_wait_time;
+        let timer = tx.timer;
+        // TODO(cloutiertyler): We should probably track the tx.commit() time separately.
+        let res = tx.commit_downgrade(ctx);
+
+        // Record metrics for the transaction at the very end right before we drop
+        // the MutTx and release the lock.
+        record_metrics(ctx, timer, lock_wait_time, true);
+        Ok(Some(res))
+    }
+}
+
 impl Programmable for Locking {
     fn program_hash(&self, tx: &TxId) -> Result<Option<spacetimedb_sats::hash::Hash>> {
         tx.iter(&ExecutionContext::internal(self.database_address), &ST_MODULE_ID)?

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -3,6 +3,7 @@ use super::{
     datastore::Result,
     sequence::{Sequence, SequencesState},
     state_view::{IndexSeekIterMutTxId, Iter, IterByColRange, ScanIterByColRange, StateView},
+    tx::TxId,
     tx_state::TxState,
     SharedMutexGuard, SharedWriteGuard,
 };
@@ -689,8 +690,32 @@ impl MutTxId {
         committed_state_write_lock.merge(tx_state, ctx)
     }
 
+    pub fn commit_downgrade(self, ctx: &ExecutionContext) -> (TxData, TxId) {
+        let Self {
+            mut committed_state_write_lock,
+            tx_state,
+            ..
+        } = self;
+        let tx_data = committed_state_write_lock.merge(tx_state, ctx);
+        let tx = TxId {
+            committed_state_shared_lock: SharedWriteGuard::downgrade(committed_state_write_lock),
+            lock_wait_time: Duration::ZERO,
+            timer: Instant::now(),
+        };
+        (tx_data, tx)
+    }
+
     pub fn rollback(self) {
         // TODO: Check that no sequences exceed their allocation after the rollback.
+    }
+
+    pub fn rollback_downgrade(self) -> TxId {
+        // TODO: Check that no sequences exceed their allocation after the rollback.
+        TxId {
+            committed_state_shared_lock: SharedWriteGuard::downgrade(self.committed_state_write_lock),
+            lock_wait_time: Duration::ZERO,
+            timer: Instant::now(),
+        }
     }
 }
 

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -25,7 +25,7 @@ use crate::identity::Identity;
 use crate::messages::control_db::Database;
 use crate::module_host_context::ModuleCreationContext;
 use crate::sql;
-use crate::subscription::module_subscription_actor::ModuleSubscriptions;
+use crate::subscription::module_subscription_actor::{ModuleSubscriptions, WriteSkew};
 use crate::util::const_unwrap;
 use crate::util::prometheus_handle::HistogramExt;
 use crate::worker_metrics::WORKER_METRICS;
@@ -579,14 +579,8 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         }
         reducer_span.exit();
 
-        // Take a lock on our subscriptions now. Otherwise, we could have a race condition where we commit
-        // the tx, someone adds a subscription and receives this tx as an initial update, and then receives the
-        // update again when we broadcast_event.
-        let subscriptions = self.info.subscriptions.subscriptions.read();
         let status = match call_result {
             Err(err) => {
-                stdb.rollback_mut_tx(&ctx, tx);
-
                 T::log_traceback("reducer", reducer_name, &err);
 
                 WORKER_METRICS
@@ -604,22 +598,12 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
                 }
             }
             Ok(Err(errmsg)) => {
-                stdb.rollback_mut_tx(&ctx, tx);
-
                 log::info!("reducer returned error: {errmsg}");
 
                 EventStatus::Failed(errmsg.into())
             }
-            Ok(Ok(())) => {
-                if let Some(tx_data) = stdb.commit_tx(&ctx, tx).unwrap() {
-                    EventStatus::Committed(DatabaseUpdate::from_writes(&tx_data))
-                } else {
-                    todo!("Write skew, you need to implement retries my man, T-dawg.");
-                }
-            }
+            Ok(Ok(())) => EventStatus::Committed(DatabaseUpdate::default()),
         };
-
-        let outcome = ReducerOutcome::from(&status);
 
         let event = ModuleEvent {
             timestamp,
@@ -635,12 +619,18 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
             request_id,
             timer,
         };
-        self.info
+        let event = match self
+            .info
             .subscriptions
-            .blocking_broadcast_event(client.as_deref(), &subscriptions, Arc::new(event));
+            .commit_and_broadcast_event(client.as_deref(), event, &ctx, tx)
+            .unwrap()
+        {
+            Ok(ev) => ev,
+            Err(WriteSkew) => todo!("Write skew, you need to implement retries my man, T-dawg."),
+        };
 
         ReducerCallResult {
-            outcome,
+            outcome: ReducerOutcome::from(&event.status),
             energy_used: energy.used,
             execution_duration: timings.total_duration,
         }

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -1,7 +1,7 @@
 use super::execution_unit::{ExecutionUnit, QueryHash};
 use crate::client::messages::{SerializableMessage, SubscriptionUpdate, TransactionUpdateMessage};
 use crate::client::{ClientConnectionSender, Protocol};
-use crate::db::relational_db::RelationalDB;
+use crate::db::relational_db::{RelationalDB, Tx};
 use crate::execution_context::ExecutionContext;
 use crate::host::module_host::{DatabaseTableUpdate, DatabaseUpdate, ModuleEvent, ProtocolDatabaseUpdate};
 use crate::json::client_api::{TableRowOperationJson, TableUpdateJson};
@@ -12,7 +12,6 @@ use spacetimedb_client_api_messages::client_api::{TableRowOperation, TableUpdate
 use spacetimedb_data_structures::map::{Entry, HashMap, HashSet, IntMap};
 use spacetimedb_lib::{Address, Identity};
 use spacetimedb_primitives::TableId;
-use std::ops::Deref;
 use std::sync::Arc;
 
 /// Clients are uniquely identified by their Identity and Address.
@@ -119,14 +118,12 @@ impl SubscriptionManager {
     pub fn eval_updates(
         &self,
         db: &RelationalDB,
+        tx: &Tx,
         event: Arc<ModuleEvent>,
         sender_client: Option<&ClientConnectionSender>,
     ) {
         let tables = &event.status.database_update().unwrap().tables;
         let slow = db.read_config().slow_query;
-        let tx = scopeguard::guard(db.begin_tx(), |tx| {
-            tx.release(&ExecutionContext::incremental_update(db.address(), slow));
-        });
 
         // Put the main work on a rayon compute thread.
         rayon::scope(|_| {
@@ -144,7 +141,7 @@ impl SubscriptionManager {
 
             let span = tracing::info_span!("eval_incr").entered();
             let ctx = ExecutionContext::incremental_update(db.address(), slow);
-            let tx = &tx.deref().into();
+            let tx = &tx.into();
             let eval = units
                 .par_iter()
                 .filter_map(|(&hash, tables)| {
@@ -545,7 +542,8 @@ mod tests {
             timer: None,
         });
 
-        subscriptions.eval_updates(&db, event, Some(&client0));
+        let ctx = ExecutionContext::incremental_update(db.address(), db.read_config().slow_query);
+        db.with_read_only(&ctx, |tx| subscriptions.eval_updates(&db, tx, event, Some(&client0)));
 
         tokio::runtime::Builder::new_current_thread()
             .enable_time()


### PR DESCRIPTION
# Description of Changes

Also, move the logic with committing and taking the subscription lock into module_subscription_actor. Best reviewed ignoring whitespace.

before/after:
![diagram](https://github.com/clockworklabs/SpacetimeDB/assets/33094578/07d58f6a-2c2b-4d79-905b-4cc0fcc60ffa)
