### PR TITLE
Move `StaticBsatnLayout` code to its module + harden test

### DIFF
--- a/crates/table/src/bflatn_to_bsatn_fast_path.rs
+++ b/crates/table/src/bflatn_to_bsatn_fast_path.rs
@@ -34,7 +34,7 @@ use core::ptr;
 /// A precomputed BSATN layout for a type whose encoded length is a known constant,
 /// enabling fast BFLATN -> BSATN conversion.
 #[derive(PartialEq, Eq, Debug, Clone)]
-pub struct StaticBsatnLayout {
+pub(crate) struct StaticBsatnLayout {
     /// The length of the encoded BSATN representation of a row of this type,
     /// in bytes.
     ///
@@ -57,7 +57,7 @@ impl StaticBsatnLayout {
     ///   for which `self` was computed.
     ///   As a consequence of this, for every `field` in `self.fields`,
     ///   `row[field.bflatn_offset .. field.bflatn_offset + length]` will be initialized.
-    pub unsafe fn serialize_row_into(&self, buf: &mut [MaybeUninit<Byte>], row: &Bytes) {
+    unsafe fn serialize_row_into(&self, buf: &mut [MaybeUninit<Byte>], row: &Bytes) {
         debug_assert!(buf.len() >= self.bsatn_length as usize);
         for field in &self.fields[..] {
             // SAFETY: forward caller requirements.
@@ -65,12 +65,70 @@ impl StaticBsatnLayout {
         }
     }
 
+    /// Serialize `row` from BFLATN to BSATN into a `Vec<u8>`.
+    ///
+    /// # Safety
+    ///
+    /// - `row` must store a valid, initialized instance of the BFLATN row type
+    ///   for which `self` was computed.
+    ///   As a consequence of this, for every `field` in `self.fields`,
+    ///   `row[field.bflatn_offset .. field.bflatn_offset + length]` will be initialized.
+    pub(crate) unsafe fn serialize_row_into_vec(&self, row: &Bytes) -> Vec<u8> {
+        // Create an uninitialized buffer `buf` of the correct length.
+        let bsatn_len = self.bsatn_length as usize;
+        let mut buf = Vec::with_capacity(bsatn_len);
+        let sink = buf.spare_capacity_mut();
+
+        // (1) Write the row into the slice using a series of `memcpy`s.
+        // SAFETY:
+        // - Caller promised that `row` is valid for `self`.
+        // - `sink` was constructed with exactly the correct length above.
+        unsafe {
+            self.serialize_row_into(sink, row);
+        }
+
+        // SAFETY: In (1), we initialized `0..len`
+        // as `row` was valid for `self` per caller requirements.
+        unsafe { buf.set_len(bsatn_len) }
+        buf
+    }
+
+    /// Serialize `row` from BFLATN to BSATN, appending the BSATN to `buf`.
+    ///
+    /// # Safety
+    ///
+    /// - `row` must store a valid, initialized instance of the BFLATN row type
+    ///   for which `self` was computed.
+    ///   As a consequence of this, for every `field` in `self.fields`,
+    ///   `row[field.bflatn_offset .. field.bflatn_offset + length]` will be initialized.
+    pub(crate) unsafe fn serialize_row_extend(&self, buf: &mut Vec<u8>, row: &Bytes) {
+        // Get an uninitialized slice within `buf` of the correct length.
+        let start = buf.len();
+        let len = self.bsatn_length as usize;
+        buf.reserve(len);
+        let sink = &mut buf.spare_capacity_mut()[..len];
+
+        // (1) Write the row into the slice using a series of `memcpy`s.
+        // SAFETY:
+        // - Caller promised that `row` is valid for `self`.
+        // - `sink` was constructed with exactly the correct length above.
+        unsafe {
+            self.serialize_row_into(sink, row);
+        }
+
+        // SAFETY: In (1), we initialized `start .. start + len`
+        // as `row` was valid for `self` per caller requirements
+        // and we had initialized up to `start` before,
+        // so now we have initialized up to `start + len`.
+        unsafe { buf.set_len(start + len) }
+    }
+
     /// Construct a `StaticBsatnLayout` for converting BFLATN rows of `row_type` into BSATN.
     ///
     /// Returns `None` if `row_type` contains a column which does not have a constant length in BSATN,
     /// either a [`VarLenType`]
     /// or a [`SumTypeLayout`] whose variants do not have the same "live" unpadded length.
-    pub fn for_row_type(row_type: &RowTypeLayout) -> Option<Self> {
+    pub(crate) fn for_row_type(row_type: &RowTypeLayout) -> Option<Self> {
         let mut builder = LayoutBuilder::new_builder();
         builder.visit_product(row_type.product())?;
         Some(builder.build())
@@ -480,27 +538,28 @@ mod test {
         fn known_bsatn_same_as_bflatn_from((ty, val) in generate_typed_row()) {
             let mut blob_store = HashMapBlobStore::default();
             let mut table = crate::table::test::table(ty);
-            let Some(bsatn_layout) = StaticBsatnLayout::for_row_type(table.row_layout()) else {
+            let Some(bsatn_layout) = table.static_bsatn_layout().cloned() else {
                 // `ty` has a var-len member or a sum with different payload lengths,
                 // so the fast path doesn't apply.
                 return Err(TestCaseError::reject("Var-length type"));
             };
 
             let (_, row_ref) = table.insert(&mut blob_store, &val).unwrap();
+            let bytes = row_ref.get_row_data();
 
             let slow_path = bsatn::to_vec(&row_ref).unwrap();
 
-            let bytes = row_ref.get_row_data();
+            let fast_path = unsafe {
+                bsatn_layout.serialize_row_into_vec(bytes)
+            };
 
-            let len = bsatn_layout.bsatn_length as usize;
-            let mut fast_path = Vec::with_capacity(len);
-            let buf = fast_path.spare_capacity_mut();
+            let mut fast_path2 = Vec::new();
             unsafe {
-                bsatn_layout.serialize_row_into(buf, bytes);
-            }
-            unsafe { fast_path.set_len(len); }
+                bsatn_layout.serialize_row_extend(&mut fast_path2, bytes)
+            };
 
             assert_eq!(slow_path, fast_path);
+            assert_eq!(slow_path, fast_path2);
         }
     }
 }


### PR DESCRIPTION
# Description of Changes

This moves some code to the relevant module + puts more code under test, hardening said tests.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

The `known_bsatn_same_as_bflatn_from` test now exercises more production code and exercises both extend and non-extend codepaths.