### PR TITLE
Privatize `Table::row_layout` + related `BTreeIndex` refactoring

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -34,7 +34,6 @@ use spacetimedb_sats::{
 };
 use spacetimedb_table::{
     blob_store::{BlobStore, HashMapBlobStore},
-    btree_index::BTreeIndex,
     indexes::{RowPointer, SquashedOffset},
     table::{IndexScanIter, InsertError, RowRef, Table},
 };
@@ -302,14 +301,8 @@ impl CommittedState {
             let Some((table, blob_store)) = self.get_table_and_blob_store(index_row.table_id) else {
                 panic!("Cannot create index for table which doesn't exist in committed state");
             };
-            let mut index = BTreeIndex::new(
-                index_row.index_id,
-                table.row_layout(),
-                &index_row.columns,
-                index_row.is_unique,
-            )?;
-            index.build_from_rows(&index_row.columns, table.scan_rows(blob_store))?;
-            table.indexes.insert(index_row.columns, index);
+            let index = table.new_index(index_row.index_id, &index_row.columns, index_row.is_unique)?;
+            table.insert_index(blob_store, index_row.columns, index);
         }
         Ok(())
     }

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -36,7 +36,6 @@ use spacetimedb_sats::{
     AlgebraicValue, ProductType, ProductValue,
 };
 use spacetimedb_table::{
-    btree_index::BTreeIndex,
     indexes::{RowPointer, SquashedOffset},
     table::{InsertError, RowRef, Table},
 };
@@ -325,7 +324,7 @@ impl MutTxId {
             self.tx_state.get_table_and_blob_store(table_id).unwrap()
         };
 
-        let mut insert_index = BTreeIndex::new(index.index_id, table.row_layout(), &index.columns, index.is_unique)?;
+        let mut insert_index = table.new_index(index.index_id, &index.columns, index.is_unique)?;
         insert_index.build_from_rows(&index.columns, table.scan_rows(blob_store))?;
 
         // NOTE: Also add all the rows in the already committed table to the index.

--- a/crates/table/benches/page_manager.rs
+++ b/crates/table/benches/page_manager.rs
@@ -11,7 +11,6 @@ use spacetimedb_primitives::{ColList, IndexId, TableId};
 use spacetimedb_sats::db::def::{TableDef, TableSchema};
 use spacetimedb_sats::{AlgebraicType, AlgebraicValue, ProductType, ProductValue};
 use spacetimedb_table::blob_store::NullBlobStore;
-use spacetimedb_table::btree_index::BTreeIndex;
 use spacetimedb_table::indexes::Byte;
 use spacetimedb_table::indexes::{Bytes, PageOffset, RowPointer, Size, SquashedOffset, PAGE_DATA_SIZE};
 use spacetimedb_table::layout::{row_size_for_bytes, row_size_for_type};
@@ -693,7 +692,7 @@ fn make_table_with_indexes<R: IndexedRow>() -> Table {
     let mut tbl = Table::new(schema.into(), SquashedOffset::COMMITTED_STATE);
 
     let cols = R::indexed_columns();
-    let idx = BTreeIndex::new(IndexId(0), &R::row_type().into(), &cols, false).unwrap();
+    let idx = tbl.new_index(IndexId(0), &cols, false).unwrap();
     tbl.insert_index(&NullBlobStore, cols, idx);
 
     tbl

--- a/crates/table/src/lib.rs
+++ b/crates/table/src/lib.rs
@@ -8,11 +8,11 @@
 
 pub mod bflatn_from;
 pub mod bflatn_to;
-pub mod bflatn_to_bsatn_fast_path;
+mod bflatn_to_bsatn_fast_path;
 pub mod blob_store;
-pub mod btree_index;
+mod btree_index;
 pub mod eq;
-pub mod eq_to_pv;
+mod eq_to_pv;
 mod fixed_bit_set;
 pub mod indexes;
 pub mod layout;


### PR DESCRIPTION
# Description of Changes

- Make `fn Table::row_layout` private and add  `Table::new_index`.
- Use `Table::insert_index` more.
- Privatize some `spacetimedb_table` modules

# API and ABI breaking changes

None

# Expected complexity level and risk

1