### PR TITLE
Misc datastore cleanups & less cloning

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -9,11 +9,11 @@ use crate::{
     db::{
         datastore::{
             system_tables::{
-                st_columns_schema, st_constraints_schema, st_indexes_schema, st_module_schema, st_sequences_schema,
-                st_table_schema, system_tables, StColumnRow, StConstraintRow, StIndexRow, StSequenceRow, StTableFields,
-                StTableRow, SystemTable, ST_COLUMNS_ID, ST_COLUMNS_NAME, ST_CONSTRAINTS_ID, ST_CONSTRAINTS_NAME,
-                ST_INDEXES_ID, ST_INDEXES_NAME, ST_MODULE_ID, ST_RESERVED_SEQUENCE_RANGE, ST_SEQUENCES_ID,
-                ST_SEQUENCES_NAME, ST_TABLES_ID,
+                system_tables, StColumnRow, StConstraintRow, StIndexRow, StSequenceRow, StTableFields, StTableRow,
+                SystemTable, ST_COLUMNS_ID, ST_COLUMNS_IDX, ST_COLUMNS_NAME, ST_CONSTRAINTS_ID, ST_CONSTRAINTS_IDX,
+                ST_CONSTRAINTS_NAME, ST_INDEXES_ID, ST_INDEXES_IDX, ST_INDEXES_NAME, ST_MODULE_ID, ST_MODULE_IDX,
+                ST_RESERVED_SEQUENCE_RANGE, ST_SEQUENCES_ID, ST_SEQUENCES_IDX, ST_SEQUENCES_NAME, ST_TABLES_ID,
+                ST_TABLES_IDX,
             },
             traits::TxData,
         },
@@ -52,17 +52,14 @@ pub(crate) struct CommittedState {
 }
 
 impl StateView for CommittedState {
-    fn get_schema(&self, table_id: &TableId) -> Option<&Arc<TableSchema>> {
-        self.tables.get(table_id).map(|table| table.get_schema())
+    fn get_schema(&self, table_id: TableId) -> Option<&Arc<TableSchema>> {
+        self.tables.get(&table_id).map(|table| table.get_schema())
     }
-    fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: &TableId) -> Result<Iter<'a>> {
-        if let Some(table_name) = self.table_exists(table_id) {
-            return Ok(Iter::new(ctx, *table_id, table_name, None, self));
+    fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Iter<'a>> {
+        if let Some(table_name) = self.table_name(table_id) {
+            return Ok(Iter::new(ctx, table_id, table_name, None, self));
         }
         Err(TableError::IdNotFound(SystemTable::st_table, table_id.0).into())
-    }
-    fn table_exists(&self, table_id: &TableId) -> Option<&str> {
-        self.tables.get(table_id).map(|t| &*t.schema.table_name)
     }
     /// Returns an iterator,
     /// yielding every row in the table identified by `table_id`,
@@ -70,7 +67,7 @@ impl StateView for CommittedState {
     fn iter_by_col_range<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
         ctx: &'a ExecutionContext,
-        table_id: &TableId,
+        table_id: TableId,
         cols: ColList,
         range: R,
     ) -> Result<IterByColRange<'a, R>> {
@@ -111,17 +108,20 @@ impl CommittedState {
                 .with_label_values(&database_address, &table_id.0, table_name)
         };
 
-        // Insert the table row into st_tables, creating st_tables if it's missing
-        let (st_tables, blob_store) = self.get_table_and_blob_store_or_create(ST_TABLES_ID, st_table_schema().into());
+        let schemas = system_tables().map(Arc::new);
+        let ref_schemas = schemas.each_ref().map(|s| &**s);
+
+        // Insert the table row into st_tables, creating st_tables if it's missing.
+        let (st_tables, blob_store) = self.get_table_and_blob_store_or_create(ST_TABLES_ID, &schemas[ST_TABLES_IDX]);
         // Insert the table row into `st_tables` for all system tables
-        for schema in system_tables() {
+        for schema in ref_schemas {
             let table_id = schema.table_id;
             // Metric for this system table.
             with_label_values(table_id, &schema.table_name).set(0);
 
             let row = StTableRow {
                 table_id,
-                table_name: schema.table_name,
+                table_name: schema.table_name.clone(),
                 table_type: StTableType::System,
                 table_access: StAccess::Public,
             };
@@ -132,9 +132,8 @@ impl CommittedState {
         }
 
         // Insert the columns into `st_columns`
-        let (st_columns, blob_store) =
-            self.get_table_and_blob_store_or_create(ST_COLUMNS_ID, st_columns_schema().into());
-        for col in system_tables().into_iter().flat_map(|x| x.into_columns()) {
+        let (st_columns, blob_store) = self.get_table_and_blob_store_or_create(ST_COLUMNS_ID, &schemas[ST_COLUMNS_IDX]);
+        for col in ref_schemas.iter().flat_map(|x| x.columns()).cloned() {
             let row = StColumnRow {
                 table_id: col.table_id,
                 col_pos: col.col_pos,
@@ -153,11 +152,12 @@ impl CommittedState {
 
         // Insert constraints into `st_constraints`
         let (st_constraints, blob_store) =
-            self.get_table_and_blob_store_or_create(ST_CONSTRAINTS_ID, st_constraints_schema().into());
-        for (i, constraint) in system_tables()
-            .into_iter()
-            .flat_map(|x| x.constraints)
-            .sorted_by_key(|x| (x.table_id, x.columns.clone()))
+            self.get_table_and_blob_store_or_create(ST_CONSTRAINTS_ID, &schemas[ST_CONSTRAINTS_IDX]);
+        for (i, constraint) in ref_schemas
+            .iter()
+            .flat_map(|x| &x.constraints)
+            .sorted_by_key(|x| (x.table_id, &x.columns))
+            .cloned()
             .enumerate()
         {
             let row = StConstraintRow {
@@ -176,12 +176,12 @@ impl CommittedState {
         }
 
         // Insert the indexes into `st_indexes`
-        let (st_indexes, blob_store) =
-            self.get_table_and_blob_store_or_create(ST_INDEXES_ID, st_indexes_schema().into());
-        for (i, index) in system_tables()
-            .into_iter()
-            .flat_map(|x| x.indexes)
-            .sorted_by_key(|x| (x.table_id, x.columns.clone()))
+        let (st_indexes, blob_store) = self.get_table_and_blob_store_or_create(ST_INDEXES_ID, &schemas[ST_INDEXES_IDX]);
+        for (i, index) in ref_schemas
+            .iter()
+            .flat_map(|x| &x.indexes)
+            .sorted_by_key(|x| (x.table_id, &x.columns))
+            .cloned()
             .enumerate()
         {
             let row = StIndexRow {
@@ -202,17 +202,17 @@ impl CommittedState {
 
         // We don't add the row here but with `MutProgrammable::set_program_hash`, but we need to register the table
         // in the internal state.
-        self.create_table(ST_MODULE_ID, st_module_schema());
+        self.create_table(ST_MODULE_ID, schemas[ST_MODULE_IDX].clone());
 
         // Insert the sequences into `st_sequences`
         let (st_sequences, blob_store) =
-            self.get_table_and_blob_store_or_create(ST_SEQUENCES_ID, st_sequences_schema().into());
+            self.get_table_and_blob_store_or_create(ST_SEQUENCES_ID, &schemas[ST_SEQUENCES_IDX]);
         // We create sequences last to get right the starting number
         // so, we don't sort here
-        for (i, col) in system_tables().into_iter().flat_map(|x| x.sequences).enumerate() {
+        for (i, col) in ref_schemas.iter().flat_map(|x| &x.sequences).enumerate() {
             let row = StSequenceRow {
                 sequence_id: i.into(),
-                sequence_name: col.sequence_name,
+                sequence_name: col.sequence_name.clone(),
                 table_id: col.table_id,
                 col_pos: col.col_pos,
                 increment: col.increment,
@@ -235,9 +235,12 @@ impl CommittedState {
 
         // Re-read the schema with the correct ids...
         let ctx = ExecutionContext::internal(database_address);
-        for schema in system_tables() {
-            self.tables.get_mut(&schema.table_id).unwrap().schema =
-                Arc::new(self.schema_for_table_raw(&ctx, schema.table_id)?);
+        for table_id in ref_schemas.map(|s| s.table_id) {
+            let schema = self.schema_for_table_raw(&ctx, table_id)?;
+            self.tables
+                .get_mut(&table_id)
+                .unwrap()
+                .with_mut_schema(|ts| *ts = schema);
         }
 
         Ok(())
@@ -258,7 +261,7 @@ impl CommittedState {
     }
 
     pub fn replay_insert(&mut self, table_id: TableId, schema: &Arc<TableSchema>, row: &ProductValue) -> Result<()> {
-        let (table, blob_store) = self.get_table_and_blob_store_or_create_ref_schema(table_id, schema);
+        let (table, blob_store) = self.get_table_and_blob_store_or_create(table_id, schema);
         table.insert_internal(blob_store, row).map_err(TableError::Insert)?;
         Ok(())
     }
@@ -272,7 +275,7 @@ impl CommittedState {
             let is_system_table = self
                 .tables
                 .get(&sequence.table_id)
-                .map_or(false, |x| x.schema.table_type == StTableType::System);
+                .map_or(false, |x| x.get_schema().table_type == StTableType::System);
 
             let mut seq = Sequence::new(sequence.into());
             // Now we need to recover the last allocation value.
@@ -317,8 +320,7 @@ impl CommittedState {
         // Construct their schemas and insert tables for them.
         for table_id in table_ids {
             let schema = self.schema_for_table(&ExecutionContext::default(), table_id)?;
-            self.tables
-                .insert(table_id, Table::new(schema, SquashedOffset::COMMITTED_STATE));
+            self.tables.insert(table_id, Self::make_table(schema));
         }
         Ok(())
     }
@@ -433,9 +435,9 @@ impl CommittedState {
         //             based on the available holes in the committed state
         //             and the fullness of the page.
 
-        for (table_id, mut tx_table) in insert_tables {
+        for (table_id, tx_table) in insert_tables {
             let (commit_table, commit_blob_store) =
-                self.get_table_and_blob_store_or_create(table_id, tx_table.schema.clone());
+                self.get_table_and_blob_store_or_create(table_id, tx_table.get_schema());
 
             // NOTE: if there is a schema change the table id will not change
             // and that is what is important here so it doesn't matter if we
@@ -465,11 +467,11 @@ impl CommittedState {
                 inserts.push(pv);
             }
             if !inserts.is_empty() {
-                tx_data.set_inserts_for_table(table_id, &commit_table.schema.table_name, inserts.into());
+                tx_data.set_inserts_for_table(table_id, &commit_table.get_schema().table_name, inserts.into());
             }
 
             // Add all newly created indexes to the committed state.
-            for (cols, mut index) in std::mem::take(&mut tx_table.indexes) {
+            for (cols, mut index) in tx_table.indexes {
                 if !commit_table.indexes.contains_key(&cols) {
                     index.clear();
                     commit_table.insert_index(commit_blob_store, cols, index);
@@ -497,12 +499,15 @@ impl CommittedState {
             .map(|tbl| (tbl, &mut self.blob_store as &mut dyn BlobStore))
     }
 
-    fn create_table(&mut self, table_id: TableId, schema: TableSchema) {
-        self.tables
-            .insert(table_id, Table::new(Arc::new(schema), SquashedOffset::COMMITTED_STATE));
+    fn make_table(schema: Arc<TableSchema>) -> Table {
+        Table::new(schema, SquashedOffset::COMMITTED_STATE)
     }
 
-    pub fn get_table_and_blob_store_or_create_ref_schema<'this>(
+    fn create_table(&mut self, table_id: TableId, schema: Arc<TableSchema>) {
+        self.tables.insert(table_id, Self::make_table(schema));
+    }
+
+    pub fn get_table_and_blob_store_or_create<'this>(
         &'this mut self,
         table_id: TableId,
         schema: &Arc<TableSchema>,
@@ -510,20 +515,7 @@ impl CommittedState {
         let table = self
             .tables
             .entry(table_id)
-            .or_insert_with(|| Table::new(schema.clone(), SquashedOffset::COMMITTED_STATE));
-        let blob_store = &mut self.blob_store;
-        (table, blob_store)
-    }
-
-    pub fn get_table_and_blob_store_or_create(
-        &mut self,
-        table_id: TableId,
-        schema: Arc<TableSchema>,
-    ) -> (&mut Table, &mut dyn BlobStore) {
-        let table = self
-            .tables
-            .entry(table_id)
-            .or_insert_with(|| Table::new(schema, SquashedOffset::COMMITTED_STATE));
+            .or_insert_with(|| Self::make_table(schema.clone()));
         let blob_store = &mut self.blob_store;
         (table, blob_store)
     }
@@ -532,14 +524,14 @@ impl CommittedState {
     pub fn iter_by_col_range_maybe_index<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
         ctx: &'a ExecutionContext,
-        table_id: &TableId,
+        table_id: TableId,
         cols: ColList,
         range: R,
     ) -> Result<IterByColRange<'a, R>> {
-        match self.index_seek(*table_id, &cols, &range) {
+        match self.index_seek(table_id, &cols, &range) {
             Some(committed_rows) => Ok(IterByColRange::CommittedIndex(CommittedIndexIter::new(
                 ctx,
-                *table_id,
+                table_id,
                 None,
                 self,
                 committed_rows,

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -69,7 +69,7 @@ impl MutTxId {
         database_address: Address,
     ) -> Result<()> {
         let ctx = ExecutionContext::internal(database_address);
-        let rows = self.iter_by_col_eq(&ctx, &table_id, col_pos, value)?;
+        let rows = self.iter_by_col_eq(&ctx, table_id, col_pos, value)?;
         let ptrs_to_delete = rows.map(|row_ref| row_ref.pointer()).collect::<Vec<_>>();
         if ptrs_to_delete.is_empty() {
             return Err(TableError::IdNotFound(SystemTable::st_columns, col_pos.0).into());
@@ -241,7 +241,7 @@ impl MutTxId {
         let ctx = ExecutionContext::internal(database_address);
 
         let st_table_ref = self
-            .iter_by_col_eq(&ctx, &ST_TABLES_ID, StTableFields::TableId, &table_id.into())?
+            .iter_by_col_eq(&ctx, ST_TABLES_ID, StTableFields::TableId, &table_id.into())?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_table, table_id.into()))?;
         let mut st = StTableRow::try_from(st_table_ref)?;
@@ -258,13 +258,13 @@ impl MutTxId {
         let ctx = ExecutionContext::internal(database_address);
         let table_name = &table_name.into();
         let row = self
-            .iter_by_col_eq(&ctx, &ST_TABLES_ID, StTableFields::TableName, table_name)?
+            .iter_by_col_eq(&ctx, ST_TABLES_ID, StTableFields::TableName, table_name)?
             .next();
         Ok(row.map(|row| row.read_col(StTableFields::TableId).unwrap()))
     }
 
     pub fn table_name_from_id<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Option<Box<str>>> {
-        self.iter_by_col_eq(ctx, &ST_TABLES_ID, StTableFields::TableId, &table_id.into())
+        self.iter_by_col_eq(ctx, ST_TABLES_ID, StTableFields::TableId, &table_id.into())
             .map(|mut iter| iter.next().map(|row| row.read_col(StTableFields::TableName).unwrap()))
     }
 
@@ -275,7 +275,7 @@ impl MutTxId {
             table_id,
             index.columns
         );
-        if self.table_exists(&table_id).is_none() {
+        if self.table_name(table_id).is_none() {
             return Err(TableError::IdNotFoundState(table_id).into());
         }
 
@@ -359,7 +359,7 @@ impl MutTxId {
         let ctx = ExecutionContext::internal(database_address);
 
         let st_index_ref = self
-            .iter_by_col_eq(&ctx, &ST_INDEXES_ID, StIndexFields::IndexId, &index_id.into())?
+            .iter_by_col_eq(&ctx, ST_INDEXES_ID, StIndexFields::IndexId, &index_id.into())?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_indexes, index_id.into()))?;
         let table_id = st_index_ref.read_col(StIndexFields::TableId)?;
@@ -398,7 +398,7 @@ impl MutTxId {
     pub fn index_id_from_name(&self, index_name: &str, database_address: Address) -> Result<Option<IndexId>> {
         let ctx = ExecutionContext::internal(database_address);
         let name = &<Box<str>>::from(index_name).into();
-        self.iter_by_col_eq(&ctx, &ST_INDEXES_ID, StIndexFields::IndexName, name)
+        self.iter_by_col_eq(&ctx, ST_INDEXES_ID, StIndexFields::IndexName, name)
             .map(|mut iter| iter.next().map(|row| row.read_col(StIndexFields::IndexId).unwrap()))
     }
 
@@ -418,7 +418,7 @@ impl MutTxId {
         // If we're out of allocations, then update the sequence row in st_sequences to allocate a fresh batch of sequences.
         let ctx = ExecutionContext::internal(database_address);
         let old_seq_row_ref = self
-            .iter_by_col_eq(&ctx, &ST_SEQUENCES_ID, StSequenceFields::SequenceId, &seq_id.into())?
+            .iter_by_col_eq(&ctx, ST_SEQUENCES_ID, StSequenceFields::SequenceId, &seq_id.into())?
             .last()
             .unwrap();
         let old_seq_row_ptr = old_seq_row_ref.pointer();
@@ -491,12 +491,7 @@ impl MutTxId {
         let ctx = ExecutionContext::internal(database_address);
 
         let st_sequence_ref = self
-            .iter_by_col_eq(
-                &ctx,
-                &ST_SEQUENCES_ID,
-                StSequenceFields::SequenceId,
-                &sequence_id.into(),
-            )?
+            .iter_by_col_eq(&ctx, ST_SEQUENCES_ID, StSequenceFields::SequenceId, &sequence_id.into())?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_sequence, sequence_id.into()))?;
         let table_id = st_sequence_ref.read_col(StSequenceFields::TableId)?;
@@ -519,7 +514,7 @@ impl MutTxId {
     pub fn sequence_id_from_name(&self, seq_name: &str, database_address: Address) -> Result<Option<SequenceId>> {
         let ctx = ExecutionContext::internal(database_address);
         let name = &<Box<str>>::from(seq_name).into();
-        self.iter_by_col_eq(&ctx, &ST_SEQUENCES_ID, StSequenceFields::SequenceName, name)
+        self.iter_by_col_eq(&ctx, ST_SEQUENCES_ID, StSequenceFields::SequenceName, name)
             .map(|mut iter| {
                 iter.next()
                     .map(|row| row.read_col(StSequenceFields::SequenceId).unwrap())
@@ -591,7 +586,7 @@ impl MutTxId {
         let st_constraint_ref = self
             .iter_by_col_eq(
                 &ctx,
-                &ST_CONSTRAINTS_ID,
+                ST_CONSTRAINTS_ID,
                 StConstraintFields::ConstraintId,
                 &constraint_id.into(),
             )?
@@ -618,7 +613,7 @@ impl MutTxId {
     ) -> Result<Option<ConstraintId>> {
         self.iter_by_col_eq(
             &ExecutionContext::internal(database_address),
-            &ST_CONSTRAINTS_ID,
+            ST_CONSTRAINTS_ID,
             StConstraintFields::ConstraintName,
             &<Box<str>>::from(constraint_name).into(),
         )
@@ -646,7 +641,7 @@ impl MutTxId {
     // and has not been passed to `self.delete`
     // is sufficient to demonstrate that a call to `self.get` is safe.
     pub fn get(&self, table_id: TableId, row_ptr: RowPointer) -> Result<Option<RowRef<'_>>> {
-        if self.table_exists(&table_id).is_none() {
+        if self.table_name(table_id).is_none() {
             return Err(TableError::IdNotFound(SystemTable::st_table, table_id.0).into());
         }
         Ok(match row_ptr.squashed_offset() {
@@ -749,7 +744,7 @@ impl MutTxId {
             .iter()
             .filter(|seq| row.elements[usize::from(seq.col_pos)].is_numeric_zero())
         {
-            for seq_row in self.iter_by_col_eq(&ctx, &ST_SEQUENCES_ID, StSequenceFields::TableId, &table_id.into())? {
+            for seq_row in self.iter_by_col_eq(&ctx, ST_SEQUENCES_ID, StSequenceFields::TableId, &table_id.into())? {
                 let seq_col_pos: ColId = seq_row.read_col(StSequenceFields::ColPos)?;
                 if seq_col_pos == seq.col_pos {
                     let seq_id = seq_row.read_col(StSequenceFields::SequenceId)?;
@@ -973,26 +968,22 @@ impl MutTxId {
 }
 
 impl StateView for MutTxId {
-    fn get_schema(&self, table_id: &TableId) -> Option<&Arc<TableSchema>> {
-        if let Some(row_type) = self
-            .tx_state
+    fn get_schema(&self, table_id: TableId) -> Option<&Arc<TableSchema>> {
+        // TODO(bikeshedding, docs): should this also check if the schema is in the system tables,
+        // but the table hasn't been constructed yet?
+        // If not, document why.
+        self.tx_state
             .insert_tables
-            .get(table_id)
-            .map(|table| table.get_schema())
-        {
-            return Some(row_type);
-        }
-        self.committed_state_write_lock
-            .tables
-            .get(table_id)
+            .get(&table_id)
+            .or_else(|| self.committed_state_write_lock.tables.get(&table_id))
             .map(|table| table.get_schema())
     }
 
-    fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: &TableId) -> Result<Iter<'a>> {
-        if let Some(table_name) = self.table_exists(table_id) {
+    fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Iter<'a>> {
+        if let Some(table_name) = self.table_name(table_id) {
             return Ok(Iter::new(
                 ctx,
-                *table_id,
+                table_id,
                 table_name,
                 Some(&self.tx_state),
                 &self.committed_state_write_lock,
@@ -1001,21 +992,10 @@ impl StateView for MutTxId {
         Err(TableError::IdNotFound(SystemTable::st_table, table_id.0).into())
     }
 
-    fn table_exists(&self, table_id: &TableId) -> Option<&str> {
-        // TODO(bikeshedding, docs): should this also check if the schema is in the system tables,
-        // but the table hasn't been constructed yet?
-        // If not, document why.
-        self.tx_state
-            .insert_tables
-            .get(table_id)
-            .or_else(|| self.committed_state_write_lock.tables.get(table_id))
-            .map(|table| &*table.schema.table_name)
-    }
-
     fn iter_by_col_range<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
         ctx: &'a ExecutionContext,
-        table_id: &TableId,
+        table_id: TableId,
         cols: ColList,
         range: R,
     ) -> Result<IterByColRange<'a, R>> {
@@ -1030,31 +1010,31 @@ impl StateView for MutTxId {
         // TODO(george): It's unclear that we truly support dynamically creating an index
         // yet. In particular, I don't know if creating an index in a transaction and
         // rolling it back will leave the index in place.
-        if let Some(inserted_rows) = self.tx_state.index_seek(*table_id, &cols, &range) {
+        if let Some(inserted_rows) = self.tx_state.index_seek(table_id, &cols, &range) {
             // The current transaction has modified this table, and the table is indexed.
             Ok(IterByColRange::Index(IndexSeekIterMutTxId {
                 ctx,
-                table_id: *table_id,
+                table_id,
                 tx_state: &self.tx_state,
                 inserted_rows,
-                committed_rows: self.committed_state_write_lock.index_seek(*table_id, &cols, &range),
+                committed_rows: self.committed_state_write_lock.index_seek(table_id, &cols, &range),
                 committed_state: &self.committed_state_write_lock,
                 num_committed_rows_fetched: 0,
             }))
         } else {
             // Either the current transaction has not modified this table, or the table is not
             // indexed.
-            match self.committed_state_write_lock.index_seek(*table_id, &cols, &range) {
+            match self.committed_state_write_lock.index_seek(table_id, &cols, &range) {
                 Some(committed_rows) => Ok(IterByColRange::CommittedIndex(CommittedIndexIter::new(
                     ctx,
-                    *table_id,
+                    table_id,
                     Some(&self.tx_state),
                     &self.committed_state_write_lock,
                     committed_rows,
                 ))),
                 None => {
                     #[cfg(feature = "unindexed_iter_by_col_range_warn")]
-                    match self.schema_for_table(ctx, *table_id) {
+                    match self.schema_for_table(ctx, table_id) {
                         // TODO(ux): log these warnings to the module logs rather than host logs.
                         Err(e) => log::error!(
                             "iter_by_col_range on unindexed column, but got error from `schema_for_table` during diagnostics: {e:?}",
@@ -1063,7 +1043,7 @@ impl StateView for MutTxId {
                             const TOO_MANY_ROWS_FOR_SCAN: u64 = 1000;
 
                             let table_name = &schema.table_name;
-                            let num_rows = table_num_rows(ctx.database(), *table_id, table_name);
+                            let num_rows = table_num_rows(ctx.database(), table_id, table_name);
 
                             if num_rows >= TOO_MANY_ROWS_FOR_SCAN {
                                 let col_names = cols.iter()

--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -22,21 +22,22 @@ use std::{ops::RangeBounds, sync::Arc};
 // StateView trait, is designed to define the behavior of viewing internal datastore states.
 // Currently, it applies to: CommittedState, MutTxId, and TxId.
 pub(crate) trait StateView {
-    fn get_schema(&self, table_id: &TableId) -> Option<&Arc<TableSchema>>;
+    fn get_schema(&self, table_id: TableId) -> Option<&Arc<TableSchema>>;
 
     fn table_id_from_name(&self, table_name: &str, database_address: Address) -> Result<Option<TableId>> {
         let ctx = ExecutionContext::internal(database_address);
         let name = &<Box<str>>::from(table_name).into();
         let row = self
-            .iter_by_col_eq(&ctx, &ST_TABLES_ID, StTableFields::TableName, name)?
+            .iter_by_col_eq(&ctx, ST_TABLES_ID, StTableFields::TableName, name)?
             .next();
         Ok(row.map(|row| row.read_col(StTableFields::TableId).unwrap()))
     }
 
-    fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: &TableId) -> Result<Iter<'a>>;
+    fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Iter<'a>>;
 
-    // TODO(noa): rename to table_name, and TableId doesn't need to be a reference
-    fn table_exists(&self, table_id: &TableId) -> Option<&str>;
+    fn table_name(&self, table_id: TableId) -> Option<&str> {
+        self.get_schema(table_id).map(|s| &*s.table_name)
+    }
 
     /// Returns an iterator,
     /// yielding every row in the table identified by `table_id`,
@@ -44,7 +45,7 @@ pub(crate) trait StateView {
     fn iter_by_col_range<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
         ctx: &'a ExecutionContext,
-        table_id: &TableId,
+        table_id: TableId,
         cols: ColList,
         range: R,
     ) -> Result<IterByColRange<'a, R>>;
@@ -52,7 +53,7 @@ pub(crate) trait StateView {
     fn iter_by_col_eq<'a, 'r>(
         &'a self,
         ctx: &'a ExecutionContext,
-        table_id: &TableId,
+        table_id: TableId,
         cols: impl Into<ColList>,
         value: &'r AlgebraicValue,
     ) -> Result<IterByColEq<'a, 'r>> {
@@ -64,7 +65,7 @@ pub(crate) trait StateView {
         // Look up the table_name for the table in question.
         let value_eq = &table_id.into();
         let row = self
-            .iter_by_col_eq(ctx, &ST_TABLES_ID, StTableFields::TableId, value_eq)?
+            .iter_by_col_eq(ctx, ST_TABLES_ID, StTableFields::TableId, value_eq)?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_table, table_id.into()))?;
         let row = StTableRow::try_from(row)?;
@@ -75,7 +76,7 @@ pub(crate) trait StateView {
 
         // Look up the columns for the table in question.
         let mut columns = self
-            .iter_by_col_eq(ctx, &ST_COLUMNS_ID, StColumnFields::TableId, value_eq)?
+            .iter_by_col_eq(ctx, ST_COLUMNS_ID, StColumnFields::TableId, value_eq)?
             .map(|row| {
                 let row = StColumnRow::try_from(row)?;
                 Ok(ColumnSchema {
@@ -90,7 +91,7 @@ pub(crate) trait StateView {
 
         // Look up the constraints for the table in question.
         let constraints = self
-            .iter_by_col_eq(ctx, &ST_CONSTRAINTS_ID, StConstraintFields::TableId, value_eq)?
+            .iter_by_col_eq(ctx, ST_CONSTRAINTS_ID, StConstraintFields::TableId, value_eq)?
             .map(|row| {
                 let row = StConstraintRow::try_from(row)?;
                 Ok(ConstraintSchema {
@@ -105,7 +106,7 @@ pub(crate) trait StateView {
 
         // Look up the sequences for the table in question.
         let sequences = self
-            .iter_by_col_eq(ctx, &ST_SEQUENCES_ID, StSequenceFields::TableId, value_eq)?
+            .iter_by_col_eq(ctx, ST_SEQUENCES_ID, StSequenceFields::TableId, value_eq)?
             .map(|row| {
                 let row = StSequenceRow::try_from(row)?;
                 Ok(SequenceSchema {
@@ -124,7 +125,7 @@ pub(crate) trait StateView {
 
         // Look up the indexes for the table in question.
         let indexes = self
-            .iter_by_col_eq(ctx, &ST_INDEXES_ID, StIndexFields::TableId, value_eq)?
+            .iter_by_col_eq(ctx, ST_INDEXES_ID, StIndexFields::TableId, value_eq)?
             .map(|row| {
                 let row = StIndexRow::try_from(row)?;
                 Ok(IndexSchema {
@@ -156,7 +157,7 @@ pub(crate) trait StateView {
     ///
     /// Note: The responsibility of populating the cache is left to the caller.
     fn schema_for_table(&self, ctx: &ExecutionContext, table_id: TableId) -> Result<Arc<TableSchema>> {
-        if let Some(schema) = self.get_schema(&table_id) {
+        if let Some(schema) = self.get_schema(table_id) {
             return Ok(schema.clone());
         }
 

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -21,16 +21,12 @@ pub struct TxId {
 }
 
 impl StateView for TxId {
-    fn get_schema(&self, table_id: &TableId) -> Option<&Arc<TableSchema>> {
+    fn get_schema(&self, table_id: TableId) -> Option<&Arc<TableSchema>> {
         self.committed_state_shared_lock.get_schema(table_id)
     }
 
-    fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: &TableId) -> Result<Iter<'a>> {
+    fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Iter<'a>> {
         self.committed_state_shared_lock.iter(ctx, table_id)
-    }
-
-    fn table_exists(&self, table_id: &TableId) -> Option<&str> {
-        self.committed_state_shared_lock.table_exists(table_id)
     }
 
     /// Returns an iterator,
@@ -39,14 +35,14 @@ impl StateView for TxId {
     fn iter_by_col_range<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
         ctx: &'a ExecutionContext,
-        table_id: &TableId,
+        table_id: TableId,
         cols: ColList,
         range: R,
     ) -> Result<IterByColRange<'a, R>> {
-        match self.committed_state_shared_lock.index_seek(*table_id, &cols, &range) {
+        match self.committed_state_shared_lock.index_seek(table_id, &cols, &range) {
             Some(committed_rows) => Ok(IterByColRange::CommittedIndex(CommittedIndexIter::new(
                 ctx,
-                *table_id,
+                table_id,
                 None,
                 &self.committed_state_shared_lock,
                 committed_rows,

--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -58,6 +58,7 @@ pub enum SystemTable {
     st_indexes,
     st_constraints,
 }
+
 pub(crate) fn system_tables() -> [TableSchema; 6] {
     [
         st_table_schema(),
@@ -70,6 +71,14 @@ pub(crate) fn system_tables() -> [TableSchema; 6] {
         st_sequences_schema(),
     ]
 }
+
+// The following are indices into the array returned by [`system_tables`].
+pub(crate) const ST_TABLES_IDX: usize = 0;
+pub(crate) const ST_COLUMNS_IDX: usize = 1;
+pub(crate) const ST_INDEXES_IDX: usize = 2;
+pub(crate) const ST_CONSTRAINTS_IDX: usize = 3;
+pub(crate) const ST_MODULE_IDX: usize = 4;
+pub(crate) const ST_SEQUENCES_IDX: usize = 5;
 
 macro_rules! st_fields_enum {
     ($(#[$attr:meta])* enum $ty_name:ident { $($name:expr, $var:ident = $discr:expr,)* }) => {
@@ -174,7 +183,7 @@ st_fields_enum!(enum StModuleFields {
 /// | table_id | table_name  | table_type | table_access |
 /// |----------|-------------|----------- |------------- |
 /// | 4        | "customers" | "user"     | "public"     |
-pub fn st_table_schema() -> TableSchema {
+fn st_table_schema() -> TableSchema {
     TableDef::new(
         ST_TABLES_NAME.into(),
         vec![
@@ -195,7 +204,7 @@ pub fn st_table_schema() -> TableSchema {
 /// | table_id | col_id | col_name | col_type            |
 /// |----------|---------|----------|--------------------|
 /// | 1        | 0       | "id"     | AlgebraicType::U32 |
-pub fn st_columns_schema() -> TableSchema {
+fn st_columns_schema() -> TableSchema {
     TableDef::new(
         ST_COLUMNS_NAME.into(),
         vec![
@@ -219,7 +228,7 @@ pub fn st_columns_schema() -> TableSchema {
 /// | index_id | table_id | index_name  | columns | is_unique | index_type |
 /// |----------|----------|-------------|---------|-----------|------------|
 /// | 1        |          | "ix_sample" | [1]     | false     | "btree"    |
-pub fn st_indexes_schema() -> TableSchema {
+fn st_indexes_schema() -> TableSchema {
     TableDef::new(
         ST_INDEXES_NAME.into(),
         vec![
@@ -242,7 +251,7 @@ pub fn st_indexes_schema() -> TableSchema {
 /// | sequence_id | sequence_name     | increment | start | min_value | max_value | table_id | col_pos| allocated |
 /// |-------------|-------------------|-----------|-------|-----------|-----------|----------|--------|-----------|
 /// | 1           | "seq_customer_id" | 1         | 100   | 10        | 1200      | 1        | 1      | 200       |
-pub(crate) fn st_sequences_schema() -> TableSchema {
+fn st_sequences_schema() -> TableSchema {
     TableDef::new(
         ST_SEQUENCES_NAME.into(),
         vec![
@@ -268,7 +277,7 @@ pub(crate) fn st_sequences_schema() -> TableSchema {
 /// | constraint_id | constraint_name      | constraints | table_id | columns |
 /// |---------------|-------------------- -|-------------|-------|------------|
 /// | 1             | "unique_customer_id" | 1           | 100   | [1, 4]     |
-pub(crate) fn st_constraints_schema() -> TableSchema {
+fn st_constraints_schema() -> TableSchema {
     TableDef::new(
         ST_CONSTRAINTS_NAME.into(),
         vec![
@@ -299,7 +308,7 @@ pub(crate) fn st_constraints_schema() -> TableSchema {
 /// | program_hash        | kind     | epoch |
 /// |---------------------|----------|-------|
 /// | [250, 207, 5, ...]  | 0        | 42    |
-pub(crate) fn st_module_schema() -> TableSchema {
+fn st_module_schema() -> TableSchema {
     TableDef::new(
         ST_MODULE_NAME.into(),
         vec![

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -80,7 +80,7 @@ pub fn run(db: &RelationalDB, sql_text: &str, auth: AuthCtx) -> Result<Vec<MemTa
 /// Translates a `FieldName` to the field's name.
 pub fn translate_col(tx: &TxId, field: FieldName) -> Option<Box<str>> {
     Some(
-        tx.get_schema(&field.table)?
+        tx.get_schema(field.table)?
             .get_column(field.col.idx())?
             .col_name
             .clone(),

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -558,10 +558,9 @@ impl<'a, R: RangeBounds<AlgebraicValue>> RelOps<'a> for IndexCursor<'a, R> {
 pub(crate) mod tests {
     use super::*;
     use crate::db::datastore::system_tables::{
-        st_columns_schema, st_indexes_schema, st_sequences_schema, st_table_schema, StColumnFields, StColumnRow,
-        StIndexFields, StIndexRow, StSequenceFields, StSequenceRow, StTableFields, StTableRow, ST_COLUMNS_ID,
-        ST_COLUMNS_NAME, ST_INDEXES_ID, ST_INDEXES_NAME, ST_RESERVED_SEQUENCE_RANGE, ST_SEQUENCES_ID,
-        ST_SEQUENCES_NAME, ST_TABLES_ID, ST_TABLES_NAME,
+        StColumnFields, StColumnRow, StIndexFields, StIndexRow, StSequenceFields, StSequenceRow, StTableFields,
+        StTableRow, ST_COLUMNS_ID, ST_COLUMNS_NAME, ST_INDEXES_ID, ST_INDEXES_NAME, ST_RESERVED_SEQUENCE_RANGE,
+        ST_SEQUENCES_ID, ST_SEQUENCES_NAME, ST_TABLES_ID, ST_TABLES_NAME,
     };
     use crate::db::relational_db::tests_utils::TestDB;
     use crate::execution_context::ExecutionContext;
@@ -686,9 +685,9 @@ pub(crate) mod tests {
     #[test]
     fn test_query_catalog_tables() -> ResultTest<()> {
         let stdb = TestDB::durable()?;
-        let schema = st_table_schema();
+        let schema = &*stdb.schema_for_table(&stdb.begin_tx(), ST_TABLES_ID).unwrap();
 
-        let q = QueryExpr::new(&schema).with_select_cmp(
+        let q = QueryExpr::new(schema).with_select_cmp(
             OpCmp::Eq,
             FieldName::new(ST_TABLES_ID, StTableFields::TableName.into()),
             scalar(ST_TABLES_NAME),
@@ -700,7 +699,7 @@ pub(crate) mod tests {
             table_access: StAccess::Public,
         }
         .into();
-        check_catalog(&stdb, ST_TABLES_NAME, st_table_row, q, &schema);
+        check_catalog(&stdb, ST_TABLES_NAME, st_table_row, q, schema);
 
         Ok(())
     }
@@ -708,9 +707,9 @@ pub(crate) mod tests {
     #[test]
     fn test_query_catalog_columns() -> ResultTest<()> {
         let stdb = TestDB::durable()?;
+        let schema = &*stdb.schema_for_table(&stdb.begin_tx(), ST_COLUMNS_ID).unwrap();
 
-        let schema = st_columns_schema();
-        let q = QueryExpr::new(&schema)
+        let q = QueryExpr::new(schema)
             .with_select_cmp(
                 OpCmp::Eq,
                 FieldName::new(ST_COLUMNS_ID, StColumnFields::TableId.into()),
@@ -728,7 +727,7 @@ pub(crate) mod tests {
             col_type: AlgebraicType::U32,
         }
         .into();
-        check_catalog(&stdb, ST_COLUMNS_NAME, st_column_row, q, &schema);
+        check_catalog(&stdb, ST_COLUMNS_NAME, st_column_row, q, schema);
 
         Ok(())
     }
@@ -744,8 +743,8 @@ pub(crate) mod tests {
         let index = IndexDef::btree("idx_1".into(), ColId(0), true);
         let index_id = db.with_auto_commit(&ctx, |tx| db.create_index(tx, table_id, index))?;
 
-        let indexes_schema = st_indexes_schema();
-        let q = QueryExpr::new(&indexes_schema).with_select_cmp(
+        let indexes_schema = &*db.schema_for_table(&db.begin_tx(), ST_INDEXES_ID).unwrap();
+        let q = QueryExpr::new(indexes_schema).with_select_cmp(
             OpCmp::Eq,
             FieldName::new(ST_INDEXES_ID, StIndexFields::IndexName.into()),
             scalar("idx_1"),
@@ -759,7 +758,7 @@ pub(crate) mod tests {
             index_type: IndexType::BTree,
         }
         .into();
-        check_catalog(&db, ST_INDEXES_NAME, st_index_row, q, &indexes_schema);
+        check_catalog(&db, ST_INDEXES_NAME, st_index_row, q, indexes_schema);
 
         Ok(())
     }
@@ -768,8 +767,8 @@ pub(crate) mod tests {
     fn test_query_catalog_sequences() -> ResultTest<()> {
         let db = TestDB::durable()?;
 
-        let schema = st_sequences_schema();
-        let q = QueryExpr::new(&schema).with_select_cmp(
+        let schema = &*db.schema_for_table(&db.begin_tx(), ST_SEQUENCES_ID).unwrap();
+        let q = QueryExpr::new(schema).with_select_cmp(
             OpCmp::Eq,
             FieldName::new(ST_SEQUENCES_ID, StSequenceFields::TableId.into()),
             scalar(ST_SEQUENCES_ID),
@@ -786,7 +785,7 @@ pub(crate) mod tests {
             allocated: ST_RESERVED_SEQUENCE_RANGE as i128 * 2,
         }
         .into();
-        check_catalog(&db, ST_SEQUENCES_NAME, st_sequence_row, q, &schema);
+        check_catalog(&db, ST_SEQUENCES_NAME, st_sequence_row, q, schema);
 
         Ok(())
     }


### PR DESCRIPTION
# Description of Changes

1. Privatize `st_*_schema` functions, only used in system_tables() now.
2. Only call `system_tables()` once in `bootstrap_system_tables`. Eagerly `Arc` those and then clone as little as possible.
3. Take `TableId` by value more
4. Rename `table_exists` -> `table_name`
5. Dedup `table_name` by using `get_schema()`.
6. Other minor misc deduping.

# API and ABI breaking changes

None

# Expected complexity level and risk

2, touches some system table code but in a fairly small way.
Still, be sure to double check `ST_TABLES_IDX` and the `bootstrap_system_tables` changes.