### PR TITLE
Reserve sequence range for system tables

### DIFF
--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -560,8 +560,8 @@ pub(crate) mod tests {
     use crate::db::datastore::system_tables::{
         st_columns_schema, st_indexes_schema, st_sequences_schema, st_table_schema, StColumnFields, StColumnRow,
         StIndexFields, StIndexRow, StSequenceFields, StSequenceRow, StTableFields, StTableRow, ST_COLUMNS_ID,
-        ST_COLUMNS_NAME, ST_INDEXES_ID, ST_INDEXES_NAME, ST_SEQUENCES_ID, ST_SEQUENCES_NAME, ST_TABLES_ID,
-        ST_TABLES_NAME,
+        ST_COLUMNS_NAME, ST_INDEXES_ID, ST_INDEXES_NAME, ST_RESERVED_SEQUENCE_RANGE, ST_SEQUENCES_ID,
+        ST_SEQUENCES_NAME, ST_TABLES_ID, ST_TABLES_NAME,
     };
     use crate::db::relational_db::tests_utils::TestDB;
     use crate::execution_context::ExecutionContext;
@@ -780,10 +780,10 @@ pub(crate) mod tests {
             table_id: 2.into(),
             col_pos: 0.into(),
             increment: 1,
-            start: 4,
+            start: ST_RESERVED_SEQUENCE_RANGE as i128 + 1,
             min_value: 1,
             max_value: i128::MAX,
-            allocated: 4096,
+            allocated: ST_RESERVED_SEQUENCE_RANGE as i128 * 2,
         }
         .into();
         check_catalog(&db, ST_SEQUENCES_NAME, st_sequence_row, q, &schema);


### PR DESCRIPTION
Reserves an unreasonably large number of sequence values for use by system tables. This means that user-created tables will draw id values starting from the reserved range + 1, as opposed to number of values taken by system tables + 1.

Adding new system tables is thus unlikely to interfere with already-assigned values in existing databases.

# API and ABI breaking changes

Breaks existing databases due to id conflicts.

# Expected complexity level and risk

1

# Testing

Should be covered by smoke tests.