### PR TITLE
Add table smoketest + more smoketest logging

### DIFF
--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -23,9 +23,8 @@ STDB_CONFIG = TEST_DIR / "config.toml"
 TEMPLATE_LIB_RS = open(STDB_DIR / "crates/cli/src/subcommands/project/rust/lib._rs").read()
 TEMPLATE_CARGO_TOML = open(STDB_DIR / "crates/cli/src/subcommands/project/rust/Cargo._toml").read()
 bindings_path = (STDB_DIR / "crates/bindings").absolute()
-escaped_bindings_path = re.escape(
-    str(bindings_path).replace('\\', '\\\\')
-)
+escaped_bindings_path = str(bindings_path).replace('\\', '\\\\\\\\') # double escape for re.sub + toml
+print(f"bindings path: {bindings_path}, escaped: {escaped_bindings_path}")
 TEMPLATE_CARGO_TOML = (re.compile(r"^spacetimedb\s*=.*$", re.M) \
     .sub(f'spacetimedb = {{ path = "{escaped_bindings_path}" }}', TEMPLATE_CARGO_TOML))
 

--- a/smoketests/__main__.py
+++ b/smoketests/__main__.py
@@ -3,7 +3,6 @@
 import subprocess
 import unittest
 import argparse
-from subprocess import check_call, check_output
 from tempfile import TemporaryDirectory
 from pathlib import Path
 import os
@@ -12,10 +11,10 @@ import fnmatch
 import json
 from . import TEST_DIR, STDB_DIR, STDB_CONFIG, build_template_target
 import smoketests
-
+import logging
 
 def check_docker():
-    docker_ps = check_output(["docker", "ps", "--format=json"])
+    docker_ps = smoketests.run_cmd("docker", "ps", "--format=json")
     docker_ps = (json.loads(line) for line in docker_ps.splitlines())
     for docker_container in docker_ps:
         if "node" in docker_container["Image"]:
@@ -59,8 +58,8 @@ def main():
     parser.add_argument("-x", dest="exclude", nargs="*", default=[])
     args = parser.parse_args()
 
-    print("Compiling spacetime cli...")
-    check_call(["cargo", "build"], cwd=TEST_DIR.parent)
+    logging.info("Compiling spacetime cli...")
+    smoketests.run_cmd("cargo", "build", cwd=TEST_DIR.parent, capture_stderr=False)
 
     os.environ["SPACETIME_SKIP_CLIPPY"] = "1"
 

--- a/smoketests/tests/add_table_pseudomigration.py
+++ b/smoketests/tests/add_table_pseudomigration.py
@@ -1,0 +1,82 @@
+from .. import Smoketest
+import sys
+
+
+class AddTablePseudomigration(Smoketest):
+    MODULE_CODE = """
+use spacetimedb::{println, spacetimedb};
+
+#[spacetimedb(table)]
+pub struct Person {
+    name: String,
+}
+
+#[spacetimedb(reducer)]
+pub fn add_person(name: String) {
+    Person::insert(Person { name });
+}
+
+#[spacetimedb(reducer)]
+pub fn print_persons(prefix: String) {
+    for person in Person::iter() {
+        println!("{}: {}", prefix, person.name);
+    }
+}
+"""
+
+    MODULE_CODE_UPDATED = (
+        MODULE_CODE
+        + """
+#[spacetimedb(table)]
+pub struct Book {
+    isbn: String,
+}
+ 
+pub fn add_book(isbn: String) {
+    Book::insert(Book { isbn });
+}
+
+pub fn print_books(prefix: String) {
+    for book in Book::iter() {
+        println!("{}: {}", prefix, book.isbn);
+    }
+}
+"""
+    )
+
+    def test_upload_module_1(self):
+        """This tests uploading a basic module and calling some functions and checking logs afterwards."""
+
+        print("Initial publish complete", file=sys.stderr)
+        # initial module code is already published by test framework
+
+        self.call("add_person", "Robert")
+        self.call("add_person", "Julie")
+        self.call("add_person", "Samantha")
+        self.call("print_persons", "BEFORE")
+        logs = self.logs(100)
+        self.assertIn("BEFORE: Samantha", logs)
+        self.assertIn("BEFORE: Julie", logs)
+        self.assertIn("BEFORE: Robert", logs)
+
+        print(
+            "Initial operations complete, updating module without clear",
+            file=sys.stderr,
+        )
+
+        self.write_module_code(self.MODULE_CODE_UPDATED)
+        self.publish_module(clear=False)
+
+        print("Updated", file=sys.stderr)
+
+        self.call("add_person", "Husserl")
+        self.call("add_book", "1234567890")
+        self.call("print_persons", "AFTER_PERSON")
+        self.call("print_books", "AFTER_BOOK")
+
+        logs = self.logs(100)
+        self.assertIn("AFTER_PERSON: Samantha!", logs)
+        self.assertIn("AFTER_PERSON: Julie!", logs)
+        self.assertIn("AFTER_PERSON: Robert!", logs)
+        self.assertIn("AFTER_PERSON: Husserl!", logs)
+        self.assertIn("AFTER_BOOK: 1234567890", logs)

--- a/smoketests/tests/add_table_pseudomigration.py
+++ b/smoketests/tests/add_table_pseudomigration.py
@@ -118,7 +118,7 @@ pub struct Person {
 
 #[spacetimedb(reducer)]
 pub fn add_person(name: String) {
-    Person::insert(Person { name });
+    Person::insert(Person { name, age: 70 });
 }
 
 #[spacetimedb(reducer)]
@@ -132,7 +132,7 @@ pub fn print_persons(prefix: String) {
     def test_reject_schema_changes(self):
         """This tests that a module with invalid schema changes cannot be published without -c or a migration."""
 
-        logging.info("Initial publish complete")
+        logging.info("Initial publish complete, trying to do an invalid update.")
 
         with self.assertRaises(Exception):
             self.write_module_code(self.MODULE_CODE_UPDATED)


### PR DESCRIPTION
# Description of Changes

Addresses https://github.com/clockworklabs/SpacetimeDB/issues/1260.

I also got frustrated while debugging and made it so that smoketests log all CLI commands they execute. This should hopefully make smoketests easier to debug in the future.

<details>
<summary>Example test output</summary>

You only will see stuff like this if a test fails, of course:

```
2024-05-21 17:20:41,376 - DEBUG - $ spacetime call -- 42f8f5ecde0a43a3a68db581dff9e8c5 add_person "Robert"
2024-05-21 17:20:41,440 - DEBUG - $ spacetime call -- 42f8f5ecde0a43a3a68db581dff9e8c5 add_person "Julie"
2024-05-21 17:20:41,495 - DEBUG - $ spacetime call -- 42f8f5ecde0a43a3a68db581dff9e8c5 add_person "Samantha"
2024-05-21 17:20:41,550 - DEBUG - $ spacetime call -- 42f8f5ecde0a43a3a68db581dff9e8c5 print_persons "BEFORE"
2024-05-21 17:20:41,604 - DEBUG - $ spacetime logs --json -- 42f8f5ecde0a43a3a68db581dff9e8c5 100
2024-05-21 17:20:41,638 - DEBUG - --- stdout ---
{"level":"Info","ts":1716326441371721,"filename":"spacetimedb","message":"Creating table `Person`"}
{"level":"Info","ts":1716326441371875,"filename":"spacetimedb","message":"Database initialized"}
{"level":"Info","ts":1716326441600721,"target":"spacetime_module","filename":"src/lib.rs","line_number":17,"message":"BEFORE: Robert"}
{"level":"Info","ts":1716326441600741,"target":"spacetime_module","filename":"src/lib.rs","line_number":17,"message":"BEFORE: Julie"}
{"level":"Info","ts":1716326441600743,"target":"spacetime_module","filename":"src/lib.rs","line_number":17,"message":"BEFORE: Samantha"}
2024-05-21 17:20:41,638 - DEBUG - --------------

2024-05-21 17:20:41,638 - INFO - Initial operations complete, updating module without clear
2024-05-21 17:20:41,638 - DEBUG - $ spacetime publish 42f8f5ecde0a43a3a68db581dff9e8c5 --project-path /tmp/tmpesvo2wne
2024-05-21 17:20:42,193 - DEBUG - --- stderr ---
info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
   Compiling spacetime-module v0.1.0 (/tmp/tmpesvo2wne)
    Finished `release` profile [optimized] target(s) in 0.33s
Optimising module with wasm-opt...
Could not find wasm-opt to optimise the module.
For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases.
Continuing with unoptimised module.
2024-05-21 17:20:42,193 - DEBUG - --- stdout ---
Uploading to 127.0.0.1:3000 => http://127.0.0.1:3000
Publishing module...
Updated database with address: 42f8f5ecde0a43a3a68db581dff9e8c5
2024-05-21 17:20:42,193 - DEBUG - --------------
```
</details>

# Expected complexity level and risk

1