### PR TITLE
`execution_set.check_auth(...)` on initial subscription

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -540,11 +540,12 @@ impl RelationalDB {
             .collect()
     }
 
-    pub fn create_table_for_test(
+    pub fn create_table_for_test_with_access(
         &self,
         name: &str,
         schema: &[(&str, AlgebraicType)],
         indexes: &[(ColId, &str)],
+        access: StAccess,
     ) -> Result<TableId, DBError> {
         let indexes = indexes
             .iter()
@@ -555,9 +556,18 @@ impl RelationalDB {
         let schema = TableDef::new(name.into(), Self::col_def_for_test(schema))
             .with_indexes(indexes)
             .with_type(StTableType::User)
-            .with_access(StAccess::Public);
+            .with_access(access);
 
         self.with_auto_commit(&ExecutionContext::default(), |tx| self.create_table(tx, schema))
+    }
+
+    pub fn create_table_for_test(
+        &self,
+        name: &str,
+        schema: &[(&str, AlgebraicType)],
+        indexes: &[(ColId, &str)],
+    ) -> Result<TableId, DBError> {
+        self.create_table_for_test_with_access(name, schema, indexes, StAccess::Public)
     }
 
     pub fn create_table_for_test_multi_column(

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -11,11 +11,12 @@ use crate::json::client_api::TableUpdateJson;
 use crate::util::slow::SlowQueryLogger;
 use crate::vm::{build_query, TxMode};
 use spacetimedb_client_api_messages::client_api::TableUpdate;
-use spacetimedb_lib::ProductValue;
+use spacetimedb_lib::{Identity, ProductValue};
 use spacetimedb_primitives::TableId;
+use spacetimedb_sats::db::error::AuthError;
 use spacetimedb_sats::relation::DbTable;
 use spacetimedb_vm::eval::IterRows;
-use spacetimedb_vm::expr::{NoInMemUsed, Query, QueryExpr, SourceExpr, SourceId};
+use spacetimedb_vm::expr::{AuthAccess, NoInMemUsed, Query, QueryExpr, SourceExpr, SourceId};
 use spacetimedb_vm::rel_ops::RelOps;
 use spacetimedb_vm::relation::RelValue;
 use std::hash::Hash;
@@ -340,5 +341,11 @@ impl ExecutionUnit {
             sink.push(row);
         }
         Ok(())
+    }
+}
+
+impl AuthAccess for ExecutionUnit {
+    fn check_auth(&self, owner: Identity, caller: Identity) -> Result<(), AuthError> {
+        self.eval_plan.check_auth(owner, caller)
     }
 }

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -35,12 +35,13 @@ use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use spacetimedb_client_api_messages::client_api::TableUpdate;
 use spacetimedb_data_structures::map::HashSet;
 use spacetimedb_lib::identity::AuthCtx;
-use spacetimedb_lib::ProductValue;
+use spacetimedb_lib::{Identity, ProductValue};
 use spacetimedb_primitives::TableId;
 use spacetimedb_sats::db::auth::{StAccess, StTableType};
+use spacetimedb_sats::db::error::AuthError;
 use spacetimedb_sats::relation::DbTable;
 use spacetimedb_vm::errors::ErrorVm;
-use spacetimedb_vm::expr::{self, IndexJoin, Query, QueryExpr, SourceProvider, SourceSet};
+use spacetimedb_vm::expr::{self, AuthAccess, IndexJoin, Query, QueryExpr, SourceProvider, SourceSet};
 use spacetimedb_vm::rel_ops::RelOps;
 use spacetimedb_vm::relation::{MemTable, RelValue};
 use std::hash::Hash;
@@ -609,6 +610,12 @@ impl From<Vec<Arc<ExecutionUnit>>> for ExecutionSet {
 impl From<Vec<SupportedQuery>> for ExecutionSet {
     fn from(value: Vec<SupportedQuery>) -> Self {
         ExecutionSet::from_iter(value)
+    }
+}
+
+impl AuthAccess for ExecutionSet {
+    fn check_auth(&self, owner: Identity, caller: Identity) -> Result<(), AuthError> {
+        self.exec_units.iter().try_for_each(|eu| eu.check_auth(owner, caller))
     }
 }
 


### PR DESCRIPTION
# Description of Changes

We simply didn't check auth for initial subscriptions, and this PR fixes that.

# API and ABI breaking changes

Technically this breaks the API in the sense that we check auth now, but that is a bug fix...

# Expected complexity level and risk

1

# Testing

A test is added that ensures that we check auth.