### PR TITLE
Consistent filtering rules for Rust bindings

### DIFF
--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -483,6 +483,8 @@ impl ColumnAttr {
     }
 }
 
+/// Heuristically determine if the path `p` is one of Rust's primitive integer types.
+/// This is an approximation, as the user could do `use String as u8`.
 fn is_integer_type(p: &Path) -> bool {
     p.get_ident().map_or(false, |i| {
         matches!(

--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -21,8 +21,8 @@ use std::time::Duration;
 use syn::parse::{Parse, ParseStream};
 use syn::spanned::Spanned;
 use syn::{
-    parse_quote, BinOp, Expr, ExprBinary, ExprLit, ExprUnary, FnArg, Ident, ItemFn, ItemStruct, Member, Token, Type,
-    UnOp,
+    parse_quote, BinOp, Expr, ExprBinary, ExprLit, ExprUnary, FnArg, Ident, ItemFn, ItemStruct, Member, Path, Token,
+    Type, TypePath, UnOp,
 };
 
 mod sym {
@@ -483,6 +483,15 @@ impl ColumnAttr {
     }
 }
 
+fn is_integer_type(p: &Path) -> bool {
+    p.get_ident().map_or(false, |i| {
+        matches!(
+            i.to_string().as_str(),
+            "u8" | "i8" | "u16" | "i16" | "u32" | "i32" | "u64" | "i64" | "u128" | "i128"
+        )
+    })
+}
+
 fn spacetimedb_tabletype_impl(item: syn::DeriveInput) -> syn::Result<TokenStream> {
     let sats_ty = module::sats_type_from_derive(&item, quote!(spacetimedb::spacetimedb_lib))?;
 
@@ -528,19 +537,10 @@ fn spacetimedb_tabletype_impl(item: syn::DeriveInput) -> syn::Result<TokenStream
             col_attr |= extra_col_attr;
         }
 
-        if col_attr.contains(ColumnAttribute::AUTO_INC) {
-            let valid_for_autoinc = if let syn::Type::Path(p) = field.ty {
-                // TODO: this is janky as heck
-                matches!(
-                    &*p.path.segments.last().unwrap().ident.to_string(),
-                    "u8" | "i8" | "u16" | "i16" | "u32" | "i32" | "u64" | "i64" | "u128" | "i128"
-                )
-            } else {
-                false
-            };
-            if !valid_for_autoinc {
-                return Err(syn::Error::new(field.ident.unwrap().span(), "An `autoinc` or `identity` column must be one of the integer types: u8, i8, u16, i16, u32, i32, u64, i64, u128, i128"));
-            }
+        if col_attr.contains(ColumnAttribute::AUTO_INC)
+            && !matches!(field.ty, syn::Type::Path(p) if is_integer_type(&p.path))
+        {
+            return Err(syn::Error::new(field.ident.unwrap().span(), "An `autoinc` or `identity` column must be one of the integer types: u8, i8, u16, i16, u32, i32, u64, i64, u128, i128"));
         }
 
         let column = Column {
@@ -629,17 +629,21 @@ fn spacetimedb_tabletype_impl(item: syn::DeriveInput) -> syn::Result<TokenStream
         let filter_func_ident = format_ident!("filter_by_{}", column_ident);
         let delete_func_ident = format_ident!("delete_by_{}", column_ident);
 
-        let skip = if let syn::Type::Path(p) = column_type {
+        let is_filterable = if let syn::Type::Path(TypePath { path, .. }) = column_type {
             // TODO: this is janky as heck
-            !matches!(
-                &*p.path.segments.last().unwrap().ident.to_string(),
-                "u8" | "i8" | "u16" | "i16" | "u32" | "i32" | "u64" | "i64" | "Hash" | "Identity" | "String" | "bool"
-            )
+            is_integer_type(path)
+                || path.is_ident("String")
+                || path.is_ident("bool")
+                // For these we use the last element of the path because they can be more commonly namespaced.
+                || matches!(
+                    &*path.segments.last().unwrap().ident.to_string(),
+                    "Address" | "Identity"
+                )
         } else {
-            true
+            false
         };
 
-        if skip {
+        if !is_filterable {
             return None;
         }
 

--- a/crates/bindings/src/impls.rs
+++ b/crates/bindings/src/impls.rs
@@ -1,4 +1,3 @@
-use crate::sats::hash::Hash;
 use crate::FilterableValue;
 use spacetimedb_lib::{Address, Identity};
 
@@ -10,4 +9,4 @@ macro_rules! impl_primitives {
     };
 }
 
-impl_primitives![u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, bool, String, Hash, Identity, Address];
+impl_primitives![u8, i8, u16, i16, u32, i32, u64, i64, u128, i128, bool, String, Identity, Address];


### PR DESCRIPTION
# Description of Changes

Mostly already consistent with the proposal (#1256), except:
 - Remove filtering functions for custom Hash type.
 - Allow filtering over `i128` and `u128` fields.
 - Allow filtering over `Address` fields.
 
# API and ABI breaking changes

Removing filtering over `Hash` in Rust modules.

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
