### PR TITLE
Prune bindings deps

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1725,7 +1725,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6fb8d784f27acf97159b40fc4db5ecd8aa23b9ad5ef69cdd136d3bc80665f0c0"
 dependencies = [
  "fallible-iterator 0.3.0",
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "stable_deref_trait",
 ]
 
@@ -1747,7 +1747,7 @@ dependencies = [
  "futures-sink",
  "futures-util",
  "http",
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "slab",
  "tokio",
  "tokio-util",
@@ -2110,9 +2110,9 @@ dependencies = [
 
 [[package]]
 name = "indexmap"
-version = "2.0.2"
+version = "2.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8adf3ddd720272c6ea8bf59463c04e0f93d0bbf7c5439b691bca2987e0270897"
+checksum = "168fb715dda47215e360912c096649d23d58bf392ac62f73919e831745e40f26"
 dependencies = [
  "equivalent",
  "hashbrown 0.14.1",
@@ -2324,12 +2324,9 @@ dependencies = [
 
 [[package]]
 name = "line-wrap"
-version = "0.1.1"
+version = "0.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f30344350a2a51da54c1d53be93fade8a237e545dbcc4bdbe635413f2117cab9"
-dependencies = [
- "safemem",
-]
+checksum = "dd1bc4d24ad230d21fb898d1116b1801d7adfc449d42026475862ab48b11e70e"
 
 [[package]]
 name = "linked-hash-map"
@@ -2656,7 +2653,7 @@ checksum = "9cf5f9dd3933bd50a9e1f149ec995f39ae2c496d31fd772c1fd45ebc27e902b0"
 dependencies = [
  "crc32fast",
  "hashbrown 0.14.1",
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "memchr",
 ]
 
@@ -2864,7 +2861,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e1d3afd2628e69da2be385eb6f2fd57c8ac7977ceeff6dc166ff1657b0e386a9"
 dependencies = [
  "fixedbitset",
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
 ]
 
 [[package]]
@@ -2936,14 +2933,14 @@ checksum = "26072860ba924cbfa98ea39c8c19b4dd6a4a25423dbdf219c1eca91aa0cf6964"
 
 [[package]]
 name = "plist"
-version = "1.5.0"
+version = "1.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bdc0001cfea3db57a2e24bc0d818e9e20e554b5f97fabb9bc231dc240269ae06"
+checksum = "d9d34169e64b3c7a80c8621a48adaf44e0cf62c78a9b25dd9dd35f1881a17cf9"
 dependencies = [
  "base64 0.21.4",
- "indexmap 1.9.3",
+ "indexmap 2.2.6",
  "line-wrap",
- "quick-xml 0.29.0",
+ "quick-xml 0.31.0",
  "serde",
  "time",
 ]
@@ -3236,7 +3233,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6bf780b59d590c25f8c59b44c124166a2a93587868b619fb8f5b47fb15e9ed6d"
 dependencies = [
  "chrono",
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "nextest-workspace-hack",
  "quick-xml 0.29.0",
  "thiserror",
@@ -3257,6 +3254,15 @@ name = "quick-xml"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "81b9228215d82c7b61490fec1de287136b5de6f5700f6e58ea9ad61a7964ca51"
+dependencies = [
+ "memchr",
+]
+
+[[package]]
+name = "quick-xml"
+version = "0.31.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1004a344b30a54e2ee58d66a71b32d2db2feb0a31f9a2d302bf0536f15de2a33"
 dependencies = [
  "memchr",
 ]
@@ -3737,12 +3743,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1ad4cc8da4ef723ed60bced201181d83791ad433213d8c24efffda1eec85d741"
 
 [[package]]
-name = "safemem"
-version = "0.3.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef703b7cb59335eae2eb93ceb664c0eb7ea6bf567079d843e09420219668e072"
-
-[[package]]
 name = "same-file"
 version = "1.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3875,7 +3875,7 @@ version = "1.0.107"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6b420ce6e3d8bd882e9b243c6eed35dbc9a6110c9769e74b584e0d68d1f20c65"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "itoa",
  "ryu",
  "serde",
@@ -3922,7 +3922,7 @@ dependencies = [
  "chrono",
  "hex",
  "indexmap 1.9.3",
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "serde",
  "serde_json",
  "serde_with_macros",
@@ -4371,11 +4371,12 @@ dependencies = [
  "flate2",
  "fs2",
  "futures",
+ "hashbrown 0.14.1",
  "hex",
  "hostname",
  "hyper",
  "imara-diff",
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "itertools 0.12.0",
  "jsonwebtoken",
  "lazy_static",
@@ -4511,8 +4512,8 @@ version = "0.9.3"
 dependencies = [
  "bitflags 2.4.1",
  "either",
+ "nohash-hasher",
  "proptest",
- "spacetimedb-data-structures",
 ]
 
 [[package]]
@@ -5289,7 +5290,7 @@ version = "0.20.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "396e4d48bbb2b7554c944bde63101b5ae446cff6ec4a24227428f15eb72ef338"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "serde",
  "serde_spanned",
  "toml_datetime",
@@ -5302,7 +5303,7 @@ version = "0.22.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0c9ffdf896f8daaabf9b66ba8e77ea1ed5ed0f72821b398aba62352e95062951"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "toml_datetime",
  "winnow",
 ]
@@ -5799,7 +5800,7 @@ version = "0.116.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a58e28b80dd8340cb07b8242ae654756161f6fc8d0038123d679b7b99964fa50"
 dependencies = [
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "semver",
 ]
 
@@ -5813,7 +5814,7 @@ dependencies = [
  "bincode",
  "bumpalo",
  "cfg-if",
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "libc",
  "log",
  "object",
@@ -5912,7 +5913,7 @@ dependencies = [
  "anyhow",
  "cranelift-entity",
  "gimli",
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "log",
  "object",
  "serde",
@@ -5978,7 +5979,7 @@ dependencies = [
  "anyhow",
  "cc",
  "cfg-if",
- "indexmap 2.0.2",
+ "indexmap 2.2.6",
  "libc",
  "log",
  "mach",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4154,6 +4154,7 @@ version = "0.9.3"
 dependencies = [
  "derive_more",
  "getrandom",
+ "insta",
  "log",
  "rand 0.8.5",
  "scoped-tls",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -145,7 +145,7 @@ futures = "0.3"
 futures-channel = "0.3"
 getrandom = "0.2.7"
 glob = "0.3.1"
-hashbrown = { version = "0.14", features = ["rayon", "serde"] }
+hashbrown = "0.14"
 headers = "0.4"
 hex = "0.4.3"
 home = "0.5"

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -32,3 +32,6 @@ rand = { workspace = true, optional = true }
 # if someone tries to use rand's ThreadRng, it will fail to link
 # because no one defined __getrandom_custom
 getrandom = { workspace = true, optional = true, features = ["custom"] }
+
+[dev-dependencies]
+insta.workspace = true

--- a/crates/bindings/tests/deps.rs
+++ b/crates/bindings/tests/deps.rs
@@ -1,0 +1,39 @@
+//! Snapshot testing for the dependency tree of the `bindings` crate - we want
+//! to make sure we don't unknowningly add a bunch of dependencies here,
+//! slowing down compilation for every spacetime module.
+
+#[test]
+fn deptree_snapshot() -> std::io::Result<()> {
+    let cmd = "cargo tree -p spacetimedb -f {lib} -e no-dev";
+    let deps_tree = run_cmd(cmd);
+
+    let all_deps = run_cmd("cargo tree -p spacetimedb -e no-dev --prefix none --no-dedupe");
+    let mut all_deps = all_deps.lines().collect::<Vec<_>>();
+    all_deps.sort();
+    all_deps.dedup();
+    let num_deps = all_deps.len();
+
+    insta::assert_snapshot!(
+        "spacetimedb_bindings_dependencies",
+        format!("total crates: {num_deps}\n{deps_tree}"),
+        cmd
+    );
+
+    let cmd = "cargo tree -p spacetimedb -e no-dev -d --depth 0";
+    insta::assert_snapshot!("duplicate_deps", run_cmd(cmd), cmd);
+
+    Ok(())
+}
+
+// runs a command string, split on spaces
+#[track_caller]
+fn run_cmd(cmd: &str) -> String {
+    let mut args = cmd.split(' ');
+    let output = std::process::Command::new(args.next().unwrap())
+        .args(args)
+        .stdout(std::process::Stdio::piped())
+        .output()
+        .unwrap();
+    assert!(output.status.success());
+    String::from_utf8(output.stdout).unwrap()
+}

--- a/crates/bindings/tests/snapshots/deps__duplicate_deps.snap
+++ b/crates/bindings/tests/snapshots/deps__duplicate_deps.snap
@@ -1,0 +1,7 @@
+---
+source: crates/bindings/tests/deps.rs
+expression: cargo tree -p spacetimedb -e no-dev -d --depth 0
+---
+syn v1.0.109
+
+syn v2.0.39

--- a/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
+++ b/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
@@ -2,7 +2,7 @@
 source: crates/bindings/tests/deps.rs
 expression: "cargo tree -p spacetimedb -f {lib} -e no-dev"
 ---
-total crates: 74
+total crates: 56
 spacetimedb
 ├── derive_more
 │   ├── convert_case
@@ -37,43 +37,11 @@ spacetimedb
 │   ├── spacetimedb_primitives
 │   │   ├── bitflags
 │   │   ├── either
-│   │   └── spacetimedb_data_structures
-│   │       ├── hashbrown
-│   │       │   ├── ahash
-│   │       │   │   ├── cfg_if
-│   │       │   │   ├── once_cell
-│   │       │   │   └── zerocopy
-│   │       │   │   [build-dependencies]
-│   │       │   │   └── version_check
-│   │       │   ├── allocator_api2
-│   │       │   ├── rayon
-│   │       │   │   ├── either
-│   │       │   │   └── rayon_core
-│   │       │   │       ├── crossbeam_deque
-│   │       │   │       │   ├── cfg_if
-│   │       │   │       │   ├── crossbeam_epoch
-│   │       │   │       │   │   ├── cfg_if
-│   │       │   │       │   │   ├── crossbeam_utils
-│   │       │   │       │   │   │   └── cfg_if
-│   │       │   │       │   │   ├── memoffset
-│   │       │   │       │   │   │   [build-dependencies]
-│   │       │   │       │   │   │   └── autocfg
-│   │       │   │       │   │   └── scopeguard
-│   │       │   │       │   │   [build-dependencies]
-│   │       │   │       │   │   └── autocfg
-│   │       │   │       │   └── crossbeam_utils (*)
-│   │       │   │       └── crossbeam_utils (*)
-│   │       │   └── serde
-│   │       ├── nohash_hasher
-│   │       └── thiserror
-│   │           └── thiserror_impl
-│   │               ├── proc_macro2 (*)
-│   │               ├── quote (*)
-│   │               └── syn
-│   │                   ├── proc_macro2 (*)
-│   │                   ├── quote (*)
-│   │                   └── unicode_ident
-│   └── syn (*)
+│   │   └── nohash_hasher
+│   └── syn
+│       ├── proc_macro2 (*)
+│       ├── quote (*)
+│       └── unicode_ident
 ├── spacetimedb_bindings_sys
 │   └── spacetimedb_primitives (*)
 ├── spacetimedb_lib
@@ -89,26 +57,6 @@ spacetimedb
 │   ├── itertools
 │   │   └── either
 │   ├── spacetimedb_bindings_macro (*)
-│   ├── spacetimedb_metrics
-│   │   ├── arrayvec
-│   │   ├── itertools (*)
-│   │   ├── paste
-│   │   └── prometheus
-│   │       ├── cfg_if
-│   │       ├── fnv
-│   │       ├── lazy_static
-│   │       ├── memchr
-│   │       ├── parking_lot
-│   │       │   ├── lock_api
-│   │       │   │   └── scopeguard
-│   │       │   │   [build-dependencies]
-│   │       │   │   └── autocfg
-│   │       │   └── parking_lot_core
-│   │       │       ├── cfg_if
-│   │       │       ├── libc
-│   │       │       └── smallvec
-│   │       ├── protobuf
-│   │       └── thiserror (*)
 │   ├── spacetimedb_primitives (*)
 │   ├── spacetimedb_sats
 │   │   ├── arrayvec
@@ -137,8 +85,21 @@ spacetimedb
 │   │   │   └── keccak
 │   │   ├── smallvec
 │   │   ├── spacetimedb_bindings_macro (*)
-│   │   ├── spacetimedb_data_structures (*)
-│   │   ├── spacetimedb_metrics (*)
+│   │   ├── spacetimedb_data_structures
+│   │   │   ├── hashbrown
+│   │   │   │   ├── ahash
+│   │   │   │   │   ├── cfg_if
+│   │   │   │   │   ├── once_cell
+│   │   │   │   │   └── zerocopy
+│   │   │   │   │   [build-dependencies]
+│   │   │   │   │   └── version_check
+│   │   │   │   └── allocator_api2
+│   │   │   ├── nohash_hasher
+│   │   │   └── thiserror
+│   │   │       └── thiserror_impl
+│   │   │           ├── proc_macro2 (*)
+│   │   │           ├── quote (*)
+│   │   │           └── syn (*)
 │   │   ├── spacetimedb_primitives (*)
 │   │   └── thiserror (*)
 │   └── thiserror (*)

--- a/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
+++ b/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
@@ -1,0 +1,145 @@
+---
+source: crates/bindings/tests/deps.rs
+expression: "cargo tree -p spacetimedb -f {lib} -e no-dev"
+---
+total crates: 74
+spacetimedb
+├── derive_more
+│   ├── convert_case
+│   ├── proc_macro2
+│   │   └── unicode_ident
+│   ├── quote
+│   │   └── proc_macro2 (*)
+│   └── syn
+│       ├── proc_macro2 (*)
+│       ├── quote (*)
+│       └── unicode_ident
+│   [build-dependencies]
+│   └── rustc_version
+│       └── semver
+├── getrandom
+│   ├── cfg_if
+│   └── libc
+├── log
+├── rand
+│   ├── libc
+│   ├── rand_chacha
+│   │   ├── ppv_lite86
+│   │   └── rand_core
+│   │       └── getrandom (*)
+│   └── rand_core (*)
+├── scoped_tls
+├── spacetimedb_bindings_macro
+│   ├── bitflags
+│   ├── humantime
+│   ├── proc_macro2 (*)
+│   ├── quote (*)
+│   ├── spacetimedb_primitives
+│   │   ├── bitflags
+│   │   ├── either
+│   │   └── spacetimedb_data_structures
+│   │       ├── hashbrown
+│   │       │   ├── ahash
+│   │       │   │   ├── cfg_if
+│   │       │   │   ├── once_cell
+│   │       │   │   └── zerocopy
+│   │       │   │   [build-dependencies]
+│   │       │   │   └── version_check
+│   │       │   ├── allocator_api2
+│   │       │   ├── rayon
+│   │       │   │   ├── either
+│   │       │   │   └── rayon_core
+│   │       │   │       ├── crossbeam_deque
+│   │       │   │       │   ├── cfg_if
+│   │       │   │       │   ├── crossbeam_epoch
+│   │       │   │       │   │   ├── cfg_if
+│   │       │   │       │   │   ├── crossbeam_utils
+│   │       │   │       │   │   │   └── cfg_if
+│   │       │   │       │   │   ├── memoffset
+│   │       │   │       │   │   │   [build-dependencies]
+│   │       │   │       │   │   │   └── autocfg
+│   │       │   │       │   │   └── scopeguard
+│   │       │   │       │   │   [build-dependencies]
+│   │       │   │       │   │   └── autocfg
+│   │       │   │       │   └── crossbeam_utils (*)
+│   │       │   │       └── crossbeam_utils (*)
+│   │       │   └── serde
+│   │       ├── nohash_hasher
+│   │       └── thiserror
+│   │           └── thiserror_impl
+│   │               ├── proc_macro2 (*)
+│   │               ├── quote (*)
+│   │               └── syn
+│   │                   ├── proc_macro2 (*)
+│   │                   ├── quote (*)
+│   │                   └── unicode_ident
+│   └── syn (*)
+├── spacetimedb_bindings_sys
+│   └── spacetimedb_primitives (*)
+├── spacetimedb_lib
+│   ├── anyhow
+│   ├── bitflags
+│   ├── derive_more (*)
+│   ├── enum_as_inner
+│   │   ├── heck
+│   │   ├── proc_macro2 (*)
+│   │   ├── quote (*)
+│   │   └── syn (*)
+│   ├── hex
+│   ├── itertools
+│   │   └── either
+│   ├── spacetimedb_bindings_macro (*)
+│   ├── spacetimedb_metrics
+│   │   ├── arrayvec
+│   │   ├── itertools (*)
+│   │   ├── paste
+│   │   └── prometheus
+│   │       ├── cfg_if
+│   │       ├── fnv
+│   │       ├── lazy_static
+│   │       ├── memchr
+│   │       ├── parking_lot
+│   │       │   ├── lock_api
+│   │       │   │   └── scopeguard
+│   │       │   │   [build-dependencies]
+│   │       │   │   └── autocfg
+│   │       │   └── parking_lot_core
+│   │       │       ├── cfg_if
+│   │       │       ├── libc
+│   │       │       └── smallvec
+│   │       ├── protobuf
+│   │       └── thiserror (*)
+│   ├── spacetimedb_primitives (*)
+│   ├── spacetimedb_sats
+│   │   ├── arrayvec
+│   │   ├── bitflags
+│   │   ├── decorum
+│   │   │   ├── approx
+│   │   │   │   └── num_traits
+│   │   │   │       [build-dependencies]
+│   │   │   │       └── autocfg
+│   │   │   └── num_traits (*)
+│   │   ├── derive_more (*)
+│   │   ├── enum_as_inner (*)
+│   │   ├── hex
+│   │   ├── itertools (*)
+│   │   ├── second_stack
+│   │   ├── sha3
+│   │   │   ├── digest
+│   │   │   │   ├── block_buffer
+│   │   │   │   │   └── generic_array
+│   │   │   │   │       └── typenum
+│   │   │   │   │       [build-dependencies]
+│   │   │   │   │       └── version_check
+│   │   │   │   └── crypto_common
+│   │   │   │       ├── generic_array (*)
+│   │   │   │       └── typenum
+│   │   │   └── keccak
+│   │   ├── smallvec
+│   │   ├── spacetimedb_bindings_macro (*)
+│   │   ├── spacetimedb_data_structures (*)
+│   │   ├── spacetimedb_metrics (*)
+│   │   ├── spacetimedb_primitives (*)
+│   │   └── thiserror (*)
+│   └── thiserror (*)
+└── spacetimedb_primitives (*)

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -16,7 +16,7 @@ bench = false
 
 [dependencies]
 spacetimedb-data-structures.workspace = true
-spacetimedb-lib = { workspace = true, features = ["serde"] }
+spacetimedb-lib = { workspace = true, features = ["serde", "metrics_impls"] }
 spacetimedb-client-api-messages.workspace = true
 spacetimedb-commitlog.workspace = true
 spacetimedb-durability.workspace = true
@@ -45,6 +45,7 @@ enum-map.workspace = true
 flate2.workspace = true
 fs2.workspace = true
 futures.workspace = true
+hashbrown = { workspace = true, features = ["rayon", "serde"] }
 hex.workspace = true
 hostname.workspace = true
 hyper.workspace = true

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -15,16 +15,17 @@ name = "serde"
 required-features = ["serde"]
 
 [features]
-default = ["serde"]
+default = ["serde", "metrics_impls"]
 serde = ["dep:serde", "spacetimedb-sats/serde"]
 # Allows using `Arbitrary` impls defined in this crate.
 proptest = ["dep:proptest", "dep:proptest-derive"]
+metrics_impls = ["dep:spacetimedb-metrics", "spacetimedb-sats/metrics_impls"]
 
 [dependencies]
 spacetimedb-bindings-macro.workspace = true
 spacetimedb-sats.workspace = true
 spacetimedb-primitives.workspace = true
-spacetimedb-metrics.workspace = true
+spacetimedb-metrics = { workspace = true, optional = true }
 
 anyhow.workspace = true
 bitflags.workspace = true

--- a/crates/lib/src/address.rs
+++ b/crates/lib/src/address.rs
@@ -21,6 +21,7 @@ pub struct Address {
 
 impl_st!([] Address, _ts => AlgebraicType::product([("__address_bytes", AlgebraicType::bytes())]));
 
+#[cfg(feature = "metrics_impls")]
 impl spacetimedb_metrics::typed_prometheus::AsPrometheusLabel for Address {
     fn as_prometheus_str(&self) -> impl AsRef<str> + '_ {
         self.to_hex()

--- a/crates/lib/src/identity.rs
+++ b/crates/lib/src/identity.rs
@@ -35,6 +35,7 @@ pub struct Identity {
 
 impl_st!([] Identity, _ts => Identity::get_type());
 
+#[cfg(feature = "metrics_impls")]
 impl spacetimedb_metrics::typed_prometheus::AsPrometheusLabel for Identity {
     fn as_prometheus_str(&self) -> impl AsRef<str> + '_ {
         self.to_hex()

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -83,7 +83,7 @@ pub struct TableDesc {
 }
 
 impl TableDesc {
-    pub fn into_table_def(table: WithTypespace<'_, TableDesc>) -> anyhow::Result<spacetimedb_sats::db::def::TableDef> {
+    pub fn into_table_def(table: WithTypespace<'_, TableDesc>) -> anyhow::Result<TableDef> {
         let schema = table
             .map(|t| &t.data)
             .resolve_refs()

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -6,10 +6,9 @@ license-file = "LICENSE"
 description = "Primitives such as TableId and ColumnIndexAttribute"
 
 [dependencies]
-spacetimedb-data-structures.workspace = true
-
-either.workspace = true
 bitflags.workspace = true
+either.workspace = true
+nohash-hasher.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/primitives/src/ids.rs
+++ b/crates/primitives/src/ids.rs
@@ -1,7 +1,6 @@
 //! Provides identifiers such as `TableId`.
 
 use core::fmt;
-use spacetimedb_data_structures::map::ValidAsIdentityHash;
 
 #[derive(Debug, Default, Copy, Clone, Hash, Eq, PartialEq, Ord, PartialOrd)]
 #[repr(transparent)]
@@ -31,7 +30,7 @@ macro_rules! system_id {
             }
         }
 
-        impl ValidAsIdentityHash for $name {}
+        impl nohash_hasher::IsEnabled for $name {}
 
         impl From<i32> for $name {
             fn from(value: i32) -> Self {

--- a/crates/sats/Cargo.toml
+++ b/crates/sats/Cargo.toml
@@ -15,12 +15,13 @@ proptest = ["dep:proptest", "dep:proptest-derive"]
 # Used by `spacetimedb_table`,
 # which serializes and deserializes Blake3 hashes during snapshotting.
 blake3 = ["dep:blake3"]
+metrics_impls = ["dep:spacetimedb-metrics"]
 
 [dependencies]
 spacetimedb-bindings-macro.workspace = true
 spacetimedb-data-structures.workspace = true
 spacetimedb-primitives.workspace = true
-spacetimedb-metrics.workspace = true
+spacetimedb-metrics = { workspace = true, optional = true }
 
 arrayvec.workspace = true
 bitflags.workspace = true

--- a/crates/sats/src/hash.rs
+++ b/crates/sats/src/hash.rs
@@ -15,6 +15,7 @@ impl_st!([] Hash, _ts => AlgebraicType::bytes());
 impl_serialize!([] Hash, (self, ser) => self.data.serialize(ser));
 impl_deserialize!([] Hash, de => Ok(Self { data: <_>::deserialize(de)? }));
 
+#[cfg(feature = "metrics_impls")]
 impl spacetimedb_metrics::typed_prometheus::AsPrometheusLabel for Hash {
     fn as_prometheus_str(&self) -> impl AsRef<str> + '_ {
         self.to_hex()


### PR DESCRIPTION
# Description of Changes

I've added a snapshot test for the dependency tree of the `bindings` crate - that way, we'll know if we accidentally do something like pull in `rayon` (like we did). You can see the actual deps changes I did by looking at the diff of the second commit.

# Expected complexity level and risk

1