### PR TITLE
feat(1231): Add a configurable row limit for queries

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -157,11 +157,8 @@ impl RelationalDB {
             row_count_fn,
             disk_size_fn,
 
-            config: Arc::new(RwLock::new(DatabaseConfig::with_slow_query(
-                SlowQueryConfig::with_defaults(),
-            ))),
-
             _lock: Arc::new(lock),
+            config: Arc::new(RwLock::new(DatabaseConfig::new(SlowQueryConfig::with_defaults(), None))),
         })
     }
 

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -1,7 +1,9 @@
 use super::query::{self, Supported};
 use super::subscription::{IncrementalJoin, SupportedQuery};
+use crate::db::datastore::locking_tx_datastore::tx::TxId;
 use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::DBError;
+use crate::estimation;
 use crate::execution_context::ExecutionContext;
 use crate::host::module_host::{
     rel_value_to_table_row_op_binary, rel_value_to_table_row_op_json, DatabaseTableUpdate, DatabaseTableUpdateRelValue,
@@ -341,6 +343,11 @@ impl ExecutionUnit {
             sink.push(row);
         }
         Ok(())
+    }
+
+    /// The estimated number of rows returned by this execution unit.
+    pub fn row_estimate(&self, tx: &TxId) -> u64 {
+        estimation::num_rows(tx, &self.eval_plan)
     }
 }
 

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -23,6 +23,7 @@
 use super::execution_unit::ExecutionUnit;
 use super::query;
 use crate::client::Protocol;
+use crate::db::datastore::locking_tx_datastore::tx::TxId;
 use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::{DBError, SubscriptionError};
 use crate::execution_context::ExecutionContext;
@@ -573,6 +574,14 @@ impl ExecutionSet {
             }
         }
         Ok(DatabaseUpdateRelValue { tables })
+    }
+
+    /// The estimated number of rows returned by this execution set.
+    pub fn row_estimate(&self, tx: &TxId) -> u64 {
+        self.exec_units
+            .iter()
+            .map(|unit| unit.row_estimate(tx))
+            .fold(0, |acc, est| acc.saturating_add(est))
     }
 }
 


### PR DESCRIPTION
Closes #1231.

Queries that are estimated to exceed this row limit are rejected. And the same holds for subscriptions.

# Expected complexity level and risk

1

# Testing

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*

1. Issued `set row_limit = 5` from the SQL repl
2. Queried a table with > 5 rows using the owner identity (succeeded)
3. Queried a table with <= 5 rows using a different identity (succeeded)
4. Queried a table with > 5 rows using a different identity (failed)
