### PR TITLE
CLI - Fix `Lockfile` error message format strings

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -149,7 +149,7 @@ impl Lockfile {
         path.set_extension("lock");
         // Open with `create_new`, which fails if the file already exists.
         std::fs::File::create_new(&path).with_context(|| {
-            "Unable to acquire lock on config file {config_path:?}: failed to create lockfile {path:?}"
+            format!("Unable to acquire lock on config file {config_path:?}: failed to create lockfile {path:?}")
         })?;
 
         Ok(Lockfile { path })


### PR DESCRIPTION
# Description of Changes

Previous error text:
```
thread 'main' panicked at crates/cli/src/config.rs:911:58:
called `Result::unwrap()` on an `Err` value: Unable to acquire lock on config file {config_path:?}: failed to create lockfile {path:?}

Caused by:
    File exists (os error 17)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

New error message:
```
thread 'main' panicked at crates/cli/src/config.rs:911:58:
called `Result::unwrap()` on an `Err` value: Unable to acquire lock on config file "/home/lead/.spacetime/config.toml": failed to create lockfile "/home/lead/.spacetime/config.lock"

Caused by:
    File exists (os error 17)
note: run with `RUST_BACKTRACE=1` environment variable to display a backtrace
```

# API and ABI breaking changes

Nope

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Start `spacetime logs -f`, then try to run `spacetime call`, observe error
