### PR TITLE
CLI - Drop Config lock earlier for `spacetime logs`

### DIFF
--- a/crates/cli/src/subcommands/logs.rs
+++ b/crates/cli/src/subcommands/logs.rs
@@ -110,7 +110,10 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     // TODO: num_lines should default to like 10 if follow is specified?
     let query_parms = LogsParams { num_lines, follow };
 
-    let builder = reqwest::Client::new().get(format!("{}/database/logs/{}", config.get_host_url(server)?, address));
+    let host_url = config.get_host_url(server)?;
+    config.release_lock();
+
+    let builder = reqwest::Client::new().get(format!("{}/database/logs/{}", host_url, address));
     let builder = add_auth_header_opt(builder, &auth_header);
     let mut res = builder.query(&query_parms).send().await?;
     let status = res.status();


### PR DESCRIPTION
# Description of Changes

Previously, if a user called `spacetime logs`, the `Config` lock would be held until the program closed.

In the case of `spacetime logs --follow`, this could be arbitrarily long, and would prevent the user from calling any other `spacetime` functions, e.g. `spacetime call`.

Also, using Ctrl-C to exit `spacetime logs -f` would cause the lockfile to stick around (not get dropped properly).

This PR drops the Config lock earlier, which fixes both issues.

# API and ABI breaking changes

Nope

# Expected complexity level and risk

1

# Testing

- [x] Call `spacetime logs -f`, then try to call `spacetime call`
