### PR TITLE
core: Store address, owner and program bytes in st_module

### DIFF
--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -10,7 +10,7 @@ use spacetimedb::client::ClientActorIndex;
 use spacetimedb::energy::{EnergyBalance, EnergyQuanta};
 use spacetimedb::host::{HostController, UpdateDatabaseResult};
 use spacetimedb::identity::Identity;
-use spacetimedb::messages::control_db::{Database, DatabaseInstance, IdentityEmail, Node};
+use spacetimedb::messages::control_db::{Database, DatabaseInstance, HostType, IdentityEmail, Node};
 use spacetimedb::sendgrid_controller::SendGridController;
 use spacetimedb_client_api_messages::name::{DomainName, InsertDomainResult, RegisterTldResult, Tld};
 use spacetimedb_client_api_messages::recovery::RecoveryCode;
@@ -54,6 +54,8 @@ pub struct DatabaseDef {
     pub program_bytes: Vec<u8>,
     /// The desired number of replicas the database shall have.
     pub num_replicas: u32,
+    /// The host type of the supplied program.
+    pub host_type: HostType,
 }
 
 /// API of the SpacetimeDB control plane.

--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -747,6 +747,12 @@ pub struct PublishDatabaseQueryParams {
     client_address: Option<AddressForUrl>,
 }
 
+impl PublishDatabaseQueryParams {
+    pub fn name_or_address(&self) -> Option<&NameOrAddress> {
+        self.name_or_address.as_ref()
+    }
+}
+
 pub async fn publish<S: NodeDelegate + ControlStateDelegate>(
     State(ctx): State<S>,
     Path(PublishDatabaseParams {}): Path<PublishDatabaseParams>,

--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -27,7 +27,7 @@ use spacetimedb::host::ReducerOutcome;
 use spacetimedb::host::UpdateDatabaseSuccess;
 use spacetimedb::identity::Identity;
 use spacetimedb::json::client_api::StmtResultJson;
-use spacetimedb::messages::control_db::{Database, DatabaseInstance};
+use spacetimedb::messages::control_db::{Database, DatabaseInstance, HostType};
 use spacetimedb::sql;
 use spacetimedb::sql::execute::{ctx_sql, translate_col};
 use spacetimedb_client_api_messages::name::{self, DnsLookupResponse, DomainName, PublishOp, PublishResult};
@@ -79,7 +79,7 @@ pub async fn call<S: ControlStateDelegate + NodeDelegate>(
         log::error!("Could not find database: {}", address.to_hex());
         (StatusCode::NOT_FOUND, "No such database.")
     })?;
-    let identity = database.identity;
+    let identity = database.owner_identity;
     let database_instance = worker_ctx
         .get_leader_database_instance_by_database(database.id)
         .ok_or((
@@ -369,10 +369,9 @@ pub async fn info<S: ControlStateDelegate>(
     let host_type: &str = database.host_type.as_ref();
     let response_json = json!({
         "address": database.address,
-        "identity": database.identity,
+        "owner_identity": database.owner_identity,
         "host_type": host_type,
-        "num_replicas": database.num_replicas,
-        "program_bytes_address": database.program_bytes_address,
+        "initial_program": database.initial_program,
     });
     Ok((StatusCode::OK, axum::Json(response_json)))
 }
@@ -416,12 +415,12 @@ where
         .await?
         .ok_or((StatusCode::NOT_FOUND, "No such database."))?;
 
-    if database.identity != auth.identity {
+    if database.owner_identity != auth.identity {
         return Err((
             StatusCode::BAD_REQUEST,
             format!(
                 "Identity does not own database, expected: {} got: {}",
-                database.identity.to_hex(),
+                database.owner_identity.to_hex(),
                 auth.identity.to_hex()
             ),
         )
@@ -512,7 +511,7 @@ where
         .await?
         .ok_or((StatusCode::NOT_FOUND, "No such database."))?;
 
-    let auth = AuthCtx::new(database.identity, auth.identity);
+    let auth = AuthCtx::new(database.owner_identity, auth.identity);
     log::debug!("auth: {auth:?}");
     let database_instance = worker_ctx
         .get_leader_database_instance_by_database(database.id)
@@ -817,6 +816,7 @@ pub async fn publish<S: NodeDelegate + ControlStateDelegate>(
                 address: db_addr,
                 program_bytes: body.into(),
                 num_replicas: 1,
+                host_type: HostType::Wasm,
             },
         )
         .await
@@ -890,7 +890,7 @@ pub async fn set_name<S: ControlStateDelegate>(
         .map_err(log_and_500)?
         .ok_or((StatusCode::NOT_FOUND, "No such database."))?;
 
-    if database.identity != auth.identity {
+    if database.owner_identity != auth.identity {
         return Err((StatusCode::UNAUTHORIZED, "Identity does not own database.").into());
     }
 

--- a/crates/client-api/src/routes/identity.rs
+++ b/crates/client-api/src/routes/identity.rs
@@ -168,7 +168,7 @@ pub async fn get_databases<S: ControlStateDelegate>(
     })?;
     let addresses = all_dbs
         .iter()
-        .filter(|db| db.identity == identity)
+        .filter(|db| db.owner_identity == identity)
         .map(|db| db.address)
         .collect();
     Ok(axum::Json(GetDatabasesResponse { addresses }))

--- a/crates/core/src/database_instance_context.rs
+++ b/crates/core/src/database_instance_context.rs
@@ -1,6 +1,5 @@
 use super::database_logger::DatabaseLogger;
-use crate::db::relational_db::{ConnectedClients, RelationalDB};
-use crate::db::{Config, Storage};
+use crate::db::relational_db::RelationalDB;
 use crate::error::DBError;
 use crate::messages::control_db::Database;
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
@@ -22,49 +21,6 @@ pub struct DatabaseInstanceContext {
 }
 
 impl DatabaseInstanceContext {
-    /// Construct a [`DatabaseInstanceContext`] from a [`Database`] and
-    /// additional configuration.
-    ///
-    /// Alongside `Self`, the set of clients who were connected as of the most
-    /// recent transaction is returned as a [`ConnectedClients`]. If the value
-    /// `Some`, the set is non-empty. `__disconnect__` should be called for
-    /// each entry.
-    pub fn from_database(
-        config: Config,
-        database: Database,
-        instance_id: u64,
-        root_db_path: PathBuf,
-        rt: tokio::runtime::Handle,
-    ) -> Result<(Self, Option<ConnectedClients>)> {
-        let mut db_path = root_db_path;
-        db_path.extend([&*database.address.to_hex(), &*instance_id.to_string()]);
-        db_path.push("database");
-
-        let log_path = DatabaseLogger::filepath(&database.address, instance_id);
-        let (relational_db, dangling_connections) = match config.storage {
-            Storage::Memory => {
-                let db = RelationalDB::open(db_path, database.address, None)?;
-                (Arc::new(db), None)
-            }
-            Storage::Disk => {
-                let (db, connected_clients) = RelationalDB::local(db_path, rt, database.address)?;
-                let connected_clients = (!connected_clients.is_empty()).then_some(connected_clients);
-                (Arc::new(db), connected_clients)
-            }
-        };
-        let subscriptions = ModuleSubscriptions::new(relational_db.clone(), database.identity);
-
-        let dbic = Self {
-            database,
-            database_instance_id: instance_id,
-            logger: Arc::new(DatabaseLogger::open(log_path)),
-            subscriptions,
-            relational_db,
-        };
-
-        Ok((dbic, dangling_connections))
-    }
-
     pub fn scheduler_db_path(&self, root_db_path: PathBuf) -> PathBuf {
         let mut scheduler_db_path = root_db_path;
         scheduler_db_path.extend([&*self.address.to_hex(), &*self.database_instance_id.to_string()]);

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -10,11 +10,10 @@ use crate::{
     db::{
         datastore::{
             system_tables::{
-                Epoch, StModuleFields, StModuleRow, StTableFields, ST_MODULE_ID, ST_TABLES_ID, WASM_MODULE,
+                read_st_module_bytes_col, StModuleFields, StModuleRow, StTableFields, ST_MODULE_ID, ST_TABLES_ID,
             },
             traits::{
-                DataRow, IsolationLevel, MutProgrammable, MutTx, MutTxDatastore, Programmable, RowTypeForTable, Tx,
-                TxData, TxDatastore,
+                DataRow, IsolationLevel, Metadata, MutTx, MutTxDatastore, RowTypeForTable, Tx, TxData, TxDatastore,
             },
         },
         db_metrics::{DB_METRICS, MAX_TX_CPU_TIME},
@@ -222,6 +221,32 @@ impl TxDatastore for Locking {
             })
             .collect()
     }
+
+    fn metadata(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Option<Metadata>> {
+        self.iter_tx(ctx, tx, ST_MODULE_ID)?
+            .next()
+            .map(|row_ref| {
+                let database_address =
+                    read_st_module_bytes_col(row_ref, StModuleFields::DatabaseAddress).map(Address::from_slice)?;
+                let owner_identity = read_st_module_bytes_col(row_ref, StModuleFields::OwnerIdentity)
+                    .map(|bytes| Identity::from_slice(&bytes))?;
+                let program_hash = read_st_module_bytes_col(row_ref, StModuleFields::ProgramHash)
+                    .map(|bytes| Hash::from_slice(&bytes))?;
+                Ok(Metadata {
+                    database_address,
+                    owner_identity,
+                    program_hash,
+                })
+            })
+            .transpose()
+    }
+
+    fn program_bytes(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Option<Box<[u8]>>> {
+        self.iter_tx(ctx, tx, ST_MODULE_ID)?
+            .next()
+            .map(|row_ref| read_st_module_bytes_col(row_ref, StModuleFields::ProgramBytes))
+            .transpose()
+    }
 }
 
 impl MutTxDatastore for Locking {
@@ -400,6 +425,31 @@ impl MutTxDatastore for Locking {
     fn table_id_exists_mut_tx(&self, tx: &Self::MutTx, table_id: &TableId) -> bool {
         tx.table_name(*table_id).is_some()
     }
+
+    fn update_program(&self, tx: &mut Self::MutTx, program_hash: Hash, program_bytes: Box<[u8]>) -> Result<()> {
+        let ctx = ExecutionContext::internal(self.database_address);
+        let old = tx
+            .iter(&ctx, ST_MODULE_ID)?
+            .next()
+            .map(|row| {
+                let ptr = row.pointer();
+                let row = StModuleRow::try_from(row)?;
+                Ok::<_, DBError>((ptr, row))
+            })
+            .transpose()?;
+        match old {
+            Some((ptr, mut row)) => {
+                row.program_hash = program_hash;
+                row.program_bytes = program_bytes;
+
+                tx.delete(ST_MODULE_ID, ptr)?;
+                tx.insert(ST_MODULE_ID, &mut row.into(), self.database_address)
+                    .map(drop)
+            }
+
+            None => Err(anyhow!("database {} improperly initialized: no metadata", self.database_address).into()),
+        }
+    }
 }
 
 pub(super) fn record_metrics(ctx: &ExecutionContext, tx_timer: Instant, lock_wait_time: Duration, committed: bool) {
@@ -521,64 +571,6 @@ impl Locking {
         // the MutTx and release the lock.
         record_metrics(ctx, timer, lock_wait_time, true);
         Ok(Some(res))
-    }
-}
-
-impl Programmable for Locking {
-    fn program_hash(&self, tx: &TxId) -> Result<Option<spacetimedb_sats::hash::Hash>> {
-        tx.iter(&ExecutionContext::internal(self.database_address), ST_MODULE_ID)?
-            .next()
-            .map(|row| StModuleRow::try_from(row).map(|st| st.program_hash))
-            .transpose()
-    }
-}
-
-impl MutProgrammable for Locking {
-    type FencingToken = u128;
-
-    fn set_program_hash(&self, tx: &mut MutTxId, fence: Self::FencingToken, hash: Hash) -> Result<()> {
-        let ctx = ExecutionContext::internal(self.database_address);
-        let mut iter = tx.iter(&ctx, ST_MODULE_ID)?;
-        if let Some(row_ref) = iter.next() {
-            let epoch = row_ref.read_col::<u128>(StModuleFields::Epoch)?;
-            if fence <= epoch {
-                return Err(anyhow!("stale fencing token: {}, storage is at epoch: {}", fence, epoch).into());
-            }
-
-            // Note the borrow checker requires that we explictly drop the iterator.
-            // That is, before we delete and insert.
-            // This is because datastore iterators write to the metric store when dropped.
-            // Hence if we don't explicitly drop here,
-            // there will be another immutable borrow of self after the two mutable borrows below.
-
-            tx.delete(ST_MODULE_ID, row_ref.pointer())?;
-            tx.insert(
-                ST_MODULE_ID,
-                &mut ProductValue::from(&StModuleRow {
-                    program_hash: hash,
-                    kind: WASM_MODULE,
-                    epoch: Epoch(fence),
-                }),
-                self.database_address,
-            )?;
-            return Ok(());
-        }
-
-        // Note the borrow checker requires that we explictly drop the iterator before we insert.
-        // This is because datastore iterators write to the metric store when dropped.
-        // Hence if we don't explicitly drop here,
-        // there will be another immutable borrow of self after the mutable borrow of the insert.
-
-        tx.insert(
-            ST_MODULE_ID,
-            &mut ProductValue::from(&StModuleRow {
-                program_hash: hash,
-                kind: WASM_MODULE,
-                epoch: Epoch(fence),
-            }),
-            self.database_address,
-        )?;
-        Ok(())
     }
 }
 
@@ -1277,9 +1269,11 @@ mod tests {
             ColRow { table: 4, pos: 3, name: "table_id", ty: AlgebraicType::U32 },
             ColRow { table: 4, pos: 4, name: "columns", ty: AlgebraicType::array(AlgebraicType::U32) },
 
-            ColRow { table: 5, pos: 0, name: "program_hash", ty: AlgebraicType::array(AlgebraicType::U8) },
-            ColRow { table: 5, pos: 1, name: "kind", ty: AlgebraicType::U8 },
-            ColRow { table: 5, pos: 2, name: "epoch", ty: AlgebraicType::U128 },
+            ColRow { table: 5, pos: 0, name: "database_address", ty: AlgebraicType::bytes() },
+            ColRow { table: 5, pos: 1, name: "owner_identity", ty: AlgebraicType::bytes() },
+            ColRow { table: 5, pos: 2, name: "program_kind", ty: AlgebraicType::U8 },
+            ColRow { table: 5, pos: 3, name: "program_hash", ty: AlgebraicType::bytes() },
+            ColRow { table: 5, pos: 4, name: "program_bytes", ty: AlgebraicType::bytes() },
 
             ColRow { table: 6, pos: 0, name: "identity", ty: Identity::get_type() },
             ColRow { table: 6, pos: 1, name: "address", ty: Address::get_type() },

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -3,6 +3,7 @@ use std::borrow::Cow;
 use std::collections::BTreeMap;
 use std::{ops::RangeBounds, sync::Arc};
 
+use super::system_tables::ModuleKind;
 use super::Result;
 use crate::db::datastore::system_tables::ST_TABLES_ID;
 use crate::execution_context::ExecutionContext;
@@ -458,10 +459,21 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
         row: ProductValue,
     ) -> Result<ProductValue>;
 
+    /// Obtain the [`Metadata`] for this datastore.
+    ///
+    /// Like [`TxDatastore`], but in a mutable transaction context.
+    fn metadata_mut_tx(&self, tx: &Self::MutTx) -> Result<Option<Metadata>>;
+
     /// Update the datastore with the supplied binary program.
     ///
     /// The `program_hash` is the precomputed hash over `program_bytes`.
-    fn update_program(&self, tx: &mut Self::MutTx, program_hash: Hash, program_bytes: Box<[u8]>) -> Result<()>;
+    fn update_program(
+        &self,
+        tx: &mut Self::MutTx,
+        program_kind: ModuleKind,
+        program_hash: Hash,
+        program_bytes: Box<[u8]>,
+    ) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -252,16 +252,33 @@ impl RelationalDB {
         self.insert(tx, ST_MODULE_ID, row.into()).map(drop)
     }
 
+    /// Obtain the [`Metadata`] of this database.
+    ///
+    /// `None` if the database is not yet fully initialized.
     pub fn metadata(&self) -> Result<Option<Metadata>, DBError> {
         let ctx = ExecutionContext::internal(self.address);
         self.with_read_only(&ctx, |tx| self.inner.metadata(&ctx, tx))
     }
 
+    /// Obtain the raw bytes of the module associated with this database.
+    ///
+    /// `None` if the database is not yet fully initialized.
+    /// Note that a `Some` result may yield an empty slice.
     pub fn program_bytes(&self) -> Result<Option<Box<[u8]>>, DBError> {
         let ctx = ExecutionContext::internal(self.address);
         self.with_read_only(&ctx, |tx| self.inner.program_bytes(&ctx, tx))
     }
 
+    /// Update the module associated with this database.
+    ///
+    /// The caller must ensure that:
+    ///
+    /// - `program_hash` is the [`Hash`] over `program_bytes`.
+    /// - `program_bytes` is a valid module acc. to `host_type`.
+    /// - the schema updates contained in the module have been applied within
+    ///   the transactional context `tx`.
+    /// - the `__init__` reducer contained in the module has been executed
+    ///   within the transactional context `tx`.
     pub fn update_program(
         &self,
         tx: &mut MutTx,

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -206,7 +206,15 @@ impl RelationalDB {
         Ok((db, connected_clients))
     }
 
-    pub(crate) fn set_initialized(
+    /// Mark the database as initialized with the given module parameters.
+    ///
+    /// Records the database's address, owner and module parameters in the
+    /// system tables. The transactional context is supplied by the caller.
+    ///
+    /// It is an error to call this method on an alread-initialized database.
+    ///
+    /// See [`Self::open`] for further information.
+    pub fn set_initialized(
         &self,
         tx: &mut MutTx,
         host_type: HostType,

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -11,7 +11,6 @@ use spacetimedb_data_structures::map::HashMap;
 use spacetimedb_primitives::ConstraintKind;
 use spacetimedb_sats::db::auth::StAccess;
 use spacetimedb_sats::db::def::{ConstraintSchema, IndexSchema, SequenceSchema, TableDef, TableSchema};
-use spacetimedb_sats::hash::Hash;
 use std::collections::BTreeMap;
 use std::sync::Arc;
 use std::time::Duration;
@@ -28,8 +27,6 @@ pub fn update_database(
     stdb: &RelationalDB,
     tx: MutTxId,
     proposed_tables: Vec<TableDef>,
-    fence: u128,
-    module_hash: Hash,
     system_logger: &SystemLogger,
 ) -> anyhow::Result<Result<MutTxId, UpdateDatabaseError>> {
     let ctx = ExecutionContext::internal(stdb.address());
@@ -74,10 +71,6 @@ pub fn update_database(
                 return Ok(Err(UpdateDatabaseError::IncompatibleSchema { tables }));
             }
         }
-
-        // Update the module hash. Morally, this should be done _after_ calling
-        // the `update` reducer, but that consumes our transaction context.
-        stdb.set_program_hash(tx, fence, module_hash)?;
 
         Ok(Ok(()))
     })?;

--- a/crates/core/src/host/disk_storage.rs
+++ b/crates/core/src/host/disk_storage.rs
@@ -5,8 +5,6 @@ use std::path::PathBuf;
 use tokio::fs;
 use tokio::io::AsyncWriteExt;
 
-use crate::util::AnyBytes;
-
 use super::ExternalStorage;
 
 /// A simple [`ExternalStorage`] that stores programs in the filesystem.
@@ -78,7 +76,7 @@ impl DiskStorage {
 
 #[async_trait]
 impl ExternalStorage for DiskStorage {
-    async fn lookup(&self, program_hash: Hash) -> anyhow::Result<Option<AnyBytes>> {
-        Ok(self.get(&program_hash).await?.map(Into::into))
+    async fn lookup(&self, program_hash: Hash) -> anyhow::Result<Option<Box<[u8]>>> {
+        self.get(&program_hash).await.map_err(Into::into)
     }
 }

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -382,14 +382,14 @@ pub trait Module: Send + Sync + 'static {
 pub trait ModuleInstance: Send + 'static {
     fn trapped(&self) -> bool;
 
-    // TODO(kim): The `fence` arg below is to thread through the fencing token
-    // (see [`crate::db::datastore::traits::MutProgrammable`]). This trait
-    // should probably be generic over the type of token, but that turns out a
-    // bit unpleasant at the moment. So we just use the widest possible integer.
+    fn init_database(
+        &mut self,
+        program_hash: Hash,
+        program_bytes: Box<[u8]>,
+    ) -> anyhow::Result<Option<ReducerCallResult>>;
 
-    fn init_database(&mut self, fence: u128, args: ArgsTuple) -> anyhow::Result<Option<ReducerCallResult>>;
-
-    fn update_database(&mut self, fence: u128) -> anyhow::Result<UpdateDatabaseResult>;
+    fn update_database(&mut self, program_hash: Hash, program_bytes: Box<[u8]>)
+        -> anyhow::Result<UpdateDatabaseResult>;
 
     fn call_reducer(&mut self, params: CallReducerParams) -> ReducerCallResult;
 }
@@ -424,13 +424,21 @@ impl<T: Module> ModuleInstance for AutoReplacingModuleInstance<T> {
     fn trapped(&self) -> bool {
         self.inst.trapped()
     }
-    fn init_database(&mut self, fence: u128, args: ArgsTuple) -> anyhow::Result<Option<ReducerCallResult>> {
-        let ret = self.inst.init_database(fence, args);
+    fn init_database(
+        &mut self,
+        program_hash: Hash,
+        program_bytes: Box<[u8]>,
+    ) -> anyhow::Result<Option<ReducerCallResult>> {
+        let ret = self.inst.init_database(program_hash, program_bytes);
         self.check_trap();
         ret
     }
-    fn update_database(&mut self, fence: u128) -> anyhow::Result<UpdateDatabaseResult> {
-        let ret = self.inst.update_database(fence);
+    fn update_database(
+        &mut self,
+        program_hash: Hash,
+        program_bytes: Box<[u8]>,
+    ) -> anyhow::Result<UpdateDatabaseResult> {
+        let ret = self.inst.update_database(program_hash, program_bytes);
         self.check_trap();
         ret
     }
@@ -634,16 +642,20 @@ impl ModuleHost {
                 .reducer_wait_time
                 .with_label_values(&self.info.address, reducer)
                 .start_timer();
+            log::debug!("get instance");
             self.inner.get_instance(self.info.address).await?
         };
 
-        let result = tokio::task::spawn_blocking(move || f(&mut *inst))
-            .await
-            .unwrap_or_else(|e| {
-                log::warn!("reducer `{reducer}` panicked");
-                (self.on_panic)();
-                std::panic::resume_unwind(e.into_panic())
-            });
+        let result = tokio::task::spawn_blocking(move || {
+            log::debug!("call");
+            f(&mut *inst)
+        })
+        .await
+        .unwrap_or_else(|e| {
+            log::warn!("reducer `{reducer}` panicked");
+            (self.on_panic)();
+            std::panic::resume_unwind(e.into_panic())
+        });
         Ok(result)
     }
 
@@ -861,22 +873,26 @@ impl ModuleHost {
 
     pub async fn init_database(
         &self,
-        fence: u128,
-        args: ReducerArgs,
+        program_hash: Hash,
+        program_bytes: Box<[u8]>,
     ) -> Result<Option<ReducerCallResult>, InitDatabaseError> {
-        let args = match self.catalog().get_reducer("__init__") {
-            Some(schema) => args.into_tuple(schema)?,
-            _ => ArgsTuple::default(),
-        };
-        self.call("<init_database>", move |inst| inst.init_database(fence, args))
-            .await?
-            .map_err(InitDatabaseError::Other)
+        self.call("<init_database>", move |inst| {
+            inst.init_database(program_hash, program_bytes)
+        })
+        .await?
+        .map_err(InitDatabaseError::Other)
     }
 
-    pub async fn update_database(&self, fence: u128) -> Result<UpdateDatabaseResult, anyhow::Error> {
-        self.call("<update_database>", move |inst| inst.update_database(fence))
-            .await?
-            .map_err(Into::into)
+    pub async fn update_database(
+        &self,
+        program_hash: Hash,
+        program_bytes: Box<[u8]>,
+    ) -> Result<UpdateDatabaseResult, anyhow::Error> {
+        self.call("<update_database>", move |inst| {
+            inst.update_database(program_hash, program_bytes)
+        })
+        .await?
+        .map_err(Into::into)
     }
 
     pub async fn exit(&self) {

--- a/crates/core/src/messages/control_db.rs
+++ b/crates/core/src/messages/control_db.rs
@@ -21,14 +21,28 @@ pub struct EnergyBalance {
     pub balance: i128,
 }
 
+/// Description of a database.
 #[derive(Clone, PartialEq, Serialize, Deserialize)]
 pub struct Database {
+    /// Internal id of the database, assigned by the control database.
     pub id: u64,
+    /// Public identity (i.e. [`Address`]) of the database.
     pub address: Address,
-    pub identity: Identity,
+    /// [`Identity`] of the database's owner.
+    pub owner_identity: Identity,
+    /// [`HostType`] of the module associated with the database.
+    ///
+    /// Valid only for as long as `initial_program` is valid.
     pub host_type: HostType,
-    pub num_replicas: u32,
-    pub program_bytes_address: Hash,
+    /// [`Hash`] of the compiled module to initialize the database with.
+    ///
+    /// Updating the database's module will **not** change this value.
+    pub initial_program: Hash,
+    /// The client address of the (initial) publisher of the database.
+    ///
+    /// If set, the value will be part of the  `__init__` reducer's context.
+    /// The meaning of this value is unspecified if the `owner_identity` is
+    /// changed after creation of the database.
     pub publisher_address: Option<Address>,
 }
 

--- a/crates/sats/src/hash.rs
+++ b/crates/sats/src/hash.rs
@@ -57,6 +57,10 @@ impl Hash {
     pub fn from_hex(hex: impl AsRef<[u8]>) -> Result<Self, hex::FromHexError> {
         hex::FromHex::from_hex(hex)
     }
+
+    pub fn is_zero(&self) -> bool {
+        self == &Self::ZERO
+    }
 }
 
 pub fn hash_bytes(bytes: impl AsRef<[u8]>) -> Hash {

--- a/crates/standalone/src/control_db.rs
+++ b/crates/standalone/src/control_db.rs
@@ -352,30 +352,6 @@ impl ControlDb {
         Ok(id)
     }
 
-    pub fn update_database(&self, database: Database) -> Result<()> {
-        let tree = self.db.open_tree("database")?;
-        let tree_by_address = self.db.open_tree("database_by_address")?;
-        let key = database.address.to_hex();
-
-        let old_value = tree.get(database.id.to_be_bytes())?;
-        if let Some(old_value) = old_value {
-            let old_database: Database = bsatn::from_slice(&old_value[..])?;
-
-            if database.address != old_database.address && tree_by_address.contains_key(key.as_bytes())? {
-                return Err(Error::DatabaseAlreadyExists(database.address));
-            }
-        }
-
-        let buf = sled::IVec::from(bsatn::to_vec(&database).unwrap());
-
-        tree.insert(database.id.to_be_bytes(), buf.clone())?;
-
-        let key = database.address.to_hex();
-        tree_by_address.insert(key, buf)?;
-
-        Ok(())
-    }
-
     pub fn delete_database(&self, id: u64) -> Result<Option<u64>> {
         let tree = self.db.open_tree("database")?;
         let tree_by_address = self.db.open_tree("database_by_address")?;

--- a/crates/standalone/src/control_db.rs
+++ b/crates/standalone/src/control_db.rs
@@ -1,9 +1,4 @@
-use std::borrow::Cow;
-
-use anyhow::{anyhow, Context};
-
 use spacetimedb::address::Address;
-
 use spacetimedb::hash::hash_bytes;
 use spacetimedb::identity::Identity;
 use spacetimedb::messages::control_db::{Database, DatabaseInstance, EnergyBalance, IdentityEmail, Node};
@@ -572,81 +567,4 @@ impl ControlDb {
 
         Ok(())
     }
-
-    /// Acquire a lock on `key`.
-    ///
-    /// If the lock can not be acquired immediately, an error is returned.
-    ///
-    /// This method is essentially simulating locking in the distributed version
-    /// of SpacetimeDB. It does not, however, provide time-based expiration of
-    /// a lock.
-    pub fn lock<'a, S>(&self, key: S) -> Result<Lock<'a>>
-    where
-        S: Into<Cow<'a, str>>,
-    {
-        let tree = self.db.open_tree("locks")?;
-        let token = self.db.generate_id().map(Some)?;
-        let key = key.into();
-        match cas_u64(&tree, &key, None, token)? {
-            Ok(()) => Ok(Lock { key, token, tree }),
-            Err(_) => Err(anyhow!("Lock on `{key}` taken").into()),
-        }
-    }
-}
-
-/// A keyed lock acquired by [`ControlDb::lock`].
-///
-/// The lock is released on drop, or by calling [`Lock::release`].
-pub struct Lock<'a> {
-    key: Cow<'a, str>,
-    token: Option<u64>,
-    tree: sled::Tree,
-}
-
-impl Lock<'_> {
-    /// Return the [fencing token] associated with this lock.
-    ///
-    /// [fencing token]: https://martin.kleppmann.com/2016/02/08/how-to-do-distributed-locking.html
-    pub fn token(&self) -> u64 {
-        self.token.expect("fencing token must be set unless self was dropped")
-    }
-
-    /// Release this lock, consuming `self`.
-    ///
-    /// A [`Lock`] is automatically released when it goes out of scope, however
-    /// any errors are lost in this case. Use [`Self::release`] to observe those
-    /// errors.
-    pub fn _release(mut self) -> Result<()> {
-        let this = &mut self;
-        this.release_internal()
-    }
-
-    fn release_internal(&mut self) -> Result<()> {
-        if let Some(tok) = self.token.take() {
-            cas_u64(&self.tree, &self.key, Some(tok), None)?.context("lock token changed while held")?
-        }
-        Ok(())
-    }
-}
-
-impl Drop for Lock<'_> {
-    fn drop(&mut self) {
-        if let Err(e) = self.release_internal() {
-            log::error!("Failed to release lock on `{}`: {}", self.key, e);
-        }
-    }
-}
-
-/// [`sled::Tree::compare_and_swap`] specialized to `&str` keys and `u64` values.
-fn cas_u64(
-    tree: &sled::Tree,
-    key: &str,
-    old: Option<u64>,
-    new: Option<u64>,
-) -> sled::Result<std::result::Result<(), sled::CompareAndSwapError>> {
-    tree.compare_and_swap(
-        key,
-        old.map(|x| x.to_be_bytes()).as_ref(),
-        new.map(|x| x.to_be_bytes()).as_ref(),
-    )
 }

--- a/crates/standalone/src/control_db/tests.rs
+++ b/crates/standalone/src/control_db/tests.rs
@@ -97,10 +97,9 @@ fn test_decode() -> ResultTest<()> {
     let db = Database {
         id: 0,
         address: Default::default(),
-        identity: id,
+        owner_identity: id,
         host_type: HostType::Wasm,
-        num_replicas: 0,
-        program_bytes_address: Hash::ZERO,
+        initial_program: Hash::ZERO,
         publisher_address: Some(Address::zero()),
     };
 
@@ -109,7 +108,7 @@ fn test_decode() -> ResultTest<()> {
     let dbs = cdb.get_databases()?;
 
     assert_eq!(dbs.len(), 1);
-    assert_eq!(dbs[0].identity, id);
+    assert_eq!(dbs[0].owner_identity, id);
 
     let mut new_database_instance = DatabaseInstance {
         id: 0,

--- a/crates/standalone/src/energy_monitor.rs
+++ b/crates/standalone/src/energy_monitor.rs
@@ -38,7 +38,7 @@ impl EnergyMonitor for StandaloneEnergyMonitor {
 
     fn record_disk_usage(&self, database: &Database, _instance_id: u64, disk_usage: u64, period: Duration) {
         let amount = EnergyQuanta::from_disk_usage(disk_usage, period);
-        self.withdraw_energy(database.identity, amount)
+        self.withdraw_energy(database.owner_identity, amount)
     }
 }
 

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -287,12 +287,6 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
                     program_bytes_address,
                     publisher_address,
                 };
-
-                // NOTE: If initialization fails, we'll still have the database
-                // in the control db.
-                // This will make any subsequent access return an error about
-                // the program hash not matching expectations, until the
-                // database is published again.
                 let database_id = self.control_db.insert_database(database.clone())?;
                 database.id = database_id;
 
@@ -330,7 +324,6 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
                     .await?;
 
                 if update_result.is_ok() {
-                    self.control_db.update_database(database.clone())?;
                     self.schedule_database(Some(database), Some(existing_db)).await?;
                 }
 

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Instant;
 
+use spacetimedb::messages::control_db::HostType;
 use tokio::runtime::{Builder, Runtime};
 
 use spacetimedb::address::Address;
@@ -162,6 +163,7 @@ impl CompiledModule {
                 address: db_address,
                 program_bytes,
                 num_replicas: 1,
+                host_type: HostType::Wasm,
             },
         )
         .await

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -92,10 +92,13 @@ fn test_calling_a_reducer_with_private_table() {
             let json = r#"{"call": {"fn": "query_private", "args": []}}"#.to_string();
             module.send(json).await.unwrap();
 
-            assert_eq!(
-                read_logs(&module).await,
-                ["Private, Tyrion!", "Private, World!",].map(String::from)
-            );
+            let logs = read_logs(&module)
+                .await
+                .into_iter()
+                .skip_while(|r| r.starts_with("Timestamp"))
+                .collect::<Vec<_>>();
+
+            assert_eq!(logs, ["Private, Tyrion!", "Private, World!",].map(String::from));
         },
     );
 }
@@ -115,15 +118,17 @@ fn test_call_query_macro() {
                 .to_string();
             module.send(json).await.unwrap();
 
-            let logs = read_logs(&module).await;
-
-            assert_eq!(logs[0], "BEGIN");
-            assert!(logs[1].starts_with("sender: "));
-            assert!(logs[2].starts_with("timestamp: "));
-
+            let logs = read_logs(&module)
+                .await
+                .into_iter()
+                .filter(|line| {
+                    !(line.starts_with("sender:") || line.starts_with("timestamp:") || line.starts_with("Timestamp"))
+                })
+                .collect::<Vec<_>>();
             assert_eq!(
-                logs[3..],
+                logs,
                 [
+                    "BEGIN",
                     r#"bar: "Foo""#,
                     "Foo",
                     "Row count before delete: 1000",


### PR DESCRIPTION
# Description of Changes

This patch changes the `st_module` system table to store the compiled module directly in the database, where previously we would only store its hash. This allows to start up a database + module from just the commitlog, without requiring external storage (note: still required for initialization).

While we're changing `st_module`, we also store the database's address and owner identity, useful for snapshotting.

As a consequence, the `Database` struct stored in the control db becomes effectively immutable, as it only needs to refer to the **initial** (or: genesis) program. The number of replicas can be adjusted when publishing, or -- in the future -- through a `scale` command which doesn't require to provide a new program.

Collaterally, the long-standing TODO of threading through the module `HostType` is fixed, such that `/database/publish` could in the future accept it as a parameter.

# API and ABI breaking changes

- The schema of the `st_module` table is changed, 
   rendering existing databases unusable

- The `Database` struct is changed,
   rendering existing (standalone) control databases invalid, and
   changing the reponse type of the `/database/info` endpoint.

# Expected complexity level and risk

5

In particular, the initialization sequence is arguably less than obvious:

1. `RelationalDB::open`
2. load genesis program from external storage
3. start `ModuleHost` with program + `RelationalDB`
4. `ModuleHost::init_database` -> `RelationalDB::set_initialized` -> commit tx

A future refactoring may succeed in allowing to execute `init_database` without taking ownership of the transaction, which would help making this more robust.

# Testing

In principle, database lifecyle should be covered by the smoketests, in particular:

- a database can be created, and the `__init__` reducer is run
- a database comes back up after a server restart
- a database can be updated, and the `__update__` reducer is run
- if an update fails, the old database keeps running

Additional, hard to automate testing could involve:

- if a new named database is published concurrently using the same program, `__init__` is executed only once
- if a new named database is published concurrently using two different programs, `__init__` is executed on one of the programs, while `__update__` is executed on the other
- if a new database is published, and `__init__` returns an error, the commitlog is empty (technically: contains one segment which contains only the headers).