### PR TITLE
Fix FilterBy regression in C#

### DIFF
--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -901,7 +901,11 @@ fn autogen_csharp_access_funcs_for_struct(
         );
         indented_block(output, |output| {
             if is_unique {
-                writeln!(output, "return new[] {{ FindBy{csharp_field_name_pascal}(value) }};");
+                // Yield a single item iff `FindBy` returns a non-null record.
+                writeln!(output, "if (FindBy{csharp_field_name_pascal}(value) is {{}} found)");
+                indented_block(output, |output| {
+                    writeln!(output, "yield return found;");
+                });
             } else {
                 writeln!(output, "return Query(x => x.{csharp_field_name_pascal} == value);");
             }

--- a/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
@@ -374,7 +374,10 @@ namespace SpacetimeDB
 
 		public static IEnumerable<PkMultiIdentity> FilterById(uint value)
 		{
-			return new[] { FindById(value) };
+			if (FindById(value) is {} found)
+			{
+				yield return found;
+			}
 		}
 
 		public static PkMultiIdentity FindByOther(uint value)
@@ -385,7 +388,10 @@ namespace SpacetimeDB
 
 		public static IEnumerable<PkMultiIdentity> FilterByOther(uint value)
 		{
-			return new[] { FindByOther(value) };
+			if (FindByOther(value) is { } found)
+			{
+				yield return found;
+			}
 		}
 
 		private static object GetPrimaryKeyValue(object row) => ((PkMultiIdentity)row).Id;
@@ -1058,7 +1064,10 @@ namespace SpacetimeDB
 
 		public static IEnumerable<TestE> FilterById(ulong value)
 		{
-			return new[] { FindById(value) };
+			if (FindById(value) is { } found)
+			{
+				yield return found;
+			}
 		}
 
 		public static IEnumerable<TestE> FilterByName(string value)

--- a/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
@@ -388,7 +388,7 @@ namespace SpacetimeDB
 
 		public static IEnumerable<PkMultiIdentity> FilterByOther(uint value)
 		{
-			if (FindByOther(value) is { } found)
+			if (FindByOther(value) is {} found)
 			{
 				yield return found;
 			}
@@ -1064,7 +1064,7 @@ namespace SpacetimeDB
 
 		public static IEnumerable<TestE> FilterById(ulong value)
 		{
-			if (FindById(value) is { } found)
+			if (FindById(value) is {} found)
 			{
 				yield return found;
 			}


### PR DESCRIPTION
# Description of Changes

Fixes regression accidentally introduced in #1277: if FindBy returns null, FilterBy will return an iterable with a single null item instead of an empty iterable.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
