### PR TITLE
Bump ABI version for C# AOT

### DIFF
--- a/crates/bindings-csharp/Runtime/RawBindings.cs
+++ b/crates/bindings-csharp/Runtime/RawBindings.cs
@@ -11,7 +11,7 @@ public static partial class RawBindings
     // `LibraryImport` directly.
     const string StdbNamespace =
 #if EXPERIMENTAL_WASM_AOT
-        "spacetime_7.0"
+        "spacetime_8.0"
 #else
         "bindings"
 #endif
@@ -51,7 +51,6 @@ public static partial class RawBindings
     private const ushort ERRNO_UNIQUE_ALREADY_EXISTS = 3;
     private const ushort ERRNO_BUFFER_TOO_SMALL = 4;
 
-
     public class StdbException : Exception
     {
         public ushort Code { get; private set; }
@@ -63,28 +62,36 @@ public static partial class RawBindings
 
     public class NoSuchTableException : StdbException
     {
-        internal NoSuchTableException() : base(ERRNO_NO_SUCH_TABLE) { }
+        internal NoSuchTableException()
+            : base(ERRNO_NO_SUCH_TABLE) { }
+
         public override string Message => "No such table";
     }
 
     public class LookupNotFoundException : StdbException
     {
-        internal LookupNotFoundException() : base(ERRNO_LOOKUP_NOT_FOUND) { }
+        internal LookupNotFoundException()
+            : base(ERRNO_LOOKUP_NOT_FOUND) { }
+
         public override string Message => "Value or range provided not found in table";
     }
 
     public class UniqueAlreadyExistsException : StdbException
     {
-        internal UniqueAlreadyExistsException() : base(ERRNO_UNIQUE_ALREADY_EXISTS) { }
+        internal UniqueAlreadyExistsException()
+            : base(ERRNO_UNIQUE_ALREADY_EXISTS) { }
+
         public override string Message => "Value with given unique identifier already exists";
     }
 
     public class BufferTooSmallException : StdbException
     {
-        internal BufferTooSmallException() : base(ERRNO_BUFFER_TOO_SMALL) { }
-        public override string Message => "The provided buffer is not large enough to store the data";
-    }
+        internal BufferTooSmallException()
+            : base(ERRNO_BUFFER_TOO_SMALL) { }
 
+        public override string Message =>
+            "The provided buffer is not large enough to store the data";
+    }
 
     [NativeMarshalling(typeof(StatusMarshaller))]
     public struct CheckedStatus;

--- a/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.props
+++ b/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.props
@@ -15,7 +15,7 @@
     <DefineConstants>$(DefineConstants);EXPERIMENTAL_WASM_AOT</DefineConstants>
     <MSBuildEnableWorkloadResolver>false</MSBuildEnableWorkloadResolver>
     <UseAppHost>false</UseAppHost>
-    <SpacetimeNamespace>spacetime_7.0</SpacetimeNamespace>
+    <SpacetimeNamespace>spacetime_8.0</SpacetimeNamespace>
     <RestoreAdditionalProjectSources>https://pkgs.dev.azure.com/dnceng/public/_packaging/dotnet-experimental/nuget/v3/index.json</RestoreAdditionalProjectSources>
   </PropertyGroup>
 


### PR DESCRIPTION
# Description of Changes

Looks like these constants got missed during upgrade, making AOT version ABI-incompatible.

Unfortunately, there's no way to use a central constant here, and we don't have the Windows + Emscripten setup for testing the AOT variant yet, so we probably should add it to some "steps to do during ABI version bump" doc.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
