### PR TITLE
 Restrict multi-col index scans to `=` (`OpCmp::Eq`) on all columns 

### DIFF
--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -735,7 +735,7 @@ SELECT * FROM inventory",
         let result = run_for_testing(&db, "select * from test where a >= 3 and a <= 5 and b >= 3 and b <= 5")?;
 
         let result = result.first().unwrap().clone();
-        assert_eq!(result.data, vec![row]);
+        assert_eq!(result.data, []);
 
         Ok(())
     }


### PR DESCRIPTION
# Description of Changes

Restrict multi-col index scans to `=` (`OpCmp::Eq`) on all columns to fix the current unsound index optimization bug.
Later, we can lift the restriction with a more elaborate and correct implementation.

Fixes https://github.com/clockworklabs/SpacetimeDB/issues/1258.

# API and ABI breaking changes

None

# Expected complexity level and risk

1, localized changes.

# Testing

The tests have been hardened to catch this, both at query compilation time and query execution run-time.