### PR TITLE
metric for table size

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -36,7 +36,7 @@ use spacetimedb_sats::{
 };
 use spacetimedb_table::{
     blob_store::{BlobStore, HashMapBlobStore},
-    indexes::{RowPointer, SquashedOffset, PAGE_DATA_SIZE},
+    indexes::{RowPointer, SquashedOffset},
     table::{IndexScanIter, InsertError, RowRef, Table},
 };
 use std::collections::BTreeMap;
@@ -479,7 +479,7 @@ impl CommittedState {
                 .with_label_values(db, &table_id.into(), table_name)
                 .add(num_ins as i64);
 
-            let table_size = (commit_table.num_pages() * PAGE_DATA_SIZE) + commit_table.blob_store_bytes;
+            let table_size = commit_table.bytes_occupied_overestimate();
             DB_METRICS
                 .rdb_table_size
                 .with_label_values(db, &table_id.into(), table_name)

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -36,7 +36,7 @@ use spacetimedb_sats::{
 };
 use spacetimedb_table::{
     blob_store::{BlobStore, HashMapBlobStore},
-    indexes::{RowPointer, SquashedOffset},
+    indexes::{RowPointer, SquashedOffset, PAGE_DATA_SIZE},
     table::{IndexScanIter, InsertError, RowRef, Table},
 };
 use std::collections::BTreeMap;
@@ -478,6 +478,12 @@ impl CommittedState {
                 .rdb_num_table_rows
                 .with_label_values(db, &table_id.into(), table_name)
                 .add(num_ins as i64);
+
+            let table_size = (commit_table.num_pages() * PAGE_DATA_SIZE) + commit_table.blob_store_bytes;
+            DB_METRICS
+                .rdb_table_size
+                .with_label_values(db, &table_id.into(), table_name)
+                .set(table_size as i64);
 
             // Add all newly created indexes to the committed state.
             for (cols, mut index) in tx_table.indexes {

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -923,7 +923,7 @@ impl MutTxId {
                 "Table::insert_internal_allow_duplicates returned error of unexpected variant: {:?}",
                 e
             ),
-            Ok(row_ref) => {
+            Ok((row_ref, _)) => {
                 let hash = row_ref.row_hash();
                 let ptr = row_ref.pointer();
 

--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -75,6 +75,11 @@ metrics_group!(
         #[help = "For a given module, the size of its log file (in bytes)"]
         #[labels(db: Address)]
         pub module_log_file_size: IntGaugeVec,
+
+        #[name = spacetime_table_size_bytes]
+        #[help = "The number of bytes in a table with a precision of page size"]
+        #[labels(db: Address, table_id: u32, table_name: str)]
+        pub rdb_table_size: IntGaugeVec,
     }
 );
 

--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -77,7 +77,7 @@ metrics_group!(
         pub module_log_file_size: IntGaugeVec,
 
         #[name = spacetime_table_size_bytes]
-        #[help = "The number of bytes in a table with a precision of page size"]
+        #[help = "The number of bytes in a table with the precision of a page size"]
         #[labels(db: Address, table_id: u32, table_name: str)]
         pub rdb_table_size: IntGaugeVec,
     }

--- a/crates/table/benches/page.rs
+++ b/crates/table/benches/page.rs
@@ -739,7 +739,7 @@ fn extract_product_value_from_page(c: &mut Criterion) {
     for (name, ty, value, _null_visitor, _aligned_offsets_visitor) in product_value_test_cases() {
         let mut group = c.benchmark_group("extract_product_value");
         let (ty, mut page, visitor) = ty_page_visitor(ty);
-        let offset = unsafe { write_row_to_page(&mut page, &mut NullBlobStore, &visitor, &ty, &value) }.unwrap();
+        let (offset, _) = unsafe { write_row_to_page(&mut page, &mut NullBlobStore, &visitor, &ty, &value) }.unwrap();
         group.bench_function(name, |b| time_extract_one(b, &mut page, offset, &ty));
     }
 }
@@ -753,8 +753,8 @@ fn eq_in_page_same(c: &mut Criterion) {
     for (name, ty, value, _null_visitor, _aligned_offsets_visitor) in product_value_test_cases() {
         let (ty, mut page, visitor) = ty_page_visitor(ty);
 
-        let offset_0 = unsafe { write_row_to_page(&mut page, &mut NullBlobStore, &visitor, &ty, &value) }.unwrap();
-        let offset_1 = unsafe { write_row_to_page(&mut page, &mut NullBlobStore, &visitor, &ty, &value) }.unwrap();
+        let (offset_0, _) = unsafe { write_row_to_page(&mut page, &mut NullBlobStore, &visitor, &ty, &value) }.unwrap();
+        let (offset_1, _) = unsafe { write_row_to_page(&mut page, &mut NullBlobStore, &visitor, &ty, &value) }.unwrap();
 
         group.bench_function(name, |b| {
             b.iter(|| {
@@ -781,7 +781,7 @@ fn hash_in_page(c: &mut Criterion) {
     for (name, ty, value, _null_visitor, _aligned_offsets_visitor) in product_value_test_cases() {
         let (ty, mut page, visitor) = ty_page_visitor(ty);
 
-        let offset = unsafe { write_row_to_page(&mut page, &mut NullBlobStore, &visitor, &ty, &value) }.unwrap();
+        let (offset, _) = unsafe { write_row_to_page(&mut page, &mut NullBlobStore, &visitor, &ty, &value) }.unwrap();
         group.bench_function(name, |b| {
             let mut hasher = RowHash::hasher_builder().build_hasher();
             b.iter(|| {

--- a/crates/table/src/bflatn_to.rs
+++ b/crates/table/src/bflatn_to.rs
@@ -45,7 +45,7 @@ pub unsafe fn write_row_to_pages(
     ty: &RowTypeLayout,
     val: &ProductValue,
     squashed_offset: SquashedOffset,
-) -> Result<RowPointer, Error> {
+) -> Result<(RowPointer, usize), Error> {
     let num_granules = required_var_len_granules_for_row(val);
 
     match pages.with_page_to_insert_row(ty.size(), num_granules, |page| {
@@ -57,7 +57,9 @@ pub unsafe fn write_row_to_pages(
         // - `visitor` came from `pages` which we can trust to visit in the right order.
         unsafe { write_row_to_page(page, blob_store, visitor, ty, val) }
     })? {
-        (page, Ok(offset)) => Ok(RowPointer::new(false, page, offset, squashed_offset)),
+        (page, Ok((offset, blob_inserted))) => {
+            Ok((RowPointer::new(false, page, offset, squashed_offset), blob_inserted))
+        }
         (_, Err(e)) => Err(e),
     }
 }
@@ -83,7 +85,7 @@ pub unsafe fn write_row_to_page(
     visitor: &impl VarLenMembers,
     ty: &RowTypeLayout,
     val: &ProductValue,
-) -> Result<PageOffset, Error> {
+) -> Result<(PageOffset, usize), Error> {
     let fixed_row_size = ty.size();
     // SAFETY: We've used the right `row_size` and we trust that others have too.
     // `RowTypeLayout` also ensures that we satisfy the minimum row size.
@@ -111,9 +113,9 @@ pub unsafe fn write_row_to_page(
     }
 
     // Haven't stored large blobs or init those granules with blob hashes yet, so do it now.
-    serialized.write_large_blobs(blob_store);
+    let blob_store_inserted_bytes = serialized.write_large_blobs(blob_store);
 
-    Ok(fixed_offset)
+    Ok((fixed_offset, blob_store_inserted_bytes))
 }
 
 /// The writing / serialization context used by the function [`write_row_to_page`].
@@ -161,16 +163,18 @@ impl BflatnSerializedRowBuffer<'_> {
     }
 
     /// Insert all large blobs into `blob_store` and their hashes to their granules.
-    fn write_large_blobs(mut self, blob_store: &mut dyn BlobStore) {
+    fn write_large_blobs(mut self, blob_store: &mut dyn BlobStore) -> usize {
+        let mut blob_store_inserted_bytes = 0;
         for (vlr, value) in self.large_blob_insertions {
             // SAFETY: `vlr` was given to us by `alloc_for_slice`
             // so it is properly aligned for a `VarLenGranule` and in bounds of the page.
             // However, as it was added to `self.large_blob_insertions`,
             // we have not yet written the hash to that granule.
             unsafe {
-                self.var_view.write_large_blob_hash_to_granule(blob_store, &value, vlr);
+                blob_store_inserted_bytes += self.var_view.write_large_blob_hash_to_granule(blob_store, &value, vlr);
             }
         }
+        blob_store_inserted_bytes
     }
 
     /// Write an `val`, an [`AlgebraicValue`], typed at `ty`, to the buffer.
@@ -473,7 +477,7 @@ pub mod test {
 
             let hash_pre_ins = hash_unmodified_save_get(&mut page);
 
-            let offset = unsafe { write_row_to_page(&mut page, blob_store, &visitor, &ty, &val).unwrap() };
+            let (offset, _) = unsafe { write_row_to_page(&mut page, blob_store, &visitor, &ty, &val).unwrap() };
 
             let hash_pre_ser = hash_unmodified_save_get(&mut page);
             assert_ne!(hash_pre_ins, hash_pre_ser);

--- a/crates/table/src/page.rs
+++ b/crates/table/src/page.rs
@@ -662,7 +662,7 @@ impl<'page> VarView<'page> {
         blob_store: &mut dyn BlobStore,
         var_len_obj: &impl AsRef<[u8]>,
         vlr: VarLenRef,
-    ) {
+    ) -> usize {
         let hash = blob_store.insert_blob(var_len_obj.as_ref());
 
         let granule = vlr.first_granule;
@@ -671,6 +671,7 @@ impl<'page> VarView<'page> {
         // 2. The null granule is trivially initialized.
         // 3. The caller promised that `granule` is safe to overwrite.
         unsafe { self.write_chunk_to_granule(&hash.data, hash.data.len(), granule, PageOffset::VAR_LEN_NULL) };
+        var_len_obj.as_ref().len()
     }
 
     /// Write the `chunk` (data) to the [`VarLenGranule`] pointed to by `granule`,
@@ -811,7 +812,7 @@ impl<'page> VarView<'page> {
     /// SAFETY: `offset` must point to a valid [`VarLenGranule`] or be NULL.
     #[cold]
     #[inline(never)]
-    unsafe fn free_blob(&self, offset: PageOffset, blob_store: &mut dyn BlobStore) {
+    unsafe fn free_blob(&self, offset: PageOffset, blob_store: &mut dyn BlobStore) -> usize {
         assert!(!offset.is_var_len_null());
 
         // SAFETY: Per caller contract + the assertion above,
@@ -820,7 +821,16 @@ impl<'page> VarView<'page> {
 
         // Actually free the blob.
         let hash = granule.blob_hash();
+
+        // The size of deleted_bytes is calculated here instead of requesting it from BlobStore.
+        // This is because the actual number of bytes deleted depends on the BlobStore's logic.
+        // We prefer to measure it from the datastore's point of view.
+        let blob_store_deleted_bytes = blob_store
+            .retrieve_blob(&hash)
+            .expect("failed to free var-len blob")
+            .len();
         blob_store.free_blob(&hash).expect("failed to free var-len blob");
+        blob_store_deleted_bytes
     }
 
     /// Frees an entire var-len linked-list object.
@@ -859,13 +869,14 @@ impl<'page> VarView<'page> {
     /// Frees an entire var-len linked-list object.
     ///
     /// SAFETY: `var_len_obj.first_granule` must point to a valid [`VarLenGranule`] or be NULL.
-    unsafe fn free_object(&mut self, var_len_obj: VarLenRef, blob_store: &mut dyn BlobStore) {
+    unsafe fn free_object(&mut self, var_len_obj: VarLenRef, blob_store: &mut dyn BlobStore) -> usize {
+        let mut blob_store_deleted_bytes = 0;
         // For large blob objects, extract the hash and tell `blob_store` to discard it.
         if var_len_obj.is_large_blob() {
             // SAFETY: `var_len_obj.first_granule` was promised to
             // point to a valid [`VarLenGranule`] or be NULL, as required.
             unsafe {
-                self.free_blob(var_len_obj.first_granule, blob_store);
+                blob_store_deleted_bytes = self.free_blob(var_len_obj.first_granule, blob_store);
             }
         }
 
@@ -873,6 +884,8 @@ impl<'page> VarView<'page> {
         unsafe {
             self.free_object_ignore_blob(var_len_obj);
         }
+
+        blob_store_deleted_bytes
     }
 }
 
@@ -1350,13 +1363,15 @@ impl Page {
         fixed_row_size: Size,
         var_len_visitor: &impl VarLenMembers,
         blob_store: &mut dyn BlobStore,
-    ) {
+    ) -> usize {
         self.header.fixed.debug_check_fixed_row_size(fixed_row_size);
 
         // We're modifying the page, so clear the unmodified hash.
         self.header.unmodified_hash = None;
 
         let (mut fixed, mut var) = self.split_fixed_var_mut();
+
+        let mut blob_store_deleted_bytes = 0;
 
         // Visit the var-len members of the fixed row and free them.
         let row = fixed.get_row(fixed_row, fixed_row_size);
@@ -1367,9 +1382,7 @@ impl Page {
             // which we've justified that the above is,
             // returns an iterator, that will only yield `var_len_ref`s,
             // where `var_len_ref.first_granule` points to a valid `VarLenGranule` or is NULL.
-            unsafe {
-                var.free_object(*var_len_ref, blob_store);
-            }
+            blob_store_deleted_bytes += unsafe { var.free_object(*var_len_ref, blob_store) }
         }
 
         // SAFETY: Caller promised that `fixed_row` points to a valid row in the page.
@@ -1380,6 +1393,8 @@ impl Page {
         unsafe {
             fixed.free(fixed_row, fixed_row_size);
         }
+
+        blob_store_deleted_bytes
     }
 
     /// Returns the total number of granules used by the fixed row at `fixed_row_offset`

--- a/crates/table/src/page.rs
+++ b/crates/table/src/page.rs
@@ -822,15 +822,18 @@ impl<'page> VarView<'page> {
         // Actually free the blob.
         let hash = granule.blob_hash();
 
-        // The size of deleted_bytes is calculated here instead of requesting it from BlobStore.
-        // This is because the actual number of bytes deleted depends on the BlobStore's logic.
+        // The size of `deleted_bytes` is calculated here instead of requesting it from `blob_store`.
+        // This is because the actual number of bytes deleted depends on the `blob_store`'s logic.
         // We prefer to measure it from the datastore's point of view.
         let blob_store_deleted_bytes = blob_store
             .retrieve_blob(&hash)
             .expect("failed to free var-len blob")
             .len()
             .into();
+
+        // Actually free the blob.
         blob_store.free_blob(&hash).expect("failed to free var-len blob");
+
         blob_store_deleted_bytes
     }
 

--- a/crates/table/src/pages.rs
+++ b/crates/table/src/pages.rs
@@ -215,7 +215,7 @@ impl Pages {
         fixed_row_size: Size,
         row_ptr: RowPointer,
         blob_store: &mut dyn BlobStore,
-    ) {
+    ) -> usize {
         let page = &mut self[row_ptr.page_index()];
         let full_before = page.is_full(fixed_row_size);
         // SAFETY:
@@ -224,15 +224,15 @@ impl Pages {
         //
         // - `fixed_row_size` is consistent with the size in bytes of the fixed part of the row.
         //   The size is also conistent with `var_len_visitor`.
-        unsafe {
-            page.delete_row(row_ptr.page_offset(), fixed_row_size, var_len_visitor, blob_store);
-        }
+        let blob_store_deleted_bytes =
+            unsafe { page.delete_row(row_ptr.page_offset(), fixed_row_size, var_len_visitor, blob_store) };
 
         // If the page was previously full, mark it as non-full now,
         // since we just opened a space in it.
         if full_before {
             self.mark_page_non_full(row_ptr.page_index());
         }
+        blob_store_deleted_bytes
     }
 
     /// Materialize a view of rows in `self` for which the  `filter` returns `true`.

--- a/crates/table/src/pages.rs
+++ b/crates/table/src/pages.rs
@@ -3,6 +3,7 @@
 use super::blob_store::BlobStore;
 use super::indexes::{Bytes, PageIndex, PageOffset, RowPointer, Size};
 use super::page::Page;
+use super::table::BlobNumBytes;
 use super::var_len::VarLenMembers;
 use core::ops::{ControlFlow, Deref, Index, IndexMut};
 use thiserror::Error;
@@ -215,7 +216,7 @@ impl Pages {
         fixed_row_size: Size,
         row_ptr: RowPointer,
         blob_store: &mut dyn BlobStore,
-    ) -> usize {
+    ) -> BlobNumBytes {
         let page = &mut self[row_ptr.page_index()];
         let full_before = page.is_full(fixed_row_size);
         // SAFETY:


### PR DESCRIPTION
# Description of Changes
- Add metric `rdb_table_size` : The number of bytes in a table with a precision of page size
- Add `blob_store_bytes` in `Table` struct.
-  Inspired from `write/read` sys calls.  Make changes in few `insert`, `delete` Page relate apis to return number of blobs_byte written or deleted.
- Use `Number Of Pages * PAGE_DATASIZE` to calculate space occupying by table in pages for reporting to metrics.

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk
1