### PR TITLE
Create new crate `fs-utils`; move `Lockfile` and `create_parent_dir`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4251,6 +4251,7 @@ dependencies = [
  "spacetimedb-client-api-messages",
  "spacetimedb-core",
  "spacetimedb-data-structures",
+ "spacetimedb-fs-utils",
  "spacetimedb-lib",
  "spacetimedb-primitives",
  "spacetimedb-standalone",
@@ -4456,6 +4457,13 @@ dependencies = [
  "spacetimedb-sats",
  "tokio",
  "tracing",
+]
+
+[[package]]
+name = "spacetimedb-fs-utils"
+version = "0.9.3"
+dependencies = [
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -11,6 +11,7 @@ members = [
   "crates/core",
   "crates/data-structures",
   "crates/durability",
+  "crates/fs-utils",
   "crates/lib",
   "crates/metrics",
   "crates/primitives",
@@ -98,6 +99,7 @@ spacetimedb-sats = { path = "crates/sats", version = "0.9.3" }
 spacetimedb-standalone = { path = "crates/standalone", version = "0.9.3" }
 spacetimedb-table = { path = "crates/table", version = "0.9.3" }
 spacetimedb-vm = { path = "crates/vm", version = "0.9.3" }
+spacetimedb-fs-utils = { path = "crates/fs-utils", version = "0.9.3" }
 
 ahash = "0.8"
 anyhow = "1.0.68"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -24,6 +24,7 @@ spacetimedb-data-structures.workspace = true
 spacetimedb-lib.workspace = true
 spacetimedb-standalone = { workspace = true, optional = true }
 spacetimedb-client-api-messages.workspace = true
+spacetimedb-fs-utils.workspace = true
 
 anyhow.workspace = true
 base64.workspace = true

--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -3,6 +3,7 @@ use anyhow::Context;
 use jsonwebtoken::DecodingKey;
 use serde::{Deserialize, Serialize};
 use spacetimedb::auth::identity::decode_token;
+use spacetimedb_fs_utils::{create_parent_dir, lockfile::Lockfile};
 use spacetimedb_lib::Identity;
 use std::{
     fs,
@@ -103,65 +104,6 @@ pub struct RawConfig {
     identity_configs: Vec<IdentityConfig>,
     #[serde(default, skip_serializing_if = "Vec::is_empty")]
     server_configs: Vec<ServerConfig>,
-}
-
-fn create_parent_dir(file: &Path) -> anyhow::Result<()> {
-    let parent = file
-        .parent()
-        .with_context(|| format!("Cannot find the parent directory of path {file:?}"))?;
-
-    // If the `file` path is a relative path with no directory component,
-    // `parent` will be the empty path.
-    // In this case, do not attempt to create a directory.
-    if parent != Path::new("") {
-        // If the `file` path has a directory component,
-        // do `create_dir_all` to ensure it exists.
-        // If `parent` already exists as a directory, this is a no-op.
-        std::fs::create_dir_all(parent)
-            .with_context(|| format!("Failed to create directory structure {parent:?} to contain {file:?}"))?;
-    }
-    Ok(())
-}
-
-#[derive(Debug)]
-/// A file used as an exclusive lock on access to another file.
-///
-/// Constructing a `Lockfile` creates the `path` with [`std::fs::File::create_new`],
-/// a.k.a. `O_EXCL`, erroring if the file already exists.
-///
-/// Dropping a `Lockfile` deletes the `path`, releasing the lock.
-///
-/// Used to guarantee exclusive access to the system config file,
-/// in order to prevent racy concurrent modifications.
-struct Lockfile {
-    path: PathBuf,
-}
-
-impl Lockfile {
-    /// Acquire an exclusive lock on the configuration file `config_path`.
-    ///
-    /// `config_path` should be the full name of the SpacetimeDB configuration file.
-    fn for_config(config_path: &Path) -> anyhow::Result<Self> {
-        // Ensure the directory exists before attempting to create the lockfile.
-        create_parent_dir(config_path)?;
-
-        let mut path = config_path.to_path_buf();
-        path.set_extension("lock");
-        // Open with `create_new`, which fails if the file already exists.
-        std::fs::File::create_new(&path).with_context(|| {
-            format!("Unable to acquire lock on config file {config_path:?}: failed to create lockfile {path:?}")
-        })?;
-
-        Ok(Lockfile { path })
-    }
-}
-
-impl Drop for Lockfile {
-    fn drop(&mut self) {
-        std::fs::remove_file(&self.path)
-            .with_context(|| format!("Unable to remove lockfile {:?}", self.path))
-            .unwrap();
-    }
 }
 
 pub struct Config {
@@ -908,7 +850,7 @@ impl Config {
 
     pub fn load() -> Self {
         let home_path = Self::system_config_path();
-        let home_lock = Lockfile::for_config(&home_path).unwrap();
+        let home_lock = Lockfile::for_file(&home_path).unwrap();
         let home = if home_path.exists() {
             Self::load_from_file(&home_path)
                 .inspect_err(|e| eprintln!("config file {home_path:?} is invalid: {e:#?}"))

--- a/crates/fs-utils/Cargo.toml
+++ b/crates/fs-utils/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "spacetimedb-fs-utils"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license-file = "LICENSE"
+description = "Assorted utilities for filesystem operations used in SpacetimeDB"
+
+[dependencies]
+thiserror.workspace = true

--- a/crates/fs-utils/src/lib.rs
+++ b/crates/fs-utils/src/lib.rs
@@ -1,0 +1,23 @@
+use std::path::Path;
+
+pub mod lockfile;
+
+pub fn create_parent_dir(file: &Path) -> Result<(), std::io::Error> {
+    // If the path doesn't have a parent,
+    // i.e. is a single-component path with just a root or is empty,
+    // do nothing.
+    let Some(parent) = file.parent() else {
+        return Ok(());
+    };
+
+    // If the `file` path is a relative path with no directory component,
+    // `parent` will be the empty path.
+    // In this case, do not attempt to create a directory.
+    if parent != Path::new("") {
+        // If the `file` path has a directory component,
+        // do `create_dir_all` to ensure it exists.
+        // If `parent` already exists as a directory, this is a no-op.
+        std::fs::create_dir_all(parent)?;
+    }
+    Ok(())
+}

--- a/crates/fs-utils/src/lib.rs
+++ b/crates/fs-utils/src/lib.rs
@@ -19,5 +19,14 @@ pub fn create_parent_dir(file: &Path) -> Result<(), std::io::Error> {
         // If `parent` already exists as a directory, this is a no-op.
         std::fs::create_dir_all(parent)?;
     }
-    Ok(())
+    // If the `file` path is a relative path with no directory component,
+    // `parent` will be the empty path.
+    // In this case, do not attempt to create a directory.
+    if parent == Path::new("") {
+        return Ok(());
+    }
+    // If the `file` path has a directory component,
+    // do `create_dir_all` to ensure it exists.
+    // If `parent` already exists as a directory, this is a no-op.
+    std::fs::create_dir_all(parent)
 }

--- a/crates/fs-utils/src/lockfile.rs
+++ b/crates/fs-utils/src/lockfile.rs
@@ -1,0 +1,91 @@
+use crate::create_parent_dir;
+use std::path::{Path, PathBuf};
+
+#[derive(thiserror::Error, Debug)]
+pub enum LockfileError {
+    #[error("Failed to acquire lock on {file_path:?}: failed to create lockfile {lock_path:?}: {cause}")]
+    Acquire {
+        file_path: PathBuf,
+        lock_path: PathBuf,
+        #[source]
+        cause: std::io::Error,
+    },
+    #[error("Failed to release lock: failed to delete lockfile {lock_path:?}: {cause}")]
+    Release {
+        lock_path: PathBuf,
+        #[source]
+        cause: std::io::Error,
+    },
+}
+
+#[derive(Debug)]
+/// A file used as an exclusive lock on access to another file.
+///
+/// Constructing a `Lockfile` creates the `path` with [`std::fs::File::create_new`],
+/// a.k.a. `O_EXCL`, erroring if the file already exists.
+///
+/// Dropping a `Lockfile` deletes the `path`, releasing the lock.
+///
+/// Used to guarantee exclusive access to the system config file,
+/// in order to prevent racy concurrent modifications.
+pub struct Lockfile {
+    path: PathBuf,
+}
+
+impl Lockfile {
+    /// Acquire an exclusive lock on the file `file_path`.
+    ///
+    /// `file_path` should be the full path of the file to which to acquire exclusive access.
+    pub fn for_file(file_path: &Path) -> Result<Self, LockfileError> {
+        let path = Self::lock_path(file_path);
+
+        // Ensure the directory exists before attempting to create the lockfile.
+        create_parent_dir(file_path).map_err(|cause| LockfileError::Acquire {
+            lock_path: path.clone(),
+            file_path: file_path.to_path_buf(),
+            cause,
+        })?;
+
+        // Open with `create_new`, which fails if the file already exists.
+        std::fs::File::create_new(&path).map_err(|cause| LockfileError::Acquire {
+            lock_path: path.clone(),
+            file_path: file_path.to_path_buf(),
+            cause,
+        })?;
+
+        Ok(Lockfile { path })
+    }
+
+    /// Returns the path of a lockfile for the file `file_path`,
+    /// without actually acquiring the lock.
+    pub fn lock_path(file_path: &Path) -> PathBuf {
+        let mut path = file_path.to_path_buf();
+        path.set_extension("lock");
+        path
+    }
+
+    fn release_internal(path: &Path) -> Result<(), LockfileError> {
+        std::fs::remove_file(path).map_err(|cause| LockfileError::Release {
+            lock_path: path.to_path_buf(),
+            cause,
+        })
+    }
+
+    /// Release the lock, with the opportunity to handle the error from failing to delete the lockfile.
+    ///
+    /// Dropping a [`Lockfile`] will release the lock, but will panic on failure rather than returning `Err`.
+    pub fn release(self) -> Result<(), LockfileError> {
+        // Don't run the destructor, which does the same thing, but panics on failure.
+        let mut this = std::mem::ManuallyDrop::new(self);
+        let path = std::mem::take(&mut this.path);
+        let res = Self::release_internal(&path);
+        drop(path);
+        res
+    }
+}
+
+impl Drop for Lockfile {
+    fn drop(&mut self) {
+        Self::release_internal(&self.path).unwrap();
+    }
+}

--- a/crates/fs-utils/src/lockfile.rs
+++ b/crates/fs-utils/src/lockfile.rs
@@ -39,19 +39,17 @@ impl Lockfile {
     pub fn for_file(file_path: &Path) -> Result<Self, LockfileError> {
         let path = Self::lock_path(file_path);
 
-        // Ensure the directory exists before attempting to create the lockfile.
-        create_parent_dir(file_path).map_err(|cause| LockfileError::Acquire {
+        let fail = |cause| LockfileError::Acquire {
             lock_path: path.clone(),
             file_path: file_path.to_path_buf(),
             cause,
-        })?;
+        };
+
+        // Ensure the directory exists before attempting to create the lockfile.
+        create_parent_dir(file_path).map_err(fail)?;
 
         // Open with `create_new`, which fails if the file already exists.
-        std::fs::File::create_new(&path).map_err(|cause| LockfileError::Acquire {
-            lock_path: path.clone(),
-            file_path: file_path.to_path_buf(),
-            cause,
-        })?;
+        std::fs::File::create_new(&path).map_err(fail)?;
 
         Ok(Lockfile { path })
     }


### PR DESCRIPTION

# Description of Changes

The snapshot crate will need to create lockfiles. Rather than duplicating code to do so, we choose to move our definition of `Lockfile` into a crate that can be depended on by both `cli` and `snapshot`. No existing crate seems like an obvious choice for this -- a `Lockfile` is not really a data structure, so `data-structures` seems wrong -- so we add a new crate, `fs-utils`. Currently this contains only `Lockfile` and `create_parent_dir`, but a follow-up PR will add `DirTrie`, a Git-like on-disk object store.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [ ] CI is gonna run smoketests.
