### PR TITLE
Define `DirTrie`, a git-like on-disk object store

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4463,6 +4463,7 @@ dependencies = [
 name = "spacetimedb-fs-utils"
 version = "0.9.3"
 dependencies = [
+ "hex",
  "thiserror",
 ]
 

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4464,6 +4464,7 @@ name = "spacetimedb-fs-utils"
 version = "0.9.3"
 dependencies = [
  "hex",
+ "tempdir",
  "thiserror",
 ]
 

--- a/crates/fs-utils/Cargo.toml
+++ b/crates/fs-utils/Cargo.toml
@@ -8,3 +8,4 @@ description = "Assorted utilities for filesystem operations used in SpacetimeDB"
 
 [dependencies]
 thiserror.workspace = true
+hex.workspace = true

--- a/crates/fs-utils/Cargo.toml
+++ b/crates/fs-utils/Cargo.toml
@@ -9,3 +9,6 @@ description = "Assorted utilities for filesystem operations used in SpacetimeDB"
 [dependencies]
 thiserror.workspace = true
 hex.workspace = true
+
+[dev-dependencies]
+tempdir.workspace = true

--- a/crates/fs-utils/src/dir_trie.rs
+++ b/crates/fs-utils/src/dir_trie.rs
@@ -1,0 +1,210 @@
+//! Shallow byte-partitied directory tries.
+//!
+//! This is an implementation of the same on-disk data structure as
+//! [the git object store](https://git-scm.com/book/en/v2/Git-Internals-Git-Objects),
+//! used for storing objects in an object store keyed on a content-addressed 32-byte hash.
+//!
+//! Objects' location in the trie is computed based on the (64 character) hexadecimal encoding of their (32 byte) Blake3 hash.
+//! The leading 2 digits of this hash are the name of the directory,
+//! and the remaining 62 digits are the name of the file itself.
+//!
+//! Storing files in this way is beneficial because directories internally are unsorted arrays of file entries,
+//! so searching for a file within a directory is O(directory_size).
+//! The trie structure implemented here is still O(n), but with a drastically reduced constant factor (1/128th),
+//! which we expect to shrink the linear lookups to an acceptable size.
+
+use std::{
+    fs::{create_dir_all, File, OpenOptions, ReadDir},
+    io::{self, Write},
+    path::{Path, PathBuf},
+};
+
+/// [`OpenOptions`] corresponding to opening a file with `O_EXCL`,
+/// i.e. creating a new writeable file, failing if it already exists.
+pub fn o_excl() -> OpenOptions {
+    let mut options = OpenOptions::new();
+    options.create_new(true).write(true);
+    options
+}
+
+/// [`OpenOptions`] corresponding to opening a file with `O_RDONLY`,
+/// i.e. opening an existing file for reading.
+pub fn o_rdonly() -> OpenOptions {
+    let mut options = OpenOptions::new();
+    options.read(true);
+    options
+}
+
+/// Counter for objects written newly to disk versus hardlinked,
+/// for diagnostic purposes with operations that may hardlink or write.
+///
+/// See [`DirTrie::hardlink_or_write`].
+#[derive(Default, Debug)]
+pub struct CountCreated {
+    pub objects_written: u64,
+    pub objects_hardlinked: u64,
+}
+
+/// A directory trie.
+pub struct DirTrie {
+    /// The directory name at which the dir trie is stored.
+    root: PathBuf,
+}
+
+const FILE_ID_BYTES: usize = 32;
+const FILE_ID_HEX_CHARS: usize = FILE_ID_BYTES * 2;
+
+type FileId = [u8; FILE_ID_BYTES];
+
+/// The number of leading hex chars taken from a `FileId` as the subdirectory name.
+const DIR_HEX_CHARS: usize = 2;
+
+impl DirTrie {
+    pub fn open(root: PathBuf) -> Result<Self, io::Error> {
+        create_dir_all(&root)?;
+        Ok(Self { root })
+    }
+
+    fn file_path(&self, file_id: &FileId) -> PathBuf {
+        // TODO(perf, bikeshedding): avoid allocating a `String`.
+        let file_id_hex = hex::encode(file_id);
+
+        let mut file_path = self.root.clone();
+        // Two additional chars for slashes.
+        file_path.reserve(FILE_ID_HEX_CHARS + 2);
+
+        file_path.push(&file_id_hex[..DIR_HEX_CHARS]);
+        file_path.push(&file_id_hex[DIR_HEX_CHARS..]);
+
+        file_path
+    }
+
+    /// Hardlink the entry for `file_id` from `src_repo` into `self`.
+    ///
+    /// Hardlinking makes the object shared between both [`DirTrie`]s
+    /// without copying the data on-disk.
+    /// Note that this is only possible within a single file system;
+    /// this method will likely return an error if `self` and `src_repo`
+    /// are in different file systems.
+    /// See [Wikipedia](https://en.wikipedia.org/wiki/Hard_link) for more information on hard links.
+    ///
+    /// Returns `Ok(true)` if the `file_id` existed in `src_repo` and was successfully linked into `self`,
+    /// `Ok(false)` if the `file_id` did not exist in `src_repo`,
+    /// or an `Err` if a filesystem operation failed.
+    ///
+    /// The object's hash is not verified against its `file_id`,
+    /// so if `file_id` is corrupted within `src_repo`,
+    /// the corrupted object will be hardlinked into `self`.
+    pub fn try_hardlink_from(&self, src_repo: &DirTrie, file_id: &FileId) -> Result<bool, io::Error> {
+        let src_file = src_repo.file_path(file_id);
+        if src_file.is_file() {
+            let dst_file = self.file_path(file_id);
+            Self::create_parent(&dst_file)?;
+            std::fs::hard_link(src_file, dst_file)?;
+            Ok(true)
+        } else {
+            Ok(false)
+        }
+    }
+
+    fn create_parent(file: &Path) -> Result<(), io::Error> {
+        // Known to succeed because `self.file_path` creates a path with a parent.
+        let dir = file.parent().unwrap();
+
+        create_dir_all(dir)?;
+        Ok(())
+    }
+
+    /// Hardlink `file_id` from `src_repo` into `self`, or create it in `self` containing `contents`.
+    ///
+    /// `contents` is a thunk which will be called only if the `src_repo` does not contain `file_id`
+    /// in order to compute the file contents.
+    /// This allows callers to avoid expensive serialization if the object already exists in `src_repo`.
+    ///
+    /// If the source file exists but the hardlink operation fails, this method returns an error.
+    /// In this case, the destination file is not created.
+    /// See [`Self::try_hardlink_from`].
+    pub fn hardlink_or_write<Bytes: AsRef<[u8]>>(
+        &self,
+        src_repo: Option<&DirTrie>,
+        file_id: &FileId,
+        contents: impl FnOnce() -> Bytes,
+        counter: &mut CountCreated,
+    ) -> Result<(), io::Error> {
+        if self.contains_entry(file_id) {
+            return Ok(());
+        }
+
+        if let Some(src_repo) = src_repo {
+            if self.try_hardlink_from(src_repo, file_id)? {
+                counter.objects_hardlinked += 1;
+                return Ok(());
+            }
+        }
+
+        let mut file = self.open_entry(file_id, &o_excl())?;
+        let contents = contents();
+        file.write_all(contents.as_ref())?;
+        counter.objects_written += 1;
+        Ok(())
+    }
+
+    #[allow(unused)]
+    pub fn contains_entry(&self, file_id: &FileId) -> bool {
+        let path = self.file_path(file_id);
+
+        path.is_file()
+    }
+
+    pub fn open_entry(&self, file_id: &FileId, options: &OpenOptions) -> Result<File, io::Error> {
+        let path = self.file_path(file_id);
+        Self::create_parent(&path)?;
+        options.open(path)
+    }
+
+    #[allow(unused)]
+    pub fn iter_entries(&self) -> Result<impl Iterator<Item = Result<PathBuf, io::Error>>, io::Error> {
+        let subdirs = self.root.read_dir()?;
+        Ok(Iter {
+            subdirs,
+            current_dir: None,
+        })
+    }
+}
+
+pub struct Iter {
+    subdirs: ReadDir,
+
+    current_dir: Option<ReadDir>,
+}
+
+impl Iterator for Iter {
+    type Item = Result<PathBuf, io::Error>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        loop {
+            if let Some(current_dir) = self.current_dir.as_mut() {
+                match current_dir.next() {
+                    None => {
+                        self.current_dir = None;
+                    }
+                    Some(Err(e)) => return Some(Err(e)),
+                    Some(Ok(dirent)) => return Some(Ok(dirent.path())),
+                }
+            } else {
+                match self.subdirs.next() {
+                    None => {
+                        return None;
+                    }
+                    Some(Err(e)) => {
+                        return Some(Err(e));
+                    }
+                    Some(Ok(new_dir)) => match new_dir.path().read_dir() {
+                        Err(e) => return Some(Err(e)),
+                        Ok(new_dir) => self.current_dir = Some(new_dir),
+                    },
+                }
+            }
+        }
+    }
+}

--- a/crates/fs-utils/src/lib.rs
+++ b/crates/fs-utils/src/lib.rs
@@ -1,5 +1,6 @@
 use std::path::Path;
 
+pub mod dir_trie;
 pub mod lockfile;
 
 pub fn create_parent_dir(file: &Path) -> Result<(), std::io::Error> {


### PR DESCRIPTION
# Description of Changes

It's the git object store, but defined in our code, for 32-byte hashes! This will be used by snapshotting; each snapshot contains a `DirTrie` of its pages and large blobs.

# API and ABI breaking changes

N/a.

# Expected complexity level and risk

2 - new code, touches the FS. Not integrated anywhere yet, so it can't break anything, but future uses should be able to rely on the merged version being correct.

# Testing

- [x] Used this code in [the snapshotting draft](https://github.com/clockworklabs/SpacetimeDB/pull/1279) to create and restore snapshots.
- [x] Wrote a few simple unit tests for sanity.