### PR TITLE
Add the `snapshot` crate, which implements snapshotting at a low level

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4577,6 +4577,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "spacetimedb-snapshot"
+version = "0.9.3"
+dependencies = [
+ "anyhow",
+ "blake3",
+ "hex",
+ "log",
+ "spacetimedb-durability",
+ "spacetimedb-fs-utils",
+ "spacetimedb-lib",
+ "spacetimedb-primitives",
+ "spacetimedb-sats",
+ "spacetimedb-table",
+]
+
+[[package]]
 name = "spacetimedb-standalone"
 version = "0.9.3"
 dependencies = [

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4580,7 +4580,6 @@ dependencies = [
 name = "spacetimedb-snapshot"
 version = "0.9.3"
 dependencies = [
- "anyhow",
  "blake3",
  "hex",
  "log",
@@ -4590,6 +4589,7 @@ dependencies = [
  "spacetimedb-primitives",
  "spacetimedb-sats",
  "spacetimedb-table",
+ "thiserror",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -17,6 +17,7 @@ members = [
   "crates/primitives",
   "crates/sats",
   "crates/sdk",
+  "crates/snapshot",
   "crates/sqltest",
   "crates/standalone",
   "crates/table",
@@ -100,6 +101,7 @@ spacetimedb-standalone = { path = "crates/standalone", version = "0.9.3" }
 spacetimedb-table = { path = "crates/table", version = "0.9.3" }
 spacetimedb-vm = { path = "crates/vm", version = "0.9.3" }
 spacetimedb-fs-utils = { path = "crates/fs-utils", version = "0.9.3" }
+spacetimedb-snapshot = { path = "crates/snapshot", version = "0.9.3" }
 
 ahash = "0.8"
 anyhow = "1.0.68"

--- a/crates/fs-utils/src/dir_trie.rs
+++ b/crates/fs-utils/src/dir_trie.rs
@@ -15,7 +15,7 @@
 
 use std::{
     fs::{create_dir_all, File, OpenOptions},
-    io::{self, Write},
+    io::{self, Read, Write},
     path::{Path, PathBuf},
 };
 
@@ -175,6 +175,15 @@ impl DirTrie {
         let path = self.file_path(file_id);
         Self::create_parent(&path)?;
         options.open(path)
+    }
+
+    /// Open the entry keyed with `file_id` and read it into a `Vec<u8>`.
+    pub fn read_entry(&self, file_id: &FileId) -> Result<Vec<u8>, io::Error> {
+        let mut file = self.open_entry(file_id, &o_rdonly())?;
+        let mut buf = Vec::with_capacity(file.metadata()?.len() as usize);
+        // TODO(perf): Async IO?
+        file.read_to_end(&mut buf)?;
+        Ok(buf)
     }
 }
 

--- a/crates/fs-utils/src/dir_trie.rs
+++ b/crates/fs-utils/src/dir_trie.rs
@@ -60,6 +60,11 @@ type FileId = [u8; FILE_ID_BYTES];
 const DIR_HEX_CHARS: usize = 2;
 
 impl DirTrie {
+    /// Returns the root of this `DirTrie` on disk.
+    pub fn root(&self) -> &Path {
+        &self.root
+    }
+
     /// Open the directory trie at `root`,
     /// creating the root directory if it doesn't exist.
     ///

--- a/crates/snapshot/Cargo.toml
+++ b/crates/snapshot/Cargo.toml
@@ -14,7 +14,7 @@ spacetimedb-sats = { workspace = true, features = ["blake3"] }
 spacetimedb-primitives.workspace = true
 spacetimedb-fs-utils.workspace = true
 
-anyhow.workspace = true
 blake3.workspace = true
 hex.workspace = true
 log.workspace = true
+thiserror.workspace = true

--- a/crates/snapshot/Cargo.toml
+++ b/crates/snapshot/Cargo.toml
@@ -1,0 +1,20 @@
+[package]
+name = "spacetimedb-snapshot"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license-file = "LICENSE"
+description = "Low-level interfaces for capturing and restoring snapshots of database states"
+
+[dependencies]
+spacetimedb-table.workspace = true
+spacetimedb-durability.workspace = true
+spacetimedb-lib.workspace = true
+spacetimedb-sats = { workspace = true, features = ["blake3"] }
+spacetimedb-primitives.workspace = true
+spacetimedb-fs-utils.workspace = true
+
+anyhow.workspace = true
+blake3.workspace = true
+hex.workspace = true
+log.workspace = true

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -1,0 +1,531 @@
+use spacetimedb_durability::TxOffset;
+use spacetimedb_fs_utils::{
+    dir_trie::{o_excl, o_rdonly, CountCreated, DirTrie},
+    lockfile::Lockfile,
+};
+use spacetimedb_lib::{bsatn, de::Deserialize, ser::Serialize, Address};
+use spacetimedb_primitives::TableId;
+use spacetimedb_table::{
+    blob_store::{BlobHash, BlobStore, HashMapBlobStore},
+    page::Page,
+    table::Table,
+};
+use std::{
+    collections::BTreeMap,
+    ffi::OsStr,
+    io::{Read, Write},
+    path::{Path, PathBuf},
+};
+
+/// Magic number for snapshot files: a point in spacetime.
+///
+/// Chosen because the commitlog magic number is a spacetime interval,
+/// so a snapshot should be a point to which an interval can be applied.
+pub const MAGIC: [u8; 4] = *b"txyz";
+
+/// Snapshot format version number.
+pub const CURRENT_SNAPSHOT_VERSION: u8 = 0;
+
+/// ABI version of the module from which this snapshot was created, as [MAJOR, MINOR].
+pub const CURRENT_MODULE_ABI_VERSION: [u16; 2] = [7, 0];
+
+/// File extension of snapshot directories.
+pub const SNAPSHOT_DIR_EXT: &str = "snapshot_dir";
+
+/// File extension of snapshot files, which contain BSATN-encoded [`Snapshot`]s preceeded by [`blake3::Hash`]es.
+pub const SNAPSHOT_FILE_EXT: &str = "snapshot_bsatn";
+
+#[derive(Serialize, Deserialize)]
+/// The hash and refcount of a single blob in the blob store.
+struct BlobEntry {
+    hash: BlobHash,
+    uses: u32,
+}
+
+#[derive(Serialize, Deserialize)]
+/// A snapshot of a single table, containing the hashes of all its resident pages.
+struct TableEntry {
+    table_id: TableId,
+    pages: Vec<blake3::Hash>,
+}
+
+#[derive(Serialize, Deserialize)]
+pub struct Snapshot {
+    /// A magic number: must be equal to [`MAGIC`].
+    magic: [u8; 4],
+
+    /// The snapshot version number. Must be equal to [`CURRENT_SNAPSHOT_VERSION`].
+    version: u8,
+
+    /// The address of the snapshotted database.
+    database_address: Address,
+    /// The instance ID of the snapshotted database.
+    database_instance_id: u64,
+
+    /// ABI version of the module from which this snapshot was created, as [MAJOR, MINOR].
+    ///
+    /// As of this proposal, [7, 0].
+    module_abi_version: [u16; 2],
+
+    /// The transaction offset of the state this snapshot reflects.
+    tx_offset: TxOffset,
+
+    /// The hashes and reference counts of all objects in the blob store.
+    blobs: Vec<BlobEntry>,
+
+    /// For each table, its table ID followed by the hashes of all resident pages.
+    ///
+    /// It's necessary to store the table ID rather than relying on order
+    /// because table IDs may be sparse (and will be, once we reserve a bunch of system table ids).
+    tables: Vec<TableEntry>,
+}
+
+impl Snapshot {
+    /// Insert a single large blob from a [`BlobStore`]
+    /// into the in-memory snapshot `self`
+    /// and the on-disk object repository `object_repo`.
+    fn write_blob(
+        &mut self,
+        object_repo: &DirTrie,
+        hash: &BlobHash,
+        uses: usize,
+        blob: &[u8],
+        prev_snapshot: Option<&DirTrie>,
+        counter: &mut CountCreated,
+    ) -> anyhow::Result<()> {
+        object_repo.hardlink_or_write(prev_snapshot, &hash.data, || blob, counter)?;
+        self.blobs.push(BlobEntry {
+            hash: *hash,
+            uses: uses as u32,
+        });
+        Ok(())
+    }
+
+    /// Populate the in-memory snapshot `self`,
+    /// and the on-disk object repository `object_repo`,
+    /// with all large blos from `blobs`.
+    fn write_all_blobs(
+        &mut self,
+        object_repo: &DirTrie,
+        blobs: &dyn BlobStore,
+        prev_snapshot: Option<&DirTrie>,
+        counter: &mut CountCreated,
+    ) -> anyhow::Result<()> {
+        for (hash, uses, blob) in blobs.iter_blobs() {
+            self.write_blob(object_repo, hash, uses, blob, prev_snapshot, counter)?;
+        }
+        Ok(())
+    }
+
+    /// Insert a single large blob from a [`BlobStore`]
+    /// into the on-disk object repository `object_repo`.
+    ///
+    /// Returns the hash of the `page` so that it may be inserted into an in-memory [`Snapshot`] object
+    /// by [`Snapshot::write_table`].
+    fn write_page(
+        object_repo: &DirTrie,
+        page: &mut Page,
+        prev_snapshot: Option<&DirTrie>,
+        counter: &mut CountCreated,
+    ) -> anyhow::Result<blake3::Hash> {
+        let hash = page
+            .unmodified_hash()
+            .cloned()
+            .unwrap_or_else(|| page.save_content_hash());
+
+        object_repo.hardlink_or_write(prev_snapshot, hash.as_bytes(), || bsatn::to_vec(page).unwrap(), counter)?;
+
+        Ok(hash)
+    }
+
+    /// Populate the in-memory snapshot `self`,
+    /// and the on-disk object repository `object_repo`,
+    /// with all pages from `table`.
+    fn write_table(
+        &mut self,
+        object_repo: &DirTrie,
+        table: &mut Table,
+        prev_snapshot: Option<&DirTrie>,
+        counter: &mut CountCreated,
+    ) -> anyhow::Result<()> {
+        let pages = table
+            .pages_mut()
+            .iter_mut()
+            .map(|page| Self::write_page(object_repo, page, prev_snapshot, counter))
+            .collect::<anyhow::Result<Vec<blake3::Hash>>>()?;
+
+        self.tables.push(TableEntry {
+            table_id: table.schema.table_id,
+            pages,
+        });
+        Ok(())
+    }
+
+    /// Populate the in-memory snapshot `self`,
+    /// and the on-disk object repository `object_repo`,
+    /// with all pages from all tables in `tables`.
+    fn write_all_tables<'db>(
+        &mut self,
+        object_repo: &DirTrie,
+        tables: impl Iterator<Item = &'db mut Table>,
+        prev_snapshot: Option<&DirTrie>,
+        counter: &mut CountCreated,
+    ) -> anyhow::Result<()> {
+        for table in tables {
+            self.write_table(object_repo, table, prev_snapshot, counter)?;
+        }
+        Ok(())
+    }
+
+    /// Read a [`Snapshot`] from the file at `path`, verify its hash, and return it.
+    ///
+    /// Fails if:
+    /// - `path` does not refer to a readable file.
+    /// - The file at `path` is corrupted,
+    ///   as detected by comparing the hash of its bytes to a hash recorded in the file.
+    fn read_from_file(path: &Path) -> anyhow::Result<Self> {
+        let mut snapshot_file = o_rdonly().open(path)?;
+
+        let mut hash = [0; blake3::OUT_LEN];
+        snapshot_file.read_exact(&mut hash)?;
+        let hash = blake3::Hash::from_bytes(hash);
+        let mut snapshot_bsatn = vec![];
+        snapshot_file.read_to_end(&mut snapshot_bsatn)?;
+        let computed_hash = blake3::hash(&snapshot_bsatn);
+
+        if hash != computed_hash {
+            anyhow::bail!("Computed hash of snapshot file {path:?} does not match recorded hash: computed {computed_hash:?} but expected {hash:?}");
+        }
+
+        Ok(bsatn::from_slice::<Snapshot>(&snapshot_bsatn)?)
+    }
+
+    /// Construct a [`HashMapBlobStore`] containing all the blobs referenced in `self`,
+    /// reading their data from files in the `object_repo`.
+    ///
+    /// Fails if any of the object files is missing or corrupted,
+    /// as detected by comparing the hash of its bytes to the hash recorded in `self`.
+    fn reconstruct_blob_store(&self, object_repo: &DirTrie) -> anyhow::Result<HashMapBlobStore> {
+        let mut blob_store = HashMapBlobStore::default();
+
+        for BlobEntry { hash, uses } in &self.blobs {
+            let mut file = object_repo.open_entry(&hash.data, &o_rdonly())?;
+            let mut buf = Vec::with_capacity(file.metadata()?.len() as usize);
+            // TODO(perf): Async IO?
+            file.read_to_end(&mut buf)?;
+            let computed_hash = BlobHash::hash_from_bytes(&buf);
+            if *hash != computed_hash {
+                anyhow::bail!("Computed hash of large blob does not match recorded hash: computed {computed_hash:?} but expected {hash:?}");
+            }
+
+            blob_store.insert_with_uses(hash, *uses as usize, buf.into_boxed_slice());
+        }
+
+        Ok(blob_store)
+    }
+
+    /// Read all the pages referenced by `pages` from the `object_repo`.
+    ///
+    /// Fails if any of the pages files is missing or corrupted,
+    /// as detected by comparing the hash of its bytes to the hash listed in `pages`.
+    fn reconstruct_one_table_pages(object_repo: &DirTrie, pages: &[blake3::Hash]) -> anyhow::Result<Vec<Box<Page>>> {
+        pages.iter().map(|hash| {
+            let mut file = object_repo.open_entry(hash.as_bytes(), &o_rdonly())?;
+            // TODO: avoid allocating a `Vec` here.
+            let mut buf = Vec::with_capacity(file.metadata()?.len() as usize);
+            // TODO(perf): Async IO?
+            file.read_to_end(&mut buf)?;
+            let page = bsatn::from_slice::<Box<Page>>(&buf)?;
+
+            let computed_hash = page.content_hash();
+
+            if *hash != computed_hash {
+                anyhow::bail!("Computed hash of page does not match recorded hash: computed {computed_hash:?} but expected {hash:?}");
+            }
+
+            Ok::<Box<Page>, anyhow::Error>(page)
+        }).collect()
+    }
+
+    fn reconstruct_one_table(
+        object_repo: &DirTrie,
+        TableEntry { table_id, pages }: &TableEntry,
+    ) -> anyhow::Result<(TableId, Vec<Box<Page>>)> {
+        Ok((*table_id, Self::reconstruct_one_table_pages(object_repo, pages)?))
+    }
+
+    /// Reconstruct all the table data from `self`,
+    /// reading pages from files in the `object_repo`.
+    ///
+    /// This method cannot construct [`Table`] objects
+    /// because doing so requires knowledge of the system tables' schemas
+    /// to compute the schemas of the user-defined tables.o
+    ///
+    /// Fails if any object file referenced in `self` (as a page or large blob)
+    /// is missing or corrupted,
+    /// as detected by comparing the hash of its bytes to the hash recorded in `self`.
+    fn reconstruct_tables(&self, object_repo: &DirTrie) -> anyhow::Result<BTreeMap<TableId, Vec<Box<Page>>>> {
+        self.tables
+            .iter()
+            .map(|tbl| Self::reconstruct_one_table(object_repo, tbl))
+            .collect()
+    }
+}
+
+/// A repository of snapshots of a particular database instance.
+pub struct SnapshotRepository {
+    /// The directory which contains all the snapshots.
+    root: PathBuf,
+
+    /// The database address of the database instance for which this repository stores snapshots.
+    database_address: Address,
+
+    /// The database instance ID of the database instance for which this repository stores snapshots.
+    database_instance_id: u64,
+    // TODO(deduplication): track the most recent successful snapshot
+    // (possibly in a file)
+    // and hardlink its objects into the next snapshot for deduplication.
+}
+
+impl SnapshotRepository {
+    /// Read the [`Address`] of the database this [`SnapshotRepository`] is configured to snapshot.
+    pub fn database_address(&self) -> Address {
+        self.database_address
+    }
+
+    /// Capture a snapshot of the state of the database at `tx_offset`,
+    /// where `tables` is the committed state of all the tables in the database,
+    /// and `blobs` is the committed state's blob store.
+    ///
+    /// Returns the path of the newly-created snapshot directory.
+    pub fn create_snapshot<'db>(
+        &self,
+        tables: impl Iterator<Item = &'db mut Table>,
+        blobs: &'db dyn BlobStore,
+        tx_offset: TxOffset,
+    ) -> anyhow::Result<PathBuf> {
+        let prev_snapshot = self
+            .latest_snapshot()?
+            .map(|tx_offset| self.snapshot_dir_path(tx_offset));
+        let prev_snapshot = if let Some(prev_snapshot) = prev_snapshot {
+            assert!(
+                prev_snapshot.is_dir(),
+                "prev_snapshot {prev_snapshot:?} is not a directory"
+            );
+            let object_repo = Self::object_repo(&prev_snapshot)?;
+            Some(object_repo)
+        } else {
+            None
+        };
+
+        let mut counter = CountCreated::default();
+
+        let snapshot_dir = self.snapshot_dir_path(tx_offset);
+
+        // Before performing any observable operations,
+        // acquire a lockfile on the snapshot you want to create.
+        let _lock = Lockfile::for_file(&snapshot_dir)?;
+
+        // Create the snapshot directory.
+        std::fs::create_dir_all(&snapshot_dir)?;
+
+        // Create a new `DirTrie` to hold all the content-addressed objects in the snapshot.
+        let object_repo = Self::object_repo(&snapshot_dir)?;
+
+        // Build the in-memory `Snapshot` object.
+        let mut snapshot = self.empty_snapshot(tx_offset);
+
+        // Populate both the in-memory `Snapshot` object and the on-disk object repository
+        // with all the blobs and pages.
+        snapshot.write_all_blobs(&object_repo, blobs, prev_snapshot.as_ref(), &mut counter)?;
+        snapshot.write_all_tables(&object_repo, tables, prev_snapshot.as_ref(), &mut counter)?;
+
+        // Serialize and hash the in-memory `Snapshot` object.
+        let snapshot_bsatn = bsatn::to_vec(&snapshot)?;
+        let hash = blake3::hash(&snapshot_bsatn);
+
+        // Create the snapshot file, containing first the hash, then the `Snapshot`.
+        {
+            let mut snapshot_file = o_excl().open(Self::snapshot_file_path(tx_offset, &snapshot_dir))?;
+            snapshot_file.write_all(hash.as_bytes())?;
+            snapshot_file.write_all(&snapshot_bsatn)?;
+        }
+
+        log::info!(
+            "[{}] SNAPSHOT {:0>20}: Hardlinked {} objects and wrote {} objects",
+            self.database_address,
+            tx_offset,
+            counter.objects_hardlinked,
+            counter.objects_written,
+        );
+
+        // Success! return the directory of the newly-created snapshot.
+        // The lockfile will be dropped here.
+        Ok(snapshot_dir)
+    }
+
+    fn empty_snapshot(&self, tx_offset: TxOffset) -> Snapshot {
+        Snapshot {
+            magic: MAGIC,
+            version: CURRENT_SNAPSHOT_VERSION,
+            database_address: self.database_address,
+            database_instance_id: self.database_instance_id,
+            module_abi_version: CURRENT_MODULE_ABI_VERSION,
+            tx_offset,
+            blobs: vec![],
+            tables: vec![],
+        }
+    }
+
+    fn snapshot_dir_path(&self, tx_offset: TxOffset) -> PathBuf {
+        let dir_name = format!("{tx_offset:0>20}.{SNAPSHOT_DIR_EXT}");
+        self.root.join(dir_name)
+    }
+
+    fn snapshot_file_path(tx_offset: TxOffset, snapshot_dir: &Path) -> PathBuf {
+        let file_name = format!("{tx_offset:0>20}.{SNAPSHOT_FILE_EXT}");
+        snapshot_dir.join(file_name)
+    }
+
+    fn object_repo(snapshot_dir: &Path) -> Result<DirTrie, std::io::Error> {
+        DirTrie::open(snapshot_dir.join("objects"))
+    }
+
+    /// Read a snapshot contained in self referring to `tx_offset`,
+    /// verify its hashes,
+    /// and parse it into an in-memory structure [`ReconstructedSnapshot`]
+    /// which can be used to build a `CommittedState`.
+    ///
+    /// This method cannot construct [`Table`] objects
+    /// because doing so requires knowledge of the system tables' schemas
+    /// to compute the schemas of the user-defined tables.
+    ///
+    /// Fails if:
+    /// - No snapshot exists in `self` for `tx_offset`.
+    /// - The snapshot is incomplete, as detected by its lockfile still existing.
+    /// - Any object file (page or large blob) referenced by the snapshot file
+    ///   is missing or corrupted,
+    ///   as detected by comparing the hash of its bytes to the hash recorded in the snapshot file.
+    /// - The snapshot file's magic number does not match [`MAGIC`].
+    /// - The snapshot file's version does not match [`CURRENT_SNAPSHOT_VERSION`].
+    ///
+    /// The following conditions are not detected or considered as errors:
+    /// - The snapshot file's database address or instance ID do not match those in `self`.
+    /// - The snapshot file's module ABI version does not match [`CURRENT_MODULE_ABI_VERSION`].
+    /// - The snapshot file's recorded transaction offset does not match `tx_offset`.
+    ///
+    /// This means that callers must inspect the returned [`ReconstructedSnapshot`]
+    /// and verify that they can handle its contained database address, instance ID, module ABI version and transaction offset.
+    pub fn read_snapshot(&self, tx_offset: TxOffset) -> anyhow::Result<ReconstructedSnapshot> {
+        let snapshot_dir = self.snapshot_dir_path(tx_offset);
+        let lockfile = Lockfile::lock_path(&snapshot_dir);
+        if lockfile.try_exists()? {
+            anyhow::bail!("Refusing to reconstruct snapshot {snapshot_dir:?}: lockfile {lockfile:?} exists");
+        }
+
+        let snapshot_file_path = Self::snapshot_file_path(tx_offset, &snapshot_dir);
+        let snapshot = Snapshot::read_from_file(&snapshot_file_path)?;
+
+        if snapshot.magic != MAGIC {
+            anyhow::bail!(
+                "Refusing to reconstruct snapshot {snapshot_dir:?}: magic number {:?} ({:?}) does not match expected {:?} ({MAGIC:?})",
+                String::from_utf8_lossy(&snapshot.magic),
+                snapshot.magic,
+                std::str::from_utf8(&MAGIC).unwrap(),
+            );
+        }
+
+        if snapshot.version != CURRENT_SNAPSHOT_VERSION {
+            anyhow::bail!(
+                "Refusing to reconstruct snapshot {snapshot_dir:?}: snapshot file version {} does not match supported version {CURRENT_SNAPSHOT_VERSION}",
+                snapshot.version,
+            );
+        }
+
+        let object_repo = Self::object_repo(&snapshot_dir)?;
+
+        let blob_store = snapshot.reconstruct_blob_store(&object_repo)?;
+
+        let tables = snapshot.reconstruct_tables(&object_repo)?;
+
+        Ok(ReconstructedSnapshot {
+            database_address: snapshot.database_address,
+            database_instance_id: snapshot.database_instance_id,
+            tx_offset: snapshot.tx_offset,
+            module_abi_version: snapshot.module_abi_version,
+            blob_store,
+            tables,
+        })
+    }
+
+    pub fn open(root: PathBuf, database_address: Address, database_instance_id: u64) -> anyhow::Result<Self> {
+        if !root.is_dir() {
+            anyhow::bail!("Cannot open snapshot repository in non-directory {root:?}");
+        }
+        Ok(Self {
+            root,
+            database_address,
+            database_instance_id,
+        })
+    }
+
+    /// Return the `TxOffset` of the highest-offset complete snapshot in the repository
+    /// lower than or equal to `upper_bound`.
+    ///
+    /// When searching for a snapshot to restore,
+    /// we will pass the [`spacetimedb_durability::Durability::durable_tx_offset`]
+    /// as the `upper_bound` to ensure we don't lose TXes.
+    ///
+    /// Does not verify that the snapshot of the returned `TxOffset` is valid and uncorrupted,
+    /// so a subsequent [`Self::read_snapshot`] may fail.
+    pub fn latest_snapshot_older_than(&self, upper_bound: TxOffset) -> anyhow::Result<Option<TxOffset>> {
+        Ok(self
+            .root
+            // Item = Result<DirEntry>
+            .read_dir()?
+            // Item = DirEntry
+            .filter_map(Result::ok)
+            // Item = PathBuf
+            .map(|dirent| dirent.path())
+            // Ignore entries not shaped like snapshot directories.
+            .filter(|path| path.extension() == Some(OsStr::new(SNAPSHOT_DIR_EXT)))
+            // Ignore entries whose lockfile still exists.
+            .filter(|path| !Lockfile::lock_path(path).exists())
+            // Parse each entry's TxOffset from the file name; ignore unparseable.
+            // Item = TxOffset
+            .filter_map(|path| TxOffset::from_str_radix(path.file_stem()?.to_str()?, 10).ok())
+            // Ignore `tx_offset`s greater than the current upper bound.
+            .filter(|tx_offset| *tx_offset <= upper_bound)
+            // Select the largest TxOffset.
+            .max())
+    }
+
+    /// Return the `TxOffset` of the highest-offset complete snapshot in the repository.
+    ///
+    /// Does not verify that the snapshot of the returned `TxOffset` is valid and uncorrupted,
+    /// so a subsequent [`Self::read_snapshot`] may fail.
+    pub fn latest_snapshot(&self) -> anyhow::Result<Option<TxOffset>> {
+        self.latest_snapshot_older_than(TxOffset::MAX)
+    }
+}
+
+pub struct ReconstructedSnapshot {
+    /// The address of the snapshotted database.
+    pub database_address: Address,
+    /// The instance ID of the snapshotted database.
+    pub database_instance_id: u64,
+    /// The transaction offset of the state this snapshot reflects.
+    pub tx_offset: TxOffset,
+    /// ABI version of the module from which this snapshot was created, as [MAJOR, MINOR].
+    pub module_abi_version: [u16; 2],
+
+    /// The blob store of the snapshotted state.
+    pub blob_store: HashMapBlobStore,
+
+    /// All the tables from the snapshotted state, sans schema information and indexes.
+    ///
+    /// This includes the system tables,
+    /// so the schema of user-defined tables can be recovered
+    /// given knowledge of the schema of `st_table` and `st_column`.
+    pub tables: BTreeMap<TableId, Vec<Box<Page>>>,
+}

--- a/crates/table/src/blob_store.rs
+++ b/crates/table/src/blob_store.rs
@@ -13,14 +13,15 @@
 
 use blake3::hash;
 use spacetimedb_data_structures::map::{Entry, HashMap};
+use spacetimedb_lib::{de::Deserialize, ser::Serialize};
 
 /// The content address of a blob-stored object.
-#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Copy, Hash, Debug)]
+#[derive(Eq, PartialEq, PartialOrd, Ord, Clone, Copy, Hash, Debug, Serialize, Deserialize)]
 pub struct BlobHash {
     /// The hash of the blob-stored object.
     ///
     /// Uses BLAKE3 which fits in 32 bytes.
-    pub data: [u8; Self::SIZE],
+    pub data: [u8; BlobHash::SIZE],
 }
 
 impl BlobHash {
@@ -28,7 +29,7 @@ impl BlobHash {
     pub const SIZE: usize = 32;
 
     /// Returns the blob hash for `bytes`.
-    fn hash_from_bytes(bytes: &[u8]) -> Self {
+    pub fn hash_from_bytes(bytes: &[u8]) -> Self {
         let data = hash(bytes).into();
         Self { data }
     }
@@ -46,6 +47,14 @@ impl TryFrom<&[u8]> for BlobHash {
 /// An error that signifies that a [`BlobHash`] wasn't associated with a large blob object.
 #[derive(Debug)]
 pub struct NoSuchBlobError;
+
+/// Iterator returned by [`BlobStore::iter_blobs`].
+///
+/// Each element is a tuple `(hash, uses, data)`,
+/// where `hash` is a blob's content-addressed [`BlobHash`],
+/// `uses` is the number of references to that blob,
+/// and `data` is the data itself.
+pub type BlobsIter<'a> = Box<dyn Iterator<Item = (&'a BlobHash, usize, &'a [u8])> + 'a>;
 
 /// The interface that tables use to talk to the blob store engine for large var-len objects.
 ///
@@ -67,6 +76,11 @@ pub trait BlobStore: Sync {
     /// which can be used in [`retrieve_blob`] to fetch it.
     fn insert_blob(&mut self, bytes: &[u8]) -> BlobHash;
 
+    /// Insert `hash` referring to `bytes` and mark its refcount as `uses`.
+    ///
+    /// Used when restoring from a snapshot.
+    fn insert_with_uses(&mut self, hash: &BlobHash, uses: usize, bytes: Box<[u8]>);
+
     /// Returns the bytes stored at the content address `hash`.
     fn retrieve_blob(&self, hash: &BlobHash) -> Result<&[u8], NoSuchBlobError>;
 
@@ -76,6 +90,16 @@ pub trait BlobStore: Sync {
     /// this might not actually free the data,
     /// but rather just decrement a reference count.
     fn free_blob(&mut self, hash: &BlobHash) -> Result<(), NoSuchBlobError>;
+
+    /// Iterate over all blobs present in the blob store.
+    ///
+    /// Each element is a tuple `(hash, uses, data)`,
+    /// where `hash` is a blob's content-addressed [`BlobHash`],
+    /// `uses` is the number of references to that blob,
+    /// and `data` is the data itself.
+    ///
+    /// Used when capturing a snapshot.
+    fn iter_blobs(&self) -> BlobsIter<'_>;
 }
 
 /// A blob store that panics on all operations.
@@ -91,11 +115,20 @@ impl BlobStore for NullBlobStore {
     fn insert_blob(&mut self, _bytes: &[u8]) -> BlobHash {
         unimplemented!("NullBlobStore doesn't do anything")
     }
+
+    fn insert_with_uses(&mut self, _hash: &BlobHash, _uses: usize, _bytes: Box<[u8]>) {
+        unimplemented!("NullBlobStore doesn't do anything")
+    }
+
     fn retrieve_blob(&self, _hash: &BlobHash) -> Result<&[u8], NoSuchBlobError> {
         unimplemented!("NullBlobStore doesn't do anything")
     }
 
     fn free_blob(&mut self, _hash: &BlobHash) -> Result<(), NoSuchBlobError> {
+        unimplemented!("NullBlobStore doesn't do anything")
+    }
+
+    fn iter_blobs(&self) -> BlobsIter<'_> {
         unimplemented!("NullBlobStore doesn't do anything")
     }
 }
@@ -135,6 +168,14 @@ impl BlobStore for HashMapBlobStore {
         hash
     }
 
+    fn insert_with_uses(&mut self, hash: &BlobHash, uses: usize, bytes: Box<[u8]>) {
+        debug_assert_eq!(hash, &BlobHash::hash_from_bytes(&bytes));
+        self.map
+            .entry(*hash)
+            .and_modify(|v| v.uses += uses)
+            .or_insert_with(|| BlobObject { blob: bytes, uses });
+    }
+
     fn retrieve_blob(&self, hash: &BlobHash) -> Result<&[u8], NoSuchBlobError> {
         self.map.get(hash).map(|obj| &*obj.blob).ok_or(NoSuchBlobError)
     }
@@ -146,6 +187,10 @@ impl BlobStore for HashMapBlobStore {
             Entry::Occupied(mut entry) => entry.get_mut().uses -= 1,
         }
         Ok(())
+    }
+
+    fn iter_blobs(&self) -> BlobsIter<'_> {
+        Box::new(self.map.iter().map(|(hash, obj)| (hash, obj.uses, &obj.blob[..])))
     }
 }
 

--- a/crates/table/src/page.rs
+++ b/crates/table/src/page.rs
@@ -1696,6 +1696,14 @@ impl Page {
         self.header.unmodified_hash = Some(hash);
     }
 
+    /// Return the page's content hash, computing and saving it if it is not already stored.
+    pub fn save_or_get_content_hash(&mut self) -> blake3::Hash {
+        self.unmodified_hash().copied().unwrap_or_else(|| {
+            self.save_content_hash();
+            self.header.unmodified_hash.unwrap()
+        })
+    }
+
     /// Returns the stored unmodified hash, if any.
     pub fn unmodified_hash(&self) -> Option<&blake3::Hash> {
         self.header.unmodified_hash.as_ref()

--- a/crates/table/src/page.rs
+++ b/crates/table/src/page.rs
@@ -1691,10 +1691,9 @@ impl Page {
     }
 
     /// Computes the content hash of this page and saves it to [`PageHeader::unmodified_hash`].
-    pub fn save_content_hash(&mut self) -> blake3::Hash {
+    pub fn save_content_hash(&mut self) {
         let hash = self.content_hash();
         self.header.unmodified_hash = Some(hash);
-        hash
     }
 
     /// Returns the stored unmodified hash, if any.

--- a/crates/table/src/page.rs
+++ b/crates/table/src/page.rs
@@ -1691,9 +1691,10 @@ impl Page {
     }
 
     /// Computes the content hash of this page and saves it to [`PageHeader::unmodified_hash`].
-    pub fn save_content_hash(&mut self) {
+    pub fn save_content_hash(&mut self) -> blake3::Hash {
         let hash = self.content_hash();
         self.header.unmodified_hash = Some(hash);
+        hash
     }
 
     /// Returns the stored unmodified hash, if any.

--- a/crates/table/src/pages.rs
+++ b/crates/table/src/pages.rs
@@ -6,6 +6,7 @@ use super::page::Page;
 use super::table::BlobNumBytes;
 use super::var_len::VarLenMembers;
 use core::ops::{ControlFlow, Deref, Index, IndexMut};
+use std::ops::DerefMut;
 use thiserror::Error;
 
 #[derive(Error, Debug)]
@@ -334,5 +335,11 @@ impl Deref for Pages {
 
     fn deref(&self) -> &Self::Target {
         &self.pages
+    }
+}
+
+impl DerefMut for Pages {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.pages
     }
 }

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -1036,12 +1036,16 @@ impl Table {
         &self.inner.pages
     }
 
-    /// Returns the pages storing the physical rows of this table.
+    /// Iterates over each [`Page`] in this table, ensuring that its hash is computed before yielding it.
     ///
-    /// Exposed so snapshotting can visit each page, compute and store their hashes,
-    /// and write their data to disk.
-    pub fn pages_mut(&mut self) -> &mut Pages {
-        &mut self.inner.pages
+    /// Used when capturing a snapshot.
+    pub fn iter_pages_with_hashes(&mut self) -> impl Iterator<Item = &Page> {
+        self.inner.pages.iter_mut().map(|page| {
+            if page.unmodified_hash().is_none() {
+                page.save_content_hash();
+            }
+            &**page
+        })
     }
 
     /// Returns the number of pages storing the physical rows of this table.

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -1036,6 +1036,14 @@ impl Table {
         &self.inner.pages
     }
 
+    /// Returns the pages storing the physical rows of this table.
+    ///
+    /// Exposed so snapshotting can visit each page, compute and store their hashes,
+    /// and write their data to disk.
+    pub fn pages_mut(&mut self) -> &mut Pages {
+        &mut self.inner.pages
+    }
+
     /// Returns the number of pages storing the physical rows of this table.
     fn num_pages(&self) -> usize {
         self.inner.pages.len()

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -1039,12 +1039,10 @@ impl Table {
     /// Iterates over each [`Page`] in this table, ensuring that its hash is computed before yielding it.
     ///
     /// Used when capturing a snapshot.
-    pub fn iter_pages_with_hashes(&mut self) -> impl Iterator<Item = &Page> {
+    pub fn iter_pages_with_hashes(&mut self) -> impl Iterator<Item = (blake3::Hash, &Page)> {
         self.inner.pages.iter_mut().map(|page| {
-            if page.unmodified_hash().is_none() {
-                page.save_content_hash();
-            }
-            &**page
+            let hash = page.save_or_get_content_hash();
+            (hash, &**page)
         })
     }
 


### PR DESCRIPTION
# Description of Changes

- Requires making `BlobHash` be `Serialize` and `Deserialize`. For arcane macro-ology reasons, this requires writing `BlobHash::SIZE` instead of `Self::SIZE` (it gets embedded in a visitor struct or something).
- Requires adding two new operators to `BlobStore`.
- Adds a return value to `Page::save_content_hash`, for convenience.
- Impls `DerefMut` for `Pages`.
- ~~**Scary change:** adds `Table::pages_mut`. I think possibly this operator should be `unsafe`, since write access to the `Pages` allows an undisciplined caller to violate the `Table`'s assumptions by corrupting a `Page`. It seems like an anti-pattern to mark a method `unsafe` on the grounds that misusing its return value can cause UB, but I don't see a plausible alternative without making most methods on `Page` unsafe. Open to feedback on this one!~~
- Adds `Table::iter_pages_with_hashes`, which iterates over all pages, ensuring their hashes are present before yielding.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

3 - see above comment re: safety of `Table::pages_mut`.

# Testing

Tested manually in #1279 . Not convinced there's a useful way write tests for this in isolation i.e. before integrating.