### PR TITLE
Update quickstart modules to have public tables

### DIFF
--- a/modules/quickstart-chat/src/lib.rs
+++ b/modules/quickstart-chat/src/lib.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{spacetimedb, Identity, ReducerContext, Timestamp};
 
-#[spacetimedb(table)]
+#[spacetimedb(table(public))]
 pub struct User {
     #[primarykey]
     identity: Identity,
@@ -8,7 +8,7 @@ pub struct User {
     online: bool,
 }
 
-#[spacetimedb(table)]
+#[spacetimedb(table(public))]
 pub struct Message {
     sender: Identity,
     sent: Timestamp,

--- a/modules/spacetimedb-quickstart/src/lib.rs
+++ b/modules/spacetimedb-quickstart/src/lib.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{println, query, spacetimedb};
 
-#[spacetimedb(table)]
+#[spacetimedb(table(public))]
 pub struct Person {
     #[primarykey]
     #[autoinc]


### PR DESCRIPTION
# Description of Changes

Update `quickstart-chat` and `spacetimedb-quickstart` to have public tables. They were previously public, but became implicitly private as of https://github.com/clockworklabs/SpacetimeDB/pull/1278.

I did not update other modules in this directory, e.g. `benchmarks`.

# API and ABI breaking changes

I sure hope not.

# Expected complexity level and risk

1

# Testing
Just the CI
