### PR TITLE
Smoketest auto-disconnect after restart

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -37,11 +37,7 @@ jobs:
       - name: Start containers
         run: docker compose up -d
       - name: Run smoketests
-        run: python -m smoketests --docker -x zz_docker
-      # These cannot run in parallel, even though the script tries to handle it
-      # TODO: Fix flaky tests https://github.com/clockworklabs/SpacetimeDB/issues/630
-      # - name: Run restarting smoketests
-      #   run: python -m smoketests --docker zz_docker
+        run: python -m smoketests --docker
       - name: Stop containers
         if: always()
         run: docker compose down

--- a/smoketests/tests/zz_docker.py
+++ b/smoketests/tests/zz_docker.py
@@ -1,5 +1,6 @@
+import time
 from .. import Smoketest, run_cmd, requires_docker
-from urllib.request import urlopen, URLError
+from urllib.request import urlopen
 
 
 def restart_docker():
@@ -23,16 +24,19 @@ def restart_docker():
 def ping():
     tries = 0
     host = "127.0.0.1:3000"
-    while tries < 5:
+    while tries < 10:
         tries += 1
         try:
+            print(f"Ping Server at {host}")
             urlopen(f"http://{host}/database/ping")
+            print("Server up")
             break
-        except URLError:
+        except Exception:
             print("Server down")
+            time.sleep(3)
     else:
         raise Exception(f"Server at {host} not responding")
-    print(f"Server up after {tries} try")
+    print(f"Server up after {tries} tries")
 
 
 @requires_docker


### PR DESCRIPTION
(Re-)enables the `zz-docker` tests with some tweaking to increase the chances that a restart actually works.
Adds a smoketest which tests that clients are auto-disconnected after unclean shutdown.

Depends-on: #1343 