### PR TITLE
Make some commitlog helpers public

### DIFF
--- a/crates/commitlog/src/error.rs
+++ b/crates/commitlog/src/error.rs
@@ -62,7 +62,7 @@ pub struct Append<T> {
 pub struct ChecksumMismatch;
 
 #[derive(Debug, Error)]
-pub enum SegmentMetadata {
+pub(crate) enum SegmentMetadata {
     #[error("invalid commit encountered")]
     InvalidCommit {
         sofar: segment::Metadata,

--- a/crates/commitlog/src/error.rs
+++ b/crates/commitlog/src/error.rs
@@ -62,7 +62,7 @@ pub struct Append<T> {
 pub struct ChecksumMismatch;
 
 #[derive(Debug, Error)]
-pub(crate) enum SegmentMetadata {
+pub enum SegmentMetadata {
     #[error("invalid commit encountered")]
     InvalidCommit {
         sofar: segment::Metadata,

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -3,9 +3,9 @@ use std::{io, num::NonZeroU16, path::PathBuf, sync::RwLock};
 use log::trace;
 
 mod commit;
-mod commitlog;
-mod repo;
-mod segment;
+pub mod commitlog;
+pub mod repo;
+pub mod segment;
 mod varchar;
 mod varint;
 

--- a/crates/commitlog/src/repo/mem.rs
+++ b/crates/commitlog/src/repo/mem.rs
@@ -28,6 +28,9 @@ impl Segment {
     pub fn len(&self) -> usize {
         self.buf.read().unwrap().len()
     }
+    pub fn is_empty(&self) -> bool {
+        self.len() == 0
+    }
 }
 
 impl From<SharedBytes> for Segment {

--- a/crates/commitlog/src/segment.rs
+++ b/crates/commitlog/src/segment.rs
@@ -231,7 +231,7 @@ impl<R: io::Read> Reader<R> {
     }
 
     #[cfg(test)]
-    pub fn metadata(self) -> Result<Metadata, error::SegmentMetadata> {
+    pub(crate) fn metadata(self) -> Result<Metadata, error::SegmentMetadata> {
         Metadata::with_header(self.min_tx_offset, self.header, io::BufReader::new(self.inner))
     }
 }

--- a/crates/commitlog/src/segment.rs
+++ b/crates/commitlog/src/segment.rs
@@ -301,7 +301,7 @@ impl Metadata {
     ///
     /// This traverses the entire segment, consuming thre `reader.
     /// Doing so is necessary to determine the `max_tx_offset` and `size_in_bytes`.
-    pub fn extract<R: io::Read>(min_tx_offset: u64, mut reader: R) -> Result<Self, error::SegmentMetadata> {
+    pub(crate) fn extract<R: io::Read>(min_tx_offset: u64, mut reader: R) -> Result<Self, error::SegmentMetadata> {
         let header = Header::decode(&mut reader)?;
         Self::with_header(min_tx_offset, header, reader)
     }

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -43,7 +43,7 @@ use std::collections::BTreeMap;
 use std::sync::Arc;
 
 #[derive(Default)]
-pub(crate) struct CommittedState {
+pub struct CommittedState {
     pub(crate) next_tx_offset: u64,
     pub(crate) tables: IntMap<TableId, Table>,
     pub(crate) blob_store: HashMapBlobStore,
@@ -555,6 +555,12 @@ impl CommittedState {
 
     pub(super) fn get_table_mut(&mut self, table_id: TableId) -> Option<&mut Table> {
         self.tables.get_mut(&table_id)
+    }
+
+    pub fn get_table_and_blob_store_immutable(&self, table_id: TableId) -> Option<(&Table, &dyn BlobStore)> {
+        self.tables
+            .get(&table_id)
+            .map(|tbl| (tbl, &self.blob_store as &dyn BlobStore))
     }
 
     pub(super) fn get_table_and_blob_store(&mut self, table_id: TableId) -> Option<(&mut Table, &mut dyn BlobStore)> {

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -42,6 +42,11 @@ use spacetimedb_table::{
 use std::collections::BTreeMap;
 use std::sync::Arc;
 
+/// Contains the live, in-memory snapshot of a database. This structure
+/// is exposed in order to support tools wanting to process the commit
+/// logs directly. For normal usage, see the RelationalDB struct instead.
+///
+/// NOTE: unstable API, this may change at any point in the future.
 #[derive(Default)]
 pub struct CommittedState {
     pub(crate) next_tx_offset: u64,

--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -1,11 +1,11 @@
 #![forbid(unsafe_op_in_unsafe_fn)]
 
-pub(crate) mod committed_state;
+pub mod committed_state;
 pub mod datastore;
 mod mut_tx;
 pub use mut_tx::MutTxId;
 mod sequence;
-pub(crate) mod state_view;
+pub mod state_view;
 pub use state_view::{Iter, IterByColEq, IterByColRange};
 pub(crate) mod tx;
 mod tx_state;

--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -22,7 +22,7 @@ use std::sync::Arc;
 
 // StateView trait, is designed to define the behavior of viewing internal datastore states.
 // Currently, it applies to: CommittedState, MutTxId, and TxId.
-pub(crate) trait StateView {
+pub trait StateView {
     fn get_schema(&self, table_id: TableId) -> Option<&Arc<TableSchema>>;
 
     fn table_id_from_name(&self, table_name: &str, database_address: Address) -> Result<Option<TableId>> {


### PR DESCRIPTION
# Description of Changes

To scan the commitlog, access to CommittedState is required to maintain the schemas needed to decode the transaction records. To use CommittedState, access to the StateView trait is also needed.

To query the data for existing rows given a new row, an immutable getter is added to Table as well.

No breaks, no risks, just marking a handful of existing functions to be public outside their crates.