### PR TITLE
[C#] [NFC] Use semantic model's type where possible

### DIFF
--- a/crates/bindings-csharp/BSATN.Codegen/Utils.cs
+++ b/crates/bindings-csharp/BSATN.Codegen/Utils.cs
@@ -137,6 +137,11 @@ public static class Utils
         }
     }
 
+    public static IEnumerable<IFieldSymbol> GetFields(INamedTypeSymbol type)
+    {
+        return type.GetMembers().OfType<IFieldSymbol>().Where(f => !f.IsStatic);
+    }
+
     // Borrowed & modified code for generating in-place extensions for partial structs/classes/etc. Source:
     // https://andrewlock.net/creating-a-source-generator-part-5-finding-a-type-declarations-namespace-and-type-hierarchy/
 


### PR DESCRIPTION
# Description of Changes

This fixes issues with nullability annotations (see the removed TODO), inconsistent field selection between `[SpacetimeDB.Type]` and `[SpacetimeDB.Table]`, as well as should be more efficient overall as it gets the type model for the structure in one go instead of individually for each field.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] `dotnet test`
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
