### PR TITLE
chore: Remove max value metrics

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -17,7 +17,7 @@ use crate::{
                 TxData, TxDatastore,
             },
         },
-        db_metrics::{DB_METRICS, MAX_TX_CPU_TIME},
+        db_metrics::DB_METRICS,
     },
     error::{DBError, TableError},
     execution_context::ExecutionContext,
@@ -425,22 +425,6 @@ pub(super) fn record_metrics(ctx: &ExecutionContext, tx_timer: Instant, lock_wai
         .rdb_txn_elapsed_time_sec
         .with_label_values(workload, db, reducer)
         .observe(elapsed_time);
-
-    let mut guard = MAX_TX_CPU_TIME.lock().unwrap();
-    let max_cpu_time = *guard
-        .entry((*db, *workload, reducer.to_owned()))
-        .and_modify(|max| {
-            if cpu_time > *max {
-                *max = cpu_time;
-            }
-        })
-        .or_insert_with(|| cpu_time);
-
-    drop(guard);
-    DB_METRICS
-        .rdb_txn_cpu_time_sec_max
-        .with_label_values(workload, db, reducer)
-        .set(max_cpu_time);
 }
 
 impl MutTx for Locking {

--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -1,11 +1,9 @@
 use crate::execution_context::WorkloadType;
 use once_cell::sync::Lazy;
-use prometheus::{GaugeVec, HistogramVec, IntCounterVec, IntGaugeVec};
-use spacetimedb_data_structures::map::HashMap;
+use prometheus::{HistogramVec, IntCounterVec, IntGaugeVec};
 use spacetimedb_lib::Address;
 use spacetimedb_metrics::metrics_group;
 use spacetimedb_primitives::TableId;
-use std::sync::Mutex;
 
 metrics_group!(
     #[non_exhaustive]
@@ -61,11 +59,6 @@ metrics_group!(
         )]
         pub rdb_txn_cpu_time_sec: HistogramVec,
 
-        #[name = spacetime_txn_cpu_time_sec_max]
-        #[help = "The cpu time of the longest running transaction (in seconds)"]
-        #[labels(txn_type: WorkloadType, db: Address, reducer: str)]
-        pub rdb_txn_cpu_time_sec_max: GaugeVec,
-
         #[name = spacetime_message_log_size_bytes]
         #[help = "For a given database, the number of bytes occupied by its message log"]
         #[labels(db: Address)]
@@ -83,18 +76,7 @@ metrics_group!(
     }
 );
 
-type ReducerLabel = (Address, WorkloadType, String);
-type AddressLabel = (Address, WorkloadType);
-
-pub static MAX_TX_CPU_TIME: Lazy<Mutex<HashMap<ReducerLabel, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
-pub static MAX_QUERY_COMPILE_TIME: Lazy<Mutex<HashMap<AddressLabel, f64>>> = Lazy::new(|| Mutex::new(HashMap::new()));
 pub static DB_METRICS: Lazy<DbMetrics> = Lazy::new(DbMetrics::new);
-
-pub fn reset_counters() {
-    // Reset max reducer durations
-    DB_METRICS.rdb_txn_cpu_time_sec_max.0.reset();
-    MAX_TX_CPU_TIME.lock().unwrap().clear();
-}
 
 /// Returns the number of committed rows in the table named by `table_name` and identified by `table_id` in the database `db_address`.
 pub fn table_num_rows(db_address: Address, table_id: TableId, table_name: &str) -> u64 {

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -14,11 +14,9 @@ use energy_monitor::StandaloneEnergyMonitor;
 use openssl::ec::{EcGroup, EcKey};
 use openssl::nid::Nid;
 use openssl::pkey::PKey;
-use scopeguard::defer_on_success;
 use spacetimedb::address::Address;
 use spacetimedb::auth::identity::{DecodingKey, EncodingKey};
 use spacetimedb::client::ClientActorIndex;
-use spacetimedb::db::db_metrics;
 use spacetimedb::db::{db_metrics::DB_METRICS, Config};
 use spacetimedb::energy::{EnergyBalance, EnergyQuanta};
 use spacetimedb::host::{DiskStorage, HostController, ProgramStorage, UpdateDatabaseResult};
@@ -151,9 +149,6 @@ fn get_key_path(env: &str) -> Option<PathBuf> {
 
 impl spacetimedb_client_api::NodeDelegate for StandaloneEnv {
     fn gather_metrics(&self) -> Vec<prometheus::proto::MetricFamily> {
-        defer_on_success! {
-            db_metrics::reset_counters();
-        }
         self.metrics_registry.gather()
     }
 


### PR DESCRIPTION
When a histogram's buckets are defined correctly,
max values do not provide any additional insight over the p99.

# API and ABI breaking changes

Removes the public `reset_counters()` function

# Expected complexity level and risk

1 - code removal

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
