### PR TITLE
fix(1409): Counter metric names

### DIFF
--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -13,32 +13,32 @@ metrics_group!(
         #[labels(db: Address, table_id: u32, table_name: str)]
         pub rdb_num_table_rows: IntGaugeVec,
 
-        #[name = spacetime_num_rows_inserted_cumulative]
+        #[name = spacetime_num_rows_inserted_total]
         #[help = "The cumulative number of rows inserted into a table"]
         #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32, table_name: str)]
         pub rdb_num_rows_inserted: IntCounterVec,
 
-        #[name = spacetime_num_rows_deleted_cumulative]
+        #[name = spacetime_num_rows_deleted_total]
         #[help = "The cumulative number of rows deleted from a table"]
         #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32, table_name: str)]
         pub rdb_num_rows_deleted: IntCounterVec,
 
-        #[name = spacetime_num_rows_fetched_cumulative]
+        #[name = spacetime_num_rows_fetched_total]
         #[help = "The cumulative number of rows fetched from a table"]
         #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32, table_name: str)]
         pub rdb_num_rows_fetched: IntCounterVec,
 
-        #[name = spacetime_num_index_keys_scanned_cumulative]
+        #[name = spacetime_num_index_keys_scanned_total]
         #[help = "The cumulative number of keys scanned from an index"]
         #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32, table_name: str)]
         pub rdb_num_keys_scanned: IntCounterVec,
 
-        #[name = spacetime_num_index_seeks_cumulative]
+        #[name = spacetime_num_index_seeks_total]
         #[help = "The cumulative number of index seeks"]
         #[labels(txn_type: WorkloadType, db: Address, reducer_or_query: str, table_id: u32, table_name: str)]
         pub rdb_num_index_seeks: IntCounterVec,
 
-        #[name = spacetime_num_txns_cumulative]
+        #[name = spacetime_num_txns_total]
         #[help = "The cumulative number of transactions, including both commits and rollbacks"]
         #[labels(txn_type: WorkloadType, db: Address, reducer: str, committed: bool)]
         pub rdb_num_txns: IntCounterVec,

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -12,8 +12,8 @@ metrics_group!(
         #[labels(database_address: Address)]
         pub connected_clients: IntGaugeVec,
 
-        #[name = spacetime_websocket_requests]
-        #[help = "Number of websocket request messages"]
+        #[name = spacetime_websocket_requests_total]
+        #[help = "The cumulative number of websocket request messages"]
         #[labels(instance_id: u64, protocol: str)]
         pub websocket_requests: IntCounterVec,
 
@@ -22,8 +22,8 @@ metrics_group!(
         #[labels(instance_id: u64, protocol: str)]
         pub websocket_request_msg_size: HistogramVec,
 
-        #[name = spacetime_websocket_sent]
-        #[help = "Number of websocket messages sent to client"]
+        #[name = spacetime_websocket_sent_total]
+        #[help = "The cumulative number of websocket messages sent to client"]
         #[labels(identity: Identity)]
         pub websocket_sent: IntCounterVec,
 
@@ -51,7 +51,7 @@ metrics_group!(
         )]
         pub reducer_wait_time: HistogramVec,
 
-        #[name = spacetime_worker_wasm_instance_errors_cumulative]
+        #[name = spacetime_worker_wasm_instance_errors_total]
         #[help = "The number of fatal WASM instance errors, such as reducer panics."]
         #[labels(identity: Identity, module_hash: Hash, database_address: Address, reducer_symbol: str)]
         pub wasm_instance_errors: IntCounterVec,


### PR DESCRIPTION
Closes #1409.

Grafana expects the names of counter metrics to end in _total.

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
