### PR TITLE
chore: Remove already tracked subscription counter

### DIFF
--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -114,11 +114,6 @@ impl ModuleSubscriptions {
         let slow_query_threshold = StVarTable::sub_limit(&ctx, &self.relational_db, &tx)?.map(Duration::from_millis);
         let database_update = execution_set.eval(&ctx, sender.protocol, &self.relational_db, &tx, slow_query_threshold);
 
-        WORKER_METRICS
-            .initial_subscription_evals
-            .with_label_values(&self.relational_db.address())
-            .inc();
-
         // It acquires the subscription lock after `eval`, allowing `add_subscription` to run concurrently.
         // This also makes it possible for `broadcast_event` to get scheduled before the subsequent part here
         // but that should not pose an issue.

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -56,11 +56,6 @@ metrics_group!(
         #[labels(identity: Identity, module_hash: Hash, database_address: Address, reducer_symbol: str)]
         pub wasm_instance_errors: IntCounterVec,
 
-        #[name = spacetime_initial_subscription_evals]
-        #[help = "The cumulative number of initial subscription evaluations"]
-        #[labels(database_address: Address)]
-        pub initial_subscription_evals: IntCounterVec,
-
         #[name = spacetime_active_queries]
         #[help = "The number of active subscription queries"]
         #[labels(database_address: Address)]


### PR DESCRIPTION
We already track subscription requests through the rdb_num_txns counter.

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
