### PR TITLE
`TableDef`: clarify `generated_*` methods

### DIFF
--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -395,20 +395,14 @@ pub fn register_reftype<T: SpacetimeType>() {
 pub fn register_table<T: TableType>() {
     register_describer(|module| {
         let data = *T::make_type(module).as_ref().unwrap();
-        let columns = module
+        let columns: Vec<ColumnDef> = module
             .module
             .typespace
             .with_type(&data)
             .resolve_refs()
-            .and_then(|x| {
-                if let Ok(x) = x.into_product() {
-                    let cols: Vec<ColumnDef> = x.into();
-                    Some(cols)
-                } else {
-                    None
-                }
-            })
-            .expect("Fail to retrieve the columns from the module");
+            .and_then(|x| x.into_product().ok())
+            .expect("Fail to retrieve the columns from the module")
+            .into();
 
         let indexes: Vec<_> = T::INDEXES.iter().copied().map(Into::into).collect();
         //WARNING: The definition  of table assumes the # of constraints == # of columns elsewhere `T::COLUMN_ATTRS` is queried


### PR DESCRIPTION
# Description of Changes

To improve my understanding of what `TableDef` and `TableSchema` actually do wrt. indices & constraints, I slightly refactored the `TableDef::generated_*` methods and added commentary. This should make it easier to understand the implementation of the index hack I am working on.

One semantic aspect that changed here is that I removed the binary searches -- they don't seem to be correct, as I did not determine that we actually keep a sorted order by name in a `TableDef`.

This patch is likely to become obsolete once the new schema impl is written, but I found it helpful in the interim.

# API and ABI breaking changes

None

# Expected complexity level and risk

1