### PR TITLE
Roslyn cacheability testing and fixes

### DIFF
--- a/crates/bindings-csharp/BSATN.Codegen/Type.cs
+++ b/crates/bindings-csharp/BSATN.Codegen/Type.cs
@@ -155,9 +155,9 @@ public class Type : IIncrementalGenerator
 
                     var typeDesc = "";
 
-                    var bsatnDecls = type.Members.Select(m => (m.Name, m.TypeInfo)).ToList();
+                    var bsatnDecls = type.Members.Select(m => (m.Name, m.TypeInfo)).ToImmutableArray();
 
-                    var fieldNames = bsatnDecls.Select(m => m.Name).ToArray();
+                    var fieldNames = bsatnDecls.Select(m => m.Name).ToImmutableArray();
 
                     if (type.IsTaggedEnum)
                     {

--- a/crates/bindings-csharp/BSATN.Codegen/Type.cs
+++ b/crates/bindings-csharp/BSATN.Codegen/Type.cs
@@ -9,13 +9,13 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Utils;
 
-readonly record struct VariableDeclaration
+readonly record struct MemberDeclaration
 {
     public readonly string Name;
     public readonly string Type;
     public readonly string TypeInfo;
 
-    public VariableDeclaration(string name, ITypeSymbol typeSymbol)
+    public MemberDeclaration(string name, ITypeSymbol typeSymbol)
     {
         Name = name;
         Type = SymbolToName(typeSymbol);
@@ -29,7 +29,7 @@ record TypeDeclaration
     public readonly string ShortName;
     public readonly string FullName;
     public readonly bool IsTaggedEnum;
-    public readonly EquatableArray<VariableDeclaration> Members;
+    public readonly EquatableArray<MemberDeclaration> Members;
 
     public TypeDeclaration(
         TypeDeclarationSyntax typeSyntax,
@@ -43,7 +43,7 @@ record TypeDeclaration
         FullName = SymbolToName(type);
         IsTaggedEnum = isTaggedEnum;
         Members = new(
-            members.Select(v => new VariableDeclaration(v.Name, v.Type)).ToImmutableArray()
+            members.Select(v => new MemberDeclaration(v.Name, v.Type)).ToImmutableArray()
         );
     }
 }
@@ -155,9 +155,8 @@ public class Type : IIncrementalGenerator
 
                     var typeDesc = "";
 
-                    var bsatnDecls = type.Members.Select(m => (m.Name, m.TypeInfo)).ToImmutableArray();
-
-                    var fieldNames = bsatnDecls.Select(m => m.Name).ToImmutableArray();
+                    var bsatnDecls = type.Members.Select(m => (m.Name, m.TypeInfo));
+                    var fieldNames = type.Members.Select(m => m.Name);
 
                     if (type.IsTaggedEnum)
                     {
@@ -173,8 +172,7 @@ public class Type : IIncrementalGenerator
                             }}
                         ";
 
-                        bsatnDecls.Insert(
-                            0,
+                        bsatnDecls = bsatnDecls.Prepend(
                             (Name: "__enumTag", TypeInfo: "SpacetimeDB.BSATN.Enum<@enum>")
                         );
 

--- a/crates/bindings-csharp/BSATN.Codegen/Type.cs
+++ b/crates/bindings-csharp/BSATN.Codegen/Type.cs
@@ -9,11 +9,43 @@ using Microsoft.CodeAnalysis.CSharp;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Utils;
 
-struct VariableDeclaration(string name, ITypeSymbol typeSymbol)
+readonly record struct VariableDeclaration
 {
-    public string Name = name;
-    public string Type = SymbolToName(typeSymbol);
-    public string TypeInfo = GetTypeInfo(typeSymbol);
+    public readonly string Name;
+    public readonly string Type;
+    public readonly string TypeInfo;
+
+    public VariableDeclaration(string name, ITypeSymbol typeSymbol)
+    {
+        Name = name;
+        Type = SymbolToName(typeSymbol);
+        TypeInfo = GetTypeInfo(typeSymbol);
+    }
+}
+
+record TypeDeclaration
+{
+    public readonly Scope Scope;
+    public readonly string ShortName;
+    public readonly string FullName;
+    public readonly bool IsTaggedEnum;
+    public readonly EquatableArray<VariableDeclaration> Members;
+
+    public TypeDeclaration(
+        TypeDeclarationSyntax typeSyntax,
+        INamedTypeSymbol type,
+        bool isTaggedEnum,
+        IEnumerable<IFieldSymbol> members
+    )
+    {
+        Scope = new(typeSyntax);
+        ShortName = type.Name;
+        FullName = SymbolToName(type);
+        IsTaggedEnum = isTaggedEnum;
+        Members = new(
+            members.Select(v => new VariableDeclaration(v.Name, v.Type)).ToImmutableArray()
+        );
+    }
 }
 
 [Generator]
@@ -110,18 +142,10 @@ public class Type : IIncrementalGenerator
                         );
                     }
 
-                    return new
-                    {
-                        Scope = new Scope(typeSyntax),
-                        ShortName = type.Name,
-                        FullName = SymbolToName(type),
-                        IsTaggedEnum = isTaggedEnum,
-                        Members = fields
-                            .Select(v => new VariableDeclaration(v.Name, v.Type))
-                            .ToImmutableArray(),
-                    };
+                    return new TypeDeclaration(typeSyntax, type, isTaggedEnum, fields);
                 }
             )
+            .WithTrackingName("SpacetimeDB.Type.Parse")
             .Select(
                 (type, ct) =>
                 {
@@ -228,6 +252,7 @@ public class Type : IIncrementalGenerator
                     );
                 }
             )
+            .WithTrackingName("SpacetimeDB.Type.GenerateExtensions")
             .RegisterSourceOutputs(context);
     }
 }

--- a/crates/bindings-csharp/BSATN.Codegen/Utils.cs
+++ b/crates/bindings-csharp/BSATN.Codegen/Utils.cs
@@ -12,15 +12,12 @@ using static System.Collections.StructuralComparisons;
 
 public static class Utils
 {
-    // Even ImmutableArray<T> is not deeply equatable, which makes it a common
+    // Even `ImmutableArray<T>` is not deeply equatable, which makes it a common
     // pain point for source generators as they must use only cacheable types.
+    // As a result, everyone builds their own `EquatableArray<T>` type.
     public readonly record struct EquatableArray<T>(ImmutableArray<T> Array) : IEnumerable<T>
         where T : IEquatable<T>
     {
-        // Moves contents from the builder to the equatable array.
-        public EquatableArray(ImmutableArray<T>.Builder builder)
-            : this(builder.ToImmutable()) { }
-
         public int Length => Array.Length;
         public T this[int index] => Array[index];
 
@@ -191,7 +188,7 @@ public static class Utils
                 // Move to the next outer type
                 node = type.Parent as MemberDeclarationSyntax;
             }
-            typeScopes = new(typeScopes_);
+            typeScopes = new(typeScopes_.ToImmutable());
 
             // We've now reached the outermost type, so we can determine the namespace
             var namespaces_ = ImmutableArray.CreateBuilder<string>();
@@ -200,7 +197,7 @@ public static class Utils
                 namespaces_.Add(ns.Name.ToString());
                 node = node.Parent as MemberDeclarationSyntax;
             }
-            namespaces = new(namespaces_);
+            namespaces = new(namespaces_.ToImmutable());
         }
 
         public readonly record struct TypeScope(string Keyword, string Name, string Constraints);

--- a/crates/bindings-csharp/Codegen.Tests/Codegen.Tests.csproj
+++ b/crates/bindings-csharp/Codegen.Tests/Codegen.Tests.csproj
@@ -20,10 +20,10 @@
 
   <ItemGroup>
     <ProjectReference Include="../Codegen/Codegen.csproj" />
-    <ProjectReference Include="../Runtime/Runtime.csproj" />
-
+    <!-- we only need to make sure that Runtime is (re)built before we run tests, but we don't need the DLL in the test itself -->
+    <ProjectReference Include="../Runtime/Runtime.csproj" ReferenceOutputAssembly="false" />
+    <!-- sample code should not be part of the test compilation -->
     <Compile Remove="Sample.cs" />
-    <EmbeddedResource Include="Sample.cs" LogicalName="Sample.cs" />
   </ItemGroup>
 
 </Project>

--- a/crates/bindings-csharp/Codegen.Tests/TestInit.cs
+++ b/crates/bindings-csharp/Codegen.Tests/TestInit.cs
@@ -1,0 +1,41 @@
+namespace Codegen.Tests;
+
+using System.Runtime.CompilerServices;
+
+// Global Verify setup for all tests we might have.
+static class TestInit
+{
+    [ModuleInitializer]
+    public static void Initialize()
+    {
+        // Default diff order is weird and causes new lines to look like deleted and old as inserted.
+        Environment.SetEnvironmentVariable("DiffEngine_TargetOnLeft", "true");
+        // Store snapshots in a separate directory.
+        UseProjectRelativeDirectory("snapshots");
+        VerifySourceGenerators.Initialize();
+        // Format code for more readable snapshots and to avoid diffs on whitespace changes.
+        VerifierSettings.AddScrubber(
+            "cs",
+            (sb) =>
+            {
+                var unformattedCode = sb.ToString();
+                sb.Clear();
+                var result = CSharpier.CodeFormatter.Format(
+                    unformattedCode,
+                    new() { IncludeGenerated = true, EndOfLine = CSharpier.EndOfLine.LF }
+                );
+                if (result.CompilationErrors.Any())
+                {
+                    sb.AppendLine("// Generated code produced compilation errors:");
+                    foreach (var diag in result.CompilationErrors)
+                    {
+                        sb.Append("// ").AppendLine(diag.ToString());
+                    }
+                    sb.AppendLine();
+                }
+                sb.Append(result.Code);
+            },
+            ScrubberLocation.Last
+        );
+    }
+}

--- a/crates/bindings-csharp/Codegen.Tests/Tests.cs
+++ b/crates/bindings-csharp/Codegen.Tests/Tests.cs
@@ -15,7 +15,8 @@ public static class GeneratorSnapshotTests
 {
     // Note that we can't use assembly path here because it will be put in some deep nested folder.
     // Instead, to get the test project directory, we can use the `CallerFilePath` attribute which will magically give us path to the current file.
-    private static string GetProjectDir([CallerFilePath] string path = "") => Path.GetDirectoryName(path)!;
+    private static string GetProjectDir([CallerFilePath] string path = "") =>
+        Path.GetDirectoryName(path)!;
 
     private static readonly CSharpCompilation SampleCompilation;
 
@@ -55,23 +56,23 @@ public static class GeneratorSnapshotTests
         using var sampleSource = File.OpenRead($"{projectDir}/Sample.cs");
 
         var stdbAssemblies = ImmutableArray
-                    .Create("BSATN.Runtime", "Runtime")
-                    .Select(name => $"{projectDir}/../{name}/bin/Debug/net8.0/SpacetimeDB.{name}.dll");
+            .Create("BSATN.Runtime", "Runtime")
+            .Select(name => $"{projectDir}/../{name}/bin/Debug/net8.0/SpacetimeDB.{name}.dll");
 
         var dotNetDir = Path.GetDirectoryName(typeof(object).Assembly.Location)!;
         var dotNetAssemblies = ImmutableArray
-                    .Create("System.Private.CoreLib", "System.Runtime")
-                    .Select(name => $"{dotNetDir}/{name}.dll");
+            .Create("System.Private.CoreLib", "System.Runtime")
+            .Select(name => $"{dotNetDir}/{name}.dll");
 
         SampleCompilation = CSharpCompilation.Create(
             assemblyName: "Sample",
             references: Enumerable
-                .Concat(
-                    dotNetAssemblies,
-                    stdbAssemblies
-                )
+                .Concat(dotNetAssemblies, stdbAssemblies)
                 .Select(assemblyPath => MetadataReference.CreateFromFile(assemblyPath)),
-            options: new(OutputKind.NetModule, nullableContextOptions: NullableContextOptions.Enable),
+            options: new(
+                OutputKind.NetModule,
+                nullableContextOptions: NullableContextOptions.Enable
+            ),
             syntaxTrees: [CSharpSyntaxTree.ParseText(SourceText.From(sampleSource))]
         );
     }

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -1,6 +1,7 @@
 namespace SpacetimeDB.Codegen;
 
 using System.Collections.Generic;
+using System.Collections.Immutable;
 using System.Linq;
 using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp;
@@ -19,96 +20,168 @@ enum ColumnAttrs : byte
     PrimaryKeyAuto = PrimaryKey | AutoInc,
 }
 
+readonly record struct ColumnDeclaration
+{
+    public readonly string Name;
+    public readonly string Type;
+    public readonly string TypeInfo;
+    public readonly ColumnAttrs IndexKind;
+    public readonly bool IsEquatable;
+
+    public ColumnDeclaration(string name, ITypeSymbol type, ColumnAttrs indexKind)
+    {
+        var isInteger = type.SpecialType switch
+        {
+            SpecialType.System_Byte
+            or SpecialType.System_SByte
+            or SpecialType.System_Int16
+            or SpecialType.System_UInt16
+            or SpecialType.System_Int32
+            or SpecialType.System_UInt32
+            or SpecialType.System_Int64
+            or SpecialType.System_UInt64
+                => true,
+            SpecialType.None => type.ToString() is "System.Int128" or "System.UInt128",
+            _ => false
+        };
+
+        if (indexKind.HasFlag(ColumnAttrs.AutoInc) && !isInteger)
+        {
+            throw new System.Exception(
+                $"{type} {name} is not valid for AutoInc or Identity as it's not an integer."
+            );
+        }
+
+        IsEquatable =
+            (
+                isInteger
+                || type.SpecialType switch
+                {
+                    SpecialType.System_String or SpecialType.System_Boolean => true,
+                    SpecialType.None
+                        => type.ToString()
+                            is "SpacetimeDB.Runtime.Address"
+                                or "SpacetimeDB.Runtime.Identity",
+                    _ => false,
+                }
+            )
+            && type.NullableAnnotation != NullableAnnotation.Annotated;
+
+        if (indexKind.HasFlag(ColumnAttrs.Unique) && !IsEquatable)
+        {
+            throw new System.Exception(
+                $"{type} {name} is not valid for Identity, PrimaryKey or PrimaryKeyAuto as it's not an equatable primitive."
+            );
+        }
+
+        Name = name;
+        Type = SymbolToName(type);
+        TypeInfo = GetTypeInfo(type);
+        IndexKind = indexKind;
+    }
+}
+
+record TableDeclaration
+{
+    public readonly Scope Scope;
+    public readonly string Name;
+    public readonly string FullName;
+    public readonly EquatableArray<ColumnDeclaration> Fields;
+    public readonly bool Public;
+
+    public TableDeclaration(
+        TypeDeclarationSyntax tableSyntax,
+        INamedTypeSymbol table,
+        IEnumerable<ColumnDeclaration> columns,
+        bool isPublic
+    )
+    {
+        Scope = new Scope(tableSyntax);
+        Name = table.Name;
+        FullName = SymbolToName(table);
+        Fields = new EquatableArray<ColumnDeclaration>(columns.ToImmutableArray());
+        Public = isPublic;
+    }
+}
+
+readonly record struct ReducerParamDeclaration
+{
+    public readonly string Name;
+    public readonly string Type;
+    public readonly string TypeInfo;
+    public readonly bool IsContextArg;
+
+    public ReducerParamDeclaration(string name, ITypeSymbol type)
+    {
+        Name = name;
+        Type = SymbolToName(type);
+        TypeInfo = GetTypeInfo(type);
+        IsContextArg = Type == "SpacetimeDB.Runtime.ReducerContext";
+    }
+}
+
+record ReducerDeclaration
+{
+    public readonly string Name;
+    public readonly string ExportName;
+    public readonly string FullName;
+    public readonly EquatableArray<ReducerParamDeclaration> Args;
+    public readonly Scope Scope;
+
+    public ReducerDeclaration(
+        MethodDeclarationSyntax methodSyntax,
+        IMethodSymbol method,
+        string? exportName
+    )
+    {
+        Name = method.Name;
+        ExportName = exportName ?? Name;
+        FullName = SymbolToName(method);
+        Args = new(
+            method
+                .Parameters.Select(p => new ReducerParamDeclaration(p.Name, p.Type))
+                .ToImmutableArray()
+        );
+        Scope = new Scope(methodSyntax.Parent as MemberDeclarationSyntax);
+    }
+}
+
 [Generator]
 public class Module : IIncrementalGenerator
 {
     public void Initialize(IncrementalGeneratorInitializationContext context)
     {
-        var tables = context.SyntaxProvider.ForAttributeWithMetadataName(
-            fullyQualifiedMetadataName: "SpacetimeDB.TableAttribute",
-            predicate: (node, ct) => true, // already covered by attribute restrictions
-            transform: (context, ct) =>
-            {
-                var tableSyntax = (TypeDeclarationSyntax)context.TargetNode;
-                var table = context.SemanticModel.GetDeclaredSymbol(tableSyntax)!;
-
-                var fields = GetFields(table)
-                    .Select(f =>
-                    {
-                        var indexKind = f.GetAttributes()
-                            .Where(a =>
-                                a.AttributeClass?.ToString() == "SpacetimeDB.ColumnAttribute"
-                            )
-                            .Select(a => (ColumnAttrs)a.ConstructorArguments[0].Value!)
-                            .SingleOrDefault();
-
-                        var isInteger = f.Type.SpecialType switch
-                        {
-                            SpecialType.System_Byte
-                            or SpecialType.System_SByte
-                            or SpecialType.System_Int16
-                            or SpecialType.System_UInt16
-                            or SpecialType.System_Int32
-                            or SpecialType.System_UInt32
-                            or SpecialType.System_Int64
-                            or SpecialType.System_UInt64
-                                => true,
-                            SpecialType.None
-                                => f.Type.ToString() is "System.Int128" or "System.UInt128",
-                            _ => false
-                        };
-
-                        if (indexKind.HasFlag(ColumnAttrs.AutoInc) && !isInteger)
-                        {
-                            throw new System.Exception(
-                                $"{f.Type} {f.Name} is not valid for AutoInc or Identity as it's not an integer."
-                            );
-                        }
-
-                        var isEquatable =
-                            (
-                                isInteger
-                                || f.Type.SpecialType switch
-                                {
-                                    SpecialType.System_String or SpecialType.System_Boolean => true,
-                                    SpecialType.None
-                                        => f.Type.ToString()
-                                            is "SpacetimeDB.Runtime.Address"
-                                                or "SpacetimeDB.Runtime.Identity",
-                                    _ => false,
-                                }
-                            )
-                            && f.Type.NullableAnnotation != NullableAnnotation.Annotated;
-
-                        if (indexKind.HasFlag(ColumnAttrs.Unique) && !isEquatable)
-                        {
-                            throw new System.Exception(
-                                $"{f.Type} {f.Name} is not valid for Identity, PrimaryKey or PrimaryKeyAuto as it's not an equatable primitive."
-                            );
-                        }
-
-                        return (
-                            f.Name,
-                            Type: SymbolToName(f.Type),
-                            TypeInfo: GetTypeInfo(f.Type),
-                            IndexKind: indexKind,
-                            IsEquatable: isEquatable
-                        );
-                    })
-                    .ToArray();
-
-                return new
+        var tables = context
+            .SyntaxProvider.ForAttributeWithMetadataName(
+                fullyQualifiedMetadataName: "SpacetimeDB.TableAttribute",
+                predicate: (node, ct) => true, // already covered by attribute restrictions
+                transform: (context, ct) =>
                 {
-                    Scope = new Scope(tableSyntax),
-                    table.Name,
-                    FullName = SymbolToName(table),
-                    Fields = fields,
-                    Public = context
+                    var tableSyntax = (TypeDeclarationSyntax)context.TargetNode;
+
+                    var table = context.SemanticModel.GetDeclaredSymbol(tableSyntax)!;
+
+                    var fields = GetFields(table)
+                        .Select(f =>
+                        {
+                            var indexKind = f.GetAttributes()
+                                .Where(a =>
+                                    a.AttributeClass?.ToString() == "SpacetimeDB.ColumnAttribute"
+                                )
+                                .Select(a => (ColumnAttrs)a.ConstructorArguments[0].Value!)
+                                .SingleOrDefault();
+
+                            return new ColumnDeclaration(f.Name, f.Type, indexKind);
+                        });
+
+                    var isPublic = context
                         .Attributes.SelectMany(attr => attr.NamedArguments)
-                        .Any(pair => pair.Key == "Public" && pair.Value.Value is true)
-                };
-            }
-        );
+                        .Any(pair => pair.Key == "Public" && pair.Value.Value is true);
+
+                    return new TableDeclaration(tableSyntax, table, fields, isPublic);
+                }
+            )
+            .WithTrackingName("SpacetimeDB.Table.Parse");
 
         tables
             .Select(
@@ -198,49 +271,37 @@ public class Module : IIncrementalGenerator
                     );
                 }
             )
+            .WithTrackingName("SpacetimeDB.Table.GenerateExtensions")
             .RegisterSourceOutputs(context);
 
         var tableNames = tables.Select((t, ct) => t.FullName).Collect();
 
-        var reducers = context.SyntaxProvider.ForAttributeWithMetadataName(
-            fullyQualifiedMetadataName: "SpacetimeDB.ReducerAttribute",
-            predicate: (node, ct) => true, // already covered by attribute restrictions
-            transform: (context, ct) =>
-            {
-                var method = (IMethodSymbol)
-                    context.SemanticModel.GetDeclaredSymbol(context.TargetNode)!;
-
-                if (!method.ReturnsVoid)
+        var reducers = context
+            .SyntaxProvider.ForAttributeWithMetadataName(
+                fullyQualifiedMetadataName: "SpacetimeDB.ReducerAttribute",
+                predicate: (node, ct) => true, // already covered by attribute restrictions
+                transform: (context, ct) =>
                 {
-                    throw new System.Exception($"Reducer {method} must return void");
+                    var methodSyntax = (MethodDeclarationSyntax)context.TargetNode;
+
+                    var method = context.SemanticModel.GetDeclaredSymbol(methodSyntax)!;
+
+                    if (!method.ReturnsVoid)
+                    {
+                        throw new System.Exception($"Reducer {method} must return void");
+                    }
+
+                    var exportName = (string?)
+                        context
+                            .Attributes.SingleOrDefault()
+                            ?.ConstructorArguments
+                            .SingleOrDefault()
+                            .Value;
+
+                    return new ReducerDeclaration(methodSyntax, method, exportName);
                 }
-
-                var exportName = (string?)
-                    context
-                        .Attributes.SingleOrDefault()
-                        ?.ConstructorArguments
-                        .SingleOrDefault()
-                        .Value;
-
-                return new
-                {
-                    Name = method.Name,
-                    ExportName = exportName ?? method.Name,
-                    FullName = SymbolToName(method),
-                    Args = method
-                        .Parameters.Select(p =>
-                            (
-                                p.Name,
-                                p.Type,
-                                IsContextArg: p.Type.ToString()
-                                    == "SpacetimeDB.Runtime.ReducerContext"
-                            )
-                        )
-                        .ToArray(),
-                    Scope = new Scope((TypeDeclarationSyntax)context.TargetNode.Parent!)
-                };
-            }
-        );
+            )
+            .WithTrackingName("SpacetimeDB.Reducer.Parse");
 
         var addReducers = reducers
             .Select(
@@ -249,7 +310,7 @@ public class Module : IIncrementalGenerator
                         r.Name,
                         Class: $@"
                             class {r.Name}: IReducer {{
-                                {string.Join("\n", r.Args.Where(a => !a.IsContextArg).Select(a => $"{GetTypeInfo(a.Type)} {a.Name} = new();"))}
+                                {string.Join("\n", r.Args.Where(a => !a.IsContextArg).Select(a => $"{a.TypeInfo} {a.Name} = new();"))}
 
                                 SpacetimeDB.Module.ReducerDef IReducer.MakeReducerDef(SpacetimeDB.BSATN.ITypeRegistrar registrar) {{
                                     return new (
@@ -265,6 +326,7 @@ public class Module : IIncrementalGenerator
                         "
                     )
             )
+            .WithTrackingName("SpacetimeDB.Reducer.GenerateClass")
             .Collect();
 
         context.RegisterSourceOutput(
@@ -341,13 +403,14 @@ public class Module : IIncrementalGenerator
                             public static SpacetimeDB.Runtime.ScheduleToken Schedule{r.Name}(DateTimeOffset time{string.Join("", r.Args.Where(a => !a.IsContextArg).Select(a => $", {a.Type} {a.Name}"))}) {{
                                 using var stream = new MemoryStream();
                                 using var writer = new BinaryWriter(stream);
-                                {string.Join("\n", r.Args.Where(a => !a.IsContextArg).Select(a => $"new {GetTypeInfo(a.Type)}().Write(writer, {a.Name});"))}
+                                {string.Join("\n", r.Args.Where(a => !a.IsContextArg).Select(a => $"new {a.TypeInfo}().Write(writer, {a.Name});"))}
                                 return new(nameof({r.Name}), stream.ToArray(), time);
                             }}
                         "
                         )
                     )
             )
+            .WithTrackingName("SpacetimeDB.Reducer.GenerateSchedule")
             .RegisterSourceOutputs(context);
     }
 }


### PR DESCRIPTION
# Description of Changes

One of the main features of incremental generators over regular source generators is the cached pipelines - each step is cached by using the input structures as a key to avoid recomputing output if the input hasn't changed. This is particularly useful in IDEs where otherwise each keystroke might potentially cause the entire pipeline to regenerate new code.

Unfortunately, Roslyn doesn't provide any built-in tooling to verify that you are using only cacheable structures, doesn't warn or error out if you don't, and instead just quietly recomputes everything if you're using structures that only have default (referential) equality anywhere in the pipeline. The issue is exacerbated by the fact that none of the built-in collections implement deep equality, so as soon as you use an array, list, immutable array, or any other built-in collection, your entire pipeline becomes uncacheable.

As a result, a lot of incremental generators in the wild are not as performant as they could be, and might even cause GC to keep around ASTs that are long unused. Indeed, our generators were no exception.

Now that we have automated tests for incremental generators (#1400), I've extended them to test that trivial modifications to the code (e.g. adding a line comment to each line) don't cause recomputation of the entire pipeline, and instead reuse the existing cache.

This, in turn, required a bunch of fixes and new data structures - most notably, using `record`s everywhere as they automatically derive proper memberwise equality instead of referential one as well as a new `EquatableArray` structure for a deeply equatable collection (this is one that every author of source generators seems to have to reinvent on their own...).

Now the pipeline is fully cacheable 🥳

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

2 - might have missed some breaking changes, but doesn't seem so?

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] `dotnet test`