### PR TITLE
Include BSATN.Codegen in nuget pack

### DIFF
--- a/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
+++ b/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
@@ -9,12 +9,6 @@
     <AssemblyName>SpacetimeDB.BSATN.Codegen</AssemblyName>
     <AssemblyVersion>0.10.0</AssemblyVersion>
     <IncludeBuildOutput>false</IncludeBuildOutput>
-    <!--
-      We don't want to publish this package to NuGet to reduce maintenance cost
-      as well as shenanigans with transitive deps in source generators. (https://github.com/dotnet/roslyn/issues/43903)
-      Instead, we put its DLL directly in Unity SDK and include it in SpacetimeDB.Codegen for regular C# consumers
-    -->
-    <IsPackable>false</IsPackable>
   </PropertyGroup>
 
   <PropertyGroup>


### PR DESCRIPTION
# Description of Changes

Previously BSATN.Codegen was ignored during the `nuget pack` command. During the release preparation of v0.10.0, it was discovered that this is required by the SDK. This includes the change to start building that csproj when we build and release nuget packages.

# API and ABI breaking changes

n/a

# Expected complexity level and risk

0 - Minimal Risk or Complexity. It is only a configuration change for nuget packages.

# Testing

[x] This diff was used in the v0.10.0 release preparation and I was able to `nuget pack` and push this C# Project successfully.
