### PR TITLE
Implement the module rng proposal for C#

### DIFF
--- a/crates/bindings-csharp/Runtime/Module.cs
+++ b/crates/bindings-csharp/Runtime/Module.cs
@@ -237,6 +237,7 @@ public static class FFI
     {
         try
         {
+            Runtime.Random = new((int)timestamp);
             using var stream = new MemoryStream(args.Consume());
             using var reader = new BinaryReader(stream);
             reducers[(int)id].Invoke(

--- a/crates/bindings-csharp/Runtime/Runtime.cs
+++ b/crates/bindings-csharp/Runtime/Runtime.cs
@@ -323,4 +323,7 @@ public static partial class Runtime
             return false;
         }
     }
+
+    // An instance of `System.Random` that is reseeded by each reducer's timestamp.
+    public static Random Random { get; internal set; } = new();
 }


### PR DESCRIPTION
# Description of Changes

Adds `Runtime.Random` property which contains an instance of `System.Random` that is reseeded by each reducer's timestamp.

The API is different from Rust implementation due to underlying differences between random APIs.

Fixes #1259.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1
*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Ran C# SDK test.