### PR TITLE
perf(1351): Add a row count metric for subscriptions

### DIFF
--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -7,6 +7,7 @@ use std::io::Read;
 use std::sync::Arc;
 use std::time::Instant;
 
+use crate::execution_context::WorkloadType;
 use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent, ProtocolDatabaseUpdate};
 use crate::identity::Identity;
 use crate::json::client_api::{
@@ -77,6 +78,29 @@ pub enum SerializableMessage {
     ProtocolUpdate(TransactionUpdateMessage<ProtocolDatabaseUpdate>),
 }
 
+impl SerializableMessage {
+    /// The number of rows in the payload
+    pub fn num_rows(&self) -> Option<usize> {
+        match self {
+            Self::Query(msg) => Some(msg.num_rows()),
+            Self::Subscribe(msg) => Some(msg.num_rows()),
+            Self::DatabaseUpdate(msg) => Some(msg.num_rows()),
+            Self::ProtocolUpdate(msg) => Some(msg.num_rows()),
+            _ => None,
+        }
+    }
+
+    /// The type of workload from which this message originates
+    pub fn workload(&self) -> Option<WorkloadType> {
+        match self {
+            Self::Query(_) => Some(WorkloadType::Sql),
+            Self::Subscribe(_) => Some(WorkloadType::Subscribe),
+            Self::DatabaseUpdate(_) | Self::ProtocolUpdate(_) => Some(WorkloadType::Update),
+            _ => None,
+        }
+    }
+}
+
 impl ServerMessage for SerializableMessage {
     fn serialize_text(self) -> MessageJson {
         match self {
@@ -131,6 +155,20 @@ impl ServerMessage for IdentityTokenMessage {
 pub struct TransactionUpdateMessage<U> {
     pub event: Arc<ModuleEvent>,
     pub database_update: SubscriptionUpdate<U>,
+}
+
+impl TransactionUpdateMessage<DatabaseUpdate> {
+    /// The number of rows in the payload
+    pub fn num_rows(&self) -> usize {
+        self.database_update.database_update.num_rows()
+    }
+}
+
+impl TransactionUpdateMessage<ProtocolDatabaseUpdate> {
+    /// The number of rows in the payload
+    pub fn num_rows(&self) -> usize {
+        self.database_update.database_update.num_rows()
+    }
 }
 
 impl<U: Into<Vec<TableUpdate>> + Into<Vec<TableUpdateJson>>> ServerMessage for TransactionUpdateMessage<U> {
@@ -202,6 +240,13 @@ pub struct SubscriptionUpdateMessage {
     pub subscription_update: SubscriptionUpdate<ProtocolDatabaseUpdate>,
 }
 
+impl SubscriptionUpdateMessage {
+    /// The number of rows in the payload
+    pub fn num_rows(&self) -> usize {
+        self.subscription_update.database_update.num_rows()
+    }
+}
+
 impl ServerMessage for SubscriptionUpdateMessage {
     fn serialize_text(self) -> MessageJson {
         MessageJson::SubscriptionUpdate(self.subscription_update.into_json())
@@ -247,6 +292,13 @@ pub struct OneOffQueryResponseMessage {
     pub error: Option<String>,
     pub results: Vec<MemTable>,
     pub total_host_execution_duration: u64,
+}
+
+impl OneOffQueryResponseMessage {
+    /// The number of rows in the payload
+    pub fn num_rows(&self) -> usize {
+        self.results.iter().map(|t| t.data.len()).sum()
+    }
 }
 
 impl ServerMessage for OneOffQueryResponseMessage {

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -41,6 +41,16 @@ pub struct ProtocolDatabaseUpdate {
     pub tables: Either<Vec<TableUpdate>, Vec<TableUpdateJson>>,
 }
 
+impl ProtocolDatabaseUpdate {
+    /// The number of rows in the payload
+    pub fn num_rows(&self) -> usize {
+        match &self.tables {
+            Either::Left(updates) => updates.iter().map(|t| t.table_row_operations.len()).sum(),
+            Either::Right(updates) => updates.iter().map(|t| t.table_row_operations.len()).sum(),
+        }
+    }
+}
+
 impl From<ProtocolDatabaseUpdate> for Vec<TableUpdate> {
     fn from(update: ProtocolDatabaseUpdate) -> Self {
         update.tables.unwrap_left()
@@ -95,6 +105,11 @@ impl DatabaseUpdate {
         DatabaseUpdate {
             tables: map.into_values().collect(),
         }
+    }
+
+    /// The number of rows in the payload
+    pub fn num_rows(&self) -> usize {
+        self.tables.iter().map(|t| t.inserts.len() + t.deletes.len()).sum()
     }
 }
 

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -22,15 +22,35 @@ metrics_group!(
         #[labels(instance_id: u64, protocol: str)]
         pub websocket_request_msg_size: HistogramVec,
 
-        #[name = spacetime_websocket_sent_total]
-        #[help = "The cumulative number of websocket messages sent to client"]
-        #[labels(identity: Identity)]
-        pub websocket_sent: IntCounterVec,
-
-        #[name = spacetime_websocket_sent_msg_size]
+        #[name = spacetime_websocket_sent_msg_size_bytes]
         #[help = "The size of messages sent to connected sessions"]
-        #[labels(identity: Identity)]
+        #[labels(db: Address, workload: WorkloadType)]
+        // Prometheus histograms have default buckets,
+        // which broadly speaking,
+        // are tailored to measure the response time of a network service.
+        //
+        // Therefore we define specific buckets for this metric,
+        // since it has a different unit and a different distribution.
+        //
+        // In particular incremental update payloads could be smaller than 1KB,
+        // whereas initial subscription payloads could exceed 10MB.
+        #[buckets(100, 500, 1e3, 10e3, 100e3, 500e3, 1e6, 5e6, 10e6, 25e6, 50e6, 75e6, 100e6, 500e6)]
         pub websocket_sent_msg_size: HistogramVec,
+
+        #[name = spacetime_websocket_sent_num_rows]
+        #[help = "The number of rows sent to connected sessions"]
+        #[labels(db: Address, workload: WorkloadType)]
+        // Prometheus histograms have default buckets,
+        // which broadly speaking,
+        // are tailored to measure the response time of a network service.
+        //
+        // Therefore we define specific buckets for this metric,
+        // since it has a different unit and a different distribution.
+        //
+        // In particular incremental updates could have fewer than 10 rows,
+        // whereas initial subscriptions could exceed 100K rows.
+        #[buckets(5, 10, 50, 100, 500, 1e3, 5e3, 10e3, 50e3, 100e3, 250e3, 500e3, 750e3, 1e6, 5e6)]
+        pub websocket_sent_num_rows: HistogramVec,
 
         #[name = spacetime_worker_instance_operation_queue_length]
         #[help = "Length of the wait queue for access to a module instance."]


### PR DESCRIPTION
Closes #1351.

Also label row count and message size metrics by db address and workload.

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
