### PR TITLE
CI - Clear `.spacetime` before running benchmarks

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -93,6 +93,8 @@ jobs:
         run: echo "0" | sudo tee /sys/devices/system/cpu/cpufreq/boost
 
       - name: Branch; run bench
+        env:
+          RUST_BACKTRACE: 1
         run: |
           if [[ $PR_NUMBER ]]; then
             BASELINE_NAME=branch

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -106,6 +106,7 @@ jobs:
             echo "Running benchmarks with sqlite"
           fi
           pushd crates/bench
+          rm -rf .spacetime
           cargo bench --bench generic -- --save-baseline "$BASELINE_NAME" "$BENCH_FILTER"
           # sticker price benchmark
           cargo bench --bench generic -- --save-baseline "$BASELINE_NAME" 'stdb_module/disk/update_bulk'


### PR DESCRIPTION
# Description of Changes

If/when we have ABI breaking changes, this directory can cause benchmarks to start failing.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
