### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -767,7 +767,7 @@ dependencies = [
 
 [[package]]
 name = "connect_disconnect_client"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "spacetimedb-sdk",
@@ -4150,7 +4150,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "derive_more",
  "getrandom",
@@ -4166,7 +4166,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bench"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "anymap",
@@ -4203,7 +4203,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-macro"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bitflags 2.4.1",
  "humantime",
@@ -4215,14 +4215,14 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-sys"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "spacetimedb-primitives",
 ]
 
 [[package]]
 name = "spacetimedb-cli"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -4273,7 +4273,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4312,7 +4312,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api-messages"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "chrono",
  "hex",
@@ -4330,7 +4330,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-commitlog"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bitflags 2.4.1",
  "crc32c",
@@ -4350,7 +4350,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4445,7 +4445,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-data-structures"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "hashbrown 0.14.1",
  "nohash-hasher",
@@ -4455,7 +4455,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-durability"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "log",
@@ -4467,7 +4467,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-fs-utils"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-lib"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4502,7 +4502,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-metrics"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "arrayvec",
  "itertools 0.12.0",
@@ -4512,7 +4512,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-primitives"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bitflags 2.4.1",
  "either",
@@ -4530,7 +4530,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sats"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ahash 0.8.11",
  "arrayvec",
@@ -4558,7 +4558,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sdk"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "anymap",
@@ -4586,7 +4586,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-snapshot"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "blake3",
  "hex",
@@ -4602,7 +4602,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-standalone"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4632,7 +4632,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-table"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ahash 0.8.11",
  "blake3",
@@ -4655,7 +4655,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-testing"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap 4.4.6",
@@ -4681,7 +4681,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-vm"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4770,7 +4770,7 @@ dependencies = [
 
 [[package]]
 name = "sqltest"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5033,7 +5033,7 @@ dependencies = [
 
 [[package]]
 name = "test-client"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -5044,7 +5044,7 @@ dependencies = [
 
 [[package]]
 name = "test-counter"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "spacetimedb-data-structures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,31 +77,31 @@ inherits = "release"
 debug = true
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 # update rust-toolchain.toml too!
 rust-version = "1.78.0"
 
 [workspace.dependencies]
-spacetimedb = { path = "crates/bindings", version = "0.10.1" }
-spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "0.10.1" }
-spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "0.10.1" }
-spacetimedb-cli = { path = "crates/cli", version = "0.10.1" }
-spacetimedb-client-api = { path = "crates/client-api", version = "0.10.1" }
-spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "0.10.1" }
-spacetimedb-commitlog = { path = "crates/commitlog", version = "0.10.1" }
-spacetimedb-core = { path = "crates/core", version = "0.10.1" }
-spacetimedb-data-structures = { path = "crates/data-structures", version = "0.10.1" }
-spacetimedb-durability = { path = "crates/durability", version = "0.10.1" }
-spacetimedb-lib = { path = "crates/lib", default-features = false, version = "0.10.1" }
-spacetimedb-metrics = { path = "crates/metrics", version = "0.10.1" }
-spacetimedb-primitives = { path = "crates/primitives", version = "0.10.1" }
-spacetimedb-sats = { path = "crates/sats", version = "0.10.1" }
-spacetimedb-standalone = { path = "crates/standalone", version = "0.10.1" }
-spacetimedb-table = { path = "crates/table", version = "0.10.1" }
-spacetimedb-vm = { path = "crates/vm", version = "0.10.1" }
-spacetimedb-fs-utils = { path = "crates/fs-utils", version = "0.10.1" }
-spacetimedb-snapshot = { path = "crates/snapshot", version = "0.10.1" }
+spacetimedb = { path = "crates/bindings", version = "0.11.0" }
+spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "0.11.0" }
+spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "0.11.0" }
+spacetimedb-cli = { path = "crates/cli", version = "0.11.0" }
+spacetimedb-client-api = { path = "crates/client-api", version = "0.11.0" }
+spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "0.11.0" }
+spacetimedb-commitlog = { path = "crates/commitlog", version = "0.11.0" }
+spacetimedb-core = { path = "crates/core", version = "0.11.0" }
+spacetimedb-data-structures = { path = "crates/data-structures", version = "0.11.0" }
+spacetimedb-durability = { path = "crates/durability", version = "0.11.0" }
+spacetimedb-lib = { path = "crates/lib", default-features = false, version = "0.11.0" }
+spacetimedb-metrics = { path = "crates/metrics", version = "0.11.0" }
+spacetimedb-primitives = { path = "crates/primitives", version = "0.11.0" }
+spacetimedb-sats = { path = "crates/sats", version = "0.11.0" }
+spacetimedb-standalone = { path = "crates/standalone", version = "0.11.0" }
+spacetimedb-table = { path = "crates/table", version = "0.11.0" }
+spacetimedb-vm = { path = "crates/vm", version = "0.11.0" }
+spacetimedb-fs-utils = { path = "crates/fs-utils", version = "0.11.0" }
+spacetimedb-snapshot = { path = "crates/snapshot", version = "0.11.0" }
 
 ahash = "0.8"
 anyhow = "1.0.68"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Clockwork Laboratories, Inc.
-Licensed Work:        SpacetimeDB 0.10.1
+Licensed Work:        SpacetimeDB 0.11.0
                       The Licensed Work is
                       (c) 2023 Clockwork Laboratories, Inc.
                       

--- a/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
+++ b/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Codegen</AssemblyName>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Title>SpacetimeDB BSATN Codegen</Title>
     <Description>The SpacetimeDB BSATN Codegen implements the Roslyn incremental generators for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Runtime</AssemblyName>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Title>SpacetimeDB BSATN Runtime</Title>
     <Description>The SpacetimeDB BSATN Runtime implements APIs for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Codegen</AssemblyName>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Title>SpacetimeDB Module Codegen</Title>
     <Description>The SpacetimeDB Codegen implements the Roslyn incremental generators for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Runtime/Runtime.csproj
+++ b/crates/bindings-csharp/Runtime/Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Runtime</AssemblyName>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Title>SpacetimeDB Module Runtime</Title>
     <Description>The SpacetimeDB Runtime implements the database runtime bindings for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.11.*" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/rust/Cargo._toml
+++ b/crates/cli/src/subcommands/project/rust/Cargo._toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "0.10.1"
+spacetimedb = "0.11.0"
 log = "0.4"


### PR DESCRIPTION
# Description of Changes

https://github.com/clockworklabs/SpacetimeDB/pull/1440 has merged, requiring an upgrade to 0.11.0.

# API and ABI breaking changes

No

# Expected complexity level and risk

1

# Testing

None