### PR TITLE
core: Replace host scheduler on update

### DIFF
--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -831,6 +831,7 @@ impl Host {
         .await?;
         trace!("update result: {update_result:?}");
         if update_result.is_ok() {
+            self.scheduler = scheduler;
             scheduler_starter.start(&module)?;
             let old_module = self.module.send_replace(module);
             old_module.exit().await;


### PR DESCRIPTION
When updating a `Host`, replace its `Scheduler` with the new one.

This is only a minor fix: the `Host` only uses the `Scheduler` to create a
fresh `Scheduler` with the same underlying database, while the actual
scheduling happens elsewhere. By not dropping the old `Scheduler`, we'd
leak a channel with no receivers and a pointer to the database.

# Expected complexity level and risk

1
