### PR TITLE
CLI - Update help text suggesting `spacetime server fingerprint` to have the correct `-s` param

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -80,7 +80,7 @@ Or initialize a default identity with:
                 format!(
                     "Cannot verify tokens using invalid saved fingerprint from server: {server}
 Update the fingerprint with:
-\tspacetime server fingerprint {server}",
+\tspacetime server fingerprint -s {server}",
                 )
             })?;
             decode_token(&decoder, &id.token).map_err(|_| {
@@ -387,7 +387,7 @@ Import an existing identity with:
                     anyhow::anyhow!(
                         "Cannot delete identities for server without saved identity: {server}
 Fetch the server's fingerprint with:
-\tspacetime server fingerprint {server}"
+\tspacetime server fingerprint -s {server}"
                     )
                 })?;
                 self.remove_identities_for_fingerprint(&fingerprint)?
@@ -404,7 +404,7 @@ Fetch the server's fingerprint with:
         let decoder = DecodingKey::from_ec_pem(fingerprint.as_bytes()).with_context(|| {
             "Cannot delete identities for server without saved identity: {server}
 Fetch the server's fingerprint with:
-\tspacetime server fingerprint {server}"
+\tspacetime server fingerprint -s {server}"
         })?;
 
         // TODO: use `Vec::extract_if` instead when it stabilizes.
@@ -456,7 +456,7 @@ Fetch the server's fingerprint with:
                 format!(
                     "No saved fingerprint for server: {server}
 Fetch the server's fingerprint with:
-\tspacetime server fingerprint {server}"
+\tspacetime server fingerprint -s {server}"
                 )
             })
             .map(|cfg| cfg.ecdsa_public_key.as_deref())
@@ -1006,7 +1006,7 @@ Import an existing identity with:
                     format!(
                         "Unable to parse invalid saved server fingerprint as ECDSA public key.
 Update the server's fingerprint with:
-\tspacetime server fingerprint {}",
+\tspacetime server fingerprint -s {}",
                         server.unwrap_or("")
                     )
                 })

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -500,7 +500,7 @@ async fn exec_list(config: Config, args: &ArgMatches) -> Result<(), anyhow::Erro
             format!(
                 "Cannot list identities for server without a saved fingerprint: {server_name}
 Fetch the server's fingerprint with:
-\tspacetime server fingerprint {server_name}"
+\tspacetime server fingerprint -s {server_name}"
             )
         })?;
         let default_identity = config.get_default_identity_config(server).ok().map(|cfg| cfg.identity);


### PR DESCRIPTION
# Description of Changes

We have help text in several places that suggests `spacetime server fingerprint $SERVER` without the `-s` parameter we added in https://github.com/clockworklabs/SpacetimeDB/pull/1131.

# API and ABI breaking changes

Nope. Just help text.

# Expected complexity level and risk

1

# Testing
Nope. Just help text.