### PR TITLE
Fixed exceptions in C# SDK when someone disconnects or when a transaction originates from CLI

### DIFF
--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -712,6 +712,8 @@ pub fn autogen_csharp_globals(items: &[GenItem], namespace: &str) -> Vec<(String
                     );
                 }
                 writeln!(output, "\"<none>\" => null,");
+                writeln!(output, "\"__identity_disconnected__\" => null,");
+                writeln!(output, "\"\" => null,"); //Transaction from CLI command
                 writeln!(
                     output,
                     r#"var reducer => throw new ArgumentOutOfRangeException("Reducer", $"Unknown reducer {{reducer}}")"#

--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -712,6 +712,7 @@ pub fn autogen_csharp_globals(items: &[GenItem], namespace: &str) -> Vec<(String
                     );
                 }
                 writeln!(output, "\"<none>\" => null,");
+                writeln!(output, "\"__identity_connected__\" => null,");
                 writeln!(output, "\"__identity_disconnected__\" => null,");
                 writeln!(output, "\"\" => null,"); //Transaction from CLI command
                 writeln!(

--- a/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
@@ -738,6 +738,8 @@ namespace SpacetimeDB
 				"repeating_test" => BSATNHelpers.FromProtoBytes<RepeatingTestArgsStruct>(argBytes),
 				"test" => BSATNHelpers.FromProtoBytes<TestArgsStruct>(argBytes),
 				"<none>" => null,
+				"__identity_disconnected__" => null,
+				"" => null,
 				var reducer => throw new ArgumentOutOfRangeException("Reducer", $"Unknown reducer {reducer}")
 			};
 			return new ReducerEvent(dbEvent, args);

--- a/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
@@ -738,6 +738,7 @@ namespace SpacetimeDB
 				"repeating_test" => BSATNHelpers.FromProtoBytes<RepeatingTestArgsStruct>(argBytes),
 				"test" => BSATNHelpers.FromProtoBytes<TestArgsStruct>(argBytes),
 				"<none>" => null,
+				"__identity_connected__" => null,
 				"__identity_disconnected__" => null,
 				"" => null,
 				var reducer => throw new ArgumentOutOfRangeException("Reducer", $"Unknown reducer {reducer}")


### PR DESCRIPTION
Trivial

# Description of Changes
- Added two cases to code gen switch that parses args based on reducer name
  - "__identity_disconnected__" - another client disconnects
  - "" (empty string) - when calling UPDATE / DELETE from CLI

# Expected complexity level and risk
Complexity: 1/5
Risk: 1/5

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Re-generate C# code with this change
- [x] Open "main" client and connect to server
- [x] Have another client connect to same server
- [x] Close another client. Note there is no exception logged in "main" client
- [x] Open CLI and run an UPDATE / DELETE query. Note there are no exceptions logged in "main" client