### PR TITLE
Ensure MacOS builds from CI are executable

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -31,7 +31,9 @@ jobs:
       - name: Compile Aarch64
         run: |
           cargo build --release -p spacetimedb-cli --target=aarch64-apple-darwin
-          dd if=target/aarch64-apple-darwin/release/spacetime of=build/spacetime conv=noerror,sync  
+          # dd is used to avoid incompatibilities between BSD tar vs. GNU tar
+          dd if=target/aarch64-apple-darwin/release/spacetime of=build/spacetime conv=noerror,sync
+          chmod +x build/spacetime
           cd build && tar -czf spacetime.darwin-arm64.tar.gz spacetime
           rm spacetime
 


### PR DESCRIPTION
# Description of Changes

The `spacetime` binary in the MacOS build's tarball is not flagged as executable.

This makes it executable.

# API and ABI breaking changes

n/a

# Expected complexity level and risk

It only affects future release automation. I assume there is next to no risk.

# Testing

Untested as this specific CI is only ran on `master`, `release` branches, and tags.
