### PR TITLE
[bfops/pr-post]: Add thing

### DIFF
--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -1,0 +1,21 @@
+name: Discord notifications
+
+on:
+  pull_request:
+    types: [closed]
+
+jobs:
+  discordNotification:
+    runs-on: ubuntu-latest
+    if: github.event.pull_request.merged == true
+    steps:
+      - name: Send Discord notification
+        env:
+          DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
+          PR_TITLE: ${{ github.event.pull_request.title }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          PR_URL: ${{ github.event.pull_request.html_url }}
+        run: |
+          curl -X POST -H 'Content-Type: application/json' -d '{
+            "content": "'"PR merged: [(#${PR_NUMBER}) ${PR_TITLE}](${PR_URL})"'"
+          }' ${DISCORD_WEBHOOK_URL}


### PR DESCRIPTION
# Description of Changes

When a PR merges, post a message to a specified Discord Webhook.


# API and ABI breaking changes

No

# Expected complexity level and risk

2?

# Testing

There's an identical workflow in https://github.com/clockworklabs/github-tooling-test. I tested it with a personal discord server where I have admin access.

Looks like this (`GitHub test` is the name I gave the bot in my test)
![image](https://github.com/clockworklabs/SpacetimeDB/assets/196249/c7c5bfee-fdff-4c3f-a6c8-166c7facab61)