### PR TITLE
`ColList`: preserve list order on `list.push(..)`

### DIFF
--- a/crates/primitives/proptest-regressions/col_list.txt
+++ b/crates/primitives/proptest-regressions/col_list.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 70b4e531ebb215f2a8efd7d316970aa75d0ec8d555411bd73d1c63c33d8ea1ed # shrinks to cols = [ColId(19), ColId(0)]
+cc 4f5950efc2ad78c3b31cc3f50158d88c10da3229fabdca6ce3e6ceab665e19c8 # shrinks to cols = [ColId(39), ColId(39)]


### PR DESCRIPTION
# Description of Changes

Preserve the list order of `ColList` for e.g., `col_list![2, 0]` by heapifying in those cases.
This might not be the optimal performance solution, but this fixes the bug while preserving that `size_of::<ColList> == 8` and that it is still inline in the common case.

# API and ABI breaking changes

Rather unlikely that anyone relied on this bug.

# Expected complexity level and risk

2, some unsafe and someone might have relied on this bug.

# Testing

- Tests are amended to ensure that the list order is preserved.