### PR TITLE
Fix C# module smoketests

### DIFF
--- a/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
+++ b/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Codegen</AssemblyName>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Title>SpacetimeDB BSATN Codegen</Title>
     <Description>The SpacetimeDB BSATN Codegen implements the Roslyn incremental generators for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
+++ b/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Codegen</AssemblyName>
-    <Version>0.11.0</Version>
+    <Version>0.10.0</Version>
     <Title>SpacetimeDB BSATN Codegen</Title>
     <Description>The SpacetimeDB BSATN Codegen implements the Roslyn incremental generators for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Runtime</AssemblyName>
-    <Version>0.11.0</Version>
+    <Version>0.10.0</Version>
     <Title>SpacetimeDB BSATN Runtime</Title>
     <Description>The SpacetimeDB BSATN Runtime implements APIs for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Runtime</AssemblyName>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Title>SpacetimeDB BSATN Runtime</Title>
     <Description>The SpacetimeDB BSATN Runtime implements APIs for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Codegen</AssemblyName>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Title>SpacetimeDB Module Codegen</Title>
     <Description>The SpacetimeDB Codegen implements the Roslyn incremental generators for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Codegen</AssemblyName>
-    <Version>0.11.0</Version>
+    <Version>0.10.0</Version>
     <Title>SpacetimeDB Module Codegen</Title>
     <Description>The SpacetimeDB Codegen implements the Roslyn incremental generators for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Runtime/Runtime.csproj
+++ b/crates/bindings-csharp/Runtime/Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Runtime</AssemblyName>
-    <Version>0.11.0</Version>
+    <Version>0.10.0</Version>
     <Title>SpacetimeDB Module Runtime</Title>
     <Description>The SpacetimeDB Runtime implements the database runtime bindings for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Runtime/Runtime.csproj
+++ b/crates/bindings-csharp/Runtime/Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Runtime</AssemblyName>
-    <Version>0.10.0</Version>
+    <Version>0.11.0</Version>
     <Title>SpacetimeDB Module Runtime</Title>
     <Description>The SpacetimeDB Runtime implements the database runtime bindings for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.0" />
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.0" />
+    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.1" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.1" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.0" />
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.0" />
+    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.*" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.*" />
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.*" />
+    <PackageReference Include="SpacetimeDB.Codegen" Version="0.11.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.11.*" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,7 +8,6 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Codegen" Version="0.11.*" />
     <PackageReference Include="SpacetimeDB.Runtime" Version="0.11.*" />
   </ItemGroup>
 

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.1" />
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.1" />
+    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.*" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.*" />
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.*" />
+    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.1" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.1" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.1" />
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.1" />
+    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.0" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.0" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.11.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.*" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Codegen" Version="0.11.*" />
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.11.*" />
+    <PackageReference Include="SpacetimeDB.Codegen" Version="0.11.0" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.11.0" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Codegen" Version="0.11.0" />
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.11.0" />
+    <PackageReference Include="SpacetimeDB.Codegen" Version="0.11.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.11.*" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,6 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.*" />
     <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.*" />
   </ItemGroup>
 

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,8 +8,8 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.*" />
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.*" />
+    <PackageReference Include="SpacetimeDB.Codegen" Version="0.10.0" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.0" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -9,6 +9,7 @@
 
   <ItemGroup>
     <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.*" />
+    <PackageReference Include="SpacetimeDB.BSATN.Runtime" Version="0.10.*" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,8 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.*" />
-    <PackageReference Include="SpacetimeDB.BSATN.Runtime" Version="0.10.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.11.*" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="0.10.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="0.11.*" />
   </ItemGroup>
 
 </Project>

--- a/smoketests/tests/csharp_module.py
+++ b/smoketests/tests/csharp_module.py
@@ -22,25 +22,6 @@ class CreateProject(unittest.TestCase):
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 spacetime("init", "--lang=csharp", tmpdir)
-
-                packed_projects = ["BSATN.Runtime", "Runtime"]
-                restore_sources = [str(bindings / project / "bin" / "Release") for project in packed_projects]
-                # note that nuget URL comes last, which ensures local sources should override it.
-                restore_sources.append("https://api.nuget.org/v3/index.json")
-
-                csproj = Path(tmpdir) / "StdbModule.csproj"
-                with open(csproj, "r") as f:
-                    contents = f.read()
-
-                contents = contents.replace(
-                    "</PropertyGroup>",
-                    # note that nuget URL comes last, which ensures local sources should override it.
-                    f"""<RestoreSources>{str.join(";", restore_sources)}</RestoreSources>
-</PropertyGroup>""",
-                )
-                with open(csproj, "w") as f:
-                    f.write(contents)
-
                 run_cmd("dotnet", "publish", cwd=tmpdir, capture_stderr=True)
 
         except subprocess.CalledProcessError as e:

--- a/smoketests/tests/csharp_module.py
+++ b/smoketests/tests/csharp_module.py
@@ -17,7 +17,7 @@ class CreateProject(unittest.TestCase):
 
         try:
 
-            run_cmd("dotnet", "locals", "all", "--clear", cwd=bindings, capture_stderr=True)
+            run_cmd("dotnet", "nuget", "locals", "all", "--clear", cwd=bindings, capture_stderr=True)
             run_cmd("dotnet", "workload", "install", "wasi-experimental")
             run_cmd("dotnet", "pack", cwd=bindings, capture_stderr=True)
 

--- a/smoketests/tests/csharp_module.py
+++ b/smoketests/tests/csharp_module.py
@@ -24,9 +24,7 @@ class CreateProject(unittest.TestCase):
                 spacetime("init", "--lang=csharp", tmpdir)
 
                 packed_projects = ["BSATN.Runtime", "Runtime"]
-                restore_sources = [str(bindings / project / "bin" / "Release") for project in packed_projects]
-                # note that nuget URL comes last, which ensures local sources should override it.
-                restore_sources.append("https://api.nuget.org/v3/index.json")
+                restore_sources = [str(bindings / project) for project in packed_projects]
 
                 csproj = Path(tmpdir) / "StdbModule.csproj"
                 with open(csproj, "r") as f:
@@ -35,7 +33,7 @@ class CreateProject(unittest.TestCase):
                 contents = contents.replace(
                     "</PropertyGroup>",
                     # note that nuget URL comes last, which ensures local sources should override it.
-                    f"""<RestoreSources>{str.join(";", restore_sources)}</RestoreSources>
+                    f"""<RestoreAdditionalProjectSources>{str.join(";", restore_sources)}</RestoreAdditionalProjectSources>
 </PropertyGroup>""",
                 )
                 with open(csproj, "w") as f:

--- a/smoketests/tests/csharp_module.py
+++ b/smoketests/tests/csharp_module.py
@@ -24,7 +24,9 @@ class CreateProject(unittest.TestCase):
                 spacetime("init", "--lang=csharp", tmpdir)
 
                 packed_projects = ["BSATN.Runtime", "Runtime"]
-                restore_sources = [str(bindings / project) for project in packed_projects]
+                restore_sources = [str(bindings / project / "bin" / "Release") for project in packed_projects]
+                # note that nuget URL comes last, which ensures local sources should override it.
+                restore_sources.append("https://api.nuget.org/v3/index.json")
 
                 csproj = Path(tmpdir) / "StdbModule.csproj"
                 with open(csproj, "r") as f:
@@ -33,7 +35,7 @@ class CreateProject(unittest.TestCase):
                 contents = contents.replace(
                     "</PropertyGroup>",
                     # note that nuget URL comes last, which ensures local sources should override it.
-                    f"""<RestoreAdditionalProjectSources>{str.join(";", restore_sources)}</RestoreAdditionalProjectSources>
+                    f"""<RestoreSources>{str.join(";", restore_sources)}</RestoreSources>
 </PropertyGroup>""",
                 )
                 with open(csproj, "w") as f:

--- a/smoketests/tests/csharp_module.py
+++ b/smoketests/tests/csharp_module.py
@@ -22,6 +22,25 @@ class CreateProject(unittest.TestCase):
 
             with tempfile.TemporaryDirectory() as tmpdir:
                 spacetime("init", "--lang=csharp", tmpdir)
+
+                packed_projects = ["BSATN.Runtime", "Runtime"]
+                restore_sources = [str(bindings / project / "bin" / "Release") for project in packed_projects]
+                # note that nuget URL comes last, which ensures local sources should override it.
+                restore_sources.append("https://api.nuget.org/v3/index.json")
+
+                csproj = Path(tmpdir) / "StdbModule.csproj"
+                with open(csproj, "r") as f:
+                    contents = f.read()
+
+                contents = contents.replace(
+                    "</PropertyGroup>",
+                    # note that nuget URL comes last, which ensures local sources should override it.
+                    f"""<RestoreSources>{str.join(";", restore_sources)}</RestoreSources>
+</PropertyGroup>""",
+                )
+                with open(csproj, "w") as f:
+                    f.write(contents)
+
                 run_cmd("dotnet", "publish", cwd=tmpdir, capture_stderr=True)
 
         except subprocess.CalledProcessError as e:

--- a/smoketests/tests/csharp_module.py
+++ b/smoketests/tests/csharp_module.py
@@ -26,8 +26,6 @@ class CreateProject(unittest.TestCase):
 
                 packed_projects = ["BSATN.Runtime", "Runtime"]
                 restore_sources = [str(bindings / project / "bin" / "Release") for project in packed_projects]
-                # note that nuget URL comes last, which ensures local sources should override it.
-                restore_sources.append("https://api.nuget.org/v3/index.json")
 
                 csproj = Path(tmpdir) / "StdbModule.csproj"
                 with open(csproj, "r") as f:

--- a/smoketests/tests/csharp_module.py
+++ b/smoketests/tests/csharp_module.py
@@ -26,6 +26,8 @@ class CreateProject(unittest.TestCase):
 
                 packed_projects = ["BSATN.Runtime", "Runtime"]
                 restore_sources = [str(bindings / project / "bin" / "Release") for project in packed_projects]
+                # note that nuget URL comes last, which ensures local sources should override it.
+                restore_sources.append("https://api.nuget.org/v3/index.json")
 
                 csproj = Path(tmpdir) / "StdbModule.csproj"
                 with open(csproj, "r") as f:

--- a/smoketests/tests/csharp_module.py
+++ b/smoketests/tests/csharp_module.py
@@ -17,6 +17,7 @@ class CreateProject(unittest.TestCase):
 
         try:
 
+            run_cmd("dotnet", "locals", "all", "--clear", cwd=bindings, capture_stderr=True)
             run_cmd("dotnet", "workload", "install", "wasi-experimental")
             run_cmd("dotnet", "pack", cwd=bindings, capture_stderr=True)
 


### PR DESCRIPTION
# Description of Changes

https://github.com/clockworklabs/SpacetimeDB/pull/1440 restructured our NuGet packages, and correspondingly updated the `.csproj` files we generate. However, since we haven't actually published the restructured NuGet packages, `.csproj`s expecting the _new_ NuGet package structure will be broken, including the smoketests.

It seems like this behavior was _sometimes_ causing smoketests to fail. It's unclear why it's only sometimes, but our best guess is "something something caching", so this PR forcibly clears the NuGet package cache.

Additionally, we bump the versions of the local NuGet packages to 0.11, so that they cannot be found on the NuGet servers. This means that the smoketests can _only_ find them in local directories, so they do not get confused about where to get these packages.

# API and ABI breaking changes

No

# Testing

- [x] CI passes
- [x] `spacetime init --lang csharp` followed by `spacetime build` works successfully
- [x] smoketests pass when merged with https://github.com/clockworklabs/SpacetimeDB/pull/1459 in https://github.com/clockworklabs/SpacetimeDB/pull/1476