### PR TITLE
Fix running 'cargo test' in crates/lib

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -193,7 +193,7 @@ scoped-tls = "1.0.1"
 scopeguard = "1.1.0"
 second-stack = "0.3"
 sendgrid = "0.21"
-serde = "1.0.136"
+serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.87", features = ["raw_value"] }
 serde_path_to_error = "0.1.9"
 serde_with = { version = "3.3.0", features = ["base64", "hex"] }


### PR DESCRIPTION
# Description of Changes
Currently, if you `cd crates/lib && cargo test`, it fails, due to serde missing a feature. This failure does not show up on CI because when you run `cargo test --all` in the project root, `serde` ends up tagged with the `derive` feature by something in the tree. 

# API and ABI breaking changes

None

# Expected complexity level and risk

0

# Testing

I ran the same command after this change and it worked.