### PR TITLE
CLI: Put some common params in a central place

### DIFF
--- a/crates/cli/src/common_args.rs
+++ b/crates/cli/src/common_args.rs
@@ -1,0 +1,15 @@
+use clap::Arg;
+
+pub fn server() -> Arg {
+    Arg::new("server")
+        .long("server")
+        .short('s')
+        .help("The nickname, host name or URL of the server")
+}
+
+pub fn identity() -> Arg {
+    Arg::new("identity")
+        .long("identity")
+        .short('i')
+        .help("The identity to use")
+}

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,4 +1,5 @@
 pub mod api;
+mod common_args;
 mod config;
 mod edit_distance;
 mod errors;

--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -28,7 +28,6 @@ pub fn cli() -> clap::Command {
                 .help("The name of the reducer to call"),
         )
         .arg(Arg::new("arguments").help("arguments formatted as JSON").num_args(1..))
-        .arg(common_args::server())
         .arg(common_args::server().help("The nickname, host name or URL of the server hosting the database"))
         .arg(
             common_args::identity()

--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -29,7 +29,12 @@ pub fn cli() -> clap::Command {
         )
         .arg(Arg::new("arguments").help("arguments formatted as JSON").num_args(1..))
         .arg(common_args::server())
-        .arg(common_args::identity().conflicts_with("anon_identity"))
+        .arg(common_args::server().help("The nickname, host name or URL of the server hosting the database"))
+        .arg(
+            common_args::identity()
+                .conflicts_with("anon_identity")
+                .help("The identity to use for the call"),
+        )
         .arg(
             Arg::new("anon_identity")
                 .long("anon-identity")

--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -1,3 +1,4 @@
+use crate::common_args;
 use crate::config::Config;
 use crate::edit_distance::{edit_distance, find_best_match_for_name};
 use crate::generate::rust::{write_arglist_no_delimiters, write_type};
@@ -27,19 +28,8 @@ pub fn cli() -> clap::Command {
                 .help("The name of the reducer to call"),
         )
         .arg(Arg::new("arguments").help("arguments formatted as JSON").num_args(1..))
-        .arg(
-            Arg::new("server")
-                .long("server")
-                .short('s')
-                .help("The nickname, host name or URL of the server hosting the database"),
-        )
-        .arg(
-            Arg::new("identity")
-                .long("identity")
-                .short('i')
-                .conflicts_with("anon_identity")
-                .help("The identity to use for the call"),
-        )
+        .arg(common_args::server())
+        .arg(common_args::identity().conflicts_with("anon_identity"))
         .arg(
             Arg::new("anon_identity")
                 .long("anon-identity")

--- a/crates/cli/src/subcommands/delete.rs
+++ b/crates/cli/src/subcommands/delete.rs
@@ -1,3 +1,4 @@
+use crate::common_args;
 use crate::config::Config;
 use crate::util::{add_auth_header_opt, database_address, get_auth_header_only};
 use clap::{Arg, ArgMatches};
@@ -10,19 +11,10 @@ pub fn cli() -> clap::Command {
                 .required(true)
                 .help("The domain or address of the database to delete"),
         )
-        .arg(
-            Arg::new("identity")
-                .long("identity")
-                .short('i')
-                .help("The identity to use for deleting this database")
-                .long_help("The identity to use for deleting this database. If no identity is provided, the default one will be used."),
-        )
-        .arg(
-            Arg::new("server")
-                .long("server")
-                .short('s')
-                .help("The nickname, host name or URL of the server hosting the database")
-        )
+        .arg(common_args::identity().long_help(
+            "The identity to use for deleting this database. If no identity is provided, the default one will be used.",
+        ))
+        .arg(common_args::server())
         .after_help("Run `spacetime help delete` for more detailed information.\n")
 }
 

--- a/crates/cli/src/subcommands/delete.rs
+++ b/crates/cli/src/subcommands/delete.rs
@@ -11,10 +11,15 @@ pub fn cli() -> clap::Command {
                 .required(true)
                 .help("The domain or address of the database to delete"),
         )
-        .arg(common_args::identity().long_help(
-            "The identity to use for deleting this database. If no identity is provided, the default one will be used.",
-        ))
-        .arg(common_args::server())
+        .arg(
+            common_args::identity()
+                .help("The identity to use for deleting this database")
+                .long_help("The identity to use for deleting this database. If no identity is provided, the default one will be used."),
+        )
+        .arg(
+            common_args::server()
+                .help("The nickname, host name or URL of the server hosting the database")
+        )
         .after_help("Run `spacetime help delete` for more detailed information.\n")
 }
 

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -1,3 +1,4 @@
+use crate::common_args;
 use crate::config::Config;
 use crate::util::{add_auth_header_opt, database_address, get_auth_header_only};
 use clap::{Arg, ArgAction::SetTrue, ArgMatches};
@@ -20,16 +21,16 @@ pub fn cli() -> clap::Command {
                 .requires("entity_type")
                 .help("The name of the entity to describe"),
         )
-        .arg(Arg::new("brief").long("brief").short('b').action(SetTrue)
-            .help("If this flag is present, a brief description shall be returned"))
         .arg(
-            Arg::new("identity")
-                .long("identity")
-                .short('i')
-                .conflicts_with("anon_identity")
-                .help("The identity to use to describe the entity")
-                .long_help("The identity to use to describe the entity. If no identity is provided, the default one will be used."),
+            Arg::new("brief")
+                .long("brief")
+                .short('b')
+                .action(SetTrue)
+                .help("If this flag is present, a brief description shall be returned"),
         )
+        .arg(common_args::identity().conflicts_with("anon_identity").long_help(
+            "The identity to use to describe the entity. If no identity is provided, the default one will be used.",
+        ))
         .arg(
             Arg::new("anon_identity")
                 .long("anon-identity")
@@ -38,12 +39,7 @@ pub fn cli() -> clap::Command {
                 .action(SetTrue)
                 .help("If this flag is present, no identity will be provided when describing the database"),
         )
-        .arg(
-            Arg::new("server")
-                .long("server")
-                .short('s')
-                .help("The nickname, host name or URL of the server hosting the database"),
-        )
+        .arg(common_args::server())
         .after_help("Run `spacetime help describe` for more detailed information.\n")
 }
 

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -21,16 +21,14 @@ pub fn cli() -> clap::Command {
                 .requires("entity_type")
                 .help("The name of the entity to describe"),
         )
+        .arg(Arg::new("brief").long("brief").short('b').action(SetTrue)
+            .help("If this flag is present, a brief description shall be returned"))
         .arg(
-            Arg::new("brief")
-                .long("brief")
-                .short('b')
-                .action(SetTrue)
-                .help("If this flag is present, a brief description shall be returned"),
+            common_args::identity()
+                .conflicts_with("anon_identity")
+                .help("The identity to use to describe the entity")
+                .long_help("The identity to use to describe the entity. If no identity is provided, the default one will be used."),
         )
-        .arg(common_args::identity().conflicts_with("anon_identity").long_help(
-            "The identity to use to describe the entity. If no identity is provided, the default one will be used.",
-        ))
         .arg(
             Arg::new("anon_identity")
                 .long("anon-identity")
@@ -39,7 +37,10 @@ pub fn cli() -> clap::Command {
                 .action(SetTrue)
                 .help("If this flag is present, no identity will be provided when describing the database"),
         )
-        .arg(common_args::server())
+        .arg(
+            common_args::server()
+                .help("The nickname, host name or URL of the server hosting the database"),
+        )
         .after_help("Run `spacetime help describe` for more detailed information.\n")
 }
 

--- a/crates/cli/src/subcommands/dns.rs
+++ b/crates/cli/src/subcommands/dns.rs
@@ -1,3 +1,4 @@
+use crate::common_args;
 use crate::config::Config;
 use crate::util::{
     add_auth_header_opt, get_auth_header_only, spacetime_dns, spacetime_register_tld, spacetime_reverse_dns,
@@ -30,49 +31,34 @@ fn get_subcommands() -> Vec<Command> {
                     .required(true)
                     .help("The top level domain that you would like to register"),
             )
-            .arg(Arg::new("identity").long("identity").short('i').help(
-                "The identity that should own this tld. If no identity is specified, then the default identity is used",
-            ))
             .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
-                    .help("The nickname, host name or URL of the server on which to register the domain"),
+                common_args::identity()
+                .help("The identity that should own this tld. If no identity is specified, then the default identity is used"),
             )
+            .arg(common_args::server())
             .after_help("Run `spacetime dns register-tld --help` for more detailed information.\n"),
         Command::new("lookup")
             .about("Resolves a domain to a database address")
             .arg(Arg::new("domain").required(true).help("The name of the domain to lookup"))
-            .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
-                    .help("The nickname, host name or URL of the server on which to look up the domain name"),
-            )
+            .arg(common_args::server())
             .after_help("Run `spacetime dns lookup --help` for more detailed information"),
         Command::new("reverse-lookup")
             .about("Returns the domains for the provided database address")
             .arg(Arg::new("address").required(true).help("The address you would like to find all of the known domains for"))
-            .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
-                    .help("The nickname, host name or URL of the server on which to look up the address"),
-            )
+            .arg(common_args::server())
             .after_help("Run `spacetime dns reverse-lookup --help` for more detailed information.\n"),
         Command::new("set-name")
             .about("Sets the domain of the database")
             .arg(Arg::new("domain").required(true).help("The domain you would like to assign or create"))
             .arg(Arg::new("address").required(true).help("The database address to assign to the domain"))
-            .arg(Arg::new("identity").long("identity").short('i').long_help(
-                "The identity that owns the tld for this domain. If no identity is specified, the default identity is used.",
-            ).help("The identity that owns the tld for this domain"))
             .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
-                    .help("The nickname, host name or URL of the server on which to set the name"),
+                common_args::identity()
+                .long_help(
+                    "The identity that owns the tld for this domain. If no identity is specified, the default identity is used.",
+                )
+                .help("The identity that owns the tld for this domain")
             )
+            .arg(common_args::server())
             .after_help("Run `spacetime dns set-name --help` for more detailed information.\n"),
     ]
 }

--- a/crates/cli/src/subcommands/dns.rs
+++ b/crates/cli/src/subcommands/dns.rs
@@ -31,34 +31,41 @@ fn get_subcommands() -> Vec<Command> {
                     .required(true)
                     .help("The top level domain that you would like to register"),
             )
+            .arg(common_args::identity().help(
+                "The identity that should own this tld. If no identity is specified, then the default identity is used",
+            ))
             .arg(
-                common_args::identity()
-                .help("The identity that should own this tld. If no identity is specified, then the default identity is used"),
+                common_args::server()
+                    .help("The nickname, host name or URL of the server on which to register the domain"),
             )
-            .arg(common_args::server())
             .after_help("Run `spacetime dns register-tld --help` for more detailed information.\n"),
         Command::new("lookup")
             .about("Resolves a domain to a database address")
             .arg(Arg::new("domain").required(true).help("The name of the domain to lookup"))
-            .arg(common_args::server())
+            .arg(
+                common_args::server()
+                    .help("The nickname, host name or URL of the server on which to look up the domain name"),
+            )
             .after_help("Run `spacetime dns lookup --help` for more detailed information"),
         Command::new("reverse-lookup")
             .about("Returns the domains for the provided database address")
             .arg(Arg::new("address").required(true).help("The address you would like to find all of the known domains for"))
-            .arg(common_args::server())
+            .arg(
+                common_args::server()
+                    .help("The nickname, host name or URL of the server on which to look up the address"),
+            )
             .after_help("Run `spacetime dns reverse-lookup --help` for more detailed information.\n"),
         Command::new("set-name")
             .about("Sets the domain of the database")
             .arg(Arg::new("domain").required(true).help("The domain you would like to assign or create"))
             .arg(Arg::new("address").required(true).help("The database address to assign to the domain"))
+            .arg(common_args::identity().long_help(
+                "The identity that owns the tld for this domain. If no identity is specified, the default identity is used.",
+            ).help("The identity that owns the tld for this domain"))
             .arg(
-                common_args::identity()
-                .long_help(
-                    "The identity that owns the tld for this domain. If no identity is specified, the default identity is used.",
-                )
-                .help("The identity that owns the tld for this domain")
+                common_args::server()
+                    .help("The nickname, host name or URL of the server on which to set the name"),
             )
-            .arg(common_args::server())
             .after_help("Run `spacetime dns set-name --help` for more detailed information.\n"),
     ]
 }

--- a/crates/cli/src/subcommands/energy.rs
+++ b/crates/cli/src/subcommands/energy.rs
@@ -24,7 +24,10 @@ fn get_energy_subcommands() -> Vec<clap::Command> {
                     "The identity to check the balance for. If no identity is provided, the default one will be used.",
                 ),
             )
-            .arg(common_args::server()),
+            .arg(
+                common_args::server()
+                    .help("The nickname, host name or URL of the server from which to request balance information"),
+            ),
         clap::Command::new("set-balance")
             .about("Update the current budget balance for a database")
             .arg(

--- a/crates/cli/src/subcommands/energy.rs
+++ b/crates/cli/src/subcommands/energy.rs
@@ -1,4 +1,5 @@
 // use clap::Arg;
+use crate::common_args;
 use clap::{value_parser, Arg, ArgMatches};
 use spacetimedb_lib::Identity;
 
@@ -23,12 +24,7 @@ fn get_energy_subcommands() -> Vec<clap::Command> {
                     "The identity to check the balance for. If no identity is provided, the default one will be used.",
                 ),
             )
-            .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
-                    .help("The nickname, host name or URL of the server from which to request balance information"),
-            ),
+            .arg(common_args::server()),
         clap::Command::new("set-balance")
             .about("Update the current budget balance for a database")
             .arg(
@@ -45,9 +41,7 @@ fn get_energy_subcommands() -> Vec<clap::Command> {
                     ),
             )
             .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
+                common_args::server()
                     .help("The nickname, host name or URL of the server on which to update the identity's balance"),
             )
             .arg(

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -35,7 +35,9 @@ fn get_subcommands() -> Vec<Command> {
                     .required(true)
                     .help("The email associated with the identity that you would like to find"),
             )
-            .arg(common_args::server()),
+            .arg(common_args::server()
+                    .help("The server to search for identities matching the email"),
+            ),
         Command::new("import")
             .about("Import an existing identity into your spacetime config")
             .arg(
@@ -79,6 +81,7 @@ fn get_subcommands() -> Vec<Command> {
         Command::new("list").about("List saved identities which apply to a server")
             .arg(
                 common_args::server()
+                    .help("The nickname, host name or URL of the server to list identities for")
                     .conflicts_with("all")
             )
             .arg(
@@ -142,7 +145,9 @@ fn get_subcommands() -> Vec<Command> {
             .arg(Arg::new("identity").required(true).help(
                 "The identity you would like to recover. This identity must be associated with the email provided.",
             ).value_parser(clap::value_parser!(Identity)))
-            .arg(common_args::server())
+            .arg(common_args::server()
+                    .help("The server from which to request recovery codes"),
+            )
             // TODO: project flag?
             ,
         Command::new("remove")

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -1,4 +1,5 @@
 use crate::{
+    common_args,
     config::{Config, IdentityConfig},
     util::{init_default, y_or_n, IdentityTokenJson, InitDefaultResultType},
 };
@@ -34,12 +35,7 @@ fn get_subcommands() -> Vec<Command> {
                     .required(true)
                     .help("The email associated with the identity that you would like to find"),
             )
-            .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
-                    .help("The server to search for identities matching the email"),
-            ),
+            .arg(common_args::server()),
         Command::new("import")
             .about("Import an existing identity into your spacetime config")
             .arg(
@@ -64,9 +60,7 @@ fn get_subcommands() -> Vec<Command> {
         Command::new("init-default")
             .about("Initialize a new default identity if it is missing from a server's config")
             .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
+                common_args::server()
                     .help("The nickname, host name or URL of the server for which to set the default identity"),
             )
             .arg(
@@ -84,10 +78,7 @@ fn get_subcommands() -> Vec<Command> {
             ),
         Command::new("list").about("List saved identities which apply to a server")
             .arg(
-                Arg::new("server")
-                    .short('s')
-                    .long("server")
-                    .help("The nickname, host name or URL of the server to list identities for")
+                common_args::server()
                     .conflicts_with("all")
             )
             .arg(
@@ -103,9 +94,7 @@ fn get_subcommands() -> Vec<Command> {
         Command::new("new")
             .about("Creates a new identity")
             .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
+                common_args::server()
                     .help("The nickname, host name or URL of the server from which to request the identity"),
             )
             .arg(
@@ -153,12 +142,7 @@ fn get_subcommands() -> Vec<Command> {
             .arg(Arg::new("identity").required(true).help(
                 "The identity you would like to recover. This identity must be associated with the email provided.",
             ).value_parser(clap::value_parser!(Identity)))
-            .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
-                    .help("The server from which to request recovery codes"),
-            )
+            .arg(common_args::server())
             // TODO: project flag?
             ,
         Command::new("remove")
@@ -201,9 +185,7 @@ fn get_subcommands() -> Vec<Command> {
                     .required(true),
             )
             .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
+                common_args::server()
                     .help("The server nickname, host name or URL of the server which should use this identity as a default")
             )
             // TODO: project flag?
@@ -221,9 +203,7 @@ fn get_subcommands() -> Vec<Command> {
                     .required(true),
             )
             .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
+                common_args::server()
                     .help("The server that should be informed of the email change")
                     .conflicts_with("all-servers")
             )

--- a/crates/cli/src/subcommands/list.rs
+++ b/crates/cli/src/subcommands/list.rs
@@ -18,7 +18,7 @@ pub fn cli() -> Command {
                 .required(true)
                 .help("The identity to list databases for"),
         )
-        .arg(common_args::server())
+        .arg(common_args::server().help("The nickname, host name or URL of the server from which to list databases"))
 }
 
 #[derive(Deserialize)]

--- a/crates/cli/src/subcommands/list.rs
+++ b/crates/cli/src/subcommands/list.rs
@@ -1,3 +1,4 @@
+use crate::common_args;
 use crate::Config;
 use anyhow::Context;
 use clap::{Arg, ArgMatches, Command};
@@ -17,12 +18,7 @@ pub fn cli() -> Command {
                 .required(true)
                 .help("The identity to list databases for"),
         )
-        .arg(
-            Arg::new("server")
-                .long("server")
-                .short('s')
-                .help("The nickname, host name or URL of the server from which to list databases"),
-        )
+        .arg(common_args::server())
 }
 
 #[derive(Deserialize)]

--- a/crates/cli/src/subcommands/logs.rs
+++ b/crates/cli/src/subcommands/logs.rs
@@ -18,7 +18,10 @@ pub fn cli() -> clap::Command {
                 .required(true)
                 .help("The domain or address of the database to print logs from"),
         )
-        .arg(common_args::server())
+        .arg(
+            common_args::server()
+                .help("The nickname, host name or URL of the server hosting the database"),
+        )
         .arg(
             common_args::identity()
                 .help("The identity to use for printing logs from this database"),

--- a/crates/cli/src/subcommands/logs.rs
+++ b/crates/cli/src/subcommands/logs.rs
@@ -1,6 +1,7 @@
 use std::borrow::Cow;
 use std::io::{self, Write};
 
+use crate::common_args;
 use crate::config::Config;
 use crate::util::{add_auth_header_opt, database_address, get_auth_header_only};
 use clap::{Arg, ArgAction, ArgMatches};
@@ -17,16 +18,9 @@ pub fn cli() -> clap::Command {
                 .required(true)
                 .help("The domain or address of the database to print logs from"),
         )
+        .arg(common_args::server())
         .arg(
-            Arg::new("server")
-                .long("server")
-                .short('s')
-                .help("The nickname, host name or URL of the server hosting the database"),
-        )
-        .arg(
-            Arg::new("identity")
-                .long("identity")
-                .short('i')
+            common_args::identity()
                 .help("The identity to use for printing logs from this database"),
         )
         .arg(

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -89,7 +89,9 @@ pub fn cli() -> clap::Command {
             Arg::new("name|address")
                 .help("A valid domain or address for this database"),
         )
-        .arg(common_args::server())
+        .arg(common_args::server()
+                .help("The nickname, domain name or URL of the server to host the database."),
+        )
         .arg(
             Arg::new("force")
                 .long("force")

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -9,6 +9,7 @@ use std::fs;
 use std::io::Write;
 use std::path::PathBuf;
 
+use crate::common_args;
 use crate::config::Config;
 use crate::util::unauth_error_context;
 use crate::util::{add_auth_header_opt, get_auth_header};
@@ -55,9 +56,7 @@ pub fn cli() -> clap::Command {
                 .action(SetTrue),
         )
         .arg(
-            Arg::new("identity")
-                .long("identity")
-                .short('i')
+            common_args::identity()
                 .help("The identity that should own the database")
                 .long_help("The identity that should own the database. If no identity is provided, your default identity will be used.")
                 .required(false)
@@ -90,12 +89,7 @@ pub fn cli() -> clap::Command {
             Arg::new("name|address")
                 .help("A valid domain or address for this database"),
         )
-        .arg(
-            Arg::new("server")
-                .long("server")
-                .short('s')
-                .help("The nickname, domain name or URL of the server to host the database."),
-        )
+        .arg(common_args::server())
         .arg(
             Arg::new("force")
                 .long("force")

--- a/crates/cli/src/subcommands/server.rs
+++ b/crates/cli/src/subcommands/server.rs
@@ -1,4 +1,5 @@
 use crate::{
+    common_args,
     util::{host_or_url_to_host_and_protocol, spacetime_server_fingerprint, y_or_n, VALID_PROTOCOLS},
     Config,
 };
@@ -67,12 +68,7 @@ fn get_subcommands() -> Vec<Command> {
             ),
         Command::new("fingerprint")
             .about("Show or update a saved server's fingerprint")
-            .arg(
-                Arg::new("server")
-                    .short('s')
-                    .long("server")
-                    .help("The nickname, host name or URL of the server"),
-            )
+            .arg(common_args::server().help("The nickname, host name or URL of the server"))
             .arg(
                 Arg::new("force")
                     .help("Save changes to the server's configuration without confirming")

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -28,31 +28,34 @@ pub fn cli() -> clap::Command {
                 .conflicts_with("interactive")
                 .help("The SQL query to execute"),
         )
-        .arg(
-            Arg::new("interactive")
-                .long("interactive")
-                .action(ArgAction::SetTrue)
-                .conflicts_with("query")
-                .help("Runs an interactive command prompt for `SQL` expressions"),
-        )
+        .arg(Arg::new("interactive")
+                 .long("interactive")
+                 .action(ArgAction::SetTrue)
+                 .conflicts_with("query")
+                 .help("Runs an interactive command prompt for `SQL` expressions"),)
         .group(
             ArgGroup::new("mode")
-                .args(["interactive", "query"])
+                .args(["interactive","query"])
                 .multiple(false)
-                .required(true),
+                .required(true)
         )
-        .arg(common_args::identity().conflicts_with("anon_identity").long_help(
-            "The identity to use for querying the database. If no identity is provided, the default one will be used.",
-        ))
+        .arg(
+            common_args::identity()
+                .conflicts_with("anon_identity")
+                .help("The identity to use for querying the database")
+                .long_help("The identity to use for querying the database. If no identity is provided, the default one will be used."),
+        )
         .arg(
             Arg::new("anon_identity")
                 .long("anon-identity")
                 .short('a')
                 .conflicts_with("identity")
                 .action(ArgAction::SetTrue)
-                .help("If this flag is present, no identity will be provided when querying the database"),
+                .help("If this flag is present, no identity will be provided when querying the database")
         )
-        .arg(common_args::server())
+        .arg(common_args::server()
+                .help("The nickname, host name or URL of the server hosting the database"),
+        )
 }
 
 pub(crate) async fn parse_req(mut config: Config, args: &ArgMatches) -> Result<Connection, anyhow::Error> {

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -1,6 +1,7 @@
 use std::time::Instant;
 
 use crate::api::{from_json_seed, ClientApi, Connection, StmtResultJson};
+use crate::common_args;
 use clap::{Arg, ArgAction, ArgGroup, ArgMatches};
 use itertools::Itertools;
 use reqwest::RequestBuilder;
@@ -27,39 +28,31 @@ pub fn cli() -> clap::Command {
                 .conflicts_with("interactive")
                 .help("The SQL query to execute"),
         )
-        .arg(Arg::new("interactive")
-                 .long("interactive")
-                 .action(ArgAction::SetTrue)
-                 .conflicts_with("query")
-                 .help("Runs an interactive command prompt for `SQL` expressions"),)
+        .arg(
+            Arg::new("interactive")
+                .long("interactive")
+                .action(ArgAction::SetTrue)
+                .conflicts_with("query")
+                .help("Runs an interactive command prompt for `SQL` expressions"),
+        )
         .group(
             ArgGroup::new("mode")
-                .args(["interactive","query"])
+                .args(["interactive", "query"])
                 .multiple(false)
-                .required(true)
+                .required(true),
         )
-        .arg(
-            Arg::new("identity")
-                .long("identity")
-                .short('i')
-                .conflicts_with("anon_identity")
-                .help("The identity to use for querying the database")
-                .long_help("The identity to use for querying the database. If no identity is provided, the default one will be used."),
-        )
+        .arg(common_args::identity().conflicts_with("anon_identity").long_help(
+            "The identity to use for querying the database. If no identity is provided, the default one will be used.",
+        ))
         .arg(
             Arg::new("anon_identity")
                 .long("anon-identity")
                 .short('a')
                 .conflicts_with("identity")
                 .action(ArgAction::SetTrue)
-                .help("If this flag is present, no identity will be provided when querying the database")
+                .help("If this flag is present, no identity will be provided when querying the database"),
         )
-        .arg(
-            Arg::new("server")
-                .long("server")
-                .short('s')
-                .help("The nickname, host name or URL of the server hosting the database"),
-        )
+        .arg(common_args::server())
 }
 
 pub(crate) async fn parse_req(mut config: Config, args: &ArgMatches) -> Result<Connection, anyhow::Error> {

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -14,6 +14,7 @@ use tokio_tungstenite::tungstenite::client::IntoClientRequest;
 use tokio_tungstenite::tungstenite::Message as WsMessage;
 
 use crate::api::ClientApi;
+use crate::common_args;
 use crate::sql::parse_req;
 use crate::Config;
 
@@ -59,17 +60,10 @@ pub fn cli() -> clap::Command {
                 .action(ArgAction::SetTrue)
                 .help("Print the initial update for the queries."),
         )
-        .arg(
-            Arg::new("identity")
-                .long("identity")
-                .short('i')
-                .conflicts_with("anon_identity")
-                .help("The identity to use for querying the database")
-                .long_help(
-                    "The identity to use for querying the database. \
+        .arg(common_args::identity().conflicts_with("anon_identity").long_help(
+            "The identity to use for querying the database. \
                      If no identity is provided, the default one will be used.",
-                ),
-        )
+        ))
         .arg(
             Arg::new("anon_identity")
                 .long("anon-identity")
@@ -78,12 +72,7 @@ pub fn cli() -> clap::Command {
                 .action(ArgAction::SetTrue)
                 .help("If this flag is present, no identity will be provided when querying the database"),
         )
-        .arg(
-            Arg::new("server")
-                .long("server")
-                .short('s')
-                .help("The nickname, host name or URL of the server hosting the database"),
-        )
+        .arg(common_args::server())
 }
 
 #[derive(serde::Serialize)]

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -60,10 +60,15 @@ pub fn cli() -> clap::Command {
                 .action(ArgAction::SetTrue)
                 .help("Print the initial update for the queries."),
         )
-        .arg(common_args::identity().conflicts_with("anon_identity").long_help(
-            "The identity to use for querying the database. \
+        .arg(
+            common_args::identity()
+                .conflicts_with("anon_identity")
+                .help("The identity to use for querying the database")
+                .long_help(
+                    "The identity to use for querying the database. \
                      If no identity is provided, the default one will be used.",
-        ))
+                ),
+        )
         .arg(
             Arg::new("anon_identity")
                 .long("anon-identity")
@@ -72,7 +77,7 @@ pub fn cli() -> clap::Command {
                 .action(ArgAction::SetTrue)
                 .help("If this flag is present, no identity will be provided when querying the database"),
         )
-        .arg(common_args::server())
+        .arg(common_args::server().help("The nickname, host name or URL of the server hosting the database"))
 }
 
 #[derive(serde::Serialize)]

--- a/crates/cli/src/subcommands/tracelog.rs
+++ b/crates/cli/src/subcommands/tracelog.rs
@@ -1,3 +1,4 @@
+use crate::common_args;
 use crate::config::Config;
 use crate::util::database_address;
 use clap::{Arg, ArgMatches};
@@ -20,30 +21,15 @@ fn get_energy_subcommands() -> Vec<clap::Command> {
             .about("Retrieve a copy of the trace log for a database, if tracing is turned on")
             .arg(Arg::new("database").required(true))
             .arg(Arg::new("outputfile").required(true).help("path to write tracelog to"))
-            .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
-                    .help("The nickname, host name or URL of the server running tracing"),
-            ),
+            .arg(common_args::server().help("The nickname, host name or URL of the server running tracing")),
         clap::Command::new("stop")
             .about("Stop tracing on a given database")
             .arg(Arg::new("database").required(true))
-            .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
-                    .help("The nickname, host name or URL of the server running tracing"),
-            ),
+            .arg(common_args::server().help("The nickname, host name or URL of the server running tracing")),
         clap::Command::new("replay")
             .about("Replay a tracelog on a temporary fresh DB instance on the server")
             .arg(Arg::new("tracefile").required(true).help("path to read tracelog from"))
-            .arg(
-                Arg::new("server")
-                    .long("server")
-                    .short('s')
-                    .help("The nickname, host name or URL of the server running tracing"),
-            ),
+            .arg(common_args::server().help("The nickname, host name or URL of the server running tracing")),
     ]
 }
 


### PR DESCRIPTION
# Description of Changes

Created a `crates/cli/src/common_args.rs` file that currently just contains the most common form of the `--server`/`-s` param and the `--identity`/`-i` param.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] CI testing
- [x] Check that help text has been unaffected
  - Confirmed:
```
$ spacetime energy set-balance --help
Update the current budget balance for a database

Usage: spacetime energy set-balance [OPTIONS] <balance> [identity]

Arguments:
  <balance>
          The balance value to set

  [identity]
          The identity to set a balance for. If no identity is provided, the default one will be used.

Options:
  -s, --server <server>
          The nickname, host name or URL of the server on which to update the identity's balance

  -q, --quiet
          Runs command in silent mode

  -h, --help
          Print help (see a summary with '-h')
```