### PR TITLE
Track typescript import statements in a btree to deduplicate them

### DIFF
--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -1,5 +1,6 @@
 use super::util::fmt_fn;
 
+use std::collections::BTreeSet;
 use std::fmt;
 use std::ops::Deref;
 
@@ -350,7 +351,7 @@ pub fn autogen_typescript_sum(ctx: &GenCtx, name: &str, sum_type: &SumType) -> S
     writeln!(output, "// @ts-ignore");
     writeln!(output, "import {{ __SPACETIMEDB__, AlgebraicType, SumTypeVariant, BuiltinType, AlgebraicValue }} from \"@clockworklabs/spacetimedb-sdk\";");
 
-    let mut imports = Vec::new();
+    let mut imports = BTreeSet::new();
     generate_imports_variants(ctx, &sum_type.variants, &mut imports, Some("__"));
 
     for import in imports {
@@ -593,7 +594,12 @@ pub fn autogen_typescript_table(ctx: &GenCtx, table: &TableDesc) -> String {
     )
 }
 
-fn generate_imports(ctx: &GenCtx, elements: &[ProductTypeElement], imports: &mut Vec<String>, prefix: Option<&str>) {
+fn generate_imports(
+    ctx: &GenCtx,
+    elements: &[ProductTypeElement],
+    imports: &mut BTreeSet<String>,
+    prefix: Option<&str>,
+) {
     for field in elements {
         _generate_imports(ctx, &field.algebraic_type, imports, prefix);
     }
@@ -603,7 +609,7 @@ fn generate_imports(ctx: &GenCtx, elements: &[ProductTypeElement], imports: &mut
 fn generate_imports_variants(
     ctx: &GenCtx,
     variants: &[SumTypeVariant],
-    imports: &mut Vec<String>,
+    imports: &mut BTreeSet<String>,
     prefix: Option<&str>,
 ) {
     for variant in variants {
@@ -611,7 +617,7 @@ fn generate_imports_variants(
     }
 }
 
-fn _generate_imports(ctx: &GenCtx, ty: &AlgebraicType, imports: &mut Vec<String>, prefix: Option<&str>) {
+fn _generate_imports(ctx: &GenCtx, ty: &AlgebraicType, imports: &mut BTreeSet<String>, prefix: Option<&str>) {
     match ty {
         AlgebraicType::Builtin(b) => match b {
             BuiltinType::Array(ArrayType { elem_ty }) => _generate_imports(ctx, elem_ty, imports, prefix),
@@ -630,7 +636,7 @@ fn _generate_imports(ctx: &GenCtx, ty: &AlgebraicType, imports: &mut Vec<String>
                 None => class_name,
             };
             let import = format!("import {{ {imported_as} }} from \"./{filename}\";");
-            imports.push(import);
+            imports.insert(import);
         }
         // Generate imports for the fields of anonymous sum types like `Option<T>`.
         AlgebraicType::Sum(s) => {
@@ -663,7 +669,7 @@ fn autogen_typescript_product_table_common(
     writeln!(output, "// @ts-ignore");
     writeln!(output, "import {{ __SPACETIMEDB__, AlgebraicType, ProductType, BuiltinType, ProductTypeElement, SumType, SumTypeVariant, DatabaseTable, AlgebraicValue, ReducerEvent, Identity, Address, ClientDB, SpacetimeDBClient }} from \"@clockworklabs/spacetimedb-sdk\";");
 
-    let mut imports = Vec::new();
+    let mut imports = BTreeSet::new();
     generate_imports(ctx, &product_type.elements, &mut imports, None);
 
     for import in imports {
@@ -968,7 +974,7 @@ pub fn autogen_typescript_reducer(ctx: &GenCtx, reducer: &ReducerDef) -> String 
     writeln!(output, "// @ts-ignore");
     writeln!(output, "import {{ __SPACETIMEDB__, AlgebraicType, ProductType, BuiltinType, ProductTypeElement, DatabaseTable, AlgebraicValue, ReducerArgsAdapter, SumTypeVariant, Serializer, Identity, Address, ReducerEvent, Reducer, SpacetimeDBClient }} from \"@clockworklabs/spacetimedb-sdk\";");
 
-    let mut imports = Vec::new();
+    let mut imports = BTreeSet::new();
     generate_imports(
         ctx,
         &reducer.args.clone().into_iter().collect::<Vec<ProductTypeElement>>(),

--- a/crates/cli/tests/snapshots/codegen__codegen_typescript.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_typescript.snap
@@ -786,13 +786,13 @@ export default TestE;
 // @ts-ignore
 import { __SPACETIMEDB__, AlgebraicType, ProductType, BuiltinType, ProductTypeElement, DatabaseTable, AlgebraicValue, ReducerArgsAdapter, SumTypeVariant, Serializer, Identity, Address, ReducerEvent, Reducer, SpacetimeDBClient } from "@clockworklabs/spacetimedb-sdk";
 // @ts-ignore
-import { TestA } from "./test_a";
-// @ts-ignore
-import { TestB } from "./test_b";
-// @ts-ignore
 import { Namespace.TestC } from "./namespace.test_c";
 // @ts-ignore
 import { Namespace.TestF } from "./namespace.test_f";
+// @ts-ignore
+import { TestA } from "./test_a";
+// @ts-ignore
+import { TestB } from "./test_b";
 
 export class TestReducer extends Reducer
 {


### PR DESCRIPTION
# Description of Changes

When generating TS code, this tracks import statements in a set instead of a vector to avoid duplicates. With the previous code, you could have duplicate import statements if there are two enum cases with field types that require an import.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1. This is very simple and low risk.

# Testing

This fixed an issue I had with this type:
```
#[derive(Debug, Clone, Copy, SpacetimeType, Hash, Eq, PartialEq)]
enum Role {
    Spectator,
    Player(Team),
    Spymaster(Team),
}
```

Previously the import for `Team` would get generated twice.

- [x] Worked for previously failing example.
