### PR TITLE
Filter extra deps on keccak on macOS that fails snap testing

### DIFF
--- a/crates/bindings/tests/deps.rs
+++ b/crates/bindings/tests/deps.rs
@@ -2,12 +2,41 @@
 //! to make sure we don't unknowningly add a bunch of dependencies here,
 //! slowing down compilation for every spacetime module.
 
+#[cfg(target_os = "macos")]
+/// On macOS, the `keccak` crate depends on `cpufeatures/libc`, which don't on Linux.
+fn filter_keccak(input: String) -> String {
+    let mut lines = input.lines();
+    let mut found_keccak = false;
+    let mut found_cpufeatures = false;
+    let mut result = Vec::new();
+
+    while let Some(line) = lines.next() {
+        if line.contains("keccak") {
+            found_keccak = true;
+            result.push(line.to_string());
+        } else if found_keccak && line.contains("cpufeatures") {
+            found_cpufeatures = true;
+        } else if found_cpufeatures && line.contains("libc") {
+        } else {
+            result.push(line.to_string());
+        }
+    }
+
+    result.join("\n")
+}
+
+#[cfg(not(target_os = "macos"))]
+fn filter_keccak(input: String) -> String {
+    input
+}
+
 #[test]
 fn deptree_snapshot() -> std::io::Result<()> {
     let cmd = "cargo tree -p spacetimedb -f {lib} -e no-dev";
-    let deps_tree = run_cmd(cmd);
+    let deps_tree = filter_keccak(run_cmd(cmd));
 
-    let all_deps = run_cmd("cargo tree -p spacetimedb -e no-dev --prefix none --no-dedupe");
+    let all_deps = filter_keccak(run_cmd("cargo tree -p spacetimedb -e no-dev --prefix none --no-dedupe"));
+
     let mut all_deps = all_deps.lines().collect::<Vec<_>>();
     all_deps.sort();
     all_deps.dedup();


### PR DESCRIPTION
# Description of Changes

This is a workaround to make it possible to run `cargo test --all`.

Only on `macOS` when running the `cargo insta` on the `deptree_snapshot` test it gets an extra deps of

```bash
sha3 v0.10.8
└── keccak v0.1.4
            └── cpufeatures v0.2.9 # Extra on macOS
                        └── libc v0.2.153
```
 
... that causes all the other test fails by `PoisonError`.

# Expected complexity level and risk
1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Confirm with joshua this happens on macOS*
- [x] *Check `cargo test --all` now can run.*
