### PR TITLE
Return empty success from /identity GET

### DIFF
--- a/crates/client-api/src/routes/identity.rs
+++ b/crates/client-api/src/routes/identity.rs
@@ -44,7 +44,7 @@ pub async fn create_identity<S: ControlStateDelegate + NodeDelegate>(
     Ok(axum::Json(identity_response))
 }
 
-#[derive(Debug, Clone, Serialize)]
+#[derive(Debug, Clone, Serialize, Default)]
 pub struct GetIdentityResponse {
     identities: Vec<GetIdentityResponseEntry>,
 }
@@ -77,7 +77,7 @@ pub async fn get_identity<S: ControlStateDelegate>(
             (!identities.is_empty()).then_some(GetIdentityResponse { identities })
         }
     };
-    let identity_response = lookup.ok_or(StatusCode::NOT_FOUND)?;
+    let identity_response = lookup.unwrap_or_default();
     Ok(axum::Json(identity_response))
 }
 

--- a/crates/client-api/src/routes/identity.rs
+++ b/crates/client-api/src/routes/identity.rs
@@ -44,7 +44,7 @@ pub async fn create_identity<S: ControlStateDelegate + NodeDelegate>(
     Ok(axum::Json(identity_response))
 }
 
-#[derive(Debug, Clone, Serialize, Default)]
+#[derive(Debug, Clone, Serialize)]
 pub struct GetIdentityResponse {
     identities: Vec<GetIdentityResponseEntry>,
 }
@@ -63,8 +63,8 @@ pub async fn get_identity<S: ControlStateDelegate>(
     State(ctx): State<S>,
     Query(GetIdentityQueryParams { email }): Query<GetIdentityQueryParams>,
 ) -> axum::response::Result<impl IntoResponse> {
-    let lookup = match email {
-        None => None,
+    match email {
+        None => Err(StatusCode::BAD_REQUEST.into()),
         Some(email) => {
             let identities = ctx.get_identities_for_email(email.as_str()).map_err(log_and_500)?;
             let identities = identities
@@ -74,11 +74,9 @@ pub async fn get_identity<S: ControlStateDelegate>(
                     email: identity_email.email,
                 })
                 .collect::<Vec<_>>();
-            (!identities.is_empty()).then_some(GetIdentityResponse { identities })
+            Ok(axum::Json(GetIdentityResponse { identities }))
         }
-    };
-    let identity_response = lookup.unwrap_or_default();
-    Ok(axum::Json(identity_response))
+    }
 }
 
 /// A version of `Identity` appropriate for URL de/encoding.


### PR DESCRIPTION
# Description of Changes

https://github.com/clockworklabs/SpacetimeDB/issues/1371

Swap out the previous 404 for a default response.

# API and ABI breaking changes

Changes the behavior in case of an empty email match, going from a client error to an empty success for its response.

# Expected complexity level and risk

0

# Testing

```
λ curl localhost:3000/identity?email=me@example.com
{"identities":[]}

λ curl -I localhost:3000/identity
HTTP/1.1 400 Bad Request
```