### PR TITLE
Moving recovery code APIs under /identity and using POST

### DIFF
--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -628,8 +628,8 @@ async fn exec_recover(mut config: Config, args: &ArgMatches) -> Result<(), anyho
     }
 
     let client = reqwest::Client::new();
-    let builder = client.get(Url::parse_with_params(
-        format!("{}/database/request_recovery_code", config.get_host_url(server)?,).as_str(),
+    let builder = client.post(Url::parse_with_params(
+        format!("{}/identity/request_recovery_code", config.get_host_url(server)?,).as_str(),
         query_params,
     )?);
     let res = builder.send().await?;

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -653,8 +653,8 @@ async fn exec_recover(mut config: Config, args: &ArgMatches) -> Result<(), anyho
         };
 
         let client = reqwest::Client::new();
-        let builder = client.get(Url::parse_with_params(
-            format!("{}/database/confirm_recovery_code", config.get_host_url(server)?,).as_str(),
+        let builder = client.post(Url::parse_with_params(
+            format!("{}/identity/confirm_recovery_code", config.get_host_url(server)?,).as_str(),
             vec![
                 ("code", code.to_string().as_str()),
                 ("email", email.as_str()),

--- a/crates/client-api/src/routes/identity.rs
+++ b/crates/client-api/src/routes/identity.rs
@@ -339,7 +339,6 @@ pub async fn confirm_recovery_code<S: ControlStateDelegate + NodeDelegate>(
     Ok(axum::Json(result))
 }
 
-
 pub fn control_routes<S>(_: S) -> axum::Router<S>
 where
     S: NodeDelegate + ControlStateDelegate + Clone + 'static,

--- a/crates/standalone/src/routes/mod.rs
+++ b/crates/standalone/src/routes/mod.rs
@@ -16,10 +16,7 @@ where
             "/database",
             database::control_routes(ctx.clone()).merge(database::worker_routes(ctx.clone())),
         )
-        .nest(
-            "/identity",
-            identity::control_routes(ctx.clone()).merge(identity::router(ctx.clone())),
-        )
+        .nest("/identity", identity::router(ctx.clone()))
         .nest("/energy", energy::router())
         .nest("/prometheus", prometheus::router())
         .nest("/metrics", metrics::router());

--- a/crates/standalone/src/routes/mod.rs
+++ b/crates/standalone/src/routes/mod.rs
@@ -16,7 +16,10 @@ where
             "/database",
             database::control_routes(ctx.clone()).merge(database::worker_routes(ctx.clone())),
         )
-        .nest("/identity", identity::router(ctx.clone()))
+        .nest(
+            "/identity",
+            identity::control_routes(ctx.clone()).merge(identity::router(ctx.clone())),
+        )
         .nest("/energy", energy::router())
         .nest("/prometheus", prometheus::router())
         .nest("/metrics", metrics::router());


### PR DESCRIPTION
# Description of Changes

https://github.com/clockworklabs/SpacetimeDB/issues/1372

Added `control_routes` to identity, based off database's.
Moved the recovery code APIs there.
Switched them to expect POST.

# API and ABI breaking changes

Changes both the request method and the router endpoints of the recovery code API.

# Expected complexity level and risk
0

# Testing

```
curl -X POST "localhost:3000/identity/request_recovery_code?email=me@example.com&identity=1234567890123456789012345678901234567890123456789012345678901234"
curl -X POST "localhost:3000/identity/confirm_recovery_code?email=me@example.com&identity=1234567890123456789012345678901234567890123456789012345678901234&code=1"
```

Assuming the previous handler code is correct, this validates the routes and request method switches.