### PR TITLE
CI - SpacetimeDB PRs run the C# SDK tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,7 +137,7 @@ jobs:
             </configuration>
           EOF
           # clear package caches, so we get fresh ones even if version numbers haven't changed
-          dotnet nuget local all --clear
+          dotnet nuget locals all --clear
           dotnet test
 
   lints:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,17 +120,13 @@ jobs:
       - name: C# SDK tests
         run: |
           ( cd crates/bindings-csharp/BSATN.Runtime && dotnet pack )
-          ( cd crates/bindings-csharp/BSATN.Codegen && dotnet pack )
           cd spacetimedb-csharp-sdk
-          # only for testing - remove this before merging!
-          sed -i'' 's/Version="0.10.\*"/Version="0.12.*"/' SpacetimeDB.ClientSDK.csproj tests/tests.csproj
           cat >nuget.config <<EOF
             <?xml version="1.0" encoding="utf-8"?>
             <configuration>
               <packageSources>
                 <!-- Local NuGet repositories -->
                 <add key="Local SpacetimeDB.BSATN.Runtime" value="../crates/bindings-csharp/BSATN.Runtime/bin/Release" />
-                <add key="Local SpacetimeDB.BSATN.Codegen" value="../crates/bindings-csharp/BSATN.Codegen/bin/Release" />
                 <!-- Official NuGet.org server -->
                 <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
               </packageSources>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,7 +122,11 @@ jobs:
           ( cd crates/bindings-csharp/BSATN.Runtime && dotnet pack )
           cd spacetimedb-csharp-sdk
 
-          # Write out the nuget config file to `nuget.config`.
+          # Write out the nuget config file to `nuget.config`. This causes the spacetimedb-csharp-sdk repository
+          # to be aware of the local versions of the `bindings-csharp` packages in SpacetimeDB, and use them if
+          # available. Otherwise, `spacetimedb-csharp-sdk` will use the NuGet versions of the packages.
+          # This means that (if version numbers match) we will test the local versions of the C# packages, even
+          # if they're not pushed to NuGet.
           # See https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file for more info on the config file,
           # and https://tldp.org/LDP/abs/html/here-docs.html for more info on this bash feature.
           cat >nuget.config <<EOF

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,6 +80,37 @@ jobs:
       - name: C# bindings tests
         run: dotnet test crates/bindings-csharp
 
+  sdk_test:
+    name: SDK Tests
+    runs-on: spacetimedb-runner
+    steps:
+      - name: Find Git ref
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          PR_NUMBER="${{ github.event.inputs.pr_number || null }}"
+          if test -n "${PR_NUMBER}"; then
+            GIT_REF="$( gh pr view --repo clockworklabs/SpacetimeDB $PR_NUMBER --json headRefName --jq .headRefName )"
+          else
+            GIT_REF="${{ github.ref }}"
+          fi
+          echo "GIT_REF=${GIT_REF}" >>"$GITHUB_ENV"
+
+      - name: Checkout sources
+        uses: actions/checkout@v4
+        with:
+          ref: ${{ env.GIT_REF }}
+
+      - uses: dsherret/rust-toolchain-file@v1
+
+      - uses: actions/setup-dotnet@v3
+        with:
+          dotnet-version: "8.x"
+
+      - name: Create /stdb dir
+        run: |
+          sudo mkdir /stdb
+          sudo chmod 777 /stdb
       - name: Checkout C# SDK
         uses: actions/checkout@v4
         with:
@@ -90,10 +121,6 @@ jobs:
         run: |
           ( cd crates/bindings-csharp/BSATN.Runtime && dotnet pack )
           cd spacetimedb-csharp-sdk
-          # only for testing - remove this before merging!
-          sed -i'' 's/Version="0.10.\*/Version="0.11.\*/' tests/tests.csproj
-          # only for testing - remove this before merging!
-          sed -i'' 's/Version="0.10.\*/Version="0.11.\*/' SpacetimeDB.ClientSDK.csproj
           cat >nuget.config <<EOF
             <?xml version="1.0" encoding="utf-8"?>
             <configuration>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -77,8 +77,37 @@ jobs:
       - name: Run cargo test
         run: cargo test --all
 
-      - name: C# SDK tests
+      - name: C# bindings tests
         run: dotnet test crates/bindings-csharp
+
+      - name: Checkout C# SDK
+        uses: actions/checkout@v4
+        with:
+          repository: clockworklabs/spacetimedb-csharp-sdk
+          path: spacetimedb-csharp-sdk
+
+      - name: C# SDK tests
+        run: |
+          ( cd crates/bindings-csharp/BSATN.Runtime && dotnet pack )
+          cd spacetimedb-csharp-sdk
+          # only for testing - remove this before merging!
+          sed -i'' 's/Version="0.10.\*/Version="0.11.\*/' tests/tests.csproj
+          # only for testing - remove this before merging!
+          sed -i'' 's/Version="0.10.\*/Version="0.11.\*/' SpacetimeDB.ClientSDK.csproj
+          cat >nuget.config <<EOF
+            <?xml version="1.0" encoding="utf-8"?>
+            <configuration>
+              <packageSources>
+                <!-- Local NuGet repositories -->
+                <add key="Local SpacetimeDB.BSATN.Runtime" value="../crates/bindings-csharp/BSATN.Runtime/bin/Release" />
+                <!-- Official NuGet.org server -->
+                <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+              </packageSources>
+            </configuration>
+          EOF
+          # clear package caches, so we get fresh ones even if version numbers haven't changed
+          dotnet nuget local all --clear
+          dotnet test
 
   lints:
     name: Lints

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,16 +121,16 @@ jobs:
         run: |
           ( cd crates/bindings-csharp/BSATN.Runtime && dotnet pack )
           cd spacetimedb-csharp-sdk
-          cat >nuget.config <<EOF
-            <?xml version="1.0" encoding="utf-8"?>
-            <configuration>
-              <packageSources>
-                <!-- Local NuGet repositories -->
-                <add key="Local SpacetimeDB.BSATN.Runtime" value="../crates/bindings-csharp/BSATN.Runtime/bin/Release" />
-                <!-- Official NuGet.org server -->
-                <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-              </packageSources>
-            </configuration>
+          cat >nuget.config <<-EOF
+		<?xml version="1.0" encoding="utf-8"?>
+		<configuration>
+		  <packageSources>
+		    <!-- Local NuGet repositories -->
+		    <add key="Local SpacetimeDB.BSATN.Runtime" value="../crates/bindings-csharp/BSATN.Runtime/bin/Release" />
+		    <!-- Official NuGet.org server -->
+		    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+		  </packageSources>
+		</configuration>
           EOF
           # clear package caches, so we get fresh ones even if version numbers haven't changed
           dotnet nuget locals all --clear

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,17 +121,19 @@ jobs:
         run: |
           ( cd crates/bindings-csharp/BSATN.Runtime && dotnet pack )
           cd spacetimedb-csharp-sdk
-          cat >nuget.config <<-EOF
-          	<?xml version="1.0" encoding="utf-8"?>
-          	<configuration>
-          	  <packageSources>
-          	    <!-- Local NuGet repositories -->
-          	    <add key="Local SpacetimeDB.BSATN.Runtime" value="../crates/bindings-csharp/BSATN.Runtime/bin/Release" />
-          	    <!-- Official NuGet.org server -->
-          	    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-          	  </packageSources>
-          	</configuration>
+
+          cat >nuget.config <<EOF
+          <?xml version="1.0" encoding="utf-8"?>
+          <configuration>
+            <packageSources>
+              <!-- Local NuGet repositories -->
+              <add key="Local SpacetimeDB.BSATN.Runtime" value="../crates/bindings-csharp/BSATN.Runtime/bin/Release" />
+              <!-- Official NuGet.org server -->
+              <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+            </packageSources>
+          </configuration>
           EOF
+
           # clear package caches, so we get fresh ones even if version numbers haven't changed
           dotnet nuget locals all --clear
           dotnet test

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,15 +122,15 @@ jobs:
           ( cd crates/bindings-csharp/BSATN.Runtime && dotnet pack )
           cd spacetimedb-csharp-sdk
           cat >nuget.config <<-EOF
-		<?xml version="1.0" encoding="utf-8"?>
-		<configuration>
-		  <packageSources>
-		    <!-- Local NuGet repositories -->
-		    <add key="Local SpacetimeDB.BSATN.Runtime" value="../crates/bindings-csharp/BSATN.Runtime/bin/Release" />
-		    <!-- Official NuGet.org server -->
-		    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
-		  </packageSources>
-		</configuration>
+          	<?xml version="1.0" encoding="utf-8"?>
+          	<configuration>
+          	  <packageSources>
+          	    <!-- Local NuGet repositories -->
+          	    <add key="Local SpacetimeDB.BSATN.Runtime" value="../crates/bindings-csharp/BSATN.Runtime/bin/Release" />
+          	    <!-- Official NuGet.org server -->
+          	    <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
+          	  </packageSources>
+          	</configuration>
           EOF
           # clear package caches, so we get fresh ones even if version numbers haven't changed
           dotnet nuget locals all --clear

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -123,7 +123,7 @@ jobs:
           ( cd crates/bindings-csharp/BSATN.Codegen && dotnet pack )
           cd spacetimedb-csharp-sdk
           # only for testing - remove this before merging!
-          sed -i'' 's/Version="0.10.\*"/Version="0.11.*"/' SpacetimeDB.ClientSDK.csproj tests/tests.csproj
+          sed -i'' 's/Version="0.10.\*"/Version="0.12.*"/' SpacetimeDB.ClientSDK.csproj tests/tests.csproj
           cat >nuget.config <<EOF
             <?xml version="1.0" encoding="utf-8"?>
             <configuration>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,6 +121,8 @@ jobs:
         run: |
           ( cd crates/bindings-csharp/BSATN.Runtime && dotnet pack )
           cd spacetimedb-csharp-sdk
+          # only for testing - remove this before merging!
+          sed -i'' 's/Version="0.10.\*"/Version="0.11.*"/' SpacetimeDB.ClientSDK.csproj tests/tests.csproj
           cat >nuget.config <<EOF
             <?xml version="1.0" encoding="utf-8"?>
             <configuration>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -122,6 +122,9 @@ jobs:
           ( cd crates/bindings-csharp/BSATN.Runtime && dotnet pack )
           cd spacetimedb-csharp-sdk
 
+          # Write out the nuget config file to `nuget.config`.
+          # See https://learn.microsoft.com/en-us/nuget/reference/nuget-config-file for more info on the config file,
+          # and https://tldp.org/LDP/abs/html/here-docs.html for more info on this bash feature.
           cat >nuget.config <<EOF
           <?xml version="1.0" encoding="utf-8"?>
           <configuration>

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -120,6 +120,7 @@ jobs:
       - name: C# SDK tests
         run: |
           ( cd crates/bindings-csharp/BSATN.Runtime && dotnet pack )
+          ( cd crates/bindings-csharp/BSATN.Codegen && dotnet pack )
           cd spacetimedb-csharp-sdk
           # only for testing - remove this before merging!
           sed -i'' 's/Version="0.10.\*"/Version="0.11.*"/' SpacetimeDB.ClientSDK.csproj tests/tests.csproj
@@ -129,6 +130,7 @@ jobs:
               <packageSources>
                 <!-- Local NuGet repositories -->
                 <add key="Local SpacetimeDB.BSATN.Runtime" value="../crates/bindings-csharp/BSATN.Runtime/bin/Release" />
+                <add key="Local SpacetimeDB.BSATN.Codegen" value="../crates/bindings-csharp/BSATN.Codegen/bin/Release" />
                 <!-- Official NuGet.org server -->
                 <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
               </packageSources>


### PR DESCRIPTION
# Description of Changes

Added a CI step that checks out `spacetimedb-csharp-sdk` and runs its test suite.

In the current PR incarnation, if the local major/minor package versions are bumped, the C# SDK tests will continue to use the old ones. This is because the C# SDK repo will still have its version numbers pointed to e.g. `0.10.*` rather than e.g. `0.11.*`. Is this a bug or a feature?

I kind of think that the current behavior is correct - if we bump the major/minor version numbers, we're explicitly aware that we're releasing a breaking change. This effectively tests the experience of a current _user_ of the C# SDK (on `master`). In that case, we can make this a required check.

On the other hand, if we decide we want the C# SDK to _always_ use the local versions, then this should **not** be made a required check. We may sometimes release breaking changes, which will need to happen in this repository before they happen in that one.

# API and ABI breaking changes

No

# Expected complexity level and risk

2

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] CI passes
  - [x] CI logs show that `dotnet test` is, in fact, running
  - [x] If we manually downgrade the `bindings-csharp` versions to 0.10.1 (to match the latest version on NuGet), the tests use the local versions (and fail, because the C# SDK repo is not yet updated for the latest packages)
    - https://github.com/clockworklabs/SpacetimeDB/actions/runs/9944746191/job/27471462469?pr=1510