### PR TITLE
ABI BREAK: Add versioning for RawModuleDef

### DIFF
--- a/crates/bindings-csharp/Runtime/Internal/Module.cs
+++ b/crates/bindings-csharp/Runtime/Internal/Module.cs
@@ -122,7 +122,7 @@ public static partial class Module
         : SpacetimeDB.TaggedEnum<(TypeAlias TypeAlias, Unit _Reserved)>;
 
     [SpacetimeDB.Type]
-    public partial struct ModuleDef()
+    public partial struct RawModuleDefV8()
     {
         List<AlgebraicType> Types = [];
         List<TableDesc> Tables = [];
@@ -164,7 +164,11 @@ public static partial class Module
         internal void RegisterTable(TableDesc table) => Tables.Add(table);
     }
 
-    private static readonly ModuleDef moduleDef = new();
+    [SpacetimeDB.Type]
+    internal partial record RawModuleDef
+        : SpacetimeDB.TaggedEnum<(RawModuleDefV8 V8BackCompat, Unit _Reserved)>;
+
+    private static readonly RawModuleDefV0 moduleDef = new();
     private static readonly List<IReducer> reducers = [];
 
     struct TypeRegistrar() : ITypeRegistrar
@@ -224,11 +228,11 @@ public static partial class Module
 
     public static Buffer __describe_module__()
     {
-        // replace `module` with a temporary internal module that will register ModuleDef, AlgebraicType and other internal types
-        // during the ModuleDef.GetSatsTypeInfo() instead of exposing them via user's module.
+        // replace `module` with a temporary internal module that will register RawModuleDefV8, AlgebraicType and other internal types
+        // during the RawModuleDefV8.GetSatsTypeInfo() instead of exposing them via user's module.
         try
         {
-            var moduleBytes = IStructuralReadWrite.ToBytes(moduleDef);
+            var moduleBytes = IStructuralReadWrite.ToBytes(new RawModuleDef.V8BackCompat(moduleDef));
             var res = FFI._buffer_alloc(moduleBytes, (uint)moduleBytes.Length);
             return res;
         }

--- a/crates/bindings-csharp/Runtime/Internal/Module.cs
+++ b/crates/bindings-csharp/Runtime/Internal/Module.cs
@@ -232,6 +232,7 @@ public static partial class Module
         // during the RawModuleDefV8.GetSatsTypeInfo() instead of exposing them via user's module.
         try
         {
+            // We need this explicit cast here to make `ToBytes` understand the types correctly.
             RawModuleDef versioned = new RawModuleDef.V8BackCompat(moduleDef);
             var moduleBytes = IStructuralReadWrite.ToBytes(new RawModuleDef.BSATN(), versioned);
             var res = FFI._buffer_alloc(moduleBytes, (uint)moduleBytes.Length);

--- a/crates/bindings-csharp/Runtime/Internal/Module.cs
+++ b/crates/bindings-csharp/Runtime/Internal/Module.cs
@@ -168,7 +168,7 @@ public static partial class Module
     internal partial record RawModuleDef
         : SpacetimeDB.TaggedEnum<(RawModuleDefV8 V8BackCompat, Unit _Reserved)>;
 
-    private static readonly RawModuleDefV0 moduleDef = new();
+    private static readonly RawModuleDefV8 moduleDef = new();
     private static readonly List<IReducer> reducers = [];
 
     struct TypeRegistrar() : ITypeRegistrar
@@ -232,7 +232,8 @@ public static partial class Module
         // during the RawModuleDefV8.GetSatsTypeInfo() instead of exposing them via user's module.
         try
         {
-            var moduleBytes = IStructuralReadWrite.ToBytes(new RawModuleDef.V8BackCompat(moduleDef));
+            RawModuleDef versioned = new RawModuleDef.V8BackCompat(moduleDef);
+            var moduleBytes = IStructuralReadWrite.ToBytes(new RawModuleDef.BSATN(), versioned);
             var res = FFI._buffer_alloc(moduleBytes, (uint)moduleBytes.Length);
             return res;
         }

--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -16,7 +16,7 @@ use spacetimedb_lib::de::{self, Deserialize, SeqProductAccess};
 use spacetimedb_lib::sats::typespace::TypespaceBuilder;
 use spacetimedb_lib::sats::{impl_deserialize, impl_serialize, ProductTypeElement};
 use spacetimedb_lib::ser::{Serialize, SerializeSeqProduct};
-use spacetimedb_lib::{bsatn, Address, Identity, ModuleDefBuilder, ReducerDef, TableDesc};
+use spacetimedb_lib::{bsatn, Address, Identity, ModuleDefBuilder, RawModuleDef, ReducerDef, TableDesc};
 use spacetimedb_primitives::*;
 
 /// The `sender` invokes `reducer` at `timestamp` and provides it with the given `args`.
@@ -450,6 +450,7 @@ extern "C" fn __describe_module__() -> Buffer {
 
     // Serialize the module to bsatn.
     let module_def = module.inner.finish();
+    let module_def = RawModuleDef::V8BackCompat(module_def);
     let bytes = bsatn::to_vec(&module_def).expect("unable to serialize typespace");
 
     // Write the set of reducers.

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -196,6 +196,17 @@ impl RawModuleDefV8 {
     }
 }
 
+/// A versioned raw module definition.
+///
+/// This is what is actually returned by the module when `__describe_module__` is called, serialized to BSATN.
+#[derive(Debug, Clone, de::Deserialize, ser::Serialize)]
+#[non_exhaustive]
+pub enum RawModuleDef {
+    V8BackCompat(RawModuleDefV8),
+    // TODO(jgilles): It would be nice to have a custom error message if this fails with an unknown variant,
+    // but I'm not sure if that can be done via the Deserialize trait.
+}
+
 /// A builder for a [`ModuleDef`].
 #[derive(Default)]
 pub struct ModuleDefBuilder {


### PR DESCRIPTION
# Description of Changes

Modules now return a serialized enum `RawModuleDef` from `__describe_module__` for future versioning extensibility. This is an ABI break, but it will make it easier to avoid ABI breaks in the future.

# Expected complexity level and risk

1

# Testing

I still need to run the full test suite which is why I'm opening this PR.