### PR TITLE
CI - Post-to-discord workflow only fires if the PR merged to `master`

### DIFF
--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -7,7 +7,8 @@ on:
 jobs:
   discordNotification:
     runs-on: ubuntu-latest
-    if: github.event.pull_request.merged == true
+    if: github.event.pull_request.merged == true &&
+      github.event.pull_request.base.ref == 'master'
     steps:
       - name: Send Discord notification
         env:


### PR DESCRIPTION
# Description of Changes

The post-to-discord workflow was firing any time a PR merged, which included PRs merging to non-`master` branches. That's a bit noisy.

# API and ABI breaking changes

Nah

# Expected complexity level and risk

1

# Testing

- [x] Checked that a PR based on this PR doesn't trigger the workflow
  - https://github.com/clockworklabs/SpacetimeDB/pull/1521
  - Workflow shows as correctly skipped: https://github.com/clockworklabs/SpacetimeDB/actions/runs/9961094449