### PR TITLE
Add more information to UniqueConstraintViolation

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -1703,12 +1703,7 @@ mod tests {
         datastore.insert_mut_tx(&mut tx, table_id, row.clone())?;
         let result = datastore.insert_mut_tx(&mut tx, table_id, row);
         match result {
-            Err(DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation {
-                constraint_name: _,
-                table_name: _,
-                cols: _,
-                value: _,
-            }))) => (),
+            Err(DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation { .. }))) => (),
             _ => panic!("Expected an unique constraint violation error."),
         }
         #[rustfmt::skip]
@@ -1725,12 +1720,7 @@ mod tests {
         let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
         let result = datastore.insert_mut_tx(&mut tx, table_id, row);
         match result {
-            Err(DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation {
-                constraint_name: _,
-                table_name: _,
-                cols: _,
-                value: _,
-            }))) => (),
+            Err(DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation { .. }))) => (),
             _ => panic!("Expected an unique constraint violation error."),
         }
         #[rustfmt::skip]
@@ -1788,12 +1778,7 @@ mod tests {
         let row = u32_str_u32(0, "Bar", 18); // 0 will be ignored.
         let result = datastore.insert_mut_tx(&mut tx, table_id, row);
         match result {
-            Err(DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation {
-                constraint_name: _,
-                table_name: _,
-                cols: _,
-                value: _,
-            }))) => (),
+            Err(DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation { .. }))) => (),
             e => panic!("Expected an unique constraint violation error but got {e:?}."),
         }
         #[rustfmt::skip]
@@ -1835,12 +1820,7 @@ mod tests {
         let row = u32_str_u32(0, "Bar", 18); // 0 will be ignored.
         let result = datastore.insert_mut_tx(&mut tx, table_id, row);
         match result {
-            Err(DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation {
-                constraint_name: _,
-                table_name: _,
-                cols: _,
-                value: _,
-            }))) => (),
+            Err(DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation { .. }))) => (),
             _ => panic!("Expected an unique constraint violation error."),
         }
         #[rustfmt::skip]

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -877,7 +877,9 @@ impl MutTxId {
         // so this method needs only to check the committed state.
         if let Some(commit_table) = commit_table {
             commit_table
-                .check_unique_constraints(row, |maybe_conflict| self.tx_state.is_deleted(table_id, maybe_conflict))
+                .check_unique_constraints(&self.committed_state_write_lock.blob_store, row, |maybe_conflict| {
+                    self.tx_state.is_deleted(table_id, maybe_conflict)
+                })
                 .map_err(IndexError::from)?;
         }
 

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -111,10 +111,7 @@ impl InstanceEnv {
             .insert_bytes_as_row(tx, table_id, buffer)
             .inspect_err(|e| match e {
                 crate::error::DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation {
-                    constraint_name: _,
-                    table_name: _,
-                    cols: _,
-                    value: _,
+                    ..
                 })) => {}
                 _ => {
                     let res = stdb.table_name_from_id_mut(ctx, tx, table_id);

--- a/crates/core/src/host/wasm_common.rs
+++ b/crates/core/src/host/wasm_common.rs
@@ -333,12 +333,9 @@ pub fn err_to_errno(err: &NodesError) -> Option<NonZeroU16> {
         NodesError::ColumnValueNotFound | NodesError::RangeNotFound => Some(errno::LOOKUP_NOT_FOUND),
         NodesError::AlreadyExists(_) => Some(errno::UNIQUE_ALREADY_EXISTS),
         NodesError::Internal(internal) => match **internal {
-            DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation {
-                constraint_name: _,
-                table_name: _,
-                cols: _,
-                value: _,
-            })) => Some(errno::UNIQUE_ALREADY_EXISTS),
+            DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation { .. })) => {
+                Some(errno::UNIQUE_ALREADY_EXISTS)
+            }
             _ => None,
         },
         _ => None,

--- a/crates/sats/src/product_type.rs
+++ b/crates/sats/src/product_type.rs
@@ -7,6 +7,20 @@ use crate::{AlgebraicType, AlgebraicValue, ProductTypeElement, ValueWithType, Wi
 pub const IDENTITY_TAG: &str = "__identity_bytes";
 pub const ADDRESS_TAG: &str = "__address_bytes";
 
+/// Constructs a product type from a list of field types with syntax:
+///
+/// `product_type![Some("bananas") => AlgebraicType::I32, None => AlgebraicType::String, Some("apples") => AlgebraicType::I64, ...]`.
+///
+/// Repeat notation from `vec![x; n]` is not supported.
+#[macro_export]
+macro_rules! product_type {
+    [$($name:expr => $ty:expr),*$(,)?] => {
+        $crate::ProductType {
+            elements: [$($crate::ProductTypeElement::new($crate::AlgebraicType::from($ty), $name.map(|v| v.into()))),*].into(),
+        }
+    }
+}
+
 /// A structural product type  of the factors given by `elements`.
 ///
 /// This is also known as `struct` and `tuple` in many languages,


### PR DESCRIPTION
# Description of Changes

A recent issue revealed this could be better. Now it tells you everything about the conflicting rows, not just the conflicting values.

This makes UniqueConstraintViolation bigger but it's necessary for good UX. I could box it if needed.

TODO: add a product type here for better pretty printing.

# API and ABI breaking changes

Is UniqueConstraintViolation public api?

# Expected complexity level and risk

0

# Testing

CI