### PR TITLE
Bump version to 0.11.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "connect_disconnect_client"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "spacetimedb-sdk",
@@ -4065,7 +4065,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "derive_more",
  "getrandom",
@@ -4081,7 +4081,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bench"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "anymap",
@@ -4118,7 +4118,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-macro"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bitflags 2.4.1",
  "humantime",
@@ -4130,14 +4130,14 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-sys"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "spacetimedb-primitives",
 ]
 
 [[package]]
 name = "spacetimedb-cli"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -4189,7 +4189,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4228,7 +4228,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api-messages"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bytes",
  "bytestring",
@@ -4249,7 +4249,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-commitlog"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bitflags 2.4.1",
  "crc32c",
@@ -4269,7 +4269,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-core"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4362,7 +4362,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-data-structures"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "hashbrown 0.14.1",
  "nohash-hasher",
@@ -4372,7 +4372,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-durability"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "log",
@@ -4384,7 +4384,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-fs-utils"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -4395,7 +4395,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-lib"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4420,7 +4420,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-metrics"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "arrayvec",
  "itertools 0.12.0",
@@ -4430,7 +4430,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-primitives"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "bitflags 2.4.1",
  "either",
@@ -4448,7 +4448,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sats"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ahash 0.8.11",
  "arrayvec",
@@ -4476,7 +4476,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sdk"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "anymap",
@@ -4504,7 +4504,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-snapshot"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "blake3",
  "hex",
@@ -4520,7 +4520,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-standalone"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4550,7 +4550,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-table"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "ahash 0.8.11",
  "blake3",
@@ -4573,7 +4573,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-testing"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "clap 4.4.6",
@@ -4598,7 +4598,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-vm"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4687,7 +4687,7 @@ dependencies = [
 
 [[package]]
 name = "sqltest"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4960,7 +4960,7 @@ dependencies = [
 
 [[package]]
 name = "test-client"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -4971,7 +4971,7 @@ dependencies = [
 
 [[package]]
 name = "test-counter"
-version = "0.10.1"
+version = "0.11.0"
 dependencies = [
  "anyhow",
  "spacetimedb-data-structures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -77,31 +77,31 @@ inherits = "release"
 debug = true
 
 [workspace.package]
-version = "0.10.1"
+version = "0.11.0"
 edition = "2021"
 # update rust-toolchain.toml too!
 rust-version = "1.78.0"
 
 [workspace.dependencies]
-spacetimedb = { path = "crates/bindings", version = "0.10.1" }
-spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "0.10.1" }
-spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "0.10.1" }
-spacetimedb-cli = { path = "crates/cli", version = "0.10.1" }
-spacetimedb-client-api = { path = "crates/client-api", version = "0.10.1" }
-spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "0.10.1" }
-spacetimedb-commitlog = { path = "crates/commitlog", version = "0.10.1" }
-spacetimedb-core = { path = "crates/core", version = "0.10.1" }
-spacetimedb-data-structures = { path = "crates/data-structures", version = "0.10.1" }
-spacetimedb-durability = { path = "crates/durability", version = "0.10.1" }
-spacetimedb-lib = { path = "crates/lib", default-features = false, version = "0.10.1" }
-spacetimedb-metrics = { path = "crates/metrics", version = "0.10.1" }
-spacetimedb-primitives = { path = "crates/primitives", version = "0.10.1" }
-spacetimedb-sats = { path = "crates/sats", version = "0.10.1" }
-spacetimedb-standalone = { path = "crates/standalone", version = "0.10.1" }
-spacetimedb-table = { path = "crates/table", version = "0.10.1" }
-spacetimedb-vm = { path = "crates/vm", version = "0.10.1" }
-spacetimedb-fs-utils = { path = "crates/fs-utils", version = "0.10.1" }
-spacetimedb-snapshot = { path = "crates/snapshot", version = "0.10.1" }
+spacetimedb = { path = "crates/bindings", version = "0.11.0" }
+spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "0.11.0" }
+spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "0.11.0" }
+spacetimedb-cli = { path = "crates/cli", version = "0.11.0" }
+spacetimedb-client-api = { path = "crates/client-api", version = "0.11.0" }
+spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "0.11.0" }
+spacetimedb-commitlog = { path = "crates/commitlog", version = "0.11.0" }
+spacetimedb-core = { path = "crates/core", version = "0.11.0" }
+spacetimedb-data-structures = { path = "crates/data-structures", version = "0.11.0" }
+spacetimedb-durability = { path = "crates/durability", version = "0.11.0" }
+spacetimedb-lib = { path = "crates/lib", default-features = false, version = "0.11.0" }
+spacetimedb-metrics = { path = "crates/metrics", version = "0.11.0" }
+spacetimedb-primitives = { path = "crates/primitives", version = "0.11.0" }
+spacetimedb-sats = { path = "crates/sats", version = "0.11.0" }
+spacetimedb-standalone = { path = "crates/standalone", version = "0.11.0" }
+spacetimedb-table = { path = "crates/table", version = "0.11.0" }
+spacetimedb-vm = { path = "crates/vm", version = "0.11.0" }
+spacetimedb-fs-utils = { path = "crates/fs-utils", version = "0.11.0" }
+spacetimedb-snapshot = { path = "crates/snapshot", version = "0.11.0" }
 
 ahash = "0.8"
 anyhow = "1.0.68"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Clockwork Laboratories, Inc.
-Licensed Work:        SpacetimeDB 0.10.1
+Licensed Work:        SpacetimeDB 0.11.0
                       The Licensed Work is
                       (c) 2023 Clockwork Laboratories, Inc.
                       

--- a/crates/cli/src/subcommands/project/rust/Cargo._toml
+++ b/crates/cli/src/subcommands/project/rust/Cargo._toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "0.10.1"
+spacetimedb = "0.11.0"
 log = "0.4"


### PR DESCRIPTION
I thought I had already done this, but apparently I had only done it for the C# packages :monocle_face: 

We've merged several breaking changes so this version bump is overdue!