### PR TITLE
ST sequences: respect allocated amount on restart

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1224,6 +1224,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "diff"
+version = "0.1.13"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
+
+[[package]]
 name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3016,6 +3022,16 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5b40af805b3121feab8a3c29f04d8ad262fa8e0561883e7653e024ae4479e6de"
 
 [[package]]
+name = "pretty_assertions"
+version = "1.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "af7cee1a6c8a5b9208b3cb1061f10c0cb689087b3d8ce85fb9d2dd7a29b6ba66"
+dependencies = [
+ "diff",
+ "yansi",
+]
+
+[[package]]
 name = "proc-macro-crate"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4308,6 +4324,7 @@ dependencies = [
  "parking_lot 0.12.1",
  "paste",
  "pin-project-lite",
+ "pretty_assertions",
  "prometheus",
  "proptest",
  "proptest-derive",
@@ -6280,6 +6297,12 @@ checksum = "56c1936c4cc7a1c9ab21a1ebb602eb942ba868cbd44a99cb7cdc5892335e1c85"
 dependencies = [
  "linked-hash-map",
 ]
+
+[[package]]
+name = "yansi"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "09041cd90cf85f7f8b2df60c646f853b7f535ce68f85244eb6731cf89fa498ec"
 
 [[package]]
 name = "zerocopy"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -171,6 +171,7 @@ parking_lot = { version = "0.12.1", features = ["send_guard", "arc_lock"] }
 paste = "1.0"
 pin-project-lite = "0.2.9"
 postgres-types = "0.2.5"
+pretty_assertions = "1.4"
 proc-macro2 = "1.0"
 prometheus = "0.13.0"
 proptest = "1.4"

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -117,3 +117,4 @@ proptest.workspace = true
 proptest-derive.workspace = true
 rand.workspace = true
 env_logger.workspace = true
+pretty_assertions.workspace = true

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -231,9 +231,9 @@ impl CommittedState {
                 // All sequences for system tables start from the reserved
                 // range + 1.
                 // Logically, we thus have used up the default pre-allocation
-                // and must initialize the sequence with twice the amount.
+                // and must allocate again on the next increment.
                 start: ST_RESERVED_SEQUENCE_RANGE as i128 + 1,
-                allocated: (ST_RESERVED_SEQUENCE_RANGE * 2) as i128,
+                allocated: ST_RESERVED_SEQUENCE_RANGE as i128,
             };
             let row = ProductValue::from(row);
             // Insert the meta-row into the in-memory ST_SEQUENCES.

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -295,16 +295,10 @@ impl CommittedState {
         let st_sequences = self.tables.get(&ST_SEQUENCES_ID).unwrap();
         for row_ref in st_sequences.scan_rows(&self.blob_store) {
             let sequence = StSequenceRow::try_from(row_ref)?;
-            // TODO: The system tables have initialized their value already, but this is wrong:
-            // If we exceed  `SEQUENCE_PREALLOCATION_AMOUNT` we will get a unique violation
-            let is_system_table = self
-                .tables
-                .get(&sequence.table_id)
-                .map_or(false, |x| x.get_schema().table_type == StTableType::System);
 
             let mut seq = Sequence::new(sequence.into());
             // Now we need to recover the last allocation value.
-            if !is_system_table && seq.value < seq.allocated() + 1 {
+            if seq.value < seq.allocated() + 1 {
                 seq.value = seq.allocated() + 1;
             }
 

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -295,8 +295,10 @@ impl CommittedState {
         let st_sequences = self.tables.get(&ST_SEQUENCES_ID).unwrap();
         for row_ref in st_sequences.scan_rows(&self.blob_store) {
             let sequence = StSequenceRow::try_from(row_ref)?;
+            let mut seq = sequence_state
+                .remove(sequence.sequence_id)
+                .unwrap_or_else(|| Sequence::new(sequence.into()));
 
-            let mut seq = Sequence::new(sequence.into());
             // Now we need to recover the last allocation value.
             if seq.value < seq.allocated() + 1 {
                 seq.value = seq.allocated() + 1;

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -935,6 +935,7 @@ mod tests {
     use crate::db::datastore::Result;
     use crate::error::{DBError, IndexError};
     use itertools::Itertools;
+    use pretty_assertions::assert_eq;
     use spacetimedb_lib::address::Address;
     use spacetimedb_lib::db::auth::{StAccess, StTableType};
     use spacetimedb_lib::db::def::{ColumnDef, ColumnSchema, ConstraintSchema, IndexSchema, IndexType, SequenceSchema};
@@ -1140,7 +1141,7 @@ mod tests {
                 start: value.start,
                 min_value: 1,
                 max_value: 170141183460469231731687303715884105727,
-                allocated: 4096,
+                allocated: 0,
             }
         }
     }
@@ -1156,7 +1157,7 @@ mod tests {
                 start: value.start,
                 min_value: 1,
                 max_value: 170141183460469231731687303715884105727,
-                allocated: 4096,
+                allocated: 0,
             }
         }
     }
@@ -1380,7 +1381,7 @@ mod tests {
                 SequenceRow { id: 2, table: 4, col_pos: 0, name: "seq_st_constraints_constraint_id_primary_key_auto", start },
             ],
             |row| StSequenceRow {
-                allocated: ST_RESERVED_SEQUENCE_RANGE as i128 * 2,
+                allocated: ST_RESERVED_SEQUENCE_RANGE as i128,
                 ..StSequenceRow::from(row)
             }
         ));

--- a/crates/core/src/db/datastore/locking_tx_datastore/sequence.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/sequence.rs
@@ -86,7 +86,9 @@ impl Sequence {
     /// 6. incr = 1 allocated = 10, value = 10
     /// 7. next_value() -> 11
     fn needs_allocation(&self) -> bool {
-        self.value == self.schema.allocated
+        // In order to yield a value, it must be strictly less than the allocation amount,
+        // because on restart we will begin at the allocation amount.
+        self.value >= self.schema.allocated
     }
 
     pub(super) fn set_allocation(&mut self, allocated: i128) {

--- a/crates/core/src/db/datastore/locking_tx_datastore/sequence.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/sequence.rs
@@ -109,7 +109,7 @@ impl SequencesState {
         self.sequences.insert(seq_id, seq);
     }
 
-    pub(super) fn remove(&mut self, seq_id: SequenceId) {
-        self.sequences.remove(&seq_id);
+    pub(super) fn remove(&mut self, seq_id: SequenceId) -> Option<Sequence> {
+        self.sequences.remove(&seq_id)
     }
 }

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -313,6 +313,14 @@ pub struct Metadata {
     pub program_hash: Hash,
 }
 
+/// Program associated with a database.
+pub struct Program {
+    /// Hash over the program's bytes.
+    pub hash: Hash,
+    /// The raw bytes of the program.
+    pub bytes: Box<[u8]>,
+}
+
 pub trait TxDatastore: DataRow + Tx {
     type Iter<'a>: Iterator<Item = Self::RowRef<'a>>
     where
@@ -357,10 +365,10 @@ pub trait TxDatastore: DataRow + Tx {
     /// A `None` return value means that the datastore is not fully initialized yet.
     fn metadata(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Option<Metadata>>;
 
-    /// Obtain the raw bytes of the compiled module associated with this datastore.
+    /// Obtain the compiled module associated with this datastore.
     ///
     /// A `None` return value means that the datastore is not fully initialized yet.
-    fn program_bytes(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Option<Box<[u8]>>>;
+    fn program(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Option<Program>>;
 }
 
 pub trait MutTxDatastore: TxDatastore + MutTx {

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -2,7 +2,7 @@ use super::datastore::locking_tx_datastore::committed_state::CommittedState;
 use super::datastore::locking_tx_datastore::state_view::StateView as _;
 use super::datastore::system_tables::ST_MODULE_ID;
 use super::datastore::traits::{
-    IsolationLevel, Metadata, MutTx as _, MutTxDatastore, RowTypeForTable, Tx as _, TxDatastore,
+    IsolationLevel, Metadata, MutTx as _, MutTxDatastore, Program, RowTypeForTable, Tx as _, TxDatastore,
 };
 use super::datastore::{
     locking_tx_datastore::{
@@ -375,13 +375,13 @@ impl RelationalDB {
         self.with_read_only(&ctx, |tx| self.inner.metadata(&ctx, tx))
     }
 
-    /// Obtain the raw bytes of the module associated with this database.
+    /// Obtain the module associated with this database.
     ///
     /// `None` if the database is not yet fully initialized.
     /// Note that a `Some` result may yield an empty slice.
-    pub fn program_bytes(&self) -> Result<Option<Box<[u8]>>, DBError> {
+    pub fn program(&self) -> Result<Option<Program>, DBError> {
         let ctx = ExecutionContext::internal(self.address);
-        self.with_read_only(&ctx, |tx| self.inner.program_bytes(&ctx, tx))
+        self.with_read_only(&ctx, |tx| self.inner.program(&ctx, tx))
     }
 
     /// Read the set of clients currently connected to the database.

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1466,6 +1466,7 @@ mod tests {
     use commitlog::payload::txdata;
     use commitlog::Commitlog;
     use durability::EmptyHistory;
+    use pretty_assertions::assert_eq;
     use spacetimedb_client_api_messages::timestamp::Timestamp;
     use spacetimedb_data_structures::map::IntMap;
     use spacetimedb_lib::db::def::{ColumnDef, ConstraintDef};
@@ -2208,9 +2209,17 @@ mod tests {
             fn visit_delete<'a, R: BufReader<'a>>(
                 &mut self,
                 table_id: TableId,
-                _reader: &mut R,
+                reader: &mut R,
             ) -> Result<Self::Row, Self::Error> {
-                bail!("unexpected delete for table: {table_id}")
+                // Allow specifically deletes from `st_sequence`,
+                // since the transactions in this test will allocate sequence values.
+                if table_id != ST_SEQUENCES_ID {
+                    bail!("unexpected delete for table: {table_id}")
+                }
+                let ty = self.sys.get(&table_id).unwrap();
+                let row = ProductValue::decode(ty, reader)?;
+                log::debug!("delete: {table_id} {row:?}");
+                Ok(())
             }
 
             fn skip_row<'a, R: BufReader<'a>>(

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -3,7 +3,7 @@ use super::scheduler::SchedulerStarter;
 use super::Scheduler;
 use crate::database_instance_context::DatabaseInstanceContext;
 use crate::database_logger::DatabaseLogger;
-use crate::db::datastore::traits::Metadata;
+use crate::db::datastore::traits::Program;
 use crate::db::db_metrics::DB_METRICS;
 use crate::db::relational_db::{self, RelationalDB};
 use crate::energy::{EnergyMonitor, EnergyQuanta};
@@ -12,7 +12,7 @@ use crate::module_host_context::ModuleCreationContext;
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
 use crate::util::spawn_rayon;
 use crate::{db, host};
-use anyhow::{anyhow, bail, ensure, Context};
+use anyhow::{anyhow, ensure, Context};
 use async_trait::async_trait;
 use durability::EmptyHistory;
 use log::{info, trace, warn};
@@ -298,74 +298,34 @@ impl HostController {
         instance_id: u64,
         program_bytes: Box<[u8]>,
     ) -> anyhow::Result<UpdateDatabaseResult> {
-        let program_hash = hash_bytes(&program_bytes);
+        let program = Program {
+            hash: hash_bytes(&program_bytes),
+            bytes: program_bytes,
+        };
         trace!(
             "update module host {}/{}: genesis={} update-to={}",
             database.address,
             instance_id,
             database.initial_program,
-            program_hash
+            program.hash
         );
 
         let mut guard = self.acquire_write_lock(instance_id).await;
-        let (update_result, maybe_updated_host) = match guard.take() {
-            // If we don't have a running `Host`, spawn one.
+        let mut host = match guard.take() {
             None => {
                 trace!("host not running, try_init");
-                let host = self.try_init_host(database, instance_id).await?;
-                let module = host.module.borrow().clone();
-                // TODO: Make [ModuleHost] check if it supports the host type.
-                ensure!(
-                    matches!(host_type, HostType::Wasm),
-                    "unsupported host type {:?}",
-                    host_type,
-                );
-                let update_result =
-                    update_module(host.db(), &module, caller_address, (program_hash, program_bytes)).await?;
-                // If the update was not successul, drop the host.
-                // The `database` we gave it refers to a program hash which
-                // doesn't exist (because we just rejected it).
-                let maybe_updated_host = update_result.is_ok().then_some(host);
-
-                (update_result, maybe_updated_host)
+                self.try_init_host(database, instance_id).await?
             }
-
-            // Otherwise, update the host.
-            // Note that we always put back the host -- if the update failed, it
-            // will keep running the previous version of the module.
-            Some(mut host) => {
-                match host.dbic.relational_db.metadata()? {
-                    None => bail!("Host improperly initialized: no metadata"),
-                    Some(Metadata {
-                        database_address,
-                        owner_identity,
-                        ..
-                    }) => {
-                        ensure!(
-                            database_address == database.address,
-                            "cannot change database address when updating module host"
-                        );
-                        ensure!(
-                            owner_identity == database.owner_identity,
-                            "cannot change owner identity when updating module host"
-                        );
-                    }
-                }
+            Some(host) => {
                 trace!("host found, updating");
-                let update_result = host
-                    .update_module(
-                        caller_address,
-                        host_type,
-                        (program_hash, program_bytes),
-                        self.unregister_fn(instance_id),
-                    )
-                    .await?;
-
-                (update_result, Some(host))
+                host
             }
         };
+        let update_result = host
+            .update_module(caller_address, host_type, program, self.unregister_fn(instance_id))
+            .await?;
 
-        *guard = maybe_updated_host;
+        *guard = Some(host);
         Ok(update_result)
     }
 
@@ -437,7 +397,10 @@ impl HostController {
                 .update_module(
                     caller_address,
                     host_type,
-                    (program_hash, program_bytes),
+                    Program {
+                        hash: program_hash,
+                        bytes: program_bytes,
+                    },
                     self.unregister_fn(instance_id),
                 )
                 .await?;
@@ -590,13 +553,12 @@ async fn load_program(storage: &ProgramStorage, hash: Hash) -> anyhow::Result<Bo
 async fn launch_module(
     database: Database,
     instance_id: u64,
-    program_bytes: Box<[u8]>,
+    program: Program,
     on_panic: impl Fn() + Send + Sync + 'static,
     relational_db: Arc<RelationalDB>,
     energy_monitor: Arc<dyn EnergyMonitor>,
 ) -> anyhow::Result<(Arc<DatabaseInstanceContext>, ModuleHost, Scheduler, SchedulerStarter)> {
     let address = database.address;
-    let program_hash = database.initial_program;
     let host_type = database.host_type;
 
     let dbic = make_dbic(database, instance_id, relational_db).await.map(Arc::new)?;
@@ -606,15 +568,15 @@ async fn launch_module(
         ModuleCreationContext {
             dbic: dbic.clone(),
             scheduler: scheduler.clone(),
-            program_hash,
-            program_bytes: program_bytes.into(),
+            program_hash: program.hash,
+            program_bytes: program.bytes.into(),
             energy_monitor: energy_monitor.clone(),
         },
         on_panic,
     )
     .await?;
 
-    trace!("launched database {} with program {}", address, program_hash);
+    trace!("launched database {} with program {}", address, program.hash);
 
     Ok((dbic, module_host, scheduler, scheduler_starter))
 }
@@ -632,19 +594,19 @@ async fn update_module(
     db: &RelationalDB,
     module: &ModuleHost,
     caller_address: Option<Address>,
-    (program_hash, program_bytes): (Hash, Box<[u8]>),
+    program: Program,
 ) -> anyhow::Result<UpdateDatabaseResult> {
     let addr = db.address();
     match stored_program_hash(db)? {
         None => Err(anyhow!("database `{}` not yet initialized", addr)),
-        Some(stored) if stored == program_hash => {
-            info!("database `{}` up to date with program `{}`", addr, program_hash);
+        Some(stored) if stored == program.hash => {
+            info!("database `{}` up to date with program `{}`", addr, program.hash);
             anyhow::Ok(Ok(<_>::default()))
         }
         Some(stored) => {
-            info!("updating `{}` from {} to {}", addr, stored, program_hash);
+            info!("updating `{}` from {} to {}", addr, stored, program.hash);
             let update_result = module
-                .update_database(caller_address, program_hash, program_bytes)
+                .update_database(caller_address, program.hash, program.bytes)
                 .await?;
             Ok(update_result)
         }
@@ -719,13 +681,13 @@ impl Host {
                 )?
             }
         };
-        let (dbic, module_host, scheduler, scheduler_starter) = match db.program_bytes()? {
+        let (dbic, module_host, scheduler, scheduler_starter) = match db.program()? {
             // Launch module with program from existing database.
-            Some(program_bytes) => {
+            Some(program) => {
                 launch_module(
                     database,
                     instance_id,
-                    program_bytes,
+                    program,
                     on_panic,
                     Arc::new(db),
                     energy_monitor.clone(),
@@ -741,7 +703,10 @@ impl Host {
                 let res = launch_module(
                     database,
                     instance_id,
-                    program_bytes.clone(),
+                    Program {
+                        hash: program_hash,
+                        bytes: program_bytes.clone(),
+                    },
                     on_panic,
                     Arc::new(db),
                     energy_monitor.clone(),
@@ -800,7 +765,7 @@ impl Host {
         &mut self,
         caller_address: Option<Address>,
         host_type: HostType,
-        (program_hash, program_bytes): (Hash, Box<[u8]>),
+        program: Program,
         on_panic: impl Fn() + Send + Sync + 'static,
     ) -> anyhow::Result<UpdateDatabaseResult> {
         let dbic = &self.dbic;
@@ -810,22 +775,18 @@ impl Host {
             ModuleCreationContext {
                 dbic: dbic.clone(),
                 scheduler: scheduler.clone(),
-                program_bytes: program_bytes.clone().into(),
-                program_hash,
+                program_hash: program.hash,
+                program_bytes: program.bytes.clone().into(),
                 energy_monitor: self.energy_monitor.clone(),
             },
             on_panic,
         )
         .await?;
 
-        let update_result = update_module(
-            &dbic.relational_db,
-            &module,
-            caller_address,
-            (program_hash, program_bytes),
-        )
-        .await?;
+        let update_result = update_module(&dbic.relational_db, &module, caller_address, program).await?;
         trace!("update result: {update_result:?}");
+        // Only replace the module + scheduler if the update succeeded.
+        // Otherwise, we want the database to continue running with the old state.
         if update_result.is_ok() {
             self.scheduler = scheduler;
             scheduler_starter.start(&module)?;

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -136,8 +136,9 @@ impl<T: WasmModule> WasmModuleHostActor<T> {
             energy_monitor,
         } = mcc;
         log::trace!(
-            "Making new module host actor for database {}",
-            database_instance_context.address
+            "Making new module host actor for database {} with module {}",
+            database_instance_context.address,
+            module_hash,
         );
         let log_tx = database_instance_context.logger.tx.clone();
 

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -623,6 +623,7 @@ pub(crate) mod tests {
     };
     use crate::db::relational_db::tests_utils::TestDB;
     use crate::execution_context::ExecutionContext;
+    use pretty_assertions::assert_eq;
     use spacetimedb_lib::db::auth::{StAccess, StTableType};
     use spacetimedb_lib::db::def::{ColumnDef, IndexDef, IndexType, TableSchema};
     use spacetimedb_lib::error::ResultTest;
@@ -846,7 +847,7 @@ pub(crate) mod tests {
             start: ST_RESERVED_SEQUENCE_RANGE as i128 + 1,
             min_value: 1,
             max_value: i128::MAX,
-            allocated: ST_RESERVED_SEQUENCE_RANGE as i128 * 2,
+            allocated: ST_RESERVED_SEQUENCE_RANGE as i128,
         }
         .into();
         check_catalog(&db, ST_SEQUENCES_NAME, st_sequence_row, q, schema);

--- a/crates/lib/src/db/def.rs
+++ b/crates/lib/src/db/def.rs
@@ -11,7 +11,12 @@ use spacetimedb_sats::{de, ser};
 use std::sync::Arc;
 
 /// The default preallocation amount for sequences.
-pub const SEQUENCE_PREALLOCATION_AMOUNT: i128 = 4_096;
+///
+/// Start with no values allocated. The first time we advance the sequence,
+/// we will allocate [`SEQUENCE_ALLOCATION_STEP`] values.
+pub const SEQUENCE_PREALLOCATION_AMOUNT: i128 = 0;
+/// The amount sequences allocate each time they over-run their allocation.
+pub const SEQUENCE_ALLOCATION_STEP: i128 = 4096;
 
 /// Represents a schema definition for a database sequence.
 #[derive(Debug, Clone, PartialEq, Eq)]

--- a/crates/lib/src/db/def.rs
+++ b/crates/lib/src/db/def.rs
@@ -10,12 +10,10 @@ use spacetimedb_sats::product_value::InvalidFieldError;
 use spacetimedb_sats::{de, ser};
 use std::sync::Arc;
 
-/// The default preallocation amount for sequences.
-///
-/// Start with no values allocated. The first time we advance the sequence,
-/// we will allocate [`SEQUENCE_ALLOCATION_STEP`] values.
-pub const SEQUENCE_PREALLOCATION_AMOUNT: i128 = 0;
 /// The amount sequences allocate each time they over-run their allocation.
+///
+/// Note that we do not perform an initial allocation during `create_sequence` or at startup.
+/// Newly-created sequences will allocate the first time they are advanced.
 pub const SEQUENCE_ALLOCATION_STEP: i128 = 4096;
 
 /// Represents a schema definition for a database sequence.
@@ -108,7 +106,9 @@ impl SequenceDef {
             start: None,
             min_value: None,
             max_value: None,
-            allocated: SEQUENCE_PREALLOCATION_AMOUNT,
+            // Start with no values allocated. The first time we advance the sequence,
+            // we will allocate [`SEQUENCE_ALLOCATION_STEP`] values.
+            allocated: 0,
         }
     }
 }

--- a/smoketests/tests/add_remove_index.py
+++ b/smoketests/tests/add_remove_index.py
@@ -49,6 +49,14 @@ pub fn add() {
 
     JOIN_QUERY = "select T1.* from T1 join T2 on T1.id = T2.id where T2.id = 1001"
 
+    def between_publishes(self):
+        """
+        The test `AddRemoveIndexAfterRestart` in `zz_docker.py`
+        overwrites this method to restart docker between each publish,
+        otherwise reusing this test's code.
+        """
+        pass
+
     def test_add_then_remove_index(self):
         """
         First publish without the indices,
@@ -66,6 +74,8 @@ pub fn add() {
         with self.assertRaises(Exception):
             self.subscribe(self.JOIN_QUERY, n = 0)
 
+        self.between_publishes()
+
         # Publish the indexed version.
         # Now we have indices, so the query should be accepted.
         self.write_module_code(self.MODULE_CODE_INDEXED)
@@ -73,6 +83,8 @@ pub fn add() {
         sub = self.subscribe(self.JOIN_QUERY, n = 1)
         self.call("add", anon = True)
         self.assertEqual(sub(), [{'T1': {'deletes': [], 'inserts': [{'id': 1001}]}}])
+
+        self.between_publishes()
 
         # Publish the unindexed version again, removing the index.
         # The initial subscription should be rejected again.


### PR DESCRIPTION
# Description of Changes

Prior to this change, a weird special case in `build_sequence_state` which ignored system tables' sequences
made it impossible to add new database objects (tables, indexes, &c) due to unique constraint violations in the system tables.

Changing this uncovered a cascade of other failures, as our autoinc and bootstrapping sequences had a variety of tightly-coupled counterintuitive behaviors, each papering over a previous (mis-)behavior. In particular:

- We must not replace the `sequence_id` autoinc column when updating `st_sequence` rows in `MutTxId::get_next_sequence_value`, because a system sequence has ID 0. This means calling `insert_row_internal` rather than `insert`.
- We should not pre-allocate sequence values during bootstrap, because doing (combined with the above patches) causes system sequences to advance one additional time, resulting in values starting from 8192 instead of 4096.
- From @kim : uniformly handle updates to either running or non-running hosts, #1538 .
- From @kim : refactor to avoid mismatching program hashes and program bytes, #1539 .

# API and ABI breaking changes

N/a

# Expected complexity level and risk

3 - autoinc handling is very fiddly, as evidenced by the series of intertwined bugs fixed by sequential commits in this PR.

# Testing

- [x] Published a BitCraft hotfix on the alpha staging server that added a new index, and it seems to have worked.
- [x] Our test suite passes.
