### PR TITLE
core: Store system tables in commitlog

### DIFF
--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -90,18 +90,17 @@ pub enum SystemTable {
     st_constraints,
 }
 pub(crate) fn system_tables() -> [TableSchema; 9] {
+    // Keep this sorted by `TableId`!!
     [
         st_table_schema(),
         st_columns_schema(),
+        st_sequences_schema(),
         st_indexes_schema(),
         st_constraints_schema(),
         st_module_schema(),
         st_clients_schema(),
         st_var_schema(),
         st_scheduled_schema(),
-        // Is important this is always last, so the starting sequence for each
-        // system table is correct.
-        st_sequences_schema(),
     ]
 }
 
@@ -126,16 +125,6 @@ pub trait StFields: Copy + Sized {
     }
 }
 
-// The following are indices into the array returned by [`system_tables`].
-pub(crate) const ST_TABLES_IDX: usize = 0;
-pub(crate) const ST_COLUMNS_IDX: usize = 1;
-pub(crate) const ST_INDEXES_IDX: usize = 2;
-pub(crate) const ST_CONSTRAINTS_IDX: usize = 3;
-pub(crate) const ST_MODULE_IDX: usize = 4;
-pub(crate) const ST_CLIENT_IDX: usize = 5;
-pub(crate) const ST_VAR_IDX: usize = 6;
-pub(crate) const ST_SCHEDULED_IDX: usize = 7;
-pub(crate) const ST_SEQUENCES_IDX: usize = 8;
 macro_rules! st_fields_enum {
     ($(#[$attr:meta])* enum $ty_name:ident { $($name:expr, $var:ident = $discr:expr,)* }) => {
         #[derive(Copy, Clone, Debug)]
@@ -245,7 +234,7 @@ st_fields_enum!(enum StScheduledFields {
 /// | table_id | table_name  | table_type | table_access |
 /// |----------|-------------|----------- |------------- |
 /// | 4        | "customers" | "user"     | "public"     |
-fn st_table_schema() -> TableSchema {
+pub(crate) fn st_table_schema() -> TableSchema {
     TableDef::new(
         ST_TABLES_NAME.into(),
         vec![
@@ -266,7 +255,7 @@ fn st_table_schema() -> TableSchema {
 /// | table_id | col_id | col_name | col_type            |
 /// |----------|---------|----------|--------------------|
 /// | 1        | 0       | "id"     | AlgebraicType::U32 |
-fn st_columns_schema() -> TableSchema {
+pub(crate) fn st_columns_schema() -> TableSchema {
     TableDef::new(
         ST_COLUMNS_NAME.into(),
         vec![

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -300,6 +300,8 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
         let stdb = &*self.database_instance_context().relational_db;
         let ctx = ExecutionContext::internal(stdb.address());
         let tx = stdb.begin_mut_tx(IsolationLevel::Serializable);
+        // Create tables and insert the program.
+        // If the `tx` later rolls back, none of this happened.
         let (tx, ()) = stdb
             .with_auto_rollback(&ctx, tx, |tx| {
                 for schema in get_tabledefs(&self.info) {

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -838,7 +838,7 @@ pub(crate) mod tests {
             )
             .unwrap();
         let st_sequence_row = StSequenceRow {
-            sequence_id: 3.into(),
+            sequence_id: 1.into(),
             sequence_name: "seq_st_sequence_sequence_id_primary_key_auto".into(),
             table_id: 2.into(),
             col_pos: 0.into(),


### PR DESCRIPTION
Changes the bootstrap sequence, such that the initial system table
schemas and contents are stored in the commitlog.

Opening a database proceeds as follows:

- If a snapshot exists, restore it and replay the history suffix
- Otherwise:
  - Create the "seed tables" `st_table` and `st_columns` in-memory
  - Replay the history
    - Whenever a table in the reserved system table range is found,
      reset the system table schema and layout information in the
      page manager, so as to repair incomplete schema information.
  - If the history was empty:
    - Create the rest of the system tables (i.e. sans seed tables) in a
      transaction.
    - Commit and persist that transaction.


## Alternatives Considered

The already brittle bootrapping process is now even more brittle. In particular
the various incantations of repair / rebuild routines is hard to follow and easy
to break.

It is also unfortunate that the commitlog will be non-empty in case the
initialization from the user-supplied module fails.

As an alternative, a snapshot could be taken right after the database was fully
initialized, incl. the module. Instead of hashes, this snapshot could contain
their preimages and be inlined into the commitlog.

Restoring a database from such a snapshot requires only the statically known
schemas of the seed tables and a single repair pass.

# API and ABI breaking changes

It will not be possible to open a database from a commitlog created by an older
version, because bootstrapping the system tables will only occur if the history
is empty.

# Expected complexity level and risk

5 - database bootstrap is highly fragile
