### PR TITLE
`spacetime generate` - make the source args optional

### DIFF
--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -5,8 +5,8 @@ use std::io::Write;
 use std::ops::Deref;
 use std::path::{Path, PathBuf};
 
+use clap::Arg;
 use clap::ArgAction::SetTrue;
-use clap::{Arg, ArgGroup};
 use convert_case::{Case, Casing};
 use duct::cmd;
 use spacetimedb_lib::db::def::ColumnDef;
@@ -31,7 +31,6 @@ pub fn cli() -> clap::Command {
     clap::Command::new("generate")
         .about("Generate client files for a spacetime module.")
         .override_usage("spacetime generate --lang <LANG> --out-dir <DIR> [--project-path <DIR> | --wasm-file <PATH>]")
-        .group(ArgGroup::new("source").required(true))
         .arg(
             Arg::new("wasm_file")
                 .value_parser(clap::value_parser!(PathBuf))


### PR DESCRIPTION
# Description of Changes

https://github.com/clockworklabs/SpacetimeDB/pull/1077 made it required to provide either the `--project-path` or `--wasm-file` arg.

This PR reverts that, so that if none of those arguments are provided, we use the default of `--project-path .`

# API and ABI breaking changes

An "un-breaking" change

# Expected complexity level and risk

1

# Testing
- [x] BitCraft's `generate-client-files.sh` now runs successfully
- [x] `source` group args are still mutually exclusive
```
$ cargo run -- generate --project-path . --wasm-file . --json-module .
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
     Running `target/debug/spacetime generate --project-path . --wasm-file . --json-module .`
error: the argument '--project-path <project_path>' cannot be used with:
  --wasm-file <wasm_file>
  --json-module [<json_module>]

Usage: spacetime generate --lang <LANG> --out-dir <DIR> [--project-path <DIR> | --wasm-file <PATH>]

For more information, try '--help'.
```
- [x] `source` group ares not listed as required
```
$ cargo run -- generate
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.21s
     Running `target/debug/spacetime generate`
error: the following required arguments were not provided:
  --out-dir <out_dir>
  --lang <lang>

Usage: spacetime generate --lang <LANG> --out-dir <DIR> [--project-path <DIR> | --wasm-file <PATH>]

For more information, try '--help'.
```