### PR TITLE
core: Load program hash alongside bytes

### DIFF
--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -313,6 +313,14 @@ pub struct Metadata {
     pub program_hash: Hash,
 }
 
+/// Program associated with a database.
+pub struct Program {
+    /// Hash over the program's bytes.
+    pub hash: Hash,
+    /// The raw bytes of the program.
+    pub bytes: Box<[u8]>,
+}
+
 pub trait TxDatastore: DataRow + Tx {
     type Iter<'a>: Iterator<Item = Self::RowRef<'a>>
     where
@@ -357,10 +365,10 @@ pub trait TxDatastore: DataRow + Tx {
     /// A `None` return value means that the datastore is not fully initialized yet.
     fn metadata(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Option<Metadata>>;
 
-    /// Obtain the raw bytes of the compiled module associated with this datastore.
+    /// Obtain the compiled module associated with this datastore.
     ///
     /// A `None` return value means that the datastore is not fully initialized yet.
-    fn program_bytes(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Option<Box<[u8]>>>;
+    fn program(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Option<Program>>;
 }
 
 pub trait MutTxDatastore: TxDatastore + MutTx {

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -2,7 +2,7 @@ use super::datastore::locking_tx_datastore::committed_state::CommittedState;
 use super::datastore::locking_tx_datastore::state_view::StateView as _;
 use super::datastore::system_tables::ST_MODULE_ID;
 use super::datastore::traits::{
-    IsolationLevel, Metadata, MutTx as _, MutTxDatastore, RowTypeForTable, Tx as _, TxDatastore,
+    IsolationLevel, Metadata, MutTx as _, MutTxDatastore, Program, RowTypeForTable, Tx as _, TxDatastore,
 };
 use super::datastore::{
     locking_tx_datastore::{
@@ -375,13 +375,13 @@ impl RelationalDB {
         self.with_read_only(&ctx, |tx| self.inner.metadata(&ctx, tx))
     }
 
-    /// Obtain the raw bytes of the module associated with this database.
+    /// Obtain the module associated with this database.
     ///
     /// `None` if the database is not yet fully initialized.
     /// Note that a `Some` result may yield an empty slice.
-    pub fn program_bytes(&self) -> Result<Option<Box<[u8]>>, DBError> {
+    pub fn program(&self) -> Result<Option<Program>, DBError> {
         let ctx = ExecutionContext::internal(self.address);
-        self.with_read_only(&ctx, |tx| self.inner.program_bytes(&ctx, tx))
+        self.with_read_only(&ctx, |tx| self.inner.program(&ctx, tx))
     }
 
     /// Read the set of clients currently connected to the database.

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -136,8 +136,9 @@ impl<T: WasmModule> WasmModuleHostActor<T> {
             energy_monitor,
         } = mcc;
         log::trace!(
-            "Making new module host actor for database {}",
-            database_instance_context.address
+            "Making new module host actor for database {} with module {}",
+            database_instance_context.address,
+            module_hash,
         );
         let log_tx = database_instance_context.logger.tx.clone();
 


### PR DESCRIPTION
Passing around the pair of (hash, bytes) in the host controller proved confusionary. Also, the `TxDatastore::program_bytes` method would in one instance require to compute the hash unnecessarily.

Thus, refactor to always load the hash and bytes together, and introduce a named pair `Program` containing both.

Depends-on: #1538 

# API and ABI breaking changes

Changes datastore traits.

# Expected complexity level and risk

1