### PR TITLE
Add lib::db::{column_ordering, raw_def::v9}

### DIFF
--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -19,6 +19,8 @@ default = ["serde", "metrics_impls"]
 serde = ["dep:serde", "spacetimedb-sats/serde"]
 # Allows using `Arbitrary` impls defined in this crate.
 proptest = ["dep:proptest", "dep:proptest-derive"]
+# Allows using additional test methods.
+test = ["proptest", "spacetimedb-sats/test"]
 metrics_impls = ["dep:spacetimedb-metrics", "spacetimedb-sats/metrics_impls"]
 
 [dependencies]
@@ -42,6 +44,7 @@ proptest = { workspace = true, optional = true }
 proptest-derive = { workspace = true, optional = true }
 
 [dev-dependencies]
+spacetimedb-sats = { workspace = true, features = ["test"] }
 rand.workspace = true
 bytes.workspace = true
 serde_json.workspace = true

--- a/crates/lib/proptest-regressions/db/column_ordering.txt
+++ b/crates/lib/proptest-regressions/db/column_ordering.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc d098ce789585509a02ec9ebca8809bb0515e306ecdcbf4d7f883b571ff56b919 # shrinks to v = [42, 42]

--- a/crates/lib/src/db/default_element_ordering.rs
+++ b/crates/lib/src/db/default_element_ordering.rs
@@ -1,0 +1,123 @@
+//! This module defines the default ordering for fields of a `ProductType` and variants of a `SumType`.
+//!
+//! - In ABI version 8, the default ordering was not applied.
+//! - In ABI version 9, the default ordering is applied to all types in a spacetime module, unless they explicitly declare a custom ordering.
+
+use spacetimedb_sats::{ProductType, ProductTypeElement, SumType, SumTypeVariant};
+
+/// A label for a field of a `ProductType` or a variant of a `SumType`.
+///
+/// The ordering on this type defines the default ordering for the fields of a `ProductType` and the variants of a `SumType`.
+#[derive(PartialEq, Eq, PartialOrd, Ord)]
+pub enum ElementLabel<'a> {
+    /// An unnamed field with a position.
+    /// The unnamed fields in a type do not necessarily have contiguous positions.
+    Unnamed(usize),
+    /// A named field.
+    /// Names are required to be unique within the product type.
+    Named(&'a str),
+}
+
+impl<'a> From<(usize, &'a ProductTypeElement)> for ElementLabel<'a> {
+    fn from((i, element): (usize, &'a ProductTypeElement)) -> Self {
+        match &element.name {
+            Some(name) => ElementLabel::Named(&name[..]),
+            None => ElementLabel::Unnamed(i),
+        }
+    }
+}
+impl<'a> From<(usize, &'a SumTypeVariant)> for ElementLabel<'a> {
+    fn from((i, element): (usize, &'a SumTypeVariant)) -> Self {
+        match &element.name {
+            Some(name) => ElementLabel::Named(&name[..]),
+            None => ElementLabel::Unnamed(i),
+        }
+    }
+}
+
+/// Checks if a sum type has the default ordering.
+///
+/// Not a recursive check.
+pub fn sum_type_has_default_ordering(ty: &SumType) -> bool {
+    is_sorted(ty.variants.iter().enumerate().map(ElementLabel::from))
+}
+
+/// Checks if a product type has the default ordering.
+///
+/// Not a recursive check.
+pub fn product_type_has_default_ordering(ty: &ProductType) -> bool {
+    is_sorted(ty.elements.iter().enumerate().map(ElementLabel::from))
+}
+
+/// Check that an iterator is sorted.
+fn is_sorted<T: Ord>(it: impl Iterator<Item = T>) -> bool {
+    let mut current = None;
+    for next in it {
+        if let Some(current) = current {
+            if current > next {
+                return false;
+            }
+        }
+        current = Some(next);
+    }
+    true
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::proptest;
+
+    #[test]
+    fn test_element_label_comparison() {
+        let a = ElementLabel::Unnamed(0);
+        let b = ElementLabel::Unnamed(2);
+        let c = ElementLabel::Named("apples");
+        let d = ElementLabel::Named("oranges");
+        let e = ElementLabel::Named("oranges_tomorrow");
+
+        assert!(a == a);
+        assert!(a < b);
+        assert!(a < c);
+        assert!(a < d);
+        assert!(a < e);
+
+        assert!(b > a);
+        assert!(b == b);
+        assert!(b < c);
+        assert!(b < d);
+        assert!(b < e);
+
+        assert!(c > a);
+        assert!(c > b);
+        assert!(c == c);
+        assert!(c < d);
+        assert!(c < e);
+
+        assert!(d > a);
+        assert!(d > b);
+        assert!(d > c);
+        assert!(d == d);
+        assert!(d < e);
+
+        assert!(e > a);
+        assert!(e > b);
+        assert!(e > c);
+        assert!(e > d);
+        assert!(e == e);
+    }
+
+    proptest! {
+        #[test]
+        fn test_is_sorted(v in proptest::collection::vec(0..100, 0..100)) {
+            let mut v: Vec<i32> = v;
+            v.sort();
+            assert!(is_sorted(v.iter()));
+        }
+    }
+
+    #[test]
+    fn test_is_not_sorted() {
+        assert!(!is_sorted([1, 2, 4, 3].iter()));
+    }
+}

--- a/crates/lib/src/db/default_element_ordering.rs
+++ b/crates/lib/src/db/default_element_ordering.rs
@@ -50,13 +50,15 @@ pub fn product_type_has_default_ordering(ty: &ProductType) -> bool {
 }
 
 /// Check that an iterator is sorted.
-fn is_sorted<T: Ord>(it: impl Iterator<Item = T>) -> bool {
+///
+/// TODO: remove this when [`Iterator`::is_sorted`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.is_sorted) is stabilized.
+fn is_sorted<T: Ord>(mut it: impl Iterator<Item = T>) -> bool {
     let Some(mut curr) = it.next() else {
         return true;
     };
     it.all(|next| {
         let ordered = curr <= next;
-        current = next;
+        curr = next;
         ordered
     })
 }

--- a/crates/lib/src/db/default_element_ordering.rs
+++ b/crates/lib/src/db/default_element_ordering.rs
@@ -51,16 +51,14 @@ pub fn product_type_has_default_ordering(ty: &ProductType) -> bool {
 
 /// Check that an iterator is sorted.
 fn is_sorted<T: Ord>(it: impl Iterator<Item = T>) -> bool {
-    let mut current = None;
-    for next in it {
-        if let Some(current) = current {
-            if current > next {
-                return false;
-            }
-        }
-        current = Some(next);
-    }
-    true
+    let Some(mut curr) = it.next() else {
+        return true;
+    };
+    it.all(|next| {
+        let ordered = curr <= next;
+        current = next;
+        ordered
+    })
 }
 
 #[cfg(test)]

--- a/crates/lib/src/db/mod.rs
+++ b/crates/lib/src/db/mod.rs
@@ -2,5 +2,6 @@
 
 pub mod attr;
 pub mod auth;
+pub mod default_element_ordering;
 pub mod error;
 pub mod raw_def;

--- a/crates/lib/src/db/raw_def.rs
+++ b/crates/lib/src/db/raw_def.rs
@@ -12,3 +12,5 @@ pub mod v8;
 
 // for backwards-compatibility
 pub use v8::*;
+
+pub mod v9;

--- a/crates/lib/src/db/raw_def/v8.rs
+++ b/crates/lib/src/db/raw_def/v8.rs
@@ -512,4 +512,3 @@ impl RawTableDefV8 {
         self.columns.iter().find(|x| &*x.col_name == col_name)
     }
 }
-}

--- a/crates/lib/src/db/raw_def/v8.rs
+++ b/crates/lib/src/db/raw_def/v8.rs
@@ -169,9 +169,7 @@ pub struct RawColumnDefV8 {
     pub col_name: Box<str>,
     /// The type of the column.
     ///
-    /// Must be either a `AlgebraicType::Builtin` or `AlgebraicType::Ref`.
-    /// Any `AlgebraicType::Ref` MUST have a corresponding `TypeAlias` declaration within
-    /// the containing `ModuleDefV8`.
+    /// Must be in "nominal normal form", as determined by [AlgebraicType::is_nominal_normal_form].
     pub col_type: AlgebraicType,
 }
 
@@ -513,4 +511,5 @@ impl RawTableDefV8 {
     pub fn get_column_by_name(&self, col_name: &str) -> Option<&RawColumnDefV8> {
         self.columns.iter().find(|x| &*x.col_name == col_name)
     }
+}
 }

--- a/crates/lib/src/db/raw_def/v8.rs
+++ b/crates/lib/src/db/raw_def/v8.rs
@@ -20,7 +20,6 @@ pub const SEQUENCE_ALLOCATION_STEP: i128 = 4096;
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, ser::Serialize, de::Deserialize)]
 pub struct RawSequenceDefV8 {
     /// The name of the sequence.
-    /// Deprecated. In the future, sequences will be identified by col_pos.
     pub sequence_name: Box<str>,
     /// The position of the column associated with this sequence.
     pub col_pos: ColId,
@@ -169,6 +168,10 @@ pub struct RawColumnDefV8 {
     /// The name of the column.
     pub col_name: Box<str>,
     /// The type of the column.
+    ///
+    /// Must be either a `AlgebraicType::Builtin` or `AlgebraicType::Ref`.
+    /// Any `AlgebraicType::Ref` MUST have a corresponding `TypeAlias` declaration within
+    /// the containing `ModuleDefV8`.
     pub col_type: AlgebraicType,
 }
 
@@ -204,6 +207,7 @@ impl RawColumnDefV8 {
     /// * `field_name`: The name for which to create a column definition.
     /// * `col_type`: The [AlgebraicType] of the column.
     ///
+    /// If `type_` is not `AlgebraicType::Builtin` or `AlgebraicType::Ref`, an error will result at validation time.
     pub fn sys(field_name: &str, col_type: AlgebraicType) -> Self {
         Self {
             col_name: field_name.into(),
@@ -217,8 +221,6 @@ impl RawColumnDefV8 {
 #[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, ser::Serialize, de::Deserialize)]
 pub struct RawConstraintDefV8 {
     /// The name of the constraint.
-    /// Deprecated, in the future columns will be identified by their constraint type and the columns
-    /// they are associated with.
     pub constraint_name: Box<str>,
     /// The constraints applied to the columns.
     pub constraints: Constraints,

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -1,5 +1,3 @@
-//! This module contains the "raw definitions" returned by modules to the database.
-
 use crate::db::auth::{StAccess, StTableType};
 use itertools::Itertools;
 use spacetimedb_primitives::*;
@@ -180,6 +178,7 @@ pub struct RawTableDefV9 {
     /// Must be a valid [crate::db::identifier::Identifier].
     pub name: RawIdentifier,
     /// A reference to a product type containing the columns of this table.
+    /// This is the single source of truth for the table's columns.
     ///
     /// Like all types in the module, this must have the [default element ordering](crate::db::default_element_ordering), UNLESS a custom ordering is declared via `ModuleDef.misc_exports` for this type.
     pub product_type_ref: AlgebraicTypeRef,
@@ -257,47 +256,6 @@ pub enum RawIndexAlgorithm {
         /// The columns to index on. These are ordered.
         columns: ColList,
     },
-}
-
-/// The definition of a database column.
-#[derive(Debug, Clone, ser::Serialize, de::Deserialize)]
-#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
-pub struct RawColumnDefV9 {
-    /// The name of the column.
-    pub name: RawIdentifier,
-
-    /// The type of the column.
-    ///
-    /// Must be either a `AlgebraicType::Builtin` or `AlgebraicType::Ref`.
-    ///
-    /// Any `AlgebraicType::Ref` MUST have a corresponding `TypeAlias` declaration within
-    /// the containing `ModuleDefV9`.
-    /// Otherwise, an error will result at validation time.
-    ///
-    /// Similarly, if any type referred to transitively by `ty` is a `Product` or `Sum` type not
-    /// referred to via an `AlgebraicType::Ref`, an error will result.
-    pub ty: AlgebraicType,
-}
-
-impl RawColumnDefV9 {
-    /// Creates a new [RawColumnDef] for a field with the specified data type.
-    ///
-    /// This method is typically used to define columns with predefined names and data types for tests.
-    ///
-    /// # Parameters
-    ///
-    /// * `name`: The name for which to create a column definition.
-    /// * `ty`: The [AlgebraicType] of the column.
-    ///
-    /// If `ty` is not `AlgebraicType::Builtin` or `AlgebraicType::Ref`, an error will result at validation time.
-    /// Similarly, if any type referred to transitively by `ty` is a `Product` or `Sum` type not
-    /// referred to via an `AlgebraicType::Ref`, an error will result.
-    ///
-    /// Any `AlgebraicType::Ref` MUST have a corresponding `TypeAlias` declaration within
-    /// the containing `ModuleDefV9`.
-    pub fn new(name: RawIdentifier, ty: AlgebraicType) -> Self {
-        Self { name, ty }
-    }
 }
 
 /// Requires that the projection of the table onto these `columns` is a bijection.

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -74,11 +74,11 @@ impl RawModuleDefV9 {
     /// Build a new table.
     ///
     /// Does not validate that the product_type_ref is valid; this is left to the module validation code.
-    pub fn build_table(&mut self, table_name: RawIdentifier, product_type_ref: AlgebraicTypeRef) -> RawTableDefBuilder {
+    pub fn build_table(&mut self, name: RawIdentifier, product_type_ref: AlgebraicTypeRef) -> RawTableDefBuilder {
         RawTableDefBuilder {
             module_def: self,
             table: RawTableDefV9 {
-                table_name,
+                name,
                 product_type_ref,
                 indexes: vec![],
                 unique_constraints: vec![],
@@ -178,7 +178,7 @@ pub struct RawTableDefV9 {
     /// The name of the table.
     /// Unique within a module, acts as the table's identifier.
     /// Must be a valid [crate::db::identifier::Identifier].
-    pub table_name: RawIdentifier,
+    pub name: RawIdentifier,
     /// A reference to a product type containing the columns of this table.
     ///
     /// Like all types in the module, this must have the [default element ordering](crate::db::default_element_ordering), UNLESS a custom ordering is declared via `ModuleDef.misc_exports` for this type.
@@ -274,9 +274,9 @@ pub struct RawColumnDefV9 {
     /// the containing `ModuleDefV9`.
     /// Otherwise, an error will result at validation time.
     ///
-    /// Similarly, if any type referred to transitively by `type_` is a `Product` or `Sum` type not
+    /// Similarly, if any type referred to transitively by `ty` is a `Product` or `Sum` type not
     /// referred to via an `AlgebraicType::Ref`, an error will result.
-    pub type_: AlgebraicType,
+    pub ty: AlgebraicType,
 }
 
 impl RawColumnDefV9 {
@@ -287,16 +287,16 @@ impl RawColumnDefV9 {
     /// # Parameters
     ///
     /// * `name`: The name for which to create a column definition.
-    /// * `type_`: The [AlgebraicType] of the column.
+    /// * `ty`: The [AlgebraicType] of the column.
     ///
-    /// If `type_` is not `AlgebraicType::Builtin` or `AlgebraicType::Ref`, an error will result at validation time.
-    /// Similarly, if any type referred to transitively by `type_` is a `Product` or `Sum` type not
+    /// If `ty` is not `AlgebraicType::Builtin` or `AlgebraicType::Ref`, an error will result at validation time.
+    /// Similarly, if any type referred to transitively by `ty` is a `Product` or `Sum` type not
     /// referred to via an `AlgebraicType::Ref`, an error will result.
     ///
     /// Any `AlgebraicType::Ref` MUST have a corresponding `TypeAlias` declaration within
     /// the containing `ModuleDefV9`.
-    pub fn new(name: RawIdentifier, type_: AlgebraicType) -> Self {
-        Self { name, type_ }
+    pub fn new(name: RawIdentifier, ty: AlgebraicType) -> Self {
+        Self { name, ty }
     }
 }
 
@@ -494,27 +494,27 @@ impl<'a> RawTableDefBuilder<'a> {
             RawIndexAlgorithm::Hash { columns } => ("hash", columns),
         };
         let column_names = self.concat_column_names(columns);
-        let table_name = &self.table.table_name;
+        let table_name = &self.table.name;
         format!("{table_name}_{label}_{column_names}").into()
     }
 
     /// YOU CANNOT RELY ON SEQUENCES HAVING THIS NAME FORMAT.
     fn generate_sequence_name(&self, column: ColId) -> RawIdentifier {
         let column_name = self.column_name(column);
-        let table_name = &self.table.table_name;
+        let table_name = &self.table.name;
         format!("{table_name}_seq_{column_name}").into()
     }
 
     /// YOU CANNOT RELY ON SCHEDULES HAVING THIS NAME FORMAT.
     fn generate_schedule_name(&self) -> RawIdentifier {
-        let table_name = &self.table.table_name;
+        let table_name = &self.table.name;
         format!("{table_name}_schedule").into()
     }
 
     /// YOU CANNOT RELY ON UNIQUE CONSTRAINTS HAVING THIS NAME FORMAT.
     fn generate_unique_constraint_name(&self, columns: &ColList) -> RawIdentifier {
         let column_names = self.concat_column_names(columns);
-        let table_name = &self.table.table_name;
+        let table_name = &self.table.name;
         format!("{table_name}_unique_{column_names}").into()
     }
 }

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -40,10 +40,9 @@ pub struct RawModuleDefV9 {
     ///
     /// Any `Product` or `Sum` types used transitively by the module MUST be declared in this typespace.
     ///
-    /// Every `Product`, `Sum`, and `Ref` type in this typespace MUST have a corresponding `TypeAlias` declaration in the `misc_exports` field, with a module-unique name.
+    /// Every `Product`, `Sum`, and `Ref` type in this typespace MUST have a corresponding `RawTypeDefV9` declaration in the `types` field, with a module-unique name.
     ///
-    /// All product and sum types in this typespace MUST have the [default element ordering](crate::db::default_element_ordering) UNLESS they declare a custom ordering.
-    /// Custom orderings are declared in `misc_exports`.
+    /// All product and sum types in this typespace MUST have the [default element ordering](crate::db::default_element_ordering) UNLESS they declare a custom ordering via their `RawTypeDefV9`.
     ///
     /// It is permitted but not required to refer to `Builtin` or "primitive" types via this typespace.
     ///

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -454,7 +454,7 @@ impl<'a> RawTableDefBuilder<'a> {
         let column = column.as_ref();
         self.columns()?
             .iter()
-            .position(|x| x.name.as_ref().map(|s| &s[..]) == Some(column))
+            .position(|x| x.name().is_some_and(|s| s == column))
             .map(|x| x.into())
     }
 
@@ -463,9 +463,10 @@ impl<'a> RawTableDefBuilder<'a> {
     /// Returns `None` if this `TableDef` has been constructed with an invalid `ProductTypeRef`.
     fn columns(&self) -> Option<&[ProductTypeElement]> {
         self.module_def
-            .typespace.get(self.table.product_type_ref)
+            .typespace
+            .get(self.table.product_type_ref)
             .and_then(|ty| ty.as_product())
-            .map(|p| &p.elements)
+            .map(|p| &p.elements[..])
     }
 
     /// Get the name of a column in the typespace.

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -437,9 +437,15 @@ impl<'a> RawTableDefBuilder<'a> {
         self
     }
 
+    /// Build the table and add it to the module.
+    pub fn finish(self) {
+        // self is now dropped.
+    }
+
     /// Get the column ID of the column with the specified name, if any.
     ///
-    /// Returns `None` if this `TableDef` has been constructed with an invalid `ProductTypeRef`.
+    /// Returns `None` if this `TableDef` has been constructed with an invalid `ProductTypeRef`,
+    /// or if no column exists with that name.
     pub fn get_col_id(&self, column: impl AsRef<str>) -> Option<ColId> {
         let column = column.as_ref();
         self.columns()?
@@ -505,5 +511,11 @@ impl<'a> RawTableDefBuilder<'a> {
         let column_names = self.concat_column_names(columns);
         let table_name = &self.table.table_name;
         format!("{table_name}_unique_{column_names}").into()
+    }
+}
+
+impl<'a> Drop for RawTableDefBuilder<'a> {
+    fn drop(&mut self) {
+        self.module_def.tables.push(self.table.clone());
     }
 }

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -177,8 +177,9 @@ pub struct RawTableDefV9 {
     /// Unique within a module, acts as the table's identifier.
     /// Must be a valid [crate::db::identifier::Identifier].
     pub name: RawIdentifier,
-    /// A reference to a product type containing the columns of this table.
+    /// A reference to a `ProductType` containing the columns of this table.
     /// This is the single source of truth for the table's columns.
+    /// All elements of the `ProductType` must have names.
     ///
     /// Like all types in the module, this must have the [default element ordering](crate::db::default_element_ordering), UNLESS a custom ordering is declared via `ModuleDef.misc_exports` for this type.
     pub product_type_ref: AlgebraicTypeRef,

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -59,7 +59,7 @@ pub struct RawModuleDefV9 {
     pub reducers: Vec<RawReducerDefV9>,
 
     /// The types exported by the module.
-    pub types: Vec<RawTypeV9>,
+    pub types: Vec<RawTypeDefV9>,
 
     /// Miscellaneous additional module exports.
     pub misc_exports: Vec<RawMiscModuleExportV9>,
@@ -125,7 +125,7 @@ impl RawModuleDefV9 {
         let ty = self.typespace.add(product_type.into().into());
 
         let name = name.into();
-        self.types.push(RawTypeV9 {
+        self.types.push(RawTypeDefV9 {
             name,
             ty,
             custom_ordering,
@@ -149,7 +149,7 @@ impl RawModuleDefV9 {
         let ty = self.typespace.add(sum_type.into().into());
 
         let name = name.into();
-        self.types.push(RawTypeV9 {
+        self.types.push(RawTypeDefV9 {
             name,
             ty,
             custom_ordering,
@@ -295,7 +295,7 @@ pub enum RawMiscModuleExportV9 {}
 /// Exactly of these must be attached to every `Product` and `Sum` type used by a module.
 #[derive(Debug, Clone, de::Deserialize, ser::Serialize)]
 #[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
-pub struct RawTypeV9 {
+pub struct RawTypeDefV9 {
     /// The name of the type. This must be unique within the module.
     ///
     /// Eventually, we may add more information to this, such as the module name and generic arguments.

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -1,0 +1,509 @@
+//! This module contains the "raw definitions" returned by modules to the database.
+
+use crate::db::auth::{StAccess, StTableType};
+use itertools::Itertools;
+use spacetimedb_primitives::*;
+use spacetimedb_sats::AlgebraicType;
+use spacetimedb_sats::AlgebraicTypeRef;
+use spacetimedb_sats::ProductTypeElement;
+use spacetimedb_sats::{de, ser, Typespace};
+
+/// A not-yet-validated identifier.
+pub type RawIdentifier = Box<str>;
+
+/// A possibly-invalid raw module definition.
+///
+/// ABI Version 9.
+///
+/// These "raw definitions" may contain invalid data, and are validated by the `validate` module into a proper `spacetimedb_schema::ModuleDef`, or a collection of errors.
+///
+/// The module definition has a single logical global namespace, which maps `Identifier`s to:
+///
+/// - database-level objects:
+///     - logical schema objects:
+///         - tables
+///         - constraints
+///         - sequence definitions
+///     - physical schema objects:
+///         - indexes
+/// - module-level objects:
+///     - reducers
+///     - schedule definitions
+/// - binding-level objects:
+///     - type aliases
+///
+/// All of these types of objects must have unique names within the module.
+/// The exception is columns, which need unique names only within a table.
+#[derive(Debug, Clone, Default, ser::Serialize, de::Deserialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+pub struct RawModuleDefV9 {
+    /// The types used in the module.
+    ///
+    /// `AlgebraicTypeRef`s in the table, reducer, and type alias declarations refer to this typespace.
+    ///
+    /// Any `Product` or `Sum` types used transitively by the module MUST be declared in this typespace.
+    ///
+    /// Every `Product`, `Sum`, and `Ref` type in this typespace MUST have a corresponding `TypeAlias` declaration in the `misc_exports` field, with a module-unique name.
+    ///
+    /// All product and sum types in this typespace MUST have the [default element ordering](crate::db::default_element_ordering) UNLESS they declare a custom ordering.
+    /// Custom orderings are declared in `misc_exports`.
+    ///
+    /// It is permitted but not required to refer to `Builtin` or "primitive" types via this typespace.
+    ///
+    /// The typespace must satisfy `Typespace::is_nominal`. That is, it is not permitted to refer to `Sum` or `Product` types in this typespace except via `AlgebraicType::Ref`.
+    pub typespace: Typespace,
+
+    /// The tables of the database definition used in the module.
+    ///
+    /// Each table must have a unique name.
+    pub tables: Vec<RawTableDefV9>,
+
+    /// The reducers used by the module.
+    pub reducers: Vec<RawReducerDefV9>,
+
+    /// Miscellaneous additional module exports.
+    pub misc_exports: Vec<RawMiscModuleExportV9>,
+}
+
+impl RawModuleDefV9 {
+    /// Creates a new, empty [RawDatabaseDef] instance with no types in its typespace.
+    pub fn new() -> Self {
+        Default::default()
+    }
+
+    /// Build a new table.
+    ///
+    /// Does not validate that the product_type_ref is valid; this is left to the module validation code.
+    pub fn build_table(&mut self, table_name: RawIdentifier, product_type_ref: AlgebraicTypeRef) -> RawTableDefBuilder {
+        RawTableDefBuilder {
+            module_def: self,
+            table: RawTableDefV9 {
+                table_name,
+                product_type_ref,
+                indexes: vec![],
+                unique_constraints: vec![],
+                sequences: vec![],
+                schedule: None,
+                table_type: StTableType::User,
+                // TODO: make the default `Private` before 1.0.
+                table_access: StAccess::Public,
+            },
+        }
+    }
+
+    /// Build a new table with a product type.
+    ///
+    /// This is a convenience method for tests, since in real modules, the product type is initialized automatically by `ModuleBuilder`.
+    #[cfg(feature = "test")]
+    pub fn build_table_with_product_type(
+        &mut self,
+        table_name: RawIdentifier,
+        product_type: spacetimedb_sats::ProductType,
+        custom_ordering: bool,
+    ) -> RawTableDefBuilder {
+        let product_type_ref = self.add_product_for_tests(table_name.clone(), product_type, custom_ordering);
+
+        self.build_table(table_name, product_type_ref)
+    }
+
+    /// Add a product type to the typespace, along with a type alias declaring its name.
+    /// This is a convenience method for tests, since the actual module code uses ModuleBuilder.
+    ///
+    /// NOT idempotent, calling this twice with the same name will cause errors during
+    /// validation.
+    ///
+    /// `custom_ordering` must be set correctly, otherwise an error will result during validation.
+    ///
+    /// Returns an AlgebraicType::Ref.
+    #[cfg(feature = "test")]
+    pub fn add_product_for_tests(
+        &mut self,
+        name: impl Into<RawIdentifier>,
+        product_type: impl Into<spacetimedb_sats::ProductType>,
+        custom_ordering: bool,
+    ) -> AlgebraicTypeRef {
+        let ref_ = self.typespace.add(product_type.into().into());
+        self.misc_exports.push(RawMiscModuleExportV9::TypeAlias(RawTypeAliasV9 {
+            name: name.into(),
+            ty: ref_,
+        }));
+        if custom_ordering {
+            self.misc_exports
+                .push(RawMiscModuleExportV9::CustomTypeOrdering(RawCustomTypeOrderingV9 {
+                    ty: ref_,
+                }));
+        }
+        ref_
+    }
+
+    /// Add a product type to the typespace, along with a type alias declaring its name.
+    ///
+    /// NOT idempotent, calling this twice with the same name will cause errors during
+    /// validation.
+    ///
+    /// Returns an AlgebraicType::Ref.
+    #[cfg(feature = "test")]
+    pub fn add_sum_for_tests(
+        &mut self,
+        name: impl Into<RawIdentifier>,
+        sum_type: impl Into<spacetimedb_sats::SumType>,
+    ) -> AlgebraicTypeRef {
+        let ref_ = self.typespace.add(sum_type.into().into());
+        self.misc_exports.push(RawMiscModuleExportV9::TypeAlias(RawTypeAliasV9 {
+            name: name.into(),
+            ty: ref_,
+        }));
+        ref_
+    }
+}
+
+/// The definition of a database table.
+///
+/// This struct holds information about the table, including its name, columns, indexes,
+/// constraints, sequences, type, and access rights.
+///
+/// Validation rules:
+/// - The table name must be a valid [crate::db::identifier::Identifier].
+/// - The table's columns MUST be sorted according to [crate::db::ordering::canonical_ordering].
+///   This is a sanity check to ensure that modules know the correct ordering to use for their tables.
+///     - TODO(jgilles): add a test-only validation method that allows tables with unusual
+///       column orderings. This will enable more test coverage in the `table` crate,
+///       in case we allow more orderings in the future.
+/// - The table's indexes, constraints, and sequences need not be sorted; they will be sorted according to their respective ordering rules.
+/// - The table's column types may refer only to types in the containing RawDatabaseDef's typespace.
+/// - The table's column names must be unique.
+#[derive(Debug, Clone, ser::Serialize, de::Deserialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+pub struct RawTableDefV9 {
+    /// The name of the table.
+    /// Unique within a module, acts as the table's identifier.
+    /// Must be a valid [crate::db::identifier::Identifier].
+    pub table_name: RawIdentifier,
+    /// A reference to a product type containing the columns of this table.
+    ///
+    /// Like all types in the module, this must have the [default element ordering](crate::db::default_element_ordering), UNLESS a custom ordering is declared via `ModuleDef.misc_exports` for this type.
+    pub product_type_ref: AlgebraicTypeRef,
+    /// The indices of the table.
+    pub indexes: Vec<RawIndexDefV9>,
+    /// Any unique constraints on the table.
+    pub unique_constraints: Vec<RawUniqueConstraintDefV9>,
+    /// The sequences for the table.
+    pub sequences: Vec<RawSequenceDefV9>,
+    /// The schedule for the table.
+    pub schedule: Option<RawScheduleDefV9>,
+    /// Whether this is a system- or user-created table.
+    pub table_type: StTableType,
+    /// Whether this table is public or private.
+    pub table_access: StAccess,
+}
+
+/// A sequence definition for a database table column.
+#[derive(Debug, Clone, ser::Serialize, de::Deserialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+pub struct RawSequenceDefV9 {
+    /// The name of the sequence. Must be unique within the containing `RawDatabaseDef`.
+    pub name: RawIdentifier,
+
+    /// The position of the column associated with this sequence.
+    /// This refers to a column in the same `RawTableDef` that contains this `RawSequenceDef`.
+    /// The column must have integral type.
+    /// This must be the unique `RawSequenceDef` for this column.
+    pub column: ColId,
+
+    /// The value to start assigning to this column.
+    /// Will be incremented by 1 for each new row.
+    /// If not present, an arbitrary start point may be selected.
+    pub start: Option<i128>,
+
+    /// The minimum allowed value in this column.
+    /// If not present, no minimum.
+    pub min_value: Option<i128>,
+
+    /// The maximum allowed value in this column.
+    /// If not present, no maximum.
+    pub max_value: Option<i128>,
+}
+
+/// The definition of a database index.
+#[derive(Debug, Clone, ser::Serialize, de::Deserialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+pub struct RawIndexDefV9 {
+    /// The name of the index.
+    ///
+    /// This can be overridden by the user and should NOT be assumed to follow
+    /// any particular format.
+    ///
+    /// Unique within the containing `DatabaseDef`.
+    pub name: RawIdentifier,
+
+    /// The algorithm parameters for the index.
+    pub algorithm: RawIndexAlgorithm,
+}
+
+/// Data specifying an index algorithm.
+#[non_exhaustive]
+#[derive(Debug, Clone, ser::Serialize, de::Deserialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+pub enum RawIndexAlgorithm {
+    /// Implemented using a rust `std::collections::BTreeMap`.
+    BTree {
+        /// The columns to index on. These are ordered.
+        columns: ColList,
+    },
+    /// Currently forbidden.
+    Hash {
+        /// The columns to index on. These are ordered.
+        columns: ColList,
+    },
+}
+
+/// The definition of a database column.
+#[derive(Debug, Clone, ser::Serialize, de::Deserialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+pub struct RawColumnDefV9 {
+    /// The name of the column.
+    pub name: RawIdentifier,
+
+    /// The type of the column.
+    ///
+    /// Must be either a `AlgebraicType::Builtin` or `AlgebraicType::Ref`.
+    ///
+    /// Any `AlgebraicType::Ref` MUST have a corresponding `TypeAlias` declaration within
+    /// the containing `ModuleDefV9`.
+    /// Otherwise, an error will result at validation time.
+    ///
+    /// Similarly, if any type referred to transitively by `type_` is a `Product` or `Sum` type not
+    /// referred to via an `AlgebraicType::Ref`, an error will result.
+    pub type_: AlgebraicType,
+}
+
+impl RawColumnDefV9 {
+    /// Creates a new [RawColumnDef] for a field with the specified data type.
+    ///
+    /// This method is typically used to define columns with predefined names and data types for tests.
+    ///
+    /// # Parameters
+    ///
+    /// * `name`: The name for which to create a column definition.
+    /// * `type_`: The [AlgebraicType] of the column.
+    ///
+    /// If `type_` is not `AlgebraicType::Builtin` or `AlgebraicType::Ref`, an error will result at validation time.
+    /// Similarly, if any type referred to transitively by `type_` is a `Product` or `Sum` type not
+    /// referred to via an `AlgebraicType::Ref`, an error will result.
+    ///
+    /// Any `AlgebraicType::Ref` MUST have a corresponding `TypeAlias` declaration within
+    /// the containing `ModuleDefV9`.
+    pub fn new(name: RawIdentifier, type_: AlgebraicType) -> Self {
+        Self { name, type_ }
+    }
+}
+
+/// Requires that the projection of the table onto these columns is an bijection.
+#[derive(Debug, Clone, ser::Serialize, de::Deserialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+pub struct RawUniqueConstraintDefV9 {
+    /// The name of the unique constraint. Must be unique within the containing `RawDatabaseDef`.
+    pub name: RawIdentifier,
+
+    /// The columns that must be unique.
+    pub columns: ColList,
+}
+
+/// Marks a table as a timer table for a scheduled reducer.
+#[derive(Debug, Clone, ser::Serialize, de::Deserialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+pub struct RawScheduleDefV9 {
+    /// The name of the schedule. Must be unique within the containing `RawDatabaseDef`.
+    pub name: RawIdentifier,
+
+    /// The column that stores the desired invocation time.
+    pub at_column: ColId,
+
+    /// The name of the reducer to call.
+    pub reducer_name: RawIdentifier,
+}
+
+/// A miscellaneous module export.
+#[derive(Debug, Clone, ser::Serialize, de::Deserialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+#[non_exhaustive]
+pub enum RawMiscModuleExportV9 {
+    /// A type alias, declaring a name for an `AlgebraicTypeRef`.
+    TypeAlias(RawTypeAliasV9),
+    /// Annotates a type as possessing a custom ordering.
+    /// If this is not present, the type is required to have the [default ordering](crate::db::default_element_ordering).
+    /// Only `ProductType`s are allowed to have custom orderings.
+    CustomTypeOrdering(RawCustomTypeOrderingV9),
+}
+
+/// A type alias.
+///
+/// Exactly of these must be attached to every Product and Sum type used by a module.
+#[derive(Debug, Clone, de::Deserialize, ser::Serialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+pub struct RawTypeAliasV9 {
+    /// The name of the type. This must be unique within the module.
+    ///
+    /// Eventually, we may add more information to this, such as the module name and generic arguments.
+    pub name: RawIdentifier,
+
+    /// The type to which the alias refers.
+    pub ty: AlgebraicTypeRef,
+}
+
+/// Marks a type as possessing a custom ordering.
+///
+/// Types not marked with this are required to have the default ordering.
+#[derive(Debug, Clone, de::Deserialize, ser::Serialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+pub struct RawCustomTypeOrderingV9 {
+    pub ty: AlgebraicTypeRef,
+}
+
+/// A reducer definition.
+#[derive(Debug, Clone, de::Deserialize, ser::Serialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+pub struct RawReducerDefV9 {
+    /// The name of the reducer.
+    pub name: RawIdentifier,
+
+    /// The types and optional names of the parameters, in order.
+    /// Parameters are identified by their position in the list, not name.
+    pub args: Vec<ProductTypeElement>,
+}
+
+/// Builder for a `RawTableDef`.
+pub struct RawTableDefBuilder<'a> {
+    module_def: &'a mut RawModuleDefV9,
+    table: RawTableDefV9,
+}
+
+impl<'a> RawTableDefBuilder<'a> {
+    /// Sets the type of the table and return it.
+    ///
+    /// This is not about column algebraic types, but about whether the table
+    /// was created by the system or the user.
+    pub fn with_type(mut self, table_type: StTableType) -> Self {
+        self.table.table_type = table_type;
+        self
+    }
+
+    /// Sets the access rights for the table and return it.
+    pub fn with_access(mut self, table_access: StAccess) -> Self {
+        self.table.table_access = table_access;
+        self
+    }
+
+    /// Generates a [UniqueConstraintDef] using the supplied `columns`.
+    pub fn with_unique_constraint(mut self, columns: ColList, name: Option<RawIdentifier>) -> Self {
+        let name = name.unwrap_or_else(|| self.generate_unique_constraint_name(&columns));
+        self.table
+            .unique_constraints
+            .push(RawUniqueConstraintDefV9 { name, columns });
+        self
+    }
+
+    /// Generates a [RawIndexDef] using the supplied `columns`.
+    pub fn with_index(mut self, algorithm: RawIndexAlgorithm, name: Option<RawIdentifier>) -> Self {
+        let name = name.unwrap_or_else(|| self.generate_index_name(&algorithm));
+
+        self.table.indexes.push(RawIndexDefV9 { name, algorithm });
+        self
+    }
+
+    /// Adds a [RawSequenceDef] on the supplied `column`.
+    pub fn with_column_sequence(mut self, column: ColId, name: Option<RawIdentifier>) -> Self {
+        let name = name.unwrap_or_else(|| self.generate_sequence_name(column));
+        self.table.sequences.push(RawSequenceDefV9 {
+            name,
+            column,
+            start: None,
+            min_value: None,
+            max_value: None,
+        });
+
+        self
+    }
+
+    /// Adds a schedule definition to the table.
+    /// The `at` column must be (TODO).
+    pub fn with_schedule(mut self, at_column: ColId, reducer_name: RawIdentifier, name: Option<RawIdentifier>) -> Self {
+        let name = name.unwrap_or_else(|| self.generate_schedule_name());
+        self.table.schedule = Some(RawScheduleDefV9 {
+            name,
+            at_column,
+            reducer_name,
+        });
+        self
+    }
+
+    /// Get the column ID of the column with the specified name, if any.
+    ///
+    /// Returns `None` if this `TableDef` has been constructed with an invalid `ProductTypeRef`.
+    pub fn get_col_id(&self, column: impl AsRef<str>) -> Option<ColId> {
+        let column = column.as_ref();
+        self.columns()?
+            .iter()
+            .position(|x| x.name.as_ref().map(|s| &s[..]) == Some(column))
+            .map(|x| ColId(x as u32))
+    }
+
+    /// Get the columns of this type.
+    ///
+    /// Returns `None` if this `TableDef` has been constructed with an invalid `ProductTypeRef`.
+    fn columns(&self) -> Option<&[ProductTypeElement]> {
+        match self.module_def.typespace.get(self.table.product_type_ref) {
+            Some(AlgebraicType::Product(product)) => Some(&product.elements),
+            _ => None,
+        }
+    }
+
+    /// Get the name of a column in the typespace.
+    ///
+    /// Only used for generating names for indexes, sequences, and unique constraints.
+    ///
+    /// Generates `col_{column}` if the column has no name or if the `RawTableDef`'s `product_type_ref`
+    /// was initialized incorrectly.
+    fn column_name(&self, column: ColId) -> String {
+        self.columns()
+            .and_then(|columns| columns.get(column.0 as usize))
+            .and_then(|column| column.name().map(ToString::to_string))
+            .unwrap_or_else(|| format!("col_{}", column.0))
+    }
+
+    /// Concatenate a list of column names.
+    fn concat_column_names(&self, selected: &ColList) -> String {
+        selected.iter().map(|col| self.column_name(col)).join("_")
+    }
+
+    /// YOU CANNOT RELY ON INDEXES HAVING THIS NAME FORMAT.
+    fn generate_index_name(&self, algorithm: &RawIndexAlgorithm) -> RawIdentifier {
+        let (label, columns) = match algorithm {
+            RawIndexAlgorithm::BTree { columns } => ("btree", columns),
+            RawIndexAlgorithm::Hash { columns } => ("hash", columns),
+        };
+        let column_names = self.concat_column_names(columns);
+        let table_name = &self.table.table_name;
+        format!("{table_name}_{label}_{column_names}").into()
+    }
+
+    /// YOU CANNOT RELY ON SEQUENCES HAVING THIS NAME FORMAT.
+    fn generate_sequence_name(&self, column: ColId) -> RawIdentifier {
+        let column_name = self.column_name(column);
+        let table_name = &self.table.table_name;
+        format!("{table_name}_seq_{column_name}").into()
+    }
+
+    /// YOU CANNOT RELY ON SCHEDULES HAVING THIS NAME FORMAT.
+    fn generate_schedule_name(&self) -> RawIdentifier {
+        let table_name = &self.table.table_name;
+        format!("{table_name}_schedule").into()
+    }
+
+    /// YOU CANNOT RELY ON UNIQUE CONSTRAINTS HAVING THIS NAME FORMAT.
+    fn generate_unique_constraint_name(&self, columns: &ColList) -> RawIdentifier {
+        let column_names = self.concat_column_names(columns);
+        let table_name = &self.table.table_name;
+        format!("{table_name}_unique_{column_names}").into()
+    }
+}

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -162,11 +162,6 @@ impl RawModuleDefV9 {
 ///
 /// Validation rules:
 /// - The table name must be a valid [crate::db::identifier::Identifier].
-/// - The table's columns MUST be sorted according to [crate::db::ordering::canonical_ordering].
-///   This is a sanity check to ensure that modules know the correct ordering to use for their tables.
-///     - TODO(jgilles): add a test-only validation method that allows tables with unusual
-///       column orderings. This will enable more test coverage in the `table` crate,
-///       in case we allow more orderings in the future.
 /// - The table's indexes, constraints, and sequences need not be sorted; they will be sorted according to their respective ordering rules.
 /// - The table's column types may refer only to types in the containing RawDatabaseDef's typespace.
 /// - The table's column names must be unique.

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -203,6 +203,7 @@ impl RawModuleDefV8 {
 #[non_exhaustive]
 pub enum RawModuleDef {
     V8BackCompat(RawModuleDefV8),
+    V9(db::raw_def::v9::RawModuleDefV9),
     // TODO(jgilles): It would be nice to have a custom error message if this fails with an unknown variant,
     // but I'm not sure if that can be done via the Deserialize trait.
 }

--- a/crates/sats/Cargo.toml
+++ b/crates/sats/Cargo.toml
@@ -11,6 +11,8 @@ description = "Spacetime Algebraic Type Notation"
 serde = ["dep:serde"]
 # Allows using `Arbitrary` impls defined in this crate.
 proptest = ["dep:proptest", "dep:proptest-derive"]
+# Allows using additional test-only methods defined in this crate.
+test = ["proptest"]
 # Impls `Serialize` and `Deserialize` for `blake3::Hash`.
 # Used by `spacetimedb_table`,
 # which serializes and deserializes Blake3 hashes during snapshotting.

--- a/crates/sats/src/typespace.rs
+++ b/crates/sats/src/typespace.rs
@@ -34,6 +34,7 @@ pub enum TypeRefError {
 ///
 /// [System F]: https://en.wikipedia.org/wiki/System_F
 #[derive(Debug, Clone, Deserialize, Serialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
 #[sats(crate = crate)]
 pub struct Typespace {
     /// The types in our typing context that can be referred to with [`AlgebraicTypeRef`]s.

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -10,3 +10,6 @@ spacetimedb-primitives.workspace = true
 spacetimedb-sats.workspace = true
 spacetimedb-data-structures.workspace = true
 itertools.workspace = true
+
+[dev-dependencies]
+spacetimedb-lib = { workspace = true, features = ["test"] }


### PR DESCRIPTION
# Description of Changes

This is NOT an ABI or API break because we have enums now!!

I decided to split these out from the validation & migration code PR to make it easier to review.
I haven't added any code to work with these, just the definitions.

The new "test" features are going to be exercised in my next PR.

# Expected complexity level and risk

a mild 1/5: this adds some new types that aren't used anywhere, which is perhaps slightly confusing. 

# Testing

CI should suffice.