### PR TITLE
C#: ignore fields in partial declaration not marked with BSATN attribute

### DIFF
--- a/crates/bindings-csharp/BSATN.Codegen/Type.cs
+++ b/crates/bindings-csharp/BSATN.Codegen/Type.cs
@@ -114,7 +114,7 @@ public class Type : IIncrementalGenerator
                 {
                     var typeSyntax = (TypeDeclarationSyntax)context.TargetNode;
                     var type = context.SemanticModel.GetDeclaredSymbol(typeSyntax, ct)!;
-                    var fields = GetFields(type);
+                    var fields = GetFields(typeSyntax, type);
                     var attr = context.Attributes.Single();
 
                     TypeKind kind =

--- a/crates/bindings-csharp/Codegen.Tests/Sample.cs
+++ b/crates/bindings-csharp/Codegen.Tests/Sample.cs
@@ -24,6 +24,11 @@ public partial struct CustomClass
     public string StringField;
 }
 
+public partial struct CustomClass
+{
+    public int IgnoreExtraFields;
+}
+
 [SpacetimeDB.Type]
 public enum CustomEnum
 {

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -175,10 +175,9 @@ public class Module : IIncrementalGenerator
                 transform: (context, ct) =>
                 {
                     var tableSyntax = (TypeDeclarationSyntax)context.TargetNode;
-
                     var table = context.SemanticModel.GetDeclaredSymbol(tableSyntax)!;
 
-                    var fields = GetFields(table)
+                    var fields = GetFields(tableSyntax, table)
                         .Select(f =>
                         {
                             var indexKind = f.GetAttributes()


### PR DESCRIPTION
# Description of Changes

Some of the recent changes broke BitCraft which relies on being able to add extra fields to structures marked with `[SpacetimeDB.Type]`.

It wants those fields to be available in runtime, but ignored for BSATN and table purposes, which is a usecase I didn't consider in the past so it caused a few issues here and there. This one in particular is a regression from #1401.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Added a failing codegen test + verified that it's no longer failing after a fix.
- [ ] Run `dotnet test` as well, or try to load BitCraft with updated codegen DLL.