### PR TITLE
C#: remove `using SpacetimeDB.ClientApi;`

### DIFF
--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -178,7 +178,6 @@ impl CsharpAutogen {
         if namespace != "SpacetimeDB" {
             writeln!(output, "using SpacetimeDB;");
         }
-        writeln!(output, "using SpacetimeDB.ClientApi;");
         for extra_using in extra_usings {
             writeln!(output, "using {extra_using};");
         }
@@ -607,7 +606,7 @@ pub fn autogen_csharp_globals(items: &[GenItem], namespace: &str) -> Vec<(String
         .map(|reducer| reducer.name.deref().to_case(Case::Pascal))
         .collect();
 
-    let mut output = CsharpAutogen::new(namespace, &[]);
+    let mut output = CsharpAutogen::new(namespace, &["SpacetimeDB.ClientApi"]);
 
     writeln!(output, "public enum ReducerType");
     indented_block(&mut output, |output| {

--- a/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
@@ -1,6 +1,5 @@
 ---
 source: crates/cli/tests/codegen.rs
-assertion_line: 32
 expression: outfiles
 ---
 "AddPlayerReducer.cs" = '''
@@ -416,7 +415,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -522,7 +520,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 
 namespace SpacetimeDB
 {

--- a/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
@@ -11,7 +11,6 @@ expression: outfiles
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 
 namespace SpacetimeDB
 {
@@ -56,7 +55,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 
 namespace SpacetimeDB
 {
@@ -101,7 +99,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 
 namespace SpacetimeDB
 {
@@ -146,7 +143,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 
 namespace SpacetimeDB
 {
@@ -191,7 +187,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 
 namespace SpacetimeDB
 {
@@ -217,7 +212,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 
 namespace SpacetimeDB
 {
@@ -243,7 +237,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -315,7 +308,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -353,7 +345,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -384,7 +375,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 
 namespace SpacetimeDB
 {
@@ -488,7 +478,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 
 namespace SpacetimeDB
 {
@@ -552,7 +541,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -597,7 +585,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -622,7 +609,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -648,7 +634,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 using System.Collections.Generic;
 using System.Linq;
 using System.Runtime.Serialization;
@@ -708,7 +693,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 
 namespace SpacetimeDB
 {
@@ -856,7 +840,6 @@ namespace SpacetimeDB
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
 
 namespace SpacetimeDB
 {


### PR DESCRIPTION
# Description of Changes

This using was added in the protobufectomy PR to all autogenerated files, even though it's unused in all of them but one (SpacetimeDBClient.cs).

As a result, it makes the autogen diff very noisy on large projects like BitCraft for no benefit.

This PR fixes it by only adding using in that single file where it's necessary.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] `dotnet test` for snapshot testing
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
