### PR TITLE
`Typespace::is_nominal_normal_form`

### DIFF
--- a/crates/sats/proptest-regressions/typespace.txt
+++ b/crates/sats/proptest-regressions/typespace.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9b3c83dd8794aa57dc9f2a3dd07111510ab1c537a23d6cdbcaa6d8dda3445c4c # shrinks to typespace = Typespace { types: [Builtin(Bool), Builtin(Bool), Builtin(Bool), Builtin(Bool), Product(ProductType { elements: [ProductTypeElement { name: None, algebraic_type: Product(ProductType { elements: [] }) }] })] }

--- a/crates/sats/src/product_type.rs
+++ b/crates/sats/src/product_type.rs
@@ -71,9 +71,15 @@ impl ProductType {
     pub fn is_special_tag(tag_name: &str) -> bool {
         tag_name == IDENTITY_TAG || tag_name == ADDRESS_TAG
     }
+
     /// Returns whether this is a special known type, currently `Address` or `Identity`.
     pub fn is_special(&self) -> bool {
         self.is_identity() || self.is_address()
+    }
+
+    /// Returns whether this is a unit type, that is, has no elements.
+    pub fn is_unit(&self) -> bool {
+        self.elements.is_empty()
     }
 
     /// Returns index of the field with the given `name`.

--- a/crates/sats/src/sum_type.rs
+++ b/crates/sats/src/sum_type.rs
@@ -49,10 +49,14 @@ impl SumType {
         Self { variants }
     }
 
-    /// Returns whether this sum type looks like an option type.
+    /// Check whether this sum type is a structural option type.
     ///
-    /// An option type has `some(T)` as its first variant and `none` as its second.
+    /// A structural option type has `some(T)` as its first variant and `none` as its second.
     /// That is, `{ some(T), none }` or `some: T | none` depending on your notation.
+    /// Note that `some` and `none` are lowercase, unlike Rust's `Option`.
+    /// Order matters, and an option type with these variants in the opposite order will not be recognized.
+    ///
+    /// If the type does look like a structural option type, returns the type `T`.
     pub fn as_option(&self) -> Option<&AlgebraicType> {
         match &*self.variants {
             [first, second]
@@ -64,6 +68,11 @@ impl SumType {
             }
             _ => None,
         }
+    }
+
+    /// Return whether this sum type is empty, that is, has no variants.
+    pub fn is_empty(&self) -> bool {
+        self.variants.is_empty()
     }
 
     /// Returns whether this sum type is like on in C without data attached to the variants.


### PR DESCRIPTION
# Description of Changes

Introduces a notion of "nominal normal form" for `Typespace`s, which requires that `Sum` and `Product` types always be referred to via `Ref`s. The intention is that this lets us validate that the `Typespace` is in a format that makes sense for performing codegen in a nominal language, where each `Ref` corresponds to a fresh type. (Or type alias, if the `Ref` points to a `Ref`.)

This is used in my upcoming module validation PR. Note that in a module, we also have names attached to these slots via `MiscModuleExport`, but this code doesn't care about that.

The module bindings should automatically produce `Typespace`s satisfying this requirement.

We could strengthen this in various ways:
- Require that *all* types be referred to via `Ref`s.
   - We could additionally require that each `Builtin` is referred to by **at most one** ref.
   - `AlgebraicType::unit` and `AlgebraicType::never` would then be in a slightly odd place, because they are rep'd as the empty product/sum. I guess you could say that *exactly one* empty product should have no type alias, and that one will be treated as the "true" unit type.
   - We could introduce new enums for this, possibly in a crate outside `sats` since most users won't care.
- Forbid `Ref` chains, or introduce a method to collapse them. This allows generating code for languages without type aliases. 

(Please bikeshed the name. Is there a type theory name for this?)

# Expected complexity level and risk

1, I mainly just wanna validate that I am checking the right things.

# Testing

Added proptests.