### PR TITLE
core: Singular system table names

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -4,8 +4,8 @@ use super::{
 use crate::{
     db::datastore::system_tables::{
         StColumnFields, StColumnRow, StConstraintFields, StConstraintRow, StIndexFields, StIndexRow, StScheduledFields,
-        StScheduledRow, StSequenceFields, StSequenceRow, StTableFields, StTableRow, SystemTable, ST_COLUMNS_ID,
-        ST_CONSTRAINTS_ID, ST_INDEXES_ID, ST_SCHEDULED_ID, ST_SEQUENCES_ID, ST_TABLES_ID,
+        StScheduledRow, StSequenceFields, StSequenceRow, StTableFields, StTableRow, SystemTable, ST_COLUMN_ID,
+        ST_CONSTRAINT_ID, ST_INDEX_ID, ST_SCHEDULED_ID, ST_SEQUENCE_ID, ST_TABLE_ID,
     },
     error::TableError,
     execution_context::ExecutionContext,
@@ -27,7 +27,7 @@ pub trait StateView {
         let ctx = ExecutionContext::internal(database_address);
         let name = &<Box<str>>::from(table_name).into();
         let row = self
-            .iter_by_col_eq(&ctx, ST_TABLES_ID, StTableFields::TableName, name)?
+            .iter_by_col_eq(&ctx, ST_TABLE_ID, StTableFields::TableName, name)?
             .next();
         Ok(row.map(|row| row.read_col(StTableFields::TableId).unwrap()))
     }
@@ -64,7 +64,7 @@ pub trait StateView {
         // Look up the table_name for the table in question.
         let value_eq = &table_id.into();
         let row = self
-            .iter_by_col_eq(ctx, ST_TABLES_ID, StTableFields::TableId, value_eq)?
+            .iter_by_col_eq(ctx, ST_TABLE_ID, StTableFields::TableId, value_eq)?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_table, table_id.into()))?;
         let row = StTableRow::try_from(row)?;
@@ -75,7 +75,7 @@ pub trait StateView {
 
         // Look up the columns for the table in question.
         let mut columns = self
-            .iter_by_col_eq(ctx, ST_COLUMNS_ID, StColumnFields::TableId, value_eq)?
+            .iter_by_col_eq(ctx, ST_COLUMN_ID, StColumnFields::TableId, value_eq)?
             .map(|row| {
                 let row = StColumnRow::try_from(row)?;
                 Ok(ColumnSchema {
@@ -90,7 +90,7 @@ pub trait StateView {
 
         // Look up the constraints for the table in question.
         let constraints = self
-            .iter_by_col_eq(ctx, ST_CONSTRAINTS_ID, StConstraintFields::TableId, value_eq)?
+            .iter_by_col_eq(ctx, ST_CONSTRAINT_ID, StConstraintFields::TableId, value_eq)?
             .map(|row| {
                 let row = StConstraintRow::try_from(row)?;
                 Ok(ConstraintSchema {
@@ -105,7 +105,7 @@ pub trait StateView {
 
         // Look up the sequences for the table in question.
         let sequences = self
-            .iter_by_col_eq(ctx, ST_SEQUENCES_ID, StSequenceFields::TableId, value_eq)?
+            .iter_by_col_eq(ctx, ST_SEQUENCE_ID, StSequenceFields::TableId, value_eq)?
             .map(|row| {
                 let row = StSequenceRow::try_from(row)?;
                 Ok(SequenceSchema {
@@ -124,7 +124,7 @@ pub trait StateView {
 
         // Look up the indexes for the table in question.
         let indexes = self
-            .iter_by_col_eq(ctx, ST_INDEXES_ID, StIndexFields::TableId, value_eq)?
+            .iter_by_col_eq(ctx, ST_INDEX_ID, StIndexFields::TableId, value_eq)?
             .map(|row| {
                 let row = StIndexRow::try_from(row)?;
                 Ok(IndexSchema {

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -5,7 +5,7 @@ use std::{ops::RangeBounds, sync::Arc};
 
 use super::system_tables::ModuleKind;
 use super::Result;
-use crate::db::datastore::system_tables::ST_TABLES_ID;
+use crate::db::datastore::system_tables::ST_TABLE_ID;
 use crate::execution_context::ExecutionContext;
 use spacetimedb_data_structures::map::IntMap;
 use spacetimedb_lib::db::raw_def::*;
@@ -392,7 +392,7 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     ) -> Result<Option<Cow<'a, str>>>;
     fn get_all_tables_mut_tx(&self, ctx: &ExecutionContext, tx: &Self::MutTx) -> super::Result<Vec<Arc<TableSchema>>> {
         let mut tables = Vec::new();
-        let table_rows = self.iter_mut_tx(ctx, tx, ST_TABLES_ID)?.collect::<Vec<_>>();
+        let table_rows = self.iter_mut_tx(ctx, tx, ST_TABLE_ID)?.collect::<Vec<_>>();
         for row in table_rows {
             let table_id = self.read_table_id(row)?;
             tables.push(self.schema_for_table_mut_tx(tx, table_id)?);

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1456,8 +1456,8 @@ mod tests {
 
     use super::*;
     use crate::db::datastore::system_tables::{
-        system_tables, StConstraintRow, StIndexRow, StSequenceRow, StTableRow, ST_CONSTRAINTS_ID, ST_INDEXES_ID,
-        ST_SEQUENCES_ID, ST_TABLES_ID,
+        system_tables, StConstraintRow, StIndexRow, StSequenceRow, StTableRow, ST_CONSTRAINT_ID, ST_INDEX_ID,
+        ST_SEQUENCE_ID, ST_TABLE_ID,
     };
     use crate::db::relational_db::tests_utils::TestDB;
     use crate::error::IndexError;
@@ -1942,21 +1942,21 @@ mod tests {
         let table_id = stdb.create_table(&mut tx, schema)?;
 
         let indexes = stdb
-            .iter_mut(&ctx, &tx, ST_INDEXES_ID)?
+            .iter_mut(&ctx, &tx, ST_INDEX_ID)?
             .map(|x| StIndexRow::try_from(x).unwrap())
             .filter(|x| x.table_id == table_id)
             .collect::<Vec<_>>();
         assert_eq!(indexes.len(), 4, "Wrong number of indexes");
 
         let sequences = stdb
-            .iter_mut(&ctx, &tx, ST_SEQUENCES_ID)?
+            .iter_mut(&ctx, &tx, ST_SEQUENCE_ID)?
             .map(|x| StSequenceRow::try_from(x).unwrap())
             .filter(|x| x.table_id == table_id)
             .collect::<Vec<_>>();
         assert_eq!(sequences.len(), 1, "Wrong number of sequences");
 
         let constraints = stdb
-            .iter_mut(&ctx, &tx, ST_CONSTRAINTS_ID)?
+            .iter_mut(&ctx, &tx, ST_CONSTRAINT_ID)?
             .map(|x| StConstraintRow::try_from(x).unwrap())
             .filter(|x| x.table_id == table_id)
             .collect::<Vec<_>>();
@@ -1965,21 +1965,21 @@ mod tests {
         stdb.drop_table(&ctx, &mut tx, table_id)?;
 
         let indexes = stdb
-            .iter_mut(&ctx, &tx, ST_INDEXES_ID)?
+            .iter_mut(&ctx, &tx, ST_INDEX_ID)?
             .map(|x| StIndexRow::try_from(x).unwrap())
             .filter(|x| x.table_id == table_id)
             .collect::<Vec<_>>();
         assert_eq!(indexes.len(), 0, "Wrong number of indexes DROP");
 
         let sequences = stdb
-            .iter_mut(&ctx, &tx, ST_SEQUENCES_ID)?
+            .iter_mut(&ctx, &tx, ST_SEQUENCE_ID)?
             .map(|x| StSequenceRow::try_from(x).unwrap())
             .filter(|x| x.table_id == table_id)
             .collect::<Vec<_>>();
         assert_eq!(sequences.len(), 0, "Wrong number of sequences DROP");
 
         let constraints = stdb
-            .iter_mut(&ctx, &tx, ST_CONSTRAINTS_ID)?
+            .iter_mut(&ctx, &tx, ST_CONSTRAINT_ID)?
             .map(|x| StConstraintRow::try_from(x).unwrap())
             .filter(|x| x.table_id == table_id)
             .collect::<Vec<_>>();
@@ -2002,7 +2002,7 @@ mod tests {
         assert_eq!(Some("YourTable"), table_name.as_ref().map(Cow::as_ref));
         // Also make sure we've removed the old ST_TABLES_ID row
         let mut n = 0;
-        for row in stdb.iter_mut(&ctx, &tx, ST_TABLES_ID)? {
+        for row in stdb.iter_mut(&ctx, &tx, ST_TABLE_ID)? {
             let table = StTableRow::try_from(row)?;
             if table.table_id == table_id {
                 n += 1;
@@ -2220,7 +2220,7 @@ mod tests {
             ) -> Result<Self::Row, Self::Error> {
                 // Allow specifically deletes from `st_sequence`,
                 // since the transactions in this test will allocate sequence values.
-                if table_id != ST_SEQUENCES_ID {
+                if table_id != ST_SEQUENCE_ID {
                     bail!("unexpected delete for table: {table_id}")
                 }
                 let ty = self.sys.get(&table_id).unwrap();

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -5,7 +5,7 @@ use crate::client::{ClientActorId, ClientConnectionSender, Protocol};
 use crate::database_instance_context::DatabaseInstanceContext;
 use crate::database_logger::{LogLevel, Record};
 use crate::db::datastore::locking_tx_datastore::MutTxId;
-use crate::db::datastore::system_tables::{StClientsFields, StClientsRow, ST_CLIENTS_ID};
+use crate::db::datastore::system_tables::{StClientFields, StClientsRow, ST_CLIENT_ID};
 use crate::db::datastore::traits::{IsolationLevel, TxData};
 use crate::db::update::UpdateDatabaseError;
 use crate::energy::EnergyQuanta;
@@ -634,19 +634,19 @@ impl ModuleHost {
         };
 
         if connected {
-            db.insert(mut_tx, ST_CLIENTS_ID, row.into()).map(|_| ())
+            db.insert(mut_tx, ST_CLIENT_ID, row.into()).map(|_| ())
         } else {
             let row = db
                 .iter_by_col_eq_mut(
                     ctx,
                     mut_tx,
-                    ST_CLIENTS_ID,
-                    col_list![StClientsFields::Identity, StClientsFields::Address],
+                    ST_CLIENT_ID,
+                    col_list![StClientFields::Identity, StClientFields::Address],
                     &algebraic_value::AlgebraicValue::product(row),
                 )?
                 .map(|row_ref| row_ref.pointer())
                 .collect::<SmallVec<[_; 1]>>();
-            db.delete(mut_tx, ST_CLIENTS_ID, row);
+            db.delete(mut_tx, ST_CLIENT_ID, row);
             Ok::<(), DBError>(())
         }
     }

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -13,7 +13,7 @@ use super::instrumentation::CallTimes;
 use crate::database_instance_context::DatabaseInstanceContext;
 use crate::database_logger::SystemLogger;
 use crate::db::datastore::locking_tx_datastore::MutTxId;
-use crate::db::datastore::system_tables::{StClientsRow, ST_CLIENTS_ID};
+use crate::db::datastore::system_tables::{StClientsRow, ST_CLIENT_ID};
 use crate::db::datastore::traits::IsolationLevel;
 use crate::energy::{EnergyMonitor, EnergyQuanta, ReducerBudget, ReducerFingerprint};
 use crate::execution_context::{self, ExecutionContext, ReducerContext};
@@ -617,7 +617,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         let db = &*self.database_instance_context().relational_db;
         let row = &StClientsRow { identity, address };
 
-        db.insert(tx, ST_CLIENTS_ID, row.into()).map(|_| ())
+        db.insert(tx, ST_CLIENT_ID, row.into()).map(|_| ())
     }
 }
 

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -219,7 +219,7 @@ pub fn translate_col(tx: &Tx, field: FieldName) -> Option<Box<str>> {
 #[cfg(test)]
 pub(crate) mod tests {
     use super::*;
-    use crate::db::datastore::system_tables::{ST_TABLES_ID, ST_TABLES_NAME};
+    use crate::db::datastore::system_tables::{ST_TABLE_ID, ST_TABLE_NAME};
     use crate::db::relational_db::tests_utils::TestDB;
     use crate::vm::tests::create_table_with_rows;
     use spacetimedb_lib::db::auth::{StAccess, StTableType};
@@ -357,18 +357,18 @@ pub(crate) mod tests {
         let (db, _) = create_data(1)?;
 
         let tx = db.begin_tx();
-        let schema = db.schema_for_table(&tx, ST_TABLES_ID).unwrap();
+        let schema = db.schema_for_table(&tx, ST_TABLE_ID).unwrap();
         db.release_tx(&ExecutionContext::internal(db.address()), tx);
         let result = run_for_testing(
             &db,
-            &format!("SELECT * FROM {} WHERE table_id = {}", ST_TABLES_NAME, ST_TABLES_ID),
+            &format!("SELECT * FROM {} WHERE table_id = {}", ST_TABLE_NAME, ST_TABLE_ID),
         )?;
 
         assert_eq!(result.len(), 1, "Not return results");
         let result = result.first().unwrap().clone();
         let row = product![
-            ST_TABLES_ID,
-            ST_TABLES_NAME,
+            ST_TABLE_ID,
+            ST_TABLE_NAME,
             StTableType::System.as_str(),
             StAccess::Public.as_str(),
         ];

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -618,8 +618,8 @@ pub(crate) mod tests {
     use super::*;
     use crate::db::datastore::system_tables::{
         StColumnFields, StColumnRow, StFields as _, StIndexFields, StIndexRow, StSequenceFields, StSequenceRow,
-        StTableFields, StTableRow, ST_COLUMNS_ID, ST_COLUMNS_NAME, ST_INDEXES_ID, ST_INDEXES_NAME,
-        ST_RESERVED_SEQUENCE_RANGE, ST_SEQUENCES_ID, ST_SEQUENCES_NAME, ST_TABLES_ID, ST_TABLES_NAME,
+        StTableFields, StTableRow, ST_COLUMN_ID, ST_COLUMN_NAME, ST_INDEX_ID, ST_INDEX_NAME,
+        ST_RESERVED_SEQUENCE_RANGE, ST_SEQUENCE_ID, ST_SEQUENCE_NAME, ST_TABLE_ID, ST_TABLE_NAME,
     };
     use crate::db::relational_db::tests_utils::TestDB;
     use crate::execution_context::ExecutionContext;
@@ -743,23 +743,23 @@ pub(crate) mod tests {
     #[test]
     fn test_query_catalog_tables() -> ResultTest<()> {
         let stdb = TestDB::durable()?;
-        let schema = &*stdb.schema_for_table(&stdb.begin_tx(), ST_TABLES_ID).unwrap();
+        let schema = &*stdb.schema_for_table(&stdb.begin_tx(), ST_TABLE_ID).unwrap();
 
         let q = QueryExpr::new(schema)
             .with_select_cmp(
                 OpCmp::Eq,
-                FieldName::new(ST_TABLES_ID, StTableFields::TableName.into()),
-                scalar(ST_TABLES_NAME),
+                FieldName::new(ST_TABLE_ID, StTableFields::TableName.into()),
+                scalar(ST_TABLE_NAME),
             )
             .unwrap();
         let st_table_row = StTableRow {
-            table_id: ST_TABLES_ID,
-            table_name: ST_TABLES_NAME.into(),
+            table_id: ST_TABLE_ID,
+            table_name: ST_TABLE_NAME.into(),
             table_type: StTableType::System,
             table_access: StAccess::Public,
         }
         .into();
-        check_catalog(&stdb, ST_TABLES_NAME, st_table_row, q, schema);
+        check_catalog(&stdb, ST_TABLE_NAME, st_table_row, q, schema);
 
         Ok(())
     }
@@ -767,29 +767,29 @@ pub(crate) mod tests {
     #[test]
     fn test_query_catalog_columns() -> ResultTest<()> {
         let stdb = TestDB::durable()?;
-        let schema = &*stdb.schema_for_table(&stdb.begin_tx(), ST_COLUMNS_ID).unwrap();
+        let schema = &*stdb.schema_for_table(&stdb.begin_tx(), ST_COLUMN_ID).unwrap();
 
         let q = QueryExpr::new(schema)
             .with_select_cmp(
                 OpCmp::Eq,
-                FieldName::new(ST_COLUMNS_ID, StColumnFields::TableId.into()),
-                scalar(ST_COLUMNS_ID),
+                FieldName::new(ST_COLUMN_ID, StColumnFields::TableId.into()),
+                scalar(ST_COLUMN_ID),
             )
             .unwrap()
             .with_select_cmp(
                 OpCmp::Eq,
-                FieldName::new(ST_COLUMNS_ID, StColumnFields::ColPos.into()),
+                FieldName::new(ST_COLUMN_ID, StColumnFields::ColPos.into()),
                 scalar(StColumnFields::TableId as u32),
             )
             .unwrap();
         let st_column_row = StColumnRow {
-            table_id: ST_COLUMNS_ID,
+            table_id: ST_COLUMN_ID,
             col_pos: StColumnFields::TableId.col_id(),
             col_name: StColumnFields::TableId.col_name(),
             col_type: AlgebraicType::U32,
         }
         .into();
-        check_catalog(&stdb, ST_COLUMNS_NAME, st_column_row, q, schema);
+        check_catalog(&stdb, ST_COLUMN_NAME, st_column_row, q, schema);
 
         Ok(())
     }
@@ -805,11 +805,11 @@ pub(crate) mod tests {
         let index = RawIndexDefV8::btree("idx_1".into(), ColId(0), true);
         let index_id = db.with_auto_commit(&ctx, |tx| db.create_index(tx, table_id, index))?;
 
-        let indexes_schema = &*db.schema_for_table(&db.begin_tx(), ST_INDEXES_ID).unwrap();
+        let indexes_schema = &*db.schema_for_table(&db.begin_tx(), ST_INDEX_ID).unwrap();
         let q = QueryExpr::new(indexes_schema)
             .with_select_cmp(
                 OpCmp::Eq,
-                FieldName::new(ST_INDEXES_ID, StIndexFields::IndexName.into()),
+                FieldName::new(ST_INDEX_ID, StIndexFields::IndexName.into()),
                 scalar("idx_1"),
             )
             .unwrap();
@@ -822,7 +822,7 @@ pub(crate) mod tests {
             index_type: IndexType::BTree,
         }
         .into();
-        check_catalog(&db, ST_INDEXES_NAME, st_index_row, q, indexes_schema);
+        check_catalog(&db, ST_INDEX_NAME, st_index_row, q, indexes_schema);
 
         Ok(())
     }
@@ -831,12 +831,12 @@ pub(crate) mod tests {
     fn test_query_catalog_sequences() -> ResultTest<()> {
         let db = TestDB::durable()?;
 
-        let schema = &*db.schema_for_table(&db.begin_tx(), ST_SEQUENCES_ID).unwrap();
+        let schema = &*db.schema_for_table(&db.begin_tx(), ST_SEQUENCE_ID).unwrap();
         let q = QueryExpr::new(schema)
             .with_select_cmp(
                 OpCmp::Eq,
-                FieldName::new(ST_SEQUENCES_ID, StSequenceFields::TableId.into()),
-                scalar(ST_SEQUENCES_ID),
+                FieldName::new(ST_SEQUENCE_ID, StSequenceFields::TableId.into()),
+                scalar(ST_SEQUENCE_ID),
             )
             .unwrap();
         let st_sequence_row = StSequenceRow {
@@ -851,7 +851,7 @@ pub(crate) mod tests {
             allocated: ST_RESERVED_SEQUENCE_RANGE as i128,
         }
         .into();
-        check_catalog(&db, ST_SEQUENCES_NAME, st_sequence_row, q, schema);
+        check_catalog(&db, ST_SEQUENCE_NAME, st_sequence_row, q, schema);
 
         Ok(())
     }


### PR DESCRIPTION
For consistency reasons, name all system tables in singular form.

# Expected complexity level and risk

1
