### PR TITLE
`spacetime server add` - Remove trailing `/`s

### DIFF
--- a/crates/cli/src/subcommands/server.rs
+++ b/crates/cli/src/subcommands/server.rs
@@ -199,7 +199,8 @@ fn valid_protocol_or_error(protocol: &str) -> anyhow::Result<()> {
 }
 
 pub async fn exec_add(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    let url = args.get_one::<String>("url").unwrap();
+    // Trim trailing `/`s because otherwise we end up with a double `//` in some later codepaths.
+    let url = args.get_one::<String>("url").unwrap().trim_end_matches('/');
     let nickname = args.get_one::<String>("name");
     let default = *args.get_one::<bool>("default").unwrap();
     let no_fingerprint = *args.get_one::<bool>("no-fingerprint").unwrap();


### PR DESCRIPTION
# Description of Changes

Fixes https://github.com/clockworklabs/SpacetimeDB/issues/1551. See the issue for more background details.

# API and ABI breaking changes

No. Un-breaks some cases.

# Expected complexity level and risk
1

# Testing

Before:
```bash
$ spacetime server add https://testnet.spacetimedb.com/ testnet-test
Error: Unable to retrieve fingerprint for server: https://testnet.spacetimedb.com/
Is the server running?
Add a server without retrieving its fingerprint with:
	spacetime server add https://testnet.spacetimedb.com/ --no-fingerprint

Caused by:
    HTTP status client error (404 Not Found) for url (https://testnet.spacetimedb.com//identity/public-key)
```

On this branch:
```
$ cargo run -- server add https://testnet.spacetimedb.com/ testnet-test
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
     Running `target/debug/spacetime server add 'https://testnet.spacetimedb.com/' testnet-test`
For server https://testnet.spacetimedb.com, got fingerprint:
-----BEGIN PUBLIC KEY-----
MFkwEwYHKoZIzj0CAQYIKoZIzj0DAQcDQgAEmF4e1ygt1sgluqRmi1Lwz8jK+GVz
kUnUtZJsDu5ACsJqwSDiMMDnBrNW41Bx0Qrg8FJNsK7mC767nvVmSYzyDg==
-----END PUBLIC KEY-----

Error: Server already configured for host: testnet.spacetimedb.com
```