### PR TITLE
Remove support for the `update` reducer

### DIFF
--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -81,7 +81,7 @@ mod sym {
 /// The macro takes this `input`, which defines what the attribute does,
 /// and it is structured roughly like so:
 /// ```ignore
-/// input = table [ ( private | public ) ] | init | connect | disconnect | migrate
+/// input = table [ ( private | public ) ] | init | connect | disconnect
 ///       | reducer
 ///       | index(btree | hash [, name = string] [, field_name:ident]*)
 /// ```
@@ -112,9 +112,7 @@ fn route_input(input: MacroInput, item: TokenStream) -> syn::Result<TokenStream>
         MacroInput::Reducer(None) => spacetimedb_reducer(item),
         MacroInput::Connect => spacetimedb_special_reducer("__identity_connected__", item),
         MacroInput::Disconnect => spacetimedb_special_reducer("__identity_disconnected__", item),
-        MacroInput::Migrate => spacetimedb_special_reducer("__migrate__", item),
         MacroInput::Index { ty, name, field_names } => spacetimedb_index(ty, name, field_names, item),
-        MacroInput::Update => spacetimedb_special_reducer("__update__", item),
     }
 }
 
@@ -137,13 +135,11 @@ enum MacroInput {
     Reducer(Option<Span>),
     Connect,
     Disconnect,
-    Migrate,
     Index {
         ty: IndexType,
         name: Option<String>,
         field_names: Vec<Ident>,
     },
-    Update,
 }
 
 /// Parse `f()` delimited by `,` until `input` is empty.
@@ -234,7 +230,6 @@ impl syn::parse::Parse for MacroInput {
             }
             kw::connect => Self::Connect,
             kw::disconnect => Self::Disconnect,
-            kw::migrate => Self::Migrate,
             kw::index => {
                 // Extract stuff in parens.
                 let in_parens;
@@ -261,7 +256,6 @@ impl syn::parse::Parse for MacroInput {
                 })?;
                 Self::Index { ty, name, field_names }
             }
-            kw::update => Self::Update,
         }))
     }
 }
@@ -293,7 +287,6 @@ mod kw {
     syn::custom_keyword!(reducer);
     syn::custom_keyword!(connect);
     syn::custom_keyword!(disconnect);
-    syn::custom_keyword!(migrate);
     syn::custom_keyword!(index);
     syn::custom_keyword!(btree);
     syn::custom_keyword!(hash);
@@ -301,7 +294,6 @@ mod kw {
     syn::custom_keyword!(private);
     syn::custom_keyword!(public);
     syn::custom_keyword!(repeat);
-    syn::custom_keyword!(update);
     syn::custom_keyword!(scheduled);
 }
 

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -24,9 +24,7 @@ pub use disk_storage::DiskStorage;
 pub use host_controller::{
     DescribedEntityType, ExternalStorage, HostController, ProgramStorage, ReducerCallResult, ReducerOutcome,
 };
-pub use module_host::{
-    EntityDef, ModuleHost, NoSuchModule, ReducerCallError, UpdateDatabaseResult, UpdateDatabaseSuccess,
-};
+pub use module_host::{EntityDef, ModuleHost, NoSuchModule, ReducerCallError, UpdateDatabaseResult};
 pub use scheduler::Scheduler;
 pub use spacetimedb_client_api_messages::timestamp::Timestamp;
 

--- a/crates/core/src/host/wasm_common.rs
+++ b/crates/core/src/host/wasm_common.rs
@@ -21,8 +21,6 @@ pub const PREINIT_DUNDER: &str = "__preinit__";
 pub const SETUP_DUNDER: &str = "__setup__";
 /// the reducer with this name initializes the database
 pub const INIT_DUNDER: &str = "__init__";
-/// the reducer with this name is invoked when updating the database
-pub const UPDATE_DUNDER: &str = "__update__";
 /// The reducer with this name is invoked when a client connects.
 pub const CLIENT_CONNECTED_DUNDER: &str = "__identity_connected__";
 /// The reducer with this name is invoked when a client disconnects.

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -308,13 +308,7 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
                     .with_context(|| format!("Not found: leader instance for database `{}`", database_addr))?;
                 let update_result = self
                     .host_controller
-                    .update_module_host(
-                        database,
-                        publisher_address,
-                        spec.host_type,
-                        leader.id,
-                        spec.program_bytes.into(),
-                    )
+                    .update_module_host(database, spec.host_type, leader.id, spec.program_bytes.into())
                     .await?;
 
                 if update_result.is_ok() {

--- a/modules/rust-wasm-test/src/lib.rs
+++ b/modules/rust-wasm-test/src/lib.rs
@@ -94,11 +94,6 @@ pub fn init() {
     });
 }
 
-#[spacetimedb(update)]
-pub fn update() {
-    log::info!("Update called!");
-}
-
 #[spacetimedb(reducer)]
 pub fn repeating_test(ctx: ReducerContext, arg: RepeatingTestArg) {
     let delta_time = arg.prev_time.elapsed();

--- a/smoketests/tests/modules.py
+++ b/smoketests/tests/modules.py
@@ -59,8 +59,8 @@ pub struct Pet {
     species: String,
 }
 
-#[spacetimedb(update)]
-pub fn on_module_update() {
+#[spacetimedb(reducer)]
+pub fn are_we_updated_yet() {
     println!("MODULE UPDATED");
 }
 """
@@ -95,9 +95,10 @@ pub fn on_module_update() {
         # Check that the old module is still running by calling say_hello
         self.call("say_hello")
 
-        # Adding a table is ok, and invokes update
+        # Adding a table is ok
         self.write_module_code(self.MODULE_CODE_C)
         self.publish_module(name, clear=False)
+        self.call("are_we_updated_yet")
         self.assertIn("MODULE UPDATED", self.logs(2))
 
 


### PR DESCRIPTION
Remove support for the `update` reducer

In favor of migrations providing similar and more powerful functionality.
Also remove traces of the `migrate` reducer, for the same reasons.


# API and ABI breaking changes

Modules using `#[spacetimedb(update)]` will no longer compile.

# Expected complexity and risk

2

# Testing

Should work as before.