### PR TITLE
core: Use `Program` instead of `(Hash, Box<[u8]>)`

### DIFF
--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -335,10 +335,7 @@ impl Program {
 
     /// Create a [`Program`] with no bytes.
     pub fn empty() -> Self {
-        Self {
-            hash: hash_bytes([].into()),
-            bytes: [].into(),
-        }
+        Self::from_bytes([])
     }
 }
 

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -9,7 +9,7 @@ use crate::db::datastore::system_tables::ST_TABLE_ID;
 use crate::execution_context::ExecutionContext;
 use spacetimedb_data_structures::map::IntMap;
 use spacetimedb_lib::db::raw_def::*;
-use spacetimedb_lib::{Address, Identity};
+use spacetimedb_lib::{hash_bytes, Address, Identity};
 use spacetimedb_primitives::*;
 use spacetimedb_sats::hash::Hash;
 use spacetimedb_sats::{AlgebraicValue, ProductType, ProductValue};
@@ -315,11 +315,32 @@ pub struct Metadata {
 }
 
 /// Program associated with a database.
+#[derive(Clone)]
 pub struct Program {
     /// Hash over the program's bytes.
     pub hash: Hash,
     /// The raw bytes of the program.
     pub bytes: Box<[u8]>,
+}
+
+impl Program {
+    /// Create a [`Program`] from its raw bytes.
+    ///
+    /// This computes the hash over `bytes`, so prefer constructing [`Program`]
+    /// directly if the hash is already known.
+    pub fn from_bytes(bytes: impl Into<Box<[u8]>>) -> Self {
+        let bytes = bytes.into();
+        let hash = hash_bytes(&bytes);
+        Self { hash, bytes }
+    }
+
+    /// Create a [`Program`] with no bytes.
+    pub fn empty() -> Self {
+        Self {
+            hash: Hash::ZERO,
+            bytes: [].into(),
+        }
+    }
 }
 
 pub trait TxDatastore: DataRow + Tx {
@@ -479,15 +500,7 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     fn metadata_mut_tx(&self, tx: &Self::MutTx) -> Result<Option<Metadata>>;
 
     /// Update the datastore with the supplied binary program.
-    ///
-    /// The `program_hash` is the precomputed hash over `program_bytes`.
-    fn update_program(
-        &self,
-        tx: &mut Self::MutTx,
-        program_kind: ModuleKind,
-        program_hash: Hash,
-        program_bytes: Box<[u8]>,
-    ) -> Result<()>;
+    fn update_program(&self, tx: &mut Self::MutTx, program_kind: ModuleKind, program: Program) -> Result<()>;
 }
 
 #[cfg(test)]

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -315,7 +315,6 @@ pub struct Metadata {
 }
 
 /// Program associated with a database.
-#[derive(Clone)]
 pub struct Program {
     /// Hash over the program's bytes.
     pub hash: Hash,

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -336,7 +336,7 @@ impl Program {
     /// Create a [`Program`] with no bytes.
     pub fn empty() -> Self {
         Self {
-            hash: Hash::ZERO,
+            hash: hash_bytes([].into()),
             bytes: [].into(),
         }
     }

--- a/crates/core/src/host/wasmtime/mod.rs
+++ b/crates/core/src/host/wasmtime/mod.rs
@@ -53,7 +53,7 @@ static LINKER: Lazy<Linker<WasmInstanceEnv>> = Lazy::new(|| {
 });
 
 pub fn make_actor(mcc: ModuleCreationContext) -> Result<impl super::module_host::Module, ModuleCreationError> {
-    let module = Module::new(&ENGINE, &mcc.program_bytes).map_err(ModuleCreationError::WasmCompileError)?;
+    let module = Module::new(&ENGINE, &mcc.program.bytes).map_err(ModuleCreationError::WasmCompileError)?;
 
     let func_imports = module
         .imports()

--- a/crates/core/src/module_host_context.rs
+++ b/crates/core/src/module_host_context.rs
@@ -1,15 +1,12 @@
-use spacetimedb_lib::Hash;
-
 use crate::database_instance_context::DatabaseInstanceContext;
+use crate::db::datastore::traits::Program;
 use crate::energy::EnergyMonitor;
 use crate::host::scheduler::Scheduler;
-use crate::util::AnyBytes;
 use std::sync::Arc;
 
-pub struct ModuleCreationContext {
+pub struct ModuleCreationContext<'a> {
     pub dbic: Arc<DatabaseInstanceContext>,
     pub scheduler: Scheduler,
-    pub program_bytes: AnyBytes,
-    pub program_hash: Hash,
+    pub program: &'a Program,
     pub energy_monitor: Arc<dyn EnergyMonitor>,
 }

--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -1,4 +1,3 @@
-use derive_more::From;
 use futures::{Future, FutureExt};
 use std::borrow::Cow;
 use std::pin::pin;
@@ -15,40 +14,6 @@ pub(crate) fn string_from_utf8_lossy_owned(v: Vec<u8>) -> String {
         // SAFETY: from_utf8_lossy() returned Borrowed, which means the original buffer is valid utf8
         Cow::Borrowed(_) => unsafe { String::from_utf8_unchecked(v) },
         Cow::Owned(s) => s,
-    }
-}
-
-#[derive(Clone, From)]
-pub enum AnyBytes {
-    Bytes(bytes::Bytes),
-    IVec(sled::IVec),
-}
-
-impl From<Vec<u8>> for AnyBytes {
-    fn from(b: Vec<u8>) -> Self {
-        Self::Bytes(b.into())
-    }
-}
-
-impl From<Box<[u8]>> for AnyBytes {
-    fn from(b: Box<[u8]>) -> Self {
-        Self::Bytes(b.into())
-    }
-}
-
-impl AsRef<[u8]> for AnyBytes {
-    fn as_ref(&self) -> &[u8] {
-        self
-    }
-}
-
-impl std::ops::Deref for AnyBytes {
-    type Target = [u8];
-    fn deref(&self) -> &Self::Target {
-        match self {
-            AnyBytes::Bytes(b) => b,
-            AnyBytes::IVec(b) => b,
-        }
     }
 }
 


### PR DESCRIPTION
Refactor to use `Program` (introduced in #1532) throughout.

Also avoid cloning the program bytes to instantiate a wasm module.
This makes the `AnyBytes` type unused, so remove it.

# API and ABI breaking changes

No

# Expected complexity level and risk

1 -- mostly mechanical

# Testing

n/a
