### PR TITLE
client-api: Remove publisher address

### DIFF
--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -127,7 +127,6 @@ pub trait ControlStateWriteAccess: Send + Sync {
     async fn publish_database(
         &self,
         identity: &Identity,
-        publisher_address: Option<Address>,
         spec: DatabaseDef,
     ) -> anyhow::Result<Option<UpdateDatabaseResult>>;
 
@@ -221,10 +220,9 @@ impl<T: ControlStateWriteAccess + ?Sized> ControlStateWriteAccess for Arc<T> {
     async fn publish_database(
         &self,
         identity: &Identity,
-        publisher_address: Option<Address>,
         spec: DatabaseDef,
     ) -> anyhow::Result<Option<UpdateDatabaseResult>> {
-        (**self).publish_database(identity, publisher_address, spec).await
+        (**self).publish_database(identity, spec).await
     }
 
     async fn delete_database(&self, identity: &Identity, address: &Address) -> anyhow::Result<()> {

--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -634,7 +634,6 @@ pub struct PublishDatabaseQueryParams {
     #[serde(default)]
     clear: bool,
     name_or_address: Option<NameOrAddress>,
-    client_address: Option<AddressForUrl>,
 }
 
 impl PublishDatabaseQueryParams {
@@ -650,13 +649,7 @@ pub async fn publish<S: NodeDelegate + ControlStateDelegate>(
     Extension(auth): Extension<SpacetimeAuth>,
     body: Bytes,
 ) -> axum::response::Result<axum::Json<PublishResult>> {
-    let PublishDatabaseQueryParams {
-        name_or_address,
-        clear,
-        client_address,
-    } = query_params;
-
-    let client_address = client_address.map(Address::from);
+    let PublishDatabaseQueryParams { name_or_address, clear } = query_params;
 
     // You should not be able to publish to a database that you do not own
     // so, unless you are the owner, this will fail.
@@ -701,7 +694,6 @@ pub async fn publish<S: NodeDelegate + ControlStateDelegate>(
     let maybe_updated = ctx
         .publish_database(
             &auth.identity,
-            client_address,
             DatabaseDef {
                 address: db_addr,
                 program_bytes: body.into(),

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -24,7 +24,7 @@ use crate::host::module_host::{
 };
 use crate::host::{ArgsTuple, EntityDef, ReducerCallResult, ReducerId, ReducerOutcome, Scheduler};
 use crate::identity::Identity;
-use crate::messages::control_db::{Database, HostType};
+use crate::messages::control_db::HostType;
 use crate::module_host_context::ModuleCreationContext;
 use crate::subscription::module_subscription_actor::WriteConflict;
 use crate::util::const_unwrap;
@@ -335,21 +335,14 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
 
             Some(reducer_id) => {
                 self.system_logger().info("Invoking `init` reducer");
-                // If a caller address was passed to the `/database/publish` HTTP endpoint,
-                // the init reducer will receive it as the caller address.
-                // This is useful for bootstrapping the control DB in SpacetimeDB-cloud.
-                let Database {
-                    owner_identity: caller_identity,
-                    publisher_address: caller_address,
-                    ..
-                } = self.database_instance_context().database;
+                let caller_identity = self.database_instance_context().database.owner_identity;
                 let client = None;
                 Some(self.call_reducer_with_tx(
                     Some(tx),
                     CallReducerParams {
                         timestamp,
                         caller_identity,
-                        caller_address: caller_address.unwrap_or(Address::__DUMMY),
+                        caller_address: Address::__DUMMY,
                         client,
                         request_id: None,
                         timer: None,

--- a/crates/core/src/messages/control_db.rs
+++ b/crates/core/src/messages/control_db.rs
@@ -38,12 +38,6 @@ pub struct Database {
     ///
     /// Updating the database's module will **not** change this value.
     pub initial_program: Hash,
-    /// The client address of the (initial) publisher of the database.
-    ///
-    /// If set, the value will be part of the  `__init__` reducer's context.
-    /// The meaning of this value is unspecified if the `owner_identity` is
-    /// changed after creation of the database.
-    pub publisher_address: Option<Address>,
 }
 
 #[derive(Clone, PartialEq, Serialize, Deserialize)]

--- a/crates/standalone/src/control_db/tests.rs
+++ b/crates/standalone/src/control_db/tests.rs
@@ -100,7 +100,6 @@ fn test_decode() -> ResultTest<()> {
         owner_identity: id,
         host_type: HostType::Wasm,
         initial_program: Hash::ZERO,
-        publisher_address: Some(Address::zero()),
     };
 
     cdb.insert_database(db.clone())?;

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -265,7 +265,6 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
     async fn publish_database(
         &self,
         identity: &Identity,
-        publisher_address: Option<Address>,
         spec: spacetimedb_client_api::DatabaseDef,
     ) -> anyhow::Result<Option<UpdateDatabaseResult>> {
         let existing_db = self.control_db.get_database_by_address(&spec.address)?;
@@ -280,7 +279,6 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
                     owner_identity: *identity,
                     host_type: spec.host_type,
                     initial_program,
-                    publisher_address,
                 };
                 let database_id = self.control_db.insert_database(database.clone())?;
                 database.id = database_id;

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -161,7 +161,6 @@ impl CompiledModule {
 
         env.publish_database(
             &identity,
-            Some(client_address),
             DatabaseDef {
                 address: db_address,
                 program_bytes,


### PR DESCRIPTION
It was once believed that threading through the caller address of the
publish endpoint to the init / update reducer was necessary or at least
useful. This turned out to not be the case, so remove it.

Note that the standalone control db "schema" remains unchanged for
compatibility.

# API and ABI breaking changes

No.

# Expected complexity level and risk

1
