### PR TITLE
Change ResolveRefs to return a Result rather than an Option

### DIFF
--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -342,8 +342,9 @@ pub fn register_table<T: TableType>() {
                 .typespace()
                 .with_type(&data)
                 .resolve_refs()
-                .and_then(|x| x.into_product().ok())
-                .expect("Fail to retrieve the columns from the module"),
+                .expect("Failed to retrieve the column types from the module")
+                .into_product()
+                .expect("Table is not a product type"),
         );
 
         let indexes: Vec<_> = T::INDEXES.iter().copied().map(Into::into).collect();

--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -211,7 +211,7 @@ fn entity_description_json(description: WithTypespace<EntityDef>, expand: bool) 
         // TODO(noa): make this less hacky; needs coordination w/ spacetime-web
         let schema = match description.ty() {
             EntityDef::Table(table) => {
-                json!(description.with(&table.data).resolve_refs()?.as_product()?)
+                json!(description.with(&table.data).resolve_refs().ok()?.as_product()?)
             }
             EntityDef::Reducer(r) => json!({
                 "name": r.name,

--- a/crates/sats/src/resolve_refs.rs
+++ b/crates/sats/src/resolve_refs.rs
@@ -1,6 +1,6 @@
 use crate::{
-    AlgebraicType, AlgebraicTypeRef, ArrayType, MapType, ProductType, ProductTypeElement, SumType, SumTypeVariant,
-    WithTypespace,
+    typespace::TypeRefError, AlgebraicType, AlgebraicTypeRef, ArrayType, MapType, ProductType, ProductTypeElement,
+    SumType, SumTypeVariant, WithTypespace,
 };
 
 /// Resolver for [`AlgebraicTypeRef`]s within a structure.
@@ -22,8 +22,8 @@ pub trait ResolveRefs {
     /// within `this` (typing context carried) resolved
     /// using the provided resolver `state`.
     ///
-    /// `None` is only returned if there were cycles in the precense of recursive μ-types.
-    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output>;
+    /// `Err` is returned if a cycle was detected, or if any `TypeRef` touched was invalid.
+    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Result<Self::Output, TypeRefError>;
 }
 
 // -----------------------------------------------------------------------------
@@ -32,14 +32,14 @@ pub trait ResolveRefs {
 
 impl ResolveRefs for AlgebraicTypeRef {
     type Output = AlgebraicType;
-    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output> {
+    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Result<Self::Output, TypeRefError> {
         // Suppose we have `&0 = { Nil, Cons({ elem: U8, tail: &0 }) }`.
         // This is our standard cons-list type.
         // In this setup, when getting to `tail`,
         // we would recurse back to expanding `tail` again, and so or...
         // So we will never halt. This check breaks that cycle.
         if state.stack.contains(this.ty()) {
-            return None;
+            return Err(TypeRefError::RecursiveTypeRef(*this.ty()));
         }
 
         // Push ourselves to the stack.
@@ -49,6 +49,7 @@ impl ResolveRefs for AlgebraicTypeRef {
         let ret = this
             .typespace()
             .get(*this.ty())
+            .ok_or(TypeRefError::InvalidTypeRef(*this.ty()))
             .and_then(|at| this.with(at)._resolve_refs(state));
 
         // Remove ourselves.
@@ -63,7 +64,7 @@ impl ResolveRefs for AlgebraicTypeRef {
 
 impl ResolveRefs for AlgebraicType {
     type Output = Self;
-    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output> {
+    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Result<Self::Output, TypeRefError> {
         match this.ty() {
             Self::Ref(r) => this.with(r)._resolve_refs(state),
             Self::Sum(sum) => this.with(sum)._resolve_refs(state).map(Into::into),
@@ -71,15 +72,15 @@ impl ResolveRefs for AlgebraicType {
             Self::Array(ty) => this.with(ty)._resolve_refs(state).map(Into::into),
             Self::Map(m) => this.with(&**m)._resolve_refs(state).map(Into::into),
             // These types are plain and cannot have refs in them.
-            x => Some(x.clone()),
+            x => Ok(x.clone()),
         }
     }
 }
 
 impl ResolveRefs for ArrayType {
     type Output = Self;
-    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output> {
-        Some(Self {
+    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Result<Self::Output, TypeRefError> {
+        Ok(Self {
             elem_ty: Box::new(this.map(|m| &*m.elem_ty)._resolve_refs(state)?),
         })
     }
@@ -87,8 +88,8 @@ impl ResolveRefs for ArrayType {
 
 impl ResolveRefs for MapType {
     type Output = Self;
-    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output> {
-        Some(Self {
+    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Result<Self::Output, TypeRefError> {
+        Ok(Self {
             key_ty: this.map(|m| &m.key_ty)._resolve_refs(state)?,
             ty: this.map(|m| &m.ty)._resolve_refs(state)?,
         })
@@ -97,21 +98,21 @@ impl ResolveRefs for MapType {
 
 impl ResolveRefs for ProductType {
     type Output = Self;
-    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output> {
+    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Result<Self::Output, TypeRefError> {
         let elements = this
             .ty()
             .elements
             .iter()
             .map(|el| this.with(el)._resolve_refs(state))
-            .collect::<Option<_>>()?;
-        Some(ProductType { elements })
+            .collect::<Result<_, _>>()?;
+        Ok(ProductType { elements })
     }
 }
 
 impl ResolveRefs for ProductTypeElement {
     type Output = Self;
-    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output> {
-        Some(Self {
+    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Result<Self::Output, TypeRefError> {
+        Ok(Self {
             algebraic_type: this.map(|e| &e.algebraic_type)._resolve_refs(state)?,
             name: this.ty().name.clone(),
         })
@@ -120,21 +121,21 @@ impl ResolveRefs for ProductTypeElement {
 
 impl ResolveRefs for SumType {
     type Output = Self;
-    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output> {
+    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Result<Self::Output, TypeRefError> {
         let variants = this
             .ty()
             .variants
             .iter()
             .map(|v| this.with(v)._resolve_refs(state))
-            .collect::<Option<_>>()?;
-        Some(Self { variants })
+            .collect::<Result<_, _>>()?;
+        Ok(Self { variants })
     }
 }
 
 impl ResolveRefs for SumTypeVariant {
     type Output = Self;
-    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Option<Self::Output> {
-        Some(Self {
+    fn resolve_refs(this: WithTypespace<'_, Self>, state: &mut ResolveRefState) -> Result<Self::Output, TypeRefError> {
+        Ok(Self {
             algebraic_type: this.map(|v| &v.algebraic_type)._resolve_refs(state)?,
             name: this.ty().name.clone(),
         })
@@ -142,10 +143,10 @@ impl ResolveRefs for SumTypeVariant {
 }
 
 impl<T: ResolveRefs> WithTypespace<'_, T> {
-    pub fn resolve_refs(self) -> Option<T::Output> {
+    pub fn resolve_refs(self) -> Result<T::Output, TypeRefError> {
         T::resolve_refs(self, &mut ResolveRefState::default())
     }
-    fn _resolve_refs(self, state: &mut ResolveRefState) -> Option<T::Output> {
+    fn _resolve_refs(self, state: &mut ResolveRefState) -> Result<T::Output, TypeRefError> {
         T::resolve_refs(self, state)
     }
 }


### PR DESCRIPTION
# Description of Changes

This allows constructing better errors during module validation.

# API and ABI breaking changes

This is an API break. 

# Expected complexity level and risk

0

# Testing

CI