### PR TITLE
Make `schema` crate publishable

### DIFF
--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -2,6 +2,8 @@
 name = "spacetimedb-schema"
 version.workspace = true
 edition.workspace = true
+license-file = "LICENSE"
+description = "Schema library for SpacetimeDB"
 rust-version.workspace = true
 
 [dependencies]

--- a/tools/publish-crates.sh
+++ b/tools/publish-crates.sh
@@ -23,7 +23,7 @@ if [ $DRY_RUN != 1 ] ; then
 fi
 
 BASEDIR=$(pwd)
-declare -a CRATES=("metrics" "primitives" "bindings-macro" "bindings-sys" "data-structures" "sats" "lib" "bindings" "table" "vm" "client-api-messages" "commitlog" "durability" "fs-utils" "snapshot" "core" "client-api" "standalone" "cli" "sdk")
+declare -a CRATES=("metrics" "primitives" "bindings-macro" "bindings-sys" "data-structures" "sats" "lib" "schema" "bindings" "table" "vm" "client-api-messages" "commitlog" "durability" "fs-utils" "snapshot" "core" "client-api" "standalone" "cli" "sdk")
 
 for crate in "${CRATES[@]}" ; do
 	if [ ! -d "${BASEDIR}/crates/${crate}" ] ; then


### PR DESCRIPTION
# Description of Changes

Some tiny tweaks to the `schema` crate that make it publish properly to crates.io in our release process.

# API and ABI breaking changes

Nah

# Expected complexity level and risk

1

# Testing

I ran `tools/publish-crates.sh` during the release process and it worked successfully (but not without these changes).