### PR TITLE
C#: disable verbose test output in console

### DIFF
--- a/crates/bindings-csharp/Codegen.Tests/TestInit.cs
+++ b/crates/bindings-csharp/Codegen.Tests/TestInit.cs
@@ -8,6 +8,7 @@ static class TestInit
     [ModuleInitializer]
     public static void Initialize()
     {
+        VerifierSettings.OmitContentFromException();
         // Default diff order is weird and causes new lines to look like deleted and old as inserted.
         Environment.SetEnvironmentVariable("DiffEngine_TargetOnLeft", "true");
         // Store snapshots in a separate directory.


### PR DESCRIPTION
# Description of Changes

Verify tests already open diff windows for any changes, and the dump of raw source file in the console only adds unnecessary noise instead of being helpful. Hence, disabling.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
