### PR TITLE
Bump version to 0.12.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -759,7 +759,7 @@ dependencies = [
 
 [[package]]
 name = "connect_disconnect_client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "spacetimedb-sdk",
@@ -4090,7 +4090,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "derive_more",
  "getrandom",
@@ -4106,7 +4106,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bench"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "anymap",
@@ -4144,7 +4144,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-macro"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bitflags 2.4.1",
  "humantime",
@@ -4156,14 +4156,14 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-sys"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "spacetimedb-primitives",
 ]
 
 [[package]]
 name = "spacetimedb-cli"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "base64 0.21.4",
@@ -4216,7 +4216,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4255,7 +4255,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api-messages"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bytes",
  "bytestring",
@@ -4276,7 +4276,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-commitlog"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bitflags 2.4.1",
  "crc32c",
@@ -4296,7 +4296,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-core"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4391,7 +4391,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-data-structures"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "hashbrown 0.14.1",
  "nohash-hasher",
@@ -4402,7 +4402,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-durability"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "log",
@@ -4414,7 +4414,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-fs-utils"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -4425,7 +4425,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-lib"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "bitflags 2.4.1",
@@ -4450,7 +4450,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-metrics"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "arrayvec",
  "itertools 0.12.0",
@@ -4460,7 +4460,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-primitives"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "bitflags 2.4.1",
  "either",
@@ -4478,7 +4478,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sats"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash 0.8.11",
  "arrayvec",
@@ -4508,7 +4508,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-schema"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "itertools 0.12.0",
  "spacetimedb-data-structures",
@@ -4519,7 +4519,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sdk"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "anymap",
@@ -4547,7 +4547,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-snapshot"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "blake3",
  "hex",
@@ -4563,7 +4563,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-standalone"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4593,7 +4593,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-table"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "ahash 0.8.11",
  "blake3",
@@ -4617,7 +4617,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-testing"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "clap 4.4.6",
@@ -4642,7 +4642,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-vm"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4732,7 +4732,7 @@ dependencies = [
 
 [[package]]
 name = "sqltest"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5005,7 +5005,7 @@ dependencies = [
 
 [[package]]
 name = "test-client"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -5016,7 +5016,7 @@ dependencies = [
 
 [[package]]
 name = "test-counter"
-version = "0.11.0"
+version = "0.12.0"
 dependencies = [
  "anyhow",
  "spacetimedb-data-structures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -78,32 +78,32 @@ inherits = "release"
 debug = true
 
 [workspace.package]
-version = "0.11.0"
+version = "0.12.0"
 edition = "2021"
 # update rust-toolchain.toml too!
 rust-version = "1.78.0"
 
 [workspace.dependencies]
-spacetimedb = { path = "crates/bindings", version = "0.11.0" }
-spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "0.11.0" }
-spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "0.11.0" }
-spacetimedb-cli = { path = "crates/cli", version = "0.11.0" }
-spacetimedb-client-api = { path = "crates/client-api", version = "0.11.0" }
-spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "0.11.0" }
-spacetimedb-commitlog = { path = "crates/commitlog", version = "0.11.0" }
-spacetimedb-core = { path = "crates/core", version = "0.11.0" }
-spacetimedb-data-structures = { path = "crates/data-structures", version = "0.11.0" }
-spacetimedb-durability = { path = "crates/durability", version = "0.11.0" }
-spacetimedb-lib = { path = "crates/lib", default-features = false, version = "0.11.0" }
-spacetimedb-metrics = { path = "crates/metrics", version = "0.11.0" }
-spacetimedb-primitives = { path = "crates/primitives", version = "0.11.0" }
-spacetimedb-sats = { path = "crates/sats", version = "0.11.0" }
-spacetimedb-schema = { path = "crates/schema", version = "0.11.0" }
-spacetimedb-standalone = { path = "crates/standalone", version = "0.11.0" }
-spacetimedb-table = { path = "crates/table", version = "0.11.0" }
-spacetimedb-vm = { path = "crates/vm", version = "0.11.0" }
-spacetimedb-fs-utils = { path = "crates/fs-utils", version = "0.11.0" }
-spacetimedb-snapshot = { path = "crates/snapshot", version = "0.11.0" }
+spacetimedb = { path = "crates/bindings", version = "0.12.0" }
+spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "0.12.0" }
+spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "0.12.0" }
+spacetimedb-cli = { path = "crates/cli", version = "0.12.0" }
+spacetimedb-client-api = { path = "crates/client-api", version = "0.12.0" }
+spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "0.12.0" }
+spacetimedb-commitlog = { path = "crates/commitlog", version = "0.12.0" }
+spacetimedb-core = { path = "crates/core", version = "0.12.0" }
+spacetimedb-data-structures = { path = "crates/data-structures", version = "0.12.0" }
+spacetimedb-durability = { path = "crates/durability", version = "0.12.0" }
+spacetimedb-lib = { path = "crates/lib", default-features = false, version = "0.12.0" }
+spacetimedb-metrics = { path = "crates/metrics", version = "0.12.0" }
+spacetimedb-primitives = { path = "crates/primitives", version = "0.12.0" }
+spacetimedb-sats = { path = "crates/sats", version = "0.12.0" }
+spacetimedb-schema = { path = "crates/schema", version = "0.12.0" }
+spacetimedb-standalone = { path = "crates/standalone", version = "0.12.0" }
+spacetimedb-table = { path = "crates/table", version = "0.12.0" }
+spacetimedb-vm = { path = "crates/vm", version = "0.12.0" }
+spacetimedb-fs-utils = { path = "crates/fs-utils", version = "0.12.0" }
+spacetimedb-snapshot = { path = "crates/snapshot", version = "0.12.0" }
 
 ahash = "0.8"
 anyhow = "1.0.68"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Clockwork Laboratories, Inc.
-Licensed Work:        SpacetimeDB 0.11.0
+Licensed Work:        SpacetimeDB 0.12.0
                       The Licensed Work is
                       (c) 2023 Clockwork Laboratories, Inc.
                       

--- a/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
+++ b/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Codegen</AssemblyName>
-    <Version>0.11.0</Version>
+    <Version>0.12.0</Version>
     <Title>SpacetimeDB BSATN Codegen</Title>
     <Description>The SpacetimeDB BSATN Codegen implements the Roslyn incremental generators for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Runtime</AssemblyName>
-    <Version>0.11.0</Version>
+    <Version>0.12.0</Version>
     <Title>SpacetimeDB BSATN Runtime</Title>
     <Description>The SpacetimeDB BSATN Runtime implements APIs for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Codegen</AssemblyName>
-    <Version>0.11.0</Version>
+    <Version>0.12.0</Version>
     <Title>SpacetimeDB Module Codegen</Title>
     <Description>The SpacetimeDB Codegen implements the Roslyn incremental generators for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Runtime/Runtime.csproj
+++ b/crates/bindings-csharp/Runtime/Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Runtime</AssemblyName>
-    <Version>0.11.0</Version>
+    <Version>0.12.0</Version>
     <Title>SpacetimeDB Module Runtime</Title>
     <Description>The SpacetimeDB Runtime implements the database runtime bindings for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/cli/src/subcommands/project/rust/Cargo._toml
+++ b/crates/cli/src/subcommands/project/rust/Cargo._toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "0.11.0"
+spacetimedb = "0.12.0"
 log = "0.4"


### PR DESCRIPTION
# Description of Changes

Bump version to 0.12.0, in SpacetimeDB as well as the C# packages. (API/ABI-breaking changes have merged in SpacetimeDB itself, as well as in the C# portion of the repo: https://github.com/clockworklabs/SpacetimeDB/pull/1559).

# API and ABI breaking changes

No, this mainly "tracks" the existing breakage.

# Expected complexity level and risk

1

# Testing

Literally none. Well, we have CI.