### PR TITLE
[CI] Do not use branch names when publishing container images

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,7 +25,6 @@ jobs:
           images: |
             clockworklabs/spacetimedb
           tags: |
-            type=ref,event=branch,prefix=branch-
             type=sha,prefix=commit-
             type=ref,event=tag
             type=sha,suffix=-amd64
@@ -86,7 +85,6 @@ jobs:
           images: |
             clockworklabs/spacetimedb
           tags: |
-            type=ref,event=branch,prefix=branch-
             type=sha,prefix=commit-
             type=ref,event=tag
             type=sha,suffix=-arm64

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -25,9 +25,8 @@ jobs:
           images: |
             clockworklabs/spacetimedb
           tags: |
-            type=sha,prefix=commit-
             type=ref,event=tag
-            type=sha,suffix=-amd64
+            type=sha,prefix=commit-,suffix=-amd64
           flavor: |
             latest=false
       - name: Set up Docker Buildx
@@ -85,9 +84,8 @@ jobs:
           images: |
             clockworklabs/spacetimedb
           tags: |
-            type=sha,prefix=commit-
             type=ref,event=tag
-            type=sha,suffix=-arm64
+            type=sha,prefix=commit-,suffix=-arm64
           flavor: |
             latest=false
       - name: Set up Docker Buildx

--- a/tools/merge-docker-images.sh
+++ b/tools/merge-docker-images.sh
@@ -3,14 +3,14 @@ set -e
 
 # Shorten the first argument (commit sha) to 7 chars
 SHORT_SHA=${1:0:7}
-TAG="sha-$SHORT_SHA"
+TAG="commit-$SHORT_SHA"
 
 # Check if images for both amd64 and arm64 exist
 if docker pull clockworklabs/spacetimedb:$TAG-amd64 --platform amd64 >/dev/null 2>&1 && docker pull clockworklabs/spacetimedb:$TAG-arm64 --platform arm64 >/dev/null 2>&1; then
-    echo "Both images exist, preparing the merged manifest"
+  echo "Both images exist, preparing the merged manifest"
 else
-    echo "One or both images do not exist. Exiting"
-    exit 0
+  echo "One or both images do not exist. Exiting"
+  exit 0
 fi
 
 # Extract digests
@@ -36,4 +36,3 @@ docker manifest push clockworklabs/spacetimedb:$FULL_TAG
 # re-tag the manifeast with a tag
 VERSION=${GITHUB_REF#refs/*/}
 docker buildx imagetools create clockworklabs/spacetimedb:$FULL_TAG --tag clockworklabs/spacetimedb:$VERSION
-


### PR DESCRIPTION
# Description of Changes

Removes the creation of Docker Container Images with branch names as tags.

**AMD/Intel Image Build**
<img width="786" alt="Screenshot 2024-08-13 at 12 57 01 PM" src="https://github.com/user-attachments/assets/534f1b10-357d-4759-99cb-a2009dbc715e">

**ARM Image Build**
<img width="887" alt="Screenshot 2024-08-13 at 1 00 10 PM" src="https://github.com/user-attachments/assets/6f3d3fa5-fc6b-40ed-9144-3dedf6951005">


**Both images merged into a multi-platform image**
<img width="899" alt="Screenshot 2024-08-13 at 1 01 28 PM" src="https://github.com/user-attachments/assets/a46cfe31-a625-4891-a503-a1fff50b5504">

**The created images in Dockerhub**
<img width="855" alt="Screenshot 2024-08-13 at 1 02 35 PM" src="https://github.com/user-attachments/assets/b443b04e-0a11-43cd-87ca-eb31377cbd60">

Side Note: It is much nicer to cross-reference related/identical images in Github's Artifact Repository than it is in Dockerhub. Perhaps we should consider only using Dockerhub for `spacetimedb:latest` and tagged releases?


# API and ABI breaking changes

n/a

# Expected complexity level and risk

1

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

n/a

# Testing

- See the included screenshots. I created tags which matched the blob pattern `v*` and verified that the tag names are correct by looking at the CI output and cross-referencing DockerHub.
