### PR TITLE
Add `try_from_iter` to `ColList` & fix bug in `ColListBuilder`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4464,6 +4464,7 @@ version = "0.12.0"
 dependencies = [
  "bitflags 2.4.1",
  "either",
+ "itertools 0.12.0",
  "nohash-hasher",
  "proptest",
 ]

--- a/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
+++ b/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
@@ -37,6 +37,8 @@ spacetimedb
 │   ├── spacetimedb_primitives
 │   │   ├── bitflags
 │   │   ├── either
+│   │   ├── itertools
+│   │   │   └── either
 │   │   └── nohash_hasher
 │   └── syn
 │       ├── proc_macro2 (*)
@@ -54,8 +56,7 @@ spacetimedb
 │   │   ├── quote (*)
 │   │   └── syn (*)
 │   ├── hex
-│   ├── itertools
-│   │   └── either
+│   ├── itertools (*)
 │   ├── spacetimedb_bindings_macro (*)
 │   ├── spacetimedb_data_structures
 │   │   ├── hashbrown

--- a/crates/primitives/Cargo.toml
+++ b/crates/primitives/Cargo.toml
@@ -9,6 +9,7 @@ description = "Primitives such as TableId and ColumnIndexAttribute"
 bitflags.workspace = true
 either.workspace = true
 nohash-hasher.workspace = true
+itertools.workspace = true
 
 [dev-dependencies]
 proptest.workspace = true

--- a/crates/primitives/src/col_list.rs
+++ b/crates/primitives/src/col_list.rs
@@ -67,7 +67,9 @@ impl ColListBuilder {
 
     /// Build the [`ColList`] or error if it would have been empty.
     pub fn build(self) -> Result<ColList, EmptyColListError> {
-        if self.list.is_empty() {
+        // we cannot use `self.list.is_empty()` as it's always false.
+        #[allow(clippy::len_zero)]
+        if self.list.len() == 0 {
             Err(EmptyColListError)
         } else {
             Ok(self.list)
@@ -644,6 +646,10 @@ mod tests {
 
     #[test]
     fn try_from_iter() {
+        for i in 0..0 {
+            println!("i: {}", i);
+        }
+        println!("{:?}", ColList::try_from_iter(0..0));
         assert!(ColList::try_from_iter(0..0).is_err());
         assert!(ColList::try_from_iter(0..5).is_ok());
         assert!(ColList::try_from_iter([4, 3, 2, 1, 0]).is_ok());

--- a/crates/primitives/src/col_list.rs
+++ b/crates/primitives/src/col_list.rs
@@ -641,4 +641,11 @@ mod tests {
             prop_assert_eq!(list.iter().collect::<Vec<_>>(), cols);
         }
     }
+
+    #[test]
+    fn try_from_iter() {
+        assert!(ColList::try_from_iter(0..0).is_err());
+        assert!(ColList::try_from_iter(0..5).is_ok());
+        assert!(ColList::try_from_iter([4, 3, 2, 1, 0]).is_ok());
+    }
 }

--- a/crates/primitives/src/col_list.rs
+++ b/crates/primitives/src/col_list.rs
@@ -16,6 +16,7 @@ use core::{
     slice::from_raw_parts,
 };
 use either::Either;
+use itertools::Itertools;
 
 /// Constructs a `ColList` like so `col_list![0, 2]`.
 ///
@@ -230,6 +231,13 @@ impl ColList {
     /// If `col >= 63` or `col <= last_col`, the list will become heap allocated if not already.
     pub fn push(&mut self, col: ColId) {
         self.push_inner(col, self.last() < col);
+    }
+
+    /// Try to create a `ColList` from an iterator.
+    ///
+    /// Fails if the iterator is empty.
+    pub fn try_from_iter<Id: Into<ColId>>(iter: impl IntoIterator<Item = Id>) -> Result<Self, EmptyColListError> {
+        iter.into_iter().map_into().collect::<ColListBuilder>().build()
     }
 
     /// Push `col` onto the list.

--- a/crates/primitives/src/col_list.rs
+++ b/crates/primitives/src/col_list.rs
@@ -646,10 +646,6 @@ mod tests {
 
     #[test]
     fn try_from_iter() {
-        for i in 0..0 {
-            println!("i: {}", i);
-        }
-        println!("{:?}", ColList::try_from_iter(0..0));
         assert!(ColList::try_from_iter(0..0).is_err());
         assert!(ColList::try_from_iter(0..5).is_ok());
         assert!(ColList::try_from_iter([4, 3, 2, 1, 0]).is_ok());

--- a/crates/sats/src/product_type.rs
+++ b/crates/sats/src/product_type.rs
@@ -1,3 +1,6 @@
+use itertools::Itertools;
+use spacetimedb_primitives::ColId;
+
 use crate::algebraic_value::de::{ValueDeserializeError, ValueDeserializer};
 use crate::algebraic_value::ser::value_serialize;
 use crate::meta_type::MetaType;
@@ -87,6 +90,17 @@ impl ProductType {
         self.elements
             .iter()
             .position(|field| field.name.as_deref() == Some(name))
+    }
+
+    /// Get IDs of elements of this product type.
+    pub fn get_element_ids(&self) -> impl Iterator<Item = ColId> + '_ {
+        // note that we don't return a `ColList` here because `ColList` is supposed to be nonempty.
+        (0..self.elements.len()).map_into()
+    }
+
+    /// Get a column of this `ProductType` by `ColId`.
+    pub fn get_element(&self, col_id: impl Into<ColId>) -> Option<&ProductTypeElement> {
+        self.elements.get(col_id.into().idx())
     }
 }
 

--- a/crates/sats/src/product_type.rs
+++ b/crates/sats/src/product_type.rs
@@ -1,6 +1,3 @@
-use itertools::Itertools;
-use spacetimedb_primitives::ColId;
-
 use crate::algebraic_value::de::{ValueDeserializeError, ValueDeserializer};
 use crate::algebraic_value::ser::value_serialize;
 use crate::meta_type::MetaType;
@@ -90,17 +87,6 @@ impl ProductType {
         self.elements
             .iter()
             .position(|field| field.name.as_deref() == Some(name))
-    }
-
-    /// Get IDs of elements of this product type.
-    pub fn get_element_ids(&self) -> impl Iterator<Item = ColId> + '_ {
-        // note that we don't return a `ColList` here because `ColList` is supposed to be nonempty.
-        (0..self.elements.len()).map_into()
-    }
-
-    /// Get a column of this `ProductType` by `ColId`.
-    pub fn get_element(&self, col_id: impl Into<ColId>) -> Option<&ProductTypeElement> {
-        self.elements.get(col_id.into().idx())
     }
 }
 


### PR DESCRIPTION
# Description of Changes

I originally had some `ColId`-related methods added to `ProductType` as well, but then I decided that `sats` really shouldn't care about database notions like Column IDs. So this only adds a single `ColList` method. I also found a bug! `ColListBuilder` was using `is_empty` to check if it should error, but `is_empty` always returns `false`.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

0

This does add `itertools` as a dependency of `primitives`, unfortunately.

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
