### PR TITLE
Allow empty `ColList`

### DIFF
--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -396,13 +396,8 @@ pub fn register_table<T: TableType>() {
 
 impl From<crate::IndexDesc<'_>> for RawIndexDefV8 {
     fn from(index: crate::IndexDesc<'_>) -> RawIndexDefV8 {
-        let Ok(columns) = index
-            .col_ids
-            .iter()
-            .map(|x| (*x).into())
-            .collect::<ColListBuilder>()
-            .build()
-        else {
+        let columns = index.col_ids.iter().copied().collect::<ColList>();
+        if columns.is_empty() {
             panic!("Need at least one column in IndexDesc for index `{}`", index.name);
         };
 

--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -598,11 +598,7 @@ fn to_cols(row: RowRef<'_>, col_pos: impl Into<ColId>, col_name: &'static str) -
     let name = Some(col_name);
     let cols = row.read_col(col_pos)?;
     if let ArrayValue::U32(x) = &cols {
-        Ok(x.iter()
-            .map(|x| ColId::from(*x))
-            .collect::<ColListBuilder>()
-            .build()
-            .expect("empty ColList"))
+        Ok(x.iter().copied().collect::<ColList>())
     } else {
         Err(InvalidFieldError { name, col_pos }.into())
     }

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1474,16 +1474,7 @@ mod tests {
     }
 
     fn index(name: &str, cols: &[u32]) -> RawIndexDefV8 {
-        RawIndexDefV8::btree(
-            name.into(),
-            cols.iter()
-                .copied()
-                .map(ColId)
-                .collect::<ColListBuilder>()
-                .build()
-                .unwrap(),
-            false,
-        )
+        RawIndexDefV8::btree(name.into(), cols.iter().copied().map(ColId).collect::<ColList>(), false)
     }
 
     fn table(

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -17,7 +17,7 @@ use spacetimedb_lib::filter::CmpArgs;
 use spacetimedb_lib::operator::OpQuery;
 use spacetimedb_lib::relation::FieldName;
 use spacetimedb_lib::ProductValue;
-use spacetimedb_primitives::{ColId, ColListBuilder, TableId};
+use spacetimedb_primitives::{ColId, ColList, TableId};
 use spacetimedb_sats::Typespace;
 use spacetimedb_vm::expr::{FieldExpr, FieldOp, NoInMemUsed, QueryExpr};
 
@@ -234,12 +234,7 @@ impl InstanceEnv {
             }
         };
 
-        let columns = col_ids
-            .into_iter()
-            .map(Into::into)
-            .collect::<ColListBuilder>()
-            .build()
-            .expect("Attempt to create an index with zero columns");
+        let columns = col_ids.into_iter().collect::<ColList>();
 
         let is_unique = stdb.column_constraints(tx, table_id, &columns)?.has_unique();
 

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -137,9 +137,9 @@ pub fn build_query<'a>(
                     // because this patch was written (2024-04-01 pgoldman) a short time before the BitCraft alpha,
                     // and a more invasive change was infeasible.
                     Box::new(EmptyRelOps) as Box<IterRows<'a>>
-                } else if cols.is_singleton() {
+                } else if let Some(head) = cols.as_singleton() {
                     // For singleton constraints, we compare the column directly against `bounds`.
-                    let head = cols.head().idx();
+                    let head = head.idx();
                     let iter = result.select(move |row| bounds.contains(&*row.read_column(head).unwrap()));
                     Box::new(iter) as Box<IterRows<'a>>
                 } else {

--- a/crates/lib/src/db/raw_def/v8.rs
+++ b/crates/lib/src/db/raw_def/v8.rs
@@ -467,7 +467,7 @@ impl RawTableDefV8 {
             // We are only interested in constraints implying a sequence.
             .filter(|x| x.constraints.has_autoinc())
             // Create the `SequenceDef`.
-            .map(|x| RawSequenceDefV8::for_column(&self.table_name, &x.constraint_name, x.columns.head()))
+            .map(|x| RawSequenceDefV8::for_column(&self.table_name, &x.constraint_name, x.columns.head().unwrap()))
             // Only keep those we don't yet have in the list of sequences (checked by name).
             .filter(|seq| self.sequences.iter().all(|x| x.sequence_name != seq.sequence_name))
     }

--- a/crates/primitives/src/lib.rs
+++ b/crates/primitives/src/lib.rs
@@ -6,7 +6,7 @@ pub mod errno;
 mod ids;
 
 pub use attr::{AttributeKind, ColumnAttribute, ConstraintKind, Constraints};
-pub use col_list::{ColList, ColListBuilder};
+pub use col_list::ColList;
 pub use ids::{ColId, ConstraintId, IndexId, SequenceId, TableId};
 
 /// The minimum size of a chunk yielded by a wasm abi RowIter.

--- a/crates/sats/src/product_value.rs
+++ b/crates/sats/src/product_value.rs
@@ -110,16 +110,15 @@ impl ProductValue {
     /// **Important:**
     ///
     /// The resulting [AlgebraicValue] will wrap into a [ProductValue] when projecting multiple
-    /// fields, otherwise it will consist of a single [AlgebraicValue].
+    /// (including zero) fields, otherwise it will consist of a single [AlgebraicValue].
     ///
     /// **Parameters:**
     /// - `cols`: A [ColList] containing the indexes of fields to be projected.s
     pub fn project_not_empty(&self, cols: &ColList) -> Result<AlgebraicValue, InvalidFieldError> {
-        let proj_len = cols.len();
-        if proj_len == 1 {
-            self.get_field(cols.head().idx(), None).cloned()
+        if let Some(head) = cols.as_singleton() {
+            self.get_field(head.idx(), None).cloned()
         } else {
-            let mut fields = Vec::with_capacity(proj_len as usize);
+            let mut fields = Vec::with_capacity(cols.len() as usize);
             for col in cols.iter() {
                 fields.push(self.get_field(col.idx(), None)?.clone());
             }


### PR DESCRIPTION
# Description of Changes

Fix the bug found in https://github.com/clockworklabs/SpacetimeDB/pull/1585 by allowing `ColList`s to be empty, as we actually try to use the type as a possibly-empty list in some places (which is why the tests failed in #1585).

# API and ABI breaking changes

None

# Expected complexity level and risk

2, some unsafe related code affected, but there's less unsafe code now.

# Testing

- [x] Tests were extended to test the empty aspect and the new functionality.
- [x] All the ColList proptests were run in miri.