### PR TITLE
Fix builds for MacOS amd64 platform

### DIFF
--- a/.github/workflows/macos-build.yml
+++ b/.github/workflows/macos-build.yml
@@ -16,21 +16,25 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v3
 
-      - name: Add aarch64 target
+      - name: Add cross-platform targets
         run: |
           rustup target add aarch64-apple-darwin
+          rustup target add x86_64-apple-darwin
 
       - name: Compile x86
         run: |
-          cargo build --release -p spacetimedb-cli
+          cargo build --release -p spacetimedb-cli --target x86_64-apple-darwin
           mkdir build
-          dd if=target/release/spacetime of=build/spacetime conv=noerror,sync  
+          file target/x86_64-apple-darwin/release/spacetime
+          dd if=target/x86_64-apple-darwin/release/spacetime of=build/spacetime conv=noerror,sync
+          chmod +x build/spacetime
           cd build && tar -czf spacetime.darwin-amd64.tar.gz spacetime
           rm spacetime
 
       - name: Compile Aarch64
         run: |
           cargo build --release -p spacetimedb-cli --target=aarch64-apple-darwin
+          file target/aarch64-apple-darwin/release/spacetime
           # dd is used to avoid incompatibilities between BSD tar vs. GNU tar
           dd if=target/aarch64-apple-darwin/release/spacetime of=build/spacetime conv=noerror,sync
           chmod +x build/spacetime


### PR DESCRIPTION
# Description of Changes

The builds for Intel Mac are actually targeting Apple Silicon (arm64). I believe this is due to a change in Github's MacOS runner's newer generations.

The change here explicitly targets the Intel architecture.

# API and ABI breaking changes

n/a

# Expected complexity level and risk

1 - If it doesn't work, CI should fail and we'll know about it before any harm is done.

# Testing

- [x] Run it and verify that it produces a binary for the correct architeceture now

Build Log from this branch: https://github.com/clockworklabs/SpacetimeDB/actions/runs/10423008363

Local output testing that the files were built for the correct platforms:
```bash
kurtis@mbp fix-mac-on-intel-builds % ls
spacetime.darwin-amd64.tar.gz spacetime.darwin-arm64.tar.gz
kurtis@mbp fix-mac-on-intel-builds % tar xzvf spacetime.darwin-amd64.tar.gz
x spacetime
kurtis@mbp fix-mac-on-intel-builds % ls
spacetime                     spacetime.darwin-amd64.tar.gz spacetime.darwin-arm64.tar.gz
kurtis@mbp fix-mac-on-intel-builds % file spacetime
spacetime: Mach-O 64-bit executable x86_64
kurtis@mbp fix-mac-on-intel-builds % mv spacetime spacetime_x86_64
kurtis@mbp fix-mac-on-intel-builds % tar xzvf spacetime.darwin-arm64.tar.gz
x spacetime
kurtis@mbp fix-mac-on-intel-builds % file spacetime
spacetime: Mach-O 64-bit executable arm64
kurtis@mbp fix-mac-on-intel-builds % mv spacetime spacetime_arm64
kurtis@mbp fix-mac-on-intel-builds % ls
spacetime.darwin-amd64.tar.gz spacetime.darwin-arm64.tar.gz spacetime_arm64               spacetime_x86_64
kurtis@mbp fix-mac-on-intel-builds % file spacetime_x86_64 spacetime_arm64
spacetime_x86_64: Mach-O 64-bit executable x86_64
spacetime_arm64:  Mach-O 64-bit executable arm64
```
