### PR TITLE
[WASM ABI 1.0] impl `__call_reducer__` using `bytes_source_read`

### DIFF
--- a/crates/bindings-csharp/Runtime/Exceptions.cs
+++ b/crates/bindings-csharp/Runtime/Exceptions.cs
@@ -27,6 +27,11 @@ public class BufferTooSmallException : StdbException
     public override string Message => "The provided buffer is not large enough to store the data";
 }
 
+public class NoSuchBytesException : StdbException
+{
+    public override string Message => "The provided bytes source or sink does not exist";
+}
+
 public class UnknownException : StdbException
 {
     private readonly FFI.CheckedStatus.Errno code;

--- a/crates/bindings-csharp/Runtime/bindings.c
+++ b/crates/bindings-csharp/Runtime/bindings.c
@@ -19,6 +19,7 @@ OPAQUE_TYPEDEF(ColId, uint16_t);
 OPAQUE_TYPEDEF(IndexType, uint8_t);
 OPAQUE_TYPEDEF(LogLevel, uint8_t);
 OPAQUE_TYPEDEF(Buffer, uint32_t);
+OPAQUE_TYPEDEF(BytesSource, uint32_t);
 OPAQUE_TYPEDEF(RowIter, uint32_t);
 
 #define CSTR(s) (uint8_t*)s, sizeof(s) - 1
@@ -68,9 +69,8 @@ IMPORT(Status, _iter_advance,
        (RowIter iter, uint8_t* buffer, size_t* buffer_len),
        (iter, buffer, buffer_len));
 IMPORT(void, _iter_drop, (RowIter iter), (iter));
-IMPORT(uint32_t, _buffer_len, (Buffer buf), (buf));
-IMPORT(void, _buffer_consume, (Buffer buf, uint8_t* dst, uint32_t dst_len),
-       (buf, dst, dst_len));
+IMPORT(int16_t, _bytes_source_read, (BytesSource source, uint8_t* buffer_ptr, size_t* buffer_len_ptr),
+       (source, buffer_ptr, buffer_len_ptr));
 IMPORT(Buffer, _buffer_alloc, (const uint8_t* data, uint32_t len), (data, len));
 
 #ifndef EXPERIMENTAL_WASM_AOT

--- a/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
+++ b/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
@@ -14,8 +14,7 @@
     <WasmImport Include="$(SpacetimeNamespace)!_iter_start_filtered" />
     <WasmImport Include="$(SpacetimeNamespace)!_iter_next" />
     <WasmImport Include="$(SpacetimeNamespace)!_iter_drop" />
-    <WasmImport Include="$(SpacetimeNamespace)!_buffer_len" />
-    <WasmImport Include="$(SpacetimeNamespace)!_buffer_consume" />
+    <WasmImport Include="$(SpacetimeNamespace)!_bytes_source_read" />
     <WasmImport Include="$(SpacetimeNamespace)!_buffer_alloc" />
 
     <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="8.0.0-*" />

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -141,9 +141,10 @@ fn from_json_seed<'de, T: serde::de::DeserializeSeed<'de>>(s: &'de str, seed: T)
 /// Tags for each call that a `WasmInstanceEnv` can make.
 #[derive(Debug, Display, Enum, Clone, Copy, strum::AsRefStr)]
 pub enum AbiCall {
+    BytesSourceRead,
+
     CancelReducer,
     ConsoleLog,
-    CreateIndex,
     DeleteByColEq,
     DeleteByRel,
     GetTableId,

--- a/crates/core/src/host/wasm_common.rs
+++ b/crates/core/src/host/wasm_common.rs
@@ -287,10 +287,6 @@ impl<I: ResourceIndex> ResourceSlab<I> {
         I::from_u32(idx)
     }
 
-    pub fn get(&self, handle: I) -> Option<&I::Resource> {
-        self.slab.get(handle.to_u32() as usize)
-    }
-
     pub fn get_mut(&mut self, handle: I) -> Option<&mut I::Resource> {
         self.slab.get_mut(handle.to_u32() as usize)
     }
@@ -365,8 +361,7 @@ macro_rules! abi_funcs {
     ($mac:ident) => {
         $mac! {
             "spacetime_10.0"::buffer_alloc,
-            "spacetime_10.0"::buffer_consume,
-            "spacetime_10.0"::buffer_len,
+            "spacetime_10.0"::bytes_source_read,
             "spacetime_10.0"::console_log,
             "spacetime_10.0"::delete_by_col_eq,
             "spacetime_10.0"::delete_by_rel,

--- a/crates/primitives/src/errno.rs
+++ b/crates/primitives/src/errno.rs
@@ -12,6 +12,7 @@ macro_rules! errnos {
             LOOKUP_NOT_FOUND(2, "Value or range provided not found in table"),
             UNIQUE_ALREADY_EXISTS(3, "Value with given unique identifier already exists"),
             BUFFER_TOO_SMALL(4, "The provided buffer is not large enough to store the data"),
+            NO_SUCH_BYTES(8, "The provided bytes source or sink is not valid"),
         );
     };
 }


### PR DESCRIPTION
# Description of Changes

This adds `_bytes_source_read` and implements `__call_reducer__` with it.
Meanwhile, `_buffer_len` and `_buffer_consume` are removed.

cc https://github.com/clockworklabs/SpacetimeDB/issues/1460