### PR TITLE
Placate some clippy errors in `snapshot`

### DIFF
--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -21,6 +21,8 @@
 //! - Transforming a [`ReconstructedSnapshot`] into a live Spacetime datastore.
 // TODO(docs): consider making the snapshot proposal public and either linking or pasting it here.
 
+#![allow(clippy::result_large_err)]
+
 use spacetimedb_durability::TxOffset;
 use spacetimedb_fs_utils::{
     dir_trie::{o_excl, o_rdonly, CountCreated, DirTrie},


### PR DESCRIPTION
# Description of Changes

I was getting errors with 
```sh
$ cargo clippy --version
clippy 0.1.78 (9b00956e 2024-04-29)
```
on windows, this fixed them.

# Expected complexity level and risk

0
