### PR TITLE
fix: Correctly label transactions as committed

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -760,7 +760,7 @@ impl MutTxId {
             ctx,
             self.timer,
             self.lock_wait_time,
-            false,
+            true,
             Some(&tx_data),
             Some(&committed_state_write_lock),
         );
@@ -780,7 +780,7 @@ impl MutTxId {
             ctx,
             self.timer,
             self.lock_wait_time,
-            false,
+            true,
             Some(&tx_data),
             Some(&committed_state_write_lock),
         );


### PR DESCRIPTION
# Description of Changes

Committed transactions were being labeled as rollbacks.

# API and ABI breaking changes

None

# Expected complexity level and risk

1
