### PR TITLE
 [WASM ABI 1.0] impl `__call_reducer__` & `__describe_module__` using `bytes_sink_write`

### DIFF
--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#FFI.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#FFI.verified.cs
@@ -138,11 +138,11 @@ static class ModuleRegistration
     // Exports only work from the main assembly, so we need to generate forwarding methods.
 #if EXPERIMENTAL_WASM_AOT
     [UnmanagedCallersOnly(EntryPoint = "__describe_module__")]
-    public static SpacetimeDB.Internal.Buffer __describe_module__() =>
-        SpacetimeDB.Internal.Module.__describe_module__();
+    public static void __describe_module__(SpacetimeDB.Internal.BytesSink d) =>
+        SpacetimeDB.Internal.Module.__describe_module__(d);
 
     [UnmanagedCallersOnly(EntryPoint = "__call_reducer__")]
-    public static SpacetimeDB.Internal.Buffer __call_reducer__(
+    public static short __call_reducer__(
         uint id,
         ulong sender_0,
         ulong sender_1,
@@ -151,7 +151,8 @@ static class ModuleRegistration
         ulong address_0,
         ulong address_1,
         SpacetimeDB.Internal.DateTimeOffsetRepr timestamp,
-        SpacetimeDB.Internal.Buffer args
+        SpacetimeDB.Internal.BytesSource args,
+        SpacetimeDB.Internal.BytesSink error
     ) =>
         SpacetimeDB.Internal.Module.__call_reducer__(
             id,
@@ -162,7 +163,8 @@ static class ModuleRegistration
             address_0,
             address_0,
             timestamp,
-            args
+            args,
+            error
         );
 #endif
 }

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -442,10 +442,10 @@ public class Module : IIncrementalGenerator
                     // Exports only work from the main assembly, so we need to generate forwarding methods.
                     #if EXPERIMENTAL_WASM_AOT
                         [UnmanagedCallersOnly(EntryPoint = "__describe_module__")]
-                        public static SpacetimeDB.Internal.Buffer __describe_module__() => SpacetimeDB.Internal.Module.__describe_module__();
+                        public static void __describe_module__(SpacetimeDB.Internal.BytesSink d) => SpacetimeDB.Internal.Module.__describe_module__(d);
 
                         [UnmanagedCallersOnly(EntryPoint = "__call_reducer__")]
-                        public static SpacetimeDB.Internal.Buffer __call_reducer__(
+                        public static short __call_reducer__(
                             uint id,
                             ulong sender_0,
                             ulong sender_1,
@@ -454,7 +454,8 @@ public class Module : IIncrementalGenerator
                             ulong address_0,
                             ulong address_1,
                             SpacetimeDB.Internal.DateTimeOffsetRepr timestamp,
-                            SpacetimeDB.Internal.Buffer args
+                            SpacetimeDB.Internal.BytesSource args,
+                            SpacetimeDB.Internal.BytesSink error
                         ) => SpacetimeDB.Internal.Module.__call_reducer__(
                             id,
                             sender_0,
@@ -464,7 +465,8 @@ public class Module : IIncrementalGenerator
                             address_0,
                             address_0,
                             timestamp,
-                            args
+                            args,
+                            error
                         );
                     #endif
                     }

--- a/crates/bindings-csharp/Runtime/Exceptions.cs
+++ b/crates/bindings-csharp/Runtime/Exceptions.cs
@@ -32,11 +32,16 @@ public class NoSuchBytesException : StdbException
     public override string Message => "The provided bytes source or sink does not exist";
 }
 
+public class NoSpaceException : StdbException
+{
+    public override string Message => "The provided bytes sink has no more room left";
+}
+
 public class UnknownException : StdbException
 {
-    private readonly FFI.CheckedStatus.Errno code;
+    private readonly FFI.Errno code;
 
-    internal UnknownException(FFI.CheckedStatus.Errno code) => this.code = code;
+    internal UnknownException(FFI.Errno code) => this.code = code;
 
     public override string Message => $"SpacetimeDB error code {code}";
 }

--- a/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
+++ b/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
@@ -15,7 +15,7 @@
     <WasmImport Include="$(SpacetimeNamespace)!_iter_next" />
     <WasmImport Include="$(SpacetimeNamespace)!_iter_drop" />
     <WasmImport Include="$(SpacetimeNamespace)!_bytes_source_read" />
-    <WasmImport Include="$(SpacetimeNamespace)!_buffer_alloc" />
+    <WasmImport Include="$(SpacetimeNamespace)!_bytes_sink_write" />
 
     <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="8.0.0-*" />
     <PackageReference Include="runtime.win-x64.Microsoft.DotNet.ILCompiler.LLVM" Version="8.0.0-*" />

--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -377,7 +377,7 @@ fn gen_reducer(original_function: ItemFn, reducer_name: &str) -> syn::Result<Tok
     let register_describer_symbol = format!("__preinit__20_register_describer_{reducer_name}");
 
     let generated_function = quote! {
-        fn __reducer(__ctx: spacetimedb::ReducerContext, __args: &[u8]) -> spacetimedb::sys::Buffer {
+        fn __reducer(__ctx: spacetimedb::ReducerContext, __args: &[u8]) -> spacetimedb::ReducerResult {
             #(spacetimedb::rt::assert_reducer_arg::<#arg_tys>();)*
             #(spacetimedb::rt::assert_reducer_ret::<#ret_ty>();)*
             spacetimedb::rt::invoke_reducer(#func_name, __ctx, __args)

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -47,6 +47,8 @@ pub use timestamp::Timestamp;
 
 pub type Result<T = (), E = Errno> = core::result::Result<T, E>;
 
+pub type ReducerResult = core::result::Result<(), Box<str>>;
+
 /// A context that any reducer is provided with.
 #[non_exhaustive]
 #[derive(Copy, Clone)]

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -15,7 +15,7 @@ mod host_controller;
 #[allow(clippy::too_many_arguments)]
 pub mod module_host;
 pub mod scheduler;
-mod wasmtime;
+pub mod wasmtime;
 // Visible for integration testing.
 pub mod instance_env;
 mod wasm_common;
@@ -142,6 +142,7 @@ fn from_json_seed<'de, T: serde::de::DeserializeSeed<'de>>(s: &'de str, seed: T)
 #[derive(Debug, Display, Enum, Clone, Copy, strum::AsRefStr)]
 pub enum AbiCall {
     BytesSourceRead,
+    BytesSinkWrite,
 
     CancelReducer,
     ConsoleLog,

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -50,7 +50,7 @@ pub trait WasmInstancePre: Send + Sync + 'static {
 }
 
 pub trait WasmInstance: Send + Sync + 'static {
-    fn extract_descriptions(&mut self) -> Result<Bytes, DescribeError>;
+    fn extract_descriptions(&mut self) -> Result<Vec<u8>, DescribeError>;
 
     fn instance_env(&self) -> &InstanceEnv;
 
@@ -121,8 +121,6 @@ pub enum DescribeError {
     Decode(#[from] DecodeError),
     #[error(transparent)]
     RuntimeError(anyhow::Error),
-    #[error("invalid buffer")]
-    BadBuffer,
     #[error("unimplemented RawModuleDef version")]
     UnimplementedRawModuleDefVersion,
 }

--- a/crates/primitives/src/errno.rs
+++ b/crates/primitives/src/errno.rs
@@ -8,11 +8,14 @@ use core::num::NonZeroU16;
 macro_rules! errnos {
     ($mac:ident) => {
         $mac!(
-            NO_SUCH_TABLE(1, "No such table"),
+            // TODO(1.0): remove this.
             LOOKUP_NOT_FOUND(2, "Value or range provided not found in table"),
-            UNIQUE_ALREADY_EXISTS(3, "Value with given unique identifier already exists"),
-            BUFFER_TOO_SMALL(4, "The provided buffer is not large enough to store the data"),
+            HOST_CALL_FAILURE(1, "ABI called by host returned an error"),
+            NO_SUCH_TABLE(4, "No such table"),
             NO_SUCH_BYTES(8, "The provided bytes source or sink is not valid"),
+            NO_SPACE(9, "The provided sink has no more space left"),
+            BUFFER_TOO_SMALL(11, "The provided buffer is not large enough to store the data"),
+            UNIQUE_ALREADY_EXISTS(12, "Value with given unique identifier already exists"),
         );
     };
 }


### PR DESCRIPTION
# Description of Changes

This adds `_bytes_sink_write` and implements `__call_reducer__`, `__describe_module__`, and `__setup__` with it.
Meanwhile, `_buffer_len`, `_buffer_consume`, and `_buffer_alloc` are fully removed this time around (some missing stuff from previous PR).

cc #1460 