### PR TITLE
Redefine Address as `U128` + `Identity` and Hash as `U256`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -202,7 +202,7 @@ scoped-tls = "1.0.1"
 scopeguard = "1.1.0"
 second-stack = "0.3"
 serde = { version = "1.0.136", features = ["derive"] }
-serde_json = { version = "1.0.87", features = ["raw_value"] }
+serde_json = { version = "1.0.128", features = ["raw_value", "arbitrary_precision"] }
 serde_path_to_error = "0.1.9"
 serde_with = { version = "3.3.0", features = ["base64", "hex"] }
 serial_test = "2.0.0"

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -16,7 +16,7 @@ mod tests {
         sqlite::SQLite,
         ResultBench,
     };
-    use std::{io, sync::Once};
+    use std::{io, path::Path, sync::Once};
     use tracing_subscriber::{layer::SubscriberExt, util::SubscriberInitExt};
 
     static INIT: Once = Once::new();
@@ -39,6 +39,15 @@ mod tests {
                 .with(fmt_layer)
                 .with(env_filter_layer)
                 .init();
+
+            // Remove cached data from previous runs.
+            // This directory is only reused to speed up runs with Callgrind. In tests, it's fine to wipe it.
+            let mut bench_dot_spacetime = Path::new(env!("CARGO_MANIFEST_DIR")).to_path_buf();
+            bench_dot_spacetime.push(".spacetime");
+            if std::fs::metadata(&bench_dot_spacetime).is_ok() {
+                std::fs::remove_dir_all(bench_dot_spacetime)
+                    .expect("failed to wipe Spacetimedb/crates/bench/.spacetime");
+            }
         });
     }
 

--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -430,7 +430,7 @@ extern "C" fn __describe_module__(description: BytesSink) {
 /// - `sender_3` contains bytes `[24..32]`.
 ///
 /// The `address_{0-1}` are the pieces of a `[u8; 16]` (`u128`) representing the callers's `Address`.
-/// They are encoded as follows (assuming `identity.__address_bytes: [u8; 16]`):
+/// They are encoded as follows (assuming `address.__address__: u128`):
 /// - `address_0` contains bytes `[0 ..8 ]`.
 /// - `address_1` contains bytes `[8 ..16]`.
 ///

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -99,6 +99,7 @@ fn reformat_update<'a>(
             let table_ty = schema.typespace.resolve(table_schema.product_type_ref);
 
             let reformat_row = |row: &str| -> anyhow::Result<Value> {
+                // TODO: can the following two calls be merged into a single call to reduce allocations?
                 let row = serde_json::from_str::<Value>(row)?;
                 let row = serde::de::DeserializeSeed::deserialize(SeedWrapper(table_ty), row)?;
                 let row = table_ty.with_value(&row);

--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -157,7 +157,7 @@ impl ToProtocol for TransactionUpdateMessage {
                 },
                 energy_quanta_used: event.energy_quanta_used,
                 host_execution_duration_micros: event.host_execution_duration.as_micros() as u64,
-                caller_address: event.caller_address.unwrap_or(Address::zero()),
+                caller_address: event.caller_address.unwrap_or(Address::ZERO),
             };
 
             ws::ServerMessage::TransactionUpdate(tx_update)

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -1058,7 +1058,7 @@ mod tests {
     }
 
     fn get_datastore() -> Result<Locking> {
-        Locking::bootstrap(Address::zero())
+        Locking::bootstrap(Address::ZERO)
     }
 
     fn col(col: u16) -> ColList {
@@ -1374,15 +1374,15 @@ mod tests {
             ColRow { table: ST_CONSTRAINT_ID.into(), pos: 2, name: "table_id", ty: TableId::get_type() },
             ColRow { table: ST_CONSTRAINT_ID.into(), pos: 3, name: "constraint_data", ty: resolved_type_via_v9::<StConstraintData>() },
 
-            ColRow { table: ST_MODULE_ID.into(), pos: 0, name: "database_address", ty: AlgebraicType::bytes() },
-            ColRow { table: ST_MODULE_ID.into(), pos: 1, name: "owner_identity", ty: AlgebraicType::bytes() },
+            ColRow { table: ST_MODULE_ID.into(), pos: 0, name: "database_address", ty: AlgebraicType::U128 },
+            ColRow { table: ST_MODULE_ID.into(), pos: 1, name: "owner_identity", ty: AlgebraicType::U256 },
             ColRow { table: ST_MODULE_ID.into(), pos: 2, name: "program_kind", ty: AlgebraicType::U8 },
-            ColRow { table: ST_MODULE_ID.into(), pos: 3, name: "program_hash", ty: AlgebraicType::bytes() },
+            ColRow { table: ST_MODULE_ID.into(), pos: 3, name: "program_hash", ty: AlgebraicType::U256 },
             ColRow { table: ST_MODULE_ID.into(), pos: 4, name: "program_bytes", ty: AlgebraicType::bytes() },
             ColRow { table: ST_MODULE_ID.into(), pos: 5, name: "module_version", ty: AlgebraicType::String },
 
-            ColRow { table: ST_CLIENT_ID.into(), pos: 0, name: "identity", ty: AlgebraicType::bytes()},
-            ColRow { table: ST_CLIENT_ID.into(), pos: 1, name: "address", ty: AlgebraicType::bytes()},
+            ColRow { table: ST_CLIENT_ID.into(), pos: 0, name: "identity", ty: AlgebraicType::U256},
+            ColRow { table: ST_CLIENT_ID.into(), pos: 1, name: "address", ty: AlgebraicType::U128},
 
             ColRow { table: ST_VAR_ID.into(), pos: 0, name: "name", ty: AlgebraicType::String },
             ColRow { table: ST_VAR_ID.into(), pos: 1, name: "value", ty: resolved_type_via_v9::<StVarValue>() },

--- a/crates/core/src/host/wasmtime/wasmtime_module.rs
+++ b/crates/core/src/host/wasmtime/wasmtime_module.rs
@@ -194,8 +194,8 @@ impl module_host_actor::WasmInstance for WasmtimeInstance {
         set_store_fuel(store, budget.into());
 
         // Prepare sender identity and address.
-        let [sender_0, sender_1, sender_2, sender_3] = bytemuck::must_cast(*op.caller_identity.as_bytes());
-        let [address_0, address_1] = bytemuck::must_cast(*op.caller_address.as_slice());
+        let [sender_0, sender_1, sender_2, sender_3] = bytemuck::must_cast(op.caller_identity.to_byte_array());
+        let [address_0, address_1] = bytemuck::must_cast(op.caller_address.as_byte_array());
 
         // Prepare arguments to the reducer + the error sink & start timings.
         let (args_source, errors_sink) = store.data_mut().start_reducer(op.name, op.arg_bytes);

--- a/crates/core/src/sql/type_check.rs
+++ b/crates/core/src/sql/type_check.rs
@@ -110,8 +110,10 @@ fn resolve_type(field: &FieldExpr, ty: AlgebraicType) -> Result<Option<Algebraic
     }
 
     if let (AlgebraicType::Product(_), FieldExpr::Value(val)) = (&ty, field) {
-        if val.as_bytes().is_some() {
-            return Ok(Some(AlgebraicType::bytes()));
+        match val {
+            AlgebraicValue::U128(_) => return Ok(Some(AlgebraicType::U128)),
+            AlgebraicValue::U256(_) => return Ok(Some(AlgebraicType::U256)),
+            _ => {}
         }
     }
     Ok(Some(ty))
@@ -147,7 +149,7 @@ fn check_both(op: OpQuery, lhs: &Typed, rhs: &Typed) -> Result<(), PlanError> {
 fn patch_type(lhs: &FieldOp, ty_lhs: &mut Typed, ty_rhs: &Typed) -> Result<(), PlanError> {
     if let FieldOp::Field(lhs_field) = lhs {
         if let Some(ty) = ty_rhs.ty() {
-            if ty.is_sum() || ty.as_product().map_or(false, |x| x.is_special()) {
+            if ty.is_sum() || ty.as_product().is_some_and(|x| x.is_special()) {
                 ty_lhs.set_ty(resolve_type(lhs_field, ty.clone())?);
             }
         }

--- a/crates/lib/proptest-regressions/address.txt
+++ b/crates/lib/proptest-regressions/address.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 4dc1661cd0b78ee7036f894d2c7cf52955f05e41bb0322095ec00edf9b6fca77 # shrinks to val = 18446744073709551616

--- a/crates/lib/src/identity.rs
+++ b/crates/lib/src/identity.rs
@@ -1,8 +1,8 @@
 use crate::from_hex_pad;
+use core::mem;
 use spacetimedb_bindings_macro::{Deserialize, Serialize};
 use spacetimedb_sats::hex::HexString;
-use spacetimedb_sats::product_type::IDENTITY_TAG;
-use spacetimedb_sats::{hash, impl_st, AlgebraicType, AlgebraicValue, ProductValue};
+use spacetimedb_sats::{hash, impl_st, u256, AlgebraicType, AlgebraicValue};
 use std::{fmt, str::FromStr};
 
 pub type RequestId = u32;
@@ -35,10 +35,10 @@ impl AuthCtx {
 /// This is a special type.
 #[derive(Default, Eq, PartialEq, PartialOrd, Ord, Clone, Copy, Hash, Serialize, Deserialize)]
 pub struct Identity {
-    __identity_bytes: [u8; 32],
+    __identity__: u256,
 }
 
-impl_st!([] Identity, AlgebraicType::product([(IDENTITY_TAG, AlgebraicType::bytes())]));
+impl_st!([] Identity, AlgebraicType::identity());
 
 #[cfg(feature = "metrics_impls")]
 impl spacetimedb_metrics::typed_prometheus::AsPrometheusLabel for Identity {
@@ -48,15 +48,23 @@ impl spacetimedb_metrics::typed_prometheus::AsPrometheusLabel for Identity {
 }
 
 impl Identity {
-    pub const ZERO: Self = Self {
-        __identity_bytes: [0; 32],
-    };
+    pub const ZERO: Self = Self::from_u256(u256::ZERO);
 
     /// Returns an `Identity` defined as the given `bytes` byte array.
     pub const fn from_byte_array(bytes: [u8; 32]) -> Self {
-        Self {
-            __identity_bytes: bytes,
-        }
+        // SAFETY: The transmute is an implementation of `u256::from_ne_bytes`,
+        // but works in a const context.
+        Self::from_u256(u256::from_le(unsafe { mem::transmute(bytes) }))
+    }
+
+    /// Converts `__identity__: u256` to `Identity`.
+    pub const fn from_u256(__identity__: u256) -> Self {
+        Self { __identity__ }
+    }
+
+    /// Converts this identity to an `u256`.
+    pub const fn to_u256(&self) -> u256 {
+        self.__identity__
     }
 
     /// Returns an `Identity` defined as the given byte `slice`.
@@ -66,33 +74,24 @@ impl Identity {
 
     #[doc(hidden)]
     pub fn __dummy() -> Self {
-        Self::from_byte_array([0; 32])
+        Self::ZERO
     }
 
-    /// Get the special `AlgebraicType` for `Identity`.
-    pub fn get_type() -> AlgebraicType {
-        AlgebraicType::product([(IDENTITY_TAG, AlgebraicType::bytes())])
-    }
-
-    /// Returns a borrowed view of the byte array defining this `Identity`.
-    pub fn as_bytes(&self) -> &[u8; 32] {
-        &self.__identity_bytes
-    }
-
-    pub fn to_vec(&self) -> Vec<u8> {
-        self.__identity_bytes.to_vec()
+    /// Returns this `Identity` as a byte array.
+    pub fn to_byte_array(&self) -> [u8; 32] {
+        self.__identity__.to_le_bytes()
     }
 
     pub fn to_hex(&self) -> HexString<32> {
-        spacetimedb_sats::hex::encode(&self.__identity_bytes)
+        spacetimedb_sats::hex::encode(&self.to_byte_array())
     }
 
-    pub fn abbreviate(&self) -> &[u8; 8] {
-        self.__identity_bytes[..8].try_into().unwrap()
+    pub fn abbreviate(&self) -> [u8; 8] {
+        self.to_byte_array()[..8].try_into().unwrap()
     }
 
     pub fn to_abbreviated_hex(&self) -> HexString<8> {
-        spacetimedb_sats::hex::encode(self.abbreviate())
+        spacetimedb_sats::hex::encode(&self.abbreviate())
     }
 
     pub fn from_hex(hex: impl AsRef<[u8]>) -> Result<Self, hex::FromHexError> {
@@ -100,7 +99,7 @@ impl Identity {
     }
 
     pub fn from_hashing_bytes(bytes: impl AsRef<[u8]>) -> Self {
-        Identity::from_byte_array(hash::hash_bytes(bytes).data)
+        Self::from_byte_array(hash::hash_bytes(bytes).data)
     }
 }
 
@@ -120,8 +119,7 @@ impl hex::FromHex for Identity {
     type Error = hex::FromHexError;
 
     fn from_hex<T: AsRef<[u8]>>(hex: T) -> Result<Self, Self::Error> {
-        let data = from_hex_pad(hex)?;
-        Ok(Identity { __identity_bytes: data })
+        from_hex_pad(hex).map(Identity::from_byte_array)
     }
 }
 
@@ -135,14 +133,14 @@ impl FromStr for Identity {
 
 impl From<Identity> for AlgebraicValue {
     fn from(value: Identity) -> Self {
-        AlgebraicValue::Product(ProductValue::from(AlgebraicValue::Bytes(value.to_vec().into())))
+        AlgebraicValue::product([value.to_u256().into()])
     }
 }
 
 #[cfg(feature = "serde")]
 impl serde::Serialize for Identity {
     fn serialize<S: serde::Serializer>(&self, serializer: S) -> Result<S::Ok, S::Error> {
-        spacetimedb_sats::ser::serde::serialize_to(self.as_bytes(), serializer)
+        spacetimedb_sats::ser::serde::serialize_to(&self.to_byte_array(), serializer)
     }
 }
 
@@ -157,6 +155,7 @@ impl<'de> serde::Deserialize<'de> for Identity {
 #[cfg(test)]
 mod tests {
     use super::*;
+    use spacetimedb_sats::GroundSpacetimeType as _;
 
     #[test]
     fn identity_is_special() {

--- a/crates/lib/tests/serde.rs
+++ b/crates/lib/tests/serde.rs
@@ -3,7 +3,7 @@ use spacetimedb_lib::de::DeserializeSeed;
 use spacetimedb_lib::{AlgebraicType, Identity, ProductType, ProductTypeElement, ProductValue, SumType};
 use spacetimedb_sats::algebraic_value::de::ValueDeserializer;
 use spacetimedb_sats::algebraic_value::ser::value_serialize;
-use spacetimedb_sats::{satn::Satn, SumTypeVariant, Typespace, WithTypespace};
+use spacetimedb_sats::{satn::Satn, GroundSpacetimeType as _, SumTypeVariant, Typespace, WithTypespace};
 
 macro_rules! de_json_snapshot {
     ($schema:expr, $json:expr) => {
@@ -72,6 +72,7 @@ fn test_json_mappings() {
         ("and_peggy", AlgebraicType::option(AlgebraicType::F64)),
         ("identity", Identity::get_type()),
     ]);
+
     let data = r#"
 {
     "foo": 42,
@@ -79,10 +80,11 @@ fn test_json_mappings() {
     "baz": ["heyyyyyy", "hooo"],
     "quux": { "Hash": "54a3e6d2b0959deaacf102292b1cbd6fcbb8cf237f73306e27ed82c3153878aa" },
     "and_peggy": { "some": 3.141592653589793238426 },
-    "identity": ["0000000000000000000000000000000000000000000000000000000000000000"]
+    "identity": ["0x0"]
 }
 "#; // all of those ^^^^^^ digits are from memory
     de_json_snapshot!(schema, data);
+
     let data = r#"
 {
     "foo": 5654,
@@ -90,7 +92,7 @@ fn test_json_mappings() {
     "baz": ["it's 🥶°C"],
     "quux": { "Unit": [] },
     "and_peggy": null,
-    "identity": ["0000000000000000000000000000000000000000000000000000000000000000"]
+    "identity": ["0x0"]
 }
 "#;
     de_json_snapshot!(schema, data);

--- a/crates/lib/tests/snapshots/serde__json_mappings-2.snap
+++ b/crates/lib/tests/snapshots/serde__json_mappings-2.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lib/tests/serde.rs
-expression: "de_json({\n    \"foo\": 5654,\n    \"bar\": [1, 15, 44],\n    \"baz\": [\"it's 🥶°C\"],\n    \"quux\": { \"Unit\": [] },\n    \"and_peggy\": null,\n    \"identity\": [\"0000000000000000000000000000000000000000000000000000000000000000\"]\n})"
+expression: "de_json({\n    \"foo\": 5654,\n    \"bar\": [1, 15, 44],\n    \"baz\": [\"it's 🥶°C\"],\n    \"quux\": { \"Unit\": [] },\n    \"and_peggy\": null,\n    \"identity\": [\"0x0\"]\n})"
 ---
 (
     foo = 5654,
@@ -15,6 +15,6 @@ expression: "de_json({\n    \"foo\": 5654,\n    \"bar\": [1, 15, 44],\n    \"baz
         none = (),
     ),
     identity = (
-        __identity_bytes = 0x0000000000000000000000000000000000000000000000000000000000000000,
+        __identity__ = 0,
     ),
 )

--- a/crates/lib/tests/snapshots/serde__json_mappings.snap
+++ b/crates/lib/tests/snapshots/serde__json_mappings.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/lib/tests/serde.rs
-expression: "de_json({\n    \"foo\": 42,\n    \"bar\": \"404040FFFF0A48656C6C6F\",\n    \"baz\": [\"heyyyyyy\", \"hooo\"],\n    \"quux\": { \"Hash\": \"54a3e6d2b0959deaacf102292b1cbd6fcbb8cf237f73306e27ed82c3153878aa\" },\n    \"and_peggy\": { \"some\": 3.141592653589793238426 },\n    \"identity\": [\"0000000000000000000000000000000000000000000000000000000000000000\"]\n})"
+expression: "de_json({\n    \"foo\": 42,\n    \"bar\": \"404040FFFF0A48656C6C6F\",\n    \"baz\": [\"heyyyyyy\", \"hooo\"],\n    \"quux\": { \"Hash\": \"54a3e6d2b0959deaacf102292b1cbd6fcbb8cf237f73306e27ed82c3153878aa\" },\n    \"and_peggy\": { \"some\": 3.141592653589793238426 },\n    \"identity\": [\"0x0\"]\n})"
 ---
 (
     foo = 42,
@@ -16,6 +16,6 @@ expression: "de_json({\n    \"foo\": 42,\n    \"bar\": \"404040FFFF0A48656C6C6F\
         some = 3.141592653589793,
     ),
     identity = (
-        __identity_bytes = 0x0000000000000000000000000000000000000000000000000000000000000000,
+        __identity__ = 0,
     ),
 )

--- a/crates/sats/src/algebraic_type.rs
+++ b/crates/sats/src/algebraic_type.rs
@@ -291,12 +291,12 @@ impl AlgebraicType {
 
     /// Construct a copy of the `Identity` type.
     pub fn identity() -> Self {
-        AlgebraicType::product([(IDENTITY_TAG, AlgebraicType::bytes())])
+        AlgebraicType::product([(IDENTITY_TAG, AlgebraicType::U256)])
     }
 
     /// Construct a copy of the `Address` type.
     pub fn address() -> Self {
-        AlgebraicType::product([(ADDRESS_TAG, AlgebraicType::bytes())])
+        AlgebraicType::product([(ADDRESS_TAG, AlgebraicType::U128)])
     }
 
     /// Returns a sum type of unit variants with names taken from `var_names`.

--- a/crates/sats/src/hash.rs
+++ b/crates/sats/src/hash.rs
@@ -44,6 +44,10 @@ impl Hash {
     pub fn abbreviate(&self) -> &[u8; 16] {
         self.data[..16].try_into().unwrap()
     }
+
+    pub fn from_hex(hex: impl AsRef<[u8]>) -> Result<Self, hex::FromHexError> {
+        hex::FromHex::from_hex(hex)
+    }
 }
 
 pub fn hash_bytes(bytes: impl AsRef<[u8]>) -> Hash {

--- a/crates/standalone/src/control_db.rs
+++ b/crates/standalone/src/control_db.rs
@@ -210,43 +210,6 @@ impl ControlDb {
         Ok(address)
     }
 
-    pub async fn associate_email_spacetime_identity(&self, identity: Identity, email: &str) -> Result<()> {
-        // Lowercase the email before storing
-        let email = email.to_lowercase();
-
-        let tree = self.db.open_tree("email")?;
-        let identity_email = IdentityEmail { identity, email };
-        let buf = bsatn::to_vec(&identity_email).unwrap();
-        tree.insert(identity.to_byte_array(), buf)?;
-        Ok(())
-    }
-
-    pub fn get_identities_for_email(&self, email: &str) -> Result<Vec<IdentityEmail>> {
-        let mut result = Vec::<IdentityEmail>::new();
-        let tree = self.db.open_tree("email")?;
-        for i in tree.iter() {
-            let (_, value) = i?;
-            let iemail: IdentityEmail = bsatn::from_slice(&value)?;
-            if iemail.email.eq_ignore_ascii_case(email) {
-                result.push(iemail);
-            }
-        }
-        Ok(result)
-    }
-
-    pub fn get_emails_for_identity(&self, identity: &Identity) -> Result<Vec<IdentityEmail>> {
-        let mut result = Vec::<IdentityEmail>::new();
-        let tree = self.db.open_tree("email")?;
-        for i in tree.iter() {
-            let (_, value) = i?;
-            let iemail: IdentityEmail = bsatn::from_slice(&value)?;
-            if &iemail.identity == identity {
-                result.push(iemail);
-            }
-        }
-        Ok(result)
-    }
-
     pub fn get_databases(&self) -> Result<Vec<Database>> {
         let tree = self.db.open_tree("database")?;
         let mut databases = Vec::new();

--- a/crates/standalone/src/control_db.rs
+++ b/crates/standalone/src/control_db.rs
@@ -1,7 +1,7 @@
 use spacetimedb::address::Address;
 use spacetimedb::hash::hash_bytes;
 use spacetimedb::identity::Identity;
-use spacetimedb::messages::control_db::{Database, EnergyBalance, IdentityEmail, Node, Replica};
+use spacetimedb::messages::control_db::{Database, EnergyBalance, Node, Replica};
 use spacetimedb::{energy, stdb_path};
 
 use spacetimedb_client_api_messages::name::{

--- a/crates/standalone/src/control_db.rs
+++ b/crates/standalone/src/control_db.rs
@@ -1,7 +1,7 @@
 use spacetimedb::address::Address;
 use spacetimedb::hash::hash_bytes;
 use spacetimedb::identity::Identity;
-use spacetimedb::messages::control_db::{Database, EnergyBalance, Node, Replica, IdentityEmail};
+use spacetimedb::messages::control_db::{Database, EnergyBalance, IdentityEmail, Node, Replica};
 use spacetimedb::{energy, stdb_path};
 
 use spacetimedb_client_api_messages::name::{

--- a/crates/standalone/src/control_db.rs
+++ b/crates/standalone/src/control_db.rs
@@ -1,7 +1,7 @@
 use spacetimedb::address::Address;
 use spacetimedb::hash::hash_bytes;
 use spacetimedb::identity::Identity;
-use spacetimedb::messages::control_db::{Database, EnergyBalance, Node, Replica};
+use spacetimedb::messages::control_db::{Database, EnergyBalance, Node, Replica, IdentityEmail};
 use spacetimedb::{energy, stdb_path};
 
 use spacetimedb_client_api_messages::name::{
@@ -85,7 +85,7 @@ impl ControlDb {
 
     pub fn spacetime_reverse_dns(&self, address: &Address) -> Result<Vec<DomainName>> {
         let tree = self.db.open_tree("reverse_dns")?;
-        let value = tree.get(address.as_slice())?;
+        let value = tree.get(address.as_byte_array())?;
         if let Some(value) = value {
             let vec: Vec<DomainName> = serde_json::from_slice(&value[..])?;
             return Ok(vec);
@@ -140,18 +140,19 @@ impl ControlDb {
             }
         }
 
+        let addr_bytes = address.as_byte_array();
         let tree = self.db.open_tree("dns")?;
-        tree.insert(domain.to_lowercase().as_bytes(), &address.as_slice()[..])?;
+        tree.insert(domain.to_lowercase().as_bytes(), &addr_bytes)?;
 
         let tree = self.db.open_tree("reverse_dns")?;
-        match tree.get(address.as_slice())? {
+        match tree.get(addr_bytes)? {
             Some(value) => {
                 let mut vec: Vec<DomainName> = serde_json::from_slice(&value[..])?;
                 vec.push(domain.clone());
-                tree.insert(address.as_slice(), serde_json::to_string(&vec)?.as_bytes())?;
+                tree.insert(addr_bytes, serde_json::to_string(&vec)?.as_bytes())?;
             }
             None => {
-                tree.insert(address.as_slice(), serde_json::to_string(&vec![&domain])?.as_bytes())?;
+                tree.insert(addr_bytes, serde_json::to_string(&vec![&domain])?.as_bytes())?;
             }
         }
 
@@ -177,7 +178,7 @@ impl ControlDb {
                 }
             }
             None => {
-                tree.insert(key, owner_identity.as_bytes())?;
+                tree.insert(key, &owner_identity.to_byte_array())?;
                 Ok(RegisterTldResult::Success { domain: tld })
             }
         }
@@ -205,8 +206,45 @@ impl ControlDb {
         let name = b"clockworklabs:";
         let bytes = [name, bytes].concat();
         let hash = hash_bytes(bytes);
-        let address = Address::from_slice(&hash.as_slice()[..16]);
+        let address = Address::from_slice(hash.abbreviate());
         Ok(address)
+    }
+
+    pub async fn associate_email_spacetime_identity(&self, identity: Identity, email: &str) -> Result<()> {
+        // Lowercase the email before storing
+        let email = email.to_lowercase();
+
+        let tree = self.db.open_tree("email")?;
+        let identity_email = IdentityEmail { identity, email };
+        let buf = bsatn::to_vec(&identity_email).unwrap();
+        tree.insert(identity.to_byte_array(), buf)?;
+        Ok(())
+    }
+
+    pub fn get_identities_for_email(&self, email: &str) -> Result<Vec<IdentityEmail>> {
+        let mut result = Vec::<IdentityEmail>::new();
+        let tree = self.db.open_tree("email")?;
+        for i in tree.iter() {
+            let (_, value) = i?;
+            let iemail: IdentityEmail = bsatn::from_slice(&value)?;
+            if iemail.email.eq_ignore_ascii_case(email) {
+                result.push(iemail);
+            }
+        }
+        Ok(result)
+    }
+
+    pub fn get_emails_for_identity(&self, identity: &Identity) -> Result<Vec<IdentityEmail>> {
+        let mut result = Vec::<IdentityEmail>::new();
+        let tree = self.db.open_tree("email")?;
+        for i in tree.iter() {
+            let (_, value) = i?;
+            let iemail: IdentityEmail = bsatn::from_slice(&value)?;
+            if &iemail.identity == identity {
+                result.push(iemail);
+            }
+        }
+        Ok(result)
     }
 
     pub fn get_databases(&self) -> Result<Vec<Database>> {
@@ -430,7 +468,7 @@ impl ControlDb {
     /// `control_budget`, where a cached copy is stored along with business logic for managing it.
     pub fn get_energy_balance(&self, identity: &Identity) -> Result<Option<energy::EnergyBalance>> {
         let tree = self.db.open_tree("energy_budget")?;
-        let value = tree.get(identity.as_bytes())?;
+        let value = tree.get(identity.to_byte_array())?;
         if let Some(value) = value {
             let arr = <[u8; 16]>::try_from(value.as_ref()).map_err(|_| bsatn::DecodeError::BufferLength {
                 for_type: "Identity".into(),
@@ -449,7 +487,7 @@ impl ControlDb {
     /// `control_budget`, where a cached copy is stored along with business logic for managing it.
     pub fn set_energy_balance(&self, identity: Identity, energy_balance: energy::EnergyBalance) -> Result<()> {
         let tree = self.db.open_tree("energy_budget")?;
-        tree.insert(identity.as_bytes(), &energy_balance.get().to_be_bytes())?;
+        tree.insert(identity.to_byte_array(), &energy_balance.get().to_be_bytes())?;
 
         Ok(())
     }

--- a/crates/standalone/src/control_db/tests.rs
+++ b/crates/standalone/src/control_db/tests.rs
@@ -48,7 +48,7 @@ fn test_domain() -> anyhow::Result<()> {
 
     let cdb = ControlDb::at(tmp.path())?;
 
-    let addr = Address::zero();
+    let addr = Address::ZERO;
     let res = cdb.spacetime_insert_domain(&addr, domain.clone(), *ALICE, true)?;
     assert!(matches!(res, InsertDomainResult::Success { .. }));
 

--- a/smoketests/tests/identity.py
+++ b/smoketests/tests/identity.py
@@ -76,3 +76,83 @@ class IdentityImports(Smoketest):
         default_identity = next(filter(lambda s: "***" in s, identities), "")
         self.assertIn(identity, default_identity)
 
+    def test_set_email(self):
+        """Ensure that we are able to associate an email with an identity"""
+
+        self.fingerprint()
+
+        # Create a new identity
+        identity = self.new_identity(email=None)
+        email = random_email()
+        token = self.token(identity)
+
+        # Reset our config so we lose this identity
+        self.reset_config()
+
+        # Import this identity, and set it as the default identity
+        self.import_identity(identity, token, default=True)
+
+        # Configure our email
+        output = self.spacetime("identity", "set-email", "--identity", identity, email)
+        self.assertEqual(extract_field(output, "IDENTITY"), identity)
+        self.assertEqual(extract_field(output, "EMAIL").lower(), email.lower())
+
+        # Reset config again
+        self.reset_config()
+
+        # Find our identity by its email
+        output = self.spacetime("identity", "find", email)
+        self.assertEqual(extract_field(output, "IDENTITY"), identity)
+        self.assertEqual(extract_field(output, "EMAIL").lower(), email.lower())
+
+
+class IdentityFormatting(Smoketest):
+    MODULE_CODE = """
+use log::info;
+use spacetimedb::{Address, Identity, ReducerContext, Table};
+
+#[spacetimedb::table(name = connected_client)]
+pub struct ConnectedClient {
+    identity: Identity,
+    address: Address,
+}
+
+#[spacetimedb::reducer(client_connected)]
+fn on_connect(ctx: &ReducerContext) {
+    ctx.db.connected_client().insert(ConnectedClient {
+        identity: ctx.sender,
+        address: ctx.address.expect("sender address unset"),
+    });
+}
+
+#[spacetimedb::reducer(client_disconnected)]
+fn on_disconnect(ctx: &ReducerContext) {
+    let sender_identity = &ctx.sender;
+    let sender_address = ctx.address.as_ref().expect("sender address unset");
+    let match_client = |row: &ConnectedClient| {
+        &row.identity == sender_identity && &row.address == sender_address
+    };
+    if let Some(client) = ctx.db.connected_client().iter().find(match_client) {
+        ctx.db.connected_client().delete(client);
+    }
+}
+
+#[spacetimedb::reducer]
+fn print_num_connected(ctx: &ReducerContext) {
+    let n = ctx.db.connected_client().count();
+    info!("CONNECTED CLIENTS: {n}")
+}
+"""
+
+    def test_identity_formatting(self):
+        """Tests formatting of Identity."""
+
+        # Start two subscribers
+        self.subscribe("SELECT * FROM connected_client", n=2)
+        self.subscribe("SELECT * FROM connected_client", n=2)
+
+        # Assert that we have two clients + the reducer call
+        self.call("print_num_connected")
+        logs = self.logs(10)
+        self.assertEqual("CONNECTED CLIENTS: 3", logs.pop())
+

--- a/smoketests/tests/identity.py
+++ b/smoketests/tests/identity.py
@@ -76,35 +76,6 @@ class IdentityImports(Smoketest):
         default_identity = next(filter(lambda s: "***" in s, identities), "")
         self.assertIn(identity, default_identity)
 
-    def test_set_email(self):
-        """Ensure that we are able to associate an email with an identity"""
-
-        self.fingerprint()
-
-        # Create a new identity
-        identity = self.new_identity(email=None)
-        email = random_email()
-        token = self.token(identity)
-
-        # Reset our config so we lose this identity
-        self.reset_config()
-
-        # Import this identity, and set it as the default identity
-        self.import_identity(identity, token, default=True)
-
-        # Configure our email
-        output = self.spacetime("identity", "set-email", "--identity", identity, email)
-        self.assertEqual(extract_field(output, "IDENTITY"), identity)
-        self.assertEqual(extract_field(output, "EMAIL").lower(), email.lower())
-
-        # Reset config again
-        self.reset_config()
-
-        # Find our identity by its email
-        output = self.spacetime("identity", "find", email)
-        self.assertEqual(extract_field(output, "IDENTITY"), identity)
-        self.assertEqual(extract_field(output, "EMAIL").lower(), email.lower())
-
 
 class IdentityFormatting(Smoketest):
     MODULE_CODE = """


### PR DESCRIPTION
# Description of Changes

Redefines `Address` as `u128`.

# API and ABI breaking changes

Breaks the stored type of `Address` in system tables and in user tables.