### PR TITLE
Fix `cargo test --all` on Windows

### DIFF
--- a/crates/bindings/tests/deps.rs
+++ b/crates/bindings/tests/deps.rs
@@ -3,6 +3,7 @@
 //! slowing down compilation for every spacetime module.
 
 #[test]
+#[cfg_attr(target_family = "windows", ignore)] // dependency structure is different on windows
 fn deptree_snapshot() -> std::io::Result<()> {
     let cmd = "cargo tree -p spacetimedb -f {lib} -e no-dev";
     let deps_tree = run_cmd(cmd);


### PR DESCRIPTION
# Description of Changes

It was previously broken due to linker errors, now it works.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

0

# Testing

I ran `cargo test --all` on windows.