### PR TITLE
Add snapshot tests for normalized ModuleDef

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -190,7 +190,7 @@ checksum = "a66537f1bb974b254c98ed142ff995236e81b9d0fe4db0575f46612cb15eb0f9"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -528,7 +528,7 @@ checksum = "4da9a32f3fed317401fa3c862968128267c3106685286e15d5aaa3d7389c2f60"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -711,7 +711,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1157,7 +1157,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1168,7 +1168,7 @@ checksum = "836a9bbc7ad63342d6d6e7b815ccab164bc77a2d95d84bc3117a8c0d5c98e2d5"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1221,6 +1221,28 @@ dependencies = [
  "quote",
  "rustc_version",
  "syn 1.0.109",
+]
+
+[[package]]
+name = "derive_more"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4a9b99b9cbbe49445b21764dc0625032a89b145a2642e67603e1c936f5458d05"
+dependencies = [
+ "derive_more-impl",
+]
+
+[[package]]
+name = "derive_more-impl"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cb7330aeadfbe296029522e6c40f315320aba36fc43a5b3632f3795348f3bd22"
+dependencies = [
+ "convert_case 0.6.0",
+ "proc-macro2",
+ "quote",
+ "syn 2.0.74",
+ "unicode-xid",
 ]
 
 [[package]]
@@ -1351,7 +1373,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1371,7 +1393,7 @@ checksum = "04d0b288e3bb1d861c4403c1774a6f7a798781dfc519b3647df2a3dd4ae95f25"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1384,7 +1406,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1405,7 +1427,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -1643,7 +1665,7 @@ checksum = "89ca545a94061b6365f2c7355b4b32bd20df3ff95f02da9329b34ccc3bd6ee72"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2006,7 +2028,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2690,7 +2712,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2898,7 +2920,7 @@ checksum = "4359fd9c9171ec6e8c62926d6faaf553a8dc3f64e1507e76da7911b4f6a04405"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -2984,7 +3006,7 @@ dependencies = [
  "heck",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3075,9 +3097,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.70"
+version = "1.0.86"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "39278fbbf5fb4f646ce651690877f89d1c5811a3d4acb27700c1cb3cdb78fd3b"
+checksum = "5e719e8df665df0d1c8fbfd238015744736151d4445ec0836b8e628aae103b77"
 dependencies = [
  "unicode-ident",
 ]
@@ -3211,9 +3233,9 @@ dependencies = [
 
 [[package]]
 name = "quote"
-version = "1.0.33"
+version = "1.0.36"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5267fca4496028628a95160fc423a33e8b2e6af8a5302579e322e4b520293cae"
+checksum = "0fa76aaf39101c457836aec0ce2316dbdc3ab723cdda1c6bd4e6ad4208acaca7"
 dependencies = [
  "proc-macro2",
 ]
@@ -3806,7 +3828,7 @@ checksum = "1e48d1f918009ce3145511378cf68d613e3b3d9137d67272562080d68a2b32d5"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3878,7 +3900,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -3903,7 +3925,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -4093,7 +4115,7 @@ name = "spacetimedb"
 version = "0.12.0"
 dependencies = [
  "bytemuck",
- "derive_more",
+ "derive_more 1.0.0",
  "getrandom",
  "insta",
  "log",
@@ -4153,7 +4175,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "spacetimedb-primitives",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -4228,7 +4250,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "chrono",
- "derive_more",
+ "derive_more 0.99.17",
  "email_address",
  "futures",
  "headers",
@@ -4263,7 +4285,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "chrono",
- "derive_more",
+ "derive_more 1.0.0",
  "enum-as-inner",
  "hex",
  "itertools 0.12.0",
@@ -4315,7 +4337,7 @@ dependencies = [
  "clap 4.4.6",
  "criterion",
  "crossbeam-channel",
- "derive_more",
+ "derive_more 1.0.0",
  "dirs",
  "email_address",
  "enum-as-inner",
@@ -4434,7 +4456,7 @@ dependencies = [
  "anyhow",
  "bitflags 2.4.1",
  "bytes",
- "derive_more",
+ "derive_more 1.0.0",
  "enum-as-inner",
  "hex",
  "insta",
@@ -4493,7 +4515,7 @@ dependencies = [
  "bytes",
  "bytestring",
  "decorum",
- "derive_more",
+ "derive_more 1.0.0",
  "enum-as-inner",
  "ethnum",
  "hex",
@@ -4581,7 +4603,7 @@ dependencies = [
 name = "spacetimedb-sql-parser"
 version = "0.12.0"
 dependencies = [
- "derive_more",
+ "derive_more 1.0.0",
  "sqlparser",
  "thiserror",
 ]
@@ -4625,7 +4647,7 @@ dependencies = [
  "bytemuck",
  "criterion",
  "decorum",
- "derive_more",
+ "derive_more 1.0.0",
  "enum-as-inner",
  "itertools 0.12.0",
  "proptest",
@@ -4672,7 +4694,7 @@ version = "0.12.0"
 dependencies = [
  "anyhow",
  "arrayvec",
- "derive_more",
+ "derive_more 1.0.0",
  "itertools 0.12.0",
  "log",
  "smallvec",
@@ -4765,7 +4787,7 @@ dependencies = [
  "chrono",
  "clap 4.4.6",
  "console",
- "derive_more",
+ "derive_more 1.0.0",
  "fs-err",
  "futures",
  "glob",
@@ -4839,7 +4861,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -4871,9 +4893,9 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.39"
+version = "2.0.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "23e78b90f2fcf45d3e842032ce32e3f2d1545ba6636271dcbf24fa306d87be7a"
+checksum = "1fceb41e3d546d0bd83421d3409b1460cc7444cd389341a4c880fe7a042cb3d7"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -5071,7 +5093,7 @@ checksum = "10712f02019e9288794769fba95cd6847df9874d49d871d062172f9dd41bc4cc"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -5176,7 +5198,7 @@ checksum = "5b8a1e28f2deaa14e508979454cb3a223b10b938b45af148bc0986de36f1923b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -5385,7 +5407,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -5703,7 +5725,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
  "wasm-bindgen-shared",
 ]
 
@@ -5737,7 +5759,7 @@ checksum = "54681b18a46765f095758388f2d0cf16eb8d4169b639ab575a8f5693af210c7b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6021,7 +6043,7 @@ checksum = "9a347bb8ecf12275fb180afb1b1c85c9e186553c43109737bffed4f54c2aa365"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]
@@ -6375,7 +6397,7 @@ checksum = "9ce1b18ccd8e73a9321186f97e46f9f04b778851177567b1975109d26a08d2a6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.39",
+ "syn 2.0.74",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4648,6 +4648,7 @@ dependencies = [
  "clap 4.4.6",
  "duct",
  "env_logger",
+ "insta",
  "lazy_static",
  "log",
  "rand 0.8.5",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -134,7 +134,7 @@ criterion = { version = "0.5.1", features = ["async", "async_tokio", "html_repor
 crossbeam-channel = "0.5"
 cursive = { version = "0.20", default-features = false, features = ["crossterm-backend"] }
 decorum = { version = "0.3.1", default-features = false, features = ["std"] }
-derive_more = "0.99"
+derive_more = { version = "1.0", features = ["full"] }
 dirs = "5.0.1"
 duct = "0.13.5"
 either = "1.9"

--- a/crates/bindings/tests/snapshots/deps__duplicate_deps.snap
+++ b/crates/bindings/tests/snapshots/deps__duplicate_deps.snap
@@ -2,6 +2,4 @@
 source: crates/bindings/tests/deps.rs
 expression: cargo tree -p spacetimedb -e no-dev -d --depth 0
 ---
-syn v1.0.109
 
-syn v2.0.39

--- a/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
+++ b/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
@@ -2,28 +2,26 @@
 source: crates/bindings/tests/deps.rs
 expression: "cargo tree -p spacetimedb -f {lib} -e no-dev"
 ---
-total crates: 60
+total crates: 59
 spacetimedb
 ├── bytemuck
 ├── derive_more
-│   ├── convert_case
-│   ├── proc_macro2
-│   │   └── unicode_ident
-│   ├── quote
-│   │   └── proc_macro2 (*)
-│   └── syn
-│       ├── proc_macro2 (*)
-│       ├── quote (*)
-│       └── unicode_ident
-│   [build-dependencies]
-│   └── rustc_version
-│       └── semver
+│   └── derive_more_impl
+│       ├── convert_case
+│       │   └── unicode_segmentation
+│       ├── proc_macro2
+│       │   └── unicode_ident
+│       ├── quote
+│       │   └── proc_macro2 (*)
+│       ├── syn
+│       │   ├── proc_macro2 (*)
+│       │   ├── quote (*)
+│       │   └── unicode_ident
+│       └── unicode_xid
 ├── getrandom
-│   ├── cfg_if
-│   └── libc
+│   └── cfg_if
 ├── log
 ├── rand
-│   ├── libc
 │   ├── rand_chacha
 │   │   ├── ppv_lite86
 │   │   └── rand_core
@@ -42,10 +40,7 @@ spacetimedb
 │   │   ├── itertools
 │   │   │   └── either
 │   │   └── nohash_hasher
-│   └── syn
-│       ├── proc_macro2 (*)
-│       ├── quote (*)
-│       └── unicode_ident
+│   └── syn (*)
 ├── spacetimedb_bindings_sys
 │   └── spacetimedb_primitives (*)
 ├── spacetimedb_lib

--- a/crates/lib/src/db/raw_def/v8.rs
+++ b/crates/lib/src/db/raw_def/v8.rs
@@ -8,6 +8,7 @@ use crate::{AlgebraicType, ProductType, SpacetimeType};
 use derive_more::Display;
 use spacetimedb_data_structures::map::HashSet;
 use spacetimedb_primitives::*;
+use std::fmt;
 
 // TODO(1.0): move these definitions into this file,
 // along with the other structs contained in it,
@@ -171,7 +172,7 @@ impl RawIndexDefV8 {
 }
 
 /// A struct representing the definition of a database column.
-#[derive(Debug, Clone, Eq, PartialEq, PartialOrd, Ord, SpacetimeType)]
+#[derive(Clone, Eq, PartialEq, PartialOrd, Ord, SpacetimeType)]
 #[sats(crate = crate)]
 pub struct RawColumnDefV8 {
     /// The name of the column.
@@ -180,6 +181,13 @@ pub struct RawColumnDefV8 {
     ///
     /// Must satisfy [AlgebraicType::is_valid_for_client_type_use].
     pub col_type: AlgebraicType,
+}
+
+impl fmt::Debug for RawColumnDefV8 {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{:?}: ", &self.col_name)?;
+        self.col_type.fmt(f)
+    }
 }
 
 impl RawColumnDefV8 {

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -1,6 +1,6 @@
 use crate::db::raw_def::RawTableDefV8;
 use anyhow::Context;
-use sats::typespace::TypespaceBuilder;
+use sats::typespace::{TypeRefError, TypespaceBuilder};
 use spacetimedb_sats::{impl_serialize, WithTypespace};
 use std::any::TypeId;
 use std::collections::{btree_map, BTreeMap};
@@ -196,6 +196,15 @@ impl RawModuleDefV8 {
         let mut builder = Self::builder();
         f(&mut builder);
         builder.finish()
+    }
+
+    pub fn inline_table_typerefs(&mut self) -> Result<(), TypeRefError> {
+        for table in &mut self.tables {
+            for col in &mut table.schema.columns {
+                self.typespace.inline_typerefs_in_type(&mut col.col_type)?;
+            }
+        }
+        Ok(())
     }
 }
 

--- a/crates/sats/src/algebraic_type.rs
+++ b/crates/sats/src/algebraic_type.rs
@@ -20,7 +20,7 @@ use enum_as_inner::EnumAsInner;
 /// The type system unifies the concepts sum types, product types, scalar value types,
 /// and convenience types strings, arrays, and maps,
 /// into a single type system.
-#[derive(EnumAsInner, Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, SpacetimeType, From)]
+#[derive(EnumAsInner, derive_more::Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, SpacetimeType, From)]
 #[sats(crate = crate)]
 pub enum AlgebraicType {
     /// A type where the definition is given by the typing context (`Typespace`).
@@ -28,6 +28,7 @@ pub enum AlgebraicType {
     ///
     /// This should not be conflated with reference and pointer types in languages like Rust,
     /// In other words, this is not `&T` or `*const T`.
+    #[debug("{_0:?}")]
     Ref(AlgebraicTypeRef),
     /// A structural sum type.
     ///
@@ -53,6 +54,7 @@ pub enum AlgebraicType {
     /// See also: https://ncatlab.org/nlab/show/sum+type.
     ///
     /// [structural]: https://en.wikipedia.org/wiki/Structural_type_system
+    #[debug("{_0:?}")]
     Sum(SumType),
     /// A structural product type.
     ///
@@ -77,13 +79,16 @@ pub enum AlgebraicType {
     /// so for example, `values({ A: U64, B: Bool }) = values(U64) * values(Bool)`.
     ///
     /// [structural]: https://en.wikipedia.org/wiki/Structural_type_system
+    #[debug("{_0:?}")]
     Product(ProductType),
     /// The type of array values where elements are of a base type `elem_ty`.
     /// Values [`AlgebraicValue::Array(array)`](crate::AlgebraicValue::Array) will have this type.
+    #[debug("{_0:?}")]
     Array(ArrayType),
     /// The type of map values consisting of a key type `key_ty` and value `ty`.
     /// Values [`AlgebraicValue::Map(map)`](crate::AlgebraicValue::Map) will have this type.
     /// The order of entries in a map value is observable.
+    #[debug("{_0:?}")]
     Map(Box<MapType>),
     /// The UTF-8 encoded `String` type.
     /// Values [`AlgebraicValue::String(s)`](crate::AlgebraicValue::String) will have this type.

--- a/crates/sats/src/array_type.rs
+++ b/crates/sats/src/array_type.rs
@@ -2,16 +2,25 @@ use crate::algebraic_type::AlgebraicType;
 use crate::de::Deserialize;
 use crate::meta_type::MetaType;
 use crate::{impl_deserialize, impl_serialize, impl_st};
+use std::fmt;
 
 /// An array type is a homegeneous product type of dynamic length.
 ///
 /// That is, it is a product type
 /// where every element / factor / field is of the same type
 /// and where the length is statically unknown.
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash)]
 pub struct ArrayType {
     /// The base type every element of the array has.
     pub elem_ty: Box<AlgebraicType>,
+}
+
+impl fmt::Debug for ArrayType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("ArrayType(")?;
+        self.elem_ty.fmt(f)?;
+        f.write_str(")")
+    }
 }
 
 impl_serialize!([] ArrayType, (self, ser) => self.elem_ty.serialize(ser));

--- a/crates/sats/src/lib.rs
+++ b/crates/sats/src/lib.rs
@@ -233,3 +233,8 @@ where
 macro_rules! __make_register_reftype {
     ($ty:ty, $name:literal) => {};
 }
+
+// A helper for prettier Debug implementation, without extra indirection around Some("name").
+fn dbg_aggregate_name(opt: &Option<Box<str>>) -> &dyn std::fmt::Debug {
+    opt.as_ref().map_or(&None::<()>, |s| s)
+}

--- a/crates/sats/src/product_type.rs
+++ b/crates/sats/src/product_type.rs
@@ -32,7 +32,7 @@ pub const ADDRESS_TAG: &str = "__address_bytes";
 /// so for example, `values({ A: U64, B: Bool }) = values(U64) * values(Bool)`.
 ///
 /// [structural]: https://en.wikipedia.org/wiki/Structural_type_system
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, SpacetimeType)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, SpacetimeType)]
 #[sats(crate = crate)]
 pub struct ProductType {
     /// The factors of the product type.
@@ -40,6 +40,19 @@ pub struct ProductType {
     /// These factors can either be named or unnamed.
     /// When all the factors are unnamed, we can regard this as a plain tuple type.
     pub elements: Box<[ProductTypeElement]>,
+}
+
+impl std::fmt::Debug for ProductType {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("ProductType ")?;
+        f.debug_map()
+            .entries(
+                self.elements
+                    .iter()
+                    .map(|elem| (crate::dbg_aggregate_name(&elem.name), &elem.algebraic_type)),
+            )
+            .finish()
+    }
 }
 
 impl ProductType {

--- a/crates/sats/src/sum_type.rs
+++ b/crates/sats/src/sum_type.rs
@@ -3,6 +3,7 @@ use crate::algebraic_value::ser::value_serialize;
 use crate::de::Deserialize;
 use crate::meta_type::MetaType;
 use crate::{AlgebraicType, AlgebraicValue, SpacetimeType, SumTypeVariant};
+use std::fmt;
 
 /// The tag used for the `Interval` variant of the special `ScheduleAt` sum type.
 pub const SCHEDULE_AT_INTERVAL_TAG: &str = "Interval";
@@ -37,13 +38,26 @@ pub const OPTION_NONE_TAG: &str = "none";
 /// See also: https://ncatlab.org/nlab/show/sum+type.
 ///
 /// [structural]: https://en.wikipedia.org/wiki/Structural_type_system
-#[derive(Debug, Clone, Eq, PartialEq, Ord, PartialOrd, Hash, SpacetimeType)]
+#[derive(Clone, Eq, PartialEq, Ord, PartialOrd, Hash, SpacetimeType)]
 #[sats(crate = crate)]
 pub struct SumType {
     /// The possible variants of the sum type.
     ///
     /// The order is relevant as it defines the tags of the variants at runtime.
     pub variants: Box<[SumTypeVariant]>,
+}
+
+impl fmt::Debug for SumType {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("SumType ")?;
+        f.debug_map()
+            .entries(
+                self.variants
+                    .iter()
+                    .map(|variant| (crate::dbg_aggregate_name(&variant.name), &variant.algebraic_type)),
+            )
+            .finish()
+    }
 }
 
 impl SumType {

--- a/crates/sats/src/typespace.rs
+++ b/crates/sats/src/typespace.rs
@@ -145,7 +145,7 @@ impl Typespace {
     /// Inlines all nested references behind the current [`AlgebraicTypeRef`] recursively using the current typeset.
     ///
     /// Returns the fully-resolved type or an error if the type reference is invalid or self-referential.
-    fn inline_typerefs_in_ref(&mut self, r: AlgebraicTypeRef) -> Result<&AlgebraicType, TypeRefError> {
+    pub fn inline_typerefs_in_ref(&mut self, r: AlgebraicTypeRef) -> Result<&AlgebraicType, TypeRefError> {
         let resolved_ty = match self.get_mut(r) {
             None => return Err(TypeRefError::InvalidTypeRef(r)),
             // If we encountered a type reference, that means one of the parent calls
@@ -172,17 +172,6 @@ impl Typespace {
         // Now we can put the fully-resolved type back and return that place.
         *place = resolved_ty;
         Ok(place)
-    }
-
-    /// Inlines all type references in the typespace recursively.
-    ///
-    /// Errors out if any type reference is invalid or self-referential.
-    pub fn inline_all_typerefs(&mut self) -> Result<(), TypeRefError> {
-        // We need to use indices here to allow mutable reference on each iteration.
-        for r in 0..self.types.len() as u32 {
-            self.inline_typerefs_in_ref(AlgebraicTypeRef(r))?;
-        }
-        Ok(())
     }
 
     /// Iterate over types in the typespace with their references.

--- a/crates/sats/src/typespace.rs
+++ b/crates/sats/src/typespace.rs
@@ -33,12 +33,19 @@ pub enum TypeRefError {
 /// where `&0` is the type reference at index `0`.
 ///
 /// [System F]: https://en.wikipedia.org/wiki/System_F
-#[derive(Debug, Clone, SpacetimeType)]
+#[derive(Clone, SpacetimeType)]
 #[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
 #[sats(crate = crate)]
 pub struct Typespace {
     /// The types in our typing context that can be referred to with [`AlgebraicTypeRef`]s.
     pub types: Vec<AlgebraicType>,
+}
+
+impl std::fmt::Debug for Typespace {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        f.write_str("Typespace ")?;
+        f.debug_list().entries(&self.types).finish()
+    }
 }
 
 impl Default for Typespace {

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -23,6 +23,7 @@ lazy_static.workspace = true
 rand.workspace = true
 tempfile.workspace = true
 serde.workspace = true
+insta.workspace = true
 
 [dev-dependencies]
 serial_test.workspace = true

--- a/crates/testing/src/snapshots/spacetimedb_testing__sdk__descriptions@connect_disconnect_client.snap
+++ b/crates/testing/src/snapshots/spacetimedb_testing__sdk__descriptions@connect_disconnect_client.snap
@@ -1,0 +1,77 @@
+---
+source: crates/testing/src/sdk.rs
+expression: def
+---
+NormalizedModuleDef {
+    tables: {
+        "Connected": RawTableDefV8 {
+            table_name: "Connected",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "identity",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__identity_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "Disconnected": RawTableDefV8 {
+            table_name: "Disconnected",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "identity",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__identity_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+    },
+    reducers: {
+        "__identity_connected__": ProductType {
+            elements: [],
+        },
+        "__identity_disconnected__": ProductType {
+            elements: [],
+        },
+    },
+    exports: {},
+}

--- a/crates/testing/src/snapshots/spacetimedb_testing__sdk__descriptions@connect_disconnect_client.snap
+++ b/crates/testing/src/snapshots/spacetimedb_testing__sdk__descriptions@connect_disconnect_client.snap
@@ -7,24 +7,8 @@ NormalizedModuleDef {
         "Connected": RawTableDefV8 {
             table_name: "Connected",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "identity",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__identity_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "identity": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
             ],
             indexes: [],
@@ -37,24 +21,8 @@ NormalizedModuleDef {
         "Disconnected": RawTableDefV8 {
             table_name: "Disconnected",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "identity",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__identity_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "identity": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
             ],
             indexes: [],
@@ -66,12 +34,8 @@ NormalizedModuleDef {
         },
     },
     reducers: {
-        "__identity_connected__": ProductType {
-            elements: [],
-        },
-        "__identity_disconnected__": ProductType {
-            elements: [],
-        },
+        "__identity_connected__": ProductType {},
+        "__identity_disconnected__": ProductType {},
     },
     exports: {},
 }

--- a/crates/testing/src/snapshots/spacetimedb_testing__sdk__descriptions@test-client.snap
+++ b/crates/testing/src/snapshots/spacetimedb_testing__sdk__descriptions@test-client.snap
@@ -1,0 +1,9920 @@
+---
+source: crates/testing/src/sdk.rs
+expression: def
+---
+NormalizedModuleDef {
+    tables: {
+        "LargeTable": RawTableDefV8 {
+            table_name: "LargeTable",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "a",
+                    col_type: U8,
+                },
+                RawColumnDefV8 {
+                    col_name: "b",
+                    col_type: U16,
+                },
+                RawColumnDefV8 {
+                    col_name: "c",
+                    col_type: U32,
+                },
+                RawColumnDefV8 {
+                    col_name: "d",
+                    col_type: U64,
+                },
+                RawColumnDefV8 {
+                    col_name: "e",
+                    col_type: U128,
+                },
+                RawColumnDefV8 {
+                    col_name: "f",
+                    col_type: U256,
+                },
+                RawColumnDefV8 {
+                    col_name: "g",
+                    col_type: I8,
+                },
+                RawColumnDefV8 {
+                    col_name: "h",
+                    col_type: I16,
+                },
+                RawColumnDefV8 {
+                    col_name: "i",
+                    col_type: I32,
+                },
+                RawColumnDefV8 {
+                    col_name: "j",
+                    col_type: I64,
+                },
+                RawColumnDefV8 {
+                    col_name: "k",
+                    col_type: I128,
+                },
+                RawColumnDefV8 {
+                    col_name: "l",
+                    col_type: I256,
+                },
+                RawColumnDefV8 {
+                    col_name: "m",
+                    col_type: Bool,
+                },
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: F32,
+                },
+                RawColumnDefV8 {
+                    col_name: "o",
+                    col_type: F64,
+                },
+                RawColumnDefV8 {
+                    col_name: "p",
+                    col_type: String,
+                },
+                RawColumnDefV8 {
+                    col_name: "q",
+                    col_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Zero",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "One",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Two",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                RawColumnDefV8 {
+                    col_name: "r",
+                    col_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U8",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U16",
+                                    ),
+                                    algebraic_type: U16,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U32",
+                                    ),
+                                    algebraic_type: U32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U64",
+                                    ),
+                                    algebraic_type: U64,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U128",
+                                    ),
+                                    algebraic_type: U128,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U256",
+                                    ),
+                                    algebraic_type: U256,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I8",
+                                    ),
+                                    algebraic_type: I8,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I16",
+                                    ),
+                                    algebraic_type: I16,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I32",
+                                    ),
+                                    algebraic_type: I32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I64",
+                                    ),
+                                    algebraic_type: I64,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I128",
+                                    ),
+                                    algebraic_type: I128,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I256",
+                                    ),
+                                    algebraic_type: I256,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Bool",
+                                    ),
+                                    algebraic_type: Bool,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "F32",
+                                    ),
+                                    algebraic_type: F32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "F64",
+                                    ),
+                                    algebraic_type: F64,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Str",
+                                    ),
+                                    algebraic_type: String,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Identity",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__identity_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Address",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__address_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Ints",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I32,
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Strings",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: String,
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "SimpleEnums",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Sum(
+                                                SumType {
+                                                    variants: [
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "Zero",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "One",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "Two",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: Product(
+                        ProductType {
+                            elements: [],
+                        },
+                    ),
+                },
+                RawColumnDefV8 {
+                    col_name: "t",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                            ],
+                        },
+                    ),
+                },
+                RawColumnDefV8 {
+                    col_name: "u",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "a",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: U16,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "c",
+                                    ),
+                                    algebraic_type: U32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "d",
+                                    ),
+                                    algebraic_type: U64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "e",
+                                    ),
+                                    algebraic_type: U128,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "f",
+                                    ),
+                                    algebraic_type: U256,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "g",
+                                    ),
+                                    algebraic_type: I8,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "h",
+                                    ),
+                                    algebraic_type: I16,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "i",
+                                    ),
+                                    algebraic_type: I32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "j",
+                                    ),
+                                    algebraic_type: I64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "k",
+                                    ),
+                                    algebraic_type: I128,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "l",
+                                    ),
+                                    algebraic_type: I256,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "m",
+                                    ),
+                                    algebraic_type: Bool,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: F32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "o",
+                                    ),
+                                    algebraic_type: F64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "p",
+                                    ),
+                                    algebraic_type: String,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "q",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__identity_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "r",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__address_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                RawColumnDefV8 {
+                    col_name: "v",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "a",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U16,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "c",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U32,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "d",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U64,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "e",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U128,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "f",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U256,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "g",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I8,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "h",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I16,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "i",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I32,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "j",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I64,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "k",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I128,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "l",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I256,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "m",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Bool,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: F32,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "o",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: F64,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "p",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: String,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "q",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__identity_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "r",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__address_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneAddress": RawTableDefV8 {
+            table_name: "OneAddress",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "a",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__address_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneBool": RawTableDefV8 {
+            table_name: "OneBool",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "b",
+                    col_type: Bool,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneByteStruct": RawTableDefV8 {
+            table_name: "OneByteStruct",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneEnumWithPayload": RawTableDefV8 {
+            table_name: "OneEnumWithPayload",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "e",
+                    col_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U8",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U16",
+                                    ),
+                                    algebraic_type: U16,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U32",
+                                    ),
+                                    algebraic_type: U32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U64",
+                                    ),
+                                    algebraic_type: U64,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U128",
+                                    ),
+                                    algebraic_type: U128,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U256",
+                                    ),
+                                    algebraic_type: U256,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I8",
+                                    ),
+                                    algebraic_type: I8,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I16",
+                                    ),
+                                    algebraic_type: I16,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I32",
+                                    ),
+                                    algebraic_type: I32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I64",
+                                    ),
+                                    algebraic_type: I64,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I128",
+                                    ),
+                                    algebraic_type: I128,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I256",
+                                    ),
+                                    algebraic_type: I256,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Bool",
+                                    ),
+                                    algebraic_type: Bool,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "F32",
+                                    ),
+                                    algebraic_type: F32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "F64",
+                                    ),
+                                    algebraic_type: F64,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Str",
+                                    ),
+                                    algebraic_type: String,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Identity",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__identity_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Address",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__address_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Ints",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I32,
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Strings",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: String,
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "SimpleEnums",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Sum(
+                                                SumType {
+                                                    variants: [
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "Zero",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "One",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "Two",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneEveryPrimitiveStruct": RawTableDefV8 {
+            table_name: "OneEveryPrimitiveStruct",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "a",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: U16,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "c",
+                                    ),
+                                    algebraic_type: U32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "d",
+                                    ),
+                                    algebraic_type: U64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "e",
+                                    ),
+                                    algebraic_type: U128,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "f",
+                                    ),
+                                    algebraic_type: U256,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "g",
+                                    ),
+                                    algebraic_type: I8,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "h",
+                                    ),
+                                    algebraic_type: I16,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "i",
+                                    ),
+                                    algebraic_type: I32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "j",
+                                    ),
+                                    algebraic_type: I64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "k",
+                                    ),
+                                    algebraic_type: I128,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "l",
+                                    ),
+                                    algebraic_type: I256,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "m",
+                                    ),
+                                    algebraic_type: Bool,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: F32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "o",
+                                    ),
+                                    algebraic_type: F64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "p",
+                                    ),
+                                    algebraic_type: String,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "q",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__identity_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "r",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__address_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneEveryVecStruct": RawTableDefV8 {
+            table_name: "OneEveryVecStruct",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "a",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U16,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "c",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U32,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "d",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U64,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "e",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U128,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "f",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U256,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "g",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I8,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "h",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I16,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "i",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I32,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "j",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I64,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "k",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I128,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "l",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I256,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "m",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Bool,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: F32,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "o",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: F64,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "p",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: String,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "q",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__identity_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "r",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__address_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneF32": RawTableDefV8 {
+            table_name: "OneF32",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "f",
+                    col_type: F32,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneF64": RawTableDefV8 {
+            table_name: "OneF64",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "f",
+                    col_type: F64,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneI128": RawTableDefV8 {
+            table_name: "OneI128",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I128,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneI16": RawTableDefV8 {
+            table_name: "OneI16",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I16,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneI256": RawTableDefV8 {
+            table_name: "OneI256",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I256,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneI32": RawTableDefV8 {
+            table_name: "OneI32",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneI64": RawTableDefV8 {
+            table_name: "OneI64",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I64,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneI8": RawTableDefV8 {
+            table_name: "OneI8",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I8,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneIdentity": RawTableDefV8 {
+            table_name: "OneIdentity",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "i",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__identity_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneSimpleEnum": RawTableDefV8 {
+            table_name: "OneSimpleEnum",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "e",
+                    col_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Zero",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "One",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Two",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneString": RawTableDefV8 {
+            table_name: "OneString",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: String,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneU128": RawTableDefV8 {
+            table_name: "OneU128",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U128,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneU16": RawTableDefV8 {
+            table_name: "OneU16",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U16,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneU256": RawTableDefV8 {
+            table_name: "OneU256",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U256,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneU32": RawTableDefV8 {
+            table_name: "OneU32",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U32,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneU64": RawTableDefV8 {
+            table_name: "OneU64",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U64,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneU8": RawTableDefV8 {
+            table_name: "OneU8",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U8,
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OneUnitStruct": RawTableDefV8 {
+            table_name: "OneUnitStruct",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: Product(
+                        ProductType {
+                            elements: [],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OptionEveryPrimitiveStruct": RawTableDefV8 {
+            table_name: "OptionEveryPrimitiveStruct",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "some",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "a",
+                                                    ),
+                                                    algebraic_type: U8,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "b",
+                                                    ),
+                                                    algebraic_type: U16,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "c",
+                                                    ),
+                                                    algebraic_type: U32,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "d",
+                                                    ),
+                                                    algebraic_type: U64,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "e",
+                                                    ),
+                                                    algebraic_type: U128,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "f",
+                                                    ),
+                                                    algebraic_type: U256,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "g",
+                                                    ),
+                                                    algebraic_type: I8,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "h",
+                                                    ),
+                                                    algebraic_type: I16,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "i",
+                                                    ),
+                                                    algebraic_type: I32,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "j",
+                                                    ),
+                                                    algebraic_type: I64,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "k",
+                                                    ),
+                                                    algebraic_type: I128,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "l",
+                                                    ),
+                                                    algebraic_type: I256,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "m",
+                                                    ),
+                                                    algebraic_type: Bool,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "n",
+                                                    ),
+                                                    algebraic_type: F32,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "o",
+                                                    ),
+                                                    algebraic_type: F64,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "p",
+                                                    ),
+                                                    algebraic_type: String,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "q",
+                                                    ),
+                                                    algebraic_type: Product(
+                                                        ProductType {
+                                                            elements: [
+                                                                ProductTypeElement {
+                                                                    name: Some(
+                                                                        "__identity_bytes",
+                                                                    ),
+                                                                    algebraic_type: Array(
+                                                                        ArrayType {
+                                                                            elem_ty: U8,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "r",
+                                                    ),
+                                                    algebraic_type: Product(
+                                                        ProductType {
+                                                            elements: [
+                                                                ProductTypeElement {
+                                                                    name: Some(
+                                                                        "__address_bytes",
+                                                                    ),
+                                                                    algebraic_type: Array(
+                                                                        ArrayType {
+                                                                            elem_ty: U8,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "none",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OptionI32": RawTableDefV8 {
+            table_name: "OptionI32",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "some",
+                                    ),
+                                    algebraic_type: I32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "none",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OptionIdentity": RawTableDefV8 {
+            table_name: "OptionIdentity",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "i",
+                    col_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "some",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__identity_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "none",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OptionSimpleEnum": RawTableDefV8 {
+            table_name: "OptionSimpleEnum",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "e",
+                    col_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "some",
+                                    ),
+                                    algebraic_type: Sum(
+                                        SumType {
+                                            variants: [
+                                                SumTypeVariant {
+                                                    name: Some(
+                                                        "Zero",
+                                                    ),
+                                                    algebraic_type: Product(
+                                                        ProductType {
+                                                            elements: [],
+                                                        },
+                                                    ),
+                                                },
+                                                SumTypeVariant {
+                                                    name: Some(
+                                                        "One",
+                                                    ),
+                                                    algebraic_type: Product(
+                                                        ProductType {
+                                                            elements: [],
+                                                        },
+                                                    ),
+                                                },
+                                                SumTypeVariant {
+                                                    name: Some(
+                                                        "Two",
+                                                    ),
+                                                    algebraic_type: Product(
+                                                        ProductType {
+                                                            elements: [],
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "none",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OptionString": RawTableDefV8 {
+            table_name: "OptionString",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "some",
+                                    ),
+                                    algebraic_type: String,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "none",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "OptionVecOptionI32": RawTableDefV8 {
+            table_name: "OptionVecOptionI32",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "v",
+                    col_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "some",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Sum(
+                                                SumType {
+                                                    variants: [
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "some",
+                                                            ),
+                                                            algebraic_type: I32,
+                                                        },
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "none",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "none",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkAddress": RawTableDefV8 {
+            table_name: "PkAddress",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "a",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__address_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkAddress_a",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkBool": RawTableDefV8 {
+            table_name: "PkBool",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "b",
+                    col_type: Bool,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkBool_b",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkI128": RawTableDefV8 {
+            table_name: "PkI128",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I128,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkI128_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkI16": RawTableDefV8 {
+            table_name: "PkI16",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I16,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkI16_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkI256": RawTableDefV8 {
+            table_name: "PkI256",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I256,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkI256_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkI32": RawTableDefV8 {
+            table_name: "PkI32",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I32,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkI32_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkI64": RawTableDefV8 {
+            table_name: "PkI64",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I64,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkI64_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkI8": RawTableDefV8 {
+            table_name: "PkI8",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I8,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkI8_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkIdentity": RawTableDefV8 {
+            table_name: "PkIdentity",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "i",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__identity_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkIdentity_i",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkString": RawTableDefV8 {
+            table_name: "PkString",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: String,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkString_s",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkU128": RawTableDefV8 {
+            table_name: "PkU128",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U128,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkU128_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkU16": RawTableDefV8 {
+            table_name: "PkU16",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U16,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkU16_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkU256": RawTableDefV8 {
+            table_name: "PkU256",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U256,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkU256_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkU32": RawTableDefV8 {
+            table_name: "PkU32",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U32,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkU32_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkU64": RawTableDefV8 {
+            table_name: "PkU64",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U64,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkU64_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "PkU8": RawTableDefV8 {
+            table_name: "PkU8",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U8,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_PkU8_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE | PRIMARY_KEY,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "TableHoldsTable": RawTableDefV8 {
+            table_name: "TableHoldsTable",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "a",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                            ],
+                        },
+                    ),
+                },
+                RawColumnDefV8 {
+                    col_name: "b",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueAddress": RawTableDefV8 {
+            table_name: "UniqueAddress",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "a",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__address_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueAddress_a",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueBool": RawTableDefV8 {
+            table_name: "UniqueBool",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "b",
+                    col_type: Bool,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueBool_b",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueI128": RawTableDefV8 {
+            table_name: "UniqueI128",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I128,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueI128_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueI16": RawTableDefV8 {
+            table_name: "UniqueI16",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I16,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueI16_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueI256": RawTableDefV8 {
+            table_name: "UniqueI256",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I256,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueI256_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueI32": RawTableDefV8 {
+            table_name: "UniqueI32",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I32,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueI32_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueI64": RawTableDefV8 {
+            table_name: "UniqueI64",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I64,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueI64_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueI8": RawTableDefV8 {
+            table_name: "UniqueI8",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: I8,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueI8_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueIdentity": RawTableDefV8 {
+            table_name: "UniqueIdentity",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "i",
+                    col_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__identity_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueIdentity_i",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueString": RawTableDefV8 {
+            table_name: "UniqueString",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: String,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueString_s",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueU128": RawTableDefV8 {
+            table_name: "UniqueU128",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U128,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueU128_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueU16": RawTableDefV8 {
+            table_name: "UniqueU16",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U16,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueU16_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueU256": RawTableDefV8 {
+            table_name: "UniqueU256",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U256,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueU256_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueU32": RawTableDefV8 {
+            table_name: "UniqueU32",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U32,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueU32_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueU64": RawTableDefV8 {
+            table_name: "UniqueU64",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U64,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueU64_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "UniqueU8": RawTableDefV8 {
+            table_name: "UniqueU8",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: U8,
+                },
+                RawColumnDefV8 {
+                    col_name: "data",
+                    col_type: I32,
+                },
+            ],
+            indexes: [],
+            constraints: [
+                RawConstraintDefV8 {
+                    constraint_name: "ct_UniqueU8_n",
+                    constraints: Constraints {
+                        attr: ColumnAttribute(
+                            INDEXED | UNIQUE,
+                        ),
+                    },
+                    columns: [
+                        ColId(
+                            0,
+                        ),
+                    ],
+                },
+            ],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecAddress": RawTableDefV8 {
+            table_name: "VecAddress",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "a",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: Product(
+                                ProductType {
+                                    elements: [
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "__address_bytes",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U8,
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecBool": RawTableDefV8 {
+            table_name: "VecBool",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "b",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: Bool,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecByteStruct": RawTableDefV8 {
+            table_name: "VecByteStruct",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: Product(
+                                ProductType {
+                                    elements: [
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "b",
+                                            ),
+                                            algebraic_type: U8,
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecEnumWithPayload": RawTableDefV8 {
+            table_name: "VecEnumWithPayload",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "e",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: Sum(
+                                SumType {
+                                    variants: [
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "U8",
+                                            ),
+                                            algebraic_type: U8,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "U16",
+                                            ),
+                                            algebraic_type: U16,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "U32",
+                                            ),
+                                            algebraic_type: U32,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "U64",
+                                            ),
+                                            algebraic_type: U64,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "U128",
+                                            ),
+                                            algebraic_type: U128,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "U256",
+                                            ),
+                                            algebraic_type: U256,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "I8",
+                                            ),
+                                            algebraic_type: I8,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "I16",
+                                            ),
+                                            algebraic_type: I16,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "I32",
+                                            ),
+                                            algebraic_type: I32,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "I64",
+                                            ),
+                                            algebraic_type: I64,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "I128",
+                                            ),
+                                            algebraic_type: I128,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "I256",
+                                            ),
+                                            algebraic_type: I256,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Bool",
+                                            ),
+                                            algebraic_type: Bool,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "F32",
+                                            ),
+                                            algebraic_type: F32,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "F64",
+                                            ),
+                                            algebraic_type: F64,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Str",
+                                            ),
+                                            algebraic_type: String,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Identity",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__identity_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Address",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__address_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Bytes",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U8,
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Ints",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I32,
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Strings",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: String,
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "SimpleEnums",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: Sum(
+                                                        SumType {
+                                                            variants: [
+                                                                SumTypeVariant {
+                                                                    name: Some(
+                                                                        "Zero",
+                                                                    ),
+                                                                    algebraic_type: Product(
+                                                                        ProductType {
+                                                                            elements: [],
+                                                                        },
+                                                                    ),
+                                                                },
+                                                                SumTypeVariant {
+                                                                    name: Some(
+                                                                        "One",
+                                                                    ),
+                                                                    algebraic_type: Product(
+                                                                        ProductType {
+                                                                            elements: [],
+                                                                        },
+                                                                    ),
+                                                                },
+                                                                SumTypeVariant {
+                                                                    name: Some(
+                                                                        "Two",
+                                                                    ),
+                                                                    algebraic_type: Product(
+                                                                        ProductType {
+                                                                            elements: [],
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecEveryPrimitiveStruct": RawTableDefV8 {
+            table_name: "VecEveryPrimitiveStruct",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: Product(
+                                ProductType {
+                                    elements: [
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "a",
+                                            ),
+                                            algebraic_type: U8,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "b",
+                                            ),
+                                            algebraic_type: U16,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "c",
+                                            ),
+                                            algebraic_type: U32,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "d",
+                                            ),
+                                            algebraic_type: U64,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "e",
+                                            ),
+                                            algebraic_type: U128,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "f",
+                                            ),
+                                            algebraic_type: U256,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "g",
+                                            ),
+                                            algebraic_type: I8,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "h",
+                                            ),
+                                            algebraic_type: I16,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "i",
+                                            ),
+                                            algebraic_type: I32,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "j",
+                                            ),
+                                            algebraic_type: I64,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "k",
+                                            ),
+                                            algebraic_type: I128,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "l",
+                                            ),
+                                            algebraic_type: I256,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "m",
+                                            ),
+                                            algebraic_type: Bool,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "n",
+                                            ),
+                                            algebraic_type: F32,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "o",
+                                            ),
+                                            algebraic_type: F64,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "p",
+                                            ),
+                                            algebraic_type: String,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "q",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__identity_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "r",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__address_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecEveryVecStruct": RawTableDefV8 {
+            table_name: "VecEveryVecStruct",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: Product(
+                                ProductType {
+                                    elements: [
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "a",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U8,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "b",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U16,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "c",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U32,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "d",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U64,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "e",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U128,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "f",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U256,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "g",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I8,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "h",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I16,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "i",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I32,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "j",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I64,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "k",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I128,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "l",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I256,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "m",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: Bool,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "n",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: F32,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "o",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: F64,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "p",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: String,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "q",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: Product(
+                                                        ProductType {
+                                                            elements: [
+                                                                ProductTypeElement {
+                                                                    name: Some(
+                                                                        "__identity_bytes",
+                                                                    ),
+                                                                    algebraic_type: Array(
+                                                                        ArrayType {
+                                                                            elem_ty: U8,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "r",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: Product(
+                                                        ProductType {
+                                                            elements: [
+                                                                ProductTypeElement {
+                                                                    name: Some(
+                                                                        "__address_bytes",
+                                                                    ),
+                                                                    algebraic_type: Array(
+                                                                        ArrayType {
+                                                                            elem_ty: U8,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecF32": RawTableDefV8 {
+            table_name: "VecF32",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "f",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: F32,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecF64": RawTableDefV8 {
+            table_name: "VecF64",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "f",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: F64,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecI128": RawTableDefV8 {
+            table_name: "VecI128",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: I128,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecI16": RawTableDefV8 {
+            table_name: "VecI16",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: I16,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecI256": RawTableDefV8 {
+            table_name: "VecI256",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: I256,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecI32": RawTableDefV8 {
+            table_name: "VecI32",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: I32,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecI64": RawTableDefV8 {
+            table_name: "VecI64",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: I64,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecI8": RawTableDefV8 {
+            table_name: "VecI8",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: I8,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecIdentity": RawTableDefV8 {
+            table_name: "VecIdentity",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "i",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: Product(
+                                ProductType {
+                                    elements: [
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "__identity_bytes",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U8,
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecSimpleEnum": RawTableDefV8 {
+            table_name: "VecSimpleEnum",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "e",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: Sum(
+                                SumType {
+                                    variants: [
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Zero",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [],
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "One",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [],
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Two",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [],
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecString": RawTableDefV8 {
+            table_name: "VecString",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: String,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecU128": RawTableDefV8 {
+            table_name: "VecU128",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: U128,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecU16": RawTableDefV8 {
+            table_name: "VecU16",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: U16,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecU256": RawTableDefV8 {
+            table_name: "VecU256",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: U256,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecU32": RawTableDefV8 {
+            table_name: "VecU32",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: U32,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecU64": RawTableDefV8 {
+            table_name: "VecU64",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: U64,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecU8": RawTableDefV8 {
+            table_name: "VecU8",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "n",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: U8,
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+        "VecUnitStruct": RawTableDefV8 {
+            table_name: "VecUnitStruct",
+            columns: [
+                RawColumnDefV8 {
+                    col_name: "s",
+                    col_type: Array(
+                        ArrayType {
+                            elem_ty: Product(
+                                ProductType {
+                                    elements: [],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+            indexes: [],
+            constraints: [],
+            sequences: [],
+            table_type: User,
+            table_access: Public,
+            scheduled: None,
+        },
+    },
+    reducers: {
+        "delete_pk_address": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "a",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__address_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "delete_pk_bool": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "b",
+                    ),
+                    algebraic_type: Bool,
+                },
+            ],
+        },
+        "delete_pk_i128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I128,
+                },
+            ],
+        },
+        "delete_pk_i16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I16,
+                },
+            ],
+        },
+        "delete_pk_i256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I256,
+                },
+            ],
+        },
+        "delete_pk_i32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "delete_pk_i64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I64,
+                },
+            ],
+        },
+        "delete_pk_i8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I8,
+                },
+            ],
+        },
+        "delete_pk_identity": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "i",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__identity_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "delete_pk_string": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: String,
+                },
+            ],
+        },
+        "delete_pk_u128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U128,
+                },
+            ],
+        },
+        "delete_pk_u16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U16,
+                },
+            ],
+        },
+        "delete_pk_u256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U256,
+                },
+            ],
+        },
+        "delete_pk_u32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U32,
+                },
+            ],
+        },
+        "delete_pk_u64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U64,
+                },
+            ],
+        },
+        "delete_pk_u8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U8,
+                },
+            ],
+        },
+        "delete_unique_address": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "a",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__address_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "delete_unique_bool": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "b",
+                    ),
+                    algebraic_type: Bool,
+                },
+            ],
+        },
+        "delete_unique_i128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I128,
+                },
+            ],
+        },
+        "delete_unique_i16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I16,
+                },
+            ],
+        },
+        "delete_unique_i256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I256,
+                },
+            ],
+        },
+        "delete_unique_i32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "delete_unique_i64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I64,
+                },
+            ],
+        },
+        "delete_unique_i8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I8,
+                },
+            ],
+        },
+        "delete_unique_identity": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "i",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__identity_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "delete_unique_string": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: String,
+                },
+            ],
+        },
+        "delete_unique_u128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U128,
+                },
+            ],
+        },
+        "delete_unique_u16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U16,
+                },
+            ],
+        },
+        "delete_unique_u256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U256,
+                },
+            ],
+        },
+        "delete_unique_u32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U32,
+                },
+            ],
+        },
+        "delete_unique_u64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U64,
+                },
+            ],
+        },
+        "delete_unique_u8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U8,
+                },
+            ],
+        },
+        "insert_caller_one_address": ProductType {
+            elements: [],
+        },
+        "insert_caller_one_identity": ProductType {
+            elements: [],
+        },
+        "insert_caller_pk_address": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_caller_pk_identity": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_caller_unique_address": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_caller_unique_identity": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_caller_vec_address": ProductType {
+            elements: [],
+        },
+        "insert_caller_vec_identity": ProductType {
+            elements: [],
+        },
+        "insert_large_table": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "a",
+                    ),
+                    algebraic_type: U8,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "b",
+                    ),
+                    algebraic_type: U16,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "c",
+                    ),
+                    algebraic_type: U32,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "d",
+                    ),
+                    algebraic_type: U64,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "e",
+                    ),
+                    algebraic_type: U128,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "f",
+                    ),
+                    algebraic_type: U256,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "g",
+                    ),
+                    algebraic_type: I8,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "h",
+                    ),
+                    algebraic_type: I16,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "i",
+                    ),
+                    algebraic_type: I32,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "j",
+                    ),
+                    algebraic_type: I64,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "k",
+                    ),
+                    algebraic_type: I128,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "l",
+                    ),
+                    algebraic_type: I256,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "m",
+                    ),
+                    algebraic_type: Bool,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: F32,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "o",
+                    ),
+                    algebraic_type: F64,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "p",
+                    ),
+                    algebraic_type: String,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "q",
+                    ),
+                    algebraic_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Zero",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "One",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Two",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "r",
+                    ),
+                    algebraic_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U8",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U16",
+                                    ),
+                                    algebraic_type: U16,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U32",
+                                    ),
+                                    algebraic_type: U32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U64",
+                                    ),
+                                    algebraic_type: U64,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U128",
+                                    ),
+                                    algebraic_type: U128,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U256",
+                                    ),
+                                    algebraic_type: U256,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I8",
+                                    ),
+                                    algebraic_type: I8,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I16",
+                                    ),
+                                    algebraic_type: I16,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I32",
+                                    ),
+                                    algebraic_type: I32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I64",
+                                    ),
+                                    algebraic_type: I64,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I128",
+                                    ),
+                                    algebraic_type: I128,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I256",
+                                    ),
+                                    algebraic_type: I256,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Bool",
+                                    ),
+                                    algebraic_type: Bool,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "F32",
+                                    ),
+                                    algebraic_type: F32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "F64",
+                                    ),
+                                    algebraic_type: F64,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Str",
+                                    ),
+                                    algebraic_type: String,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Identity",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__identity_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Address",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__address_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Ints",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I32,
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Strings",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: String,
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "SimpleEnums",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Sum(
+                                                SumType {
+                                                    variants: [
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "Zero",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "One",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "Two",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "t",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "u",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "a",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: U16,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "c",
+                                    ),
+                                    algebraic_type: U32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "d",
+                                    ),
+                                    algebraic_type: U64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "e",
+                                    ),
+                                    algebraic_type: U128,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "f",
+                                    ),
+                                    algebraic_type: U256,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "g",
+                                    ),
+                                    algebraic_type: I8,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "h",
+                                    ),
+                                    algebraic_type: I16,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "i",
+                                    ),
+                                    algebraic_type: I32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "j",
+                                    ),
+                                    algebraic_type: I64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "k",
+                                    ),
+                                    algebraic_type: I128,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "l",
+                                    ),
+                                    algebraic_type: I256,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "m",
+                                    ),
+                                    algebraic_type: Bool,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: F32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "o",
+                                    ),
+                                    algebraic_type: F64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "p",
+                                    ),
+                                    algebraic_type: String,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "q",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__identity_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "r",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__address_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "v",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "a",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U16,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "c",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U32,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "d",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U64,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "e",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U128,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "f",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U256,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "g",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I8,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "h",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I16,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "i",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I32,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "j",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I64,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "k",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I128,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "l",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I256,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "m",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Bool,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: F32,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "o",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: F64,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "p",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: String,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "q",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__identity_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "r",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__address_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_one_address": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "a",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__address_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_one_bool": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "b",
+                    ),
+                    algebraic_type: Bool,
+                },
+            ],
+        },
+        "insert_one_byte_struct": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_one_enum_with_payload": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "e",
+                    ),
+                    algebraic_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U8",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U16",
+                                    ),
+                                    algebraic_type: U16,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U32",
+                                    ),
+                                    algebraic_type: U32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U64",
+                                    ),
+                                    algebraic_type: U64,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U128",
+                                    ),
+                                    algebraic_type: U128,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "U256",
+                                    ),
+                                    algebraic_type: U256,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I8",
+                                    ),
+                                    algebraic_type: I8,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I16",
+                                    ),
+                                    algebraic_type: I16,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I32",
+                                    ),
+                                    algebraic_type: I32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I64",
+                                    ),
+                                    algebraic_type: I64,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I128",
+                                    ),
+                                    algebraic_type: I128,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "I256",
+                                    ),
+                                    algebraic_type: I256,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Bool",
+                                    ),
+                                    algebraic_type: Bool,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "F32",
+                                    ),
+                                    algebraic_type: F32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "F64",
+                                    ),
+                                    algebraic_type: F64,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Str",
+                                    ),
+                                    algebraic_type: String,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Identity",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__identity_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Address",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__address_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Ints",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I32,
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Strings",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: String,
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "SimpleEnums",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Sum(
+                                                SumType {
+                                                    variants: [
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "Zero",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "One",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "Two",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_one_every_primitive_struct": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "a",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: U16,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "c",
+                                    ),
+                                    algebraic_type: U32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "d",
+                                    ),
+                                    algebraic_type: U64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "e",
+                                    ),
+                                    algebraic_type: U128,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "f",
+                                    ),
+                                    algebraic_type: U256,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "g",
+                                    ),
+                                    algebraic_type: I8,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "h",
+                                    ),
+                                    algebraic_type: I16,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "i",
+                                    ),
+                                    algebraic_type: I32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "j",
+                                    ),
+                                    algebraic_type: I64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "k",
+                                    ),
+                                    algebraic_type: I128,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "l",
+                                    ),
+                                    algebraic_type: I256,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "m",
+                                    ),
+                                    algebraic_type: Bool,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: F32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "o",
+                                    ),
+                                    algebraic_type: F64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "p",
+                                    ),
+                                    algebraic_type: String,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "q",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__identity_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "r",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__address_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_one_every_vec_struct": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "a",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U16,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "c",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U32,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "d",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U64,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "e",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U128,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "f",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U256,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "g",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I8,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "h",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I16,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "i",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I32,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "j",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I64,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "k",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I128,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "l",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: I256,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "m",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Bool,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: F32,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "o",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: F64,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "p",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: String,
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "q",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__identity_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "r",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__address_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_one_f32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "f",
+                    ),
+                    algebraic_type: F32,
+                },
+            ],
+        },
+        "insert_one_f64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "f",
+                    ),
+                    algebraic_type: F64,
+                },
+            ],
+        },
+        "insert_one_i128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I128,
+                },
+            ],
+        },
+        "insert_one_i16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I16,
+                },
+            ],
+        },
+        "insert_one_i256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I256,
+                },
+            ],
+        },
+        "insert_one_i32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_one_i64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I64,
+                },
+            ],
+        },
+        "insert_one_i8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I8,
+                },
+            ],
+        },
+        "insert_one_identity": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "i",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__identity_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_one_simple_enum": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "e",
+                    ),
+                    algebraic_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Zero",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "One",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "Two",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_one_string": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: String,
+                },
+            ],
+        },
+        "insert_one_u128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U128,
+                },
+            ],
+        },
+        "insert_one_u16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U16,
+                },
+            ],
+        },
+        "insert_one_u256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U256,
+                },
+            ],
+        },
+        "insert_one_u32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U32,
+                },
+            ],
+        },
+        "insert_one_u64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U64,
+                },
+            ],
+        },
+        "insert_one_u8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U8,
+                },
+            ],
+        },
+        "insert_one_unit_struct": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_option_every_primitive_struct": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "some",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "a",
+                                                    ),
+                                                    algebraic_type: U8,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "b",
+                                                    ),
+                                                    algebraic_type: U16,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "c",
+                                                    ),
+                                                    algebraic_type: U32,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "d",
+                                                    ),
+                                                    algebraic_type: U64,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "e",
+                                                    ),
+                                                    algebraic_type: U128,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "f",
+                                                    ),
+                                                    algebraic_type: U256,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "g",
+                                                    ),
+                                                    algebraic_type: I8,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "h",
+                                                    ),
+                                                    algebraic_type: I16,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "i",
+                                                    ),
+                                                    algebraic_type: I32,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "j",
+                                                    ),
+                                                    algebraic_type: I64,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "k",
+                                                    ),
+                                                    algebraic_type: I128,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "l",
+                                                    ),
+                                                    algebraic_type: I256,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "m",
+                                                    ),
+                                                    algebraic_type: Bool,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "n",
+                                                    ),
+                                                    algebraic_type: F32,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "o",
+                                                    ),
+                                                    algebraic_type: F64,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "p",
+                                                    ),
+                                                    algebraic_type: String,
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "q",
+                                                    ),
+                                                    algebraic_type: Product(
+                                                        ProductType {
+                                                            elements: [
+                                                                ProductTypeElement {
+                                                                    name: Some(
+                                                                        "__identity_bytes",
+                                                                    ),
+                                                                    algebraic_type: Array(
+                                                                        ArrayType {
+                                                                            elem_ty: U8,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "r",
+                                                    ),
+                                                    algebraic_type: Product(
+                                                        ProductType {
+                                                            elements: [
+                                                                ProductTypeElement {
+                                                                    name: Some(
+                                                                        "__address_bytes",
+                                                                    ),
+                                                                    algebraic_type: Array(
+                                                                        ArrayType {
+                                                                            elem_ty: U8,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "none",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_option_i32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "some",
+                                    ),
+                                    algebraic_type: I32,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "none",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_option_identity": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "i",
+                    ),
+                    algebraic_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "some",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__identity_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "none",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_option_simple_enum": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "e",
+                    ),
+                    algebraic_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "some",
+                                    ),
+                                    algebraic_type: Sum(
+                                        SumType {
+                                            variants: [
+                                                SumTypeVariant {
+                                                    name: Some(
+                                                        "Zero",
+                                                    ),
+                                                    algebraic_type: Product(
+                                                        ProductType {
+                                                            elements: [],
+                                                        },
+                                                    ),
+                                                },
+                                                SumTypeVariant {
+                                                    name: Some(
+                                                        "One",
+                                                    ),
+                                                    algebraic_type: Product(
+                                                        ProductType {
+                                                            elements: [],
+                                                        },
+                                                    ),
+                                                },
+                                                SumTypeVariant {
+                                                    name: Some(
+                                                        "Two",
+                                                    ),
+                                                    algebraic_type: Product(
+                                                        ProductType {
+                                                            elements: [],
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "none",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_option_string": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "some",
+                                    ),
+                                    algebraic_type: String,
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "none",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_option_vec_option_i32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "v",
+                    ),
+                    algebraic_type: Sum(
+                        SumType {
+                            variants: [
+                                SumTypeVariant {
+                                    name: Some(
+                                        "some",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: Sum(
+                                                SumType {
+                                                    variants: [
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "some",
+                                                            ),
+                                                            algebraic_type: I32,
+                                                        },
+                                                        SumTypeVariant {
+                                                            name: Some(
+                                                                "none",
+                                                            ),
+                                                            algebraic_type: Product(
+                                                                ProductType {
+                                                                    elements: [],
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ),
+                                },
+                                SumTypeVariant {
+                                    name: Some(
+                                        "none",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_pk_address": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "a",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__address_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_bool": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "b",
+                    ),
+                    algebraic_type: Bool,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_i128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I128,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_i16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I16,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_i256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I256,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_i32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I32,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_i64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I64,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_i8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I8,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_identity": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "i",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__identity_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_string": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: String,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_u128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U128,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_u16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U16,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_u256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U256,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_u32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U32,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_u64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U64,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_pk_u8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U8,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_primitives_as_strings": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "a",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "b",
+                                    ),
+                                    algebraic_type: U16,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "c",
+                                    ),
+                                    algebraic_type: U32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "d",
+                                    ),
+                                    algebraic_type: U64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "e",
+                                    ),
+                                    algebraic_type: U128,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "f",
+                                    ),
+                                    algebraic_type: U256,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "g",
+                                    ),
+                                    algebraic_type: I8,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "h",
+                                    ),
+                                    algebraic_type: I16,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "i",
+                                    ),
+                                    algebraic_type: I32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "j",
+                                    ),
+                                    algebraic_type: I64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "k",
+                                    ),
+                                    algebraic_type: I128,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "l",
+                                    ),
+                                    algebraic_type: I256,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "m",
+                                    ),
+                                    algebraic_type: Bool,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: F32,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "o",
+                                    ),
+                                    algebraic_type: F64,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "p",
+                                    ),
+                                    algebraic_type: String,
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "q",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__identity_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                                ProductTypeElement {
+                                    name: Some(
+                                        "r",
+                                    ),
+                                    algebraic_type: Product(
+                                        ProductType {
+                                            elements: [
+                                                ProductTypeElement {
+                                                    name: Some(
+                                                        "__address_bytes",
+                                                    ),
+                                                    algebraic_type: Array(
+                                                        ArrayType {
+                                                            elem_ty: U8,
+                                                        },
+                                                    ),
+                                                },
+                                            ],
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_table_holds_table": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "a",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: U8,
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "b",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "n",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_unique_address": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "a",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__address_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_bool": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "b",
+                    ),
+                    algebraic_type: Bool,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_i128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I128,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_i16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I16,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_i256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I256,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_i32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I32,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_i64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I64,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_i8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I8,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_identity": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "i",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__identity_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_string": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: String,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_u128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U128,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_u16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U16,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_u256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U256,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_u32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U32,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_u64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U64,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_unique_u8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U8,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "insert_vec_address": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "a",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: Product(
+                                ProductType {
+                                    elements: [
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "__address_bytes",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U8,
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_bool": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "b",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: Bool,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_byte_struct": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: Product(
+                                ProductType {
+                                    elements: [
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "b",
+                                            ),
+                                            algebraic_type: U8,
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_enum_with_payload": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "e",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: Sum(
+                                SumType {
+                                    variants: [
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "U8",
+                                            ),
+                                            algebraic_type: U8,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "U16",
+                                            ),
+                                            algebraic_type: U16,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "U32",
+                                            ),
+                                            algebraic_type: U32,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "U64",
+                                            ),
+                                            algebraic_type: U64,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "U128",
+                                            ),
+                                            algebraic_type: U128,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "U256",
+                                            ),
+                                            algebraic_type: U256,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "I8",
+                                            ),
+                                            algebraic_type: I8,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "I16",
+                                            ),
+                                            algebraic_type: I16,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "I32",
+                                            ),
+                                            algebraic_type: I32,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "I64",
+                                            ),
+                                            algebraic_type: I64,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "I128",
+                                            ),
+                                            algebraic_type: I128,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "I256",
+                                            ),
+                                            algebraic_type: I256,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Bool",
+                                            ),
+                                            algebraic_type: Bool,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "F32",
+                                            ),
+                                            algebraic_type: F32,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "F64",
+                                            ),
+                                            algebraic_type: F64,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Str",
+                                            ),
+                                            algebraic_type: String,
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Identity",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__identity_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Address",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__address_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Bytes",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U8,
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Ints",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I32,
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Strings",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: String,
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "SimpleEnums",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: Sum(
+                                                        SumType {
+                                                            variants: [
+                                                                SumTypeVariant {
+                                                                    name: Some(
+                                                                        "Zero",
+                                                                    ),
+                                                                    algebraic_type: Product(
+                                                                        ProductType {
+                                                                            elements: [],
+                                                                        },
+                                                                    ),
+                                                                },
+                                                                SumTypeVariant {
+                                                                    name: Some(
+                                                                        "One",
+                                                                    ),
+                                                                    algebraic_type: Product(
+                                                                        ProductType {
+                                                                            elements: [],
+                                                                        },
+                                                                    ),
+                                                                },
+                                                                SumTypeVariant {
+                                                                    name: Some(
+                                                                        "Two",
+                                                                    ),
+                                                                    algebraic_type: Product(
+                                                                        ProductType {
+                                                                            elements: [],
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_every_primitive_struct": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: Product(
+                                ProductType {
+                                    elements: [
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "a",
+                                            ),
+                                            algebraic_type: U8,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "b",
+                                            ),
+                                            algebraic_type: U16,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "c",
+                                            ),
+                                            algebraic_type: U32,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "d",
+                                            ),
+                                            algebraic_type: U64,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "e",
+                                            ),
+                                            algebraic_type: U128,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "f",
+                                            ),
+                                            algebraic_type: U256,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "g",
+                                            ),
+                                            algebraic_type: I8,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "h",
+                                            ),
+                                            algebraic_type: I16,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "i",
+                                            ),
+                                            algebraic_type: I32,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "j",
+                                            ),
+                                            algebraic_type: I64,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "k",
+                                            ),
+                                            algebraic_type: I128,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "l",
+                                            ),
+                                            algebraic_type: I256,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "m",
+                                            ),
+                                            algebraic_type: Bool,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "n",
+                                            ),
+                                            algebraic_type: F32,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "o",
+                                            ),
+                                            algebraic_type: F64,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "p",
+                                            ),
+                                            algebraic_type: String,
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "q",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__identity_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "r",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [
+                                                        ProductTypeElement {
+                                                            name: Some(
+                                                                "__address_bytes",
+                                                            ),
+                                                            algebraic_type: Array(
+                                                                ArrayType {
+                                                                    elem_ty: U8,
+                                                                },
+                                                            ),
+                                                        },
+                                                    ],
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_every_vec_struct": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: Product(
+                                ProductType {
+                                    elements: [
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "a",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U8,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "b",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U16,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "c",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U32,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "d",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U64,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "e",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U128,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "f",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U256,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "g",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I8,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "h",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I16,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "i",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I32,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "j",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I64,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "k",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I128,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "l",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: I256,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "m",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: Bool,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "n",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: F32,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "o",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: F64,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "p",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: String,
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "q",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: Product(
+                                                        ProductType {
+                                                            elements: [
+                                                                ProductTypeElement {
+                                                                    name: Some(
+                                                                        "__identity_bytes",
+                                                                    ),
+                                                                    algebraic_type: Array(
+                                                                        ArrayType {
+                                                                            elem_ty: U8,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "r",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: Product(
+                                                        ProductType {
+                                                            elements: [
+                                                                ProductTypeElement {
+                                                                    name: Some(
+                                                                        "__address_bytes",
+                                                                    ),
+                                                                    algebraic_type: Array(
+                                                                        ArrayType {
+                                                                            elem_ty: U8,
+                                                                        },
+                                                                    ),
+                                                                },
+                                                            ],
+                                                        },
+                                                    ),
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_f32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "f",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: F32,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_f64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "f",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: F64,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_i128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: I128,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_i16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: I16,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_i256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: I256,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_i32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: I32,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_i64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: I64,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_i8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: I8,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_identity": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "i",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: Product(
+                                ProductType {
+                                    elements: [
+                                        ProductTypeElement {
+                                            name: Some(
+                                                "__identity_bytes",
+                                            ),
+                                            algebraic_type: Array(
+                                                ArrayType {
+                                                    elem_ty: U8,
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_simple_enum": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "e",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: Sum(
+                                SumType {
+                                    variants: [
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Zero",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [],
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "One",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [],
+                                                },
+                                            ),
+                                        },
+                                        SumTypeVariant {
+                                            name: Some(
+                                                "Two",
+                                            ),
+                                            algebraic_type: Product(
+                                                ProductType {
+                                                    elements: [],
+                                                },
+                                            ),
+                                        },
+                                    ],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_string": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: String,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_u128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: U128,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_u16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: U16,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_u256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: U256,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_u32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: U32,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_u64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: U64,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_u8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: U8,
+                        },
+                    ),
+                },
+            ],
+        },
+        "insert_vec_unit_struct": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: Array(
+                        ArrayType {
+                            elem_ty: Product(
+                                ProductType {
+                                    elements: [],
+                                },
+                            ),
+                        },
+                    ),
+                },
+            ],
+        },
+        "no_op_succeeds": ProductType {
+            elements: [],
+        },
+        "update_pk_address": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "a",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__address_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_bool": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "b",
+                    ),
+                    algebraic_type: Bool,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_i128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I128,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_i16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I16,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_i256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I256,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_i32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I32,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_i64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I64,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_i8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I8,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_identity": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "i",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__identity_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_string": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: String,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_u128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U128,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_u16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U16,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_u256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U256,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_u32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U32,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_u64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U64,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_pk_u8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U8,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_address": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "a",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__address_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_bool": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "b",
+                    ),
+                    algebraic_type: Bool,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_i128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I128,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_i16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I16,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_i256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I256,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_i32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I32,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_i64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I64,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_i8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: I8,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_identity": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "i",
+                    ),
+                    algebraic_type: Product(
+                        ProductType {
+                            elements: [
+                                ProductTypeElement {
+                                    name: Some(
+                                        "__identity_bytes",
+                                    ),
+                                    algebraic_type: Array(
+                                        ArrayType {
+                                            elem_ty: U8,
+                                        },
+                                    ),
+                                },
+                            ],
+                        },
+                    ),
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_string": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "s",
+                    ),
+                    algebraic_type: String,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_u128": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U128,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_u16": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U16,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_u256": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U256,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_u32": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U32,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_u64": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U64,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+        "update_unique_u8": ProductType {
+            elements: [
+                ProductTypeElement {
+                    name: Some(
+                        "n",
+                    ),
+                    algebraic_type: U8,
+                },
+                ProductTypeElement {
+                    name: Some(
+                        "data",
+                    ),
+                    algebraic_type: I32,
+                },
+            ],
+        },
+    },
+    exports: {
+        "ByteStruct": Product(
+            ProductType {
+                elements: [
+                    ProductTypeElement {
+                        name: Some(
+                            "b",
+                        ),
+                        algebraic_type: U8,
+                    },
+                ],
+            },
+        ),
+        "EnumWithPayload": Sum(
+            SumType {
+                variants: [
+                    SumTypeVariant {
+                        name: Some(
+                            "U8",
+                        ),
+                        algebraic_type: U8,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "U16",
+                        ),
+                        algebraic_type: U16,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "U32",
+                        ),
+                        algebraic_type: U32,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "U64",
+                        ),
+                        algebraic_type: U64,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "U128",
+                        ),
+                        algebraic_type: U128,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "U256",
+                        ),
+                        algebraic_type: U256,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "I8",
+                        ),
+                        algebraic_type: I8,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "I16",
+                        ),
+                        algebraic_type: I16,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "I32",
+                        ),
+                        algebraic_type: I32,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "I64",
+                        ),
+                        algebraic_type: I64,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "I128",
+                        ),
+                        algebraic_type: I128,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "I256",
+                        ),
+                        algebraic_type: I256,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "Bool",
+                        ),
+                        algebraic_type: Bool,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "F32",
+                        ),
+                        algebraic_type: F32,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "F64",
+                        ),
+                        algebraic_type: F64,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "Str",
+                        ),
+                        algebraic_type: String,
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "Identity",
+                        ),
+                        algebraic_type: Product(
+                            ProductType {
+                                elements: [
+                                    ProductTypeElement {
+                                        name: Some(
+                                            "__identity_bytes",
+                                        ),
+                                        algebraic_type: Array(
+                                            ArrayType {
+                                                elem_ty: U8,
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "Address",
+                        ),
+                        algebraic_type: Product(
+                            ProductType {
+                                elements: [
+                                    ProductTypeElement {
+                                        name: Some(
+                                            "__address_bytes",
+                                        ),
+                                        algebraic_type: Array(
+                                            ArrayType {
+                                                elem_ty: U8,
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "Bytes",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: U8,
+                            },
+                        ),
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "Ints",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: I32,
+                            },
+                        ),
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "Strings",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: String,
+                            },
+                        ),
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "SimpleEnums",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: Sum(
+                                    SumType {
+                                        variants: [
+                                            SumTypeVariant {
+                                                name: Some(
+                                                    "Zero",
+                                                ),
+                                                algebraic_type: Product(
+                                                    ProductType {
+                                                        elements: [],
+                                                    },
+                                                ),
+                                            },
+                                            SumTypeVariant {
+                                                name: Some(
+                                                    "One",
+                                                ),
+                                                algebraic_type: Product(
+                                                    ProductType {
+                                                        elements: [],
+                                                    },
+                                                ),
+                                            },
+                                            SumTypeVariant {
+                                                name: Some(
+                                                    "Two",
+                                                ),
+                                                algebraic_type: Product(
+                                                    ProductType {
+                                                        elements: [],
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                ),
+                            },
+                        ),
+                    },
+                ],
+            },
+        ),
+        "EveryPrimitiveStruct": Product(
+            ProductType {
+                elements: [
+                    ProductTypeElement {
+                        name: Some(
+                            "a",
+                        ),
+                        algebraic_type: U8,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "b",
+                        ),
+                        algebraic_type: U16,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "c",
+                        ),
+                        algebraic_type: U32,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "d",
+                        ),
+                        algebraic_type: U64,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "e",
+                        ),
+                        algebraic_type: U128,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "f",
+                        ),
+                        algebraic_type: U256,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "g",
+                        ),
+                        algebraic_type: I8,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "h",
+                        ),
+                        algebraic_type: I16,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "i",
+                        ),
+                        algebraic_type: I32,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "j",
+                        ),
+                        algebraic_type: I64,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "k",
+                        ),
+                        algebraic_type: I128,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "l",
+                        ),
+                        algebraic_type: I256,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "m",
+                        ),
+                        algebraic_type: Bool,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "n",
+                        ),
+                        algebraic_type: F32,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "o",
+                        ),
+                        algebraic_type: F64,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "p",
+                        ),
+                        algebraic_type: String,
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "q",
+                        ),
+                        algebraic_type: Product(
+                            ProductType {
+                                elements: [
+                                    ProductTypeElement {
+                                        name: Some(
+                                            "__identity_bytes",
+                                        ),
+                                        algebraic_type: Array(
+                                            ArrayType {
+                                                elem_ty: U8,
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "r",
+                        ),
+                        algebraic_type: Product(
+                            ProductType {
+                                elements: [
+                                    ProductTypeElement {
+                                        name: Some(
+                                            "__address_bytes",
+                                        ),
+                                        algebraic_type: Array(
+                                            ArrayType {
+                                                elem_ty: U8,
+                                            },
+                                        ),
+                                    },
+                                ],
+                            },
+                        ),
+                    },
+                ],
+            },
+        ),
+        "EveryVecStruct": Product(
+            ProductType {
+                elements: [
+                    ProductTypeElement {
+                        name: Some(
+                            "a",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: U8,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "b",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: U16,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "c",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: U32,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "d",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: U64,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "e",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: U128,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "f",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: U256,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "g",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: I8,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "h",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: I16,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "i",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: I32,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "j",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: I64,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "k",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: I128,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "l",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: I256,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "m",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: Bool,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "n",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: F32,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "o",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: F64,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "p",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: String,
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "q",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: Product(
+                                    ProductType {
+                                        elements: [
+                                            ProductTypeElement {
+                                                name: Some(
+                                                    "__identity_bytes",
+                                                ),
+                                                algebraic_type: Array(
+                                                    ArrayType {
+                                                        elem_ty: U8,
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                ),
+                            },
+                        ),
+                    },
+                    ProductTypeElement {
+                        name: Some(
+                            "r",
+                        ),
+                        algebraic_type: Array(
+                            ArrayType {
+                                elem_ty: Product(
+                                    ProductType {
+                                        elements: [
+                                            ProductTypeElement {
+                                                name: Some(
+                                                    "__address_bytes",
+                                                ),
+                                                algebraic_type: Array(
+                                                    ArrayType {
+                                                        elem_ty: U8,
+                                                    },
+                                                ),
+                                            },
+                                        ],
+                                    },
+                                ),
+                            },
+                        ),
+                    },
+                ],
+            },
+        ),
+        "SimpleEnum": Sum(
+            SumType {
+                variants: [
+                    SumTypeVariant {
+                        name: Some(
+                            "Zero",
+                        ),
+                        algebraic_type: Product(
+                            ProductType {
+                                elements: [],
+                            },
+                        ),
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "One",
+                        ),
+                        algebraic_type: Product(
+                            ProductType {
+                                elements: [],
+                            },
+                        ),
+                    },
+                    SumTypeVariant {
+                        name: Some(
+                            "Two",
+                        ),
+                        algebraic_type: Product(
+                            ProductType {
+                                elements: [],
+                            },
+                        ),
+                    },
+                ],
+            },
+        ),
+        "UnitStruct": Product(
+            ProductType {
+                elements: [],
+            },
+        ),
+    },
+}

--- a/crates/testing/src/snapshots/spacetimedb_testing__sdk__descriptions@test-client.snap
+++ b/crates/testing/src/snapshots/spacetimedb_testing__sdk__descriptions@test-client.snap
@@ -7,719 +7,110 @@ NormalizedModuleDef {
         "LargeTable": RawTableDefV8 {
             table_name: "LargeTable",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "a",
-                    col_type: U8,
+                "a": U8,
+                "b": U16,
+                "c": U32,
+                "d": U64,
+                "e": U128,
+                "f": U256,
+                "g": I8,
+                "h": I16,
+                "i": I32,
+                "j": I64,
+                "k": I128,
+                "l": I256,
+                "m": Bool,
+                "n": F32,
+                "o": F64,
+                "p": String,
+                "q": SumType {
+                    "Zero": ProductType {},
+                    "One": ProductType {},
+                    "Two": ProductType {},
                 },
-                RawColumnDefV8 {
-                    col_name: "b",
-                    col_type: U16,
+                "r": SumType {
+                    "U8": U8,
+                    "U16": U16,
+                    "U32": U32,
+                    "U64": U64,
+                    "U128": U128,
+                    "U256": U256,
+                    "I8": I8,
+                    "I16": I16,
+                    "I32": I32,
+                    "I64": I64,
+                    "I128": I128,
+                    "I256": I256,
+                    "Bool": Bool,
+                    "F32": F32,
+                    "F64": F64,
+                    "Str": String,
+                    "Identity": ProductType {
+                        "__identity_bytes": ArrayType(U8),
+                    },
+                    "Address": ProductType {
+                        "__address_bytes": ArrayType(U8),
+                    },
+                    "Bytes": ArrayType(U8),
+                    "Ints": ArrayType(I32),
+                    "Strings": ArrayType(String),
+                    "SimpleEnums": ArrayType(SumType {
+                        "Zero": ProductType {},
+                        "One": ProductType {},
+                        "Two": ProductType {},
+                    }),
                 },
-                RawColumnDefV8 {
-                    col_name: "c",
-                    col_type: U32,
+                "s": ProductType {},
+                "t": ProductType {
+                    "b": U8,
                 },
-                RawColumnDefV8 {
-                    col_name: "d",
-                    col_type: U64,
+                "u": ProductType {
+                    "a": U8,
+                    "b": U16,
+                    "c": U32,
+                    "d": U64,
+                    "e": U128,
+                    "f": U256,
+                    "g": I8,
+                    "h": I16,
+                    "i": I32,
+                    "j": I64,
+                    "k": I128,
+                    "l": I256,
+                    "m": Bool,
+                    "n": F32,
+                    "o": F64,
+                    "p": String,
+                    "q": ProductType {
+                        "__identity_bytes": ArrayType(U8),
+                    },
+                    "r": ProductType {
+                        "__address_bytes": ArrayType(U8),
+                    },
                 },
-                RawColumnDefV8 {
-                    col_name: "e",
-                    col_type: U128,
-                },
-                RawColumnDefV8 {
-                    col_name: "f",
-                    col_type: U256,
-                },
-                RawColumnDefV8 {
-                    col_name: "g",
-                    col_type: I8,
-                },
-                RawColumnDefV8 {
-                    col_name: "h",
-                    col_type: I16,
-                },
-                RawColumnDefV8 {
-                    col_name: "i",
-                    col_type: I32,
-                },
-                RawColumnDefV8 {
-                    col_name: "j",
-                    col_type: I64,
-                },
-                RawColumnDefV8 {
-                    col_name: "k",
-                    col_type: I128,
-                },
-                RawColumnDefV8 {
-                    col_name: "l",
-                    col_type: I256,
-                },
-                RawColumnDefV8 {
-                    col_name: "m",
-                    col_type: Bool,
-                },
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: F32,
-                },
-                RawColumnDefV8 {
-                    col_name: "o",
-                    col_type: F64,
-                },
-                RawColumnDefV8 {
-                    col_name: "p",
-                    col_type: String,
-                },
-                RawColumnDefV8 {
-                    col_name: "q",
-                    col_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Zero",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "One",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Two",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                RawColumnDefV8 {
-                    col_name: "r",
-                    col_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U8",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U16",
-                                    ),
-                                    algebraic_type: U16,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U32",
-                                    ),
-                                    algebraic_type: U32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U64",
-                                    ),
-                                    algebraic_type: U64,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U128",
-                                    ),
-                                    algebraic_type: U128,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U256",
-                                    ),
-                                    algebraic_type: U256,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I8",
-                                    ),
-                                    algebraic_type: I8,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I16",
-                                    ),
-                                    algebraic_type: I16,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I32",
-                                    ),
-                                    algebraic_type: I32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I64",
-                                    ),
-                                    algebraic_type: I64,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I128",
-                                    ),
-                                    algebraic_type: I128,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I256",
-                                    ),
-                                    algebraic_type: I256,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Bool",
-                                    ),
-                                    algebraic_type: Bool,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "F32",
-                                    ),
-                                    algebraic_type: F32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "F64",
-                                    ),
-                                    algebraic_type: F64,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Str",
-                                    ),
-                                    algebraic_type: String,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Identity",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__identity_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Address",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__address_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Ints",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I32,
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Strings",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: String,
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "SimpleEnums",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Sum(
-                                                SumType {
-                                                    variants: [
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "Zero",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "One",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "Two",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: Product(
-                        ProductType {
-                            elements: [],
-                        },
-                    ),
-                },
-                RawColumnDefV8 {
-                    col_name: "t",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                            ],
-                        },
-                    ),
-                },
-                RawColumnDefV8 {
-                    col_name: "u",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "a",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: U16,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "c",
-                                    ),
-                                    algebraic_type: U32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "d",
-                                    ),
-                                    algebraic_type: U64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "e",
-                                    ),
-                                    algebraic_type: U128,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "f",
-                                    ),
-                                    algebraic_type: U256,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "g",
-                                    ),
-                                    algebraic_type: I8,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "h",
-                                    ),
-                                    algebraic_type: I16,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "i",
-                                    ),
-                                    algebraic_type: I32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "j",
-                                    ),
-                                    algebraic_type: I64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "k",
-                                    ),
-                                    algebraic_type: I128,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "l",
-                                    ),
-                                    algebraic_type: I256,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "m",
-                                    ),
-                                    algebraic_type: Bool,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: F32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "o",
-                                    ),
-                                    algebraic_type: F64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "p",
-                                    ),
-                                    algebraic_type: String,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "q",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__identity_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "r",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__address_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                RawColumnDefV8 {
-                    col_name: "v",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "a",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U16,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "c",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U32,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "d",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U64,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "e",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U128,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "f",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U256,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "g",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I8,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "h",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I16,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "i",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I32,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "j",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I64,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "k",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I128,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "l",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I256,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "m",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Bool,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: F32,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "o",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: F64,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "p",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: String,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "q",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__identity_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "r",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__address_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "v": ProductType {
+                    "a": ArrayType(U8),
+                    "b": ArrayType(U16),
+                    "c": ArrayType(U32),
+                    "d": ArrayType(U64),
+                    "e": ArrayType(U128),
+                    "f": ArrayType(U256),
+                    "g": ArrayType(I8),
+                    "h": ArrayType(I16),
+                    "i": ArrayType(I32),
+                    "j": ArrayType(I64),
+                    "k": ArrayType(I128),
+                    "l": ArrayType(I256),
+                    "m": ArrayType(Bool),
+                    "n": ArrayType(F32),
+                    "o": ArrayType(F64),
+                    "p": ArrayType(String),
+                    "q": ArrayType(ProductType {
+                        "__identity_bytes": ArrayType(U8),
+                    }),
+                    "r": ArrayType(ProductType {
+                        "__address_bytes": ArrayType(U8),
+                    }),
                 },
             ],
             indexes: [],
@@ -732,24 +123,8 @@ NormalizedModuleDef {
         "OneAddress": RawTableDefV8 {
             table_name: "OneAddress",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "a",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__address_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "a": ProductType {
+                    "__address_bytes": ArrayType(U8),
                 },
             ],
             indexes: [],
@@ -762,10 +137,7 @@ NormalizedModuleDef {
         "OneBool": RawTableDefV8 {
             table_name: "OneBool",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "b",
-                    col_type: Bool,
-                },
+                "b": Bool,
             ],
             indexes: [],
             constraints: [],
@@ -777,20 +149,8 @@ NormalizedModuleDef {
         "OneByteStruct": RawTableDefV8 {
             table_name: "OneByteStruct",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                            ],
-                        },
-                    ),
+                "s": ProductType {
+                    "b": U8,
                 },
             ],
             indexes: [],
@@ -803,227 +163,37 @@ NormalizedModuleDef {
         "OneEnumWithPayload": RawTableDefV8 {
             table_name: "OneEnumWithPayload",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "e",
-                    col_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U8",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U16",
-                                    ),
-                                    algebraic_type: U16,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U32",
-                                    ),
-                                    algebraic_type: U32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U64",
-                                    ),
-                                    algebraic_type: U64,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U128",
-                                    ),
-                                    algebraic_type: U128,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U256",
-                                    ),
-                                    algebraic_type: U256,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I8",
-                                    ),
-                                    algebraic_type: I8,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I16",
-                                    ),
-                                    algebraic_type: I16,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I32",
-                                    ),
-                                    algebraic_type: I32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I64",
-                                    ),
-                                    algebraic_type: I64,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I128",
-                                    ),
-                                    algebraic_type: I128,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I256",
-                                    ),
-                                    algebraic_type: I256,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Bool",
-                                    ),
-                                    algebraic_type: Bool,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "F32",
-                                    ),
-                                    algebraic_type: F32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "F64",
-                                    ),
-                                    algebraic_type: F64,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Str",
-                                    ),
-                                    algebraic_type: String,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Identity",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__identity_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Address",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__address_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Ints",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I32,
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Strings",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: String,
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "SimpleEnums",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Sum(
-                                                SumType {
-                                                    variants: [
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "Zero",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "One",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "Two",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "e": SumType {
+                    "U8": U8,
+                    "U16": U16,
+                    "U32": U32,
+                    "U64": U64,
+                    "U128": U128,
+                    "U256": U256,
+                    "I8": I8,
+                    "I16": I16,
+                    "I32": I32,
+                    "I64": I64,
+                    "I128": I128,
+                    "I256": I256,
+                    "Bool": Bool,
+                    "F32": F32,
+                    "F64": F64,
+                    "Str": String,
+                    "Identity": ProductType {
+                        "__identity_bytes": ArrayType(U8),
+                    },
+                    "Address": ProductType {
+                        "__address_bytes": ArrayType(U8),
+                    },
+                    "Bytes": ArrayType(U8),
+                    "Ints": ArrayType(I32),
+                    "Strings": ArrayType(String),
+                    "SimpleEnums": ArrayType(SumType {
+                        "Zero": ProductType {},
+                        "One": ProductType {},
+                        "Two": ProductType {},
+                    }),
                 },
             ],
             indexes: [],
@@ -1036,152 +206,29 @@ NormalizedModuleDef {
         "OneEveryPrimitiveStruct": RawTableDefV8 {
             table_name: "OneEveryPrimitiveStruct",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "a",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: U16,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "c",
-                                    ),
-                                    algebraic_type: U32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "d",
-                                    ),
-                                    algebraic_type: U64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "e",
-                                    ),
-                                    algebraic_type: U128,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "f",
-                                    ),
-                                    algebraic_type: U256,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "g",
-                                    ),
-                                    algebraic_type: I8,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "h",
-                                    ),
-                                    algebraic_type: I16,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "i",
-                                    ),
-                                    algebraic_type: I32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "j",
-                                    ),
-                                    algebraic_type: I64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "k",
-                                    ),
-                                    algebraic_type: I128,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "l",
-                                    ),
-                                    algebraic_type: I256,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "m",
-                                    ),
-                                    algebraic_type: Bool,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: F32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "o",
-                                    ),
-                                    algebraic_type: F64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "p",
-                                    ),
-                                    algebraic_type: String,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "q",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__identity_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "r",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__address_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "s": ProductType {
+                    "a": U8,
+                    "b": U16,
+                    "c": U32,
+                    "d": U64,
+                    "e": U128,
+                    "f": U256,
+                    "g": I8,
+                    "h": I16,
+                    "i": I32,
+                    "j": I64,
+                    "k": I128,
+                    "l": I256,
+                    "m": Bool,
+                    "n": F32,
+                    "o": F64,
+                    "p": String,
+                    "q": ProductType {
+                        "__identity_bytes": ArrayType(U8),
+                    },
+                    "r": ProductType {
+                        "__address_bytes": ArrayType(U8),
+                    },
                 },
             ],
             indexes: [],
@@ -1194,224 +241,29 @@ NormalizedModuleDef {
         "OneEveryVecStruct": RawTableDefV8 {
             table_name: "OneEveryVecStruct",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "a",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U16,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "c",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U32,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "d",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U64,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "e",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U128,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "f",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U256,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "g",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I8,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "h",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I16,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "i",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I32,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "j",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I64,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "k",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I128,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "l",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I256,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "m",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Bool,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: F32,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "o",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: F64,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "p",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: String,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "q",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__identity_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "r",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__address_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "s": ProductType {
+                    "a": ArrayType(U8),
+                    "b": ArrayType(U16),
+                    "c": ArrayType(U32),
+                    "d": ArrayType(U64),
+                    "e": ArrayType(U128),
+                    "f": ArrayType(U256),
+                    "g": ArrayType(I8),
+                    "h": ArrayType(I16),
+                    "i": ArrayType(I32),
+                    "j": ArrayType(I64),
+                    "k": ArrayType(I128),
+                    "l": ArrayType(I256),
+                    "m": ArrayType(Bool),
+                    "n": ArrayType(F32),
+                    "o": ArrayType(F64),
+                    "p": ArrayType(String),
+                    "q": ArrayType(ProductType {
+                        "__identity_bytes": ArrayType(U8),
+                    }),
+                    "r": ArrayType(ProductType {
+                        "__address_bytes": ArrayType(U8),
+                    }),
                 },
             ],
             indexes: [],
@@ -1424,10 +276,7 @@ NormalizedModuleDef {
         "OneF32": RawTableDefV8 {
             table_name: "OneF32",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "f",
-                    col_type: F32,
-                },
+                "f": F32,
             ],
             indexes: [],
             constraints: [],
@@ -1439,10 +288,7 @@ NormalizedModuleDef {
         "OneF64": RawTableDefV8 {
             table_name: "OneF64",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "f",
-                    col_type: F64,
-                },
+                "f": F64,
             ],
             indexes: [],
             constraints: [],
@@ -1454,10 +300,7 @@ NormalizedModuleDef {
         "OneI128": RawTableDefV8 {
             table_name: "OneI128",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I128,
-                },
+                "n": I128,
             ],
             indexes: [],
             constraints: [],
@@ -1469,10 +312,7 @@ NormalizedModuleDef {
         "OneI16": RawTableDefV8 {
             table_name: "OneI16",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I16,
-                },
+                "n": I16,
             ],
             indexes: [],
             constraints: [],
@@ -1484,10 +324,7 @@ NormalizedModuleDef {
         "OneI256": RawTableDefV8 {
             table_name: "OneI256",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I256,
-                },
+                "n": I256,
             ],
             indexes: [],
             constraints: [],
@@ -1499,10 +336,7 @@ NormalizedModuleDef {
         "OneI32": RawTableDefV8 {
             table_name: "OneI32",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I32,
-                },
+                "n": I32,
             ],
             indexes: [],
             constraints: [],
@@ -1514,10 +348,7 @@ NormalizedModuleDef {
         "OneI64": RawTableDefV8 {
             table_name: "OneI64",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I64,
-                },
+                "n": I64,
             ],
             indexes: [],
             constraints: [],
@@ -1529,10 +360,7 @@ NormalizedModuleDef {
         "OneI8": RawTableDefV8 {
             table_name: "OneI8",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I8,
-                },
+                "n": I8,
             ],
             indexes: [],
             constraints: [],
@@ -1544,24 +372,8 @@ NormalizedModuleDef {
         "OneIdentity": RawTableDefV8 {
             table_name: "OneIdentity",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "i",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__identity_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "i": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
             ],
             indexes: [],
@@ -1574,44 +386,10 @@ NormalizedModuleDef {
         "OneSimpleEnum": RawTableDefV8 {
             table_name: "OneSimpleEnum",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "e",
-                    col_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Zero",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "One",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Two",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "e": SumType {
+                    "Zero": ProductType {},
+                    "One": ProductType {},
+                    "Two": ProductType {},
                 },
             ],
             indexes: [],
@@ -1624,10 +402,7 @@ NormalizedModuleDef {
         "OneString": RawTableDefV8 {
             table_name: "OneString",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: String,
-                },
+                "s": String,
             ],
             indexes: [],
             constraints: [],
@@ -1639,10 +414,7 @@ NormalizedModuleDef {
         "OneU128": RawTableDefV8 {
             table_name: "OneU128",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U128,
-                },
+                "n": U128,
             ],
             indexes: [],
             constraints: [],
@@ -1654,10 +426,7 @@ NormalizedModuleDef {
         "OneU16": RawTableDefV8 {
             table_name: "OneU16",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U16,
-                },
+                "n": U16,
             ],
             indexes: [],
             constraints: [],
@@ -1669,10 +438,7 @@ NormalizedModuleDef {
         "OneU256": RawTableDefV8 {
             table_name: "OneU256",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U256,
-                },
+                "n": U256,
             ],
             indexes: [],
             constraints: [],
@@ -1684,10 +450,7 @@ NormalizedModuleDef {
         "OneU32": RawTableDefV8 {
             table_name: "OneU32",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U32,
-                },
+                "n": U32,
             ],
             indexes: [],
             constraints: [],
@@ -1699,10 +462,7 @@ NormalizedModuleDef {
         "OneU64": RawTableDefV8 {
             table_name: "OneU64",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U64,
-                },
+                "n": U64,
             ],
             indexes: [],
             constraints: [],
@@ -1714,10 +474,7 @@ NormalizedModuleDef {
         "OneU8": RawTableDefV8 {
             table_name: "OneU8",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U8,
-                },
+                "n": U8,
             ],
             indexes: [],
             constraints: [],
@@ -1729,14 +486,7 @@ NormalizedModuleDef {
         "OneUnitStruct": RawTableDefV8 {
             table_name: "OneUnitStruct",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: Product(
-                        ProductType {
-                            elements: [],
-                        },
-                    ),
-                },
+                "s": ProductType {},
             ],
             indexes: [],
             constraints: [],
@@ -1748,173 +498,32 @@ NormalizedModuleDef {
         "OptionEveryPrimitiveStruct": RawTableDefV8 {
             table_name: "OptionEveryPrimitiveStruct",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "some",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "a",
-                                                    ),
-                                                    algebraic_type: U8,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "b",
-                                                    ),
-                                                    algebraic_type: U16,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "c",
-                                                    ),
-                                                    algebraic_type: U32,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "d",
-                                                    ),
-                                                    algebraic_type: U64,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "e",
-                                                    ),
-                                                    algebraic_type: U128,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "f",
-                                                    ),
-                                                    algebraic_type: U256,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "g",
-                                                    ),
-                                                    algebraic_type: I8,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "h",
-                                                    ),
-                                                    algebraic_type: I16,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "i",
-                                                    ),
-                                                    algebraic_type: I32,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "j",
-                                                    ),
-                                                    algebraic_type: I64,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "k",
-                                                    ),
-                                                    algebraic_type: I128,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "l",
-                                                    ),
-                                                    algebraic_type: I256,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "m",
-                                                    ),
-                                                    algebraic_type: Bool,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "n",
-                                                    ),
-                                                    algebraic_type: F32,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "o",
-                                                    ),
-                                                    algebraic_type: F64,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "p",
-                                                    ),
-                                                    algebraic_type: String,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "q",
-                                                    ),
-                                                    algebraic_type: Product(
-                                                        ProductType {
-                                                            elements: [
-                                                                ProductTypeElement {
-                                                                    name: Some(
-                                                                        "__identity_bytes",
-                                                                    ),
-                                                                    algebraic_type: Array(
-                                                                        ArrayType {
-                                                                            elem_ty: U8,
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "r",
-                                                    ),
-                                                    algebraic_type: Product(
-                                                        ProductType {
-                                                            elements: [
-                                                                ProductTypeElement {
-                                                                    name: Some(
-                                                                        "__address_bytes",
-                                                                    ),
-                                                                    algebraic_type: Array(
-                                                                        ArrayType {
-                                                                            elem_ty: U8,
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "none",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
+                "s": SumType {
+                    "some": ProductType {
+                        "a": U8,
+                        "b": U16,
+                        "c": U32,
+                        "d": U64,
+                        "e": U128,
+                        "f": U256,
+                        "g": I8,
+                        "h": I16,
+                        "i": I32,
+                        "j": I64,
+                        "k": I128,
+                        "l": I256,
+                        "m": Bool,
+                        "n": F32,
+                        "o": F64,
+                        "p": String,
+                        "q": ProductType {
+                            "__identity_bytes": ArrayType(U8),
                         },
-                    ),
+                        "r": ProductType {
+                            "__address_bytes": ArrayType(U8),
+                        },
+                    },
+                    "none": ProductType {},
                 },
             ],
             indexes: [],
@@ -1927,30 +536,9 @@ NormalizedModuleDef {
         "OptionI32": RawTableDefV8 {
             table_name: "OptionI32",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "some",
-                                    ),
-                                    algebraic_type: I32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "none",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "n": SumType {
+                    "some": I32,
+                    "none": ProductType {},
                 },
             ],
             indexes: [],
@@ -1963,45 +551,11 @@ NormalizedModuleDef {
         "OptionIdentity": RawTableDefV8 {
             table_name: "OptionIdentity",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "i",
-                    col_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "some",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__identity_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "none",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "i": SumType {
+                    "some": ProductType {
+                        "__identity_bytes": ArrayType(U8),
+                    },
+                    "none": ProductType {},
                 },
             ],
             indexes: [],
@@ -2014,65 +568,13 @@ NormalizedModuleDef {
         "OptionSimpleEnum": RawTableDefV8 {
             table_name: "OptionSimpleEnum",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "e",
-                    col_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "some",
-                                    ),
-                                    algebraic_type: Sum(
-                                        SumType {
-                                            variants: [
-                                                SumTypeVariant {
-                                                    name: Some(
-                                                        "Zero",
-                                                    ),
-                                                    algebraic_type: Product(
-                                                        ProductType {
-                                                            elements: [],
-                                                        },
-                                                    ),
-                                                },
-                                                SumTypeVariant {
-                                                    name: Some(
-                                                        "One",
-                                                    ),
-                                                    algebraic_type: Product(
-                                                        ProductType {
-                                                            elements: [],
-                                                        },
-                                                    ),
-                                                },
-                                                SumTypeVariant {
-                                                    name: Some(
-                                                        "Two",
-                                                    ),
-                                                    algebraic_type: Product(
-                                                        ProductType {
-                                                            elements: [],
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "none",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "e": SumType {
+                    "some": SumType {
+                        "Zero": ProductType {},
+                        "One": ProductType {},
+                        "Two": ProductType {},
+                    },
+                    "none": ProductType {},
                 },
             ],
             indexes: [],
@@ -2085,30 +587,9 @@ NormalizedModuleDef {
         "OptionString": RawTableDefV8 {
             table_name: "OptionString",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "some",
-                                    ),
-                                    algebraic_type: String,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "none",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "s": SumType {
+                    "some": String,
+                    "none": ProductType {},
                 },
             ],
             indexes: [],
@@ -2121,55 +602,12 @@ NormalizedModuleDef {
         "OptionVecOptionI32": RawTableDefV8 {
             table_name: "OptionVecOptionI32",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "v",
-                    col_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "some",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Sum(
-                                                SumType {
-                                                    variants: [
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "some",
-                                                            ),
-                                                            algebraic_type: I32,
-                                                        },
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "none",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "none",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "v": SumType {
+                    "some": ArrayType(SumType {
+                        "some": I32,
+                        "none": ProductType {},
+                    }),
+                    "none": ProductType {},
                 },
             ],
             indexes: [],
@@ -2182,29 +620,10 @@ NormalizedModuleDef {
         "PkAddress": RawTableDefV8 {
             table_name: "PkAddress",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "a",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__address_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "a": ProductType {
+                    "__address_bytes": ArrayType(U8),
                 },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2230,14 +649,8 @@ NormalizedModuleDef {
         "PkBool": RawTableDefV8 {
             table_name: "PkBool",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "b",
-                    col_type: Bool,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "b": Bool,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2263,14 +676,8 @@ NormalizedModuleDef {
         "PkI128": RawTableDefV8 {
             table_name: "PkI128",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I128,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": I128,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2296,14 +703,8 @@ NormalizedModuleDef {
         "PkI16": RawTableDefV8 {
             table_name: "PkI16",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I16,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": I16,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2329,14 +730,8 @@ NormalizedModuleDef {
         "PkI256": RawTableDefV8 {
             table_name: "PkI256",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I256,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": I256,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2362,14 +757,8 @@ NormalizedModuleDef {
         "PkI32": RawTableDefV8 {
             table_name: "PkI32",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I32,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": I32,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2395,14 +784,8 @@ NormalizedModuleDef {
         "PkI64": RawTableDefV8 {
             table_name: "PkI64",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I64,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": I64,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2428,14 +811,8 @@ NormalizedModuleDef {
         "PkI8": RawTableDefV8 {
             table_name: "PkI8",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I8,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": I8,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2461,29 +838,10 @@ NormalizedModuleDef {
         "PkIdentity": RawTableDefV8 {
             table_name: "PkIdentity",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "i",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__identity_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "i": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2509,14 +867,8 @@ NormalizedModuleDef {
         "PkString": RawTableDefV8 {
             table_name: "PkString",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: String,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "s": String,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2542,14 +894,8 @@ NormalizedModuleDef {
         "PkU128": RawTableDefV8 {
             table_name: "PkU128",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U128,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": U128,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2575,14 +921,8 @@ NormalizedModuleDef {
         "PkU16": RawTableDefV8 {
             table_name: "PkU16",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U16,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": U16,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2608,14 +948,8 @@ NormalizedModuleDef {
         "PkU256": RawTableDefV8 {
             table_name: "PkU256",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U256,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": U256,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2641,14 +975,8 @@ NormalizedModuleDef {
         "PkU32": RawTableDefV8 {
             table_name: "PkU32",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U32,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": U32,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2674,14 +1002,8 @@ NormalizedModuleDef {
         "PkU64": RawTableDefV8 {
             table_name: "PkU64",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U64,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": U64,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2707,14 +1029,8 @@ NormalizedModuleDef {
         "PkU8": RawTableDefV8 {
             table_name: "PkU8",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U8,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": U8,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2740,39 +1056,11 @@ NormalizedModuleDef {
         "TableHoldsTable": RawTableDefV8 {
             table_name: "TableHoldsTable",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "a",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                            ],
-                        },
-                    ),
+                "a": ProductType {
+                    "n": U8,
                 },
-                RawColumnDefV8 {
-                    col_name: "b",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "b": ProductType {
+                    "n": ArrayType(U8),
                 },
             ],
             indexes: [],
@@ -2785,29 +1073,10 @@ NormalizedModuleDef {
         "UniqueAddress": RawTableDefV8 {
             table_name: "UniqueAddress",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "a",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__address_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "a": ProductType {
+                    "__address_bytes": ArrayType(U8),
                 },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2833,14 +1102,8 @@ NormalizedModuleDef {
         "UniqueBool": RawTableDefV8 {
             table_name: "UniqueBool",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "b",
-                    col_type: Bool,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "b": Bool,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2866,14 +1129,8 @@ NormalizedModuleDef {
         "UniqueI128": RawTableDefV8 {
             table_name: "UniqueI128",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I128,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": I128,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2899,14 +1156,8 @@ NormalizedModuleDef {
         "UniqueI16": RawTableDefV8 {
             table_name: "UniqueI16",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I16,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": I16,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2932,14 +1183,8 @@ NormalizedModuleDef {
         "UniqueI256": RawTableDefV8 {
             table_name: "UniqueI256",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I256,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": I256,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2965,14 +1210,8 @@ NormalizedModuleDef {
         "UniqueI32": RawTableDefV8 {
             table_name: "UniqueI32",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I32,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": I32,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -2998,14 +1237,8 @@ NormalizedModuleDef {
         "UniqueI64": RawTableDefV8 {
             table_name: "UniqueI64",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I64,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": I64,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -3031,14 +1264,8 @@ NormalizedModuleDef {
         "UniqueI8": RawTableDefV8 {
             table_name: "UniqueI8",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: I8,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": I8,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -3064,29 +1291,10 @@ NormalizedModuleDef {
         "UniqueIdentity": RawTableDefV8 {
             table_name: "UniqueIdentity",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "i",
-                    col_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__identity_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+                "i": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -3112,14 +1320,8 @@ NormalizedModuleDef {
         "UniqueString": RawTableDefV8 {
             table_name: "UniqueString",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: String,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "s": String,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -3145,14 +1347,8 @@ NormalizedModuleDef {
         "UniqueU128": RawTableDefV8 {
             table_name: "UniqueU128",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U128,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": U128,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -3178,14 +1374,8 @@ NormalizedModuleDef {
         "UniqueU16": RawTableDefV8 {
             table_name: "UniqueU16",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U16,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": U16,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -3211,14 +1401,8 @@ NormalizedModuleDef {
         "UniqueU256": RawTableDefV8 {
             table_name: "UniqueU256",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U256,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": U256,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -3244,14 +1428,8 @@ NormalizedModuleDef {
         "UniqueU32": RawTableDefV8 {
             table_name: "UniqueU32",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U32,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": U32,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -3277,14 +1455,8 @@ NormalizedModuleDef {
         "UniqueU64": RawTableDefV8 {
             table_name: "UniqueU64",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U64,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": U64,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -3310,14 +1482,8 @@ NormalizedModuleDef {
         "UniqueU8": RawTableDefV8 {
             table_name: "UniqueU8",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: U8,
-                },
-                RawColumnDefV8 {
-                    col_name: "data",
-                    col_type: I32,
-                },
+                "n": U8,
+                "data": I32,
             ],
             indexes: [],
             constraints: [
@@ -3343,29 +1509,9 @@ NormalizedModuleDef {
         "VecAddress": RawTableDefV8 {
             table_name: "VecAddress",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "a",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: Product(
-                                ProductType {
-                                    elements: [
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "__address_bytes",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U8,
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                },
+                "a": ArrayType(ProductType {
+                    "__address_bytes": ArrayType(U8),
+                }),
             ],
             indexes: [],
             constraints: [],
@@ -3377,14 +1523,7 @@ NormalizedModuleDef {
         "VecBool": RawTableDefV8 {
             table_name: "VecBool",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "b",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: Bool,
-                        },
-                    ),
-                },
+                "b": ArrayType(Bool),
             ],
             indexes: [],
             constraints: [],
@@ -3396,25 +1535,9 @@ NormalizedModuleDef {
         "VecByteStruct": RawTableDefV8 {
             table_name: "VecByteStruct",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: Product(
-                                ProductType {
-                                    elements: [
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "b",
-                                            ),
-                                            algebraic_type: U8,
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                },
+                "s": ArrayType(ProductType {
+                    "b": U8,
+                }),
             ],
             indexes: [],
             constraints: [],
@@ -3426,232 +1549,38 @@ NormalizedModuleDef {
         "VecEnumWithPayload": RawTableDefV8 {
             table_name: "VecEnumWithPayload",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "e",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: Sum(
-                                SumType {
-                                    variants: [
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "U8",
-                                            ),
-                                            algebraic_type: U8,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "U16",
-                                            ),
-                                            algebraic_type: U16,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "U32",
-                                            ),
-                                            algebraic_type: U32,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "U64",
-                                            ),
-                                            algebraic_type: U64,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "U128",
-                                            ),
-                                            algebraic_type: U128,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "U256",
-                                            ),
-                                            algebraic_type: U256,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "I8",
-                                            ),
-                                            algebraic_type: I8,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "I16",
-                                            ),
-                                            algebraic_type: I16,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "I32",
-                                            ),
-                                            algebraic_type: I32,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "I64",
-                                            ),
-                                            algebraic_type: I64,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "I128",
-                                            ),
-                                            algebraic_type: I128,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "I256",
-                                            ),
-                                            algebraic_type: I256,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Bool",
-                                            ),
-                                            algebraic_type: Bool,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "F32",
-                                            ),
-                                            algebraic_type: F32,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "F64",
-                                            ),
-                                            algebraic_type: F64,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Str",
-                                            ),
-                                            algebraic_type: String,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Identity",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__identity_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Address",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__address_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Bytes",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U8,
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Ints",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I32,
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Strings",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: String,
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "SimpleEnums",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: Sum(
-                                                        SumType {
-                                                            variants: [
-                                                                SumTypeVariant {
-                                                                    name: Some(
-                                                                        "Zero",
-                                                                    ),
-                                                                    algebraic_type: Product(
-                                                                        ProductType {
-                                                                            elements: [],
-                                                                        },
-                                                                    ),
-                                                                },
-                                                                SumTypeVariant {
-                                                                    name: Some(
-                                                                        "One",
-                                                                    ),
-                                                                    algebraic_type: Product(
-                                                                        ProductType {
-                                                                            elements: [],
-                                                                        },
-                                                                    ),
-                                                                },
-                                                                SumTypeVariant {
-                                                                    name: Some(
-                                                                        "Two",
-                                                                    ),
-                                                                    algebraic_type: Product(
-                                                                        ProductType {
-                                                                            elements: [],
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                },
+                "e": ArrayType(SumType {
+                    "U8": U8,
+                    "U16": U16,
+                    "U32": U32,
+                    "U64": U64,
+                    "U128": U128,
+                    "U256": U256,
+                    "I8": I8,
+                    "I16": I16,
+                    "I32": I32,
+                    "I64": I64,
+                    "I128": I128,
+                    "I256": I256,
+                    "Bool": Bool,
+                    "F32": F32,
+                    "F64": F64,
+                    "Str": String,
+                    "Identity": ProductType {
+                        "__identity_bytes": ArrayType(U8),
+                    },
+                    "Address": ProductType {
+                        "__address_bytes": ArrayType(U8),
+                    },
+                    "Bytes": ArrayType(U8),
+                    "Ints": ArrayType(I32),
+                    "Strings": ArrayType(String),
+                    "SimpleEnums": ArrayType(SumType {
+                        "Zero": ProductType {},
+                        "One": ProductType {},
+                        "Two": ProductType {},
+                    }),
+                }),
             ],
             indexes: [],
             constraints: [],
@@ -3663,157 +1592,30 @@ NormalizedModuleDef {
         "VecEveryPrimitiveStruct": RawTableDefV8 {
             table_name: "VecEveryPrimitiveStruct",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: Product(
-                                ProductType {
-                                    elements: [
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "a",
-                                            ),
-                                            algebraic_type: U8,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "b",
-                                            ),
-                                            algebraic_type: U16,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "c",
-                                            ),
-                                            algebraic_type: U32,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "d",
-                                            ),
-                                            algebraic_type: U64,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "e",
-                                            ),
-                                            algebraic_type: U128,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "f",
-                                            ),
-                                            algebraic_type: U256,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "g",
-                                            ),
-                                            algebraic_type: I8,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "h",
-                                            ),
-                                            algebraic_type: I16,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "i",
-                                            ),
-                                            algebraic_type: I32,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "j",
-                                            ),
-                                            algebraic_type: I64,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "k",
-                                            ),
-                                            algebraic_type: I128,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "l",
-                                            ),
-                                            algebraic_type: I256,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "m",
-                                            ),
-                                            algebraic_type: Bool,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "n",
-                                            ),
-                                            algebraic_type: F32,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "o",
-                                            ),
-                                            algebraic_type: F64,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "p",
-                                            ),
-                                            algebraic_type: String,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "q",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__identity_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "r",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__address_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                },
+                "s": ArrayType(ProductType {
+                    "a": U8,
+                    "b": U16,
+                    "c": U32,
+                    "d": U64,
+                    "e": U128,
+                    "f": U256,
+                    "g": I8,
+                    "h": I16,
+                    "i": I32,
+                    "j": I64,
+                    "k": I128,
+                    "l": I256,
+                    "m": Bool,
+                    "n": F32,
+                    "o": F64,
+                    "p": String,
+                    "q": ProductType {
+                        "__identity_bytes": ArrayType(U8),
+                    },
+                    "r": ProductType {
+                        "__address_bytes": ArrayType(U8),
+                    },
+                }),
             ],
             indexes: [],
             constraints: [],
@@ -3825,229 +1627,30 @@ NormalizedModuleDef {
         "VecEveryVecStruct": RawTableDefV8 {
             table_name: "VecEveryVecStruct",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: Product(
-                                ProductType {
-                                    elements: [
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "a",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U8,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "b",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U16,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "c",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U32,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "d",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U64,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "e",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U128,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "f",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U256,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "g",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I8,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "h",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I16,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "i",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I32,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "j",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I64,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "k",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I128,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "l",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I256,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "m",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: Bool,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "n",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: F32,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "o",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: F64,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "p",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: String,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "q",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: Product(
-                                                        ProductType {
-                                                            elements: [
-                                                                ProductTypeElement {
-                                                                    name: Some(
-                                                                        "__identity_bytes",
-                                                                    ),
-                                                                    algebraic_type: Array(
-                                                                        ArrayType {
-                                                                            elem_ty: U8,
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "r",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: Product(
-                                                        ProductType {
-                                                            elements: [
-                                                                ProductTypeElement {
-                                                                    name: Some(
-                                                                        "__address_bytes",
-                                                                    ),
-                                                                    algebraic_type: Array(
-                                                                        ArrayType {
-                                                                            elem_ty: U8,
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                },
+                "s": ArrayType(ProductType {
+                    "a": ArrayType(U8),
+                    "b": ArrayType(U16),
+                    "c": ArrayType(U32),
+                    "d": ArrayType(U64),
+                    "e": ArrayType(U128),
+                    "f": ArrayType(U256),
+                    "g": ArrayType(I8),
+                    "h": ArrayType(I16),
+                    "i": ArrayType(I32),
+                    "j": ArrayType(I64),
+                    "k": ArrayType(I128),
+                    "l": ArrayType(I256),
+                    "m": ArrayType(Bool),
+                    "n": ArrayType(F32),
+                    "o": ArrayType(F64),
+                    "p": ArrayType(String),
+                    "q": ArrayType(ProductType {
+                        "__identity_bytes": ArrayType(U8),
+                    }),
+                    "r": ArrayType(ProductType {
+                        "__address_bytes": ArrayType(U8),
+                    }),
+                }),
             ],
             indexes: [],
             constraints: [],
@@ -4059,14 +1662,7 @@ NormalizedModuleDef {
         "VecF32": RawTableDefV8 {
             table_name: "VecF32",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "f",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: F32,
-                        },
-                    ),
-                },
+                "f": ArrayType(F32),
             ],
             indexes: [],
             constraints: [],
@@ -4078,14 +1674,7 @@ NormalizedModuleDef {
         "VecF64": RawTableDefV8 {
             table_name: "VecF64",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "f",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: F64,
-                        },
-                    ),
-                },
+                "f": ArrayType(F64),
             ],
             indexes: [],
             constraints: [],
@@ -4097,14 +1686,7 @@ NormalizedModuleDef {
         "VecI128": RawTableDefV8 {
             table_name: "VecI128",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: I128,
-                        },
-                    ),
-                },
+                "n": ArrayType(I128),
             ],
             indexes: [],
             constraints: [],
@@ -4116,14 +1698,7 @@ NormalizedModuleDef {
         "VecI16": RawTableDefV8 {
             table_name: "VecI16",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: I16,
-                        },
-                    ),
-                },
+                "n": ArrayType(I16),
             ],
             indexes: [],
             constraints: [],
@@ -4135,14 +1710,7 @@ NormalizedModuleDef {
         "VecI256": RawTableDefV8 {
             table_name: "VecI256",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: I256,
-                        },
-                    ),
-                },
+                "n": ArrayType(I256),
             ],
             indexes: [],
             constraints: [],
@@ -4154,14 +1722,7 @@ NormalizedModuleDef {
         "VecI32": RawTableDefV8 {
             table_name: "VecI32",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: I32,
-                        },
-                    ),
-                },
+                "n": ArrayType(I32),
             ],
             indexes: [],
             constraints: [],
@@ -4173,14 +1734,7 @@ NormalizedModuleDef {
         "VecI64": RawTableDefV8 {
             table_name: "VecI64",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: I64,
-                        },
-                    ),
-                },
+                "n": ArrayType(I64),
             ],
             indexes: [],
             constraints: [],
@@ -4192,14 +1746,7 @@ NormalizedModuleDef {
         "VecI8": RawTableDefV8 {
             table_name: "VecI8",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: I8,
-                        },
-                    ),
-                },
+                "n": ArrayType(I8),
             ],
             indexes: [],
             constraints: [],
@@ -4211,29 +1758,9 @@ NormalizedModuleDef {
         "VecIdentity": RawTableDefV8 {
             table_name: "VecIdentity",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "i",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: Product(
-                                ProductType {
-                                    elements: [
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "__identity_bytes",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U8,
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                },
+                "i": ArrayType(ProductType {
+                    "__identity_bytes": ArrayType(U8),
+                }),
             ],
             indexes: [],
             constraints: [],
@@ -4245,49 +1772,11 @@ NormalizedModuleDef {
         "VecSimpleEnum": RawTableDefV8 {
             table_name: "VecSimpleEnum",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "e",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: Sum(
-                                SumType {
-                                    variants: [
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Zero",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [],
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "One",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [],
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Two",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [],
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                },
+                "e": ArrayType(SumType {
+                    "Zero": ProductType {},
+                    "One": ProductType {},
+                    "Two": ProductType {},
+                }),
             ],
             indexes: [],
             constraints: [],
@@ -4299,14 +1788,7 @@ NormalizedModuleDef {
         "VecString": RawTableDefV8 {
             table_name: "VecString",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: String,
-                        },
-                    ),
-                },
+                "s": ArrayType(String),
             ],
             indexes: [],
             constraints: [],
@@ -4318,14 +1800,7 @@ NormalizedModuleDef {
         "VecU128": RawTableDefV8 {
             table_name: "VecU128",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: U128,
-                        },
-                    ),
-                },
+                "n": ArrayType(U128),
             ],
             indexes: [],
             constraints: [],
@@ -4337,14 +1812,7 @@ NormalizedModuleDef {
         "VecU16": RawTableDefV8 {
             table_name: "VecU16",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: U16,
-                        },
-                    ),
-                },
+                "n": ArrayType(U16),
             ],
             indexes: [],
             constraints: [],
@@ -4356,14 +1824,7 @@ NormalizedModuleDef {
         "VecU256": RawTableDefV8 {
             table_name: "VecU256",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: U256,
-                        },
-                    ),
-                },
+                "n": ArrayType(U256),
             ],
             indexes: [],
             constraints: [],
@@ -4375,14 +1836,7 @@ NormalizedModuleDef {
         "VecU32": RawTableDefV8 {
             table_name: "VecU32",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: U32,
-                        },
-                    ),
-                },
+                "n": ArrayType(U32),
             ],
             indexes: [],
             constraints: [],
@@ -4394,14 +1848,7 @@ NormalizedModuleDef {
         "VecU64": RawTableDefV8 {
             table_name: "VecU64",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: U64,
-                        },
-                    ),
-                },
+                "n": ArrayType(U64),
             ],
             indexes: [],
             constraints: [],
@@ -4413,14 +1860,7 @@ NormalizedModuleDef {
         "VecU8": RawTableDefV8 {
             table_name: "VecU8",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "n",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: U8,
-                        },
-                    ),
-                },
+                "n": ArrayType(U8),
             ],
             indexes: [],
             constraints: [],
@@ -4432,18 +1872,7 @@ NormalizedModuleDef {
         "VecUnitStruct": RawTableDefV8 {
             table_name: "VecUnitStruct",
             columns: [
-                RawColumnDefV8 {
-                    col_name: "s",
-                    col_type: Array(
-                        ArrayType {
-                            elem_ty: Product(
-                                ProductType {
-                                    elements: [],
-                                },
-                            ),
-                        },
-                    ),
-                },
+                "s": ArrayType(ProductType {}),
             ],
             indexes: [],
             constraints: [],
@@ -4455,5466 +1884,1015 @@ NormalizedModuleDef {
     },
     reducers: {
         "delete_pk_address": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "a",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__address_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "a": ProductType {
+                "__address_bytes": ArrayType(U8),
+            },
         },
         "delete_pk_bool": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "b",
-                    ),
-                    algebraic_type: Bool,
-                },
-            ],
+            "b": Bool,
         },
         "delete_pk_i128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I128,
-                },
-            ],
+            "n": I128,
         },
         "delete_pk_i16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I16,
-                },
-            ],
+            "n": I16,
         },
         "delete_pk_i256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I256,
-                },
-            ],
+            "n": I256,
         },
         "delete_pk_i32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I32,
         },
         "delete_pk_i64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I64,
-                },
-            ],
+            "n": I64,
         },
         "delete_pk_i8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I8,
-                },
-            ],
+            "n": I8,
         },
         "delete_pk_identity": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "i",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__identity_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "i": ProductType {
+                "__identity_bytes": ArrayType(U8),
+            },
         },
         "delete_pk_string": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: String,
-                },
-            ],
+            "s": String,
         },
         "delete_pk_u128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U128,
-                },
-            ],
+            "n": U128,
         },
         "delete_pk_u16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U16,
-                },
-            ],
+            "n": U16,
         },
         "delete_pk_u256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U256,
-                },
-            ],
+            "n": U256,
         },
         "delete_pk_u32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U32,
-                },
-            ],
+            "n": U32,
         },
         "delete_pk_u64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U64,
-                },
-            ],
+            "n": U64,
         },
         "delete_pk_u8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U8,
-                },
-            ],
+            "n": U8,
         },
         "delete_unique_address": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "a",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__address_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "a": ProductType {
+                "__address_bytes": ArrayType(U8),
+            },
         },
         "delete_unique_bool": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "b",
-                    ),
-                    algebraic_type: Bool,
-                },
-            ],
+            "b": Bool,
         },
         "delete_unique_i128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I128,
-                },
-            ],
+            "n": I128,
         },
         "delete_unique_i16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I16,
-                },
-            ],
+            "n": I16,
         },
         "delete_unique_i256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I256,
-                },
-            ],
+            "n": I256,
         },
         "delete_unique_i32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I32,
         },
         "delete_unique_i64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I64,
-                },
-            ],
+            "n": I64,
         },
         "delete_unique_i8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I8,
-                },
-            ],
+            "n": I8,
         },
         "delete_unique_identity": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "i",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__identity_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "i": ProductType {
+                "__identity_bytes": ArrayType(U8),
+            },
         },
         "delete_unique_string": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: String,
-                },
-            ],
+            "s": String,
         },
         "delete_unique_u128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U128,
-                },
-            ],
+            "n": U128,
         },
         "delete_unique_u16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U16,
-                },
-            ],
+            "n": U16,
         },
         "delete_unique_u256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U256,
-                },
-            ],
+            "n": U256,
         },
         "delete_unique_u32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U32,
-                },
-            ],
+            "n": U32,
         },
         "delete_unique_u64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U64,
-                },
-            ],
+            "n": U64,
         },
         "delete_unique_u8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U8,
-                },
-            ],
+            "n": U8,
         },
-        "insert_caller_one_address": ProductType {
-            elements: [],
-        },
-        "insert_caller_one_identity": ProductType {
-            elements: [],
-        },
+        "insert_caller_one_address": ProductType {},
+        "insert_caller_one_identity": ProductType {},
         "insert_caller_pk_address": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "data": I32,
         },
         "insert_caller_pk_identity": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "data": I32,
         },
         "insert_caller_unique_address": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "data": I32,
         },
         "insert_caller_unique_identity": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "data": I32,
         },
-        "insert_caller_vec_address": ProductType {
-            elements: [],
-        },
-        "insert_caller_vec_identity": ProductType {
-            elements: [],
-        },
+        "insert_caller_vec_address": ProductType {},
+        "insert_caller_vec_identity": ProductType {},
         "insert_large_table": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "a",
-                    ),
-                    algebraic_type: U8,
+            "a": U8,
+            "b": U16,
+            "c": U32,
+            "d": U64,
+            "e": U128,
+            "f": U256,
+            "g": I8,
+            "h": I16,
+            "i": I32,
+            "j": I64,
+            "k": I128,
+            "l": I256,
+            "m": Bool,
+            "n": F32,
+            "o": F64,
+            "p": String,
+            "q": SumType {
+                "Zero": ProductType {},
+                "One": ProductType {},
+                "Two": ProductType {},
+            },
+            "r": SumType {
+                "U8": U8,
+                "U16": U16,
+                "U32": U32,
+                "U64": U64,
+                "U128": U128,
+                "U256": U256,
+                "I8": I8,
+                "I16": I16,
+                "I32": I32,
+                "I64": I64,
+                "I128": I128,
+                "I256": I256,
+                "Bool": Bool,
+                "F32": F32,
+                "F64": F64,
+                "Str": String,
+                "Identity": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
-                ProductTypeElement {
-                    name: Some(
-                        "b",
-                    ),
-                    algebraic_type: U16,
+                "Address": ProductType {
+                    "__address_bytes": ArrayType(U8),
                 },
-                ProductTypeElement {
-                    name: Some(
-                        "c",
-                    ),
-                    algebraic_type: U32,
+                "Bytes": ArrayType(U8),
+                "Ints": ArrayType(I32),
+                "Strings": ArrayType(String),
+                "SimpleEnums": ArrayType(SumType {
+                    "Zero": ProductType {},
+                    "One": ProductType {},
+                    "Two": ProductType {},
+                }),
+            },
+            "s": ProductType {},
+            "t": ProductType {
+                "b": U8,
+            },
+            "u": ProductType {
+                "a": U8,
+                "b": U16,
+                "c": U32,
+                "d": U64,
+                "e": U128,
+                "f": U256,
+                "g": I8,
+                "h": I16,
+                "i": I32,
+                "j": I64,
+                "k": I128,
+                "l": I256,
+                "m": Bool,
+                "n": F32,
+                "o": F64,
+                "p": String,
+                "q": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
-                ProductTypeElement {
-                    name: Some(
-                        "d",
-                    ),
-                    algebraic_type: U64,
+                "r": ProductType {
+                    "__address_bytes": ArrayType(U8),
                 },
-                ProductTypeElement {
-                    name: Some(
-                        "e",
-                    ),
-                    algebraic_type: U128,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "f",
-                    ),
-                    algebraic_type: U256,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "g",
-                    ),
-                    algebraic_type: I8,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "h",
-                    ),
-                    algebraic_type: I16,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "i",
-                    ),
-                    algebraic_type: I32,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "j",
-                    ),
-                    algebraic_type: I64,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "k",
-                    ),
-                    algebraic_type: I128,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "l",
-                    ),
-                    algebraic_type: I256,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "m",
-                    ),
-                    algebraic_type: Bool,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: F32,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "o",
-                    ),
-                    algebraic_type: F64,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "p",
-                    ),
-                    algebraic_type: String,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "q",
-                    ),
-                    algebraic_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Zero",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "One",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Two",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "r",
-                    ),
-                    algebraic_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U8",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U16",
-                                    ),
-                                    algebraic_type: U16,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U32",
-                                    ),
-                                    algebraic_type: U32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U64",
-                                    ),
-                                    algebraic_type: U64,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U128",
-                                    ),
-                                    algebraic_type: U128,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U256",
-                                    ),
-                                    algebraic_type: U256,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I8",
-                                    ),
-                                    algebraic_type: I8,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I16",
-                                    ),
-                                    algebraic_type: I16,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I32",
-                                    ),
-                                    algebraic_type: I32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I64",
-                                    ),
-                                    algebraic_type: I64,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I128",
-                                    ),
-                                    algebraic_type: I128,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I256",
-                                    ),
-                                    algebraic_type: I256,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Bool",
-                                    ),
-                                    algebraic_type: Bool,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "F32",
-                                    ),
-                                    algebraic_type: F32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "F64",
-                                    ),
-                                    algebraic_type: F64,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Str",
-                                    ),
-                                    algebraic_type: String,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Identity",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__identity_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Address",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__address_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Ints",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I32,
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Strings",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: String,
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "SimpleEnums",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Sum(
-                                                SumType {
-                                                    variants: [
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "Zero",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "One",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "Two",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "t",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "u",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "a",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: U16,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "c",
-                                    ),
-                                    algebraic_type: U32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "d",
-                                    ),
-                                    algebraic_type: U64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "e",
-                                    ),
-                                    algebraic_type: U128,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "f",
-                                    ),
-                                    algebraic_type: U256,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "g",
-                                    ),
-                                    algebraic_type: I8,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "h",
-                                    ),
-                                    algebraic_type: I16,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "i",
-                                    ),
-                                    algebraic_type: I32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "j",
-                                    ),
-                                    algebraic_type: I64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "k",
-                                    ),
-                                    algebraic_type: I128,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "l",
-                                    ),
-                                    algebraic_type: I256,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "m",
-                                    ),
-                                    algebraic_type: Bool,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: F32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "o",
-                                    ),
-                                    algebraic_type: F64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "p",
-                                    ),
-                                    algebraic_type: String,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "q",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__identity_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "r",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__address_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "v",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "a",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U16,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "c",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U32,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "d",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U64,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "e",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U128,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "f",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U256,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "g",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I8,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "h",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I16,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "i",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I32,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "j",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I64,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "k",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I128,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "l",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I256,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "m",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Bool,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: F32,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "o",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: F64,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "p",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: String,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "q",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__identity_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "r",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__address_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            },
+            "v": ProductType {
+                "a": ArrayType(U8),
+                "b": ArrayType(U16),
+                "c": ArrayType(U32),
+                "d": ArrayType(U64),
+                "e": ArrayType(U128),
+                "f": ArrayType(U256),
+                "g": ArrayType(I8),
+                "h": ArrayType(I16),
+                "i": ArrayType(I32),
+                "j": ArrayType(I64),
+                "k": ArrayType(I128),
+                "l": ArrayType(I256),
+                "m": ArrayType(Bool),
+                "n": ArrayType(F32),
+                "o": ArrayType(F64),
+                "p": ArrayType(String),
+                "q": ArrayType(ProductType {
+                    "__identity_bytes": ArrayType(U8),
+                }),
+                "r": ArrayType(ProductType {
+                    "__address_bytes": ArrayType(U8),
+                }),
+            },
         },
         "insert_one_address": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "a",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__address_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "a": ProductType {
+                "__address_bytes": ArrayType(U8),
+            },
         },
         "insert_one_bool": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "b",
-                    ),
-                    algebraic_type: Bool,
-                },
-            ],
+            "b": Bool,
         },
         "insert_one_byte_struct": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "s": ProductType {
+                "b": U8,
+            },
         },
         "insert_one_enum_with_payload": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "e",
-                    ),
-                    algebraic_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U8",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U16",
-                                    ),
-                                    algebraic_type: U16,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U32",
-                                    ),
-                                    algebraic_type: U32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U64",
-                                    ),
-                                    algebraic_type: U64,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U128",
-                                    ),
-                                    algebraic_type: U128,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "U256",
-                                    ),
-                                    algebraic_type: U256,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I8",
-                                    ),
-                                    algebraic_type: I8,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I16",
-                                    ),
-                                    algebraic_type: I16,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I32",
-                                    ),
-                                    algebraic_type: I32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I64",
-                                    ),
-                                    algebraic_type: I64,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I128",
-                                    ),
-                                    algebraic_type: I128,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "I256",
-                                    ),
-                                    algebraic_type: I256,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Bool",
-                                    ),
-                                    algebraic_type: Bool,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "F32",
-                                    ),
-                                    algebraic_type: F32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "F64",
-                                    ),
-                                    algebraic_type: F64,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Str",
-                                    ),
-                                    algebraic_type: String,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Identity",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__identity_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Address",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__address_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Ints",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I32,
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Strings",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: String,
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "SimpleEnums",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Sum(
-                                                SumType {
-                                                    variants: [
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "Zero",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "One",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "Two",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+            "e": SumType {
+                "U8": U8,
+                "U16": U16,
+                "U32": U32,
+                "U64": U64,
+                "U128": U128,
+                "U256": U256,
+                "I8": I8,
+                "I16": I16,
+                "I32": I32,
+                "I64": I64,
+                "I128": I128,
+                "I256": I256,
+                "Bool": Bool,
+                "F32": F32,
+                "F64": F64,
+                "Str": String,
+                "Identity": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
-            ],
+                "Address": ProductType {
+                    "__address_bytes": ArrayType(U8),
+                },
+                "Bytes": ArrayType(U8),
+                "Ints": ArrayType(I32),
+                "Strings": ArrayType(String),
+                "SimpleEnums": ArrayType(SumType {
+                    "Zero": ProductType {},
+                    "One": ProductType {},
+                    "Two": ProductType {},
+                }),
+            },
         },
         "insert_one_every_primitive_struct": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "a",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: U16,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "c",
-                                    ),
-                                    algebraic_type: U32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "d",
-                                    ),
-                                    algebraic_type: U64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "e",
-                                    ),
-                                    algebraic_type: U128,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "f",
-                                    ),
-                                    algebraic_type: U256,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "g",
-                                    ),
-                                    algebraic_type: I8,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "h",
-                                    ),
-                                    algebraic_type: I16,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "i",
-                                    ),
-                                    algebraic_type: I32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "j",
-                                    ),
-                                    algebraic_type: I64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "k",
-                                    ),
-                                    algebraic_type: I128,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "l",
-                                    ),
-                                    algebraic_type: I256,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "m",
-                                    ),
-                                    algebraic_type: Bool,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: F32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "o",
-                                    ),
-                                    algebraic_type: F64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "p",
-                                    ),
-                                    algebraic_type: String,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "q",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__identity_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "r",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__address_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+            "s": ProductType {
+                "a": U8,
+                "b": U16,
+                "c": U32,
+                "d": U64,
+                "e": U128,
+                "f": U256,
+                "g": I8,
+                "h": I16,
+                "i": I32,
+                "j": I64,
+                "k": I128,
+                "l": I256,
+                "m": Bool,
+                "n": F32,
+                "o": F64,
+                "p": String,
+                "q": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
-            ],
+                "r": ProductType {
+                    "__address_bytes": ArrayType(U8),
+                },
+            },
         },
         "insert_one_every_vec_struct": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "a",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U16,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "c",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U32,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "d",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U64,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "e",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U128,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "f",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U256,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "g",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I8,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "h",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I16,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "i",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I32,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "j",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I64,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "k",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I128,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "l",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: I256,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "m",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Bool,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: F32,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "o",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: F64,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "p",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: String,
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "q",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__identity_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "r",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__address_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "s": ProductType {
+                "a": ArrayType(U8),
+                "b": ArrayType(U16),
+                "c": ArrayType(U32),
+                "d": ArrayType(U64),
+                "e": ArrayType(U128),
+                "f": ArrayType(U256),
+                "g": ArrayType(I8),
+                "h": ArrayType(I16),
+                "i": ArrayType(I32),
+                "j": ArrayType(I64),
+                "k": ArrayType(I128),
+                "l": ArrayType(I256),
+                "m": ArrayType(Bool),
+                "n": ArrayType(F32),
+                "o": ArrayType(F64),
+                "p": ArrayType(String),
+                "q": ArrayType(ProductType {
+                    "__identity_bytes": ArrayType(U8),
+                }),
+                "r": ArrayType(ProductType {
+                    "__address_bytes": ArrayType(U8),
+                }),
+            },
         },
         "insert_one_f32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "f",
-                    ),
-                    algebraic_type: F32,
-                },
-            ],
+            "f": F32,
         },
         "insert_one_f64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "f",
-                    ),
-                    algebraic_type: F64,
-                },
-            ],
+            "f": F64,
         },
         "insert_one_i128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I128,
-                },
-            ],
+            "n": I128,
         },
         "insert_one_i16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I16,
-                },
-            ],
+            "n": I16,
         },
         "insert_one_i256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I256,
-                },
-            ],
+            "n": I256,
         },
         "insert_one_i32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I32,
         },
         "insert_one_i64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I64,
-                },
-            ],
+            "n": I64,
         },
         "insert_one_i8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I8,
-                },
-            ],
+            "n": I8,
         },
         "insert_one_identity": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "i",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__identity_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "i": ProductType {
+                "__identity_bytes": ArrayType(U8),
+            },
         },
         "insert_one_simple_enum": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "e",
-                    ),
-                    algebraic_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Zero",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "One",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "Two",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "e": SumType {
+                "Zero": ProductType {},
+                "One": ProductType {},
+                "Two": ProductType {},
+            },
         },
         "insert_one_string": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: String,
-                },
-            ],
+            "s": String,
         },
         "insert_one_u128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U128,
-                },
-            ],
+            "n": U128,
         },
         "insert_one_u16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U16,
-                },
-            ],
+            "n": U16,
         },
         "insert_one_u256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U256,
-                },
-            ],
+            "n": U256,
         },
         "insert_one_u32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U32,
-                },
-            ],
+            "n": U32,
         },
         "insert_one_u64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U64,
-                },
-            ],
+            "n": U64,
         },
         "insert_one_u8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U8,
-                },
-            ],
+            "n": U8,
         },
         "insert_one_unit_struct": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [],
-                        },
-                    ),
-                },
-            ],
+            "s": ProductType {},
         },
         "insert_option_every_primitive_struct": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "some",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "a",
-                                                    ),
-                                                    algebraic_type: U8,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "b",
-                                                    ),
-                                                    algebraic_type: U16,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "c",
-                                                    ),
-                                                    algebraic_type: U32,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "d",
-                                                    ),
-                                                    algebraic_type: U64,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "e",
-                                                    ),
-                                                    algebraic_type: U128,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "f",
-                                                    ),
-                                                    algebraic_type: U256,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "g",
-                                                    ),
-                                                    algebraic_type: I8,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "h",
-                                                    ),
-                                                    algebraic_type: I16,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "i",
-                                                    ),
-                                                    algebraic_type: I32,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "j",
-                                                    ),
-                                                    algebraic_type: I64,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "k",
-                                                    ),
-                                                    algebraic_type: I128,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "l",
-                                                    ),
-                                                    algebraic_type: I256,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "m",
-                                                    ),
-                                                    algebraic_type: Bool,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "n",
-                                                    ),
-                                                    algebraic_type: F32,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "o",
-                                                    ),
-                                                    algebraic_type: F64,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "p",
-                                                    ),
-                                                    algebraic_type: String,
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "q",
-                                                    ),
-                                                    algebraic_type: Product(
-                                                        ProductType {
-                                                            elements: [
-                                                                ProductTypeElement {
-                                                                    name: Some(
-                                                                        "__identity_bytes",
-                                                                    ),
-                                                                    algebraic_type: Array(
-                                                                        ArrayType {
-                                                                            elem_ty: U8,
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "r",
-                                                    ),
-                                                    algebraic_type: Product(
-                                                        ProductType {
-                                                            elements: [
-                                                                ProductTypeElement {
-                                                                    name: Some(
-                                                                        "__address_bytes",
-                                                                    ),
-                                                                    algebraic_type: Array(
-                                                                        ArrayType {
-                                                                            elem_ty: U8,
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "none",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+            "s": SumType {
+                "some": ProductType {
+                    "a": U8,
+                    "b": U16,
+                    "c": U32,
+                    "d": U64,
+                    "e": U128,
+                    "f": U256,
+                    "g": I8,
+                    "h": I16,
+                    "i": I32,
+                    "j": I64,
+                    "k": I128,
+                    "l": I256,
+                    "m": Bool,
+                    "n": F32,
+                    "o": F64,
+                    "p": String,
+                    "q": ProductType {
+                        "__identity_bytes": ArrayType(U8),
+                    },
+                    "r": ProductType {
+                        "__address_bytes": ArrayType(U8),
+                    },
                 },
-            ],
+                "none": ProductType {},
+            },
         },
         "insert_option_i32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "some",
-                                    ),
-                                    algebraic_type: I32,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "none",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "n": SumType {
+                "some": I32,
+                "none": ProductType {},
+            },
         },
         "insert_option_identity": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "i",
-                    ),
-                    algebraic_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "some",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__identity_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "none",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+            "i": SumType {
+                "some": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
-            ],
+                "none": ProductType {},
+            },
         },
         "insert_option_simple_enum": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "e",
-                    ),
-                    algebraic_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "some",
-                                    ),
-                                    algebraic_type: Sum(
-                                        SumType {
-                                            variants: [
-                                                SumTypeVariant {
-                                                    name: Some(
-                                                        "Zero",
-                                                    ),
-                                                    algebraic_type: Product(
-                                                        ProductType {
-                                                            elements: [],
-                                                        },
-                                                    ),
-                                                },
-                                                SumTypeVariant {
-                                                    name: Some(
-                                                        "One",
-                                                    ),
-                                                    algebraic_type: Product(
-                                                        ProductType {
-                                                            elements: [],
-                                                        },
-                                                    ),
-                                                },
-                                                SumTypeVariant {
-                                                    name: Some(
-                                                        "Two",
-                                                    ),
-                                                    algebraic_type: Product(
-                                                        ProductType {
-                                                            elements: [],
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "none",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+            "e": SumType {
+                "some": SumType {
+                    "Zero": ProductType {},
+                    "One": ProductType {},
+                    "Two": ProductType {},
                 },
-            ],
+                "none": ProductType {},
+            },
         },
         "insert_option_string": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "some",
-                                    ),
-                                    algebraic_type: String,
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "none",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "s": SumType {
+                "some": String,
+                "none": ProductType {},
+            },
         },
         "insert_option_vec_option_i32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "v",
-                    ),
-                    algebraic_type: Sum(
-                        SumType {
-                            variants: [
-                                SumTypeVariant {
-                                    name: Some(
-                                        "some",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: Sum(
-                                                SumType {
-                                                    variants: [
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "some",
-                                                            ),
-                                                            algebraic_type: I32,
-                                                        },
-                                                        SumTypeVariant {
-                                                            name: Some(
-                                                                "none",
-                                                            ),
-                                                            algebraic_type: Product(
-                                                                ProductType {
-                                                                    elements: [],
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ),
-                                },
-                                SumTypeVariant {
-                                    name: Some(
-                                        "none",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "v": SumType {
+                "some": ArrayType(SumType {
+                    "some": I32,
+                    "none": ProductType {},
+                }),
+                "none": ProductType {},
+            },
         },
         "insert_pk_address": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "a",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__address_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "a": ProductType {
+                "__address_bytes": ArrayType(U8),
+            },
+            "data": I32,
         },
         "insert_pk_bool": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "b",
-                    ),
-                    algebraic_type: Bool,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "b": Bool,
+            "data": I32,
         },
         "insert_pk_i128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I128,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I128,
+            "data": I32,
         },
         "insert_pk_i16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I16,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I16,
+            "data": I32,
         },
         "insert_pk_i256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I256,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I256,
+            "data": I32,
         },
         "insert_pk_i32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I32,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I32,
+            "data": I32,
         },
         "insert_pk_i64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I64,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I64,
+            "data": I32,
         },
         "insert_pk_i8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I8,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I8,
+            "data": I32,
         },
         "insert_pk_identity": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "i",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__identity_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "i": ProductType {
+                "__identity_bytes": ArrayType(U8),
+            },
+            "data": I32,
         },
         "insert_pk_string": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: String,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "s": String,
+            "data": I32,
         },
         "insert_pk_u128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U128,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U128,
+            "data": I32,
         },
         "insert_pk_u16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U16,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U16,
+            "data": I32,
         },
         "insert_pk_u256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U256,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U256,
+            "data": I32,
         },
         "insert_pk_u32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U32,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U32,
+            "data": I32,
         },
         "insert_pk_u64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U64,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U64,
+            "data": I32,
         },
         "insert_pk_u8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U8,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U8,
+            "data": I32,
         },
         "insert_primitives_as_strings": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "a",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "b",
-                                    ),
-                                    algebraic_type: U16,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "c",
-                                    ),
-                                    algebraic_type: U32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "d",
-                                    ),
-                                    algebraic_type: U64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "e",
-                                    ),
-                                    algebraic_type: U128,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "f",
-                                    ),
-                                    algebraic_type: U256,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "g",
-                                    ),
-                                    algebraic_type: I8,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "h",
-                                    ),
-                                    algebraic_type: I16,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "i",
-                                    ),
-                                    algebraic_type: I32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "j",
-                                    ),
-                                    algebraic_type: I64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "k",
-                                    ),
-                                    algebraic_type: I128,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "l",
-                                    ),
-                                    algebraic_type: I256,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "m",
-                                    ),
-                                    algebraic_type: Bool,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: F32,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "o",
-                                    ),
-                                    algebraic_type: F64,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "p",
-                                    ),
-                                    algebraic_type: String,
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "q",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__identity_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                                ProductTypeElement {
-                                    name: Some(
-                                        "r",
-                                    ),
-                                    algebraic_type: Product(
-                                        ProductType {
-                                            elements: [
-                                                ProductTypeElement {
-                                                    name: Some(
-                                                        "__address_bytes",
-                                                    ),
-                                                    algebraic_type: Array(
-                                                        ArrayType {
-                                                            elem_ty: U8,
-                                                        },
-                                                    ),
-                                                },
-                                            ],
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
+            "s": ProductType {
+                "a": U8,
+                "b": U16,
+                "c": U32,
+                "d": U64,
+                "e": U128,
+                "f": U256,
+                "g": I8,
+                "h": I16,
+                "i": I32,
+                "j": I64,
+                "k": I128,
+                "l": I256,
+                "m": Bool,
+                "n": F32,
+                "o": F64,
+                "p": String,
+                "q": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
-            ],
+                "r": ProductType {
+                    "__address_bytes": ArrayType(U8),
+                },
+            },
         },
         "insert_table_holds_table": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "a",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: U8,
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "b",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "n",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-            ],
+            "a": ProductType {
+                "n": U8,
+            },
+            "b": ProductType {
+                "n": ArrayType(U8),
+            },
         },
         "insert_unique_address": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "a",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__address_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "a": ProductType {
+                "__address_bytes": ArrayType(U8),
+            },
+            "data": I32,
         },
         "insert_unique_bool": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "b",
-                    ),
-                    algebraic_type: Bool,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "b": Bool,
+            "data": I32,
         },
         "insert_unique_i128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I128,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I128,
+            "data": I32,
         },
         "insert_unique_i16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I16,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I16,
+            "data": I32,
         },
         "insert_unique_i256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I256,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I256,
+            "data": I32,
         },
         "insert_unique_i32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I32,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I32,
+            "data": I32,
         },
         "insert_unique_i64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I64,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I64,
+            "data": I32,
         },
         "insert_unique_i8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I8,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I8,
+            "data": I32,
         },
         "insert_unique_identity": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "i",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__identity_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "i": ProductType {
+                "__identity_bytes": ArrayType(U8),
+            },
+            "data": I32,
         },
         "insert_unique_string": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: String,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "s": String,
+            "data": I32,
         },
         "insert_unique_u128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U128,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U128,
+            "data": I32,
         },
         "insert_unique_u16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U16,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U16,
+            "data": I32,
         },
         "insert_unique_u256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U256,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U256,
+            "data": I32,
         },
         "insert_unique_u32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U32,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U32,
+            "data": I32,
         },
         "insert_unique_u64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U64,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U64,
+            "data": I32,
         },
         "insert_unique_u8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U8,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U8,
+            "data": I32,
         },
         "insert_vec_address": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "a",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: Product(
-                                ProductType {
-                                    elements: [
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "__address_bytes",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U8,
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                },
-            ],
+            "a": ArrayType(ProductType {
+                "__address_bytes": ArrayType(U8),
+            }),
         },
         "insert_vec_bool": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "b",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: Bool,
-                        },
-                    ),
-                },
-            ],
+            "b": ArrayType(Bool),
         },
         "insert_vec_byte_struct": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: Product(
-                                ProductType {
-                                    elements: [
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "b",
-                                            ),
-                                            algebraic_type: U8,
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                },
-            ],
+            "s": ArrayType(ProductType {
+                "b": U8,
+            }),
         },
         "insert_vec_enum_with_payload": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "e",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: Sum(
-                                SumType {
-                                    variants: [
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "U8",
-                                            ),
-                                            algebraic_type: U8,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "U16",
-                                            ),
-                                            algebraic_type: U16,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "U32",
-                                            ),
-                                            algebraic_type: U32,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "U64",
-                                            ),
-                                            algebraic_type: U64,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "U128",
-                                            ),
-                                            algebraic_type: U128,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "U256",
-                                            ),
-                                            algebraic_type: U256,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "I8",
-                                            ),
-                                            algebraic_type: I8,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "I16",
-                                            ),
-                                            algebraic_type: I16,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "I32",
-                                            ),
-                                            algebraic_type: I32,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "I64",
-                                            ),
-                                            algebraic_type: I64,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "I128",
-                                            ),
-                                            algebraic_type: I128,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "I256",
-                                            ),
-                                            algebraic_type: I256,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Bool",
-                                            ),
-                                            algebraic_type: Bool,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "F32",
-                                            ),
-                                            algebraic_type: F32,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "F64",
-                                            ),
-                                            algebraic_type: F64,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Str",
-                                            ),
-                                            algebraic_type: String,
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Identity",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__identity_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Address",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__address_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Bytes",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U8,
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Ints",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I32,
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Strings",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: String,
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "SimpleEnums",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: Sum(
-                                                        SumType {
-                                                            variants: [
-                                                                SumTypeVariant {
-                                                                    name: Some(
-                                                                        "Zero",
-                                                                    ),
-                                                                    algebraic_type: Product(
-                                                                        ProductType {
-                                                                            elements: [],
-                                                                        },
-                                                                    ),
-                                                                },
-                                                                SumTypeVariant {
-                                                                    name: Some(
-                                                                        "One",
-                                                                    ),
-                                                                    algebraic_type: Product(
-                                                                        ProductType {
-                                                                            elements: [],
-                                                                        },
-                                                                    ),
-                                                                },
-                                                                SumTypeVariant {
-                                                                    name: Some(
-                                                                        "Two",
-                                                                    ),
-                                                                    algebraic_type: Product(
-                                                                        ProductType {
-                                                                            elements: [],
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
+            "e": ArrayType(SumType {
+                "U8": U8,
+                "U16": U16,
+                "U32": U32,
+                "U64": U64,
+                "U128": U128,
+                "U256": U256,
+                "I8": I8,
+                "I16": I16,
+                "I32": I32,
+                "I64": I64,
+                "I128": I128,
+                "I256": I256,
+                "Bool": Bool,
+                "F32": F32,
+                "F64": F64,
+                "Str": String,
+                "Identity": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
-            ],
+                "Address": ProductType {
+                    "__address_bytes": ArrayType(U8),
+                },
+                "Bytes": ArrayType(U8),
+                "Ints": ArrayType(I32),
+                "Strings": ArrayType(String),
+                "SimpleEnums": ArrayType(SumType {
+                    "Zero": ProductType {},
+                    "One": ProductType {},
+                    "Two": ProductType {},
+                }),
+            }),
         },
         "insert_vec_every_primitive_struct": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: Product(
-                                ProductType {
-                                    elements: [
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "a",
-                                            ),
-                                            algebraic_type: U8,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "b",
-                                            ),
-                                            algebraic_type: U16,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "c",
-                                            ),
-                                            algebraic_type: U32,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "d",
-                                            ),
-                                            algebraic_type: U64,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "e",
-                                            ),
-                                            algebraic_type: U128,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "f",
-                                            ),
-                                            algebraic_type: U256,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "g",
-                                            ),
-                                            algebraic_type: I8,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "h",
-                                            ),
-                                            algebraic_type: I16,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "i",
-                                            ),
-                                            algebraic_type: I32,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "j",
-                                            ),
-                                            algebraic_type: I64,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "k",
-                                            ),
-                                            algebraic_type: I128,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "l",
-                                            ),
-                                            algebraic_type: I256,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "m",
-                                            ),
-                                            algebraic_type: Bool,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "n",
-                                            ),
-                                            algebraic_type: F32,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "o",
-                                            ),
-                                            algebraic_type: F64,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "p",
-                                            ),
-                                            algebraic_type: String,
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "q",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__identity_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "r",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [
-                                                        ProductTypeElement {
-                                                            name: Some(
-                                                                "__address_bytes",
-                                                            ),
-                                                            algebraic_type: Array(
-                                                                ArrayType {
-                                                                    elem_ty: U8,
-                                                                },
-                                                            ),
-                                                        },
-                                                    ],
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
+            "s": ArrayType(ProductType {
+                "a": U8,
+                "b": U16,
+                "c": U32,
+                "d": U64,
+                "e": U128,
+                "f": U256,
+                "g": I8,
+                "h": I16,
+                "i": I32,
+                "j": I64,
+                "k": I128,
+                "l": I256,
+                "m": Bool,
+                "n": F32,
+                "o": F64,
+                "p": String,
+                "q": ProductType {
+                    "__identity_bytes": ArrayType(U8),
                 },
-            ],
+                "r": ProductType {
+                    "__address_bytes": ArrayType(U8),
+                },
+            }),
         },
         "insert_vec_every_vec_struct": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: Product(
-                                ProductType {
-                                    elements: [
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "a",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U8,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "b",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U16,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "c",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U32,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "d",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U64,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "e",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U128,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "f",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U256,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "g",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I8,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "h",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I16,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "i",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I32,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "j",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I64,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "k",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I128,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "l",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: I256,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "m",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: Bool,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "n",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: F32,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "o",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: F64,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "p",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: String,
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "q",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: Product(
-                                                        ProductType {
-                                                            elements: [
-                                                                ProductTypeElement {
-                                                                    name: Some(
-                                                                        "__identity_bytes",
-                                                                    ),
-                                                                    algebraic_type: Array(
-                                                                        ArrayType {
-                                                                            elem_ty: U8,
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "r",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: Product(
-                                                        ProductType {
-                                                            elements: [
-                                                                ProductTypeElement {
-                                                                    name: Some(
-                                                                        "__address_bytes",
-                                                                    ),
-                                                                    algebraic_type: Array(
-                                                                        ArrayType {
-                                                                            elem_ty: U8,
-                                                                        },
-                                                                    ),
-                                                                },
-                                                            ],
-                                                        },
-                                                    ),
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                },
-            ],
+            "s": ArrayType(ProductType {
+                "a": ArrayType(U8),
+                "b": ArrayType(U16),
+                "c": ArrayType(U32),
+                "d": ArrayType(U64),
+                "e": ArrayType(U128),
+                "f": ArrayType(U256),
+                "g": ArrayType(I8),
+                "h": ArrayType(I16),
+                "i": ArrayType(I32),
+                "j": ArrayType(I64),
+                "k": ArrayType(I128),
+                "l": ArrayType(I256),
+                "m": ArrayType(Bool),
+                "n": ArrayType(F32),
+                "o": ArrayType(F64),
+                "p": ArrayType(String),
+                "q": ArrayType(ProductType {
+                    "__identity_bytes": ArrayType(U8),
+                }),
+                "r": ArrayType(ProductType {
+                    "__address_bytes": ArrayType(U8),
+                }),
+            }),
         },
         "insert_vec_f32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "f",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: F32,
-                        },
-                    ),
-                },
-            ],
+            "f": ArrayType(F32),
         },
         "insert_vec_f64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "f",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: F64,
-                        },
-                    ),
-                },
-            ],
+            "f": ArrayType(F64),
         },
         "insert_vec_i128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: I128,
-                        },
-                    ),
-                },
-            ],
+            "n": ArrayType(I128),
         },
         "insert_vec_i16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: I16,
-                        },
-                    ),
-                },
-            ],
+            "n": ArrayType(I16),
         },
         "insert_vec_i256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: I256,
-                        },
-                    ),
-                },
-            ],
+            "n": ArrayType(I256),
         },
         "insert_vec_i32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: I32,
-                        },
-                    ),
-                },
-            ],
+            "n": ArrayType(I32),
         },
         "insert_vec_i64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: I64,
-                        },
-                    ),
-                },
-            ],
+            "n": ArrayType(I64),
         },
         "insert_vec_i8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: I8,
-                        },
-                    ),
-                },
-            ],
+            "n": ArrayType(I8),
         },
         "insert_vec_identity": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "i",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: Product(
-                                ProductType {
-                                    elements: [
-                                        ProductTypeElement {
-                                            name: Some(
-                                                "__identity_bytes",
-                                            ),
-                                            algebraic_type: Array(
-                                                ArrayType {
-                                                    elem_ty: U8,
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                },
-            ],
+            "i": ArrayType(ProductType {
+                "__identity_bytes": ArrayType(U8),
+            }),
         },
         "insert_vec_simple_enum": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "e",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: Sum(
-                                SumType {
-                                    variants: [
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Zero",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [],
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "One",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [],
-                                                },
-                                            ),
-                                        },
-                                        SumTypeVariant {
-                                            name: Some(
-                                                "Two",
-                                            ),
-                                            algebraic_type: Product(
-                                                ProductType {
-                                                    elements: [],
-                                                },
-                                            ),
-                                        },
-                                    ],
-                                },
-                            ),
-                        },
-                    ),
-                },
-            ],
+            "e": ArrayType(SumType {
+                "Zero": ProductType {},
+                "One": ProductType {},
+                "Two": ProductType {},
+            }),
         },
         "insert_vec_string": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: String,
-                        },
-                    ),
-                },
-            ],
+            "s": ArrayType(String),
         },
         "insert_vec_u128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: U128,
-                        },
-                    ),
-                },
-            ],
+            "n": ArrayType(U128),
         },
         "insert_vec_u16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: U16,
-                        },
-                    ),
-                },
-            ],
+            "n": ArrayType(U16),
         },
         "insert_vec_u256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: U256,
-                        },
-                    ),
-                },
-            ],
+            "n": ArrayType(U256),
         },
         "insert_vec_u32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: U32,
-                        },
-                    ),
-                },
-            ],
+            "n": ArrayType(U32),
         },
         "insert_vec_u64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: U64,
-                        },
-                    ),
-                },
-            ],
+            "n": ArrayType(U64),
         },
         "insert_vec_u8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: U8,
-                        },
-                    ),
-                },
-            ],
+            "n": ArrayType(U8),
         },
         "insert_vec_unit_struct": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: Array(
-                        ArrayType {
-                            elem_ty: Product(
-                                ProductType {
-                                    elements: [],
-                                },
-                            ),
-                        },
-                    ),
-                },
-            ],
+            "s": ArrayType(ProductType {}),
         },
-        "no_op_succeeds": ProductType {
-            elements: [],
-        },
+        "no_op_succeeds": ProductType {},
         "update_pk_address": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "a",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__address_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "a": ProductType {
+                "__address_bytes": ArrayType(U8),
+            },
+            "data": I32,
         },
         "update_pk_bool": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "b",
-                    ),
-                    algebraic_type: Bool,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "b": Bool,
+            "data": I32,
         },
         "update_pk_i128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I128,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I128,
+            "data": I32,
         },
         "update_pk_i16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I16,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I16,
+            "data": I32,
         },
         "update_pk_i256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I256,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I256,
+            "data": I32,
         },
         "update_pk_i32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I32,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I32,
+            "data": I32,
         },
         "update_pk_i64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I64,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I64,
+            "data": I32,
         },
         "update_pk_i8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I8,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I8,
+            "data": I32,
         },
         "update_pk_identity": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "i",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__identity_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "i": ProductType {
+                "__identity_bytes": ArrayType(U8),
+            },
+            "data": I32,
         },
         "update_pk_string": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: String,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "s": String,
+            "data": I32,
         },
         "update_pk_u128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U128,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U128,
+            "data": I32,
         },
         "update_pk_u16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U16,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U16,
+            "data": I32,
         },
         "update_pk_u256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U256,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U256,
+            "data": I32,
         },
         "update_pk_u32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U32,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U32,
+            "data": I32,
         },
         "update_pk_u64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U64,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U64,
+            "data": I32,
         },
         "update_pk_u8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U8,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U8,
+            "data": I32,
         },
         "update_unique_address": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "a",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__address_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "a": ProductType {
+                "__address_bytes": ArrayType(U8),
+            },
+            "data": I32,
         },
         "update_unique_bool": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "b",
-                    ),
-                    algebraic_type: Bool,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "b": Bool,
+            "data": I32,
         },
         "update_unique_i128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I128,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I128,
+            "data": I32,
         },
         "update_unique_i16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I16,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I16,
+            "data": I32,
         },
         "update_unique_i256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I256,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I256,
+            "data": I32,
         },
         "update_unique_i32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I32,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I32,
+            "data": I32,
         },
         "update_unique_i64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I64,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I64,
+            "data": I32,
         },
         "update_unique_i8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: I8,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": I8,
+            "data": I32,
         },
         "update_unique_identity": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "i",
-                    ),
-                    algebraic_type: Product(
-                        ProductType {
-                            elements: [
-                                ProductTypeElement {
-                                    name: Some(
-                                        "__identity_bytes",
-                                    ),
-                                    algebraic_type: Array(
-                                        ArrayType {
-                                            elem_ty: U8,
-                                        },
-                                    ),
-                                },
-                            ],
-                        },
-                    ),
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "i": ProductType {
+                "__identity_bytes": ArrayType(U8),
+            },
+            "data": I32,
         },
         "update_unique_string": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "s",
-                    ),
-                    algebraic_type: String,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "s": String,
+            "data": I32,
         },
         "update_unique_u128": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U128,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U128,
+            "data": I32,
         },
         "update_unique_u16": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U16,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U16,
+            "data": I32,
         },
         "update_unique_u256": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U256,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U256,
+            "data": I32,
         },
         "update_unique_u32": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U32,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U32,
+            "data": I32,
         },
         "update_unique_u64": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U64,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U64,
+            "data": I32,
         },
         "update_unique_u8": ProductType {
-            elements: [
-                ProductTypeElement {
-                    name: Some(
-                        "n",
-                    ),
-                    algebraic_type: U8,
-                },
-                ProductTypeElement {
-                    name: Some(
-                        "data",
-                    ),
-                    algebraic_type: I32,
-                },
-            ],
+            "n": U8,
+            "data": I32,
         },
     },
     exports: {
-        "ByteStruct": Product(
-            ProductType {
-                elements: [
-                    ProductTypeElement {
-                        name: Some(
-                            "b",
-                        ),
-                        algebraic_type: U8,
-                    },
-                ],
+        "ByteStruct": ProductType {
+            "b": U8,
+        },
+        "EnumWithPayload": SumType {
+            "U8": U8,
+            "U16": U16,
+            "U32": U32,
+            "U64": U64,
+            "U128": U128,
+            "U256": U256,
+            "I8": I8,
+            "I16": I16,
+            "I32": I32,
+            "I64": I64,
+            "I128": I128,
+            "I256": I256,
+            "Bool": Bool,
+            "F32": F32,
+            "F64": F64,
+            "Str": String,
+            "Identity": ProductType {
+                "__identity_bytes": ArrayType(U8),
             },
-        ),
-        "EnumWithPayload": Sum(
-            SumType {
-                variants: [
-                    SumTypeVariant {
-                        name: Some(
-                            "U8",
-                        ),
-                        algebraic_type: U8,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "U16",
-                        ),
-                        algebraic_type: U16,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "U32",
-                        ),
-                        algebraic_type: U32,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "U64",
-                        ),
-                        algebraic_type: U64,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "U128",
-                        ),
-                        algebraic_type: U128,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "U256",
-                        ),
-                        algebraic_type: U256,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "I8",
-                        ),
-                        algebraic_type: I8,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "I16",
-                        ),
-                        algebraic_type: I16,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "I32",
-                        ),
-                        algebraic_type: I32,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "I64",
-                        ),
-                        algebraic_type: I64,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "I128",
-                        ),
-                        algebraic_type: I128,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "I256",
-                        ),
-                        algebraic_type: I256,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "Bool",
-                        ),
-                        algebraic_type: Bool,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "F32",
-                        ),
-                        algebraic_type: F32,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "F64",
-                        ),
-                        algebraic_type: F64,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "Str",
-                        ),
-                        algebraic_type: String,
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "Identity",
-                        ),
-                        algebraic_type: Product(
-                            ProductType {
-                                elements: [
-                                    ProductTypeElement {
-                                        name: Some(
-                                            "__identity_bytes",
-                                        ),
-                                        algebraic_type: Array(
-                                            ArrayType {
-                                                elem_ty: U8,
-                                            },
-                                        ),
-                                    },
-                                ],
-                            },
-                        ),
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "Address",
-                        ),
-                        algebraic_type: Product(
-                            ProductType {
-                                elements: [
-                                    ProductTypeElement {
-                                        name: Some(
-                                            "__address_bytes",
-                                        ),
-                                        algebraic_type: Array(
-                                            ArrayType {
-                                                elem_ty: U8,
-                                            },
-                                        ),
-                                    },
-                                ],
-                            },
-                        ),
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "Bytes",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: U8,
-                            },
-                        ),
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "Ints",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: I32,
-                            },
-                        ),
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "Strings",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: String,
-                            },
-                        ),
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "SimpleEnums",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: Sum(
-                                    SumType {
-                                        variants: [
-                                            SumTypeVariant {
-                                                name: Some(
-                                                    "Zero",
-                                                ),
-                                                algebraic_type: Product(
-                                                    ProductType {
-                                                        elements: [],
-                                                    },
-                                                ),
-                                            },
-                                            SumTypeVariant {
-                                                name: Some(
-                                                    "One",
-                                                ),
-                                                algebraic_type: Product(
-                                                    ProductType {
-                                                        elements: [],
-                                                    },
-                                                ),
-                                            },
-                                            SumTypeVariant {
-                                                name: Some(
-                                                    "Two",
-                                                ),
-                                                algebraic_type: Product(
-                                                    ProductType {
-                                                        elements: [],
-                                                    },
-                                                ),
-                                            },
-                                        ],
-                                    },
-                                ),
-                            },
-                        ),
-                    },
-                ],
+            "Address": ProductType {
+                "__address_bytes": ArrayType(U8),
             },
-        ),
-        "EveryPrimitiveStruct": Product(
-            ProductType {
-                elements: [
-                    ProductTypeElement {
-                        name: Some(
-                            "a",
-                        ),
-                        algebraic_type: U8,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "b",
-                        ),
-                        algebraic_type: U16,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "c",
-                        ),
-                        algebraic_type: U32,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "d",
-                        ),
-                        algebraic_type: U64,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "e",
-                        ),
-                        algebraic_type: U128,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "f",
-                        ),
-                        algebraic_type: U256,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "g",
-                        ),
-                        algebraic_type: I8,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "h",
-                        ),
-                        algebraic_type: I16,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "i",
-                        ),
-                        algebraic_type: I32,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "j",
-                        ),
-                        algebraic_type: I64,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "k",
-                        ),
-                        algebraic_type: I128,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "l",
-                        ),
-                        algebraic_type: I256,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "m",
-                        ),
-                        algebraic_type: Bool,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "n",
-                        ),
-                        algebraic_type: F32,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "o",
-                        ),
-                        algebraic_type: F64,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "p",
-                        ),
-                        algebraic_type: String,
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "q",
-                        ),
-                        algebraic_type: Product(
-                            ProductType {
-                                elements: [
-                                    ProductTypeElement {
-                                        name: Some(
-                                            "__identity_bytes",
-                                        ),
-                                        algebraic_type: Array(
-                                            ArrayType {
-                                                elem_ty: U8,
-                                            },
-                                        ),
-                                    },
-                                ],
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "r",
-                        ),
-                        algebraic_type: Product(
-                            ProductType {
-                                elements: [
-                                    ProductTypeElement {
-                                        name: Some(
-                                            "__address_bytes",
-                                        ),
-                                        algebraic_type: Array(
-                                            ArrayType {
-                                                elem_ty: U8,
-                                            },
-                                        ),
-                                    },
-                                ],
-                            },
-                        ),
-                    },
-                ],
+            "Bytes": ArrayType(U8),
+            "Ints": ArrayType(I32),
+            "Strings": ArrayType(String),
+            "SimpleEnums": ArrayType(SumType {
+                "Zero": ProductType {},
+                "One": ProductType {},
+                "Two": ProductType {},
+            }),
+        },
+        "EveryPrimitiveStruct": ProductType {
+            "a": U8,
+            "b": U16,
+            "c": U32,
+            "d": U64,
+            "e": U128,
+            "f": U256,
+            "g": I8,
+            "h": I16,
+            "i": I32,
+            "j": I64,
+            "k": I128,
+            "l": I256,
+            "m": Bool,
+            "n": F32,
+            "o": F64,
+            "p": String,
+            "q": ProductType {
+                "__identity_bytes": ArrayType(U8),
             },
-        ),
-        "EveryVecStruct": Product(
-            ProductType {
-                elements: [
-                    ProductTypeElement {
-                        name: Some(
-                            "a",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: U8,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "b",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: U16,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "c",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: U32,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "d",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: U64,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "e",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: U128,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "f",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: U256,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "g",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: I8,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "h",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: I16,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "i",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: I32,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "j",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: I64,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "k",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: I128,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "l",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: I256,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "m",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: Bool,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "n",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: F32,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "o",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: F64,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "p",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: String,
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "q",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: Product(
-                                    ProductType {
-                                        elements: [
-                                            ProductTypeElement {
-                                                name: Some(
-                                                    "__identity_bytes",
-                                                ),
-                                                algebraic_type: Array(
-                                                    ArrayType {
-                                                        elem_ty: U8,
-                                                    },
-                                                ),
-                                            },
-                                        ],
-                                    },
-                                ),
-                            },
-                        ),
-                    },
-                    ProductTypeElement {
-                        name: Some(
-                            "r",
-                        ),
-                        algebraic_type: Array(
-                            ArrayType {
-                                elem_ty: Product(
-                                    ProductType {
-                                        elements: [
-                                            ProductTypeElement {
-                                                name: Some(
-                                                    "__address_bytes",
-                                                ),
-                                                algebraic_type: Array(
-                                                    ArrayType {
-                                                        elem_ty: U8,
-                                                    },
-                                                ),
-                                            },
-                                        ],
-                                    },
-                                ),
-                            },
-                        ),
-                    },
-                ],
+            "r": ProductType {
+                "__address_bytes": ArrayType(U8),
             },
-        ),
-        "SimpleEnum": Sum(
-            SumType {
-                variants: [
-                    SumTypeVariant {
-                        name: Some(
-                            "Zero",
-                        ),
-                        algebraic_type: Product(
-                            ProductType {
-                                elements: [],
-                            },
-                        ),
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "One",
-                        ),
-                        algebraic_type: Product(
-                            ProductType {
-                                elements: [],
-                            },
-                        ),
-                    },
-                    SumTypeVariant {
-                        name: Some(
-                            "Two",
-                        ),
-                        algebraic_type: Product(
-                            ProductType {
-                                elements: [],
-                            },
-                        ),
-                    },
-                ],
-            },
-        ),
-        "UnitStruct": Product(
-            ProductType {
-                elements: [],
-            },
-        ),
+        },
+        "EveryVecStruct": ProductType {
+            "a": ArrayType(U8),
+            "b": ArrayType(U16),
+            "c": ArrayType(U32),
+            "d": ArrayType(U64),
+            "e": ArrayType(U128),
+            "f": ArrayType(U256),
+            "g": ArrayType(I8),
+            "h": ArrayType(I16),
+            "i": ArrayType(I32),
+            "j": ArrayType(I64),
+            "k": ArrayType(I128),
+            "l": ArrayType(I256),
+            "m": ArrayType(Bool),
+            "n": ArrayType(F32),
+            "o": ArrayType(F64),
+            "p": ArrayType(String),
+            "q": ArrayType(ProductType {
+                "__identity_bytes": ArrayType(U8),
+            }),
+            "r": ArrayType(ProductType {
+                "__address_bytes": ArrayType(U8),
+            }),
+        },
+        "SimpleEnum": SumType {
+            "Zero": ProductType {},
+            "One": ProductType {},
+            "Two": ProductType {},
+        },
+        "UnitStruct": ProductType {},
     },
 }

--- a/modules/sdk-test-cs/Lib.cs
+++ b/modules/sdk-test-cs/Lib.cs
@@ -1631,7 +1631,7 @@ static partial class Module
     [SpacetimeDB.Reducer]
     public static void insert_caller_one_address(ReducerContext ctx)
     {
-        new OneAddress { a = (Address)ctx.Address!, }.Insert();
+        new OneAddress { a = (Address)ctx.Address! }.Insert();
     }
 
     [SpacetimeDB.Reducer]
@@ -1745,7 +1745,7 @@ static partial class Module
             s = typeof(EveryPrimitiveStruct)
                 .GetFields()
                 .Select(f => f.GetValue(s)!.ToString()!.ToLowerInvariant())
-                .ToList()
+                .ToList(),
         }.Insert();
     }
 


### PR DESCRIPTION
# Description of Changes

This provides snapshot testing for ModuleDef returned from Wasm modules. It will automatically compare ModuleDefs of test modules against both the previous snapshots, and across different languages.

Note that comparison doesn't (can't) use raw ModuleDef. There are some minor non-functional differences between Rust and C# that need to be cleaned up before comparing - most notably, the order in which types are registered during table traverse, plus some smaller things like Rust registering column constraints even where they're no-op. I believe those changes don't matter and are fine to remove before comparing.

The history is split into two commits - one that adds working testing with all the cleanups, and in a separate one I added more compact debug representations for AlgebraicType and child types. That commit could be reverted, but it makes the snapshots much easier to read (see the diff) and I believe will be useful for regular debugging outside this test as well.

Fixes #1589.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Ran SDK tests (`cargo test -p spacetimedb-sdk`).
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
