### PR TITLE
Update SQL AST in accordance with the SQL spec

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4574,6 +4574,15 @@ dependencies = [
 ]
 
 [[package]]
+name = "spacetimedb-sql-parser"
+version = "0.12.0"
+dependencies = [
+ "derive_more",
+ "sqlparser",
+ "thiserror",
+]
+
+[[package]]
 name = "spacetimedb-standalone"
 version = "0.12.0"
 dependencies = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,6 +20,7 @@ members = [
   "crates/sdk",
   "crates/snapshot",
   "crates/sqltest",
+  "crates/sql-parser",
   "crates/standalone",
   "crates/table",
   "crates/testing",
@@ -100,6 +101,7 @@ spacetimedb-primitives = { path = "crates/primitives", version = "0.12.0" }
 spacetimedb-sats = { path = "crates/sats", version = "0.12.0" }
 spacetimedb-schema = { path = "crates/schema", version = "0.12.0" }
 spacetimedb-standalone = { path = "crates/standalone", version = "0.12.0" }
+spacetimedb-sql-parser = { path = "crates/sql-parser", version = "0.12.0" }
 spacetimedb-table = { path = "crates/table", version = "0.12.0" }
 spacetimedb-vm = { path = "crates/vm", version = "0.12.0" }
 spacetimedb-fs-utils = { path = "crates/fs-utils", version = "0.12.0" }
@@ -247,14 +249,14 @@ wasmtime = { version = "15", default-features = false, features = ["cranelift", 
 # and reconnecting, from the tracy client to the database.
 # TODO(George): Need to be able to remove "broadcast" in some build configurations.
 tracing-tracy = { version = "0.10.4", features = [
-  "enable",
-  "system-tracing",
-  "context-switch-tracing",
-  "sampling",
-  "code-transfer",
-  "broadcast",
-  "ondemand",
-] }
+   "enable",
+   "system-tracing",
+   "context-switch-tracing",
+   "sampling",
+   "code-transfer",
+   "broadcast",
+   "ondemand",
+ ] }
 
 # Vendor the openssl we rely on, rather than depend on a
 # potentially very old system version.

--- a/crates/sql-parser/Cargo.toml
+++ b/crates/sql-parser/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "spacetimedb-sql-parser"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license-file = "LICENSE"
+description = "The SpacetimeDB SQL AST and Parser"
+
+[dependencies]
+derive_more.workspace = true
+sqlparser.workspace = true
+thiserror.workspace = true

--- a/crates/sql-parser/src/ast/mod.rs
+++ b/crates/sql-parser/src/ast/mod.rs
@@ -1,0 +1,99 @@
+use sqlparser::ast::Ident;
+
+pub mod sql;
+pub mod sub;
+
+/// The FROM clause is either a [RelExpr] or a JOIN
+pub enum SqlFrom<Ast> {
+    Expr(RelExpr<Ast>, Option<SqlIdent>),
+    Join(RelExpr<Ast>, SqlIdent, Vec<SqlJoin<Ast>>),
+}
+
+/// A RelExpr is an expression that produces a relation
+pub enum RelExpr<Ast> {
+    Var(SqlIdent),
+    Ast(Box<Ast>),
+}
+
+/// An inner join in a FROM clause
+pub struct SqlJoin<Ast> {
+    pub expr: RelExpr<Ast>,
+    pub alias: SqlIdent,
+    pub on: Option<SqlExpr>,
+}
+
+/// A projection expression in a SELECT clause
+pub struct ProjectElem(pub SqlExpr, pub Option<SqlIdent>);
+
+/// A SQL SELECT clause
+pub enum Project {
+    /// SELECT *
+    /// SELECT a.*
+    Star(Option<SqlIdent>),
+    /// SELECT a, b
+    Exprs(Vec<ProjectElem>),
+}
+
+/// A scalar SQL expression
+pub enum SqlExpr {
+    /// A constant expression
+    Lit(SqlLiteral),
+    /// Unqualified column ref
+    Var(SqlIdent),
+    /// Qualified column ref
+    Field(SqlIdent, SqlIdent),
+    /// A binary infix expression
+    Bin(Box<SqlExpr>, Box<SqlExpr>, BinOp),
+}
+
+/// A SQL identifier or named reference
+#[derive(Clone)]
+pub struct SqlIdent {
+    pub name: String,
+    pub case_sensitive: bool,
+}
+
+impl From<Ident> for SqlIdent {
+    fn from(value: Ident) -> Self {
+        match value {
+            Ident {
+                value: name,
+                quote_style: None,
+            } => SqlIdent {
+                name,
+                case_sensitive: false,
+            },
+            Ident {
+                value: name,
+                quote_style: Some(_),
+            } => SqlIdent {
+                name,
+                case_sensitive: true,
+            },
+        }
+    }
+}
+
+/// A SQL constant expression
+pub enum SqlLiteral {
+    /// A boolean constant
+    Bool(bool),
+    /// A hex value like 0xFF or x'FF'
+    Hex(String),
+    /// An integer or float value
+    Num(String),
+    /// A string value
+    Str(String),
+}
+
+/// Binary infix operators
+pub enum BinOp {
+    Eq,
+    Ne,
+    Lt,
+    Gt,
+    Lte,
+    Gte,
+    And,
+    Or,
+}

--- a/crates/sql-parser/src/ast/sql.rs
+++ b/crates/sql-parser/src/ast/sql.rs
@@ -1,0 +1,73 @@
+use super::{Project, SqlExpr, SqlFrom, SqlIdent, SqlLiteral};
+
+/// The AST for the SQL DML and query language
+pub enum SqlAst {
+    /// SELECT ...
+    Query(QueryAst),
+    /// INSERT INTO ...
+    Insert(SqlInsert),
+    /// UPDATE ...
+    Update(SqlUpdate),
+    /// DELETE FROM ...
+    Delete(SqlDelete),
+    /// SET var TO ...
+    Set(SqlSet),
+    /// SHOW var
+    Show(SqlShow),
+}
+
+/// The AST for the SQL query language
+pub struct QueryAst {
+    pub query: SqlSetOp,
+    pub order: Vec<OrderByElem>,
+    pub limit: Option<SqlLiteral>,
+}
+
+/// Set operations in the SQL query language
+pub enum SqlSetOp {
+    /// SELECT
+    Select(SqlSelect),
+    /// ORDER/LIMIT
+    Query(Box<QueryAst>),
+    /// UNION
+    Union(Box<SqlSetOp>, Box<SqlSetOp>, bool),
+    /// EXCEPT
+    Minus(Box<SqlSetOp>, Box<SqlSetOp>, bool),
+}
+
+/// A SELECT statement in the SQL query language
+pub struct SqlSelect {
+    pub project: Project,
+    pub distinct: bool,
+    pub from: SqlFrom<QueryAst>,
+    pub filter: Option<SqlExpr>,
+}
+
+/// ORDER BY cols [ ASC | DESC ]
+pub struct OrderByElem(pub SqlExpr, pub bool);
+
+/// INSERT INTO table cols VALUES literals
+pub struct SqlInsert {
+    pub table: SqlIdent,
+    pub fields: Vec<SqlIdent>,
+    pub values: SqlValues,
+}
+
+/// VALUES literals
+pub struct SqlValues(pub Vec<Vec<SqlLiteral>>);
+
+/// UPDATE table SET cols [ WHERE predicate ]
+pub struct SqlUpdate {
+    pub table: SqlIdent,
+    pub assignments: Vec<SqlSet>,
+    pub filter: Option<SqlExpr>,
+}
+
+/// DELETE FROM table [ WHERE predicate ]
+pub struct SqlDelete(pub SqlIdent, pub Option<SqlExpr>);
+
+/// SET var '=' literal
+pub struct SqlSet(pub SqlIdent, pub SqlLiteral);
+
+/// SHOW var
+pub struct SqlShow(pub SqlIdent);

--- a/crates/sql-parser/src/ast/sub.rs
+++ b/crates/sql-parser/src/ast/sub.rs
@@ -1,0 +1,17 @@
+use super::{Project, SqlExpr, SqlFrom};
+
+/// The AST for the SQL subscription language
+pub enum SqlAst {
+    Select(SqlSelect),
+    /// UNION ALL
+    Union(Box<SqlAst>, Box<SqlAst>),
+    /// EXCEPT ALL
+    Minus(Box<SqlAst>, Box<SqlAst>),
+}
+
+/// A SELECT statement in the SQL subscription language
+pub struct SqlSelect {
+    pub project: Project,
+    pub from: SqlFrom<SqlAst>,
+    pub filter: Option<SqlExpr>,
+}

--- a/crates/sql-parser/src/lib.rs
+++ b/crates/sql-parser/src/lib.rs
@@ -1,0 +1,2 @@
+pub mod ast;
+pub mod parser;

--- a/crates/sql-parser/src/parser/errors.rs
+++ b/crates/sql-parser/src/parser/errors.rs
@@ -1,0 +1,89 @@
+use std::fmt::Display;
+
+use sqlparser::{
+    ast::{BinaryOperator, Expr, ObjectName, Query, Select, SelectItem, SetExpr, TableFactor, TableWithJoins, Value},
+    parser::ParserError,
+};
+use thiserror::Error;
+
+#[derive(Error, Debug)]
+pub enum SubscriptionUnsupported {
+    #[error("Unsupported SELECT: {0}")]
+    Select(Select),
+    #[error("Unsupported: {0}")]
+    Feature(String),
+    #[error("Unsupported: Non-SELECT queries")]
+    Dml,
+}
+
+impl SubscriptionUnsupported {
+    pub(crate) fn feature(expr: impl Display) -> Self {
+        Self::Feature(format!("{expr}"))
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum SqlUnsupported {
+    #[error("Unsupported literal expression: {0}")]
+    Literal(Value),
+    #[error("Unsupported LIMIT expression: {0}")]
+    Limit(Expr),
+    #[error("Unsupported expression: {0}")]
+    Expr(Expr),
+    #[error("Unsupported binary operator: {0}")]
+    BinOp(BinaryOperator),
+    #[error("Unsupported projection: {0}")]
+    Projection(SelectItem),
+    #[error("Unsupported FROM expression: {0}")]
+    From(TableFactor),
+    #[error("Unsupported set operation: {0}")]
+    SetOp(SetExpr),
+    #[error("Unsupported INSERT expression: {0}")]
+    Insert(Query),
+    #[error("Unsupported INSERT value: {0}")]
+    InsertValue(Expr),
+    #[error("Unsupported table expression in DELETE: {0}")]
+    DeleteTable(TableWithJoins),
+    #[error("Unsupported column/variable assignment expression: {0}")]
+    Assignment(Expr),
+    #[error("Multi-part names are not supported: {0}")]
+    MultiPartName(ObjectName),
+    #[error("Unsupported: {0}")]
+    Feature(String),
+    #[error("Non-inner joins are not supported")]
+    JoinType,
+    #[error("Implicit joins are not supported")]
+    ImplicitJoins,
+    #[error("Mixed wildcard projections are not supported")]
+    MixedWildcardProject,
+    #[error("Multiple SQL statements are not supported")]
+    MultiStatement,
+    #[error("Multi-table DELETE is not supported")]
+    MultiTableDelete,
+}
+
+impl SqlUnsupported {
+    pub(crate) fn feature(expr: impl Display) -> Self {
+        Self::Feature(format!("{expr}"))
+    }
+}
+
+#[derive(Error, Debug)]
+pub enum SqlRequired {
+    #[error("A FROM clause is required")]
+    From,
+    #[error("Aliases are required for JOIN")]
+    JoinAlias,
+}
+
+#[derive(Error, Debug)]
+pub enum SqlParseError {
+    #[error(transparent)]
+    SqlUnsupported(#[from] SqlUnsupported),
+    #[error(transparent)]
+    SubscriptionUnsupported(#[from] SubscriptionUnsupported),
+    #[error(transparent)]
+    SqlRequired(#[from] SqlRequired),
+    #[error(transparent)]
+    ParserError(#[from] ParserError),
+}

--- a/crates/sql-parser/src/parser/mod.rs
+++ b/crates/sql-parser/src/parser/mod.rs
@@ -1,0 +1,219 @@
+use errors::{SqlParseError, SqlRequired, SqlUnsupported};
+use sqlparser::ast::{
+    BinaryOperator, Expr, Ident, Join, JoinConstraint, JoinOperator, ObjectName, Query, SelectItem, TableAlias,
+    TableFactor, TableWithJoins, Value, WildcardAdditionalOptions,
+};
+
+use crate::ast::{BinOp, Project, ProjectElem, RelExpr, SqlExpr, SqlFrom, SqlIdent, SqlJoin, SqlLiteral};
+
+pub mod errors;
+pub mod sql;
+pub mod sub;
+
+pub type SqlParseResult<T> = core::result::Result<T, SqlParseError>;
+
+/// Methods for parsing a relation expression.
+/// Note we abstract over the type of the relation expression,
+/// as each language has a different definition for it.
+trait RelParser {
+    type Ast;
+
+    /// Parse a top level relation expression
+    fn parse_query(query: Query) -> SqlParseResult<Self::Ast>;
+
+    /// Parse a FROM clause
+    fn parse_from(mut tables: Vec<TableWithJoins>) -> SqlParseResult<SqlFrom<Self::Ast>> {
+        if tables.is_empty() {
+            return Err(SqlRequired::From.into());
+        }
+        if tables.len() > 1 {
+            return Err(SqlUnsupported::ImplicitJoins.into());
+        }
+        let TableWithJoins { relation, joins } = tables.swap_remove(0);
+        let (expr, alias) = Self::parse_rel(relation)?;
+        if joins.is_empty() {
+            return Ok(SqlFrom::Expr(expr, alias));
+        }
+        let (expr, alias) = Self::parse_alias((expr, alias))?;
+        Ok(SqlFrom::Join(expr, alias, Self::parse_joins(joins)?))
+    }
+
+    /// Parse a sequence of JOIN clauses
+    fn parse_joins(joins: Vec<Join>) -> SqlParseResult<Vec<SqlJoin<Self::Ast>>> {
+        joins.into_iter().map(Self::parse_join).collect()
+    }
+
+    /// Parse a single JOIN clause
+    fn parse_join(join: Join) -> SqlParseResult<SqlJoin<Self::Ast>> {
+        let (expr, alias) = Self::parse_alias(Self::parse_rel(join.relation)?)?;
+        match join.join_operator {
+            JoinOperator::CrossJoin => Ok(SqlJoin { expr, alias, on: None }),
+            JoinOperator::Inner(JoinConstraint::None) => Ok(SqlJoin { expr, alias, on: None }),
+            JoinOperator::Inner(JoinConstraint::On(on)) => Ok(SqlJoin {
+                expr,
+                alias,
+                on: Some(parse_expr(on)?),
+            }),
+            _ => Err(SqlUnsupported::JoinType.into()),
+        }
+    }
+
+    /// Check optional and required table aliases in a JOIN clause
+    fn parse_alias(item: (RelExpr<Self::Ast>, Option<SqlIdent>)) -> SqlParseResult<(RelExpr<Self::Ast>, SqlIdent)> {
+        match item {
+            (RelExpr::Var(alias), None) => Ok((RelExpr::Var(alias.clone()), alias)),
+            (expr, Some(alias)) => Ok((expr, alias)),
+            _ => Err(SqlRequired::JoinAlias.into()),
+        }
+    }
+
+    /// Parse a relation expression in a FROM clause
+    fn parse_rel(expr: TableFactor) -> SqlParseResult<(RelExpr<Self::Ast>, Option<SqlIdent>)> {
+        match expr {
+            // Relvar no alias
+            TableFactor::Table {
+                name,
+                alias: None,
+                args: None,
+                with_hints,
+                version: None,
+                partitions,
+            } if with_hints.is_empty() && partitions.is_empty() => Ok((RelExpr::Var(parse_ident(name)?), None)),
+            // Relvar with alias
+            TableFactor::Table {
+                name,
+                alias: Some(TableAlias { name: alias, columns }),
+                args: None,
+                with_hints,
+                version: None,
+                partitions,
+            } if with_hints.is_empty() && partitions.is_empty() && columns.is_empty() => {
+                Ok((RelExpr::Var(parse_ident(name)?), Some(alias.into())))
+            }
+            // RelExpr no alias
+            TableFactor::Derived {
+                lateral: false,
+                subquery,
+                alias: None,
+            } => Ok((RelExpr::Ast(Box::new(Self::parse_query(*subquery)?)), None)),
+            // RelExpr with alias
+            TableFactor::Derived {
+                lateral: false,
+                subquery,
+                alias: Some(TableAlias { name, columns }),
+            } if columns.is_empty() => Ok((RelExpr::Ast(Box::new(Self::parse_query(*subquery)?)), Some(name.into()))),
+            _ => Err(SqlUnsupported::From(expr).into()),
+        }
+    }
+}
+
+/// Parse the items of a SELECT clause
+pub(crate) fn parse_projection(mut items: Vec<SelectItem>) -> SqlParseResult<Project> {
+    if items.len() == 1 {
+        return parse_project(items.swap_remove(0));
+    }
+    Ok(Project::Exprs(
+        items
+            .into_iter()
+            .map(parse_project_elem)
+            .collect::<SqlParseResult<_>>()?,
+    ))
+}
+
+/// Parse a SELECT clause with only a single item
+pub(crate) fn parse_project(item: SelectItem) -> SqlParseResult<Project> {
+    match item {
+        SelectItem::Wildcard(WildcardAdditionalOptions {
+            opt_exclude: None,
+            opt_except: None,
+            opt_rename: None,
+            opt_replace: None,
+        }) => Ok(Project::Star(None)),
+        SelectItem::QualifiedWildcard(
+            table_name,
+            WildcardAdditionalOptions {
+                opt_exclude: None,
+                opt_except: None,
+                opt_rename: None,
+                opt_replace: None,
+            },
+        ) => Ok(Project::Star(Some(parse_ident(table_name)?))),
+        SelectItem::UnnamedExpr(_) | SelectItem::ExprWithAlias { .. } => {
+            Ok(Project::Exprs(vec![parse_project_elem(item)?]))
+        }
+        item => Err(SqlUnsupported::Projection(item).into()),
+    }
+}
+
+/// Parse an item in a SELECT clause
+pub(crate) fn parse_project_elem(item: SelectItem) -> SqlParseResult<ProjectElem> {
+    match item {
+        SelectItem::Wildcard(_) => Err(SqlUnsupported::MixedWildcardProject.into()),
+        SelectItem::QualifiedWildcard(..) => Err(SqlUnsupported::MixedWildcardProject.into()),
+        SelectItem::UnnamedExpr(expr) => Ok(ProjectElem(parse_expr(expr)?, None)),
+        SelectItem::ExprWithAlias { expr, alias } => Ok(ProjectElem(parse_expr(expr)?, Some(alias.into()))),
+    }
+}
+
+/// Parse a scalar expression
+pub(crate) fn parse_expr(expr: Expr) -> SqlParseResult<SqlExpr> {
+    match expr {
+        Expr::Value(v) => Ok(SqlExpr::Lit(parse_literal(v)?)),
+        Expr::Identifier(ident) => Ok(SqlExpr::Var(ident.into())),
+        Expr::CompoundIdentifier(mut idents) if idents.len() == 2 => {
+            let table = idents.swap_remove(0).into();
+            let field = idents.swap_remove(0).into();
+            Ok(SqlExpr::Field(table, field))
+        }
+        Expr::BinaryOp { left, op, right } => {
+            let l = parse_expr(*left)?;
+            let r = parse_expr(*right)?;
+            Ok(SqlExpr::Bin(Box::new(l), Box::new(r), parse_binop(op)?))
+        }
+        _ => Err(SqlUnsupported::Expr(expr).into()),
+    }
+}
+
+/// Parse an optional scalar expression
+pub(crate) fn parse_expr_opt(opt: Option<Expr>) -> SqlParseResult<Option<SqlExpr>> {
+    opt.map(parse_expr).transpose()
+}
+
+/// Parse a scalar binary operator
+pub(crate) fn parse_binop(op: BinaryOperator) -> SqlParseResult<BinOp> {
+    match op {
+        BinaryOperator::Eq => Ok(BinOp::Eq),
+        BinaryOperator::NotEq => Ok(BinOp::Ne),
+        BinaryOperator::Lt => Ok(BinOp::Lt),
+        BinaryOperator::LtEq => Ok(BinOp::Lte),
+        BinaryOperator::Gt => Ok(BinOp::Gt),
+        BinaryOperator::GtEq => Ok(BinOp::Gte),
+        BinaryOperator::And => Ok(BinOp::And),
+        BinaryOperator::Or => Ok(BinOp::Or),
+        _ => Err(SqlUnsupported::BinOp(op).into()),
+    }
+}
+
+/// Parse a literal expression
+pub(crate) fn parse_literal(value: Value) -> SqlParseResult<SqlLiteral> {
+    match value {
+        Value::Boolean(v) => Ok(SqlLiteral::Bool(v)),
+        Value::Number(v, _) => Ok(SqlLiteral::Num(v)),
+        Value::SingleQuotedString(s) => Ok(SqlLiteral::Str(s)),
+        Value::HexStringLiteral(s) => Ok(SqlLiteral::Hex(s)),
+        _ => Err(SqlUnsupported::Literal(value).into()),
+    }
+}
+
+/// Parse an identifier
+pub(crate) fn parse_ident(ObjectName(parts): ObjectName) -> SqlParseResult<SqlIdent> {
+    parse_parts(parts)
+}
+
+/// Parse an identifier
+pub(crate) fn parse_parts(mut parts: Vec<Ident>) -> SqlParseResult<SqlIdent> {
+    if parts.len() == 1 {
+        return Ok(parts.swap_remove(0).into());
+    }
+    Err(SqlUnsupported::MultiPartName(ObjectName(parts)).into())
+}

--- a/crates/sql-parser/src/parser/sql.rs
+++ b/crates/sql-parser/src/parser/sql.rs
@@ -1,0 +1,526 @@
+//! The SpacetimeDB SQL grammar
+//!
+//! ```ebnf
+//! statement
+//!     = select
+//!     | insert
+//!     | delete
+//!     | update
+//!     | set
+//!     | show
+//!     ;
+//!
+//! insert
+//!     = INSERT INTO table [ '(' column { ',' column } ')' ] VALUES '(' literal { ',' literal } ')'
+//!     ;
+//!
+//! delete
+//!     = DELETE FROM table [ WHERE predicate ]
+//!     ;
+//!
+//! update
+//!     = UPDATE table SET [ '(' assignment { ',' assignment } ')' ] [ WHERE predicate ]
+//!     ;
+//!
+//! assignment
+//!     = column '=' expr
+//!     ;
+//!
+//! set
+//!     = SET var ( TO | '=' ) literal
+//!     ;
+//!
+//! show
+//!     = SHOW var
+//!     ;
+//!
+//! var
+//!     = ident
+//!     ;
+//!
+//! select
+//!     = SELECT [ DISTINCT ] projection FROM relation [ [ WHERE predicate ] [ ORDER BY order ] [ LIMIT limit ] ]
+//!     ;
+//!
+//! projection
+//!     = listExpr
+//!     | projExpr { ',' projExpr }
+//!     | aggrExpr { ',' aggrExpr }
+//!     ;
+//!
+//! listExpr
+//!     = STAR
+//!     | ident '.' STAR
+//!     ;
+//!
+//! projExpr
+//!     = columnExpr [ [ AS ] ident ]
+//!     ;
+//!
+//! columnExpr
+//!     = column
+//!     | field
+//!     ;
+//!
+//! aggrExpr
+//!     = COUNT '(' STAR ')' AS ident
+//!     | COUNT '(' DISTINCT columnExpr ')' AS ident
+//!     | SUM   '(' columnExpr ')' AS ident
+//!     ;
+//!
+//! relation
+//!     = table
+//!     | '(' query ')'
+//!     | relation [ [AS] ident ] { [INNER] JOIN relation [ [AS] ident ] ON predicate }
+//!     ;
+//!
+//! predicate
+//!     = expr
+//!     | predicate AND predicate
+//!     | predicate OR  predicate
+//!     ;
+//!
+//! expr
+//!     = literal
+//!     | ident
+//!     | field
+//!     | expr op expr
+//!     ;
+//!
+//! field
+//!     = ident '.' ident
+//!     ;
+//!
+//! op
+//!     = '='
+//!     | '<'
+//!     | '>'
+//!     | '<' '='
+//!     | '>' '='
+//!     | '!' '='
+//!     | '<' '>'
+//!     ;
+//!
+//! order
+//!     = columnExpr [ ASC | DESC ] { ',' columnExpr [ ASC | DESC ] }
+//!     ;
+//!
+//! limit
+//!     = INTEGER
+//!     ;
+//!
+//! table
+//!     = ident
+//!     ;
+//!
+//! column
+//!     = ident
+//!     ;
+//!
+//! literal
+//!     = INTEGER
+//!     | FLOAT
+//!     | STRING
+//!     | HEX
+//!     | TRUE
+//!     | FALSE
+//!     ;
+//! ```
+
+use sqlparser::{
+    ast::{
+        Assignment, Distinct, Expr, GroupByExpr, ObjectName, OrderByExpr, Query, Select, SetExpr, SetOperator,
+        SetQuantifier, Statement, TableFactor, TableWithJoins, Values,
+    },
+    dialect::PostgreSqlDialect,
+    parser::Parser,
+};
+
+use crate::ast::{
+    sql::{
+        OrderByElem, QueryAst, SqlAst, SqlDelete, SqlInsert, SqlSelect, SqlSet, SqlSetOp, SqlShow, SqlUpdate, SqlValues,
+    },
+    SqlIdent, SqlLiteral,
+};
+
+use super::{
+    errors::SqlUnsupported, parse_expr, parse_expr_opt, parse_ident, parse_literal, parse_parts, parse_projection,
+    RelParser, SqlParseResult,
+};
+
+/// Parse a SQL string
+pub fn parse_sql(sql: &str) -> SqlParseResult<SqlAst> {
+    let mut stmts = Parser::parse_sql(&PostgreSqlDialect {}, sql)?;
+    if stmts.len() > 1 {
+        return Err(SqlUnsupported::MultiStatement.into());
+    }
+    parse_statement(stmts.swap_remove(0))
+}
+
+/// Parse a SQL statement
+fn parse_statement(stmt: Statement) -> SqlParseResult<SqlAst> {
+    match stmt {
+        Statement::Query(query) => Ok(SqlAst::Query(SqlParser::parse_query(*query)?)),
+        Statement::Insert {
+            or: None,
+            table_name,
+            columns,
+            overwrite: false,
+            source,
+            partitioned: None,
+            after_columns,
+            table: false,
+            on: None,
+            returning: None,
+            ..
+        } if after_columns.is_empty() => Ok(SqlAst::Insert(SqlInsert {
+            table: parse_ident(table_name)?,
+            fields: columns.into_iter().map(SqlIdent::from).collect(),
+            values: parse_values(*source)?,
+        })),
+        Statement::Update {
+            table:
+                TableWithJoins {
+                    relation:
+                        TableFactor::Table {
+                            name,
+                            alias: None,
+                            args: None,
+                            with_hints,
+                            version: None,
+                            partitions,
+                        },
+                    joins,
+                },
+            assignments,
+            from: None,
+            selection,
+            returning: None,
+        } if joins.is_empty() && with_hints.is_empty() && partitions.is_empty() => Ok(SqlAst::Update(SqlUpdate {
+            table: parse_ident(name)?,
+            assignments: parse_assignments(assignments)?,
+            filter: parse_expr_opt(selection)?,
+        })),
+        Statement::Delete {
+            tables,
+            from,
+            using: None,
+            selection,
+            returning: None,
+        } if tables.is_empty() => Ok(SqlAst::Delete(parse_delete(from, selection)?)),
+        Statement::SetVariable {
+            local: false,
+            hivevar: false,
+            variable,
+            value,
+        } => Ok(SqlAst::Set(parse_set_var(variable, value)?)),
+        Statement::ShowVariable { variable } => Ok(SqlAst::Show(SqlShow(parse_parts(variable)?))),
+        _ => Err(SqlUnsupported::feature(stmt).into()),
+    }
+}
+
+/// Parse a VALUES expression
+fn parse_values(values: Query) -> SqlParseResult<SqlValues> {
+    match values {
+        Query {
+            with: None,
+            body,
+            order_by,
+            limit: None,
+            offset: None,
+            fetch: None,
+            locks,
+        } if order_by.is_empty() && locks.is_empty() => match *body {
+            SetExpr::Values(Values {
+                explicit_row: false,
+                rows,
+            }) => {
+                let mut row_literals = Vec::new();
+                for row in rows {
+                    let mut literals = Vec::new();
+                    for expr in row {
+                        if let Expr::Value(value) = expr {
+                            literals.push(parse_literal(value)?);
+                        } else {
+                            return Err(SqlUnsupported::InsertValue(expr).into());
+                        }
+                    }
+                    row_literals.push(literals);
+                }
+                Ok(SqlValues(row_literals))
+            }
+            _ => Err(SqlUnsupported::Insert(Query {
+                with: None,
+                body,
+                order_by,
+                limit: None,
+                offset: None,
+                fetch: None,
+                locks,
+            })
+            .into()),
+        },
+        _ => Err(SqlUnsupported::Insert(values).into()),
+    }
+}
+
+/// Parse column/variable assignments in an UPDATE or SET statement
+fn parse_assignments(assignments: Vec<Assignment>) -> SqlParseResult<Vec<SqlSet>> {
+    assignments.into_iter().map(parse_assignment).collect()
+}
+
+/// Parse a column/variable assignment in an UPDATE or SET statement
+fn parse_assignment(Assignment { id, value }: Assignment) -> SqlParseResult<SqlSet> {
+    match value {
+        Expr::Value(value) => Ok(SqlSet(parse_parts(id)?, parse_literal(value)?)),
+        _ => Err(SqlUnsupported::Assignment(value).into()),
+    }
+}
+
+/// Parse a DELETE statement
+fn parse_delete(mut from: Vec<TableWithJoins>, selection: Option<Expr>) -> SqlParseResult<SqlDelete> {
+    if from.len() == 1 {
+        match from.swap_remove(0) {
+            TableWithJoins {
+                relation:
+                    TableFactor::Table {
+                        name,
+                        alias: None,
+                        args: None,
+                        with_hints,
+                        version: None,
+                        partitions,
+                    },
+                joins,
+            } if joins.is_empty() && with_hints.is_empty() && partitions.is_empty() => {
+                Ok(SqlDelete(parse_ident(name)?, parse_expr_opt(selection)?))
+            }
+            t => Err(SqlUnsupported::DeleteTable(t).into()),
+        }
+    } else {
+        Err(SqlUnsupported::MultiTableDelete.into())
+    }
+}
+
+/// Parse a SET variable statement
+fn parse_set_var(variable: ObjectName, mut value: Vec<Expr>) -> SqlParseResult<SqlSet> {
+    if value.len() == 1 {
+        Ok(SqlSet(
+            parse_ident(variable)?,
+            match value.swap_remove(0) {
+                Expr::Value(value) => parse_literal(value)?,
+                expr => {
+                    return Err(SqlUnsupported::Assignment(expr).into());
+                }
+            },
+        ))
+    } else {
+        Err(SqlUnsupported::feature(Statement::SetVariable {
+            local: false,
+            hivevar: false,
+            variable,
+            value,
+        })
+        .into())
+    }
+}
+
+struct SqlParser;
+
+impl RelParser for SqlParser {
+    type Ast = QueryAst;
+
+    fn parse_query(query: Query) -> SqlParseResult<Self::Ast> {
+        match query {
+            Query {
+                with: None,
+                body,
+                order_by,
+                limit,
+                offset: None,
+                fetch: None,
+                locks,
+            } if locks.is_empty() => Ok(QueryAst {
+                query: parse_set_op(*body)?,
+                order: parse_order_by(order_by)?,
+                limit: parse_limit(limit)?,
+            }),
+            _ => Err(SqlUnsupported::feature(query).into()),
+        }
+    }
+}
+
+/// Parse ORDER BY
+fn parse_order_by(items: Vec<OrderByExpr>) -> SqlParseResult<Vec<OrderByElem>> {
+    let mut elems = Vec::new();
+    for item in items {
+        elems.push(OrderByElem(
+            parse_expr(item.expr)?,
+            matches!(item.asc, Some(true)) || item.asc.is_none(),
+        ));
+    }
+    Ok(elems)
+}
+
+/// Parse LIMIT
+fn parse_limit(limit: Option<Expr>) -> SqlParseResult<Option<SqlLiteral>> {
+    limit
+        .map(|expr| {
+            if let Expr::Value(v) = expr {
+                parse_literal(v)
+            } else {
+                Err(SqlUnsupported::Limit(expr).into())
+            }
+        })
+        .transpose()
+}
+
+/// Parse a set operation
+fn parse_set_op(expr: SetExpr) -> SqlParseResult<SqlSetOp> {
+    match expr {
+        SetExpr::Query(query) => Ok(SqlSetOp::Query(Box::new(SqlParser::parse_query(*query)?))),
+        SetExpr::Select(select) => Ok(SqlSetOp::Select(parse_select(*select)?)),
+        SetExpr::SetOperation {
+            op: SetOperator::Union,
+            set_quantifier: SetQuantifier::All,
+            left,
+            right,
+        } => Ok(SqlSetOp::Union(
+            Box::new(parse_set_op(*left)?),
+            Box::new(parse_set_op(*right)?),
+            true,
+        )),
+        SetExpr::SetOperation {
+            op: SetOperator::Union,
+            set_quantifier: SetQuantifier::None,
+            left,
+            right,
+        } => Ok(SqlSetOp::Union(
+            Box::new(parse_set_op(*left)?),
+            Box::new(parse_set_op(*right)?),
+            false,
+        )),
+        SetExpr::SetOperation {
+            op: SetOperator::Except,
+            set_quantifier: SetQuantifier::All,
+            left,
+            right,
+        } => Ok(SqlSetOp::Minus(
+            Box::new(parse_set_op(*left)?),
+            Box::new(parse_set_op(*right)?),
+            true,
+        )),
+        SetExpr::SetOperation {
+            op: SetOperator::Except,
+            set_quantifier: SetQuantifier::None,
+            left,
+            right,
+        } => Ok(SqlSetOp::Minus(
+            Box::new(parse_set_op(*left)?),
+            Box::new(parse_set_op(*right)?),
+            false,
+        )),
+        _ => Err(SqlUnsupported::feature(expr).into()),
+    }
+}
+
+/// Parse a SELECT statement
+fn parse_select(select: Select) -> SqlParseResult<SqlSelect> {
+    match select {
+        Select {
+            distinct,
+            top: None,
+            projection,
+            into: None,
+            from,
+            lateral_views,
+            selection,
+            group_by: GroupByExpr::Expressions(exprs),
+            cluster_by,
+            distribute_by,
+            sort_by,
+            having: None,
+            named_window,
+            qualify: None,
+        } if lateral_views.is_empty()
+            && exprs.is_empty()
+            && cluster_by.is_empty()
+            && distribute_by.is_empty()
+            && sort_by.is_empty()
+            && named_window.is_empty() =>
+        {
+            Ok(SqlSelect {
+                project: parse_projection(projection)?,
+                distinct: matches!(distinct, Some(Distinct::Distinct)),
+                from: SqlParser::parse_from(from)?,
+                filter: parse_expr_opt(selection)?,
+            })
+        }
+        _ => Err(SqlUnsupported::feature(select).into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::sql::parse_sql;
+
+    #[test]
+    fn unsupported() {
+        for sql in [
+            // FROM is required
+            "select 1",
+            // Multi-part table names
+            "select a from s.t",
+            // Bit-string literals
+            "select * from t where a = B'1010'",
+            // Wildcard with non-wildcard projections
+            "select a.*, b, c from t",
+            // Limit expression
+            "select * from t order by a limit b",
+            // GROUP BY
+            "select a, count(*) from t group by a",
+            // Join updates
+            "update t as a join s as b on a.id = b.id set c = 1",
+            // Join updates
+            "update t set a = 1 from s where t.id = s.id and s.b = 2",
+            // Implicit joins
+            "select a.* from t as a, s as b where a.id = b.id and b.c = 1",
+        ] {
+            assert!(parse_sql(sql).is_err());
+        }
+    }
+
+    #[test]
+    fn supported() {
+        for sql in [
+            "select a from t",
+            "select distinct a from t",
+            "select * from t order by a limit 5",
+            "select * from t where a = 1 union select * from t where a = 2",
+            "insert into t values (1, 2)",
+            "insert into t (a, b) values (1, 2)",
+            "delete from t",
+            "delete from t where a = 1",
+            "update t set a = 1, b = 2",
+            "update t set a = 1, b = 2 where c = 3",
+        ] {
+            assert!(parse_sql(sql).is_ok());
+        }
+    }
+
+    #[test]
+    fn invalid() {
+        for sql in [
+            // Empty SELECT
+            "select from t",
+            // Empty FROM
+            "select a from where b = 1",
+            // Empty WHERE
+            "select a from t where",
+            // Empty GROUP BY
+            "select a, count(*) from t group by",
+        ] {
+            assert!(parse_sql(sql).is_err());
+        }
+    }
+}

--- a/crates/sql-parser/src/parser/sub.rs
+++ b/crates/sql-parser/src/parser/sub.rs
@@ -1,0 +1,201 @@
+//! The SpacetimeDB SQL subscription grammar
+//!
+//! ```ebnf
+//! query
+//!     = SELECT projection FROM relation [ WHERE predicate ]
+//!     ;
+//!
+//! projection
+//!     = STAR
+//!     | ident '.' STAR
+//!     ;
+//!
+//! relation
+//!     = table
+//!     | '(' query ')'
+//!     | relation [ [AS] ident ] { [INNER] JOIN relation [ [AS] ident ] ON predicate }
+//!     ;
+//!
+//! predicate
+//!     = expr
+//!     | predicate AND predicate
+//!     | predicate OR  predicate
+//!     ;
+//!
+//! expr
+//!     = literal
+//!     | ident
+//!     | field
+//!     | expr op expr
+//!     ;
+//!
+//! field
+//!     = ident '.' ident
+//!     ;
+//!
+//! op
+//!     = '='
+//!     | '<'
+//!     | '>'
+//!     | '<' '='
+//!     | '>' '='
+//!     | '!' '='
+//!     | '<' '>'
+//!     ;
+//!
+//! literal
+//!     = INTEGER
+//!     | FLOAT
+//!     | STRING
+//!     | HEX
+//!     | TRUE
+//!     | FALSE
+//!     ;
+//! ```
+
+use sqlparser::{
+    ast::{GroupByExpr, Query, Select, SetExpr, SetOperator, SetQuantifier, Statement},
+    dialect::PostgreSqlDialect,
+    parser::Parser,
+};
+
+use crate::ast::sub::{SqlAst, SqlSelect};
+
+use super::{
+    errors::{SqlUnsupported, SubscriptionUnsupported},
+    parse_expr_opt, parse_projection, RelParser, SqlParseResult,
+};
+
+/// Parse a SQL string
+pub fn parse_subscription(sql: &str) -> SqlParseResult<SqlAst> {
+    let mut stmts = Parser::parse_sql(&PostgreSqlDialect {}, sql)?;
+    if stmts.len() > 1 {
+        return Err(SqlUnsupported::MultiStatement.into());
+    }
+    parse_statement(stmts.swap_remove(0))
+}
+
+/// Parse a SQL query
+fn parse_statement(stmt: Statement) -> SqlParseResult<SqlAst> {
+    match stmt {
+        Statement::Query(query) => SubParser::parse_query(*query),
+        _ => Err(SubscriptionUnsupported::Dml.into()),
+    }
+}
+
+struct SubParser;
+
+impl RelParser for SubParser {
+    type Ast = SqlAst;
+
+    fn parse_query(query: Query) -> SqlParseResult<Self::Ast> {
+        match query {
+            Query {
+                with: None,
+                body,
+                order_by,
+                limit: None,
+                offset: None,
+                fetch: None,
+                locks,
+            } if order_by.is_empty() && locks.is_empty() => parse_set_op(*body),
+            _ => Err(SubscriptionUnsupported::feature(query).into()),
+        }
+    }
+}
+
+/// Parse a set operation
+fn parse_set_op(expr: SetExpr) -> SqlParseResult<SqlAst> {
+    match expr {
+        SetExpr::Query(query) => SubParser::parse_query(*query),
+        SetExpr::Select(select) => Ok(SqlAst::Select(parse_select(*select)?)),
+        SetExpr::SetOperation {
+            op: SetOperator::Union,
+            set_quantifier: SetQuantifier::All,
+            left,
+            right,
+        } => Ok(SqlAst::Union(
+            Box::new(parse_set_op(*left)?),
+            Box::new(parse_set_op(*right)?),
+        )),
+        SetExpr::SetOperation {
+            op: SetOperator::Except,
+            set_quantifier: SetQuantifier::All,
+            left,
+            right,
+        } => Ok(SqlAst::Minus(
+            Box::new(parse_set_op(*left)?),
+            Box::new(parse_set_op(*right)?),
+        )),
+        _ => Err(SqlUnsupported::SetOp(expr).into()),
+    }
+}
+
+// Parse a SELECT statement
+fn parse_select(select: Select) -> SqlParseResult<SqlSelect> {
+    match select {
+        Select {
+            distinct: None,
+            top: None,
+            projection,
+            into: None,
+            from,
+            lateral_views,
+            selection,
+            group_by: GroupByExpr::Expressions(exprs),
+            cluster_by,
+            distribute_by,
+            sort_by,
+            having: None,
+            named_window,
+            qualify: None,
+        } if lateral_views.is_empty()
+            && exprs.is_empty()
+            && cluster_by.is_empty()
+            && distribute_by.is_empty()
+            && sort_by.is_empty()
+            && named_window.is_empty() =>
+        {
+            Ok(SqlSelect {
+                from: SubParser::parse_from(from)?,
+                filter: parse_expr_opt(selection)?,
+                project: parse_projection(projection)?,
+            })
+        }
+        _ => Err(SubscriptionUnsupported::Select(select).into()),
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use crate::parser::sub::parse_subscription;
+
+    #[test]
+    fn unsupported() {
+        for sql in [
+            "delete from t",
+            "select distinct a from t",
+            "select * from (select * from t) join (select * from s) on a = b",
+        ] {
+            assert!(parse_subscription(sql).is_err());
+        }
+    }
+
+    #[test]
+    fn supported() {
+        for sql in [
+            "select * from t",
+            "select * from t where a = 1",
+            "select * from t where a <> 1",
+            "select * from t where a = 1 or a = 2",
+            "select * from t where a = 1 union all select * from t where a = 2",
+            "select * from (select * from t)",
+            "select * from (select t.* from t join s)",
+            "select * from (select t.* from t join s on t.c = s.d)",
+            "select * from (select a.* from t as a join s as b on a.c = b.d)",
+            "select * from (select t.* from (select * from t) t join (select * from s) s on s.id = t.id)",
+        ] {
+            assert!(parse_subscription(sql).is_ok());
+        }
+    }
+}


### PR DESCRIPTION
# Description of Changes

The first step towards updating the parsing of `SQL` to match the spec for `SpacetimeDB`, as asked by ticket #1563.


This is the syntactic parser, without being integrated yet into the codebase, to be done later.

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Generate test for both valid and invalid cases, and pretty printer of the `ast`*
