### PR TITLE
Updated docker internal port to 3000

### DIFF
--- a/crates/standalone/src/subcommands/start.rs
+++ b/crates/standalone/src/subcommands/start.rs
@@ -25,7 +25,7 @@ impl ProgramMode {
     /// based on the mode we're running the program in.
     fn listen_addr(&self) -> &'static str {
         match self {
-            ProgramMode::Standalone => "0.0.0.0:80",
+            ProgramMode::Standalone => "0.0.0.0:3000",
             ProgramMode::CLI => "127.0.0.1:3000",
         }
     }

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -24,7 +24,7 @@ services:
       - key_files:/etc/spacetimedb
       - /stdb
     ports:
-      - "3000:80"
+      - "3000:3000"
       # Tracy
       - "8086:8086"
     entrypoint: cargo watch -i flamegraphs -i log.conf --why -C crates/standalone -x 'run start'


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

~~I have updated the port used by the docker-compose file to `3000`~~ I have updated the default port for `spacetimedb-standalone` to be `3000`. Originally we were using port `80` internally and then in the docker-compose file (and in other places) we were mapping `3000 => 80`. This works fine but it was very confusing that you would get this start-up message:

```
...
node-1  | │  .d8888b.                                     888    d8b                        8888888b.  888888b.   │
node-1  | │ d88P  Y88b                                    888    Y8P                        888  "Y88b 888  "88b  │
node-1  | │ Y88b.                                         888                               888    888 888  .88P  │
node-1  | │  "Y888b.   88888b.   8888b.   .d8888b .d88b.  888888 888 88888b.d88b.   .d88b.  888    888 8888888K.  │
node-1  | │     "Y88b. 888 "88b     "88b d88P"   d8P  Y8b 888    888 888 "888 "88b d8P  Y8b 888    888 888  "Y88b │
node-1  | │       "888 888  888 .d888888 888     88888888 888    888 888  888  888 88888888 888    888 888    888 │
node-1  | │ Y88b  d88P 888 d88P 888  888 Y88b.   Y8b.     Y88b.  888 888  888  888 Y8b.     888  .d88P 888   d88P │
node-1  | │  "Y8888P"  88888P"  "Y888888  "Y8888P "Y8888   "Y888 888 888  888  888  "Y8888  8888888P"  8888888P"  │
node-1  | │            888                                                                                        │
node-1  | │            888                                                                                        │
node-1  | │            888                                                                                        │
node-1  | │                                  "Multiplayer at the speed of light"                                  │
node-1  | └───────────────────────────────────────────────────────────────────────────────────────────────────────┘
node-1  |
node-1  | spacetimedb version: 0.12.0
node-1  | spacetimedb path: /usr/src/app/target/debug/spacetimedb
node-1  | 2024-08-23T03:07:40.392627Z DEBUG crates/standalone/src/subcommands/start.rs:222: Starting SpacetimeDB listening on 0.0.0.0:80
```

This PR rectifies the problem and now you get the following start-up message:

```
...
node-1  | │  .d8888b.                                     888    d8b                        8888888b.  888888b.   │
node-1  | │ d88P  Y88b                                    888    Y8P                        888  "Y88b 888  "88b  │
node-1  | │ Y88b.                                         888                               888    888 888  .88P  │
node-1  | │  "Y888b.   88888b.   8888b.   .d8888b .d88b.  888888 888 88888b.d88b.   .d88b.  888    888 8888888K.  │
node-1  | │     "Y88b. 888 "88b     "88b d88P"   d8P  Y8b 888    888 888 "888 "88b d8P  Y8b 888    888 888  "Y88b │
node-1  | │       "888 888  888 .d888888 888     88888888 888    888 888  888  888 88888888 888    888 888    888 │
node-1  | │ Y88b  d88P 888 d88P 888  888 Y88b.   Y8b.     Y88b.  888 888  888  888 Y8b.     888  .d88P 888   d88P │
node-1  | │  "Y8888P"  88888P"  "Y888888  "Y8888P "Y8888   "Y888 888 888  888  888  "Y8888  8888888P"  8888888P"  │
node-1  | │            888                                                                                        │
node-1  | │            888                                                                                        │
node-1  | │            888                                                                                        │
node-1  | │                                  "Multiplayer at the speed of light"                                  │
node-1  | └───────────────────────────────────────────────────────────────────────────────────────────────────────┘
node-1  |
node-1  | spacetimedb version: 0.12.0
node-1  | spacetimedb path: /usr/src/app/target/debug/spacetimedb
node-1  | 2024-08-23T03:16:58.734561Z DEBUG crates/standalone/src/subcommands/start.rs:222: Starting SpacetimeDB listening on 0.0.0.0:3000
```
> scroll to the right to see the change in port

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

~~This is *technically* breaking but not in a way that actually matters. I've only updated the docker-compose file, not the default port (which is actually still set to 80 right now).~~

This is now a somewhat larger breaking change because everywhere where we use this docker container and we're not using the default `docker-compose.yml` then we have to update the port to be 3000 instead of 80. Notibly this will likely affect our ansible playbooks.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Use `docker-compose up` to bring the container up and try to connect to it. It should work exactly as it worked before except now the start-up printout has been updated to use port 3000 internally.
