### PR TITLE
Allow converting new ModuleDef to old TableSchema

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4512,9 +4512,11 @@ dependencies = [
 name = "spacetimedb-schema"
 version = "0.12.0"
 dependencies = [
+ "hashbrown 0.14.1",
  "itertools 0.12.0",
  "lazy_static",
  "proptest",
+ "serde_json",
  "smallvec",
  "spacetimedb-cli",
  "spacetimedb-data-structures",

--- a/crates/bench/benches/special.rs
+++ b/crates/bench/benches/special.rs
@@ -155,6 +155,7 @@ fn serialize_benchmarks<
         );
     });
 
+    #[allow(deprecated)]
     let mut table = spacetimedb_table::table::Table::new(
         TableSchema::from_def(0.into(), RawTableDefV8::from_product(name, T::product_type().clone())).into(),
         spacetimedb_table::indexes::SquashedOffset::COMMITTED_STATE,

--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -267,6 +267,7 @@ pub fn autogen_csharp_tuple(ctx: &GenCtx, name: &str, tuple: &ProductType, names
     autogen_csharp_product_table_common(ctx, name, tuple, None, namespace)
 }
 
+#[allow(deprecated)]
 pub fn autogen_csharp_table(ctx: &GenCtx, table: &TableDesc, namespace: &str) -> String {
     let tuple = ctx.typespace[table.data].as_product().unwrap();
     autogen_csharp_product_table_common(

--- a/crates/cli/src/subcommands/generate/rust.rs
+++ b/crates/cli/src/subcommands/generate/rust.rs
@@ -324,6 +324,7 @@ fn find_product_type(ctx: &GenCtx, ty: AlgebraicTypeRef) -> &ProductType {
 
 /// Generate a file which defines a `struct` corresponding to the `table`'s `ProductType`,
 /// and implements `spacetimedb_sdk::table::TableType` for it.
+#[allow(deprecated)]
 pub fn autogen_rust_table(ctx: &GenCtx, table: &TableDesc) -> String {
     let mut output = CodeIndenter::new(String::new());
     let out = &mut output;
@@ -847,6 +848,7 @@ fn print_spacetime_module_struct_defn(ctx: &GenCtx, out: &mut Indenter, items: &
 /// Define the `handle_table_update` method,
 /// which dispatches on the table name in a `TableUpdate` message
 /// to call an appropriate method on the `ClientCache`.
+#[allow(deprecated)]
 fn print_handle_table_update_defn(_ctx: &GenCtx, out: &mut Indenter, items: &[GenItem]) {
     out.delimited_block(
         "fn handle_table_update(&self, table_update: TableUpdate, client_cache: &mut ClientCache, callbacks: &mut RowCallbackReminders) {",

--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -498,6 +498,7 @@ fn typescript_field_name(field_name: String) -> String {
 pub fn autogen_typescript_tuple(ctx: &GenCtx, name: &str, tuple: &ProductType) -> String {
     autogen_typescript_product_table_common(ctx, name, tuple, None)
 }
+#[allow(deprecated)]
 pub fn autogen_typescript_table(ctx: &GenCtx, table: &TableDesc) -> String {
     let tuple = ctx.typespace[table.data].as_product().unwrap();
     autogen_typescript_product_table_common(

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -84,6 +84,7 @@ impl MutTxId {
             return Err(TableError::System(table_schema.table_name.clone()).into());
         }
 
+        #[allow(deprecated)]
         TableSchema::from_def(0.into(), table_schema.clone())
             .validated()
             .map_err(|err| DBError::Schema(SchemaErrors(err)))?;
@@ -111,6 +112,7 @@ impl MutTxId {
             .read_col(StTableFields::TableId)?;
 
         // Generate the full definition of the table, with the generated indexes, constraints, sequences...
+        #[allow(deprecated)]
         let table_schema = TableSchema::from_def(table_id, table_schema);
 
         // Insert the columns into `st_columns`
@@ -346,6 +348,7 @@ impl MutTxId {
             .read_col(StIndexFields::IndexId)?;
 
         // Construct the index schema.
+        #[allow(deprecated)]
         let mut index = IndexSchema::from_def(table_id, index.clone());
         index.index_id = index_id;
 
@@ -637,6 +640,7 @@ impl MutTxId {
         // TODO: Can we return early here?
 
         let (table, ..) = self.get_or_create_insert_table_mut(table_id)?;
+        #[allow(deprecated)]
         let mut constraint = ConstraintSchema::from_def(table_id, constraint);
         constraint.constraint_id = constraint_id;
         // This won't clone-write when creating a table but likely to otherwise.

--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -245,6 +245,7 @@ st_fields_enum!(enum StScheduledFields {
 /// |----------|-------------|----------- |------------- |
 /// | 4        | "customers" | "user"     | "public"     |
 fn st_table_schema() -> TableSchema {
+    #[allow(deprecated)]
     TableSchema::from_def(
         ST_TABLE_ID,
         RawTableDefV8::new(
@@ -268,6 +269,7 @@ fn st_table_schema() -> TableSchema {
 /// |----------|---------|----------|--------------------|
 /// | 1        | 0       | "id"     | AlgebraicType::U32 |
 fn st_column_schema() -> TableSchema {
+    #[allow(deprecated)]
     TableSchema::from_def(
         ST_COLUMN_ID,
         RawTableDefV8::new(
@@ -293,6 +295,7 @@ fn st_column_schema() -> TableSchema {
 /// |----------|----------|-------------|---------|-----------|------------|
 /// | 1        |          | "ix_sample" | [1]     | false     | "btree"    |
 fn st_index_schema() -> TableSchema {
+    #[allow(deprecated)]
     TableSchema::from_def(
         ST_INDEX_ID,
         RawTableDefV8::new(
@@ -318,6 +321,7 @@ fn st_index_schema() -> TableSchema {
 /// |-------------|-------------------|-----------|-------|-----------|-----------|----------|--------|-----------|
 /// | 1           | "seq_customer_id" | 1         | 100   | 10        | 1200      | 1        | 1      | 200       |
 fn st_sequence_schema() -> TableSchema {
+    #[allow(deprecated)]
     TableSchema::from_def(
         ST_SEQUENCE_ID,
         RawTableDefV8::new(
@@ -346,6 +350,7 @@ fn st_sequence_schema() -> TableSchema {
 /// |---------------|-------------------- -|-------------|-------|------------|
 /// | 1             | "unique_customer_id" | 1           | 100   | [1, 4]     |
 fn st_constraint_schema() -> TableSchema {
+    #[allow(deprecated)]
     TableSchema::from_def(
         ST_CONSTRAINT_ID,
         RawTableDefV8::new(
@@ -381,6 +386,7 @@ fn st_constraint_schema() -> TableSchema {
 /// |------------------|----------------|---------------|---------------|---------------------|
 /// | <bytes>          | <bytes>        |  0            | <bytes>       | <bytes>             |
 pub(crate) fn st_module_schema() -> TableSchema {
+    #[allow(deprecated)]
     TableSchema::from_def(
         ST_MODULE_ID,
         RawTableDefV8::new(
@@ -403,6 +409,7 @@ pub(crate) fn st_module_schema() -> TableSchema {
 // -----------------------------------------------------------------------------------------+--------------------------------------------------------
 //  (__identity_bytes = 0x7452047061ea2502003412941d85a42f89b0702588b823ab55fc4f12e9ea8363) | (__address_bytes = 0x6bdea3ab517f5857dc9b1b5fe99e1b14)
 fn st_client_schema() -> TableSchema {
+    #[allow(deprecated)]
     TableSchema::from_def(
         ST_CLIENT_ID,
         RawTableDefV8::new(
@@ -418,6 +425,7 @@ fn st_client_schema() -> TableSchema {
 }
 
 fn st_scheduled_schema() -> TableSchema {
+    #[allow(deprecated)]
     TableSchema::from_def(
         ST_SCHEDULED_ID,
         RawTableDefV8::new(
@@ -438,6 +446,7 @@ fn st_scheduled_schema() -> TableSchema {
 /// |-------------|-----------|
 /// | "row_limit" | (U64 = 5) |
 pub fn st_var_schema() -> TableSchema {
+    #[allow(deprecated)]
     TableSchema::from_def(
         ST_VAR_ID,
         RawTableDefV8::new(

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -213,6 +213,7 @@ pub fn schema_updates(
                 known_schema.table_access,
                 known_schema.scheduled.clone(),
             );
+            #[allow(deprecated)]
             let proposed_schema = TableSchema::from_def(known_schema.table_id, proposed_schema_def);
 
             let (schema_is_incompatible, known_schema, proposed_schema) =
@@ -438,6 +439,7 @@ mod tests {
 
     #[test]
     fn test_updates_schema_mismatch() {
+        #[allow(deprecated)]
         let current = [Arc::new(TableSchema::from_def(
             42.into(),
             RawTableDefV8::new(
@@ -468,6 +470,7 @@ mod tests {
 
     #[test]
     fn test_updates_orphaned_table() {
+        #[allow(deprecated)]
         let current = [Arc::new(TableSchema::from_def(
             42.into(),
             RawTableDefV8::new(
@@ -498,6 +501,7 @@ mod tests {
                 col_type: AlgebraicType::String,
             }],
         );
+        #[allow(deprecated)]
         let current = [Arc::new(TableSchema::from_def(42.into(), table_def.clone()))];
         let proposed = vec![table_def.with_column_index(ColId(0), false)];
 
@@ -548,6 +552,7 @@ mod tests {
 
     #[test]
     fn test_updates_add_constraint() {
+        #[allow(deprecated)]
         let current = [Arc::new(TableSchema::from_def(
             42.into(),
             RawTableDefV8::new(
@@ -572,6 +577,7 @@ mod tests {
 
     #[test]
     fn test_updates_drop_constraint() {
+        #[allow(deprecated)]
         let current = [Arc::new(TableSchema::from_def(
             42.into(),
             RawTableDefV8::new(

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -408,22 +408,22 @@ impl RawModuleDefV9Builder {
     }
 
     /// Build a new table with a product type.
-    ///
-    /// This is a convenience method for tests, since in real modules, the product type is initialized via the `SpacetimeType` trait.
-    #[cfg(feature = "test")]
-    pub fn build_table_for_tests(
+    /// Adds the type to the module.
+    pub fn build_table_with_new_type(
         &mut self,
         table_name: impl Into<RawIdentifier>,
         product_type: spacetimedb_sats::ProductType,
         custom_ordering: bool,
     ) -> RawTableDefBuilder {
         let table_name = table_name.into();
-        let product_type_ref = self.add_type_for_tests([], table_name.clone(), product_type.into(), custom_ordering);
+        let product_type_ref = self.add_algebraic_type([], table_name.clone(), product_type.into(), custom_ordering);
 
         self.build_table(table_name, product_type_ref)
     }
 
     /// Add a type to the typespace, along with a type alias declaring its name.
+    /// This method should only be use for `AlgebraicType`s not corresponding to a Rust
+    /// type that implements `SpacetimeType`.
     ///
     /// Returns a reference to the newly-added type.
     ///
@@ -431,11 +431,7 @@ impl RawModuleDefV9Builder {
     /// validation.
     ///
     /// You must set `custom_ordering` if you're not using the default element ordering.
-    ///
-    /// This is a convenience method for tests, since in real modules, types are added to the
-    /// typespace via the `SpacetimeType` trait.
-    #[cfg(feature = "test")]
-    pub fn add_type_for_tests(
+    pub fn add_algebraic_type(
         &mut self,
         scope: impl IntoIterator<Item = RawIdentifier>,
         name: impl Into<RawIdentifier>,

--- a/crates/primitives/src/attr.rs
+++ b/crates/primitives/src/attr.rs
@@ -211,6 +211,13 @@ impl Constraints {
         Self::new(self.attr | other.attr)
     }
 
+    /// Add auto-increment constraint to the existing constraints.
+    /// Returns Err if the result would not be valid.
+    #[allow(clippy::result_unit_err)]
+    pub fn push_auto_inc(self) -> Result<Self, ()> {
+        Self::try_from(self.attr | ColumnAttribute::AUTO_INC)
+    }
+
     /// Returns the bits representing the constraints.
     pub const fn bits(&self) -> u8 {
         self.attr.bits()

--- a/crates/primitives/src/col_list.rs
+++ b/crates/primitives/src/col_list.rs
@@ -72,6 +72,11 @@ impl<C: Into<ColId>> FromIterator<C> for ColList {
 }
 
 impl ColList {
+    /// Returns an empty list.
+    pub fn empty() -> Self {
+        Self::from_inline(0)
+    }
+
     /// Returns a list with a single column.
     /// As long `col` is below `62`, this will not allocate.
     pub fn new(col: ColId) -> Self {

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -17,7 +17,9 @@ lazy_static.workspace = true
 thiserror.workspace = true
 unicode-ident.workspace = true
 unicode-normalization.workspace = true
+serde_json.workspace = true
 smallvec.workspace = true
+hashbrown.workspace = true
 
 [dev-dependencies]
 spacetimedb-lib = { workspace = true, features = ["test"] }

--- a/crates/schema/src/def/validate/v9.rs
+++ b/crates/schema/src/def/validate/v9.rs
@@ -3,10 +3,7 @@ use crate::error::{RawColumnName, ValidationError};
 use crate::{def::validate::Result, error::TypeLocation};
 use spacetimedb_data_structures::error_stream::{CollectAllErrors, CombineErrors};
 use spacetimedb_data_structures::map::HashSet;
-use spacetimedb_lib::db::{
-    default_element_ordering::{product_type_has_default_ordering, sum_type_has_default_ordering},
-    raw_def::v9::*,
-};
+use spacetimedb_lib::db::default_element_ordering::{product_type_has_default_ordering, sum_type_has_default_ordering};
 use spacetimedb_lib::ProductType;
 use spacetimedb_sats::WithTypespace;
 
@@ -827,7 +824,7 @@ mod tests {
         let mut builder = RawModuleDefV9Builder::new();
 
         let product_type = AlgebraicType::product([("a", AlgebraicType::U64), ("b", AlgebraicType::String)]);
-        let product_type_ref = builder.add_type_for_tests(
+        let product_type_ref = builder.add_algebraic_type(
             ["scope1".into(), "scope2".into()],
             "ReferencedProduct",
             product_type.clone(),
@@ -835,12 +832,12 @@ mod tests {
         );
 
         let sum_type = AlgebraicType::simple_enum(["Gala", "GrannySmith", "RedDelicious"].into_iter());
-        let sum_type_ref = builder.add_type_for_tests([], "ReferencedSum", sum_type.clone(), false);
+        let sum_type_ref = builder.add_algebraic_type([], "ReferencedSum", sum_type.clone(), false);
 
         let schedule_at_type = builder.add_type::<ScheduleAt>();
 
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Apples",
                 ProductType::from([
                     ("id", AlgebraicType::U64),
@@ -861,7 +858,7 @@ mod tests {
             .finish();
 
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Bananas",
                 ProductType::from([
                     ("count", AlgebraicType::U16),
@@ -893,7 +890,7 @@ mod tests {
             .finish();
 
         let deliveries_product_type = builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Deliveries",
                 ProductType::from([
                     ("id", AlgebraicType::U64),
@@ -1090,7 +1087,7 @@ mod tests {
         let mut builder = RawModuleDefV9Builder::new();
         let product_type = ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::U64)]);
         builder
-            .build_table_for_tests("Bananas", product_type.clone(), false)
+            .build_table_with_new_type("Bananas", product_type.clone(), false)
             .finish();
         let result: Result<ModuleDef> = builder.finish().try_into();
 
@@ -1105,7 +1102,7 @@ mod tests {
     fn invalid_table_name() {
         let mut builder = RawModuleDefV9Builder::new();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "",
                 ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::U64)]),
                 false,
@@ -1122,7 +1119,7 @@ mod tests {
     fn invalid_column_name() {
         let mut builder = RawModuleDefV9Builder::new();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "",
                 ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::U64)]),
                 false,
@@ -1139,7 +1136,7 @@ mod tests {
     fn invalid_index_column_ref() {
         let mut builder = RawModuleDefV9Builder::new();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Bananas",
                 ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::U64)]),
                 false,
@@ -1165,7 +1162,7 @@ mod tests {
     fn invalid_unique_constraint_column_ref() {
         let mut builder = RawModuleDefV9Builder::new();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Bananas",
                 ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::U64)]),
                 false,
@@ -1186,7 +1183,7 @@ mod tests {
         // invalid column id
         let mut builder = RawModuleDefV9Builder::new();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Bananas",
                 ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::U64)]),
                 false,
@@ -1204,7 +1201,7 @@ mod tests {
         // incorrect column type
         let mut builder = RawModuleDefV9Builder::new();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Bananas",
                 ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::String)]),
                 false,
@@ -1224,7 +1221,7 @@ mod tests {
     fn invalid_index_column_duplicates() {
         let mut builder = RawModuleDefV9Builder::new();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Bananas",
                 ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::U64)]),
                 false,
@@ -1248,7 +1245,7 @@ mod tests {
     fn invalid_unique_constraint_column_duplicates() {
         let mut builder = RawModuleDefV9Builder::new();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Bananas",
                 ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::U64)]),
                 false,
@@ -1267,7 +1264,7 @@ mod tests {
         let recursive_type = AlgebraicType::product([("a", AlgebraicTypeRef(0).into())]);
 
         let mut builder = RawModuleDefV9Builder::new();
-        builder.add_type_for_tests([], "Recursive", recursive_type.clone(), false);
+        builder.add_algebraic_type([], "Recursive", recursive_type.clone(), false);
         builder.add_reducer("silly", ProductType::from([("a", recursive_type.clone())]), None);
         let result: Result<ModuleDef> = builder.finish().try_into();
 
@@ -1295,7 +1292,7 @@ mod tests {
         let invalid_type_1 = AlgebraicType::product([("a", AlgebraicTypeRef(31).into())]);
         let invalid_type_2 = AlgebraicType::option(AlgebraicTypeRef(55).into());
         let mut builder = RawModuleDefV9Builder::new();
-        builder.add_type_for_tests([], "Invalid", invalid_type_1.clone(), false);
+        builder.add_algebraic_type([], "Invalid", invalid_type_1.clone(), false);
         builder.add_reducer("silly", ProductType::from([("a", invalid_type_2.clone())]), None);
         let result: Result<ModuleDef> = builder.finish().try_into();
 
@@ -1320,7 +1317,7 @@ mod tests {
         let inner_type_invalid_for_use = AlgebraicType::product([("b", AlgebraicType::U32)]);
         let invalid_type = AlgebraicType::product([("a", inner_type_invalid_for_use.clone())]);
         let mut builder = RawModuleDefV9Builder::new();
-        builder.add_type_for_tests([], "Invalid", invalid_type.clone(), false);
+        builder.add_algebraic_type([], "Invalid", invalid_type.clone(), false);
         builder.add_reducer("silly", ProductType::from([("a", invalid_type.clone())]), None);
         let result: Result<ModuleDef> = builder.finish().try_into();
 
@@ -1342,7 +1339,7 @@ mod tests {
     fn only_btree_indexes() {
         let mut builder = RawModuleDefV9Builder::new();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Bananas",
                 ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::U64)]),
                 false,
@@ -1364,7 +1361,7 @@ mod tests {
     fn one_auto_inc() {
         let mut builder = RawModuleDefV9Builder::new();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Bananas",
                 ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::U64)]),
                 false,
@@ -1383,7 +1380,7 @@ mod tests {
     fn invalid_primary_key() {
         let mut builder = RawModuleDefV9Builder::new();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Bananas",
                 ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::U64)]),
                 false,
@@ -1403,7 +1400,7 @@ mod tests {
     fn missing_primary_key_unique_constraint() {
         let mut builder = RawModuleDefV9Builder::new();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Bananas",
                 ProductType::from([("b", AlgebraicType::U16), ("a", AlgebraicType::U64)]),
                 false,
@@ -1420,13 +1417,13 @@ mod tests {
     #[test]
     fn duplicate_type_name() {
         let mut builder = RawModuleDefV9Builder::new();
-        builder.add_type_for_tests(
+        builder.add_algebraic_type(
             ["scope1".into(), "scope2".into()],
             "Duplicate",
             AlgebraicType::U64,
             false,
         );
-        builder.add_type_for_tests(
+        builder.add_algebraic_type(
             ["scope1".into(), "scope2".into()],
             "Duplicate",
             AlgebraicType::U32,
@@ -1456,7 +1453,7 @@ mod tests {
         let mut builder = RawModuleDefV9Builder::new();
         let schedule_at_type = builder.add_type::<ScheduleAt>();
         builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Deliveries",
                 ProductType::from([
                     ("id", AlgebraicType::U64),
@@ -1481,7 +1478,7 @@ mod tests {
         let mut builder = RawModuleDefV9Builder::new();
         let schedule_at_type = builder.add_type::<ScheduleAt>();
         let deliveries_product_type = builder
-            .build_table_for_tests(
+            .build_table_with_new_type(
                 "Deliveries",
                 ProductType::from([
                     ("id", AlgebraicType::U64),

--- a/crates/schema/src/identifier.rs
+++ b/crates/schema/src/identifier.rs
@@ -1,4 +1,5 @@
 use crate::error::IdentifierError;
+use hashbrown::Equivalent;
 use spacetimedb_data_structures::map::HashSet;
 use spacetimedb_sats::{de, ser};
 use std::fmt::{self, Debug, Display};
@@ -93,6 +94,18 @@ impl Deref for Identifier {
 
     fn deref(&self) -> &str {
         &self.id
+    }
+}
+
+impl From<Identifier> for Box<str> {
+    fn from(value: Identifier) -> Self {
+        value.id
+    }
+}
+
+impl Equivalent<Identifier> for str {
+    fn equivalent(&self, other: &Identifier) -> bool {
+        self == &other.id[..]
     }
 }
 

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -2,15 +2,40 @@
 //! These are used at runtime by the vm to store the schema of the database.
 
 use itertools::Itertools;
-use spacetimedb_data_structures::map::HashMap;
+use spacetimedb_data_structures::map::{HashMap, HashSet};
 use spacetimedb_lib::db::auth::{StAccess, StTableType};
 use spacetimedb_lib::db::error::{DefType, SchemaError};
-use spacetimedb_lib::db::raw_def::*;
+use spacetimedb_lib::db::raw_def::{
+    generate_cols_name, IndexType, RawColumnDefV8, RawConstraintDefV8, RawIndexDefV8, RawSequenceDefV8, RawTableDefV8,
+};
 use spacetimedb_lib::relation::{Column, DbTable, FieldName, Header};
 use spacetimedb_lib::{AlgebraicType, ProductType, ProductTypeElement};
 use spacetimedb_primitives::*;
 use spacetimedb_sats::product_value::InvalidFieldError;
 use std::sync::Arc;
+
+use crate::def::{
+    ColumnDef, IndexAlgorithm, IndexDef, ModuleDef, ModuleDefLookup, SequenceDef, TableDef, UniqueConstraintDef,
+};
+use crate::identifier::Identifier;
+
+/// Helper trait documenting allowing schema entities to be built from a validated `ModuleDef`.
+/// Currently private, because the `TableSchema` constructor needs to do some fixing-up after calling some of these
+/// and it isn't obvious how to incorporate that in a generic way.
+/// Once `TableSchema` is closer to `ModuleDef` this shouldn't be a problem and this trait can be made public.
+trait Schema: Sized {
+    /// The `Def` type corresponding to this schema type.
+    type Def: ModuleDefLookup;
+    /// The `Id` type corresponding to this schema type.
+    type Id;
+    /// The `Id` type corresponding to the parent of this schema type.
+    /// Set to `()` if there is no parent.
+    type ParentId;
+
+    /// Construct a schema entity from a validated `ModuleDef`.
+    /// Panics if `module_def` does not contain `def`.
+    fn from_module_def(def: &Self::Def, parent_id: Self::ParentId, id: Self::Id) -> Self;
+}
 
 /// A data structure representing the schema of a database table.
 ///
@@ -226,6 +251,8 @@ impl TableSchema {
     ///
     /// - `table_id`: The unique identifier for the table.
     /// - `schema`: The `TableDef` containing the schema information.
+    #[deprecated]
+    #[allow(deprecated)]
     pub fn from_def(table_id: TableId, schema: RawTableDefV8) -> Self {
         let indexes = schema.generated_indexes().collect::<Vec<_>>();
         let sequences = schema.generated_sequences().collect::<Vec<_>>();
@@ -484,6 +511,122 @@ impl TableSchema {
             Err(errors)
         }
     }
+
+    /// Create a `TableSchema` from a validated `ModuleDef`.
+    pub fn from_module_def(def: &TableDef, table_id: TableId) -> Self {
+        let TableDef {
+            name,
+            product_type_ref: _,
+            primary_key,
+            columns,
+            indexes,
+            unique_constraints,
+            sequences,
+            schedule,
+            table_type,
+            table_access,
+        } = def;
+
+        let columns: Vec<ColumnSchema> = columns
+            .iter()
+            .enumerate()
+            .map(|(col_pos, def)| ColumnSchema::from_module_def(def, (), (table_id, col_pos.into())))
+            .collect();
+
+        let unique_col_lists = unique_constraints
+            .values()
+            .map(|x| x.columns.clone())
+            .collect::<HashSet<_>>();
+
+        let mut constraints: Vec<ConstraintSchema> = vec![];
+
+        // note: these Ids are fixed up somewhere else, so we can just use 0 here...
+        // but it would be nice to pass the correct values into this method.
+        let indexes = indexes
+            .values()
+            .map(|def| {
+                let mut result = IndexSchema::from_module_def(def, table_id, IndexId(0));
+                // TODO: do we need to worry about ordering here?
+                if unique_col_lists.contains(&result.columns) {
+                    result.is_unique = true;
+                } else {
+                    let cols_name = generate_cols_name(&result.columns, |x| columns.get(x.idx()).map(|x| &*x.col_name));
+                    #[allow(deprecated)]
+                    constraints.push(ConstraintSchema::from_def(
+                        table_id,
+                        RawConstraintDefV8::for_column(
+                            name,
+                            &cols_name,
+                            Constraints::indexed(),
+                            result.columns.clone(),
+                        ),
+                    ));
+                }
+                result
+            })
+            .collect();
+
+        let sequence_col_lists: HashSet<ColList> = sequences.values().map(|x| ColList::new(x.column)).collect();
+
+        let sequences = sequences
+            .values()
+            .map(|def| SequenceSchema::from_module_def(def, table_id, SequenceId(0)))
+            .collect();
+
+        let pk_col_list = primary_key.map(ColList::from).unwrap_or(ColList::empty());
+
+        constraints.extend(unique_constraints.values().map(|def| {
+            let mut result = ConstraintSchema::from_module_def(def, table_id, ConstraintId(0));
+            if result.columns == pk_col_list {
+                result.constraints = result.constraints.push(Constraints::primary_key());
+            }
+            if sequence_col_lists.contains(&result.columns) {
+                result.constraints = result.constraints.push_auto_inc().expect("could not set auto_inc?");
+            }
+            result
+        }));
+
+        let scheduled = schedule.as_ref().map(|schedule| (*schedule.reducer_name).into());
+
+        TableSchema::new(
+            table_id,
+            (*name).clone().into(),
+            columns,
+            indexes,
+            constraints,
+            sequences,
+            (*table_type).into(),
+            (*table_access).into(),
+            scheduled,
+        )
+    }
+
+    /// The C# and Rust SDKs are inconsistent about whether column defs store resolved or unresolved algebraic types.
+    /// This method works around this problem by copying the column types from the module def into the table schema.
+    pub fn janky_fix_column_defs(&mut self, module_def: &ModuleDef) {
+        let table_name = Identifier::new(self.table_name.clone()).unwrap();
+        for col in &mut self.columns {
+            let def: &ColumnDef = module_def
+                .lookup((&table_name, &Identifier::new(col.col_name.clone()).unwrap()))
+                .unwrap();
+            col.col_type = def.ty.clone();
+        }
+        let table_def: &TableDef = module_def.expect_lookup(&table_name);
+        self.row_type = module_def.typespace()[table_def.product_type_ref]
+            .as_product()
+            .unwrap()
+            .clone();
+    }
+
+    /// Normalize a `TableSchema`.
+    /// The result is semantically equivalent, but may have reordered indexes, constraints, or sequences.
+    /// Columns will not be reordered.
+    pub fn normalize(&mut self) {
+        self.indexes.sort_by(|a, b| a.index_name.cmp(&b.index_name));
+        self.constraints
+            .sort_by(|a, b| a.constraint_name.cmp(&b.constraint_name));
+        self.sequences.sort_by(|a, b| a.sequence_name.cmp(&b.sequence_name));
+    }
 }
 
 impl From<&TableSchema> for ProductType {
@@ -581,12 +724,30 @@ impl ColumnSchema {
     /// * `table_id`: Identifier of the table to which the column belongs.
     /// * `col_pos`: Position of the column within the table.
     /// * `column`: The `ColumnDef` containing column information.
+    #[deprecated]
     pub fn from_def(table_id: TableId, col_pos: ColId, column: RawColumnDefV8) -> Self {
         ColumnSchema {
             table_id,
             col_pos,
             col_name: column.col_name.trim().into(),
             col_type: column.col_type,
+        }
+    }
+}
+
+impl Schema for ColumnSchema {
+    type Def = ColumnDef;
+    type ParentId = ();
+    // This is not like the other ID types: it's a tuple of the table ID and the column position.
+    // A `ColId` alone does NOT suffice to identify a column!
+    type Id = (TableId, ColId);
+
+    fn from_module_def(def: &ColumnDef, _parent_id: (), (table_id, col_pos): (TableId, ColId)) -> Self {
+        ColumnSchema {
+            table_id,
+            col_pos,
+            col_name: (*def.name).into(),
+            col_type: def.ty.clone(),
         }
     }
 }
@@ -695,6 +856,26 @@ impl SequenceSchema {
     }
 }
 
+impl Schema for SequenceSchema {
+    type Def = SequenceDef;
+    type Id = SequenceId;
+    type ParentId = TableId;
+
+    fn from_module_def(def: &Self::Def, parent_id: Self::ParentId, id: Self::Id) -> Self {
+        SequenceSchema {
+            sequence_id: id,
+            sequence_name: (*def.name).into(),
+            table_id: parent_id,
+            col_pos: def.column,
+            increment: def.increment,
+            start: def.start.unwrap_or(1),
+            min_value: def.min_value.unwrap_or(1),
+            max_value: def.max_value.unwrap_or(i128::MAX),
+            allocated: 0, // TODO: information not available in the `Def`s anymore, which is correct, but this may need to be overridden later.
+        }
+    }
+}
+
 impl From<SequenceSchema> for RawSequenceDefV8 {
     fn from(value: SequenceSchema) -> Self {
         RawSequenceDefV8 {
@@ -733,6 +914,7 @@ pub struct IndexSchema {
 
 impl IndexSchema {
     /// Constructs an [IndexSchema] from a given [IndexDef] and `table_id`.
+    #[deprecated(note = "Use TableSchema::from_module_def instead")]
     pub fn from_def(table_id: TableId, index: RawIndexDefV8) -> Self {
         IndexSchema {
             index_id: IndexId(0), // Set to 0 as it may be assigned later.
@@ -741,6 +923,26 @@ impl IndexSchema {
             index_name: index.index_name.trim().into(),
             is_unique: index.is_unique,
             columns: index.columns,
+        }
+    }
+}
+
+impl Schema for IndexSchema {
+    type Def = IndexDef;
+    type Id = IndexId;
+    type ParentId = TableId;
+
+    fn from_module_def(def: &Self::Def, parent_id: Self::ParentId, id: Self::Id) -> Self {
+        let (index_type, columns) = match &def.algorithm {
+            IndexAlgorithm::BTree { columns } => (IndexType::BTree, columns.clone()),
+        };
+        IndexSchema {
+            index_id: id,
+            table_id: parent_id,
+            index_type,
+            index_name: (*def.name).into(),
+            is_unique: false,
+            columns,
         }
     }
 }
@@ -782,6 +984,7 @@ impl ConstraintSchema {
     ///
     /// * `table_id`: Identifier of the table to which the constraint belongs.
     /// * `constraint`: The `ConstraintDef` containing constraint information.
+    #[deprecated(note = "Use TableSchema::from_module_def instead")]
     pub fn from_def(table_id: TableId, constraint: RawConstraintDefV8) -> Self {
         ConstraintSchema {
             constraint_id: ConstraintId(0), // Set to 0 as it may be assigned later.
@@ -789,6 +992,22 @@ impl ConstraintSchema {
             constraints: constraint.constraints,
             table_id,
             columns: constraint.columns,
+        }
+    }
+}
+
+impl Schema for ConstraintSchema {
+    type Def = UniqueConstraintDef;
+    type Id = ConstraintId;
+    type ParentId = TableId;
+
+    fn from_module_def(def: &Self::Def, parent_id: Self::ParentId, id: Self::Id) -> Self {
+        ConstraintSchema {
+            constraint_id: id,
+            constraint_name: (*def.name).into(),
+            constraints: Constraints::unique(),
+            table_id: parent_id,
+            columns: def.columns.clone(),
         }
     }
 }
@@ -804,6 +1023,7 @@ impl From<ConstraintSchema> for RawConstraintDefV8 {
 }
 
 #[cfg(test)]
+#[allow(deprecated)]
 mod tests {
     use super::*;
     use spacetimedb_primitives::col_list;

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -601,8 +601,9 @@ impl TableSchema {
         )
     }
 
-    /// The C# and Rust SDKs are inconsistent about whether column defs store resolved or unresolved algebraic types.
+    /// The C# and Rust SDKs are inconsistent about whether v8 column defs store resolved or unresolved algebraic types.
     /// This method works around this problem by copying the column types from the module def into the table schema.
+    /// It can be removed once v8 is removed, since v9 will reject modules with an inconsistency like this.
     pub fn janky_fix_column_defs(&mut self, module_def: &ModuleDef) {
         let table_name = Identifier::new(self.table_name.clone()).unwrap();
         for col in &mut self.columns {

--- a/crates/schema/tests/validate_integration.rs
+++ b/crates/schema/tests/validate_integration.rs
@@ -4,9 +4,16 @@
 //! The name should refer to a path in the `modules` directory of this repo.
 
 use spacetimedb_cli::generate::extract_descriptions;
-use spacetimedb_lib::RawModuleDefV8;
-use spacetimedb_schema::def::ModuleDef;
+use spacetimedb_lib::{db::raw_def::v9::RawModuleDefV9, ser::serde::SerializeWrapper, RawModuleDefV8};
+use spacetimedb_primitives::TableId;
+use spacetimedb_schema::{
+    def::{ModuleDef, TableDef},
+    identifier::Identifier,
+    schema::TableSchema,
+};
 use spacetimedb_testing::modules::{CompilationMode, CompiledModule};
+
+const TEST_TABLE_ID: TableId = TableId(1337);
 
 #[allow(clippy::disallowed_macros)] // LET ME PRINTLN >:(
 fn validate_module(module_name: &str) {
@@ -14,12 +21,60 @@ fn validate_module(module_name: &str) {
     let raw_module_def: RawModuleDefV8 =
         extract_descriptions(module.path()).expect("failed to extract module descriptions");
 
-    if let Err(err) = ModuleDef::try_from(raw_module_def) {
-        // use `{}` so we get prettily-formatted errors
-        panic!("Failed to validate module: {module_name}\n{err}");
+    // v8 -> ModuleDef
+    let result = ModuleDef::try_from(raw_module_def.clone());
+
+    // we don't use `expect` here because we want to format via `Display`, not `Debug`.
+    let result = match result {
+        Ok(result) => result,
+        Err(err) => panic!("Module {} is invalid: \n{}", module_name, err),
+    };
+
+    // (ModuleDef -> v9 -> ModuleDef) == noop
+    let result_as_raw: RawModuleDefV9 = result.clone().into();
+    let result_from_raw = ModuleDef::try_from(result_as_raw).expect("failed to convert back to ModuleDef");
+    assert_identical(result.clone(), result_from_raw);
+
+    let mut tables = vec![];
+
+    // (v8 -> ModuleDef -> TableSchema) == (v8 -> TableSchema)
+    let mut failed = false;
+    for table in raw_module_def.tables.into_iter() {
+        let name = Identifier::new(table.schema.table_name.clone()).expect("already validated");
+        let new_def: &TableDef = result.lookup(&name).expect("already validated");
+
+        #[allow(deprecated)]
+        let mut schema_old_path = TableSchema::from_def(TEST_TABLE_ID, table.schema);
+        let mut schema_new_path = TableSchema::from_module_def(new_def, TEST_TABLE_ID);
+
+        schema_old_path.janky_fix_column_defs(&result);
+        schema_old_path.normalize();
+        schema_new_path.janky_fix_column_defs(&result);
+        schema_new_path.normalize();
+
+        if schema_old_path != schema_new_path {
+            failed = true;
+            eprintln!("Mismatched TableSchemas: Old path:\n{schema_old_path:#?}\nNew path:\n{schema_new_path:#?}");
+        }
+
+        schema_old_path.validated().expect("TableSchema is invalid");
+        tables.push(schema_new_path.validated().expect("TableSchema is invalid"));
     }
-    // TODO: once we have the conversion TableDef -> TableSchema, go through and validate that the old path
-    // from RawModuleDefV8 -> TableSchema is equivalent to the new path.
+    if failed {
+        panic!("TableSchemas mismatched");
+    }
+}
+
+/// Assert that two ModuleDefs are identical.
+/// TODO: implement better ModuleDef comparison. This just checks that their serialized forms are the same,
+/// which is fine for this test, but we need a more relaxed comparison in general.
+/// Allowing typespace permutations, etc.
+fn assert_identical(module_def_1: ModuleDef, module_def_2: ModuleDef) {
+    let module_def_1: RawModuleDefV9 = module_def_1.into();
+    let module_def_2: RawModuleDefV9 = module_def_2.into();
+    let s1 = serde_json::to_string_pretty(&SerializeWrapper::new(&module_def_1)).unwrap();
+    let s2 = serde_json::to_string_pretty(&SerializeWrapper::new(&module_def_2)).unwrap();
+    assert_eq!(s1, s2, "ModuleDefs are not identical");
 }
 
 #[test]
@@ -33,6 +88,20 @@ fn validate_sdk_test() {
 }
 
 #[test]
-fn validate_sdk_test_cs() {
+fn validate_cs_modules() {
+    // These need to be called in sequence because running them in parallel locks the codegen DLLs
+    // which causes a compilation failure. Thanks, .NET
     validate_module("sdk-test-cs");
+    validate_module("sdk-test-connect-disconnect-cs");
+    validate_module("spacetimedb-quickstart-cs");
+}
+
+#[test]
+fn validate_sdk_test_connect_disconnect() {
+    validate_module("sdk-test-connect-disconnect");
+}
+
+#[test]
+fn validate_spacetimedb_quickstart() {
+    validate_module("spacetimedb-quickstart");
 }

--- a/crates/table/benches/page_manager.rs
+++ b/crates/table/benches/page_manager.rs
@@ -450,6 +450,7 @@ criterion_group!(
 );
 
 fn schema_from_ty(ty: ProductType, name: &str) -> TableSchema {
+    #[allow(deprecated)]
     TableSchema::from_def(TableId(0), RawTableDefV8::from_product(name, ty))
 }
 
@@ -654,6 +655,7 @@ trait IndexedRow: Row + Sized {
             .with_column_index(Self::indexed_columns(), false)
     }
     fn make_schema() -> TableSchema {
+        #[allow(deprecated)]
         TableSchema::from_def(TableId(0), Self::make_table_def())
     }
     fn throughput() -> Throughput {

--- a/crates/table/src/btree_index.rs
+++ b/crates/table/src/btree_index.rs
@@ -480,6 +480,7 @@ mod test {
 
     fn table(ty: ProductType) -> Table {
         let def = RawTableDefV8::from_product("", ty);
+        #[allow(deprecated)]
         let schema = TableSchema::from_def(0.into(), def);
         Table::new(schema.into(), SquashedOffset::COMMITTED_STATE)
     }

--- a/crates/table/src/read_column.rs
+++ b/crates/table/src/read_column.rs
@@ -350,6 +350,7 @@ mod test {
 
     fn table(ty: ProductType) -> Table {
         let def = RawTableDefV8::from_product("", ty);
+        #[allow(deprecated)]
         let schema = TableSchema::from_def(0.into(), def);
         Table::new(schema.into(), SquashedOffset::COMMITTED_STATE)
     }

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -1158,6 +1158,7 @@ pub(crate) mod test {
 
     pub(crate) fn table(ty: ProductType) -> Table {
         let def = RawTableDefV8::from_product("", ty);
+        #[allow(deprecated)]
         let schema = TableSchema::from_def(0.into(), def);
         Table::new(schema.into(), SquashedOffset::COMMITTED_STATE)
     }
@@ -1181,6 +1182,7 @@ pub(crate) mod test {
             is_unique: true,
             index_type: IndexType::BTree,
         }]);
+        #[allow(deprecated)]
         let schema = TableSchema::from_def(0.into(), table_def);
         let index_schema = schema.indexes[0].clone();
         let mut table = Table::new(schema.into(), SquashedOffset::COMMITTED_STATE);


### PR DESCRIPTION
# Description of Changes

This was not painful at all! The code is a mess but the tests pass, the paths commute! Gonna rewrite to be cleaner, but the logic is there.

It should be possible to go in reverse from TableSchema -> ModuleDef via RawModuleDefv8, I have not implemented that yet. Eventually we'll update TableSchema to look like v9 and then we can throw out that path. 

# API and ABI breaking changes

None

# Expected complexity level and risk

1, this is tricky but I think I've got it right.

# Testing

We test that this produces identical results for the old and the new path for all of the modules in `modules` (up to a small amount of sorting).