### PR TITLE
NFC: use record for BigInt equality and hash

### DIFF
--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/I128.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/I128.cs
@@ -3,13 +3,12 @@
 
 namespace SpacetimeDB;
 
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
 /// <summary>Represents a 128-bit signed integer.</summary>
 [StructLayout(LayoutKind.Sequential)]
-public readonly struct I128 : IEquatable<I128>, IComparable, IComparable<I128>
+public readonly record struct I128 : IEquatable<I128>, IComparable, IComparable<I128>
 {
     internal const int Size = 16;
 
@@ -98,30 +97,6 @@ public readonly struct I128 : IEquatable<I128>, IComparable, IComparable<I128>
 
     /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
     public static bool IsNegative(I128 value) => (long)value._upper < 0;
-
-    //
-    // IEqualityOperators
-    //
-
-    /// <inheritdoc cref="IEqualityOperators{TSelf, TOther, TResult}.op_Equality(TSelf, TOther)" />
-    public static bool operator ==(I128 left, I128 right) =>
-        (left._lower == right._lower) && (left._upper == right._upper);
-
-    /// <inheritdoc cref="IEqualityOperators{TSelf, TOther, TResult}.op_Inequality(TSelf, TOther)" />
-    public static bool operator !=(I128 left, I128 right) =>
-        (left._lower != right._lower) || (left._upper != right._upper);
-
-    /// <inheritdoc cref="object.Equals(object?)" />
-    public override bool Equals([NotNullWhen(true)] object? obj)
-    {
-        return (obj is I128 other) && Equals(other);
-    }
-
-    /// <inheritdoc cref="IEquatable{T}.Equals(T)" />
-    public bool Equals(I128 x) => _upper == x._upper && _lower == x._lower;
-
-    /// <inheritdoc cref="object.GetHashCode()" />
-    public override int GetHashCode() => HashCode.Combine(_lower, _upper);
 
     private BigInteger AsBigInt() =>
         new(

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/I256.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/I256.cs
@@ -4,13 +4,12 @@
 namespace SpacetimeDB;
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
 /// <summary>Represents a 256-bit signed integer.</summary>
 [StructLayout(LayoutKind.Sequential)]
-public readonly struct I256 : IEquatable<I256>, IComparable, IComparable<I256>
+public readonly record struct I256 : IEquatable<I256>, IComparable, IComparable<I256>
 {
     internal const int Size = 32;
 
@@ -100,30 +99,6 @@ public readonly struct I256 : IEquatable<I256>, IComparable, IComparable<I256>
     /// <inheritdoc cref="INumberBase{TSelf}.IsNegative(TSelf)" />
 
     public static bool IsNegative(I256 value) => (long)value._upper.Upper < 0;
-
-    //
-    // IEqualityOperators
-    //
-
-    /// <inheritdoc cref="IEqualityOperators{TSelf, TOther, TResult}.op_Equality(TSelf, TOther)" />
-    public static bool operator ==(I256 left, I256 right) =>
-        (left._lower == right._lower) && (left._upper == right._upper);
-
-    /// <inheritdoc cref="IEqualityOperators{TSelf, TOther, TResult}.op_Inequality(TSelf, TOther)" />
-    public static bool operator !=(I256 left, I256 right) =>
-        (left._lower != right._lower) || (left._upper != right._upper);
-
-    /// <inheritdoc cref="object.Equals(object?)" />
-    public override bool Equals([NotNullWhen(true)] object? obj)
-    {
-        return (obj is I256 other) && Equals(other);
-    }
-
-    /// <inheritdoc cref="IEquatable{T}.Equals(T)" />
-    public bool Equals(I256 x) => _upper == x._upper && _lower == x._lower;
-
-    /// <inheritdoc cref="object.GetHashCode()" />
-    public override int GetHashCode() => HashCode.Combine(_lower, _upper);
 
     private BigInteger AsBigInt() =>
         new(

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/U128.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/U128.cs
@@ -3,13 +3,12 @@
 
 namespace SpacetimeDB;
 
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
 /// <summary>Represents a 128-bit unsigned integer.</summary>
 [StructLayout(LayoutKind.Sequential)]
-public readonly struct U128 : IEquatable<U128>, IComparable, IComparable<U128>
+public readonly record struct U128 : IEquatable<U128>, IComparable, IComparable<U128>
 {
     internal const int Size = 16;
 
@@ -81,30 +80,6 @@ public readonly struct U128 : IEquatable<U128>, IComparable, IComparable<U128>
         return (left._upper > right._upper)
             || (left._upper == right._upper) && (left._lower > right._lower);
     }
-
-    //
-    // IEqualityOperators
-    //
-
-    /// <inheritdoc cref="IEqualityOperators{TSelf, TOther, TResult}.op_Equality(TSelf, TOther)" />
-    public static bool operator ==(U128 left, U128 right) =>
-        (left._lower == right._lower) && (left._upper == right._upper);
-
-    /// <inheritdoc cref="IEqualityOperators{TSelf, TOther, TResult}.op_Inequality(TSelf, TOther)" />
-    public static bool operator !=(U128 left, U128 right) =>
-        (left._lower != right._lower) || (left._upper != right._upper);
-
-    /// <inheritdoc cref="object.Equals(object?)" />
-    public override bool Equals([NotNullWhen(true)] object? obj)
-    {
-        return (obj is U128 other) && Equals(other);
-    }
-
-    /// <inheritdoc cref="IEquatable{T}.Equals(T)" />
-    public bool Equals(U128 x) => _upper == x._upper && _lower == x._lower;
-
-    /// <inheritdoc cref="object.GetHashCode()" />
-    public override int GetHashCode() => HashCode.Combine(_lower, _upper);
 
     private BigInteger AsBigInt() =>
         new(

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/U256.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/U256.cs
@@ -1,13 +1,12 @@
 namespace SpacetimeDB;
 
 using System;
-using System.Diagnostics.CodeAnalysis;
 using System.Numerics;
 using System.Runtime.InteropServices;
 
 /// <summary>Represents a 128-bit unsigned integer.</summary>
 [StructLayout(LayoutKind.Sequential)]
-public readonly struct U256 : IEquatable<U256>, IComparable, IComparable<U256>
+public readonly record struct U256 : IEquatable<U256>, IComparable, IComparable<U256>
 {
     internal const int Size = 32;
 
@@ -79,30 +78,6 @@ public readonly struct U256 : IEquatable<U256>, IComparable, IComparable<U256>
         return (left._upper > right._upper)
             || (left._upper == right._upper) && (left._lower > right._lower);
     }
-
-    //
-    // IEqualityOperators
-    //
-
-    /// <inheritdoc cref="IEqualityOperators{TSelf, TOther, TResult}.op_Equality(TSelf, TOther)" />
-    public static bool operator ==(U256 left, U256 right) =>
-        (left._lower == right._lower) && (left._upper == right._upper);
-
-    /// <inheritdoc cref="IEqualityOperators{TSelf, TOther, TResult}.op_Inequality(TSelf, TOther)" />
-    public static bool operator !=(U256 left, U256 right) =>
-        (left._lower != right._lower) || (left._upper != right._upper);
-
-    /// <inheritdoc cref="object.Equals(object?)" />
-    public override bool Equals([NotNullWhen(true)] object? obj)
-    {
-        return (obj is U256 other) && Equals(other);
-    }
-
-    /// <inheritdoc cref="IEquatable{T}.Equals(T)" />
-    public bool Equals(U256 x) => _upper == x._upper && _lower == x._lower;
-
-    /// <inheritdoc cref="object.GetHashCode()" />
-    public override int GetHashCode() => HashCode.Combine(_lower, _upper);
 
     private BigInteger AsBigInt() =>
         new(


### PR DESCRIPTION
# Description of Changes

Slightly simplifies the implementations by leveraging `record struct` to provide field-by-field equality and hashing automatically.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
