### PR TITLE
WASM ABI: `delete_by_rel` -> `datastore_delete_all_by_eq_bsatn`

### DIFF
--- a/crates/bindings-csharp/Runtime/Exceptions.cs
+++ b/crates/bindings-csharp/Runtime/Exceptions.cs
@@ -12,6 +12,11 @@ public class NotInTransactionException : StdbException
     public override string Message => "ABI call can only be made while in a transaction";
 }
 
+public class BsatnDecodeException : StdbException
+{
+    public override string Message => "Couldn't decode the BSATN to the expected type";
+}
+
 public class NoSuchTableException : StdbException
 {
     public override string Message => "No such table";

--- a/crates/bindings-csharp/Runtime/Internal/FFI.cs
+++ b/crates/bindings-csharp/Runtime/Internal/FFI.cs
@@ -24,6 +24,7 @@ public enum Errno : short
     OK = 0,
     HOST_CALL_FAILURE = 1,
     NOT_IN_TRANSACTION = 2,
+    BSATN_DECODE_ERROR = 3,
     NO_SUCH_TABLE = 4,
     NO_SUCH_ITER = 6,
     NO_SUCH_BYTES = 8,
@@ -70,11 +71,13 @@ internal static partial class FFI
                 throw status switch
                 {
                     Errno.NOT_IN_TRANSACTION => new NotInTransactionException(),
+                    Errno.BSATN_DECODE_ERROR => new BsatnDecodeException(),
                     Errno.NO_SUCH_TABLE => new NoSuchTableException(),
-                    Errno.UNIQUE_ALREADY_EXISTS => new UniqueAlreadyExistsException(),
-                    Errno.BUFFER_TOO_SMALL => new BufferTooSmallException(),
+                    Errno.NO_SUCH_ITER => new NoSuchIterException(),
                     Errno.NO_SUCH_BYTES => new NoSuchBytesException(),
                     Errno.NO_SPACE => new NoSpaceException(),
+                    Errno.BUFFER_TOO_SMALL => new BufferTooSmallException(),
+                    Errno.UNIQUE_ALREADY_EXISTS => new UniqueAlreadyExistsException(),
                     _ => new UnknownException(status),
                 };
             }
@@ -154,14 +157,6 @@ internal static partial class FFI
     );
 
     [LibraryImport(StdbNamespace)]
-    public static partial CheckedStatus _delete_by_rel(
-        TableId table_id,
-        [In] byte[] relation,
-        uint relation_len,
-        out uint out_
-    );
-
-    [LibraryImport(StdbNamespace)]
     public static partial CheckedStatus _iter_start_filtered(
         TableId table_id,
         [In] byte[] filter,
@@ -178,6 +173,14 @@ internal static partial class FFI
 
     [LibraryImport(StdbNamespace)]
     public static partial CheckedStatus _row_iter_bsatn_close(RowIter iter_handle);
+
+    [LibraryImport(StdbNamespace)]
+    public static partial CheckedStatus _datastore_delete_all_by_eq_bsatn(
+        TableId table_id,
+        [In] byte[] relation,
+        uint relation_len,
+        out uint out_
+    );
 
     [LibraryImport(StdbNamespace)]
     public static partial void _volatile_nonatomic_schedule_immediate(

--- a/crates/bindings-csharp/Runtime/bindings.c
+++ b/crates/bindings-csharp/Runtime/bindings.c
@@ -60,10 +60,6 @@ IMPORT(Status, _delete_by_col_eq,
        (TableId table_id, ColId col_id, const uint8_t* value,
         uint32_t value_len, uint32_t* num_deleted),
        (table_id, col_id, value, value_len, num_deleted));
-IMPORT(Status, _delete_by_rel,
-       (TableId table_id, const uint8_t* relation, uint32_t relation_len,
-        uint32_t* num_deleted),
-       (table_id, relation, relation_len, num_deleted));
 IMPORT(Status, _iter_start_filtered,
        (TableId table_id, const uint8_t* filter, uint32_t filter_len,
         RowIter* iter),
@@ -72,6 +68,10 @@ IMPORT(int16_t, _row_iter_bsatn_advance,
        (RowIter iter, uint8_t* buffer_ptr, size_t* buffer_len_ptr),
        (iter, buffer_ptr, buffer_len_ptr));
 IMPORT(uint16_t, _row_iter_bsatn_close, (RowIter iter), (iter));
+IMPORT(Status, _datastore_delete_all_by_eq_bsatn,
+       (TableId table_id, const uint8_t* rel_ptr, uint32_t rel_len,
+        uint32_t* num_deleted),
+       (table_id, rel_ptr, rel_len, num_deleted));
 IMPORT(void, _volatile_nonatomic_schedule_immediate,
        (const uint8_t* name, size_t name_len, const uint8_t* args, size_t args_len),
        (name, name_len, args, args_len));

--- a/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
+++ b/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
@@ -7,13 +7,13 @@
     <WasmImport Include="$(SpacetimeNamespace)!_iter_by_col_eq" />
     <WasmImport Include="$(SpacetimeNamespace)!_insert" />
     <WasmImport Include="$(SpacetimeNamespace)!_delete_by_col_eq" />
-    <WasmImport Include="$(SpacetimeNamespace)!_delete_by_rel" />
     <WasmImport Include="$(SpacetimeNamespace)!_iter_start_filtered" />
     <WasmImport Include="$(SpacetimeNamespace)!_table_id_from_name" />
     <WasmImport Include="$(SpacetimeNamespace)!_datastore_table_row_count" />
     <WasmImport Include="$(SpacetimeNamespace)!_datastore_table_scan_bsatn" />
     <WasmImport Include="$(SpacetimeNamespace)!_row_iter_bsatn_advance" />
     <WasmImport Include="$(SpacetimeNamespace)!_row_iter_bsatn_close" />
+    <WasmImport Include="$(SpacetimeNamespace)!_datastore_delete_all_by_eq_bsatn" />
     <WasmImport Include="$(SpacetimeNamespace)!_bytes_source_read" />
     <WasmImport Include="$(SpacetimeNamespace)!_bytes_sink_write" />
 

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -225,13 +225,14 @@ pub fn delete_by_col_eq(table_id: TableId, col_id: ColId, value: &impl Serialize
 /// Returns an error if
 /// - a table with the provided `table_id` doesn't exist
 /// - `(relation, relation_len)` doesn't decode from BSATN to a `Vec<ProductValue>`
+/// - this is called outside a transaction
 ///
 /// Panics when serialization fails.
 pub fn delete_by_rel(table_id: TableId, relation: &[impl Serialize]) -> Result<u32> {
     with_row_buf(|bytes| {
         // Encode `value` as BSATN into `bytes` and then use that.
         bsatn::to_writer(bytes, relation).unwrap();
-        sys::delete_by_rel(table_id, bytes)
+        sys::datastore_delete_all_by_eq_bsatn(table_id, bytes)
     })
 }
 

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -169,9 +169,12 @@ impl InstanceEnv {
     /// where the rows match one in `relation`
     /// which is a bsatn encoding of `Vec<ProductValue>`.
     ///
-    /// Returns an error if no rows were deleted.
+    /// Returns an error if
+    /// - not in a transaction.
+    /// - the table didn't exist.
+    /// - a row couldn't be decoded to the table schema type.
     #[tracing::instrument(skip(self, relation))]
-    pub fn delete_by_rel(&self, table_id: TableId, relation: &[u8]) -> Result<u32, NodesError> {
+    pub fn datastore_delete_all_by_eq_bsatn(&self, table_id: TableId, relation: &[u8]) -> Result<u32, NodesError> {
         let stdb = &*self.dbic.relational_db;
         let tx = &mut *self.get_tx()?;
 

--- a/crates/core/src/host/wasm_common.rs
+++ b/crates/core/src/host/wasm_common.rs
@@ -320,6 +320,7 @@ pub(super) type TimingSpanSet = ResourceSlab<TimingSpanIdx>;
 pub fn err_to_errno(err: &NodesError) -> Option<NonZeroU16> {
     match err {
         NodesError::NotInTransaction => Some(errno::NOT_IN_TRANSACTION),
+        NodesError::DecodeRow(_) => Some(errno::BSATN_DECODE_ERROR),
         NodesError::TableNotFound => Some(errno::NO_SUCH_TABLE),
         NodesError::AlreadyExists(_) => Some(errno::UNIQUE_ALREADY_EXISTS),
         NodesError::Internal(internal) => match **internal {
@@ -351,12 +352,12 @@ macro_rules! abi_funcs {
             "spacetime_10.0"::datastore_table_scan_bsatn,
             "spacetime_10.0"::row_iter_bsatn_advance,
             "spacetime_10.0"::row_iter_bsatn_close,
+            "spacetime_10.0"::datastore_delete_all_by_eq_bsatn,
             "spacetime_10.0"::bytes_source_read,
             "spacetime_10.0"::bytes_sink_write,
 
             "spacetime_10.0"::console_log,
             "spacetime_10.0"::delete_by_col_eq,
-            "spacetime_10.0"::delete_by_rel,
             "spacetime_10.0"::insert,
             "spacetime_10.0"::iter_by_col_eq,
             "spacetime_10.0"::iter_start_filtered,

--- a/crates/primitives/src/errno.rs
+++ b/crates/primitives/src/errno.rs
@@ -10,6 +10,7 @@ macro_rules! errnos {
         $mac!(
             HOST_CALL_FAILURE(1, "ABI called by host returned an error"),
             NOT_IN_TRANSACTION(2, "ABI call can only be made while in a transaction"),
+            BSATN_DECODE_ERROR(3, "Couldn't decode the BSATN to the expected type"),
             NO_SUCH_TABLE(4, "No such table"),
             NO_SUCH_ITER(6, "The provided row iterator is not valid"),
             NO_SUCH_BYTES(8, "The provided bytes source or sink is not valid"),


### PR DESCRIPTION
# Description of Changes

Rename `delete_by_rel` -> `datastore_delete_all_by_eq_bsatn` and adjust semantics to proposal.

cc #1460 