### PR TITLE
Fix issue with identity creation

### DIFF
--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -398,10 +398,6 @@ async fn exec_new(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
         query_params,
     )?);
 
-    if let Ok(identity_token) = config.get_default_identity_config(server) {
-        builder = builder.basic_auth("token", Some(identity_token.token.clone()));
-    }
-
     let identity_token: IdentityTokenJson = builder.send().await?.error_for_status()?.json().await?;
     let identity = identity_token.identity;
 

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -393,7 +393,7 @@ async fn exec_new(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
         query_params.push(("email", email.as_str()))
     }
 
-    let mut builder = reqwest::Client::new().post(Url::parse_with_params(
+    let builder = reqwest::Client::new().post(Url::parse_with_params(
         format!("{}/identity", config.get_host_url(server)?).as_str(),
         query_params,
     )?);


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

This fixes the following issue:
```
REDACTED@geralt MINGW64 ~/REDACTED/REDACTED
$ bash ./sp_deploy.sh REDACTED-bot-test
Error: Identity 93dda09db9a56d8fa6c024d843e805d8262191db3b4ba84c5efcd1ad451fed4e is not valid for server REDACTED-bot-test
List valid identities for server REDACTED-bot-test with:
        spacetime identity list -s REDACTED-bot-test

REDACTED@geralt MINGW64 ~/REDACTED/REDACTED
$ spacetime server ^C

REDACTED@geralt MINGW64 ~/REDACTED/REDACTED
$ spacetime identity new --no-email -s REDACTED-bot-test
Error: Identity 5ebd1221afb10aaf61d6c8a527413d82a1ad9ee9ac9ea420e8dc80dc9350394e is not valid for server REDACTED-bot-test
List valid identities for server REDACTED-bot-test with:
        spacetime identity list -s REDACTED-bot-test

REDACTED@geralt MINGW64 ~/REDACTED/REDACTED
$ spacetime identity list -s REDACTED-bot-test
Identities for REDACTED-bot-test:
 DEFAULT  IDENTITY  NAME
```

@gefjon There is probably a deeper issue here that needs investigating but this fixes the surface level problem which is all I care about from the UX side.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

Not breaking

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] `spacetime identity new -s <server>` works regardless of what existing identities you have.
