### PR TITLE
[WASM ABI 1.0] Fix `bytes_source_read`

### DIFF
--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -848,7 +848,7 @@ impl WasmInstanceEnv {
                 env.call_reducer_args = None;
                 Ok(-1i32)
             } else {
-                *cursor = can_read_len;
+                *cursor += can_read_len;
                 Ok(0)
             }
         })


### PR DESCRIPTION
When decoding reducer args, `bytes_source_read` would incorrectly set
instead of advance the read cursor, causing decoding of large args to
fail.

# Expected complexity level and risk

1

# Testing

This would cause non-public tests to fail, which use large reducer args.
We may want to create a large-args test case here as well.
