### PR TITLE
Fix flaky smoketest due to race condition in subscribe

### DIFF
--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -237,11 +237,14 @@ class Smoketest(unittest.TestCase):
             sys.stderr.writelines(proc.stderr)
         threading.Thread(target=stderr_task).start()
 
-        init_update = proc.stdout.readline()
-        code = proc.poll()
-        if code:
-            raise subprocess.CalledProcessError(code, fake_args)
-        print("initial update:", init_update)
+        init_update = proc.stdout.readline().strip()
+        if init_update:
+            print("initial update:", init_update)
+        else:
+            code = proc.poll()
+            if code:
+                raise subprocess.CalledProcessError(code, fake_args)
+            print("no inital update, but no error code either")
 
         def run():
             updates = list(map(json.loads, proc.stdout))

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -241,10 +241,13 @@ class Smoketest(unittest.TestCase):
         if init_update:
             print("initial update:", init_update)
         else:
-            code = proc.poll()
-            if code:
-                raise subprocess.CalledProcessError(code, fake_args)
-            print("no inital update, but no error code either")
+            try:
+                code = proc.wait()
+                if code:
+                    raise subprocess.CalledProcessError(code, fake_args)
+                print("no inital update, but no error code either")
+            except subprocess.TimeoutExpired:
+                print("no initial update, but process is still running")
 
         def run():
             updates = list(map(json.loads, proc.stdout))

--- a/smoketests/tests/add_remove_index.py
+++ b/smoketests/tests/add_remove_index.py
@@ -72,7 +72,7 @@ pub fn add() {
         # There are no indices, resulting in an unsupported unindexed join.
         self.publish_module(name, clear = False)
         with self.assertRaises(Exception):
-            self.subscribe(self.JOIN_QUERY, n = 0)()
+            self.subscribe(self.JOIN_QUERY, n = 0)
 
         self.between_publishes()
 
@@ -91,4 +91,4 @@ pub fn add() {
         self.write_module_code(self.MODULE_CODE)
         self.publish_module(name, clear = False)
         with self.assertRaises(Exception):
-            self.subscribe(self.JOIN_QUERY, n = 0)()
+            self.subscribe(self.JOIN_QUERY, n = 0)

--- a/smoketests/tests/permissions.py
+++ b/smoketests/tests/permissions.py
@@ -118,7 +118,7 @@ pub fn do_thing() {
             self.spacetime("sql", self.address, "select * from Secret")
 
         with self.assertRaises(Exception):
-            self.subscribe("SELECT * FROM Secret", n=0)()
+            self.subscribe("SELECT * FROM Secret", n=0)
 
         sub = self.subscribe("SELECT * FROM *", n=1)
         self.call("do_thing", anon=True)


### PR DESCRIPTION
This should fix it - now it'll only error if the initial update was never printed, i.e. the subscription never started. I'm about 90% sure that this should fix any race condition issues, but if there's any flakiness we can just go back to the fix from before.