### PR TITLE
WIP: updating Schema and system tables

### DIFF
--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -173,7 +173,7 @@ macro_rules! st_fields_enum {
 // WARNING: For a stable schema, don't change the field names and discriminants.
 st_fields_enum!(enum StTableFields {
     "table_id", TableId = 0,
-    "table_name", TableName = 1,
+    "name", TableName = 1,
     "table_type", TableType = 2,
     "table_access", TablesAccess = 3,
 });
@@ -181,18 +181,16 @@ st_fields_enum!(enum StTableFields {
 st_fields_enum!(enum StColumnFields {
     "table_id", TableId = 0,
     "col_pos", ColPos = 1,
-    "col_name", ColName = 2,
-    "col_type", ColType = 3,
+    "name", ColName = 2,
+    "type", ColType = 3,
 });
 // WARNING: For a stable schema, don't change the field names and discriminants.
-st_fields_enum!(enum StIndexFields {
-    "index_id", IndexId = 0,
-    "table_id", TableId = 1,
-    "index_name", IndexName = 2,
-    "columns", Columns = 3,
-    "is_unique", IsUnique = 4,
-    "index_type", IndexType = 5,
-});
+st_fields_enum!(
+    enum StIndexFields {
+        // TODO(jgilles): how do we add a system table that stores only an enum?
+        // What if we need to add new variants to the enum?
+    }
+);
 // WARNING: For a stable schema, don't change the field names and discriminants.
 st_fields_enum!(
     /// The fields that define the internal table [crate::db::relational_db::ST_SEQUENCES_NAME].
@@ -208,13 +206,12 @@ st_fields_enum!(
     "allocated", Allocated = 8,
 });
 // WARNING: For a stable schema, don't change the field names and discriminants.
-st_fields_enum!(enum StConstraintFields {
-    "constraint_id", ConstraintId = 0,
-    "constraint_name", ConstraintName = 1,
-    "constraints", Constraints = 2,
-    "table_id", TableId = 3,
-    "columns", Columns = 4,
-});
+st_fields_enum!(
+    enum StConstraintFields {
+        // TODO(jgilles): how do we add a system table that stores only an enum?
+        // What if we need to add new variants to the enum?
+    }
+);
 // WARNING: For a stable schema, don't change the field names and discriminants.
 st_fields_enum!(enum StModuleFields {
     "database_address", DatabaseAddress = 0,
@@ -233,10 +230,10 @@ st_fields_enum!(enum StVarFields {
     "name", Name = 0,
     "value", Value = 1,
 });
-
 st_fields_enum!(enum StScheduledFields {
     "table_id", TableId = 0,
     "reducer_name", ReducerName = 1,
+    "name", Name = 2,
 });
 
 /// System Table [ST_TABLE_NAME]

--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -187,8 +187,14 @@ st_fields_enum!(enum StColumnFields {
 // WARNING: For a stable schema, don't change the field names and discriminants.
 st_fields_enum!(
     enum StIndexFields {
-        // TODO(jgilles): how do we add a system table that stores only an enum?
-        // What if we need to add new variants to the enum?
+        "index_id", IndexId = 0,
+        "table_id", TableId = 1,
+        "index_name", IndexName = 2,
+
+        // TODO(jgilles): can a system table store an enum?
+        // What if we need to add new variants to the enum? Will that break
+        // the schema? Does this need to store a byte array instead?
+        "index_algorithm", IndexAlgorithm = 3,
     }
 );
 // WARNING: For a stable schema, don't change the field names and discriminants.
@@ -208,8 +214,12 @@ st_fields_enum!(
 // WARNING: For a stable schema, don't change the field names and discriminants.
 st_fields_enum!(
     enum StConstraintFields {
-        // TODO(jgilles): how do we add a system table that stores only an enum?
-        // What if we need to add new variants to the enum?
+        "constraint_id", ConstraintId = 0,
+        "name", ConstraintName = 1,
+        // TODO(jgilles): can a system table store an enum?
+        // What if we need to add new variants to the enum? Will that break
+        // the schema? Does this need to store a byte array instead?
+        "data", ConstraintData = 3,
     }
 );
 // WARNING: For a stable schema, don't change the field names and discriminants.

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -117,8 +117,8 @@ pub struct RawTableDefV9 {
     /// The indices of the table.
     pub indexes: Vec<RawIndexDefV9>,
 
-    /// Any unique constraints on the table.
-    pub unique_constraints: Vec<RawUniqueConstraintDefV9>,
+    /// Any constraints on the table.
+    pub constraints: Vec<RawConstraintDefV9>,
 
     /// The sequences for the table.
     pub sequences: Vec<RawSequenceDefV9>,
@@ -272,6 +272,13 @@ pub struct RawUniqueConstraintDefV9 {
     pub columns: ColList,
 }
 
+#[derive(Debug, Clone, ser::Serialize, de::Deserialize)]
+#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+#[non_exhaustive]
+pub enum RawConstraintDefV9 {
+    Unique(RawUniqueConstraintDefV9),
+}
+
 /// Marks a table as a timer table for a scheduled reducer.
 ///
 /// The table must have columns:
@@ -397,7 +404,7 @@ impl RawModuleDefV9Builder {
                 name,
                 product_type_ref,
                 indexes: vec![],
-                unique_constraints: vec![],
+                constraints: vec![],
                 sequences: vec![],
                 schedule: None,
                 primary_key: None,
@@ -570,8 +577,8 @@ impl<'a> RawTableDefBuilder<'a> {
     pub fn with_unique_constraint(mut self, columns: ColList, name: Option<RawIdentifier>) -> Self {
         let name = name.unwrap_or_else(|| self.generate_unique_constraint_name(&columns));
         self.table
-            .unique_constraints
-            .push(RawUniqueConstraintDefV9 { name, columns });
+            .constraints
+            .push(RawConstraintDefV9::Unique(RawUniqueConstraintDefV9 { name, columns }));
         self
     }
 

--- a/crates/schema/src/def.rs
+++ b/crates/schema/src/def.rs
@@ -518,9 +518,17 @@ pub struct ColumnDef {
     pub table_name: Identifier,
 }
 
-/// A constraint on a table.
+/// A constraint definition.
+pub struct ConstraintDef {
+    /// The name of the constraint.
+    pub name: Identifier,
+    /// The data for the constraint.
+    pub data: ConstraintData,
+}
+
+/// Data for a constraint.
 #[non_exhaustive]
-pub enum ConstraintDef {
+pub enum ConstraintData {
     Unique(UniqueConstraintDef),
 }
 
@@ -530,9 +538,6 @@ pub enum ConstraintDef {
 #[derive(Debug, Clone, Eq, PartialEq)]
 #[non_exhaustive]
 pub struct UniqueConstraintDef {
-    /// The name of the unique constraint. Must be unique within the containing `RawDatabaseDef`.
-    pub name: Identifier,
-
     /// The columns on the containing `TableDef`
     pub columns: ColList,
 }

--- a/crates/schema/src/def.rs
+++ b/crates/schema/src/def.rs
@@ -329,8 +329,8 @@ pub struct TableDef {
     /// The indices on the table, indexed by name.
     pub indexes: IdentifierMap<IndexDef>,
 
-    /// The unique constraints on the table, indexed by name.
-    pub unique_constraints: IdentifierMap<UniqueConstraintDef>,
+    /// The constraints on the table, indexed by name.
+    pub constraints: IdentifierMap<ConstraintDef>,
 
     /// The sequences for the table, indexed by name.
     pub sequences: IdentifierMap<SequenceDef>,
@@ -376,7 +376,7 @@ impl From<TableDef> for RawTableDefV9 {
             product_type_ref,
             primary_key,
             indexes: to_raw(indexes, |index: &RawIndexDefV9| &index.name),
-            unique_constraints: to_raw(unique_constraints, |constraint: &RawUniqueConstraintDefV9| {
+            constraints: to_raw(unique_constraints, |constraint: &RawUniqueConstraintDefV9| {
                 &constraint.name
             }),
             sequences: to_raw(sequences, |sequence: &RawSequenceDefV9| &sequence.name),
@@ -516,6 +516,12 @@ pub struct ColumnDef {
 
     /// The table this `ColumnDef` is stored in.
     pub table_name: Identifier,
+}
+
+/// A constraint on a table.
+#[non_exhaustive]
+pub enum ConstraintDef {
+    Unique(UniqueConstraintDef),
 }
 
 /// Requires that the projection of the table onto these columns is an bijection.

--- a/crates/schema/src/def/validate/v8.rs
+++ b/crates/schema/src/def/validate/v8.rs
@@ -124,7 +124,7 @@ fn upgrade_table(
         product_type_ref,
         primary_key,
         indexes,
-        unique_constraints,
+        constraints: unique_constraints,
         sequences,
         schedule,
         table_type,

--- a/crates/schema/src/def/validate/v9.rs
+++ b/crates/schema/src/def/validate/v9.rs
@@ -129,7 +129,7 @@ impl ModuleValidator<'_> {
             product_type_ref,
             primary_key,
             indexes,
-            unique_constraints,
+            constraints: unique_constraints,
             sequences,
             schedule,
             table_type,

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -46,7 +46,7 @@ pub struct TableSchema {
     /// The unique identifier of the table within the database.
     pub table_id: TableId,
     /// The name of the table.
-    pub table_name: Box<str>,
+    pub name: Box<str>,
     /// The columns of the table.
     /// Inaccessible to prevent mutation.
     /// The ordering of the columns is significant. Columns are frequently identified by `ColId`, that is, position in this list.
@@ -714,6 +714,7 @@ pub struct ColumnSchema {
     /// The name of the column. Unique within the table.
     pub col_name: Box<str>,
     /// The type of the column.
+    /// May refer to the `Typespace` of the module.
     pub col_type: AlgebraicType,
 }
 
@@ -893,23 +894,20 @@ impl From<SequenceSchema> for RawSequenceDefV8 {
 
 /// A struct representing the schema of a database index.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct IndexSchema {
-    /// The unique ID of the index within the schema.
+pub enum IndexSchema {
+    BTree(BTreeIndexSchema),
+}
+
+/// A BTree index.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct BTreeIndexSchema {
+    /// The ID of the index.
     pub index_id: IndexId,
-    /// The ID of the table associated with the index.
+    /// The ID of the table to which the index is attached.
     pub table_id: TableId,
-    /// The type of the index.
-    pub index_type: IndexType,
-    /// The name of the index. This should not be assumed to follow any particular format.
-    /// Unique within the table.
-    // TODO(jgilles): check and/or specify if this is currently unique within the database.
-    pub index_name: Box<str>,
-    /// If the index is unique.
-    pub is_unique: bool,
-    /// The list of columns associated with the index.
-    /// This is truly a list: the order of the columns is significant.
-    /// The columns are projected and serialized to bitstrings in this order,
-    /// which affects the order of elements within a BTreeIndex.
+    /// The name of the index.
+    pub name: Box<str>,
+    /// The columns of the index.
     pub columns: ColList,
 }
 
@@ -964,17 +962,15 @@ impl From<IndexSchema> for RawIndexDefV8 {
 /// This struct holds information about a database constraint, including its unique identifier,
 /// name, the table it belongs to, and the columns it is associated with.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub struct ConstraintSchema {
-    /// The unique ID of the constraint within the database.
+pub enum ConstraintSchema {
+    Unique(UniqueConstraintSchema),
+}
+
+/// A unique constraint.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct UniqueConstraintSchema {
+    pub name: Identifier,
     pub constraint_id: ConstraintId,
-    /// The name of the constraint.
-    /// Deprecated, in the future constraints will be identified by the columns they refer to and their constraint type.
-    pub constraint_name: Box<str>,
-    /// The constraints applied to the columns
-    pub constraints: Constraints,
-    /// The ID of the table the constraint applies to.
-    pub table_id: TableId,
-    /// The columns the constraint applies to.
     pub columns: ColList,
 }
 


### PR DESCRIPTION
# Description of Changes

Sketch of updating the system tables + updating ModuleDef to be a little easier to add constraints to, as suggested by Mazdak a while back.

I will probably split off the ModuleDef update into its own PR, since it is fairly contained and can be merged in the next day or two.
That is blocked on merging https://github.com/clockworklabs/SpacetimeDB/pull/1658 and https://github.com/clockworklabs/SpacetimeDB/pull/1661.

This code is full of errors, the draft is just here to allow review of the new Schema definitions.

# API and ABI breaking changes

This breaks the ABI and API, it rearranges system tables.

# Expected complexity level and risk

4, this is going to reverberate across the entire codebase.

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
