### PR TITLE
Add edition to .rustfmt.toml

### DIFF
--- a/.rustfmt.toml
+++ b/.rustfmt.toml
@@ -1,1 +1,2 @@
 max_width = 120
+edition = "2021"


### PR DESCRIPTION
# Description of Changes

When invoked standalone (i.e. not through `cargo fmt`), `rustfmt` does not respect the edition (or any other configuration) in `Cargo.toml`, instead relying solely on `rustfmt.toml` or `.rustfmt.toml`. My editor automatically invokes `rustfmt` on individual files on save. Unless `rustfmt` sees a specified edition, it assumes 2018, and rejects any code that uses `async`. This is a huge pain.

Specify `edition = "2021"` in `.rustfmt.toml` so that standalone `rustfmt` works.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

0

# Testing

N/a