### PR TITLE
WASM ABI: implement console ABIs

### DIFF
--- a/crates/bindings-csharp/Runtime/bindings.c
+++ b/crates/bindings-csharp/Runtime/bindings.c
@@ -36,11 +36,11 @@ OPAQUE_TYPEDEF(RowIter, uint32_t);
 #endif
 
 IMPORT(void, _console_log,
-       (LogLevel level, const uint8_t* target, uint32_t target_len,
-        const uint8_t* filename, uint32_t filename_len, uint32_t line_number,
-        const uint8_t* message, uint32_t message_len),
-       (level, target, target_len, filename, filename_len, line_number, message,
-        message_len));
+       (LogLevel level, const uint8_t* target_ptr, uint32_t target_len,
+        const uint8_t* filename_ptr, uint32_t filename_len, uint32_t line_number,
+        const uint8_t* message_ptr, uint32_t message_len),
+       (level, target_ptr, target_len, filename_ptr, filename_len, line_number,
+        message_ptr, message_len));
 
 IMPORT(Status, _table_id_from_name,
        (const uint8_t* name, uint32_t name_len, TableId* id),

--- a/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
+++ b/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
@@ -3,7 +3,6 @@
   <ItemGroup Condition="'$(EXPERIMENTAL_WASM_AOT)' == '1'">
     <NativeLibrary Include="$(MSBuildThisFileDirectory)..\bindings.c" />
     <UnmanagedEntryPointsAssembly Include="SpacetimeDB.Runtime" />
-    <WasmImport Include="$(SpacetimeNamespace)!_console_log" />
     <WasmImport Include="$(SpacetimeNamespace)!_iter_by_col_eq" />
     <WasmImport Include="$(SpacetimeNamespace)!_delete_by_col_eq" />
     <WasmImport Include="$(SpacetimeNamespace)!_iter_start_filtered" />
@@ -16,6 +15,7 @@
     <WasmImport Include="$(SpacetimeNamespace)!_datastore_delete_all_by_eq_bsatn" />
     <WasmImport Include="$(SpacetimeNamespace)!_bytes_source_read" />
     <WasmImport Include="$(SpacetimeNamespace)!_bytes_sink_write" />
+    <WasmImport Include="$(SpacetimeNamespace)!_console_log" />
 
     <PackageReference Include="Microsoft.DotNet.ILCompiler.LLVM" Version="8.0.0-*" />
     <PackageReference Include="runtime.win-x64.Microsoft.DotNet.ILCompiler.LLVM" Version="8.0.0-*" />

--- a/crates/bindings/src/time_span.rs
+++ b/crates/bindings/src/time_span.rs
@@ -5,7 +5,7 @@ pub struct Span {
 impl Span {
     pub fn start(name: &str) -> Self {
         let name = name.as_bytes();
-        let id = unsafe { spacetimedb_bindings_sys::raw::_span_start(name.as_ptr(), name.len()) };
+        let id = unsafe { spacetimedb_bindings_sys::raw::_console_timer_start(name.as_ptr(), name.len()) };
         Self { span_id: id }
     }
 
@@ -17,7 +17,7 @@ impl Span {
 impl std::ops::Drop for Span {
     fn drop(&mut self) {
         unsafe {
-            spacetimedb_bindings_sys::raw::_span_end(self.span_id);
+            spacetimedb_bindings_sys::raw::_console_timer_end(self.span_id);
         }
     }
 }

--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -415,15 +415,15 @@ pub fn extract_descriptions(wasm_file: &Path) -> anyhow::Result<RawModuleDefV8> 
         "_console_log",
         |mut caller: Caller<'_, WasmCtx>,
          _level: u32,
-         _target: u32,
+         _target_ptr: u32,
          _target_len: u32,
-         _filename: u32,
+         _filename_ptr: u32,
          _filename_len: u32,
          _line_number: u32,
-         message: u32,
+         message_ptr: u32,
          message_len: u32| {
             let (mem, _) = WasmCtx::mem_env(&mut caller);
-            let slice = mem.deref_slice(message, message_len).unwrap();
+            let slice = mem.deref_slice(message_ptr, message_len).unwrap();
             println!("from wasm: {}", String::from_utf8_lossy(slice));
         },
     )?;

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -143,18 +143,20 @@ fn from_json_seed<'de, T: serde::de::DeserializeSeed<'de>>(s: &'de str, seed: T)
 pub enum AbiCall {
     TableIdFromName,
     DatastoreTableRowCount,
+    DatastoreTableScanBsatn,
     RowIterBsatnAdvance,
     RowIterBsatnClose,
+    DatastoreInsertBsatn,
+    DatastoreDeleteAllByEqBsatn,
     BytesSourceRead,
     BytesSinkWrite,
-
-    CancelReducer,
     ConsoleLog,
+    ConsoleTimerStart,
+    ConsoleTimerEnd,
+
     DeleteByColEq,
-    DeleteByRel,
-    DatastoreInsertBsatn,
     IterByColEq,
-    IterStart,
     IterStartFiltered,
-    ScheduleReducer,
+
+    VolatileNonatomicScheduleImmediate,
 }

--- a/crates/core/src/host/wasm_common.rs
+++ b/crates/core/src/host/wasm_common.rs
@@ -302,11 +302,11 @@ pub(super) type RowIters = ResourceSlab<RowIterIdx>;
 
 pub(super) struct TimingSpan {
     pub start: Instant,
-    pub name: Vec<u8>,
+    pub name: String,
 }
 
 impl TimingSpan {
-    pub fn new(name: Vec<u8>) -> Self {
+    pub fn new(name: String) -> Self {
         Self {
             start: Instant::now(),
             name,
@@ -357,10 +357,9 @@ macro_rules! abi_funcs {
             "spacetime_10.0"::datastore_delete_all_by_eq_bsatn,
             "spacetime_10.0"::bytes_source_read,
             "spacetime_10.0"::bytes_sink_write,
-
             "spacetime_10.0"::console_log,
-            "spacetime_10.0"::span_end,
-            "spacetime_10.0"::span_start,
+            "spacetime_10.0"::console_timer_start,
+            "spacetime_10.0"::console_timer_end,
 
             "spacetime_10.0"::delete_by_col_eq,
             "spacetime_10.0"::iter_by_col_eq,

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -291,63 +291,6 @@ impl WasmInstanceEnv {
         Ok(col_id.into())
     }
 
-    /// Log at `level` a `message` message occuring in `filename:line_number`
-    /// with [`target`] being the module path at the `log!` invocation site.
-    ///
-    /// These various pointers are interpreted lossily as UTF-8 strings with a corresponding `_len`.
-    ///
-    /// The `target` and `filename` pointers are ignored by passing `NULL`.
-    /// The line number is ignored if `line_number == u32::MAX`.
-    ///
-    /// No message is logged if
-    /// - `target != NULL && target + target_len > u64::MAX`
-    /// - `filename != NULL && filename + filename_len > u64::MAX`
-    /// - `message + message_len > u64::MAX`
-    ///
-    /// [`target`]: https://docs.rs/log/latest/log/struct.Record.html#method.target
-    #[tracing::instrument(skip_all)]
-    pub fn console_log(
-        caller: Caller<'_, Self>,
-        level: u32,
-        target: WasmPtr<u8>,
-        target_len: u32,
-        filename: WasmPtr<u8>,
-        filename_len: u32,
-        line_number: u32,
-        message: WasmPtr<u8>,
-        message_len: u32,
-    ) {
-        let do_console_log = |caller: &mut Caller<'_, Self>| -> WasmResult<()> {
-            let env = caller.data();
-            let mem = env.get_mem().view(&caller);
-
-            // Read the `target`, `filename`, and `message` strings from WASM memory.
-            let target = mem.deref_str_lossy(target, target_len).check_nullptr()?;
-            let filename = mem.deref_str_lossy(filename, filename_len).check_nullptr()?;
-            let message = mem.deref_str_lossy(message, message_len)?;
-
-            // The line number cannot be `u32::MAX` as this represents `Option::None`.
-            let line_number = (line_number != u32::MAX).then_some(line_number);
-
-            let record = Record {
-                // TODO: figure out whether to use walltime now or logical reducer now (env.reducer_start)
-                ts: chrono::Utc::now(),
-                target: target.as_deref(),
-                filename: filename.as_deref(),
-                line_number,
-                message: &message,
-            };
-
-            // Write the log record to the `DatabaseLogger` in the database instance context (dbic).
-            env.instance_env
-                .console_log((level as u8).into(), &record, &caller.as_context());
-            Ok(())
-        };
-        Self::cvt_noret(caller, AbiCall::ConsoleLog, |caller| {
-            let _ = do_console_log(caller);
-        })
-    }
-
     /// Deletes all rows in the table identified by `table_id`
     /// where the column identified by `cols` matches the byte string,
     /// in WASM memory, pointed to at by `value`.
@@ -463,7 +406,7 @@ impl WasmInstanceEnv {
         table_id: u32,
         out: WasmPtr<RowIterIdx>,
     ) -> RtResult<u32> {
-        Self::cvt_ret(caller, AbiCall::IterStart, out, |caller| {
+        Self::cvt_ret(caller, AbiCall::DatastoreTableScanBsatn, out, |caller| {
             let env = caller.data_mut();
             // Retrieve the execution context for the current reducer.
             let ctx = env.reducer_context()?;
@@ -779,7 +722,7 @@ impl WasmInstanceEnv {
         rel_len: u32,
         out: WasmPtr<u32>,
     ) -> RtResult<u32> {
-        Self::cvt_ret(caller, AbiCall::DeleteByRel, out, |caller| {
+        Self::cvt_ret(caller, AbiCall::DatastoreDeleteAllByEqBsatn, out, |caller| {
             let (mem, env) = Self::mem_env(caller);
             let relation = mem.deref_slice(rel_ptr, rel_len)?;
             Ok(env
@@ -789,21 +732,23 @@ impl WasmInstanceEnv {
     }
 
     pub fn volatile_nonatomic_schedule_immediate(
-        mut caller: Caller<'_, Self>,
+        caller: Caller<'_, Self>,
         name: WasmPtr<u8>,
         name_len: u32,
         args: WasmPtr<u8>,
         args_len: u32,
     ) -> RtResult<()> {
-        let (mem, env) = Self::mem_env(&mut caller);
-        let name = mem.deref_str(name, name_len)?;
-        let args = mem.deref_slice(args, args_len)?;
-        env.instance_env.scheduler.volatile_nonatomic_schedule_immediate(
-            name.to_owned(),
-            crate::host::ReducerArgs::Bsatn(args.to_vec().into()),
-        );
+        Self::with_span(caller, AbiCall::VolatileNonatomicScheduleImmediate, |caller| {
+            let (mem, env) = Self::mem_env(caller);
+            let name = mem.deref_str(name, name_len)?;
+            let args = mem.deref_slice(args, args_len)?;
+            env.instance_env.scheduler.volatile_nonatomic_schedule_immediate(
+                name.to_owned(),
+                crate::host::ReducerArgs::Bsatn(args.to_vec().into()),
+            );
 
-        Ok(())
+            Ok(())
+        })
     }
 
     /// Reads bytes from `source`, registered in the host environment,
@@ -956,36 +901,112 @@ impl WasmInstanceEnv {
         })
     }
 
-    pub fn span_start(mut caller: Caller<'_, Self>, name: WasmPtr<u8>, name_len: u32) -> RtResult<u32> {
-        let (mem, env) = Self::mem_env(&mut caller);
-        let name = mem.deref_slice(name, name_len)?.to_vec();
-        Ok(env.timing_spans.insert(TimingSpan::new(name)).0)
+    /// Logs at `level` a `message` message occuring in `filename:line_number`
+    /// with [`target`](target) being the module path at the `log!` invocation site.
+    ///
+    /// These various pointers are interpreted lossily as UTF-8 strings with a corresponding `_len`.
+    ///
+    /// The `target` and `filename` pointers are ignored by passing `NULL`.
+    /// The line number is ignored if `line_number == u32::MAX`.
+    ///
+    /// No message is logged if
+    /// - `target != NULL && target + target_len > u64::MAX`
+    /// - `filename != NULL && filename + filename_len > u64::MAX`
+    /// - `message + message_len > u64::MAX`
+    ///
+    /// # Traps
+    ///
+    /// Traps if:
+    /// - `target` is not NULL and `target_ptr[..target_len]` is not in bounds of WASM memory.
+    /// - `filename` is not NULL and `filename_ptr[..filename_len]` is not in bounds of WASM memory.
+    /// - `message` is not NULL and `message_ptr[..message_len]` is not in bounds of WASM memory.
+    ///
+    /// [target]: https://docs.rs/log/latest/log/struct.Record.html#method.target
+    #[tracing::instrument(skip_all)]
+    pub fn console_log(
+        caller: Caller<'_, Self>,
+        level: u32,
+        target_ptr: WasmPtr<u8>,
+        target_len: u32,
+        filename_ptr: WasmPtr<u8>,
+        filename_len: u32,
+        line_number: u32,
+        message_ptr: WasmPtr<u8>,
+        message_len: u32,
+    ) {
+        let do_console_log = |caller: &mut Caller<'_, Self>| -> WasmResult<()> {
+            let env = caller.data();
+            let mem = env.get_mem().view(&caller);
+
+            // Read the `target`, `filename`, and `message` strings from WASM memory.
+            let target = mem.deref_str_lossy(target_ptr, target_len).check_nullptr()?;
+            let filename = mem.deref_str_lossy(filename_ptr, filename_len).check_nullptr()?;
+            let message = mem.deref_str_lossy(message_ptr, message_len)?;
+
+            // The line number cannot be `u32::MAX` as this represents `Option::None`.
+            let line_number = (line_number != u32::MAX).then_some(line_number);
+
+            let record = Record {
+                // TODO: figure out whether to use walltime now or logical reducer now (env.reducer_start)
+                ts: chrono::Utc::now(),
+                target: target.as_deref(),
+                filename: filename.as_deref(),
+                line_number,
+                message: &message,
+            };
+
+            // Write the log record to the `DatabaseLogger` in the database instance context (dbic).
+            env.instance_env
+                .console_log((level as u8).into(), &record, &caller.as_context());
+            Ok(())
+        };
+        Self::cvt_noret(caller, AbiCall::ConsoleLog, |caller| {
+            let _ = do_console_log(caller);
+        })
     }
 
-    pub fn span_end(mut caller: Caller<'_, Self>, span_id: u32) -> RtResult<()> {
-        let span = caller
-            .data_mut()
-            .timing_spans
-            .take(TimingSpanIdx(span_id))
-            .context("no such timing span")?;
+    /// Begins a timing span with `name = name_ptr[..name_len]`.
+    ///
+    /// When the returned `ConsoleTimerId` is passed to [`console_timer_end`],
+    /// the duration between the calls will be printed to the module's logs.
+    ///
+    /// The `name` is interpreted lossily as a UTF-8 string.
+    ///
+    /// # Traps
+    ///
+    /// Traps if:
+    /// - `name_ptr` is NULL or `name` is not in bounds of WASM memory.
+    pub fn console_timer_start(caller: Caller<'_, Self>, name_ptr: WasmPtr<u8>, name_len: u32) -> RtResult<u32> {
+        Self::with_span(caller, AbiCall::ConsoleTimerStart, |caller| {
+            let (mem, env) = Self::mem_env(caller);
+            let name = mem.deref_str_lossy(name_ptr, name_len)?.into_owned();
+            Ok(env.timing_spans.insert(TimingSpan::new(name)).0)
+        })
+    }
 
-        let elapsed = span.start.elapsed();
+    pub fn console_timer_end(caller: Caller<'_, Self>, span_id: u32) -> RtResult<u32> {
+        Self::cvt_custom(caller, AbiCall::ConsoleTimerEnd, |caller| {
+            let Some(span) = caller.data_mut().timing_spans.take(TimingSpanIdx(span_id)) else {
+                return Ok(errno::NO_SUCH_CONSOLE_TIMER.get().into());
+            };
 
-        let name = String::from_utf8_lossy(&span.name);
-        let message = format!("Timing span {:?}: {:?}", name, elapsed);
+            let elapsed = span.start.elapsed();
+            let message = format!("Timing span {:?}: {:?}", &span.name, elapsed);
 
-        let record = Record {
-            ts: chrono::Utc::now(),
-            target: None,
-            filename: None,
-            line_number: None,
-            message: &message,
-        };
-        caller
-            .data()
-            .instance_env
-            .console_log(crate::database_logger::LogLevel::Info, &record, &caller.as_context());
-        Ok(())
+            let record = Record {
+                ts: chrono::Utc::now(),
+                target: None,
+                filename: None,
+                line_number: None,
+                message: &message,
+            };
+            caller.data().instance_env.console_log(
+                crate::database_logger::LogLevel::Info,
+                &record,
+                &caller.as_context(),
+            );
+            Ok(0)
+        })
     }
 }
 

--- a/crates/primitives/src/errno.rs
+++ b/crates/primitives/src/errno.rs
@@ -13,6 +13,7 @@ macro_rules! errnos {
             BSATN_DECODE_ERROR(3, "Couldn't decode the BSATN to the expected type"),
             NO_SUCH_TABLE(4, "No such table"),
             NO_SUCH_ITER(6, "The provided row iterator is not valid"),
+            NO_SUCH_CONSOLE_TIMER(7, "The started console timer does not exist"),
             NO_SUCH_BYTES(8, "The provided bytes source or sink is not valid"),
             NO_SPACE(9, "The provided sink has no more space left"),
             BUFFER_TOO_SMALL(11, "The provided buffer is not large enough to store the data"),


### PR DESCRIPTION
# Description of Changes

Adjusts the docs of `console_log` and `span_{start, end}` are now `console_timer_{start, end}` with some semantics adjusted according to the proposal. For the latter two, C# support did not exist, so this is not added in this PR.

cc https://github.com/clockworklabs/SpacetimeDB/issues/1460
