### PR TITLE
Switched table names to singular

### DIFF
--- a/modules/benchmarks/src/circles.rs
+++ b/modules/benchmarks/src/circles.rs
@@ -11,7 +11,7 @@ pub struct Vector2 {
 
 // ---------- schemas ----------
 
-#[spacetimedb::table(name = entities)]
+#[spacetimedb::table(name = entity)]
 pub struct Entity {
     #[auto_inc]
     #[primary_key]
@@ -30,7 +30,7 @@ impl Entity {
     }
 }
 
-#[spacetimedb::table(name = circles)]
+#[spacetimedb::table(name = circle)]
 pub struct Circle {
     #[primary_key]
     pub entity_id: u32,

--- a/modules/perf-test/src/lib.rs
+++ b/modules/perf-test/src/lib.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{query, time_span::Span};
 
-#[spacetimedb::table(name = locations, index(name = coordinates, btree(columns = [x, z, dimension])))]
+#[spacetimedb::table(name = location, index(name = coordinates, btree(columns = [x, z, dimension])))]
 #[derive(Debug, PartialEq, Eq)]
 pub struct Location {
     #[primary_key]

--- a/modules/quickstart-chat/src/lib.rs
+++ b/modules/quickstart-chat/src/lib.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{Identity, ReducerContext, Timestamp};
 
-#[spacetimedb::table(name = users, public)]
+#[spacetimedb::table(name = user, public)]
 pub struct User {
     #[primary_key]
     identity: Identity,
@@ -8,7 +8,7 @@ pub struct User {
     online: bool,
 }
 
-#[spacetimedb::table(name = messages, public)]
+#[spacetimedb::table(name = message, public)]
 pub struct Message {
     sender: Identity,
     sent: Timestamp,

--- a/modules/rust-wasm-test/src/lib.rs
+++ b/modules/rust-wasm-test/src/lib.rs
@@ -81,7 +81,7 @@ pub type TestAlias = TestA;
 // #[spacetimedb::migrate]
 // pub fn migrate() {}
 
-#[spacetimedb::table(name = repeating_test_args, scheduled(repeating_test))]
+#[spacetimedb::table(name = repeating_test_arg, scheduled(repeating_test))]
 pub struct RepeatingTestArg {
     prev_time: Timestamp,
 }

--- a/modules/spacetimedb-quickstart/src/lib.rs
+++ b/modules/spacetimedb-quickstart/src/lib.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{println, query};
 
-#[spacetimedb::table(name = people, public)]
+#[spacetimedb::table(name = person, public)]
 pub struct Person {
     #[primary_key]
     #[auto_inc]

--- a/smoketests/tests/add_table_pseudomigration.py
+++ b/smoketests/tests/add_table_pseudomigration.py
@@ -7,7 +7,7 @@ class AddTablePseudomigration(Smoketest):
     MODULE_CODE = """
 use spacetimedb::println;
 
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     name: String,
 }
@@ -28,7 +28,7 @@ pub fn print_persons(prefix: String) {
     MODULE_CODE_UPDATED = (
         MODULE_CODE
         + """
-#[spacetimedb::table(name = books)]
+#[spacetimedb::table(name = book)]
 pub struct Book {
     isbn: String,
 }
@@ -89,7 +89,7 @@ class RejectTableChanges(Smoketest):
     MODULE_CODE = """
 use spacetimedb::println;
 
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     name: String,
 }
@@ -110,7 +110,7 @@ pub fn print_persons(prefix: String) {
     MODULE_CODE_UPDATED = """
 use spacetimedb::println;
 
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     name: String,
     age: u128,

--- a/smoketests/tests/auto_inc.py
+++ b/smoketests/tests/auto_inc.py
@@ -14,7 +14,7 @@ class IntTests:
 
 
 autoinc1_template = string.Template("""
-#[spacetimedb::table(name = people_$KEY_TY)]
+#[spacetimedb::table(name = person_$KEY_TY)]
 pub struct Person_$KEY_TY {
     #[auto_inc]
     key_col: $KEY_TY,
@@ -61,7 +61,7 @@ use spacetimedb::println;
 
 
 autoinc2_template = string.Template("""
-#[spacetimedb::table(name = people_$KEY_TY)]
+#[spacetimedb::table(name = person_$KEY_TY)]
 pub struct Person_$KEY_TY {
     #[auto_inc]
     #[unique]

--- a/smoketests/tests/describe.py
+++ b/smoketests/tests/describe.py
@@ -4,7 +4,7 @@ class ModuleDescription(Smoketest):
     MODULE_CODE = """
 use spacetimedb::println;
 
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     name: String,
 }
@@ -28,4 +28,4 @@ pub fn say_hello() {
 
         self.spacetime("describe", self.address)
         self.spacetime("describe", self.address, "reducer", "say_hello")
-        self.spacetime("describe", self.address, "table", "people")
+        self.spacetime("describe", self.address, "table", "person")

--- a/smoketests/tests/filtering.py
+++ b/smoketests/tests/filtering.py
@@ -4,7 +4,7 @@ class Filtering(Smoketest):
     MODULE_CODE = """
 use spacetimedb::{println, Identity};
 
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     #[unique]
     id: i32,
@@ -58,7 +58,7 @@ pub fn find_person_by_nick(nick: String) {
     }
 }
 
-#[spacetimedb::table(name = nonunique_people)]
+#[spacetimedb::table(name = nonunique_person)]
 pub struct NonuniquePerson {
     #[index(btree)]
     id: i32,
@@ -93,7 +93,7 @@ pub fn find_nonunique_non_humans() {
 }
 
 // Ensure that [Identity] is filterable and a legal unique column.
-#[spacetimedb::table(name = identified_people)]
+#[spacetimedb::table(name = identified_person)]
 struct IdentifiedPerson {
     #[unique]
     identity: Identity,

--- a/smoketests/tests/module_nested_op.py
+++ b/smoketests/tests/module_nested_op.py
@@ -4,7 +4,7 @@ class ModuleNestedOp(Smoketest):
     MODULE_CODE = """
 use spacetimedb::println;
 
-#[spacetimedb::table(name = accounts)]
+#[spacetimedb::table(name = account)]
 pub struct Account {
     name: String,
     #[unique]

--- a/smoketests/tests/modules.py
+++ b/smoketests/tests/modules.py
@@ -9,7 +9,7 @@ class UpdateModule(Smoketest):
     MODULE_CODE = """
 use spacetimedb::println;
 
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     #[primary_key]
     #[auto_inc]
@@ -31,7 +31,7 @@ pub fn say_hello() {
 }
 """
     MODULE_CODE_B = """
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     #[primary_key]
     #[auto_inc]
@@ -44,7 +44,7 @@ pub struct Person {
     MODULE_CODE_C = """
 use spacetimedb::println;
 
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     #[primary_key]
     #[auto_inc]
@@ -104,7 +104,7 @@ class UploadModule1(Smoketest):
     MODULE_CODE = """
 use spacetimedb::println;
 
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     name: String,
 }
@@ -171,7 +171,7 @@ class HotswapModule(Smoketest):
     AUTOPUBLISH = False
 
     MODULE_CODE = """
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     #[primary_key]
     #[auto_inc]
@@ -188,7 +188,7 @@ pub fn add_person(name: String) {
     MODULE_CODE_B = """
 use spacetimedb;
 
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     #[primary_key]
     #[auto_inc]
@@ -236,6 +236,6 @@ pub fn add_pet(species: String) {
         # Note that 'SELECT * FROM *' does NOT get refreshed to include the
         # new table (this is a known limitation).
         self.assertEqual(sub(), [
-            {'people': {'deletes': [], 'inserts': [{'id': 1, 'name': 'Horst'}]}},
-            {'people': {'deletes': [], 'inserts': [{'id': 2, 'name': 'Cindy'}]}}
+            {'person': {'deletes': [], 'inserts': [{'id': 1, 'name': 'Horst'}]}},
+            {'person': {'deletes': [], 'inserts': [{'id': 2, 'name': 'Cindy'}]}}
         ])

--- a/smoketests/tests/new_user_flow.py
+++ b/smoketests/tests/new_user_flow.py
@@ -6,7 +6,7 @@ class NewUserFlow(Smoketest):
     MODULE_CODE = """
 use spacetimedb::println;
 
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     name: String
 }
@@ -43,7 +43,7 @@ pub fn say_hello() {
         self.assertEqual(self.logs(5).count("Hello, World!"), 2)
         self.assertEqual(self.logs(5).count("Hello, Tyler!"), 1)
 
-        out = self.spacetime("sql", self.address, "SELECT * FROM people")
+        out = self.spacetime("sql", self.address, "SELECT * FROM person")
         # The spaces after the name are important
         self.assertMultiLineEqual(out, """\
  name    

--- a/smoketests/tests/permissions.py
+++ b/smoketests/tests/permissions.py
@@ -77,7 +77,7 @@ class Permissions(Smoketest):
 
 class PrivateTablePermissions(Smoketest):
     MODULE_CODE = """
-#[spacetimedb::table(name = secrets)]
+#[spacetimedb::table(name = secret)]
 pub struct Secret {
     answer: u8,
 }
@@ -102,7 +102,7 @@ pub fn do_thing() {
     def test_private_table(self):
         """Ensure that a private table can only be queried by the database owner"""
 
-        out = self.spacetime("sql", self.address, "select * from secrets")
+        out = self.spacetime("sql", self.address, "select * from secret")
         self.assertMultiLineEqual(out, """\
  answer 
 --------
@@ -113,10 +113,10 @@ pub fn do_thing() {
         self.new_identity(email=None)
 
         with self.assertRaises(Exception):
-            self.spacetime("sql", self.address, "select * from secrets")
+            self.spacetime("sql", self.address, "select * from secret")
 
         with self.assertRaises(Exception):
-            self.subscribe("SELECT * FROM secrets", n=0)
+            self.subscribe("SELECT * FROM secret", n=0)
 
         sub = self.subscribe("SELECT * FROM *", n=1)
         self.call("do_thing", anon=True)

--- a/smoketests/tests/zz_docker.py
+++ b/smoketests/tests/zz_docker.py
@@ -47,7 +47,7 @@ class DockerRestartModule(Smoketest):
     MODULE_CODE = """
 use spacetimedb::println;
 
-#[spacetimedb::table(name = people, index(name = name_idx, btree(columns = [name])))]
+#[spacetimedb::table(name = person, index(name = name_idx, btree(columns = [name])))]
 pub struct Person {
     #[primary_key]
     #[auto_inc]
@@ -93,7 +93,7 @@ class DockerRestartSql(Smoketest):
     MODULE_CODE = """
 use spacetimedb::println;
 
-#[spacetimedb::table(name = people, index(name = name_idx, btree(columns = [name])))]
+#[spacetimedb::table(name = person, index(name = name_idx, btree(columns = [name])))]
 pub struct Person {
     #[primary_key]
     #[auto_inc]
@@ -130,7 +130,7 @@ pub fn say_hello() {
 
         restart_docker()
 
-        sql_out = self.spacetime("sql", self.address, "SELECT name FROM people WHERE id = 3")
+        sql_out = self.spacetime("sql", self.address, "SELECT name FROM person WHERE id = 3")
         self.assertMultiLineEqual(sql_out, """ name       \n------------\n "Samantha" \n""")
 
 @requires_docker
@@ -139,15 +139,15 @@ class DockerRestartAutoDisconnect(Smoketest):
 use log::info;
 use spacetimedb::{Address, Identity, ReducerContext, TableType};
 
-#[spacetimedb::table(name = connected_clients)]
-pub struct ConnectedClients {
+#[spacetimedb::table(name = connected_client)]
+pub struct ConnectedClient {
     identity: Identity,
     address: Address,
-}
+
 
 #[spacetimedb::reducer(client_connected)]
 fn on_connect(ctx: ReducerContext) {
-    ConnectedClients::insert(ConnectedClients {
+    ConnectedClient::insert(ConnectedClient {
         identity: ctx.sender,
         address: ctx.address.expect("sender address unset"),
     });
@@ -157,17 +157,17 @@ fn on_connect(ctx: ReducerContext) {
 fn on_disconnect(ctx: ReducerContext) {
     let sender_identity = &ctx.sender;
     let sender_address = ctx.address.as_ref().expect("sender address unset");
-    let match_client = |row: &ConnectedClients| {
+    let match_client = |row: &ConnectedClient| {
         &row.identity == sender_identity && &row.address == sender_address
     };
-    if let Some(client) = ConnectedClients::iter().find(match_client) {
-        ConnectedClients::delete(&client);
+    if let Some(client) = ConnectedClient::iter().find(match_client) {
+        ConnectedClient::delete(&client);
     }
 }
 
 #[spacetimedb::reducer]
 fn print_num_connected() {
-    let n = ConnectedClients::iter().count();
+    let n = ConnectedClient::iter().count();
     info!("CONNECTED CLIENTS: {n}")
 }
 """
@@ -176,8 +176,8 @@ fn print_num_connected() {
         """Tests if clients are automatically disconnected after a restart"""
 
         # Start two subscribers
-        self.subscribe("SELECT * FROM connected_clients", n=2)
-        self.subscribe("SELECT * FROM connected_clients", n=2)
+        self.subscribe("SELECT * FROM connected_client", n=2)
+        self.subscribe("SELECT * FROM connected_client", n=2)
 
         # Assert that we have two clients + the reducer call
         self.call("print_num_connected")

--- a/test/tests/update-module.sh
+++ b/test/tests/update-module.sh
@@ -12,7 +12,7 @@ source "./test/lib.include"
 cat > "${PROJECT_PATH}/src/lib.rs" << EOF
 use spacetimedb::println;
 
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     #[primary_key]
     #[auto_inc]
@@ -54,7 +54,7 @@ run_test cargo run publish --skip_clippy --project-path "$PROJECT_PATH" "$IDENT"
 
 # Changing an existing table isn't
 cat > "${PROJECT_PATH}/src/lib.rs" <<EOF
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     #[primary_key]
     #[auto_inc]
@@ -73,7 +73,7 @@ run_test cargo run call "$IDENT" say_hello
 cat > "${PROJECT_PATH}/src/lib.rs" <<EOF
 use spacetimedb::println;
 
-#[spacetimedb::table(name = people)]
+#[spacetimedb::table(name = person)]
 pub struct Person {
     #[primary_key]
     #[auto_inc]
@@ -81,7 +81,7 @@ pub struct Person {
     name: String,
 }
 
-#[spacetimedb::table(name = pets)]
+#[spacetimedb::table(name = pet)]
 pub struct Pet {
     species: String,
 }


### PR DESCRIPTION
This pull request focuses on renaming database table names across various modules and tests to ensure consistency and clarity. The primary changes involve renaming the table names from plural to singular forms.