### PR TITLE
commitlog: Make commit module public, and allow access to header fields

### DIFF
--- a/crates/commitlog/src/commit.rs
+++ b/crates/commitlog/src/commit.rs
@@ -9,9 +9,9 @@ use spacetimedb_sats::buffer::{BufReader, Cursor, DecodeError};
 use crate::{error::ChecksumMismatch, payload::Decoder, segment::CHECKSUM_ALGORITHM_CRC32C, Transaction};
 
 pub struct Header {
-    min_tx_offset: u64,
-    n: u16,
-    len: u32,
+    pub min_tx_offset: u64,
+    pub n: u16,
+    pub len: u32,
 }
 
 impl Header {

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -2,7 +2,7 @@ use std::{io, num::NonZeroU16, path::PathBuf, sync::RwLock};
 
 use log::trace;
 
-mod commit;
+pub mod commit;
 pub mod commitlog;
 pub mod repo;
 pub mod segment;


### PR DESCRIPTION
Useful for alternate traversals, in particular in async contexts.

# Expected complexity level and risk

1
