### PR TITLE
Bump bytemuck

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -513,9 +513,9 @@ checksum = "ad152d03a2c813c80bb94fedbf3a3f02b28f793e39e7c214c8a0bcc196343de7"
 
 [[package]]
 name = "bytemuck"
-version = "1.16.0"
+version = "1.18.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "78834c15cb5d5efe3452d58b1e8ba890dd62d21907f867f383358198e56ebca5"
+checksum = "94bbb0ad554ad961ddc5da507a12a29b14e4ae5bda06b19f575a3e6079d2e2ae"
 dependencies = [
  "bytemuck_derive",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -34,7 +34,7 @@ members = [
   "crates/sdk/tests/test-client",
   "crates/sdk/tests/test-counter",
   "crates/sdk/tests/connect_disconnect_client",
-  "tools/upgrade-version", 
+  "tools/upgrade-version",
 ]
 default-members = ["crates/cli"]
 # cargo feature graph resolver. v2 is default in edition2021 but workspace
@@ -118,7 +118,7 @@ bitflags = "2.3.3"
 blake3 = "1.5.1"
 brotli = "3.5"
 byte-unit = "4.0.18"
-bytemuck = { version = "1.16", features = ["must_cast"] }
+bytemuck = { version = "1.16.2", features = ["must_cast"] }
 bytes = "1.2.1"
 bytestring = { version = "1.2.0", features = ["serde"] }
 cargo_metadata = "0.17.0"


### PR DESCRIPTION
Releases 1.14.1-1.16.1 of the `bytemuck` crate have been yanked from
crates.io. To prevent non-obvious build errors (namely in `--locked`
builds), bump the minimal version to 1.16.2.

# Expected complexity level and risk

1
