### PR TITLE
NFC: enforce more C# code style + enable it in Visual Studio

### DIFF
--- a/crates/bindings-csharp/.editorconfig
+++ b/crates/bindings-csharp/.editorconfig
@@ -1,5 +1,112 @@
 root = true
 
 [*.cs]
-csharp_using_directive_placement = inside_namespace
-csharp_style_namespace_declarations = file_scoped
+csharp_using_directive_placement = inside_namespace:warning
+csharp_style_namespace_declarations = file_scoped:warning
+csharp_prefer_simple_using_statement = true:warning
+csharp_prefer_braces = true:silent
+csharp_style_prefer_method_group_conversion = true:silent
+csharp_style_prefer_top_level_statements = true:silent
+csharp_style_prefer_primary_constructors = true:warning
+csharp_style_expression_bodied_methods = when_on_single_line:silent
+csharp_style_expression_bodied_constructors = when_on_single_line:silent
+csharp_style_expression_bodied_operators = when_on_single_line:silent
+csharp_style_expression_bodied_properties = when_on_single_line:silent
+csharp_style_expression_bodied_indexers = when_on_single_line:silent
+csharp_style_expression_bodied_accessors = when_on_single_line:silent
+csharp_style_expression_bodied_lambdas = when_on_single_line:silent
+csharp_style_expression_bodied_local_functions = when_on_single_line:silent
+csharp_indent_labels = one_less_than_current
+csharp_style_inlined_variable_declaration = true:warning
+csharp_style_deconstructed_variable_declaration = true:suggestion
+csharp_style_var_for_built_in_types = true:warning
+csharp_style_var_when_type_is_apparent = true:warning
+csharp_style_var_elsewhere = true:suggestion
+csharp_style_prefer_extended_property_pattern = true:suggestion
+csharp_style_prefer_not_pattern = true:suggestion
+csharp_style_pattern_matching_over_as_with_null_check = true:suggestion
+csharp_style_pattern_matching_over_is_with_cast_check = true:suggestion
+csharp_style_prefer_pattern_matching = true:warning
+csharp_style_prefer_switch_expression = true:warning
+csharp_style_conditional_delegate_call = true:warning
+csharp_style_prefer_readonly_struct_member = true:warning
+csharp_style_prefer_readonly_struct = true:warning
+csharp_prefer_static_anonymous_function = true:suggestion
+csharp_prefer_static_local_function = true:suggestion
+csharp_space_around_binary_operators = before_and_after
+
+[*.{cs,vb}]
+#### Naming styles ####
+
+# Naming rules
+
+dotnet_naming_rule.interface_should_be_begins_with_i.severity = suggestion
+dotnet_naming_rule.interface_should_be_begins_with_i.symbols = interface
+dotnet_naming_rule.interface_should_be_begins_with_i.style = begins_with_i
+
+dotnet_naming_rule.types_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.types_should_be_pascal_case.symbols = types
+dotnet_naming_rule.types_should_be_pascal_case.style = pascal_case
+
+dotnet_naming_rule.non_field_members_should_be_pascal_case.severity = suggestion
+dotnet_naming_rule.non_field_members_should_be_pascal_case.symbols = non_field_members
+dotnet_naming_rule.non_field_members_should_be_pascal_case.style = pascal_case
+
+# Symbol specifications
+
+dotnet_naming_symbols.interface.applicable_kinds = interface
+dotnet_naming_symbols.interface.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.interface.required_modifiers = 
+
+dotnet_naming_symbols.types.applicable_kinds = class, struct, interface, enum
+dotnet_naming_symbols.types.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.types.required_modifiers = 
+
+dotnet_naming_symbols.non_field_members.applicable_kinds = property, event, method
+dotnet_naming_symbols.non_field_members.applicable_accessibilities = public, internal, private, protected, protected_internal, private_protected
+dotnet_naming_symbols.non_field_members.required_modifiers = 
+
+# Naming styles
+
+dotnet_naming_style.begins_with_i.required_prefix = I
+dotnet_naming_style.begins_with_i.required_suffix = 
+dotnet_naming_style.begins_with_i.word_separator = 
+dotnet_naming_style.begins_with_i.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+
+dotnet_naming_style.pascal_case.required_prefix = 
+dotnet_naming_style.pascal_case.required_suffix = 
+dotnet_naming_style.pascal_case.word_separator = 
+dotnet_naming_style.pascal_case.capitalization = pascal_case
+dotnet_style_coalesce_expression = true:suggestion
+dotnet_style_null_propagation = true:suggestion
+dotnet_style_prefer_is_null_check_over_reference_equality_method = true:suggestion
+dotnet_style_prefer_auto_properties = true:silent
+dotnet_style_object_initializer = true:suggestion
+dotnet_style_collection_initializer = true:suggestion
+dotnet_style_prefer_simplified_boolean_expressions = true:suggestion
+dotnet_style_prefer_conditional_expression_over_assignment = true:silent
+dotnet_style_prefer_conditional_expression_over_return = true:silent
+dotnet_style_explicit_tuple_names = true:suggestion
+dotnet_style_operator_placement_when_wrapping = beginning_of_line
+tab_width = 4
+indent_size = 4
+end_of_line = crlf
+dotnet_style_qualification_for_event = false:silent
+dotnet_style_qualification_for_method = false:silent
+dotnet_style_qualification_for_property = false:silent
+dotnet_style_qualification_for_field = false:silent
+dotnet_style_parentheses_in_other_operators = never_if_unnecessary:silent
+dotnet_style_parentheses_in_relational_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_other_binary_operators = always_for_clarity:silent
+dotnet_style_parentheses_in_arithmetic_binary_operators = always_for_clarity:silent
+dotnet_code_quality_unused_parameters = all:suggestion
+dotnet_style_require_accessibility_modifiers = all:silent
+dotnet_style_namespace_match_folder = true:suggestion
+
+# https://csharpier.com/docs/IntegratingWithLinters
+dotnet_diagnostic.IDE0055.severity = none

--- a/crates/bindings-csharp/.editorconfig
+++ b/crates/bindings-csharp/.editorconfig
@@ -95,7 +95,6 @@ dotnet_style_explicit_tuple_names = true:suggestion
 dotnet_style_operator_placement_when_wrapping = beginning_of_line
 tab_width = 4
 indent_size = 4
-end_of_line = crlf
 dotnet_style_qualification_for_event = false:silent
 dotnet_style_qualification_for_method = false:silent
 dotnet_style_qualification_for_property = false:silent

--- a/crates/bindings-csharp/BSATN.Codegen/Type.cs
+++ b/crates/bindings-csharp/BSATN.Codegen/Type.cs
@@ -257,7 +257,9 @@ public class Type : IIncrementalGenerator
                 {
                     // structs and classes should be always processed
                     if (node is not EnumDeclarationSyntax enumType)
+                    {
                         return true;
+                    }
 
                     // Ensure variants are contiguous as SATS enums don't support explicit tags.
                     if (enumType.Members.Any(m => m.EqualsValue is not null))

--- a/crates/bindings-csharp/BSATN.Runtime/Attrs.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/Attrs.cs
@@ -1,6 +1,6 @@
-﻿using System.Runtime.CompilerServices;
+﻿namespace SpacetimeDB;
 
-namespace SpacetimeDB;
+using System.Runtime.CompilerServices;
 
 [AttributeUsage(
     AttributeTargets.Struct | AttributeTargets.Class | AttributeTargets.Enum,

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
@@ -1,6 +1,6 @@
-using System.Text;
-
 namespace SpacetimeDB.BSATN;
+
+using System.Text;
 
 public interface IStructuralReadWrite
 {

--- a/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
@@ -1,8 +1,8 @@
+namespace SpacetimeDB;
+
 using System.Diagnostics;
 using SpacetimeDB.BSATN;
 using SpacetimeDB.Internal;
-
-namespace SpacetimeDB;
 
 public readonly partial struct Unit
 {

--- a/crates/bindings-csharp/BSATN.Runtime/Internal/ByteArrayComparer.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/Internal/ByteArrayComparer.cs
@@ -1,6 +1,6 @@
-using System.Runtime.CompilerServices;
-
 namespace SpacetimeDB.Internal;
+
+using System.Runtime.CompilerServices;
 
 // Note: this utility struct is used by the C# client SDK so it needs to be public.
 public readonly struct ByteArrayComparer : IEqualityComparer<byte[]>
@@ -25,7 +25,7 @@ public readonly struct ByteArrayComparer : IEqualityComparer<byte[]>
     [MethodImpl(MethodImplOptions.AggressiveInlining)]
     static bool EqualsUnvectorized(byte[] left, byte[] right)
     {
-        for (int i = 0; i < left.Length; i++)
+        for (var i = 0; i < left.Length; i++)
         {
             if (left[i] != right[i])
             {
@@ -38,8 +38,8 @@ public readonly struct ByteArrayComparer : IEqualityComparer<byte[]>
 
     public int GetHashCode(byte[] obj)
     {
-        int hash = 17;
-        foreach (byte b in obj)
+        var hash = 17;
+        foreach (var b in obj)
         {
             hash = hash * 31 + b;
         }

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/client/Lib.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/client/Lib.cs
@@ -12,7 +12,6 @@ public partial struct CustomStruct
     public static readonly string IGNORE_ME_TOO = "";
     public int IntField;
     public string StringField;
-    //public DateTime DateTimeField;
 }
 
 [SpacetimeDB.Type]

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/client/Lib.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/client/Lib.cs
@@ -1,9 +1,9 @@
 ﻿using System;
 using System.Collections.Generic;
-using System.IO;
-using System.Linq;
 using System.Runtime.InteropServices;
 using SpacetimeDB;
+
+#pragma warning disable CA1050 // Declare types in namespaces - this is a test fixture, no need for a namespace.
 
 [SpacetimeDB.Type]
 public partial struct CustomStruct
@@ -12,6 +12,7 @@ public partial struct CustomStruct
     public static readonly string IGNORE_ME_TOO = "";
     public int IntField;
     public string StringField;
+    //public DateTime DateTimeField;
 }
 
 [SpacetimeDB.Type]

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/Lib.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/Lib.cs
@@ -1,6 +1,8 @@
 ﻿using System.Runtime.InteropServices;
 using SpacetimeDB;
 
+#pragma warning disable CA1050 // Declare types in namespaces - this is a test fixture, no need for a namespace.
+
 [SpacetimeDB.Type]
 public partial struct CustomStruct
 {

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -424,7 +424,9 @@ public class Module : IIncrementalGenerator
                 var addReducers = tuple.Right.Sort((a, b) => a.Key.CompareTo(b.Key));
                 // Don't generate the FFI boilerplate if there are no tables or reducers.
                 if (tableNames.IsEmpty && addReducers.IsEmpty)
+                {
                     return;
+                }
                 context.AddSource(
                     "FFI.cs",
                     $$"""

--- a/crates/bindings-csharp/Directory.Build.props
+++ b/crates/bindings-csharp/Directory.Build.props
@@ -17,7 +17,14 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AnalysisLevel>latest-Minimum</AnalysisLevel>
+    <AnalysisModeStyle>Recommended</AnalysisModeStyle>
     <EnforceCodeStyleInBuild>true</EnforceCodeStyleInBuild>
+  </PropertyGroup>
+
+  <!-- Detect unused usings; see https://github.com/dotnet/roslyn/issues/41640. -->
+  <PropertyGroup>
+    <GenerateDocumentationFile>true</GenerateDocumentationFile>
+    <NoWarn>$(NoWarn);CS1591;CS1574</NoWarn>
   </PropertyGroup>
 
   <ItemGroup>

--- a/crates/bindings-csharp/SpacetimeSharpSATS.sln
+++ b/crates/bindings-csharp/SpacetimeSharpSATS.sln
@@ -3,23 +3,25 @@ Microsoft Visual Studio Solution File, Format Version 12.00
 # Visual Studio Version 17
 VisualStudioVersion = 17.0.31903.59
 MinimumVisualStudioVersion = 10.0.40219.1
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Codegen", "Codegen\Codegen.csproj", "{1E37FF71-567A-4AC8-947E-117098F01142}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Codegen", "Codegen\Codegen.csproj", "{1E37FF71-567A-4AC8-947E-117098F01142}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Runtime", "Runtime\Runtime.csproj", "{003DDE57-BB32-49F0-B94E-88F2D0414D19}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Runtime", "Runtime\Runtime.csproj", "{003DDE57-BB32-49F0-B94E-88F2D0414D19}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BSATN.Codegen", "BSATN.Codegen\BSATN.Codegen.csproj", "{771D5368-E850-4441-8B82-90B38BF3DD9E}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BSATN.Codegen", "BSATN.Codegen\BSATN.Codegen.csproj", "{771D5368-E850-4441-8B82-90B38BF3DD9E}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "BSATN.Runtime", "BSATN.Runtime\BSATN.Runtime.csproj", "{A3AFB5AD-15DE-46CC-ACEE-E5819C07BE58}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BSATN.Runtime", "BSATN.Runtime\BSATN.Runtime.csproj", "{A3AFB5AD-15DE-46CC-ACEE-E5819C07BE58}"
 EndProject
-Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "Codegen.Tests", "Codegen.Tests\Codegen.Tests.csproj", "{2C282EBD-8E37-4F4C-8EE1-E91E21E75FEE}"
+Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "Codegen.Tests", "Codegen.Tests\Codegen.Tests.csproj", "{2C282EBD-8E37-4F4C-8EE1-E91E21E75FEE}"
+EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "config", "config", "{12907A52-3915-43D6-B4D0-94E2938CB647}"
+	ProjectSection(SolutionItems) = preProject
+		.editorconfig = .editorconfig
+	EndProjectSection
 EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
 		Release|Any CPU = Release|Any CPU
-	EndGlobalSection
-	GlobalSection(SolutionProperties) = preSolution
-		HideSolutionNode = FALSE
 	EndGlobalSection
 	GlobalSection(ProjectConfigurationPlatforms) = postSolution
 		{1E37FF71-567A-4AC8-947E-117098F01142}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
@@ -42,5 +44,11 @@ Global
 		{2C282EBD-8E37-4F4C-8EE1-E91E21E75FEE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{2C282EBD-8E37-4F4C-8EE1-E91E21E75FEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2C282EBD-8E37-4F4C-8EE1-E91E21E75FEE}.Release|Any CPU.Build.0 = Release|Any CPU
+	EndGlobalSection
+	GlobalSection(SolutionProperties) = preSolution
+		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(ExtensibilityGlobals) = postSolution
+		SolutionGuid = {8A5DE392-1C9D-4806-B6C7-EDD4D33C5D1E}
 	EndGlobalSection
 EndGlobal


### PR DESCRIPTION
# Description of Changes

This is a follow-up to #1567:

 - Add `.editorconfig` to Visual Studio solution, otherwise devs on VS don't see same code style suggestions as VSCode and/or MSBuild. Note that Visual Studio automatically regenerates `.editorconfig` with all the properties explicitly set, hence the larger file than before.
 - Configure and auto-fix few more minor code style deviations.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
