### PR TITLE
C#: hide ReadGenFields from the public API

### DIFF
--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PrivateTable.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PrivateTable.verified.cs
@@ -26,7 +26,7 @@ partial class PrivateTable : SpacetimeDB.Internal.ITable<PrivateTable>
             ));
     }
 
-    public void ReadGenFields(System.IO.BinaryReader reader) { }
+    void SpacetimeDB.Internal.ITable<PrivateTable>.ReadGenFields(System.IO.BinaryReader reader) { }
 
     static SpacetimeDB.Internal.Module.TableDesc SpacetimeDB.Internal.ITable<PrivateTable>.MakeTableDesc(
         SpacetimeDB.BSATN.ITypeRegistrar registrar

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PublicTable.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PublicTable.verified.cs
@@ -188,7 +188,7 @@ partial struct PublicTable : SpacetimeDB.Internal.ITable<PublicTable>
             ));
     }
 
-    public void ReadGenFields(System.IO.BinaryReader reader)
+    void SpacetimeDB.Internal.ITable<PublicTable>.ReadGenFields(System.IO.BinaryReader reader)
     {
         if (Id == default)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#Timers.SendMessageTimer.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#Timers.SendMessageTimer.verified.cs
@@ -53,7 +53,9 @@ partial class Timers
         public ulong ScheduledId;
         public SpacetimeDB.ScheduleAt ScheduledAt;
 
-        public void ReadGenFields(System.IO.BinaryReader reader)
+        void SpacetimeDB.Internal.ITable<SendMessageTimer>.ReadGenFields(
+            System.IO.BinaryReader reader
+        )
         {
             if (ScheduledId == default)
             {

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -188,7 +188,7 @@ record TableDeclaration : BaseTypeDeclaration<ColumnDeclaration>
 
         extensions.Contents.Append(
             $$"""
-            public void ReadGenFields(System.IO.BinaryReader reader) {
+            void {{iTable}}.ReadGenFields(System.IO.BinaryReader reader) {
                 {{string.Join(
                     "\n",
                     autoIncFields.Select(name =>


### PR DESCRIPTION
# Description of Changes

This shouldn't be a public API visible in autocomplete and such, so make it an explicit interface implementation.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
