### PR TITLE
CLI - Remove admin `energy` subcommands

### DIFF
--- a/crates/cli/src/subcommands/energy.rs
+++ b/crates/cli/src/subcommands/energy.rs
@@ -1,6 +1,6 @@
 // use clap::Arg;
 use crate::common_args;
-use clap::{value_parser, Arg, ArgMatches};
+use clap::ArgMatches;
 use spacetimedb_lib::Identity;
 
 use crate::config::Config;
@@ -14,53 +14,24 @@ pub fn cli() -> clap::Command {
 }
 
 fn get_energy_subcommands() -> Vec<clap::Command> {
-    vec![
-        clap::Command::new("status")
-            .about("Show current energy balance for an identity")
-            .arg(
-                common_args::identity()
-                    .help("The identity to check the balance for")
-                    .long_help(
+    vec![clap::Command::new("status")
+        .about("Show current energy balance for an identity")
+        .arg(
+            common_args::identity()
+                .help("The identity to check the balance for")
+                .long_help(
                     "The identity to check the balance for. If no identity is provided, the default one will be used.",
                 ),
-            )
-            .arg(
-                common_args::server()
-                    .help("The nickname, host name or URL of the server from which to request balance information"),
-            ),
-        clap::Command::new("set-balance")
-            .about("Update the current budget balance for a database")
-            .arg(
-                Arg::new("balance")
-                    .required(true)
-                    .value_parser(value_parser!(i128))
-                    .help("The balance value to set"),
-            )
-            .arg(
-                common_args::identity()
-                    .help("The identity to set a balance for")
-                    .long_help(
-                        "The identity to set a balance for. If no identity is provided, the default one will be used.",
-                    ),
-            )
-            .arg(
-                common_args::server()
-                    .help("The nickname, host name or URL of the server on which to update the identity's balance"),
-            )
-            .arg(
-                Arg::new("quiet")
-                    .long("quiet")
-                    .short('q')
-                    .action(clap::ArgAction::SetTrue)
-                    .help("Runs command in silent mode"),
-            ),
-    ]
+        )
+        .arg(
+            common_args::server()
+                .help("The nickname, host name or URL of the server from which to request balance information"),
+        )]
 }
 
 async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Result<(), anyhow::Error> {
     match cmd {
         "status" => exec_status(config, args).await,
-        "set-balance" => exec_update_balance(config, args).await,
         unknown => Err(anyhow::anyhow!("Invalid subcommand: {}", unknown)),
     }
 }
@@ -68,23 +39,6 @@ async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Result
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let (cmd, subcommand_args) = args.subcommand().expect("Subcommand required");
     exec_subcommand(config, cmd, subcommand_args).await
-}
-
-async fn exec_update_balance(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    // let project_name = args.value_of("project name").unwrap();
-    let identity = args.get_one::<String>("identity");
-    let balance = *args.get_one::<i128>("balance").unwrap();
-    let quiet = args.get_flag("quiet");
-    let server = args.get_one::<String>("server").map(|s| s.as_ref());
-
-    let hex_id = resolve_id_or_default(identity, &config, server)?;
-    let res = set_balance(&reqwest::Client::new(), &config, &hex_id, balance, server).await?;
-
-    if !quiet {
-        println!("{}", res.text().await?);
-    }
-
-    Ok(())
 }
 
 async fn exec_status(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
@@ -111,23 +65,4 @@ fn resolve_id_or_default(identity: Option<&String>, config: &Config, server: Opt
         Some(identity) => config.resolve_name_to_identity(identity),
         None => Ok(config.get_default_identity_config(server)?.identity),
     }
-}
-
-pub(super) async fn set_balance(
-    client: &reqwest::Client,
-    config: &Config,
-    identity: &Identity,
-    balance: i128,
-    server: Option<&str>,
-) -> anyhow::Result<reqwest::Response> {
-    // TODO: this really should be form data in POST body, not query string parameter, but gotham
-    // does not support that on the server side without an extension.
-    // see https://github.com/gotham-rs/gotham/issues/11
-    client
-        .post(format!("{}/energy/{}", config.get_host_url(server)?, identity,))
-        .query(&[("balance", balance)])
-        .send()
-        .await?
-        .error_for_status()
-        .map_err(|e| e.into())
 }


### PR DESCRIPTION
# Description of Changes

The `set-balance` subcommand is half-finished. We are removing it for now. We may add it back in future reworks of the energy system.

# API and ABI breaking changes

Removes the `spacetime energy set-balance` subcommand.

# Expected complexity level and risk

1

# Testing

Existing CI only.