### PR TITLE
WASM ABI: add `datastore_delete_by_btree_scan_bsatn`

### DIFF
--- a/crates/bindings-sys/src/lib.rs
+++ b/crates/bindings-sys/src/lib.rs
@@ -214,6 +214,54 @@ pub mod raw {
             out: *mut u32,
         ) -> u16;
 
+        /// Deletes all rows found in the index identified by `index_id`,
+        /// according to the:
+        /// - `prefix = prefix_ptr[..prefix_len]`,
+        /// - `rstart = rstart_ptr[..rstart_len]`,
+        /// - `rend = rend_ptr[..rend_len]`,
+        /// in WASM memory.
+        ///
+        /// This syscall will delete all the rows found by
+        /// [`datastore_btree_scan_bsatn`] with the same arguments passed,
+        /// including `prefix_elems`.
+        /// See `datastore_btree_scan_bsatn` for details.
+        ///
+        /// The number of rows deleted is written to the WASM pointer `out`.
+        ///
+        /// # Traps
+        ///
+        /// Traps if:
+        /// - `prefix_elems > 0`
+        ///    and (`prefix_ptr` is NULL or `prefix` is not in bounds of WASM memory).
+        /// - `rstart` is NULL or `rstart` is not in bounds of WASM memory.
+        /// - `rend` is NULL or `rend` is not in bounds of WASM memory.
+        /// - `out` is NULL or `out[..size_of::<u32>()]` is not in bounds of WASM memory.
+        ///
+        /// # Errors
+        ///
+        /// Returns an error:
+        ///
+        /// - `NOT_IN_TRANSACTION`, when called outside of a transaction.
+        /// - `NO_SUCH_INDEX`, when `index_id` is not a known ID of an index.
+        /// - `WRONG_INDEX_ALGO` if the index is not a btree index.
+        /// - `BSATN_DECODE_ERROR`, when `prefix` cannot be decoded to
+        ///    a `prefix_elems` number of `AlgebraicValue`
+        ///    typed at the initial `prefix_elems` `AlgebraicType`s of the index's key type.
+        ///    Or when `rstart` or `rend` cannot be decoded to an `Bound<AlgebraicValue>`
+        ///    where the inner `AlgebraicValue`s are
+        ///    typed at the `prefix_elems + 1` `AlgebraicType` of the index's key type.
+        pub fn _datastore_delete_by_btree_scan_bsatn(
+            index_id: IndexId,
+            prefix_ptr: *const u8,
+            prefix_len: usize,
+            prefix_elems: ColId,
+            rstart_ptr: *const u8, // Bound<AlgebraicValue>
+            rstart_len: usize,
+            rend_ptr: *const u8, // Bound<AlgebraicValue>
+            rend_len: usize,
+            out: *mut u32,
+        ) -> u16;
+
         /// Deletes those rows, in the table identified by `table_id`,
         /// that match any row in the byte string `rel = rel_ptr[..rel_len]` in WASM memory.
         ///
@@ -896,6 +944,53 @@ pub fn datastore_btree_scan_bsatn(
         })?
     };
     Ok(RowIter { raw })
+}
+
+/// Deletes all rows found in the index identified by `index_id`,
+/// according to the `prefix`, `rstart`, and `rend`.
+///
+/// This syscall will delete all the rows found by
+/// [`datastore_btree_scan_bsatn`] with the same arguments passed,
+/// including `prefix_elems`.
+/// See `datastore_btree_scan_bsatn` for details.
+///
+/// The number of rows deleted is returned on success.
+///
+/// # Errors
+///
+/// Returns an error:
+///
+/// - `NOT_IN_TRANSACTION`, when called outside of a transaction.
+/// - `NO_SUCH_INDEX`, when `index_id` is not a known ID of an index.
+/// - `WRONG_INDEX_ALGO` if the index is not a btree index.
+/// - `BSATN_DECODE_ERROR`, when `prefix` cannot be decoded to
+///    a `prefix_elems` number of `AlgebraicValue`
+///    typed at the initial `prefix_elems` `AlgebraicType`s of the index's key type.
+///    Or when `rstart` or `rend` cannot be decoded to an `Bound<AlgebraicValue>`
+///    where the inner `AlgebraicValue`s are
+///    typed at the `prefix_elems + 1` `AlgebraicType` of the index's key type.
+pub fn datastore_delete_by_btree_scan_bsatn(
+    index_id: IndexId,
+    prefix: &[u8],
+    prefix_elems: ColId,
+    rstart: &[u8],
+    rend: &[u8],
+) -> Result<u32, Errno> {
+    unsafe {
+        call(|out| {
+            raw::_datastore_delete_by_btree_scan_bsatn(
+                index_id,
+                prefix.as_ptr(),
+                prefix.len(),
+                prefix_elems,
+                rstart.as_ptr(),
+                rstart.len(),
+                rend.as_ptr(),
+                rend.len(),
+                out,
+            )
+        })
+    }
 }
 
 /// Iterate through a table, filtering by an encoded `spacetimedb_lib::filter::Expr`.

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1073,7 +1073,7 @@ impl RelationalDB {
         prefix_elems: ColId,
         rstart: &[u8],
         rend: &[u8],
-    ) -> Result<impl Iterator<Item = RowRef<'a>>, DBError> {
+    ) -> Result<(TableId, impl Iterator<Item = RowRef<'a>>), DBError> {
         tx.btree_scan(index_id, prefix, prefix_elems, rstart, rend)
     }
 

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -149,6 +149,7 @@ pub enum AbiCall {
     RowIterBsatnAdvance,
     RowIterBsatnClose,
     DatastoreInsertBsatn,
+    DatastoreDeleteByBtreeScanBsatn,
     DatastoreDeleteAllByEqBsatn,
     BytesSourceRead,
     BytesSinkWrite,


### PR DESCRIPTION
# Description of Changes

Adds the `datastore_delete_by_btree_scan_bsatn` ABI.

cc https://github.com/clockworklabs/SpacetimeDB/issues/1460

# API and ABI breaking changes

None

# Expected complexity level and risk

1, most of the complex logic is in `MutTxId::btree_scan`.

# TODO (to unblock folks, again, I suggest that these be follow ups)

- testing
- C# module bindings changes