### PR TITLE
Filter out deps that only is added to keccack on arm that broke local testing

### DIFF
--- a/crates/bindings/tests/deps.rs
+++ b/crates/bindings/tests/deps.rs
@@ -2,9 +2,9 @@
 //! to make sure we don't unknowningly add a bunch of dependencies here,
 //! slowing down compilation for every spacetime module.
 
-// We need to remove the `cpufeatures` and `libc` dependencies from the output, it added on `macOS` with `arm` architecture:
+// We need to remove the `cpufeatures` and `libc` dependencies from the output, it added on `arm` architecture:
 // https://github.com/RustCrypto/sponges/blob/master/keccak/Cargo.toml#L24-L25, breaking local testing.
-#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+#[cfg(target_arch = "aarch64")]
 fn hack_keccack(cmd: String) -> String {
     let mut found = false;
     let mut lines = cmd.lines().peekable();
@@ -31,7 +31,7 @@ fn hack_keccack(cmd: String) -> String {
 
     output
 }
-#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+#[cfg(not(target_arch = "aarch64"))]
 fn hack_keccack(cmd: String) -> String {
     cmd
 }

--- a/crates/bindings/tests/deps.rs
+++ b/crates/bindings/tests/deps.rs
@@ -2,12 +2,45 @@
 //! to make sure we don't unknowningly add a bunch of dependencies here,
 //! slowing down compilation for every spacetime module.
 
+// We need to remove the `cpufeatures` and `libc` dependencies from the output, it added on `macOS` with `arm` architecture:
+// https://github.com/RustCrypto/sponges/blob/master/keccak/Cargo.toml#L24-L25, breaking local testing.
+#[cfg(all(target_os = "macos", target_arch = "aarch64"))]
+fn hack_keccack(cmd: String) -> String {
+    let mut found = false;
+    let mut lines = cmd.lines().peekable();
+    let mut output = String::new();
+
+    while let Some(line) = lines.next() {
+        // Check we only match keccak/cpufeatures/libc
+        if line.contains("keccak") {
+            found = true;
+        }
+        if found && line.contains("cpufeatures") {
+            if let Some(next_line) = lines.peek() {
+                if next_line.contains("libc") {
+                    found = false;
+                    // Skip libc
+                    lines.next();
+                    continue;
+                }
+            }
+        }
+        output.push_str(line);
+        output.push('\n');
+    }
+
+    output
+}
+#[cfg(not(all(target_os = "macos", target_arch = "aarch64")))]
+fn hack_keccack(cmd: String) -> String {
+    cmd
+}
+
 #[test]
 fn deptree_snapshot() -> std::io::Result<()> {
     let cmd = "cargo tree -p spacetimedb -f {lib} -e no-dev";
-    let deps_tree = run_cmd(cmd);
-
-    let all_deps = run_cmd("cargo tree -p spacetimedb -e no-dev --prefix none --no-dedupe");
+    let deps_tree = hack_keccack(run_cmd(cmd));
+    let all_deps = hack_keccack(run_cmd("cargo tree -p spacetimedb -e no-dev --prefix none --no-dedupe"));
     let mut all_deps = all_deps.lines().collect::<Vec<_>>();
     all_deps.sort();
     all_deps.dedup();


### PR DESCRIPTION
# Description of Changes

This is to let the developers that run test on  `arm` (like `Apple M1`) pass the `deptree_snapshot` check.

# Expected complexity level and risk
1
# Testing

This must be checked on `arm`. In other targets is as before.

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
