### PR TITLE
CI - Discord PR merge notification includes status of `Internal tests` check

### DIFF
--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -11,15 +11,19 @@ jobs:
       github.event.pull_request.base.ref == 'master'
     env:
       CHECK_NAME: Internal Tests
+      GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
     steps:
       - name: Set up GitHub CLI
-        uses: actions/setup-gh@v3
-        with:
-          token: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          curl -fsSL https://cli.github.com/packages/githubcli-archive-keyring.gpg | sudo tee /usr/share/keyrings/githubcli-archive-keyring.gpg > /dev/null
+          sudo apt-get install -y apt-transport-https
+          echo "deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list
+          sudo apt-get update
+          sudo apt-get install gh
 
       - name: Fetch Check Run Results
         run: |
-          RESULT="$(gh pr checks "${{github.event.pull_request.number}}" --json 'name,state' |
+          RESULT="$(gh pr checks "${{github.event.pull_request.html_url}}" --json 'name,state' |
             jq -r ".[] | select(.name==\"${CHECK_NAME}\").state")"
 
           if [ -z "$RESULT" ]; then

--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -37,5 +37,5 @@ jobs:
           CHECK_RESULT: ${{ env.CHECK_RESULT }}
         run: |
           curl -X POST -H 'Content-Type: application/json' -d '{
-            "content": "PR merged: [(#${PR_NUMBER}) ${PR_TITLE}](${PR_URL})\\n${CHECK_NAME} result: ${CHECK_RESULT}"
+            "content": "'"PR merged: [(#${PR_NUMBER}) ${PR_TITLE}](${PR_URL})\\n${CHECK_NAME} result: ${CHECK_RESULT}"'"
           }' ${DISCORD_WEBHOOK_URL}

--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -9,14 +9,33 @@ jobs:
     runs-on: ubuntu-latest
     if: github.event.pull_request.merged == true &&
       github.event.pull_request.base.ref == 'master'
+    env:
+      CHECK_NAME: Internal Tests
     steps:
+      - name: Set up GitHub CLI
+        uses: actions/setup-gh@v3
+        with:
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Fetch Check Run Results
+        run: |
+          RESULT="$(gh pr checks "${{github.event.pull_request.number}}" --json 'name,state' |
+            jq -r ".[] | select(.name==\"${CHECK_NAME}\").state")"
+
+          if [ -z "$RESULT" ]; then
+            RESULT="The check did not run!"
+          fi
+
+          echo "CHECK_RESULT=${RESULT}" >> $GITHUB_ENV
+
       - name: Send Discord notification
         env:
           DISCORD_WEBHOOK_URL: ${{ secrets.DISCORD_WEBHOOK_URL }}
           PR_TITLE: ${{ github.event.pull_request.title }}
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
+          CHECK_RESULT: ${{ env.CHECK_RESULT }}
         run: |
           curl -X POST -H 'Content-Type: application/json' -d '{
-            "content": "'"PR merged: [(#${PR_NUMBER}) ${PR_TITLE}](${PR_URL})"'"
+            "content": "PR merged: [(#${PR_NUMBER}) ${PR_TITLE}](${PR_URL})\\n${CHECK_NAME} result: ${CHECK_RESULT}"
           }' ${DISCORD_WEBHOOK_URL}


### PR DESCRIPTION
# Description of Changes

The Discord post for merged PRs now includes the status of the `Internal tests` check.

# API and ABI breaking changes

No

# Expected complexity level and risk

2

# Testing

Tested in the `github-tooling-test` repo here: https://github.com/clockworklabs/github-tooling-test/actions/workflows/post-pr-merge.yml.

![image](https://github.com/user-attachments/assets/57decb78-3ac4-4701-9ff1-5a068bcfddf6)
