### PR TITLE
CI - Discord post will ping a particular role if CI check was not successful

### DIFF
--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -39,7 +39,7 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           CHECK_RESULT: ${{ env.CHECK_RESULT }}
-          PING_ON_FAILURE: ${{ secrets.DEV_OPS_ROLE_ID }}
+          MENTION_ON_FAILURE: ${{ secrets.DEV_OPS_ROLE_ID }}
         run: |
           message="PR merged: [(#${PR_NUMBER}) ${PR_TITLE}](${PR_URL})"
           message+=$'\n'
@@ -48,7 +48,7 @@ jobs:
           if [[ "${CHECK_RESULT}" != "SUCCESS" ]]; then
             # This uses special Discord syntax for pinging a particular role.
             # Note the '&' - this is the difference between pinging a *role* and pinging a *person*.
-            message+=" (cc <@&${PING_ON_FAILURE}>)"
+            message+=" (cc <@&${MENTION_ON_FAILURE}>)"
           fi
           # Use `jq` to construct the json data blob in the format required by the webhook.
           data="$(jq --null-input --arg msg "$message" '.content=$msg')"

--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -44,9 +44,12 @@ jobs:
           message="PR merged: [(#${PR_NUMBER}) ${PR_TITLE}](${PR_URL})"
           message+=$'\n'
           message+="${CHECK_NAME} result: ${CHECK_RESULT}"
+          # Note that anything besides success is treated as a failure (e.g. if the check did not run at all, or if it is still pending).
           if [[ "${CHECK_RESULT}" != "SUCCESS" ]]; then
+            # This uses special Discord syntax for pinging a particular role.
+            # Note the '&' - this is the difference between pinging a *role* and pinging a *person*.
             message+=" (cc <@&${PING_ON_FAILURE}>)"
           fi
-          # Construct the json data blog to be passed to the webhook
+          # Use `jq` to construct the json data blob in the format required by the webhook.
           data="$(jq --null-input --arg msg "$message" '.content=$msg')"
           curl -X POST -H 'Content-Type: application/json' -d "$data" "${DISCORD_WEBHOOK_URL}"

--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -39,7 +39,14 @@ jobs:
           PR_NUMBER: ${{ github.event.pull_request.number }}
           PR_URL: ${{ github.event.pull_request.html_url }}
           CHECK_RESULT: ${{ env.CHECK_RESULT }}
+          PING_ON_FAILURE: ${{ secrets.DEV_OPS_ROLE_ID }}
         run: |
-          curl -X POST -H 'Content-Type: application/json' -d '{
-            "content": "'"PR merged: [(#${PR_NUMBER}) ${PR_TITLE}](${PR_URL})\\n${CHECK_NAME} result: ${CHECK_RESULT}"'"
-          }' ${DISCORD_WEBHOOK_URL}
+          message="PR merged: [(#${PR_NUMBER}) ${PR_TITLE}](${PR_URL})"
+          message+=$'\n'
+          message+="${CHECK_NAME} result: ${CHECK_RESULT}"
+          if [[ "${CHECK_RESULT}" != "SUCCESS" ]]; then
+            message+=" (cc <@&${PING_ON_FAILURE}>)"
+          fi
+          # Construct the json data blog to be passed to the webhook
+          data="$(jq --null-input --arg msg "$message" '.content=$msg')"
+          curl -X POST -H 'Content-Type: application/json' -d "$data" "${DISCORD_WEBHOOK_URL}"


### PR DESCRIPTION
# Description of Changes

The CI check will ping the `DEV_OPS_ROLE_ID` in Discord if the specified CI check fails (in this case, `Internal tests`).

# API and ABI breaking changes

CI only.

# Expected complexity level and risk

1

# Testing
I tested in the [github-tooling-test repo](https://github.com/clockworklabs/github-tooling-test/blob/default/.github/workflows/discord-posts.yml):

![image](https://github.com/user-attachments/assets/4554ddbc-42b1-45b5-816f-ace9a509eaa8)
