### PR TITLE
[C#] [NFC] Reuse attribute classes from runtime

### DIFF
--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PublicTable.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PublicTable.verified.cs
@@ -256,7 +256,12 @@ partial struct PublicTable : SpacetimeDB.Internal.ITable<PublicTable>
                 Indexes: [],
                 Constraints:
                 [
-                    new(nameof(PublicTable), 0, nameof(Id), SpacetimeDB.ColumnAttrs.PrimaryKeyAuto)
+                    new(
+                        nameof(PublicTable),
+                        0,
+                        nameof(Id),
+                        SpacetimeDB.ColumnAttrs.PrimaryKeyIdentity
+                    )
                 ],
                 Sequences: [],
                 // "system" | "user"

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#Timers.SendMessageTimer.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#Timers.SendMessageTimer.verified.cs
@@ -82,7 +82,7 @@ partial class Timers
                             nameof(SendMessageTimer),
                             1,
                             nameof(ScheduledId),
-                            SpacetimeDB.ColumnAttrs.PrimaryKeyAuto
+                            SpacetimeDB.ColumnAttrs.PrimaryKeyIdentity
                         )
                     ],
                     Sequences: [],

--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -29,6 +29,16 @@
     <PackageReference Include="Microsoft.CodeAnalysis.CSharp" Version="4.3.1" PrivateAssets="all" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- dev-dependency to add internal C# classes and attributes not included in .NET Standard -->
+    <PackageReference Include="PolySharp" Version="1.14.1" PrivateAssets="all" />
+  </ItemGroup>
+
+  <ItemGroup>
+    <!-- reuse attribute and adjacent types from the runtime -->
+    <Compile Include="../Runtime/Attrs.cs" />
+  </ItemGroup>
+
   <!-- Local project references (used by SpacetimeDB/modules/*-cs) don't use NuGet resolution. -->
   <!-- We need a different hack to include BSATN.Codegen as a transitive analyzer dependency. https://github.com/dotnet/roslyn/issues/47275#issuecomment-685482999 -->
   <ItemGroup>

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -378,7 +378,7 @@ public class Module : IIncrementalGenerator
 
         var reducers = context
             .SyntaxProvider.ForAttributeWithMetadataName(
-                fullyQualifiedMetadataName: "SpacetimeDB.ReducerAttribute",
+                fullyQualifiedMetadataName: typeof(ReducerAttribute).FullName,
                 predicate: (node, ct) => true, // already covered by attribute restrictions
                 transform: (context, ct) => new ReducerDeclaration(context)
             )

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -363,7 +363,7 @@ public class Module : IIncrementalGenerator
     {
         var tables = context
             .SyntaxProvider.ForAttributeWithMetadataName(
-                fullyQualifiedMetadataName: "SpacetimeDB.TableAttribute",
+                fullyQualifiedMetadataName: typeof(TableAttribute).FullName,
                 predicate: (node, ct) => true, // already covered by attribute restrictions
                 transform: (context, ct) => new TableDeclaration(context)
             )

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -5,18 +5,6 @@ using Microsoft.CodeAnalysis;
 using Microsoft.CodeAnalysis.CSharp.Syntax;
 using static Utils;
 
-[Flags]
-enum ColumnAttrs : byte
-{
-    UnSet = 0b0000,
-    Indexed = 0b0001,
-    AutoInc = 0b0010,
-    Unique = Indexed | 0b0100,
-    Identity = Unique | AutoInc,
-    PrimaryKey = Unique | 0b1000,
-    PrimaryKeyAuto = PrimaryKey | AutoInc,
-}
-
 record ColumnDeclaration : MemberDeclaration
 {
     public readonly ColumnAttrs Attrs;
@@ -40,8 +28,8 @@ record ColumnDeclaration : MemberDeclaration
     {
         Attrs = field
             .GetAttributes()
-            .Where(a => a.AttributeClass?.ToString() == "SpacetimeDB.ColumnAttribute")
-            .Select(a => (ColumnAttrs)a.ConstructorArguments[0].Value!)
+            .Where(a => a.AttributeClass?.ToString() == typeof(ColumnAttribute).FullName)
+            .Select(a => a.ParseAs<ColumnAttribute>().Type)
             .SingleOrDefault();
 
         var type = field.Type;
@@ -129,14 +117,10 @@ record TableDeclaration : BaseTypeDeclaration<ColumnDeclaration>
             throw new InvalidOperationException("Tagged enums cannot be tables.");
         }
 
-        var attrArgs = context.Attributes.Single().NamedArguments;
+        var attr = context.Attributes.Single().ParseAs<TableAttribute>();
 
-        IsPublic = attrArgs.Any(pair => pair is { Key: "Public", Value.Value: true });
-
-        Scheduled = attrArgs
-            .Where(pair => pair.Key == "Scheduled")
-            .Select(pair => (string?)pair.Value.Value)
-            .SingleOrDefault();
+        IsPublic = attr.Public;
+        Scheduled = attr.Scheduled;
 
         if (Scheduled is not null)
         {
@@ -304,17 +288,15 @@ record ReducerDeclaration
     {
         var methodSyntax = (MethodDeclarationSyntax)context.TargetNode;
         var method = (IMethodSymbol)context.TargetSymbol;
-        var attr = context.Attributes.Single();
+        var attr = context.Attributes.Single().ParseAs<ReducerAttribute>();
 
         if (!method.ReturnsVoid)
         {
             throw new Exception($"Reducer {method} must return void");
         }
 
-        var exportName = (string?)attr.ConstructorArguments.SingleOrDefault().Value;
-
         Name = method.Name;
-        ExportName = exportName ?? Name;
+        ExportName = attr.Name ?? Name;
         FullName = SymbolToName(method);
         Args = new(
             method.Parameters.Select(p => new ReducerParamDeclaration(p)).ToImmutableArray()

--- a/modules/benchmarks-cs/StdbModule.csproj
+++ b/modules/benchmarks-cs/StdbModule.csproj
@@ -15,7 +15,7 @@
     at least it simplifies workflow for editing and testing C# code itself.
   -->
   <ItemGroup>
-    <ProjectReference Include="../../crates/bindings-csharp/Codegen/Codegen.csproj" OutputItemType="Analyzer" />
+    <ProjectReference Include="../../crates/bindings-csharp/Codegen/Codegen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="../../crates/bindings-csharp/Runtime/Runtime.csproj" />
   </ItemGroup>
 

--- a/modules/sdk-test-connect-disconnect-cs/StdbModule.csproj
+++ b/modules/sdk-test-connect-disconnect-cs/StdbModule.csproj
@@ -13,7 +13,7 @@
     at least it simplifies workflow for editing and testing C# code itself.
   -->
   <ItemGroup>
-    <ProjectReference Include="../../crates/bindings-csharp/Codegen/Codegen.csproj" OutputItemType="Analyzer" />
+    <ProjectReference Include="../../crates/bindings-csharp/Codegen/Codegen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="../../crates/bindings-csharp/Runtime/Runtime.csproj" />
   </ItemGroup>
 

--- a/modules/sdk-test-cs/StdbModule.csproj
+++ b/modules/sdk-test-cs/StdbModule.csproj
@@ -17,7 +17,7 @@
     at least it simplifies workflow for editing and testing C# code itself.
   -->
   <ItemGroup>
-    <ProjectReference Include="../../crates/bindings-csharp/Codegen/Codegen.csproj" OutputItemType="Analyzer" />
+    <ProjectReference Include="../../crates/bindings-csharp/Codegen/Codegen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="../../crates/bindings-csharp/Runtime/Runtime.csproj" />
   </ItemGroup>
 

--- a/modules/spacetimedb-quickstart-cs/StdbModule.csproj
+++ b/modules/spacetimedb-quickstart-cs/StdbModule.csproj
@@ -13,7 +13,7 @@
     at least it simplifies workflow for editing and testing C# code itself.
   -->
   <ItemGroup>
-    <ProjectReference Include="../../crates/bindings-csharp/Codegen/Codegen.csproj" OutputItemType="Analyzer" />
+    <ProjectReference Include="../../crates/bindings-csharp/Codegen/Codegen.csproj" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
     <ProjectReference Include="../../crates/bindings-csharp/Runtime/Runtime.csproj" />
   </ItemGroup>
 


### PR DESCRIPTION
Currently, we have to copy-paste and hardcode property names and types from the runtime in the codegen, which is pretty error-prone, and is getting harder as our API is going to rapidly expand.

In this PR I'm implementing a basic helper that allows to reuse original attribute classes from the runtime in the codegen by taking the syntax data and reconstructing the same attribute instance via reflection.

This ensures that we have all the same typechecked properties on both sides instead of having to extract them manually by name + explicit casts.

# Description of Changes

Please describe your change, mention any related tickets, and so on here.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
