### PR TITLE
Fixes showing server errors on `cli sql` calls

### DIFF
--- a/crates/cli/src/errors.rs
+++ b/crates/cli/src/errors.rs
@@ -25,7 +25,8 @@ pub async fn error_for_status(response: Response) -> Result<Response, CliError> 
     if let Some(kind) = status
         .is_client_error()
         .then_some(RequestSource::Client)
-        .or_else(|| status.is_client_error().then_some(RequestSource::Server))
+        // Anything that is not a success is an error for the client, even a redirect that is not followed.
+        .or_else(|| (!status.is_success()).then_some(RequestSource::Server))
     {
         let msg = response.text().await?;
         return Err(CliError::Request { kind, msg, status });


### PR DESCRIPTION
# Description of Changes

The `cli` incorrectly tries to parse as `json` an `http error` masquing the problem. Now it checks that the `StatusCode` is within `200-299.` before returning.

# Expected complexity level and risk

1

# Testing

- [x] *Check the `sql` calls that could generar `error 500`.*
- [x] *Use my branch of adding a new system table that is broken to get errors.
