### PR TITLE
cli: Remove dbg!

### DIFF
--- a/crates/cli/src/subcommands/generate/rust.rs
+++ b/crates/cli/src/subcommands/generate/rust.rs
@@ -712,7 +712,6 @@ fn print_dispatch_imports(out: &mut Indenter) {
 }
 
 fn iter_module_names(module: &ModuleDef) -> impl Iterator<Item = String> + '_ {
-    dbg!(module.types().map(|ty| (&ty.name, ty.ty)).collect::<Vec<_>>());
     itertools::chain!(
         module
             .types()


### PR DESCRIPTION
Our clippy.toml should disallow this, but doesn't.
Anyway, running codegen with a debug build is not so uncommon, and this
dbg! output is not too informative (unless debugging codegen).

# Expected complexity level and risk

0
