### PR TITLE
Tighten package sources in C# smoketests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -137,9 +137,14 @@ jobs:
             <packageSources>
               <!-- Local NuGet repositories -->
               <add key="Local SpacetimeDB.BSATN.Runtime" value="../crates/bindings-csharp/BSATN.Runtime/bin/Release" />
-              <!-- Official NuGet.org server -->
-              <add key="NuGet.org" value="https://api.nuget.org/v3/index.json" />
             </packageSources>
+            <packageSourceMapping>
+              <!-- Ensure that SpacetimeDB.BSATN.Runtime is used from the local folder. -->
+              <!-- Otherwise we risk an outdated version being quietly pulled from NuGet for testing. -->
+              <packageSource key="Local SpacetimeDB.BSATN.Runtime">
+                <package pattern="SpacetimeDB.BSATN.Runtime" />
+              </packageSource>
+            </packageSourceMapping>
           </configuration>
           EOF
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -144,6 +144,10 @@ jobs:
               <packageSource key="Local SpacetimeDB.BSATN.Runtime">
                 <package pattern="SpacetimeDB.BSATN.Runtime" />
               </packageSource>
+              <!-- Fallback to NuGet for other packages. -->
+              <packageSource key="nuget.org">
+                <package pattern="*" />
+              </packageSource>
             </packageSourceMapping>
           </configuration>
           EOF

--- a/smoketests/tests/csharp_module.py
+++ b/smoketests/tests/csharp_module.py
@@ -35,6 +35,7 @@ class CreateProject(unittest.TestCase):
                 for project in packed_projects:
                     # Add local build directories as NuGet repositories.
                     path = bindings / project / "bin" / "Release"
+                    project = f"SpacetimeDB.{project}"
                     xml.SubElement(sources, "add", key=project, value=str(path))
 
                     # Add strict package source mappings to ensure that

--- a/smoketests/tests/csharp_module.py
+++ b/smoketests/tests/csharp_module.py
@@ -4,6 +4,7 @@ import tempfile
 from pathlib import Path
 import shutil
 import subprocess
+import xml.etree.ElementTree as xml
 
 
 @requires_dotnet
@@ -26,20 +27,27 @@ class CreateProject(unittest.TestCase):
 
                 packed_projects = ["BSATN.Runtime", "Runtime"]
 
-                config = []
-                config.append("<?xml version=\"1.0\" encoding=\"utf-8\"?>")
-                config.append("<configuration>")
-                config.append("<packageSources>")
-                config.append("<!-- Local NuGet repositories -->")
-                for project in packed_projects:
-                    path = bindings / project / "bin" / "Release"
-                    config.append("<add key=\"Local %s\" value=\"%s\" />\n" % (project, str(path)))
-                config.append("<!-- Official NuGet.org server -->")
-                config.append("<add key=\"NuGet.org\" value=\"https://api.nuget.org/v3/index.json\" />")
-                config.append("</packageSources>")
-                config.append("</configuration>")
+                config = xml.Element("configuration")
 
-                config = "\n".join(config)
+                sources = xml.SubElement(config, "packageSources")
+                mappings = xml.SubElement(config, "packageSourceMapping")
+
+                for project in packed_projects:
+                    # Add local build directories as NuGet repositories.
+                    path = bindings / project / "bin" / "Release"
+                    xml.SubElement(sources, "add", key=project, value=str(path))
+
+                    # Add strict package source mappings to ensure that
+                    # SpacetimeDB.* packages are used from those directories
+                    # and never from nuget.org.
+                    #
+                    # This prevents bugs where we silently used an outdated
+                    # version which led to tests passing when they shouldn't.
+                    mapping = xml.SubElement(mappings, "packageSource", key=project)
+                    xml.SubElement(mapping, "package", pattern=project)
+
+                xml.indent(config)
+                config = xml.tostring(config, encoding="unicode", xml_declaration=True)
 
                 print("Writing `nuget.config` contents:")
                 print(config)


### PR DESCRIPTION
# Description of Changes

Before this, we couple of times ran into issues where a version in SpacetimeDB template was outdated, or NuGet sources were in incorrect order, and so on, which led to either tests failing with misleading error (https://github.com/clockworklabs/SpacetimeDB/commit/2b09c8d1f8868c22f8d3b6af30a492ef1ac9569c being most recent example), or, worse, quietly passing even when code or versions are actually broken.

Apparently, NuGet has a package source mapping feature which allows to ensure that specific packages are only pulled from specific custom sources, which is exactly what we want here. It allows us to ensure that SpacetimeDB.* pacakges for smoketests are pulled from our local build folders, and not from nuget.org.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
