### PR TITLE
Downlevel some info messages

### DIFF
--- a/crates/commitlog/src/index/indexfile.rs
+++ b/crates/commitlog/src/index/indexfile.rs
@@ -56,7 +56,6 @@ impl<Key: Into<u64> + From<u64>> IndexFileMut<Key> {
     /// # Error
     ///
     /// - `IndexError::KeyNotFound`: If the key is smaller than the first entry key
-    // TODO: use binary search
     pub fn find_index(&self, key: Key) -> Result<(Key, u64), IndexError> {
         let key = key.into();
 


### PR DESCRIPTION
# Description of Changes
Offset Index responds error if it gets 0 as key to append, Refactored a code a bit to not call offset index append if there has been no commit since last append.

Downlevelling `info!()` -> `debug!()`

# API and ABI breaking changes
N/A

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*
1

