### PR TITLE
CLI - `build` command has a param for wasm-opt flags

### DIFF
--- a/crates/bench/src/spacetime_module.rs
+++ b/crates/bench/src/spacetime_module.rs
@@ -6,7 +6,7 @@ use spacetimedb_lib::{
     AlgebraicValue,
 };
 use spacetimedb_primitives::ColId;
-use spacetimedb_testing::modules::{start_runtime, CompilationMode, CompiledModule, LoggerRecord, ModuleHandle};
+use spacetimedb_testing::modules::{start_runtime, CompiledModule, LoggerRecord, ModuleHandle, ReleaseLevel};
 use tokio::runtime::Runtime;
 
 use crate::{
@@ -18,14 +18,14 @@ use crate::{
 lazy_static::lazy_static! {
     pub static ref BENCHMARKS_MODULE: CompiledModule = {
         if std::env::var_os("STDB_BENCH_CS").is_some() {
-            CompiledModule::compile("benchmarks-cs", CompilationMode::Release)
+            CompiledModule::compile("benchmarks-cs", ReleaseLevel::ReleaseWithWasmOpt)
         } else {
             // Temporarily add CARGO_TARGET_DIR override to avoid conflicts with main target dir.
             // Otherwise for some reason Cargo will mark all dependencies with build scripts as
             // fresh - but only if running benchmarks (if modules are built in release mode).
             // See https://github.com/clockworklabs/SpacetimeDB/issues/401.
             std::env::set_var("CARGO_TARGET_DIR", concat!(env!("CARGO_MANIFEST_DIR"), "/target"));
-            let module = CompiledModule::compile("benchmarks", CompilationMode::Release);
+            let module = CompiledModule::compile("benchmarks", ReleaseLevel::ReleaseWithWasmOpt);
             std::env::remove_var("CARGO_TARGET_DIR");
             module
         }

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -54,7 +54,7 @@ pub async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Re
         "logs" => logs::exec(config, args).await,
         "sql" => sql::exec(config, args).await,
         "dns" => dns::exec(config, args).await,
-        "generate" => generate::exec(config, args),
+        "generate" => generate::exec(config, args).await,
         "list" => list::exec(config, args).await,
         "local" => local::exec(config, args).await,
         "init" => init::exec(config, args).await,

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -58,7 +58,7 @@ pub async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Re
         "list" => list::exec(config, args).await,
         "local" => local::exec(config, args).await,
         "init" => init::exec(config, args).await,
-        "build" => build::exec(config, args).await,
+        "build" => build::exec(config, args).await.map(drop),
         "server" => server::exec(config, args).await,
         "subscribe" => subscribe::exec(config, args).await,
         #[cfg(feature = "standalone")]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -12,7 +12,7 @@ use clap::{ArgMatches, Command};
 pub use config::Config;
 use spacetimedb_standalone::subcommands::start::ProgramMode;
 pub use subcommands::*;
-pub use tasks::build;
+pub use tasks::{build, ReleaseLevel};
 
 #[cfg(feature = "standalone")]
 use spacetimedb_standalone::subcommands::start;

--- a/crates/cli/src/subcommands/build.rs
+++ b/crates/cli/src/subcommands/build.rs
@@ -57,3 +57,11 @@ pub async fn exec(_config: Config, args: &ArgMatches) -> Result<PathBuf, anyhow:
 
     Ok(bin_path)
 }
+
+pub async fn exec_with_argstring(config: Config, project_path: &PathBuf, args: &str) -> Result<PathBuf, anyhow::Error> {
+    // Note: "build" must be the start of the string, because `build::cli()` is the entire build subcommand.
+    // If we don't include this, the args will be misinterpreted (e.g. as commands).
+    let build_options = format!("build {} --project-path {}", args, project_path.display());
+    let build_args = cli().get_matches_from(build_options.split_whitespace());
+    exec(config.clone(), &build_args).await
+}

--- a/crates/cli/src/subcommands/build.rs
+++ b/crates/cli/src/subcommands/build.rs
@@ -58,10 +58,14 @@ pub async fn exec(_config: Config, args: &ArgMatches) -> Result<PathBuf, anyhow:
     Ok(bin_path)
 }
 
-pub async fn exec_with_argstring(config: Config, project_path: &Path, args: &str) -> Result<PathBuf, anyhow::Error> {
+pub async fn exec_with_argstring(
+    config: Config,
+    project_path: &Path,
+    arg_string: &str,
+) -> Result<PathBuf, anyhow::Error> {
     // Note: "build" must be the start of the string, because `build::cli()` is the entire build subcommand.
     // If we don't include this, the args will be misinterpreted (e.g. as commands).
-    let build_options = format!("build {} --project-path {}", args, project_path.display());
-    let build_args = cli().get_matches_from(build_options.split_whitespace());
-    exec(config.clone(), &build_args).await
+    let arg_string = format!("build {} --project-path {}", arg_string, project_path.display());
+    let arg_matches = cli().get_matches_from(arg_string.split_whitespace());
+    exec(config.clone(), &arg_matches).await
 }

--- a/crates/cli/src/subcommands/build.rs
+++ b/crates/cli/src/subcommands/build.rs
@@ -32,7 +32,7 @@ pub fn cli() -> clap::Command {
         )
 }
 
-pub async fn exec(_config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+pub async fn exec(_config: Config, args: &ArgMatches) -> Result<PathBuf, anyhow::Error> {
     let project_path = args.get_one::<PathBuf>("project_path").unwrap();
     let skip_clippy = args.get_flag("skip_clippy");
     let build_debug = args.get_flag("debug");
@@ -52,8 +52,8 @@ pub async fn exec(_config: Config, args: &ArgMatches) -> Result<(), anyhow::Erro
         ));
     }
 
-    crate::tasks::build(project_path, skip_clippy, build_debug)?;
+    let bin_path = crate::tasks::build(project_path, skip_clippy, build_debug)?;
     println!("Build finished successfully.");
 
-    Ok(())
+    Ok(bin_path)
 }

--- a/crates/cli/src/subcommands/build.rs
+++ b/crates/cli/src/subcommands/build.rs
@@ -1,7 +1,7 @@
 use crate::Config;
 use clap::ArgAction::SetTrue;
 use clap::{Arg, ArgMatches};
-use std::path::PathBuf;
+use std::path::{Path, PathBuf};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("build")
@@ -58,7 +58,7 @@ pub async fn exec(_config: Config, args: &ArgMatches) -> Result<PathBuf, anyhow:
     Ok(bin_path)
 }
 
-pub async fn exec_with_argstring(config: Config, project_path: &PathBuf, args: &str) -> Result<PathBuf, anyhow::Error> {
+pub async fn exec_with_argstring(config: Config, project_path: &Path, args: &str) -> Result<PathBuf, anyhow::Error> {
     // Note: "build" must be the start of the string, because `build::cli()` is the entire build subcommand.
     // If we don't include this, the args will be misinterpreted (e.g. as commands).
     let build_options = format!("build {} --project-path {}", args, project_path.display());

--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -43,6 +43,8 @@ pub fn cli() -> clap::Command {
                 .long("wasm-file")
                 .short('w')
                 .group("source")
+                .conflicts_with("project_path")
+                .conflicts_with("build_options")
                 .help("The system path (absolute or relative) to the wasm file we should inspect"),
         )
         .arg(
@@ -86,25 +88,19 @@ pub fn cli() -> clap::Command {
                 .value_parser(clap::value_parser!(Language))
                 .help("The language to generate"),
         )
-        .arg(
-            Arg::new("skip_clippy")
-                .long("skip_clippy")
-                .short('s')
-                .short('S')
-                .action(SetTrue)
-                .env("SPACETIME_SKIP_CLIPPY")
-                .value_parser(clap::builder::FalseyValueParser::new())
-                .help(
-                    "Skips running clippy on the module before generating \
-                     (intended to speed up local iteration, not recommended \
-                     for CI)",
-                ),
-        )
         .arg(Arg::new("delete_files").long("delete-files").action(SetTrue).help(
             "Delete outdated generated files whose definitions have been \
              removed from the module. Prompts before deleting unless --force is \
              supplied.",
         ))
+        .arg(
+            Arg::new("build_options")
+                .long("build-options")
+                .alias("build-opts")
+                .action(Set)
+                .default_value("")
+                .help("Options to pass to the build command"),
+        )
         .arg(
             Arg::new("force")
                 .long("force")
@@ -112,10 +108,6 @@ pub fn cli() -> clap::Command {
                 .requires("delete_files")
                 .help("delete-files without prompting first. Useful for scripts."),
         )
-        .arg(Arg::new("debug").long("debug").short('d').action(SetTrue).help(
-            "Builds the module using debug instead of release (intended to \
-             speed up local iteration, not recommended for CI)",
-        ))
         .after_help("Run `spacetime help publish` for more detailed information.")
 }
 
@@ -126,10 +118,9 @@ pub fn exec(_config: Config, args: &clap::ArgMatches) -> anyhow::Result<()> {
     let out_dir = args.get_one::<PathBuf>("out_dir").unwrap();
     let lang = *args.get_one::<Language>("lang").unwrap();
     let namespace = args.get_one::<String>("namespace").unwrap();
-    let skip_clippy = args.get_flag("skip_clippy");
-    let build_debug = args.get_flag("debug");
     let delete_files = args.get_flag("delete_files");
     let force = args.get_flag("force");
+    let build_options = args.get_one::<String>("build_options").unwrap();
 
     let module = if let Some(mut json_module) = json_module {
         let DeserializeWrapper(module) = if let Some(path) = json_module.next() {
@@ -147,7 +138,11 @@ pub fn exec(_config: Config, args: &clap::ArgMatches) -> anyhow::Result<()> {
             println!("Skipping build. Instead we are inspecting {}", path.display());
             path.clone()
         } else {
-            crate::tasks::build(project_path, skip_clippy, build_debug)?
+            // Note: "build" must be the start of the string, because `build::cli()` is the entire build subcommand.
+            // If we don't include this, the args will be misinterpreted (e.g. as commands).
+            let build_options = format!("build {} --project-path {}", build_options, path_to_project.display());
+            let build_args = build::cli().get_matches_from(build_options.split_whitespace());
+            build::exec(config.clone(), &build_args).await?
         };
         extract_descriptions(&wasm_path)?
     };

--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -139,11 +139,7 @@ pub async fn exec(config: Config, args: &clap::ArgMatches) -> anyhow::Result<()>
             println!("Skipping build. Instead we are inspecting {}", path.display());
             path.clone()
         } else {
-            // Note: "build" must be the start of the string, because `build::cli()` is the entire build subcommand.
-            // If we don't include this, the args will be misinterpreted (e.g. as commands).
-            let build_options = format!("build {} --project-path {}", build_options, project_path.display());
-            let build_args = build::cli().get_matches_from(build_options.split_whitespace());
-            build::exec(config.clone(), &build_args).await?
+            build::exec_with_argstring(config.clone(), project_path, build_options).await?
         };
         extract_descriptions(&wasm_path)?
     };

--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -1,7 +1,7 @@
 #![warn(clippy::uninlined_format_args)]
 
 use clap::Arg;
-use clap::ArgAction::SetTrue;
+use clap::ArgAction::{Set, SetTrue};
 use convert_case::{Case, Casing};
 use core::mem;
 use duct::cmd;
@@ -22,6 +22,7 @@ use std::ops::Deref;
 use std::path::{Path, PathBuf};
 use wasmtime::{Caller, StoreContextMut};
 
+use crate::build;
 use crate::util::y_or_n;
 use crate::Config;
 
@@ -111,7 +112,7 @@ pub fn cli() -> clap::Command {
         .after_help("Run `spacetime help publish` for more detailed information.")
 }
 
-pub fn exec(_config: Config, args: &clap::ArgMatches) -> anyhow::Result<()> {
+pub async fn exec(config: Config, args: &clap::ArgMatches) -> anyhow::Result<()> {
     let project_path = args.get_one::<PathBuf>("project_path").unwrap();
     let wasm_file = args.get_one::<PathBuf>("wasm_file").cloned();
     let json_module = args.get_many::<PathBuf>("json_module");
@@ -140,7 +141,7 @@ pub fn exec(_config: Config, args: &clap::ArgMatches) -> anyhow::Result<()> {
         } else {
             // Note: "build" must be the start of the string, because `build::cli()` is the entire build subcommand.
             // If we don't include this, the args will be misinterpreted (e.g. as commands).
-            let build_options = format!("build {} --project-path {}", build_options, path_to_project.display());
+            let build_options = format!("build {} --project-path {}", build_options, project_path.display());
             let build_args = build::cli().get_matches_from(build_options.split_whitespace());
             build::exec(config.clone(), &build_args).await?
         };

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -147,11 +147,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
         println!("Skipping build. Instead we are publishing {}", path.display());
         path.clone()
     } else {
-        // Note: "build" must be the start of the string, because `build::cli()` is the entire build subcommand.
-        // If we don't include this, the args will be misinterpreted (e.g. as commands).
-        let build_options = format!("build {} --project-path {}", build_options, path_to_project.display());
-        let build_args = build::cli().get_matches_from(build_options.split_whitespace());
-        build::exec(config.clone(), &build_args).await?
+        build::exec_with_argstring(config.clone(), path_to_project, build_options).await?
     };
     let program_bytes = fs::read(path_to_wasm)?;
     println!(

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -147,6 +147,8 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
         println!("Skipping build. Instead we are publishing {}", path.display());
         path.clone()
     } else {
+        // Note: "build" must be the start of the string, because `build::cli()` is the entire build subcommand.
+        // If we don't include this, the args will be misinterpreted (e.g. as commands).
         let build_options = format!("build {} --project-path {}", build_options, path_to_project.display());
         let build_args = build::cli().get_matches_from(build_options.split_whitespace());
         build::exec(config.clone(), &build_args).await?

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -1,6 +1,6 @@
 use anyhow::bail;
 use clap::Arg;
-use clap::ArgAction::SetTrue;
+use clap::ArgAction::{Set, SetTrue};
 use clap::ArgMatches;
 use reqwest::{StatusCode, Url};
 use spacetimedb_client_api_messages::name::PublishOp;
@@ -8,10 +8,10 @@ use spacetimedb_client_api_messages::name::{is_address, parse_domain_name, Publi
 use std::fs;
 use std::path::PathBuf;
 
-use crate::common_args;
 use crate::config::Config;
 use crate::util::{add_auth_header_opt, get_auth_header};
 use crate::util::{unauth_error_context, y_or_n};
+use crate::{build, common_args};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("publish")
@@ -33,6 +33,14 @@ pub fn cli() -> clap::Command {
                 .help("When publishing to an existing address, first DESTROY all data associated with the module"),
         )
         .arg(
+            Arg::new("build_options")
+                .long("build-options")
+                .alias("build-opts")
+                .action(Set)
+                .default_value("")
+                .help("Options to pass to the build command")
+        )
+        .arg(
             Arg::new("project_path")
                 .value_parser(clap::value_parser!(PathBuf))
                 .default_value(".")
@@ -46,6 +54,7 @@ pub fn cli() -> clap::Command {
                 .long("wasm-file")
                 .short('w')
                 .conflicts_with("project_path")
+                .conflicts_with("build_options")
                 .help("The system path (absolute or relative) to the wasm file we should publish, instead of building the project."),
         )
         .arg(
@@ -67,22 +76,6 @@ pub fn cli() -> clap::Command {
                 .short('a')
                 .action(SetTrue)
                 .help("Instruct SpacetimeDB to allocate a new identity to own this database"),
-        )
-        .arg(
-            Arg::new("skip_clippy")
-                .long("skip_clippy")
-                .short('S')
-                .action(SetTrue)
-                .env("SPACETIME_SKIP_CLIPPY")
-                .value_parser(clap::builder::FalseyValueParser::new())
-                .help("Skips running clippy on the module before publishing (intended to speed up local iteration, not recommended for CI)"),
-        )
-        .arg(
-            Arg::new("debug")
-                .long("debug")
-                .short('d')
-                .action(SetTrue)
-                .help("Builds the module using debug instead of release (intended to speed up local iteration, not recommended for CI)"),
         )
         .arg(
             Arg::new("name|address")
@@ -110,10 +103,9 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     let force = args.get_flag("force");
     let trace_log = args.get_flag("trace_log");
     let anon_identity = args.get_flag("anon_identity");
-    let skip_clippy = args.get_flag("skip_clippy");
-    let build_debug = args.get_flag("debug");
     let wasm_file = args.get_one::<PathBuf>("wasm_file");
     let database_host = config.get_host_url(server)?;
+    let build_options = args.get_one::<String>("build_options").unwrap();
 
     // If the user didn't specify an identity and we didn't specify an anonymous identity, then
     // we want to use the default identity
@@ -155,7 +147,9 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
         println!("Skipping build. Instead we are publishing {}", path.display());
         path.clone()
     } else {
-        crate::tasks::build(path_to_project, skip_clippy, build_debug)?
+        let build_options = format!("build {} --project-path {}", build_options, path_to_project.display());
+        let build_args = build::cli().try_get_matches_from(build_options.split_whitespace())?;
+        build::exec(config.clone(), &build_args).await?
     };
     let program_bytes = fs::read(path_to_wasm)?;
     println!(

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -148,7 +148,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
         path.clone()
     } else {
         let build_options = format!("build {} --project-path {}", build_options, path_to_project.display());
-        let build_args = build::cli().try_get_matches_from(build_options.split_whitespace())?;
+        let build_args = build::cli().get_matches_from(build_options.split_whitespace());
         build::exec(config.clone(), &build_args).await?
     };
     let program_bytes = fs::read(path_to_wasm)?;

--- a/crates/cli/tests/codegen.rs
+++ b/crates/cli/tests/codegen.rs
@@ -1,13 +1,13 @@
 use spacetimedb_cli::generate;
 use spacetimedb_data_structures::map::HashMap;
-use spacetimedb_testing::modules::{CompilationMode, CompiledModule};
+use spacetimedb_testing::modules::{CompiledModule, ReleaseLevel};
 use std::path::Path;
 use std::sync::OnceLock;
 
 fn compiled_module() -> &'static Path {
     static COMPILED_MODULE: OnceLock<CompiledModule> = OnceLock::new();
     COMPILED_MODULE
-        .get_or_init(|| CompiledModule::compile("rust-wasm-test", CompilationMode::Debug))
+        .get_or_init(|| CompiledModule::compile("rust-wasm-test", ReleaseLevel::Debug))
         .path()
 }
 

--- a/crates/schema/tests/validate_integration.rs
+++ b/crates/schema/tests/validate_integration.rs
@@ -11,13 +11,13 @@ use spacetimedb_schema::{
     identifier::Identifier,
     schema::TableSchema,
 };
-use spacetimedb_testing::modules::{CompilationMode, CompiledModule};
+use spacetimedb_testing::modules::{CompiledModule, ReleaseLevel};
 
 const TEST_TABLE_ID: TableId = TableId(1337);
 
 #[allow(clippy::disallowed_macros)] // LET ME PRINTLN >:(
 fn validate_module(module_name: &str) {
-    let module = CompiledModule::compile(module_name, CompilationMode::Debug);
+    let module = CompiledModule::compile(module_name, ReleaseLevel::Debug);
     let raw_module_def: RawModuleDef =
         extract_descriptions(module.path()).expect("failed to extract module descriptions");
     let RawModuleDef::V8BackCompat(raw_module_def) = raw_module_def else {

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -5,6 +5,7 @@ use std::sync::OnceLock;
 use std::time::Instant;
 
 use spacetimedb::messages::control_db::HostType;
+pub use spacetimedb_cli::ReleaseLevel;
 use spacetimedb_lib::ser::serde::SerializeWrapper;
 use tokio::runtime::{Builder, Runtime};
 
@@ -86,15 +87,9 @@ pub struct CompiledModule {
     program_bytes: OnceLock<Vec<u8>>,
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub enum CompilationMode {
-    Debug,
-    Release,
-}
-
 impl CompiledModule {
-    pub fn compile(name: &str, mode: CompilationMode) -> Self {
-        let path = spacetimedb_cli::build(&module_path(name), false, mode == CompilationMode::Debug).unwrap();
+    pub fn compile(name: &str, mode: ReleaseLevel) -> Self {
+        let path = spacetimedb_cli::build(&module_path(name), false, mode).unwrap();
         Self {
             name: name.to_owned(),
             path,

--- a/crates/testing/src/sdk.rs
+++ b/crates/testing/src/sdk.rs
@@ -149,7 +149,7 @@ fn publish_module(wasm_file: &str) -> String {
         "publish",
         "--server",
         "local",
-        "--debug",
+        "--build-options=--debug",
         "--project-path",
         wasm_file,
         "--skip_clippy",

--- a/crates/testing/src/sdk.rs
+++ b/crates/testing/src/sdk.rs
@@ -193,7 +193,6 @@ fn generate_bindings(language: &str, wasm_file: &str, client_project: &str, gene
         create_dir_all(generate_dir).expect("Error creating generate subdir");
         invoke_cli(&[
             "generate",
-            "--build-options=\"--debug --skip_clippy\"",
             "--lang",
             language,
             "--wasm-file",

--- a/crates/testing/src/sdk.rs
+++ b/crates/testing/src/sdk.rs
@@ -7,7 +7,8 @@ use std::sync::Mutex;
 use std::thread::JoinHandle;
 
 use crate::invoke_cli;
-use crate::modules::{CompilationMode, CompiledModule};
+use crate::modules::CompiledModule;
+use spacetimedb_cli::ReleaseLevel;
 use tempfile::TempDir;
 
 pub fn ensure_standalone_process() {
@@ -136,7 +137,7 @@ fn compile_module(module: &str) -> String {
     let module = module.to_owned();
 
     memoized!(|module: String| -> String {
-        let module = CompiledModule::compile(module, CompilationMode::Debug);
+        let module = CompiledModule::compile(module, ReleaseLevel::Debug);
         module.path().to_str().unwrap().to_owned()
     })
 }

--- a/crates/testing/src/sdk.rs
+++ b/crates/testing/src/sdk.rs
@@ -145,15 +145,7 @@ fn compile_module(module: &str) -> String {
 // module as a separate clean database instance for isolation purposes.
 fn publish_module(wasm_file: &str) -> String {
     let name = random_module_name();
-    invoke_cli(&[
-        "publish",
-        "--server",
-        "local",
-        "--build-options=\"--debug --skip_clippy\"",
-        "--project-path",
-        wasm_file,
-        &name,
-    ]);
+    invoke_cli(&["publish", "--server", "local", "--wasm-file", wasm_file, &name]);
     name
 }
 

--- a/crates/testing/src/sdk.rs
+++ b/crates/testing/src/sdk.rs
@@ -149,10 +149,9 @@ fn publish_module(wasm_file: &str) -> String {
         "publish",
         "--server",
         "local",
-        "--build-options=--debug",
+        "--build-options=\"--debug --skip_clippy\"",
         "--project-path",
         wasm_file,
-        "--skip_clippy",
         &name,
     ]);
     name
@@ -194,8 +193,7 @@ fn generate_bindings(language: &str, wasm_file: &str, client_project: &str, gene
         create_dir_all(generate_dir).expect("Error creating generate subdir");
         invoke_cli(&[
             "generate",
-            "--debug",
-            "--skip_clippy",
+            "--build-options=\"--debug --skip_clippy\"",
             "--lang",
             language,
             "--wasm-file",


### PR DESCRIPTION
# Description of Changes

Add a `spacetime build --wasm-opt=false` option, so users can skip wasm-opt even if they have it installed.

Note that this is mutually exclusive with `--debug`. I could be persuaded to merge `--wasm-opt` and `--debug` into a `--profile=debug|release|release-no-wasm-opt` flag if that's preferred.

It also doesn't error if you provide `--wasm-opt=true` and then it can't find wasm-opt. Should that be an error instead of a "warning"? (And the default would become "wasm-opt-if-available" or something).

Addresses https://github.com/clockworklabs/SpacetimeDB/issues/846.

# API and ABI breaking changes

No. This is a new param.

# Expected complexity level and risk

2

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
