### PR TITLE
CLI - Change default server back to `local`

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -151,7 +151,7 @@ impl RawConfig {
             ecdsa_public_key: None,
         };
         RawConfig {
-            default_server: testnet.nickname.clone(),
+            default_server: local.nickname.clone(),
             identity_configs: Vec::new(),
             server_configs: vec![local, testnet],
         }


### PR DESCRIPTION
# Description of Changes

We have resolved to change the default server back to `local` for the time being.

# API and ABI breaking changes

Mostly no. This changes the behavior of e.g. any automation that creates a fresh CLI install, but that doesn't seem very widespread.

# Expected complexity level and risk

1

# Testing
Literally none