### PR TITLE
CLI - `--anon-identity` -> `--anonymous`

### DIFF
--- a/crates/cli/src/common_args.rs
+++ b/crates/cli/src/common_args.rs
@@ -1,4 +1,5 @@
 use clap::Arg;
+use clap::ArgAction::SetTrue;
 
 pub fn server() -> Arg {
     Arg::new("server")
@@ -12,4 +13,11 @@ pub fn identity() -> Arg {
         .long("identity")
         .short('i')
         .help("The identity to use")
+}
+
+pub fn anonymous() -> Arg {
+    Arg::new("anon_identity")
+        .long("anonymous")
+        .action(SetTrue)
+        .help("Perform this action as an arbitrary newly-created user instead of as myself")
 }

--- a/crates/cli/src/common_args.rs
+++ b/crates/cli/src/common_args.rs
@@ -19,5 +19,5 @@ pub fn anonymous() -> Arg {
     Arg::new("anon_identity")
         .long("anonymous")
         .action(SetTrue)
-        .help("Perform this action as an arbitrary newly-created user instead of as myself")
+        .help("Perform this action with an anonymous identity")
 }

--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -33,7 +33,7 @@ pub fn cli() -> clap::Command {
                 .conflicts_with("anon_identity")
                 .help("The identity to use for the call"),
         )
-        .arg(common_args::anonymous().conflicts_with("identity"))
+        .arg(common_args::anonymous())
         .after_help("Run `spacetime help call` for more detailed information.\n")
 }
 

--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -4,7 +4,7 @@ use crate::edit_distance::{edit_distance, find_best_match_for_name};
 use crate::util;
 use crate::util::{add_auth_header_opt, database_address, get_auth_header_only};
 use anyhow::{bail, Context, Error};
-use clap::{Arg, ArgAction, ArgMatches};
+use clap::{Arg, ArgMatches};
 use itertools::Either;
 use serde_json::Value;
 use spacetimedb_lib::de::serde::deserialize_from;
@@ -33,14 +33,7 @@ pub fn cli() -> clap::Command {
                 .conflicts_with("anon_identity")
                 .help("The identity to use for the call"),
         )
-        .arg(
-            Arg::new("anon_identity")
-                .long("anon-identity")
-                .short('a')
-                .conflicts_with("identity")
-                .action(ArgAction::SetTrue)
-                .help("If this flag is present, the call will be executed with no identity provided"),
-        )
+        .arg(common_args::anonymous().conflicts_with("identity"))
         .after_help("Run `spacetime help call` for more detailed information.\n")
 }
 

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -1,7 +1,7 @@
 use crate::common_args;
 use crate::config::Config;
 use crate::util::{add_auth_header_opt, database_address, get_auth_header_only};
-use clap::{Arg, ArgAction::SetTrue, ArgMatches};
+use clap::{Arg, ArgMatches};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("describe")
@@ -30,12 +30,7 @@ pub fn cli() -> clap::Command {
                 .long_help("The identity to use to describe the entity. If no identity is provided, the default one will be used."),
         )
         .arg(
-            Arg::new("anon_identity")
-                .long("anon-identity")
-                .short('a')
-                .conflicts_with("identity")
-                .action(SetTrue)
-                .help("If this flag is present, no identity will be provided when describing the database"),
+            common_args::anonymous().conflicts_with("identity")
         )
         .arg(
             common_args::server()

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -30,7 +30,7 @@ pub fn cli() -> clap::Command {
                 .long_help("The identity to use to describe the entity. If no identity is provided, the default one will be used."),
         )
         .arg(
-            common_args::anonymous().conflicts_with("identity")
+            common_args::anonymous()
         )
         .arg(
             common_args::server()

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -1,7 +1,7 @@
 use crate::common_args;
 use crate::config::Config;
 use crate::util::{add_auth_header_opt, database_address, get_auth_header_only};
-use clap::{Arg, ArgMatches};
+use clap::{Arg, ArgAction::SetTrue, ArgMatches};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("describe")

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -62,11 +62,7 @@ pub fn cli() -> clap::Command {
                 .conflicts_with("anon_identity")
         )
         .arg(
-            Arg::new("anon_identity")
-                .long("anon-identity")
-                .short('a')
-                .action(SetTrue)
-                .help("Instruct SpacetimeDB to allocate a new identity to own this database"),
+            common_args::anonymous()
         )
         .arg(
             Arg::new("skip_clippy")

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -40,7 +40,7 @@ pub fn cli() -> clap::Command {
                 .long_help("The identity to use for querying the database. If no identity is provided, the default one will be used."),
         )
         .arg(
-            common_args::anonymous().conflicts_with("identity")
+            common_args::anonymous()
         )
         .arg(common_args::server()
                 .help("The nickname, host name or URL of the server hosting the database"),

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -40,12 +40,7 @@ pub fn cli() -> clap::Command {
                 .long_help("The identity to use for querying the database. If no identity is provided, the default one will be used."),
         )
         .arg(
-            Arg::new("anon_identity")
-                .long("anon-identity")
-                .short('a')
-                .conflicts_with("identity")
-                .action(ArgAction::SetTrue)
-                .help("If this flag is present, no identity will be provided when querying the database")
+            common_args::anonymous().conflicts_with("identity")
         )
         .arg(common_args::server()
                 .help("The nickname, host name or URL of the server hosting the database"),

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -71,7 +71,7 @@ pub fn cli() -> clap::Command {
                      If no identity is provided, the default one will be used.",
                 ),
         )
-        .arg(common_args::anonymous().conflicts_with("identity"))
+        .arg(common_args::anonymous())
         .arg(common_args::server().help("The nickname, host name or URL of the server hosting the database"))
 }
 

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -71,14 +71,7 @@ pub fn cli() -> clap::Command {
                      If no identity is provided, the default one will be used.",
                 ),
         )
-        .arg(
-            Arg::new("anon_identity")
-                .long("anon-identity")
-                .short('a')
-                .conflicts_with("identity")
-                .action(ArgAction::SetTrue)
-                .help("If this flag is present, no identity will be provided when querying the database"),
-        )
+        .arg(common_args::anonymous().conflicts_with("identity"))
         .arg(common_args::server().help("The nickname, host name or URL of the server hosting the database"))
 }
 

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -164,7 +164,7 @@ class Smoketest(unittest.TestCase):
 
     def call(self, reducer, *args, anon=False):
         self._check_published()
-        anon = ["-a"] if anon else []
+        anon = ["--anonymous"] if anon else []
         self.spacetime("call", *anon, "--", self.address, reducer, *map(json.dumps, args))
 
     def logs(self, n):


### PR DESCRIPTION
# Description of Changes

Updates `--anon-identity` to be `--anonymous`. We also remove the shorthand `-a` because we're planning to make identities much more robust, so this should be much less frequent.

# API and ABI breaking changes

Yes, it changes a CLI arg.

# Expected complexity level and risk

2

# Testing

Existing smoketests have been updated