### PR TITLE
Minor attribute cleanups for C# module

### DIFF
--- a/crates/bindings-csharp/BSATN.Codegen/Utils.cs
+++ b/crates/bindings-csharp/BSATN.Codegen/Utils.cs
@@ -182,9 +182,10 @@ public static class Utils
             _ => constant.Value,
         };
 
-    public static T ParseAs<T>(this AttributeData attrData)
+    public static T ParseAs<T>(this AttributeData attrData, System.Type? type = null)
         where T : Attribute
     {
+        type ??= typeof(T);
         var ctorArgs = attrData.ConstructorArguments.Select(ResolveConstant).ToArray();
         // For now only support attributes with a single constructor.
         //
@@ -193,10 +194,10 @@ public static class Utils
         // which prevent APIs like `Activator.CreateInstance` from finding the constructor.
         //
         // Expand logic in the future if it ever becomes actually necessary.
-        var attr = (T)typeof(T).GetConstructors().Single().Invoke(ctorArgs);
+        var attr = (T)type.GetConstructors().Single().Invoke(ctorArgs);
         foreach (var arg in attrData.NamedArguments)
         {
-            typeof(T).GetProperty(arg.Key).SetValue(attr, ResolveConstant(arg.Value));
+            type.GetProperty(arg.Key).SetValue(attr, ResolveConstant(arg.Value));
         }
         return attr;
     }

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PublicTable.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PublicTable.verified.cs
@@ -255,7 +255,12 @@ partial struct PublicTable : SpacetimeDB.Internal.ITable<PublicTable>
                     Indexes: [],
                     Constraints:
                     [
-                        new(nameof(PublicTable), 0, nameof(Id), (SpacetimeDB.ColumnAttrs)15)
+                        new(
+                            nameof(PublicTable),
+                            0,
+                            nameof(Id),
+                            SpacetimeDB.Internal.ColumnAttrs.PrimaryKeyAuto
+                        )
                     ],
                     Sequences: [],
                     // "system" | "user"

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#Timers.SendMessageTimer.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#Timers.SendMessageTimer.verified.cs
@@ -73,7 +73,7 @@ partial class Timers
                                 nameof(SendMessageTimer),
                                 1,
                                 nameof(ScheduledId),
-                                (SpacetimeDB.ColumnAttrs)15
+                                SpacetimeDB.Internal.ColumnAttrs.PrimaryKeyAuto
                             )
                         ],
                         Sequences: [],

--- a/crates/bindings-csharp/Runtime/Attrs.cs
+++ b/crates/bindings-csharp/Runtime/Attrs.cs
@@ -1,73 +1,87 @@
-﻿namespace SpacetimeDB;
-
-[Flags]
-public enum ColumnAttrs : byte
+﻿namespace SpacetimeDB
 {
-    UnSet = 0b0000,
-    Indexed = 0b0001,
-    AutoInc = 0b0010,
-    Unique = Indexed | 0b0100,
-    Identity = Unique | AutoInc,
-    PrimaryKey = Unique | 0b1000,
-    PrimaryKeyAuto = PrimaryKey | AutoInc,
+    namespace Internal
+    {
+        [Flags]
+        public enum ColumnAttrs : byte
+        {
+            UnSet = 0b0000,
+            Indexed = 0b0001,
+            AutoInc = 0b0010,
+            Unique = Indexed | 0b0100,
+            Identity = Unique | AutoInc,
+            PrimaryKey = Unique | 0b1000,
+            PrimaryKeyAuto = PrimaryKey | AutoInc,
+        }
 
-    // A legacy alias, originally defined as `PrimaryKey | Identity` which is numerically same as above.
-    PrimaryKeyIdentity = PrimaryKeyAuto,
-}
-
-/// <summary>
-/// Registers a type as the row structure of a SpacetimeDB table, enabling codegen for it.
-///
-/// <para>
-/// Multiple [Table] attributes per type are supported. This is useful to reuse row types.
-/// Each attribute instance must have a unique name and will create a SpacetimeDB table.
-/// </para>
-/// </summary>
-[AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class, AllowMultiple = true)]
-public sealed class TableAttribute : Attribute
-{
-    /// <summary>
-    /// This identifier is used to name the SpacetimeDB table on the host as well as the
-    /// table handle structures generated to access the table from within a reducer call.
-    ///
-    /// <para>Defaults to the <c>nameof</c> of the target type.</para>
-    /// </summary>
-    public string? Name { get; init; }
+        [AttributeUsage(AttributeTargets.Field)]
+        public abstract class ColumnAttribute : Attribute
+        {
+            public string? Table { get; init; }
+            internal abstract ColumnAttrs Mask { get; }
+        }
+    }
 
     /// <summary>
-    /// Set to <c>true</c> to make the table visible to everyone.
+    /// Registers a type as the row structure of a SpacetimeDB table, enabling codegen for it.
     ///
-    /// <para>Defaults to the table only being visible to its owner.</para>
+    /// <para>
+    /// Multiple [Table] attributes per type are supported. This is useful to reuse row types.
+    /// Each attribute instance must have a unique name and will create a SpacetimeDB table.
+    /// </para>
     /// </summary>
-    public bool Public { get; init; } = false;
+    [AttributeUsage(AttributeTargets.Struct | AttributeTargets.Class, AllowMultiple = true)]
+    public sealed class TableAttribute : Attribute
+    {
+        /// <summary>
+        /// This identifier is used to name the SpacetimeDB table on the host as well as the
+        /// table handle structures generated to access the table from within a reducer call.
+        ///
+        /// <para>Defaults to the <c>nameof</c> of the target type.</para>
+        /// </summary>
+        public string? Name { get; init; }
 
-    public string? Scheduled { get; init; }
-}
+        /// <summary>
+        /// Set to <c>true</c> to make the table visible to everyone.
+        ///
+        /// <para>Defaults to the table only being visible to its owner.</para>
+        /// </summary>
+        public bool Public { get; init; } = false;
 
-[AttributeUsage(AttributeTargets.Field)]
-public abstract class ColumnAttribute : Attribute
-{
-    public string? Table { get; init; }
-}
+        public string? Scheduled { get; init; }
+    }
 
-public sealed class AutoIncAttribute : ColumnAttribute { }
+    public sealed class AutoIncAttribute : Internal.ColumnAttribute
+    {
+        internal override Internal.ColumnAttrs Mask => Internal.ColumnAttrs.AutoInc;
+    }
 
-public sealed class PrimaryKeyAttribute : ColumnAttribute { }
+    public sealed class PrimaryKeyAttribute : Internal.ColumnAttribute
+    {
+        internal override Internal.ColumnAttrs Mask => Internal.ColumnAttrs.PrimaryKey;
+    }
 
-public sealed class UniqueAttribute : ColumnAttribute { }
+    public sealed class UniqueAttribute : Internal.ColumnAttribute
+    {
+        internal override Internal.ColumnAttrs Mask => Internal.ColumnAttrs.Unique;
+    }
 
-public sealed class IndexedAttribute : ColumnAttribute { }
+    public sealed class IndexedAttribute : Internal.ColumnAttribute
+    {
+        internal override Internal.ColumnAttrs Mask => Internal.ColumnAttrs.Indexed;
+    }
 
-public static class ReducerKind
-{
-    public const string Init = "__init__";
-    public const string Update = "__update__";
-    public const string Connect = "__identity_connected__";
-    public const string Disconnect = "__identity_disconnected__";
-}
+    public static class ReducerKind
+    {
+        public const string Init = "__init__";
+        public const string Update = "__update__";
+        public const string Connect = "__identity_connected__";
+        public const string Disconnect = "__identity_disconnected__";
+    }
 
-[AttributeUsage(AttributeTargets.Method, Inherited = false)]
-public sealed class ReducerAttribute(string? name = null) : Attribute
-{
-    public string? Name => name;
+    [AttributeUsage(AttributeTargets.Method, Inherited = false)]
+    public sealed class ReducerAttribute(string? name = null) : Attribute
+    {
+        public string? Name => name;
+    }
 }

--- a/crates/bindings-csharp/SpacetimeSharpSATS.sln
+++ b/crates/bindings-csharp/SpacetimeSharpSATS.sln
@@ -26,6 +26,8 @@ Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "spacetimedb-quickstart-serv
 EndProject
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "sdk-test-multi-cs", "..\..\modules\sdk-test-multi-cs\sdk-test-multi-cs.csproj", "{960384A9-D78F-4C07-986A-1D1F3846AEBE}"
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "sdk-tests", "sdk-tests", "{D39E8203-6C3C-4C4B-9C7D-7911AA19D7CC}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU
@@ -53,24 +55,26 @@ Global
 		{2C282EBD-8E37-4F4C-8EE1-E91E21E75FEE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{2C282EBD-8E37-4F4C-8EE1-E91E21E75FEE}.Release|Any CPU.Build.0 = Release|Any CPU
 		{5393711C-44B0-4752-B8D0-852C73D6866F}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{5393711C-44B0-4752-B8D0-852C73D6866F}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{5393711C-44B0-4752-B8D0-852C73D6866F}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{5393711C-44B0-4752-B8D0-852C73D6866F}.Release|Any CPU.Build.0 = Release|Any CPU
 		{40F1C615-EDD9-463F-A012-B232F6710FA5}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{40F1C615-EDD9-463F-A012-B232F6710FA5}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{40F1C615-EDD9-463F-A012-B232F6710FA5}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{40F1C615-EDD9-463F-A012-B232F6710FA5}.Release|Any CPU.Build.0 = Release|Any CPU
 		{FDACD960-168E-44F9-B036-2E29EA391BE7}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{FDACD960-168E-44F9-B036-2E29EA391BE7}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{FDACD960-168E-44F9-B036-2E29EA391BE7}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{FDACD960-168E-44F9-B036-2E29EA391BE7}.Release|Any CPU.Build.0 = Release|Any CPU
 		{960384A9-D78F-4C07-986A-1D1F3846AEBE}.Debug|Any CPU.ActiveCfg = Debug|Any CPU
-		{960384A9-D78F-4C07-986A-1D1F3846AEBE}.Debug|Any CPU.Build.0 = Debug|Any CPU
 		{960384A9-D78F-4C07-986A-1D1F3846AEBE}.Release|Any CPU.ActiveCfg = Release|Any CPU
 		{960384A9-D78F-4C07-986A-1D1F3846AEBE}.Release|Any CPU.Build.0 = Release|Any CPU
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE
+	EndGlobalSection
+	GlobalSection(NestedProjects) = preSolution
+		{5393711C-44B0-4752-B8D0-852C73D6866F} = {D39E8203-6C3C-4C4B-9C7D-7911AA19D7CC}
+		{40F1C615-EDD9-463F-A012-B232F6710FA5} = {D39E8203-6C3C-4C4B-9C7D-7911AA19D7CC}
+		{FDACD960-168E-44F9-B036-2E29EA391BE7} = {D39E8203-6C3C-4C4B-9C7D-7911AA19D7CC}
+		{960384A9-D78F-4C07-986A-1D1F3846AEBE} = {D39E8203-6C3C-4C4B-9C7D-7911AA19D7CC}
 	EndGlobalSection
 	GlobalSection(ExtensibilityGlobals) = postSolution
 		SolutionGuid = {8A5DE392-1C9D-4806-B6C7-EDD4D33C5D1E}

--- a/modules/Directory.Build.props
+++ b/modules/Directory.Build.props
@@ -1,4 +1,9 @@
 <Project xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <!-- Only needed when referencing local dependencies as projects. For published packages, these are imported automatically. -->
   <Import Project="../crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.props" />
+
+  <!-- Prevent test projects from being picked up by `dotnet pack`. -->
+  <PropertyGroup>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
 </Project>


### PR DESCRIPTION
# Description of Changes

A follow-up to #1719:

 - Hide `ColumnAttrs` and base `ColumnAttribute` classes into `SpacetimeDB.Internal` since they shouldn't be accessed by user.
 - Remove legacy `PrimaryKeyIdentity` alias as `ColumnAttrs` is no longer part of the public API.
 - Extend `ParseAs` helper to support abstract classes by accepting an explicit type.
 - Reuse `ParseAs` in couple of places instead of manual parsing.
 - Combine attributes by table early during parsing to reduce number of stored elements that need to be cached and iterated over.
 - Stringify ColumnAttrs as variant name again.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
