### PR TITLE
Remove abi functions that are no longer needed

### DIFF
--- a/crates/bindings/src/table.rs
+++ b/crates/bindings/src/table.rs
@@ -635,7 +635,7 @@ fn insert<T: Table>(mut row: T::Row, mut buf: IterBuf) -> Result<T::Row, TryInse
 
     // Insert row into table.
     // When table has an auto-incrementing column, we must re-decode the changed `buf`.
-    let res = sys::insert(table_id, &mut buf).map(|gen_cols| {
+    let res = sys::datastore_insert_bsatn(table_id, &mut buf).map(|gen_cols| {
         // Let the caller handle any generated columns written back by `sys::insert` to `buf`.
         T::integrate_generated_columns(&mut row, gen_cols);
         row

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -160,9 +160,5 @@ pub enum AbiCall {
     ConsoleTimerStart,
     ConsoleTimerEnd,
 
-    DeleteByColEq,
-    IterByColEq,
-    IterStartFiltered,
-
     VolatileNonatomicScheduleImmediate,
 }

--- a/crates/core/src/host/wasm_common.rs
+++ b/crates/core/src/host/wasm_common.rs
@@ -361,14 +361,12 @@ macro_rules! abi_funcs {
             "spacetime_10.0"::console_log,
             "spacetime_10.0"::console_timer_start,
             "spacetime_10.0"::console_timer_end,
-
-            "spacetime_10.0"::delete_by_col_eq,
-            "spacetime_10.0"::iter_by_col_eq,
-            "spacetime_10.0"::iter_start_filtered,
-            "spacetime_10.0"::volatile_nonatomic_schedule_immediate,
             "spacetime_10.0"::index_id_from_name,
             "spacetime_10.0"::datastore_btree_scan_bsatn,
             "spacetime_10.0"::datastore_delete_by_btree_scan_bsatn,
+
+            // unstable:
+            "spacetime_10.0"::volatile_nonatomic_schedule_immediate,
         }
     };
 }


### PR DESCRIPTION
# Description of Changes

I left the implementations in `instance_env`, but removed them in `wasm_instance_env`. This is probably pending the csharp sdk switching over to btree_scan functions.

# API and ABI breaking changes

Yes.

# Expected complexity level and risk

2