### PR TITLE
offset index read integration

### DIFF
--- a/crates/commitlog/src/commitlog.rs
+++ b/crates/commitlog/src/commitlog.rs
@@ -556,7 +556,19 @@ impl<R: Repo> Commits<R> {
         debug!("index lookup for key={tx_offset}: found key={index_key} byte-offset={byte_offset}");
 
         if index_key <= tx_offset {
-            segment.seek(byte_offset).map(|_| ()).map_err(Into::into)
+            // Check if the offset index is pointing to the right commit.
+            segment.peek_commit_header(byte_offset).map(|hdr| {
+                if hdr.min_tx_offset == index_key {
+                    // Advance the segment Seek if expected commit is found.
+                    segment.seek(byte_offset).map(|_| ()).map_err(Into::into)
+                } else {
+                    Err(io::Error::new(
+                        io::ErrorKind::InvalidData,
+                        format!("mismatch key in offset file {}", segment.min_tx_offset),
+                    )
+                    .into())
+                }
+            })?
         } else {
             // Index lookup should never return key greater than the requested key.
             Err(io::Error::new(io::ErrorKind::InvalidData, "no smaller index key found").into())
@@ -598,7 +610,7 @@ impl<R: Repo> Iterator for Commits<R> {
                     // Try to use offset index to advance segment to Intial commit
                     if let CommitInfo::Initial { next_offset } = self.last_commit {
                         let _ = self.advance_segment(&mut segment, next_offset).inspect_err(|e| {
-                            warn!("commitlog offset index is not usedRu{e}");
+                            warn!("commitlog offset index is not used: {e}");
                         });
                     }
 

--- a/crates/commitlog/src/index/indexfile.rs
+++ b/crates/commitlog/src/index/indexfile.rs
@@ -245,7 +245,10 @@ pub struct IndexFile<Key: Into<u64> + From<u64>> {
 
 impl<Key: Into<u64> + From<u64>> IndexFile<Key> {
     pub fn open_index_file(path: &Path, offset: u64) -> io::Result<Self> {
-        let file = File::options().read(true).open(offset_index_file_path(path, offset))?;
+        let file = File::options()
+            .read(true)
+            .append(true)
+            .open(offset_index_file_path(path, offset))?;
         let mmap = unsafe { MmapMut::map_mut(&file)? };
 
         let mut inner = IndexFileMut {

--- a/crates/commitlog/src/index/mod.rs
+++ b/crates/commitlog/src/index/mod.rs
@@ -3,10 +3,8 @@ use std::io;
 use thiserror::Error;
 mod indexfile;
 
-pub use indexfile::create_index_file;
-pub use indexfile::delete_index_file;
 pub use indexfile::offset_index_file_path;
-pub use indexfile::IndexFileMut;
+pub use indexfile::{IndexFile, IndexFileMut};
 
 #[derive(Error, Debug)]
 pub enum IndexError {

--- a/crates/commitlog/src/repo/fs.rs
+++ b/crates/commitlog/src/repo/fs.rs
@@ -6,9 +6,9 @@ use std::{
 
 use log::{debug, warn};
 
-use crate::index::{create_index_file, delete_index_file, offset_index_file_path};
+use crate::index::offset_index_file_path;
 
-use super::{Repo, TxOffset, TxOffsetIndex};
+use super::{Repo, TxOffset, TxOffsetIndex, TxOffsetIndexMut};
 
 const SEGMENT_FILE_EXT: &str = ".stdb.log";
 
@@ -128,11 +128,15 @@ impl Repo for Fs {
         Ok(segments)
     }
 
-    fn get_offset_index(&self, offset: TxOffset, cap: u64) -> io::Result<TxOffsetIndex> {
-        create_index_file(&self.root, offset, cap)
+    fn create_offset_index(&self, offset: TxOffset, cap: u64) -> io::Result<TxOffsetIndexMut> {
+        TxOffsetIndexMut::create_index_file(&self.root, offset, cap)
     }
 
     fn remove_offset_index(&self, offset: TxOffset) -> io::Result<()> {
-        delete_index_file(&self.root, offset)
+        TxOffsetIndexMut::delete_index_file(&self.root, offset)
+    }
+
+    fn get_offset_index(&self, offset: TxOffset) -> io::Result<TxOffsetIndex> {
+        TxOffsetIndex::open_index_file(&self.root, offset)
     }
 }


### PR DESCRIPTION
# Description of Changes
1. Create `IndexFile`: a wrapper around `IndexFileMut` for exposing only read apis.
2. Update `Repo` trait to get `IndexFile`
3. Refactoring: Method naming changes to show clear distinction between read and write version of `IndexFile`
4. Modify `Commits` iterator to lookup through Index for initial commit. 

# API and ABI breaking changes
N/A


# Testing
![image](https://github.com/user-attachments/assets/885efca9-3db0-410d-81d1-34b3345660eb)
Did some manual testing
