### PR TITLE
CLI - Fix identity removal helptext

### DIFF
--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -363,7 +363,7 @@ pub fn unauth_error_context<T>(res: anyhow::Result<T>, identity: &str, server: &
             "Identity {identity} is not valid for server {server}.
 Has the server rotated its keys?
 Remove the outdated identity with:
-\tspacetime identity remove {identity}
+\tspacetime identity remove -i {identity}
 Generate a new identity with:
 \tspacetime identity new --no-email --server {server} --default"
         )


### PR DESCRIPTION
# Description of Changes

If an identity has become invalid, we advise users to call `spacetime identity remove ${IDENTITY}`.. but it should be `spacetime identity remove -i ${IDENTITY}` since https://github.com/clockworklabs/SpacetimeDB/pull/1482/ landed.

# API and ABI breaking changes

Nope, just helptext.

# Expected complexity level and risk

1

# Testing
Literally none