### PR TITLE
commitlog: Yield `StoredCommit` in iterators

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4570,6 +4570,7 @@ name = "spacetimedb-durability"
 version = "1.0.0-rc1"
 dependencies = [
  "anyhow",
+ "itertools 0.12.1",
  "log",
  "spacetimedb-commitlog",
  "spacetimedb-sats",

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -89,7 +89,7 @@ impl Default for Options {
 /// The canonical commitlog, backed by on-disk log files.
 ///
 /// Records in the log are of type `T`, which canonically is instantiated to
-/// [`Txdata`].
+/// [`payload::Txdata`].
 pub struct Commitlog<T> {
     inner: RwLock<commitlog::Generic<repo::Fs, T>>,
 }
@@ -372,7 +372,7 @@ impl<T: Encode> Commitlog<T> {
     /// data (e.g. `Decoder<Record = ()>`), as it will not allocate the commit
     /// payload into a struct.
     ///
-    /// Note that, unlike [`Self::transaction`], this method will ignore a
+    /// Note that, unlike [`Self::transactions`], this method will ignore a
     /// corrupt commit at the very end of the traversed log.
     pub fn fold_transactions<D>(&self, de: D) -> Result<(), D::Error>
     where

--- a/crates/commitlog/src/payload.rs
+++ b/crates/commitlog/src/payload.rs
@@ -41,7 +41,7 @@ impl Encode for () {
 ///
 /// Unlike [`Encode`], this is not a datatype: the canonical commitlog format
 /// requires to look up row types during log traversal in order to be able to
-/// decode (see also [`RowDecoder`]).
+/// decode.
 pub trait Decoder {
     /// The type of records this decoder can decode.
     /// This is also the type which can be appended to a commitlog, and so must
@@ -53,7 +53,7 @@ pub trait Decoder {
     /// Decode one [`Self::Record`] from the given buffer.
     ///
     /// The `version` argument corresponds to the log format version of the
-    /// current segment (see [`segment::Header::log_format_version`]).
+    /// current segment (see [`crate::segment::Header::log_format_version`]).
     ///
     /// The `tx_argument` is the transaction offset of the current record
     /// relative to the start of the log.

--- a/crates/commitlog/src/payload/txdata.rs
+++ b/crates/commitlog/src/payload/txdata.rs
@@ -13,7 +13,7 @@ use crate::{
 // Re-export so we get a hyperlink in rustdocs by default
 pub use spacetimedb_primitives::TableId;
 
-/// A visitor useful to implement stateful [`Decoder`]s of [`Txdata`] payloads.
+/// A visitor useful to implement stateful [`super::Decoder`]s of [`Txdata`] payloads.
 pub trait Visitor {
     type Error: From<DecodeError>;
     /// The type corresponding to one element in [`Ops::rowdata`].

--- a/crates/commitlog/src/repo/mod.rs
+++ b/crates/commitlog/src/repo/mod.rs
@@ -46,7 +46,7 @@ pub trait Repo: Clone {
     /// `offset` does not exist.
     ///
     /// The method does not guarantee that the segment is non-empty -- this case
-    /// will be caught by [`open_segment_writer`] and [`open_segment_reader`]
+    /// will be caught by [`resume_segment_writer`] and [`open_segment_reader`]
     /// respectively.
     fn open_segment(&self, offset: u64) -> io::Result<Self::Segment>;
 
@@ -178,9 +178,9 @@ pub fn resume_segment_writer<R: Repo>(
 
 /// Open the existing segment at `offset` for reading.
 ///
-/// Unlike [`open_segment_writer`], this does not traverse the segment. It does,
-/// however, attempt to read the segment header and checks that the log format
-/// version and checksum algorithm are compatible.
+/// Unlike [`resume_segment_writer`], this does not traverse the segment. It
+/// does, however, attempt to read the segment header and checks that the log
+/// format version and checksum algorithm are compatible.
 pub fn open_segment_reader<R: Repo>(
     repo: &R,
     max_log_format_version: u8,

--- a/crates/durability/Cargo.toml
+++ b/crates/durability/Cargo.toml
@@ -9,6 +9,7 @@ description = "Traits and single-node implementation of durability for Spacetime
 
 [dependencies]
 anyhow.workspace = true
+itertools.workspace = true
 log.workspace = true
 spacetimedb-commitlog.workspace = true
 spacetimedb-sats.workspace = true

--- a/crates/durability/src/imp/local.rs
+++ b/crates/durability/src/imp/local.rs
@@ -14,6 +14,7 @@ use std::{
 };
 
 use anyhow::Context as _;
+use itertools::Itertools as _;
 use log::{info, trace, warn};
 use spacetimedb_commitlog::{error, payload::Txdata, Commit, Commitlog, Decoder, Encode, Transaction};
 use tokio::{
@@ -140,7 +141,7 @@ impl<T: Encode + Send + Sync + 'static> Local<T> {
 
     /// Obtain an iterator over the [`Commit`]s in the underlying log.
     pub fn commits_from(&self, offset: TxOffset) -> impl Iterator<Item = Result<Commit, error::Traversal>> {
-        self.clog.commits_from(offset)
+        self.clog.commits_from(offset).map_ok(Commit::from)
     }
 
     /// Apply all outstanding transactions to the [`Commitlog`] and flush it


### PR DESCRIPTION
This provides access to the checksum, which may be of interest.
Leaving the `History` trait as-is, as there is no immediate need for the
checksum.

Also fix rustdoc warnings.