### PR TITLE
Fix a rustfmt issue that occurs during rust client code generation

### DIFF
--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -473,7 +473,7 @@ fn format_files(generated_files: Vec<PathBuf>, lang: Language) -> anyhow::Result
         Language::Rust => {
             cmd!("rustup", "component", "add", "rustfmt").run()?;
             for path in generated_files {
-                cmd!("rustfmt", path.to_str().unwrap()).run()?;
+                cmd!("rustfmt", "--edition", "2021", path.to_str().unwrap()).run()?;
             }
         }
         Language::Csharp => {}


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

On latest master I was having this issue where I wanted to generate bindings for a rust client, but I kept getting this strange error from `rustfmt` during code generation:

```
boppy@spacetimedb-scratch:~/sdk-quickstart$ spacetime generate --lang rust --out-dir client/src/module_bindings --project-path server
Saving config to /home/boppy/.spacetime/config.toml.
info: component 'rust-std' for target 'wasm32-unknown-unknown' is up to date
checking crate with spacetimedb's clippy configuration
    Checking spacetime-module v0.1.0 (/home/boppy/sdk-quickstart/server)
    Finished `release` profile [optimized] target(s) in 0.32s
    Finished `release` profile [optimized] target(s) in 0.07s
Optimising module with wasm-opt...
Could not find wasm-opt to optimise the module.
For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases.
Continuing with unoptimised module.
Build finished successfully.
compilation took 69.048009ms
info: component 'rustfmt' for target 'x86_64-unknown-linux-gnu' is up to date
error[E0670]: `async fn` is not permitted in Rust 2015
   --> /home/boppy/sdk-quickstart/client/src/module_bindings/mod.rs:270:9
    |
270 |     pub async fn advance_one_message_async(&self) -> __anyhow::Result<()> {
    |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
    = help: pass `--edition 2021` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide

error[E0670]: `async fn` is not permitted in Rust 2015
   --> /home/boppy/sdk-quickstart/client/src/module_bindings/mod.rs:286:9
    |
286 |     pub async fn run_async(&self) -> __anyhow::Result<()> {
    |         ^^^^^ to use `async fn`, switch to Rust 2018 or later
    |
    = help: pass `--edition 2021` to `rustc`
    = note: for more on editions, read https://doc.rust-lang.org/edition-guide
```

Apparently if you don't specify `rustfmt` is using the 2015 edition by default. This PR updates the command that's run during generation to specifically target the 2021 edition.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

Not breaking

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Create a new rust project via `spacetime init ./my-new-project --lang rust`
- [x] Successfully generate bindings via `spacetime generate ... --lang rust`. The client language must be rust.
