### PR TITLE
Revert "CLI - Print out config path when saving (#1673)"

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -817,7 +817,6 @@ impl Config {
 
         let config = toml::to_string_pretty(&self.home).unwrap();
 
-        eprintln!("Saving config to {}.", home_path.display());
         // TODO: We currently have a race condition if multiple processes are modifying the config.
         // If process X and process Y read the config, each make independent changes, and then save
         // the config, the first writer will have its changes clobbered by the second writer.
@@ -829,7 +828,7 @@ impl Config {
         // We should address this issue, but we currently don't expect it to arise very frequently
         // (see https://github.com/clockworklabs/SpacetimeDB/pull/1341#issuecomment-2150857432).
         if let Err(e) = atomic_write(&home_path, config) {
-            eprintln!("Could not save config file: {e}")
+            eprintln!("could not save config file: {e}")
         }
     }
 


### PR DESCRIPTION
# Description of Changes

This reverts commit cb3ca4d1d570bae2da7b107744f9baee8c80efb6.

It currently prints too often, because we save the config too often.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
