### PR TITLE
CLI - Remove the always-save-config behavior

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -792,14 +792,19 @@ impl Config {
 
     pub fn load() -> anyhow::Result<Self> {
         let home_path = Self::system_config_path();
-        let home = if home_path.exists() {
-            Self::load_from_file(&home_path)
-                .inspect_err(|e| eprintln!("config file {home_path:?} is invalid: {e:#?}"))?
+        let config = if home_path.exists() {
+            Self {
+                home: Self::load_from_file(&home_path)
+                    .inspect_err(|e| eprintln!("config file {home_path:?} is invalid: {e:#?}"))?,
+            }
         } else {
-            RawConfig::new_with_localhost()
+            let config = Self {
+                home: RawConfig::new_with_localhost(),
+            };
+            config.save();
+            config
         };
-
-        Ok(Self { home })
+        Ok(config)
     }
 
     #[doc(hidden)]

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -14,8 +14,6 @@ async fn main() -> Result<(), anyhow::Error> {
     let (cmd, subcommand_args) = matches.subcommand().unwrap();
 
     let config = Config::load()?;
-    // Save a default version to disk
-    config.save();
 
     exec_subcommand(config, cmd, subcommand_args).await?;
 


### PR DESCRIPTION
# Description of Changes

We used to unconditionally call `config.save()` at the start of every CLI command, in order to ensure that a default version of the config is written to disk if it wasn't already there.

This PR updates the behavior to only save to disk _if_ the file didn't exist.

This addresses https://github.com/clockworklabs/SpacetimeDB/issues/1762.

# API and ABI breaking changes

None.

# Expected complexity level and risk
2

# Testing

```
$ cargo run -- server list
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/spacetime server list`
 DEFAULT  HOSTNAME                                              PROTOCOL  NICKNAME                    
     ***  127.0.0.1:3000                                        http      local                       
          testnet.spacetimedb.com                               https     testnet                     
          bitcraft-team.spacetimedb.org                         https     bitcraft-internal           
          bitcraft-internal-bitcraft-internal-spacetimedb:3000  http      bitcraft-internal-tailscale 
          testnet.staging.spacetimedb.com                       https     staging                     

$ mv ~/.spacetime/config.toml{,.bak} 

$ cargo run -- server list
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/spacetime server list`
Saving config to /home/lead/.spacetime/config.toml.
 DEFAULT  HOSTNAME                 PROTOCOL  NICKNAME 
     ***  127.0.0.1:3000           http      local    
          testnet.spacetimedb.com  https     testnet  
```