### PR TITLE
Add gzip + none compression algos and let SDK pick compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4422,6 +4422,7 @@ dependencies = [
  "chrono",
  "derive_more",
  "enum-as-inner",
+ "flate2",
  "hex",
  "itertools 0.12.1",
  "proptest",

--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -1,5 +1,4 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
-use spacetimedb::db::relational_db::RelationalDB;
 use spacetimedb::error::DBError;
 use spacetimedb::execution_context::ExecutionContext;
 use spacetimedb::host::module_host::DatabaseTableUpdate;
@@ -7,6 +6,7 @@ use spacetimedb::identity::AuthCtx;
 use spacetimedb::messages::websocket::BsatnFormat;
 use spacetimedb::subscription::query::compile_read_only_query;
 use spacetimedb::subscription::subscription::ExecutionSet;
+use spacetimedb::{db::relational_db::RelationalDB, messages::websocket::Compression};
 use spacetimedb_bench::database::BenchDatabase as _;
 use spacetimedb_bench::spacetime_raw::SpacetimeRaw;
 use spacetimedb_primitives::{col_list, TableId};
@@ -104,7 +104,15 @@ fn eval(c: &mut Criterion) {
             let query = compile_read_only_query(&raw.db, &AuthCtx::for_testing(), &tx, sql).unwrap();
             let query: ExecutionSet = query.into();
             let ctx = &ExecutionContext::subscribe(raw.db.address());
-            b.iter(|| drop(black_box(query.eval::<BsatnFormat>(ctx, &raw.db, &tx, None))))
+            b.iter(|| {
+                drop(black_box(query.eval::<BsatnFormat>(
+                    ctx,
+                    &raw.db,
+                    &tx,
+                    None,
+                    Compression::Brotli,
+                )))
+            })
         });
     };
 

--- a/crates/client-api-messages/Cargo.toml
+++ b/crates/client-api-messages/Cargo.toml
@@ -15,6 +15,7 @@ bytestring.workspace = true
 brotli.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 enum-as-inner.workspace = true
+flate2.workspace = true
 serde = { workspace = true, features = ["derive"] }
 serde_json.workspace = true
 smallvec.workspace = true

--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -12,7 +12,7 @@ use crate::util::prometheus_handle::IntGaugeExt;
 use crate::worker_metrics::WORKER_METRICS;
 use derive_more::From;
 use futures::prelude::*;
-use spacetimedb_client_api_messages::websocket::FormatSwitch;
+use spacetimedb_client_api_messages::websocket::{Compression, FormatSwitch};
 use spacetimedb_lib::identity::RequestId;
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::AbortHandle;
@@ -36,6 +36,7 @@ impl Protocol {
 pub struct ClientConnectionSender {
     pub id: ClientActorId,
     pub protocol: Protocol,
+    pub compression: Compression,
     sendtx: mpsc::Sender<SerializableMessage>,
     abort_handle: AbortHandle,
     cancelled: AtomicBool,
@@ -61,6 +62,7 @@ impl ClientConnectionSender {
             Self {
                 id,
                 protocol,
+                compression: Compression::Brotli,
                 sendtx,
                 abort_handle,
                 cancelled: AtomicBool::new(false),
@@ -143,6 +145,7 @@ impl ClientConnection {
     pub async fn spawn<F, Fut>(
         id: ClientActorId,
         protocol: Protocol,
+        compression: Compression,
         replica_id: u64,
         mut module_rx: watch::Receiver<ModuleHost>,
         actor: F,
@@ -178,6 +181,7 @@ impl ClientConnection {
         let sender = Arc::new(ClientConnectionSender {
             id,
             protocol,
+            compression,
             sendtx,
             abort_handle,
             cancelled: AtomicBool::new(false),

--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -5,8 +5,8 @@ use crate::host::ArgsTuple;
 use crate::messages::websocket as ws;
 use derive_more::From;
 use spacetimedb_client_api_messages::websocket::{
-    BsatnFormat, FormatSwitch, JsonFormat, WebsocketFormat, SERVER_MSG_COMPRESSION_TAG_BROTLI,
-    SERVER_MSG_COMPRESSION_TAG_NONE,
+    BsatnFormat, Compression, FormatSwitch, JsonFormat, WebsocketFormat, SERVER_MSG_COMPRESSION_TAG_BROTLI,
+    SERVER_MSG_COMPRESSION_TAG_GZIP, SERVER_MSG_COMPRESSION_TAG_NONE,
 };
 use spacetimedb_lib::identity::RequestId;
 use spacetimedb_lib::ser::serde::SerializeWrapper;
@@ -28,8 +28,13 @@ pub(super) type SwitchedServerMessage = FormatSwitch<ws::ServerMessage<BsatnForm
 
 /// Serialize `msg` into a [`DataMessage`] containing a [`ws::ServerMessage`].
 ///
-/// If `protocol` is [`Protocol::Binary`], the message will be compressed by this method.
-pub fn serialize(msg: impl ToProtocol<Encoded = SwitchedServerMessage>, protocol: Protocol) -> DataMessage {
+/// If `protocol` is [`Protocol::Binary`],
+/// the message will be conditionally compressed by this method according to `compression`.
+pub fn serialize(
+    msg: impl ToProtocol<Encoded = SwitchedServerMessage>,
+    protocol: Protocol,
+    compression: Compression,
+) -> DataMessage {
     // TODO(centril, perf): here we are allocating buffers only to throw them away eventually.
     // Consider pooling these allocations so that we reuse them.
     match msg.to_protocol(protocol) {
@@ -40,12 +45,19 @@ pub fn serialize(msg: impl ToProtocol<Encoded = SwitchedServerMessage>, protocol
             bsatn::to_writer(&mut msg_bytes, &msg).unwrap();
 
             // Conditionally compress the message.
-            let msg_bytes = if ws::should_compress(msg_bytes[1..].len()) {
-                let mut out = vec![SERVER_MSG_COMPRESSION_TAG_BROTLI];
-                ws::brotli_compress(&msg_bytes[1..], &mut out);
-                out
-            } else {
-                msg_bytes
+            let srv_msg = &msg_bytes[1..];
+            let msg_bytes = match ws::decide_compression(srv_msg.len(), compression) {
+                Compression::None => msg_bytes,
+                Compression::Brotli => {
+                    let mut out = vec![SERVER_MSG_COMPRESSION_TAG_BROTLI];
+                    ws::brotli_compress(srv_msg, &mut out);
+                    out
+                }
+                Compression::Gzip => {
+                    let mut out = vec![SERVER_MSG_COMPRESSION_TAG_GZIP];
+                    ws::gzip_compress(srv_msg, &mut out);
+                    out
+                }
             };
             msg_bytes.into()
         }

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -24,7 +24,7 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use smallvec::SmallVec;
 use spacetimedb_client_api_messages::timestamp::Timestamp;
-use spacetimedb_client_api_messages::websocket::{QueryUpdate, WebsocketFormat};
+use spacetimedb_client_api_messages::websocket::{Compression, QueryUpdate, WebsocketFormat};
 use spacetimedb_data_structures::error_stream::ErrorStream;
 use spacetimedb_data_structures::map::{HashCollectionExt as _, IntMap};
 use spacetimedb_lib::identity::{AuthCtx, RequestId};
@@ -124,12 +124,12 @@ impl UpdatesRelValue<'_> {
         !(self.deletes.is_empty() && self.inserts.is_empty())
     }
 
-    pub fn encode<F: WebsocketFormat>(&self) -> (F::QueryUpdate, u64) {
+    pub fn encode<F: WebsocketFormat>(&self, compression: Compression) -> (F::QueryUpdate, u64) {
         let (deletes, nr_del) = F::encode_list(self.deletes.iter());
         let (inserts, nr_ins) = F::encode_list(self.inserts.iter());
         let num_rows = nr_del + nr_ins;
         let qu = QueryUpdate { deletes, inserts };
-        let cqu = F::into_query_update(qu);
+        let cqu = F::into_query_update(qu, compression);
         (cqu, num_rows)
     }
 }

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -9,7 +9,7 @@ use crate::host::module_host::{DatabaseTableUpdate, DatabaseTableUpdateRelValue,
 use crate::messages::websocket::TableUpdate;
 use crate::util::slow::SlowQueryLogger;
 use crate::vm::{build_query, TxMode};
-use spacetimedb_client_api_messages::websocket::{QueryUpdate, RowListLen as _, WebsocketFormat};
+use spacetimedb_client_api_messages::websocket::{Compression, QueryUpdate, RowListLen as _, WebsocketFormat};
 use spacetimedb_lib::db::error::AuthError;
 use spacetimedb_lib::relation::DbTable;
 use spacetimedb_lib::{Identity, ProductValue};
@@ -209,6 +209,7 @@ impl ExecutionUnit {
         tx: &Tx,
         sql: &str,
         slow_query_threshold: Option<Duration>,
+        compression: Compression,
     ) -> Option<TableUpdate<F>> {
         let _slow_query = SlowQueryLogger::new(sql, slow_query_threshold, ctx.workload()).log_guard();
 
@@ -220,7 +221,8 @@ impl ExecutionUnit {
 
         (!inserts.is_empty()).then(|| {
             let deletes = F::List::default();
-            let update = F::into_query_update(QueryUpdate { deletes, inserts });
+            let qu = QueryUpdate { deletes, inserts };
+            let update = F::into_query_update(qu, compression);
             TableUpdate::new(self.return_table(), self.return_name(), (update, num_rows))
         })
     }

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -120,12 +120,20 @@ impl ModuleSubscriptions {
 
         let slow_query_threshold = StVarTable::sub_limit(&ctx, &self.relational_db, &tx)?.map(Duration::from_millis);
         let database_update = match sender.protocol {
-            Protocol::Text => {
-                FormatSwitch::Json(execution_set.eval(&ctx, &self.relational_db, &tx, slow_query_threshold))
-            }
-            Protocol::Binary => {
-                FormatSwitch::Bsatn(execution_set.eval(&ctx, &self.relational_db, &tx, slow_query_threshold))
-            }
+            Protocol::Text => FormatSwitch::Json(execution_set.eval(
+                &ctx,
+                &self.relational_db,
+                &tx,
+                slow_query_threshold,
+                sender.compression,
+            )),
+            Protocol::Binary => FormatSwitch::Bsatn(execution_set.eval(
+                &ctx,
+                &self.relational_db,
+                &tx,
+                slow_query_threshold,
+                sender.compression,
+            )),
         };
 
         // It acquires the subscription lock after `eval`, allowing `add_subscription` to run concurrently.

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -168,15 +168,16 @@ impl SubscriptionManager {
                     let mut ops_bin: Option<(CompressableQueryUpdate<BsatnFormat>, _)> = None;
                     let mut ops_json: Option<(QueryUpdate<JsonFormat>, _)> = None;
                     self.subscribers.get(hash).into_iter().flatten().map(move |id| {
-                        let ops = match self.clients[id].protocol {
+                        let client = &*self.clients[id];
+                        let ops = match client.protocol {
                             Protocol::Binary => Bsatn(
                                 ops_bin
-                                    .get_or_insert_with(|| delta.updates.encode::<BsatnFormat>())
+                                    .get_or_insert_with(|| delta.updates.encode::<BsatnFormat>(client.compression))
                                     .clone(),
                             ),
                             Protocol::Text => Json(
                                 ops_json
-                                    .get_or_insert_with(|| delta.updates.encode::<JsonFormat>())
+                                    .get_or_insert_with(|| delta.updates.encode::<JsonFormat>(client.compression))
                                     .clone(),
                             ),
                         };

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -32,7 +32,7 @@ use crate::vm::{build_query, TxMode};
 use anyhow::Context;
 use itertools::Either;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
-use spacetimedb_client_api_messages::websocket::WebsocketFormat;
+use spacetimedb_client_api_messages::websocket::{Compression, WebsocketFormat};
 use spacetimedb_data_structures::map::HashSet;
 use spacetimedb_lib::db::auth::{StAccess, StTableType};
 use spacetimedb_lib::db::error::AuthError;
@@ -521,13 +521,14 @@ impl ExecutionSet {
         db: &RelationalDB,
         tx: &Tx,
         slow_query_threshold: Option<Duration>,
+        compression: Compression,
     ) -> ws::DatabaseUpdate<F> {
         // evaluate each of the execution units in this ExecutionSet in parallel
         let tables = self
             .exec_units
             // if you need eval to run single-threaded for debugging, change this to .iter()
             .par_iter()
-            .filter_map(|unit| unit.eval(ctx, db, tx, &unit.sql, slow_query_threshold))
+            .filter_map(|unit| unit.eval(ctx, db, tx, &unit.sql, slow_query_threshold, compression))
             .collect();
         ws::DatabaseUpdate { tables }
     }

--- a/crates/sdk/examples/quickstart-chat/main.rs
+++ b/crates/sdk/examples/quickstart-chat/main.rs
@@ -2,6 +2,7 @@
 mod module_bindings;
 use module_bindings::*;
 
+use spacetimedb_client_api_messages::websocket::Compression;
 use spacetimedb_sdk::{credentials, DbContext, Event, Identity, ReducerEvent, Status, Table, TableWithPrimaryKey};
 
 // # Our main function
@@ -171,6 +172,7 @@ fn connect_to_db() -> DbConnection {
         .with_credentials(creds_store().load().expect("Error loading credentials"))
         .with_module_name(DB_NAME)
         .with_uri(HOST)
+        .with_compression(Compression::Gzip)
         .build()
         .expect("Failed to connect")
 }


### PR DESCRIPTION
# Description of Changes

Adds gzip and none compression choices, and expose it to the rust sdk via `DbConnectionBuilder::with_compression`.

- [x] Implement in Host
- [x] Implement in Rust SDK
- [x] Implement in TS SDK, https://github.com/clockworklabs/spacetimedb-typescript-sdk/pull/109
- [x] Implement in C# SDK, https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/155

Fixes https://github.com/clockworklabs/SpacetimeDB/issues/1463.
Closes https://github.com/clockworklabs/SpacetimeDB/pull/1642.

# API and ABI breaking changes

None. If a compression is not chosen brotli is used.