### PR TITLE
Make smoketests not log expected teardown errors

### DIFF
--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -65,7 +65,7 @@ def build_template_target():
 
         BuildModule.setUpClass()
         env = { **os.environ, "CARGO_TARGET_DIR": str(TEMPLATE_TARGET_DIR) }
-        spacetime("build", "--project-path", BuildModule.project_path, env=env, capture_stderr=False)
+        spacetime("build", "--project-path", BuildModule.project_path, env=env)
         BuildModule.tearDownClass()
         BuildModule.doClassCleanups()
 
@@ -276,7 +276,7 @@ class Smoketest(unittest.TestCase):
         if "address" in self.__dict__:
             try:
                 # TODO: save the credentials in publish_module()
-                self.spacetime("delete", self.address, capture_stderr=False)
+                self.spacetime("delete", self.address)
             except Exception:
                 pass
 
@@ -285,7 +285,7 @@ class Smoketest(unittest.TestCase):
         if hasattr(cls, "address"):
             try:
                 # TODO: save the credentials in publish_module()
-                cls.spacetime("delete", cls.address, capture_stderr=False)
+                cls.spacetime("delete", cls.address)
             except Exception:
                 pass
 


### PR DESCRIPTION
# Description of Changes

There were teardown errors in the logs despite the tests not failing (because our testing framework doesn't instrument stdout/stderr during teardown, I think). Getting rid of them makes it easier to diagnose actual test failures

# Testing

Ran the smoketests