### PR TITLE
CLI - `spacetime upgrade` takes `--yes` instead of deprecated `--force`

### DIFF
--- a/crates/cli/src/subcommands/upgrade.rs
+++ b/crates/cli/src/subcommands/upgrade.rs
@@ -4,7 +4,7 @@ use std::{env, fs};
 extern crate regex;
 
 use crate::util::y_or_n;
-use crate::{version, Config};
+use crate::{common_args, version, Config};
 use clap::{Arg, ArgMatches};
 use flate2::read::GzDecoder;
 use futures::stream::StreamExt;
@@ -19,13 +19,7 @@ pub fn cli() -> clap::Command {
     clap::Command::new("upgrade")
         .about("Checks for updates for the currently running spacetime CLI tool")
         .arg(Arg::new("version").help("The specific version to upgrade to"))
-        .arg(
-            Arg::new("force")
-                .short('f')
-                .long("force")
-                .help("If this flag is present, the upgrade will be performed even if the version is the same")
-                .action(clap::ArgAction::SetTrue),
-        )
+        .arg(common_args::yes())
         .after_help("Run `spacetime help upgrade` for more detailed information.\n")
 }
 


### PR DESCRIPTION
# Description of Changes

I missed making this change in https://github.com/clockworklabs/SpacetimeDB/pull/1752. This PR migrates `spacetime upgrade` to `--yes` as well.

# API and ABI breaking changes

Yes, this breaks `spacetime upgrade --force`.

# Expected complexity level and risk

1

# Testing

```
$ cargo run -- upgrade 0.12.0 --yes
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.22s
     Running `target/debug/spacetime upgrade 0.12.0 --yes`
Finding version...done.
You're already running the latest version: 0.12.0
Skipping confirmation due to --yes
You are currently running version 0.12.0 of spacetime. The version you're upgrading to is 0.12.0.
This will replace the current executable at /mnt/nutera/work/localhd-symlinks/SpacetimeDBPrivate/public/target/debug/spacetime.
Skipping confirmation due to --yes
  Downloading update... 18.64MiB/18.64MiB (0s)
```