### PR TITLE
Correct `Schema::check_compatible` to resolve types in a ModuleDef

### DIFF
--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -30,16 +30,16 @@ pub fn update_database(
     let existing_tables = stdb.get_all_tables_mut(tx)?;
 
     // TODO: consider using `ErrorStream` here.
-    let old_def = plan.old_def();
+    let old_module_def = plan.old_def();
     for table in existing_tables
         .iter()
         .filter(|table| table.table_type != StTableType::System)
     {
-        let old_def = old_def
+        let old_def = old_module_def
             .table(&table.table_name[..])
-            .ok_or_else(|| anyhow::anyhow!("table {} not found in old_def", table.table_name))?;
+            .ok_or_else(|| anyhow::anyhow!("table {} not found in old_module_def", table.table_name))?;
 
-        table.check_compatible(old_def)?;
+        table.check_compatible(old_module_def, old_def)?;
     }
 
     match plan {

--- a/smoketests/tests/auto_migration.py
+++ b/smoketests/tests/auto_migration.py
@@ -3,9 +3,9 @@ import sys
 import logging
 
 
-class AddTablePseudomigration(Smoketest):
+class AddTableAutoMigration(Smoketest):
     MODULE_CODE = """
-use spacetimedb::{println, ReducerContext, Table};
+use spacetimedb::{println, ReducerContext, Table, SpacetimeType};
 
 #[spacetimedb::table(name = person)]
 pub struct Person {
@@ -22,6 +22,19 @@ pub fn print_persons(ctx: &ReducerContext, prefix: String) {
     for person in ctx.db.person().iter() {
         println!("{}: {}", prefix, person.name);
     }
+}
+
+#[spacetimedb::table(name = point_mass)]
+pub struct PointMass {
+    mass: f64,
+    /// This used to cause an error when check_compatible did not resolve types in a `ModuleDef`.
+    position: Vector2,
+}
+
+#[derive(SpacetimeType, Clone, Copy)]
+pub struct Vector2 {
+    x: f64,
+    y: f64,
 }
 """
 
@@ -47,7 +60,7 @@ pub fn print_books(ctx: &ReducerContext, prefix: String) {
 """
     )
 
-    def test_add_table_pseudomigration(self):
+    def test_add_table_auto_migration(self):
         """This tests uploading a module with a schema change that should not require clearing the database."""
 
         logging.info("Initial publish complete")


### PR DESCRIPTION
# Description of Changes

When performing an automatic migration, we check the old moduledef is compatible with the data stored in the system tables.
But right now, the types stored in the system tables are resolved, but the types in the moduledef are not. So the check breaks on nested types. This PR fixes that and adds a regression test for it.

I'd like to do a followup PR adding more intensive automigration testing.

# Expected complexity level and risk

0

# Testing

Added a failing test, fixed the test.