### PR TITLE
Add CODEOWNERS for CLI crate

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,4 +3,4 @@
 /.github/CODEOWNERS @cloutiertyler
 LICENSE.txt @cloutiertyler
 /crates/client-api-messages/src/websocket.rs @centril @gefjon
-/crates/cli/ @bfops @jdetter @cloutiertyler
+/crates/cli/src/ @bfops @jdetter @cloutiertyler

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,3 +3,4 @@
 /.github/CODEOWNERS @cloutiertyler
 LICENSE.txt @cloutiertyler
 /crates/client-api-messages/src/websocket.rs @centril @gefjon
+/crates/cli/ @bfops @jdetter @cloutiertyler


### PR DESCRIPTION
# Description of Changes

I made @bfops @jdetter and @cloutiertyler the CODEOWNERS for the CLI crate's `src/` subdirectory.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Eh :shrug: 