### PR TITLE
Make ARM64 and AMD64 docker builds more resilient

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Install jq
         run: sudo apt-get install jq -y
+      - name: Prune stale references
+        run: git remote prune origin
       - name: Checkout
         uses: actions/checkout@v3
       - name: Docker meta
@@ -75,6 +77,8 @@ jobs:
     steps:
       - name: Install jq
         run: sudo apt-get install jq -y
+      - name: Prune stale references
+        run: git remote prune origin
       - name: Checkout
         uses: actions/checkout@v3
       - name: Docker meta


### PR DESCRIPTION
# Description of Changes

Please describe your change, mention any related tickets, and so on here.

- During the release of 0.12.0 we had an issue where we pushed a tag, deleted that tag and then pushed the tag again. It is known that typically updating tags isn't supported in our CI and in this case this caused a downstream issue with the docker container images that get built for the website. This PR makes the build more resilient to hopefully prevent future issues.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

Not breaking

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

I pushed a tag `vjdetter-test-tag` which then built successfully (expected) <https://github.com/clockworklabs/SpacetimeDB/actions/runs/11293014896>
Then I deleted the tag via:
```
git push -u origin :vjdetter-test-tag
```
Then I pushed the tag again (with a different commit!) and it also built successfully <https://github.com/clockworklabs/SpacetimeDB/actions/runs/11293114243>