### PR TITLE
RLS: Adding a new filter! macro

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4315,6 +4315,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "spacetimedb-primitives",
+ "spacetimedb-sql-parser",
  "syn 2.0.79",
 ]
 

--- a/crates/bindings-macro/Cargo.toml
+++ b/crates/bindings-macro/Cargo.toml
@@ -13,6 +13,7 @@ bench = false
 
 [dependencies]
 spacetimedb-primitives.workspace = true
+spacetimedb-sql-parser.workspace = true
 
 bitflags.workspace = true
 humantime.workspace = true

--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -17,7 +17,6 @@ use proc_macro::TokenStream as StdTokenStream;
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use std::borrow::Cow;
-use std::collections::HashMap;
 use std::hash::{DefaultHasher, Hash, Hasher};
 use std::time::Duration;
 use syn::ext::IdentExt;

--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -17,6 +17,8 @@ use proc_macro::TokenStream as StdTokenStream;
 use proc_macro2::{Span, TokenStream};
 use quote::{format_ident, quote, quote_spanned, ToTokens};
 use std::borrow::Cow;
+use std::collections::HashMap;
+use std::hash::{DefaultHasher, Hash, Hasher};
 use std::time::Duration;
 use syn::ext::IdentExt;
 use syn::meta::ParseNestedMeta;
@@ -1236,4 +1238,75 @@ pub fn schema_type(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
     })()
     .unwrap_or_else(syn::Error::into_compile_error)
     .into()
+}
+
+fn parse_sql(input: ParseStream) -> syn::Result<String> {
+    use spacetimedb_sql_parser::parser::sub;
+
+    let lookahead = input.lookahead1();
+    let sql = if lookahead.peek(syn::LitStr) {
+        let s = input.parse::<syn::LitStr>()?;
+        // Checks the query is syntactically valid
+        let _ = sub::parse_subscription(&s.value()).map_err(|e| syn::Error::new(s.span(), format_args!("{e}")))?;
+
+        s.value()
+    } else {
+        return Err(lookahead.error());
+    };
+
+    Ok(sql)
+}
+
+/// Generates code for registering a row-level security `SQL` function.
+///
+/// A row-level security function takes a `SQL` query expression that is used to filter rows.
+///
+/// The query follows the same syntax as a subscription query.
+///
+/// **Example:**
+///
+/// ```rust,ignore
+/// /// Players can only see what's in their chunk
+/// spacetimedb::filter!("
+///     SELECT * FROM LocationState WHERE chunk_index IN (
+///         SELECT chunk_index FROM LocationState WHERE entity_id IN (
+///             SELECT entity_id FROM UserState WHERE identity = @sender
+///         )
+///     )
+/// ");
+/// ```
+///
+/// **NOTE:** The `SQL` query expression is pre-parsed at compile time, but only check is a valid
+/// subscription query *syntactically*, not that the query is valid when executed.
+///
+/// For example, it could refer to a non-existent table.
+#[proc_macro]
+pub fn filter(input: proc_macro::TokenStream) -> proc_macro::TokenStream {
+    let rls_sql = syn::parse_macro_input!(input with parse_sql);
+
+    let mut hasher = DefaultHasher::new();
+    rls_sql.hash(&mut hasher);
+    let rls_name = format_ident!("rls_{}", hasher.finish());
+
+    let register_rls_symbol = format!("__preinit__20_register_{rls_name}");
+
+    let generated_describe_function = quote! {
+        #[export_name = #register_rls_symbol]
+        extern "C" fn __register_rls() {
+            spacetimedb::rt::register_row_level_security::<#rls_name>()
+        }
+    };
+
+    let emission = quote! {
+        const _: () = {
+            #generated_describe_function
+        };
+        #[allow(non_camel_case_types)]
+        struct #rls_name { _never: ::core::convert::Infallible }
+        impl spacetimedb::rt::RowLevelSecurityInfo for #rls_name {
+            const SQL: &'static str = #rls_sql;
+        }
+    };
+
+    emission.into()
 }

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -26,7 +26,7 @@ pub use rng::StdbRng;
 pub use sats::SpacetimeType;
 #[doc(hidden)]
 pub use spacetimedb_bindings_macro::__TableHelper;
-pub use spacetimedb_bindings_macro::{duration, reducer, table};
+pub use spacetimedb_bindings_macro::{duration, filter, reducer, table};
 pub use spacetimedb_bindings_sys as sys;
 pub use spacetimedb_lib;
 pub use spacetimedb_lib::de::{Deserialize, DeserializeOwned};

--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -290,6 +290,12 @@ impl RepeaterArgs for (Timestamp,) {
     }
 }
 
+/// A trait for types that can *describe* a row-level security policy.
+pub trait RowLevelSecurityInfo {
+    /// The SQL expression for the row-level security policy.
+    const SQL: &'static str;
+}
+
 /// Registers into `DESCRIBERS` a function `f` to modify the module builder.
 fn register_describer(f: fn(&mut ModuleBuilder)) {
     DESCRIBERS.lock().unwrap().push(f)
@@ -349,6 +355,13 @@ pub fn register_reducer<'a, A: Args<'a>, I: ReducerInfo>(_: impl Reducer<'a, A>)
         let params = A::schema::<I>(&mut module.inner);
         module.inner.add_reducer(I::NAME, params, I::LIFECYCLE);
         module.reducers.push(I::INVOKE);
+    })
+}
+
+/// Registers a row-level security policy.
+pub fn register_row_level_security<R: RowLevelSecurityInfo>() {
+    register_describer(|module| {
+        module.inner.add_row_level_security(R::SQL);
     })
 }
 

--- a/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
+++ b/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
@@ -2,7 +2,7 @@
 source: crates/bindings/tests/deps.rs
 expression: "cargo tree -p spacetimedb -f {lib} -e no-dev"
 ---
-total crates: 62
+total crates: 64
 spacetimedb
 ├── bytemuck
 ├── derive_more
@@ -48,6 +48,15 @@ spacetimedb
 │   │   ├── itertools
 │   │   │   └── either
 │   │   └── nohash_hasher
+│   ├── spacetimedb_sql_parser
+│   │   ├── derive_more (*)
+│   │   ├── sqlparser
+│   │   │   └── log
+│   │   └── thiserror
+│   │       └── thiserror_impl
+│   │           ├── proc_macro2 (*)
+│   │           ├── quote (*)
+│   │           └── syn (*)
 │   └── syn (*)
 ├── spacetimedb_bindings_sys
 │   └── spacetimedb_primitives (*)
@@ -75,11 +84,7 @@ spacetimedb
 │   │   │   └── equivalent
 │   │   ├── nohash_hasher
 │   │   ├── smallvec
-│   │   └── thiserror
-│   │       └── thiserror_impl
-│   │           ├── proc_macro2 (*)
-│   │           ├── quote (*)
-│   │           └── syn (*)
+│   │   └── thiserror (*)
 │   ├── spacetimedb_primitives (*)
 │   ├── spacetimedb_sats
 │   │   ├── arrayvec

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -227,7 +227,7 @@ fn auto_migrate_database(
             spacetimedb_schema::auto_migrate::AutoMigrateStep::AddRowLevelSecurity(sql_rls) => {
                 system_logger.info(&format!("Adding row-level security `{sql_rls}`"));
                 log::info!("Adding row-level security `{sql_rls}`");
-                let rls = RawRowLevelSecurityDefV9::lookup(plan.new, sql_rls).unwrap();
+                let rls = plan.new.lookup_expect(sql_rls);
                 let rls = RowLevelExpr::build_row_level_expr(stdb, tx, rls)?;
 
                 stdb.create_row_level_security(tx, rls.def)?;

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -274,7 +274,7 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
                     let table_name = &def.name;
                     self.system_logger().info(&format!("Creating table `{table_name}`"));
                     let schema = TableSchema::from_module_def(&self.info.module_def, def, (), TableId::SENTINEL);
-                    stdb.create_table(tx, schema.clone())
+                    stdb.create_table(tx, schema)
                         .with_context(|| format!("failed to create table {table_name}"))?;
                 }
                 // Insert the late-bound row-level security expressions.

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -269,24 +269,20 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
             .with_auto_rollback(&ctx, tx, |tx| {
                 let mut table_defs: Vec<_> = self.info.module_def.tables().collect();
                 table_defs.sort_by(|a, b| a.name.cmp(&b.name));
-                let mut table_schemas = Vec::with_capacity(table_defs.len());
 
                 for def in table_defs {
                     let table_name = &def.name;
                     self.system_logger().info(&format!("Creating table `{table_name}`"));
-                    let mut schema = TableSchema::from_module_def(&self.info.module_def, def, (), TableId::SENTINEL);
-                    let table_id = stdb
-                        .create_table(tx, schema.clone())
+                    let schema = TableSchema::from_module_def(&self.info.module_def, def, (), TableId::SENTINEL);
+                    stdb.create_table(tx, schema.clone())
                         .with_context(|| format!("failed to create table {table_name}"))?;
-                    schema.table_id = table_id;
-                    table_schemas.push(schema.into());
                 }
                 // Insert the late-bound row-level security expressions.
                 for rls in self.info.module_def.row_level_security() {
                     self.system_logger()
                         .info(&format!("Creating row level security `{}`", rls.sql));
 
-                    let rls = RowLevelExpr::try_from((rls, table_schemas.as_slice()))
+                    let rls = RowLevelExpr::build_row_level_expr(stdb, tx, rls)
                         .with_context(|| format!("failed to create row-level security: `{}`", rls.sql))?;
                     let table_id = rls.def.table_id;
                     let sql = rls.def.sql.clone();

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -9,9 +9,6 @@ use spacetimedb_schema::schema::{Schema, TableSchema};
 use std::sync::Arc;
 use std::time::Duration;
 
-use spacetimedb_lib::buffer::DecodeError;
-use spacetimedb_lib::{bsatn, Address, RawModuleDef};
-
 use super::instrumentation::CallTimes;
 use crate::database_logger::SystemLogger;
 use crate::db::datastore::locking_tx_datastore::MutTxId;
@@ -33,6 +30,9 @@ use crate::subscription::module_subscription_actor::WriteConflict;
 use crate::util::const_unwrap;
 use crate::util::prometheus_handle::HistogramExt;
 use crate::worker_metrics::WORKER_METRICS;
+use spacetimedb_lib::buffer::DecodeError;
+use spacetimedb_lib::identity::AuthCtx;
+use spacetimedb_lib::{bsatn, Address, RawModuleDef};
 
 use super::*;
 
@@ -264,6 +264,7 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
         let timestamp = Timestamp::now();
         let stdb = &*self.replica_context().relational_db;
         let ctx = ExecutionContext::internal(stdb.address());
+        let auth_ctx = AuthCtx::for_current(self.replica_context().database.owner_identity);
         let tx = stdb.begin_mut_tx(IsolationLevel::Serializable);
         let (tx, ()) = stdb
             .with_auto_rollback(&ctx, tx, |tx| {
@@ -282,7 +283,7 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
                     self.system_logger()
                         .info(&format!("Creating row level security `{}`", rls.sql));
 
-                    let rls = RowLevelExpr::build_row_level_expr(stdb, tx, rls)
+                    let rls = RowLevelExpr::build_row_level_expr(stdb, tx, &auth_ctx, rls)
                         .with_context(|| format!("failed to create row-level security: `{}`", rls.sql))?;
                     let table_id = rls.def.table_id;
                     let sql = rls.def.sql.clone();
@@ -349,7 +350,8 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
         let (mut tx, _) = stdb.with_auto_rollback(&ctx, tx, |tx| stdb.update_program(tx, HostType::Wasm, program))?;
         self.system_logger().info(&format!("Updated program to {program_hash}"));
 
-        let res = crate::db::update::update_database(stdb, &mut tx, plan, self.system_logger());
+        let auth_ctx = AuthCtx::for_current(self.replica_context().database.owner_identity);
+        let res = crate::db::update::update_database(stdb, &mut tx, auth_ctx, plan, self.system_logger());
 
         match res {
             Err(e) => {

--- a/crates/core/src/sql/mod.rs
+++ b/crates/core/src/sql/mod.rs
@@ -1,4 +1,5 @@
 pub mod ast;
 pub mod compiler;
 pub mod execute;
+pub mod parser;
 mod type_check;

--- a/crates/core/src/sql/parser.rs
+++ b/crates/core/src/sql/parser.rs
@@ -1,0 +1,29 @@
+use spacetimedb_expr::check::parse_and_type_sub;
+use spacetimedb_expr::errors::TypingError;
+use spacetimedb_expr::expr::RelExpr;
+use spacetimedb_expr::ty::TyCtx;
+use spacetimedb_lib::db::raw_def::v9::RawRowLevelSecurityDefV9;
+use spacetimedb_schema::schema::{RowLevelSecuritySchema, TableSchema};
+use std::sync::Arc;
+
+pub struct RowLevelExpr {
+    pub sql: RelExpr,
+    pub def: RowLevelSecuritySchema,
+}
+
+impl TryFrom<(&RawRowLevelSecurityDefV9, &[Arc<TableSchema>])> for RowLevelExpr {
+    type Error = TypingError;
+
+    fn try_from((rls, tx): (&RawRowLevelSecurityDefV9, &[Arc<TableSchema>])) -> Result<Self, Self::Error> {
+        let mut ctx = TyCtx::default();
+        let sql = parse_and_type_sub(&mut ctx, &rls.sql, &tx)?;
+
+        Ok(Self {
+            def: RowLevelSecuritySchema {
+                table_id: sql.table_id(&mut ctx)?,
+                sql: rls.sql.clone(),
+            },
+            sql,
+        })
+    }
+}

--- a/crates/core/src/sql/parser.rs
+++ b/crates/core/src/sql/parser.rs
@@ -1,22 +1,31 @@
+use crate::db::datastore::locking_tx_datastore::MutTxId;
+use crate::db::relational_db::RelationalDB;
+use crate::sql::ast::SchemaViewer;
 use spacetimedb_expr::check::parse_and_type_sub;
 use spacetimedb_expr::errors::TypingError;
 use spacetimedb_expr::expr::RelExpr;
 use spacetimedb_expr::ty::TyCtx;
 use spacetimedb_lib::db::raw_def::v9::RawRowLevelSecurityDefV9;
-use spacetimedb_schema::schema::{RowLevelSecuritySchema, TableSchema};
-use std::sync::Arc;
+use spacetimedb_lib::identity::AuthCtx;
+use spacetimedb_schema::schema::RowLevelSecuritySchema;
 
 pub struct RowLevelExpr {
     pub sql: RelExpr,
     pub def: RowLevelSecuritySchema,
 }
 
-impl TryFrom<(&RawRowLevelSecurityDefV9, &[Arc<TableSchema>])> for RowLevelExpr {
-    type Error = TypingError;
-
-    fn try_from((rls, tx): (&RawRowLevelSecurityDefV9, &[Arc<TableSchema>])) -> Result<Self, Self::Error> {
+impl RowLevelExpr {
+    pub fn build_row_level_expr(
+        stdb: &RelationalDB,
+        tx: &mut MutTxId,
+        rls: &RawRowLevelSecurityDefV9,
+    ) -> Result<Self, TypingError> {
         let mut ctx = TyCtx::default();
-        let sql = parse_and_type_sub(&mut ctx, &rls.sql, &tx)?;
+        let sql = parse_and_type_sub(
+            &mut ctx,
+            &rls.sql,
+            &SchemaViewer::new(stdb, tx, &AuthCtx::for_testing()),
+        )?;
 
         Ok(Self {
             def: RowLevelSecuritySchema {

--- a/crates/core/src/sql/parser.rs
+++ b/crates/core/src/sql/parser.rs
@@ -18,14 +18,11 @@ impl RowLevelExpr {
     pub fn build_row_level_expr(
         stdb: &RelationalDB,
         tx: &mut MutTxId,
+        auth_ctx: &AuthCtx,
         rls: &RawRowLevelSecurityDefV9,
     ) -> Result<Self, TypingError> {
         let mut ctx = TyCtx::default();
-        let sql = parse_and_type_sub(
-            &mut ctx,
-            &rls.sql,
-            &SchemaViewer::new(stdb, tx, &AuthCtx::for_testing()),
-        )?;
+        let sql = parse_and_type_sub(&mut ctx, &rls.sql, &SchemaViewer::new(stdb, tx, auth_ctx))?;
 
         Ok(Self {
             def: RowLevelSecuritySchema {

--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -27,6 +27,11 @@ pub trait SchemaView {
     fn schema(&self, name: &str) -> Option<Arc<TableSchema>>;
 }
 
+impl SchemaView for &[Arc<TableSchema>] {
+    fn schema(&self, name: &str) -> Option<Arc<TableSchema>> {
+        self.iter().find(|schema| schema.table_name == Box::from(name)).cloned()
+    }
+}
 pub trait TypeChecker {
     type Ast;
     type Set;

--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -27,11 +27,6 @@ pub trait SchemaView {
     fn schema(&self, name: &str) -> Option<Arc<TableSchema>>;
 }
 
-impl SchemaView for &[Arc<TableSchema>] {
-    fn schema(&self, name: &str) -> Option<Arc<TableSchema>> {
-        self.iter().find(|schema| schema.table_name == Box::from(name)).cloned()
-    }
-}
 pub trait TypeChecker {
     type Ast;
     type Set;

--- a/crates/expr/src/errors.rs
+++ b/crates/expr/src/errors.rs
@@ -135,8 +135,8 @@ impl UnexpectedType {
 pub struct DuplicateName(pub String);
 
 #[derive(Debug, Error)]
-#[error("No `TableId` found in `sql` expression")]
-pub struct NoTableId;
+#[error("`filter!` does not support column projections; Must return table rows")]
+pub struct FilterReturnType;
 
 #[derive(Error, Debug)]
 pub enum TypingError {

--- a/crates/expr/src/errors.rs
+++ b/crates/expr/src/errors.rs
@@ -1,10 +1,10 @@
-use spacetimedb_sql_parser::{ast::BinOp, parser::errors::SqlParseError};
-use thiserror::Error;
-
 use super::{
     statement::InvalidVar,
     ty::{InvalidTypeId, TypeWithCtx},
 };
+use spacetimedb_sql_parser::ast::BinOp;
+use spacetimedb_sql_parser::parser::errors::SqlParseError;
+use thiserror::Error;
 
 #[derive(Error, Debug)]
 pub enum Unresolved {
@@ -134,6 +134,10 @@ impl UnexpectedType {
 #[error("Duplicate name `{0}`")]
 pub struct DuplicateName(pub String);
 
+#[derive(Debug, Error)]
+#[error("No `TableId` found in `sql` expression")]
+pub struct NoTableId;
+
 #[derive(Error, Debug)]
 pub enum TypingError {
     #[error(transparent)]
@@ -163,4 +167,6 @@ pub enum TypingError {
     Wildcard(#[from] InvalidWildcard),
     #[error(transparent)]
     DuplicateName(#[from] DuplicateName),
+    #[error(transparent)]
+    NoTableId(#[from] NoTableId),
 }

--- a/crates/expr/src/errors.rs
+++ b/crates/expr/src/errors.rs
@@ -168,5 +168,5 @@ pub enum TypingError {
     #[error(transparent)]
     DuplicateName(#[from] DuplicateName),
     #[error(transparent)]
-    NoTableId(#[from] NoTableId),
+    FilterReturnType(#[from] FilterReturnType),
 }

--- a/crates/expr/src/expr.rs
+++ b/crates/expr/src/expr.rs
@@ -1,6 +1,6 @@
 use std::sync::Arc;
 
-use crate::errors::{NoTableId, TypingError};
+use crate::errors::{FilterReturnType, TypingError};
 use crate::static_assert_size;
 use spacetimedb_lib::AlgebraicValue;
 use spacetimedb_primitives::TableId;
@@ -59,7 +59,7 @@ impl RelExpr {
     pub fn table_id(&self, ctx: &mut TyCtx) -> Result<TableId, TypingError> {
         match &*self.ty(ctx)? {
             Type::Var(id, _) => Ok(*id),
-            _ => Err(NoTableId.into()),
+            _ => Err(FilterReturnType.into()),
         }
     }
 }

--- a/crates/expr/src/expr.rs
+++ b/crates/expr/src/expr.rs
@@ -1,12 +1,13 @@
 use std::sync::Arc;
 
+use crate::errors::{NoTableId, TypingError};
+use crate::static_assert_size;
 use spacetimedb_lib::AlgebraicValue;
+use spacetimedb_primitives::TableId;
 use spacetimedb_schema::schema::TableSchema;
 use spacetimedb_sql_parser::ast::BinOp;
 
-use crate::static_assert_size;
-
-use super::ty::{InvalidTypeId, Symbol, TyCtx, TyId, TypeWithCtx};
+use super::ty::{InvalidTypeId, Symbol, TyCtx, TyId, Type, TypeWithCtx};
 
 /// A logical relational expression
 #[derive(Debug)]
@@ -53,6 +54,13 @@ impl RelExpr {
     /// The type of this relation expression
     pub fn ty<'a>(&self, ctx: &'a TyCtx) -> Result<TypeWithCtx<'a>, InvalidTypeId> {
         ctx.try_resolve(self.ty_id())
+    }
+
+    pub fn table_id(&self, ctx: &mut TyCtx) -> Result<TableId, TypingError> {
+        match &*self.ty(ctx)? {
+            Type::Var(id, _) => Ok(*id),
+            _ => Err(NoTableId.into()),
+        }
     }
 }
 

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -339,9 +339,9 @@ pub struct RawUniqueConstraintDataV9 {
 }
 
 /// Data for the `RLS` policy on a table.
-#[derive(Debug, Clone, SpacetimeType)]
+#[derive(Debug, Clone, PartialEq, Eq, SpacetimeType)]
 #[sats(crate = crate)]
-#[cfg_attr(feature = "test", derive(PartialEq, Eq, PartialOrd, Ord))]
+#[cfg_attr(feature = "test", derive(PartialOrd, Ord))]
 pub struct RawRowLevelSecurityDefV9 {
     /// The `sql` expression to use for row-level security.
     pub sql: RawSql,

--- a/crates/schema/src/auto_migrate.rs
+++ b/crates/schema/src/auto_migrate.rs
@@ -174,7 +174,9 @@ pub fn ponder_auto_migrate<'def>(old: &'def ModuleDef, new: &'def ModuleDef) -> 
     let indexes_ok = auto_migrate_indexes(&mut plan, &new_tables);
     let sequences_ok = auto_migrate_sequences(&mut plan, &new_tables);
     let constraints_ok = auto_migrate_constraints(&mut plan, &new_tables);
-    // Is important that this is the last step, because it needs the list of tables
+    // IMPORTANT: RLS auto-migrate steps must come last,
+    // since they assume that any schema changes, like adding or dropping tables,
+    // have already been reflected in the database state.
     let rls_ok = auto_migrate_row_level_security(&mut plan);
 
     let ((), (), (), (), ()) = (tables_ok, indexes_ok, sequences_ok, constraints_ok, rls_ok).combine_errors()?;

--- a/modules/sdk-test/src/lib.rs
+++ b/modules/sdk-test/src/lib.rs
@@ -639,3 +639,5 @@ define_tables! {
 
 #[spacetimedb::reducer]
 fn no_op_succeeds(_ctx: &ReducerContext) {}
+
+spacetimedb::filter!("SELECT * FROM one_u8");

--- a/smoketests/tests/auto_migration.py
+++ b/smoketests/tests/auto_migration.py
@@ -36,6 +36,8 @@ pub struct Vector2 {
     x: f64,
     y: f64,
 }
+
+spacetimedb::filter!("SELECT * FROM person");
 """
 
     MODULE_CODE_UPDATED = (
@@ -57,11 +59,27 @@ pub fn print_books(ctx: &ReducerContext, prefix: String) {
         println!("{}: {}", prefix, book.isbn);
     }
 }
+
+spacetimedb::filter!("SELECT * FROM book");
 """
     )
 
+    def assertSql(self, sql, expected):
+        self.maxDiff = None
+        sql_out = self.spacetime("sql", self.address, sql)
+        sql_out = "\n".join([line.rstrip() for line in sql_out.splitlines()])
+        expected = "\n".join([line.rstrip() for line in expected.splitlines()])
+        self.assertMultiLineEqual(sql_out, expected)
+
     def test_add_table_auto_migration(self):
         """This tests uploading a module with a schema change that should not require clearing the database."""
+
+        # Check the row-level SQL filter is created correctly
+        self.assertSql("SELECT sql FROM st_row_level_security", """\
+ sql
+------------------------
+ "SELECT * FROM person"
+""")
 
         logging.info("Initial publish complete")
         # initial module code is already published by test framework
@@ -83,6 +101,15 @@ pub fn print_books(ctx: &ReducerContext, prefix: String) {
         self.publish_module(self.address, clear=False)
 
         logging.info("Updated")
+
+        # Check the row-level SQL filter is added correctly
+        self.assertSql("SELECT sql FROM st_row_level_security", """\
+ sql
+------------------------
+ "SELECT * FROM person"
+ "SELECT * FROM book"
+""")
+
         self.logs(100)
 
         self.call("add_person", "Husserl")


### PR DESCRIPTION
# Description of Changes

Add a new `filter!` `proc-macro` for defining row-level security policies (`rls`) using `SQL`. 

It is a continuation of #1746.

Closes #1602.

The new macro:

* Only checks the syntax of the `SQL` query at compile time using the subscription dialect. It is impossible to fully validate it until we publish the module and all the table definitions are already committed to the database.
* Can be placed anywhere in the module

To avoid tracking a graph of dependencies, we remove and then add against all the `rls` and finally compile them to validate it.

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Unit testing that assert the presence of the migration steps.*
- [x] *Update smoke test `auto_migration.py`.*
- [x] *Manual inspection using the `cli`* 
