### PR TITLE
CLI - Add helptext for `--build-options`

### DIFF
--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -93,7 +93,7 @@ pub fn cli() -> clap::Command {
                 .alias("build-opts")
                 .action(Set)
                 .default_value("")
-                .help("Options to pass to the build command"),
+                .help("Options to pass to the build command, for example --build-options='--skip-println-checks'"),
         )
         .arg(common_args::yes())
         .after_help("Run `spacetime help publish` for more detailed information.")

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -30,7 +30,7 @@ pub fn cli() -> clap::Command {
                 .alias("build-opts")
                 .action(Set)
                 .default_value("")
-                .help("Options to pass to the build command")
+                .help("Options to pass to the build command, for example --build-options='--skip-println-checks'")
         )
         .arg(
             Arg::new("project_path")


### PR DESCRIPTION
# Description of Changes

Fix https://github.com/clockworklabs/SpacetimeDB/issues/1852.

# API and ABI breaking changes

Nope

# Expected complexity level and risk

1

# Testing

New helptext below. Unfortunately, clap still shows the example using a space, but hopefully the helptext helps.
```
Usage: spacetime publish [OPTIONS] [name|address]

Arguments:
  [name|address]
          A valid domain or address for this database

Options:
  -c, --delete-data
          When publishing to an existing address, first DESTROY all data associated with the module

      --build-options <build_options>
          Options to pass to the build command, for example --build-options='--skip-println-checks'
          
          [default: ]

  -p, --project-path <project_path>
          The system path (absolute or relative) to the module project
          
          [default: .]

  -b, --bin-path <wasm_file>
          The system path (absolute or relative) to the compiled wasm binary we should publish, instead of building the project.

  -i, --identity <identity>
          The identity that should own the database. If no identity is provided, your default identity will be used.

      --anonymous
          Perform this action with an anonymous identity

  -s, --server <server>
          The nickname, domain name or URL of the server to host the database.

  -y, --yes
          Assume "yes" as answer to all prompts and run non-interactively

  -h, --help
          Print help (see a summary with '-h')

Run `spacetime help publish` for more detailed information.