### PR TITLE
Have the scheduled_id/at columns be specified in the schema, not by the column name

### DIFF
--- a/crates/bindings-csharp/Runtime/Internal/Autogen/RawScheduleDefV9.cs
+++ b/crates/bindings-csharp/Runtime/Internal/Autogen/RawScheduleDefV9.cs
@@ -19,14 +19,18 @@ namespace SpacetimeDB.Internal
 		public string Name;
 		[DataMember(Name = "reducer_name")]
 		public string ReducerName;
+		[DataMember(Name = "scheduled_at_column")]
+		public ushort ScheduledAtColumn;
 
 		public RawScheduleDefV9(
 			string Name,
-			string ReducerName
+			string ReducerName,
+			ushort ScheduledAtColumn
 		)
 		{
 			this.Name = Name;
 			this.ReducerName = ReducerName;
+			this.ScheduledAtColumn = ScheduledAtColumn;
 		}
 
 		public RawScheduleDefV9()

--- a/crates/bindings-csharp/Runtime/Internal/Autogen/RawTableDefV9.cs
+++ b/crates/bindings-csharp/Runtime/Internal/Autogen/RawTableDefV9.cs
@@ -20,7 +20,7 @@ namespace SpacetimeDB.Internal
 		[DataMember(Name = "product_type_ref")]
 		public uint ProductTypeRef;
 		[DataMember(Name = "primary_key")]
-		public ushort? PrimaryKey;
+		public System.Collections.Generic.List<ushort> PrimaryKey;
 		[DataMember(Name = "indexes")]
 		public System.Collections.Generic.List<SpacetimeDB.Internal.RawIndexDefV9> Indexes;
 		[DataMember(Name = "constraints")]
@@ -37,7 +37,7 @@ namespace SpacetimeDB.Internal
 		public RawTableDefV9(
 			string Name,
 			uint ProductTypeRef,
-			ushort? PrimaryKey,
+			System.Collections.Generic.List<ushort> PrimaryKey,
 			System.Collections.Generic.List<SpacetimeDB.Internal.RawIndexDefV9> Indexes,
 			System.Collections.Generic.List<SpacetimeDB.Internal.RawConstraintDefV9> Constraints,
 			System.Collections.Generic.List<SpacetimeDB.Internal.RawSequenceDefV9> Sequences,
@@ -60,6 +60,7 @@ namespace SpacetimeDB.Internal
 		public RawTableDefV9()
 		{
 			this.Name = "";
+			this.PrimaryKey = new();
 			this.Indexes = new();
 			this.Constraints = new();
 			this.Sequences = new();

--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -1029,7 +1029,19 @@ fn table_impl(mut args: TableArgs, mut item: MutItem<syn::DeriveInput>) -> syn::
     let unique_col_ids = unique_columns.iter().map(|col| col.index);
     let primary_col_id = primary_key_column.iter().map(|col| col.index);
     let sequence_col_ids = sequenced_columns.iter().map(|col| col.index);
-    let scheduled_reducer_ident = args.scheduled.iter();
+
+    let schedule = args
+        .scheduled
+        .as_ref()
+        .map(|reducer| {
+            // scheduled_at was inserted as the last field
+            let scheduled_at_id = (fields.len() - 1) as u16;
+            quote!(spacetimedb::table::ScheduleDesc {
+                reducer_name: <#reducer as spacetimedb::rt::ReducerInfo>::NAME,
+                scheduled_at_column: #scheduled_at_id,
+            })
+        })
+        .into_iter();
 
     let unique_err = if !unique_columns.is_empty() {
         quote!(spacetimedb::UniqueConstraintViolation)
@@ -1062,7 +1074,7 @@ fn table_impl(mut args: TableArgs, mut item: MutItem<syn::DeriveInput>) -> syn::
             const INDEXES: &'static [spacetimedb::table::IndexDesc<'static>] = &[#(#index_descs),*];
             #(const PRIMARY_KEY: Option<u16> = Some(#primary_col_id);)*
             const SEQUENCES: &'static [u16] = &[#(#sequence_col_ids),*];
-            #(const SCHEDULED_REDUCER_NAME: Option<&'static str> = Some(<#scheduled_reducer_ident as spacetimedb::rt::ReducerInfo>::NAME);)*
+            #(const SCHEDULE: Option<spacetimedb::table::ScheduleDesc<'static>> = Some(#schedule);)*
 
             #table_id_from_name_func
         }

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -35,6 +35,7 @@ pub use spacetimedb_lib::ser::Serialize;
 pub use spacetimedb_lib::Address;
 pub use spacetimedb_lib::AlgebraicValue;
 pub use spacetimedb_lib::Identity;
+pub use spacetimedb_lib::ScheduleAt;
 pub use spacetimedb_primitives::TableId;
 pub use sys::Errno;
 pub use table::{AutoIncOverflow, BTreeIndex, Table, TryInsertError, UniqueColumn, UniqueConstraintViolation};

--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -165,6 +165,20 @@ pub trait TableColumn {
 }
 impl<T: SpacetimeType> TableColumn for T {}
 
+/// Assert that the primary_key column of a scheduled table is a u64.
+pub const fn assert_scheduled_table_primary_key<T: ScheduledTablePrimaryKey>() {}
+
+mod sealed {
+    pub trait Sealed {}
+}
+#[diagnostic::on_unimplemented(
+    message = "scheduled table primary key must be a `u64`",
+    label = "should be `u64`, not `{Self}`"
+)]
+pub trait ScheduledTablePrimaryKey: sealed::Sealed {}
+impl sealed::Sealed for u64 {}
+impl ScheduledTablePrimaryKey for u64 {}
+
 /// Used in the last type parameter of `Reducer` to indicate that the
 /// context argument *should* be passed to the reducer logic.
 pub struct ContextArg;
@@ -325,8 +339,8 @@ pub fn register_table<T: Table>() {
         for &col in T::SEQUENCES {
             table = table.with_column_sequence(col, None);
         }
-        if let Some(scheduled_reducer) = T::SCHEDULED_REDUCER_NAME {
-            table = table.with_schedule(scheduled_reducer, None);
+        if let Some(schedule) = T::SCHEDULE {
+            table = table.with_schedule(schedule.reducer_name, schedule.scheduled_at_column, None);
         }
 
         table.finish();

--- a/crates/bindings/src/table.rs
+++ b/crates/bindings/src/table.rs
@@ -124,7 +124,7 @@ pub trait TableInternal: Sized {
     const INDEXES: &'static [IndexDesc<'static>];
     const PRIMARY_KEY: Option<u16> = None;
     const SEQUENCES: &'static [u16];
-    const SCHEDULED_REDUCER_NAME: Option<&'static str> = None;
+    const SCHEDULE: Option<ScheduleDesc<'static>> = None;
 
     /// Returns the ID of this table.
     fn table_id() -> TableId;
@@ -141,6 +141,11 @@ pub struct IndexDesc<'a> {
 #[derive(Clone, Copy)]
 pub enum IndexAlgo<'a> {
     BTree { columns: &'a [u16] },
+}
+
+pub struct ScheduleDesc<'a> {
+    pub reducer_name: &'a str,
+    pub scheduled_at_column: u16,
 }
 
 #[doc(hidden)]

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -1391,6 +1391,7 @@ mod tests {
             ColRow { table: ST_SCHEDULED_ID.into(), pos: 1, name: "table_id", ty: TableId::get_type() },
             ColRow { table: ST_SCHEDULED_ID.into(), pos: 2, name: "reducer_name", ty: AlgebraicType::String },
             ColRow { table: ST_SCHEDULED_ID.into(), pos: 3, name: "schedule_name", ty: AlgebraicType::String },
+            ColRow { table: ST_SCHEDULED_ID.into(), pos: 4, name: "at_column", ty: AlgebraicType::U16 },
 
             ColRow { table: ST_ROW_LEVEL_SECURITY_ID.into(), pos: 0, name: "table_id", ty: TableId::get_type() },
             ColRow { table: ST_ROW_LEVEL_SECURITY_ID.into(), pos: 1, name: "sql", ty: AlgebraicType::String },

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -156,6 +156,7 @@ impl MutTxId {
                 schedule_id: ScheduleId::SENTINEL,
                 schedule_name: schedule.schedule_name,
                 reducer_name: schedule.reducer_name,
+                at_column: schedule.at_column,
             };
             let (generated, ..) = self.insert(ST_SCHEDULED_ID, &mut row.into(), database_address)?;
             let id = generated.as_u32();

--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -266,6 +266,7 @@ st_fields_enum!(enum StScheduledFields {
     "table_id", TableId = 1,
     "reducer_name", ReducerName = 2,
     "schedule_name", ScheduleName = 3,
+    "at_column", AtColumn = 4,
 });
 
 /// Helper method to check that a system table has the correct fields.
@@ -1279,6 +1280,7 @@ pub struct StScheduledRow {
     pub(crate) table_id: TableId,
     pub(crate) reducer_name: Box<str>,
     pub(crate) schedule_name: Box<str>,
+    pub(crate) at_column: ColId,
 }
 
 impl TryFrom<RowRef<'_>> for StScheduledRow {
@@ -1301,6 +1303,7 @@ impl From<StScheduledRow> for ScheduleSchema {
             reducer_name: row.reducer_name,
             schedule_id: row.schedule_id,
             schedule_name: row.schedule_name,
+            at_column: row.at_column,
         }
     }
 }

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -128,14 +128,14 @@ impl InstanceEnv {
                 }
             })?;
 
-        if stdb.is_scheduled_table(ctx, tx, table_id)? {
+        if let Some((id_column, at_column)) = stdb.table_scheduled_id_and_at(ctx, tx, table_id)? {
             let row_ref = tx.get(table_id, row_ptr)?.unwrap();
-            let (schedule_id, schedule_at) = get_schedule_from_row(tx, stdb, table_id, &row_ref)
+            let (schedule_id, schedule_at) = get_schedule_from_row(&row_ref, id_column, at_column)
                 // NOTE(centril): Should never happen,
                 // as we successfully inserted and thus `ret` is verified against the table schema.
                 .map_err(|e| NodesError::ScheduleError(ScheduleError::DecodingError(e)))?;
             self.scheduler
-                .schedule(table_id, schedule_id, schedule_at)
+                .schedule(table_id, schedule_id, schedule_at, id_column, at_column)
                 .map_err(NodesError::ScheduleError)?;
         }
 

--- a/crates/core/src/host/scheduler.rs
+++ b/crates/core/src/host/scheduler.rs
@@ -8,15 +8,13 @@ use spacetimedb_client_api_messages::energy::EnergyQuanta;
 use spacetimedb_client_api_messages::timestamp::Timestamp;
 use spacetimedb_lib::scheduler::ScheduleAt;
 use spacetimedb_lib::Address;
-use spacetimedb_primitives::TableId;
+use spacetimedb_primitives::{ColId, TableId};
 use spacetimedb_sats::{bsatn::ToBsatn as _, AlgebraicValue};
-use spacetimedb_schema::schema::TableSchema;
 use spacetimedb_table::table::RowRef;
 use tokio::sync::mpsc;
 use tokio_util::time::delay_queue::Expired;
 use tokio_util::time::{delay_queue, DelayQueue};
 
-use crate::db::datastore::locking_tx_datastore::tx::TxId;
 use crate::db::datastore::locking_tx_datastore::MutTxId;
 use crate::db::datastore::system_tables::{StFields, StScheduledFields, ST_SCHEDULED_ID};
 use crate::db::datastore::traits::IsolationLevel;
@@ -36,7 +34,16 @@ pub struct ScheduledReducerId {
     table_id: TableId,
     /// The particular schedule row in the reducer scheduling table referred to by `self.table_id`.
     schedule_id: u64,
+    // These may seem redundant, but they're actually free - they fit in the struct padding.
+    // `scheduled_id: u64, table_id: u32, id_column: u16, at_column: u16` == 16 bytes, same as
+    // (`scheduled_id: u64, table_id: u32` == 12 bytes).pad_to_align() == 16 bytes
+    /// The column that the primary key (`scheduled_id`) is in.
+    id_column: ColId,
+    /// The column that the `ScheduleAt` value is in.
+    at_column: ColId,
 }
+
+spacetimedb_table::static_assert_size!(ScheduledReducerId, 16);
 
 enum MsgOrExit<T> {
     Msg(T),
@@ -75,9 +82,6 @@ impl Scheduler {
     }
 }
 
-const SCHEDULED_AT_FIELD: [&str; 2] = ["scheduled_at", "ScheduledAt"];
-const SCHEDULED_ID_FIELD: [&str; 2] = ["scheduled_id", "ScheduledId"];
-
 impl SchedulerStarter {
     // TODO(cloutiertyler): This whole start dance is scuffed, but I don't have
     // time to make it better right now.
@@ -98,14 +102,25 @@ impl SchedulerStarter {
         // Find all Scheduled tables
         for st_scheduled_row in self.db.iter(ctx, &tx, ST_SCHEDULED_ID)? {
             let table_id = st_scheduled_row.read_col(StScheduledFields::TableId)?;
+            let (id_column, at_column) = self
+                .db
+                .table_scheduled_id_and_at(ctx, &tx, table_id)?
+                .ok_or_else(|| anyhow!("scheduled table {table_id} doesn't have valid columns"))?;
 
             // Insert each entry (row) in the scheduled table into `queue`.
             for scheduled_row in self.db.iter(ctx, &tx, table_id)? {
-                let schedule_id = get_schedule_id(&tx, &self.db, table_id, &scheduled_row)?;
-                let schedule_at = get_schedule_at(&tx, &self.db, table_id, &scheduled_row)?;
+                let (schedule_id, schedule_at) = get_schedule_from_row(&scheduled_row, id_column, at_column)?;
                 // calculate duration left to call the scheduled reducer
                 let duration = schedule_at.to_duration_from_now();
-                queue.insert(QueueItem::Id(ScheduledReducerId { table_id, schedule_id }), duration);
+                queue.insert(
+                    QueueItem::Id(ScheduledReducerId {
+                        table_id,
+                        schedule_id,
+                        id_column,
+                        at_column,
+                    }),
+                    duration,
+                );
             }
         }
 
@@ -163,7 +178,14 @@ pub enum ScheduleError {
 }
 
 impl Scheduler {
-    pub fn schedule(&self, table_id: TableId, schedule_id: u64, schedule_at: ScheduleAt) -> Result<(), ScheduleError> {
+    pub(super) fn schedule(
+        &self,
+        table_id: TableId,
+        schedule_id: u64,
+        schedule_at: ScheduleAt,
+        id_column: ColId,
+        at_column: ColId,
+    ) -> Result<(), ScheduleError> {
         // Check that `at` is within `tokio_utils::time::DelayQueue`'s accepted time-range.
         //
         // `DelayQueue` uses a sliding window,
@@ -194,7 +216,12 @@ impl Scheduler {
         // if the actor has exited, it's fine to ignore; it means that the host actor calling
         // schedule will exit soon as well, and it'll be scheduled to run when the module host restarts
         let _ = self.tx.send(MsgOrExit::Msg(SchedulerMessage::Schedule {
-            id: ScheduledReducerId { table_id, schedule_id },
+            id: ScheduledReducerId {
+                table_id,
+                schedule_id,
+                id_column,
+                at_column,
+            },
             at: schedule_at,
         }));
 
@@ -311,8 +338,7 @@ impl SchedulerActor {
                 return Ok(None);
             };
 
-            let ScheduledReducer { reducer, bsatn_args } =
-                proccess_schedule(&ctx, tx, &db, id.table_id, &schedule_row)?;
+            let ScheduledReducer { reducer, bsatn_args } = process_schedule(&ctx, tx, &db, id.table_id, &schedule_row)?;
 
             let (reducer_seed, reducer_id) = module_info
                 .reducer_seed_and_id(&reducer[..])
@@ -361,12 +387,10 @@ impl SchedulerActor {
     /// return true if it is repeated schedule
     fn handle_repeated_schedule(
         &mut self,
-        tx: &MutTxId,
-        db: &RelationalDB,
         id: ScheduledReducerId,
         schedule_row: &RowRef<'_>,
     ) -> Result<bool, anyhow::Error> {
-        let schedule_at = get_schedule_at_mut(tx, db, id.table_id, schedule_row)?;
+        let schedule_at = read_schedule_at(schedule_row, id.at_column)?;
 
         if let ScheduleAt::Interval(dur) = schedule_at {
             let key = self.queue.insert(QueueItem::Id(id), Duration::from_micros(dur));
@@ -388,7 +412,7 @@ impl SchedulerActor {
 
         match get_schedule_row_mut(ctx, &tx, db, id) {
             Ok(schedule_row) => {
-                if let Ok(is_repeated) = self.handle_repeated_schedule(&tx, db, id, &schedule_row) {
+                if let Ok(is_repeated) = self.handle_repeated_schedule(id, &schedule_row) {
                     if is_repeated {
                         return; // Do not delete entry for repeated reducer
                     }
@@ -436,7 +460,7 @@ fn commit_and_broadcast_deletion_event(ctx: &ExecutionContext, tx: MutTxId, modu
 }
 
 /// Generate `ScheduledReducer` for given `ScheduledReducerId`
-fn proccess_schedule(
+fn process_schedule(
     ctx: &ExecutionContext,
     tx: &MutTxId,
     db: &RelationalDB,
@@ -463,24 +487,6 @@ fn proccess_schedule(
     })
 }
 
-/// Helper to get schedule_id from schedule_row with `TxId`
-fn get_schedule_id(tx: &TxId, db: &RelationalDB, table_id: TableId, schedule_row: &RowRef<'_>) -> anyhow::Result<u64> {
-    let schema = db.schema_for_table(tx, table_id)?;
-    let schedule_id_pos = schema
-        .get_column_id_by_name(SCHEDULED_ID_FIELD[0])
-        .or_else(|| schema.get_column_id_by_name(SCHEDULED_ID_FIELD[1]))
-        .ok_or_else(|| anyhow!("Column '{}' not found in table {}", SCHEDULED_ID_FIELD[0], table_id))?;
-
-    schedule_row.read_col::<u64>(schedule_id_pos).map_err(|e| {
-        anyhow!(
-            "Error reading column '{}' from schedule table id:{}, row: {} ",
-            SCHEDULED_ID_FIELD[0],
-            table_id,
-            e
-        )
-    })
-}
-
 /// Helper to get schedule_row with `MutTxId`
 fn get_schedule_row_mut<'a>(
     ctx: &'a ExecutionContext,
@@ -488,84 +494,24 @@ fn get_schedule_row_mut<'a>(
     db: &'a RelationalDB,
     id: ScheduledReducerId,
 ) -> anyhow::Result<RowRef<'a>> {
-    let ScheduledReducerId { schedule_id, table_id } = id;
-    let schema = db.schema_for_table_mut(tx, table_id)?;
-    let scheduled_id_pos = schema
-        .get_column_id_by_name(SCHEDULED_ID_FIELD[0])
-        .or_else(|| schema.get_column_id_by_name(SCHEDULED_ID_FIELD[1]))
-        .ok_or_else(|| anyhow!("Column '{}' not found in table {}", SCHEDULED_ID_FIELD[0], table_id))?;
-
-    db.iter_by_col_eq_mut(ctx, tx, table_id, scheduled_id_pos, &schedule_id.into())?
+    db.iter_by_col_eq_mut(ctx, tx, id.table_id, id.id_column, &id.schedule_id.into())?
         .next()
-        .ok_or_else(|| anyhow!("Schedule with ID {} not found in table {}", schedule_id, table_id))
+        .ok_or_else(|| anyhow!("Schedule with ID {} not found in table {}", id.schedule_id, id.table_id))
 }
 
 /// Helper to get schedule_id and schedule_at from schedule_row product value
 pub fn get_schedule_from_row(
-    tx: &MutTxId,
-    db: &RelationalDB,
-    table_id: TableId,
     row: &RowRef<'_>,
+    id_column: ColId,
+    at_column: ColId,
 ) -> anyhow::Result<(u64, ScheduleAt)> {
-    let row_ty = db.row_schema_for_table(tx, table_id)?;
-
-    let col_pos = |field_name: &str| -> anyhow::Result<usize> {
-        row_ty
-            .index_of_field_name(field_name)
-            .ok_or_else(|| anyhow!("Column '{}' not found in row schema for table {}", field_name, table_id))
-    };
-
-    let schedule_id_col_pos = col_pos(SCHEDULED_ID_FIELD[0]).or_else(|_| col_pos(SCHEDULED_ID_FIELD[1]))?;
-    let schedule_at_col_pos = col_pos(SCHEDULED_AT_FIELD[0]).or_else(|_| col_pos(SCHEDULED_AT_FIELD[1]))?;
-
-    let schedule_id: u64 = row.read_col(schedule_id_col_pos)?;
-    let schedule_at_av: AlgebraicValue = row.read_col(schedule_at_col_pos)?;
-    let schedule_at = ScheduleAt::try_from(schedule_at_av.clone()).map_err(|e| {
-        anyhow!(
-            "Failed to convert field '{}' to ScheduleAt: {:?}",
-            SCHEDULED_AT_FIELD[0],
-            e
-        )
-    })?;
+    let schedule_id: u64 = row.read_col(id_column)?;
+    let schedule_at = read_schedule_at(row, at_column)?;
 
     Ok((schedule_id, schedule_at))
 }
 
-/// Helper to get schedule_at from schedule_row with `TxId`
-fn get_schedule_at(
-    tx: &TxId,
-    db: &RelationalDB,
-    table_id: TableId,
-    schedule_row: &RowRef<'_>,
-) -> anyhow::Result<ScheduleAt> {
-    let schema = db.schema_for_table(tx, table_id)?;
-    get_schedule_at_from_schema(table_id, schema, schedule_row)
-}
-
-/// Helper to get schedule_at from schedule_row with `MutTxId`
-fn get_schedule_at_mut(
-    tx: &MutTxId,
-    db: &RelationalDB,
-    table_id: TableId,
-    schedule_row: &RowRef<'_>,
-) -> anyhow::Result<ScheduleAt> {
-    let schema = db.schema_for_table_mut(tx, table_id)?;
-    get_schedule_at_from_schema(table_id, schema, schedule_row)
-}
-
-/// Helper to get schedule_at from schedule_row
-fn get_schedule_at_from_schema(
-    table_id: TableId,
-    table_schema: Arc<TableSchema>,
-    schedule_row: &RowRef<'_>,
-) -> anyhow::Result<ScheduleAt> {
-    let schedule_at_pos = table_schema
-        .get_column_id_by_name(SCHEDULED_AT_FIELD[0])
-        .or_else(|| table_schema.get_column_id_by_name(SCHEDULED_AT_FIELD[1]))
-        .ok_or_else(|| anyhow!("Column '{}' not found in table {}", SCHEDULED_AT_FIELD[0], table_id))?;
-
-    schedule_row
-        .read_col::<AlgebraicValue>(schedule_at_pos)?
-        .try_into()
-        .map_err(|_| anyhow!("Failed to convert column '{}' to ScheduleAt", SCHEDULED_AT_FIELD[0],))
+fn read_schedule_at(row: &RowRef<'_>, at_column: ColId) -> anyhow::Result<ScheduleAt> {
+    let schedule_at_av: AlgebraicValue = row.read_col(at_column)?;
+    ScheduleAt::try_from(schedule_at_av).map_err(|e| anyhow!("Failed to convert 'scheduled_at' to ScheduleAt: {e:?}"))
 }

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -122,7 +122,9 @@ pub struct RawTableDefV9 {
     /// Eventually, we may remove the requirement for an index.
     ///
     /// The database engine does not actually care about this, but client code generation does.
-    pub primary_key: Option<ColId>,
+    ///
+    /// A list of length 0 means no primary key. Currently, a list of length >1 is not supported.
+    pub primary_key: ColList,
 
     /// The indices of the table.
     pub indexes: Vec<RawIndexDefV9>,
@@ -303,6 +305,9 @@ pub struct RawScheduleDefV9 {
 
     /// The name of the reducer to call.
     pub reducer_name: RawIdentifier,
+
+    /// The column of the `scheduled_at` field of this scheduled table.
+    pub scheduled_at_column: ColId,
 }
 
 /// A constraint definition attached to a table.
@@ -471,7 +476,7 @@ impl RawModuleDefV9Builder {
                 constraints: vec![],
                 sequences: vec![],
                 schedule: None,
-                primary_key: None,
+                primary_key: ColList::empty(),
                 table_type: TableType::User,
                 table_access: TableAccess::Public,
             },
@@ -662,7 +667,7 @@ impl<'a> RawTableDefBuilder<'a> {
     /// Adds a primary key to the table.
     /// You must also add a unique constraint on the primary key column.
     pub fn with_primary_key(mut self, column: impl Into<ColId>) -> Self {
-        self.table.primary_key = Some(column.into());
+        self.table.primary_key = ColList::new(column.into());
         self
     }
 
@@ -712,10 +717,20 @@ impl<'a> RawTableDefBuilder<'a> {
     /// Adds a schedule definition to the table.
     ///
     /// The table must have the appropriate columns for a scheduled table.
-    pub fn with_schedule(mut self, reducer_name: impl Into<RawIdentifier>, name: Option<RawIdentifier>) -> Self {
+    pub fn with_schedule(
+        mut self,
+        reducer_name: impl Into<RawIdentifier>,
+        scheduled_at_column: impl Into<ColId>,
+        name: Option<RawIdentifier>,
+    ) -> Self {
         let reducer_name = reducer_name.into();
         let name = name.unwrap_or_else(|| self.generate_schedule_name());
-        self.table.schedule = Some(RawScheduleDefV9 { name, reducer_name });
+        let scheduled_at_column = scheduled_at_column.into();
+        self.table.schedule = Some(RawScheduleDefV9 {
+            name,
+            reducer_name,
+            scheduled_at_column,
+        });
         self
     }
 

--- a/crates/schema/src/auto_migrate.rs
+++ b/crates/schema/src/auto_migrate.rs
@@ -471,7 +471,8 @@ mod tests {
                 ]),
                 true,
             )
-            .with_schedule("check_deliveries", None)
+            .with_auto_inc_primary_key(0)
+            .with_schedule("check_deliveries", 1, None)
             .finish();
         old_builder.add_reducer(
             "check_deliveries",
@@ -488,6 +489,7 @@ mod tests {
                 ]),
                 true,
             )
+            .with_auto_inc_primary_key(0)
             .finish();
 
         let old_def: ModuleDef = old_builder
@@ -553,6 +555,7 @@ mod tests {
                 ]),
                 true,
             )
+            .with_auto_inc_primary_key(0)
             // remove schedule def
             .finish();
 
@@ -571,8 +574,9 @@ mod tests {
                 ]),
                 true,
             )
+            .with_auto_inc_primary_key(0)
             // add schedule def
-            .with_schedule("perform_inspection", None)
+            .with_schedule("perform_inspection", 1, None)
             .finish();
 
         // add reducer.

--- a/crates/schema/src/def.rs
+++ b/crates/schema/src/def.rs
@@ -467,7 +467,7 @@ impl From<TableDef> for RawTableDefV9 {
         RawTableDefV9 {
             name: name.into(),
             product_type_ref,
-            primary_key,
+            primary_key: ColList::from_iter(primary_key),
             indexes: to_raw(indexes, |index: &RawIndexDefV9| &index.name),
             constraints: to_raw(constraints, |constraint: &RawConstraintDefV9| &constraint.name),
             sequences: to_raw(sequences, |sequence: &RawSequenceDefV9| &sequence.name),
@@ -740,6 +740,7 @@ impl From<ScheduleDef> for RawScheduleDefV9 {
         RawScheduleDefV9 {
             name: val.name.into(),
             reducer_name: val.reducer_name.into(),
+            scheduled_at_column: val.at_column,
         }
     }
 }

--- a/crates/schema/src/def/validate/v8.rs
+++ b/crates/schema/src/def/validate/v8.rs
@@ -11,7 +11,7 @@ use spacetimedb_lib::{
     TableDesc as RawTableDescV8,
     TypeAlias as RawTypeAliasV8,
 };
-use spacetimedb_primitives::ColId;
+use spacetimedb_primitives::{ColId, ColList};
 use spacetimedb_sats::{AlgebraicTypeRef, Typespace, WithTypespace};
 
 use crate::def::{validate::Result, ModuleDef};
@@ -89,12 +89,16 @@ fn upgrade_table(
     } = table;
 
     // Check all column defs, then discard them.
+    let scheduled_at_col = columns
+        .iter()
+        .position(|x| &*x.col_name == "scheduled_at")
+        .map(|i| i as u16);
     check_all_column_defs(product_type_ref, columns, &table_name, typespace, extra_errors);
 
     // Now we're ready to go through the various definitions and upgrade them.
     let indexes = convert_all(indexes, upgrade_index);
     let sequences = convert_all(sequences.into_iter().chain(generated_sequences), upgrade_sequence);
-    let schedule = upgrade_schedule(scheduled, &table_name);
+    let schedule = upgrade_schedule(scheduled, &table_name, scheduled_at_col);
 
     // Constraints are pretty hairy, which is why we're getting rid of v8.
     let mut primary_key = None;
@@ -110,7 +114,7 @@ fn upgrade_table(
     RawTableDefV9 {
         name: table_name,
         product_type_ref,
-        primary_key,
+        primary_key: ColList::from_iter(primary_key),
         indexes,
         constraints: unique_constraints,
         sequences,
@@ -269,10 +273,16 @@ fn upgrade_constraint(
     }
 }
 
-fn upgrade_schedule(schedule: Option<RawIdentifier>, table_name: &RawIdentifier) -> Option<RawScheduleDefV9> {
+fn upgrade_schedule(
+    schedule: Option<RawIdentifier>,
+    table_name: &RawIdentifier,
+    scheduled_at_col: Option<u16>,
+) -> Option<RawScheduleDefV9> {
+    let scheduled_at_col = scheduled_at_col?;
     schedule.map(|reducer_name| RawScheduleDefV9 {
         name: format!("{table_name}_schedule").into(),
         reducer_name,
+        scheduled_at_column: scheduled_at_col.into(),
     })
 }
 
@@ -396,6 +406,7 @@ mod tests {
                     ("scheduled_id", AlgebraicType::U64),
                 ]),
             )
+            .with_column_constraint(Constraints::primary_key_auto(), 2)
             .with_scheduled(Some("check_deliveries".into())),
         );
 
@@ -464,7 +475,7 @@ mod tests {
             &delivery_def.schedule.as_ref().unwrap().reducer_name[..],
             "check_deliveries"
         );
-        assert_eq!(delivery_def.primary_key, None);
+        assert_eq!(delivery_def.primary_key, Some(ColId(2)));
 
         assert_eq!(def.typespace.get(product_type_ref), Some(&product_type));
         assert_eq!(def.typespace.get(sum_type_ref), Some(&sum_type));

--- a/crates/schema/src/def/validate/v9.rs
+++ b/crates/schema/src/def/validate/v9.rs
@@ -186,6 +186,7 @@ impl ModuleValidator<'_> {
             .collect_all_errors();
 
         // We can't validate the primary key without validating the unique constraints first.
+        let primary_key_head = primary_key.head();
         let constraints_primary_key = constraints
             .into_iter()
             .map(|constraint| {
@@ -208,7 +209,7 @@ impl ModuleValidator<'_> {
             .collect_all_errors();
 
         let schedule = schedule
-            .map(|schedule| table_in_progress.validate_schedule_def(schedule))
+            .map(|schedule| table_in_progress.validate_schedule_def(schedule, primary_key_head))
             .transpose();
 
         let name = table_in_progress
@@ -455,9 +456,16 @@ impl TableValidator<'_, '_> {
     fn validate_primary_key(
         &mut self,
         validated_constraints: IdentifierMap<ConstraintDef>,
-        primary_key: Option<ColId>,
+        primary_key: ColList,
     ) -> Result<(IdentifierMap<ConstraintDef>, Option<ColId>)> {
+        if primary_key.len() > 1 {
+            return Err(ValidationError::RepeatedPrimaryKey {
+                table: self.raw_name.clone(),
+            }
+            .into());
+        }
         let pk = primary_key
+            .head()
             .map(|pk| -> Result<ColId> {
                 let pk = self.validate_col_id(&self.raw_name, pk)?;
                 let pk_col_list = ColSet::from(pk);
@@ -590,18 +598,25 @@ impl TableValidator<'_, '_> {
     }
 
     /// Validate a schedule definition.
-    fn validate_schedule_def(&mut self, schedule: RawScheduleDefV9) -> Result<ScheduleDef> {
-        let RawScheduleDefV9 { name, reducer_name } = schedule;
+    fn validate_schedule_def(&mut self, schedule: RawScheduleDefV9, primary_key: Option<ColId>) -> Result<ScheduleDef> {
+        let RawScheduleDefV9 {
+            name,
+            reducer_name,
+            scheduled_at_column,
+        } = schedule;
 
         // Find the appropriate columns.
         let at_column = self
             .product_type
             .elements
-            .iter()
-            .enumerate()
-            .find(|(_, element)| element.name() == Some("scheduled_at"));
-        let id_column = self.product_type.elements.iter().enumerate().find(|(_, element)| {
-            element.name() == Some("scheduled_id") && element.algebraic_type == AlgebraicType::U64
+            .get(scheduled_at_column.idx())
+            .is_some_and(|ty| ty.algebraic_type.is_schedule_at())
+            .then_some(scheduled_at_column);
+        let id_column = primary_key.filter(|pk| {
+            self.product_type
+                .elements
+                .get(pk.idx())
+                .is_some_and(|ty| ty.algebraic_type == AlgebraicType::U64)
         });
 
         // Error if either column is missing.
@@ -617,9 +632,6 @@ impl TableValidator<'_, '_> {
         let reducer_name = identifier(reducer_name);
 
         let (name, (at_column, id_column), reducer_name) = (name, at_id, reducer_name).combine_errors()?;
-
-        let at_column = at_column.0.into();
-        let id_column = id_column.0.into();
 
         Ok(ScheduleDef {
             name,
@@ -845,7 +857,8 @@ mod tests {
                 ]),
                 true,
             )
-            .with_schedule("check_deliveries", Some("check_deliveries_schedule".into()))
+            .with_auto_inc_primary_key(2)
+            .with_schedule("check_deliveries", 1, Some("check_deliveries_schedule".into()))
             .with_type(TableType::System)
             .finish();
 
@@ -969,7 +982,7 @@ mod tests {
             &delivery_def.schedule.as_ref().unwrap().reducer_name[..],
             "check_deliveries"
         );
-        assert_eq!(delivery_def.primary_key, None);
+        assert_eq!(delivery_def.primary_key, Some(ColId(2)));
 
         assert_eq!(def.typespace.get(product_type_ref), Some(&product_type));
         assert_eq!(def.typespace.get(sum_type_ref), Some(&sum_type));
@@ -1386,7 +1399,8 @@ mod tests {
                 ]),
                 true,
             )
-            .with_schedule("check_deliveries", Some("check_deliveries_schedule".into()))
+            .with_auto_inc_primary_key(2)
+            .with_schedule("check_deliveries", 1, Some("check_deliveries_schedule".into()))
             .with_type(TableType::System)
             .finish();
         let result: Result<ModuleDef> = builder.finish().try_into();
@@ -1411,7 +1425,8 @@ mod tests {
                 ]),
                 true,
             )
-            .with_schedule("check_deliveries", Some("check_deliveries_schedule".into()))
+            .with_auto_inc_primary_key(2)
+            .with_schedule("check_deliveries", 1, Some("check_deliveries_schedule".into()))
             .with_type(TableType::System)
             .finish();
         builder.add_reducer("check_deliveries", ProductType::from([("a", AlgebraicType::U64)]), None);

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -874,8 +874,11 @@ pub struct ScheduleSchema {
     /// The name of the schedule.
     pub schedule_name: Box<str>,
 
-    // The name of the reducer to call.
+    /// The name of the reducer to call.
     pub reducer_name: Box<str>,
+
+    /// The column containing the `ScheduleAt` enum.
+    pub at_column: ColId,
 }
 
 impl Schema for ScheduleSchema {
@@ -893,6 +896,7 @@ impl Schema for ScheduleSchema {
             schedule_id: id,
             schedule_name: (*def.name).into(),
             reducer_name: (*def.reducer_name).into(),
+            at_column: def.at_column,
             // Ignore def.at_column and id_column. Those are recovered at runtime.
         }
     }


### PR DESCRIPTION
# Description of Changes

Resolves #1816. Also changes `primary_key` to be a `ColList` for future compat reasons.

# API and ABI breaking changes

Breaking, yes, but so we can be compatible with future changes.