### PR TITLE
Fix compression threshold bug

### DIFF
--- a/crates/client-api-messages/src/websocket.rs
+++ b/crates/client-api-messages/src/websocket.rs
@@ -519,7 +519,7 @@ pub fn should_compress(len: usize) -> bool {
     /// TODO(perf): measure!
     const COMPRESS_THRESHOLD: usize = 1024;
 
-    len <= COMPRESS_THRESHOLD
+    len >= COMPRESS_THRESHOLD
 }
 
 pub fn brotli_compress(bytes: &[u8], out: &mut Vec<u8>) {


### PR DESCRIPTION
# Description of Changes

I discovered this issue when testing deliveryz. The packets that are supposed to be compressed aren't compressed and the ones that aren't supposed to be compressed are compressed. We had a simple logic inversion here which I've corrected.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

Not breaking

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] I ran deliveryz against this PR and the compression is now correct
