### PR TITLE
C# codegen making state relative to a DbConnection

### DIFF
--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -412,6 +412,14 @@ fn autogen_csharp_access_funcs_for_struct(
             "public readonly ref struct {csharp_field_name_pascal}UniqueIndex"
         );
         indented_block(output, |output| {
+            writeln!(output, "readonly {csharp_table_name}Handle Handle;");
+            write!(
+                output,
+                "internal {csharp_field_name_pascal}UniqueIndex({csharp_table_name}Handle handle) => "
+            );
+            writeln!(output, "Handle = handle;");
+            writeln!(output);
+
             writeln!(
                 output,
                 "public {struct_name_pascal_case}? Find({csharp_field_type} value)"
@@ -419,7 +427,7 @@ fn autogen_csharp_access_funcs_for_struct(
             indented_block(output, |output| {
                 writeln!(
                     output,
-                    "{csharp_field_name_pascal}_Index.TryGetValue(value, out var r);"
+                    "Handle.{csharp_field_name_pascal}_Index.TryGetValue(value, out var r);"
                 );
                 writeln!(output, "return r;");
             });
@@ -428,7 +436,7 @@ fn autogen_csharp_access_funcs_for_struct(
         writeln!(output);
         writeln!(
             output,
-            "public {csharp_field_name_pascal}UniqueIndex {csharp_field_name_pascal} => new();"
+            "public {csharp_field_name_pascal}UniqueIndex {csharp_field_name_pascal} => new(this);"
         );
         writeln!(output);
     }
@@ -592,7 +600,7 @@ pub fn autogen_csharp_globals(ctx: &GenCtx, items: &[GenItem], namespace: &str) 
                     let type_name = ty_fmt(ctx, &col.col_type, namespace);
                     writeln!(
                         output,
-                        "private static Dictionary<{type_name}, {table_type}> {field_name}_Index = new(16);"
+                        "private Dictionary<{type_name}, {table_type}> {field_name}_Index = new(16);"
                     );
                     unique_indexes.push(field_name);
                 }

--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -411,7 +411,7 @@ fn autogen_csharp_access_funcs_for_struct(
         indented_block(output, |output| {
             write!(
                 output,
-                "internal readonly Dictionary<{csharp_field_type}, {csharp_table_name}> Cache = new(16);"
+                "internal readonly Dictionary<{csharp_field_type}, {struct_name_pascal_case}> Cache = new(16);"
             );
             writeln!(output);
 

--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -411,7 +411,7 @@ fn autogen_csharp_access_funcs_for_struct(
         indented_block(output, |output| {
             write!(
                 output,
-                "internal readonly Dictionary<{csharp_field_type}, {csharp_table_name}> __Cache = new(16);"
+                "internal readonly Dictionary<{csharp_field_type}, {csharp_table_name}> Cache = new(16);"
             );
             writeln!(output);
 
@@ -420,7 +420,7 @@ fn autogen_csharp_access_funcs_for_struct(
                 "public {struct_name_pascal_case}? Find({csharp_field_type} value)"
             );
             indented_block(output, |output| {
-                writeln!(output, "__Cache.TryGetValue(value, out var r);");
+                writeln!(output, "Cache.TryGetValue(value, out var r);");
                 writeln!(output, "return r;");
             });
             writeln!(output);
@@ -605,7 +605,7 @@ pub fn autogen_csharp_globals(ctx: &GenCtx, items: &[GenItem], namespace: &str) 
                             if !constraints[&ColList::new(col.col_pos)].has_unique() {
                                 continue;
                             }
-                            writeln!(output, "{field_name}.__Cache[value.{field_name}] = value;");
+                            writeln!(output, "{field_name}.Cache[value.{field_name}] = value;");
                         }
                     });
                     writeln!(output);
@@ -620,7 +620,7 @@ pub fn autogen_csharp_globals(ctx: &GenCtx, items: &[GenItem], namespace: &str) 
                             if !constraints[&ColList::new(col.col_pos)].has_unique() {
                                 continue;
                             }
-                            writeln!(output, "{field_name}.__Cache.Remove((({table_type})row).{field_name});");
+                            writeln!(output, "{field_name}.Cache.Remove((({table_type})row).{field_name});");
                         }
                     });
                     writeln!(output);

--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -407,12 +407,12 @@ fn autogen_csharp_access_funcs_for_struct(
             None => continue,
             Some(x) => x,
         };
-        writeln!(
-            output,
-            "public class {csharp_field_name_pascal}UniqueIndex"
-        );
+        writeln!(output, "public class {csharp_field_name_pascal}UniqueIndex");
         indented_block(output, |output| {
-            write!(output, "internal readonly Dictionary<{csharp_field_type}, {csharp_table_name}> __Cache = new(16);");
+            write!(
+                output,
+                "internal readonly Dictionary<{csharp_field_type}, {csharp_table_name}> __Cache = new(16);"
+            );
             writeln!(output);
 
             writeln!(
@@ -420,10 +420,7 @@ fn autogen_csharp_access_funcs_for_struct(
                 "public {struct_name_pascal_case}? Find({csharp_field_type} value)"
             );
             indented_block(output, |output| {
-                writeln!(
-                    output,
-                    "__Cache.TryGetValue(value, out var r);"
-                );
+                writeln!(output, "__Cache.TryGetValue(value, out var r);");
                 writeln!(output, "return r;");
             });
             writeln!(output);

--- a/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
@@ -672,51 +672,45 @@ namespace SpacetimeDB
 
 		public class PkMultiIdentityHandle : RemoteTableHandle<EventContext, PkMultiIdentity>
 		{
-			private Dictionary<uint, PkMultiIdentity> Id_Index = new(16);
-			private Dictionary<uint, PkMultiIdentity> Other_Index = new(16);
 
 			public override void InternalInvokeValueInserted(IDatabaseRow row)
 			{
 				var value = (PkMultiIdentity)row;
-				Id_Index[value.Id] = value;
-				Other_Index[value.Other] = value;
+				Id.__Cache[value.Id] = value;
+				Other.__Cache[value.Other] = value;
 			}
 
 			public override void InternalInvokeValueDeleted(IDatabaseRow row)
 			{
-				Id_Index.Remove(((PkMultiIdentity)row).Id);
-				Other_Index.Remove(((PkMultiIdentity)row).Other);
+				Id.__Cache.Remove(((PkMultiIdentity)row).Id);
+				Other.__Cache.Remove(((PkMultiIdentity)row).Other);
 			}
 
-			public readonly ref struct IdUniqueIndex
+			public class IdUniqueIndex
 			{
-				readonly PkMultiIdentityHandle Handle;
-				internal IdUniqueIndex(PkMultiIdentityHandle handle) => Handle = handle;
-
+				internal readonly Dictionary<uint, PkMultiIdentity> __Cache = new(16);
 				public PkMultiIdentity? Find(uint value)
 				{
-					Handle.Id_Index.TryGetValue(value, out var r);
+					__Cache.TryGetValue(value, out var r);
 					return r;
 				}
 
 			}
 
-			public IdUniqueIndex Id => new(this);
+			public IdUniqueIndex Id = new();
 
-			public readonly ref struct OtherUniqueIndex
+			public class OtherUniqueIndex
 			{
-				readonly PkMultiIdentityHandle Handle;
-				internal OtherUniqueIndex(PkMultiIdentityHandle handle) => Handle = handle;
-
+				internal readonly Dictionary<uint, PkMultiIdentity> __Cache = new(16);
 				public PkMultiIdentity? Find(uint value)
 				{
-					Handle.Other_Index.TryGetValue(value, out var r);
+					__Cache.TryGetValue(value, out var r);
 					return r;
 				}
 
 			}
 
-			public OtherUniqueIndex Other => new(this);
+			public OtherUniqueIndex Other = new();
 
 			internal PkMultiIdentityHandle()
 			{
@@ -760,33 +754,30 @@ namespace SpacetimeDB
 
 		public class RepeatingTestArgHandle : RemoteTableHandle<EventContext, RepeatingTestArg>
 		{
-			private Dictionary<ulong, RepeatingTestArg> ScheduledId_Index = new(16);
 
 			public override void InternalInvokeValueInserted(IDatabaseRow row)
 			{
 				var value = (RepeatingTestArg)row;
-				ScheduledId_Index[value.ScheduledId] = value;
+				ScheduledId.__Cache[value.ScheduledId] = value;
 			}
 
 			public override void InternalInvokeValueDeleted(IDatabaseRow row)
 			{
-				ScheduledId_Index.Remove(((RepeatingTestArg)row).ScheduledId);
+				ScheduledId.__Cache.Remove(((RepeatingTestArg)row).ScheduledId);
 			}
 
-			public readonly ref struct ScheduledIdUniqueIndex
+			public class ScheduledIdUniqueIndex
 			{
-				readonly RepeatingTestArgHandle Handle;
-				internal ScheduledIdUniqueIndex(RepeatingTestArgHandle handle) => Handle = handle;
-
+				internal readonly Dictionary<ulong, RepeatingTestArg> __Cache = new(16);
 				public RepeatingTestArg? Find(ulong value)
 				{
-					Handle.ScheduledId_Index.TryGetValue(value, out var r);
+					__Cache.TryGetValue(value, out var r);
 					return r;
 				}
 
 			}
 
-			public ScheduledIdUniqueIndex ScheduledId => new(this);
+			public ScheduledIdUniqueIndex ScheduledId = new();
 
 			internal RepeatingTestArgHandle()
 			{
@@ -830,33 +821,30 @@ namespace SpacetimeDB
 
 		public class TestEHandle : RemoteTableHandle<EventContext, TestE>
 		{
-			private Dictionary<ulong, TestE> Id_Index = new(16);
 
 			public override void InternalInvokeValueInserted(IDatabaseRow row)
 			{
 				var value = (TestE)row;
-				Id_Index[value.Id] = value;
+				Id.__Cache[value.Id] = value;
 			}
 
 			public override void InternalInvokeValueDeleted(IDatabaseRow row)
 			{
-				Id_Index.Remove(((TestE)row).Id);
+				Id.__Cache.Remove(((TestE)row).Id);
 			}
 
-			public readonly ref struct IdUniqueIndex
+			public class IdUniqueIndex
 			{
-				readonly TestEHandle Handle;
-				internal IdUniqueIndex(TestEHandle handle) => Handle = handle;
-
+				internal readonly Dictionary<ulong, TestE> __Cache = new(16);
 				public TestE? Find(ulong value)
 				{
-					Handle.Id_Index.TryGetValue(value, out var r);
+					__Cache.TryGetValue(value, out var r);
 					return r;
 				}
 
 			}
 
-			public IdUniqueIndex Id => new(this);
+			public IdUniqueIndex Id = new();
 
 			public class NameIndex
 			{

--- a/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
@@ -676,22 +676,22 @@ namespace SpacetimeDB
 			public override void InternalInvokeValueInserted(IDatabaseRow row)
 			{
 				var value = (PkMultiIdentity)row;
-				Id.__Cache[value.Id] = value;
-				Other.__Cache[value.Other] = value;
+				Id.Cache[value.Id] = value;
+				Other.Cache[value.Other] = value;
 			}
 
 			public override void InternalInvokeValueDeleted(IDatabaseRow row)
 			{
-				Id.__Cache.Remove(((PkMultiIdentity)row).Id);
-				Other.__Cache.Remove(((PkMultiIdentity)row).Other);
+				Id.Cache.Remove(((PkMultiIdentity)row).Id);
+				Other.Cache.Remove(((PkMultiIdentity)row).Other);
 			}
 
 			public class IdUniqueIndex
 			{
-				internal readonly Dictionary<uint, PkMultiIdentity> __Cache = new(16);
+				internal readonly Dictionary<uint, PkMultiIdentity> Cache = new(16);
 				public PkMultiIdentity? Find(uint value)
 				{
-					__Cache.TryGetValue(value, out var r);
+					Cache.TryGetValue(value, out var r);
 					return r;
 				}
 
@@ -701,10 +701,10 @@ namespace SpacetimeDB
 
 			public class OtherUniqueIndex
 			{
-				internal readonly Dictionary<uint, PkMultiIdentity> __Cache = new(16);
+				internal readonly Dictionary<uint, PkMultiIdentity> Cache = new(16);
 				public PkMultiIdentity? Find(uint value)
 				{
-					__Cache.TryGetValue(value, out var r);
+					Cache.TryGetValue(value, out var r);
 					return r;
 				}
 
@@ -758,20 +758,20 @@ namespace SpacetimeDB
 			public override void InternalInvokeValueInserted(IDatabaseRow row)
 			{
 				var value = (RepeatingTestArg)row;
-				ScheduledId.__Cache[value.ScheduledId] = value;
+				ScheduledId.Cache[value.ScheduledId] = value;
 			}
 
 			public override void InternalInvokeValueDeleted(IDatabaseRow row)
 			{
-				ScheduledId.__Cache.Remove(((RepeatingTestArg)row).ScheduledId);
+				ScheduledId.Cache.Remove(((RepeatingTestArg)row).ScheduledId);
 			}
 
 			public class ScheduledIdUniqueIndex
 			{
-				internal readonly Dictionary<ulong, RepeatingTestArg> __Cache = new(16);
+				internal readonly Dictionary<ulong, RepeatingTestArg> Cache = new(16);
 				public RepeatingTestArg? Find(ulong value)
 				{
-					__Cache.TryGetValue(value, out var r);
+					Cache.TryGetValue(value, out var r);
 					return r;
 				}
 
@@ -825,20 +825,20 @@ namespace SpacetimeDB
 			public override void InternalInvokeValueInserted(IDatabaseRow row)
 			{
 				var value = (TestE)row;
-				Id.__Cache[value.Id] = value;
+				Id.Cache[value.Id] = value;
 			}
 
 			public override void InternalInvokeValueDeleted(IDatabaseRow row)
 			{
-				Id.__Cache.Remove(((TestE)row).Id);
+				Id.Cache.Remove(((TestE)row).Id);
 			}
 
 			public class IdUniqueIndex
 			{
-				internal readonly Dictionary<ulong, TestE> __Cache = new(16);
+				internal readonly Dictionary<ulong, TestE> Cache = new(16);
 				public TestE? Find(ulong value)
 				{
-					__Cache.TryGetValue(value, out var r);
+					Cache.TryGetValue(value, out var r);
 					return r;
 				}
 

--- a/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
@@ -672,8 +672,8 @@ namespace SpacetimeDB
 
 		public class PkMultiIdentityHandle : RemoteTableHandle<EventContext, PkMultiIdentity>
 		{
-			private static Dictionary<uint, PkMultiIdentity> Id_Index = new(16);
-			private static Dictionary<uint, PkMultiIdentity> Other_Index = new(16);
+			private Dictionary<uint, PkMultiIdentity> Id_Index = new(16);
+			private Dictionary<uint, PkMultiIdentity> Other_Index = new(16);
 
 			public override void InternalInvokeValueInserted(IDatabaseRow row)
 			{
@@ -690,27 +690,33 @@ namespace SpacetimeDB
 
 			public readonly ref struct IdUniqueIndex
 			{
+				readonly PkMultiIdentityHandle Handle;
+				internal IdUniqueIndex(PkMultiIdentityHandle handle) => Handle = handle;
+
 				public PkMultiIdentity? Find(uint value)
 				{
-					Id_Index.TryGetValue(value, out var r);
+					Handle.Id_Index.TryGetValue(value, out var r);
 					return r;
 				}
 
 			}
 
-			public IdUniqueIndex Id => new();
+			public IdUniqueIndex Id => new(this);
 
 			public readonly ref struct OtherUniqueIndex
 			{
+				readonly PkMultiIdentityHandle Handle;
+				internal OtherUniqueIndex(PkMultiIdentityHandle handle) => Handle = handle;
+
 				public PkMultiIdentity? Find(uint value)
 				{
-					Other_Index.TryGetValue(value, out var r);
+					Handle.Other_Index.TryGetValue(value, out var r);
 					return r;
 				}
 
 			}
 
-			public OtherUniqueIndex Other => new();
+			public OtherUniqueIndex Other => new(this);
 
 			internal PkMultiIdentityHandle()
 			{
@@ -754,7 +760,7 @@ namespace SpacetimeDB
 
 		public class RepeatingTestArgHandle : RemoteTableHandle<EventContext, RepeatingTestArg>
 		{
-			private static Dictionary<ulong, RepeatingTestArg> ScheduledId_Index = new(16);
+			private Dictionary<ulong, RepeatingTestArg> ScheduledId_Index = new(16);
 
 			public override void InternalInvokeValueInserted(IDatabaseRow row)
 			{
@@ -769,15 +775,18 @@ namespace SpacetimeDB
 
 			public readonly ref struct ScheduledIdUniqueIndex
 			{
+				readonly RepeatingTestArgHandle Handle;
+				internal ScheduledIdUniqueIndex(RepeatingTestArgHandle handle) => Handle = handle;
+
 				public RepeatingTestArg? Find(ulong value)
 				{
-					ScheduledId_Index.TryGetValue(value, out var r);
+					Handle.ScheduledId_Index.TryGetValue(value, out var r);
 					return r;
 				}
 
 			}
 
-			public ScheduledIdUniqueIndex ScheduledId => new();
+			public ScheduledIdUniqueIndex ScheduledId => new(this);
 
 			internal RepeatingTestArgHandle()
 			{
@@ -821,7 +830,7 @@ namespace SpacetimeDB
 
 		public class TestEHandle : RemoteTableHandle<EventContext, TestE>
 		{
-			private static Dictionary<ulong, TestE> Id_Index = new(16);
+			private Dictionary<ulong, TestE> Id_Index = new(16);
 
 			public override void InternalInvokeValueInserted(IDatabaseRow row)
 			{
@@ -836,15 +845,18 @@ namespace SpacetimeDB
 
 			public readonly ref struct IdUniqueIndex
 			{
+				readonly TestEHandle Handle;
+				internal IdUniqueIndex(TestEHandle handle) => Handle = handle;
+
 				public TestE? Find(ulong value)
 				{
-					Id_Index.TryGetValue(value, out var r);
+					Handle.Id_Index.TryGetValue(value, out var r);
 					return r;
 				}
 
 			}
 
-			public IdUniqueIndex Id => new();
+			public IdUniqueIndex Id => new(this);
 
 			public class NameIndex
 			{


### PR DESCRIPTION
# Description of Changes

Make the static fields indexing primary keys instance fields.

# API and ABI breaking changes

# Expected complexity level and risk

# Testing

Codegen compiles. Same code as before but going through a `this` pointer instead of a `static` .

Context from Boppy: The Unity testsuite exercises this feature in the testsuite: https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/168
