### PR TITLE
Put `ExecutionContext` inside the Tx context

### DIFF
--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -1,6 +1,6 @@
 use criterion::{black_box, criterion_group, criterion_main, Criterion};
 use spacetimedb::error::DBError;
-use spacetimedb::execution_context::ExecutionContext;
+use spacetimedb::execution_context::Workload;
 use spacetimedb::host::module_host::DatabaseTableUpdate;
 use spacetimedb::identity::AuthCtx;
 use spacetimedb::messages::websocket::BsatnFormat;
@@ -52,9 +52,10 @@ fn eval(c: &mut Criterion) {
     let lhs = create_table_footprint(&raw.db).unwrap();
     let rhs = create_table_location(&raw.db).unwrap();
 
+    //TODO: Change this to `Workload::ForTest` once `#[cfg(bench)]` is stabilized.
     let _ = raw
         .db
-        .with_auto_commit(&ExecutionContext::default(), |tx| -> Result<(), DBError> {
+        .with_auto_commit(Workload::Internal, |tx| -> Result<(), DBError> {
             // 1M rows
             for entity_id in 0u64..1_000_000 {
                 let owner = entity_id % 1_000;
@@ -67,7 +68,7 @@ fn eval(c: &mut Criterion) {
 
     let _ = raw
         .db
-        .with_auto_commit(&ExecutionContext::default(), |tx| -> Result<(), DBError> {
+        .with_auto_commit(Workload::Internal, |tx| -> Result<(), DBError> {
             // 1000 chunks, 1200 rows per chunk = 1.2M rows
             for chunk_index in 0u64..1_000 {
                 for i in 0u64..1200 {
@@ -100,13 +101,12 @@ fn eval(c: &mut Criterion) {
 
     let bench_eval = |c: &mut Criterion, name, sql| {
         c.bench_function(name, |b| {
-            let tx = raw.db.begin_tx();
+            let tx = raw.db.begin_tx(Workload::Update);
             let query = compile_read_only_query(&raw.db, &AuthCtx::for_testing(), &tx, sql).unwrap();
             let query: ExecutionSet = query.into();
-            let ctx = &ExecutionContext::subscribe(raw.db.database_identity());
+
             b.iter(|| {
                 drop(black_box(query.eval::<BsatnFormat>(
-                    ctx,
                     &raw.db,
                     &tx,
                     None,
@@ -134,25 +134,19 @@ fn eval(c: &mut Criterion) {
     );
     bench_eval(c, "full-join", &name);
 
-    let ctx_incr = &ExecutionContext::incremental_update(raw.db.database_identity());
-
     // To profile this benchmark for 30s
     // samply record -r 10000000 cargo bench --bench=subscription --profile=profiling -- incr-select --exact --profile-time=30
     c.bench_function("incr-select", |b| {
         // A passthru executed independently of the database.
         let select_lhs = "select * from footprint";
         let select_rhs = "select * from location";
-        let tx = &raw.db.begin_tx();
+        let tx = &raw.db.begin_tx(Workload::Update);
         let query_lhs = compile_read_only_query(&raw.db, &AuthCtx::for_testing(), tx, select_lhs).unwrap();
         let query_rhs = compile_read_only_query(&raw.db, &AuthCtx::for_testing(), tx, select_rhs).unwrap();
         let query = ExecutionSet::from_iter(query_lhs.into_iter().chain(query_rhs));
         let tx = &tx.into();
 
-        b.iter(|| {
-            drop(black_box(
-                query.eval_incr_for_test(ctx_incr, &raw.db, tx, &update, None),
-            ))
-        })
+        b.iter(|| drop(black_box(query.eval_incr_for_test(&raw.db, tx, &update, None))))
     });
 
     // To profile this benchmark for 30s
@@ -165,16 +159,12 @@ fn eval(c: &mut Criterion) {
             from footprint join location on footprint.entity_id = location.entity_id \
             where location.chunk_index = {chunk_index}"
         );
-        let tx = &raw.db.begin_tx();
+        let tx = &raw.db.begin_tx(Workload::Update);
         let query = compile_read_only_query(&raw.db, &AuthCtx::for_testing(), tx, &join).unwrap();
         let query: ExecutionSet = query.into();
         let tx = &tx.into();
 
-        b.iter(|| {
-            drop(black_box(
-                query.eval_incr_for_test(ctx_incr, &raw.db, tx, &update, None),
-            ))
-        });
+        b.iter(|| drop(black_box(query.eval_incr_for_test(&raw.db, tx, &update, None))));
     });
 
     // To profile this benchmark for 30s

--- a/crates/bench/src/spacetime_raw.rs
+++ b/crates/bench/src/spacetime_raw.rs
@@ -4,7 +4,7 @@ use crate::{
     ResultBench,
 };
 use spacetimedb::db::relational_db::{tests_utils::TestDB, RelationalDB};
-use spacetimedb::execution_context::ExecutionContext;
+use spacetimedb::execution_context::Workload;
 use spacetimedb_lib::sats::AlgebraicValue;
 use spacetimedb_primitives::{ColId, IndexId, TableId};
 use spacetimedb_schema::{
@@ -40,7 +40,7 @@ impl BenchDatabase for SpacetimeRaw {
 
     fn create_table<T: BenchTable>(&mut self, index_strategy: IndexStrategy) -> ResultBench<Self::TableId> {
         let name = table_name::<T>(index_strategy);
-        self.db.with_auto_commit(&ExecutionContext::default(), |tx| {
+        self.db.with_auto_commit(Workload::Internal, |tx| {
             let mut table_schema = TableSchema::from_product_type(T::product_type());
             table_schema.table_name = name.clone().into();
             let table_id = self.db.create_table(tx, table_schema)?;
@@ -84,25 +84,24 @@ impl BenchDatabase for SpacetimeRaw {
     }
 
     fn clear_table(&mut self, table_id: &Self::TableId) -> ResultBench<()> {
-        self.db.with_auto_commit(&ExecutionContext::default(), |tx| {
+        self.db.with_auto_commit(Workload::Internal, |tx| {
             self.db.clear_table(tx, *table_id)?;
             Ok(())
         })
     }
 
     fn count_table(&mut self, table_id: &Self::TableId) -> ResultBench<u32> {
-        let ctx = ExecutionContext::default();
-        self.db.with_auto_commit(&ctx, |tx| {
-            Ok(self.db.iter_mut(&ctx, tx, *table_id)?.map(|_| 1u32).sum())
+        self.db.with_auto_commit(Workload::Internal, |tx| {
+            Ok(self.db.iter_mut(tx, *table_id)?.map(|_| 1u32).sum())
         })
     }
 
     fn empty_transaction(&mut self) -> ResultBench<()> {
-        self.db.with_auto_commit(&ExecutionContext::default(), |_tx| Ok(()))
+        self.db.with_auto_commit(Workload::Internal, |_tx| Ok(()))
     }
 
     fn insert_bulk<T: BenchTable>(&mut self, table_id: &Self::TableId, rows: Vec<T>) -> ResultBench<()> {
-        self.db.with_auto_commit(&ExecutionContext::default(), |tx| {
+        self.db.with_auto_commit(Workload::Internal, |tx| {
             for row in rows {
                 self.db.insert(tx, *table_id, row.into_product_value())?;
             }
@@ -111,11 +110,10 @@ impl BenchDatabase for SpacetimeRaw {
     }
 
     fn update_bulk<T: BenchTable>(&mut self, table_id: &Self::TableId, row_count: u32) -> ResultBench<()> {
-        let ctx = ExecutionContext::default();
-        self.db.with_auto_commit(&ctx, |tx| {
+        self.db.with_auto_commit(Workload::Internal, |tx| {
             let rows = self
                 .db
-                .iter_mut(&ctx, tx, *table_id)?
+                .iter_mut(tx, *table_id)?
                 .take(row_count as usize)
                 .map(|row| row.to_product_value())
                 .collect::<Vec<_>>();
@@ -127,7 +125,7 @@ impl BenchDatabase for SpacetimeRaw {
                 // (update_by_{field} -> spacetimedb::query::update_by_field -> (delete_by_col_eq; insert))
                 let id = self
                     .db
-                    .iter_by_col_eq_mut(&ctx, tx, *table_id, 0, &row.elements[0])?
+                    .iter_by_col_eq_mut(tx, *table_id, 0, &row.elements[0])?
                     .next()
                     .expect("failed to find row during update!")
                     .pointer();
@@ -152,9 +150,8 @@ impl BenchDatabase for SpacetimeRaw {
     }
 
     fn iterate(&mut self, table_id: &Self::TableId) -> ResultBench<()> {
-        let ctx = ExecutionContext::default();
-        self.db.with_auto_commit(&ctx, |tx| {
-            for row in self.db.iter_mut(&ctx, tx, *table_id)? {
+        self.db.with_auto_commit(Workload::Internal, |tx| {
+            for row in self.db.iter_mut(tx, *table_id)? {
                 black_box(row);
             }
             Ok(())
@@ -167,9 +164,8 @@ impl BenchDatabase for SpacetimeRaw {
         col_id: impl Into<ColId>,
         value: AlgebraicValue,
     ) -> ResultBench<()> {
-        let ctx = ExecutionContext::default();
-        self.db.with_auto_commit(&ctx, |tx| {
-            for row in self.db.iter_by_col_eq_mut(&ctx, tx, *table_id, col_id, &value)? {
+        self.db.with_auto_commit(Workload::Internal, |tx| {
+            for row in self.db.iter_by_col_eq_mut(tx, *table_id, col_id, &value)? {
                 black_box(row);
             }
             Ok(())

--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -16,6 +16,7 @@ use serde::Deserialize;
 use serde_json::{json, Value};
 use spacetimedb::address::Address;
 use spacetimedb::database_logger::DatabaseLogger;
+use spacetimedb::execution_context::Workload;
 use spacetimedb::host::ReducerCallError;
 use spacetimedb::host::ReducerOutcome;
 use spacetimedb::host::{DescribedEntityType, UpdateDatabaseResult};
@@ -24,7 +25,7 @@ use spacetimedb::identity::Identity;
 use spacetimedb::json::client_api::StmtResultJson;
 use spacetimedb::messages::control_db::{Database, HostType, Replica};
 use spacetimedb::sql;
-use spacetimedb::sql::execute::{ctx_sql, translate_col};
+use spacetimedb::sql::execute::translate_col;
 use spacetimedb_client_api_messages::name::{self, DnsLookupResponse, DomainName, PublishOp, PublishResult};
 use spacetimedb_data_structures::map::HashMap;
 use spacetimedb_lib::address::AddressForUrl;
@@ -557,7 +558,7 @@ where
                         }
                     })?;
 
-                let json = db.with_read_only(&ctx_sql(db), |tx| {
+                let json = db.with_read_only(Workload::Sql, |tx| {
                     results
                         .into_iter()
                         .map(|result| {

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -6,6 +6,7 @@ use super::{
     tx::TxId,
     tx_state::TxState,
 };
+use crate::execution_context::Workload;
 use crate::{
     db::{
         datastore::{
@@ -102,7 +103,6 @@ impl Locking {
         // This is intentional.
         let datastore = Self::new(database_identity);
         let mut commit_state = datastore.committed_state.write_arc();
-        let database_identity = datastore.database_identity;
         // TODO(cloutiertyler): One thing to consider in the future is, should
         // we persist the bootstrap transaction in the message log? My intuition
         // is no, because then if we change the schema of the system tables we
@@ -178,8 +178,6 @@ impl Locking {
         let mut committed_state = datastore.committed_state.write_arc();
         committed_state.blob_store = blob_store;
 
-        let ctx = ExecutionContext::internal(datastore.database_identity);
-
         // Note that `tables` is a `BTreeMap`, and so iterates in increasing order.
         // This means that we will instantiate and populate the system tables before any user tables.
         for (table_id, pages) in tables {
@@ -188,7 +186,7 @@ impl Locking {
                 // In this case, `schema_for_table` will never see a cached schema,
                 // as the committed state is newly constructed and we have not accessed this schema yet.
                 // As such, this call will compute and save the schema from `st_table` and friends.
-                None => committed_state.schema_for_table(&ctx, table_id)?,
+                None => committed_state.schema_for_table(table_id)?,
             };
             let (table, blob_store) = committed_state.get_table_and_blob_store_or_create(table_id, &schema);
             unsafe {
@@ -219,7 +217,7 @@ impl Locking {
         }
 
         // Fix up auto_inc IDs in the cached system table schemas.
-        committed_state.reset_system_table_schemas(database_identity)?;
+        committed_state.reset_system_table_schemas()?;
 
         // The next TX offset after restoring from a snapshot is one greater than the snapshotted offset.
         committed_state.next_tx_offset = tx_offset + 1;
@@ -274,10 +272,9 @@ impl Locking {
     /// reading from the `st_clients` system table.
     pub fn connected_clients<'a>(
         &'a self,
-        ctx: &'a ExecutionContext,
         tx: &'a TxId,
     ) -> Result<impl Iterator<Item = Result<(Identity, Address)>> + 'a> {
-        let iter = self.iter_tx(ctx, tx, ST_CLIENT_ID)?.map(|row_ref| {
+        let iter = self.iter_tx(tx, ST_CLIENT_ID)?.map(|row_ref| {
             let row = StClientRow::try_from(row_ref)?;
             Ok((row.identity.0, row.address.0))
         });
@@ -290,7 +287,7 @@ impl Locking {
             .table_id_from_name_mut_tx(tx, &name)?
             .ok_or_else(|| TableError::NotFound(name.into()))?;
 
-        tx.alter_table_access(self.database_identity, table_id, access)
+        tx.alter_table_access(table_id, access)
     }
 }
 
@@ -306,20 +303,22 @@ impl DataRow for Locking {
 impl Tx for Locking {
     type Tx = TxId;
 
-    fn begin_tx(&self) -> Self::Tx {
+    fn begin_tx(&self, workload: Workload) -> Self::Tx {
         let timer = Instant::now();
 
         let committed_state_shared_lock = self.committed_state.read_arc();
         let lock_wait_time = timer.elapsed();
+        let ctx = ExecutionContext::with_workload(self.database_identity, workload);
         Self::Tx {
             committed_state_shared_lock,
             lock_wait_time,
             timer,
+            ctx,
         }
     }
 
-    fn release_tx(&self, ctx: &ExecutionContext, tx: Self::Tx) {
-        tx.release(ctx);
+    fn release_tx(&self, tx: Self::Tx) {
+        tx.release();
     }
 }
 
@@ -337,30 +336,28 @@ impl TxDatastore for Locking {
     where
         Self: 'a;
 
-    fn iter_tx<'a>(&'a self, ctx: &'a ExecutionContext, tx: &'a Self::Tx, table_id: TableId) -> Result<Self::Iter<'a>> {
-        tx.iter(ctx, table_id)
+    fn iter_tx<'a>(&'a self, tx: &'a Self::Tx, table_id: TableId) -> Result<Self::Iter<'a>> {
+        tx.iter(table_id)
     }
 
     fn iter_by_col_range_tx<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
-        ctx: &'a ExecutionContext,
         tx: &'a Self::Tx,
         table_id: TableId,
         cols: impl Into<ColList>,
         range: R,
     ) -> Result<Self::IterByColRange<'a, R>> {
-        tx.iter_by_col_range(ctx, table_id, cols.into(), range)
+        tx.iter_by_col_range(table_id, cols.into(), range)
     }
 
     fn iter_by_col_eq_tx<'a, 'r>(
         &'a self,
-        ctx: &'a ExecutionContext,
         tx: &'a Self::Tx,
         table_id: TableId,
         cols: impl Into<ColList>,
         value: &'r AlgebraicValue,
     ) -> Result<Self::IterByColEq<'a, 'r>> {
-        tx.iter_by_col_eq(ctx, table_id, cols, value)
+        tx.iter_by_col_eq(table_id, cols, value)
     }
 
     fn table_id_exists_tx(&self, tx: &Self::Tx, table_id: &TableId) -> bool {
@@ -368,7 +365,7 @@ impl TxDatastore for Locking {
     }
 
     fn table_id_from_name_tx(&self, tx: &Self::Tx, table_name: &str) -> Result<Option<TableId>> {
-        tx.table_id_from_name(table_name, self.database_identity)
+        tx.table_id_from_name(table_name)
     }
 
     fn table_name_from_id_tx<'a>(&'a self, tx: &'a Self::Tx, table_id: TableId) -> Result<Option<Cow<'a, str>>> {
@@ -376,11 +373,11 @@ impl TxDatastore for Locking {
     }
 
     fn schema_for_table_tx(&self, tx: &Self::Tx, table_id: TableId) -> Result<Arc<TableSchema>> {
-        tx.schema_for_table(&ExecutionContext::internal(self.database_identity), table_id)
+        tx.schema_for_table(table_id)
     }
 
-    fn get_all_tables_tx(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Vec<Arc<TableSchema>>> {
-        self.iter_tx(ctx, tx, ST_TABLE_ID)?
+    fn get_all_tables_tx(&self, tx: &Self::Tx) -> Result<Vec<Arc<TableSchema>>> {
+        self.iter_tx(tx, ST_TABLE_ID)?
             .map(|row_ref| {
                 let table_id = row_ref.read_col(StTableFields::TableId)?;
                 self.schema_for_table_tx(tx, table_id)
@@ -388,15 +385,15 @@ impl TxDatastore for Locking {
             .collect()
     }
 
-    fn metadata(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Option<Metadata>> {
-        self.iter_tx(ctx, tx, ST_MODULE_ID)?
+    fn metadata(&self, tx: &Self::Tx) -> Result<Option<Metadata>> {
+        self.iter_tx(tx, ST_MODULE_ID)?
             .next()
             .map(metadata_from_row)
             .transpose()
     }
 
-    fn program(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Option<Program>> {
-        self.iter_tx(ctx, tx, ST_MODULE_ID)?
+    fn program(&self, tx: &Self::Tx) -> Result<Option<Program>> {
+        self.iter_tx(tx, ST_MODULE_ID)?
             .next()
             .map(|row_ref| {
                 let hash = read_hash_from_col(row_ref, StModuleFields::ProgramHash)?;
@@ -409,7 +406,7 @@ impl TxDatastore for Locking {
 
 impl MutTxDatastore for Locking {
     fn create_table_mut_tx(&self, tx: &mut Self::MutTx, schema: TableSchema) -> Result<TableId> {
-        tx.create_table(schema, self.database_identity)
+        tx.create_table(schema)
     }
 
     /// This function is used to get the `ProductType` of the rows in a
@@ -426,7 +423,7 @@ impl MutTxDatastore for Locking {
     ///
     /// This function is known to be called quite frequently.
     fn row_type_for_table_mut_tx<'tx>(&self, tx: &'tx Self::MutTx, table_id: TableId) -> Result<RowTypeForTable<'tx>> {
-        tx.row_type_for_table(table_id, self.database_identity)
+        tx.row_type_for_table(table_id)
     }
 
     /// IMPORTANT! This function is relatively expensive, and much more
@@ -434,105 +431,90 @@ impl MutTxDatastore for Locking {
     /// `row_type_for_table_mut_tx` if you only need to access the `ProductType`
     /// of the table.
     fn schema_for_table_mut_tx(&self, tx: &Self::MutTx, table_id: TableId) -> Result<Arc<TableSchema>> {
-        tx.schema_for_table(&ExecutionContext::internal(self.database_identity), table_id)
+        tx.schema_for_table(table_id)
     }
 
     /// This function is relatively expensive because it needs to be
     /// transactional, however we don't expect to be dropping tables very often.
     fn drop_table_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId) -> Result<()> {
-        tx.drop_table(table_id, self.database_identity)
+        tx.drop_table(table_id)
     }
 
     fn rename_table_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, new_name: &str) -> Result<()> {
-        tx.rename_table(table_id, new_name, self.database_identity)
+        tx.rename_table(table_id, new_name)
     }
 
     fn table_id_from_name_mut_tx(&self, tx: &Self::MutTx, table_name: &str) -> Result<Option<TableId>> {
-        tx.table_id_from_name(table_name, self.database_identity)
+        tx.table_id_from_name(table_name)
     }
 
     fn table_id_exists_mut_tx(&self, tx: &Self::MutTx, table_id: &TableId) -> bool {
         tx.table_name(*table_id).is_some()
     }
 
-    fn table_name_from_id_mut_tx<'a>(
-        &'a self,
-        ctx: &'a ExecutionContext,
-        tx: &'a Self::MutTx,
-        table_id: TableId,
-    ) -> Result<Option<Cow<'a, str>>> {
-        tx.table_name_from_id(ctx, table_id)
+    fn table_name_from_id_mut_tx<'a>(&'a self, tx: &'a Self::MutTx, table_id: TableId) -> Result<Option<Cow<'a, str>>> {
+        tx.table_name_from_id(table_id)
             .map(|opt| opt.map(|s| Cow::Owned(s.into())))
     }
 
     fn create_index_mut_tx(&self, tx: &mut Self::MutTx, index_schema: IndexSchema, is_unique: bool) -> Result<IndexId> {
-        let ctx = &ExecutionContext::internal(self.database_identity);
-        tx.create_index(ctx, index_schema, is_unique)
+        tx.create_index(index_schema, is_unique)
     }
 
     fn drop_index_mut_tx(&self, tx: &mut Self::MutTx, index_id: IndexId) -> Result<()> {
-        tx.drop_index(index_id, self.database_identity)
+        tx.drop_index(index_id)
     }
 
     fn index_id_from_name_mut_tx(&self, tx: &Self::MutTx, index_name: &str) -> Result<Option<IndexId>> {
-        tx.index_id_from_name(index_name, self.database_identity)
+        tx.index_id_from_name(index_name)
     }
 
     fn get_next_sequence_value_mut_tx(&self, tx: &mut Self::MutTx, seq_id: SequenceId) -> Result<i128> {
-        tx.get_next_sequence_value(seq_id, self.database_identity)
+        tx.get_next_sequence_value(seq_id)
     }
 
     fn create_sequence_mut_tx(&self, tx: &mut Self::MutTx, sequence_schema: SequenceSchema) -> Result<SequenceId> {
-        tx.create_sequence(sequence_schema, self.database_identity)
+        tx.create_sequence(sequence_schema)
     }
 
     fn drop_sequence_mut_tx(&self, tx: &mut Self::MutTx, seq_id: SequenceId) -> Result<()> {
-        tx.drop_sequence(seq_id, self.database_identity)
+        tx.drop_sequence(seq_id)
     }
 
     fn sequence_id_from_name_mut_tx(&self, tx: &Self::MutTx, sequence_name: &str) -> Result<Option<SequenceId>> {
-        tx.sequence_id_from_name(sequence_name, self.database_identity)
+        tx.sequence_id_from_name(sequence_name)
     }
 
     fn drop_constraint_mut_tx(&self, tx: &mut Self::MutTx, constraint_id: ConstraintId) -> Result<()> {
-        let ctx = &ExecutionContext::internal(self.database_identity);
-        tx.drop_constraint(ctx, constraint_id)
+        tx.drop_constraint(constraint_id)
     }
 
     fn constraint_id_from_name(&self, tx: &Self::MutTx, constraint_name: &str) -> Result<Option<ConstraintId>> {
-        let ctx = &ExecutionContext::internal(self.database_identity);
-        tx.constraint_id_from_name(ctx, constraint_name)
+        tx.constraint_id_from_name(constraint_name)
     }
 
-    fn iter_mut_tx<'a>(
-        &'a self,
-        ctx: &'a ExecutionContext,
-        tx: &'a Self::MutTx,
-        table_id: TableId,
-    ) -> Result<Self::Iter<'a>> {
-        tx.iter(ctx, table_id)
+    fn iter_mut_tx<'a>(&'a self, tx: &'a Self::MutTx, table_id: TableId) -> Result<Self::Iter<'a>> {
+        tx.iter(table_id)
     }
 
     fn iter_by_col_range_mut_tx<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
-        ctx: &'a ExecutionContext,
         tx: &'a Self::MutTx,
         table_id: TableId,
         cols: impl Into<ColList>,
         range: R,
     ) -> Result<Self::IterByColRange<'a, R>> {
-        tx.iter_by_col_range(ctx, table_id, cols.into(), range)
+        tx.iter_by_col_range(table_id, cols.into(), range)
     }
 
     fn iter_by_col_eq_mut_tx<'a, 'r>(
         &'a self,
-        ctx: &'a ExecutionContext,
         tx: &'a Self::MutTx,
         table_id: TableId,
         cols: impl Into<ColList>,
         value: &'r AlgebraicValue,
     ) -> Result<Self::IterByColEq<'a, 'r>> {
-        tx.iter_by_col_eq(ctx, table_id, cols.into(), value)
+        tx.iter_by_col_eq(table_id, cols.into(), value)
     }
 
     fn get_mut_tx<'a>(
@@ -583,19 +565,17 @@ impl MutTxDatastore for Locking {
         table_id: TableId,
         mut row: ProductValue,
     ) -> Result<(AlgebraicValue, RowRef<'a>)> {
-        let (gens, row_ref) = tx.insert(table_id, &mut row, self.database_identity)?;
+        let (gens, row_ref) = tx.insert(table_id, &mut row)?;
         Ok((gens, row_ref.collapse()))
     }
 
     fn metadata_mut_tx(&self, tx: &Self::MutTx) -> Result<Option<Metadata>> {
-        let ctx = ExecutionContext::internal(self.database_identity);
-        tx.iter(&ctx, ST_MODULE_ID)?.next().map(metadata_from_row).transpose()
+        tx.iter(ST_MODULE_ID)?.next().map(metadata_from_row).transpose()
     }
 
     fn update_program(&self, tx: &mut Self::MutTx, program_kind: ModuleKind, program: Program) -> Result<()> {
-        let ctx = ExecutionContext::internal(self.database_identity);
         let old = tx
-            .iter(&ctx, ST_MODULE_ID)?
+            .iter(ST_MODULE_ID)?
             .next()
             .map(|row| {
                 let ptr = row.pointer();
@@ -610,8 +590,7 @@ impl MutTxDatastore for Locking {
                 row.program_bytes = program.bytes;
 
                 tx.delete(ST_MODULE_ID, ptr)?;
-                tx.insert(ST_MODULE_ID, &mut row.into(), self.database_identity)
-                    .map(drop)
+                tx.insert(ST_MODULE_ID, &mut row.into()).map(drop)
             }
 
             None => Err(anyhow!(
@@ -625,7 +604,7 @@ impl MutTxDatastore for Locking {
 
 /// This utility is responsible for recording all transaction metrics.
 pub(super) fn record_metrics(
-    ctx: &ExecutionContext,
+    ctx: ExecutionContext,
     tx_timer: Instant,
     lock_wait_time: Duration,
     committed: bool,
@@ -700,47 +679,39 @@ impl MutTx for Locking {
 
     /// Note: We do not use the isolation level here because this implementation
     /// guarantees the highest isolation level, Serializable.
-    fn begin_mut_tx(&self, _isolation_level: IsolationLevel) -> Self::MutTx {
+    fn begin_mut_tx(&self, _isolation_level: IsolationLevel, workload: Workload) -> Self::MutTx {
         let timer = Instant::now();
 
         let committed_state_write_lock = self.committed_state.write_arc();
         let sequence_state_lock = self.sequence_state.lock_arc();
         let lock_wait_time = timer.elapsed();
+        let ctx = ExecutionContext::with_workload(self.database_identity, workload);
         MutTxId {
             committed_state_write_lock,
             sequence_state_lock,
             tx_state: TxState::default(),
             lock_wait_time,
             timer,
+            ctx,
         }
     }
 
-    fn rollback_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTx) {
-        tx.rollback(ctx);
+    fn rollback_mut_tx(&self, tx: Self::MutTx) {
+        tx.rollback();
     }
 
-    fn commit_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTx) -> Result<Option<TxData>> {
-        Ok(Some(tx.commit(ctx)))
-    }
-
-    #[cfg(test)]
-    fn commit_mut_tx_for_test(&self, tx: Self::MutTx) -> crate::db::datastore::Result<Option<TxData>> {
-        self.commit_mut_tx(&ExecutionContext::default(), tx)
-    }
-
-    #[cfg(test)]
-    fn rollback_mut_tx_for_test(&self, tx: Self::MutTx) {
-        self.rollback_mut_tx(&ExecutionContext::default(), tx)
+    fn commit_mut_tx(&self, tx: Self::MutTx) -> Result<Option<TxData>> {
+        Ok(Some(tx.commit()))
     }
 }
 
 impl Locking {
-    pub fn rollback_mut_tx_downgrade(&self, ctx: &ExecutionContext, tx: MutTxId) -> TxId {
-        tx.rollback_downgrade(ctx)
+    pub fn rollback_mut_tx_downgrade(&self, tx: MutTxId, workload: Workload) -> TxId {
+        tx.rollback_downgrade(workload)
     }
 
-    pub fn commit_mut_tx_downgrade(&self, ctx: &ExecutionContext, tx: MutTxId) -> Result<Option<(TxData, TxId)>> {
-        Ok(Some(tx.commit_downgrade(ctx)))
+    pub fn commit_mut_tx_downgrade(&self, tx: MutTxId, workload: Workload) -> Result<Option<(TxData, TxId)>> {
+        Ok(Some(tx.commit_downgrade(workload)))
     }
 }
 
@@ -891,9 +862,7 @@ impl<F: FnMut(u64)> spacetimedb_commitlog::payload::txdata::Visitor for ReplayVi
         table_id: TableId,
         reader: &mut R,
     ) -> std::result::Result<(), Self::Error> {
-        let schema = self
-            .committed_state
-            .schema_for_table(&ExecutionContext::default(), table_id)?;
+        let schema = self.committed_state.schema_for_table(table_id)?;
         ProductValue::decode(schema.get_row_type(), reader)?;
         Ok(())
     }
@@ -903,9 +872,7 @@ impl<F: FnMut(u64)> spacetimedb_commitlog::payload::txdata::Visitor for ReplayVi
         table_id: TableId,
         reader: &mut R,
     ) -> std::result::Result<Self::Row, Self::Error> {
-        let schema = self
-            .committed_state
-            .schema_for_table(&ExecutionContext::default(), table_id)?;
+        let schema = self.committed_state.schema_for_table(table_id)?;
         let row = ProductValue::decode(schema.get_row_type(), reader)?;
 
         self.committed_state
@@ -931,9 +898,7 @@ impl<F: FnMut(u64)> spacetimedb_commitlog::payload::txdata::Visitor for ReplayVi
         table_id: TableId,
         reader: &mut R,
     ) -> std::result::Result<Self::Row, Self::Error> {
-        let schema = self
-            .committed_state
-            .schema_for_table(&ExecutionContext::default(), table_id)?;
+        let schema = self.committed_state.schema_for_table(table_id)?;
         // TODO: avoid clone
         let table_name = schema.table_name.clone();
         let row = ProductValue::decode(schema.get_row_type(), reader)?;
@@ -1032,18 +997,17 @@ mod tests {
     /// Utility to query the system tables and return their concrete table row
     pub struct SystemTableQuery<'a> {
         db: &'a MutTxId,
-        ctx: &'a ExecutionContext,
     }
 
-    fn query_st_tables<'a>(ctx: &'a ExecutionContext, tx: &'a MutTxId) -> SystemTableQuery<'a> {
-        SystemTableQuery { db: tx, ctx }
+    fn query_st_tables(tx: &MutTxId) -> SystemTableQuery<'_> {
+        SystemTableQuery { db: tx }
     }
 
     impl SystemTableQuery<'_> {
         pub fn scan_st_tables(&self) -> Result<Vec<StTableRow>> {
             Ok(self
                 .db
-                .iter(self.ctx, ST_TABLE_ID)?
+                .iter(ST_TABLE_ID)?
                 .map(|row| StTableRow::try_from(row).unwrap())
                 .sorted_by_key(|x| x.table_id)
                 .collect::<Vec<_>>())
@@ -1056,7 +1020,7 @@ mod tests {
         ) -> Result<Vec<StTableRow>> {
             Ok(self
                 .db
-                .iter_by_col_eq(self.ctx, ST_TABLE_ID, cols.into(), value)?
+                .iter_by_col_eq(ST_TABLE_ID, cols.into(), value)?
                 .map(|row| StTableRow::try_from(row).unwrap())
                 .sorted_by_key(|x| x.table_id)
                 .collect::<Vec<_>>())
@@ -1065,7 +1029,7 @@ mod tests {
         pub fn scan_st_columns(&self) -> Result<Vec<StColumnRow>> {
             Ok(self
                 .db
-                .iter(self.ctx, ST_COLUMN_ID)?
+                .iter(ST_COLUMN_ID)?
                 .map(|row| StColumnRow::try_from(row).unwrap())
                 .sorted_by_key(|x| (x.table_id, x.col_pos))
                 .collect::<Vec<_>>())
@@ -1078,7 +1042,7 @@ mod tests {
         ) -> Result<Vec<StColumnRow>> {
             Ok(self
                 .db
-                .iter_by_col_eq(self.ctx, ST_COLUMN_ID, cols.into(), value)?
+                .iter_by_col_eq(ST_COLUMN_ID, cols.into(), value)?
                 .map(|row| StColumnRow::try_from(row).unwrap())
                 .sorted_by_key(|x| (x.table_id, x.col_pos))
                 .collect::<Vec<_>>())
@@ -1087,7 +1051,7 @@ mod tests {
         pub fn scan_st_constraints(&self) -> Result<Vec<StConstraintRow>> {
             Ok(self
                 .db
-                .iter(self.ctx, ST_CONSTRAINT_ID)?
+                .iter(ST_CONSTRAINT_ID)?
                 .map(|row| StConstraintRow::try_from(row).unwrap())
                 .sorted_by_key(|x| x.constraint_id)
                 .collect::<Vec<_>>())
@@ -1096,7 +1060,7 @@ mod tests {
         pub fn scan_st_sequences(&self) -> Result<Vec<StSequenceRow>> {
             Ok(self
                 .db
-                .iter(self.ctx, ST_SEQUENCE_ID)?
+                .iter(ST_SEQUENCE_ID)?
                 .map(|row| StSequenceRow::try_from(row).unwrap())
                 .sorted_by_key(|x| (x.table_id, x.sequence_id))
                 .collect::<Vec<_>>())
@@ -1105,7 +1069,7 @@ mod tests {
         pub fn scan_st_indexes(&self) -> Result<Vec<StIndexRow>> {
             Ok(self
                 .db
-                .iter(self.ctx, ST_INDEX_ID)?
+                .iter(ST_INDEX_ID)?
                 .map(|row| StIndexRow::try_from(row).unwrap())
                 .sorted_by_key(|x| x.index_id)
                 .collect::<Vec<_>>())
@@ -1360,7 +1324,7 @@ mod tests {
 
     fn setup_table() -> ResultTest<(Locking, MutTxId, TableId)> {
         let datastore = get_datastore()?;
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         let schema = basic_table_schema();
         let table_id = datastore.create_table_mut_tx(&mut tx, schema)?;
         Ok((datastore, tx, table_id))
@@ -1368,14 +1332,14 @@ mod tests {
 
     fn all_rows(datastore: &Locking, tx: &MutTxId, table_id: TableId) -> Vec<ProductValue> {
         datastore
-            .iter_mut_tx(&ExecutionContext::default(), tx, table_id)
+            .iter_mut_tx(tx, table_id)
             .unwrap()
             .map(|r| r.to_product_value().clone())
             .collect()
     }
 
     fn all_rows_tx(tx: &TxId, table_id: TableId) -> Vec<ProductValue> {
-        tx.iter(&ExecutionContext::default(), table_id)
+        tx.iter(table_id)
             .unwrap()
             .map(|r| r.to_product_value().clone())
             .collect()
@@ -1384,9 +1348,8 @@ mod tests {
     #[test]
     fn test_bootstrapping_sets_up_tables() -> ResultTest<()> {
         let datastore = get_datastore()?;
-        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
-        let ctx = ExecutionContext::default();
-        let query = query_st_tables(&ctx, &tx);
+        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
+        let query = query_st_tables(&tx);
         #[rustfmt::skip]
         assert_eq!(query.scan_st_tables()?, map_array([
             TableRow { id: ST_TABLE_ID.into(), name: ST_TABLE_NAME, ty: StTableType::System, access: StAccess::Public, primary_key: Some(StTableFields::TableId.into()) },
@@ -1553,15 +1516,14 @@ mod tests {
             );
         }
 
-        datastore.rollback_mut_tx_for_test(tx);
+        datastore.rollback_mut_tx(tx);
         Ok(())
     }
 
     #[test]
     fn test_create_table_pre_commit() -> ResultTest<()> {
         let (_, tx, table_id) = setup_table()?;
-        let ctx = ExecutionContext::default();
-        let query = query_st_tables(&ctx, &tx);
+        let query = query_st_tables(&tx);
 
         let table_rows = query.scan_st_tables_by_col(ColId(0), &table_id.into())?;
         #[rustfmt::skip]
@@ -1577,10 +1539,9 @@ mod tests {
     #[test]
     fn test_create_table_post_commit() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
-        datastore.commit_mut_tx_for_test(tx)?;
-        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
-        let ctx = ExecutionContext::default();
-        let query = query_st_tables(&ctx, &tx);
+        datastore.commit_mut_tx(tx)?;
+        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
+        let query = query_st_tables(&tx);
 
         let table_rows = query.scan_st_tables_by_col(ColId(0), &table_id.into())?;
         #[rustfmt::skip]
@@ -1597,14 +1558,13 @@ mod tests {
     #[test]
     fn test_create_table_post_rollback() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
-        datastore.rollback_mut_tx_for_test(tx);
-        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        datastore.rollback_mut_tx(tx);
+        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         assert!(
             !datastore.table_id_exists_mut_tx(&tx, &table_id),
             "Table should not exist"
         );
-        let ctx = ExecutionContext::default();
-        let query = query_st_tables(&ctx, &tx);
+        let query = query_st_tables(&tx);
 
         let table_rows = query.scan_st_tables_by_col(ColId(0), &table_id.into())?;
         assert_eq!(table_rows, []);
@@ -1614,9 +1574,8 @@ mod tests {
     }
 
     fn verify_schemas_consistent(tx: &mut MutTxId, table_id: TableId) {
-        let ctx = &ExecutionContext::default();
         let s1 = tx.get_schema(table_id).expect("should exist");
-        let s2 = tx.schema_for_table_raw(ctx, table_id).expect("should exist");
+        let s2 = tx.schema_for_table_raw(table_id).expect("should exist");
         assert_eq!(**s1, s2);
     }
 
@@ -1635,8 +1594,8 @@ mod tests {
     #[test]
     fn test_schema_for_table_post_commit() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
-        datastore.commit_mut_tx_for_test(tx)?;
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        datastore.commit_mut_tx(tx)?;
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         verify_schemas_consistent(&mut tx, table_id);
         let schema = &*datastore.schema_for_table_mut_tx(&tx, table_id)?;
         #[rustfmt::skip]
@@ -1647,9 +1606,9 @@ mod tests {
     #[test]
     fn test_schema_for_table_alter_indexes() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
-        datastore.commit_mut_tx_for_test(tx)?;
+        datastore.commit_mut_tx(tx)?;
 
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         let schema = datastore.schema_for_table_mut_tx(&tx, table_id)?;
 
         let mut dropped_indexes = 0;
@@ -1661,9 +1620,9 @@ mod tests {
             datastore.schema_for_table_mut_tx(&tx, table_id)?.indexes.is_empty(),
             "no indexes should be left in the schema pre-commit"
         );
-        datastore.commit_mut_tx_for_test(tx)?;
+        datastore.commit_mut_tx(tx)?;
 
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         assert!(
             datastore.schema_for_table_mut_tx(&tx, table_id)?.indexes.is_empty(),
             "no indexes should be left in the schema post-commit"
@@ -1697,16 +1656,16 @@ mod tests {
             "created index should be present in schema pre-commit"
         );
 
-        datastore.commit_mut_tx_for_test(tx)?;
+        datastore.commit_mut_tx(tx)?;
 
-        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         assert_eq!(
             datastore.schema_for_table_mut_tx(&tx, table_id)?.indexes,
             expected_indexes,
             "created index should be present in schema post-commit"
         );
 
-        datastore.commit_mut_tx_for_test(tx)?;
+        datastore.commit_mut_tx(tx)?;
 
         Ok(())
     }
@@ -1714,8 +1673,8 @@ mod tests {
     #[test]
     fn test_schema_for_table_rollback() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
-        datastore.rollback_mut_tx_for_test(tx);
-        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        datastore.rollback_mut_tx(tx);
+        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         let schema = datastore.schema_for_table_mut_tx(&tx, table_id);
         assert!(schema.is_err());
         Ok(())
@@ -1746,8 +1705,8 @@ mod tests {
         let (datastore, mut tx, table_id) = setup_table()?;
         // 0 will be ignored.
         datastore.insert_mut_tx(&mut tx, table_id, u32_str_u32(0, "Foo", 18))?;
-        datastore.commit_mut_tx_for_test(tx)?;
-        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        datastore.commit_mut_tx(tx)?;
+        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         #[rustfmt::skip]
         assert_eq!(all_rows(&datastore, &tx, table_id), vec![u32_str_u32(1, "Foo", 18)]);
         Ok(())
@@ -1757,11 +1716,11 @@ mod tests {
     fn test_insert_post_rollback() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
         let row = u32_str_u32(15, "Foo", 18); // 15 is ignored.
-        datastore.commit_mut_tx_for_test(tx)?;
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        datastore.commit_mut_tx(tx)?;
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         datastore.insert_mut_tx(&mut tx, table_id, row)?;
-        datastore.rollback_mut_tx_for_test(tx);
-        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        datastore.rollback_mut_tx(tx);
+        let tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         #[rustfmt::skip]
         assert_eq!(all_rows(&datastore, &tx, table_id), vec![]);
         Ok(())
@@ -1772,8 +1731,8 @@ mod tests {
         let (datastore, mut tx, table_id) = setup_table()?;
         let row = u32_str_u32(0, "Foo", 18); // 0 will be ignored.
         datastore.insert_mut_tx(&mut tx, table_id, row)?;
-        datastore.commit_mut_tx_for_test(tx)?;
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        datastore.commit_mut_tx(tx)?;
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         let created_row = u32_str_u32(1, "Foo", 18);
         let num_deleted = datastore.delete_by_rel_mut_tx(&mut tx, table_id, [created_row]);
         assert_eq!(num_deleted, 1);
@@ -1841,8 +1800,8 @@ mod tests {
         let (datastore, mut tx, table_id) = setup_table()?;
         let row = u32_str_u32(0, "Foo", 18); // 0 will be ignored.
         datastore.insert_mut_tx(&mut tx, table_id, row.clone())?;
-        datastore.commit_mut_tx_for_test(tx)?;
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        datastore.commit_mut_tx(tx)?;
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         let result = datastore.insert_mut_tx(&mut tx, table_id, row);
         match result {
             Err(DBError::Index(IndexError::UniqueConstraintViolation(UniqueConstraintViolation {
@@ -1861,12 +1820,12 @@ mod tests {
     #[test]
     fn test_unique_constraint_post_rollback() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
-        datastore.commit_mut_tx_for_test(tx)?;
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        datastore.commit_mut_tx(tx)?;
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         let row = u32_str_u32(0, "Foo", 18); // 0 will be ignored.
         datastore.insert_mut_tx(&mut tx, table_id, row.clone())?;
-        datastore.rollback_mut_tx_for_test(tx);
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        datastore.rollback_mut_tx(tx);
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         datastore.insert_mut_tx(&mut tx, table_id, row)?;
         #[rustfmt::skip]
         assert_eq!(all_rows(&datastore, &tx, table_id), vec![u32_str_u32(2, "Foo", 18)]);
@@ -1876,14 +1835,14 @@ mod tests {
     #[test]
     fn test_create_index_pre_commit() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
-        datastore.commit_mut_tx_for_test(tx)?;
+        datastore.commit_mut_tx(tx)?;
 
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         let row = u32_str_u32(0, "Foo", 18); // 0 will be ignored.
         datastore.insert_mut_tx(&mut tx, table_id, row)?;
-        datastore.commit_mut_tx_for_test(tx)?;
+        datastore.commit_mut_tx(tx)?;
 
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         let index_def = IndexSchema {
             index_id: IndexId::SENTINEL,
             table_id,
@@ -1893,8 +1852,7 @@ mod tests {
         // TODO: it's slightly incorrect to create an index with `is_unique: true` without creating a corresponding constraint.
         // But the `Table` crate allows it for now.
         datastore.create_index_mut_tx(&mut tx, index_def, true)?;
-        let ctx = ExecutionContext::default();
-        let query = query_st_tables(&ctx, &tx);
+        let query = query_st_tables(&tx);
         let seq_start = FIRST_NON_SYSTEM_ID;
         let index_rows = query.scan_st_indexes()?;
         #[rustfmt::skip]
@@ -1936,8 +1894,8 @@ mod tests {
         let (datastore, mut tx, table_id) = setup_table()?;
         let row = u32_str_u32(0, "Foo", 18); // 0 will be ignored.
         datastore.insert_mut_tx(&mut tx, table_id, row)?;
-        datastore.commit_mut_tx_for_test(tx)?;
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        datastore.commit_mut_tx(tx)?;
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         let index_def = IndexSchema {
             index_id: IndexId::SENTINEL,
             table_id,
@@ -1945,10 +1903,9 @@ mod tests {
             index_algorithm: IndexAlgorithm::BTree(BTreeAlgorithm { columns: col_list![2] }),
         };
         datastore.create_index_mut_tx(&mut tx, index_def, true)?;
-        datastore.commit_mut_tx_for_test(tx)?;
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
-        let ctx = ExecutionContext::default();
-        let query = query_st_tables(&ctx, &tx);
+        datastore.commit_mut_tx(tx)?;
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
+        let query = query_st_tables(&tx);
 
         let seq_start = FIRST_NON_SYSTEM_ID;
         let index_rows = query.scan_st_indexes()?;
@@ -1991,8 +1948,8 @@ mod tests {
         let (datastore, mut tx, table_id) = setup_table()?;
         let row = u32_str_u32(0, "Foo", 18); // 0 will be ignored.
         datastore.insert_mut_tx(&mut tx, table_id, row)?;
-        datastore.commit_mut_tx_for_test(tx)?;
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        datastore.commit_mut_tx(tx)?;
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         let index_def = IndexSchema {
             index_id: IndexId::SENTINEL,
             table_id,
@@ -2001,10 +1958,9 @@ mod tests {
         };
         datastore.create_index_mut_tx(&mut tx, index_def, true)?;
 
-        datastore.rollback_mut_tx_for_test(tx);
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
-        let ctx = ExecutionContext::default();
-        let query = query_st_tables(&ctx, &tx);
+        datastore.rollback_mut_tx(tx);
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
+        let query = query_st_tables(&tx);
 
         let seq_start = FIRST_NON_SYSTEM_ID;
         let index_rows = query.scan_st_indexes()?;
@@ -2044,24 +2000,18 @@ mod tests {
                                              // Because of auto_inc columns, we will get a slightly different
                                              // value than the one we inserted.
         let row = datastore.insert_mut_tx(&mut tx, table_id, row)?.1.to_product_value();
-        datastore.commit_mut_tx_for_test(tx)?;
+        datastore.commit_mut_tx(tx)?;
 
         let all_rows_col_0_eq_1 = |tx: &MutTxId| {
             datastore
-                .iter_by_col_eq_mut_tx(
-                    &ExecutionContext::default(),
-                    tx,
-                    table_id,
-                    ColId(0),
-                    &AlgebraicValue::U32(1),
-                )
+                .iter_by_col_eq_mut_tx(tx, table_id, ColId(0), &AlgebraicValue::U32(1))
                 .unwrap()
                 .map(|row_ref| row_ref.to_product_value())
                 .collect::<Vec<_>>()
         };
 
         // Update the db with the same actual value for that row, in a new tx.
-        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable);
+        let mut tx = datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
         // Iterate over all rows with the value 1 (from the auto_inc) in column 0.
         let rows = all_rows_col_0_eq_1(&tx);
         assert_eq!(rows.len(), 1);
@@ -2084,7 +2034,7 @@ mod tests {
         // second transaction, and see exactly one row.
         assert_eq!(all_rows_col_0_eq_1(&tx).len(), 1);
 
-        datastore.commit_mut_tx_for_test(tx)?;
+        datastore.commit_mut_tx(tx)?;
 
         Ok(())
     }
@@ -2098,16 +2048,16 @@ mod tests {
         datastore.insert_mut_tx(&mut tx, table_id, row1.clone())?;
         let row2 = u32_str_u32(2, "Bar", 20);
         datastore.insert_mut_tx(&mut tx, table_id, row2.clone())?;
-        datastore.commit_mut_tx_for_test(tx)?;
+        datastore.commit_mut_tx(tx)?;
 
         // create multiple read only tx, and use them together.
-        let read_tx_1 = datastore.begin_tx();
-        let read_tx_2 = datastore.begin_tx();
+        let read_tx_1 = datastore.begin_tx(Workload::Internal);
+        let read_tx_2 = datastore.begin_tx(Workload::Internal);
         let rows = &[row1, row2];
         assert_eq!(&all_rows_tx(&read_tx_2, table_id), rows);
         assert_eq!(&all_rows_tx(&read_tx_1, table_id), rows);
-        read_tx_2.release(&ExecutionContext::default());
-        read_tx_1.release(&ExecutionContext::default());
+        read_tx_2.release();
+        read_tx_1.release();
         Ok(())
     }
 
@@ -2119,10 +2069,9 @@ mod tests {
             sql: "SELECT * FROM bar".into(),
             table_id,
         };
-        let ctx = ExecutionContext::default();
-        tx.create_row_level_security(&ctx, rls.clone())?;
+        tx.create_row_level_security(rls.clone())?;
 
-        let result = tx.row_level_security_for_table_id(&ctx, table_id)?;
+        let result = tx.row_level_security_for_table_id(table_id)?;
         assert_eq!(
             result,
             vec![RowLevelSecuritySchema {
@@ -2131,8 +2080,8 @@ mod tests {
             }]
         );
 
-        tx.drop_row_level_security(&ctx, rls.sql)?;
-        assert_eq!(tx.row_level_security_for_table_id(&ctx, table_id)?, []);
+        tx.drop_row_level_security(rls.sql)?;
+        assert_eq!(tx.row_level_security_for_table_id(table_id)?, []);
 
         Ok(())
     }

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -16,6 +16,7 @@ use crate::db::datastore::{
     },
     traits::{RowTypeForTable, TxData},
 };
+use crate::execution_context::Workload;
 use crate::{
     error::{IndexError, SequenceError, TableError},
     execution_context::ExecutionContext,
@@ -23,12 +24,12 @@ use crate::{
 use core::ops::RangeBounds;
 use core::{iter, ops::Bound};
 use smallvec::SmallVec;
+use spacetimedb_lib::db::raw_def::v9::RawSql;
 use spacetimedb_lib::{
     bsatn::Deserializer,
     db::{auth::StAccess, raw_def::SEQUENCE_ALLOCATION_STEP},
     de::DeserializeSeed,
 };
-use spacetimedb_lib::{db::raw_def::v9::RawSql, Identity};
 use spacetimedb_primitives::{ColId, ColList, ColSet, ConstraintId, IndexId, ScheduleId, SequenceId, TableId};
 use spacetimedb_sats::{
     bsatn::{self, DecodeError},
@@ -62,18 +63,12 @@ pub struct MutTxId {
     pub(super) sequence_state_lock: SharedMutexGuard<SequencesState>,
     pub(super) lock_wait_time: Duration,
     pub(crate) timer: Instant,
+    pub(crate) ctx: ExecutionContext,
 }
 
 impl MutTxId {
-    fn drop_col_eq(
-        &mut self,
-        table_id: TableId,
-        col_pos: ColId,
-        value: &AlgebraicValue,
-        database_identity: Identity,
-    ) -> Result<()> {
-        let ctx = ExecutionContext::internal(database_identity);
-        let rows = self.iter_by_col_eq(&ctx, table_id, col_pos, value)?;
+    fn drop_col_eq(&mut self, table_id: TableId, col_pos: ColId, value: &AlgebraicValue) -> Result<()> {
+        let rows = self.iter_by_col_eq(table_id, col_pos, value)?;
         let ptrs_to_delete = rows.map(|row_ref| row_ref.pointer()).collect::<Vec<_>>();
         if ptrs_to_delete.is_empty() {
             return Err(TableError::IdNotFound(SystemTable::st_column, col_pos.0 as _).into());
@@ -99,7 +94,7 @@ impl MutTxId {
     /// - An in-memory insert table is created for the transaction, allowing the transaction to insert rows into the table.
     /// - The table metadata is inserted into the system tables.
     /// - The returned ID is unique and not `TableId::SENTINEL`.
-    pub fn create_table(&mut self, mut table_schema: TableSchema, database_identity: Identity) -> Result<TableId> {
+    pub fn create_table(&mut self, mut table_schema: TableSchema) -> Result<TableId> {
         if table_schema.table_id != TableId::SENTINEL {
             return Err(anyhow::anyhow!("`table_id` must be `TableId::SENTINEL` in `{:#?}`", table_schema).into());
             // checks for children are performed in the relevant `create_...` functions.
@@ -118,7 +113,7 @@ impl MutTxId {
             table_primary_key: table_schema.primary_key.map(Into::into),
         };
         let table_id = self
-            .insert(ST_TABLE_ID, &mut row.into(), database_identity)?
+            .insert(ST_TABLE_ID, &mut row.into())?
             .1
             .collapse()
             .read_col(StTableFields::TableId)?;
@@ -135,7 +130,7 @@ impl MutTxId {
                 col_name: col.col_name.clone(),
                 col_type: col.col_type.clone().into(),
             };
-            self.insert(ST_COLUMN_ID, &mut row.into(), database_identity)?;
+            self.insert(ST_COLUMN_ID, &mut row.into())?;
         }
 
         let mut schema_internal = table_schema.clone();
@@ -157,7 +152,7 @@ impl MutTxId {
                 reducer_name: schedule.reducer_name,
                 at_column: schedule.at_column,
             };
-            let (generated, ..) = self.insert(ST_SCHEDULED_ID, &mut row.into(), database_identity)?;
+            let (generated, ..) = self.insert(ST_SCHEDULED_ID, &mut row.into())?;
             let id = generated.as_u32();
 
             if let Some(&id) = id {
@@ -174,14 +169,13 @@ impl MutTxId {
         }
 
         // Insert constraints into `st_constraints`
-        let ctx = ExecutionContext::internal(database_identity);
         for constraint in table_schema.constraints.iter().cloned() {
-            self.create_constraint(&ctx, constraint)?;
+            self.create_constraint(constraint)?;
         }
 
         // Insert sequences into `st_sequences`
         for seq in table_schema.sequences {
-            self.create_sequence(seq, database_identity)?;
+            self.create_sequence(seq)?;
         }
 
         // Create the indexes for the table
@@ -191,7 +185,7 @@ impl MutTxId {
                 .constraints
                 .iter()
                 .any(|c| c.data.unique_columns() == Some(&col_set));
-            self.create_index(&ctx, index, is_unique)?;
+            self.create_index(index, is_unique)?;
         }
 
         log::trace!("TABLE CREATED: {}, table_id: {table_id}", table_schema.table_name);
@@ -220,14 +214,12 @@ impl MutTxId {
             .map(|table| table.get_row_type())
     }
 
-    pub fn row_type_for_table(&self, table_id: TableId, database_identity: Identity) -> Result<RowTypeForTable<'_>> {
+    pub fn row_type_for_table(&self, table_id: TableId) -> Result<RowTypeForTable<'_>> {
         // Fetch the `ProductType` from the in memory table if it exists.
         // The `ProductType` is invalidated if the schema of the table changes.
         if let Some(row_type) = self.get_row_type(table_id) {
             return Ok(RowTypeForTable::Ref(row_type));
         }
-
-        let ctx = ExecutionContext::internal(database_identity);
 
         // Look up the columns for the table in question.
         // NOTE: This is quite an expensive operation, although we only need
@@ -235,44 +227,33 @@ impl MutTxId {
         // representation of a table. This would happen in situations where
         // we have created the table in the database, but have not yet
         // represented in memory or inserted any rows into it.
-        Ok(RowTypeForTable::Arc(self.schema_for_table(&ctx, table_id)?))
+        Ok(RowTypeForTable::Arc(self.schema_for_table(table_id)?))
     }
 
-    pub fn drop_table(&mut self, table_id: TableId, database_identity: Identity) -> Result<()> {
-        let ctx = &ExecutionContext::internal(database_identity);
-        let schema = &*self.schema_for_table(ctx, table_id)?;
+    pub fn drop_table(&mut self, table_id: TableId) -> Result<()> {
+        let schema = &*self.schema_for_table(table_id)?;
 
         for row in &schema.indexes {
-            self.drop_index(row.index_id, database_identity)?;
+            self.drop_index(row.index_id)?;
         }
 
         for row in &schema.sequences {
-            self.drop_sequence(row.sequence_id, database_identity)?;
+            self.drop_sequence(row.sequence_id)?;
         }
 
         for row in &schema.constraints {
-            self.drop_constraint(ctx, row.constraint_id)?;
+            self.drop_constraint(row.constraint_id)?;
         }
 
         // Drop the table and their columns
-        self.drop_col_eq(
-            ST_TABLE_ID,
-            StTableFields::TableId.col_id(),
-            &table_id.into(),
-            database_identity,
-        )?;
-        self.drop_col_eq(
-            ST_COLUMN_ID,
-            StColumnFields::TableId.col_id(),
-            &table_id.into(),
-            database_identity,
-        )?;
+        self.drop_col_eq(ST_TABLE_ID, StTableFields::TableId.col_id(), &table_id.into())?;
+        self.drop_col_eq(ST_COLUMN_ID, StColumnFields::TableId.col_id(), &table_id.into())?;
+
         if let Some(schedule) = &schema.schedule {
             self.drop_col_eq(
                 ST_SCHEDULED_ID,
                 StScheduledFields::ScheduleId.col_id(),
                 &schedule.schedule_id.into(),
-                database_identity,
             )?;
         }
 
@@ -285,22 +266,15 @@ impl MutTxId {
         Ok(())
     }
 
-    pub fn rename_table(&mut self, table_id: TableId, new_name: &str, database_identity: Identity) -> Result<()> {
-        let ctx = ExecutionContext::internal(database_identity);
+    pub fn rename_table(&mut self, table_id: TableId, new_name: &str) -> Result<()> {
         // Update the table's name in st_tables.
-        self.update_st_table_row(&ctx, database_identity, table_id, |st| st.table_name = new_name.into())
+        self.update_st_table_row(table_id, |st| st.table_name = new_name.into())
     }
 
-    fn update_st_table_row(
-        &mut self,
-        ctx: &ExecutionContext,
-        database_identity: Identity,
-        table_id: TableId,
-        updater: impl FnOnce(&mut StTableRow),
-    ) -> Result<()> {
+    fn update_st_table_row(&mut self, table_id: TableId, updater: impl FnOnce(&mut StTableRow)) -> Result<()> {
         // Fetch the row.
         let st_table_ref = self
-            .iter_by_col_eq(ctx, ST_TABLE_ID, StTableFields::TableId, &table_id.into())?
+            .iter_by_col_eq(ST_TABLE_ID, StTableFields::TableId, &table_id.into())?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_table, table_id.into()))?;
         let mut row = StTableRow::try_from(st_table_ref)?;
@@ -309,22 +283,21 @@ impl MutTxId {
         // Delete the row, run updates, and insert again.
         self.delete(ST_TABLE_ID, ptr)?;
         updater(&mut row);
-        self.insert(ST_TABLE_ID, &mut row.into(), database_identity)?;
+        self.insert(ST_TABLE_ID, &mut row.into())?;
 
         Ok(())
     }
 
-    pub fn table_id_from_name(&self, table_name: &str, database_identity: Identity) -> Result<Option<TableId>> {
-        let ctx = ExecutionContext::internal(database_identity);
+    pub fn table_id_from_name(&self, table_name: &str) -> Result<Option<TableId>> {
         let table_name = &table_name.into();
         let row = self
-            .iter_by_col_eq(&ctx, ST_TABLE_ID, StTableFields::TableName, table_name)?
+            .iter_by_col_eq(ST_TABLE_ID, StTableFields::TableName, table_name)?
             .next();
         Ok(row.map(|row| row.read_col(StTableFields::TableId).unwrap()))
     }
 
-    pub fn table_name_from_id<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Option<Box<str>>> {
-        self.iter_by_col_eq(ctx, ST_TABLE_ID, StTableFields::TableId, &table_id.into())
+    pub fn table_name_from_id(&self, table_id: TableId) -> Result<Option<Box<str>>> {
+        self.iter_by_col_eq(ST_TABLE_ID, StTableFields::TableId, &table_id.into())
             .map(|mut iter| iter.next().map(|row| row.read_col(StTableFields::TableName).unwrap()))
     }
 
@@ -358,19 +331,13 @@ impl MutTxId {
     }
 
     /// Set the table access of `table_id` to `access`.
-    pub(crate) fn alter_table_access(
-        &mut self,
-        database_identity: Identity,
-        table_id: TableId,
-        access: StAccess,
-    ) -> Result<()> {
+    pub(crate) fn alter_table_access(&mut self, table_id: TableId, access: StAccess) -> Result<()> {
         // Write to the table in the tx state.
         let (table, ..) = self.get_or_create_insert_table_mut(table_id)?;
         table.with_mut_schema(|s| s.table_access = access);
 
         // Update system tables.
-        let ctx = ExecutionContext::internal(database_identity);
-        self.update_st_table_row(&ctx, database_identity, table_id, |st| st.table_access = access)?;
+        self.update_st_table_row(table_id, |st| st.table_access = access)?;
         Ok(())
     }
 
@@ -386,7 +353,7 @@ impl MutTxId {
     /// Ensures:
     /// - The index metadata is inserted into the system tables (and other data structures reflecting them).
     /// - The returned ID is unique and is not `IndexId::SENTINEL`.
-    pub fn create_index(&mut self, ctx: &ExecutionContext, mut index: IndexSchema, is_unique: bool) -> Result<IndexId> {
+    pub fn create_index(&mut self, mut index: IndexSchema, is_unique: bool) -> Result<IndexId> {
         if index.index_id != IndexId::SENTINEL {
             return Err(anyhow::anyhow!("`index_id` must be `IndexId::SENTINEL` in `{:#?}`", index).into());
         }
@@ -415,7 +382,7 @@ impl MutTxId {
             index_algorithm: index.index_algorithm.clone().into(),
         };
         let index_id = self
-            .insert(ST_INDEX_ID, &mut row.into(), ctx.database_identity())?
+            .insert(ST_INDEX_ID, &mut row.into())?
             .1
             .collapse()
             .read_col(StIndexFields::IndexId)?;
@@ -458,13 +425,11 @@ impl MutTxId {
         Ok(index_id)
     }
 
-    pub fn drop_index(&mut self, index_id: IndexId, database_identity: Identity) -> Result<()> {
+    pub fn drop_index(&mut self, index_id: IndexId) -> Result<()> {
         log::trace!("INDEX DROPPING: {}", index_id);
-        let ctx = ExecutionContext::internal(database_identity);
-
         // Find the index in `st_indexes`.
         let st_index_ref = self
-            .iter_by_col_eq(&ctx, ST_INDEX_ID, StIndexFields::IndexId, &index_id.into())?
+            .iter_by_col_eq(ST_INDEX_ID, StIndexFields::IndexId, &index_id.into())?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_index, index_id.into()))?;
         let st_index_row = StIndexRow::try_from(st_index_ref)?;
@@ -499,12 +464,9 @@ impl MutTxId {
         Ok(())
     }
 
-    pub fn index_id_from_name(&self, index_name: &str, database_identity: Identity) -> Result<Option<IndexId>> {
-        let ctx = ExecutionContext::internal(database_identity);
+    pub fn index_id_from_name(&self, index_name: &str) -> Result<Option<IndexId>> {
         let name = &index_name.into();
-        let row = self
-            .iter_by_col_eq(&ctx, ST_INDEX_ID, StIndexFields::IndexName, name)?
-            .next();
+        let row = self.iter_by_col_eq(ST_INDEX_ID, StIndexFields::IndexName, name)?.next();
         Ok(row.map(|row| row.read_col(StIndexFields::IndexId).unwrap()))
     }
 
@@ -694,7 +656,7 @@ impl MutTxId {
         (range_start, range_end)
     }
 
-    pub fn get_next_sequence_value(&mut self, seq_id: SequenceId, database_identity: Identity) -> Result<i128> {
+    pub fn get_next_sequence_value(&mut self, seq_id: SequenceId) -> Result<i128> {
         {
             let Some(sequence) = self.sequence_state_lock.get_sequence_mut(seq_id) else {
                 return Err(SequenceError::NotFound(seq_id).into());
@@ -710,9 +672,8 @@ impl MutTxId {
         }
         // Allocate new sequence values
         // If we're out of allocations, then update the sequence row in st_sequences to allocate a fresh batch of sequences.
-        let ctx = ExecutionContext::internal(database_identity);
         let old_seq_row_ref = self
-            .iter_by_col_eq(&ctx, ST_SEQUENCE_ID, StSequenceFields::SequenceId, &seq_id.into())?
+            .iter_by_col_eq(ST_SEQUENCE_ID, StSequenceFields::SequenceId, &seq_id.into())?
             .last()
             .unwrap();
         let old_seq_row_ptr = old_seq_row_ref.pointer();
@@ -754,7 +715,7 @@ impl MutTxId {
     /// Ensures:
     /// - The sequence metadata is inserted into the system tables (and other data structures reflecting them).
     /// - The returned ID is unique and not `SequenceId::SENTINEL`.
-    pub fn create_sequence(&mut self, seq: SequenceSchema, database_identity: Identity) -> Result<SequenceId> {
+    pub fn create_sequence(&mut self, seq: SequenceSchema) -> Result<SequenceId> {
         if seq.sequence_id != SequenceId::SENTINEL {
             return Err(anyhow::anyhow!("`sequence_id` must be `SequenceId::SENTINEL` in `{:#?}`", seq).into());
         }
@@ -784,7 +745,7 @@ impl MutTxId {
             min_value: seq.min_value,
             max_value: seq.max_value,
         };
-        let row = self.insert(ST_SEQUENCE_ID, &mut sequence_row.clone().into(), database_identity)?;
+        let row = self.insert(ST_SEQUENCE_ID, &mut sequence_row.clone().into())?;
         let seq_id = row.1.collapse().read_col(StSequenceFields::SequenceId)?;
         sequence_row.sequence_id = seq_id;
 
@@ -799,11 +760,9 @@ impl MutTxId {
         Ok(seq_id)
     }
 
-    pub fn drop_sequence(&mut self, sequence_id: SequenceId, database_identity: Identity) -> Result<()> {
-        let ctx = ExecutionContext::internal(database_identity);
-
+    pub fn drop_sequence(&mut self, sequence_id: SequenceId) -> Result<()> {
         let st_sequence_ref = self
-            .iter_by_col_eq(&ctx, ST_SEQUENCE_ID, StSequenceFields::SequenceId, &sequence_id.into())?
+            .iter_by_col_eq(ST_SEQUENCE_ID, StSequenceFields::SequenceId, &sequence_id.into())?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_sequence, sequence_id.into()))?;
         let table_id = st_sequence_ref.read_col(StSequenceFields::TableId)?;
@@ -823,10 +782,9 @@ impl MutTxId {
         Ok(())
     }
 
-    pub fn sequence_id_from_name(&self, seq_name: &str, database_identity: Identity) -> Result<Option<SequenceId>> {
-        let ctx = ExecutionContext::internal(database_identity);
+    pub fn sequence_id_from_name(&self, seq_name: &str) -> Result<Option<SequenceId>> {
         let name = &<Box<str>>::from(seq_name).into();
-        self.iter_by_col_eq(&ctx, ST_SEQUENCE_ID, StSequenceFields::SequenceName, name)
+        self.iter_by_col_eq(ST_SEQUENCE_ID, StSequenceFields::SequenceName, name)
             .map(|mut iter| {
                 iter.next()
                     .map(|row| row.read_col(StSequenceFields::SequenceId).unwrap())
@@ -845,7 +803,7 @@ impl MutTxId {
     /// Ensures:
     /// - The constraint metadata is inserted into the system tables (and other data structures reflecting them).
     /// - The returned ID is unique and is not `constraintId::SENTINEL`.
-    fn create_constraint(&mut self, ctx: &ExecutionContext, mut constraint: ConstraintSchema) -> Result<ConstraintId> {
+    fn create_constraint(&mut self, mut constraint: ConstraintSchema) -> Result<ConstraintId> {
         if constraint.constraint_id != ConstraintId::SENTINEL {
             return Err(anyhow::anyhow!(
                 "`constraint_id` must be `ConstraintId::SENTINEL` in `{:#?}`",
@@ -876,11 +834,7 @@ impl MutTxId {
             constraint_data: constraint.data.clone().into(),
         };
 
-        let constraint_row = self.insert(
-            ST_CONSTRAINT_ID,
-            &mut ProductValue::from(constraint_row),
-            ctx.database_identity(),
-        )?;
+        let constraint_row = self.insert(ST_CONSTRAINT_ID, &mut ProductValue::from(constraint_row))?;
         let constraint_id = constraint_row.1.collapse().read_col(StConstraintFields::ConstraintId)?;
         let existed = matches!(constraint_row.1, RowRefInsertion::Existed(_));
         // TODO: Can we return early here?
@@ -906,11 +860,10 @@ impl MutTxId {
             .ok_or_else(|| TableError::IdNotFoundState(table_id).into())
     }
 
-    pub fn drop_constraint(&mut self, ctx: &ExecutionContext, constraint_id: ConstraintId) -> Result<()> {
+    pub fn drop_constraint(&mut self, constraint_id: ConstraintId) -> Result<()> {
         // Delete row in `st_constraint`.
         let st_constraint_ref = self
             .iter_by_col_eq(
-                ctx,
                 ST_CONSTRAINT_ID,
                 StConstraintFields::ConstraintId,
                 &constraint_id.into(),
@@ -931,13 +884,8 @@ impl MutTxId {
         Ok(())
     }
 
-    pub fn constraint_id_from_name(
-        &self,
-        ctx: &ExecutionContext,
-        constraint_name: &str,
-    ) -> Result<Option<ConstraintId>> {
+    pub fn constraint_id_from_name(&self, constraint_name: &str) -> Result<Option<ConstraintId>> {
         self.iter_by_col_eq(
-            ctx,
             ST_CONSTRAINT_ID,
             StConstraintFields::ConstraintName,
             &<Box<str>>::from(constraint_name).into(),
@@ -958,11 +906,7 @@ impl MutTxId {
     ///
     /// - The row level security policy metadata is inserted into the system tables (and other data structures reflecting them).
     /// - The returned `sql` is unique.
-    pub fn create_row_level_security(
-        &mut self,
-        ctx: &ExecutionContext,
-        row_level_security_schema: RowLevelSecuritySchema,
-    ) -> Result<RawSql> {
+    pub fn create_row_level_security(&mut self, row_level_security_schema: RowLevelSecuritySchema) -> Result<RawSql> {
         if row_level_security_schema.table_id == TableId::SENTINEL {
             return Err(anyhow::anyhow!(
                 "`table_id` must not be `TableId::SENTINEL` in `{:#?}`",
@@ -984,11 +928,7 @@ impl MutTxId {
             sql: row_level_security_schema.sql,
         };
 
-        let row = self.insert(
-            ST_ROW_LEVEL_SECURITY_ID,
-            &mut ProductValue::from(row),
-            ctx.database_identity(),
-        )?;
+        let row = self.insert(ST_ROW_LEVEL_SECURITY_ID, &mut ProductValue::from(row))?;
         let row_level_security_sql = row.1.collapse().read_col(StRowLevelSecurityFields::Sql)?;
         let existed = matches!(row.1, RowRefInsertion::Existed(_));
 
@@ -1004,14 +944,9 @@ impl MutTxId {
         Ok(row_level_security_sql)
     }
 
-    pub fn row_level_security_for_table_id(
-        &self,
-        ctx: &ExecutionContext,
-        table_id: TableId,
-    ) -> Result<Vec<RowLevelSecuritySchema>> {
+    pub fn row_level_security_for_table_id(&self, table_id: TableId) -> Result<Vec<RowLevelSecuritySchema>> {
         Ok(self
             .iter_by_col_eq(
-                ctx,
                 ST_ROW_LEVEL_SECURITY_ID,
                 StRowLevelSecurityFields::TableId,
                 &table_id.into(),
@@ -1023,10 +958,9 @@ impl MutTxId {
             .collect())
     }
 
-    pub fn drop_row_level_security(&mut self, ctx: &ExecutionContext, sql: RawSql) -> Result<()> {
+    pub fn drop_row_level_security(&mut self, sql: RawSql) -> Result<()> {
         let st_rls_ref = self
             .iter_by_col_eq(
-                ctx,
                 ST_ROW_LEVEL_SECURITY_ID,
                 StRowLevelSecurityFields::Sql,
                 &sql.clone().into(),
@@ -1084,17 +1018,17 @@ impl MutTxId {
         })
     }
 
-    pub fn commit(self, ctx: &ExecutionContext) -> TxData {
+    pub fn commit(self) -> TxData {
         let Self {
             mut committed_state_write_lock,
             tx_state,
             ..
         } = self;
-        let tx_data = committed_state_write_lock.merge(tx_state, ctx);
+        let tx_data = committed_state_write_lock.merge(tx_state, &self.ctx);
         // Record metrics for the transaction at the very end,
         // right before we drop and release the lock.
         record_metrics(
-            ctx,
+            self.ctx,
             self.timer,
             self.lock_wait_time,
             true,
@@ -1104,17 +1038,18 @@ impl MutTxId {
         tx_data
     }
 
-    pub fn commit_downgrade(self, ctx: &ExecutionContext) -> (TxData, TxId) {
+    pub fn commit_downgrade(self, workload: Workload) -> (TxData, TxId) {
         let Self {
             mut committed_state_write_lock,
             tx_state,
             ..
         } = self;
-        let tx_data = committed_state_write_lock.merge(tx_state, ctx);
+        let tx_data = committed_state_write_lock.merge(tx_state, &self.ctx);
+        let database_identity = self.ctx.database_identity();
         // Record metrics for the transaction at the very end,
         // right before we drop and release the lock.
         record_metrics(
-            ctx,
+            self.ctx,
             self.timer,
             self.lock_wait_time,
             true,
@@ -1125,24 +1060,27 @@ impl MutTxId {
             committed_state_shared_lock: SharedWriteGuard::downgrade(committed_state_write_lock),
             lock_wait_time: Duration::ZERO,
             timer: Instant::now(),
+            ctx: ExecutionContext::with_workload(database_identity, workload),
         };
         (tx_data, tx)
     }
 
-    pub fn rollback(self, ctx: &ExecutionContext) {
+    pub fn rollback(self) {
         // Record metrics for the transaction at the very end,
         // right before we drop and release the lock.
-        record_metrics(ctx, self.timer, self.lock_wait_time, false, None, None);
+        record_metrics(self.ctx, self.timer, self.lock_wait_time, false, None, None);
     }
 
-    pub fn rollback_downgrade(self, ctx: &ExecutionContext) -> TxId {
+    pub fn rollback_downgrade(self, workload: Workload) -> TxId {
         // Record metrics for the transaction at the very end,
         // right before we drop and release the lock.
-        record_metrics(ctx, self.timer, self.lock_wait_time, false, None, None);
+        let database_identity = self.ctx.database_identity();
+        record_metrics(self.ctx, self.timer, self.lock_wait_time, false, None, None);
         TxId {
             committed_state_shared_lock: SharedWriteGuard::downgrade(self.committed_state_write_lock),
             lock_wait_time: Duration::ZERO,
             timer: Instant::now(),
+            ctx: ExecutionContext::with_workload(database_identity, workload),
         }
     }
 }
@@ -1220,26 +1158,18 @@ impl MutTxId {
         &'a mut self,
         table_id: TableId,
         row: &mut ProductValue,
-        database_identity: Identity,
     ) -> Result<(AlgebraicValue, RowRefInsertion<'a>)> {
-        let generated = self.write_sequence_values(table_id, row, database_identity)?;
+        let generated = self.write_sequence_values(table_id, row)?;
         let row_ref = self.insert_row_internal(table_id, row)?;
         Ok((generated, row_ref))
     }
 
     /// Generate and write sequence values to `row`
     /// and return a projection of `row` with only the generated column values.
-    fn write_sequence_values(
-        &mut self,
-        table_id: TableId,
-        row: &mut ProductValue,
-        database_identity: Identity,
-    ) -> Result<AlgebraicValue> {
-        let ctx = ExecutionContext::internal(database_identity);
-
+    fn write_sequence_values(&mut self, table_id: TableId, row: &mut ProductValue) -> Result<AlgebraicValue> {
         // TODO: Executing schema_for_table for every row insert is expensive.
         // However we ask for the schema in the [Table] struct instead.
-        let schema = self.schema_for_table(&ctx, table_id)?;
+        let schema = self.schema_for_table(table_id)?;
 
         // Collect all the columns with sequences that need generation.
         let (cols_to_update, seqs_to_use): (ColList, SmallVec<[_; 1]>) = schema
@@ -1252,7 +1182,7 @@ impl MutTxId {
         // Update every column in the row that needs it.
         // We assume here that column with a sequence is of a sequence-compatible type.
         for (col_id, sequence_id) in cols_to_update.iter().zip(seqs_to_use) {
-            let seq_val = self.get_next_sequence_value(sequence_id, database_identity)?;
+            let seq_val = self.get_next_sequence_value(sequence_id)?;
             let col_typ = &schema.columns()[col_id.idx()].col_type;
             let gen_val = AlgebraicValue::from_sequence_value(col_typ, seq_val);
             row.elements[col_id.idx()] = gen_val;
@@ -1479,10 +1409,9 @@ impl StateView for MutTxId {
         }
     }
 
-    fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Iter<'a>> {
+    fn iter(&self, table_id: TableId) -> Result<Iter<'_>> {
         if let Some(table_name) = self.table_name(table_id) {
             return Ok(Iter::new(
-                ctx,
                 table_id,
                 table_name,
                 Some(&self.tx_state),
@@ -1492,13 +1421,12 @@ impl StateView for MutTxId {
         Err(TableError::IdNotFound(SystemTable::st_table, table_id.0).into())
     }
 
-    fn iter_by_col_range<'a, R: RangeBounds<AlgebraicValue>>(
-        &'a self,
-        ctx: &'a ExecutionContext,
+    fn iter_by_col_range<R: RangeBounds<AlgebraicValue>>(
+        &self,
         table_id: TableId,
         cols: ColList,
         range: R,
-    ) -> Result<IterByColRange<'a, R>> {
+    ) -> Result<IterByColRange<'_, R>> {
         // We have to index_seek in both the committed state and the current tx state.
         // First, we will check modifications in the current tx. It may be that the table
         // has not been modified yet in the current tx, in which case we will only search
@@ -1513,7 +1441,7 @@ impl StateView for MutTxId {
         if let Some(inserted_rows) = self.tx_state.index_seek(table_id, &cols, &range) {
             // The current transaction has modified this table, and the table is indexed.
             Ok(IterByColRange::Index(IndexSeekIterMutTxId {
-                ctx,
+                ctx: &self.ctx,
                 table_id,
                 tx_state: &self.tx_state,
                 inserted_rows,
@@ -1526,7 +1454,6 @@ impl StateView for MutTxId {
             // indexed.
             match self.committed_state_write_lock.index_seek(table_id, &cols, &range) {
                 Some(committed_rows) => Ok(IterByColRange::CommittedIndex(CommittedIndexIter::new(
-                    ctx,
                     table_id,
                     Some(&self.tx_state),
                     &self.committed_state_write_lock,
@@ -1542,7 +1469,7 @@ impl StateView for MutTxId {
                         Some(num_rows) => {
                             const TOO_MANY_ROWS_FOR_SCAN: u64 = 1000;
                             if num_rows >= TOO_MANY_ROWS_FOR_SCAN {
-                                let schema = self.schema_for_table(ctx, table_id).unwrap();
+                                let schema = self.schema_for_table(table_id).unwrap();
                                 let table_name = &schema.table_name;
                                 let col_names = cols
                                     .iter()
@@ -1562,7 +1489,7 @@ impl StateView for MutTxId {
                     }
 
                     Ok(IterByColRange::Scan(ScanIterByColRange::new(
-                        self.iter(ctx, table_id)?,
+                        self.iter(table_id)?,
                         cols,
                         range,
                     )))

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -1441,12 +1441,10 @@ impl StateView for MutTxId {
         if let Some(inserted_rows) = self.tx_state.index_seek(table_id, &cols, &range) {
             // The current transaction has modified this table, and the table is indexed.
             Ok(IterByColRange::Index(IndexSeekIterMutTxId {
-                ctx: &self.ctx,
                 table_id,
                 tx_state: &self.tx_state,
                 inserted_rows,
                 committed_rows: self.committed_state_write_lock.index_seek(table_id, &cols, &range),
-                committed_state: &self.committed_state_write_lock,
                 num_committed_rows_fetched: 0,
             }))
         } else {

--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -11,7 +11,6 @@ use crate::{
     execution_context::ExecutionContext,
 };
 use core::ops::RangeBounds;
-use spacetimedb_lib::Identity;
 use spacetimedb_primitives::{ColList, TableId};
 use spacetimedb_sats::AlgebraicValue;
 use spacetimedb_schema::schema::{ColumnSchema, TableSchema};
@@ -23,19 +22,16 @@ use std::sync::Arc;
 pub trait StateView {
     fn get_schema(&self, table_id: TableId) -> Option<&Arc<TableSchema>>;
 
-    fn table_id_from_name(&self, table_name: &str, database_identity: Identity) -> Result<Option<TableId>> {
-        let ctx = ExecutionContext::internal(database_identity);
+    fn table_id_from_name(&self, table_name: &str) -> Result<Option<TableId>> {
         let name = &<Box<str>>::from(table_name).into();
-        let row = self
-            .iter_by_col_eq(&ctx, ST_TABLE_ID, StTableFields::TableName, name)?
-            .next();
+        let row = self.iter_by_col_eq(ST_TABLE_ID, StTableFields::TableName, name)?.next();
         Ok(row.map(|row| row.read_col(StTableFields::TableId).unwrap()))
     }
 
     /// Returns the number of rows in the table identified by `table_id`.
     fn table_row_count(&self, table_id: TableId) -> Option<u64>;
 
-    fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Iter<'a>>;
+    fn iter(&self, table_id: TableId) -> Result<Iter<'_>>;
 
     fn table_name(&self, table_id: TableId) -> Option<&str> {
         self.get_schema(table_id).map(|s| &*s.table_name)
@@ -44,30 +40,28 @@ pub trait StateView {
     /// Returns an iterator,
     /// yielding every row in the table identified by `table_id`,
     /// where the values of `cols` are contained in `range`.
-    fn iter_by_col_range<'a, R: RangeBounds<AlgebraicValue>>(
-        &'a self,
-        ctx: &'a ExecutionContext,
+    fn iter_by_col_range<R: RangeBounds<AlgebraicValue>>(
+        &self,
         table_id: TableId,
         cols: ColList,
         range: R,
-    ) -> Result<IterByColRange<'a, R>>;
+    ) -> Result<IterByColRange<'_, R>>;
 
     fn iter_by_col_eq<'a, 'r>(
         &'a self,
-        ctx: &'a ExecutionContext,
         table_id: TableId,
         cols: impl Into<ColList>,
         value: &'r AlgebraicValue,
     ) -> Result<IterByColEq<'a, 'r>> {
-        self.iter_by_col_range(ctx, table_id, cols.into(), value)
+        self.iter_by_col_range(table_id, cols.into(), value)
     }
 
     /// Reads the schema information for the specified `table_id` directly from the database.
-    fn schema_for_table_raw(&self, ctx: &ExecutionContext, table_id: TableId) -> Result<TableSchema> {
+    fn schema_for_table_raw(&self, table_id: TableId) -> Result<TableSchema> {
         // Look up the table_name for the table in question.
         let value_eq = &table_id.into();
         let row = self
-            .iter_by_col_eq(ctx, ST_TABLE_ID, StTableFields::TableId, value_eq)?
+            .iter_by_col_eq(ST_TABLE_ID, StTableFields::TableId, value_eq)?
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_table, table_id.into()))?;
         let row = StTableRow::try_from(row)?;
@@ -79,7 +73,7 @@ pub trait StateView {
 
         // Look up the columns for the table in question.
         let mut columns: Vec<ColumnSchema> = self
-            .iter_by_col_eq(ctx, ST_COLUMN_ID, StColumnFields::TableId, value_eq)?
+            .iter_by_col_eq(ST_COLUMN_ID, StColumnFields::TableId, value_eq)?
             .map(|row| {
                 let row = StColumnRow::try_from(row)?;
                 Ok(row.into())
@@ -89,7 +83,7 @@ pub trait StateView {
 
         // Look up the constraints for the table in question.
         let constraints = self
-            .iter_by_col_eq(ctx, ST_CONSTRAINT_ID, StConstraintFields::TableId, value_eq)?
+            .iter_by_col_eq(ST_CONSTRAINT_ID, StConstraintFields::TableId, value_eq)?
             .map(|row| {
                 let row = StConstraintRow::try_from(row)?;
                 Ok(row.into())
@@ -98,7 +92,7 @@ pub trait StateView {
 
         // Look up the sequences for the table in question.
         let sequences = self
-            .iter_by_col_eq(ctx, ST_SEQUENCE_ID, StSequenceFields::TableId, value_eq)?
+            .iter_by_col_eq(ST_SEQUENCE_ID, StSequenceFields::TableId, value_eq)?
             .map(|row| {
                 let row = StSequenceRow::try_from(row)?;
                 Ok(row.into())
@@ -107,7 +101,7 @@ pub trait StateView {
 
         // Look up the indexes for the table in question.
         let indexes = self
-            .iter_by_col_eq(ctx, ST_INDEX_ID, StIndexFields::TableId, value_eq)?
+            .iter_by_col_eq(ST_INDEX_ID, StIndexFields::TableId, value_eq)?
             .map(|row| {
                 let row = StIndexRow::try_from(row)?;
                 Ok(row.into())
@@ -115,7 +109,7 @@ pub trait StateView {
             .collect::<Result<Vec<_>>>()?;
 
         let schedule = self
-            .iter_by_col_eq(ctx, ST_SCHEDULED_ID, StScheduledFields::TableId, value_eq)?
+            .iter_by_col_eq(ST_SCHEDULED_ID, StScheduledFields::TableId, value_eq)?
             .next()
             .map(|row| -> Result<_> {
                 let row = StScheduledRow::try_from(row)?;
@@ -142,18 +136,16 @@ pub trait StateView {
     /// If the schema is not found in the cache, the method calls [Self::schema_for_table_raw].
     ///
     /// Note: The responsibility of populating the cache is left to the caller.
-    fn schema_for_table(&self, ctx: &ExecutionContext, table_id: TableId) -> Result<Arc<TableSchema>> {
+    fn schema_for_table(&self, table_id: TableId) -> Result<Arc<TableSchema>> {
         if let Some(schema) = self.get_schema(table_id) {
             return Ok(schema.clone());
         }
 
-        self.schema_for_table_raw(ctx, table_id).map(Arc::new)
+        self.schema_for_table_raw(table_id).map(Arc::new)
     }
 }
 
 pub struct Iter<'a> {
-    #[allow(dead_code)]
-    ctx: &'a ExecutionContext,
     table_id: TableId,
     tx_state: Option<&'a TxState>,
     committed_state: &'a CommittedState,
@@ -178,14 +170,12 @@ pub struct Iter<'a> {
 
 impl<'a> Iter<'a> {
     pub(super) fn new(
-        ctx: &'a ExecutionContext,
         table_id: TableId,
         table_name: &'a str,
         tx_state: Option<&'a TxState>,
         committed_state: &'a CommittedState,
     ) -> Self {
         Self {
-            ctx,
             table_id,
             tx_state,
             committed_state,

--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -8,7 +8,6 @@ use crate::{
         ST_CONSTRAINT_ID, ST_INDEX_ID, ST_SCHEDULED_ID, ST_SEQUENCE_ID, ST_TABLE_ID,
     },
     error::TableError,
-    execution_context::ExecutionContext,
 };
 use core::ops::RangeBounds;
 use spacetimedb_primitives::{ColList, TableId};
@@ -288,12 +287,8 @@ impl<'a> Iterator for Iter<'a> {
 }
 
 pub struct IndexSeekIterMutTxId<'a> {
-    #[allow(dead_code)]
-    pub(super) ctx: &'a ExecutionContext,
     pub(super) table_id: TableId,
     pub(super) tx_state: &'a TxState,
-    #[allow(dead_code)]
-    pub(super) committed_state: &'a CommittedState,
     pub(super) inserted_rows: IndexScanIter<'a>,
     pub(super) committed_rows: Option<IndexScanIter<'a>>,
     pub(super) num_committed_rows_fetched: u64,

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -19,6 +19,7 @@ pub struct TxId {
     pub(super) committed_state_shared_lock: SharedReadGuard<CommittedState>,
     pub(super) lock_wait_time: Duration,
     pub(super) timer: Instant,
+    pub(crate) ctx: ExecutionContext,
 }
 
 impl StateView for TxId {
@@ -30,23 +31,21 @@ impl StateView for TxId {
         self.committed_state_shared_lock.table_row_count(table_id)
     }
 
-    fn iter<'a>(&'a self, ctx: &'a ExecutionContext, table_id: TableId) -> Result<Iter<'a>> {
-        self.committed_state_shared_lock.iter(ctx, table_id)
+    fn iter(&self, table_id: TableId) -> Result<Iter<'_>> {
+        self.committed_state_shared_lock.iter(table_id)
     }
 
     /// Returns an iterator,
     /// yielding every row in the table identified by `table_id`,
     /// where the values of `cols` are contained in `range`.
-    fn iter_by_col_range<'a, R: RangeBounds<AlgebraicValue>>(
-        &'a self,
-        ctx: &'a ExecutionContext,
+    fn iter_by_col_range<R: RangeBounds<AlgebraicValue>>(
+        &self,
         table_id: TableId,
         cols: ColList,
         range: R,
-    ) -> Result<IterByColRange<'a, R>> {
+    ) -> Result<IterByColRange<'_, R>> {
         match self.committed_state_shared_lock.index_seek(table_id, &cols, &range) {
             Some(committed_rows) => Ok(IterByColRange::CommittedIndex(CommittedIndexIter::new(
-                ctx,
                 table_id,
                 None,
                 &self.committed_state_shared_lock,
@@ -54,14 +53,14 @@ impl StateView for TxId {
             ))),
             None => self
                 .committed_state_shared_lock
-                .iter_by_col_range(ctx, table_id, cols, range),
+                .iter_by_col_range(table_id, cols, range),
         }
     }
 }
 
 impl TxId {
-    pub(super) fn release(self, ctx: &ExecutionContext) {
-        record_metrics(ctx, self.timer, self.lock_wait_time, true, None, None);
+    pub(super) fn release(self) {
+        record_metrics(self.ctx, self.timer, self.lock_wait_time, true, None, None);
     }
 
     /// The Number of Distinct Values (NDV) for a column or list of columns,

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -6,7 +6,7 @@ use std::{ops::RangeBounds, sync::Arc};
 use super::system_tables::ModuleKind;
 use super::Result;
 use crate::db::datastore::system_tables::ST_TABLE_ID;
-use crate::execution_context::ExecutionContext;
+use crate::execution_context::{ReducerContext, Workload};
 use spacetimedb_data_structures::map::IntMap;
 use spacetimedb_lib::{hash_bytes, Identity};
 use spacetimedb_primitives::*;
@@ -246,6 +246,18 @@ impl TxData {
             (table_id, table_name.as_str(), rows)
         })
     }
+
+    /// Check if this [`TxData`] contains any `inserted | deleted` rows or `connect/disconnect` operations.
+    ///
+    /// This is used to determine if a transaction should be written to disk.
+    pub fn has_rows_or_connect_disconnect(&self, reducer_context: Option<&ReducerContext>) -> bool {
+        self.inserts().any(|(_, inserted_rows)| !inserted_rows.is_empty())
+            || self.deletes().any(|(_, deleted_rows)| !deleted_rows.is_empty())
+            || matches!(
+                reducer_context.map(|rcx| rcx.name.strip_prefix("__identity_")),
+                Some(Some("connected__" | "disconnected__"))
+            )
+    }
 }
 
 /// The result of [`MutTxDatastore::row_type_for_table_mut_tx`] and friends.
@@ -285,22 +297,16 @@ pub trait DataRow: Send + Sync {
 pub trait Tx {
     type Tx;
 
-    fn begin_tx(&self) -> Self::Tx;
-    fn release_tx(&self, ctx: &ExecutionContext, tx: Self::Tx);
+    fn begin_tx(&self, workload: Workload) -> Self::Tx;
+    fn release_tx(&self, tx: Self::Tx);
 }
 
 pub trait MutTx {
     type MutTx;
 
-    fn begin_mut_tx(&self, isolation_level: IsolationLevel) -> Self::MutTx;
-    fn commit_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTx) -> Result<Option<TxData>>;
-    fn rollback_mut_tx(&self, ctx: &ExecutionContext, tx: Self::MutTx);
-
-    #[cfg(test)]
-    fn commit_mut_tx_for_test(&self, tx: Self::MutTx) -> Result<Option<TxData>>;
-
-    #[cfg(test)]
-    fn rollback_mut_tx_for_test(&self, tx: Self::MutTx);
+    fn begin_mut_tx(&self, isolation_level: IsolationLevel, workload: Workload) -> Self::MutTx;
+    fn commit_mut_tx(&self, tx: Self::MutTx) -> Result<Option<TxData>>;
+    fn rollback_mut_tx(&self, tx: Self::MutTx);
 }
 
 /// Standard metadata associated with a database.
@@ -352,11 +358,10 @@ pub trait TxDatastore: DataRow + Tx {
     where
         Self: 'a;
 
-    fn iter_tx<'a>(&'a self, ctx: &'a ExecutionContext, tx: &'a Self::Tx, table_id: TableId) -> Result<Self::Iter<'a>>;
+    fn iter_tx<'a>(&'a self, tx: &'a Self::Tx, table_id: TableId) -> Result<Self::Iter<'a>>;
 
     fn iter_by_col_range_tx<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
-        ctx: &'a ExecutionContext,
         tx: &'a Self::Tx,
         table_id: TableId,
         cols: impl Into<ColList>,
@@ -365,7 +370,6 @@ pub trait TxDatastore: DataRow + Tx {
 
     fn iter_by_col_eq_tx<'a, 'r>(
         &'a self,
-        ctx: &'a ExecutionContext,
         tx: &'a Self::Tx,
         table_id: TableId,
         cols: impl Into<ColList>,
@@ -376,17 +380,17 @@ pub trait TxDatastore: DataRow + Tx {
     fn table_id_from_name_tx(&self, tx: &Self::Tx, table_name: &str) -> Result<Option<TableId>>;
     fn table_name_from_id_tx<'a>(&'a self, tx: &'a Self::Tx, table_id: TableId) -> Result<Option<Cow<'a, str>>>;
     fn schema_for_table_tx(&self, tx: &Self::Tx, table_id: TableId) -> super::Result<Arc<TableSchema>>;
-    fn get_all_tables_tx(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> super::Result<Vec<Arc<TableSchema>>>;
+    fn get_all_tables_tx(&self, tx: &Self::Tx) -> super::Result<Vec<Arc<TableSchema>>>;
 
     /// Obtain the [`Metadata`] for this datastore.
     ///
     /// A `None` return value means that the datastore is not fully initialized yet.
-    fn metadata(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Option<Metadata>>;
+    fn metadata(&self, tx: &Self::Tx) -> Result<Option<Metadata>>;
 
     /// Obtain the compiled module associated with this datastore.
     ///
     /// A `None` return value means that the datastore is not fully initialized yet.
-    fn program(&self, ctx: &ExecutionContext, tx: &Self::Tx) -> Result<Option<Program>>;
+    fn program(&self, tx: &Self::Tx) -> Result<Option<Program>>;
 }
 
 pub trait MutTxDatastore: TxDatastore + MutTx {
@@ -401,15 +405,10 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     fn rename_table_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, new_name: &str) -> Result<()>;
     fn table_id_from_name_mut_tx(&self, tx: &Self::MutTx, table_name: &str) -> Result<Option<TableId>>;
     fn table_id_exists_mut_tx(&self, tx: &Self::MutTx, table_id: &TableId) -> bool;
-    fn table_name_from_id_mut_tx<'a>(
-        &'a self,
-        ctx: &'a ExecutionContext,
-        tx: &'a Self::MutTx,
-        table_id: TableId,
-    ) -> Result<Option<Cow<'a, str>>>;
-    fn get_all_tables_mut_tx(&self, ctx: &ExecutionContext, tx: &Self::MutTx) -> super::Result<Vec<Arc<TableSchema>>> {
+    fn table_name_from_id_mut_tx<'a>(&'a self, tx: &'a Self::MutTx, table_id: TableId) -> Result<Option<Cow<'a, str>>>;
+    fn get_all_tables_mut_tx(&self, tx: &Self::MutTx) -> super::Result<Vec<Arc<TableSchema>>> {
         let mut tables = Vec::new();
-        let table_rows = self.iter_mut_tx(ctx, tx, ST_TABLE_ID)?.collect::<Vec<_>>();
+        let table_rows = self.iter_mut_tx(tx, ST_TABLE_ID)?.collect::<Vec<_>>();
         for row in table_rows {
             let table_id = self.read_table_id(row)?;
             tables.push(self.schema_for_table_mut_tx(tx, table_id)?);
@@ -439,15 +438,9 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     fn constraint_id_from_name(&self, tx: &Self::MutTx, constraint_name: &str) -> super::Result<Option<ConstraintId>>;
 
     // Data
-    fn iter_mut_tx<'a>(
-        &'a self,
-        ctx: &'a ExecutionContext,
-        tx: &'a Self::MutTx,
-        table_id: TableId,
-    ) -> Result<Self::Iter<'a>>;
+    fn iter_mut_tx<'a>(&'a self, tx: &'a Self::MutTx, table_id: TableId) -> Result<Self::Iter<'a>>;
     fn iter_by_col_range_mut_tx<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
-        ctx: &'a ExecutionContext,
         tx: &'a Self::MutTx,
         table_id: TableId,
         cols: impl Into<ColList>,
@@ -455,7 +448,6 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     ) -> Result<Self::IterByColRange<'a, R>>;
     fn iter_by_col_eq_mut_tx<'a, 'r>(
         &'a self,
-        ctx: &'a ExecutionContext,
         tx: &'a Self::MutTx,
         table_id: TableId,
         cols: impl Into<ColList>,

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -1,7 +1,6 @@
 use super::datastore::locking_tx_datastore::MutTxId;
 use super::relational_db::RelationalDB;
 use crate::database_logger::SystemLogger;
-use crate::execution_context::ExecutionContext;
 use crate::sql::parser::RowLevelExpr;
 use spacetimedb_data_structures::map::HashMap;
 use spacetimedb_lib::db::auth::StTableType;
@@ -79,8 +78,6 @@ fn auto_migrate_database(
         .map(|table| (table.table_name.clone(), table))
         .collect::<HashMap<_, _>>();
 
-    let ctx = &ExecutionContext::internal(stdb.database_identity());
-
     log::info!("Running database update prechecks: {}", stdb.database_identity());
 
     for precheck in plan.prechecks {
@@ -97,7 +94,7 @@ fn auto_migrate_database(
                 let range = min..max;
 
                 if stdb
-                    .iter_by_col_range_mut(ctx, tx, table_schema.table_id, sequence_def.column, range)?
+                    .iter_by_col_range_mut(tx, table_schema.table_id, sequence_def.column, range)?
                     .next()
                     .is_some()
                 {

--- a/crates/core/src/execution_context.rs
+++ b/crates/core/src/execution_context.rs
@@ -181,6 +181,20 @@ impl TryFrom<&txdata::Inputs> for ReducerContext {
     }
 }
 
+/// Represents the type of workload that is being executed.
+///
+/// Used as constructor helper for [ExecutionContext].
+#[derive(Clone)]
+pub enum Workload {
+    #[cfg(test)]
+    ForTests,
+    Reducer(ReducerContext),
+    Sql,
+    Subscribe,
+    Update,
+    Internal,
+}
+
 /// Classifies a transaction according to its workload.
 /// A transaction can be executing a reducer.
 /// It can be used to satisfy a one-off sql query or subscription.
@@ -208,6 +222,19 @@ impl ExecutionContext {
             reducer,
             workload,
             metrics: <_>::default(),
+        }
+    }
+
+    /// Returns an [ExecutionContext] with the provided [Workload] and empty metrics.
+    pub(crate) fn with_workload(database_identity: Identity, workload: Workload) -> Self {
+        match workload {
+            #[cfg(test)]
+            Workload::ForTests => Self::default(),
+            Workload::Internal => Self::internal(database_identity),
+            Workload::Reducer(ctx) => Self::reducer(database_identity, ctx),
+            Workload::Sql => Self::sql(database_identity),
+            Workload::Subscribe => Self::subscribe(database_identity),
+            Workload::Update => Self::incremental_update(database_identity),
         }
     }
 

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -14,7 +14,7 @@ use crate::db::datastore::locking_tx_datastore::MutTxId;
 use crate::db::datastore::system_tables::{StClientRow, ST_CLIENT_ID};
 use crate::db::datastore::traits::{IsolationLevel, Program};
 use crate::energy::{EnergyMonitor, EnergyQuanta, ReducerBudget, ReducerFingerprint};
-use crate::execution_context::{self, ExecutionContext, ReducerContext, Workload};
+use crate::execution_context::{self, ReducerContext, Workload};
 use crate::host::instance_env::InstanceEnv;
 use crate::host::module_host::{
     CallReducerParams, DatabaseUpdate, EventStatus, Module, ModuleEvent, ModuleFunctionCall, ModuleInfo, ModuleInstance,
@@ -456,10 +456,10 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
             energy.used = tracing::field::Empty,
         )
         .entered();
-        let ctx = ExecutionContext::reducer(address, ReducerContext::from(op.clone()));
+
         // run the call_reducer call in rayon. it's important that we don't acquire a lock inside a rayon task,
         // as that can lead to deadlock.
-        let (mut tx, result) = rayon::scope(|_| tx_slot.set(ctx, tx, || self.instance.call_reducer(op, budget)));
+        let (mut tx, result) = rayon::scope(|_| tx_slot.set(tx, || self.instance.call_reducer(op, budget)));
 
         let ExecuteResult {
             energy,

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -1,6 +1,5 @@
 use anyhow::Context;
 use bytes::Bytes;
-use once_cell::unsync::Lazy;
 use spacetimedb_client_api_messages::timestamp::Timestamp;
 use spacetimedb_primitives::TableId;
 use spacetimedb_schema::auto_migrate::ponder_migrate;
@@ -15,7 +14,7 @@ use crate::db::datastore::locking_tx_datastore::MutTxId;
 use crate::db::datastore::system_tables::{StClientRow, ST_CLIENT_ID};
 use crate::db::datastore::traits::{IsolationLevel, Program};
 use crate::energy::{EnergyMonitor, EnergyQuanta, ReducerBudget, ReducerFingerprint};
-use crate::execution_context::{self, ExecutionContext, ReducerContext};
+use crate::execution_context::{self, ExecutionContext, ReducerContext, Workload};
 use crate::host::instance_env::InstanceEnv;
 use crate::host::module_host::{
     CallReducerParams, DatabaseUpdate, EventStatus, Module, ModuleEvent, ModuleFunctionCall, ModuleInfo, ModuleInstance,
@@ -263,11 +262,11 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
         log::debug!("init database");
         let timestamp = Timestamp::now();
         let stdb = &*self.replica_context().relational_db;
-        let ctx = ExecutionContext::internal(stdb.database_identity());
+
+        let tx = stdb.begin_mut_tx(IsolationLevel::Serializable, Workload::Internal);
         let auth_ctx = AuthCtx::for_current(self.replica_context().database.owner_identity);
-        let tx = stdb.begin_mut_tx(IsolationLevel::Serializable);
         let (tx, ()) = stdb
-            .with_auto_rollback(&ctx, tx, |tx| {
+            .with_auto_rollback(tx, |tx| {
                 let mut table_defs: Vec<_> = self.info.module_def.tables().collect();
                 table_defs.sort_by(|a, b| a.name.cmp(&b.name));
 
@@ -300,7 +299,7 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
 
         let rcr = match self.info.reducers_map.lookup_id(INIT_DUNDER) {
             None => {
-                stdb.commit_tx(&ctx, tx)?;
+                stdb.commit_tx(tx)?;
                 None
             }
 
@@ -343,11 +342,10 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
             }
         };
         let stdb = &*self.replica_context().relational_db;
-        let ctx = Lazy::new(|| ExecutionContext::internal(stdb.database_identity()));
 
         let program_hash = program.hash;
-        let tx = stdb.begin_mut_tx(IsolationLevel::Serializable);
-        let (mut tx, _) = stdb.with_auto_rollback(&ctx, tx, |tx| stdb.update_program(tx, HostType::Wasm, program))?;
+        let tx = stdb.begin_mut_tx(IsolationLevel::Serializable, Workload::Internal);
+        let (mut tx, _) = stdb.with_auto_rollback(tx, |tx| stdb.update_program(tx, HostType::Wasm, program))?;
         self.system_logger().info(&format!("Updated program to {program_hash}"));
 
         let auth_ctx = AuthCtx::for_current(self.replica_context().database.owner_identity);
@@ -357,11 +355,11 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
             Err(e) => {
                 log::warn!("Database update failed: {} @ {}", e, stdb.database_identity());
                 self.system_logger().warn(&format!("Database update failed: {e}"));
-                stdb.rollback_mut_tx(&ctx, tx);
+                stdb.rollback_mut_tx(tx);
                 Ok(UpdateDatabaseResult::ErrorExecutingMigration(e))
             }
             Ok(()) => {
-                stdb.commit_tx(&ctx, tx)?;
+                stdb.commit_tx(tx)?;
                 self.system_logger().info("Database updated");
                 log::info!("Database updated, {}", stdb.database_identity());
                 Ok(UpdateDatabaseResult::UpdatePerformed)
@@ -437,7 +435,13 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
             timestamp,
             arg_bytes: args.get_bsatn().clone(),
         };
-        let tx = tx.unwrap_or_else(|| stdb.begin_mut_tx(IsolationLevel::Serializable));
+
+        let tx = tx.unwrap_or_else(|| {
+            stdb.begin_mut_tx(
+                IsolationLevel::Serializable,
+                Workload::Reducer(ReducerContext::from(op.clone())),
+            )
+        });
         let _guard = WORKER_METRICS
             .reducer_plus_query_duration
             .with_label_values(&address, op.name)
@@ -455,7 +459,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         let ctx = ExecutionContext::reducer(address, ReducerContext::from(op.clone()));
         // run the call_reducer call in rayon. it's important that we don't acquire a lock inside a rayon task,
         // as that can lead to deadlock.
-        let (ctx, mut tx, result) = rayon::scope(|_| tx_slot.set(ctx, tx, || self.instance.call_reducer(op, budget)));
+        let (mut tx, result) = rayon::scope(|_| tx_slot.set(ctx, tx, || self.instance.call_reducer(op, budget)));
 
         let ExecuteResult {
             energy,
@@ -538,7 +542,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         let event = match self
             .info
             .subscriptions
-            .commit_and_broadcast_event(client.as_deref(), event, &ctx, tx)
+            .commit_and_broadcast_event(client.as_deref(), event, tx)
             .unwrap()
         {
             Ok(ev) => ev,

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -406,6 +406,7 @@ impl WasmInstanceEnv {
         Self::cvt_ret(caller, AbiCall::DatastoreTableScanBsatn, out, |caller| {
             let env = caller.data_mut();
             // Retrieve the execution context for the current reducer.
+            // TODO: Why is necessary to drop the context here?
             let ctx = env.reducer_context()?;
             // Collect the iterator chunks.
             let chunks = env.instance_env.datastore_table_scan_bsatn_chunks(table_id.into())?;

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -408,9 +408,7 @@ impl WasmInstanceEnv {
             // Retrieve the execution context for the current reducer.
             let ctx = env.reducer_context()?;
             // Collect the iterator chunks.
-            let chunks = env
-                .instance_env
-                .datastore_table_scan_bsatn_chunks(&ctx, table_id.into())?;
+            let chunks = env.instance_env.datastore_table_scan_bsatn_chunks(table_id.into())?;
             drop(ctx);
             // Register the iterator and get back the index to write to `out`.
             // Calls to the iterator are done through dynamic dispatch.
@@ -687,8 +685,7 @@ impl WasmInstanceEnv {
 
             // Insert the row into the DB.
             // This will return back the generated column values.
-            let ctx = env.reducer_context()?;
-            let gen_cols = env.instance_env.insert(&ctx, table_id.into(), row)?;
+            let gen_cols = env.instance_env.insert(table_id.into(), row)?;
 
             // Write back the generated column values to `row`
             // and the encoded length to `row_len`.

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -25,7 +25,6 @@ use super::query;
 use crate::db::datastore::locking_tx_datastore::tx::TxId;
 use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::{DBError, SubscriptionError};
-use crate::execution_context::ExecutionContext;
 use crate::host::module_host::{DatabaseTableUpdate, DatabaseUpdateRelValue, UpdatesRelValue};
 use crate::messages::websocket as ws;
 use crate::vm::{build_query, TxMode};
@@ -126,13 +125,12 @@ impl AsRef<QueryExpr> for SupportedQuery {
 
 /// Evaluates `query` and returns all the updates.
 fn eval_updates<'a>(
-    ctx: &'a ExecutionContext,
     db: &'a RelationalDB,
     tx: &'a TxMode<'a>,
     query: &'a QueryExpr,
     mut sources: impl SourceProvider<'a>,
 ) -> impl 'a + Iterator<Item = RelValue<'a>> {
-    let mut query = build_query(ctx, db, tx, query, &mut sources);
+    let mut query = build_query(db, tx, query, &mut sources);
     iter::from_fn(move || query.next())
 }
 
@@ -261,29 +259,26 @@ impl IncrementalJoin {
     /// Evaluate join plan for lhs updates.
     fn eval_lhs<'a>(
         &'a self,
-        ctx: &'a ExecutionContext,
         db: &'a RelationalDB,
         tx: &'a TxMode<'a>,
         lhs: impl 'a + Iterator<Item = &'a ProductValue>,
     ) -> impl Iterator<Item = RelValue<'a>> {
-        eval_updates(ctx, db, tx, self.plan_for_delta_lhs(), Some(lhs.map(RelValue::ProjRef)))
+        eval_updates(db, tx, self.plan_for_delta_lhs(), Some(lhs.map(RelValue::ProjRef)))
     }
 
     /// Evaluate join plan for rhs updates.
     fn eval_rhs<'a>(
         &'a self,
-        ctx: &'a ExecutionContext,
         db: &'a RelationalDB,
         tx: &'a TxMode<'a>,
         rhs: impl 'a + Iterator<Item = &'a ProductValue>,
     ) -> impl Iterator<Item = RelValue<'a>> {
-        eval_updates(ctx, db, tx, self.plan_for_delta_rhs(), Some(rhs.map(RelValue::ProjRef)))
+        eval_updates(db, tx, self.plan_for_delta_rhs(), Some(rhs.map(RelValue::ProjRef)))
     }
 
     /// Evaluate join plan for both lhs and rhs updates.
     fn eval_all<'a>(
         &'a self,
-        ctx: &'a ExecutionContext,
         db: &'a RelationalDB,
         tx: &'a TxMode<'a>,
         lhs: impl 'a + Iterator<Item = &'a ProductValue>,
@@ -292,7 +287,7 @@ impl IncrementalJoin {
         let is = Either::Left(lhs.map(RelValue::ProjRef));
         let ps = Either::Right(rhs.map(RelValue::ProjRef));
         let sources: SourceSet<_, 2> = if self.return_index_rows { [is, ps] } else { [ps, is] }.into();
-        eval_updates(ctx, db, tx, &self.virtual_plan, sources)
+        eval_updates(db, tx, &self.virtual_plan, sources)
     }
 
     /// Evaluate this [`IncrementalJoin`] over the row updates of a transaction t.
@@ -349,7 +344,6 @@ impl IncrementalJoin {
     /// (8) A+ x B-
     pub fn eval<'a>(
         &'a self,
-        ctx: &'a ExecutionContext,
         db: &'a RelationalDB,
         tx: &'a TxMode<'a>,
         updates: impl 'a + Clone + Iterator<Item = &'a DatabaseTableUpdate>,
@@ -420,35 +414,35 @@ impl IncrementalJoin {
 
         // (1) A+ x B(t)
         let j1_lhs_ins = lhs_inserts.clone();
-        let join_1 = make_iter(has_lhs_inserts, || self.eval_lhs(ctx, db, tx, j1_lhs_ins));
+        let join_1 = make_iter(has_lhs_inserts, || self.eval_lhs(db, tx, j1_lhs_ins));
         // (2) A- x B(t)
         let j2_lhs_del = lhs_deletes.clone();
-        let mut join_2 = collect_set(has_lhs_deletes, || self.eval_lhs(ctx, db, tx, j2_lhs_del));
+        let mut join_2 = collect_set(has_lhs_deletes, || self.eval_lhs(db, tx, j2_lhs_del));
         // (3) A- x B+
         let j3_lhs_del = lhs_deletes.clone();
         let j3_rhs_ins = rhs_inserts.clone();
         let join_3 = make_iter(has_lhs_deletes && has_rhs_inserts, || {
-            self.eval_all(ctx, db, tx, j3_lhs_del, j3_rhs_ins)
+            self.eval_all(db, tx, j3_lhs_del, j3_rhs_ins)
         });
         // (4) A- x B-
         let j4_rhs_del = rhs_deletes.clone();
         let join_4 = make_iter(has_lhs_deletes && has_rhs_deletes, || {
-            self.eval_all(ctx, db, tx, lhs_deletes, j4_rhs_del)
+            self.eval_all(db, tx, lhs_deletes, j4_rhs_del)
         });
         // (5) A(t) x B+
         let j5_rhs_ins = rhs_inserts.clone();
-        let mut join_5 = collect_set(has_rhs_inserts, || self.eval_rhs(ctx, db, tx, j5_rhs_ins));
+        let mut join_5 = collect_set(has_rhs_inserts, || self.eval_rhs(db, tx, j5_rhs_ins));
         // (6) A(t) x B-
         let j6_rhs_del = rhs_deletes.clone();
-        let mut join_6 = collect_set(has_rhs_deletes, || self.eval_rhs(ctx, db, tx, j6_rhs_del));
+        let mut join_6 = collect_set(has_rhs_deletes, || self.eval_rhs(db, tx, j6_rhs_del));
         // (7) A+ x B+
         let j7_lhs_ins = lhs_inserts.clone();
         let join_7 = make_iter(has_lhs_inserts && has_rhs_inserts, || {
-            self.eval_all(ctx, db, tx, j7_lhs_ins, rhs_inserts)
+            self.eval_all(db, tx, j7_lhs_ins, rhs_inserts)
         });
         // (8) A+ x B-
         let join_8 = make_iter(has_lhs_inserts && has_rhs_deletes, || {
-            self.eval_all(ctx, db, tx, lhs_inserts, rhs_deletes)
+            self.eval_all(db, tx, lhs_inserts, rhs_deletes)
         });
 
         // A- x B(s) = A- x B(t) \ A- x B+
@@ -517,7 +511,6 @@ pub struct ExecutionSet {
 impl ExecutionSet {
     pub fn eval<F: WebsocketFormat>(
         &self,
-        ctx: &ExecutionContext,
         db: &RelationalDB,
         tx: &Tx,
         slow_query_threshold: Option<Duration>,
@@ -528,7 +521,7 @@ impl ExecutionSet {
             .exec_units
             // if you need eval to run single-threaded for debugging, change this to .iter()
             .par_iter()
-            .filter_map(|unit| unit.eval(ctx, db, tx, &unit.sql, slow_query_threshold, compression))
+            .filter_map(|unit| unit.eval(db, tx, &unit.sql, slow_query_threshold, compression))
             .collect();
         ws::DatabaseUpdate { tables }
     }
@@ -536,7 +529,7 @@ impl ExecutionSet {
     #[tracing::instrument(skip_all)]
     pub fn eval_incr_for_test<'a>(
         &'a self,
-        ctx: &'a ExecutionContext,
+
         db: &'a RelationalDB,
         tx: &'a TxMode<'a>,
         database_update: &'a [&'a DatabaseTableUpdate],
@@ -544,14 +537,9 @@ impl ExecutionSet {
     ) -> DatabaseUpdateRelValue<'a> {
         let mut tables = Vec::new();
         for unit in &self.exec_units {
-            if let Some(table) = unit.eval_incr(
-                ctx,
-                db,
-                tx,
-                &unit.sql,
-                database_update.iter().copied(),
-                slow_query_threshold,
-            ) {
+            if let Some(table) =
+                unit.eval_incr(db, tx, &unit.sql, database_update.iter().copied(), slow_query_threshold)
+            {
                 tables.push(table);
             }
         }
@@ -634,6 +622,7 @@ pub(crate) fn get_all(relational_db: &RelationalDB, tx: &Tx, auth: &AuthCtx) -> 
 mod tests {
     use super::*;
     use crate::db::relational_db::tests_utils::TestDB;
+    use crate::execution_context::Workload;
     use crate::sql::compiler::compile_sql;
     use spacetimedb_lib::relation::DbTable;
     use spacetimedb_lib::{error::ResultTest, identity::AuthCtx};
@@ -660,7 +649,7 @@ mod tests {
         let indexes = &[(0.into(), "b"), (1.into(), "c")];
         let rhs_id = db.create_table_for_test("rhs", schema, indexes)?;
 
-        let tx = db.begin_tx();
+        let tx = db.begin_tx(Workload::ForTests);
         // Should generate an index join since there is an index on `lhs.b`.
         // Should push the sargable range condition into the index join's probe side.
         let sql = "select lhs.* from lhs join rhs on lhs.b = rhs.b where rhs.c > 2 and rhs.c < 4 and rhs.d = 3";
@@ -740,7 +729,7 @@ mod tests {
         let indexes = &[(0.into(), "b"), (1.into(), "c")];
         let _ = db.create_table_for_test("rhs", schema, indexes)?;
 
-        let tx = db.begin_tx();
+        let tx = db.begin_tx(Workload::ForTests);
         // Should generate an index join since there is an index on `lhs.b`.
         // Should push the sargable range condition into the index join's probe side.
         let sql = "select lhs.* from lhs join rhs on lhs.b = rhs.b where rhs.c > 2 and rhs.c < 4 and rhs.d = 3";
@@ -824,7 +813,7 @@ mod tests {
             .create_table_for_test("rhs", schema, indexes)
             .expect("Failed to create_table_for_test rhs");
 
-        let tx = db.begin_tx();
+        let tx = db.begin_tx(Workload::ForTests);
 
         // Should generate an index join since there is an index on `lhs.b`.
         // Should push the sargable range condition into the index join's probe side.

--- a/crates/core/src/util/slow.rs
+++ b/crates/core/src/util/slow.rs
@@ -48,27 +48,28 @@ impl<'a> SlowQueryLogger<'a> {
 mod tests {
     use super::*;
 
+    use crate::db::datastore::system_tables::ST_VARNAME_SLOW_QRY;
     use crate::db::datastore::system_tables::{StVarName, StVarValue, ST_VARNAME_SLOW_INC, ST_VARNAME_SLOW_SUB};
     use crate::sql::compiler::compile_sql;
     use crate::sql::execute::tests::execute_for_testing;
-    use crate::{db::datastore::system_tables::ST_VARNAME_SLOW_QRY, execution_context::ExecutionContext};
     use spacetimedb_lib::error::ResultTest;
     use spacetimedb_lib::identity::AuthCtx;
     use spacetimedb_lib::ProductValue;
 
     use crate::db::relational_db::tests_utils::TestDB;
     use crate::db::relational_db::RelationalDB;
+    use crate::execution_context::Workload;
     use spacetimedb_sats::{product, AlgebraicType};
     use spacetimedb_vm::relation::MemTable;
 
     fn run_query(db: &RelationalDB, sql: String) -> ResultTest<MemTable> {
-        let tx = db.begin_tx();
+        let tx = db.begin_tx(Workload::ForTests);
         let q = compile_sql(db, &AuthCtx::for_testing(), &tx, &sql)?;
         Ok(execute_for_testing(db, &sql, q)?.pop().unwrap())
     }
 
     fn run_query_write(db: &RelationalDB, sql: String) -> ResultTest<()> {
-        let tx = db.begin_tx();
+        let tx = db.begin_tx(Workload::ForTests);
         let q = compile_sql(db, &AuthCtx::for_testing(), &tx, &sql)?;
         drop(tx);
 
@@ -83,20 +84,18 @@ mod tests {
         let table_id =
             db.create_table_for_test("test", &[("x", AlgebraicType::I32), ("y", AlgebraicType::I32)], &[])?;
 
-        let ctx = ExecutionContext::default();
-
-        db.with_auto_commit(&ctx, |tx| -> ResultTest<_> {
+        db.with_auto_commit(Workload::ForTests, |tx| -> ResultTest<_> {
             for i in 0..100_000 {
                 db.insert(tx, table_id, product![i, i * 2])?;
             }
             Ok(())
         })?;
-        let tx = db.begin_tx();
+        let tx = db.begin_tx(Workload::ForTests);
 
         let sql = "select * from test where x > 0";
         let q = compile_sql(&db, &AuthCtx::for_testing(), &tx, sql)?;
 
-        let slow = SlowQueryLogger::new(sql, Some(Duration::from_millis(1)), ctx.workload());
+        let slow = SlowQueryLogger::new(sql, Some(Duration::from_millis(1)), tx.ctx.workload());
 
         let result = execute_for_testing(&db, sql, q)?;
         assert_eq!(result[0].data[0], product![1, 2]);

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -297,7 +297,7 @@ pub struct IndexSemiJoinLeft<'a, 'c, Rhs: RelOps<'a>> {
     pub tx: &'a TxMode<'a>,
 }
 
-static_assert_size!(IndexSemiJoinLeft<Box<IterRows<'static>>>, 296);
+static_assert_size!(IndexSemiJoinLeft<Box<IterRows<'static>>>, 280);
 
 impl<'a, Rhs: RelOps<'a>> IndexSemiJoinLeft<'a, '_, Rhs> {
     fn filter(&self, index_row: &RelValue<'_>) -> bool {

--- a/crates/sqltest/src/space.rs
+++ b/crates/sqltest/src/space.rs
@@ -2,7 +2,7 @@ use crate::db::DBRunner;
 use async_trait::async_trait;
 use spacetimedb::db::relational_db::tests_utils::TestDB;
 use spacetimedb::error::DBError;
-use spacetimedb::execution_context::ExecutionContext;
+use spacetimedb::execution_context::Workload;
 use spacetimedb::sql::compiler::compile_sql;
 use spacetimedb::sql::execute::execute_sql;
 use spacetimedb::subscription::module_subscription_actor::ModuleSubscriptions;
@@ -69,7 +69,7 @@ impl SpaceDb {
     }
 
     pub(crate) fn run_sql(&self, sql: &str) -> anyhow::Result<Vec<MemTable>> {
-        self.conn.with_read_only(&ExecutionContext::default(), |tx| {
+        self.conn.with_read_only(Workload::Sql, |tx| {
             let ast = compile_sql(&self.conn, &AuthCtx::for_testing(), tx, sql)?;
             let subs = ModuleSubscriptions::new(Arc::new(self.conn.db.clone()), Identity::ZERO);
             let result = execute_sql(&self.conn, sql, ast, self.auth, Some(&subs))?;


### PR DESCRIPTION
# Description of Changes

As a preparatory step for further PRs, like those related to the new `Query Engine`, most usages of `ExecutionContext` as an additional context in database calls are removed and put inside the `Tx` contexts instead.

# API and ABI breaking changes

* This pr touches everything related to the db
* It could change the metrics. There were many places where the `ExecutionContext` was overwritten and now it should provide more exact measurements.
* Is necessary to check if it passes correctly the `Identity` & `Address` of replicas

# Expected complexity level and risk

3

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
