### PR TITLE
CLI - Fix `spacetime server edit` failing on renames

### DIFF
--- a/crates/cli/src/subcommands/server.rs
+++ b/crates/cli/src/subcommands/server.rs
@@ -379,6 +379,7 @@ pub async fn exec_edit(mut config: Config, args: &ArgMatches) -> Result<(), anyh
     }
 
     let (old_nick, old_host, old_proto) = config.edit_server(server, new_nick, new_host, new_proto)?;
+    let server = new_nick.unwrap_or(server);
 
     if let (Some(new_nick), Some(old_nick)) = (new_nick, old_nick) {
         println!("Changing nickname from {} to {}", old_nick, new_nick);

--- a/smoketests/tests/servers.py
+++ b/smoketests/tests/servers.py
@@ -24,8 +24,6 @@ class Servers(Smoketest):
         out = self.spacetime("server", "fingerprint", "-s", "localhost")
         self.assertIn("Fingerprint is unchanged for server localhost", out)
 
-        self.spacetime("server", "remove", "-s", "testnet", "--yes")
-
     def test_edit_server(self):
         """Verify that we can edit server configurations"""
 

--- a/smoketests/tests/servers.py
+++ b/smoketests/tests/servers.py
@@ -28,7 +28,7 @@ class Servers(Smoketest):
         """Verify that we can edit server configurations"""
 
         out = self.spacetime("server", "add", "https://foo.com", "foo", "--no-fingerprint")
-        out = self.spacetime("server", "edit", "-s", "foo", "--host", "testnet.spacetimedb.com", "--nickname", "testnet", "--no-fingerprint")
+        out = self.spacetime("server", "edit", "-s", "foo", "--host", "testnet.spacetimedb.com", "--nickname", "testnet", "--no-fingerprint", "--yes")
         self.assertEqual(extract_field(out, "Host:"), "testnet.spacetimedb.com")
         self.assertEqual(extract_field(out, "Protocol:"), "https")
 

--- a/smoketests/tests/servers.py
+++ b/smoketests/tests/servers.py
@@ -30,12 +30,7 @@ class Servers(Smoketest):
         """Verify that we can edit server configurations"""
 
         out = self.spacetime("server", "add", "https://foo.com", "foo", "--no-fingerprint")
-        out = self.spacetime("server", "edit", "-s", "foo", "--host", "testnet.spacetimedb.com", "--nickname", "testnet", "--no-fingerprint", "--yes")
-        self.assertEqual(extract_field(out, "Host:"), "testnet.spacetimedb.com")
-        self.assertEqual(extract_field(out, "Protocol:"), "https")
+        out = self.spacetime("server", "edit", "-s", "foo", "--host", "edited-testnet.spacetimedb.com", "--nickname", "edited-testnet", "--no-fingerprint", "--yes")
 
         servers = self.spacetime("server", "list")
-        self.assertRegex(servers, re.compile(r"^\s*testnet\.spacetimedb\.com\s+https\s+testnet\s*$", re.M))
-        self.assertRegex(servers, re.compile(r"^\s*\*\*\*\s+127\.0\.0\.1:3000\s+http\s+localhost\s*$", re.M))
-
-        self.spacetime("server", "remove", "-s", "testnet", "--yes")
+        self.assertRegex(servers, re.compile(r"^\s*edited-testnet\.spacetimedb\.com\s+https\s+edited-testnet\s*$", re.M))

--- a/smoketests/tests/servers.py
+++ b/smoketests/tests/servers.py
@@ -24,6 +24,8 @@ class Servers(Smoketest):
         out = self.spacetime("server", "fingerprint", "-s", "localhost")
         self.assertIn("Fingerprint is unchanged for server localhost", out)
 
+        self.spacetime("server", "remove", "-s", "testnet", "--yes")
+
     def test_edit_server(self):
         """Verify that we can edit server configurations"""
 
@@ -36,4 +38,4 @@ class Servers(Smoketest):
         self.assertRegex(servers, re.compile(r"^\s*testnet\.spacetimedb\.com\s+https\s+testnet\s*$", re.M))
         self.assertRegex(servers, re.compile(r"^\s*\*\*\*\s+127\.0\.0\.1:3000\s+http\s+localhost\s*$", re.M))
 
-        self.spacetime("server", "remove", "-s", "foo", "--yes")
+        self.spacetime("server", "remove", "-s", "testnet", "--yes")

--- a/smoketests/tests/servers.py
+++ b/smoketests/tests/servers.py
@@ -23,3 +23,15 @@ class Servers(Smoketest):
 
         out = self.spacetime("server", "fingerprint", "-s", "localhost")
         self.assertIn("Fingerprint is unchanged for server localhost", out)
+
+    def test_edit_server(self):
+        """Verify that we can edit server configurations"""
+
+        out = self.spacetime("server", "add", "--url", "https://foo.com", "foo", "--no-fingerprint")
+        out = self.spacetime("server", "edit", "-s", "foo", "--host", "testnet.spacetimedb.com", "--nickname", "testnet", "--no-fingerprint")
+        self.assertEqual(extract_field(out, "Host:"), "testnet.spacetimedb.com")
+        self.assertEqual(extract_field(out, "Protocol:"), "https")
+
+        servers = self.spacetime("server", "list")
+        self.assertRegex(servers, re.compile(r"^\s*testnet\.spacetimedb\.com\s+https\s+testnet\s*$", re.M))
+        self.assertRegex(servers, re.compile(r"^\s*\*\*\*\s+127\.0\.0\.1:3000\s+http\s+localhost\s*$", re.M))

--- a/smoketests/tests/servers.py
+++ b/smoketests/tests/servers.py
@@ -35,3 +35,5 @@ class Servers(Smoketest):
         servers = self.spacetime("server", "list")
         self.assertRegex(servers, re.compile(r"^\s*testnet\.spacetimedb\.com\s+https\s+testnet\s*$", re.M))
         self.assertRegex(servers, re.compile(r"^\s*\*\*\*\s+127\.0\.0\.1:3000\s+http\s+localhost\s*$", re.M))
+
+        self.spacetime("server", "remove", "-s", "foo", "--yes")

--- a/smoketests/tests/servers.py
+++ b/smoketests/tests/servers.py
@@ -27,7 +27,7 @@ class Servers(Smoketest):
     def test_edit_server(self):
         """Verify that we can edit server configurations"""
 
-        out = self.spacetime("server", "add", "--url", "https://foo.com", "foo", "--no-fingerprint")
+        out = self.spacetime("server", "add", "https://foo.com", "foo", "--no-fingerprint")
         out = self.spacetime("server", "edit", "-s", "foo", "--host", "testnet.spacetimedb.com", "--nickname", "testnet", "--no-fingerprint")
         self.assertEqual(extract_field(out, "Host:"), "testnet.spacetimedb.com")
         self.assertEqual(extract_field(out, "Protocol:"), "https")


### PR DESCRIPTION
# Description of Changes

`spacetime server edit` had a bug during renames, where it would try to access the server config by the old name, causing an error.

This must have been broken for a long time. The code has been in this state for a while, looks like about a year from the git history (a1e9984840ff60d77023f04927e50929cc7e0102).

# API and ABI breaking changes

No. Bugfix.

# Expected complexity level and risk

1

# Testing

I added a smoketest.