### PR TITLE
Remove CODEOWNERS from CLI codegen

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -3,6 +3,7 @@
 /.github/CODEOWNERS @cloutiertyler
 LICENSE.txt @cloutiertyler
 /crates/client-api-messages/src/websocket.rs @centril @gefjon
+
 /crates/cli/src/ @bfops @jdetter @cloutiertyler
 /crates/cli/src/generate/ # No owners
-/crates/cli/src/generate/mod.rs @bfops @jdetter @cloutiertyler # The root itself
+/crates/cli/src/generate/mod.rs @bfops @jdetter @cloutiertyler # These codeowners should be the same as the "root" CLI codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@ LICENSE.txt @cloutiertyler
 /crates/client-api-messages/src/websocket.rs @centril @gefjon
 
 /crates/cli/src/ @bfops @jdetter @cloutiertyler
-/crates/cli/src/generate/** # No owners
-/crates/cli/src/generate/mod.rs @bfops @jdetter @cloutiertyler # These codeowners should be the same as the "root" CLI codeowners
+/crates/cli/src/subcommands/generate/ # No owners
+/crates/cli/src/subcommands/generate/mod.rs @bfops @jdetter @cloutiertyler # These codeowners should be the same as the "root" CLI codeowners

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,3 +4,5 @@
 LICENSE.txt @cloutiertyler
 /crates/client-api-messages/src/websocket.rs @centril @gefjon
 /crates/cli/src/ @bfops @jdetter @cloutiertyler
+/crates/cli/src/generate/ # No owners
+/crates/cli/src/generate/mod.rs @bfops @jdetter @cloutiertyler # The root itself

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -5,5 +5,5 @@ LICENSE.txt @cloutiertyler
 /crates/client-api-messages/src/websocket.rs @centril @gefjon
 
 /crates/cli/src/ @bfops @jdetter @cloutiertyler
-/crates/cli/src/generate/ # No owners
+/crates/cli/src/generate/** # No owners
 /crates/cli/src/generate/mod.rs @bfops @jdetter @cloutiertyler # These codeowners should be the same as the "root" CLI codeowners


### PR DESCRIPTION
# Description of Changes

I removed CODEOWNERS for the `generate/` subdirectory of the CLI code, since this logic is pretty separate from the rest of the CLI.

**However** I keep the codeowners on `generate/mod.rs` because this includes the "interface" itself. I'm fine with somebody moving more code-generation code out of `mod.rs` so that it doesn't require codeowner review.

# API and ABI breaking changes

No code changes.

# Expected complexity level and risk

1

# Testing

- [x] Modifying `generate/rust.rs` no longer requires codeowner approval: https://github.com/clockworklabs/SpacetimeDB/pull/1887
- [x] Modifying `generate/mod.rs` still requires codeowner approval: https://github.com/clockworklabs/SpacetimeDB/pull/1888 