### PR TITLE
CLI - Fix helptext after #1845

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -80,7 +80,7 @@ Or initialize a default identity with:
                 format!(
                     "Cannot verify tokens using invalid saved fingerprint from server: {server}
 Update the fingerprint with:
-\tspacetime server fingerprint -s {server}",
+\tspacetime server fingerprint {server}",
                 )
             })?;
             decode_token(&decoder, &id.token).map_err(|_| {
@@ -120,13 +120,13 @@ const NO_DEFAULT_SERVER_ERROR_MESSAGE: &str = "No default server configuration.
 Set an existing server as the default with:
 \tspacetime server set-default <server>
 Or add a new server which will become the default:
-\tspacetime server add <url> --default";
+\tspacetime server add {server} <url> --default";
 
 fn no_such_server_error(server: &str) -> anyhow::Error {
     anyhow::anyhow!(
         "No such saved server configuration: {server}
 Add a new server configuration with:
-\tspacetime server add <url>",
+\tspacetime server add {server} --url <url>",
     )
 }
 
@@ -973,7 +973,7 @@ Import an existing identity with:
                     format!(
                         "Unable to parse invalid saved server fingerprint as ECDSA public key.
 Update the server's fingerprint with:
-\tspacetime server fingerprint -s {}",
+\tspacetime server fingerprint {}",
                         server.unwrap_or("")
                     )
                 })

--- a/crates/cli/src/subcommands/identity.rs
+++ b/crates/cli/src/subcommands/identity.rs
@@ -393,7 +393,7 @@ async fn exec_list(config: Config, args: &ArgMatches) -> Result<(), anyhow::Erro
             format!(
                 "Cannot list identities for server without a saved fingerprint: {server_name}
 Fetch the server's fingerprint with:
-\tspacetime server fingerprint -s {server_name}"
+\tspacetime server fingerprint {server_name}"
             )
         })?;
         let default_identity = config.get_default_identity_config(server).ok().map(|cfg| cfg.identity);

--- a/crates/cli/src/subcommands/server.rs
+++ b/crates/cli/src/subcommands/server.rs
@@ -216,7 +216,7 @@ pub async fn exec_add(mut config: Config, args: &ArgMatches) -> Result<(), anyho
                 "Unable to retrieve fingerprint for server: {url}
 Is the server running?
 Add a server without retrieving its fingerprint with:
-\tspacetime server add {url} --no-fingerprint",
+\tspacetime server add --url {url} --no-fingerprint",
             )
         })?;
         println!("For server {}, got fingerprint:\n{}", url, fingerprint);


### PR DESCRIPTION
# Description of Changes

Fix helptext that should have been updated in https://github.com/clockworklabs/SpacetimeDB/pull/1845.

# API and ABI breaking changes

No

# Expected complexity level and risk

1

# Testing

None, just error messages have been updated.