### PR TITLE
Optimize integrate_generated_columns

### DIFF
--- a/crates/bindings-macro/src/table.rs
+++ b/crates/bindings-macro/src/table.rs
@@ -526,14 +526,11 @@ pub(crate) fn table_impl(mut args: TableArgs, mut item: MutItem<syn::DeriveInput
     let integrate_gen_col = sequenced_columns.iter().map(|col| {
         let field = col.field.ident.unwrap();
         quote_spanned!(field.span()=>
-            if spacetimedb::table::IsSequenceTrigger::is_sequence_trigger(&_row.#field) {
-                _row.#field = spacetimedb::sats::bsatn::from_reader(_in).unwrap();
-            }
+            spacetimedb::table::SequenceTrigger::maybe_decode_into(&mut __row.#field, &mut __generated_cols);
         )
     });
     let integrate_generated_columns = quote_spanned!(item.span() =>
-        fn integrate_generated_columns(_row: &mut #row_type, mut _generated_cols: &[u8]) {
-            let mut _in = &mut _generated_cols;
+        fn integrate_generated_columns(__row: &mut #row_type, mut __generated_cols: &[u8]) {
             #(#integrate_gen_col)*
         }
     );

--- a/crates/bindings/src/table.rs
+++ b/crates/bindings/src/table.rs
@@ -3,7 +3,7 @@ use std::convert::Infallible;
 use std::marker::PhantomData;
 use std::{fmt, ops};
 
-use spacetimedb_lib::buffer::{BufReader, Cursor};
+use spacetimedb_lib::buffer::{BufReader, Cursor, DecodeError};
 use spacetimedb_lib::sats::{i256, u256};
 
 pub use spacetimedb_lib::db::raw_def::v9::TableAccess;
@@ -755,38 +755,77 @@ impl_terminator!(
 // impl<T, U, V> BTreeIndexBounds<(T, U, V)> for (T, U, Range<V>) {}
 // impl<T, U, V> BTreeIndexBounds<(T, U, V)> for (T, U, V) {}
 
-/// A trait for types that know if their value will trigger a sequence.
+/// A trait for types that can have a sequence based on them.
 /// This is used for auto-inc columns to determine if an insertion of a row
 /// will require the column to be updated in the row.
-///
-/// For now, this is equivalent to a "is zero" test.
-pub trait IsSequenceTrigger {
+pub trait SequenceTrigger: Sized {
     /// Is this value one that will trigger a sequence, if any,
     /// when used as a column value.
     fn is_sequence_trigger(&self) -> bool;
+    /// BufReader::get_[< self >]
+    fn decode(reader: &mut &[u8]) -> Result<Self, DecodeError>;
+    /// Read a generated column from the slice, if this row was a sequence trigger.
+    #[inline(always)]
+    fn maybe_decode_into(&mut self, gen_cols: &mut &[u8]) {
+        if self.is_sequence_trigger() {
+            *self = Self::decode(gen_cols).unwrap_or_else(|_| sequence_decode_error())
+        }
+    }
 }
 
-macro_rules! impl_is_seq_trigger {
-    ($($t:ty),*) => {
+#[cold]
+#[inline(never)]
+fn sequence_decode_error() -> ! {
+    unreachable!("a row was a sequence trigger but there was no generated column for it.")
+}
+
+macro_rules! impl_seq_trigger {
+    ($($get:ident($t:ty),)*) => {
         $(
-            impl IsSequenceTrigger for $t {
+            impl SequenceTrigger for $t {
+                #[inline(always)]
                 fn is_sequence_trigger(&self) -> bool { *self == 0 }
+                #[inline(always)]
+                fn decode(reader: &mut &[u8]) -> Result<Self, DecodeError> {
+                    reader.$get()
+                }
             }
         )*
     };
 }
 
-impl_is_seq_trigger![u8, i8, u16, i16, u32, i32, u64, i64, u128, i128];
+impl_seq_trigger!(
+    get_u8(u8),
+    get_i8(i8),
+    get_u16(u16),
+    get_i16(i16),
+    get_u32(u32),
+    get_i32(i32),
+    get_u64(u64),
+    get_i64(i64),
+    get_u128(u128),
+    get_i128(i128),
+);
 
-impl IsSequenceTrigger for crate::sats::i256 {
+impl SequenceTrigger for crate::sats::i256 {
+    #[inline(always)]
     fn is_sequence_trigger(&self) -> bool {
         *self == Self::ZERO
     }
+    #[inline(always)]
+    fn decode(reader: &mut &[u8]) -> Result<Self, DecodeError> {
+        reader.get_i256()
+    }
 }
 
-impl IsSequenceTrigger for crate::sats::u256 {
+impl SequenceTrigger for crate::sats::u256 {
+    #[inline(always)]
     fn is_sequence_trigger(&self) -> bool {
         *self == Self::ZERO
+    }
+    #[inline(always)]
+    fn decode(reader: &mut &[u8]) -> Result<Self, DecodeError> {
+        reader.get_u256()
     }
 }
 

--- a/crates/commitlog/src/payload.rs
+++ b/crates/commitlog/src/payload.rs
@@ -115,7 +115,7 @@ impl<const N: usize> Decoder for ArrayDecoder<N> {
         _tx_offset: u64,
         reader: &mut R,
     ) -> Result<Self::Record, Self::Error> {
-        Ok(reader.get_array()?)
+        Ok(*reader.get_array()?)
     }
 
     fn skip_record<'a, R: BufReader<'a>>(

--- a/crates/sats/src/buffer.rs
+++ b/crates/sats/src/buffer.rs
@@ -12,7 +12,7 @@ use core::str::Utf8Error;
 pub enum DecodeError {
     /// Not enough data was provided in the input.
     BufferLength {
-        for_type: String,
+        for_type: &'static str,
         expected: usize,
         given: usize,
     },
@@ -126,117 +126,161 @@ pub trait BufWriter {
     }
 }
 
+macro_rules! get_int {
+    ($self:ident, $int:ident) => {
+        match $self.get_array_chunk() {
+            Some(&arr) => Ok($int::from_le_bytes(arr)),
+            None => Err(DecodeError::BufferLength {
+                for_type: stringify!($int),
+                expected: std::mem::size_of::<$int>(),
+                given: $self.remaining(),
+            }),
+        }
+    };
+}
+
 /// A buffered reader of some kind.
 ///
 /// The lifetime `'de` allows the output of deserialization to borrow from the input.
 pub trait BufReader<'de> {
-    /// Reads and returns a byte slice of `.len() = size` advancing the cursor.
-    fn get_slice(&mut self, size: usize) -> Result<&'de [u8], DecodeError>;
+    /// Reads and returns a chunk of `.len() = size` advancing the cursor iff `self.remaining() >= size`.
+    fn get_chunk(&mut self, size: usize) -> Option<&'de [u8]>;
 
     /// Returns the number of bytes left to read in the input.
     fn remaining(&self) -> usize;
 
+    /// Reads and returns a chunk of `.len() = N` as an array, advancing the cursor.
+    #[inline]
+    fn get_array_chunk<const N: usize>(&mut self) -> Option<&'de [u8; N]> {
+        self.get_chunk(N)?.try_into().ok()
+    }
+
+    /// Reads and returns a byte slice of `.len() = size` advancing the cursor.
+    #[inline]
+    fn get_slice(&mut self, size: usize) -> Result<&'de [u8], DecodeError> {
+        self.get_chunk(size).ok_or(DecodeError::BufferLength {
+            for_type: "[u8]",
+            expected: size,
+            given: self.remaining(),
+        })
+    }
+
+    /// Reads an array of type `[u8; N]` from the input.
+    #[inline]
+    fn get_array<const N: usize>(&mut self) -> Result<&'de [u8; N], DecodeError> {
+        self.get_array_chunk().ok_or(DecodeError::BufferLength {
+            for_type: "[u8; _]",
+            expected: N,
+            given: self.remaining(),
+        })
+    }
+
     /// Reads a `u8` in little endian (LE) encoding from the input.
     ///
     /// This method is provided for convenience
-    /// and is derived from [`get_slice`](BufReader::get_slice)'s definition.
+    /// and is derived from [`get_chunk`](BufReader::get_chunk)'s definition.
+    #[inline]
     fn get_u8(&mut self) -> Result<u8, DecodeError> {
-        self.get_array().map(u8::from_le_bytes)
+        get_int!(self, u8)
     }
 
     /// Reads a `u16` in little endian (LE) encoding from the input.
     ///
     /// This method is provided for convenience
-    /// and is derived from [`get_slice`](BufReader::get_slice)'s definition.
+    /// and is derived from [`get_chunk`](BufReader::get_chunk)'s definition.
+    #[inline]
     fn get_u16(&mut self) -> Result<u16, DecodeError> {
-        self.get_array().map(u16::from_le_bytes)
+        get_int!(self, u16)
     }
 
     /// Reads a `u32` in little endian (LE) encoding from the input.
     ///
     /// This method is provided for convenience
-    /// and is derived from [`get_slice`](BufReader::get_slice)'s definition.
+    /// and is derived from [`get_chunk`](BufReader::get_chunk)'s definition.
+    #[inline]
     fn get_u32(&mut self) -> Result<u32, DecodeError> {
-        self.get_array().map(u32::from_le_bytes)
+        get_int!(self, u32)
     }
 
     /// Reads a `u64` in little endian (LE) encoding from the input.
     ///
     /// This method is provided for convenience
-    /// and is derived from [`get_slice`](BufReader::get_slice)'s definition.
+    /// and is derived from [`get_chunk`](BufReader::get_chunk)'s definition.
+    #[inline]
     fn get_u64(&mut self) -> Result<u64, DecodeError> {
-        self.get_array().map(u64::from_le_bytes)
+        get_int!(self, u64)
     }
 
     /// Reads a `u128` in little endian (LE) encoding from the input.
     ///
     /// This method is provided for convenience
-    /// and is derived from [`get_slice`](BufReader::get_slice)'s definition.
+    /// and is derived from [`get_chunk`](BufReader::get_chunk)'s definition.
+    #[inline]
     fn get_u128(&mut self) -> Result<u128, DecodeError> {
-        self.get_array().map(u128::from_le_bytes)
+        get_int!(self, u128)
     }
 
     /// Reads a `u256` in little endian (LE) encoding from the input.
     ///
     /// This method is provided for convenience
-    /// and is derived from [`get_slice`](BufReader::get_slice)'s definition.
+    /// and is derived from [`get_chunk`](BufReader::get_chunk)'s definition.
+    #[inline]
     fn get_u256(&mut self) -> Result<u256, DecodeError> {
-        self.get_array().map(u256::from_le_bytes)
+        get_int!(self, u256)
     }
 
     /// Reads an `i8` in little endian (LE) encoding from the input.
     ///
     /// This method is provided for convenience
-    /// and is derived from [`get_slice`](BufReader::get_slice)'s definition.
+    /// and is derived from [`get_chunk`](BufReader::get_chunk)'s definition.
+    #[inline]
     fn get_i8(&mut self) -> Result<i8, DecodeError> {
-        self.get_array().map(i8::from_le_bytes)
+        get_int!(self, i8)
     }
 
     /// Reads an `i16` in little endian (LE) encoding from the input.
     ///
     /// This method is provided for convenience
-    /// and is derived from [`get_slice`](BufReader::get_slice)'s definition.
+    /// and is derived from [`get_chunk`](BufReader::get_chunk)'s definition.
+    #[inline]
     fn get_i16(&mut self) -> Result<i16, DecodeError> {
-        self.get_array().map(i16::from_le_bytes)
+        get_int!(self, i16)
     }
 
     /// Reads an `i32` in little endian (LE) encoding from the input.
     ///
     /// This method is provided for convenience
-    /// and is derived from [`get_slice`](BufReader::get_slice)'s definition.
+    /// and is derived from [`get_chunk`](BufReader::get_chunk)'s definition.
+    #[inline]
     fn get_i32(&mut self) -> Result<i32, DecodeError> {
-        self.get_array().map(i32::from_le_bytes)
+        get_int!(self, i32)
     }
 
     /// Reads an `i64` in little endian (LE) encoding from the input.
     ///
     /// This method is provided for convenience
-    /// and is derived from [`get_slice`](BufReader::get_slice)'s definition.
+    /// and is derived from [`get_chunk`](BufReader::get_chunk)'s definition.
+    #[inline]
     fn get_i64(&mut self) -> Result<i64, DecodeError> {
-        self.get_array().map(i64::from_le_bytes)
+        get_int!(self, i64)
     }
 
     /// Reads an `i128` in little endian (LE) encoding from the input.
     ///
     /// This method is provided for convenience
-    /// and is derived from [`get_slice`](BufReader::get_slice)'s definition.
+    /// and is derived from [`get_chunk`](BufReader::get_chunk)'s definition.
+    #[inline]
     fn get_i128(&mut self) -> Result<i128, DecodeError> {
-        self.get_array().map(i128::from_le_bytes)
+        get_int!(self, i128)
     }
 
     /// Reads an `i256` in little endian (LE) encoding from the input.
     ///
     /// This method is provided for convenience
-    /// and is derived from [`get_slice`](BufReader::get_slice)'s definition.
+    /// and is derived from [`get_chunk`](BufReader::get_chunk)'s definition.
+    #[inline]
     fn get_i256(&mut self) -> Result<i256, DecodeError> {
-        self.get_array().map(i256::from_le_bytes)
-    }
-
-    /// Reads an array of type `[u8; C]` from the input.
-    fn get_array<const C: usize>(&mut self) -> Result<[u8; C], DecodeError> {
-        let mut buf: [u8; C] = [0; C];
-        buf.copy_from_slice(self.get_slice(C)?);
-        Ok(buf)
+        get_int!(self, i256)
     }
 }
 
@@ -297,19 +341,25 @@ impl<W1: BufWriter, W2: BufWriter> BufWriter for TeeWriter<W1, W2> {
 }
 
 impl<'de> BufReader<'de> for &'de [u8] {
-    fn get_slice(&mut self, size: usize) -> Result<&'de [u8], DecodeError> {
+    #[inline]
+    fn get_chunk(&mut self, size: usize) -> Option<&'de [u8]> {
+        // TODO: split_at_checked once our msrv >= 1.80
         if self.len() < size {
-            return Err(DecodeError::BufferLength {
-                for_type: "[u8]".into(),
-                expected: size,
-                given: self.len(),
-            });
+            return None;
         }
         let (ret, rest) = self.split_at(size);
         *self = rest;
-        Ok(ret)
+        Some(ret)
     }
 
+    #[inline]
+    fn get_array_chunk<const N: usize>(&mut self) -> Option<&'de [u8; N]> {
+        let (ret, rest) = self.split_first_chunk()?;
+        *self = rest;
+        Some(ret)
+    }
+
+    #[inline(always)]
     fn remaining(&self) -> usize {
         self.len()
     }
@@ -334,19 +384,28 @@ impl<I> Cursor<I> {
 }
 
 impl<'de, I: AsRef<[u8]>> BufReader<'de> for &'de Cursor<I> {
-    fn get_slice(&mut self, size: usize) -> Result<&'de [u8], DecodeError> {
+    #[inline]
+    fn get_chunk(&mut self, size: usize) -> Option<&'de [u8]> {
         // "Read" the slice `buf[pos..size]`.
         let buf = &self.buf.as_ref()[self.pos.get()..];
-        let ret = buf.get(..size).ok_or_else(|| DecodeError::BufferLength {
-            for_type: "Cursor".into(),
-            expected: size,
-            given: buf.len(),
-        })?;
+        let ret = buf.get(..size)?;
 
         // Advance the cursor by `size` bytes.
         self.pos.set(self.pos.get() + size);
 
-        Ok(ret)
+        Some(ret)
+    }
+
+    #[inline]
+    fn get_array_chunk<const N: usize>(&mut self) -> Option<&'de [u8; N]> {
+        // "Read" the slice `buf[pos..size]`.
+        let buf = &self.buf.as_ref()[self.pos.get()..];
+        let ret = buf.first_chunk()?;
+
+        // Advance the cursor by `size` bytes.
+        self.pos.set(self.pos.get() + N);
+
+        Some(ret)
     }
 
     fn remaining(&self) -> usize {

--- a/crates/standalone/src/control_db.rs
+++ b/crates/standalone/src/control_db.rs
@@ -399,7 +399,7 @@ impl ControlDb {
                 }
             };
             let arr = <[u8; 16]>::try_from(balance_entry.1.as_ref()).map_err(|_| bsatn::DecodeError::BufferLength {
-                for_type: "balance_entry".into(),
+                for_type: "balance_entry",
                 expected: 16,
                 given: balance_entry.1.len(),
             })?;
@@ -421,7 +421,7 @@ impl ControlDb {
         let value = tree.get(identity.to_byte_array())?;
         if let Some(value) = value {
             let arr = <[u8; 16]>::try_from(value.as_ref()).map_err(|_| bsatn::DecodeError::BufferLength {
-                for_type: "Identity".into(),
+                for_type: "Identity",
                 expected: 16,
                 given: value.as_ref().len(),
             })?;


### PR DESCRIPTION
# Description of Changes

Not really important, just something I noticed could be cleaner.

Comparison for `integrate_generated_columns` for:
```rust
pub struct TestE {
    #[primary_key]
    #[auto_inc]
    id: u64,
    #[index(btree)]
    name: String,
}
```

<details><summary>LLVM IR before this change:</summary>

```ll
; <rust_wasm_test_module::_::test_e__TableHandle as spacetimedb::table::Table>::integrate_generated_columns
; Function Attrs: noinline nounwind nonlazybind
define internal fastcc void @"<rust_wasm_test_module::_::test_e__TableHandle as spacetimedb::table::Table>::integrate_generated_columns"(ptr noalias nocapture noundef align 8 dereferenceable(32) %_row, ptr noalias noundef nonnull readonly align 1 %0, i64 noundef %1) unnamed_addr #5 personality ptr @rust_eh_personality {
start:
  %self1.i.i = alloca %"core::result::Result<&[u8], spacetimedb_sats::buffer::DecodeError>", align 8
  %e.i = alloca %"spacetimedb_sats::buffer::DecodeError", align 8
  %_generated_cols = alloca { ptr, i64 }, align 8
  store ptr %0, ptr %_generated_cols, align 8
  %2 = getelementptr inbounds i8, ptr %_generated_cols, i64 8
  store i64 %1, ptr %2, align 8
  %3 = getelementptr inbounds i8, ptr %_row, i64 24
  %_8 = load i64, ptr %3, align 8, !noundef !27
  %4 = icmp eq i64 %_8, 0
  br i1 %4, label %bb1, label %bb4

bb1:                                              ; preds = %start
  call void @llvm.lifetime.start.p0(i64 40, ptr nonnull %self1.i.i), !noalias !2900
; call <&[u8] as spacetimedb_sats::buffer::BufReader>::get_slice
  call void @"<&[u8] as spacetimedb_sats::buffer::BufReader>::get_slice"(ptr noalias nocapture noundef nonnull sret([40 x i8]) align 8 dereferenceable(40) %self1.i.i, ptr noalias noundef nonnull align 8 dereferenceable(16) %_generated_cols, i64 noundef 8) #19, !noalias !2907
  %5 = load i64, ptr %self1.i.i, align 8, !range !2697, !noalias !2900, !noundef !27
  %6 = icmp eq i64 %5, -9223372036854775805
  %7 = getelementptr inbounds i8, ptr %self1.i.i, i64 8
  %v.0.i.i = load ptr, ptr %7, align 8, !noalias !2900
  %8 = getelementptr inbounds i8, ptr %self1.i.i, i64 16
  %v.1.i.i = load i64, ptr %8, align 8, !noalias !2900
  br i1 %6, label %bb6.i.i, label %bb2.i

bb6.i.i:                                          ; preds = %bb1
  call void @llvm.lifetime.end.p0(i64 40, ptr nonnull %self1.i.i), !noalias !2900
  call void @llvm.experimental.noalias.scope.decl(metadata !2908)
  call void @llvm.experimental.noalias.scope.decl(metadata !2911)
  %_3.not.i.i.i = icmp eq i64 %v.1.i.i, 8
  br i1 %_3.not.i.i.i, label %"core::result::Result<T,E>::unwrap.exit", label %bb1.i.i.i

bb1.i.i.i:                                        ; preds = %bb6.i.i
; call core::slice::<impl [T]>::copy_from_slice::len_mismatch_fail
  call void @"core::slice::<impl [T]>::copy_from_slice::len_mismatch_fail"(i64 noundef 8, i64 noundef %v.1.i.i, ptr noalias noundef nonnull readonly align 8 dereferenceable(24) @alloc_825ed530fe0ece941722f5f5e2ef3a35) #20, !noalias !2913
  unreachable

bb2.i:                                            ; preds = %bb1
  %e.sroa.7.0.self1.sroa_idx.i.i = getelementptr inbounds i8, ptr %self1.i.i, i64 24
  %_6.sroa.10.0.e.i.sroa_idx = getelementptr inbounds i8, ptr %e.i, i64 24
  call void @llvm.lifetime.start.p0(i64 40, ptr nonnull %e.i), !noalias !2914
  call void @llvm.memcpy.p0.p0.i64(ptr noundef nonnull align 8 dereferenceable(16) %_6.sroa.10.0.e.i.sroa_idx, ptr noundef nonnull align 8 dereferenceable(16) %e.sroa.7.0.self1.sroa_idx.i.i, i64 16, i1 false), !noalias !27
  call void @llvm.lifetime.end.p0(i64 40, ptr nonnull %self1.i.i), !noalias !2900
  %9 = ptrtoint ptr %v.0.i.i to i64
  store i64 %5, ptr %e.i, align 8, !noalias !2918
  %_6.sroa.6.0.e.i.sroa_idx = getelementptr inbounds i8, ptr %e.i, i64 8
  store i64 %9, ptr %_6.sroa.6.0.e.i.sroa_idx, align 8, !noalias !2918
  %_6.sroa.9.0.e.i.sroa_idx = getelementptr inbounds i8, ptr %e.i, i64 16
  store i64 %v.1.i.i, ptr %_6.sroa.9.0.e.i.sroa_idx, align 8, !noalias !2918
; call core::result::unwrap_failed
  call void @core::result::unwrap_failed(ptr noalias noundef nonnull readonly align 1 @alloc_00ae4b301f7fab8ac9617c03fcbd7274, i64 noundef 43, ptr noundef nonnull align 1 %e.i, ptr noalias noundef nonnull readonly align 8 dereferenceable(24) @vtable.2, ptr noalias noundef nonnull readonly align 8 dereferenceable(24) @alloc_579c227a4403128ce5fbcc2607f38818) #20, !noalias !2919
  unreachable

"core::result::Result<T,E>::unwrap.exit": ; preds = %bb6.i.i
  %buf.sroa.0.0.copyload6.i6.i = load i64, ptr %v.0.i.i, align 1, !alias.scope !2920, !noalias !2907
  store i64 %buf.sroa.0.0.copyload6.i6.i, ptr %3, align 8
  br label %bb4

bb4:                                              ; preds = %start, %"core::result::Result<T,E>::unwrap.exit"
  ret void
}
```
</details>

<details><summary>LLVM IR after this change:</summary>

```ll
; <rust_wasm_test_module::_::test_e__TableHandle as spacetimedb::table::Table>::integrate_generated_columns
; Function Attrs: noinline nounwind nonlazybind
define internal fastcc void @"<rust_wasm_test_module::_::test_e__TableHandle as spacetimedb::table::Table>::integrate_generated_columns"(ptr noalias nocapture noundef align 8 dereferenceable(32) %__row, ptr noalias nocapture noundef nonnull readonly align 1 %0, i64 noundef %1) unnamed_addr #5 personality ptr @rust_eh_personality {
start:
  %_4 = getelementptr inbounds i8, ptr %__row, i64 24
  %_2.i = load i64, ptr %_4, align 8, !alias.scope !2799, !noalias !2802, !noundef !27
  %_0.i = icmp eq i64 %_2.i, 0
  br i1 %_0.i, label %bb2.i, label %spacetimedb::table::SequenceTrigger::maybe_decode_into.exit

bb2.i:                                            ; preds = %start
  %_5.i.i = icmp ult i64 %1, 8
  br i1 %_5.i.i, label %bb10.i, label %bb11.i

bb11.i:                                           ; preds = %bb2.i
  %2 = load i64, ptr %0, align 1, !noalias !2805
  store i64 %2, ptr %_4, align 8, !alias.scope !2809, !noalias !2802
  br label %spacetimedb::table::SequenceTrigger::maybe_decode_into.exit

bb10.i:                                           ; preds = %bb2.i
; call spacetimedb::table::sequence_decode_error
  tail call void @spacetimedb::table::sequence_decode_error() #20
  unreachable

spacetimedb::table::SequenceTrigger::maybe_decode_into.exit: ; preds = %start, %bb11.i
  ret void
}
```
</details>

# Expected complexity level and risk

1