### PR TITLE
commitlog: Improve skipping behavior of traversals

### DIFF
--- a/crates/commitlog/src/commitlog.rs
+++ b/crates/commitlog/src/commitlog.rs
@@ -306,7 +306,6 @@ pub fn commits_from<R: Repo>(repo: R, max_log_format_version: u8, offset: u64) -
     if let Some(pos) = offsets.iter().rposition(|&off| off <= offset) {
         offsets = offsets.split_off(pos);
     }
-    let next_offset = offsets.first().cloned().unwrap_or(offset);
     let segments = Segments {
         offs: offsets.into_iter(),
         repo,
@@ -315,7 +314,7 @@ pub fn commits_from<R: Repo>(repo: R, max_log_format_version: u8, offset: u64) -
     Ok(Commits {
         inner: None,
         segments,
-        last_commit: CommitInfo::Initial { next_offset },
+        last_commit: CommitInfo::Initial { next_offset: offset },
         last_error: None,
     })
 }
@@ -359,10 +358,9 @@ where
 {
     commits
         .map(|x| x.map_err(D::Error::from))
-        .map_ok(move |(version, commit)| commit.into_transactions(version, de))
+        .map_ok(move |(version, commit)| commit.into_transactions(version, offset, de))
         .flatten_ok()
         .map(|x| x.and_then(|y| y))
-        .skip_while(move |x| x.as_ref().map(|tx| tx.offset < offset).unwrap_or(false))
 }
 
 fn fold_transactions_internal<R, D>(mut commits: CommitsWithVersion<R>, de: D, from: u64) -> Result<(), D::Error>
@@ -507,48 +505,75 @@ impl<R: Repo> Commits<R> {
         CommitsWithVersion { inner: self }
     }
 
-    /// Helper to handle a successfully extracted commit in [`Self::next`].
+    /// Advance the current-segment iterator to yield the next commit.
     ///
-    /// Checks that the offset sequence is contiguous.
-    fn next_commit(&mut self, commit: StoredCommit) -> Option<Result<StoredCommit, error::Traversal>> {
-        // Pop the last error. Either we'll return it below, or it's no longer
-        // interesting.
-        let prev_error = self.last_error.take();
+    /// Checks that the offset sequence is contiguous, and may skip commits
+    /// until the requested offset.
+    ///
+    /// Returns `None` if the segment iterator is exhausted or returns an error.
+    fn next_commit(&mut self) -> Option<Result<StoredCommit, error::Traversal>> {
+        loop {
+            match self.inner.as_mut()?.next()? {
+                Ok(commit) => {
+                    // Pop the last error. Either we'll return it below, or it's no longer
+                    // interesting.
+                    let prev_error = self.last_error.take();
 
-        // Skip entries before the initial commit.
-        if self.last_commit.adjust_initial_offset(&commit) {
-            self.next()
-        // Same offset: ignore if duplicate (same crc), else report a "fork".
-        } else if self.last_commit.same_offset_as(&commit) {
-            if !self.last_commit.same_checksum_as(&commit) {
-                warn!(
-                    "forked: commit={:?} last-error={:?} last-crc={:?}",
-                    commit,
-                    prev_error,
-                    self.last_commit.checksum()
-                );
-                Some(Err(error::Traversal::Forked {
-                    offset: commit.min_tx_offset,
-                }))
-            } else {
-                self.next()
+                    // Skip entries before the initial commit.
+                    if self.last_commit.adjust_initial_offset(&commit) {
+                        trace!("adjust initial offset");
+                        continue;
+                    // Same offset: ignore if duplicate (same crc), else report a "fork".
+                    } else if self.last_commit.same_offset_as(&commit) {
+                        if !self.last_commit.same_checksum_as(&commit) {
+                            warn!(
+                                "forked: commit={:?} last-error={:?} last-crc={:?}",
+                                commit,
+                                prev_error,
+                                self.last_commit.checksum()
+                            );
+                            return Some(Err(error::Traversal::Forked {
+                                offset: commit.min_tx_offset,
+                            }));
+                        } else {
+                            trace!("ignore duplicate");
+                            continue;
+                        }
+                    // Not the expected offset: report out-of-order.
+                    } else if self.last_commit.expected_offset() != &commit.min_tx_offset {
+                        warn!("out-of-order: commit={:?} last-error={:?}", commit, prev_error);
+                        return Some(Err(error::Traversal::OutOfOrder {
+                            expected_offset: *self.last_commit.expected_offset(),
+                            actual_offset: commit.min_tx_offset,
+                            prev_error: prev_error.map(Box::new),
+                        }));
+                    // Seems legit, record info.
+                    } else {
+                        self.last_commit = CommitInfo::LastSeen {
+                            tx_range: commit.tx_range(),
+                            checksum: commit.checksum,
+                        };
+
+                        return Some(Ok(commit));
+                    }
+                }
+
+                Err(e) => {
+                    warn!("error reading next commit: {e}");
+                    // Stop traversing this segment here.
+                    //
+                    // If this is just a partial write at the end of the segment,
+                    // we may be able to obtain a commit with right offset from
+                    // the next segment.
+                    //
+                    // If we don't, the error here is likely more helpful, but
+                    // would be clobbered by `OutOfOrder`. Therefore we store it
+                    // here.
+                    self.set_last_error(e);
+
+                    return None;
+                }
             }
-        // Not the expected offset: report out-of-order.
-        } else if self.last_commit.expected_offset() != &commit.min_tx_offset {
-            warn!("out-of-order: commit={:?} last-error={:?}", commit, prev_error);
-            Some(Err(error::Traversal::OutOfOrder {
-                expected_offset: *self.last_commit.expected_offset(),
-                actual_offset: commit.min_tx_offset,
-                prev_error: prev_error.map(Box::new),
-            }))
-        // Seems legit, record info.
-        } else {
-            self.last_commit = CommitInfo::LastSeen {
-                tx_range: commit.tx_range(),
-                checksum: commit.checksum,
-            };
-
-            Some(Ok(commit))
         }
     }
 
@@ -569,31 +594,33 @@ impl<R: Repo> Commits<R> {
         };
         self.last_error = Some(last_error);
     }
+
+    /// If we're still looking for the initial commit, try to use the offset
+    /// index to advance the segment reader.
+    fn try_seek_to_initial_offset(&self, segment: &mut segment::Reader<R::Segment>) {
+        if let CommitInfo::Initial { next_offset } = &self.last_commit {
+            let _ = self
+                .segments
+                .repo
+                .get_offset_index(segment.min_tx_offset)
+                .map_err(Into::into)
+                .and_then(|index_file| segment.seek_to_offset(&index_file, *next_offset))
+                .inspect_err(|e| {
+                    warn!(
+                        "commitlog offset index is not used at segment {}: {}",
+                        segment.min_tx_offset, e
+                    );
+                });
+        }
+    }
 }
 
 impl<R: Repo> Iterator for Commits<R> {
     type Item = Result<StoredCommit, error::Traversal>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        if let Some(commits) = self.inner.as_mut() {
-            if let Some(commit) = commits.next() {
-                match commit {
-                    Ok(commit) => return self.next_commit(commit),
-                    Err(e) => {
-                        warn!("error reading next commit: {e}");
-                        // Fall through to peek at next segment.
-                        //
-                        // If this is just a partial write at the end of a
-                        // segment, we may be able to obtain a commit with the
-                        // right offset from the next segment.
-                        //
-                        // However, the error here may be more helpful and would
-                        // be clobbered by `OutOfOrder`, and so we store it
-                        // until we recurse below.
-                        self.set_last_error(e);
-                    }
-                }
-            }
+        if let Some(item) = self.next_commit() {
+            return Some(item);
         }
 
         match self.segments.next() {
@@ -602,22 +629,7 @@ impl<R: Repo> Iterator for Commits<R> {
             Some(segment) => segment.map_or_else(
                 |e| Some(Err(e.into())),
                 |mut segment| {
-                    // Try to use offset index to advance segment to Intial commit
-                    if let CommitInfo::Initial { next_offset } = self.last_commit {
-                        let _ = self
-                            .segments
-                            .repo
-                            .get_offset_index(segment.min_tx_offset)
-                            .map_err(Into::into)
-                            .and_then(|index_file| segment.seek_to_offset(&index_file, next_offset))
-                            .inspect_err(|e| {
-                                warn!(
-                                    "commitlog offset index is not used: {}, at: segment {}",
-                                    e, segment.min_tx_offset
-                                );
-                            });
-                    }
-
+                    self.try_seek_to_initial_offset(&mut segment);
                     self.inner = Some(segment.commits());
                     self.next()
                 },

--- a/crates/commitlog/src/payload.rs
+++ b/crates/commitlog/src/payload.rs
@@ -124,7 +124,6 @@ impl<const N: usize> Decoder for ArrayDecoder<N> {
         tx_offset: u64,
         reader: &mut R,
     ) -> Result<(), Self::Error> {
-        self.decode_record(version, tx_offset, reader)?;
-        Ok(())
+        self.decode_record(version, tx_offset, reader).map(drop)
     }
 }

--- a/crates/commitlog/src/segment.rs
+++ b/crates/commitlog/src/segment.rs
@@ -353,9 +353,12 @@ impl<R: io::Read + io::Seek> Reader<R> {
         self.commits()
             .with_log_format_version()
             .map(|x| x.map_err(Into::into))
-            .map_ok(move |(version, commit)| commit.into_transactions(version, de))
+            .map_ok(move |(version, commit)| {
+                let start = commit.min_tx_offset;
+                commit.into_transactions(version, start, de)
+            })
             .flatten_ok()
-            .flatten_ok()
+            .map(|x| x.and_then(|y| y))
     }
 
     #[cfg(test)]


### PR DESCRIPTION
The `*_from` style traversals have historically yielded commits or transactions before the given from-offset, leaving it to downstream consumers to handle skipping.

While folding handles it internally, this behavior is not great for transaction iterators, due to the statefulness of decoding -- it is usually necessary to call `Decoder::skip_record` until the desired offset is found.

We would also yield all commits from the start of the nearest segment boundary, which can be quite confusing when using the commit iterators directly.

This patch fixes the situation by:

* Setting the desired offset as the inital next offset in the `Commits` iterator, instead of the nearest segment boundary.
* Looping instead of recursing in the `Commits` iterator while skipping commits, so we can skip until the initial offset without blowing the stack.
* Passing the desired offset to `Commit::into_transactions`, such that `Decoder::skip_record` can be called if the offset doesn't lie on the commit boundary.


# Expected complexity level and risk

2.5 -- makes head spin


**NOTE**: On top of #1901, because tooling work depends on the whole series