### PR TITLE
feat: Add non-unique index join iterator

### DIFF
--- a/crates/execution/Cargo.toml
+++ b/crates/execution/Cargo.toml
@@ -7,6 +7,6 @@ license-file = "LICENSE"
 description = "The SpacetimeDB query engine"
 
 [dependencies]
-spacetimedb-lib.workspace = true
 spacetimedb-expr.workspace = true
+spacetimedb-lib.workspace = true
 spacetimedb-table.workspace = true


### PR DESCRIPTION
* Adds a non-unique (constraint) index join iterator
* Abstracts over index key projections in order to reuse code between unique and non-unique index joins