### PR TITLE
Don't redownload WASI SDK

### DIFF
--- a/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
+++ b/crates/bindings-csharp/Runtime/build/SpacetimeDB.Runtime.targets
@@ -56,7 +56,7 @@
             SourceUrl="$(WasiSdkUrl)"
             DestinationFolder="$(IntermediateOutputPath)"
             DestinationFileName="$([System.IO.Path]::GetFileName('$(WasiSdkDownloadTempFile)'))"
-            Condition="!Exists('$(WasiSdkDownloadTempFile)')" />
+            Condition="!Exists('$(WasiClang)')" />
 
     <Message Importance="high" Text="Extracting $(WasiSdkDownloadTempFile) to $(WasiSdkRoot)..." Condition="!Exists('$(WasiClang)')" />
     <MakeDir Directories="$(WasiSdkRoot)" />


### PR DESCRIPTION
# Description of Changes

The condition should be looking at the globally extracted WASI SDK, not at the temporary local archive.

This fixes an issue where WASI SDK would be redownloaded anew on new projects, even though it's supposed to be installed only once globally.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
