### PR TITLE
Fix Find() with struct-based rows

### DIFF
--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/ExtraCompilationErrors.verified.txt
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/ExtraCompilationErrors.verified.txt
@@ -184,6 +184,259 @@ internal static readonly SpacetimeDB.BSATN.IReadWrite<System.Exception> Unsuppor
     }
   },
   {/*
+
+    public sealed class TestUniqueNotEquatableUniqueIndex : UniqueIndex<TestUniqueNotEquatable, global::TestUniqueNotEquatable, int?, SpacetimeDB.BSATN.ValueOption<int, SpacetimeDB.BSATN.I32>> {
+                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_UniqueField_unique") {}
+*/
+    Message: Partial declarations of 'TestUniqueNotEquatable.TestUniqueNotEquatableUniqueIndex' must not specify different base classes,
+    Severity: Error,
+    Descriptor: {
+      Id: CS0263,
+      Title: ,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0263),
+      MessageFormat: Partial declarations of '{0}' must not specify different base classes,
+      Category: Compiler,
+      DefaultSeverity: Error,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        NotConfigurable
+      ]
+    }
+  },
+  {/*
+    public sealed class TestUniqueNotEquatableUniqueIndex : UniqueIndex<TestUniqueNotEquatable, global::TestUniqueNotEquatable, int?, SpacetimeDB.BSATN.ValueOption<int, SpacetimeDB.BSATN.I32>> {
+    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_UniqueField_unique") {}
+                                                                                ^^^^
+    // Important: don't move this to the base class.
+*/
+    Message: 'UniqueIndex<TestUniqueNotEquatable, TestUniqueNotEquatable, int?, ValueOption<int, I32>>.UniqueIndex(TestUniqueNotEquatable, string)' is inaccessible due to its protection level,
+    Severity: Error,
+    Descriptor: {
+      Id: CS0122,
+      Title: ,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0122),
+      MessageFormat: '{0}' is inaccessible due to its protection level,
+      Category: Compiler,
+      DefaultSeverity: Error,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        NotConfigurable
+      ]
+    }
+  },
+  {/*
+    // `globalName` in one generic definition, leading to buggy `Row?` expansion for either one or another.
+    public global::TestUniqueNotEquatable? Find(int? key) => DoFilter(key).Cast<global::TestUniqueNotEquatable?>().SingleOrDefault();
+                                                             ^^^^^^^^
+    public bool Update(global::TestUniqueNotEquatable row) => DoUpdate(row.UniqueField, row);
+*/
+    Message: The name 'DoFilter' does not exist in the current context,
+    Severity: Error,
+    Descriptor: {
+      Id: CS0103,
+      Title: ,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0103),
+      MessageFormat: The name '{0}' does not exist in the current context,
+      Category: Compiler,
+      DefaultSeverity: Error,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        NotConfigurable
+      ]
+    }
+  },
+  {/*
+    public global::TestUniqueNotEquatable? Find(int? key) => DoFilter(key).Cast<global::TestUniqueNotEquatable?>().SingleOrDefault();
+    public bool Update(global::TestUniqueNotEquatable row) => DoUpdate(row.UniqueField, row);
+                                                              ^^^^^^^^
+}
+*/
+    Message: The name 'DoUpdate' does not exist in the current context,
+    Severity: Error,
+    Descriptor: {
+      Id: CS0103,
+      Title: ,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0103),
+      MessageFormat: The name '{0}' does not exist in the current context,
+      Category: Compiler,
+      DefaultSeverity: Error,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        NotConfigurable
+      ]
+    }
+  },
+  {/*
+}
+public TestUniqueNotEquatableUniqueIndex UniqueField => new(this);
+                                                        ^^^^^^^^^
+public sealed class TestUniqueNotEquatableUniqueIndex : UniqueIndex<TestUniqueNotEquatable, global::TestUniqueNotEquatable, TestEnumWithExplicitValues, SpacetimeDB.BSATN.Enum<TestEnumWithExplicitValues>> {
+*/
+    Message: The call is ambiguous between the following methods or properties: 'TestUniqueNotEquatable.TestUniqueNotEquatableUniqueIndex.TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable)' and 'TestUniqueNotEquatable.TestUniqueNotEquatableUniqueIndex.TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable)',
+    Severity: Error,
+    Descriptor: {
+      Id: CS0121,
+      Title: ,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0121),
+      MessageFormat: The call is ambiguous between the following methods or properties: '{0}' and '{1}',
+      Category: Compiler,
+      DefaultSeverity: Error,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        NotConfigurable
+      ]
+    }
+  },
+  {/*
+public TestUniqueNotEquatableUniqueIndex UniqueField => new(this);
+public sealed class TestUniqueNotEquatableUniqueIndex : UniqueIndex<TestUniqueNotEquatable, global::TestUniqueNotEquatable, TestEnumWithExplicitValues, SpacetimeDB.BSATN.Enum<TestEnumWithExplicitValues>> {
+                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_PrimaryKeyField_unique") {}
+*/
+    Message: The type 'TestUniqueNotEquatable' already contains a definition for 'TestUniqueNotEquatableUniqueIndex',
+    Severity: Error,
+    Descriptor: {
+      Id: CS0102,
+      Title: ,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0102),
+      MessageFormat: The type '{0}' already contains a definition for '{1}',
+      Category: Compiler,
+      DefaultSeverity: Error,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        NotConfigurable
+      ]
+    }
+  },
+  {/*
+public sealed class TestUniqueNotEquatableUniqueIndex : UniqueIndex<TestUniqueNotEquatable, global::TestUniqueNotEquatable, TestEnumWithExplicitValues, SpacetimeDB.BSATN.Enum<TestEnumWithExplicitValues>> {
+    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_PrimaryKeyField_unique") {}
+             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    // Important: don't move this to the base class.
+*/
+    Message: Type 'TestUniqueNotEquatable.TestUniqueNotEquatableUniqueIndex' already defines a member called 'TestUniqueNotEquatableUniqueIndex' with the same parameter types,
+    Severity: Error,
+    Descriptor: {
+      Id: CS0111,
+      Title: ,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0111),
+      MessageFormat: Type '{1}' already defines a member called '{0}' with the same parameter types,
+      Category: Compiler,
+      DefaultSeverity: Error,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        NotConfigurable
+      ]
+    }
+  },
+  {/*
+public sealed class TestUniqueNotEquatableUniqueIndex : UniqueIndex<TestUniqueNotEquatable, global::TestUniqueNotEquatable, TestEnumWithExplicitValues, SpacetimeDB.BSATN.Enum<TestEnumWithExplicitValues>> {
+    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_PrimaryKeyField_unique") {}
+                                                                                ^^^^
+    // Important: don't move this to the base class.
+*/
+    Message: 'UniqueIndex<TestUniqueNotEquatable, TestUniqueNotEquatable, int?, ValueOption<int, I32>>.UniqueIndex(TestUniqueNotEquatable, string)' is inaccessible due to its protection level,
+    Severity: Error,
+    Descriptor: {
+      Id: CS0122,
+      Title: ,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0122),
+      MessageFormat: '{0}' is inaccessible due to its protection level,
+      Category: Compiler,
+      DefaultSeverity: Error,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        NotConfigurable
+      ]
+    }
+  },
+  {/*
+    // `globalName` in one generic definition, leading to buggy `Row?` expansion for either one or another.
+    public global::TestUniqueNotEquatable? Find(TestEnumWithExplicitValues key) => DoFilter(key).Cast<global::TestUniqueNotEquatable?>().SingleOrDefault();
+                                                                                   ^^^^^^^^
+    public bool Update(global::TestUniqueNotEquatable row) => DoUpdate(row.PrimaryKeyField, row);
+*/
+    Message: The name 'DoFilter' does not exist in the current context,
+    Severity: Error,
+    Descriptor: {
+      Id: CS0103,
+      Title: ,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0103),
+      MessageFormat: The name '{0}' does not exist in the current context,
+      Category: Compiler,
+      DefaultSeverity: Error,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        NotConfigurable
+      ]
+    }
+  },
+  {/*
+    public global::TestUniqueNotEquatable? Find(TestEnumWithExplicitValues key) => DoFilter(key).Cast<global::TestUniqueNotEquatable?>().SingleOrDefault();
+    public bool Update(global::TestUniqueNotEquatable row) => DoUpdate(row.PrimaryKeyField, row);
+                ^^^^^^
+}
+*/
+    Message: Type 'TestUniqueNotEquatable.TestUniqueNotEquatableUniqueIndex' already defines a member called 'Update' with the same parameter types,
+    Severity: Error,
+    Descriptor: {
+      Id: CS0111,
+      Title: ,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0111),
+      MessageFormat: Type '{1}' already defines a member called '{0}' with the same parameter types,
+      Category: Compiler,
+      DefaultSeverity: Error,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        NotConfigurable
+      ]
+    }
+  },
+  {/*
+    public global::TestUniqueNotEquatable? Find(TestEnumWithExplicitValues key) => DoFilter(key).Cast<global::TestUniqueNotEquatable?>().SingleOrDefault();
+    public bool Update(global::TestUniqueNotEquatable row) => DoUpdate(row.PrimaryKeyField, row);
+                                                              ^^^^^^^^
+}
+*/
+    Message: The name 'DoUpdate' does not exist in the current context,
+    Severity: Error,
+    Descriptor: {
+      Id: CS0103,
+      Title: ,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0103),
+      MessageFormat: The name '{0}' does not exist in the current context,
+      Category: Compiler,
+      DefaultSeverity: Error,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        NotConfigurable
+      ]
+    }
+  },
+  {/*
 }
 public TestUniqueNotEquatableUniqueIndex PrimaryKeyField => new(this);
                                                             ^^^^^^^^^
@@ -541,213 +794,6 @@ public readonly struct TestTableTaggedEnum : SpacetimeDB.Internal.ITableView<Tes
       Title: ,
       HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0310),
       MessageFormat: '{2}' must be a non-abstract type with a public parameterless constructor in order to use it as parameter '{1}' in the generic type or method '{0}',
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
-  },
-  {/*
-
-    public sealed class TestUniqueNotEquatableUniqueIndex : UniqueIndex<TestUniqueNotEquatable, global::TestUniqueNotEquatable, int?, SpacetimeDB.BSATN.ValueOption<int, SpacetimeDB.BSATN.I32>> {
-                        ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_UniqueField_unique") {}
-*/
-    Message: Partial declarations of 'TestUniqueNotEquatable.TestUniqueNotEquatableUniqueIndex' must not specify different base classes,
-    Severity: Error,
-    Descriptor: {
-      Id: CS0263,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0263),
-      MessageFormat: Partial declarations of '{0}' must not specify different base classes,
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
-  },
-  {/*
-    public sealed class TestUniqueNotEquatableUniqueIndex : UniqueIndex<TestUniqueNotEquatable, global::TestUniqueNotEquatable, int?, SpacetimeDB.BSATN.ValueOption<int, SpacetimeDB.BSATN.I32>> {
-    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_UniqueField_unique") {}
-                                                                                ^^^^
-    public bool Update(global::TestUniqueNotEquatable row) => DoUpdate(row.UniqueField, row);
-*/
-    Message: 'UniqueIndex<TestUniqueNotEquatable, TestUniqueNotEquatable, int?, ValueOption<int, I32>>.UniqueIndex(TestUniqueNotEquatable, string)' is inaccessible due to its protection level,
-    Severity: Error,
-    Descriptor: {
-      Id: CS0122,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0122),
-      MessageFormat: '{0}' is inaccessible due to its protection level,
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
-  },
-  {/*
-    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_UniqueField_unique") {}
-    public bool Update(global::TestUniqueNotEquatable row) => DoUpdate(row.UniqueField, row);
-                                                              ^^^^^^^^
-}
-*/
-    Message: The name 'DoUpdate' does not exist in the current context,
-    Severity: Error,
-    Descriptor: {
-      Id: CS0103,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0103),
-      MessageFormat: The name '{0}' does not exist in the current context,
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
-  },
-  {/*
-}
-public TestUniqueNotEquatableUniqueIndex UniqueField => new(this);
-                                                        ^^^^^^^^^
-public sealed class TestUniqueNotEquatableUniqueIndex : UniqueIndex<TestUniqueNotEquatable, global::TestUniqueNotEquatable, TestEnumWithExplicitValues, SpacetimeDB.BSATN.Enum<TestEnumWithExplicitValues>> {
-*/
-    Message: The call is ambiguous between the following methods or properties: 'TestUniqueNotEquatable.TestUniqueNotEquatableUniqueIndex.TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable)' and 'TestUniqueNotEquatable.TestUniqueNotEquatableUniqueIndex.TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable)',
-    Severity: Error,
-    Descriptor: {
-      Id: CS0121,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0121),
-      MessageFormat: The call is ambiguous between the following methods or properties: '{0}' and '{1}',
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
-  },
-  {/*
-public TestUniqueNotEquatableUniqueIndex UniqueField => new(this);
-public sealed class TestUniqueNotEquatableUniqueIndex : UniqueIndex<TestUniqueNotEquatable, global::TestUniqueNotEquatable, TestEnumWithExplicitValues, SpacetimeDB.BSATN.Enum<TestEnumWithExplicitValues>> {
-                    ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_PrimaryKeyField_unique") {}
-*/
-    Message: The type 'TestUniqueNotEquatable' already contains a definition for 'TestUniqueNotEquatableUniqueIndex',
-    Severity: Error,
-    Descriptor: {
-      Id: CS0102,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0102),
-      MessageFormat: The type '{0}' already contains a definition for '{1}',
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
-  },
-  {/*
-public sealed class TestUniqueNotEquatableUniqueIndex : UniqueIndex<TestUniqueNotEquatable, global::TestUniqueNotEquatable, TestEnumWithExplicitValues, SpacetimeDB.BSATN.Enum<TestEnumWithExplicitValues>> {
-    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_PrimaryKeyField_unique") {}
-             ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
-    public bool Update(global::TestUniqueNotEquatable row) => DoUpdate(row.PrimaryKeyField, row);
-*/
-    Message: Type 'TestUniqueNotEquatable.TestUniqueNotEquatableUniqueIndex' already defines a member called 'TestUniqueNotEquatableUniqueIndex' with the same parameter types,
-    Severity: Error,
-    Descriptor: {
-      Id: CS0111,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0111),
-      MessageFormat: Type '{1}' already defines a member called '{0}' with the same parameter types,
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
-  },
-  {/*
-public sealed class TestUniqueNotEquatableUniqueIndex : UniqueIndex<TestUniqueNotEquatable, global::TestUniqueNotEquatable, TestEnumWithExplicitValues, SpacetimeDB.BSATN.Enum<TestEnumWithExplicitValues>> {
-    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_PrimaryKeyField_unique") {}
-                                                                                ^^^^
-    public bool Update(global::TestUniqueNotEquatable row) => DoUpdate(row.PrimaryKeyField, row);
-*/
-    Message: 'UniqueIndex<TestUniqueNotEquatable, TestUniqueNotEquatable, int?, ValueOption<int, I32>>.UniqueIndex(TestUniqueNotEquatable, string)' is inaccessible due to its protection level,
-    Severity: Error,
-    Descriptor: {
-      Id: CS0122,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0122),
-      MessageFormat: '{0}' is inaccessible due to its protection level,
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
-  },
-  {/*
-    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_PrimaryKeyField_unique") {}
-    public bool Update(global::TestUniqueNotEquatable row) => DoUpdate(row.PrimaryKeyField, row);
-                ^^^^^^
-}
-*/
-    Message: Type 'TestUniqueNotEquatable.TestUniqueNotEquatableUniqueIndex' already defines a member called 'Update' with the same parameter types,
-    Severity: Error,
-    Descriptor: {
-      Id: CS0111,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0111),
-      MessageFormat: Type '{1}' already defines a member called '{0}' with the same parameter types,
-      Category: Compiler,
-      DefaultSeverity: Error,
-      IsEnabledByDefault: true,
-      CustomTags: [
-        Compiler,
-        Telemetry,
-        NotConfigurable
-      ]
-    }
-  },
-  {/*
-    internal TestUniqueNotEquatableUniqueIndex(TestUniqueNotEquatable handle) : base(handle, "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_PrimaryKeyField_unique") {}
-    public bool Update(global::TestUniqueNotEquatable row) => DoUpdate(row.PrimaryKeyField, row);
-                                                              ^^^^^^^^
-}
-*/
-    Message: The name 'DoUpdate' does not exist in the current context,
-    Severity: Error,
-    Descriptor: {
-      Id: CS0103,
-      Title: ,
-      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS0103),
-      MessageFormat: The name '{0}' does not exist in the current context,
       Category: Compiler,
       DefaultSeverity: Error,
       IsEnabledByDefault: true,

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#FFI.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#FFI.verified.cs
@@ -92,6 +92,12 @@ namespace SpacetimeDB
                         "idx_TestAutoIncNotInteger_TestAutoIncNotInteger_IdentityField_unique"
                     ) { }
 
+                // Important: don't move this to the base class.
+                // C# generics don't play well with nullable types and can't accept both struct-type-based and class-type-based
+                // `globalName` in one generic definition, leading to buggy `Row?` expansion for either one or another.
+                public global::TestAutoIncNotInteger? Find(string key) =>
+                    DoFilter(key).Cast<global::TestAutoIncNotInteger?>().SingleOrDefault();
+
                 public bool Update(global::TestAutoIncNotInteger row) =>
                     DoUpdate(row.IdentityField, row);
             }
@@ -196,6 +202,12 @@ namespace SpacetimeDB
                         "idx_TestIncompatibleSchedule1_TestIncompatibleSchedule1_ScheduledId_unique"
                     ) { }
 
+                // Important: don't move this to the base class.
+                // C# generics don't play well with nullable types and can't accept both struct-type-based and class-type-based
+                // `globalName` in one generic definition, leading to buggy `Row?` expansion for either one or another.
+                public global::TestIncompatibleSchedule? Find(ulong key) =>
+                    DoFilter(key).Cast<global::TestIncompatibleSchedule?>().SingleOrDefault();
+
                 public bool Update(global::TestIncompatibleSchedule row) =>
                     DoUpdate(row.ScheduledId, row);
             }
@@ -260,6 +272,12 @@ namespace SpacetimeDB
                         handle,
                         "idx_TestIncompatibleSchedule2_TestIncompatibleSchedule2_ScheduledId_unique"
                     ) { }
+
+                // Important: don't move this to the base class.
+                // C# generics don't play well with nullable types and can't accept both struct-type-based and class-type-based
+                // `globalName` in one generic definition, leading to buggy `Row?` expansion for either one or another.
+                public global::TestIncompatibleSchedule? Find(ulong key) =>
+                    DoFilter(key).Cast<global::TestIncompatibleSchedule?>().SingleOrDefault();
 
                 public bool Update(global::TestIncompatibleSchedule row) =>
                     DoUpdate(row.ScheduledId, row);
@@ -356,6 +374,12 @@ namespace SpacetimeDB
                         "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_UniqueField_unique"
                     ) { }
 
+                // Important: don't move this to the base class.
+                // C# generics don't play well with nullable types and can't accept both struct-type-based and class-type-based
+                // `globalName` in one generic definition, leading to buggy `Row?` expansion for either one or another.
+                public global::TestUniqueNotEquatable? Find(int? key) =>
+                    DoFilter(key).Cast<global::TestUniqueNotEquatable?>().SingleOrDefault();
+
                 public bool Update(global::TestUniqueNotEquatable row) =>
                     DoUpdate(row.UniqueField, row);
             }
@@ -375,6 +399,12 @@ namespace SpacetimeDB
                         handle,
                         "idx_TestUniqueNotEquatable_TestUniqueNotEquatable_PrimaryKeyField_unique"
                     ) { }
+
+                // Important: don't move this to the base class.
+                // C# generics don't play well with nullable types and can't accept both struct-type-based and class-type-based
+                // `globalName` in one generic definition, leading to buggy `Row?` expansion for either one or another.
+                public global::TestUniqueNotEquatable? Find(TestEnumWithExplicitValues key) =>
+                    DoFilter(key).Cast<global::TestUniqueNotEquatable?>().SingleOrDefault();
 
                 public bool Update(global::TestUniqueNotEquatable row) =>
                     DoUpdate(row.PrimaryKeyField, row);

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#FFI.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#FFI.verified.cs
@@ -219,6 +219,12 @@ namespace SpacetimeDB
                 internal BTreeViewsUniqueIndex(BTreeViews handle)
                     : base(handle, "idx_BTreeViews_BTreeViews_Id_unique") { }
 
+                // Important: don't move this to the base class.
+                // C# generics don't play well with nullable types and can't accept both struct-type-based and class-type-based
+                // `globalName` in one generic definition, leading to buggy `Row?` expansion for either one or another.
+                public global::BTreeViews? Find(SpacetimeDB.Identity key) =>
+                    DoFilter(key).Cast<global::BTreeViews?>().SingleOrDefault();
+
                 public bool Update(global::BTreeViews row) => DoUpdate(row.Id, row);
             }
 
@@ -358,6 +364,12 @@ namespace SpacetimeDB
                 internal MultiTable1UniqueIndex(MultiTable1 handle)
                     : base(handle, "idx_MultiTable1_MultiTable1_Foo_unique") { }
 
+                // Important: don't move this to the base class.
+                // C# generics don't play well with nullable types and can't accept both struct-type-based and class-type-based
+                // `globalName` in one generic definition, leading to buggy `Row?` expansion for either one or another.
+                public global::MultiTableRow? Find(uint key) =>
+                    DoFilter(key).Cast<global::MultiTableRow?>().SingleOrDefault();
+
                 public bool Update(global::MultiTableRow row) => DoUpdate(row.Foo, row);
             }
 
@@ -431,6 +443,12 @@ namespace SpacetimeDB
                 internal MultiTable2UniqueIndex(MultiTable2 handle)
                     : base(handle, "idx_MultiTable2_MultiTable2_Bar_unique") { }
 
+                // Important: don't move this to the base class.
+                // C# generics don't play well with nullable types and can't accept both struct-type-based and class-type-based
+                // `globalName` in one generic definition, leading to buggy `Row?` expansion for either one or another.
+                public global::MultiTableRow? Find(uint key) =>
+                    DoFilter(key).Cast<global::MultiTableRow?>().SingleOrDefault();
+
                 public bool Update(global::MultiTableRow row) => DoUpdate(row.Bar, row);
             }
 
@@ -494,6 +512,12 @@ namespace SpacetimeDB
                 internal PublicTableUniqueIndex(PublicTable handle)
                     : base(handle, "idx_PublicTable_PublicTable_Id_unique") { }
 
+                // Important: don't move this to the base class.
+                // C# generics don't play well with nullable types and can't accept both struct-type-based and class-type-based
+                // `globalName` in one generic definition, leading to buggy `Row?` expansion for either one or another.
+                public global::PublicTable? Find(int key) =>
+                    DoFilter(key).Cast<global::PublicTable?>().SingleOrDefault();
+
                 public bool Update(global::PublicTable row) => DoUpdate(row.Id, row);
             }
 
@@ -551,6 +575,12 @@ namespace SpacetimeDB
             {
                 internal SendMessageTimerUniqueIndex(SendMessageTimer handle)
                     : base(handle, "idx_SendMessageTimer_SendMessageTimer_ScheduledId_unique") { }
+
+                // Important: don't move this to the base class.
+                // C# generics don't play well with nullable types and can't accept both struct-type-based and class-type-based
+                // `globalName` in one generic definition, leading to buggy `Row?` expansion for either one or another.
+                public global::Timers.SendMessageTimer? Find(ulong key) =>
+                    DoFilter(key).Cast<global::Timers.SendMessageTimer?>().SingleOrDefault();
 
                 public bool Update(global::Timers.SendMessageTimer row) =>
                     DoUpdate(row.ScheduledId, row);

--- a/crates/bindings-csharp/Runtime/Attrs.cs
+++ b/crates/bindings-csharp/Runtime/Attrs.cs
@@ -76,11 +76,6 @@
         internal override Internal.ColumnAttrs Mask => Internal.ColumnAttrs.Unique;
     }
 
-    public sealed class IndexedAttribute : Internal.ColumnAttribute
-    {
-        internal override Internal.ColumnAttrs Mask => Internal.ColumnAttrs.Indexed;
-    }
-
     public enum ReducerKind
     {
         /// <summary>

--- a/crates/bindings-csharp/Runtime/Internal/IIndex.cs
+++ b/crates/bindings-csharp/Runtime/Internal/IIndex.cs
@@ -92,7 +92,7 @@ public abstract class UniqueIndex<Handle, Row, T, RW>(Handle table, string name)
 {
     private static BTreeIndexBounds<T, RW> ToBounds(T key) => new(key);
 
-    public Row? Find(T key) => DoFilter(ToBounds(key)).Cast<Row?>().SingleOrDefault();
+    protected IEnumerable<Row> DoFilter(T key) => DoFilter(ToBounds(key));
 
     public bool Delete(T key) => DoDelete(ToBounds(key)) > 0;
 

--- a/crates/bindings-csharp/Runtime/Internal/IIndex.cs
+++ b/crates/bindings-csharp/Runtime/Internal/IIndex.cs
@@ -1,7 +1,6 @@
 ﻿namespace SpacetimeDB.Internal;
 
 using System;
-using System.Linq;
 
 public abstract class IndexBase<Row>
     where Row : ITable<Row>, new()

--- a/crates/schema/tests/validate_integration.rs
+++ b/crates/schema/tests/validate_integration.rs
@@ -70,4 +70,5 @@ fn validate_cs_modules() {
     validate_module("sdk-test-cs");
     validate_module("sdk-test-connect-disconnect-cs");
     validate_module("spacetimedb-quickstart-cs");
+    validate_module("benchmarks-cs");
 }

--- a/modules/benchmarks-cs/ia_loop.cs
+++ b/modules/benchmarks-cs/ia_loop.cs
@@ -4,7 +4,7 @@ namespace Benchmarks;
 
 public static partial class ia_loop
 {
-    [SpacetimeDB.Table]
+    [SpacetimeDB.Table(Name = "velocity")]
     public partial struct Velocity(uint entity_id, float x, float y, float z)
     {
         [PrimaryKey]
@@ -14,7 +14,7 @@ public static partial class ia_loop
         public float z = z;
     }
 
-    [SpacetimeDB.Table]
+    [SpacetimeDB.Table(Name = "position")]
     public partial struct Position(uint entity_id, float x, float y, float z)
     {
         [PrimaryKey]
@@ -44,7 +44,7 @@ public static partial class ia_loop
         Fighting,
     }
 
-    [SpacetimeDB.Table]
+    [SpacetimeDB.Table(Name = "game_enemy_ai_agent_state")]
     public partial struct GameEnemyAiAgentState(
         ulong entity_id,
         List<ulong> last_move_timestamps,
@@ -59,25 +59,28 @@ public static partial class ia_loop
         public AgentAction action = action;
     }
 
-    [SpacetimeDB.Table]
+    [SpacetimeDB.Table(Name = "game_targetable_state")]
+    [SpacetimeDB.Index(BTree = [nameof(quad)])]
     public partial struct GameTargetableState(ulong entity_id, long quad)
     {
         [PrimaryKey]
         public ulong entity_id = entity_id;
+
         public long quad = quad;
     }
 
-    [SpacetimeDB.Table]
+    [SpacetimeDB.Table(Name = "game_live_targetable_state")]
+    [SpacetimeDB.Index(BTree = [nameof(quad)])]
     public partial struct GameLiveTargetableState(ulong entity_id, long quad)
     {
         [Unique]
         public ulong entity_id = entity_id;
 
-        [Indexed]
         public long quad = quad;
     }
 
-    [SpacetimeDB.Table]
+    [SpacetimeDB.Table(Name = "game_mobile_entity_state")]
+    [SpacetimeDB.Index(BTree = [nameof(location_x)])]
     public partial struct GameMobileEntityState(
         ulong entity_id,
         int location_x,
@@ -88,13 +91,12 @@ public static partial class ia_loop
         [PrimaryKey]
         public ulong entity_id = entity_id;
 
-        [Indexed]
         public int location_x = location_x;
         public int location_y = location_y;
         public ulong timestamp = timestamp;
     }
 
-    [SpacetimeDB.Table]
+    [SpacetimeDB.Table(Name = "game_enemy_state")]
     public partial struct GameEnemyState(ulong entity_id, int herd_id)
     {
         [PrimaryKey]
@@ -110,7 +112,7 @@ public static partial class ia_loop
         public uint dimension = dimension;
     }
 
-    [SpacetimeDB.Table]
+    [SpacetimeDB.Table(Name = "game_herd_cache")]
     public partial struct GameHerdCache(
         int id,
         uint dimension_id,
@@ -136,7 +138,7 @@ public static partial class ia_loop
     {
         for (uint id = 0; id < count; id++)
         {
-            ctx.Db.Position.Insert(new(id, id, id + 5, id * 5));
+            ctx.Db.position.Insert(new(id, id, id + 5, id * 5));
         }
         Log.Info($"INSERT POSITION: {count}");
     }
@@ -146,7 +148,7 @@ public static partial class ia_loop
     {
         for (uint id = 0; id < count; id++)
         {
-            ctx.Db.Velocity.Insert(new(id, id, id + 5, id * 5));
+            ctx.Db.velocity.Insert(new(id, id, id + 5, id * 5));
         }
         Log.Info($"INSERT VELOCITY: {count}");
     }
@@ -155,7 +157,7 @@ public static partial class ia_loop
     public static void update_position_all(ReducerContext ctx, uint expected)
     {
         uint count = 0;
-        foreach (Position position in ctx.Db.Position.Iter())
+        foreach (Position position in ctx.Db.position.Iter())
         {
             Position newPosition = position;
 
@@ -163,7 +165,7 @@ public static partial class ia_loop
             newPosition.y += position.vy;
             newPosition.z += position.vz;
 
-            ctx.Db.Position.UpdateByentity_id(position.entity_id, newPosition);
+            ctx.Db.position.entity_id.Update(newPosition);
             count++;
         }
         Log.Info($"UPDATE POSITION ALL: {expected}, processed: {count}");
@@ -173,9 +175,9 @@ public static partial class ia_loop
     public static void update_position_with_velocity(ReducerContext ctx, uint expected)
     {
         uint count = 0;
-        foreach (Velocity velocity in ctx.Db.Velocity.Iter())
+        foreach (Velocity velocity in ctx.Db.velocity.Iter())
         {
-            if (ctx.Db.Position.FindByentity_id(velocity.entity_id) is not { } position)
+            if (ctx.Db.position.entity_id.Find(velocity.entity_id) is not { } position)
             {
                 continue;
             }
@@ -184,7 +186,7 @@ public static partial class ia_loop
             position.y += velocity.y;
             position.z += velocity.z;
 
-            ctx.Db.Position.UpdateByentity_id(position.entity_id, position);
+            ctx.Db.position.entity_id.Update(position);
             count++;
         }
         Log.Info($"UPDATE POSITION BY VELOCITY: {expected}, processed: {count}");
@@ -198,19 +200,19 @@ public static partial class ia_loop
             ulong next_action_timestamp =
                 (i & 2) == 2 ? MomentMilliseconds() + 2000 : MomentMilliseconds();
 
-            ctx.Db.GameEnemyAiAgentState.Insert(
+            ctx.Db.game_enemy_ai_agent_state.Insert(
                 new(i, [i, 0, i * 2], next_action_timestamp, AgentAction.Idle)
             );
 
-            ctx.Db.GameLiveTargetableState.Insert(new(i, (long)i));
+            ctx.Db.game_live_targetable_state.Insert(new(i, (long)i));
 
-            ctx.Db.GameTargetableState.Insert(new(i, (long)i));
+            ctx.Db.game_targetable_state.Insert(new(i, (long)i));
 
-            ctx.Db.GameMobileEntityState.Insert(new(i, (int)i, (int)i, next_action_timestamp));
+            ctx.Db.game_mobile_entity_state.Insert(new(i, (int)i, (int)i, next_action_timestamp));
 
-            ctx.Db.GameEnemyState.Insert(new(i, (int)i));
+            ctx.Db.game_enemy_state.Insert(new(i, (int)i));
 
-            ctx.Db.GameHerdCache.Insert(
+            ctx.Db.game_herd_cache.Insert(
                 new(
                     (int)i,
                     (uint)i,
@@ -236,11 +238,11 @@ public static partial class ia_loop
         for (ulong id = entity_id; id < num_players; id++)
         {
             foreach (
-                GameLiveTargetableState t in ctx.Db.GameLiveTargetableState.FilterByquad((long)id)
+                GameLiveTargetableState t in ctx.Db.game_live_targetable_state.quad.Filter((long)id)
             )
             {
                 result.Add(
-                    ctx.Db.GameTargetableState.FindByentity_id(t.entity_id)
+                    ctx.Db.game_targetable_state.entity_id.Find(t.entity_id)
                         ?? throw new Exception("Identity not found")
                 );
             }
@@ -261,9 +263,9 @@ public static partial class ia_loop
         ulong entity_id = agent.entity_id;
 
         GameEnemyState enemy =
-            ctx.Db.GameEnemyState.FindByentity_id(entity_id)
+            ctx.Db.game_enemy_state.entity_id.Find(entity_id)
             ?? throw new Exception("GameEnemyState Entity ID not found");
-        ctx.Db.GameEnemyState.UpdateByentity_id(entity_id, enemy);
+        ctx.Db.game_enemy_state.entity_id.Update(enemy);
 
         agent.next_action_timestamp = current_time_ms + 2000;
 
@@ -274,27 +276,27 @@ public static partial class ia_loop
         }
 
         GameTargetableState targetable =
-            ctx.Db.GameTargetableState.FindByentity_id(entity_id)
+            ctx.Db.game_targetable_state.entity_id.Find(entity_id)
             ?? throw new Exception("GameTargetableState Entity ID not found");
         int new_hash = targetable.quad.GetHashCode();
         targetable.quad = new_hash;
-        ctx.Db.GameTargetableState.UpdateByentity_id(entity_id, targetable);
+        ctx.Db.game_targetable_state.entity_id.Update(targetable);
 
-        if (ctx.Db.GameLiveTargetableState.FindByentity_id(entity_id) is not null)
+        if (ctx.Db.game_live_targetable_state.entity_id.Find(entity_id) is not null)
         {
-            ctx.Db.GameLiveTargetableState.UpdateByentity_id(entity_id, new(entity_id, new_hash));
+            ctx.Db.game_live_targetable_state.entity_id.Update(new(entity_id, new_hash));
         }
 
         GameMobileEntityState mobile_entity =
-            ctx.Db.GameMobileEntityState.FindByentity_id(entity_id)
+            ctx.Db.game_mobile_entity_state.entity_id.Find(entity_id)
             ?? throw new Exception("GameMobileEntityState Entity ID not found");
         mobile_entity.location_x += 1;
         mobile_entity.location_y += 1;
         mobile_entity.timestamp = MomentMilliseconds();
 
-        ctx.Db.GameEnemyAiAgentState.UpdateByentity_id(entity_id, agent);
+        ctx.Db.game_enemy_ai_agent_state.entity_id.Update(agent);
 
-        ctx.Db.GameMobileEntityState.UpdateByentity_id(entity_id, mobile_entity);
+        ctx.Db.game_mobile_entity_state.entity_id.Update(mobile_entity);
     }
 
     public static void AgentLoop(
@@ -307,16 +309,16 @@ public static partial class ia_loop
     {
         ulong entity_id = agent.entity_id;
 
-        IEnumerable<GameMobileEntityState> coordinates =
-            ctx.Db.GameMobileEntityState.FilterByentity_id(entity_id)
+        GameMobileEntityState? coordinates =
+            ctx.Db.game_mobile_entity_state.entity_id.Find(entity_id)
             ?? throw new Exception("GameMobileEntityState Entity ID not found");
 
         GameEnemyState agent_entity =
-            ctx.Db.GameEnemyState.FindByentity_id(entity_id)
+            ctx.Db.game_enemy_state.entity_id.Find(entity_id)
             ?? throw new Exception("GameEnemyState Entity ID not found");
 
         GameHerdCache agent_herd =
-            ctx.Db.GameHerdCache.FindByid(agent_entity.herd_id)
+            ctx.Db.game_herd_cache.id.Find(agent_entity.herd_id)
             ?? throw new Exception("GameHerdCache Entity ID not found");
 
         SmallHexTile agent_herd_coordinates = agent_herd.location;
@@ -330,7 +332,7 @@ public static partial class ia_loop
         uint count = 0;
         ulong current_time_ms = MomentMilliseconds();
 
-        foreach (GameEnemyAiAgentState agent in ctx.Db.GameEnemyAiAgentState.Iter())
+        foreach (GameEnemyAiAgentState agent in ctx.Db.game_enemy_ai_agent_state.Iter())
         {
             if (agent.next_action_timestamp > current_time_ms)
             {
@@ -338,7 +340,7 @@ public static partial class ia_loop
             }
 
             GameTargetableState agent_targetable =
-                ctx.Db.GameTargetableState.FindByentity_id(agent.entity_id)
+                ctx.Db.game_targetable_state.entity_id.Find(agent.entity_id)
                 ?? throw new Exception("No TargetableState for AgentState entity");
 
             List<GameTargetableState> surrounding_agents = GetTargetablesNearQuad(

--- a/modules/benchmarks-cs/synthetic.cs
+++ b/modules/benchmarks-cs/synthetic.cs
@@ -24,15 +24,13 @@ public static partial class synthetic
     }
 
     [SpacetimeDB.Table]
+    [SpacetimeDB.Index(BTree = [nameof(id)])]
+    [SpacetimeDB.Index(BTree = [nameof(age)])]
+    [SpacetimeDB.Index(BTree = [nameof(name)])]
     public partial struct btree_each_column_u32_u64_str
     {
-        [Indexed]
         public uint id;
-
-        [Indexed]
         public ulong age;
-
-        [Indexed]
         public string name;
     }
 
@@ -54,15 +52,13 @@ public static partial class synthetic
     }
 
     [SpacetimeDB.Table]
+    [SpacetimeDB.Index(BTree = [nameof(id)])]
+    [SpacetimeDB.Index(BTree = [nameof(x)])]
+    [SpacetimeDB.Index(BTree = [nameof(y)])]
     public partial struct btree_each_column_u32_u64_u64
     {
-        [Indexed]
         public uint id;
-
-        [Indexed]
         public ulong x;
-
-        [Indexed]
         public ulong y;
     }
 
@@ -254,8 +250,7 @@ public static partial class synthetic
         foreach (unique_0_u32_u64_u64 loc in ctx.Db.unique_0_u32_u64_u64.Iter().Take((int)rowCount))
         {
             hit++;
-            ctx.Db.unique_0_u32_u64_u64.UpdateByid(
-                loc.id,
+            ctx.Db.unique_0_u32_u64_u64.id.Update(
                 new()
                 {
                     id = loc.id,
@@ -281,8 +276,7 @@ public static partial class synthetic
         )
         {
             hit++;
-            ctx.Db.unique_0_u32_u64_str.UpdateByid(
-                u32_u64_str.id,
+            ctx.Db.unique_0_u32_u64_str.id.Update(
                 new()
                 {
                     id = u32_u64_str.id,
@@ -322,91 +316,91 @@ public static partial class synthetic
     [SpacetimeDB.Reducer]
     public static void filter_unique_0_u32_u64_str_by_id(ReducerContext ctx, uint id)
     {
-        Bench.BlackBox(ctx.Db.unique_0_u32_u64_str.FindByid(id));
+        Bench.BlackBox(ctx.Db.unique_0_u32_u64_str.id.Find(id));
     }
 
     [SpacetimeDB.Reducer]
     public static void filter_no_index_u32_u64_str_by_id(ReducerContext ctx, uint id)
     {
-        Bench.BlackBox(ctx.Db.no_index_u32_u64_str.FilterByid(id));
+        Bench.BlackBox(ctx.Db.no_index_u32_u64_str.Iter().Where(row => row.id == id));
     }
 
     [SpacetimeDB.Reducer]
     public static void filter_btree_each_column_u32_u64_str_by_id(ReducerContext ctx, uint id)
     {
-        Bench.BlackBox(ctx.Db.btree_each_column_u32_u64_str.FilterByid(id));
+        Bench.BlackBox(ctx.Db.btree_each_column_u32_u64_str.id.Filter(id));
     }
 
     [SpacetimeDB.Reducer]
     public static void filter_unique_0_u32_u64_str_by_name(ReducerContext ctx, string name)
     {
-        Bench.BlackBox(ctx.Db.unique_0_u32_u64_str.FilterByname(name));
+        Bench.BlackBox(ctx.Db.unique_0_u32_u64_str.Iter().Where(row => row.name == name));
     }
 
     [SpacetimeDB.Reducer]
     public static void filter_no_index_u32_u64_str_by_name(ReducerContext ctx, string name)
     {
-        Bench.BlackBox(ctx.Db.no_index_u32_u64_str.FilterByname(name));
+        Bench.BlackBox(ctx.Db.no_index_u32_u64_str.Iter().Where(row => row.name == name));
     }
 
     [SpacetimeDB.Reducer]
     public static void filter_btree_each_column_u32_u64_str_by_name(ReducerContext ctx, string name)
     {
-        Bench.BlackBox(ctx.Db.btree_each_column_u32_u64_str.FilterByname(name));
+        Bench.BlackBox(ctx.Db.btree_each_column_u32_u64_str.name.Filter(name));
     }
 
     [SpacetimeDB.Reducer]
     public static void filter_unique_0_u32_u64_u64_by_id(ReducerContext ctx, uint id)
     {
-        Bench.BlackBox(ctx.Db.unique_0_u32_u64_u64.FindByid(id));
+        Bench.BlackBox(ctx.Db.unique_0_u32_u64_u64.id.Find(id));
     }
 
     [SpacetimeDB.Reducer]
     public static void filter_no_index_u32_u64_u64_by_id(ReducerContext ctx, uint id)
     {
-        Bench.BlackBox(ctx.Db.no_index_u32_u64_u64.FilterByid(id));
+        Bench.BlackBox(ctx.Db.no_index_u32_u64_u64.Iter().Where(row => row.id == id));
     }
 
     [SpacetimeDB.Reducer]
     public static void filter_btree_each_column_u32_u64_u64_by_id(ReducerContext ctx, uint id)
     {
-        Bench.BlackBox(ctx.Db.btree_each_column_u32_u64_u64.FilterByid(id));
+        Bench.BlackBox(ctx.Db.btree_each_column_u32_u64_u64.Iter().Where(row => row.id == id));
     }
 
     [SpacetimeDB.Reducer]
     public static void filter_unique_0_u32_u64_u64_by_x(ReducerContext ctx, ulong x)
     {
-        Bench.BlackBox(ctx.Db.unique_0_u32_u64_u64.FilterByx(x));
+        Bench.BlackBox(ctx.Db.unique_0_u32_u64_u64.Iter().Where(row => row.x == x));
     }
 
     [SpacetimeDB.Reducer]
     public static void filter_no_index_u32_u64_u64_by_x(ReducerContext ctx, ulong x)
     {
-        Bench.BlackBox(ctx.Db.no_index_u32_u64_u64.FilterByx(x));
+        Bench.BlackBox(ctx.Db.no_index_u32_u64_u64.Iter().Where(row => row.x == x));
     }
 
     [SpacetimeDB.Reducer]
     public static void filter_btree_each_column_u32_u64_u64_by_x(ReducerContext ctx, ulong x)
     {
-        Bench.BlackBox(ctx.Db.btree_each_column_u32_u64_u64.FilterByx(x));
+        Bench.BlackBox(ctx.Db.btree_each_column_u32_u64_u64.x.Filter(x));
     }
 
     [SpacetimeDB.Reducer]
-    public static void filter_unique_0_u32_u64_u64_by_y(ReducerContext ctx, ulong x)
+    public static void filter_unique_0_u32_u64_u64_by_y(ReducerContext ctx, ulong y)
     {
-        Bench.BlackBox(ctx.Db.unique_0_u32_u64_u64.FilterByy(x));
+        Bench.BlackBox(ctx.Db.unique_0_u32_u64_u64.Iter().Where(row => row.y == y));
     }
 
     [SpacetimeDB.Reducer]
-    public static void filter_no_index_u32_u64_u64_by_y(ReducerContext ctx, ulong x)
+    public static void filter_no_index_u32_u64_u64_by_y(ReducerContext ctx, ulong y)
     {
-        Bench.BlackBox(ctx.Db.no_index_u32_u64_u64.FilterByy(x));
+        Bench.BlackBox(ctx.Db.no_index_u32_u64_u64.Iter().Where(row => row.y == y));
     }
 
     [SpacetimeDB.Reducer]
-    public static void filter_btree_each_column_u32_u64_u64_by_y(ReducerContext ctx, ulong x)
+    public static void filter_btree_each_column_u32_u64_u64_by_y(ReducerContext ctx, ulong y)
     {
-        Bench.BlackBox(ctx.Db.btree_each_column_u32_u64_u64.FilterByy(x));
+        Bench.BlackBox(ctx.Db.btree_each_column_u32_u64_u64.y.Filter(y));
     }
 
     // ---------- delete ----------
@@ -414,13 +408,13 @@ public static partial class synthetic
     [SpacetimeDB.Reducer]
     public static void delete_unique_0_u32_u64_str_by_id(ReducerContext ctx, uint id)
     {
-        ctx.Db.unique_0_u32_u64_str.DeleteByid(id);
+        ctx.Db.unique_0_u32_u64_str.id.Delete(id);
     }
 
     [SpacetimeDB.Reducer]
     public static void delete_unique_0_u32_u64_u64_by_id(ReducerContext ctx, uint id)
     {
-        ctx.Db.unique_0_u32_u64_u64.DeleteByid(id);
+        ctx.Db.unique_0_u32_u64_u64.id.Delete(id);
     }
 
     // ---------- clear table ----------
@@ -466,37 +460,37 @@ public static partial class synthetic
     [SpacetimeDB.Reducer]
     public static void count_unique_0_u32_u64_str(ReducerContext ctx)
     {
-        Log.Info("COUNT: " + ctx.Db.unique_0_u32_u64_str.Iter().Count());
+        Log.Info("COUNT: " + ctx.Db.unique_0_u32_u64_str.Count);
     }
 
     [SpacetimeDB.Reducer]
     public static void count_no_index_u32_u64_str(ReducerContext ctx)
     {
-        Log.Info("COUNT: " + ctx.Db.no_index_u32_u64_str.Iter().Count());
+        Log.Info("COUNT: " + ctx.Db.no_index_u32_u64_str.Count);
     }
 
     [SpacetimeDB.Reducer]
     public static void count_btree_each_column_u32_u64_str(ReducerContext ctx)
     {
-        Log.Info("COUNT: " + ctx.Db.btree_each_column_u32_u64_str.Iter().Count());
+        Log.Info("COUNT: " + ctx.Db.btree_each_column_u32_u64_str.Count);
     }
 
     [SpacetimeDB.Reducer]
     public static void count_unique_0_u32_u64_u64(ReducerContext ctx)
     {
-        Log.Info("COUNT: " + ctx.Db.unique_0_u32_u64_u64.Iter().Count());
+        Log.Info("COUNT: " + ctx.Db.unique_0_u32_u64_u64.Count);
     }
 
     [SpacetimeDB.Reducer]
     public static void count_no_index_u32_u64_u64(ReducerContext ctx)
     {
-        Log.Info("COUNT: " + ctx.Db.no_index_u32_u64_u64.Iter().Count());
+        Log.Info("COUNT: " + ctx.Db.no_index_u32_u64_u64.Count);
     }
 
     [SpacetimeDB.Reducer]
     public static void count_btree_each_column_u32_u64_u64(ReducerContext ctx)
     {
-        Log.Info("COUNT: " + ctx.Db.btree_each_column_u32_u64_u64.Iter().Count());
+        Log.Info("COUNT: " + ctx.Db.btree_each_column_u32_u64_u64.Count);
     }
 
     // ---------- module-specific stuff ----------

--- a/modules/benchmarks/src/synthetic.rs
+++ b/modules/benchmarks/src/synthetic.rs
@@ -302,22 +302,22 @@ pub fn filter_btree_each_column_u32_u64_u64_by_x(ctx: &ReducerContext, x: u64) {
 }
 
 #[spacetimedb::reducer]
-pub fn filter_unique_0_u32_u64_u64_by_y(ctx: &ReducerContext, x: u64) {
-    for loc in ctx.db.unique_0_u32_u64_u64().iter().filter(|p| p.y == x) {
+pub fn filter_unique_0_u32_u64_u64_by_y(ctx: &ReducerContext, y: u64) {
+    for loc in ctx.db.unique_0_u32_u64_u64().iter().filter(|p| p.y == y) {
         black_box(loc);
     }
 }
 
 #[spacetimedb::reducer]
-pub fn filter_no_index_u32_u64_u64_by_y(ctx: &ReducerContext, x: u64) {
-    for loc in ctx.db.no_index_u32_u64_u64().iter().filter(|p| p.y == x) {
+pub fn filter_no_index_u32_u64_u64_by_y(ctx: &ReducerContext, y: u64) {
+    for loc in ctx.db.no_index_u32_u64_u64().iter().filter(|p| p.y == y) {
         black_box(loc);
     }
 }
 
 #[spacetimedb::reducer]
-pub fn filter_btree_each_column_u32_u64_u64_by_y(ctx: &ReducerContext, x: u64) {
-    for loc in ctx.db.btree_each_column_u32_u64_u64().y().filter(&x) {
+pub fn filter_btree_each_column_u32_u64_u64_by_y(ctx: &ReducerContext, y: u64) {
+    for loc in ctx.db.btree_each_column_u32_u64_u64().y().filter(&y) {
         black_box(loc);
     }
 }


### PR DESCRIPTION
# Description of Changes

Before this, `Find()` would not return a nullable `Row?` when `Row` is a value type (a `struct`), leading to compilation errors at best and at a struct with all fields set to `0` or `null` at worst.

This issue was found while updating benchmarks-cs and it's not covered by other `modules/*` tests, which is why I bundled it with other fixes that make benchmarks-cs compile again in the same PR. I also made a change that ensures that `becnhmarks-cs` actually compiles in CI (before this, it could only be executed manually).

The fix for this particular issue is in `Codegen/Module.cs`, while other fixes are removing `IndexedAttribute` (which shouldn't be exposed to the users) and adding actual indexes to the benchmarks, updating table names, using new `.Find` / `.Filter` APIs and such.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
