### PR TITLE
Fix benches for ia_loop, circles

### DIFF
--- a/crates/bench/benches/special.rs
+++ b/crates/bench/benches/special.rs
@@ -10,7 +10,6 @@ use spacetimedb_lib::{bsatn::ToBsatn as _, sats, ProductValue};
 use spacetimedb_schema::schema::TableSchema;
 use spacetimedb_testing::modules::start_runtime;
 use std::sync::OnceLock;
-use std::time::Instant;
 use std::{hint::black_box, sync::Arc};
 
 #[global_allocator]
@@ -79,18 +78,10 @@ fn custom_db_benchmarks(c: &mut Criterion) {
                 });
             });
 
-            b.iter_custom(|iters| {
-                let start = Instant::now();
-
-                for _ in 0..iters {
-                    black_box(
-                        runtime.block_on(async {
-                            module.call_reducer_binary("run_game_circles", args.clone()).await.ok()
-                        }),
-                    );
-                }
-
-                start.elapsed()
+            b.iter(|| {
+                black_box(
+                    runtime.block_on(async { module.call_reducer_binary("run_game_circles", args.clone()).await.ok() }),
+                );
             })
         });
     }
@@ -109,14 +100,10 @@ fn custom_db_benchmarks(c: &mut Criterion) {
                 })
             });
 
-            b.iter_custom(|_iters| {
-                let start = Instant::now();
-
+            b.iter(|| {
                 black_box(
                     runtime.block_on(async { module.call_reducer_binary("run_game_ia_loop", args.clone()).await.ok() }),
                 );
-
-                start.elapsed()
             })
         });
     }

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -308,7 +308,7 @@ fn test_calling_bench_db_ia_loop() {
                 ("update_position_all", 20_000, "UPDATE POSITION ALL: 20000, processed: 20000"),
                 ("update_position_with_velocity", 10_000, "UPDATE POSITION BY VELOCITY: 10000, processed: 10000"),
                 ("insert_world", 5_000, "INSERT WORLD PLAYERS: 5000"),
-                ("game_loop_enemy_ia", 5_000, "ENEMY IA LOOP PLAYERS: 5000, processed: 2500"),
+                ("game_loop_enemy_ia", 5_000, "ENEMY IA LOOP PLAYERS: 5000, processed: 5000"),
             ];
 
             _run_bench_db(module, &benches).await

--- a/modules/benchmarks/src/ia_loop.rs
+++ b/modules/benchmarks/src/ia_loop.rs
@@ -347,7 +347,7 @@ fn move_agent(
         entity_id,
         location_x: mobile_entity.location_x + 1,
         location_y: mobile_entity.location_y + 1,
-        timestamp: moment_milliseconds(),
+        timestamp: agent.next_action_timestamp,
     };
 
     ctx.db.game_enemy_ai_agent_state().entity_id().update(agent.clone());
@@ -394,10 +394,6 @@ pub fn game_loop_enemy_ia(ctx: &ReducerContext, players: u64) {
     let current_time_ms = moment_milliseconds();
 
     for mut agent in ctx.db.game_enemy_ai_agent_state().iter() {
-        if agent.next_action_timestamp > current_time_ms {
-            continue;
-        }
-
         let agent_targetable = ctx
             .db
             .game_targetable_state()


### PR DESCRIPTION
# Description of Changes

Corrections to how are benched `ia_loop ` & `circles`.

Basically, `circles` have `auto_inc` in their tables definitions, but `ia_loop` does not. 

The consequence is that `circles` take a lot of time because the `init_game_circles` get called by each iteration of the benches, resulting in a big table with up to `1_000_000` rows when the setup was meant to be at most `10_000`. 

Then for the `ia_loop` the lack of `auto_inc` causes a `unique constraint violation` because the table is forbidden to grow. 

Now:

* In both, the database is initialized just once with the maximum amount of rows
* Is removed `group.measurement_time(Duration::from_secs(60 * 2));` that causes the bench to run longer than must
* Removed the filtering in the `ia_loop` game loop based on `timestamps`, it causes the code to run differently between the integration test and benches.
*  Increase the size of `ia_loop` from `[10, 100]` to `[500, 5_000]` so criterion has something to measure:
```bash
# BEFORE
special/db_game/ia_loop/load=100
                        time:   [0.0000 ps 0.0000 ps 0.0000 ps]
# AFTER
special/db_game/ia_loop/load=500
                        time:   [386.62 ps 461.53 ps 640.54 ps]
```


# API and ABI breaking changes

Nothing, but this change invalidates the numbers of previous benchmarks.

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Runing a lot of benches with different parameters*

