### PR TITLE
Use actual types for api responses, not ad-hoc `json!()` objects

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4779,6 +4779,7 @@ dependencies = [
  "scopeguard",
  "serde",
  "serde_json",
+ "serde_with",
  "spacetimedb-client-api-messages",
  "spacetimedb-core",
  "spacetimedb-data-structures",

--- a/crates/client-api/Cargo.toml
+++ b/crates/client-api/Cargo.toml
@@ -7,9 +7,10 @@ description = "The HTTP API for SpacetimeDB"
 
 [dependencies]
 spacetimedb-client-api-messages.workspace = true
-spacetimedb-data-structures.workspace = true
 spacetimedb-core.workspace = true
+spacetimedb-data-structures.workspace = true
 spacetimedb-lib = { workspace = true, features = ["serde"] }
+spacetimedb-paths.workspace = true
 spacetimedb-schema.workspace = true
 
 tokio = { version = "1.2", features = ["full"] }
@@ -43,7 +44,7 @@ derive_more = "0.99.17"
 uuid.workspace = true
 jsonwebtoken.workspace = true
 scopeguard.workspace = true
-spacetimedb-paths.workspace = true
+serde_with.workspace = true
 
 [dev-dependencies]
 jsonwebtoken.workspace = true

--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -277,7 +277,6 @@ where
     let response_json: SchemaEntities = HashMap::from_iter([(&*entity, entity_description_json(description))]);
 
     Ok((
-        StatusCode::OK,
         TypedHeader(SpacetimeIdentity(auth.identity)),
         TypedHeader(SpacetimeIdentityToken(auth.creds)),
         axum::Json(response_json).into_response(),
@@ -351,7 +350,6 @@ where
     };
 
     Ok((
-        StatusCode::OK,
         TypedHeader(SpacetimeIdentity(auth.identity)),
         TypedHeader(SpacetimeIdentityToken(auth.creds)),
         response_json,
@@ -397,7 +395,7 @@ pub async fn info<S: ControlStateDelegate>(
     log::trace!("Fetched database from the worker db for address: {database_identity:?}");
 
     let response = InfoResponse::from(database);
-    Ok((StatusCode::OK, axum::Json(response)))
+    Ok(axum::Json(response))
 }
 
 #[derive(Deserialize)]
@@ -486,7 +484,6 @@ where
     };
 
     Ok((
-        StatusCode::OK,
         TypedHeader(headers::CacheControl::new().with_no_cache()),
         TypedHeader(headers::ContentType::from(mime_ndjson())),
         body,
@@ -542,7 +539,7 @@ where
         .ok_or(StatusCode::NOT_FOUND)?;
     let json = host.exec_sql(auth, database, body).await?;
 
-    Ok((StatusCode::OK, axum::Json(json)))
+    Ok(axum::Json(json))
 }
 
 #[derive(Deserialize)]

--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -183,8 +183,10 @@ impl<'a> EntityDef<'a> {
     }
 }
 
+#[serde_with::serde_as]
 #[derive(Serialize)]
 struct EntityDescription<'a> {
+    #[serde_as(as = "serde_with::DisplayFromStr")]
     r#type: DescribedEntityType,
     arity: usize,
     schema: EntityDescriptionSchema<'a>,

--- a/crates/core/src/messages/control_db.rs
+++ b/crates/core/src/messages/control_db.rs
@@ -70,10 +70,7 @@ pub struct NodeStatus {
     /// SEE: <https://kubernetes.io/docs/reference/kubernetes-api/cluster-resources/node-v1/#NodeStatus>
     pub state: String,
 }
-#[derive(
-    Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize, strum::EnumString, strum::AsRefStr,
-)]
-#[strum(serialize_all = "lowercase")]
+#[derive(Clone, Copy, Debug, PartialEq, Eq, Hash, PartialOrd, Ord, Serialize, Deserialize)]
 #[repr(i32)]
 pub enum HostType {
     Wasm = 0,

--- a/crates/sats/src/lib.rs
+++ b/crates/sats/src/lib.rs
@@ -26,6 +26,41 @@ pub mod typespace;
 #[cfg(any(test, feature = "proptest"))]
 pub mod proptest;
 
+#[cfg(feature = "serde")]
+pub mod serde {
+    pub use crate::de::serde::{deserialize_from as deserialize, SerdeDeserializer};
+    pub use crate::ser::serde::{serialize_to as serialize, SerdeSerializer};
+
+    /// A wrapper around a `serde` error which occured while translating SATS <-> serde.
+    #[repr(transparent)]
+    pub struct SerdeError<E>(pub E);
+
+    /// A wrapper type that implements `serde` traits when `T` implements SATS traits.
+    ///
+    /// Specifically:
+    /// - <code>T: [sats::Serialize][crate::ser::Serialize] => `SerializeWrapper<T>`: [serde::Serialize]</code>
+    /// - <code>T: [sats::Deserialize<'de>][crate::de::Deserialize] => `SerializeWrapper<T>`: [serde::Deserialize<'de>]</code>
+    /// - <code>T: [sats::DeserializeSeed<'de>][crate::de::DeserializeSeed] => `SerializeWrapper<T>`: [serde::DeserializeSeed<'de>]</code>
+    #[repr(transparent)]
+    pub struct SerdeWrapper<T: ?Sized>(pub T);
+
+    impl<T: ?Sized> SerdeWrapper<T> {
+        /// Wraps a value in `SerdeWrapper`.
+        pub fn new(t: T) -> Self
+        where
+            T: Sized,
+        {
+            Self(t)
+        }
+
+        /// Converts `&T` to `&SerializeWrapper<T>`.
+        pub fn from_ref(t: &T) -> &Self {
+            // SAFETY: OK because of `repr(transparent)`.
+            unsafe { &*(t as *const T as *const SerdeWrapper<T>) }
+        }
+    }
+}
+
 /// Allows the macros in [`spacetimedb_bindings_macro`] to accept `crate = spacetimedb_sats`,
 /// which will then emit `$krate::sats`.
 #[doc(hidden)]


### PR DESCRIPTION
# Description of Changes

No behavior change, but it feels important to be able to see the actual structure of the response, especially as we're stabilizing.

# Expected complexity level and risk

1

# Testing

Was not able to get spacetime-web working to test this, but it's the same schema as it was before, and it matches with the typedef in typescript in spacetime-web.