### PR TITLE
Use previous reducer context when downgrading a tx

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -604,7 +604,7 @@ impl MutTxDatastore for Locking {
 
 /// This utility is responsible for recording all transaction metrics.
 pub(super) fn record_metrics(
-    ctx: ExecutionContext,
+    ctx: &ExecutionContext,
     tx_timer: Instant,
     lock_wait_time: Duration,
     committed: bool,

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -60,7 +60,7 @@ impl StateView for TxId {
 
 impl TxId {
     pub(super) fn release(self) {
-        record_metrics(self.ctx, self.timer, self.lock_wait_time, true, None, None);
+        record_metrics(&self.ctx, self.timer, self.lock_wait_time, true, None, None);
     }
 
     /// The Number of Distinct Values (NDV) for a column or list of columns,

--- a/crates/core/src/execution_context.rs
+++ b/crates/core/src/execution_context.rs
@@ -13,11 +13,11 @@ use spacetimedb_sats::bsatn;
 #[derive(Default, Clone)]
 pub struct ExecutionContext {
     /// The identity of the database on which a transaction is being executed.
-    database_identity: Identity,
+    pub database_identity: Identity,
     /// The reducer from which the current transaction originated.
-    reducer: Option<ReducerContext>,
+    pub reducer: Option<ReducerContext>,
     /// The type of workload that is being executed.
-    workload: WorkloadType,
+    pub workload: WorkloadType,
 }
 
 /// If an [`ExecutionContext`] is a reducer context, describes the reducer.
@@ -115,6 +115,20 @@ pub enum WorkloadType {
     Subscribe,
     Update,
     Internal,
+}
+
+impl From<Workload> for WorkloadType {
+    fn from(value: Workload) -> Self {
+        match value {
+            #[cfg(test)]
+            Workload::ForTests => Self::Internal,
+            Workload::Reducer(_) => Self::Reducer,
+            Workload::Sql => Self::Sql,
+            Workload::Subscribe => Self::Subscribe,
+            Workload::Update => Self::Update,
+            Workload::Internal => Self::Internal,
+        }
+    }
 }
 
 impl Default for WorkloadType {


### PR DESCRIPTION
So that we can correlate subscription updates with reducers