### PR TITLE
Remove jdetter as codeowner for now

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,9 +1,9 @@
 /crates/core/src/db/datastore/traits.rs @cloutiertyler
-/rust-toolchain.toml @jdetter @cloutiertyler
+/rust-toolchain.toml @cloutiertyler
 /.github/CODEOWNERS @cloutiertyler
 LICENSE.txt @cloutiertyler
 /crates/client-api-messages/src/websocket.rs @centril @gefjon
 
-/crates/cli/src/ @bfops @jdetter @cloutiertyler
+/crates/cli/src/ @bfops @cloutiertyler
 /crates/cli/src/subcommands/generate/ # No owners
-/crates/cli/src/subcommands/generate/mod.rs @bfops @jdetter @cloutiertyler # These codeowners should be the same as the "root" CLI codeowners
+/crates/cli/src/subcommands/generate/mod.rs @bfops @cloutiertyler # These codeowners should be the same as the "root" CLI codeowners


### PR DESCRIPTION
# Description of Changes

As I'm not directly involved with the development of SpacetimeDB over the next few months, I'm removing myself as a codeowner so that PRs aren't blocked on my review.

# API and ABI breaking changes

No breaking changes

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

1 - this is just a meta change

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

No testing is needed for this
