### PR TITLE
Decode identity correctly

### DIFF
--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -5,7 +5,7 @@ use base64::{
 };
 use reqwest::RequestBuilder;
 use serde::Deserialize;
-use spacetimedb::auth::identity::SpacetimeIdentityClaims2;
+use spacetimedb::auth::identity::{IncomingClaims, SpacetimeIdentityClaims2};
 use spacetimedb_client_api_messages::name::{DnsLookupResponse, RegisterTldResult, ReverseDNSResponse};
 use spacetimedb_data_structures::map::HashMap;
 use spacetimedb_lib::{AlgebraicType, Identity};
@@ -280,7 +280,8 @@ pub fn decode_identity(config: &Config) -> anyhow::Result<String> {
     let decoded_bytes = BASE_64_STD_NO_PAD.decode(token_parts[1])?;
     let decoded_string = String::from_utf8(decoded_bytes)?;
 
-    let claims_data: SpacetimeIdentityClaims2 = serde_json::from_str(decoded_string.as_str())?;
+    let claims_data: IncomingClaims = serde_json::from_str(decoded_string.as_str())?;
+    let claims_data: SpacetimeIdentityClaims2 = claims_data.try_into()?;
 
     Ok(claims_data.identity.to_string())
 }


### PR DESCRIPTION
# Description of Changes

The `token show` command was decoding tokens in a way that required the identity field to be set. When we parse tokens from clients, we can compute the identity from the other claims. This PR fixes the `token show` command to do the same.

# Expected complexity level and risk

1

# Testing

@bfops tested this manually.
