### PR TITLE
CLI - Fix stale helptext instructing users to use `spacetime identity`

### DIFF
--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -259,11 +259,7 @@ pub fn unauth_error_context<T>(res: anyhow::Result<T>, identity: &str, server: &
     res.with_context(|| {
         format!(
             "Identity {identity} is not valid for server {server}.
-Has the server rotated its keys?
-Remove the outdated identity with:
-\tspacetime identity remove -i {identity}
-Generate a new identity with:
-\tspacetime identity new --no-email --server {server} --default"
+Please log back in with `spacetime logout` and then `spacetime login`."
         )
     })
 }


### PR DESCRIPTION
# Description of Changes

Update stale help text that referred to `spacetime identity` (which has been removed).

# API and ABI breaking changes

No breaking changes

# Expected complexity level and risk

1

# Testing

Existing tests only