### PR TITLE
CLI - Tell users if they're already logged in

### DIFF
--- a/crates/cli/src/subcommands/login.rs
+++ b/crates/cli/src/subcommands/login.rs
@@ -93,6 +93,8 @@ async fn exec_show(config: Config, args: &ArgMatches) -> Result<(), anyhow::Erro
 }
 
 async fn spacetimedb_token_cached(config: &mut Config, host: &Url, direct_login: bool) -> anyhow::Result<String> {
+    TODO: Print a message if we're already logged in
+
     // Currently, this token does not expire. However, it will at some point in the future. When that happens,
     // this code will need to happen before any request to a spacetimedb server, rather than at the end of the login flow here.
     if let Some(token) = config.spacetimedb_token() {

--- a/crates/cli/src/subcommands/login.rs
+++ b/crates/cli/src/subcommands/login.rs
@@ -93,11 +93,11 @@ async fn exec_show(config: Config, args: &ArgMatches) -> Result<(), anyhow::Erro
 }
 
 async fn spacetimedb_token_cached(config: &mut Config, host: &Url, direct_login: bool) -> anyhow::Result<String> {
-    TODO: Print a message if we're already logged in
-
     // Currently, this token does not expire. However, it will at some point in the future. When that happens,
     // this code will need to happen before any request to a spacetimedb server, rather than at the end of the login flow here.
     if let Some(token) = config.spacetimedb_token() {
+        println!("You are already logged in.");
+        println!("If you want to log out, use spacetime logout.");
         Ok(token.clone())
     } else {
         let token = if direct_login {


### PR DESCRIPTION
# Description of Changes

Currently, `spacetime login` just silently returns if the user is already logged in.

This PR adds a message informing the user that they are already logged in.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] When I run `spacetime login`, I see the message.
```
$ cargo run -- login
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.27s
     Running `target/debug/spacetime login`
You are already logged in.
If you want to log out, use spacetime logout.
```