### PR TITLE
Track time spent in datastore methods; use this to charge energy

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -1263,8 +1263,9 @@ impl MutTxId {
         (tx_data, tx)
     }
 
-    /// Returns a [`Duration`] representing the total time spent performing datastore operations
-    /// during the transaction, for which energy should be charged.
+    /// Returns a [`DatastoreComputeDuration`]
+    /// representing the total time spent performing datastore operations during the transaction,
+    /// for which energy should be charged.
     pub fn rollback(self) -> DatastoreComputeDuration {
         // Record metrics for the transaction at the very end,
         // right before we drop and release the lock.

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -110,8 +110,9 @@ impl TxId {
         res
     }
 
-    /// Returns a [`Duration`] representing the total time spent performing datastore operations
-    /// during the transaction, for which energy should be charged.
+    /// Returns a [`DatastoreComputeDuration`]
+    /// representing the total time spent performing datastore operations during the transaction,
+    /// for which energy should be charged.
     ///
     /// If this transaction was created by downgrading a [`super::mut_tx::MutTxId`],
     /// the returned time includes compute time spent in both the original mutable transaction

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -1,14 +1,17 @@
 use super::datastore::record_metrics;
+use super::mut_tx::elapsed_or_zero;
 use super::{
     committed_state::{CommittedIndexIter, CommittedState},
     datastore::Result,
     state_view::{Iter, IterByColRange, StateView},
     SharedReadGuard,
 };
+use crate::energy::DatastoreComputeDuration;
 use crate::execution_context::ExecutionContext;
 use spacetimedb_primitives::{ColList, TableId};
 use spacetimedb_sats::AlgebraicValue;
 use spacetimedb_schema::schema::TableSchema;
+use std::sync::atomic::{AtomicU64, Ordering};
 use std::sync::Arc;
 use std::{
     ops::RangeBounds,
@@ -20,18 +23,35 @@ pub struct TxId {
     pub(super) lock_wait_time: Duration,
     pub(super) timer: Instant,
     pub(crate) ctx: ExecutionContext,
+
+    /// Time spent performing operations that access the database,
+    /// for which energy will be charged.
+    ///
+    /// Will be used as a shared counter with [`Ordering::Relaxed`] atomics.
+    /// Does not provide any synchronization.
+    /// This means that accesses should mostly compile into relatively-efficient unfenced operations.
+    /// These accesses may, however, be contended, as we execute some read-only transactions in parallel.
+    ///
+    /// Incremental evaluation
+    pub(super) datastore_compute_time_microseconds: AtomicU64,
 }
 
 impl StateView for TxId {
     fn get_schema(&self, table_id: TableId) -> Option<&Arc<TableSchema>> {
-        self.committed_state_shared_lock.get_schema(table_id)
+        self.while_tracking_compute_time(|this| this.committed_state_shared_lock.get_schema(table_id))
     }
 
     fn table_row_count(&self, table_id: TableId) -> Option<u64> {
-        self.committed_state_shared_lock.table_row_count(table_id)
+        self.while_tracking_compute_time(|this| this.committed_state_shared_lock.table_row_count(table_id))
     }
 
     fn iter(&self, table_id: TableId) -> Result<Iter<'_>> {
+        // TODO(energy): track compute time spent in the iterator.
+        // This is challenging to do while maintaining non-reentrancy,
+        // and there are concerns about overhead - wrapping the body of `next`
+        // in (the equivalent of) `while_tracking_compute_time` means two clock reads for every row,
+        // which is potentially too much.
+
         self.committed_state_shared_lock.iter(table_id)
     }
 
@@ -44,6 +64,12 @@ impl StateView for TxId {
         cols: ColList,
         range: R,
     ) -> Result<IterByColRange<'_, R>> {
+        // TODO(energy): track compute time spent in the iterator.
+        // This is challenging to do while maintaining non-reentrancy,
+        // and there are concerns about overhead - wrapping the body of `next`
+        // in (the equivalent of) `while_tracking_compute_time` means two clock reads for every row,
+        // which is potentially too much.
+
         match self.committed_state_shared_lock.index_seek(table_id, &cols, &range) {
             Some(committed_rows) => Ok(IterByColRange::CommittedIndex(CommittedIndexIter::new(
                 table_id,
@@ -59,15 +85,50 @@ impl StateView for TxId {
 }
 
 impl TxId {
-    pub(super) fn release(self) {
+    /// Run `f` on `self` while tracking database compute time for `self`.
+    ///
+    /// Odd signature with explicit lifetimes here to allow `Res` to borrow from `self`.
+    ///
+    /// This method must never be called re-entrantly from the `f` of either this method
+    /// or [`Self::while_tracking_compute_time_mut`].
+    /// Doing so will double-count compute time in release builds.
+    /// However, it is acceptable for multiple actors to call `while_tracking_compute_time` in parallel.
+    /// In this case, the total tracked compute time will be the sum of all the callers' durations.
+    ///
+    /// Most, if not all, `pub` methods of `TxId` should have their bodies enclosed
+    /// in either this or [`Self::while_tracking_compute_time`].
+    fn while_tracking_compute_time<'a, Res>(&'a self, f: impl FnOnce(&'a Self) -> Res) -> Res {
+        let before = Instant::now();
+        let res = f(self);
+        let elapsed = elapsed_or_zero(before);
+
+        self.datastore_compute_time_microseconds
+            // `self.datastore_compute_time_microseconds` is not used for any synchronization;
+            // it is strictly a shared counter. As such, `Ordering::Relaxed` is sufficient.
+            .fetch_add(elapsed.as_micros() as u64, Ordering::Relaxed);
+
+        res
+    }
+
+    /// Returns a [`Duration`] representing the total time spent performing datastore operations
+    /// during the transaction, for which energy should be charged.
+    ///
+    /// If this transaction was created by downgrading a [`super::mut_tx::MutTxId`],
+    /// the returned time includes compute time spent in both the original mutable transaction
+    /// and the subsequent immutable transaction.
+    pub(super) fn release(self) -> DatastoreComputeDuration {
         record_metrics(&self.ctx, self.timer, self.lock_wait_time, true, None, None);
+
+        DatastoreComputeDuration::from_micros(self.datastore_compute_time_microseconds.into_inner())
     }
 
     /// The Number of Distinct Values (NDV) for a column or list of columns,
     /// if there's an index available on `cols`.
     pub(crate) fn num_distinct_values(&self, table_id: TableId, cols: &ColList) -> Option<u64> {
-        self.committed_state_shared_lock
-            .get_table(table_id)
-            .and_then(|t| t.indexes.get(cols).map(|index| index.num_keys() as u64))
+        self.while_tracking_compute_time(|this| {
+            this.committed_state_shared_lock
+                .get_table(table_id)
+                .and_then(|t| t.indexes.get(cols).map(|index| index.num_keys() as u64))
+        })
     }
 }

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -299,8 +299,9 @@ pub trait Tx {
     type Tx;
 
     fn begin_tx(&self, workload: Workload) -> Self::Tx;
-    /// Returns a [`Duration`] representing the total time spent performing datastore operations
-    /// during the transaction, for which energy should be charged.
+    /// Returns a [`DatastoreComputeduration`]
+    /// representing the total time spent performing datastore operations during the transaction,
+    /// for which energy should be charged.
     fn release_tx(&self, tx: Self::Tx) -> DatastoreComputeDuration;
 }
 
@@ -311,12 +312,14 @@ pub trait MutTx {
     /// Returns as two values:
     /// - A [`TxData`] containing all the mutations performed by the TX,
     ///   which can be used to compute incremental queries.
-    /// - A [`Duration`] representing the total time spent performing datastore operations
-    ///   during the transaction, for which energy should be charged.
+    /// - A [`DatastoreComputeduration`]
+    ///   representing the total time spent performing datastore operations during the transaction,
+    ///   for which energy should be charged.
     fn commit_mut_tx(&self, tx: Self::MutTx) -> Result<Option<(TxData, DatastoreComputeDuration)>>;
-    #[must_use]
-    /// Returns a [`Duration`] representing the total time spent performing datastore operations
-    /// during the transaction, for which energy should be charged.
+
+    /// Returns a [`DatastoreComputeDuration`]
+    /// representing the total time spent performing datastore operations during the transaction,
+    /// for which energy should be charged.
     fn rollback_mut_tx(&self, tx: Self::MutTx) -> DatastoreComputeDuration;
 }
 

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -618,8 +618,9 @@ impl RelationalDB {
     }
 
     #[tracing::instrument(skip_all)]
-    /// Returns a [`Duration`] representing the total time spent performing datastore operations
-    /// during the transaction, for which energy should be charged.
+    /// Returns a [`DatastoreComputeDuration`]
+    /// representing the total time spent performing datastore operations during the transaction,
+    /// for which energy should be charged.
     pub fn release_tx(&self, tx: Tx) {
         log::trace!("RELEASE TX");
         let compute_duration = self.inner.release_tx(tx);

--- a/crates/core/src/energy.rs
+++ b/crates/core/src/energy.rs
@@ -22,6 +22,7 @@ pub trait EnergyMonitor: Send + Sync + 'static {
     );
     fn record_disk_usage(&self, database: &Database, replica_id: u64, disk_usage: u64, period: Duration);
     fn record_memory_usage(&self, database: &Database, replica_id: u64, mem_usage: u64, period: Duration);
+    fn record_datastore_time(&self, module_identity: Identity, execution_duration: DatastoreComputeDuration);
 }
 
 #[derive(Default)]
@@ -43,4 +44,6 @@ impl EnergyMonitor for NullEnergyMonitor {
     fn record_disk_usage(&self, _database: &Database, _replica_id: u64, _disk_usage: u64, _period: Duration) {}
 
     fn record_memory_usage(&self, _database: &Database, _replica_id: u64, _mem_usage: u64, _period: Duration) {}
+
+    fn record_datastore_time(&self, _module_identity: Identity, _execution_duration: DatastoreComputeDuration) {}
 }

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -687,6 +687,7 @@ impl Host {
                 EmptyHistory::new(),
                 None,
                 None,
+                energy_monitor.clone(),
             )?,
             db::Storage::Disk => {
                 let (durability, disk_size_fn) = relational_db::local_durability(&db_path).await?;
@@ -700,6 +701,7 @@ impl Host {
                     history,
                     Some((durability, disk_size_fn)),
                     Some(snapshot_repo),
+                    energy_monitor.clone(),
                 )?
             }
         };

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -249,7 +249,7 @@ impl ExecutionUnit {
 
     fn eval_query_expr_against_memtable<'a>(
         db: &'a RelationalDB,
-        tx: &'a TxMode,
+        tx: &'a TxMode<'a>,
         mem_table: &'a [ProductValue],
         eval_incr_plan: &'a QueryExpr,
     ) -> Box<IterRows<'a>> {

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -202,9 +202,7 @@ impl ModuleSubscriptions {
                     stdb.rollback_mut_tx_downgrade(tx, Workload::Update)
                 }
             },
-            |tx| {
-                self.relational_db.release_tx(tx);
-            },
+            |tx| self.relational_db.release_tx(tx),
         );
         let event = Arc::new(event);
 

--- a/crates/standalone/src/energy_monitor.rs
+++ b/crates/standalone/src/energy_monitor.rs
@@ -1,5 +1,7 @@
 use crate::control_db::ControlDb;
-use spacetimedb::energy::{EnergyBalance, EnergyMonitor, EnergyQuanta, ReducerBudget, ReducerFingerprint};
+use spacetimedb::energy::{
+    DatastoreComputeDuration, EnergyBalance, EnergyMonitor, EnergyQuanta, ReducerBudget, ReducerFingerprint,
+};
 use spacetimedb::messages::control_db::Database;
 use spacetimedb_lib::Identity;
 use std::time::Duration;
@@ -44,6 +46,11 @@ impl EnergyMonitor for StandaloneEnergyMonitor {
     fn record_memory_usage(&self, database: &Database, _instance_id: u64, mem_usage: u64, period: Duration) {
         let amount = EnergyQuanta::from_memory_usage(mem_usage, period);
         self.withdraw_energy(database.owner_identity, amount)
+    }
+
+    fn record_datastore_time(&self, module_identity: Identity, execution_duration: DatastoreComputeDuration) {
+        let amount = EnergyQuanta::from_datastore_compute_duration(execution_duration);
+        self.withdraw_energy(module_identity, amount)
     }
 }
 


### PR DESCRIPTION
# Description of Changes

`TxId` and `MutTxId` now read from the `Instant` clock around all of their public methods, and accumulate the total `Duration` spent in those methods throughout the life of the transaction. Then, when committing or aborting the transaction, the `RelationalDB` charges energy via a new `EnergyMonitor` method, `record_datastore_time`.

This necessitates having `RelationalDB` hold an `Arc<dyn EnergyMonitor>`, as previously it had no mechanism by which to access the energy monitor.

Note that this approach is intended as a stopgap, rather than a permanent solution. Notable flaws include:

- Energy consumed by datastore operations is not included in the WS broadcasts sent to clients; these contain only WASM execution energy. This is because we construct the `ModuleEvent` before downgrading the TX and running incremental queries, and the total datastore energy cost is only available after those operations.

- Wall time is a very noisy measurement. It is not necessarily incorrect to pass this noise on to our customers, since many of the unpredictable costs are caused by events like page allocations which are caused by the user code, and in general we expect any variance not caused by user code to disappear as the total time grows large. Still, it's not wonderful that we will end up charging different amounts of energy to run the same operations against the same data sets multiple times.

- This patch does not track time spent in iterator or `RowRef` operations, only methods on the (`Mut`-) `TxId` (which are generally accessed through the `RelationalDB`).

- We also need to take care that this does not significantly regress performance, since it involves a potentially large number of added clock reads and relaxed atomic increments. My hope is that the atomics are uncontended and so it's not a significant cost, but hey, this is why we have benchmarks, right?
  - Update: Callgrind benchmarks look fine.

# API and ABI breaking changes

Will require private PR, which I will do after we determine that this is an acceptable approach and that the overhead is low. No user-facing interfaces change.

# Expected complexity level and risk

2 - performance risks, and may under- or over-charge energy, but seems unlikely to break functionality.

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [ ] None - curious to hear reviewers' thoughts on how best to test this!
