### PR TITLE
CI - Run `tools/publish-crates.sh --dry-run`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -200,3 +200,15 @@ jobs:
 
       - name: Run bindgen tests
         run: cargo test -p spacetimedb-cli
+
+  dry_run_publish:
+    name: Dry run publish to crates.io
+    runs-on: spacetimedb-runner
+    steps:
+      - uses: actions/checkout@v3
+
+      - uses: dsherret/rust-toolchain-file@v1
+      - run: echo ::add-matcher::.github/workflows/rust_matcher.json
+
+      - name: Run publish script
+        run: tools/publish-crates.sh --dry-run

--- a/tools/publish-crates.sh
+++ b/tools/publish-crates.sh
@@ -23,7 +23,7 @@ if [ $DRY_RUN != 1 ] ; then
 fi
 
 BASEDIR=$(pwd)
-declare -a CRATES=("metrics" "primitives" "bindings-macro" "bindings-sys" "data-structures" "sats" "lib" "schema" "bindings" "table" "vm" "client-api-messages" "commitlog" "durability" "fs-utils" "snapshot" "core" "client-api" "standalone" "cli" "sdk")
+declare -a CRATES=("metrics" "primitives" "bindings-macro" "bindings-sys" "data-structures" "sats" "lib" "schema" "bindings" "table" "vm" "client-api-messages" "commitlog" "durability" "fs-utils" "snapshot" "expr" "core" "client-api" "standalone" "cli" "sdk")
 
 for crate in "${CRATES[@]}" ; do
 	if [ ! -d "${BASEDIR}/crates/${crate}" ] ; then


### PR DESCRIPTION
# Description of Changes

We keep discovering issues during release, e.g. due to missing `LICENSE` files.

This adds `tools/publish-crates.sh --dry-run` as a CI step, so we will learn of these issues when they are initially introduced, instead of during release.

**Once this is merged, we should make it a required check.**

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [ ] CI fails initially, since we have not added the `expr` crate to the publish list
- [ ] CI passes now