### PR TITLE
commitlog: Small tweaks

### DIFF
--- a/crates/commitlog/Cargo.toml
+++ b/crates/commitlog/Cargo.toml
@@ -9,6 +9,8 @@ description = "Implementation of the SpacetimeDB commitlog."
 
 [features]
 default = ["serde"]
+# Enable types + impls useful for testing
+test = []
 
 [dependencies]
 bitflags.workspace = true

--- a/crates/commitlog/src/repo/mod.rs
+++ b/crates/commitlog/src/repo/mod.rs
@@ -28,7 +28,7 @@ pub type TxOffsetIndex = IndexFile<TxOffset>;
 /// representation.
 pub trait Repo: Clone {
     /// The type of log segments managed by this repo, which must behave like a file.
-    type Segment: io::Read + io::Write + FileLike + io::Seek;
+    type Segment: io::Read + io::Write + FileLike + io::Seek + Send + Sync + 'static;
 
     /// Create a new segment with the minimum transaction offset `offset`.
     ///

--- a/crates/commitlog/src/repo/mod.rs
+++ b/crates/commitlog/src/repo/mod.rs
@@ -11,11 +11,11 @@ use crate::{
 };
 
 pub(crate) mod fs;
-#[cfg(test)]
+#[cfg(any(test, feature = "test"))]
 pub mod mem;
 
 pub use fs::Fs;
-#[cfg(test)]
+#[cfg(any(test, feature = "test"))]
 pub use mem::Memory;
 
 pub type TxOffset = u64;


### PR DESCRIPTION
* Export memory `Repo` when feature "test" is enabled
* Add `Send + Sync + 'static` constraint to `Repo::Segment`