### PR TITLE
NFC: Remove unused fsync param in benchmarks

### DIFF
--- a/crates/bench/benches/callgrind.rs
+++ b/crates/bench/benches/callgrind.rs
@@ -60,7 +60,7 @@ mod callgrind_benches {
             assert_eq!(self.db, DB::name(), "provided metadata has incorrect db name");
             assert_eq!(self.schema, T::name(), "provided metadata has incorrect db name");
 
-            let mut db = DB::build(self.in_memory, false).unwrap();
+            let mut db = DB::build(self.in_memory).unwrap();
 
             let table_id = db.create_table::<T>(self.indices).unwrap();
             let mut data = create_sequential::<T>(0xdeadbeef, self.count + self.preload, 64);
@@ -134,7 +134,7 @@ mod callgrind_benches {
                 "provided metadata has incorrect index strategy"
             );
 
-            let mut db = DB::build(self.in_memory, false).unwrap();
+            let mut db = DB::build(self.in_memory).unwrap();
 
             let table_id = db.create_table::<T>(self.indices).unwrap();
             let data = create_sequential::<T>(0xdeadbeef, self.preload, 64);
@@ -198,7 +198,7 @@ mod callgrind_benches {
             assert_eq!(self.db, DB::name(), "provided metadata has incorrect db name");
             assert_eq!(self.schema, T::name(), "provided metadata has incorrect db name");
 
-            let mut db = DB::build(self.in_memory, false).unwrap();
+            let mut db = DB::build(self.in_memory).unwrap();
 
             let table_id = db.create_table::<T>(self.indices).unwrap();
             let data = create_sequential::<T>(0xdeadbeef, self.count, 64);
@@ -294,7 +294,7 @@ mod callgrind_benches {
                 "provided metadata has incorrect data type"
             );
 
-            let mut db = DB::build(self.in_memory, false).unwrap();
+            let mut db = DB::build(self.in_memory).unwrap();
 
             let table_id = db.create_table::<T>(self.indices).unwrap();
             let data = create_partly_identical::<T>(0xdeadbeef, self.count as u64, self.preload as u64);
@@ -429,7 +429,7 @@ mod callgrind_benches {
                 "primary key in tuple slot 0 must be u32"
             );
 
-            let mut db = DB::build(false, false).unwrap();
+            let mut db = DB::build(false).unwrap();
 
             let table_id = db.create_table::<T>(self.indices).unwrap();
 
@@ -470,7 +470,7 @@ mod callgrind_benches {
             );
             assert_eq!(self.db, DB::name(), "provided metadata has incorrect db name");
 
-            let mut db = DB::build(self.in_memory, false).unwrap();
+            let mut db = DB::build(self.in_memory).unwrap();
 
             // warm up
             db.empty_transaction().unwrap();

--- a/crates/bench/benches/generic.rs
+++ b/crates/bench/benches/generic.rs
@@ -32,7 +32,7 @@ fn criterion_benchmark(c: &mut Criterion) {
 
 #[inline(never)]
 fn bench_suite<DB: BenchDatabase>(c: &mut Criterion, in_memory: bool) -> ResultBench<()> {
-    let mut db = DB::build(in_memory, false)?; // don't need fsync benchmarks anymore
+    let mut db = DB::build(in_memory)?;
     let param_db_name = DB::name();
     let param_in_memory = if in_memory { "mem" } else { "disk" };
     let db_params = format!("{param_db_name}/{param_in_memory}");

--- a/crates/bench/benches/special.rs
+++ b/crates/bench/benches/special.rs
@@ -20,7 +20,7 @@ fn criterion_benchmark(c: &mut Criterion) {
     serialize_benchmarks::<u32_u64_u64>(c);
     serialize_benchmarks::<u64_u64_u32>(c);
 
-    let db = SpacetimeModule::build(true, true).unwrap();
+    let db = SpacetimeModule::build(true).unwrap();
 
     custom_module_benchmarks(&db, c);
     custom_db_benchmarks(&db, c);

--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -47,7 +47,7 @@ fn insert_op(table_id: TableId, table_name: &str, row: ProductValue) -> Database
 }
 
 fn eval(c: &mut Criterion) {
-    let raw = SpacetimeRaw::build(false, false).unwrap();
+    let raw = SpacetimeRaw::build(false).unwrap();
 
     let lhs = create_table_footprint(&raw.db).unwrap();
     let rhs = create_table_location(&raw.db).unwrap();

--- a/crates/bench/src/database.rs
+++ b/crates/bench/src/database.rs
@@ -14,7 +14,7 @@ pub trait BenchDatabase: Sized {
 
     type TableId: Clone + 'static;
 
-    fn build(in_memory: bool, fsync: bool) -> ResultBench<Self>
+    fn build(in_memory: bool) -> ResultBench<Self>
     where
         Self: Sized;
 

--- a/crates/bench/src/lib.rs
+++ b/crates/bench/src/lib.rs
@@ -57,7 +57,7 @@ mod tests {
     ) -> ResultBench<()> {
         prepare_tests();
 
-        let mut db = DB::build(in_memory, false)?;
+        let mut db = DB::build(in_memory)?;
         let table_id = db.create_table::<T>(index_strategy)?;
         assert_eq!(db.count_table(&table_id)?, 0, "tables should begin empty");
 

--- a/crates/bench/src/spacetime_module.rs
+++ b/crates/bench/src/spacetime_module.rs
@@ -65,7 +65,7 @@ impl BenchDatabase for SpacetimeModule {
 
     type TableId = TableId;
 
-    fn build(in_memory: bool, _fsync: bool) -> ResultBench<Self>
+    fn build(in_memory: bool) -> ResultBench<Self>
     where
         Self: Sized,
     {

--- a/crates/bench/src/spacetime_raw.rs
+++ b/crates/bench/src/spacetime_raw.rs
@@ -26,7 +26,7 @@ impl BenchDatabase for SpacetimeRaw {
     }
     type TableId = TableId;
 
-    fn build(in_memory: bool, _fsync: bool) -> ResultBench<Self>
+    fn build(in_memory: bool) -> ResultBench<Self>
     where
         Self: Sized,
     {

--- a/crates/bench/src/sqlite.rs
+++ b/crates/bench/src/sqlite.rs
@@ -27,7 +27,7 @@ impl BenchDatabase for SQLite {
         "sqlite"
     }
 
-    fn build(in_memory: bool, fsync: bool) -> ResultBench<Self>
+    fn build(in_memory: bool) -> ResultBench<Self>
     where
         Self: Sized,
     {
@@ -37,13 +37,9 @@ impl BenchDatabase for SQLite {
         } else {
             Connection::open(temp_dir.path().join("test.db"))?
         };
-        // For sqlite benchmarks we should set synchronous to either full or off which more
-        // closely aligns with wal_fsync=true and wal_fsync=false respectively in stdb.
-        db.execute_batch(if fsync {
-            "PRAGMA journal_mode = WAL; PRAGMA synchronous = full;"
-        } else {
-            "PRAGMA journal_mode = WAL; PRAGMA synchronous = off;"
-        })?;
+        // For sqlite benchmarks we should set synchronous to off which more
+        // closely aligns with wal_fsync=false in stdb.
+        db.execute_batch("PRAGMA journal_mode = WAL; PRAGMA synchronous = off;")?;
 
         Ok(SQLite {
             db,


### PR DESCRIPTION
# Description of Changes

As the removed code comment said, fsync benchmarks are no longer necessary and no longer called, plus in most impls this param was entirely unused, so removing it altogether for clarity.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
