### PR TITLE
core: Make NDV non-zero

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -9,6 +9,7 @@ use crate::execution_context::ExecutionContext;
 use spacetimedb_primitives::{ColList, TableId};
 use spacetimedb_sats::AlgebraicValue;
 use spacetimedb_schema::schema::TableSchema;
+use std::num::NonZeroU64;
 use std::sync::Arc;
 use std::{
     ops::RangeBounds,
@@ -65,9 +66,17 @@ impl TxId {
 
     /// The Number of Distinct Values (NDV) for a column or list of columns,
     /// if there's an index available on `cols`.
-    pub(crate) fn num_distinct_values(&self, table_id: TableId, cols: &ColList) -> Option<u64> {
-        self.committed_state_shared_lock
-            .get_table(table_id)
-            .and_then(|t| t.indexes.get(cols).map(|index| index.num_keys() as u64))
+    ///
+    /// Returns `None` if:
+    /// - No such table as `table_id` exists.
+    /// - The table `table_id` does not have an index on exactly the `cols`.
+    /// - The table `table_id` contains zero rows (i.e. the index is empty).
+    //
+    // This method must never return 0, as it's used as the divisor in quotients.
+    // Do not change its return type to a bare `u64`.
+    pub(crate) fn num_distinct_values(&self, table_id: TableId, cols: &ColList) -> Option<NonZeroU64> {
+        let table = self.committed_state_shared_lock.get_table(table_id)?;
+        let index = table.indexes.get(cols)?;
+        NonZeroU64::new(index.num_keys() as u64)
     }
 }


### PR DESCRIPTION
Change `TxId::num_distinct_values` to return `Option<NonZeroU64>`.

It will now return `None` if either the table doesn't exist, no index
exists for the given column list, or the index is empty.
Otherwise, `Some` non-zero number of distinct values is returned.

Fixes a division-by-zero bug in the query row estimation.

# Expected complexity level and risk

1

# Testing

No functional change, `estimation::index_row_est` is now statically guaranteed
to not panic due to division-by-zero
