### PR TITLE
test: No divide by zero for row estimation of empty index

### DIFF
--- a/crates/core/src/estimation.rs
+++ b/crates/core/src/estimation.rs
@@ -127,6 +127,13 @@ mod tests {
         .expect("failed to insert into table");
     }
 
+    fn create_empty_table_r(db: &RelationalDB, indexed: bool) {
+        let indexes = &[(0.into(), "a")];
+        let indexes = if indexed { indexes } else { &[] as &[_] };
+        db.create_table_for_test("R", &["a", "b"].map(|n| (n, AlgebraicType::U64)), indexes)
+            .expect("Failed to create table");
+    }
+
     /// Cardinality estimation for an index lookup depends only on
     /// (1) the total number of rows,
     /// (2) the number of distinct values.
@@ -135,6 +142,13 @@ mod tests {
         let db = in_mem_db();
         create_table_t(&db, true);
         assert_eq!(NUM_T_ROWS / NDV_T, num_rows_for(&db, "select * from T where a = 0"));
+    }
+
+    #[test]
+    fn cardinality_estimation_0_ndv() {
+        let db = in_mem_db();
+        create_empty_table_r(&db, true);
+        assert_eq!(0, num_rows_for(&db, "select * from R where a = 0"));
     }
 
     /// We estimate an index range to return all input rows.


### PR DESCRIPTION
# Description of Changes

Adds test that fails before https://github.com/clockworklabs/SpacetimeDB/pull/1985
