### PR TITLE
Clean up auth related code with traits, and reuse existing key generation code.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -76,9 +76,9 @@ dependencies = [
 
 [[package]]
 name = "allocator-api2"
-version = "0.2.18"
+version = "0.2.20"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c6cb57a04249c6480766f7f7cef5467412af1490f8d1e243141daddada3264f"
+checksum = "45862d1c77f2228b9e10bc609d5bc203d86ebc9b87ad8d5d5167a6c9abf739d9"
 
 [[package]]
 name = "android-tzdata"
@@ -103,9 +103,9 @@ checksum = "4b46cbb362ab8752921c97e041f5e366ee6297bd428a31275b9fcf1e380f7299"
 
 [[package]]
 name = "anstream"
-version = "0.6.15"
+version = "0.6.18"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "64e15c1ab1f89faffbf04a634d5e1962e9074f2741eef6d97f3c4e322426d526"
+checksum = "8acc5369981196006228e28809f761875c0327210a891e941f4c683b3a99529b"
 dependencies = [
  "anstyle",
  "anstyle-parse",
@@ -118,43 +118,43 @@ dependencies = [
 
 [[package]]
 name = "anstyle"
-version = "1.0.8"
+version = "1.0.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1bec1de6f59aedf83baf9ff929c98f2ad654b97c9510f4e70cf6f661d49fd5b1"
+checksum = "55cc3b69f167a1ef2e161439aa98aed94e6028e5f9a59be9a6ffb47aef1651f9"
 
 [[package]]
 name = "anstyle-parse"
-version = "0.2.5"
+version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eb47de1e80c2b463c735db5b217a0ddc39d612e7ac9e2e96a5aed1f57616c1cb"
+checksum = "3b2d16507662817a6a20a9ea92df6652ee4f94f914589377d69f3b21bc5798a9"
 dependencies = [
  "utf8parse",
 ]
 
 [[package]]
 name = "anstyle-query"
-version = "1.1.1"
+version = "1.1.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6d36fc52c7f6c869915e99412912f22093507da8d9e942ceaf66fe4b7c14422a"
+checksum = "79947af37f4177cfead1110013d678905c37501914fba0efea834c3fe9a8d60c"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anstyle-wincon"
-version = "3.0.4"
+version = "3.0.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5bf74e1b6e971609db8ca7a9ce79fd5768ab6ae46441c572e46cf596f59e57f8"
+checksum = "2109dbce0e72be3ec00bed26e6a7479ca384ad226efdd66db8fa2e3a38c83125"
 dependencies = [
  "anstyle",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
 name = "anyhow"
-version = "1.0.91"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c042108f3ed77fd83760a5fd79b53be043192bb3b9dba91d8c574c0ada7850c8"
+checksum = "4c95c10ba0b00a02636238b814946408b1322d5ac4760326e6fb8ec956d85775"
 dependencies = [
  "backtrace",
 ]
@@ -176,9 +176,9 @@ dependencies = [
 
 [[package]]
 name = "arbitrary"
-version = "1.3.2"
+version = "1.4.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7d5a26814d8dcb93b0e5a0ff3c6d80a8843bafb21b39e8e18a6f05471870e110"
+checksum = "dde20b3d026af13f561bdd0f15edf01fc734f0dafcedbaf42bba506a9517f223"
 
 [[package]]
 name = "arrayref"
@@ -193,16 +193,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "assert-json-diff"
-version = "2.0.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "47e4f2b81832e72834d7518d8487a0396a28cc408186a2e8854c0f98011faf12"
-dependencies = [
- "serde",
- "serde_json",
-]
-
-[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -210,7 +200,7 @@ checksum = "721cae7de5c34fbb2acd27e21e6d2cf7b886dce0c27388d46c4e6c47ea4318dd"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -259,12 +249,6 @@ dependencies = [
  "libc",
  "winapi",
 ]
-
-[[package]]
-name = "auto-future"
-version = "1.0.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3c1e7e457ea78e524f48639f551fd79703ac3f2237f5ecccdf4708f8a75ad373"
 
 [[package]]
 name = "autocfg"
@@ -351,35 +335,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "axum-test"
-version = "16.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3254184de359bbae2a8ca10b050870a7a4f1c8332a2c27d53f360b9835bb3911"
-dependencies = [
- "anyhow",
- "assert-json-diff",
- "auto-future",
- "axum",
- "bytes",
- "cookie",
- "http 1.1.0",
- "http-body-util",
- "hyper 1.5.0",
- "hyper-util",
- "mime",
- "pretty_assertions",
- "reserve-port",
- "rust-multipart-rfc7578_2",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "smallvec",
- "tokio",
- "tower",
- "url",
-]
-
-[[package]]
 name = "backtrace"
 version = "0.3.74"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -393,12 +348,6 @@ dependencies = [
  "rustc-demangle",
  "windows-targets 0.52.6",
 ]
-
-[[package]]
-name = "base64"
-version = "0.13.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
 
 [[package]]
 name = "base64"
@@ -495,15 +444,6 @@ dependencies = [
 
 [[package]]
 name = "block-buffer"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4152116fd6e9dadb291ae18fc1ec3575ed6d84c29642d97890f4b4a3417297e4"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "block-buffer"
 version = "0.10.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3078c7629b62d3f0439517fa394996acacc5cbc91c5a20d8c658e77abd503a71"
@@ -522,9 +462,9 @@ dependencies = [
 
 [[package]]
 name = "borsh"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6362ed55def622cddc70a4746a68554d7b687713770de539e59a739b249f8ed"
+checksum = "f5327f6c99920069d1fe374aa743be1af0031dea9f250852cdf1ae6a0861ee24"
 dependencies = [
  "borsh-derive",
  "cfg_aliases",
@@ -532,16 +472,15 @@ dependencies = [
 
 [[package]]
 name = "borsh-derive"
-version = "1.5.1"
+version = "1.5.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c3ef8005764f53cd4dca619f5bf64cafd4664dada50ece25e4d81de54c80cc0b"
+checksum = "10aedd8f1a81a8aafbfde924b0e3061cd6fedd6f6bbcfc6a76e6fd426d7bfe26"
 dependencies = [
  "once_cell",
  "proc-macro-crate",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
- "syn_derive",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -626,7 +565,7 @@ checksum = "bcfcc3cd946cb52f0bbfdbbcfa2f4e24f75ebb6c0e1002f7c25904fada18b9ec"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -691,9 +630,9 @@ checksum = "37b2a672a2cb129a2e41c10b1224bb368f9f37a2b16b612598138befd7b37eb5"
 
 [[package]]
 name = "cc"
-version = "1.1.31"
+version = "1.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c2e7962b54006dcfcc61cb72735f4d89bb97061dd6a7ed882ec6b8ee53714c6f"
+checksum = "1aeb932158bd710538c73702db6945cb68a8fb08c519e6e12706b94263b36db8"
 dependencies = [
  "jobserver",
  "libc",
@@ -822,7 +761,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -859,9 +798,9 @@ checksum = "67ba02a97a2bd10f4b59b25c7973101c79642302776489e030cd13cdab09ed15"
 
 [[package]]
 name = "colorchoice"
-version = "1.0.2"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3fd119d74b830634cea2a0f58bbd0d54540518a14397557951e79340abc28c0"
+checksum = "5b63caa9aa9397e2d9480a9b13673856c78d8ac123288526c37d7839f2a86990"
 
 [[package]]
 name = "colored"
@@ -906,12 +845,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "const-oid"
-version = "0.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d6f2aa4d0537bcc1c74df8755072bd31c1ef1a3a1b85a68e8404a8c353b7b8b"
-
-[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -930,16 +863,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ec182b0ca2f35d8fc196cf3404988fd8b8c739a4d270ff118a398feb0cbec1ca"
 dependencies = [
  "unicode-segmentation",
-]
-
-[[package]]
-name = "cookie"
-version = "0.18.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ddef33a339a91ea89fb53151bd0a4689cfce27055c291dfa69945475d22c747"
-dependencies = [
- "time",
- "version_check",
 ]
 
 [[package]]
@@ -979,27 +902,27 @@ dependencies = [
 
 [[package]]
 name = "cpufeatures"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "608697df725056feaccfa42cffdaeeec3fccc4ffc38358ecd19b243e716a78e0"
+checksum = "0ca741a962e1b0bff6d724a1a0958b686406e853bb14061f218562e1896f95e6"
 dependencies = [
  "libc",
 ]
 
 [[package]]
 name = "cranelift-bforest"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7b765ed4349e66bedd9b88c7691da42e24c7f62067a6be17ddffa949367b6e17"
+checksum = "69792bd40d21be8059f7c709f44200ded3bbd073df7eb3fa3c282b387c7ffa5b"
 dependencies = [
  "cranelift-entity",
 ]
 
 [[package]]
 name = "cranelift-bitset"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9eaa2aece6237198afd32bff57699e08d4dccb8d3902c214fc1e6ba907247ca4"
+checksum = "38da1eb6f7d8cdfa92f05acfae63c9a1d7a337e49ce7a2d0769c7fa03a2613a5"
 dependencies = [
  "serde",
  "serde_derive",
@@ -1007,9 +930,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "351824439e59d42f0e4fa5aac1d13deded155120043565769e55cd4ad3ca8ed9"
+checksum = "709f5567a2bff9f06edf911a7cb5ebb091e4c81701714dc6ab574d08b4a69a0d"
 dependencies = [
  "bumpalo",
  "cranelift-bforest",
@@ -1030,33 +953,33 @@ dependencies = [
 
 [[package]]
 name = "cranelift-codegen-meta"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5a0ce0273d7a493ef8f31f606849a4e931c19187a4923f5f87fc1f2b13109981"
+checksum = "72d39a6b194c069fd091ca1f17b9d86ff1a4627ccad8806095828f61989a691f"
 dependencies = [
  "cranelift-codegen-shared",
 ]
 
 [[package]]
 name = "cranelift-codegen-shared"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0f72016ac35579051913f4f07f6b36c509ed69412d852fd44c8e1d7b7fa6d92a"
+checksum = "18f81aefad1f80ed4132ae33f40b92779eeb57edeb1e28bb24424a4098c963a2"
 
 [[package]]
 name = "cranelift-control"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "db28951d21512c4fd0554ef179bfb11e4eb6815062957a9173824eee5de0c46c"
+checksum = "6adbaac785ad4683c4f199686f9e15c1471f52ae2f4c013a3be039b4719db754"
 dependencies = [
  "arbitrary",
 ]
 
 [[package]]
 name = "cranelift-entity"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "14ebe592a2f81af9237cf9be29dd3854ecb72108cfffa59e85ef12389bf939e3"
+checksum = "70b85ed43567e13782cd1b25baf42a8167ee57169a60dfd3d7307c6ca3839da0"
 dependencies = [
  "cranelift-bitset",
  "serde",
@@ -1065,9 +988,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-frontend"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4437db9d60c7053ac91ded0802740c2ccf123ee6d6898dd906c34f8c530cd119"
+checksum = "8349f71373bb69c6f73992c6c1606236a66c8134e7a60e04e03fbd64b1aa7dcf"
 dependencies = [
  "cranelift-codegen",
  "log",
@@ -1077,15 +1000,15 @@ dependencies = [
 
 [[package]]
 name = "cranelift-isle"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "230cb33572b9926e210f2ca28145f2bc87f389e1456560932168e2591feb65c1"
+checksum = "464a6b958ce05e0c237c8b25508012b6c644e8c37348213a8c786ba29e28cfdb"
 
 [[package]]
 name = "cranelift-native"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "364524ac7aef7070b1141478724abebeec297d4ea1e87ad8b8986465e91146d9"
+checksum = "ffc4acaf6894ee323ff4e9ce786bec09f0ebbe49941e8012f1c1052f1d965034"
 dependencies = [
  "cranelift-codegen",
  "libc",
@@ -1094,9 +1017,9 @@ dependencies = [
 
 [[package]]
 name = "cranelift-wasm"
-version = "0.112.2"
+version = "0.112.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0572cbd9d136a62c0f39837b6bce3b0978b96b8586794042bec0c214668fd6f5"
+checksum = "b878860895cca97454ef8d8b12bfda9d0889dd49efee175dba78d54ff8363ec2"
 dependencies = [
  "cranelift-codegen",
  "cranelift-entity",
@@ -1230,18 +1153,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7a81dae078cea95a014a339291cec439d2f232ebe854a9d672b796c6afafa9b7"
 
 [[package]]
-name = "crypto-bigint"
-version = "0.2.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f83bd3bb4314701c568e340cd8cf78c975aa0ca79e03d3f6d1677d5b0c9c0c03"
-dependencies = [
- "generic-array",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
-
-[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1249,16 +1160,6 @@ checksum = "1bfb12502f3fc46cca1bb51ac28df9d618d813cdc3d2f25b9fe775a34af26bb3"
 dependencies = [
  "generic-array",
  "typenum",
-]
-
-[[package]]
-name = "crypto-mac"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b1d1a86f49236c215f271d40892d5fc950490551400b02ef360692c29815c714"
-dependencies = [
- "generic-array",
- "subtle",
 ]
 
 [[package]]
@@ -1341,7 +1242,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "strsim 0.11.1",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1352,7 +1253,7 @@ checksum = "d336a2a514f6ccccaa3e09b02d41d35330c07ddf03a62165fcec10bb561c7806"
 dependencies = [
  "darling_core",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1399,15 +1300,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "der"
-version = "0.4.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "79b71cca7d95d7681a4b3b9cdf63c8dbc3730d0584c2c74e31416d64a90493f4"
-dependencies = [
- "const-oid",
-]
-
-[[package]]
 name = "deranged"
 version = "0.3.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1427,7 +1319,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustc_version",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1438,20 +1330,11 @@ checksum = "56254986775e3233ffa9c4d7d3faaf6d36a2c09d30b20687e9f88bc8bafc16c8"
 
 [[package]]
 name = "digest"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d3dd60d1080a57a05ab032377049e0591415d2b31afd7028356dbf3cc6dcb066"
-dependencies = [
- "generic-array",
-]
-
-[[package]]
-name = "digest"
 version = "0.10.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
- "block-buffer 0.10.4",
+ "block-buffer",
  "crypto-common",
  "subtle",
 ]
@@ -1499,6 +1382,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "displaydoc"
+version = "0.2.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97369cbbc041bc366949bc74d34658d6cda5621039731c6310521892a3a20ae0"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "duct"
 version = "0.13.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1508,18 +1402,6 @@ dependencies = [
  "once_cell",
  "os_pipe",
  "shared_child",
-]
-
-[[package]]
-name = "ecdsa"
-version = "0.12.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "43ee23aa5b4f68c7a092b5c3beb25f50c406adc75e2363634f242f28ab255372"
-dependencies = [
- "der",
- "elliptic-curve",
- "hmac 0.11.0",
- "signature",
 ]
 
 [[package]]
@@ -1539,22 +1421,6 @@ name = "either"
 version = "1.13.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "60b1af1c220855b6ceac025d3f6ecdd2b7c4894bfe9cd9bda4fbb4bc7c0d4cf0"
-
-[[package]]
-name = "elliptic-curve"
-version = "0.10.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "beca177dcb8eb540133e7680baff45e7cc4d93bf22002676cec549f82343721b"
-dependencies = [
- "crypto-bigint",
- "ff",
- "generic-array",
- "group",
- "pkcs8",
- "rand_core 0.6.4",
- "subtle",
- "zeroize",
-]
 
 [[package]]
 name = "email_address"
@@ -1585,9 +1451,9 @@ checksum = "a357d28ed41a50f9c765dbfe56cbc04a64e53e5fc58ba79fbc34c10ef3df831f"
 
 [[package]]
 name = "encoding_rs"
-version = "0.8.34"
+version = "0.8.35"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b45de904aa0b010bce2ab45264d0631681847fa7b6f2eaa7dab7619943bc4f59"
+checksum = "75030f3c4f45dafd7586dd6780965a8c7e8e285a5ecb86713e63a79c5b2766f3"
 dependencies = [
  "cfg-if",
 ]
@@ -1607,7 +1473,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1627,7 +1493,7 @@ checksum = "f282cfdfe92516eb26c2af8589c274c7c17681f5ecc03c18255fe741c6aa64eb"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1640,7 +1506,7 @@ dependencies = [
  "num-traits",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1661,7 +1527,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -1742,9 +1608,9 @@ dependencies = [
 
 [[package]]
 name = "fastrand"
-version = "2.1.1"
+version = "2.2.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e8c02a5121d4ea3eb16a80748c74f5549a5665e4c21333c6098f283870fbdea6"
+checksum = "486f806e73c5707928240ddc295403b1b93c96a02038563881c4a2fd84b81ac4"
 
 [[package]]
 name = "faststr"
@@ -1766,16 +1632,6 @@ dependencies = [
  "cfg-if",
  "rustix",
  "windows-sys 0.48.0",
-]
-
-[[package]]
-name = "ff"
-version = "0.10.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d0f40b2dcd8bc322217a5f6559ae5f9e9d1de202a2ecee2e9eafcbece7562a4f"
-dependencies = [
- "rand_core 0.6.4",
- "subtle",
 ]
 
 [[package]]
@@ -1929,7 +1785,7 @@ checksum = "162ee34ebcb7c64a8abebc059ce0fee27c2262618d7b60ed8faf72fef13c3650"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2031,17 +1887,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d2fabcfbdc87f4758337ca535fb41a6d701b65693ce38287d856d1674551ec9b"
 
 [[package]]
-name = "group"
-version = "0.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c363a5301b8f153d80747126a04b3c82073b9fe3130571a9d170cacdeaf7912"
-dependencies = [
- "ff",
- "rand_core 0.6.4",
- "subtle",
-]
-
-[[package]]
 name = "h2"
 version = "0.3.26"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2120,9 +1965,9 @@ dependencies = [
 
 [[package]]
 name = "hashbrown"
-version = "0.15.0"
+version = "0.15.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1e087f84d4f86bf4b218b927129862374b72199ae7d8657835f1e89000eea4fb"
+checksum = "3a9bfc1af68b1726ea47d3d5109de126281def866b33970e10fbab11b5dafab3"
 dependencies = [
  "equivalent",
  "foldhash",
@@ -2204,21 +2049,11 @@ checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
 name = "hmac"
-version = "0.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2a2a2320eb7ec0ebe8da8f744d7812d9fc4cb4d09344ac01898dbcb6a20ae69b"
-dependencies = [
- "crypto-mac",
- "digest 0.9.0",
-]
-
-[[package]]
-name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6c49c37c09c17a53d937dfbb742eb3a961d65a994e6bcdcf37e7399d0cc8ab5e"
 dependencies = [
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2361,6 +2196,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "hyper-rustls"
+version = "0.27.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "08afdbb5c31130e3034af566421053ab03787c640246a446327f550d11bcb333"
+dependencies = [
+ "futures-util",
+ "http 1.1.0",
+ "hyper 1.5.0",
+ "hyper-util",
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
+ "tokio-rustls",
+ "tower-service",
+]
+
+[[package]]
 name = "hyper-tls"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2391,9 +2243,9 @@ dependencies = [
 
 [[package]]
 name = "hyper-util"
-version = "0.1.9"
+version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41296eb09f183ac68eec06e03cdbea2e759633d4067b2f6552fc2e009bcad08b"
+checksum = "df2dcfbe0677734ab2f3ffa7fa7bfd4706bfdc1ef393f2ee30184aed67e631b4"
 dependencies = [
  "bytes",
  "futures-channel",
@@ -2426,7 +2278,7 @@ dependencies = [
  "proc-macro-error",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -2479,6 +2331,124 @@ dependencies = [
 ]
 
 [[package]]
+name = "icu_collections"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "db2fa452206ebee18c4b5c2274dbf1de17008e874b4dc4f0aea9d01ca79e4526"
+dependencies = [
+ "displaydoc",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "13acbb8371917fc971be86fc8057c41a64b521c184808a698c02acc242dbf637"
+dependencies = [
+ "displaydoc",
+ "litemap",
+ "tinystr",
+ "writeable",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "01d11ac35de8e40fdeda00d9e1e9d92525f3f9d887cdd7aa81d727596788b54e"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_locid_transform_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_locid_transform_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fdc8ff3388f852bede6b579ad4e978ab004f139284d7b28715f773507b946f6e"
+
+[[package]]
+name = "icu_normalizer"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "19ce3e0da2ec68599d193c93d088142efd7f9c5d6fc9b803774855747dc6a84f"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_normalizer_data",
+ "icu_properties",
+ "icu_provider",
+ "smallvec",
+ "utf16_iter",
+ "utf8_iter",
+ "write16",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_normalizer_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8cafbf7aa791e9b22bec55a167906f9e1215fd475cd22adfcf660e03e989516"
+
+[[package]]
+name = "icu_properties"
+version = "1.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "93d6020766cfc6302c15dbbc9c8778c37e62c14427cb7f6e601d849e092aeef5"
+dependencies = [
+ "displaydoc",
+ "icu_collections",
+ "icu_locid_transform",
+ "icu_properties_data",
+ "icu_provider",
+ "tinystr",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_properties_data"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67a8effbc3dd3e4ba1afa8ad918d5684b8868b3b26500753effea8d2eed19569"
+
+[[package]]
+name = "icu_provider"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "6ed421c8a8ef78d3e2dbc98a973be2f3770cb42b606e3ab18d6237c4dfde68d9"
+dependencies = [
+ "displaydoc",
+ "icu_locid",
+ "icu_provider_macros",
+ "stable_deref_trait",
+ "tinystr",
+ "writeable",
+ "yoke",
+ "zerofrom",
+ "zerovec",
+]
+
+[[package]]
+name = "icu_provider_macros"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1ec89e9337638ecdc08744df490b221a7399bf8d164eb52a665454e60e075ad6"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "id-arena"
 version = "2.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2492,12 +2462,23 @@ checksum = "b9e0384b61958566e926dc50660321d12159025e767c18e043daf26b70104c39"
 
 [[package]]
 name = "idna"
-version = "0.5.0"
+version = "1.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "634d9b1461af396cad843f47fdba5597a4f9e6ddd4bfb6ff5d85028c25cb12f6"
+checksum = "686f825264d630750a544639377bae737628043f20d38bbc029e8f29ea968a7e"
 dependencies = [
- "unicode-bidi",
- "unicode-normalization",
+ "idna_adapter",
+ "smallvec",
+ "utf8_iter",
+]
+
+[[package]]
+name = "idna_adapter"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "daca1df1c957320b2cf139ac61e7bd64fed304c5040df000a745aa1de3b4ef71"
+dependencies = [
+ "icu_normalizer",
+ "icu_properties",
 ]
 
 [[package]]
@@ -2542,7 +2523,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "707907fe3c25f5424cce2cb7e1cbcafee6bdbe735ca90ef77c29e84591e5b9da"
 dependencies = [
  "equivalent",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "serde",
 ]
 
@@ -2580,9 +2561,9 @@ dependencies = [
 
 [[package]]
 name = "insta"
-version = "1.40.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6593a41c7a73841868772495db7dc1e8ecab43bb5c0b6da2059246c4b506ab60"
+checksum = "7e9ffc4d4892617c50a928c52b2961cb5174b6fc6ebf252b2fac9d21955c48b8"
 dependencies = [
  "console",
  "lazy_static",
@@ -2698,40 +2679,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "jsonwebkey"
-version = "0.3.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c57c852b14147e2bd58c14fde40398864453403ef632b1101db130282ee6e2cc"
-dependencies = [
- "base64 0.13.1",
- "bitflags 1.3.2",
- "generic-array",
- "jsonwebtoken",
- "num-bigint",
- "p256",
- "rand 0.8.5",
- "serde",
- "serde_json",
- "thiserror",
- "yasna",
- "zeroize",
-]
-
-[[package]]
-name = "jsonwebtoken"
-version = "8.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6971da4d9c3aa03c3d8f3ff0f4155b534aad021292003895a469716b2a230378"
-dependencies = [
- "base64 0.21.7",
- "pem 1.1.1",
- "ring 0.16.20",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
 name = "keccak"
 version = "0.1.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2754,15 +2701,15 @@ checksum = "884e2677b40cc8c339eaefcb701c32ef1fd2493d71118dc0ca4b6a736c93bd67"
 
 [[package]]
 name = "libc"
-version = "0.2.161"
+version = "0.2.162"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8e9489c2807c139ffd9c1794f4af0ebe86a828db53ecdc7fea2111d0fed085d1"
+checksum = "18d287de67fe55fd7e1581fe933d965a5a9477b38e949cfa9f8574ef01506398"
 
 [[package]]
 name = "libm"
-version = "0.2.8"
+version = "0.2.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ec2a862134d2a7d32d7983ddcdd1c4923530833c9f2ea1a44fc5fa473989058"
+checksum = "8355be11b20d696c8f18f6cc018c4e372165b1fa8126cef092399c9951984ffa"
 
 [[package]]
 name = "libmimalloc-sys"
@@ -2818,6 +2765,12 @@ name = "linux-raw-sys"
 version = "0.4.14"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "78b3ae25bc7c8c38cec158d1f2757ee79e9b3740fbc7ccf0e59e4b08d793fa89"
+
+[[package]]
+name = "litemap"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "643cb0b8d4fcc284004d5fd0d67ccf61dfffadb7f75e1e71bc420f4688a3a704"
 
 [[package]]
 name = "lock_api"
@@ -2885,7 +2838,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d89e7ee0cfbedfc4da3340218492196241d89eefb6dab27de5df917a6d2e78cf"
 dependencies = [
  "cfg-if",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -2926,16 +2879,6 @@ name = "mime"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6877bb514081ee2a7ff5ef9de3281f14a4dd4bceac4c09388074a6b5df8a139a"
-
-[[package]]
-name = "mime_guess"
-version = "2.0.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f7c44f8e672c00fe5308fa235f821cb4198414e1c77935c1ab6948d3fd78550e"
-dependencies = [
- "mime",
- "unicase",
-]
 
 [[package]]
 name = "miniz_oxide"
@@ -3183,7 +3126,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "aedf0a2d09c573ed1d8d85b30c119153926a2b36dce0ab28322c09a117a4683e"
 dependencies = [
  "crc32fast",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "indexmap 2.6.0",
  "memchr",
 ]
@@ -3199,12 +3142,6 @@ name = "oorandom"
 version = "11.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b410bbe7e14ab526a0e86877eb47c6996a2bd7746f027ba551028c925390e4e9"
-
-[[package]]
-name = "opaque-debug"
-version = "0.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c08d65885ee38876c4f86fa503fb49d7b507c2b62552df7c70b2fce627e06381"
 
 [[package]]
 name = "openssl"
@@ -3229,7 +3166,7 @@ checksum = "a948666b637a0f465e8564c73e89d4dde00d72d4d473cc972f390fc3dcee7d9c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3304,17 +3241,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1b04fb49957986fdce4d6ee7a65027d55d4b6d2265e5848bbb507b58ccfdb6f"
 
 [[package]]
-name = "p256"
-version = "0.9.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d053368e1bae4c8a672953397bd1bd7183dde1c72b0b7612a15719173148d186"
-dependencies = [
- "ecdsa",
- "elliptic-curve",
- "sha2 0.9.9",
-]
-
-[[package]]
 name = "papergrid"
 version = "0.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3381,15 +3307,6 @@ checksum = "57c0d7b74b563b49d38dae00a0c37d4d6de9b432382b2892f0574ddcae73fd0a"
 
 [[package]]
 name = "pem"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a8835c273a76a90455d7344889b0964598e3316e2a79ede8e36f16bdcf2228b8"
-dependencies = [
- "base64 0.13.1",
-]
-
-[[package]]
-name = "pem"
 version = "3.0.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8e459365e590736a54c3fa561947c84837534b8e9af6fc5bf781307e82658fae"
@@ -3453,45 +3370,35 @@ dependencies = [
 
 [[package]]
 name = "pin-project"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "baf123a161dde1e524adf36f90bc5d8d3462824a9c43553ad07a8183161189ec"
+checksum = "be57f64e946e500c8ee36ef6331845d40a93055567ec57e8fae13efd33759b95"
 dependencies = [
  "pin-project-internal",
 ]
 
 [[package]]
 name = "pin-project-internal"
-version = "1.1.6"
+version = "1.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4502d8515ca9f32f1fb543d987f63d95a14934883db45bdb48060b6b69257f8"
+checksum = "3c0f5fad0874fc7abcd4d750e76917eaebbecaa2c20bde22e1dbeeba8beb758c"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "pin-project-lite"
-version = "0.2.14"
+version = "0.2.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bda66fc9667c18cb2758a2ac84d1167245054bcf85d5d1aaa6923f45801bdd02"
+checksum = "915a1e146535de9163f3987b8944ed8cf49a18bb0056bcebcdcece385cece4ff"
 
 [[package]]
 name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
-
-[[package]]
-name = "pkcs8"
-version = "0.7.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ee3ef9b64d26bad0536099c816c6734379e45bbd5f14798def6809e5cc350447"
-dependencies = [
- "der",
- "spki",
-]
 
 [[package]]
 name = "pkg-config"
@@ -3561,7 +3468,7 @@ dependencies = [
  "heck 0.5.0",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -3574,11 +3481,11 @@ dependencies = [
  "byteorder",
  "bytes",
  "fallible-iterator 0.2.0",
- "hmac 0.12.1",
+ "hmac",
  "md-5",
  "memchr",
  "rand 0.8.5",
- "sha2 0.10.8",
+ "sha2",
  "stringprep",
 ]
 
@@ -3972,13 +3879,13 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.11.0"
+version = "1.11.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "38200e5ee88914975b69f657f0801b6f6dccafd44fd9326302a4aaeecfacb1d8"
+checksum = "b544ef1b4eac5dc2db33ea63606ae9ffcfac26c1416a2806ae0bf5f56b201191"
 dependencies = [
  "aho-corasick",
  "memchr",
- "regex-automata 0.4.8",
+ "regex-automata 0.4.9",
  "regex-syntax 0.8.5",
 ]
 
@@ -3993,9 +3900,9 @@ dependencies = [
 
 [[package]]
 name = "regex-automata"
-version = "0.4.8"
+version = "0.4.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "368758f23274712b504848e9d5a6f010445cc8b87a7cdb4d7cbee666c1288da3"
+checksum = "809e8dc61f6de73b46c85f4c96486310fe304c434cfa43669d7b40f711150908"
 dependencies = [
  "aho-corasick",
  "memchr",
@@ -4061,7 +3968,7 @@ dependencies = [
  "serde_json",
  "serde_urlencoded",
  "sync_wrapper 0.1.2",
- "system-configuration",
+ "system-configuration 0.5.1",
  "tokio",
  "tokio-native-tls",
  "tower-service",
@@ -4069,14 +3976,14 @@ dependencies = [
  "wasm-bindgen",
  "wasm-bindgen-futures",
  "web-sys",
- "winreg 0.50.0",
+ "winreg",
 ]
 
 [[package]]
 name = "reqwest"
-version = "0.12.4"
+version = "0.12.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "566cafdd92868e0939d3fb961bd0dc25fcfaaed179291093b3d43e6b3150ea10"
+checksum = "a77c62af46e79de0a562e1a9849205ffcb7fc1238876e9bd743357570e04046f"
 dependencies = [
  "base64 0.22.1",
  "bytes",
@@ -4088,6 +3995,7 @@ dependencies = [
  "http-body 1.0.1",
  "http-body-util",
  "hyper 1.5.0",
+ "hyper-rustls",
  "hyper-tls 0.6.0",
  "hyper-util",
  "ipnet",
@@ -4102,8 +4010,8 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration",
+ "sync_wrapper 1.0.1",
+ "system-configuration 0.6.1",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -4113,17 +4021,7 @@ dependencies = [
  "wasm-bindgen-futures",
  "wasm-streams",
  "web-sys",
- "winreg 0.52.0",
-]
-
-[[package]]
-name = "reserve-port"
-version = "2.0.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9838134a2bfaa8e1f40738fcc972ac799de6e0e06b5157acb95fc2b05a0ea283"
-dependencies = [
- "lazy_static",
- "thiserror",
+ "windows-registry",
 ]
 
 [[package]]
@@ -4137,21 +4035,6 @@ dependencies = [
 
 [[package]]
 name = "ring"
-version = "0.16.20"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3053cf52e236a3ed746dfc745aa9cacf1b791d846bdaf412f60a8d7d6e17c8fc"
-dependencies = [
- "cc",
- "libc",
- "once_cell",
- "spin 0.5.2",
- "untrusted 0.7.1",
- "web-sys",
- "winapi",
-]
-
-[[package]]
-name = "ring"
 version = "0.17.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c17fa4cb658e3583423e915b9f3acc01cceaee1860e33d59ebae66adc3a2dc0d"
@@ -4160,8 +4043,8 @@ dependencies = [
  "cfg-if",
  "getrandom",
  "libc",
- "spin 0.9.8",
- "untrusted 0.9.0",
+ "spin",
+ "untrusted",
  "windows-sys 0.52.0",
 ]
 
@@ -4221,22 +4104,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "rust-multipart-rfc7578_2"
-version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "03b748410c0afdef2ebbe3685a6a862e2ee937127cdaae623336a459451c8d57"
-dependencies = [
- "bytes",
- "futures-core",
- "futures-util",
- "http 0.2.12",
- "mime",
- "mime_guess",
- "rand 0.8.5",
- "thiserror",
-]
-
-[[package]]
 name = "rust-wasm-test-module"
 version = "0.0.0"
 dependencies = [
@@ -4285,15 +4152,28 @@ dependencies = [
 
 [[package]]
 name = "rustix"
-version = "0.38.37"
+version = "0.38.40"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8acb788b847c24f28525660c4d7758620a7210875711f79e7f663cc152726811"
+checksum = "99e4ea3e1cdc4b559b8e5650f9c8e5998e3e5c1343b4eaf034565f32318d63c0"
 dependencies = [
  "bitflags 2.6.0",
  "errno",
  "libc",
  "linux-raw-sys",
  "windows-sys 0.52.0",
+]
+
+[[package]]
+name = "rustls"
+version = "0.23.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eee87ff5d9b36712a58574e12e9f0ea80f915a5b0ac518d322b24a465617925e"
+dependencies = [
+ "once_cell",
+ "rustls-pki-types",
+ "rustls-webpki",
+ "subtle",
+ "zeroize",
 ]
 
 [[package]]
@@ -4319,6 +4199,17 @@ name = "rustls-pki-types"
 version = "1.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "16f1201b3c9a7ee8039bcadc17b7e605e2945b27eee7631788c1bd2b0643674b"
+
+[[package]]
+name = "rustls-webpki"
+version = "0.102.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "64ca1bc8749bd4cf37b5ce386cc146580777b4e8572c7b97baf22c83f444bee9"
+dependencies = [
+ "ring",
+ "rustls-pki-types",
+ "untrusted",
+]
 
 [[package]]
 name = "rustversion"
@@ -4444,9 +4335,9 @@ dependencies = [
 
 [[package]]
 name = "security-framework-sys"
-version = "2.12.0"
+version = "2.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ea4a292869320c0272d7bc55a5a6aafaff59b4f63404a003887b679a2e05b4b6"
+checksum = "fa39c7303dc58b5543c94d22c1766b0d31f2ee58306363ea622b10bbc075eaa2"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -4463,22 +4354,22 @@ dependencies = [
 
 [[package]]
 name = "serde"
-version = "1.0.213"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3ea7893ff5e2466df8d720bb615088341b295f849602c6956047f8f80f0e9bc1"
+checksum = "6513c1ad0b11a9376da888e3e0baa0077f1aed55c17f50e7b2397136129fb88f"
 dependencies = [
  "serde_derive",
 ]
 
 [[package]]
 name = "serde_derive"
-version = "1.0.213"
+version = "1.0.215"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e85ad2009c50b58e87caa8cd6dac16bdf511bbfb7af6c33df902396aa480fa5"
+checksum = "ad1e866f866923f252f05c889987993144fb74e722403468a4ebd70c3cd756c0"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4552,7 +4443,7 @@ dependencies = [
  "darling",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4577,7 +4468,7 @@ checksum = "91d129178576168c589c9ec973feedf7d3126c01ac2bf08795109aa35b69fb8f"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4588,20 +4479,7 @@ checksum = "e3bf829a2d51ab4a5ddf1352d8470c140cadc8301b2ae1789db023f01cedd6ba"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
-]
-
-[[package]]
-name = "sha2"
-version = "0.9.9"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4d58a1e1bf39749807d89cf2d98ac2dfa0ff1cb3faa38fbb64dd88ac8013d800"
-dependencies = [
- "block-buffer 0.9.0",
- "cfg-if",
- "cpufeatures",
- "digest 0.9.0",
- "opaque-debug",
+ "digest",
 ]
 
 [[package]]
@@ -4612,7 +4490,7 @@ checksum = "793db75ad2bcafc3ffa7c68b215fee268f537982cd901d132f89c6343f3a3dc8"
 dependencies = [
  "cfg-if",
  "cpufeatures",
- "digest 0.10.7",
+ "digest",
 ]
 
 [[package]]
@@ -4621,7 +4499,7 @@ version = "0.10.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "75872d278a8f37ef87fa0ddbda7802605cb18344497949862c0d4dcb291eba60"
 dependencies = [
- "digest 0.10.7",
+ "digest",
  "keccak",
 ]
 
@@ -4678,16 +4556,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9e9e0b4211b72e7b8b6e85c807d36c212bdb33ea8587f7569562a84df5465b1"
 dependencies = [
  "libc",
-]
-
-[[package]]
-name = "signature"
-version = "1.3.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2807892cfa58e081aa1f1111391c7a0649d4fa127a4ffbe34bcbfb35a1171a4"
-dependencies = [
- "digest 0.9.0",
- "rand_core 0.6.4",
 ]
 
 [[package]]
@@ -4856,7 +4724,7 @@ dependencies = [
  "quote",
  "spacetimedb-primitives",
  "spacetimedb-sql-parser",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -4891,7 +4759,7 @@ dependencies = [
  "itertools 0.12.1",
  "mimalloc",
  "regex",
- "reqwest 0.12.4",
+ "reqwest 0.12.9",
  "rustyline",
  "serde",
  "serde_json",
@@ -4930,7 +4798,6 @@ dependencies = [
  "async-trait",
  "axum",
  "axum-extra",
- "blake3",
  "bytes",
  "bytestring",
  "chrono",
@@ -4942,7 +4809,6 @@ dependencies = [
  "hyper 1.5.0",
  "hyper-util",
  "itoa",
- "jsonwebkey",
  "lazy_static",
  "log",
  "mime",
@@ -5021,7 +4887,6 @@ dependencies = [
  "async-trait",
  "async_cache",
  "axum",
- "axum-test",
  "backtrace",
  "base64 0.21.7",
  "blake3",
@@ -5035,7 +4900,6 @@ dependencies = [
  "crossbeam-channel",
  "derive_more",
  "dirs",
- "email_address",
  "enum-as-inner",
  "enum-map",
  "env_logger",
@@ -5043,14 +4907,13 @@ dependencies = [
  "flate2",
  "fs2",
  "futures",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "hex",
  "hostname",
  "hyper 1.5.0",
  "imara-diff",
  "indexmap 2.6.0",
  "itertools 0.12.1",
- "jsonwebkey",
  "lazy_static",
  "log",
  "memchr",
@@ -5123,7 +4986,7 @@ name = "spacetimedb-data-structures"
 version = "1.0.0-rc2"
 dependencies = [
  "ahash 0.8.11",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "nohash-hasher",
  "serde",
  "smallvec",
@@ -5187,8 +5050,8 @@ checksum = "f626b7b56a60c3ec4552bc928a4e26b12ec76af826c0b152a87811fb4a68544f"
 dependencies = [
  "base64 0.22.1",
  "js-sys",
- "pem 3.0.4",
- "ring 0.17.8",
+ "pem",
+ "ring",
  "serde",
  "serde_json",
  "simple_asn1",
@@ -5326,7 +5189,7 @@ version = "1.0.0-rc2"
 dependencies = [
  "anyhow",
  "enum-as-inner",
- "hashbrown 0.15.0",
+ "hashbrown 0.15.1",
  "itertools 0.12.1",
  "lazy_static",
  "petgraph",
@@ -5504,24 +5367,9 @@ dependencies = [
 
 [[package]]
 name = "spin"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6e63cff320ae2c57904679ba7cb63280a3dc4613885beafb148ee7bf9aa9042d"
-
-[[package]]
-name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-
-[[package]]
-name = "spki"
-version = "0.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5c01a0c15da1b0b0e1494112e7af814a678fec9bd157881b49beac661e9b6f32"
-dependencies = [
- "der",
-]
 
 [[package]]
 name = "sptr"
@@ -5694,7 +5542,7 @@ dependencies = [
  "proc-macro2",
  "quote",
  "rustversion",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5709,9 +5557,9 @@ dependencies = [
 
 [[package]]
 name = "subtle"
-version = "2.4.1"
+version = "2.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6bdef32e8150c2a081110b42772ffe7d7c9032b606bc226c8260fd97e0976601"
+checksum = "13c2bddecc57b384dee18652358fb23172facb8a2c51ccc10d74c157bdea3292"
 
 [[package]]
 name = "syn"
@@ -5726,25 +5574,13 @@ dependencies = [
 
 [[package]]
 name = "syn"
-version = "2.0.82"
+version = "2.0.87"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "83540f837a8afc019423a8edb95b52a8effe46957ee402287f4292fae35be021"
+checksum = "25aa4ce346d03a6dcd68dd8b4010bcb74e54e62c90c573f394c46eae99aba32d"
 dependencies = [
  "proc-macro2",
  "quote",
  "unicode-ident",
-]
-
-[[package]]
-name = "syn_derive"
-version = "0.1.8"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1329189c02ff984e9736652b1631330da25eaa6bc639089ed4915d25446cbe7b"
-dependencies = [
- "proc-macro-error",
- "proc-macro2",
- "quote",
- "syn 2.0.82",
 ]
 
 [[package]]
@@ -5758,6 +5594,9 @@ name = "sync_wrapper"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a7065abeca94b6a8a577f9bd45aa0867a2238b74e8eb67cf10d492bc39351394"
+dependencies = [
+ "futures-core",
+]
 
 [[package]]
 name = "synstructure"
@@ -5779,7 +5618,7 @@ checksum = "c8af7666ab7b6390ab78131fb5b0fce11d6b7a6951602017c35fa82800708971"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -5812,7 +5651,18 @@ checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
 dependencies = [
  "bitflags 1.3.2",
  "core-foundation 0.9.4",
- "system-configuration-sys",
+ "system-configuration-sys 0.5.0",
+]
+
+[[package]]
+name = "system-configuration"
+version = "0.6.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
+dependencies = [
+ "bitflags 2.6.0",
+ "core-foundation 0.9.4",
+ "system-configuration-sys 0.6.0",
 ]
 
 [[package]]
@@ -5820,6 +5670,16 @@ name = "system-configuration-sys"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
+dependencies = [
+ "core-foundation-sys",
+ "libc",
+]
+
+[[package]]
+name = "system-configuration-sys"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "8e1d1b10ced5ca923a1fcb8d03e96b8d3268065d724548c0211415ff6ac6bac4"
 dependencies = [
  "core-foundation-sys",
  "libc",
@@ -5857,9 +5717,9 @@ checksum = "55937e1799185b12863d447f42597ed69d9928686b8d88a1df17376a097d8369"
 
 [[package]]
 name = "tar"
-version = "0.4.42"
+version = "0.4.43"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ff6c40d3aedb5e06b57c6f669ad17ab063dd1e63d977c6a88e7f4dfa4f04020"
+checksum = "c65998313f8e17d0d553d28f91a0df93e4dbbbf770279c7bc21ca0f09ea1a1f6"
 dependencies = [
  "filetime",
  "libc",
@@ -5890,9 +5750,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.13.0"
+version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f0f2c9fc62d0beef6951ccffd757e241266a2c833136efbe35af6cd2567dca5b"
+checksum = "28cce251fcbc87fac86a866eeb0d6c2d536fc16d06f184bb61aeae11aa4cee0c"
 dependencies = [
  "cfg-if",
  "fastrand",
@@ -5953,22 +5813,22 @@ checksum = "a38c90d48152c236a3ab59271da4f4ae63d678c5d7ad6b7714d7cb9760be5e4b"
 
 [[package]]
 name = "thiserror"
-version = "1.0.65"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d11abd9594d9b38965ef50805c5e469ca9cc6f197f883f717e0269a3057b3d5"
+checksum = "b6aaf5339b578ea85b50e080feb250a3e8ae8cfcdff9a461c9ec2904bc923f52"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.65"
+version = "1.0.69"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ae71770322cbd277e69d762a16c444af02aa0575ac0d174f0b9562d3b37f8602"
+checksum = "4fee6c4efc90059e10f81e6d42c60a18f76588c3d74cb83a0b242a2b6c7504c1"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6024,6 +5884,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "tinystr"
+version = "0.7.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9117f5d4db391c1cf6927e7bea3db74b9a1c1add8f7eda9ffd5364f40f57b82f"
+dependencies = [
+ "displaydoc",
+ "zerovec",
+]
+
+[[package]]
 name = "tinytemplate"
 version = "1.2.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6050,9 +5920,9 @@ checksum = "1f3ccbac311fea05f86f61904b462b55fb3df8837a366dfc601a0161d0532f20"
 
 [[package]]
 name = "tokio"
-version = "1.41.0"
+version = "1.41.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "145f3413504347a2be84393cc8a7d2fb4d863b375909ea59f2158261aa258bbb"
+checksum = "22cfb5bee7a6a52939ca9224d6ac897bb669134078daa8735560897f69de4d33"
 dependencies = [
  "backtrace",
  "bytes",
@@ -6074,7 +5944,7 @@ checksum = "693d596312e88961bc67d7f1f97af8a70227d9f90c31bba5806eec004978d752"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6111,6 +5981,17 @@ dependencies = [
  "tokio",
  "tokio-util",
  "whoami",
+]
+
+[[package]]
+name = "tokio-rustls"
+version = "0.26.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0c7bc40d0e5a97695bb96e27995cd3a08538541b0a846f65bba7a359f36700d4"
+dependencies = [
+ "rustls",
+ "rustls-pki-types",
+ "tokio",
 ]
 
 [[package]]
@@ -6272,7 +6153,7 @@ checksum = "34704c8d6ebcbc939824180af020566b01a7c01f80641264eba0999f6c2b6be7"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -6427,12 +6308,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eaea85b334db583fe3274d12b4cd1880032beab409c0d774be044d4480ab9a94"
 
 [[package]]
-name = "unicase"
-version = "2.8.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7e51b68083f157f853b6379db119d1c1be0e6e4dec98101079dec41f6f5cf6df"
-
-[[package]]
 name = "unicode-bidi"
 version = "0.3.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6479,12 +6354,6 @@ checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
 
 [[package]]
 name = "untrusted"
-version = "0.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
-
-[[package]]
-name = "untrusted"
 version = "0.9.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8ecb6da28b8a351d773b68d5825ac39017e680750f980f3a1a85cd8dd28a47c1"
@@ -6502,9 +6371,9 @@ dependencies = [
 
 [[package]]
 name = "url"
-version = "2.5.2"
+version = "2.5.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "22784dbdf76fdde8af1aeda5622b546b422b6fc585325248a2bf9f5e41e94d6c"
+checksum = "8d157f1b96d14500ffdc1f10ba712e780825526c03d9a49b4d0324b0d9113ada"
 dependencies = [
  "form_urlencoded",
  "idna",
@@ -6524,10 +6393,22 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "09cc8ee72d2a9becf2f2febe0205bbed8fc6615b7cb429ad062dc7b7ddd036a9"
 
 [[package]]
+name = "utf16_iter"
+version = "1.0.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8232dd3cdaed5356e0f716d285e4b40b932ac434100fe9b7e0e8e935b9e6246"
+
+[[package]]
 name = "utf8-width"
 version = "0.1.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "86bd8d4e895da8537e5315b8254664e6b769c4ff3db18321b297a1e7004392e3"
+
+[[package]]
+name = "utf8_iter"
+version = "1.0.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6c140620e7ffbb22c2dee59cafe6084a59b5ffc27a8859a5f0d494b5d52b6be"
 
 [[package]]
 name = "utf8parse"
@@ -6650,7 +6531,7 @@ dependencies = [
  "once_cell",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
  "wasm-bindgen-shared",
 ]
 
@@ -6684,7 +6565,7 @@ checksum = "26c6ab57572f7a24a4985830b120de1594465e5d500f24afe89e16b4e833ef68"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
  "wasm-bindgen-backend",
  "wasm-bindgen-shared",
 ]
@@ -6706,9 +6587,9 @@ dependencies = [
 
 [[package]]
 name = "wasm-streams"
-version = "0.4.1"
+version = "0.4.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4e072d4e72f700fb3443d8fe94a39315df013eef1104903cdb0a2abd322bbecd"
+checksum = "15053d8d85c7eccdbefef60f06769760a563c7f0a9d6902a13d35c7800b0ad65"
 dependencies = [
  "futures-util",
  "js-sys",
@@ -6738,7 +6619,7 @@ checksum = "3961bf864c790b5a06939f8f36d2a1a6be5bf0f926ddc25fb159b1766f2874db"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
  "synstructure 0.13.1",
  "thiserror",
 ]
@@ -6770,9 +6651,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ef01f9cb9636ed42a7ec5a09d785c0643590199dc7372dc22c7e2ba7a31a97d4"
+checksum = "f38dbf42dc56a6fe41ccd77211ea8ec90855de05e52cd00df5a0a3bca87d6147"
 dependencies = [
  "addr2line 0.22.0",
  "anyhow",
@@ -6814,18 +6695,18 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-asm-macros"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba5b20797419d6baf2296db2354f864e8bb3447cacca9d151ce7700ae08b4460"
+checksum = "30e0c7f9983c2d60109a939d9ab0e0df301901085c3608e1c22c27c98390a027"
 dependencies = [
  "cfg-if",
 ]
 
 [[package]]
 name = "wasmtime-cache"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "272d5939e989c5b54e3fa83ef420e4a6dba3995c3065626066428b2f73ad1e06"
+checksum = "e52eaa50abc14a9a2550d05e99e5e72d43ba75ea99cac1a440b61f1b9b87cd11"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -6835,7 +6716,7 @@ dependencies = [
  "rustix",
  "serde",
  "serde_derive",
- "sha2 0.10.8",
+ "sha2",
  "toml 0.8.19",
  "windows-sys 0.52.0",
  "zstd",
@@ -6843,14 +6724,14 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-macro"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "26593c4b18c76ca3c3fbdd813d6692256537b639b851d8a6fe827e3d6966fc01"
+checksum = "0929ffffaca32dd8770b56848c94056036963ca05de25fb47cac644e20262168"
 dependencies = [
  "anyhow",
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
  "wasmtime-component-util",
  "wasmtime-wit-bindgen",
  "wit-parser",
@@ -6858,15 +6739,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-component-util"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a2ed562fbb0cbed20a56c369c8de146c1de06a48c19e26ed9aa45f073514ee60"
+checksum = "fdc29d2b56629d66d2fd791d1b46471d0016e0d684ed2dc299e870d127082268"
 
 [[package]]
 name = "wasmtime-cranelift"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f389b789cbcb53a8499131182135dea21d7d97ad77e7fb66830f69479ef0e68c"
+checksum = "f8c8af1197703f4de556a274384adf5db36a146f9892bc9607bad16881e75c80"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -6889,9 +6770,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-environ"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "84b72debe8899f19bedf66f7071310f06ef62de943a1369ba9b373613e77dd3d"
+checksum = "3f1b5af7bac868c5bce3b78a366a10677caacf6e6467c156301297e36ed31f3e"
 dependencies = [
  "anyhow",
  "cpp_demangle",
@@ -6914,9 +6795,9 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-jit-icache-coherence"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1d930bc1325bc0448be6a11754156d770f56f6c3a61f440e9567f36cd2ea3065"
+checksum = "5d7314e32c624f645ad7d6b9fc3ac89eb7d2b9aa06695d6445cec087958ec27d"
 dependencies = [
  "anyhow",
  "cfg-if",
@@ -6926,15 +6807,15 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-slab"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "055a181b8d03998511294faea14798df436503f14d7fd20edcf7370ec583e80a"
+checksum = "f75cba1a8cc327839f493cfc3036c9de3d077d59ab76296bc710ee5f95be5391"
 
 [[package]]
 name = "wasmtime-types"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c8340d976673ac3fdacac781f2afdc4933920c1adc738c3409e825dab3955399"
+checksum = "c6d83a7816947a4974e2380c311eacb1db009b8bad86081dc726b705603c93c7"
 dependencies = [
  "anyhow",
  "cranelift-entity",
@@ -6946,20 +6827,20 @@ dependencies = [
 
 [[package]]
 name = "wasmtime-versioned-export-macros"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a4b0c1f76891f778db9602ee3fbb4eb7e9a3f511847d1fb1b69eddbcea28303c"
+checksum = "6879a8e168aef3fe07335343b7fbede12fa494215e83322e173d4018e124a846"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
 name = "wasmtime-wit-bindgen"
-version = "25.0.2"
+version = "25.0.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b2fca2cbb5bb390f65d4434c19bf8d9873dfc60f10802918ebcd6f819a38d703"
+checksum = "3f571f63ac1d532e986eb3973bbef3a45e4ae83de521a8d573b0fe0594dc9608"
 dependencies = [
  "anyhow",
  "heck 0.4.1",
@@ -7089,7 +6970,7 @@ checksum = "2bbd5b46c938e506ecbce286b6628a02171d56153ba733b6c741fc627ec9579b"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]
@@ -7100,7 +6981,18 @@ checksum = "053c4c462dc91d3b1504c6fe5a726dd15e216ba718e84a0e46a88fbe5ded3515"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "windows-registry"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e400001bb720a623c1c69032f8e3e4cf09984deec740f007dd2b03ec864804b0"
+dependencies = [
+ "windows-result",
+ "windows-strings",
+ "windows-targets 0.52.6",
 ]
 
 [[package]]
@@ -7356,16 +7248,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.52.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a277a57398d4bfa075df44f501a17cfdf8542d224f0d36095a2adc7aee4ef0a5"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "wit-parser"
 version = "0.217.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7382,6 +7264,18 @@ dependencies = [
  "unicode-xid",
  "wasmparser",
 ]
+
+[[package]]
+name = "write16"
+version = "1.0.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d1890f4022759daae28ed4fe62859b1236caebfc61ede2f63ed4e695f3f6d936"
+
+[[package]]
+name = "writeable"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1e9df38ee2d2c3c5948ea468a8406ff0db0b29ae1ffde1bcf20ef305bcc95c51"
 
 [[package]]
 name = "wyz"
@@ -7431,12 +7325,27 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cfe53a6657fd280eaa890a3bc59152892ffa3e30101319d168b781ed6529b049"
 
 [[package]]
-name = "yasna"
-version = "0.4.0"
+name = "yoke"
+version = "0.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e262a29d0e61ccf2b6190d7050d4b237535fc76ce4c1210d9caa316f71dffa75"
+checksum = "6c5b1314b079b0930c31e3af543d8ee1757b1951ae1e1565ec704403a7240ca5"
 dependencies = [
- "num-bigint",
+ "serde",
+ "stable_deref_trait",
+ "yoke-derive",
+ "zerofrom",
+]
+
+[[package]]
+name = "yoke-derive"
+version = "0.7.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28cc31741b18cb6f1d5ff12f5b7523e3d6eb0852bbbad19d73905511d9849b95"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
@@ -7457,27 +7366,56 @@ checksum = "fa4f8080344d4671fb4e831a13ad1e68092748387dfc4f55e356242fae12ce3e"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
+]
+
+[[package]]
+name = "zerofrom"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "91ec111ce797d0e0784a1116d0ddcdbea84322cd79e5d5ad173daeba4f93ab55"
+dependencies = [
+ "zerofrom-derive",
+]
+
+[[package]]
+name = "zerofrom-derive"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ea7b4a3637ea8669cedf0f1fd5c286a17f3de97b8dd5a70a6c167a1730e63a5"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+ "synstructure 0.13.1",
 ]
 
 [[package]]
 name = "zeroize"
-version = "1.4.3"
+version = "1.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d68d9dcec5f9b43a30d38c49f91dfedfaac384cb8f085faca366c26207dd1619"
+checksum = "ced3678a2879b30306d323f4542626697a464a97c0a07c9aebf7ebca65cd4dde"
+
+[[package]]
+name = "zerovec"
+version = "0.10.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aa2b893d79df23bfb12d5461018d408ea19dfafe76c2c7ef6d4eba614f8ff079"
 dependencies = [
- "zeroize_derive",
+ "yoke",
+ "zerofrom",
+ "zerovec-derive",
 ]
 
 [[package]]
-name = "zeroize_derive"
-version = "1.4.2"
+name = "zerovec-derive"
+version = "0.10.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ce36e65b0d2999d2aafac989fb249189a141aee1f53c612c1f37d72631959f69"
+checksum = "6eafa6dfb17584ea3e2bd6e76e0cc15ad7af12b09abdd1ca55961bed9b1063c6"
 dependencies = [
  "proc-macro2",
  "quote",
- "syn 2.0.82",
+ "syn 2.0.87",
 ]
 
 [[package]]

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -5,7 +5,7 @@ use base64::{
 };
 use reqwest::RequestBuilder;
 use serde::Deserialize;
-use spacetimedb::auth::identity::{IncomingClaims, SpacetimeIdentityClaims2};
+use spacetimedb::auth::identity::{IncomingClaims, SpacetimeIdentityClaims};
 use spacetimedb_client_api_messages::name::{DnsLookupResponse, RegisterTldResult, ReverseDNSResponse};
 use spacetimedb_data_structures::map::HashMap;
 use spacetimedb_lib::{AlgebraicType, Identity};
@@ -277,7 +277,7 @@ pub fn decode_identity(config: &Config) -> anyhow::Result<String> {
     let decoded_string = String::from_utf8(decoded_bytes)?;
 
     let claims_data: IncomingClaims = serde_json::from_str(decoded_string.as_str())?;
-    let claims_data: SpacetimeIdentityClaims2 = claims_data.try_into()?;
+    let claims_data: SpacetimeIdentityClaims = claims_data.try_into()?;
 
     Ok(claims_data.identity.to_string())
 }

--- a/crates/client-api/Cargo.toml
+++ b/crates/client-api/Cargo.toml
@@ -41,10 +41,8 @@ tokio-tungstenite.workspace = true
 itoa.workspace = true
 derive_more = "0.99.17"
 uuid.workspace = true
-blake3.workspace = true
 jsonwebtoken.workspace = true
 scopeguard.workspace = true
 
 [dev-dependencies]
-jsonwebkey = { version = "0.3.5", features = ["generate","jwt-convert"] }
 jsonwebtoken.workspace = true

--- a/crates/client-api/src/auth.rs
+++ b/crates/client-api/src/auth.rs
@@ -130,7 +130,6 @@ impl TokenClaims {
 
     pub fn encode_and_sign_with_expiry(
         &self,
-        // private_key: &EncodingKey,
         signer: &impl TokenSigner,
         expiry: Option<Duration>,
     ) -> Result<String, JwtError> {
@@ -186,15 +185,12 @@ impl SpacetimeAuth {
         )
     }
 
-    pub fn re_sign_with_expiry(&self, signer: &impl TokenSigner, expiry: Duration) -> Result<String, JwtError> {
-        TokenClaims::from(self.clone()).encode_and_sign_with_expiry(signer, Some(expiry))
-    }
     // Sign a new token with the same claims and a new expiry.
     // Note that this will not change the issuer, so the private_key might not match.
     // We do this to create short-lived tokens that we will be able to verify.
-    // pub fn re_sign_with_expiry(&self, private_key: &EncodingKey, expiry: Duration) -> Result<String, JwtError> {
-    //     TokenClaims::from(self.clone()).encode_and_sign_with_expiry(private_key, Some(expiry))
-    // }
+    pub fn re_sign_with_expiry(&self, signer: &impl TokenSigner, expiry: Duration) -> Result<String, JwtError> {
+        TokenClaims::from(self.clone()).encode_and_sign_with_expiry(signer, Some(expiry))
+    }
 }
 
 // JwtAuthProvider is used for signing and verifying JWT tokens.

--- a/crates/client-api/src/auth.rs
+++ b/crates/client-api/src/auth.rs
@@ -6,12 +6,13 @@ use axum::response::IntoResponse;
 use axum_extra::typed_header::TypedHeader;
 use headers::{authorization, HeaderMapExt};
 use http::{request, HeaderValue, StatusCode};
-use serde::Deserialize;
-use spacetimedb::auth::identity::SpacetimeIdentityClaims2;
-use spacetimedb::auth::identity::{
-    decode_token, encode_token, DecodingKey, EncodingKey, JwtError, JwtErrorKind, SpacetimeIdentityClaims,
+use serde::{Deserialize, Serialize};
+use spacetimedb::auth::identity::SpacetimeIdentityClaims;
+use spacetimedb::auth::identity::{JwtError, JwtErrorKind};
+use spacetimedb::auth::token_validation::{
+    new_validator, DefaultValidator, TokenSigner, TokenValidationError, TokenValidator,
 };
-use spacetimedb::auth::token_validation::{validate_token, TokenValidationError};
+use spacetimedb::auth::JwtKeys;
 use spacetimedb::energy::EnergyQuanta;
 use spacetimedb::identity::Identity;
 use uuid::Uuid;
@@ -57,17 +58,9 @@ impl SpacetimeCreds {
     pub fn token(&self) -> &str {
         &self.token
     }
-    /// Decode this token into auth claims.
-    pub fn decode_token(&self, public_key: &DecodingKey) -> Result<SpacetimeIdentityClaims, JwtError> {
-        decode_token(public_key, self.token()).map(|x| x.claims)
-    }
+
     pub fn from_signed_token(token: String) -> Self {
         Self { token }
-    }
-    /// Mint a new credentials JWT for an identity.
-    pub fn encode_token(private_key: &EncodingKey, identity: Identity) -> Result<Self, JwtError> {
-        let token = encode_token(private_key, identity)?;
-        Ok(Self { token })
     }
 
     /// Extract credentials from the headers or else query string of a request.
@@ -137,12 +130,13 @@ impl TokenClaims {
 
     pub fn encode_and_sign_with_expiry(
         &self,
-        private_key: &EncodingKey,
+        // private_key: &EncodingKey,
+        signer: &impl TokenSigner,
         expiry: Option<Duration>,
     ) -> Result<String, JwtError> {
         let iat = SystemTime::now();
         let exp = expiry.map(|dur| iat + dur);
-        let claims = SpacetimeIdentityClaims2 {
+        let claims = SpacetimeIdentityClaims {
             identity: self.id(),
             subject: self.subject.clone(),
             issuer: self.issuer.clone(),
@@ -150,12 +144,11 @@ impl TokenClaims {
             iat,
             exp,
         };
-        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
-        jsonwebtoken::encode(&header, &claims, private_key)
+        signer.sign(&claims)
     }
 
-    pub fn encode_and_sign(&self, private_key: &EncodingKey) -> Result<String, JwtError> {
-        self.encode_and_sign_with_expiry(private_key, None)
+    pub fn encode_and_sign(&self, signer: &impl TokenSigner) -> Result<String, JwtError> {
+        self.encode_and_sign_with_expiry(signer, None)
     }
 }
 
@@ -165,7 +158,7 @@ impl SpacetimeAuth {
         // Generate claims with a random subject.
         let subject = Uuid::new_v4().to_string();
         let claims = TokenClaims {
-            issuer: ctx.local_issuer(),
+            issuer: ctx.jwt_auth_provider().local_issuer().to_owned(),
             subject: subject.clone(),
             // Placeholder audience.
             audience: vec!["spacetimedb".to_string()],
@@ -173,7 +166,7 @@ impl SpacetimeAuth {
 
         let identity = claims.id();
         let creds = {
-            let token = claims.encode_and_sign(ctx.private_key()).map_err(log_and_500)?;
+            let token = claims.encode_and_sign(ctx.jwt_auth_provider()).map_err(log_and_500)?;
             SpacetimeCreds::from_signed_token(token)
         };
 
@@ -181,7 +174,7 @@ impl SpacetimeAuth {
             creds,
             identity,
             subject,
-            issuer: ctx.local_issuer(),
+            issuer: ctx.jwt_auth_provider().local_issuer().to_string(),
         })
     }
 
@@ -193,11 +186,76 @@ impl SpacetimeAuth {
         )
     }
 
+    pub fn re_sign_with_expiry(&self, signer: &impl TokenSigner, expiry: Duration) -> Result<String, JwtError> {
+        TokenClaims::from(self.clone()).encode_and_sign_with_expiry(signer, Some(expiry))
+    }
     // Sign a new token with the same claims and a new expiry.
     // Note that this will not change the issuer, so the private_key might not match.
     // We do this to create short-lived tokens that we will be able to verify.
-    pub fn re_sign_with_expiry(&self, private_key: &EncodingKey, expiry: Duration) -> Result<String, JwtError> {
-        TokenClaims::from(self.clone()).encode_and_sign_with_expiry(private_key, Some(expiry))
+    // pub fn re_sign_with_expiry(&self, private_key: &EncodingKey, expiry: Duration) -> Result<String, JwtError> {
+    //     TokenClaims::from(self.clone()).encode_and_sign_with_expiry(private_key, Some(expiry))
+    // }
+}
+
+// JwtAuthProvider is used for signing and verifying JWT tokens.
+pub trait JwtAuthProvider: Sync + Send + TokenSigner {
+    type TV: TokenValidator + Send + Sync;
+    /// Used to validate incoming JWTs.
+    fn validator(&self) -> &Self::TV;
+
+    /// The issuer to use when signing JWTs.
+    fn local_issuer(&self) -> &str;
+
+    /// Return the public key used to verify JWTs, as the bytes of a PEM public key file.
+    ///
+    /// The `/identity/public-key` route calls this method to return the public key to callers.
+    fn public_key_bytes(&self) -> &[u8];
+}
+
+pub struct JwtKeyAuthProvider<TV: TokenValidator + Send + Sync> {
+    keys: JwtKeys,
+    local_issuer: String,
+    validator: TV,
+}
+
+pub type DefaultJwtAuthProvider = JwtKeyAuthProvider<DefaultValidator>;
+
+// Create a new AuthEnvironment using the default caching validator.
+pub fn default_auth_environment(keys: JwtKeys, local_issuer: String) -> JwtKeyAuthProvider<DefaultValidator> {
+    let validator = new_validator(keys.public.clone(), local_issuer.clone());
+    JwtKeyAuthProvider::new(keys, local_issuer, validator)
+}
+
+impl<TV: TokenValidator + Send + Sync> JwtKeyAuthProvider<TV> {
+    fn new(keys: JwtKeys, local_issuer: String, validator: TV) -> Self {
+        Self {
+            keys,
+            local_issuer,
+            validator,
+        }
+    }
+}
+
+impl<TV: TokenValidator + Send + Sync> TokenSigner for JwtKeyAuthProvider<TV> {
+    fn sign<T: Serialize>(&self, claims: &T) -> Result<String, JwtError> {
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
+        jsonwebtoken::encode(&header, &claims, &self.keys.private)
+    }
+}
+
+impl<TV: TokenValidator + Send + Sync> JwtAuthProvider for JwtKeyAuthProvider<TV> {
+    type TV = TV;
+
+    fn local_issuer(&self) -> &str {
+        &self.local_issuer
+    }
+
+    fn public_key_bytes(&self) -> &[u8] {
+        &self.keys.public_pem
+    }
+
+    fn validator(&self) -> &Self::TV {
+        &self.validator
     }
 }
 
@@ -205,32 +263,12 @@ impl SpacetimeAuth {
 mod tests {
     use crate::auth::TokenClaims;
     use anyhow::Ok;
-    use jsonwebkey as jwk;
-    use jsonwebtoken::{DecodingKey, EncodingKey};
-    use spacetimedb::auth::identity;
-
-    // TODO: this keypair stuff is duplicated. We should create a test-only crate with helpers.
-    struct KeyPair {
-        pub public_key: DecodingKey,
-        pub private_key: EncodingKey,
-    }
-
-    fn new_keypair() -> anyhow::Result<KeyPair> {
-        let mut my_jwk = jwk::JsonWebKey::new(jwk::Key::generate_p256());
-
-        my_jwk.set_algorithm(jwk::Algorithm::ES256).unwrap();
-        let public_key = jsonwebtoken::DecodingKey::from_ec_pem(my_jwk.key.to_public().unwrap().to_pem().as_bytes())?;
-        let private_key = jsonwebtoken::EncodingKey::from_ec_pem(my_jwk.key.try_to_pem()?.as_bytes())?;
-        Ok(KeyPair {
-            public_key,
-            private_key,
-        })
-    }
+    use spacetimedb::auth::{token_validation::TokenValidator, JwtKeys};
 
     // Make sure that when we encode TokenClaims, we can decode to get the expected identity.
-    #[test]
-    fn decode_encoded_token() -> Result<(), anyhow::Error> {
-        let kp = new_keypair()?;
+    #[tokio::test]
+    async fn decode_encoded_token() -> Result<(), anyhow::Error> {
+        let kp = JwtKeys::generate()?;
 
         let claims = TokenClaims {
             issuer: "localhost".to_string(),
@@ -238,10 +276,10 @@ mod tests {
             audience: vec!["spacetimedb".to_string()],
         };
         let id = claims.id();
-        let token = claims.encode_and_sign(&kp.private_key)?;
+        let token = claims.encode_and_sign(&kp.private)?;
+        let decoded = kp.public.validate_token(&token).await?;
 
-        let decoded = identity::decode_token(&kp.public_key, &token)?;
-        assert_eq!(decoded.claims.identity, id);
+        assert_eq!(decoded.identity, id);
         Ok(())
     }
 }
@@ -258,7 +296,10 @@ impl<S: NodeDelegate + Send + Sync> axum::extract::FromRequestParts<S> for Space
             return Ok(Self { auth: None });
         };
 
-        let claims = validate_token(state.public_key().clone(), &state.local_issuer(), &creds.token)
+        let claims = state
+            .jwt_auth_provider()
+            .validator()
+            .validate_token(&creds.token)
             .await
             .map_err(AuthorizationRejection::Custom)?;
 

--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -4,7 +4,6 @@ use async_trait::async_trait;
 use axum::response::ErrorResponse;
 use http::StatusCode;
 
-use spacetimedb::auth::identity::{DecodingKey, EncodingKey};
 use spacetimedb::client::ClientActorIndex;
 use spacetimedb::energy::{EnergyBalance, EnergyQuanta};
 use spacetimedb::host::{HostController, UpdateDatabaseResult};
@@ -26,19 +25,8 @@ pub trait NodeDelegate: Send + Sync {
     fn host_controller(&self) -> &HostController;
     fn client_actor_index(&self) -> &ClientActorIndex;
 
-    /// Return a JWT decoding key for verifying credentials.
-    fn public_key(&self) -> &DecodingKey;
-
-    // The issuer to use when signing JWTs.
-    fn local_issuer(&self) -> String;
-
-    /// Return the public key used to verify JWTs, as the bytes of a PEM public key file.
-    ///
-    /// The `/identity/public-key` route calls this method to return the public key to callers.
-    fn public_key_bytes(&self) -> &[u8];
-
-    /// Return a JWT encoding key for signing credentials.
-    fn private_key(&self) -> &EncodingKey;
+    type JwtAuthProviderT: auth::JwtAuthProvider;
+    fn jwt_auth_provider(&self) -> &Self::JwtAuthProviderT;
 }
 
 /// Parameters for publishing a database.
@@ -222,12 +210,9 @@ impl<T: ControlStateWriteAccess + ?Sized> ControlStateWriteAccess for Arc<T> {
 }
 
 impl<T: NodeDelegate + ?Sized> NodeDelegate for Arc<T> {
+    type JwtAuthProviderT = T::JwtAuthProviderT;
     fn gather_metrics(&self) -> Vec<prometheus::proto::MetricFamily> {
         (**self).gather_metrics()
-    }
-
-    fn local_issuer(&self) -> String {
-        (**self).local_issuer()
     }
 
     fn host_controller(&self) -> &HostController {
@@ -238,16 +223,8 @@ impl<T: NodeDelegate + ?Sized> NodeDelegate for Arc<T> {
         (**self).client_actor_index()
     }
 
-    fn public_key(&self) -> &DecodingKey {
-        (**self).public_key()
-    }
-
-    fn public_key_bytes(&self) -> &[u8] {
-        (**self).public_key_bytes()
-    }
-
-    fn private_key(&self) -> &EncodingKey {
-        (**self).private_key()
+    fn jwt_auth_provider(&self) -> &Self::JwtAuthProviderT {
+        (**self).jwt_auth_provider()
     }
 }
 

--- a/crates/client-api/src/routes/identity.rs
+++ b/crates/client-api/src/routes/identity.rs
@@ -9,7 +9,7 @@ use serde::{Deserialize, Serialize};
 use spacetimedb_lib::de::serde::DeserializeWrapper;
 use spacetimedb_lib::Identity;
 
-use crate::auth::{SpacetimeAuth, SpacetimeAuthRequired};
+use crate::auth::{JwtAuthProvider, SpacetimeAuth, SpacetimeAuthRequired};
 use crate::{log_and_500, ControlStateDelegate, NodeDelegate};
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
@@ -104,7 +104,7 @@ pub async fn create_websocket_token<S: NodeDelegate>(
 ) -> axum::response::Result<impl IntoResponse> {
     let expiry = Duration::from_secs(60);
     let token = auth
-        .re_sign_with_expiry(ctx.private_key(), expiry)
+        .re_sign_with_expiry(ctx.jwt_auth_provider(), expiry)
         .map_err(log_and_500)?;
     // let token = encode_token_with_expiry(ctx.private_key(), auth.identity, Some(expiry)).map_err(log_and_500)?;
     Ok(axum::Json(WebsocketTokenResponse { token }))
@@ -131,7 +131,7 @@ pub async fn validate_token(
 pub async fn get_public_key<S: NodeDelegate>(State(ctx): State<S>) -> axum::response::Result<impl IntoResponse> {
     Ok((
         [(CONTENT_TYPE, "application/pem-certificate-chain")],
-        ctx.public_key_bytes().to_owned(),
+        ctx.jwt_auth_provider().public_key_bytes().to_owned(),
     ))
 }
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -45,7 +45,6 @@ clap.workspace = true
 crossbeam-channel.workspace = true
 derive_more.workspace = true
 dirs.workspace = true
-email_address.workspace = true
 enum-as-inner.workspace = true
 enum-map.workspace = true
 flate2.workspace = true
@@ -127,7 +126,5 @@ proptest-derive.workspace = true
 rand.workspace = true
 env_logger.workspace = true
 pretty_assertions.workspace = true
-jsonwebkey = { version = "0.3.5", features = ["generate", "jwt-convert"] }
 jsonwebtoken.workspace = true
-axum-test = "16.2.0"
 axum.workspace = true

--- a/crates/core/src/auth/mod.rs
+++ b/crates/core/src/auth/mod.rs
@@ -10,10 +10,12 @@ pub mod identity;
 pub mod token_validation;
 
 /// JWT verification and signing keys.
+#[derive(Clone)]
 pub struct JwtKeys {
     pub public: DecodingKey,
     pub public_pem: Box<[u8]>,
     pub private: EncodingKey,
+    pub kid: Option<String>,
 }
 
 impl JwtKeys {
@@ -30,10 +32,18 @@ impl JwtKeys {
             public,
             private,
             public_pem,
+            kid: None,
         })
+    }
+
+    pub fn generate() -> anyhow::Result<Self> {
+        let keypair = EcKeyPair::generate()?;
+        keypair.try_into()
     }
 }
 
+// Get the key pair if the given files exist. If they don't, create them.
+// If only one of the files exists, return an error.
 pub fn get_or_create_keys(certs: &CertificateAuthority) -> anyhow::Result<JwtKeys> {
     let public_key_path = &certs.jwt_pub_key_path;
     let private_key_path = &certs.jwt_priv_key_path;
@@ -42,33 +52,66 @@ pub fn get_or_create_keys(certs: &CertificateAuthority) -> anyhow::Result<JwtKey
     let private_key_bytes = private_key_path.read().ok();
 
     // If both keys are unspecified, create them
-    let (public_key_bytes, private_key_bytes) = match (public_key_bytes, private_key_bytes) {
-        (Some(pub_), Some(priv_)) => (pub_, priv_),
-        (None, None) => create_keys(public_key_path, private_key_path)?,
+    let key_pair = match (public_key_bytes, private_key_bytes) {
+        (Some(pub_), Some(priv_)) => EcKeyPair::new(pub_, priv_),
+        (None, None) => {
+            let keys = EcKeyPair::generate()?;
+            keys.write_to_files(public_key_path, private_key_path)?;
+            keys
+        }
         (None, Some(_)) => anyhow::bail!("Unable to read public key for JWT token verification"),
         (Some(_), None) => anyhow::bail!("Unable to read private key for JWT token signing"),
     };
 
-    JwtKeys::new(public_key_bytes, &private_key_bytes)
+    key_pair.try_into()
 }
 
-pub fn create_keys(public_key_path: &PubKeyPath, private_key_path: &PrivKeyPath) -> anyhow::Result<(Vec<u8>, Vec<u8>)> {
-    // Create a new EC group from a named curve.
-    let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)?;
+// An Ec key pair in pem format.
+pub struct EcKeyPair {
+    pub public_key_bytes: Vec<u8>,
+    pub private_key_bytes: Vec<u8>,
+}
 
-    // Create a new EC key with the specified group.
-    let eckey = EcKey::generate(&group)?;
+impl TryFrom<EcKeyPair> for JwtKeys {
+    type Error = anyhow::Error;
+    fn try_from(pair: EcKeyPair) -> anyhow::Result<Self> {
+        JwtKeys::new(pair.public_key_bytes, &pair.private_key_bytes)
+    }
+}
 
-    // Create a new PKey from the EC key.
-    let pkey = PKey::from_ec_key(eckey.clone())?;
+impl EcKeyPair {
+    pub fn new(public_key_bytes: Vec<u8>, private_key_bytes: Vec<u8>) -> Self {
+        Self {
+            public_key_bytes,
+            private_key_bytes,
+        }
+    }
 
-    // Get the private key in PKCS#8 PEM format & write it.
-    let private_key = pkey.private_key_to_pem_pkcs8()?;
-    private_key_path.write(&private_key)?;
+    pub fn generate() -> anyhow::Result<Self> {
+        // Create a new EC group from a named curve.
+        let group = EcGroup::from_curve_name(Nid::X9_62_PRIME256V1)?;
 
-    // Get the public key in PEM format & write it.
-    let public_key = eckey.public_key_to_pem()?;
-    public_key_path.write(&public_key)?;
+        // Create a new EC key with the specified group.
+        let eckey = EcKey::generate(&group)?;
 
-    Ok((public_key, private_key))
+        // Create a new PKey from the EC key.
+        let pkey = PKey::from_ec_key(eckey.clone())?;
+
+        // Get the private key in PKCS#8 PEM format & write it.
+        let private_key_bytes = pkey.private_key_to_pem_pkcs8()?;
+
+        // Get the public key in PEM format & write it.
+        let public_key_bytes = eckey.public_key_to_pem()?;
+
+        Ok(Self {
+            public_key_bytes,
+            private_key_bytes,
+        })
+    }
+
+    pub fn write_to_files(&self, public_key_path: &PubKeyPath, private_key_path: &PrivKeyPath) -> anyhow::Result<()> {
+        public_key_path.write(&self.public_key_bytes)?;
+        private_key_path.write(&self.private_key_bytes)?;
+        Ok(())
+    }
 }

--- a/crates/core/src/auth/token_validation.rs
+++ b/crates/core/src/auth/token_validation.rs
@@ -9,11 +9,13 @@ use jsonwebtoken::{decode, Validation};
 pub use jsonwebtoken::{DecodingKey, EncodingKey};
 use jwks::Jwks;
 use lazy_static::lazy_static;
+use serde::Serialize;
 use std::sync::Arc;
 use std::time::Duration;
 use thiserror;
 
-use super::identity::{IncomingClaims, SpacetimeIdentityClaims2};
+use super::identity::{IncomingClaims, SpacetimeIdentityClaims};
+use super::JwtKeys;
 
 #[derive(thiserror::Error, Debug)]
 pub enum TokenValidationError {
@@ -35,18 +37,37 @@ pub enum TokenValidationError {
     Other(#[from] anyhow::Error),
 }
 
+// A token signer is responsible for signing tokens without doing any validation.
+pub trait TokenSigner: Sync + Send {
+    // Serialize the given claims and sign a JWT token with them as the payload.
+    fn sign<T: Serialize>(&self, claims: &T) -> Result<String, JwtError>;
+}
+
+impl TokenSigner for EncodingKey {
+    fn sign<Token: Serialize>(&self, claims: &Token) -> Result<String, JwtError> {
+        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
+        jsonwebtoken::encode(&header, claims, self)
+    }
+}
+
+impl TokenSigner for JwtKeys {
+    fn sign<Token: Serialize>(&self, claims: &Token) -> Result<String, JwtError> {
+        self.private.sign(claims)
+    }
+}
+
 // A TokenValidator is responsible for validating a token and returning the claims.
 // This includes looking up the public key for the issuer and verifying the signature.
 // It is also responsible for enforcing the rules around the claims.
 // For example, this must ensure that the issuer and sub are no longer than 128 bytes.
 #[async_trait]
 pub trait TokenValidator {
-    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims2, TokenValidationError>;
+    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims, TokenValidationError>;
 }
 
 #[async_trait]
 impl<T: TokenValidator + Send + Sync> TokenValidator for Arc<T> {
-    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims2, TokenValidationError> {
+    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims, TokenValidationError> {
         (**self).validate_token(token).await
     }
 }
@@ -55,7 +76,7 @@ pub struct UnimplementedTokenValidator;
 
 #[async_trait]
 impl TokenValidator for UnimplementedTokenValidator {
-    async fn validate_token(&self, _token: &str) -> Result<SpacetimeIdentityClaims2, TokenValidationError> {
+    async fn validate_token(&self, _token: &str) -> Result<SpacetimeIdentityClaims, TokenValidationError> {
         Err(TokenValidationError::Other(anyhow::anyhow!("Unimplemented")))
     }
 }
@@ -74,7 +95,7 @@ impl<T> TokenValidator for FullTokenValidator<T>
 where
     T: TokenValidator + Send + Sync,
 {
-    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims2, TokenValidationError> {
+    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims, TokenValidationError> {
         let local_key_error = {
             let first_validator = BasicTokenValidator {
                 public_key: self.local_key.clone(),
@@ -97,18 +118,14 @@ where
     }
 }
 
-// This is a helper function that uses a global JWK cache. We should remove this eventually, and make the server hold on to its own.
-pub async fn validate_token(
-    local_key: DecodingKey,
-    local_issuer: &str,
-    token: &str,
-) -> Result<SpacetimeIdentityClaims2, TokenValidationError> {
-    let validator = FullTokenValidator {
+pub type DefaultValidator = FullTokenValidator<CachingOidcTokenValidator>;
+
+pub fn new_validator(local_key: DecodingKey, local_issuer: String) -> FullTokenValidator<CachingOidcTokenValidator> {
+    FullTokenValidator {
         local_key,
-        local_issuer: local_issuer.to_string(),
-        oidc_validator: GLOBAL_OIDC_VALIDATOR.clone(),
-    };
-    validator.validate_token(token).await
+        local_issuer,
+        oidc_validator: CachingOidcTokenValidator::get_default(),
+    }
 }
 
 // This verifies against a given public key and expected issuer.
@@ -124,15 +141,9 @@ lazy_static! {
     static ref REQUIRED_CLAIMS: Vec<&'static str> = vec!["sub", "iss"];
 }
 
-lazy_static! {
-    // Eventually we will want to add more required claims.
-    static ref GLOBAL_OIDC_VALIDATOR: Arc<CachingOidcTokenValidator> = Arc::new(CachingOidcTokenValidator::get_default());
-}
-
 #[async_trait]
-impl TokenValidator for BasicTokenValidator {
-    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims2, TokenValidationError> {
-        // TODO: Make this stored in the struct so we don't need to keep creating it.
+impl TokenValidator for DecodingKey {
+    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims, TokenValidationError> {
         let mut validation = Validation::new(jsonwebtoken::Algorithm::ES256);
         validation.algorithms = vec![
             jsonwebtoken::Algorithm::ES256,
@@ -141,15 +152,20 @@ impl TokenValidator for BasicTokenValidator {
         ];
         validation.set_required_spec_claims(&REQUIRED_CLAIMS);
 
-        if let Some(expected_issuer) = &self.issuer {
-            validation.set_issuer(&[expected_issuer.clone()]);
-        }
-
         // TODO: We should require a specific audience at some point.
         validation.validate_aud = false;
 
-        let data = decode::<IncomingClaims>(token, &self.public_key, &validation)?;
+        let data = decode::<IncomingClaims>(token, self, &validation)?;
         let claims = data.claims;
+        claims.try_into()
+    }
+}
+
+#[async_trait]
+impl TokenValidator for BasicTokenValidator {
+    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims, TokenValidationError> {
+        // This validates everything but the issuer.
+        let claims = self.public_key.validate_token(token).await?;
         if let Some(expected_issuer) = &self.issuer {
             if claims.issuer != *expected_issuer {
                 return Err(TokenValidationError::Other(anyhow::anyhow!(
@@ -159,7 +175,7 @@ impl TokenValidator for BasicTokenValidator {
                 )));
             }
         }
-        claims.try_into()
+        Ok(claims)
     }
 }
 
@@ -210,7 +226,7 @@ impl async_cache::Fetcher<Arc<JwksValidator>> for KeyFetcher {
 
 #[async_trait]
 impl TokenValidator for CachingOidcTokenValidator {
-    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims2, TokenValidationError> {
+    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims, TokenValidationError> {
         let raw_issuer = get_raw_issuer(token)?;
         log::debug!("Getting validator for issuer {}", raw_issuer.clone());
         let validator = self
@@ -240,7 +256,7 @@ fn get_raw_issuer(token: &str) -> Result<String, TokenValidationError> {
 
 #[async_trait]
 impl TokenValidator for OidcTokenValidator {
-    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims2, TokenValidationError> {
+    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims, TokenValidationError> {
         // TODO: Make this stored in the struct so we don't need to keep creating it.
         let raw_issuer = get_raw_issuer(token)?;
         // TODO: Consider checking for trailing slashes or requiring a scheme.
@@ -261,7 +277,7 @@ struct JwksValidator {
 
 #[async_trait]
 impl TokenValidator for JwksValidator {
-    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims2, TokenValidationError> {
+    async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims, TokenValidationError> {
         let header = decode_header(token)?;
         if let Some(kid) = header.kid {
             let key = self
@@ -301,69 +317,21 @@ impl TokenValidator for JwksValidator {
 
 #[cfg(test)]
 mod tests {
-
-    use std::sync::Arc;
-
-    use crate::auth::identity::{IncomingClaims, SpacetimeIdentityClaims2};
+    use crate::auth::identity::{IncomingClaims, SpacetimeIdentityClaims};
     use crate::auth::token_validation::{
-        BasicTokenValidator, CachingOidcTokenValidator, FullTokenValidator, OidcTokenValidator, TokenValidator,
+        BasicTokenValidator, CachingOidcTokenValidator, FullTokenValidator, OidcTokenValidator, TokenSigner,
+        TokenValidator,
     };
-    use jsonwebkey as jwk;
-    use jsonwebtoken::{DecodingKey, EncodingKey};
-    use rand::distributions::{Alphanumeric, DistString};
-    use rand::thread_rng;
+    use crate::auth::JwtKeys;
+    use base64::Engine;
+    use openssl::ec::{EcGroup, EcKey};
     use serde_json;
     use spacetimedb_lib::Identity;
-
-    struct KeyPair {
-        pub public_key: DecodingKey,
-        pub private_key: EncodingKey,
-        pub key_id: String,
-        pub jwk: jwk::JsonWebKey,
-    }
-
-    fn to_jwks_json<I, K>(keys: I) -> String
-    where
-        I: IntoIterator<Item = K>,
-        K: AsRef<KeyPair>,
-    {
-        format!(
-            r#"{{"keys":[{}]}}"#,
-            keys.into_iter()
-                .map(|key| serde_json::to_string(&key.as_ref().to_public()).unwrap())
-                .collect::<Vec<String>>()
-                .join(",")
-        )
-    }
-
-    impl KeyPair {
-        fn generate_p256() -> anyhow::Result<KeyPair> {
-            let key_id = Alphanumeric.sample_string(&mut thread_rng(), 16);
-            let mut my_jwk = jwk::JsonWebKey::new(jwk::Key::generate_p256());
-            my_jwk.key_id = Some(key_id.clone());
-            my_jwk.set_algorithm(jwk::Algorithm::ES256).unwrap();
-            let public_key =
-                jsonwebtoken::DecodingKey::from_ec_pem(my_jwk.key.to_public().unwrap().to_pem().as_bytes())?;
-            let private_key = jsonwebtoken::EncodingKey::from_ec_pem(my_jwk.key.try_to_pem()?.as_bytes())?;
-            Ok(KeyPair {
-                public_key,
-                private_key,
-                key_id,
-                jwk: my_jwk,
-            })
-        }
-
-        fn to_public(&self) -> jwk::JsonWebKey {
-            let mut public_only = self.jwk.clone();
-            public_only.key = Box::from(public_only.key.to_public().unwrap().into_owned());
-            public_only
-        }
-    }
 
     #[tokio::test]
     async fn test_local_validator_checks_issuer() -> anyhow::Result<()> {
         // Test that the issuer must match the expected issuer for LocalTokenValidator.
-        let kp = KeyPair::generate_p256()?;
+        let kp = JwtKeys::generate()?;
         let issuer = "test1";
         let subject = "test_subject";
 
@@ -375,17 +343,16 @@ mod tests {
             iat: std::time::SystemTime::now(),
             exp: None,
         };
-        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
-        let token = jsonwebtoken::encode(&header, &orig_claims, &kp.private_key)?;
+        let token = kp.private.sign(&orig_claims)?;
 
         {
             // Test that we can validate it.
             let validator = BasicTokenValidator {
-                public_key: kp.public_key.clone(),
+                public_key: kp.public.clone(),
                 issuer: Some(issuer.to_string()),
             };
 
-            let parsed_claims: SpacetimeIdentityClaims2 = validator.validate_token(&token).await?;
+            let parsed_claims: SpacetimeIdentityClaims = validator.validate_token(&token).await?;
             assert_eq!(parsed_claims.issuer, issuer);
             assert_eq!(parsed_claims.subject, subject);
             assert_eq!(parsed_claims.identity, Identity::from_claims(issuer, subject));
@@ -393,7 +360,7 @@ mod tests {
         {
             // Now try with the wrong expected issuer.
             let validator = BasicTokenValidator {
-                public_key: kp.public_key.clone(),
+                public_key: kp.public.clone(),
                 issuer: Some("otherissuer".to_string()),
             };
 
@@ -406,7 +373,7 @@ mod tests {
     #[tokio::test]
     async fn test_local_validator_checks_key() -> anyhow::Result<()> {
         // Test that the decoding key must work for LocalTokenValidator.
-        let kp = KeyPair::generate_p256()?;
+        let kp = JwtKeys::generate()?;
         let issuer = "test1";
         let subject = "test_subject";
 
@@ -418,27 +385,26 @@ mod tests {
             iat: std::time::SystemTime::now(),
             exp: None,
         };
-        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
-        let token = jsonwebtoken::encode(&header, &orig_claims, &kp.private_key)?;
+        let token = kp.private.sign(&orig_claims)?;
 
         {
             // Test that we can validate it.
             let validator = BasicTokenValidator {
-                public_key: kp.public_key.clone(),
+                public_key: kp.public.clone(),
                 issuer: Some(issuer.to_string()),
             };
 
-            let parsed_claims: SpacetimeIdentityClaims2 = validator.validate_token(&token).await?;
+            let parsed_claims: SpacetimeIdentityClaims = validator.validate_token(&token).await?;
             assert_eq!(parsed_claims.issuer, issuer);
             assert_eq!(parsed_claims.subject, subject);
             assert_eq!(parsed_claims.identity, Identity::from_claims(issuer, subject));
         }
         {
             // We generate a new keypair and try to decode with that key.
-            let other_kp = KeyPair::generate_p256()?;
+            let other_kp = JwtKeys::generate()?;
             // Now try with the wrong expected issuer.
             let validator = BasicTokenValidator {
-                public_key: other_kp.public_key.clone(),
+                public_key: other_kp.public.clone(),
                 issuer: Some("otherissuer".to_string()),
             };
 
@@ -460,7 +426,7 @@ mod tests {
     #[tokio::test]
     async fn resigned_token_ignores_issuer() -> anyhow::Result<()> {
         // Test that the decoding key must work for LocalTokenValidator.
-        let kp = KeyPair::generate_p256()?;
+        let kp = JwtKeys::generate()?;
         let local_issuer = "test1";
         let external_issuer = "other_issuer";
         let subject = "test_subject";
@@ -473,18 +439,17 @@ mod tests {
             iat: std::time::SystemTime::now(),
             exp: None,
         };
-        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
-        let token = jsonwebtoken::encode(&header, &orig_claims, &kp.private_key)?;
+        let token = kp.private.sign(&orig_claims)?;
 
         // First, try the successful case with the FullTokenValidator.
         {
             let validator = FullTokenValidator {
-                local_key: kp.public_key.clone(),
+                local_key: kp.public.clone(),
                 local_issuer: local_issuer.to_string(),
                 oidc_validator: OidcTokenValidator,
             };
 
-            let parsed_claims: SpacetimeIdentityClaims2 = validator.validate_token(&token).await?;
+            let parsed_claims: SpacetimeIdentityClaims = validator.validate_token(&token).await?;
             assert_eq!(parsed_claims.issuer, external_issuer);
             assert_eq!(parsed_claims.subject, subject);
             assert_eq!(parsed_claims.identity, Identity::from_claims(external_issuer, subject));
@@ -494,7 +459,7 @@ mod tests {
         // Double check that validation fails if we check the issuer.
         assert_validation_fails(
             &BasicTokenValidator {
-                public_key: kp.public_key.clone(),
+                public_key: kp.public.clone(),
                 issuer: Some(local_issuer.to_string()),
             },
             &token,
@@ -531,11 +496,7 @@ mod tests {
     }
 
     impl OIDCServerHandle {
-        pub async fn start_new<I, K>(ks: I) -> anyhow::Result<Self>
-        where
-            I: IntoIterator<Item = K>,
-            K: AsRef<KeyPair>,
-        {
+        pub async fn start_new(jwks_json: String) -> anyhow::Result<Self> {
             let listener = TcpListener::bind("0.0.0.0:0").await.unwrap();
             let addr = listener.local_addr()?;
             let port = addr.port();
@@ -544,7 +505,6 @@ mod tests {
                 jwks_uri: format!("{}/jwks.json", base_url),
             };
             let (shutdown_tx, shutdown_rx) = oneshot::channel::<()>();
-            let jwks_json = to_jwks_json(ks);
 
             let app = Router::new()
                 .route(
@@ -583,13 +543,22 @@ mod tests {
 
     async fn run_oidc_test<T: TokenValidator>(validator: T) -> anyhow::Result<()> {
         // We will put 2 keys in the keyset.
-        let kp1 = Arc::new(KeyPair::generate_p256()?);
-        let kp2 = Arc::new(KeyPair::generate_p256()?);
+        let mut kp1 = JwtKeys::generate()?;
+        let mut kp2 = JwtKeys::generate()?;
+
+        // Note: our fetcher library requires these, even though they are optional in the spec.
+        // We should replace the jwks fetcher at some point, but most OIDC providers will have these.
+        kp1.kid = Some("key1".to_string());
+        kp2.kid = Some("key2".to_string());
 
         // We won't put this in the keyset.
-        let invalid_kp = KeyPair::generate_p256()?;
+        let invalid_kp = JwtKeys::generate()?;
 
-        let handle = OIDCServerHandle::start_new(vec![kp1.clone(), kp2.clone()]).await?;
+        let valid_keys: Vec<JwtKeys> = vec![kp1.clone(), kp2.clone()];
+        // let jwks = keyset_to_json(vec![&jk, &kp1])?;
+        let jwks = keyset_to_json(valid_keys)?;
+
+        let handle = OIDCServerHandle::start_new(jwks).await?;
 
         let issuer = handle.base_url.clone();
         let subject = "test_subject";
@@ -602,10 +571,10 @@ mod tests {
             iat: std::time::SystemTime::now(),
             exp: None,
         };
-        let header = jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256);
         for kp in [kp1, kp2] {
-            log::debug!("Testing with key {}", kp.key_id);
-            let token = jsonwebtoken::encode(&header, &orig_claims, &kp.private_key)?;
+            log::debug!("Testing with key {:?}", kp.kid);
+            // TODO: This test should also try using key ids in the token headers.
+            let token = kp.private.sign(&orig_claims)?;
 
             let validated_claims = validator.validate_token(&token).await?;
             assert_eq!(validated_claims.issuer, issuer);
@@ -613,7 +582,7 @@ mod tests {
             assert_eq!(validated_claims.identity, Identity::from_claims(&issuer, subject));
         }
 
-        let invalid_token = jsonwebtoken::encode(&header, &orig_claims, &invalid_kp.private_key)?;
+        let invalid_token = invalid_kp.private.sign(&orig_claims)?;
         assert!(validator.validate_token(&invalid_token).await.is_err());
 
         Ok(())
@@ -623,6 +592,7 @@ mod tests {
     async fn test_oidc_flow() -> anyhow::Result<()> {
         run_oidc_test(OidcTokenValidator).await
     }
+
     #[tokio::test]
     async fn test_caching_oidc_flow() -> anyhow::Result<()> {
         let v = CachingOidcTokenValidator::get_default();
@@ -631,12 +601,60 @@ mod tests {
 
     #[tokio::test]
     async fn test_full_validator_fallback() -> anyhow::Result<()> {
-        let kp = KeyPair::generate_p256()?;
+        let kp = JwtKeys::generate()?;
         let v = FullTokenValidator {
-            local_key: kp.public_key.clone(),
+            local_key: kp.public,
             local_issuer: "local_issuer".to_string(),
             oidc_validator: OidcTokenValidator,
         };
         run_oidc_test(v).await
+    }
+
+    /// Convert a set of keys to a JWKS JSON string.
+    fn keyset_to_json<I>(jks: I) -> anyhow::Result<String>
+    where
+        I: IntoIterator<Item = JwtKeys>,
+    {
+        let jks = jks
+            .into_iter()
+            .map(|key| to_jwk_json(&key).unwrap())
+            .collect::<Vec<serde_json::Value>>();
+
+        let j = serde_json::json!({
+            "keys": jks,
+        });
+        Ok(j.to_string())
+    }
+
+    // Extract the x and y coordinates from a public key and return a JWK for a single key.
+    fn to_jwk_json(jk: &JwtKeys) -> anyhow::Result<serde_json::Value> {
+        let eck = EcKey::public_key_from_pem(&jk.public_pem)?;
+
+        let group = EcGroup::from_curve_name(openssl::nid::Nid::X9_62_PRIME256V1)?;
+        let mut ctx = openssl::bn::BigNumContext::new()?;
+
+        // Get the x and y coordinates.
+        let mut x = openssl::bn::BigNum::new()?;
+        // let mut x = openssl::bn::BigNumRef
+        let mut y = openssl::bn::BigNum::new()?;
+        eck.public_key().affine_coordinates(&group, &mut x, &mut y, &mut ctx)?;
+
+        let x_b64 = base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(x.to_vec());
+        let y_b64 = base64::prelude::BASE64_URL_SAFE_NO_PAD.encode(y.to_vec());
+
+        let mut jwks = serde_json::json!(
+            {
+                "kty": "EC",
+                "crv": "P-256",
+                "use": "sig",
+                "alg": "ES256",
+                "x": x_b64,
+                "y": y_b64
+            }
+        );
+        if let Some(kid) = &jk.kid {
+            jwks["kid"] = kid.to_string().into();
+        }
+        Ok(jwks)
     }
 }


### PR DESCRIPTION
# Description of Changes

This is an attempt to clean up auth-related code. To summarize the main changes:

1. We don't use a global OIDC key cache any more.
2. The 4 JWT related functions in the `NodeDelegate` trait were removed, and the functionality was put in the `JwtAuthProvider` trait. `NodeDelegate` now just has one function to return an auth provider. This should make it easier to change this in the future. The new trait also exposes functions for signing and verifying keys, rather than giving the concrete keys.
3. `SpacetimeIdentityClaims2` is now the only `SpacetimeIdentityClaims`.
4. Instead of using `jsonwebkey` in the token validation tests, we use the same key generate code that is used for standalone key generation. There were some small changes to the key generate code to make it easier to reuse.

There is a corresponding [private PR](https://github.com/clockworklabs/SpacetimeDBPrivate/pull/1158).

# API and ABI breaking changes

None.

# Expected complexity level and risk

1. This is close to functionally equivalent, and should make future auth changes less complex.

# Testing

Most of the unit tests for this code are in `token_validation.rs`.
