### PR TITLE
Use `NonZeroU64` for `num_distinct_values` to avoid div-by-zero

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
       - master
       - staging
       - dev
+      - phoebe/hotfix/0.11.1/divide-by-zero
     tags:
       - 'v*'
 

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -81,7 +81,7 @@ impl TxId {
         self.committed_state_shared_lock.get_table(table_id).and_then(|t| {
             t.indexes
                 .get(cols)
-                .map(|index| NonZeroU64::new(index.num_keys() as u64))
+                .and_then(|index| NonZeroU64::new(index.num_keys() as u64))
         })
     }
 }

--- a/crates/core/src/estimation.rs
+++ b/crates/core/src/estimation.rs
@@ -18,6 +18,8 @@ fn row_est(tx: &Tx, src: &SourceExpr, ops: &[Query]) -> u64 {
             // We assume a uniform distribution of keys,
             // which implies a selectivity = 1 / NDV,
             // where NDV stands for Number of Distinct Values.
+            // We assume that the table exists and has an index on the columns,
+            // so `index_row_est` will only return 0 if the table is empty.
             Query::IndexScan(scan) if scan.is_point() => {
                 index_row_est(tx, scan.table.table_id, &scan.columns)
             }
@@ -41,6 +43,8 @@ fn row_est(tx: &Tx, src: &SourceExpr, ops: &[Query]) -> u64 {
             Query::IndexJoin(join) => {
                 row_est(tx, &join.probe_side.source, &join.probe_side.query)
                     .saturating_mul(
+                        // We assume that the table exists and has an index on the columns,
+                        // so `index_row_est` will only return 0 if the table is empty.
                         index_row_est(tx, src.table_id().unwrap(), &join.index_col.into())
                     )
             }

--- a/crates/core/src/estimation.rs
+++ b/crates/core/src/estimation.rs
@@ -59,8 +59,15 @@ fn row_est(tx: &Tx, src: &SourceExpr, ops: &[Query]) -> u64 {
 
 /// The estimated number of rows that an index probe will return.
 /// Note this method is not applicable to range scans.
+///
+/// Returns 0 in any case that [`Tx::num_distinct_values`] would return `None`:
+/// - If there is no such table as `table_id`.
+/// - If the table `table_id` does not have an index on exactly the `cols`.
+/// - If the table `table_id` contains 0 rows.
 fn index_row_est(tx: &Tx, table_id: TableId, cols: &ColList) -> u64 {
     tx.num_distinct_values(table_id, cols)
+        // `num_distinct_values` returns `Option<NonZeroU64>`,
+        // so this division can never panic.
         .map_or(0, |ndv| tx.get_row_count(table_id).unwrap_or(0) / ndv)
 }
 


### PR DESCRIPTION
# Description of Changes

Hotfix for a div-by-zero panic encountered by the BitCraft Alpha.

What was happening was, `num_distinct_values` on an empty table returned 0, which `index_row_est` then used as a divisor, leading to a panic. It seems reasonably clear to me that the correct estimate of distinct values in an empty index is 0, not bottom, so adjusting `num_distinct_values` to return `Option<NonZeroU64>`, and then making `index_row_est` return 0 in that case, seems an obvious fix.

# API and ABI breaking changes

N/a.

# Expected complexity level and risk

1 - Hard to be more broken.

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

- [ ] I am unsure how to test this. Perhaps we can deploy to staging, then do whatever the BitCraft team did that was broken, and verify that it no longer panics?
