### PR TITLE
Avoid div-by-zero in row count estimations for empty tables

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -9,6 +9,7 @@ use crate::execution_context::ExecutionContext;
 use spacetimedb_primitives::{ColList, TableId};
 use spacetimedb_sats::AlgebraicValue;
 use spacetimedb_schema::schema::TableSchema;
+use std::num::NonZeroU64;
 use std::sync::Arc;
 use std::{
     ops::RangeBounds,
@@ -65,9 +66,19 @@ impl TxId {
 
     /// The Number of Distinct Values (NDV) for a column or list of columns,
     /// if there's an index available on `cols`.
-    pub(crate) fn num_distinct_values(&self, table_id: TableId, cols: &ColList) -> Option<u64> {
-        self.committed_state_shared_lock
-            .get_table(table_id)
-            .and_then(|t| t.indexes.get(cols).map(|index| index.num_keys() as u64))
+    ///
+    /// Returns `None` if:
+    /// - No such table as `table_id` exists.
+    /// - The table `table_id` does not have an index on exactly the `cols`.
+    /// - The table `table_id` contains zero rows.
+    //
+    // This method must never return 0, as it's used as the divisor in quotients.
+    // Do not change its return type to a bare `u64`.
+    pub(crate) fn num_distinct_values(&self, table_id: TableId, cols: &ColList) -> Option<NonZeroU64> {
+        self.committed_state_shared_lock.get_table(table_id).and_then(|t| {
+            t.indexes
+                .get(cols)
+                .and_then(|index| NonZeroU64::from(index.num_keys() as u64))
+        })
     }
 }

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -78,7 +78,7 @@ impl TxId {
         self.committed_state_shared_lock.get_table(table_id).and_then(|t| {
             t.indexes
                 .get(cols)
-                .and_then(|index| NonZeroU64::from(index.num_keys() as u64))
+                .and_then(|index| NonZeroU64::new(index.num_keys() as u64))
         })
     }
 }

--- a/crates/core/src/estimation.rs
+++ b/crates/core/src/estimation.rs
@@ -18,6 +18,8 @@ fn row_est(tx: &Tx, src: &SourceExpr, ops: &[Query]) -> u64 {
             // We assume a uniform distribution of keys,
             // which implies a selectivity = 1 / NDV,
             // where NDV stands for Number of Distinct Values.
+            // We assume that the table exists and has an index on the columns,
+            // so `index_row_est` will only return 0 if the table is empty.
             Query::IndexScan(scan) if scan.is_point() => {
                 index_row_est(tx, scan.table.table_id, &scan.columns)
             }
@@ -41,6 +43,8 @@ fn row_est(tx: &Tx, src: &SourceExpr, ops: &[Query]) -> u64 {
             Query::IndexJoin(join) => {
                 row_est(tx, &join.probe_side.source, &join.probe_side.query)
                     .saturating_mul(
+                        // We assume that the table exists and has an index on the columns,
+                        // so `index_row_est` will only return 0 if the table is empty.
                         index_row_est(tx, src.table_id().unwrap(), &join.index_col.into())
                     )
             }
@@ -59,8 +63,15 @@ fn row_est(tx: &Tx, src: &SourceExpr, ops: &[Query]) -> u64 {
 
 /// The estimated number of rows that an index probe will return.
 /// Note this method is not applicable to range scans.
+///
+/// Returns 0 in any case that [`Tx::num_distinct_values`] would return `None`:
+/// - If there is no such table as `table_id`.
+/// - If the table `table_id` does not have an index on exactly the `cols`.
+/// - If the table `table_id` contains 0 rows.
 fn index_row_est(tx: &Tx, table_id: TableId, cols: &ColList) -> u64 {
     tx.num_distinct_values(table_id, cols)
+        // `num_distinct_values` returns `Option<NonZeroU64>`,
+        // so this division can never panic.
         .map_or(0, |ndv| tx.table_row_count(table_id).unwrap_or(0) / ndv)
 }
 


### PR DESCRIPTION
# Description of Changes

Forward-port of #1991 , an 0.11.1 hotfix for the BitCraft alpha, into master.

What was happening was, `num_distinct_values` on an empty table returned 0, which `index_row_est` then used as a divisor, leading to a panic. It seems reasonably clear to me that
the correct estimate of distinct values in an empty index is 0, not bottom, so adjusting `num_distinct_values` to return `Option<NonZeroU64>`, and then making `index_row_est` return 0 in that case, seems an obvious fix.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [ ] Check that it works for the BitCraft alpha.
- [ ] Maybe write a smoketest?