### PR TITLE
Fix inference for UNION

### DIFF
--- a/crates/core/src/sql/ast.rs
+++ b/crates/core/src/sql/ast.rs
@@ -3,6 +3,7 @@ use crate::error::{DBError, PlanError};
 use spacetimedb_data_structures::map::{HashCollectionExt as _, IntMap};
 use spacetimedb_expr::check::SchemaView;
 use spacetimedb_expr::statement::compile_sql_stmt;
+use spacetimedb_expr::ty::TyCtx;
 use spacetimedb_lib::db::auth::StAccess;
 use spacetimedb_lib::db::error::RelationError;
 use spacetimedb_lib::identity::AuthCtx;
@@ -952,7 +953,7 @@ pub(crate) fn compile_to_ast<T: TableSchemaView>(
 ) -> Result<Vec<SqlAst>, DBError> {
     // NOTE: The following ensures compliance with the 1.0 sql api.
     // Come 1.0, it will have replaced the current compilation stack.
-    compile_sql_stmt(sql_text, &SchemaViewer::new(db, tx, auth))?;
+    compile_sql_stmt(&mut TyCtx::default(), sql_text, &SchemaViewer::new(db, tx, auth))?;
 
     let dialect = PostgreSqlDialect {};
     let ast = Parser::parse_sql(&dialect, sql_text).map_err(|error| DBError::SqlParser {

--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -175,6 +175,7 @@ impl TypeChecker for SubChecker {
 
 /// Parse and type check a subscription query
 pub fn parse_and_type_sub(ctx: &mut TyCtx, sql: &str, tx: &impl SchemaView) -> TypingResult<RelExpr> {
+    ctx.source = StatementSource::Subscription;
     let expr = SubChecker::type_ast(ctx, parse_subscription(sql)?, tx)?;
     expect_table_type(ctx, expr)
 }

--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -359,6 +359,7 @@ pub(crate) fn parse(value: String, ty: TypeWithCtx) -> Result<AlgebraicValue, In
 }
 
 /// The source of a statement
+#[derive(Debug)]
 pub enum StatementSource {
     Subscription,
     Query,

--- a/crates/expr/src/statement.rs
+++ b/crates/expr/src/statement.rs
@@ -348,20 +348,20 @@ impl TypeChecker for SqlChecker {
     }
 }
 
-fn parse_and_type_sql(sql: &str, tx: &impl SchemaView) -> TypingResult<Statement> {
+fn parse_and_type_sql(ctx: &mut TyCtx, sql: &str, tx: &impl SchemaView) -> TypingResult<Statement> {
     match parse_sql(sql)? {
-        SqlAst::Insert(insert) => Ok(Statement::Insert(type_insert(&mut TyCtx::default(), insert, tx)?)),
-        SqlAst::Delete(delete) => Ok(Statement::Delete(type_delete(&mut TyCtx::default(), delete, tx)?)),
-        SqlAst::Update(update) => Ok(Statement::Update(type_update(&mut TyCtx::default(), update, tx)?)),
-        SqlAst::Query(ast) => Ok(Statement::Select(SqlChecker::type_ast(&mut TyCtx::default(), ast, tx)?)),
-        SqlAst::Set(set) => Ok(Statement::Set(type_set(&TyCtx::default(), set)?)),
+        SqlAst::Insert(insert) => Ok(Statement::Insert(type_insert(ctx, insert, tx)?)),
+        SqlAst::Delete(delete) => Ok(Statement::Delete(type_delete(ctx, delete, tx)?)),
+        SqlAst::Update(update) => Ok(Statement::Update(type_update(ctx, update, tx)?)),
+        SqlAst::Query(ast) => Ok(Statement::Select(SqlChecker::type_ast(ctx, ast, tx)?)),
+        SqlAst::Set(set) => Ok(Statement::Set(type_set(ctx, set)?)),
         SqlAst::Show(show) => Ok(Statement::Show(type_show(show)?)),
     }
 }
 
 /// Parse and type check a *general* query into a [StatementCtx].
-pub fn compile_sql_stmt<'a>(sql: &'a str, tx: &impl SchemaView) -> TypingResult<StatementCtx<'a>> {
-    let statement = parse_and_type_sql(sql, tx)?;
+pub fn compile_sql_stmt<'a>(ctx: &mut TyCtx, sql: &'a str, tx: &impl SchemaView) -> TypingResult<StatementCtx<'a>> {
+    let statement = parse_and_type_sql(ctx, sql, tx)?;
     Ok(StatementCtx {
         statement,
         sql,

--- a/crates/expr/src/statement.rs
+++ b/crates/expr/src/statement.rs
@@ -349,6 +349,7 @@ impl TypeChecker for SqlChecker {
 }
 
 fn parse_and_type_sql(ctx: &mut TyCtx, sql: &str, tx: &impl SchemaView) -> TypingResult<Statement> {
+    ctx.source = StatementSource::Query;
     match parse_sql(sql)? {
         SqlAst::Insert(insert) => Ok(Statement::Insert(type_insert(ctx, insert, tx)?)),
         SqlAst::Delete(delete) => Ok(Statement::Delete(type_delete(ctx, delete, tx)?)),

--- a/crates/physical-plan/src/compile.rs
+++ b/crates/physical-plan/src/compile.rs
@@ -147,10 +147,11 @@ mod tests {
         Ok((expr, ctx))
     }
 
-    fn compile_sql_stmt_test(sql: &str) -> ResultTest<StatementCtx> {
+    fn compile_sql_stmt_test(sql: &str) -> ResultTest<(StatementCtx, TyCtx)> {
         let tx = SchemaViewer(module_def());
-        let statement = compile_sql_stmt(sql, &tx)?;
-        Ok(statement)
+        let mut ctx = TyCtx::default();
+        let statement = compile_sql_stmt(&mut ctx, sql, &tx)?;
+        Ok((statement, ctx))
     }
 
     impl PhysicalPlan {
@@ -184,7 +185,7 @@ mod tests {
         let (ast, ctx) = compile_sql_sub_test("SELECT * FROM t")?;
         assert!(matches!(compile(&ctx, ast).plan, PhysicalPlan::TableScan(_)));
 
-        let ast = compile_sql_stmt_test("SELECT u32 FROM t")?;
+        let (ast, ctx) = compile_sql_stmt_test("SELECT u32 FROM t")?;
         assert!(matches!(compile(&ctx, ast).plan, PhysicalPlan::Project(..)));
 
         Ok(())


### PR DESCRIPTION
# Description of Changes

When trying to infer the type for `UNION` like queries we get:

```bash
 Unexpected type: (expected) (u32: U32f32: F32str: String) != (u32: U32f32: F32str: String) (inferred)
```

Because the check is only 'nominal' (aka: test both `table_id` are the same), this patch also makes a structural check.


# Expected complexity level and risk
1
# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
