### PR TITLE
CLI should not depend on rustup

### DIFF
--- a/crates/cli/src/detect.rs
+++ b/crates/cli/src/detect.rs
@@ -6,54 +6,56 @@ use std::path::Path;
 pub(crate) fn find_executable(exe_name: impl AsRef<Path>) -> Option<std::path::PathBuf> {
     std::env::var_os("PATH").and_then(|paths| {
         std::env::split_paths(&paths)
-            .filter_map(|dir| {
-                let full_path = dir.join(&exe_name);
-                full_path.is_file().then_some(full_path)
-            })
-            .next()
+            .map(|dir| dir.join(&exe_name))
+            .find(|x| x.is_file())
     })
 }
 
 /// Check if `rustup` is installed (aka: Is in the `PATH`).
-pub(crate) fn has_rust_up() -> anyhow::Result<bool> {
-    Ok(match std::env::consts::OS {
+pub(crate) fn has_rust_up() -> bool {
+    match std::env::consts::OS {
         "linux" | "freebsd" | "netbsd" | "openbsd" | "solaris" | "macos" => find_executable("rustup").is_some(),
         "windows" => find_executable("rustup.exe").is_some(),
         unsupported_os => {
-            return Err(anyhow::anyhow!(
-                "This OS may be unsupported for `rustup`: {unsupported_os}"
-            ));
+            eprintln!("This OS may be unsupported for `rustup`: {unsupported_os}");
+            false
         }
-    })
+    }
 }
 
 /// Check if `rustfmt` is installed (aka: Is in the `PATH`).
-pub(crate) fn has_rust_fmt() -> anyhow::Result<bool> {
-    Ok(match std::env::consts::OS {
+pub(crate) fn has_rust_fmt() -> bool {
+    match std::env::consts::OS {
         "linux" | "freebsd" | "netbsd" | "openbsd" | "solaris" | "macos" => find_executable("rustfmt").is_some(),
         "windows" => find_executable("rustfmt.exe").is_some(),
         unsupported_os => {
-            return Err(anyhow::anyhow!(
-                "This OS may be unsupported for `rustfmt`: {unsupported_os}"
-            ));
+            eprintln!("This OS may be unsupported for `rustfmt`: {unsupported_os}");
+            false
         }
-    })
+    }
 }
 
 /// Check if the [Target] is installed.
 ///
 /// **NOTE:** If `rustup` is not installed, we check inside the `rustc sysroot` directory.
-pub(crate) fn has_wasm32_target() -> anyhow::Result<bool> {
-    if has_rust_up()? {
-        let output = cmd!("rustup", "target", "list", "--installed").read()?;
-        Ok(output.contains("wasm32-unknown-unknown"))
-    } else {
-        // When `rustup` is not installed, we need to manually check the [Target] inside the sysroot directory
-        let root = cmd!("rustc", "--print", "sysroot").read()?;
-        Path::new(&format!("{}/lib/rustlib/{}", root.trim(), "wasm32-unknown-unknown"))
-            .try_exists()
-            .map_err(|err: io::Error| anyhow::anyhow!(err))
-    }
+pub(crate) fn has_wasm32_target() -> bool {
+    let result = || {
+        if has_rust_up() {
+            let output = cmd!("rustup", "target", "list", "--installed").read()?;
+            Ok(output.contains("wasm32-unknown-unknown"))
+        } else {
+            // When `rustup` is not installed, we need to manually check the [Target] inside the sysroot directory
+            let root = cmd!("rustc", "--print", "sysroot").read()?;
+            Path::new(&format!("{}/lib/rustlib/{}", root.trim(), "wasm32-unknown-unknown"))
+                .try_exists()
+                .map_err(|err: io::Error| anyhow::anyhow!(err))
+        }
+    };
+
+    result().unwrap_or_else(|err| {
+        eprintln!("Error checking for wasm32 target: {err}");
+        false
+    })
 }
 
 #[cfg(test)]
@@ -62,7 +64,7 @@ mod tests {
 
     #[test]
     fn test_has_target() -> anyhow::Result<()> {
-        assert!(has_wasm32_target()?);
+        assert!(has_wasm32_target());
         Ok(())
     }
 }

--- a/crates/cli/src/detect.rs
+++ b/crates/cli/src/detect.rs
@@ -1,0 +1,68 @@
+use duct::cmd;
+use std::io;
+use std::path::Path;
+
+/// Find an executable in the `PATH`.
+pub(crate) fn find_executable(exe_name: impl AsRef<Path>) -> Option<std::path::PathBuf> {
+    std::env::var_os("PATH").and_then(|paths| {
+        std::env::split_paths(&paths)
+            .filter_map(|dir| {
+                let full_path = dir.join(&exe_name);
+                full_path.is_file().then_some(full_path)
+            })
+            .next()
+    })
+}
+
+/// Check if `rustup` is installed (aka: Is in the `PATH`).
+pub(crate) fn has_rust_up() -> anyhow::Result<bool> {
+    Ok(match std::env::consts::OS {
+        "linux" | "freebsd" | "netbsd" | "openbsd" | "solaris" | "macos" => find_executable("rustup").is_some(),
+        "windows" => find_executable("rustup.exe").is_some(),
+        unsupported_os => {
+            return Err(anyhow::anyhow!(
+                "This OS may be unsupported for `rustup`: {unsupported_os}"
+            ));
+        }
+    })
+}
+
+/// Check if `rustfmt` is installed (aka: Is in the `PATH`).
+pub(crate) fn has_rust_fmt() -> anyhow::Result<bool> {
+    Ok(match std::env::consts::OS {
+        "linux" | "freebsd" | "netbsd" | "openbsd" | "solaris" | "macos" => find_executable("rustfmt").is_some(),
+        "windows" => find_executable("rustfmt.exe").is_some(),
+        unsupported_os => {
+            return Err(anyhow::anyhow!(
+                "This OS may be unsupported for `rustfmt`: {unsupported_os}"
+            ));
+        }
+    })
+}
+
+/// Check if the [Target] is installed.
+///
+/// **NOTE:** If `rustup` is not installed, we check inside the `rustc sysroot` directory.
+pub(crate) fn has_wasm32_target() -> anyhow::Result<bool> {
+    if has_rust_up()? {
+        let output = cmd!("rustup", "target", "list", "--installed").read()?;
+        Ok(output.contains("wasm32-unknown-unknown"))
+    } else {
+        // When `rustup` is not installed, we need to manually check the [Target] inside the sysroot directory
+        let root = cmd!("rustc", "--print", "sysroot").read()?;
+        Path::new(&format!("{}/lib/rustlib/{}", root.trim(), "wasm32-unknown-unknown"))
+            .try_exists()
+            .map_err(|err: io::Error| anyhow::anyhow!(err))
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_has_target() -> anyhow::Result<()> {
+        assert!(has_wasm32_target()?);
+        Ok(())
+    }
+}

--- a/crates/cli/src/detect.rs
+++ b/crates/cli/src/detect.rs
@@ -35,21 +35,20 @@ pub(crate) fn has_rust_fmt() -> bool {
     }
 }
 
-/// Check if the [Target] is installed.
-///
-/// **NOTE:** If `rustup` is not installed, we check inside the `rustc sysroot` directory.
+/// Check if the target `wasm32-unknown-unknown` is installed.
 pub(crate) fn has_wasm32_target() -> bool {
     let result = || {
-        if has_rust_up() {
-            let output = cmd!("rustup", "target", "list", "--installed").read()?;
-            Ok(output.contains("wasm32-unknown-unknown"))
-        } else {
-            // When `rustup` is not installed, we need to manually check the [Target] inside the sysroot directory
-            let root = cmd!("rustc", "--print", "sysroot").read()?;
-            Path::new(&format!("{}/lib/rustlib/{}", root.trim(), "wasm32-unknown-unknown"))
-                .try_exists()
-                .map_err(|err: io::Error| anyhow::anyhow!(err))
-        }
+        let path = cmd!(
+            "rustc",
+            "--print",
+            "target-libdir",
+            "--target",
+            "wasm32-unknown-unknown"
+        )
+        .read()?;
+        Path::new(path.trim())
+            .try_exists()
+            .map_err(|err: io::Error| anyhow::anyhow!(err))
     };
 
     result().unwrap_or_else(|err| {

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -1,6 +1,7 @@
 pub mod api;
 mod common_args;
 mod config;
+pub(crate) mod detect;
 mod edit_distance;
 mod errors;
 mod subcommands;

--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -1,5 +1,6 @@
 #![warn(clippy::uninlined_format_args)]
 
+use anyhow::Context;
 use clap::parser::ValueSource;
 use clap::Arg;
 use clap::ArgAction::Set;
@@ -474,11 +475,11 @@ fn format_files(generated_files: Vec<PathBuf>, lang: Language) -> anyhow::Result
         Language::Rust => {
             if !has_rust_fmt() {
                 if has_rust_up() {
-                    if let Err(err) = cmd!("rustup", "component", "add", "rustfmt").run() {
-                        return Err(anyhow::anyhow!("Failed to install rustfmt with rustup: {err}"));
-                    }
+                    cmd!("rustup", "component", "add", "rustfmt")
+                        .run()
+                        .context("Failed to install rustfmt with Rustup")?;
                 } else {
-                    return Err(anyhow::anyhow!("rustfmt is not installed. Please install it."));
+                    anyhow::bail!("rustfmt is not installed. Please install it.");
                 }
             }
             for path in generated_files {

--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -472,8 +472,8 @@ impl WasmCtx {
 fn format_files(generated_files: Vec<PathBuf>, lang: Language) -> anyhow::Result<()> {
     match lang {
         Language::Rust => {
-            if !has_rust_fmt()? {
-                if has_rust_up()? {
+            if !has_rust_fmt() {
+                if has_rust_up() {
                     if let Err(err) = cmd!("rustup", "component", "add", "rustfmt").run() {
                         println!("Warning: Failed to install rustfmt: {err}");
                     }

--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -475,7 +475,7 @@ fn format_files(generated_files: Vec<PathBuf>, lang: Language) -> anyhow::Result
             if !has_rust_fmt() {
                 if has_rust_up() {
                     if let Err(err) = cmd!("rustup", "component", "add", "rustfmt").run() {
-                        println!("Warning: Failed to install rustfmt: {err}");
+                        return Err(anyhow::anyhow!("Failed to install rustfmt with rustup: {err}"));
                     }
                 } else {
                     return Err(anyhow::anyhow!("rustfmt is not installed. Please install it."));

--- a/crates/cli/src/subcommands/init.rs
+++ b/crates/cli/src/subcommands/init.rs
@@ -1,3 +1,4 @@
+use crate::detect::find_executable;
 use crate::util::ModuleLanguage;
 use crate::Config;
 use anyhow::Context;
@@ -201,15 +202,4 @@ pub async fn exec_init_csharp(args: &ArgMatches) -> anyhow::Result<()> {
 
 fn create_directory(path: &Path) -> Result<(), anyhow::Error> {
     std::fs::create_dir_all(path).context("Failed to create directory")
-}
-
-fn find_executable(exe_name: impl AsRef<Path>) -> Option<std::path::PathBuf> {
-    std::env::var_os("PATH").and_then(|paths| {
-        std::env::split_paths(&paths)
-            .filter_map(|dir| {
-                let full_path = dir.join(&exe_name);
-                full_path.is_file().then_some(full_path)
-            })
-            .next()
-    })
 }

--- a/crates/cli/src/tasks/rust.rs
+++ b/crates/cli/src/tasks/rust.rs
@@ -21,8 +21,8 @@ fn cargo_cmd(subcommand: &str, build_debug: bool, args: &[&str]) -> duct::Expres
 }
 
 pub(crate) fn build_rust(project_path: &Path, skip_clippy: bool, build_debug: bool) -> anyhow::Result<PathBuf> {
-    if !has_wasm32_target()? {
-        if has_rust_up()? {
+    if !has_wasm32_target() {
+        if has_rust_up() {
             // Make sure that we have the wasm target installed (ok to run if its already installed)
             if let Err(err) = cmd!("rustup", "target", "add", "wasm32-unknown-unknown").run() {
                 println!("Warning: Failed to install wasm32-unknown-unknown target: {}", err);

--- a/crates/cli/src/tasks/rust.rs
+++ b/crates/cli/src/tasks/rust.rs
@@ -21,12 +21,12 @@ fn cargo_cmd(subcommand: &str, build_debug: bool, args: &[&str]) -> duct::Expres
 }
 
 pub(crate) fn build_rust(project_path: &Path, skip_clippy: bool, build_debug: bool) -> anyhow::Result<PathBuf> {
+    // Make sure that we have the wasm target installed
     if !has_wasm32_target() {
         if has_rust_up() {
-            // Make sure that we have the wasm target installed (ok to run if its already installed)
-            if let Err(err) = cmd!("rustup", "target", "add", "wasm32-unknown-unknown").run() {
-                anyhow::bail!("Failed to install wasm32-unknown-unknown target with rustup: {}", err);
-            }
+            cmd!("rustup", "target", "add", "wasm32-unknown-unknown")
+                .run()
+                .context("Failed to install wasm32-unknown-unknown target with rustup")?;
         } else {
             anyhow::bail!("wasm32-unknown-unknown target is not installed. Please install it.");
         }

--- a/crates/cli/src/tasks/rust.rs
+++ b/crates/cli/src/tasks/rust.rs
@@ -25,7 +25,7 @@ pub(crate) fn build_rust(project_path: &Path, skip_clippy: bool, build_debug: bo
         if has_rust_up() {
             // Make sure that we have the wasm target installed (ok to run if its already installed)
             if let Err(err) = cmd!("rustup", "target", "add", "wasm32-unknown-unknown").run() {
-                println!("Warning: Failed to install wasm32-unknown-unknown target: {}", err);
+                anyhow::bail!("Failed to install wasm32-unknown-unknown target with rustup: {}", err);
             }
         } else {
             anyhow::bail!("wasm32-unknown-unknown target is not installed. Please install it.");


### PR DESCRIPTION
# Description of Changes

Rustup could not be installed (for example, for people who use `nix`). 

Now, the `cli` defensively check for it. It also try to find the target `wasm32-unknown-unknown` in case is not installed.

Closes #1971.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test*
- [x] *Run manually in windows*
