### PR TITLE
Subscriptions impl, server side

### DIFF
--- a/crates/core/src/client/message_handlers.rs
+++ b/crates/core/src/client/message_handlers.rs
@@ -87,6 +87,14 @@ pub async fn handle(client: &ClientConnection, message: DataMessage, timer: Inst
                 .observe(timer.elapsed().as_secs_f64());
             res.map_err(|e| (None, None, e.into()))
         }
+        ClientMessage::Unsubscribe(request) => {
+            let res = client.unsubscribe(request, timer).await;
+            WORKER_METRICS
+                .request_round_trip
+                .with_label_values(&WorkloadType::Unsubscribe, &address, "")
+                .observe(timer.elapsed().as_secs_f64());
+            res.map_err(|e| (None, None, e.into()))
+        }
         ClientMessage::OneOffQuery(OneOffQuery {
             query_string: query,
             message_id,

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -99,7 +99,9 @@ pub enum SubscriptionError {
     NotFound(IndexId),
     #[error("Empty string")]
     Empty,
-    #[error("Queries with side effects not allowed: {0:?}")]
+    #[error("Queries over multiple tables are not supported")]
+    Multiple,
+    #[error("Queries with side effects are not allowed: {0:?}")]
     SideEffect(Crud),
     #[error("Unsupported query on subscription: {0:?}")]
     Unsupported(String),

--- a/crates/core/src/execution_context.rs
+++ b/crates/core/src/execution_context.rs
@@ -100,6 +100,7 @@ pub enum Workload {
     Reducer(ReducerContext),
     Sql,
     Subscribe,
+    Unsubscribe,
     Update,
     Internal,
 }
@@ -113,6 +114,7 @@ pub enum WorkloadType {
     Reducer,
     Sql,
     Subscribe,
+    Unsubscribe,
     Update,
     Internal,
 }
@@ -125,6 +127,7 @@ impl From<Workload> for WorkloadType {
             Workload::Reducer(_) => Self::Reducer,
             Workload::Sql => Self::Sql,
             Workload::Subscribe => Self::Subscribe,
+            Workload::Unsubscribe => Self::Unsubscribe,
             Workload::Update => Self::Update,
             Workload::Internal => Self::Internal,
         }
@@ -156,6 +159,7 @@ impl ExecutionContext {
             Workload::Reducer(ctx) => Self::reducer(database_identity, ctx),
             Workload::Sql => Self::sql(database_identity),
             Workload::Subscribe => Self::subscribe(database_identity),
+            Workload::Unsubscribe => Self::unsubscribe(database_identity),
             Workload::Update => Self::incremental_update(database_identity),
         }
     }
@@ -173,6 +177,11 @@ impl ExecutionContext {
     /// Returns an [ExecutionContext] for an initial subscribe call.
     pub fn subscribe(database: Identity) -> Self {
         Self::new(database, None, WorkloadType::Subscribe)
+    }
+
+    /// Returns an [ExecutionContext] for an initial unsubscribe call.
+    pub fn unsubscribe(database: Identity) -> Self {
+        Self::new(database, None, WorkloadType::Unsubscribe)
     }
 
     /// Returns an [ExecutionContext] for a subscription update.

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -540,7 +540,7 @@ impl ModuleHost {
     pub async fn disconnect_client(&self, client_id: ClientActorId) {
         let this = self.clone();
         let _ = tokio::task::spawn_blocking(move || {
-            this.subscriptions().remove_subscriber(client_id);
+            this.subscriptions().remove_all_subscribers(client_id);
         })
         .await;
         // ignore NoSuchModule; if the module's already closed, that's fine


### PR DESCRIPTION
# Description of Changes

Moving subscriptions from one batch-subscribe call to one call per subscribe with matching unsubscribe call.

# API and ABI breaking changes

Updates to the websocket API and introduction of new messages.

# Expected complexity level and risk

3: changes the way subscriptions are stored and used.

# Testing

In progress
