### PR TITLE
Fix flaky oidc tests

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4931,6 +4931,7 @@ dependencies = [
  "rayon",
  "rayon-core",
  "regex",
+ "reqwest 0.12.9",
  "rustc-demangle",
  "rustc-hash",
  "scopeguard",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -128,3 +128,4 @@ env_logger.workspace = true
 pretty_assertions.workspace = true
 jsonwebtoken.workspace = true
 axum.workspace = true
+reqwest.workspace = true

--- a/crates/core/src/auth/token_validation.rs
+++ b/crates/core/src/auth/token_validation.rs
@@ -545,7 +545,7 @@ mod tests {
             // Wait for server to be ready
             let client = reqwest::Client::new();
             let health_check_url = format!("{}/ok", base_url);
-            
+
             let mut attempts = 0;
             const MAX_ATTEMPTS: u32 = 10;
             const DELAY_MS: u64 = 50;
@@ -564,7 +564,6 @@ mod tests {
             if attempts == MAX_ATTEMPTS {
                 return Err(anyhow::anyhow!("Server failed to start after maximum attempts"));
             }
-
 
             Ok(OIDCServerHandle {
                 base_url,

--- a/crates/core/src/auth/token_validation.rs
+++ b/crates/core/src/auth/token_validation.rs
@@ -261,7 +261,14 @@ impl TokenValidator for OidcTokenValidator {
         let raw_issuer = get_raw_issuer(token)?;
         // TODO: Consider checking for trailing slashes or requiring a scheme.
         let oidc_url = format!("{}/.well-known/openid-configuration", raw_issuer);
-        let keys = Jwks::from_oidc_url(oidc_url).await?;
+        log::debug!("Fetching key for issuer {}", raw_issuer.clone());
+        let key_or_error = Jwks::from_oidc_url(oidc_url).await;
+        // TODO: We should probably add debouncing to avoid spamming the logs.
+        // Alternatively we could add a backoff before retrying.
+        if let Err(e) = &key_or_error {
+            log::warn!("Error fetching public key for issuer {}: {:?}", raw_issuer, e);
+        }
+        let keys = key_or_error?;
         let validator = JwksValidator {
             issuer: raw_issuer,
             keyset: keys,
@@ -317,6 +324,8 @@ impl TokenValidator for JwksValidator {
 
 #[cfg(test)]
 mod tests {
+    use std::time::Duration;
+
     use crate::auth::identity::{IncomingClaims, SpacetimeIdentityClaims};
     use crate::auth::token_validation::{
         BasicTokenValidator, CachingOidcTokenValidator, FullTokenValidator, OidcTokenValidator, TokenSigner,
@@ -532,6 +541,30 @@ mod tests {
                     .await
                     .unwrap();
             });
+
+            // Wait for server to be ready
+            let client = reqwest::Client::new();
+            let health_check_url = format!("{}/ok", base_url);
+            
+            let mut attempts = 0;
+            const MAX_ATTEMPTS: u32 = 10;
+            const DELAY_MS: u64 = 50;
+
+            while attempts < MAX_ATTEMPTS {
+                match client.get(&health_check_url).send().await {
+                    Ok(response) if response.status().is_success() => break,
+                    _ => {
+                        log::debug!("Server not ready. Waiting...");
+                        tokio::time::sleep(Duration::from_millis(DELAY_MS)).await;
+                        attempts += 1;
+                    }
+                }
+            }
+
+            if attempts == MAX_ATTEMPTS {
+                return Err(anyhow::anyhow!("Server failed to start after maximum attempts"));
+            }
+
 
             Ok(OIDCServerHandle {
                 base_url,


### PR DESCRIPTION
# Description of Changes

The test_oidc_flow test has had some spurious failures, so this adds the following:

1. We have a few more debug logs that should help figure out whats happening if there are more failures.
2. When starting up an OIDC server in the tests, we wait for a successful request before continuing. This is just in case there is some race condition around server startup.
3. The actual fix is that we encode the key parameters correctly in our tests.

The cause for the failures is that when we encoded keys to JWKS in tests, we used `openssl::bn::BigNum` for our parameters, which is a dynamically sized number. If the 8 most significant digits of a parameter happened to be 8, our JWKs would have a 31 byte parameter. According to the spec, that is invalid [section 6.2.1.2](https://www.rfc-editor.org/rfc/rfc7518#section-6.2.1.2). This was tricky to debug because when I tested the failing keys with node/webcrypto, that library just left-padded the parameter, so it seemed valid.

The library that we are using doesn't reject the key or left-pad it. I'm not sure how or if it fills in missing bytes, but it was returning an invalid signature error instead of an invalid key error.

We should update the library at some point to handle this sort of invalid key better, in case this encoding bug is more common.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

0

# Testing

This is a test only change.
