### PR TITLE
Speed up `state_view::Iter` by special casing committed-with-no-deletes

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -78,8 +78,8 @@ impl StateView for CommittedState {
     }
 
     fn iter(&self, table_id: TableId) -> Result<Iter<'_>> {
-        if let Some(table_name) = self.table_name(table_id) {
-            return Ok(Iter::new(table_id, table_name, None, self));
+        if self.table_name(table_id).is_some() {
+            return Ok(Iter::new(table_id, None, self));
         }
         Err(TableError::IdNotFound(SystemTable::st_table, table_id.0).into())
     }

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -1412,10 +1412,9 @@ impl StateView for MutTxId {
     }
 
     fn iter(&self, table_id: TableId) -> Result<Iter<'_>> {
-        if let Some(table_name) = self.table_name(table_id) {
+        if self.table_name(table_id).is_some() {
             return Ok(Iter::new(
                 table_id,
-                table_name,
                 Some(&self.tx_state),
                 &self.committed_state_write_lock,
             ));


### PR DESCRIPTION
# Description of Changes

Based on flamegraphs of `iter`, this speeds it up by avoiding checking the delete tables for every committed row if there isn't a delete table. Meanwhile, here, we also only fetch the delete table once instead of for every committed row.

Fixes https://github.com/clockworklabs/SpacetimeDB/issues/2012.

# API and ABI breaking changes

None

# Expected complexity level and risk

1, localized and already well tested change.
