### PR TITLE
commitlog: Fix set_epoch

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4869,6 +4869,7 @@ dependencies = [
  "log",
  "memmap2",
  "once_cell",
+ "pretty_assertions",
  "proptest",
  "proptest-derive",
  "rand 0.8.5",

--- a/crates/client-api/Cargo.toml
+++ b/crates/client-api/Cargo.toml
@@ -23,7 +23,7 @@ prometheus = "0.13.0"
 email_address = "0.2.3"
 tempfile.workspace = true
 async-trait = "0.1.60"
-chrono = { version = "0.4.23", features = ["serde"] }
+chrono = { workspace = true, features = ["serde"] }
 rand = "0.8.5"
 axum.workspace = true
 axum-extra.workspace = true

--- a/crates/commitlog/Cargo.toml
+++ b/crates/commitlog/Cargo.toml
@@ -28,6 +28,7 @@ thiserror.workspace = true
 [dev-dependencies]
 env_logger.workspace = true
 once_cell.workspace = true
+pretty_assertions = { workspace = true, features = ["unstable"] }
 proptest-derive.workspace = true
 proptest.workspace = true
 rand.workspace = true

--- a/crates/commitlog/src/segment.rs
+++ b/crates/commitlog/src/segment.rs
@@ -78,6 +78,7 @@ impl Default for Header {
 }
 
 /// Metadata about a [`Commit`] which was successfully written via [`Writer::commit`].
+#[derive(Debug, PartialEq)]
 pub struct Committed {
     /// The range of transaction offsets included in the commit.
     pub tx_range: Range<u64>,

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -8,7 +8,7 @@ description = "The spacetimedb directory structure, represented as a type hierar
 
 [dependencies]
 anyhow.workspace = true
-chrono.workspace = true
+chrono = { workspace = true, features = ["now"] }
 fs2.workspace = true
 itoa.workspace = true
 serde.workspace = true


### PR DESCRIPTION
The `cmp` arguments were flipped, sabotaging the intent. Add some tests while we're at it.

Also make sure the `spacetimedb-paths` crate selects the features it needs, so that we don't need to rely on workspace feature unification to be able to run said tests.