### PR TITLE
Split binaries

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4734,7 +4734,6 @@ dependencies = [
  "spacetimedb-paths",
  "spacetimedb-primitives",
  "spacetimedb-schema",
- "spacetimedb-standalone",
  "spacetimedb-testing",
  "syntect",
  "tabled",
@@ -5088,6 +5087,7 @@ dependencies = [
  "dirs",
  "fs2",
  "itoa",
+ "semver",
  "serde",
  "tempfile",
  "thiserror",
@@ -5334,6 +5334,16 @@ dependencies = [
  "tempfile",
  "tokio",
  "wasmbin",
+]
+
+[[package]]
+name = "spacetimedb-update"
+version = "1.0.0-rc3"
+dependencies = [
+ "anyhow",
+ "clap 4.5.20",
+ "semver",
+ "spacetimedb-paths",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -29,6 +29,7 @@ members = [
   "crates/standalone",
   "crates/table",
   "crates/testing",
+  "crates/update",
   "crates/vm",
   "modules/benchmarks",
   "modules/perf-test",

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -10,7 +10,7 @@ rust-version.workspace = true
 bench = false
 
 [[bin]]
-name = "spacetime"
+name = "spacetimedb-cli"
 path = "src/main.rs"
 # Benching off, because of https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options
 bench = false
@@ -26,7 +26,6 @@ spacetimedb-lib.workspace = true
 spacetimedb-paths.workspace = true
 spacetimedb-primitives.workspace = true
 spacetimedb-schema.workspace = true
-spacetimedb-standalone = { workspace = true, optional = true }
 
 anyhow.workspace = true
 base64.workspace = true
@@ -72,7 +71,3 @@ webbrowser.workspace = true
 insta.workspace = true
 fs-err.workspace = true
 spacetimedb-testing = { path = "../testing" }
-
-[features]
-standalone = ["spacetimedb-standalone"]
-default = ["standalone"]

--- a/crates/cli/src/lib.rs
+++ b/crates/cli/src/lib.rs
@@ -4,20 +4,19 @@ mod config;
 pub(crate) mod detect;
 mod edit_distance;
 mod errors;
+mod start;
 mod subcommands;
 mod tasks;
 pub mod util;
+
+use std::process::ExitCode;
 
 use clap::{ArgMatches, Command};
 
 pub use config::Config;
 use spacetimedb_paths::SpacetimePaths;
-use spacetimedb_standalone::subcommands::start::ProgramMode;
 pub use subcommands::*;
 pub use tasks::build;
-
-#[cfg(feature = "standalone")]
-use spacetimedb_standalone::subcommands::start;
 
 pub fn get_subcommands() -> Vec<Command> {
     vec![
@@ -39,8 +38,7 @@ pub fn get_subcommands() -> Vec<Command> {
         server::cli(),
         upgrade::cli(),
         subscribe::cli(),
-        #[cfg(feature = "standalone")]
-        start::cli(ProgramMode::CLI),
+        start::cli(),
     ]
 }
 
@@ -49,7 +47,7 @@ pub async fn exec_subcommand(
     paths: &SpacetimePaths,
     cmd: &str,
     args: &ArgMatches,
-) -> Result<(), anyhow::Error> {
+) -> anyhow::Result<ExitCode> {
     match cmd {
         "version" => version::exec(config, args).await,
         "call" => call::exec(config, args).await,
@@ -66,11 +64,11 @@ pub async fn exec_subcommand(
         "build" => build::exec(config, args).await.map(drop),
         "server" => server::exec(config, paths, args).await,
         "subscribe" => subscribe::exec(config, args).await,
-        #[cfg(feature = "standalone")]
-        "start" => start::exec(Some(paths), args).await,
+        "start" => return start::exec(paths, args).await,
         "login" => login::exec(config, args).await,
         "logout" => logout::exec(config, args).await,
         "upgrade" => upgrade::exec(config, args).await,
         unknown => Err(anyhow::anyhow!("Invalid subcommand: {}", unknown)),
     }
+    .map(|()| ExitCode::SUCCESS)
 }

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,3 +1,5 @@
+use std::process::ExitCode;
+
 use clap::{Arg, Command};
 use mimalloc::MiMalloc;
 use spacetimedb_cli::*;
@@ -8,7 +10,7 @@ use spacetimedb_paths::{RootDir, SpacetimePaths};
 static GLOBAL: MiMalloc = MiMalloc;
 
 #[tokio::main]
-async fn main() -> Result<(), anyhow::Error> {
+async fn main() -> anyhow::Result<ExitCode> {
     // Compute matches before loading the config, because `Config` has an observable `drop` method
     // (which deletes a lockfile),
     // and Clap calls `exit` on parse failure rather than panicing, so destructors never run.
@@ -25,9 +27,7 @@ async fn main() -> Result<(), anyhow::Error> {
         .unwrap_or_else(|| paths.cli_config_dir.cli_toml());
     let config = Config::load(cli_toml)?;
 
-    exec_subcommand(config, &paths, cmd, subcommand_args).await?;
-
-    Ok(())
+    exec_subcommand(config, &paths, cmd, subcommand_args).await
 }
 
 fn get_command() -> Command {

--- a/crates/cli/src/start.rs
+++ b/crates/cli/src/start.rs
@@ -1,0 +1,68 @@
+use std::ffi::OsString;
+use std::process::{Command, ExitCode};
+
+use anyhow::Context;
+use clap::{Arg, ArgMatches};
+use spacetimedb_paths::SpacetimePaths;
+
+pub fn cli() -> clap::Command {
+    clap::Command::new("start")
+        .about("Start a local SpacetimeDB instance")
+        .disable_help_flag(true)
+        .arg(
+            Arg::new("edition")
+                .long("edition")
+                .help("The edition of SpacetimeDB to start up")
+                .value_parser(clap::value_parser!(Edition))
+                .default_value("standalone"),
+        )
+        .arg(
+            Arg::new("args")
+                .help("The args to pass to `spacetimedb-{edition} start`")
+                .value_parser(clap::value_parser!(OsString))
+                .allow_hyphen_values(true)
+                .num_args(0..),
+        )
+}
+
+#[derive(clap::ValueEnum, Clone, Copy)]
+enum Edition {
+    Standalone,
+    Cloud,
+}
+
+pub async fn exec(paths: &SpacetimePaths, args: &ArgMatches) -> anyhow::Result<ExitCode> {
+    let edition = args.get_one::<Edition>("edition").unwrap();
+    let args = args.get_many::<OsString>("args").unwrap_or_default();
+    let bin_name = match edition {
+        Edition::Standalone => "spacetimedb-standalone",
+        Edition::Cloud => "spacetimedb-cloud",
+    };
+    let resolved_exe = std::env::current_exe().context("could not retrieve current exe")?;
+    let bin_path = resolved_exe
+        .parent()
+        .unwrap()
+        .join(bin_name)
+        .with_extension(std::env::consts::EXE_EXTENSION);
+    let mut cmd = Command::new(&bin_path);
+    cmd.arg("start")
+        .arg("--data-dir")
+        .arg(&paths.data_dir)
+        .arg("--jwt-key-dir")
+        .arg(&paths.cli_config_dir)
+        .args(args);
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        let err = cmd.exec();
+        Err(err).context(format!("exec failed for {}", bin_path.display()))
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::ExitCodeExt;
+        let status = cmd
+            .status()
+            .with_context(|| format!("failed to run {}", bin_path.display()))?;
+        Ok(ExitCode::from_raw(status.code().unwrap_or(1) as u32))
+    }
+}

--- a/crates/cli/src/start.rs
+++ b/crates/cli/src/start.rs
@@ -51,18 +51,14 @@ pub async fn exec(paths: &SpacetimePaths, args: &ArgMatches) -> anyhow::Result<E
         .arg("--jwt-key-dir")
         .arg(&paths.cli_config_dir)
         .args(args);
-    #[cfg(unix)]
-    {
-        use std::os::unix::process::CommandExt;
-        let err = cmd.exec();
-        Err(err).context(format!("exec failed for {}", bin_path.display()))
-    }
-    #[cfg(windows)]
-    {
-        use std::os::windows::process::ExitCodeExt;
-        let status = cmd
-            .status()
-            .with_context(|| format!("failed to run {}", bin_path.display()))?;
-        Ok(ExitCode::from_raw(status.code().unwrap_or(1) as u32))
-    }
+
+    // TODO(noa): use std::os::unix::process::CommandExt::exec() here once we have windows CI
+    // use std::os::unix::process::CommandExt;
+    // let err = cmd.exec();
+    // Err(err).context(format!("exec failed for {}", bin_path.display()))
+
+    let status = cmd
+        .status()
+        .with_context(|| format!("exec failed for {}", bin_path.display()))?;
+    Ok(ExitCode::from(status.code().unwrap_or(1).try_into().unwrap_or(1)))
 }

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -9,7 +9,6 @@ use spacetimedb_data_structures::map::HashMap;
 use spacetimedb_lib::db::raw_def::v9::RawModuleDefV9;
 use spacetimedb_lib::de::serde::{DeserializeWrapper, SeedWrapper};
 use spacetimedb_lib::ser::serde::SerializeWrapper;
-use spacetimedb_standalone::TEXT_PROTOCOL;
 use std::time::Duration;
 use tokio::io::AsyncWriteExt;
 use tokio_tungstenite::tungstenite::client::IntoClientRequest;
@@ -144,7 +143,10 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error
 
     // Create the websocket request.
     let mut req = http::Uri::from_parts(uri)?.into_client_request()?;
-    req.headers_mut().insert(header::SEC_WEBSOCKET_PROTOCOL, TEXT_PROTOCOL);
+    req.headers_mut().insert(
+        header::SEC_WEBSOCKET_PROTOCOL,
+        http::HeaderValue::from_static(ws::TEXT_PROTOCOL),
+    );
     //  Add the authorization header, if any.
     if let Some(auth_header) = &api.con.auth_header {
         req.headers_mut().insert(header::AUTHORIZATION, auth_header.try_into()?);

--- a/crates/client-api-messages/src/websocket.rs
+++ b/crates/client-api-messages/src/websocket.rs
@@ -38,6 +38,9 @@ use std::{
     sync::Arc,
 };
 
+pub const TEXT_PROTOCOL: &str = "v1.json.spacetimedb";
+pub const BIN_PROTOCOL: &str = "v1.bsatn.spacetimedb";
+
 pub trait RowListLen {
     /// Returns the length of the list.
     fn len(&self) -> usize;

--- a/crates/client-api/src/routes/subscribe.rs
+++ b/crates/client-api/src/routes/subscribe.rs
@@ -17,7 +17,7 @@ use spacetimedb::client::{ClientActorId, ClientConfig, ClientConnection, DataMes
 use spacetimedb::host::NoSuchModule;
 use spacetimedb::util::also_poll;
 use spacetimedb::worker_metrics::WORKER_METRICS;
-use spacetimedb_client_api_messages::websocket::Compression;
+use spacetimedb_client_api_messages::websocket::{self as ws_api, Compression};
 use spacetimedb_lib::address::AddressForUrl;
 use spacetimedb_lib::Address;
 use std::time::Instant;
@@ -31,9 +31,9 @@ use crate::util::{NameOrIdentity, XForwardedFor};
 use crate::{log_and_500, ControlStateDelegate, NodeDelegate};
 
 #[allow(clippy::declare_interior_mutable_const)]
-pub const TEXT_PROTOCOL: HeaderValue = HeaderValue::from_static("v1.json.spacetimedb");
+pub const TEXT_PROTOCOL: HeaderValue = HeaderValue::from_static(ws_api::TEXT_PROTOCOL);
 #[allow(clippy::declare_interior_mutable_const)]
-pub const BIN_PROTOCOL: HeaderValue = HeaderValue::from_static("v1.bsatn.spacetimedb");
+pub const BIN_PROTOCOL: HeaderValue = HeaderValue::from_static(ws_api::BIN_PROTOCOL);
 
 #[derive(Deserialize)]
 pub struct SubscribeParams {

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1178,10 +1178,10 @@ struct LockFile {
 impl LockFile {
     pub fn lock(root: &ReplicaDir) -> Result<Self, DBError> {
         root.create()?;
-        let path = root.as_ref().join("db.lock");
+        let path = root.0.join("db.lock");
         let lock = File::create(&path)?;
         lock.try_lock_exclusive()
-            .map_err(|e| DatabaseError::DatabasedOpened(root.as_ref().to_path_buf(), e.into()))?;
+            .map_err(|e| DatabaseError::DatabasedOpened(root.0.clone(), e.into()))?;
 
         Ok(Self {
             path: path.into(),

--- a/crates/paths/Cargo.toml
+++ b/crates/paths/Cargo.toml
@@ -11,6 +11,7 @@ anyhow.workspace = true
 chrono = { workspace = true, features = ["now"] }
 fs2.workspace = true
 itoa.workspace = true
+semver.workspace = true
 serde.workspace = true
 thiserror.workspace = true
 

--- a/crates/paths/src/cli.rs
+++ b/crates/paths/src/cli.rs
@@ -1,4 +1,4 @@
-use crate::utils::path_type;
+use crate::utils::{path_type, PathBufExt};
 
 path_type! {
     /// The configuration directory for the CLI & keyfiles.
@@ -21,6 +21,23 @@ path_type!(#[non_exhaustive(FALSE)] PrivKeyPath: file);
 path_type!(#[non_exhaustive(FALSE)] PubKeyPath: file);
 
 path_type!(BinFile: file);
+
 path_type!(BinDir: dir);
+
+impl BinDir {
+    pub fn version_dir(&self, version: semver::Version) -> VersionBinDir {
+        VersionBinDir(self.0.join(version.to_string()))
+    }
+}
+
+path_type!(VersionBinDir: dir);
+
+impl VersionBinDir {
+    pub fn spacetimedb_cli(self) -> SpacetimedbCliBin {
+        SpacetimedbCliBin(self.0.joined("spacetimedb-cli").with_exe_ext())
+    }
+}
+
+path_type!(SpacetimedbCliBin: file);
 
 path_type!(CliTomlPath: file);

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -153,8 +153,6 @@
 //!                         └── 040a8585e6dc2c579c0c8f6017c7e6a0179a5d0410cd8db4b4affbd7d4d04f
 //! ```
 
-use std::env::consts::EXE_EXTENSION;
-
 use crate::utils::PathBufExt;
 
 pub mod cli;
@@ -185,9 +183,7 @@ impl RootDir {
     }
 
     pub fn cli_bin_file(&self) -> cli::BinFile {
-        let mut path = self.0.join("spacetime");
-        path.set_extension(EXE_EXTENSION);
-        cli::BinFile(path)
+        cli::BinFile(self.0.join("spacetime").with_exe_ext())
     }
 
     pub fn cli_bin_dir(&self) -> cli::BinDir {
@@ -320,10 +316,7 @@ mod tests {
         let root = Path::new("/custom/path");
         let paths = SpacetimePaths::from_root_dir(&RootDir(root.to_owned()));
         assert_eq!(paths.cli_config_dir.0, root.join("config"));
-        assert_eq!(
-            paths.cli_bin_file.0,
-            root.join("spacetime").with_extension(EXE_EXTENSION)
-        );
+        assert_eq!(paths.cli_bin_file.0, root.join("spacetime").with_exe_ext());
         assert_eq!(paths.cli_bin_dir.0, root.join("bin"));
         assert_eq!(paths.data_dir.0, root.join("data"));
     }

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -6,7 +6,7 @@ license-file = "LICENSE"
 description = "An executable for running a single SpacetimeDB standalone instance"
 
 [[bin]]
-name = "spacetimedb"   # The name of the target.
+name = "spacetimedb-standalone"   # The name of the target.
 path = "src/main.rs"   # The source file of the target.
 test = true            # Is tested by default.
 bench = false          # Benching off, because of https://bheisler.github.io/criterion.rs/book/faq.html#cargo-bench-gives-unrecognized-option-errors-for-valid-command-line-options

--- a/crates/testing/src/lib.rs
+++ b/crates/testing/src/lib.rs
@@ -21,5 +21,5 @@ pub fn invoke_cli(paths: &SpacetimePaths, args: &[&str]) {
 
     RUNTIME
         .block_on(spacetimedb_cli::exec_subcommand(config, paths, cmd, args))
-        .unwrap()
+        .unwrap();
 }

--- a/crates/testing/src/sdk.rs
+++ b/crates/testing/src/sdk.rs
@@ -7,14 +7,14 @@ use std::sync::{Mutex, OnceLock};
 use std::thread::JoinHandle;
 
 use crate::invoke_cli;
-use crate::modules::{CompilationMode, CompiledModule};
+use crate::modules::{start_runtime, CompilationMode, CompiledModule};
 use tempfile::TempDir;
 
 /// Ensure that the server thread we're testing against is still running, starting
 /// it if it hasn't been started yet.
 pub fn ensure_standalone_process() -> &'static SpacetimePaths {
     static PATHS: OnceLock<SpacetimePaths> = OnceLock::new();
-    static JOIN_HANDLE: OnceLock<Mutex<Option<JoinHandle<()>>>> = OnceLock::new();
+    static JOIN_HANDLE: OnceLock<Mutex<Option<JoinHandle<anyhow::Result<()>>>>> = OnceLock::new();
 
     let paths = PATHS.get_or_init(|| {
         let dir = TempDir::with_prefix("stdb-sdk-test")
@@ -26,10 +26,12 @@ pub fn ensure_standalone_process() -> &'static SpacetimePaths {
         SpacetimePaths::from_root_dir(&RootDir(dir))
     });
 
-    let data_dir = paths.data_dir.0.to_str().unwrap();
     let join_handle = JOIN_HANDLE.get_or_init(|| {
         Mutex::new(Some(std::thread::spawn(move || {
-            invoke_cli(paths, &["start", "--data-dir", data_dir])
+            start_runtime().block_on(spacetimedb_standalone::start_server(
+                &paths.data_dir,
+                Some(&paths.cli_config_dir.0),
+            ))
         })))
     });
 
@@ -40,7 +42,20 @@ pub fn ensure_standalone_process() -> &'static SpacetimePaths {
         .expect("Standalone process already finished")
         .is_finished()
     {
-        join_handle.take().unwrap().join().expect("Standalone process failed");
+        match join_handle.take().unwrap().join() {
+            Ok(Ok(())) => {}
+            Ok(Err(e)) => panic!("standalone process failed: {e:?}"),
+            Err(e) => {
+                let msg = if let Some(s) = e.downcast_ref::<String>() {
+                    s
+                } else if let Some(s) = e.downcast_ref::<&str>() {
+                    s
+                } else {
+                    "dyn Any"
+                };
+                panic!("standalone process failed by panic: {msg}")
+            }
+        }
     }
 
     paths

--- a/crates/update/Cargo.toml
+++ b/crates/update/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "spacetimedb-update"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+
+[dependencies]
+spacetimedb-paths.workspace = true
+
+anyhow.workspace = true
+clap.workspace = true
+semver.workspace = true

--- a/crates/update/src/main.rs
+++ b/crates/update/src/main.rs
@@ -1,0 +1,95 @@
+use std::ffi::OsString;
+use std::path::{Path, PathBuf};
+use std::process::ExitCode;
+
+use anyhow::Context;
+use clap::Parser;
+use spacetimedb_paths::{RootDir, SpacetimePaths};
+
+mod proxy;
+
+fn main() -> anyhow::Result<ExitCode> {
+    let mut args = std::env::args_os();
+    let argv0: PathBuf = args.next().unwrap().into();
+    let file_stem = argv0.file_stem().context("argv0 must have a filename")?;
+    if file_stem == "spacetimedb-update" {
+        spacetimedb_update_main()
+    } else if file_stem == "spacetime" {
+        proxy::spacetimedb_cli_proxy(Some(argv0.as_os_str()), args.collect())
+    } else {
+        anyhow::bail!(
+            "unknown command name for spacetimedb-update multicall binary: {}",
+            Path::new(file_stem).display()
+        )
+    }
+}
+
+#[derive(clap::Parser)]
+struct Args {
+    #[arg(long)]
+    root_dir: Option<RootDir>,
+    #[command(subcommand)]
+    cmd: Subcommand,
+}
+
+#[derive(clap::Subcommand)]
+enum Subcommand {
+    Version(Version),
+    UseVersion(UseVersion),
+    Upgrade,
+    Install(Install),
+    Uninstall(Uninstall),
+    #[command(hide = true)]
+    Cli {
+        #[clap(allow_hyphen_values = true)]
+        args: Vec<OsString>,
+    },
+}
+
+#[derive(clap::Args)]
+struct Version {
+    #[command(subcommand)]
+    subcmd: Option<VersionSubcommand>,
+}
+
+#[derive(clap::Subcommand)]
+enum VersionSubcommand {
+    List,
+}
+
+#[derive(clap::Args)]
+struct UseVersion {
+    #[arg(long)]
+    edition: String,
+    #[arg(long)]
+    version: semver::Version,
+}
+
+#[derive(clap::Args)]
+struct Install {
+    edition: String,
+    version: semver::Version,
+}
+
+#[derive(clap::Args)]
+struct Uninstall {
+    edition: String,
+    version: semver::Version,
+}
+
+fn spacetimedb_update_main() -> anyhow::Result<ExitCode> {
+    let args = Args::parse();
+    let paths = match &args.root_dir {
+        Some(root_dir) => SpacetimePaths::from_root_dir(root_dir),
+        None => SpacetimePaths::platform_defaults()?,
+    };
+    match args.cmd {
+        Subcommand::Cli { args: mut cli_args } => {
+            if let Some(root_dir) = &args.root_dir {
+                cli_args.insert(0, OsString::from_iter(["--root-dir=".as_ref(), root_dir.as_ref()]));
+            }
+            proxy::run_cli(&paths, None, cli_args)
+        }
+        _ => unimplemented!(),
+    }
+}

--- a/crates/update/src/proxy.rs
+++ b/crates/update/src/proxy.rs
@@ -1,0 +1,82 @@
+use anyhow::Context;
+use spacetimedb_paths::RootDir;
+use spacetimedb_paths::SpacetimePaths;
+use std::ffi::OsStr;
+use std::ffi::OsString;
+use std::process::Command;
+use std::process::ExitCode;
+
+pub(super) fn spacetimedb_cli_proxy(argv0: Option<&OsStr>, args: Vec<OsString>) -> anyhow::Result<ExitCode> {
+    let paths = match extract_root_dir_arg(&args)? {
+        Some(root_dir) => SpacetimePaths::from_root_dir(&root_dir),
+        None => SpacetimePaths::platform_defaults()?,
+    };
+    run_cli(&paths, argv0, args)
+}
+pub(crate) fn run_cli(paths: &SpacetimePaths, argv0: Option<&OsStr>, args: Vec<OsString>) -> anyhow::Result<ExitCode> {
+    let version = get_current_version();
+    let cli_path = paths.cli_bin_dir.version_dir(version).spacetimedb_cli();
+    let mut cmd = Command::new(&cli_path);
+    cmd.args(args);
+    #[cfg(unix)]
+    {
+        use std::os::unix::process::CommandExt;
+        if let Some(argv0) = argv0 {
+            cmd.arg0(argv0);
+        }
+        let err = cmd.exec();
+        Err(err).context(format!("exec failed for {}", cli_path.display()))
+    }
+    #[cfg(windows)]
+    {
+        use std::os::windows::process::ExitCodeExt;
+        let status = cmd
+            .status()
+            .with_context(|| format!("failed to run {}", cli_path.display()))?;
+        Ok(ExitCode::from_raw(status.code().unwrap_or(1) as u32))
+    }
+}
+
+fn get_current_version() -> semver::Version {
+    // TODO:
+    "1.0.0".parse().unwrap()
+}
+
+fn extract_root_dir_arg(args: &[OsString]) -> anyhow::Result<Option<RootDir>> {
+    let mut args = args.iter();
+    let mut root_dir = None;
+    while let Some(arg) = args.next() {
+        let is_arg_value = |s: &OsStr| !os_str_starts_with(arg, "-") || s == "-";
+        // "parse" only up to the first subcommand
+        if is_arg_value(arg) || arg == "--" {
+            break;
+        }
+        let root_dir_arg = if arg == "--root-dir" {
+            args.next()
+                .filter(|s| is_arg_value(s))
+                .context("a value is required for '--root-dir <root_dir>' but none was supplied")?
+        } else if let Some(arg) = os_str_strip_prefix(arg, "--root-dir=") {
+            arg
+        } else {
+            continue;
+        };
+        anyhow::ensure!(
+            root_dir.is_none(),
+            "the argument '--root-dir <root_dir>' cannot be used multiple times"
+        );
+        root_dir = Some(RootDir(root_dir_arg.into()));
+    }
+    Ok(root_dir)
+}
+
+fn os_str_starts_with(s: &OsStr, pref: &str) -> bool {
+    s.as_encoded_bytes().starts_with(pref.as_bytes())
+}
+
+fn os_str_strip_prefix<'a>(s: &'a OsStr, pref: &str) -> Option<&'a OsStr> {
+    os_str_starts_with(s, pref).then(|| {
+        // SAFETY: we're splitting immediately after a valid non-empty UTF-8 substring.
+        //         (if pref is empty then this is a no-op and trivially safe)
+        unsafe { OsStr::from_encoded_bytes_unchecked(&s.as_encoded_bytes()[pref.len()..]) }
+    })
+}

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -17,7 +17,7 @@ import logging
 # miscellaneous file paths
 TEST_DIR = Path(__file__).parent
 STDB_DIR = TEST_DIR.parent
-SPACETIME_BIN = STDB_DIR / "target/debug/spacetimedb-cli"
+SPACETIME_BIN = STDB_DIR / "target/debug/spacetime"
 TEMPLATE_TARGET_DIR = STDB_DIR / "target/_stdbsmoketests"
 STDB_CONFIG = TEST_DIR / "config.toml"
 

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -17,7 +17,7 @@ import logging
 # miscellaneous file paths
 TEST_DIR = Path(__file__).parent
 STDB_DIR = TEST_DIR.parent
-SPACETIME_BIN = STDB_DIR / "target/debug/spacetime"
+SPACETIME_BIN = STDB_DIR / "target/debug/spacetimedb-cli"
 TEMPLATE_TARGET_DIR = STDB_DIR / "target/_stdbsmoketests"
 STDB_CONFIG = TEST_DIR / "config.toml"
 


### PR DESCRIPTION
# Description of Changes

Resolves #1838

Adds a `spacetimedb-update` multicall binary that proxies to `spacetimedb-cli`, and makes `spacetime run` call out to the `spacetimedb-standalone` binary instead of embedding the whole server in the cli. Functionality for the `update` binary itself forthcoming in another PR.

# Expected complexity level and risk

3 - adds the proxy binary and changes how `run` works under-the-hood, but the deeper changes will come in the follow-up.

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Smoketests use new proxy binary and work.
- [x] Manually set up a test environment and `spacetimedb-update` proxied to the cli binary.