### PR TITLE
Fix subscription benchmarks by fixing `create_table_for_test_with_the_works`

### DIFF
--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -110,7 +110,7 @@ fn eval(c: &mut Criterion) {
                     &raw.db,
                     &tx,
                     None,
-                    Compression::Brotli,
+                    Compression::None,
                 )))
             })
         });

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -841,8 +841,9 @@ impl RelationalDB {
         access: StAccess,
     ) -> Result<TableId, DBError> {
         let mut module_def_builder = RawModuleDefV9Builder::new();
+
         let mut table_builder = module_def_builder
-            .build_table_with_new_type(name, ProductType::from_iter(schema.iter().cloned()), true)
+            .build_table_with_new_type_for_tests(name, ProductType::from_iter(schema.iter().cloned()), true)
             .with_access(access.into());
 
         for columns in indexes {

--- a/crates/sats/src/sum_type.rs
+++ b/crates/sats/src/sum_type.rs
@@ -68,15 +68,30 @@ impl SumType {
     /// If the type does look like a structural option type, returns the type `T`.
     pub fn as_option(&self) -> Option<&AlgebraicType> {
         match &*self.variants {
-            [first, second]
-                if second.is_unit() // Done first to avoid pointer indirection when it doesn't matter.
-                    && first.has_name(OPTION_SOME_TAG)
-                    && second.has_name(OPTION_NONE_TAG) =>
-            {
-                Some(&first.algebraic_type)
-            }
+            [first, second] if Self::are_variants_option(first, second) => Some(&first.algebraic_type),
             _ => None,
         }
+    }
+
+    /// Check whether this sum type is a structural option type.
+    ///
+    /// A structural option type has `some(T)` as its first variant and `none` as its second.
+    /// That is, `{ some(T), none }` or `some: T | none` depending on your notation.
+    /// Note that `some` and `none` are lowercase, unlike Rust's `Option`.
+    /// Order matters, and an option type with these variants in the opposite order will not be recognized.
+    ///
+    /// If the type does look like a structural option type, returns the type `T`.
+    pub fn as_option_mut(&mut self) -> Option<&mut AlgebraicType> {
+        match &mut *self.variants {
+            [first, second] if Self::are_variants_option(first, second) => Some(&mut first.algebraic_type),
+            _ => None,
+        }
+    }
+
+    fn are_variants_option(first: &SumTypeVariant, second: &SumTypeVariant) -> bool {
+        second.is_unit() // Done first to avoid pointer indirection when it doesn't matter.
+        && first.has_name(OPTION_SOME_TAG)
+        && second.has_name(OPTION_NONE_TAG)
     }
 
     /// Check whether this sum type is a structural option type.


### PR DESCRIPTION
# Description of Changes

Basically replace with `::Ref`s as needed.

The numbers, just to set a baseline for any future work, are as of this PR:

```
Benchmarking full-scan: Collecting 100 samples in estimated 5.6924 s (200
full-scan               time:   [27.842 ms 28.019 ms 28.249 ms]

Benchmarking full-join: Collecting 100 samples in estimated 5.7658 s (25k
full-join               time:   [222.02 µs 222.63 µs 223.53 µs]

Benchmarking incr-select: Collecting 100 samples in estimated 5.0003 s (3
incr-select             time:   [153.60 ns 159.05 ns 169.53 ns]

Benchmarking incr-join: Collecting 100 samples in estimated 5.0028 s (7.0
incr-join               time:   [700.16 ns 704.12 ns 711.24 ns]

Benchmarking query-indexes-multi: Collecting 100 samples in estimated 5.0
query-indexes-multi     time:   [640.48 ns 643.12 ns 648.56 ns]
```


Fixes https://github.com/clockworklabs/SpacetimeDB/issues/1993


# API and ABI breaking changes

No, this just fixes tests and benches.