### PR TITLE
Allocation pool the chunked iters in `InstanceEnv`

### DIFF
--- a/crates/core/src/host/wasm_common.rs
+++ b/crates/core/src/host/wasm_common.rs
@@ -324,7 +324,7 @@ impl<I: ResourceIndex> ResourceSlab<I> {
     }
 }
 
-decl_index!(RowIterIdx => std::vec::IntoIter<Box<[u8]>>);
+decl_index!(RowIterIdx => std::vec::IntoIter<Vec<u8>>);
 pub(super) type RowIters = ResourceSlab<RowIterIdx>;
 
 pub(super) struct TimingSpan {


### PR DESCRIPTION
# Description of Changes

This adds a `ChunkPool` which `ChunkedWriter` uses.
Also removes some dead code in `InstanceEnv`.

~Based on flame graphs and timings, I'm not sure this changes much :/
We might want to try a different approach that doesn't do any chunking at all but rather writes to a singe buffer that we pool.
We can then keep an offset when iterating instead. Not sure how this will work with row boundaries though.~

I measured things again for `.iter()`, and in this case, it seems like the time spent in `datastore_table_scan_bsatn` decreased by a few %. Not a huge amount, but still an improvement. The index scan bit not improving makes sense -- there's a unique index there and only a single element is fetched.

Fixes https://github.com/clockworklabs/SpacetimeDB/issues/2020.