### PR TITLE
Split Iter & IterByColRange types into Tx and MutTxId versions

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -2,11 +2,11 @@ use super::{
     committed_state::CommittedState,
     mut_tx::MutTxId,
     sequence::SequencesState,
-    state_view::{IterTxByColRange, StateView},
+    state_view::{IterByColRangeTx, StateView},
     tx::TxId,
     tx_state::TxState,
 };
-use crate::db::datastore::locking_tx_datastore::state_view::{IterMutTx, IterMutTxByColRange, IterTx};
+use crate::db::datastore::locking_tx_datastore::state_view::{IterByColRangeMutTx, IterMutTx, IterTx};
 use crate::execution_context::Workload;
 use crate::{
     db::{
@@ -323,31 +323,31 @@ impl Tx for Locking {
 }
 
 impl TxDatastore for Locking {
-    type Iter<'a>
+    type IterTx<'a>
         = IterTx<'a>
     where
         Self: 'a;
     type IterMutTx<'a>= IterMutTx<'a>
     where
         Self: 'a;
-    type IterByColRange<'a, R: RangeBounds<AlgebraicValue>>
-        = IterTxByColRange<'a, R>
+    type IterByColRangeTx<'a, R: RangeBounds<AlgebraicValue>>
+        = IterByColRangeTx<'a, R>
     where
         Self: 'a;
-    type IterMutByColRange<'a, R: RangeBounds<AlgebraicValue>>
-    = IterMutTxByColRange<'a, R>
+    type IterByColRangeMutTx<'a, R: RangeBounds<AlgebraicValue>>
+    = IterByColRangeMutTx<'a, R>
     where
         Self: 'a;
-    type IterByColEq<'a, 'r>
-        = IterTxByColRange<'a, &'r AlgebraicValue>
+    type IterByColEqTx<'a, 'r>
+        = IterByColRangeTx<'a, &'r AlgebraicValue>
     where
         Self: 'a;
-    type IterMutByColEq<'a, 'r>
-    = IterMutTxByColRange<'a, &'r AlgebraicValue>
+    type IterByColEqMutTx<'a, 'r>
+    = IterByColRangeMutTx<'a, &'r AlgebraicValue>
     where
         Self: 'a;
 
-    fn iter_tx<'a>(&'a self, tx: &'a Self::Tx, table_id: TableId) -> Result<Self::Iter<'a>> {
+    fn iter_tx<'a>(&'a self, tx: &'a Self::Tx, table_id: TableId) -> Result<Self::IterTx<'a>> {
         tx.iter(table_id)
     }
 
@@ -357,7 +357,7 @@ impl TxDatastore for Locking {
         table_id: TableId,
         cols: impl Into<ColList>,
         range: R,
-    ) -> Result<Self::IterByColRange<'a, R>> {
+    ) -> Result<Self::IterByColRangeTx<'a, R>> {
         tx.iter_by_col_range(table_id, cols.into(), range)
     }
 
@@ -367,7 +367,7 @@ impl TxDatastore for Locking {
         table_id: TableId,
         cols: impl Into<ColList>,
         value: &'r AlgebraicValue,
-    ) -> Result<Self::IterByColEq<'a, 'r>> {
+    ) -> Result<Self::IterByColEqTx<'a, 'r>> {
         tx.iter_by_col_eq(table_id, cols, value)
     }
 
@@ -514,7 +514,7 @@ impl MutTxDatastore for Locking {
         table_id: TableId,
         cols: impl Into<ColList>,
         range: R,
-    ) -> Result<Self::IterMutByColRange<'a, R>> {
+    ) -> Result<Self::IterByColRangeMutTx<'a, R>> {
         tx.iter_by_col_range(table_id, cols.into(), range)
     }
 
@@ -524,7 +524,7 @@ impl MutTxDatastore for Locking {
         table_id: TableId,
         cols: impl Into<ColList>,
         value: &'r AlgebraicValue,
-    ) -> Result<Self::IterMutByColEq<'a, 'r>> {
+    ) -> Result<Self::IterByColEqMutTx<'a, 'r>> {
         tx.iter_by_col_eq(table_id, cols.into(), value)
     }
 

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -327,23 +327,12 @@ impl TxDatastore for Locking {
         = IterTx<'a>
     where
         Self: 'a;
-    type IterMutTx<'a>= IterMutTx<'a>
-    where
-        Self: 'a;
     type IterByColRangeTx<'a, R: RangeBounds<AlgebraicValue>>
         = IterByColRangeTx<'a, R>
     where
         Self: 'a;
-    type IterByColRangeMutTx<'a, R: RangeBounds<AlgebraicValue>>
-    = IterByColRangeMutTx<'a, R>
-    where
-        Self: 'a;
     type IterByColEqTx<'a, 'r>
         = IterByColRangeTx<'a, &'r AlgebraicValue>
-    where
-        Self: 'a;
-    type IterByColEqMutTx<'a, 'r>
-    = IterByColRangeMutTx<'a, &'r AlgebraicValue>
     where
         Self: 'a;
 
@@ -416,6 +405,15 @@ impl TxDatastore for Locking {
 }
 
 impl MutTxDatastore for Locking {
+    type IterMutTx<'a>= IterMutTx<'a>
+    where
+        Self: 'a;
+    type IterByColRangeMutTx<'a, R: RangeBounds<AlgebraicValue>> = IterByColRangeMutTx<'a, R>;
+    type IterByColEqMutTx<'a, 'r>
+    = IterByColRangeMutTx<'a, &'r AlgebraicValue>
+    where
+        Self: 'a;
+
     fn create_table_mut_tx(&self, tx: &mut Self::MutTx, schema: TableSchema) -> Result<TableId> {
         tx.create_table(schema)
     }

--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -6,7 +6,7 @@ mod mut_tx;
 pub use mut_tx::MutTxId;
 mod sequence;
 pub mod state_view;
-pub use state_view::{Iter, IterByColEq, IterByColRange};
+pub use state_view::{IterByColEq, IterTxByColRange};
 pub(crate) mod tx;
 mod tx_state;
 

--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -6,7 +6,7 @@ mod mut_tx;
 pub use mut_tx::MutTxId;
 mod sequence;
 pub mod state_view;
-pub use state_view::{IterByColEq, IterTxByColRange};
+pub use state_view::{IterByColEqTx, IterByColRangeTx};
 pub(crate) mod tx;
 mod tx_state;
 

--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -173,7 +173,7 @@ impl<'a> IterMutTx<'a> {
         let stage = if let Some(table) = committed_state.tables.get(&table_id) {
             // The committed state has changes for this table.
             let iter = table.scan_rows(&committed_state.blob_store);
-            if let Some(del_tables) = tx_state.delete_tables.get(&table_id).filter(|del| !del.is_empty()) {
+            if let Some(del_tables) = tx_state.get_delete_table(table_id) {
                 // There are deletes in the tx state
                 // so we must exclude those (1b).
                 ScanStage::CommittedWithTxDeletes { iter, del_tables }

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -46,12 +46,7 @@ impl StateView for TxId {
         range: R,
     ) -> Result<IterByColRange<'_, R>> {
         match self.committed_state_shared_lock.index_seek(table_id, &cols, &range) {
-            Some(committed_rows) => Ok(IterByColRange::CommittedIndex(CommittedIndexIter::new(
-                table_id,
-                None,
-                &self.committed_state_shared_lock,
-                committed_rows,
-            ))),
+            Some(committed_rows) => Ok(IterByColRange::CommittedIndex(CommittedIndexIter::tx(committed_rows))),
             None => self
                 .committed_state_shared_lock
                 .iter_by_col_range(table_id, cols, range),

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx_state.rs
@@ -145,6 +145,12 @@ impl TxState {
             .unwrap_or(false)
     }
 
+    /// Returns the [DeleteTable] for the given `table_id`, checking if it's empty.
+    pub(super) fn get_delete_table(&self, table_id: TableId) -> Option<&DeleteTable> {
+        self.delete_tables.get(&table_id).filter(|x| !x.is_empty())
+    }
+
+    /// Guarantees that the `table_id` returns a `DeleteTable`.
     pub(super) fn get_delete_table_mut(&mut self, table_id: TableId) -> &mut DeleteTable {
         self.delete_tables.entry(table_id).or_default()
     }

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -350,21 +350,10 @@ pub trait TxDatastore: DataRow + Tx {
     where
         Self: 'a;
 
-    type IterMutTx<'a>: Iterator<Item = Self::RowRef<'a>>
-    where
-        Self: 'a;
-
     type IterByColRangeTx<'a, R: RangeBounds<AlgebraicValue>>: Iterator<Item = Self::RowRef<'a>>
     where
         Self: 'a;
-    type IterByColRangeMutTx<'a, R: RangeBounds<AlgebraicValue>>: Iterator<Item = Self::RowRef<'a>>
-    where
-        Self: 'a;
     type IterByColEqTx<'a, 'r>: Iterator<Item = Self::RowRef<'a>>
-    where
-        Self: 'a;
-
-    type IterByColEqMutTx<'a, 'r>: Iterator<Item = Self::RowRef<'a>>
     where
         Self: 'a;
 
@@ -404,6 +393,18 @@ pub trait TxDatastore: DataRow + Tx {
 }
 
 pub trait MutTxDatastore: TxDatastore + MutTx {
+    type IterMutTx<'a>: Iterator<Item = Self::RowRef<'a>>
+    where
+        Self: 'a;
+
+    type IterByColRangeMutTx<'a, R: RangeBounds<AlgebraicValue>>: Iterator<Item = Self::RowRef<'a>>
+    where
+        Self: 'a;
+
+    type IterByColEqMutTx<'a, 'r>: Iterator<Item = Self::RowRef<'a>>
+    where
+        Self: 'a;
+
     // Tables
     fn create_table_mut_tx(&self, tx: &mut Self::MutTx, schema: TableSchema) -> Result<TableId>;
     // In these methods, we use `'tx` because the return type must borrow data

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -350,11 +350,21 @@ pub trait TxDatastore: DataRow + Tx {
     where
         Self: 'a;
 
-    type IterByColRange<'a, R: RangeBounds<AlgebraicValue>>: Iterator<Item = Self::RowRef<'a>>
+    type IterMutTx<'a>: Iterator<Item = Self::RowRef<'a>>
     where
         Self: 'a;
 
+    type IterByColRange<'a, R: RangeBounds<AlgebraicValue>>: Iterator<Item = Self::RowRef<'a>>
+    where
+        Self: 'a;
+    type IterMutByColRange<'a, R: RangeBounds<AlgebraicValue>>: Iterator<Item = Self::RowRef<'a>>
+    where
+        Self: 'a;
     type IterByColEq<'a, 'r>: Iterator<Item = Self::RowRef<'a>>
+    where
+        Self: 'a;
+
+    type IterMutByColEq<'a, 'r>: Iterator<Item = Self::RowRef<'a>>
     where
         Self: 'a;
 
@@ -438,21 +448,21 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     fn constraint_id_from_name(&self, tx: &Self::MutTx, constraint_name: &str) -> super::Result<Option<ConstraintId>>;
 
     // Data
-    fn iter_mut_tx<'a>(&'a self, tx: &'a Self::MutTx, table_id: TableId) -> Result<Self::Iter<'a>>;
+    fn iter_mut_tx<'a>(&'a self, tx: &'a Self::MutTx, table_id: TableId) -> Result<Self::IterMutTx<'a>>;
     fn iter_by_col_range_mut_tx<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
         tx: &'a Self::MutTx,
         table_id: TableId,
         cols: impl Into<ColList>,
         range: R,
-    ) -> Result<Self::IterByColRange<'a, R>>;
+    ) -> Result<Self::IterMutByColRange<'a, R>>;
     fn iter_by_col_eq_mut_tx<'a, 'r>(
         &'a self,
         tx: &'a Self::MutTx,
         table_id: TableId,
         cols: impl Into<ColList>,
         value: &'r AlgebraicValue,
-    ) -> Result<Self::IterByColEq<'a, 'r>>;
+    ) -> Result<Self::IterMutByColEq<'a, 'r>>;
     fn get_mut_tx<'a>(
         &self,
         tx: &'a Self::MutTx,

--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -346,7 +346,7 @@ impl Program {
 }
 
 pub trait TxDatastore: DataRow + Tx {
-    type Iter<'a>: Iterator<Item = Self::RowRef<'a>>
+    type IterTx<'a>: Iterator<Item = Self::RowRef<'a>>
     where
         Self: 'a;
 
@@ -354,21 +354,21 @@ pub trait TxDatastore: DataRow + Tx {
     where
         Self: 'a;
 
-    type IterByColRange<'a, R: RangeBounds<AlgebraicValue>>: Iterator<Item = Self::RowRef<'a>>
+    type IterByColRangeTx<'a, R: RangeBounds<AlgebraicValue>>: Iterator<Item = Self::RowRef<'a>>
     where
         Self: 'a;
-    type IterMutByColRange<'a, R: RangeBounds<AlgebraicValue>>: Iterator<Item = Self::RowRef<'a>>
+    type IterByColRangeMutTx<'a, R: RangeBounds<AlgebraicValue>>: Iterator<Item = Self::RowRef<'a>>
     where
         Self: 'a;
-    type IterByColEq<'a, 'r>: Iterator<Item = Self::RowRef<'a>>
-    where
-        Self: 'a;
-
-    type IterMutByColEq<'a, 'r>: Iterator<Item = Self::RowRef<'a>>
+    type IterByColEqTx<'a, 'r>: Iterator<Item = Self::RowRef<'a>>
     where
         Self: 'a;
 
-    fn iter_tx<'a>(&'a self, tx: &'a Self::Tx, table_id: TableId) -> Result<Self::Iter<'a>>;
+    type IterByColEqMutTx<'a, 'r>: Iterator<Item = Self::RowRef<'a>>
+    where
+        Self: 'a;
+
+    fn iter_tx<'a>(&'a self, tx: &'a Self::Tx, table_id: TableId) -> Result<Self::IterTx<'a>>;
 
     fn iter_by_col_range_tx<'a, R: RangeBounds<AlgebraicValue>>(
         &'a self,
@@ -376,7 +376,7 @@ pub trait TxDatastore: DataRow + Tx {
         table_id: TableId,
         cols: impl Into<ColList>,
         range: R,
-    ) -> Result<Self::IterByColRange<'a, R>>;
+    ) -> Result<Self::IterByColRangeTx<'a, R>>;
 
     fn iter_by_col_eq_tx<'a, 'r>(
         &'a self,
@@ -384,7 +384,7 @@ pub trait TxDatastore: DataRow + Tx {
         table_id: TableId,
         cols: impl Into<ColList>,
         value: &'r AlgebraicValue,
-    ) -> Result<Self::IterByColEq<'a, 'r>>;
+    ) -> Result<Self::IterByColEqTx<'a, 'r>>;
 
     fn table_id_exists_tx(&self, tx: &Self::Tx, table_id: &TableId) -> bool;
     fn table_id_from_name_tx(&self, tx: &Self::Tx, table_name: &str) -> Result<Option<TableId>>;
@@ -455,14 +455,14 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
         table_id: TableId,
         cols: impl Into<ColList>,
         range: R,
-    ) -> Result<Self::IterMutByColRange<'a, R>>;
+    ) -> Result<Self::IterByColRangeMutTx<'a, R>>;
     fn iter_by_col_eq_mut_tx<'a, 'r>(
         &'a self,
         tx: &'a Self::MutTx,
         table_id: TableId,
         cols: impl Into<ColList>,
         value: &'r AlgebraicValue,
-    ) -> Result<Self::IterMutByColEq<'a, 'r>>;
+    ) -> Result<Self::IterByColEqMutTx<'a, 'r>>;
     fn get_mut_tx<'a>(
         &self,
         tx: &'a Self::MutTx,

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1,6 +1,6 @@
 use super::datastore::locking_tx_datastore::committed_state::CommittedState;
 use super::datastore::locking_tx_datastore::state_view::{
-    IterMutTx, IterMutTxByColEq, IterMutTxByColRange, IterTx, StateView,
+    IterByColEqMutTx, IterByColRangeMutTx, IterMutTx, IterTx, StateView,
 };
 use super::datastore::system_tables::ST_MODULE_ID;
 use super::datastore::traits::{
@@ -9,7 +9,7 @@ use super::datastore::traits::{
 use super::datastore::{
     locking_tx_datastore::{
         datastore::Locking,
-        state_view::{IterByColEq, IterTxByColRange},
+        state_view::{IterByColEqTx, IterByColRangeTx},
     },
     traits::TxData,
 };
@@ -1065,7 +1065,7 @@ impl RelationalDB {
         table_id: impl Into<TableId>,
         cols: impl Into<ColList>,
         value: &'r AlgebraicValue,
-    ) -> Result<IterMutTxByColEq<'a, 'r>, DBError> {
+    ) -> Result<IterByColEqMutTx<'a, 'r>, DBError> {
         self.inner.iter_by_col_eq_mut_tx(tx, table_id.into(), cols, value)
     }
 
@@ -1075,7 +1075,7 @@ impl RelationalDB {
         table_id: impl Into<TableId>,
         cols: impl Into<ColList>,
         value: &'r AlgebraicValue,
-    ) -> Result<IterByColEq<'a, 'r>, DBError> {
+    ) -> Result<IterByColEqTx<'a, 'r>, DBError> {
         self.inner.iter_by_col_eq_tx(tx, table_id.into(), cols, value)
     }
 
@@ -1090,7 +1090,7 @@ impl RelationalDB {
         table_id: impl Into<TableId>,
         cols: impl Into<ColList>,
         range: R,
-    ) -> Result<IterMutTxByColRange<'a, R>, DBError> {
+    ) -> Result<IterByColRangeMutTx<'a, R>, DBError> {
         self.inner.iter_by_col_range_mut_tx(tx, table_id.into(), cols, range)
     }
 
@@ -1105,7 +1105,7 @@ impl RelationalDB {
         table_id: impl Into<TableId>,
         cols: impl Into<ColList>,
         range: R,
-    ) -> Result<IterTxByColRange<'a, R>, DBError> {
+    ) -> Result<IterByColRangeTx<'a, R>, DBError> {
         self.inner.iter_by_col_range_tx(tx, table_id.into(), cols, range)
     }
 
@@ -2148,7 +2148,7 @@ mod tests {
         let cols = col_list![0, 1];
         let value = product![0u64, 1u64].into();
 
-        let IterMutTxByColEq::Index(mut iter) = stdb.iter_by_col_eq_mut(&tx, table_id, cols, &value)? else {
+        let IterByColEqMutTx::Index(mut iter) = stdb.iter_by_col_eq_mut(&tx, table_id, cols, &value)? else {
             panic!("expected index iterator");
         };
 

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -1,7 +1,8 @@
 //! The [DbProgram] that execute arbitrary queries & code against the database.
 
+use crate::db::datastore::locking_tx_datastore::state_view::IterMutTxByColRange;
 use crate::db::datastore::locking_tx_datastore::tx::TxId;
-use crate::db::datastore::locking_tx_datastore::IterByColRange;
+use crate::db::datastore::locking_tx_datastore::IterTxByColRange;
 use crate::db::datastore::system_tables::{st_var_schema, StVarName, StVarRow, StVarTable};
 use crate::db::relational_db::{MutTx, RelationalDB, Tx};
 use crate::error::DBError;
@@ -17,7 +18,7 @@ use spacetimedb_sats::{AlgebraicValue, ProductValue};
 use spacetimedb_table::static_assert_size;
 use spacetimedb_table::table::RowRef;
 use spacetimedb_vm::errors::ErrorVm;
-use spacetimedb_vm::eval::{build_project, build_select, join_inner, IterRows};
+use spacetimedb_vm::eval::{box_iter, build_project, build_select, join_inner, IterRows};
 use spacetimedb_vm::expr::*;
 use spacetimedb_vm::iterators::RelIter;
 use spacetimedb_vm::program::{ProgramVm, Sources};
@@ -184,26 +185,9 @@ pub fn build_query<'a>(
                 let index_table = index_side.table_id().unwrap();
 
                 if *return_index_rows {
-                    Box::new(IndexSemiJoinLeft {
-                        db,
-                        tx,
-                        probe_side,
-                        probe_col: *probe_col,
-                        index_select,
-                        index_table,
-                        index_col: *index_col,
-                        index_iter: None,
-                    }) as Box<IterRows<'_>>
+                    index_semi_join_left(db, tx, probe_side, *probe_col, index_select, index_table, *index_col)
                 } else {
-                    Box::new(IndexSemiJoinRight {
-                        db,
-                        tx,
-                        probe_side,
-                        probe_col: *probe_col,
-                        index_select,
-                        index_table,
-                        index_col: *index_col,
-                    })
+                    index_semi_join_right(db, tx, probe_side, *probe_col, index_select, index_table, *index_col)
                 }
             }
             Query::Select(cmp) => build_select(result_or_base(sources, &mut result), cmp),
@@ -246,8 +230,8 @@ fn get_table<'a>(
                 .into_iter(),
         ),
         SourceExpr::DbTable(db_table) => build_iter_from_db(match tx {
-            TxMode::MutTx(tx) => stdb.iter_mut(tx, db_table.table_id),
-            TxMode::Tx(tx) => stdb.iter(tx, db_table.table_id),
+            TxMode::MutTx(tx) => stdb.iter_mut(tx, db_table.table_id).map(box_iter),
+            TxMode::Tx(tx) => stdb.iter(tx, db_table.table_id).map(box_iter),
         }),
     }
 }
@@ -260,8 +244,10 @@ fn iter_by_col_range<'a>(
     range: impl RangeBounds<AlgebraicValue> + 'a,
 ) -> Box<IterRows<'a>> {
     build_iter_from_db(match tx {
-        TxMode::MutTx(tx) => db.iter_by_col_range_mut(tx, table.table_id, columns, range),
-        TxMode::Tx(tx) => db.iter_by_col_range(tx, table.table_id, columns, range),
+        TxMode::MutTx(tx) => db
+            .iter_by_col_range_mut(tx, table.table_id, columns, range)
+            .map(box_iter),
+        TxMode::Tx(tx) => db.iter_by_col_range(tx, table.table_id, columns, range).map(box_iter),
     })
 }
 
@@ -276,36 +262,38 @@ fn build_iter<'a>(iter: impl 'a + Iterator<Item = RelValue<'a>>) -> Box<IterRows
 const TABLE_ID_EXPECTED_VALID: &str = "all `table_id`s in compiled query should be valid";
 
 /// An index join operator that returns matching rows from the index side.
-pub struct IndexSemiJoinLeft<'a, 'c, Rhs: RelOps<'a>> {
+pub struct IndexSemiJoinLeft<'c, Rhs, IndexIter, F> {
     /// An iterator for the probe side.
     /// The values returned will be used to probe the index.
-    pub probe_side: Rhs,
+    probe_side: Rhs,
     /// The column whose value will be used to probe the index.
-    pub probe_col: ColId,
+    probe_col: ColId,
     /// An optional predicate to evaluate over the matching rows of the index.
-    pub index_select: &'c Option<ColumnOp>,
-    /// The table id on which the index is defined.
-    pub index_table: TableId,
-    /// The column id for which the index is defined.
-    pub index_col: ColId,
+    index_select: &'c Option<ColumnOp>,
     /// An iterator for the index side.
     /// A new iterator will be instantiated for each row on the probe side.
-    pub index_iter: Option<IterByColRange<'a, AlgebraicValue>>,
-    /// A reference to the database.
-    pub db: &'a RelationalDB,
-    /// A reference to the current transaction.
-    pub tx: &'a TxMode<'a>,
+    index_iter: Option<IndexIter>,
+    /// The function that returns an iterator for the index side.
+    index_function: F,
 }
 
-static_assert_size!(IndexSemiJoinLeft<Box<IterRows<'static>>>, 264);
-
-impl<'a, Rhs: RelOps<'a>> IndexSemiJoinLeft<'a, '_, Rhs> {
+impl<'a, 'c, Rhs, IndexIter, F> IndexSemiJoinLeft<'c, Rhs, IndexIter, F>
+where
+    F: Fn(AlgebraicValue) -> Result<IndexIter, DBError>,
+    IndexIter: Iterator<Item = RowRef<'a>>,
+    Rhs: RelOps<'a>,
+{
     fn filter(&self, index_row: &RelValue<'_>) -> bool {
         self.index_select.as_ref().map_or(true, |op| op.eval_bool(index_row))
     }
 }
 
-impl<'a, Rhs: RelOps<'a>> RelOps<'a> for IndexSemiJoinLeft<'a, '_, Rhs> {
+impl<'a, 'c, Rhs, IndexIter, F> RelOps<'a> for IndexSemiJoinLeft<'c, Rhs, IndexIter, F>
+where
+    F: Fn(AlgebraicValue) -> Result<IndexIter, DBError>,
+    IndexIter: Iterator<Item = RowRef<'a>>,
+    Rhs: RelOps<'a>,
+{
     fn next(&mut self) -> Option<RelValue<'a>> {
         // Return a value from the current index iterator, if not exhausted.
         while let Some(index_row) = self.index_iter.as_mut().and_then(|iter| iter.next()).map(RelValue::Row) {
@@ -315,16 +303,10 @@ impl<'a, Rhs: RelOps<'a>> RelOps<'a> for IndexSemiJoinLeft<'a, '_, Rhs> {
         }
 
         // Otherwise probe the index with a row from the probe side.
-        let table_id = self.index_table;
-        let index_col = self.index_col;
         let probe_col = self.probe_col.idx();
         while let Some(mut row) = self.probe_side.next() {
             if let Some(value) = row.read_or_take_column(probe_col) {
-                let index_iter = match self.tx {
-                    TxMode::MutTx(tx) => self.db.iter_by_col_range_mut(tx, table_id, index_col, value),
-                    TxMode::Tx(tx) => self.db.iter_by_col_range(tx, table_id, index_col, value),
-                };
-                let mut index_iter = index_iter.expect(TABLE_ID_EXPECTED_VALID);
+                let mut index_iter = (self.index_function)(value).expect(TABLE_ID_EXPECTED_VALID);
                 while let Some(index_row) = index_iter.next().map(RelValue::Row) {
                     if self.filter(&index_row) {
                         self.index_iter = Some(index_iter);
@@ -337,47 +319,85 @@ impl<'a, Rhs: RelOps<'a>> RelOps<'a> for IndexSemiJoinLeft<'a, '_, Rhs> {
     }
 }
 
-/// An index join operator that returns matching rows from the probe side.
-pub struct IndexSemiJoinRight<'a, 'c, Rhs: RelOps<'a>> {
-    /// An iterator for the probe side.
-    /// The values returned will be used to probe the index.
-    pub probe_side: Rhs,
-    /// The column whose value will be used to probe the index.
-    pub probe_col: ColId,
-    /// An optional predicate to evaluate over the matching rows of the index.
-    pub index_select: &'c Option<ColumnOp>,
-    /// The table id on which the index is defined.
-    pub index_table: TableId,
-    /// The column id for which the index is defined.
-    pub index_col: ColId,
-    /// A reference to the database.
-    pub db: &'a RelationalDB,
-    /// A reference to the current transaction.
-    pub tx: &'a TxMode<'a>,
+/// Return an iterator index join operator that returns matching rows from the index side.
+pub fn index_semi_join_left<'a>(
+    db: &'a RelationalDB,
+    tx: &'a TxMode<'a>,
+    probe_side: Box<IterRows<'a>>,
+    probe_col: ColId,
+    index_select: &'a Option<ColumnOp>,
+    index_table: TableId,
+    index_col: ColId,
+) -> Box<IterRows<'a>> {
+    match tx {
+        TxMode::MutTx(tx) => Box::new(IndexSemiJoinLeft {
+            probe_side,
+            probe_col,
+            index_select,
+            index_iter: None,
+            index_function: move |value| db.iter_by_col_range_mut(tx, index_table, index_col, value),
+        }),
+        TxMode::Tx(tx) => Box::new(IndexSemiJoinLeft {
+            probe_side,
+            probe_col,
+            index_select,
+            index_iter: None,
+            index_function: move |value| db.iter_by_col_range(tx, index_table, index_col, value),
+        }),
+    }
 }
 
-static_assert_size!(IndexSemiJoinRight<Box<IterRows<'static>>>, 48);
+static_assert_size!(
+    IndexSemiJoinLeft<
+        Box<IterRows<'static>>,
+        fn(AlgebraicValue) -> Result<IterTxByColRange<'static, AlgebraicValue>, DBError>,
+        IterTxByColRange<'static, AlgebraicValue>,
+    >,
+    256
+);
+static_assert_size!(
+    IndexSemiJoinLeft<
+        Box<IterRows<'static>>,
+        fn(AlgebraicValue) -> Result<IterMutTxByColRange<'static, AlgebraicValue>, DBError>,
+        IterMutTxByColRange<'static, AlgebraicValue>,
+    >,
+    256
+);
 
-impl<'a, Rhs: RelOps<'a>> IndexSemiJoinRight<'a, '_, Rhs> {
+/// An index join operator that returns matching rows from the probe side.
+pub struct IndexSemiJoinRight<'c, Rhs: RelOps<'c>, F> {
+    /// An iterator for the probe side.
+    /// The values returned will be useSd to probe the index.
+    probe_side: Rhs,
+    /// The column whose value will be used to probe the index.
+    probe_col: ColId,
+    /// An optional predicate to evaluate over the matching rows of the index.
+    index_select: &'c Option<ColumnOp>,
+    /// A function that returns an iterator for the index side.
+    index_function: F,
+}
+
+impl<'a, Rhs: RelOps<'a>, F, IndexIter> IndexSemiJoinRight<'a, Rhs, F>
+where
+    F: Fn(AlgebraicValue) -> Result<IndexIter, DBError>,
+    IndexIter: Iterator<Item = RowRef<'a>>,
+{
     fn filter(&self, index_row: &RelValue<'_>) -> bool {
         self.index_select.as_ref().map_or(true, |op| op.eval_bool(index_row))
     }
 }
 
-impl<'a, Rhs: RelOps<'a>> RelOps<'a> for IndexSemiJoinRight<'a, '_, Rhs> {
+impl<'a, Rhs: RelOps<'a>, F, IndexIter> RelOps<'a> for IndexSemiJoinRight<'a, Rhs, F>
+where
+    F: Fn(AlgebraicValue) -> Result<IndexIter, DBError>,
+    IndexIter: Iterator<Item = RowRef<'a>>,
+{
     fn next(&mut self) -> Option<RelValue<'a>> {
         // Otherwise probe the index with a row from the probe side.
-        let table_id = self.index_table;
-        let index_col = self.index_col;
         let probe_col = self.probe_col.idx();
-        while let Some(row) = self.probe_side.next() {
-            if let Some(value) = row.read_column(probe_col) {
-                let value = &*value;
-                let index_iter = match self.tx {
-                    TxMode::MutTx(tx) => self.db.iter_by_col_range_mut(tx, table_id, index_col, value),
-                    TxMode::Tx(tx) => self.db.iter_by_col_range(tx, table_id, index_col, value),
-                };
-                let mut index_iter = index_iter.expect(TABLE_ID_EXPECTED_VALID);
+        while let Some(mut row) = self.probe_side.next() {
+            if let Some(value) = row.read_or_take_column(probe_col) {
+                let mut index_iter = (self.index_function)(value).expect(TABLE_ID_EXPECTED_VALID);
                 while let Some(index_row) = index_iter.next().map(RelValue::Row) {
                     if self.filter(&index_row) {
                         return Some(row);
@@ -388,6 +408,46 @@ impl<'a, Rhs: RelOps<'a>> RelOps<'a> for IndexSemiJoinRight<'a, '_, Rhs> {
         None
     }
 }
+
+/// Return an iterator index join operator that returns matching rows from the probe side.
+pub fn index_semi_join_right<'a>(
+    db: &'a RelationalDB,
+    tx: &'a TxMode<'a>,
+    probe_side: Box<IterRows<'a>>,
+    probe_col: ColId,
+    index_select: &'a Option<ColumnOp>,
+    index_table: TableId,
+    index_col: ColId,
+) -> Box<IterRows<'a>> {
+    match tx {
+        TxMode::MutTx(tx) => Box::new(IndexSemiJoinRight {
+            probe_side,
+            probe_col,
+            index_select,
+            index_function: move |value| db.iter_by_col_range_mut(tx, index_table, index_col, value),
+        }),
+        TxMode::Tx(tx) => Box::new(IndexSemiJoinRight {
+            probe_side,
+            probe_col,
+            index_select,
+            index_function: move |value| db.iter_by_col_range(tx, index_table, index_col, value),
+        }),
+    }
+}
+static_assert_size!(
+    IndexSemiJoinRight<
+        Box<IterRows<'static>>,
+        fn(AlgebraicValue) -> Result<IterTxByColRange<'static, AlgebraicValue>, DBError>,
+    >,
+    40
+);
+static_assert_size!(
+    IndexSemiJoinRight<
+        Box<IterRows<'static>>,
+        fn(AlgebraicValue) -> Result<IterMutTxByColRange<'static, AlgebraicValue>, DBError>,
+    >,
+    40
+);
 
 /// A [ProgramVm] implementation that carry a [RelationalDB] for it
 /// query execution

--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -1,8 +1,8 @@
 //! The [DbProgram] that execute arbitrary queries & code against the database.
 
-use crate::db::datastore::locking_tx_datastore::state_view::IterMutTxByColRange;
+use crate::db::datastore::locking_tx_datastore::state_view::IterByColRangeMutTx;
 use crate::db::datastore::locking_tx_datastore::tx::TxId;
-use crate::db::datastore::locking_tx_datastore::IterTxByColRange;
+use crate::db::datastore::locking_tx_datastore::IterByColRangeTx;
 use crate::db::datastore::system_tables::{st_var_schema, StVarName, StVarRow, StVarTable};
 use crate::db::relational_db::{MutTx, RelationalDB, Tx};
 use crate::error::DBError;
@@ -350,24 +350,24 @@ pub fn index_semi_join_left<'a>(
 static_assert_size!(
     IndexSemiJoinLeft<
         Box<IterRows<'static>>,
-        fn(AlgebraicValue) -> Result<IterTxByColRange<'static, AlgebraicValue>, DBError>,
-        IterTxByColRange<'static, AlgebraicValue>,
+        fn(AlgebraicValue) -> Result<IterByColRangeTx<'static, AlgebraicValue>, DBError>,
+        IterByColRangeTx<'static, AlgebraicValue>,
     >,
-    256
+    232
 );
 static_assert_size!(
     IndexSemiJoinLeft<
         Box<IterRows<'static>>,
-        fn(AlgebraicValue) -> Result<IterMutTxByColRange<'static, AlgebraicValue>, DBError>,
-        IterMutTxByColRange<'static, AlgebraicValue>,
+        fn(AlgebraicValue) -> Result<IterByColRangeMutTx<'static, AlgebraicValue>, DBError>,
+        IterByColRangeMutTx<'static, AlgebraicValue>,
     >,
-    256
+    240
 );
 
 /// An index join operator that returns matching rows from the probe side.
 pub struct IndexSemiJoinRight<'c, Rhs: RelOps<'c>, F> {
     /// An iterator for the probe side.
-    /// The values returned will be useSd to probe the index.
+    /// The values returned will be used to probe the index.
     probe_side: Rhs,
     /// The column whose value will be used to probe the index.
     probe_col: ColId,
@@ -437,14 +437,14 @@ pub fn index_semi_join_right<'a>(
 static_assert_size!(
     IndexSemiJoinRight<
         Box<IterRows<'static>>,
-        fn(AlgebraicValue) -> Result<IterTxByColRange<'static, AlgebraicValue>, DBError>,
+        fn(AlgebraicValue) -> Result<IterByColRangeTx<'static, AlgebraicValue>, DBError>,
     >,
     40
 );
 static_assert_size!(
     IndexSemiJoinRight<
         Box<IterRows<'static>>,
-        fn(AlgebraicValue) -> Result<IterMutTxByColRange<'static, AlgebraicValue>, DBError>,
+        fn(AlgebraicValue) -> Result<IterByColRangeMutTx<'static, AlgebraicValue>, DBError>,
     >,
     40
 );

--- a/crates/vm/src/eval.rs
+++ b/crates/vm/src/eval.rs
@@ -4,8 +4,14 @@ use crate::program::{ProgramVm, Sources};
 use crate::rel_ops::RelOps;
 use crate::relation::RelValue;
 use spacetimedb_sats::ProductValue;
+use spacetimedb_table::table::RowRef;
 
 pub type IterRows<'a> = dyn RelOps<'a> + 'a;
+
+/// Utility to simplify the creation of a boxed iterator.
+pub fn box_iter<'a, T: Iterator<Item = RowRef<'a>> + 'a>(iter: T) -> Box<dyn Iterator<Item = RowRef<'a>> + 'a> {
+    Box::new(iter)
+}
 
 pub fn build_select<'a>(base: impl RelOps<'a> + 'a, cmp: &'a ColumnOp) -> Box<IterRows<'a>> {
     Box::new(base.select(move |row| cmp.eval_bool(row)))


### PR DESCRIPTION
# Description of Changes

Refactor `Iter / CommittedIndexIter` for `Tx` & `MutTx` variants, and solves early the logic for decide the state machine.

Closes #2024

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Run benches with `sudo nice -n -20 taskpolicy -B -t 5 -l 5 -c utility cargo bench --bench subscription --  --save-baseline subs`*
