### PR TITLE
Enforce .NET 8 SDK for new C# modules

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -88,7 +88,7 @@ jobs:
       - name: Install .NET toolchain
         uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "8.x"
+          global-json-file: modules/global.json
         env:
           DOTNET_INSTALL_DIR: ~/.dotnet
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -36,7 +36,7 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "8.x"
+          global-json-file: modules/global.json
       - name: Start containers
         run: docker compose up -d
       - name: Run smoketests
@@ -70,7 +70,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "8.x"
+          global-json-file: modules/global.json
 
       - name: Create /stdb dir
         run: |
@@ -114,7 +114,7 @@ jobs:
 
       - uses: actions/setup-dotnet@v3
         with:
-          dotnet-version: "8.x"
+          global-json-file: modules/global.json
 
       - name: Create /stdb dir
         run: |

--- a/crates/cli/src/subcommands/init.rs
+++ b/crates/cli/src/subcommands/init.rs
@@ -178,8 +178,7 @@ pub async fn exec_init_csharp(args: &ArgMatches) -> anyhow::Result<()> {
         (include_str!("project/csharp/StdbModule._csproj"), "StdbModule.csproj"),
         (include_str!("project/csharp/Lib._cs"), "Lib.cs"),
         (include_str!("project/csharp/_gitignore"), ".gitignore"),
-        // Reuse global.json from modules instead of a separate template to ensure that we stay in sync.
-        (include_str!("../../../../modules/global.json"), "global.json"),
+        (include_str!("project/csharp/global._json"), "global.json"),
     ];
 
     // Check all dependencies

--- a/crates/cli/src/subcommands/init.rs
+++ b/crates/cli/src/subcommands/init.rs
@@ -178,6 +178,8 @@ pub async fn exec_init_csharp(args: &ArgMatches) -> anyhow::Result<()> {
         (include_str!("project/csharp/StdbModule._csproj"), "StdbModule.csproj"),
         (include_str!("project/csharp/Lib._cs"), "Lib.cs"),
         (include_str!("project/csharp/_gitignore"), ".gitignore"),
+        // Reuse global.json from modules instead of a separate template to ensure that we stay in sync.
+        (include_str!("../../../../modules/global.json"), "global.json"),
     ];
 
     // Check all dependencies

--- a/crates/cli/src/subcommands/project/csharp/global._json
+++ b/crates/cli/src/subcommands/project/csharp/global._json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.400",
+    "rollForward": "latestMinor"
+  }
+}

--- a/modules/global.json
+++ b/modules/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.400",
+    "rollForward": "latestMinor"
+  }
+}


### PR DESCRIPTION
# Description of Changes

This fixes an issue where users with .NET 9 SDK installed can't build C# modules even if .NET 8 SDK is installed as well.

Unfortunately, this covers only new projects created with `spacetime init` as that's the only place where we control the project directory. For everyone else, we print instructions with a link to the official configuration docs.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

Have both .NET 8 and .NET 9 installed globally (e.g. latest Visual Studio includes .NET 9 SDK by default, and you can install .NET 8 SDK manually from the official website).

Try to init a new Spacetime C# module and publish it. Before this PR, it will fail, with this PR it will work.

I have run the above testing manually.
