### PR TITLE
fix: filter pushdown over table scan

### DIFF
--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -22,7 +22,7 @@ pub enum PhysicalProject {
 impl PhysicalProject {
     pub fn optimize(self) -> Self {
         match self {
-            Self::None(_) => self,
+            Self::None(plan) => Self::None(plan.optimize(vec![])),
             Self::Relvar(plan, var) => Self::None(plan.optimize(vec![var])),
             Self::Fields(plan, fields) => {
                 Self::Fields(plan.optimize(fields.iter().map(|(_, proj)| proj.var).collect()), fields)
@@ -1237,11 +1237,14 @@ mod tests {
         def::{BTreeAlgorithm, ConstraintData, IndexAlgorithm, UniqueConstraintData},
         schema::{ColumnSchema, ConstraintSchema, IndexSchema, TableSchema},
     };
+    use spacetimedb_sql_parser::ast::BinOp;
 
     use crate::{
         compile::compile,
         plan::{HashJoin, IxJoin, IxScan, PhysicalPlan, PhysicalProject, ProjectField, Sarg, Semi},
     };
+
+    use super::PhysicalExpr;
 
     struct SchemaViewer {
         schemas: Vec<Arc<TableSchema>>,
@@ -1307,6 +1310,76 @@ mod tests {
             None,
             primary_key.map(ColId::from),
         )
+    }
+
+    /// No rewrites applied to a simple table scan
+    #[test]
+    fn table_scan_noop() {
+        let t_id = TableId(1);
+
+        let t = Arc::new(schema(
+            t_id,
+            "t",
+            &[("id", AlgebraicType::U64), ("x", AlgebraicType::U64)],
+            &[&[0]],
+            &[&[0]],
+            Some(0),
+        ));
+
+        let db = SchemaViewer {
+            schemas: vec![t.clone()],
+        };
+
+        let sql = "select * from t";
+
+        let lp = compile_sql_sub(sql, &db).unwrap();
+        let pp = compile(lp).plan.optimize();
+
+        match pp {
+            PhysicalProject::None(PhysicalPlan::TableScan(schema, _)) => {
+                assert_eq!(schema.table_id, t_id);
+            }
+            proj => panic!("unexpected project: {:#?}", proj),
+        };
+    }
+
+    /// No rewrites applied to a table scan + filter
+    #[test]
+    fn filter_noop() {
+        let t_id = TableId(1);
+
+        let t = Arc::new(schema(
+            t_id,
+            "t",
+            &[("id", AlgebraicType::U64), ("x", AlgebraicType::U64)],
+            &[&[0]],
+            &[&[0]],
+            Some(0),
+        ));
+
+        let db = SchemaViewer {
+            schemas: vec![t.clone()],
+        };
+
+        let sql = "select * from t where x = 5";
+
+        let lp = compile_sql_sub(sql, &db).unwrap();
+        let pp = compile(lp).plan.optimize();
+
+        match pp {
+            PhysicalProject::None(PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, field, value))) => {
+                assert!(matches!(*field, PhysicalExpr::Field(ProjectField { pos: 1, .. })));
+                assert!(matches!(*value, PhysicalExpr::Value(AlgebraicValue::U64(5))));
+
+                match *input {
+                    PhysicalPlan::TableScan(schema, _) => {
+                        assert_eq!(schema.table_id, t_id);
+                    }
+                    plan => panic!("unexpected plan: {:#?}", plan),
+                }
+            }
+            proj => panic!("unexpected project: {:#?}", proj),
+        };
     }
 
     /// Given the following operator notation:


### PR DESCRIPTION
# Description of Changes

1. Optimizes `PhysicalProject::None`
2. Fixes filter pushdown rewrite rule so as not to match a `table_scan + filter`

# Expected complexity level and risk

1
