### PR TITLE
Pretty print auto-migration plans

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5153,6 +5153,7 @@ name = "spacetimedb-schema"
 version = "1.0.0-rc3"
 dependencies = [
  "anyhow",
+ "colored",
  "enum-as-inner",
  "hashbrown 0.15.1",
  "indexmap 2.6.0",
@@ -5160,6 +5161,7 @@ dependencies = [
  "lazy_static",
  "petgraph",
  "proptest",
+ "regex",
  "serde_json",
  "serial_test",
  "smallvec",

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -179,6 +179,7 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error
             domain,
             database_identity,
             op,
+            update_summary,
         } => {
             let op = match op {
                 PublishOp::Created => "Created new",
@@ -188,6 +189,9 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error
                 println!("{} database with name: {}, identity: {}", op, domain, database_identity);
             } else {
                 println!("{} database with identity: {}", op, database_identity);
+            }
+            if let Some(update_summary) = update_summary {
+                println!("{}", update_summary);
             }
         }
         PublishResult::TldNotRegistered { domain } => {

--- a/crates/client-api-messages/src/name.rs
+++ b/crates/client-api-messages/src/name.rs
@@ -59,8 +59,14 @@ pub enum PublishResult {
         op: PublishOp,
 
         /// If the database was updated, may contain a string describing the update.
-        /// Contains ANSI escape codes for color.
-        /// Suitable for printing to the console.
+        /// Contains ANSI escape codes for color. You can use
+        /// `spacetimedb_schema::auto_migrate::pretty_print::strip_ansi_escape_codes`
+        /// to remove these if needed.
+        ///
+        /// TODO: it would be much better to put a more structured data type here.
+        /// This could then be formatted on client, possibly in a machine-readable form;
+        /// it could also allow, say, a GUI that shows migration histories on the website.
+        /// However, this requires reworking the `MigrationPlan` type to be serializable.
         update_summary: Option<String>,
     },
 

--- a/crates/client-api-messages/src/name.rs
+++ b/crates/client-api-messages/src/name.rs
@@ -57,6 +57,11 @@ pub enum PublishResult {
         /// or not.
         database_identity: Identity,
         op: PublishOp,
+
+        /// If the database was updated, may contain a string describing the update.
+        /// Contains ANSI escape codes for color.
+        /// Suitable for printing to the console.
+        update_summary: Option<String>,
     },
 
     // TODO: below variants are obsolete with control db module

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -7,7 +7,7 @@ use spacetimedb_lib::db::auth::StTableType;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::AlgebraicValue;
 use spacetimedb_primitives::ColSet;
-use spacetimedb_schema::auto_migrate::{AutoMigratePlan, ManualMigratePlan, MigratePlan};
+use spacetimedb_schema::auto_migrate::{AutoMigratePlan, MigratePlan};
 use spacetimedb_schema::def::TableDef;
 use spacetimedb_schema::schema::{IndexSchema, Schema, SequenceSchema, TableSchema};
 use std::sync::Arc;
@@ -45,20 +45,8 @@ pub fn update_database(
     }
 
     match plan {
-        MigratePlan::Manual(plan) => manual_migrate_database(stdb, tx, plan, system_logger, existing_tables),
         MigratePlan::Auto(plan) => auto_migrate_database(stdb, tx, auth_ctx, plan, system_logger, existing_tables),
     }
-}
-
-/// Manually migrate a database.
-fn manual_migrate_database(
-    _stdb: &RelationalDB,
-    _tx: &mut MutTxId,
-    _plan: ManualMigratePlan,
-    _system_logger: &SystemLogger,
-    _existing_tables: Vec<Arc<TableSchema>>,
-) -> anyhow::Result<()> {
-    unimplemented!("Manual database migrations are not yet implemented")
 }
 
 /// Automatically migrate a database.

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -426,7 +426,7 @@ impl HostController {
                 )
                 .await?;
             match update_result {
-                UpdateDatabaseResult::NoUpdateNeeded | UpdateDatabaseResult::UpdatePerformed => {
+                UpdateDatabaseResult::NoUpdateNeeded | UpdateDatabaseResult::UpdatePerformed(_) => {
                     *guard = Some(host);
                 }
                 UpdateDatabaseResult::AutoMigrateError(e) => {

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -448,7 +448,9 @@ pub struct WeakModuleHost {
 #[derive(Debug)]
 pub enum UpdateDatabaseResult {
     NoUpdateNeeded,
-    UpdatePerformed,
+    /// The string is a printable summary of the update that happened.
+    /// Contains ANSI escape sequences for color.
+    UpdatePerformed(String),
     AutoMigrateError(ErrorStream<AutoMigrateError>),
     ErrorExecutingMigration(anyhow::Error),
 }
@@ -457,7 +459,7 @@ impl UpdateDatabaseResult {
     pub fn was_successful(&self) -> bool {
         matches!(
             self,
-            UpdateDatabaseResult::UpdatePerformed | UpdateDatabaseResult::NoUpdateNeeded
+            UpdateDatabaseResult::UpdatePerformed(_) | UpdateDatabaseResult::NoUpdateNeeded
         )
     }
 }

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -16,7 +16,9 @@ spacetimedb-sats.workspace = true
 spacetimedb-data-structures.workspace = true
 spacetimedb-sql-parser.workspace = true
 
+regex.workspace = true
 anyhow.workspace = true
+colored.workspace = true
 indexmap.workspace = true
 itertools.workspace = true
 lazy_static.workspace = true

--- a/crates/schema/src/auto_migrate.rs
+++ b/crates/schema/src/auto_migrate.rs
@@ -62,12 +62,14 @@ pub enum AutoMigrateStep<'def> {
     // It is important FOR CORRECTNESS that `Remove` variants are declared before `Add` variants in this enum!
     //
     // The ordering is used to sort the steps of an auto-migration.
-    // If adds go before removes, the following can occur:
+    // If adds go before removes, and the user tries to remove an index and then re-add it with new configuration,
+    // the following can occur:
     //
-    // 1. `AddIndex("my_special_boy)`
-    // 2. `RemoveIndex("my_special_boy)`
+    // 1. `AddIndex("indexname")`
+    // 2. `RemoveIndex("indexname")`
     //
-    // You see the problem.
+    // This results in the index being added -- which, at time of writing, does nothing -- and then removed,
+    // resulting in the intended index not being created.
     //
     // For now, we just ensure that we declare all `Remove` variants before `Add` variants
     // and let `#[derive(PartialOrd)]` take care of the rest.

--- a/crates/schema/src/auto_migrate.rs
+++ b/crates/schema/src/auto_migrate.rs
@@ -6,12 +6,13 @@ use spacetimedb_data_structures::{
 use spacetimedb_lib::db::raw_def::v9::{RawRowLevelSecurityDefV9, TableType};
 use spacetimedb_sats::WithTypespace;
 
+pub mod pretty_print;
+
 pub type Result<T> = std::result::Result<T, ErrorStream<AutoMigrateError>>;
 
 /// A plan for a migration.
 #[derive(Debug)]
 pub enum MigratePlan<'def> {
-    Manual(ManualMigratePlan<'def>),
     Auto(AutoMigratePlan<'def>),
 }
 
@@ -19,7 +20,6 @@ impl<'def> MigratePlan<'def> {
     /// Get the old `ModuleDef` for this migration plan.
     pub fn old_def(&self) -> &'def ModuleDef {
         match self {
-            MigratePlan::Manual(plan) => plan.old,
             MigratePlan::Auto(plan) => plan.old,
         }
     }
@@ -27,18 +27,9 @@ impl<'def> MigratePlan<'def> {
     /// Get the new `ModuleDef` for this migration plan.
     pub fn new_def(&self) -> &'def ModuleDef {
         match self {
-            MigratePlan::Manual(plan) => plan.new,
             MigratePlan::Auto(plan) => plan.new,
         }
     }
-}
-
-/// A plan for a manual migration.
-/// `new` must have a reducer marked with `Lifecycle::Update`.
-#[derive(Debug)]
-pub struct ManualMigratePlan<'def> {
-    pub old: &'def ModuleDef,
-    pub new: &'def ModuleDef,
 }
 
 /// A plan for an automatic migration.

--- a/crates/schema/src/auto_migrate.rs
+++ b/crates/schema/src/auto_migrate.rs
@@ -49,7 +49,7 @@ pub struct AutoMigratePlan<'def> {
 
 /// Checks that must be performed before performing an automatic migration.
 /// These checks can access table contents and other database state.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, PartialOrd, Ord)]
 pub enum AutoMigratePrecheck<'def> {
     /// Perform a check that adding a sequence is valid (the relevant column contains no values
     /// greater than the sequence's start value).
@@ -57,7 +57,7 @@ pub enum AutoMigratePrecheck<'def> {
 }
 
 /// A step in an automatic migration.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, PartialOrd, Ord)]
 pub enum AutoMigrateStep<'def> {
     /// Add a table, including all indexes, constraints, and sequences.
     /// There will NOT be separate steps in the plan for adding indexes, constraints, and sequences.
@@ -171,6 +171,9 @@ pub fn ponder_auto_migrate<'def>(old: &'def ModuleDef, new: &'def ModuleDef) -> 
     let rls_ok = auto_migrate_row_level_security(&mut plan);
 
     let ((), (), (), (), ()) = (tables_ok, indexes_ok, sequences_ok, constraints_ok, rls_ok).combine_errors()?;
+
+    plan.steps.sort();
+    plan.prechecks.sort();
 
     Ok(plan)
 }

--- a/crates/schema/src/auto_migrate/pretty_print.rs
+++ b/crates/schema/src/auto_migrate/pretty_print.rs
@@ -1,0 +1,266 @@
+//! This module provides a function [`pretty_print`](pretty_print) that renders an automatic migration plan to a string.
+
+use super::{AutoMigratePlan, IndexAlgorithm, TableDef};
+use crate::{auto_migrate::AutoMigrateStep, def::ConstraintData};
+use colored::{self, ColoredString, Colorize};
+use lazy_static::lazy_static;
+use regex::Regex;
+use spacetimedb_lib::db::raw_def::v9::{TableAccess, TableType};
+use spacetimedb_primitives::{ColId, ColList};
+use spacetimedb_sats::{algebraic_type::fmt::fmt_algebraic_type, WithTypespace};
+use std::fmt::{self, Write};
+
+lazy_static! {
+    // https://superuser.com/questions/380772/removing-ansi-color-codes-from-text-stream
+    static ref ANSI_ESCAPE_SEQUENCE: Regex = Regex::new(
+        r#"(?x) # verbose mode
+        (?:
+            \x1b \[ [\x30-\x3f]* [\x20-\x2f]* [\x40-\x7e]   # CSI sequences (start with "ESC [")
+            | \x1b [PX^_] .*? \x1b \\                       # String Terminator sequences (end with "ESC \")
+            | \x1b \] [^\x07]* (?: \x07 | \x1b \\ )         # Sequences ending in BEL ("\x07")
+            | \x1b [\x40-\x5f] 
+        )"#
+    )
+    .unwrap();
+}
+
+/// Strip ANSI escape sequences from a string.
+/// This is needed when printing in a terminal without support for these sequences,
+/// such as `CMD.exe`.
+pub fn strip_ansi_escape_codes(s: &str) -> String {
+    ANSI_ESCAPE_SEQUENCE.replace_all(s, "").into_owned()
+}
+
+/// Pretty print a migration plan, resulting in a string (containing ANSI escape codes).
+/// If you are printing
+pub fn pretty_print(plan: &AutoMigratePlan) -> Result<String, fmt::Error> {
+    let mut out = String::new();
+    let outr = &mut out;
+
+    writeln!(outr, "{}", "Migration plan".blue())?;
+    writeln!(outr, "{}", "--------------")?;
+    writeln!(outr, "")?;
+
+    let added = "+".green().bold();
+    let removed = "-".red().bold();
+
+    for step in &plan.steps {
+        match step {
+            AutoMigrateStep::AddTable(t) => {
+                let table = plan.new.table(*t).ok_or(fmt::Error)?;
+
+                write!(outr, "{} table: {}", added, table_name(&*table.name))?;
+                if table.table_type == TableType::System {
+                    write!(outr, " (system)")?;
+                }
+                match table.table_access {
+                    TableAccess::Private => write!(outr, "(private)")?,
+                    TableAccess::Public => write!(outr, "(public)")?,
+                }
+                writeln!(outr)?;
+                for column in &table.columns {
+                    let resolved = WithTypespace::new(plan.new.typespace(), &column.ty)
+                        .resolve_refs()
+                        .map_err(|_| fmt::Error)?;
+
+                    writeln!(
+                        outr,
+                        "  {} column: {}: {}",
+                        added,
+                        column.name,
+                        fmt_algebraic_type(&resolved)
+                    )?;
+                }
+                for constraint in table.constraints.values() {
+                    match &constraint.data {
+                        ConstraintData::Unique(unique) => {
+                            write!(outr, "  {} unique constraint on ", added)?;
+                            write_col_list(outr, &unique.columns.clone().into(), table)?;
+                            writeln!(outr)?;
+                        }
+                    }
+                }
+                for index in table.indexes.values() {
+                    match &index.algorithm {
+                        IndexAlgorithm::BTree(btree) => {
+                            write!(outr, "  {} btree index on ", added)?;
+                            write_col_list(outr, &btree.columns, table)?;
+                            writeln!(outr)?;
+                        }
+                    }
+                }
+                for sequence in table.sequences.values() {
+                    let column = column_name(table, sequence.column);
+                    writeln!(outr, "  {} sequence on {}", added, column)?;
+                }
+                if let Some(schedule) = &table.schedule {
+                    let reducer = reducer_name(&*schedule.reducer_name);
+                    writeln!(outr, "  {} schedule calling {}", added, reducer)?;
+                }
+            }
+            AutoMigrateStep::AddIndex(index) => {
+                let table_def = plan.new.stored_in_table_def(*index).ok_or(fmt::Error)?;
+                let index_def = table_def.indexes.get(*index).ok_or(fmt::Error)?;
+
+                write!(
+                    outr,
+                    "{} index on table {} columns ",
+                    added,
+                    table_name(&*table_def.name)
+                )?;
+                write_col_list(outr, index_def.algorithm.columns(), table_def)?;
+                writeln!(outr)?;
+            }
+            AutoMigrateStep::RemoveIndex(index) => {
+                let table_def = plan.old.stored_in_table_def(*index).ok_or(fmt::Error)?;
+                let index_def = table_def.indexes.get(*index).ok_or(fmt::Error)?;
+
+                write!(
+                    outr,
+                    "{} index on table {} columns ",
+                    removed,
+                    table_name(&*table_def.name)
+                )?;
+                write_col_list(outr, index_def.algorithm.columns(), table_def)?;
+                writeln!(outr)?;
+            }
+            AutoMigrateStep::RemoveConstraint(constraint) => {
+                let table_def = plan.old.stored_in_table_def(constraint).ok_or(fmt::Error)?;
+                let constraint_def = table_def.constraints.get(*constraint).ok_or(fmt::Error)?;
+                match &constraint_def.data {
+                    ConstraintData::Unique(unique_constraint_data) => {
+                        write!(
+                            outr,
+                            "{} unique constraint on table {} columns ",
+                            removed,
+                            table_name(&*table_def.name)
+                        )?;
+                        write_col_list(outr, &unique_constraint_data.columns.clone().into(), table_def)?;
+                        writeln!(outr)?;
+                    }
+                }
+            }
+            AutoMigrateStep::AddSequence(sequence) => {
+                let table_def = plan.new.stored_in_table_def(*sequence).ok_or(fmt::Error)?;
+                let sequence_def = table_def.sequences.get(*sequence).ok_or(fmt::Error)?;
+
+                write!(
+                    outr,
+                    "{} sequence on table {} column {}",
+                    added,
+                    table_name(&*table_def.name),
+                    column_name(table_def, sequence_def.column)
+                )?;
+                writeln!(outr)?;
+            }
+            AutoMigrateStep::RemoveSequence(sequence) => {
+                let table_def = plan.old.stored_in_table_def(*sequence).ok_or(fmt::Error)?;
+                let sequence_def = table_def.sequences.get(*sequence).ok_or(fmt::Error)?;
+
+                write!(
+                    outr,
+                    "{} sequence on table {} column {}",
+                    removed,
+                    table_name(&*table_def.name),
+                    column_name(table_def, sequence_def.column)
+                )?;
+                writeln!(outr)?;
+            }
+            AutoMigrateStep::ChangeAccess(table) => {
+                let table_def = plan.new.table(*table).ok_or(fmt::Error)?;
+
+                write!(
+                    outr,
+                    "{} table access for table {}",
+                    added,
+                    table_name(&*table_def.name)
+                )?;
+                match table_def.table_access {
+                    TableAccess::Private => write!(outr, " (public -> private)")?,
+                    TableAccess::Public => write!(outr, " (private -> public)")?,
+                }
+                writeln!(outr)?;
+            }
+            AutoMigrateStep::AddSchedule(schedule) => {
+                let table_def = plan.new.table(*schedule).ok_or(fmt::Error)?;
+                let schedule_def = table_def.schedule.as_ref().ok_or(fmt::Error)?;
+
+                let reducer = reducer_name(&*schedule_def.reducer_name);
+                write!(
+                    outr,
+                    "{} schedule for table {} calling {}",
+                    added,
+                    table_name(&*table_def.name),
+                    reducer
+                )?;
+                writeln!(outr)?;
+            }
+            AutoMigrateStep::RemoveSchedule(schedule) => {
+                let table_def = plan.old.table(*schedule).ok_or(fmt::Error)?;
+                let schedule_def = table_def.schedule.as_ref().ok_or(fmt::Error)?;
+
+                let reducer = reducer_name(&*schedule_def.reducer_name);
+                write!(
+                    outr,
+                    "{} schedule for table {} calling {}",
+                    removed,
+                    table_name(&*table_def.name),
+                    reducer
+                )?;
+                writeln!(outr)?;
+            }
+            AutoMigrateStep::AddRowLevelSecurity(rls) => {
+                writeln!(outr, "{} row level security policy:", added)?;
+                writeln!(outr, "=============================")?;
+                writeln!(outr, "{}", rls)?;
+                writeln!(outr, "=============================")?;
+            }
+            AutoMigrateStep::RemoveRowLevelSecurity(rls) => {
+                writeln!(outr, "{} row level security policy:", removed)?;
+                writeln!(outr, "=============================")?;
+                writeln!(outr, "{}", rls)?;
+                writeln!(outr, "=============================")?;
+            }
+        }
+    }
+
+    Ok(out)
+}
+
+fn column_name(table_def: &TableDef, col_id: ColId) -> ColoredString {
+    table_def
+        .columns
+        .get(col_id.idx())
+        .map(|def| &*def.name)
+        .unwrap_or("unknown_column")
+        .magenta()
+}
+
+fn reducer_name(name: &str) -> ColoredString {
+    name.blue()
+}
+
+fn table_name(name: &str) -> ColoredString {
+    name.green()
+}
+
+fn write_col_list(out: &mut String, col_list: &ColList, table_def: &TableDef) -> Result<(), fmt::Error> {
+    write!(out, "[")?;
+    for (i, col) in col_list.iter().enumerate() {
+        let join = if i == 0 { "" } else { ", " };
+        write!(out, "{}{}", join, column_name(table_def, col))?;
+    }
+    write!(out, "]")?;
+
+    Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn test_strip_ansi_escape_sequences() {
+        let input = "\x1b[31mHello, \x1b[32mworld!\x1b[0m";
+        let expected = "Hello, world!";
+        assert_eq!(super::strip_ansi_escape_codes(input), expected);
+    }
+}

--- a/crates/schema/src/auto_migrate/pretty_print.rs
+++ b/crates/schema/src/auto_migrate/pretty_print.rs
@@ -1,6 +1,6 @@
 //! This module provides a function [`pretty_print`](pretty_print) that renders an automatic migration plan to a string.
 
-use super::{AutoMigratePlan, IndexAlgorithm, TableDef};
+use super::{IndexAlgorithm, MigratePlan, TableDef};
 use crate::{auto_migrate::AutoMigrateStep, def::ConstraintData};
 use colored::{self, ColoredString, Colorize};
 use lazy_static::lazy_static;
@@ -33,7 +33,10 @@ pub fn strip_ansi_escape_codes(s: &str) -> String {
 
 /// Pretty print a migration plan, resulting in a string (containing ANSI escape codes).
 /// If you are printing
-pub fn pretty_print(plan: &AutoMigratePlan) -> Result<String, fmt::Error> {
+pub fn pretty_print(plan: &MigratePlan) -> Result<String, fmt::Error> {
+    let plan = match plan {
+        MigratePlan::Auto(plan) => plan,
+    };
     let mut out = String::new();
     let outr = &mut out;
 

--- a/crates/schema/src/def.rs
+++ b/crates/schema/src/def.rs
@@ -122,6 +122,7 @@ pub struct ModuleDef {
     /// The row-level security policies.
     ///
     /// **Note**: Are only validated syntax-wise.
+    // TODO: for consistency, this should be changed to store a `RowLevelSecurityDef` instead.
     row_level_security_raw: HashMap<RawSql, RawRowLevelSecurityDefV9>,
 }
 

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -191,6 +191,7 @@ class Smoketest(unittest.TestCase):
         )
         self.resolved_identity = re.search(r"identity: ([0-9a-fA-F]+)", publish_output)[1]
         self.database_identity = domain if domain is not None else self.resolved_identity
+        return publish_output
 
     @classmethod
     def reset_config(cls):

--- a/smoketests/tests/auto_migration.py
+++ b/smoketests/tests/auto_migration.py
@@ -247,8 +247,8 @@ Performed automatic migration
             """\
  sql
 ------------------------
- "SELECT * FROM person"
  "SELECT * FROM book"
+ "SELECT * FROM person"
 """,
         )
 

--- a/smoketests/tests/auto_migration.py
+++ b/smoketests/tests/auto_migration.py
@@ -1,6 +1,23 @@
 from .. import Smoketest
 import sys
 import logging
+import re
+
+# 7-bit C1 ANSI sequences
+ansi_escape = re.compile(r'''
+    \x1B  # ESC
+    (?:   # 7-bit C1 Fe (except CSI)
+        [@-Z\\-_]
+    |     # or [ for CSI, followed by a control sequence
+        \[
+        [0-?]*  # Parameter bytes
+        [ -/]*  # Intermediate bytes
+        [@-~]   # Final byte
+    )
+''', re.VERBOSE)
+
+def strip_ansi_escape_codes(text: str) -> str:
+    return ansi_escape.sub('', text)
 
 
 class AddTableAutoMigration(Smoketest):
@@ -25,7 +42,11 @@ pub fn print_persons(ctx: &ReducerContext, prefix: String) {
 }
 
 #[spacetimedb::table(name = point_mass)]
+#[index(name = point_masses_by_mass, btree(columns = position))]
 pub struct PointMass {
+    #[primary_key]
+    #[auto_inc]
+    id: u64,
     mass: f64,
     /// This used to cause an error when check_compatible did not resolve types in a `ModuleDef`.
     position: Vector2,
@@ -37,12 +58,82 @@ pub struct Vector2 {
     y: f64,
 }
 
+#[spacetimedb::table(name = scheduled_table, scheduled(send_scheduled_message), public)]
+pub struct ScheduledTable {
+    #[primary_key]
+    #[auto_inc]
+    scheduled_id: u64,
+    #[scheduled_at]
+    scheduled_at: spacetimedb::ScheduleAt,
+    text: String,
+}
+
+#[spacetimedb::reducer]
+fn send_scheduled_message(_ctx: &ReducerContext, arg: ScheduledTable) {
+    let _ = arg.text;
+    let _ = arg.scheduled_at;
+    let _ = arg.scheduled_id;
+}
+
 spacetimedb::filter!("SELECT * FROM person");
 """
 
-    MODULE_CODE_UPDATED = (
-        MODULE_CODE
-        + """
+    MODULE_CODE_UPDATED = """
+use spacetimedb::{log, ReducerContext, Table, SpacetimeType};
+
+#[spacetimedb::table(name = person)]
+pub struct Person {
+    name: String,
+}
+
+#[spacetimedb::reducer]
+pub fn add_person(ctx: &ReducerContext, name: String) {
+    ctx.db.person().insert(Person { name });
+}
+
+#[spacetimedb::reducer]
+pub fn print_persons(ctx: &ReducerContext, prefix: String) {
+    for person in ctx.db.person().iter() {
+        log::info!("{}: {}", prefix, person.name);
+    }
+}
+
+#[spacetimedb::table(name = point_mass, public)] // private -> public
+// remove index
+pub struct PointMass {
+    // remove primary_key and auto_inc
+    id: u64,
+    mass: f64,
+    /// This used to cause an error when check_compatible did not resolve types in a `ModuleDef`.
+    position: Vector2,
+}
+
+#[derive(SpacetimeType, Clone, Copy)]
+pub struct Vector2 {
+    x: f64,
+    y: f64,
+}
+
+// TODO: once removing schedules is implemented, remove the schedule here.
+#[spacetimedb::table(name = scheduled_table, scheduled(send_scheduled_message), public)]
+pub struct ScheduledTable {
+    #[primary_key]
+    #[auto_inc]
+    scheduled_id: u64,
+    #[scheduled_at]
+    scheduled_at: spacetimedb::ScheduleAt,
+    text: String,
+}
+
+#[spacetimedb::reducer]
+fn send_scheduled_message(_ctx: &ReducerContext, arg: ScheduledTable) {
+    let _ = arg.text;
+    let _ = arg.scheduled_at;
+    let _ = arg.scheduled_id;
+}
+
+spacetimedb::filter!("SELECT * FROM person");
+
 #[spacetimedb::table(name = book)]
 pub struct Book {
     isbn: String,
@@ -61,8 +152,44 @@ pub fn print_books(ctx: &ReducerContext, prefix: String) {
 }
 
 spacetimedb::filter!("SELECT * FROM book");
+
+#[spacetimedb::table(name = parabolas)]
+#[index(name = parabolas_by_b_c, btree(columns = [b, c]))]
+pub struct Parabola {
+    #[primary_key]
+    #[auto_inc]
+    id: u64,
+    a: f64,
+    b: f64,
+    c: f64,
+}
 """
-    )
+
+    EXPECTED_MIGRATION_REPORT = """--------------
+Performed automatic migration
+--------------
+- Removed index `point_mass_id_idx_btree` on columns [`id`] of table `point_mass`
+- Removed unique constraint `point_mass_id_key` on columns [`id`] of table `point_mass`
+- Removed auto-increment constraint `point_mass_id_seq` on column `id` of table `point_mass`
+- Created table: `book` (private)
+    - Columns:
+        - `isbn`: String
+- Created table: `parabolas` (private)
+    - Columns:
+        - `id`: U64
+        - `a`: F64
+        - `b`: F64
+        - `c`: F64
+    - Unique constraints:
+        - `parabolas_id_key` on [`id`]
+    - Indexes:
+        - `parabolas_id_idx_btree` on [`id`]
+    - Auto-increment constraints:
+        - `parabolas_id_seq` on `id`
+- Created row level security policy:
+    `SELECT * FROM book`
+- Changed access for table `point_mass` (private -> public)"""
+
 
     def assertSql(self, sql, expected):
         self.maxDiff = None
@@ -98,7 +225,15 @@ spacetimedb::filter!("SELECT * FROM book");
         )
 
         self.write_module_code(self.MODULE_CODE_UPDATED)
-        self.publish_module(self.database_identity, clear=False)
+        output = self.publish_module(self.database_identity, clear=False)
+        output = strip_ansi_escape_codes(output)
+
+        print("got output\n", output)
+
+        # Remark: if this test ever fails mysteriously,
+        # try double-checking the pretty printing code for trailing spaces before newlines.
+        # Also make sure the pretty-printing is deterministic.
+        self.assertIn(self.EXPECTED_MIGRATION_REPORT, output)
 
         logging.info("Updated")
 

--- a/smoketests/tests/auto_migration.py
+++ b/smoketests/tests/auto_migration.py
@@ -4,7 +4,8 @@ import logging
 import re
 
 # 7-bit C1 ANSI sequences
-ansi_escape = re.compile(r'''
+ansi_escape = re.compile(
+    r"""
     \x1B  # ESC
     (?:   # 7-bit C1 Fe (except CSI)
         [@-Z\\-_]
@@ -14,10 +15,13 @@ ansi_escape = re.compile(r'''
         [ -/]*  # Intermediate bytes
         [@-~]   # Final byte
     )
-''', re.VERBOSE)
+""",
+    re.VERBOSE,
+)
+
 
 def strip_ansi_escape_codes(text: str) -> str:
-    return ansi_escape.sub('', text)
+    return ansi_escape.sub("", text)
 
 
 class AddTableAutoMigration(Smoketest):
@@ -63,7 +67,6 @@ pub struct ScheduledTable {
     #[primary_key]
     #[auto_inc]
     scheduled_id: u64,
-    #[scheduled_at]
     scheduled_at: spacetimedb::ScheduleAt,
     text: String,
 }
@@ -120,7 +123,6 @@ pub struct ScheduledTable {
     #[primary_key]
     #[auto_inc]
     scheduled_id: u64,
-    #[scheduled_at]
     scheduled_at: spacetimedb::ScheduleAt,
     text: String,
 }
@@ -190,7 +192,6 @@ Performed automatic migration
     `SELECT * FROM book`
 - Changed access for table `point_mass` (private -> public)"""
 
-
     def assertSql(self, sql, expected):
         self.maxDiff = None
         sql_out = self.spacetime("sql", self.database_identity, sql)
@@ -202,11 +203,14 @@ Performed automatic migration
         """This tests uploading a module with a schema change that should not require clearing the database."""
 
         # Check the row-level SQL filter is created correctly
-        self.assertSql("SELECT sql FROM st_row_level_security", """\
+        self.assertSql(
+            "SELECT sql FROM st_row_level_security",
+            """\
  sql
 ------------------------
  "SELECT * FROM person"
-""")
+""",
+        )
 
         logging.info("Initial publish complete")
         # initial module code is already published by test framework
@@ -238,12 +242,15 @@ Performed automatic migration
         logging.info("Updated")
 
         # Check the row-level SQL filter is added correctly
-        self.assertSql("SELECT sql FROM st_row_level_security", """\
+        self.assertSql(
+            "SELECT sql FROM st_row_level_security",
+            """\
  sql
 ------------------------
  "SELECT * FROM person"
  "SELECT * FROM book"
-""")
+""",
+        )
 
         self.logs(100)
 


### PR DESCRIPTION
# Description of Changes

Implements https://github.com/orgs/clockworklabs/projects/22/views/16?filterQuery=migration&pane=issue&itemId=91111218.

While implementing this, I discovered auto-migration plans applied their steps in a nondeterministic order (I was iterating a hashmap and had forgotten to sort.)

This interacted in a particularly bad way with row-level-security policies:
- Row level security policies are removed and re-added in every automigration, to allow the core crate to re-initialize the relevant queries. (I disagree with this -- it should be an implementation detail of the core crate, not mentioned in auto-migrations -- but I'm not changing it in this PR; see my comments about it in the code.)
- Since ordering was random, the Add step for the policy could be run before the Remove step.
- Adding an already existing policy was implemented in an idempotent way by the core crate.
- So, any auto-migration could nondeterministically drop row-level-security policies!

This is now fixed by simply sorting the steps of an auto-migration in a prescribed way.

# API and ABI breaking changes

This is a minor breaking change to the client API since it adds data to the result of an update call.

# Expected complexity level and risk

0

# Testing

Added a smoketest.
TODO: I want to add to the integration tests of the `schema` crate as well.