### PR TITLE
commitlog: Fix offset index truncation

### DIFF
--- a/crates/commitlog/src/commitlog.rs
+++ b/crates/commitlog/src/commitlog.rs
@@ -267,7 +267,10 @@ impl<R: Repo, T> Generic<R, T> {
                     let byte_offset = segment::Header::LEN as u64 + bytes_read;
                     debug!("truncating segment {segment} to {offset} at {byte_offset}");
                     let mut file = self.repo.open_segment(segment)?;
-                    file.ftruncate(offset, byte_offset)?;
+                    // Note: The offset index truncates equal or greater,
+                    // inclusive. We'd like to retain `offset` in the index, as
+                    // the commit is also retained in the log.
+                    file.ftruncate(offset + 1, byte_offset)?;
                     // Some filesystems require fsync after ftruncate.
                     file.fsync()?;
                     break;


### PR DESCRIPTION
Fix the `ftruncate` implementation for the offset index writer to use the correct argument (transaction not byte offset). Add a test for it.

Also change the commitlog `reset_to` method to truncate to `offset + 1`, so as to retain the `offset` in the index if it is there. This matches the semantics of `reset_to`, which keeps the given offset.

# Expected complexity level and risk

1

# Testing

This patch adds a test.