### PR TITLE
query engine integration

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4658,9 +4658,11 @@ dependencies = [
  "spacetimedb-client-api",
  "spacetimedb-core",
  "spacetimedb-data-structures",
+ "spacetimedb-execution",
  "spacetimedb-lib",
  "spacetimedb-paths",
  "spacetimedb-primitives",
+ "spacetimedb-query",
  "spacetimedb-sats",
  "spacetimedb-schema",
  "spacetimedb-standalone",
@@ -4910,13 +4912,16 @@ dependencies = [
  "spacetimedb-commitlog",
  "spacetimedb-data-structures",
  "spacetimedb-durability",
+ "spacetimedb-execution",
  "spacetimedb-expr",
  "spacetimedb-jsonwebtoken",
  "spacetimedb-jwks",
  "spacetimedb-lib",
  "spacetimedb-metrics",
  "spacetimedb-paths",
+ "spacetimedb-physical-plan",
  "spacetimedb-primitives",
+ "spacetimedb-query",
  "spacetimedb-sats",
  "spacetimedb-schema",
  "spacetimedb-snapshot",
@@ -4975,9 +4980,12 @@ dependencies = [
 name = "spacetimedb-execution"
 version = "1.0.0-rc3"
 dependencies = [
+ "anyhow",
  "spacetimedb-expr",
  "spacetimedb-lib",
+ "spacetimedb-physical-plan",
  "spacetimedb-primitives",
+ "spacetimedb-sql-parser",
  "spacetimedb-table",
 ]
 
@@ -5091,12 +5099,15 @@ dependencies = [
 name = "spacetimedb-physical-plan"
 version = "1.0.0-rc3"
 dependencies = [
+ "anyhow",
  "derive_more",
+ "pretty_assertions",
  "spacetimedb-expr",
  "spacetimedb-lib",
  "spacetimedb-primitives",
  "spacetimedb-schema",
  "spacetimedb-sql-parser",
+ "spacetimedb-table",
 ]
 
 [[package]]
@@ -5108,6 +5119,23 @@ dependencies = [
  "itertools 0.12.1",
  "nohash-hasher",
  "proptest",
+]
+
+[[package]]
+name = "spacetimedb-query"
+version = "1.0.0-rc3"
+dependencies = [
+ "anyhow",
+ "itertools 0.12.1",
+ "rayon",
+ "spacetimedb-client-api-messages",
+ "spacetimedb-execution",
+ "spacetimedb-expr",
+ "spacetimedb-lib",
+ "spacetimedb-physical-plan",
+ "spacetimedb-primitives",
+ "spacetimedb-sql-parser",
+ "spacetimedb-table",
 ]
 
 [[package]]
@@ -5320,6 +5348,7 @@ dependencies = [
  "log",
  "smallvec",
  "spacetimedb-data-structures",
+ "spacetimedb-execution",
  "spacetimedb-lib",
  "spacetimedb-primitives",
  "spacetimedb-sats",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,6 +19,7 @@ members = [
   "crates/paths",
   "crates/physical-plan",
   "crates/primitives",
+  "crates/query",
   "crates/sats",
   "crates/schema",
   "crates/sdk",
@@ -106,6 +107,7 @@ spacetimedb-metrics = { path = "crates/metrics", version = "1.0.0-rc3" }
 spacetimedb-paths = { path = "crates/paths", version = "1.0.0-rc3" }
 spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.0.0-rc3" }
 spacetimedb-primitives = { path = "crates/primitives", version = "1.0.0-rc3" }
+spacetimedb-query = { path = "crates/query", version = "1.0.0-rc3" }
 spacetimedb-sats = { path = "crates/sats", version = "1.0.0-rc3" }
 spacetimedb-schema = { path = "crates/schema", version = "1.0.0-rc3" }
 spacetimedb-standalone = { path = "crates/standalone", version = "1.0.0-rc3" }

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -31,9 +31,11 @@ bench = false
 spacetimedb-client-api = { path = "../client-api" }
 spacetimedb-core = { path = "../core", features = ["test"] }
 spacetimedb-data-structures.workspace = true
+spacetimedb-execution = { path = "../execution" }
 spacetimedb-lib = { path = "../lib" }
 spacetimedb-paths.workspace = true
 spacetimedb-primitives = { path = "../primitives" }
+spacetimedb-query = { path = "../query" }
 spacetimedb-sats = { path = "../sats" }
 spacetimedb-schema = { workspace = true, features = ["test"] }
 spacetimedb-standalone = { path = "../standalone" }

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -23,12 +23,15 @@ spacetimedb-durability.workspace = true
 spacetimedb-metrics.workspace = true
 spacetimedb-primitives.workspace = true
 spacetimedb-paths.workspace = true
+spacetimedb-physical-plan.workspace = true
+spacetimedb-query.workspace = true
 spacetimedb-sats = { workspace = true, features = ["serde"] }
 spacetimedb-schema.workspace = true
 spacetimedb-table.workspace = true
 spacetimedb-vm.workspace = true
 spacetimedb-snapshot.workspace = true
 spacetimedb-expr.workspace = true
+spacetimedb-execution.workspace = true
 
 anyhow = { workspace = true, features = ["backtrace"] }
 arrayvec.workspace = true

--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -13,7 +13,7 @@ use crate::worker_metrics::WORKER_METRICS;
 use derive_more::From;
 use futures::prelude::*;
 use spacetimedb_client_api_messages::websocket::{
-    CallReducerFlags, Compression, FormatSwitch, SubscribeSingle, Unsubscribe,
+    BsatnFormat, CallReducerFlags, Compression, FormatSwitch, JsonFormat, SubscribeSingle, Unsubscribe, WebsocketFormat,
 };
 use spacetimedb_lib::identity::RequestId;
 use tokio::sync::{mpsc, oneshot, watch};
@@ -314,26 +314,41 @@ impl ClientConnection {
         .unwrap()
     }
 
-    pub fn one_off_query(&self, query: &str, message_id: &[u8], timer: Instant) -> Result<(), anyhow::Error> {
-        let result = self.module.one_off_query(self.id.identity, query.to_owned());
+    pub fn one_off_query_json(&self, query: &str, message_id: &[u8], timer: Instant) -> Result<(), anyhow::Error> {
+        let response = self.one_off_query::<JsonFormat>(query, message_id, timer);
+        self.send_message(response)?;
+        Ok(())
+    }
+
+    pub fn one_off_query_bsatn(&self, query: &str, message_id: &[u8], timer: Instant) -> Result<(), anyhow::Error> {
+        let response = self.one_off_query::<BsatnFormat>(query, message_id, timer);
+        self.send_message(response)?;
+        Ok(())
+    }
+
+    fn one_off_query<F: WebsocketFormat>(
+        &self,
+        query: &str,
+        message_id: &[u8],
+        timer: Instant,
+    ) -> OneOffQueryResponseMessage<F> {
+        let result = self.module.one_off_query::<F>(self.id.identity, query.to_owned());
         let message_id = message_id.to_owned();
         let total_host_execution_duration = timer.elapsed().as_micros() as u64;
-        let response = match result {
+        match result {
             Ok(results) => OneOffQueryResponseMessage {
                 message_id,
                 error: None,
-                results,
+                results: vec![results],
                 total_host_execution_duration,
             },
             Err(err) => OneOffQueryResponseMessage {
                 message_id,
                 error: Some(format!("{}", err)),
-                results: Vec::new(),
+                results: vec![],
                 total_host_execution_duration,
             },
-        };
-        self.send_message(response)?;
-        Ok(())
+        }
     }
 
     pub async fn disconnect(self) {

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -7,9 +7,12 @@ use super::{
 };
 use crate::db::datastore::locking_tx_datastore::state_view::IterTx;
 use crate::execution_context::ExecutionContext;
+use spacetimedb_execution::Datastore;
 use spacetimedb_primitives::{ColList, TableId};
 use spacetimedb_sats::AlgebraicValue;
 use spacetimedb_schema::schema::TableSchema;
+use spacetimedb_table::blob_store::BlobStore;
+use spacetimedb_table::table::Table;
 use std::num::NonZeroU64;
 use std::sync::Arc;
 use std::{
@@ -22,6 +25,16 @@ pub struct TxId {
     pub(super) lock_wait_time: Duration,
     pub(super) timer: Instant,
     pub(crate) ctx: ExecutionContext,
+}
+
+impl Datastore for TxId {
+    fn blob_store(&self) -> &dyn BlobStore {
+        &self.committed_state_shared_lock.blob_store
+    }
+
+    fn table(&self, table_id: TableId) -> Option<&Table> {
+        self.committed_state_shared_lock.get_table(table_id)
+    }
 }
 
 impl StateView for TxId {

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -227,7 +227,7 @@ fn auto_migrate_database(
                 system_logger.info(&format!("Adding row-level security `{sql_rls}`"));
                 log::info!("Adding row-level security `{sql_rls}`");
                 let rls = plan.new.lookup_expect(sql_rls);
-                let rls = RowLevelExpr::build_row_level_expr(stdb, tx, &auth_ctx, rls)?;
+                let rls = RowLevelExpr::build_row_level_expr(tx, &auth_ctx, rls)?;
 
                 stdb.create_row_level_security(tx, rls.def)?;
             }

--- a/crates/core/src/estimation.rs
+++ b/crates/core/src/estimation.rs
@@ -1,10 +1,86 @@
 use crate::db::{datastore::locking_tx_datastore::state_view::StateView as _, relational_db::Tx};
+use spacetimedb_lib::query::Delta;
+use spacetimedb_physical_plan::plan::{HashJoin, IxJoin, IxScan, PhysicalPlan, Sarg};
 use spacetimedb_primitives::{ColList, TableId};
 use spacetimedb_vm::expr::{Query, QueryExpr, SourceExpr};
 
 /// The estimated number of rows that a query plan will return.
 pub fn num_rows(tx: &Tx, expr: &QueryExpr) -> u64 {
     row_est(tx, &expr.source, &expr.query)
+}
+
+/// Use cardinality estimates to predict the total number of rows scanned by a query
+pub fn estimate_rows_scanned(tx: &Tx, plan: &PhysicalPlan) -> u64 {
+    match plan {
+        PhysicalPlan::TableScan(..) | PhysicalPlan::IxScan(..) => row_estimate(tx, plan),
+        PhysicalPlan::Filter(input, _) => estimate_rows_scanned(tx, input).saturating_add(row_estimate(tx, input)),
+        PhysicalPlan::NLJoin(lhs, rhs) => estimate_rows_scanned(tx, lhs)
+            .saturating_add(estimate_rows_scanned(tx, rhs))
+            .saturating_add(row_estimate(tx, lhs).saturating_mul(row_estimate(tx, rhs))),
+        PhysicalPlan::IxJoin(IxJoin { lhs, unique: true, .. }, _) => {
+            estimate_rows_scanned(tx, lhs).saturating_add(row_estimate(tx, lhs))
+        }
+        PhysicalPlan::IxJoin(
+            IxJoin {
+                lhs, rhs, rhs_field, ..
+            },
+            _,
+        ) => estimate_rows_scanned(tx, lhs).saturating_add(row_estimate(tx, lhs).saturating_mul(index_row_est(
+            tx,
+            rhs.table_id,
+            &ColList::from(*rhs_field),
+        ))),
+        PhysicalPlan::HashJoin(
+            HashJoin {
+                lhs, rhs, unique: true, ..
+            },
+            _,
+        ) => estimate_rows_scanned(tx, lhs)
+            .saturating_add(estimate_rows_scanned(tx, rhs))
+            .saturating_add(row_estimate(tx, lhs)),
+        PhysicalPlan::HashJoin(HashJoin { lhs, rhs, .. }, _) => estimate_rows_scanned(tx, lhs)
+            .saturating_add(estimate_rows_scanned(tx, rhs))
+            .saturating_add(row_estimate(tx, lhs).saturating_mul(row_estimate(tx, rhs))),
+    }
+}
+
+/// Estimate the cardinality of a physical plan
+pub fn row_estimate(tx: &Tx, plan: &PhysicalPlan) -> u64 {
+    match plan {
+        // Table scans return the number of rows in the table
+        PhysicalPlan::TableScan(schema, _, None) => tx.table_row_count(schema.table_id).unwrap_or_default(),
+        PhysicalPlan::TableScan(_, _, Some(Delta::Inserts(n) | Delta::Deletes(n))) => *n as u64,
+        // The selectivity of a single column index scan is 1 / NDV,
+        // where NDV is the Number of Distinct Values of a column.
+        // Note, this assumes a uniform distribution of column values.
+        PhysicalPlan::IxScan(
+            ix @ IxScan {
+                arg: Sarg::Eq(col_id, _),
+                ..
+            },
+            _,
+        ) if ix.prefix.is_empty() => index_row_est(tx, ix.schema.table_id, &ColList::from(*col_id)),
+        // For all other index scans we assume a worst-case scenario.
+        PhysicalPlan::IxScan(IxScan { schema, .. }, _) => tx.table_row_count(schema.table_id).unwrap_or_default(),
+        // Same for filters
+        PhysicalPlan::Filter(input, _) => row_estimate(tx, input),
+        // Nested loop joins are cross joins
+        PhysicalPlan::NLJoin(lhs, rhs) => row_estimate(tx, lhs).saturating_mul(row_estimate(tx, rhs)),
+        // Unique joins return a maximal estimation.
+        // We assume every lhs row has a matching rhs row.
+        PhysicalPlan::IxJoin(IxJoin { lhs, unique: true, .. }, _)
+        | PhysicalPlan::HashJoin(HashJoin { lhs, unique: true, .. }, _) => row_estimate(tx, lhs),
+        // Otherwise we estimate the rows returned from the rhs
+        PhysicalPlan::IxJoin(
+            IxJoin {
+                lhs, rhs, rhs_field, ..
+            },
+            _,
+        ) => row_estimate(tx, lhs).saturating_mul(index_row_est(tx, rhs.table_id, &ColList::from(*rhs_field))),
+        PhysicalPlan::HashJoin(HashJoin { lhs, rhs, .. }, _) => {
+            row_estimate(tx, lhs).saturating_mul(row_estimate(tx, rhs))
+        }
+    }
 }
 
 /// The estimated number of rows that a query sub-plan will return.
@@ -68,6 +144,7 @@ fn index_row_est(tx: &Tx, table_id: TableId, cols: &ColList) -> u64 {
 mod tests {
     use crate::db::relational_db::tests_utils::insert;
     use crate::execution_context::Workload;
+    use crate::sql::ast::SchemaViewer;
     use crate::{
         db::relational_db::{tests_utils::TestDB, RelationalDB},
         error::DBError,
@@ -75,8 +152,11 @@ mod tests {
         sql::compiler::compile_sql,
     };
     use spacetimedb_lib::{identity::AuthCtx, AlgebraicType};
+    use spacetimedb_query::SubscribePlan;
     use spacetimedb_sats::product;
     use spacetimedb_vm::expr::CrudExpr;
+
+    use super::row_estimate;
 
     fn in_mem_db() -> TestDB {
         TestDB::in_memory().expect("failed to make test db")
@@ -88,6 +168,15 @@ mod tests {
             [CrudExpr::Query(expr)] => num_rows(&tx, expr),
             exprs => panic!("unexpected result from compilation: {:#?}", exprs),
         }
+    }
+
+    /// Using the new query plan
+    fn new_row_estimate(db: &RelationalDB, sql: &str) -> u64 {
+        let auth = AuthCtx::for_testing();
+        let tx = db.begin_tx(Workload::ForTests);
+        let tx = SchemaViewer::new(&tx, &auth);
+        let plan = SubscribePlan::compile(sql, &tx).expect("failed to compile sql");
+        row_estimate(&tx, &plan)
     }
 
     const NUM_T_ROWS: u64 = 10;
@@ -141,14 +230,19 @@ mod tests {
     fn cardinality_estimation_index_lookup() {
         let db = in_mem_db();
         create_table_t(&db, true);
-        assert_eq!(NUM_T_ROWS / NDV_T, num_rows_for(&db, "select * from T where a = 0"));
+        let sql = "select * from T where a = 0";
+        let est = NUM_T_ROWS / NDV_T;
+        assert_eq!(est, num_rows_for(&db, sql));
+        assert_eq!(est, new_row_estimate(&db, sql));
     }
 
     #[test]
     fn cardinality_estimation_0_ndv() {
         let db = in_mem_db();
         create_empty_table_r(&db, true);
-        assert_eq!(0, num_rows_for(&db, "select * from R where a = 0"));
+        let sql = "select * from R where a = 0";
+        assert_eq!(0, num_rows_for(&db, sql));
+        assert_eq!(0, new_row_estimate(&db, sql));
     }
 
     /// We estimate an index range to return all input rows.
@@ -156,7 +250,9 @@ mod tests {
     fn cardinality_estimation_index_range() {
         let db = in_mem_db();
         create_table_t(&db, true);
-        assert_eq!(NUM_T_ROWS, num_rows_for(&db, "select * from T where a > 0 and a < 2"));
+        let sql = "select * from T where a > 0 and a < 2";
+        assert_eq!(NUM_T_ROWS, num_rows_for(&db, sql));
+        assert_eq!(NUM_T_ROWS, new_row_estimate(&db, sql));
     }
 
     /// We estimate a selection on a non-indexed column to return all input rows.
@@ -164,7 +260,9 @@ mod tests {
     fn select_cardinality_estimation() {
         let db = in_mem_db();
         create_table_t(&db, true);
-        assert_eq!(NUM_T_ROWS, num_rows_for(&db, "select * from T where b = 0"));
+        let sql = "select * from T where b = 0";
+        assert_eq!(NUM_T_ROWS, num_rows_for(&db, sql));
+        assert_eq!(NUM_T_ROWS, new_row_estimate(&db, sql));
     }
 
     /// We estimate a projection to return all input rows.
@@ -172,7 +270,8 @@ mod tests {
     fn project_cardinality_estimation() {
         let db = in_mem_db();
         create_table_t(&db, true);
-        assert_eq!(NUM_T_ROWS, num_rows_for(&db, "select a from T"));
+        let sql = "select a from T";
+        assert_eq!(NUM_T_ROWS, num_rows_for(&db, sql));
     }
 
     /// We estimate an inner join to return the product of its input sizes.
@@ -181,10 +280,10 @@ mod tests {
         let db = in_mem_db();
         create_table_t(&db, false);
         create_table_s(&db, false);
-        assert_eq!(
-            NUM_T_ROWS * NUM_S_ROWS, // => 20
-            num_rows_for(&db, "select T.* from T join S on T.a = S.a where S.c = 0")
-        );
+        let sql = "select T.* from T join S on T.a = S.a where S.c = 0";
+        let est = NUM_T_ROWS * NUM_S_ROWS;
+        assert_eq!(est, num_rows_for(&db, sql));
+        assert_eq!(est, new_row_estimate(&db, sql));
     }
 
     /// An index join estimates its output cardinality in the same way.
@@ -194,9 +293,9 @@ mod tests {
         let db = in_mem_db();
         create_table_t(&db, true);
         create_table_s(&db, true);
-        assert_eq!(
-            NUM_T_ROWS / NDV_T * NUM_S_ROWS / NDV_S, // => 2
-            num_rows_for(&db, "select T.* from T join S on T.a = S.a where S.c = 0")
-        );
+        let sql = "select T.* from T join S on T.a = S.a where S.c = 0";
+        let est = NUM_T_ROWS / NDV_T * NUM_S_ROWS / NDV_S;
+        assert_eq!(est, num_rows_for(&db, sql));
+        assert_eq!(est, new_row_estimate(&db, sql));
     }
 }

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -7,14 +7,17 @@ use crate::db::datastore::system_tables::{StClientFields, StClientRow, ST_CLIENT
 use crate::db::datastore::traits::{IsolationLevel, Program, TxData};
 use crate::energy::EnergyQuanta;
 use crate::error::DBError;
+use crate::estimation::estimate_rows_scanned;
 use crate::execution_context::{ExecutionContext, ReducerContext, Workload};
 use crate::hash::Hash;
 use crate::identity::Identity;
 use crate::messages::control_db::Database;
 use crate::replica_context::ReplicaContext;
-use crate::sql;
+use crate::sql::ast::SchemaViewer;
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
+use crate::subscription::tx::DeltaTx;
 use crate::util::lending_pool::{Closed, LendingPool, LentResource, PoolClosed};
+use crate::vm::check_row_limit;
 use crate::worker_metrics::WORKER_METRICS;
 use anyhow::Context;
 use bytes::Bytes;
@@ -24,17 +27,18 @@ use indexmap::IndexSet;
 use itertools::Itertools;
 use smallvec::SmallVec;
 use spacetimedb_client_api_messages::timestamp::Timestamp;
-use spacetimedb_client_api_messages::websocket::{Compression, QueryUpdate, WebsocketFormat};
+use spacetimedb_client_api_messages::websocket::{Compression, OneOffTable, QueryUpdate, WebsocketFormat};
 use spacetimedb_data_structures::error_stream::ErrorStream;
 use spacetimedb_data_structures::map::{HashCollectionExt as _, IntMap};
 use spacetimedb_lib::identity::{AuthCtx, RequestId};
 use spacetimedb_lib::Address;
 use spacetimedb_primitives::{col_list, TableId};
+use spacetimedb_query::SubscribePlan;
 use spacetimedb_sats::{algebraic_value, ProductValue};
 use spacetimedb_schema::auto_migrate::AutoMigrateError;
 use spacetimedb_schema::def::deserialize::ReducerArgsDeserializeSeed;
 use spacetimedb_schema::def::{ModuleDef, ReducerDef};
-use spacetimedb_vm::relation::{MemTable, RelValue};
+use spacetimedb_vm::relation::RelValue;
 use std::fmt;
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
@@ -836,15 +840,25 @@ impl ModuleHost {
     }
 
     #[tracing::instrument(skip_all)]
-    pub fn one_off_query(&self, caller_identity: Identity, query: String) -> Result<Vec<MemTable>, anyhow::Error> {
+    pub fn one_off_query<F: WebsocketFormat>(
+        &self,
+        caller_identity: Identity,
+        query: String,
+    ) -> Result<OneOffTable<F>, anyhow::Error> {
         let replica_ctx = self.replica_ctx();
         let db = &replica_ctx.relational_db;
         let auth = AuthCtx::new(replica_ctx.owner_identity, caller_identity);
         log::debug!("One-off query: {query}");
 
         db.with_read_only(Workload::Sql, |tx| {
-            let ast = sql::compiler::compile_sql(db, &auth, tx, &query)?;
-            sql::execute::execute_sql_tx(db, tx, &query, ast, auth)?
+            let tx = SchemaViewer::new(tx, &auth);
+            let plan = SubscribePlan::compile(&query, &tx)?;
+            check_row_limit(&plan, db, &tx, |plan, tx| estimate_rows_scanned(tx, plan), &auth)?;
+            plan.execute::<_, F>(&DeltaTx::from(&*tx))
+                .map(|(rows, _)| OneOffTable {
+                    table_name: plan.table_name().to_owned().into_boxed_str(),
+                    rows,
+                })
                 .context("One-off queries are not allowed to modify the database")
         })
     }

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -282,7 +282,7 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
                     self.system_logger()
                         .info(&format!("Creating row level security `{}`", rls.sql));
 
-                    let rls = RowLevelExpr::build_row_level_expr(stdb, tx, &auth_ctx, rls)
+                    let rls = RowLevelExpr::build_row_level_expr(tx, &auth_ctx, rls)
                         .with_context(|| format!("failed to create row-level security: `{}`", rls.sql))?;
                     let table_id = rls.def.table_id;
                     let sql = rls.def.sql.clone();

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -1,5 +1,6 @@
 use super::ast::{compile_to_ast, Column, From, Join, Selection, SqlAst};
 use super::type_check::TypeCheck;
+use crate::db::datastore::locking_tx_datastore::state_view::StateView;
 use crate::db::relational_db::RelationalDB;
 use crate::error::{DBError, PlanError};
 use core::ops::Deref;
@@ -20,7 +21,7 @@ use super::ast::TableSchemaView;
 const MAX_SQL_LENGTH: usize = 50_000;
 
 /// Compile the `SQL` expression into an `ast`
-pub fn compile_sql<T: TableSchemaView>(
+pub fn compile_sql<T: TableSchemaView + StateView>(
     db: &RelationalDB,
     auth: &AuthCtx,
     tx: &T,
@@ -268,7 +269,11 @@ mod tests {
         assert!(matches!(op, Query::Select(_)));
     }
 
-    fn compile_sql<T: TableSchemaView>(db: &RelationalDB, tx: &T, sql: &str) -> Result<Vec<CrudExpr>, DBError> {
+    fn compile_sql<T: TableSchemaView + StateView>(
+        db: &RelationalDB,
+        tx: &T,
+        sql: &str,
+    ) -> Result<Vec<CrudExpr>, DBError> {
         super::compile_sql(db, &AuthCtx::for_testing(), tx, sql)
     }
 

--- a/crates/core/src/sql/parser.rs
+++ b/crates/core/src/sql/parser.rs
@@ -1,26 +1,24 @@
 use crate::db::datastore::locking_tx_datastore::MutTxId;
-use crate::db::relational_db::RelationalDB;
 use crate::sql::ast::SchemaViewer;
 use spacetimedb_expr::check::parse_and_type_sub;
 use spacetimedb_expr::errors::TypingError;
-use spacetimedb_expr::expr::Project;
+use spacetimedb_expr::expr::ProjectName;
 use spacetimedb_lib::db::raw_def::v9::RawRowLevelSecurityDefV9;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_schema::schema::RowLevelSecuritySchema;
 
 pub struct RowLevelExpr {
-    pub sql: Project,
+    pub sql: ProjectName,
     pub def: RowLevelSecuritySchema,
 }
 
 impl RowLevelExpr {
     pub fn build_row_level_expr(
-        stdb: &RelationalDB,
         tx: &mut MutTxId,
         auth_ctx: &AuthCtx,
         rls: &RawRowLevelSecurityDefV9,
     ) -> Result<Self, TypingError> {
-        let sql = parse_and_type_sub(&rls.sql, &SchemaViewer::new(stdb, tx, auth_ctx))?;
+        let sql = parse_and_type_sub(&rls.sql, &SchemaViewer::new(tx, auth_ctx))?;
 
         Ok(Self {
             def: RowLevelSecuritySchema {

--- a/crates/core/src/subscription/delta.rs
+++ b/crates/core/src/subscription/delta.rs
@@ -1,0 +1,61 @@
+use std::collections::HashMap;
+
+use anyhow::Result;
+use spacetimedb_execution::{Datastore, DeltaStore};
+use spacetimedb_query::delta::DeltaPlanEvaluator;
+use spacetimedb_vm::relation::RelValue;
+
+use crate::host::module_host::UpdatesRelValue;
+
+/// This utility deduplicates an incremental update.
+/// That is, if a row is both inserted and deleted,
+/// this method removes it from the result set.
+///
+/// Note, the 1.0 api does allow for duplicate rows.
+/// Hence this may be removed at any time after 1.0.
+pub fn eval_delta<'a, Tx: Datastore + DeltaStore>(
+    tx: &'a Tx,
+    delta: &'a DeltaPlanEvaluator,
+) -> Result<UpdatesRelValue<'a>> {
+    if !delta.is_join() {
+        return Ok(UpdatesRelValue {
+            inserts: delta.eval_inserts(tx)?.map(RelValue::from).collect(),
+            deletes: delta.eval_deletes(tx)?.map(RelValue::from).collect(),
+        });
+    }
+    if delta.has_inserts() && !delta.has_deletes() {
+        return Ok(UpdatesRelValue {
+            inserts: delta.eval_inserts(tx)?.map(RelValue::from).collect(),
+            deletes: vec![],
+        });
+    }
+    if delta.has_deletes() && !delta.has_inserts() {
+        return Ok(UpdatesRelValue {
+            deletes: delta.eval_deletes(tx)?.map(RelValue::from).collect(),
+            inserts: vec![],
+        });
+    }
+    let mut inserts = HashMap::new();
+
+    for row in delta.eval_inserts(tx)?.map(RelValue::from) {
+        inserts.entry(row).and_modify(|n| *n += 1).or_insert(1);
+    }
+
+    let deletes = delta
+        .eval_deletes(tx)?
+        .map(RelValue::from)
+        .filter(|row| match inserts.get_mut(row) {
+            None => true,
+            Some(1) => inserts.remove(row).is_none(),
+            Some(n) => {
+                *n -= 1;
+                false
+            }
+        })
+        .collect();
+
+    Ok(UpdatesRelValue {
+        inserts: inserts.into_keys().collect(),
+        deletes,
+    })
+}

--- a/crates/core/src/subscription/mod.rs
+++ b/crates/core/src/subscription/mod.rs
@@ -1,6 +1,8 @@
+pub mod delta;
 pub mod execution_unit;
 pub mod module_subscription_actor;
 pub mod module_subscription_manager;
 pub mod query;
 #[allow(clippy::module_inception)] // it's right this isn't ideal :/
 pub mod subscription;
+pub mod tx;

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -1,32 +1,28 @@
-use super::execution_unit::{ExecutionUnit, QueryHash};
-use super::module_subscription_manager::SubscriptionManager;
-use super::query::{compile_read_only_query, compile_read_only_queryset};
-use super::subscription::ExecutionSet;
+use super::execution_unit::QueryHash;
+use super::module_subscription_manager::{Plan, SubscriptionManager};
+use super::query::compile_read_only_query;
+use super::tx::DeltaTx;
 use crate::client::messages::{
     SubscriptionError, SubscriptionMessage, SubscriptionResult, SubscriptionRows, SubscriptionUpdateMessage,
     TransactionUpdateMessage,
 };
 use crate::client::{ClientActorId, ClientConnectionSender, Protocol};
 use crate::db::datastore::locking_tx_datastore::tx::TxId;
-use crate::db::datastore::system_tables::StVarTable;
 use crate::db::relational_db::{MutTx, RelationalDB, Tx};
 use crate::error::DBError;
+use crate::estimation::estimate_rows_scanned;
 use crate::execution_context::Workload;
 use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent};
 use crate::messages::websocket::Subscribe;
-use crate::sql::ast::SchemaViewer;
 use crate::vm::check_row_limit;
 use crate::worker_metrics::WORKER_METRICS;
 use parking_lot::RwLock;
 use spacetimedb_client_api_messages::websocket::{
     BsatnFormat, FormatSwitch, JsonFormat, SubscribeSingle, TableUpdate, Unsubscribe,
 };
-use spacetimedb_expr::check::compile_sql_sub;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::Identity;
-use spacetimedb_vm::errors::ErrorVm;
-use spacetimedb_vm::expr::AuthAccess;
-use std::time::Duration;
+use spacetimedb_query::{execute_plans, SubscribePlan};
 use std::{sync::Arc, time::Instant};
 
 type Subscriptions = Arc<RwLock<SubscriptionManager>>;
@@ -55,44 +51,25 @@ impl ModuleSubscriptions {
     fn evaluate_initial_subscription(
         &self,
         sender: Arc<ClientConnectionSender>,
-        query: Arc<ExecutionUnit>,
-        auth: AuthCtx,
+        query: Arc<Plan>,
         tx: &TxId,
+        auth: &AuthCtx,
     ) -> Result<FormatSwitch<TableUpdate<BsatnFormat>, TableUpdate<JsonFormat>>, DBError> {
-        query.check_auth(auth.owner, auth.caller).map_err(ErrorVm::Auth)?;
+        let comp = sender.config.compression;
+        let plan = SubscribePlan::from_delta_plan(&query);
 
         check_row_limit(
-            &query,
+            &plan,
             &self.relational_db,
             tx,
-            |query, tx| query.row_estimate(tx),
-            &auth,
+            |plan, tx| estimate_rows_scanned(tx, plan),
+            auth,
         )?;
 
-        let slow_query_threshold = StVarTable::sub_limit(&self.relational_db, tx)?.map(Duration::from_millis);
+        let tx = DeltaTx::from(tx);
         Ok(match sender.config.protocol {
-            Protocol::Binary => FormatSwitch::Bsatn(
-                query
-                    .eval(
-                        &self.relational_db,
-                        tx,
-                        &query.sql,
-                        slow_query_threshold,
-                        sender.config.compression,
-                    )
-                    .unwrap_or(TableUpdate::empty(query.return_table(), query.return_name())),
-            ),
-            Protocol::Text => FormatSwitch::Json(
-                query
-                    .eval(
-                        &self.relational_db,
-                        tx,
-                        &query.sql,
-                        slow_query_threshold,
-                        sender.config.compression,
-                    )
-                    .unwrap_or(TableUpdate::empty(query.return_table(), query.return_name())),
-            ),
+            Protocol::Binary => FormatSwitch::Bsatn(plan.collect_table_update(comp, &tx)?),
+            Protocol::Text => FormatSwitch::Json(plan.collect_table_update(comp, &tx)?),
         })
     }
 
@@ -115,17 +92,13 @@ impl ModuleSubscriptions {
         let query = if let Some(unit) = guard.query(&hash) {
             unit
         } else {
-            // NOTE: The following ensures compliance with the 1.0 sql api.
-            // Come 1.0, it will have replaced the current compilation stack.
-            compile_sql_sub(sql, &SchemaViewer::new(&self.relational_db, &*tx, &auth))?;
-
-            let compiled = compile_read_only_query(&self.relational_db, &auth, &tx, sql)?;
-            Arc::new(ExecutionUnit::new(compiled, hash)?)
+            let compiled = compile_read_only_query(&auth, &tx, sql)?;
+            Arc::new(compiled)
         };
 
         drop(guard);
 
-        let table_rows = self.evaluate_initial_subscription(sender.clone(), query.clone(), auth, &tx)?;
+        let table_rows = self.evaluate_initial_subscription(sender.clone(), query.clone(), &tx, &auth)?;
 
         // It acquires the subscription lock after `eval`, allowing `add_subscription` to run concurrently.
         // This also makes it possible for `broadcast_event` to get scheduled before the subsequent part here
@@ -152,8 +125,8 @@ impl ModuleSubscriptions {
             query_id: Some(request.query_id),
             timer: Some(timer),
             result: SubscriptionResult::Subscribe(SubscriptionRows {
-                table_id: query.return_table(),
-                table_name: query.return_name(),
+                table_id: query.table_id(),
+                table_name: query.table_name(),
                 table_rows,
             }),
         });
@@ -183,11 +156,12 @@ impl ModuleSubscriptions {
                 return Ok(());
             }
         };
-        let auth = AuthCtx::new(self.owner_identity, sender.id.identity);
+
         let tx = scopeguard::guard(self.relational_db.begin_tx(Workload::Unsubscribe), |tx| {
             self.relational_db.release_tx(tx);
         });
-        let table_rows = self.evaluate_initial_subscription(sender.clone(), query.clone(), auth, &tx)?;
+        let auth = AuthCtx::new(self.owner_identity, sender.id.identity);
+        let table_rows = self.evaluate_initial_subscription(sender.clone(), query.clone(), &tx, &auth)?;
 
         WORKER_METRICS
             .subscription_queries
@@ -198,8 +172,8 @@ impl ModuleSubscriptions {
             query_id: Some(request.query_id),
             timer: Some(timer),
             result: SubscriptionResult::Unsubscribe(SubscriptionRows {
-                table_id: query.return_table(),
-                table_name: query.return_name(),
+                table_id: query.table_id(),
+                table_name: query.table_name(),
                 table_rows,
             }),
         });
@@ -235,11 +209,7 @@ impl ModuleSubscriptions {
                 queries.extend(
                     super::subscription::get_all(&self.relational_db, &tx, &auth)?
                         .into_iter()
-                        .map(|query| {
-                            let hash = QueryHash::from_string(&query.sql);
-                            ExecutionUnit::new(query, hash).map(Arc::new)
-                        })
-                        .collect::<Result<Vec<_>, _>>()?,
+                        .map(Arc::new),
                 );
                 continue;
             }
@@ -247,58 +217,46 @@ impl ModuleSubscriptions {
             if let Some(unit) = guard.query(&hash) {
                 queries.push(unit);
             } else {
-                // NOTE: The following ensures compliance with the 1.0 sql api.
-                // Come 1.0, it will have replaced the current compilation stack.
-                compile_sql_sub(sql, &SchemaViewer::new(&self.relational_db, &*tx, &auth))?;
-
-                let mut compiled = compile_read_only_queryset(&self.relational_db, &auth, &tx, sql)?;
-                // Note that no error path is needed here.
-                // We know this vec only has a single element,
-                // since `parse_and_type_sub` guarantees it.
-                // This check will be removed come 1.0.
-                if compiled.len() == 1 {
-                    queries.push(Arc::new(ExecutionUnit::new(compiled.remove(0), hash)?));
-                }
+                let compiled = compile_read_only_query(&auth, &tx, sql)?;
+                queries.push(Arc::new(compiled));
             }
         }
 
         drop(guard);
 
-        let execution_set: ExecutionSet = queries.into();
+        let comp = sender.config.compression;
+        let plans = queries
+            .iter()
+            .map(|plan| &***plan)
+            .map(SubscribePlan::from_delta_plan)
+            .collect::<Vec<_>>();
 
-        execution_set
-            .check_auth(auth.owner, auth.caller)
-            .map_err(ErrorVm::Auth)?;
+        fn rows_scanned(tx: &TxId, plans: &[SubscribePlan]) -> u64 {
+            plans
+                .iter()
+                .map(|plan| estimate_rows_scanned(tx, plan))
+                .fold(0, |acc, n| acc.saturating_add(n))
+        }
 
         check_row_limit(
-            &execution_set,
+            &plans,
             &self.relational_db,
             &tx,
-            |execution_set, tx| execution_set.row_estimate(tx),
+            |plan, tx| rows_scanned(tx, plan),
             &auth,
         )?;
 
-        let slow_query_threshold = StVarTable::sub_limit(&self.relational_db, &tx)?.map(Duration::from_millis);
+        let tx = DeltaTx::from(&*tx);
         let database_update = match sender.config.protocol {
-            Protocol::Text => FormatSwitch::Json(execution_set.eval(
-                &self.relational_db,
-                &tx,
-                slow_query_threshold,
-                sender.config.compression,
-            )),
-            Protocol::Binary => FormatSwitch::Bsatn(execution_set.eval(
-                &self.relational_db,
-                &tx,
-                slow_query_threshold,
-                sender.config.compression,
-            )),
+            Protocol::Text => FormatSwitch::Json(execute_plans(plans, comp, &tx)?),
+            Protocol::Binary => FormatSwitch::Bsatn(execute_plans(plans, comp, &tx)?),
         };
 
         // It acquires the subscription lock after `eval`, allowing `add_subscription` to run concurrently.
         // This also makes it possible for `broadcast_event` to get scheduled before the subsequent part here
         // but that should not pose an issue.
         let mut subscriptions = self.subscriptions.write();
-        subscriptions.set_legacy_subscription(sender.clone(), execution_set.into_iter());
+        subscriptions.set_legacy_subscription(sender.clone(), queries.into_iter());
         let num_queries = subscriptions.num_unique_queries();
 
         WORKER_METRICS
@@ -345,30 +303,32 @@ impl ModuleSubscriptions {
         let stdb = &self.relational_db;
         // Downgrade mutable tx.
         // Ensure tx is released/cleaned up once out of scope.
-        let read_tx = scopeguard::guard(
-            match &mut event.status {
-                EventStatus::Committed(db_update) => {
-                    let Some((tx_data, read_tx)) = stdb.commit_tx_downgrade(tx, Workload::Update)? else {
-                        return Ok(Err(WriteConflict));
-                    };
-                    *db_update = DatabaseUpdate::from_writes(&tx_data);
-                    read_tx
-                }
-                EventStatus::Failed(_) | EventStatus::OutOfEnergy => {
-                    stdb.rollback_mut_tx_downgrade(tx, Workload::Update)
-                }
-            },
-            |tx| {
-                self.relational_db.release_tx(tx);
-            },
-        );
+        let (read_tx, tx_data) = match &mut event.status {
+            EventStatus::Committed(db_update) => {
+                let Some((tx_data, read_tx)) = stdb.commit_tx_downgrade(tx, Workload::Update)? else {
+                    return Ok(Err(WriteConflict));
+                };
+                *db_update = DatabaseUpdate::from_writes(&tx_data);
+                (read_tx, Some(tx_data))
+            }
+            EventStatus::Failed(_) | EventStatus::OutOfEnergy => {
+                (stdb.rollback_mut_tx_downgrade(tx, Workload::Update), None)
+            }
+        };
+
+        let read_tx = scopeguard::guard(read_tx, |tx| {
+            self.relational_db.release_tx(tx);
+        });
+
+        let read_tx = tx_data
+            .as_ref()
+            .map(|tx_data| DeltaTx::new(&read_tx, tx_data))
+            .unwrap_or_else(|| DeltaTx::from(&*read_tx));
+
         let event = Arc::new(event);
 
         match &event.status {
-            EventStatus::Committed(_) => {
-                let slow_query_threshold = StVarTable::incr_limit(stdb, &read_tx)?.map(Duration::from_millis);
-                subscriptions.eval_updates(stdb, &read_tx, event.clone(), caller, slow_query_threshold)
-            }
+            EventStatus::Committed(_) => subscriptions.eval_updates(&read_tx, event.clone(), caller),
             EventStatus::Failed(_) => {
                 if let Some(client) = caller {
                     let message = TransactionUpdateMessage {
@@ -398,7 +358,6 @@ mod tests {
     use crate::error::DBError;
     use crate::execution_context::Workload;
     use spacetimedb_client_api_messages::websocket::Subscribe;
-    use spacetimedb_expr::errors::{TypingError, Unresolved};
     use spacetimedb_lib::db::auth::StAccess;
     use spacetimedb_lib::{error::ResultTest, AlgebraicType, Identity};
     use spacetimedb_sats::product;
@@ -499,10 +458,7 @@ mod tests {
             "SELECT public.* FROM public JOIN private ON public.a = private.a WHERE private.a = 1",
             "SELECT private.* FROM private JOIN public ON private.a = public.a WHERE public.a = 1",
         ] {
-            assert!(matches!(
-                subscribe(sql).unwrap_err(),
-                DBError::TypeError(TypingError::Unresolved(Unresolved::Table(_)))
-            ));
+            assert!(subscribe(sql).is_err(),);
         }
 
         Ok(())

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -20,13 +20,15 @@
 //! materialized views are necessary. We find, however, that a particular kind
 //! of join query _can_ be evaluated incrementally without materialized views.
 
-use super::execution_unit::ExecutionUnit;
+use super::execution_unit::{ExecutionUnit, QueryHash};
+use super::module_subscription_manager::Plan;
 use super::query;
 use crate::db::datastore::locking_tx_datastore::tx::TxId;
 use crate::db::relational_db::{RelationalDB, Tx};
 use crate::error::{DBError, SubscriptionError};
 use crate::host::module_host::{DatabaseTableUpdate, DatabaseUpdateRelValue, UpdatesRelValue};
 use crate::messages::websocket as ws;
+use crate::sql::ast::SchemaViewer;
 use crate::vm::{build_query, TxMode};
 use anyhow::Context;
 use itertools::Either;
@@ -39,6 +41,7 @@ use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::relation::DbTable;
 use spacetimedb_lib::{Identity, ProductValue};
 use spacetimedb_primitives::TableId;
+use spacetimedb_query::delta::DeltaPlan;
 use spacetimedb_vm::expr::{self, AuthAccess, IndexJoin, Query, QueryExpr, SourceExpr, SourceProvider, SourceSet};
 use spacetimedb_vm::rel_ops::RelOps;
 use spacetimedb_vm::relation::{MemTable, RelValue};
@@ -554,6 +557,11 @@ impl ExecutionSet {
             .map(|unit| unit.row_estimate(tx))
             .fold(0, |acc, est| acc.saturating_add(est))
     }
+
+    /// Return an iterator over the execution units
+    pub fn iter(&self) -> impl Iterator<Item = &ExecutionUnit> {
+        self.exec_units.iter().map(|arc| &**arc)
+    }
 }
 
 impl FromIterator<SupportedQuery> for ExecutionSet {
@@ -602,7 +610,31 @@ impl AuthAccess for ExecutionSet {
 /// Queries all the [`StTableType::User`] tables *right now*
 /// and turns them into [`QueryExpr`],
 /// the moral equivalent of `SELECT * FROM table`.
-pub(crate) fn get_all(relational_db: &RelationalDB, tx: &Tx, auth: &AuthCtx) -> Result<Vec<SupportedQuery>, DBError> {
+pub(crate) fn get_all(relational_db: &RelationalDB, tx: &Tx, auth: &AuthCtx) -> Result<Vec<Plan>, DBError> {
+    Ok(relational_db
+        .get_all_tables(tx)?
+        .iter()
+        .map(Deref::deref)
+        .filter(|t| {
+            t.table_type == StTableType::User && (auth.owner == auth.caller || t.table_access == StAccess::Public)
+        })
+        .map(|schema| {
+            let sql = format!("SELECT * FROM {}", schema.table_name);
+            let hash = QueryHash::from_string(&sql);
+            DeltaPlan::compile(&sql, &SchemaViewer::new(tx, auth)).map(|plan| Plan::new(plan, hash))
+        })
+        .collect::<Result<_, _>>()?)
+}
+
+/// Queries all the [`StTableType::User`] tables *right now*
+/// and turns them into [`QueryExpr`],
+/// the moral equivalent of `SELECT * FROM table`.
+#[cfg(test)]
+pub(crate) fn legacy_get_all(
+    relational_db: &RelationalDB,
+    tx: &Tx,
+    auth: &AuthCtx,
+) -> Result<Vec<SupportedQuery>, DBError> {
     Ok(relational_db
         .get_all_tables(tx)?
         .iter()

--- a/crates/core/src/subscription/tx.rs
+++ b/crates/core/src/subscription/tx.rs
@@ -1,0 +1,78 @@
+use std::ops::Deref;
+
+use spacetimedb_execution::{Datastore, DeltaStore};
+use spacetimedb_lib::{query::Delta, ProductValue};
+use spacetimedb_primitives::TableId;
+use spacetimedb_table::{blob_store::BlobStore, table::Table};
+
+use crate::db::datastore::{locking_tx_datastore::tx::TxId, traits::TxData};
+
+/// A wrapper around a read only tx delta queries
+pub struct DeltaTx<'a> {
+    tx: &'a TxId,
+    data: Option<&'a TxData>,
+}
+
+impl<'a> DeltaTx<'a> {
+    pub fn new(tx: &'a TxId, data: &'a TxData) -> Self {
+        Self { tx, data: Some(data) }
+    }
+}
+
+impl<'a> Deref for DeltaTx<'a> {
+    type Target = TxId;
+
+    fn deref(&self) -> &Self::Target {
+        self.tx
+    }
+}
+
+impl<'a> From<&'a TxId> for DeltaTx<'a> {
+    fn from(tx: &'a TxId) -> Self {
+        Self { tx, data: None }
+    }
+}
+
+impl Datastore for DeltaTx<'_> {
+    fn table(&self, table_id: TableId) -> Option<&Table> {
+        self.tx.table(table_id)
+    }
+
+    fn blob_store(&self) -> &dyn BlobStore {
+        self.tx.blob_store()
+    }
+}
+
+impl DeltaStore for DeltaTx<'_> {
+    fn has_inserts(&self, table_id: TableId) -> Option<Delta> {
+        self.data.and_then(|data| {
+            data.inserts()
+                .find(|(id, rows)| **id == table_id && !rows.is_empty())
+                .map(|(_, rows)| Delta::Inserts(rows.len()))
+        })
+    }
+
+    fn has_deletes(&self, table_id: TableId) -> Option<Delta> {
+        self.data.and_then(|data| {
+            data.deletes()
+                .find(|(id, rows)| **id == table_id && !rows.is_empty())
+                .map(|(_, rows)| Delta::Deletes(rows.len()))
+        })
+    }
+
+    fn inserts_for_table(&self, table_id: TableId) -> Option<std::slice::Iter<'_, ProductValue>> {
+        self.data.and_then(|data| {
+            data.inserts()
+                .find(|(id, rows)| **id == table_id && !rows.is_empty())
+                .map(|(_, rows)| rows.iter())
+        })
+    }
+
+    fn deletes_for_table(&self, table_id: TableId) -> Option<std::slice::Iter<'_, ProductValue>> {
+        self.data.and_then(|data| {
+            data.deletes()
+                .find(|(id, rows)| **id == table_id && !rows.is_empty())
+                .map(|(_, rows)| rows.iter())
+        })
+    }
+}

--- a/crates/execution/src/iter.rs
+++ b/crates/execution/src/iter.rs
@@ -1,243 +1,80 @@
-use std::ops::{Bound, RangeBounds};
+use std::collections::{HashMap, HashSet};
 
-use spacetimedb_lib::{AlgebraicValue, ProductValue};
-use spacetimedb_primitives::{IndexId, TableId};
+use anyhow::{anyhow, bail, Result};
+use spacetimedb_lib::{query::Delta, AlgebraicValue, ProductValue};
+use spacetimedb_physical_plan::plan::{
+    HashJoin, IxJoin, IxScan, PhysicalExpr, PhysicalPlan, ProjectField, ProjectPlan, Sarg, Semi, TupleField,
+};
 use spacetimedb_table::{
     blob_store::BlobStore,
     btree_index::{BTreeIndex, BTreeIndexRangeIter},
-    static_assert_size,
-    table::{IndexScanIter, RowRef, Table, TableScanIter},
+    table::{IndexScanIter, Table, TableScanIter},
 };
 
-/// A row from a base table in the form of a pointer or product value
-#[derive(Clone)]
-pub enum Row<'a> {
-    Ptr(RowRef<'a>),
-    Ref(&'a ProductValue),
+use crate::{Datastore, DeltaScanIter, DeltaStore, Row, Tuple};
+
+/// The different iterators for evaluating query plans
+pub enum PlanIter<'a> {
+    Table(TableScanIter<'a>),
+    Index(IndexScanIter<'a>),
+    Delta(DeltaScanIter<'a>),
+    RowId(RowRefIter<'a>),
+    Tuple(ProjectIter<'a>),
 }
 
-impl Row<'_> {
-    /// Expect a pointer value, panic otherwise
-    pub fn expect_ptr(&self) -> &RowRef {
-        match self {
-            Self::Ptr(ptr) => ptr,
-            _ => unreachable!(),
-        }
-    }
-
-    /// Expect a product value, panic otherwise
-    pub fn expect_ref(&self) -> &ProductValue {
-        match self {
-            Self::Ref(r) => r,
-            _ => unreachable!(),
-        }
-    }
-}
-
-static_assert_size!(Row, 32);
-
-/// A tuple returned by a query iterator
-#[derive(Clone)]
-pub enum Tuple<'a> {
-    /// A row from a base table
-    Row(Row<'a>),
-    /// A temporary constructed by a query operator
-    Join(Vec<Row<'a>>),
-}
-
-static_assert_size!(Tuple, 40);
-
-impl Tuple<'_> {
-    /// Expect a row from a base table, panic otherwise
-    pub fn expect_row(&self) -> &Row {
-        match self {
-            Self::Row(row) => row,
-            _ => unreachable!(),
-        }
-    }
-
-    /// Expect a temporary tuple, panic otherwise
-    pub fn expect_join(&self) -> &[Row] {
-        match self {
-            Self::Join(elems) => elems.as_slice(),
-            _ => unreachable!(),
-        }
+impl<'a> PlanIter<'a> {
+    pub(crate) fn build<Tx>(plan: &'a ProjectPlan, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        ProjectIter::build(plan, tx).map(|iter| match iter {
+            ProjectIter::None(Iter::Row(RowRefIter::TableScan(iter))) => Self::Table(iter),
+            ProjectIter::None(Iter::Row(RowRefIter::IndexScan(iter))) => Self::Index(iter),
+            ProjectIter::None(Iter::Row(iter)) => Self::RowId(iter),
+            _ => Self::Tuple(iter),
+        })
     }
 }
 
-/// An execution plan for a tuple-at-a-time iterator.
-/// As the name suggests it is meant to be cached.
-/// Building the iterator should incur minimal overhead.
-pub struct CachedIterPlan {
-    /// The relational ops
-    iter_ops: Box<[IterOp]>,
-    /// The expression ops
-    expr_ops: Box<[OpCode]>,
-    /// The constants referenced by the plan
-    constants: Box<[AlgebraicValue]>,
+/// Implements a tuple projection for a query plan
+pub enum ProjectIter<'a> {
+    None(Iter<'a>),
+    Some(Iter<'a>, usize),
 }
 
-static_assert_size!(CachedIterPlan, 48);
-
-impl CachedIterPlan {
-    /// Returns an interator over the query ops
-    fn ops(&self) -> impl Iterator<Item = IterOp> + '_ {
-        self.iter_ops.iter().copied()
-    }
-
-    /// Lookup a constant in the plan
-    fn constant(&self, i: u16) -> &AlgebraicValue {
-        &self.constants[i as usize]
-    }
-}
-
-/// An opcode for a tuple-at-a-time execution plan
-#[derive(Clone, Copy)]
-pub enum IterOp {
-    /// A table scan opcode takes 1 arg: A [TableId]
-    TableScan(TableId),
-    /// A delta scan opcode takes 1 arg: A [TableId]
-    DeltaScan(TableId),
-    /// An index scan opcode takes 2 args:
-    /// 1. An [IndexId]
-    /// 2. A ptr to an [AlgebraicValue]
-    IxScanEq(IndexId, u16),
-    /// An index range scan opcode takes 3 args:
-    /// 1. An [IndexId]
-    /// 2. A ptr to the lower bound
-    /// 3. A ptr to the upper bound
-    IxScanRange(IndexId, Bound<u16>, Bound<u16>),
-    /// Pops its 2 args from the stack
-    NLJoin,
-    /// An index join opcode takes 2 args:
-    /// 1. An [IndexId]
-    /// 2. An instruction ptr
-    /// 3. A length
-    IxJoin(IndexId, usize, u16),
-    /// An index join opcode takes 2 args:
-    /// 1. An [IndexId]
-    /// 2. An instruction ptr
-    /// 3. A length
-    UniqueIxJoin(IndexId, usize, u16),
-    /// A filter opcode takes 2 args:
-    /// 1. An instruction ptr
-    /// 2. A length
-    Filter(usize, u32),
-}
-
-static_assert_size!(IterOp, 16);
-
-pub trait Datastore {
-    fn delta_scan_iter(&self, table_id: TableId) -> DeltaScanIter;
-    fn table_scan_iter(&self, table_id: TableId) -> TableScanIter;
-    fn index_scan_iter(&self, index_id: IndexId, range: &impl RangeBounds<AlgebraicValue>) -> IndexScanIter;
-    fn get_table_for_index(&self, index_id: &IndexId) -> &Table;
-    fn get_index(&self, index_id: &IndexId) -> &BTreeIndex;
-    fn get_blob_store(&self) -> &dyn BlobStore;
-}
-
-/// An iterator for a delta table
-pub struct DeltaScanIter<'a> {
-    iter: std::slice::Iter<'a, ProductValue>,
-}
-
-impl<'a> Iterator for DeltaScanIter<'a> {
-    type Item = &'a ProductValue;
+impl<'a> Iterator for ProjectIter<'a> {
+    type Item = Row<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
-    }
-}
-
-impl CachedIterPlan {
-    pub fn iter<'a>(&'a self, tx: &'a impl Datastore) -> Iter<'a> {
-        let mut stack = vec![];
-        for op in self.ops() {
-            match op {
-                IterOp::TableScan(table_id) => {
-                    // Push table scan
-                    stack.push(Iter::TableScan(tx.table_scan_iter(table_id)));
+        match self {
+            Self::None(iter) => iter.find_map(|tuple| {
+                if let Tuple::Row(ptr) = tuple {
+                    return Some(ptr);
                 }
-                IterOp::DeltaScan(table_id) => {
-                    // Push delta scan
-                    stack.push(Iter::DeltaScan(tx.delta_scan_iter(table_id)));
-                }
-                IterOp::IxScanEq(index_id, ptr) => {
-                    // Push index scan
-                    stack.push(Iter::IndexScan(tx.index_scan_iter(index_id, &self.constant(ptr))));
-                }
-                IterOp::IxScanRange(index_id, lower, upper) => {
-                    // Push range scan
-                    let lower = lower.map(|ptr| self.constant(ptr));
-                    let upper = upper.map(|ptr| self.constant(ptr));
-                    stack.push(Iter::IndexScan(tx.index_scan_iter(index_id, &(lower, upper))));
-                }
-                IterOp::NLJoin => {
-                    // Pop args and push nested loop join
-                    let rhs = stack.pop().unwrap();
-                    let lhs = stack.pop().unwrap();
-                    stack.push(Iter::NLJoin(NestedLoopJoin::new(lhs, rhs)));
-                }
-                IterOp::IxJoin(index_id, i, n) => {
-                    // Pop arg and push index join
-                    let input = stack.pop().unwrap();
-                    let index = tx.get_index(&index_id);
-                    let table = tx.get_table_for_index(&index_id);
-                    let blob_store = tx.get_blob_store();
-                    let ops = &self.expr_ops[i..i + n as usize];
-                    let program = ExprProgram::new(ops, &self.constants);
-                    let projection = ProgramEvaluator::from(program);
-                    stack.push(Iter::IxJoin(LeftDeepJoin::Eq(IndexJoin::new(
-                        input, index, table, blob_store, projection,
-                    ))));
-                }
-                IterOp::UniqueIxJoin(index_id, i, n) => {
-                    // Pop arg and push index join
-                    let input = stack.pop().unwrap();
-                    let index = tx.get_index(&index_id);
-                    let table = tx.get_table_for_index(&index_id);
-                    let blob_store = tx.get_blob_store();
-                    let ops = &self.expr_ops[i..i + n as usize];
-                    let program = ExprProgram::new(ops, &self.constants);
-                    let projection = ProgramEvaluator::from(program);
-                    stack.push(Iter::UniqueIxJoin(LeftDeepJoin::Eq(UniqueIndexJoin::new(
-                        input, index, table, blob_store, projection,
-                    ))));
-                }
-                IterOp::Filter(i, n) => {
-                    // Pop arg and push filter
-                    let input = Box::new(stack.pop().unwrap());
-                    let ops = &self.expr_ops[i..i + n as usize];
-                    let program = ExprProgram::new(ops, &self.constants);
-                    let program = ProgramEvaluator::from(program);
-                    stack.push(Iter::Filter(Filter { input, program }));
-                }
-            }
+                None
+            }),
+            Self::Some(iter, i) => iter.find_map(|tuple| tuple.select(*i)),
         }
-        stack.pop().unwrap()
     }
 }
 
-/// A tuple-at-a-time query iterator.
-/// Notice there is no explicit projection operation.
-/// This is because for applicable plans,
-/// the optimizer can remove intermediate projections,
-/// implementing a form of late materialization.
+impl<'a> ProjectIter<'a> {
+    pub fn build<Tx>(plan: &'a ProjectPlan, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        match plan {
+            ProjectPlan::None(plan) | ProjectPlan::Name(plan, _, None) => Iter::build(plan, tx).map(Self::None),
+            ProjectPlan::Name(plan, _, Some(i)) => Iter::build(plan, tx).map(|iter| Self::Some(iter, *i)),
+        }
+    }
+}
+
+/// A generic tuple-at-a-time iterator for a query plan
 pub enum Iter<'a> {
-    /// A [RowRef] table iterator
-    TableScan(TableScanIter<'a>),
-    /// A [ProductValue] ref iterator
-    DeltaScan(DeltaScanIter<'a>),
-    /// A [RowRef] index iterator
-    IndexScan(IndexScanIter<'a>),
-    /// A nested loop join iterator
-    NLJoin(NestedLoopJoin<'a>),
-    /// A non-unique (constraint) index join iterator
-    IxJoin(LeftDeepJoin<IndexJoin<'a>>),
-    /// A unique (constraint) index join iterator
-    UniqueIxJoin(LeftDeepJoin<UniqueIndexJoin<'a>>),
-    /// A tuple-at-a-time filter iterator
-    Filter(Filter<'a>),
+    Row(RowRefIter<'a>),
+    Join(LeftDeepJoinIter<'a>),
+    Filter(Filter<'a, Iter<'a>>),
 }
 
 impl<'a> Iterator for Iter<'a> {
@@ -245,297 +82,967 @@ impl<'a> Iterator for Iter<'a> {
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            Self::TableScan(iter) => {
-                // Returns row ids
-                iter.next().map(Row::Ptr).map(Tuple::Row)
+            Self::Row(iter) => iter.next().map(Tuple::Row),
+            Self::Join(iter) => iter.next(),
+            Self::Filter(iter) => iter.next(),
+        }
+    }
+}
+
+impl<'a> Iter<'a> {
+    fn build<Tx>(plan: &'a PhysicalPlan, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        match plan {
+            PhysicalPlan::TableScan(..) | PhysicalPlan::IxScan(..) => RowRefIter::build(plan, tx).map(Self::Row),
+            PhysicalPlan::Filter(input, expr) => {
+                // Build a filter iterator
+                Iter::build(input, tx)
+                    .map(Box::new)
+                    .map(|input| Filter { input, expr })
+                    .map(Iter::Filter)
             }
-            Self::DeltaScan(iter) => {
-                // Returns product refs
-                iter.next().map(Row::Ref).map(Tuple::Row)
+            PhysicalPlan::NLJoin(lhs, rhs) => {
+                // Build a nested loop join iterator
+                NLJoin::build_from(lhs, rhs, tx)
+                    .map(LeftDeepJoinIter::NLJoin)
+                    .map(Iter::Join)
             }
-            Self::IndexScan(iter) => {
-                // Returns row ids
-                iter.next().map(Row::Ptr).map(Tuple::Row)
+            PhysicalPlan::IxJoin(join @ IxJoin { unique: false, .. }, Semi::Lhs) => {
+                // Build a left index semijoin iterator
+                IxJoinLhs::build_from(join, tx)
+                    .map(SemiJoin::Lhs)
+                    .map(LeftDeepJoinIter::IxJoin)
+                    .map(Iter::Join)
             }
-            Self::IxJoin(iter) => {
-                // Returns row ids for semijoins, (n+1)-tuples otherwise
-                iter.next()
+            PhysicalPlan::IxJoin(join @ IxJoin { unique: false, .. }, Semi::Rhs) => {
+                // Build a right index semijoin iterator
+                IxJoinRhs::build_from(join, tx)
+                    .map(SemiJoin::Rhs)
+                    .map(LeftDeepJoinIter::IxJoin)
+                    .map(Iter::Join)
             }
-            Self::UniqueIxJoin(iter) => {
-                // Returns row ids for semijoins, (n+1)-tuples otherwise
-                iter.next()
+            PhysicalPlan::IxJoin(join @ IxJoin { unique: false, .. }, Semi::All) => {
+                // Build an index join iterator
+                IxJoinIter::build_from(join, tx)
+                    .map(SemiJoin::All)
+                    .map(LeftDeepJoinIter::IxJoin)
+                    .map(Iter::Join)
             }
-            Self::Filter(iter) => {
-                // Filter is a passthru
-                iter.next()
+            PhysicalPlan::IxJoin(join @ IxJoin { unique: true, .. }, Semi::Lhs) => {
+                // Build a unique left index semijoin iterator
+                UniqueIxJoinLhs::build_from(join, tx)
+                    .map(SemiJoin::Lhs)
+                    .map(LeftDeepJoinIter::UniqueIxJoin)
+                    .map(Iter::Join)
             }
-            Self::NLJoin(iter) => {
-                iter.next().map(|t| {
-                    match t {
-                        // A leaf join
-                        //   x
-                        //  / \
-                        // a   b
-                        (Tuple::Row(u), Tuple::Row(v)) => {
-                            // Returns a 2-tuple
-                            Tuple::Join(vec![u, v])
-                        }
-                        // A right deep join
-                        //   x
-                        //  / \
-                        // a   x
-                        //    / \
-                        //   b   c
-                        (Tuple::Row(r), Tuple::Join(mut rows)) => {
-                            // Returns an (n+1)-tuple
-                            let mut pointers = vec![r];
-                            pointers.append(&mut rows);
-                            Tuple::Join(pointers)
-                        }
-                        // A left deep join
-                        //     x
-                        //    / \
-                        //   x   c
-                        //  / \
-                        // a   b
-                        (Tuple::Join(mut rows), Tuple::Row(r)) => {
-                            // Returns an (n+1)-tuple
-                            rows.push(r);
-                            Tuple::Join(rows)
-                        }
-                        // A bushy join
-                        //      x
-                        //     / \
-                        //    /   \
-                        //   x     x
-                        //  / \   / \
-                        // a   b c   d
-                        (Tuple::Join(mut lhs), Tuple::Join(mut rhs)) => {
-                            // Returns an (n+m)-tuple
-                            lhs.append(&mut rhs);
-                            Tuple::Join(lhs)
-                        }
-                    }
-                })
+            PhysicalPlan::IxJoin(join @ IxJoin { unique: true, .. }, Semi::Rhs) => {
+                // Build a unique right index semijoin iterator
+                UniqueIxJoinRhs::build_from(join, tx)
+                    .map(SemiJoin::Rhs)
+                    .map(LeftDeepJoinIter::UniqueIxJoin)
+                    .map(Iter::Join)
+            }
+            PhysicalPlan::IxJoin(join @ IxJoin { unique: true, .. }, Semi::All) => {
+                // Build a unique index join iterator
+                UniqueIxJoin::build_from(join, tx)
+                    .map(SemiJoin::All)
+                    .map(LeftDeepJoinIter::UniqueIxJoin)
+                    .map(Iter::Join)
+            }
+            PhysicalPlan::HashJoin(join @ HashJoin { unique: false, .. }, Semi::Lhs) => {
+                // Build a left hash semijoin iterator
+                HashJoinLhs::build_from(join, tx)
+                    .map(SemiJoin::Lhs)
+                    .map(LeftDeepJoinIter::HashJoin)
+                    .map(Iter::Join)
+            }
+            PhysicalPlan::HashJoin(join @ HashJoin { unique: false, .. }, Semi::Rhs) => {
+                // Build a right hash semijoin iterator
+                HashJoinRhs::build_from(join, tx)
+                    .map(SemiJoin::Rhs)
+                    .map(LeftDeepJoinIter::HashJoin)
+                    .map(Iter::Join)
+            }
+            PhysicalPlan::HashJoin(join @ HashJoin { unique: false, .. }, Semi::All) => {
+                // Build a hash join iterator
+                HashJoinIter::build_from(join, tx)
+                    .map(SemiJoin::All)
+                    .map(LeftDeepJoinIter::HashJoin)
+                    .map(Iter::Join)
+            }
+            PhysicalPlan::HashJoin(join @ HashJoin { unique: true, .. }, Semi::Lhs) => {
+                // Build a unique left hash semijoin iterator
+                UniqueHashJoinLhs::build_from(join, tx)
+                    .map(SemiJoin::Lhs)
+                    .map(LeftDeepJoinIter::UniqueHashJoin)
+                    .map(Iter::Join)
+            }
+            PhysicalPlan::HashJoin(join @ HashJoin { unique: true, .. }, Semi::Rhs) => {
+                // Build a unique right hash semijoin iterator
+                UniqueHashJoinRhs::build_from(join, tx)
+                    .map(SemiJoin::Rhs)
+                    .map(LeftDeepJoinIter::UniqueHashJoin)
+                    .map(Iter::Join)
+            }
+            PhysicalPlan::HashJoin(join @ HashJoin { unique: true, .. }, Semi::All) => {
+                // Build a unique hash join iterator
+                UniqueHashJoin::build_from(join, tx)
+                    .map(SemiJoin::All)
+                    .map(LeftDeepJoinIter::UniqueHashJoin)
+                    .map(Iter::Join)
             }
         }
     }
 }
 
-/// An iterator for a left deep join tree
-pub enum LeftDeepJoin<Iter> {
-    /// A standard join
-    Eq(Iter),
-    /// A semijoin that returns the lhs
-    SemiLhs(Iter),
-    /// A semijion that returns the rhs
-    SemiRhs(Iter),
+/// An iterator that always returns [RowRef]s
+pub enum RowRefIter<'a> {
+    TableScan(TableScanIter<'a>),
+    IndexScan(IndexScanIter<'a>),
+    DeltaScan(DeltaScanIter<'a>),
+    RowFilter(Filter<'a, RowRefIter<'a>>),
 }
 
-impl<'a, Iter> Iterator for LeftDeepJoin<Iter>
+impl<'a> Iterator for RowRefIter<'a> {
+    type Item = Row<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::TableScan(iter) => iter.next().map(Row::Ptr),
+            Self::IndexScan(iter) => iter.next().map(Row::Ptr),
+            Self::DeltaScan(iter) => iter.next().map(Row::Ref),
+            Self::RowFilter(iter) => iter.next(),
+        }
+    }
+}
+
+impl<'a> RowRefIter<'a> {
+    /// Instantiate an iterator from a [PhysicalPlan].
+    /// The compiler ensures this isn't called on a join.
+    fn build<Tx>(plan: &'a PhysicalPlan, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let concat = |prefix: &[(_, AlgebraicValue)], v| {
+            ProductValue::from_iter(prefix.iter().map(|(_, v)| v).chain([v]).cloned())
+        };
+        match plan {
+            PhysicalPlan::TableScan(schema, _, None) => tx.table_scan(schema.table_id).map(Self::TableScan),
+            PhysicalPlan::TableScan(schema, _, Some(Delta::Inserts(..))) => {
+                tx.delta_scan(schema.table_id, true).map(Self::DeltaScan)
+            }
+            PhysicalPlan::TableScan(schema, _, Some(Delta::Deletes(..))) => {
+                tx.delta_scan(schema.table_id, false).map(Self::DeltaScan)
+            }
+            PhysicalPlan::IxScan(
+                scan @ IxScan {
+                    arg: Sarg::Eq(_, v), ..
+                },
+                _,
+            ) if scan.prefix.is_empty() => tx
+                .index_scan(scan.schema.table_id, scan.index_id, v)
+                .map(Self::IndexScan),
+            PhysicalPlan::IxScan(
+                scan @ IxScan {
+                    arg: Sarg::Eq(_, v), ..
+                },
+                _,
+            ) => tx
+                .index_scan(
+                    scan.schema.table_id,
+                    scan.index_id,
+                    &AlgebraicValue::product(concat(&scan.prefix, v)),
+                )
+                .map(Self::IndexScan),
+            PhysicalPlan::IxScan(
+                scan @ IxScan {
+                    arg: Sarg::Range(_, lower, upper),
+                    ..
+                },
+                _,
+            ) if scan.prefix.is_empty() => tx
+                .index_scan(scan.schema.table_id, scan.index_id, &(lower.as_ref(), upper.as_ref()))
+                .map(Self::IndexScan),
+            PhysicalPlan::IxScan(
+                scan @ IxScan {
+                    arg: Sarg::Range(_, lower, upper),
+                    ..
+                },
+                _,
+            ) => tx
+                .index_scan(
+                    scan.schema.table_id,
+                    scan.index_id,
+                    &(
+                        lower
+                            .as_ref()
+                            .map(|v| concat(&scan.prefix, v))
+                            .map(AlgebraicValue::Product),
+                        upper
+                            .as_ref()
+                            .map(|v| concat(&scan.prefix, v))
+                            .map(AlgebraicValue::Product),
+                    ),
+                )
+                .map(Self::IndexScan),
+            PhysicalPlan::Filter(input, expr) => Self::build(input, tx)
+                .map(Box::new)
+                .map(|input| Filter { input, expr })
+                .map(Self::RowFilter),
+            _ => bail!("Plan does not return row ids"),
+        }
+    }
+}
+
+/// An iterator for a left deep join tree.
+///
+/// ```text
+///     x
+///    / \
+///   x   c
+///  / \
+/// a   b
+/// ```
+pub enum LeftDeepJoinIter<'a> {
+    /// A nested loop join
+    NLJoin(NLJoin<'a>),
+    /// An index join
+    IxJoin(SemiJoin<IxJoinIter<'a>, IxJoinLhs<'a>, IxJoinRhs<'a>>),
+    /// An index join for a unique constraint
+    UniqueIxJoin(SemiJoin<UniqueIxJoin<'a>, UniqueIxJoinLhs<'a>, UniqueIxJoinRhs<'a>>),
+    /// A hash join
+    HashJoin(SemiJoin<HashJoinIter<'a>, HashJoinLhs<'a>, HashJoinRhs<'a>>),
+    /// A hash join for a unique constraint
+    UniqueHashJoin(SemiJoin<UniqueHashJoin<'a>, UniqueHashJoinLhs<'a>, UniqueHashJoinRhs<'a>>),
+}
+
+impl<'a> Iterator for LeftDeepJoinIter<'a> {
+    type Item = Tuple<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self {
+            Self::NLJoin(iter) => iter.next().map(|(tuple, rhs)| tuple.append(rhs)),
+            Self::IxJoin(iter) => iter.next(),
+            Self::UniqueIxJoin(iter) => iter.next(),
+            Self::HashJoin(iter) => iter.next(),
+            Self::UniqueHashJoin(iter) => iter.next(),
+        }
+    }
+}
+
+/// A semijoin iterator.
+/// Returns [RowRef]s if this is a right semijoin.
+/// Returns [Tuple]s otherwise.
+pub enum SemiJoin<All, Lhs, Rhs> {
+    All(All),
+    Lhs(Lhs),
+    Rhs(Rhs),
+}
+
+impl<'a, All, Lhs, Rhs> Iterator for SemiJoin<All, Lhs, Rhs>
 where
-    Iter: Iterator<Item = (Tuple<'a>, RowRef<'a>)>,
+    All: Iterator<Item = (Tuple<'a>, Row<'a>)>,
+    Lhs: Iterator<Item = Tuple<'a>>,
+    Rhs: Iterator<Item = Row<'a>>,
 {
     type Item = Tuple<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
         match self {
-            Self::SemiLhs(iter) => {
-                // Return the lhs tuple
-                iter.next().map(|(t, _)| t)
-            }
-            Self::SemiRhs(iter) => {
-                // Return the rhs row
-                iter.next().map(|(_, ptr)| ptr).map(Row::Ptr).map(Tuple::Row)
-            }
-            Self::Eq(iter) => {
-                iter.next().map(|(tuple, ptr)| {
-                    match (tuple, ptr) {
-                        // A leaf join
-                        //   x
-                        //  / \
-                        // a   b
-                        (Tuple::Row(u), ptr) => {
-                            // Returns a 2-tuple
-                            Tuple::Join(vec![u, Row::Ptr(ptr)])
-                        }
-                        // A left deep join
-                        //     x
-                        //    / \
-                        //   x   c
-                        //  / \
-                        // a   b
-                        (Tuple::Join(mut rows), ptr) => {
-                            // Returns an (n+1)-tuple
-                            rows.push(Row::Ptr(ptr));
-                            Tuple::Join(rows)
-                        }
-                    }
-                })
-            }
+            Self::All(iter) => iter.next().map(|(tuple, ptr)| tuple.append(ptr)),
+            Self::Lhs(iter) => iter.next(),
+            Self::Rhs(iter) => iter.next().map(Tuple::Row),
         }
     }
 }
 
-/// A unique (constraint) index join iterator
-pub struct UniqueIndexJoin<'a> {
+/// An index join that uses a unique constraint index
+pub struct UniqueIxJoin<'a> {
     /// The lhs of the join
-    input: Box<Iter<'a>>,
+    lhs: Box<Iter<'a>>,
     /// The rhs index
-    index: &'a BTreeIndex,
+    rhs_index: &'a BTreeIndex,
     /// A handle to the datastore
-    table: &'a Table,
+    rhs_table: &'a Table,
     /// A handle to the blobstore
     blob_store: &'a dyn BlobStore,
-    /// The lhs index key projection
-    projection: ProgramEvaluator<'a>,
+    /// The lhs probe field
+    lhs_field: &'a TupleField,
 }
 
-impl<'a> UniqueIndexJoin<'a> {
-    fn new(
-        input: Iter<'a>,
-        index: &'a BTreeIndex,
-        table: &'a Table,
-        blob_store: &'a dyn BlobStore,
-        projection: ProgramEvaluator<'a>,
-    ) -> Self {
-        Self {
-            input: Box::new(input),
-            index,
-            table,
-            blob_store,
-            projection,
-        }
+impl<'a> UniqueIxJoin<'a> {
+    fn build_from<Tx>(join: &'a IxJoin, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(&join.lhs, tx)?;
+        let rhs_table = tx.table_or_err(join.rhs.table_id)?;
+        let rhs_index = rhs_table
+            .get_index(join.rhs_index)
+            .ok_or_else(|| anyhow!("IndexId `{}` does not exist", join.rhs_index))?;
+        Ok(Self {
+            lhs: Box::new(lhs),
+            rhs_index,
+            rhs_table,
+            blob_store: tx.blob_store(),
+            lhs_field: &join.lhs_field,
+        })
     }
 }
 
-impl<'a> Iterator for UniqueIndexJoin<'a> {
-    type Item = (Tuple<'a>, RowRef<'a>);
+impl<'a> Iterator for UniqueIxJoin<'a> {
+    type Item = (Tuple<'a>, Row<'a>);
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.input.find_map(|tuple| {
-            self.index
-                .seek(&self.projection.eval(&tuple))
+        self.lhs.find_map(|tuple| {
+            self.rhs_index
+                .seek(&tuple.project(self.lhs_field))
                 .next()
-                .and_then(|ptr| self.table.get_row_ref(self.blob_store, ptr))
+                .and_then(|ptr| self.rhs_table.get_row_ref(self.blob_store, ptr))
+                .map(Row::Ptr)
                 .map(|ptr| (tuple, ptr))
         })
     }
 }
 
-/// A non-unique (constraint) index join iterator
-pub struct IndexJoin<'a> {
+/// A left semijoin that uses a unique constraint index
+pub struct UniqueIxJoinLhs<'a> {
     /// The lhs of the join
-    input: Box<Iter<'a>>,
-    /// The current tuple from the lhs
-    tuple: Option<Tuple<'a>>,
+    lhs: Box<Iter<'a>>,
     /// The rhs index
-    index: &'a BTreeIndex,
-    /// The current cursor for the rhs index
-    index_cursor: Option<BTreeIndexRangeIter<'a>>,
-    /// A handle to the datastore
-    table: &'a Table,
-    /// A handle to the blobstore
-    blob_store: &'a dyn BlobStore,
-    /// The lhs index key projection
-    projection: ProgramEvaluator<'a>,
+    rhs: &'a BTreeIndex,
+    /// The lhs probe field
+    lhs_field: &'a TupleField,
 }
 
-impl<'a> IndexJoin<'a> {
-    fn new(
-        input: Iter<'a>,
-        index: &'a BTreeIndex,
-        table: &'a Table,
-        blob_store: &'a dyn BlobStore,
-        projection: ProgramEvaluator<'a>,
-    ) -> Self {
-        Self {
-            input: Box::new(input),
-            tuple: None,
-            index,
-            index_cursor: None,
-            table,
-            blob_store,
-            projection,
-        }
+impl<'a> UniqueIxJoinLhs<'a> {
+    fn build_from<Tx>(join: &'a IxJoin, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(&join.lhs, tx)?;
+        let rhs_table = tx.table_or_err(join.rhs.table_id)?;
+        let rhs_index = rhs_table
+            .get_index(join.rhs_index)
+            .ok_or_else(|| anyhow!("IndexId `{}` does not exist", join.rhs_index))?;
+        Ok(Self {
+            lhs: Box::new(lhs),
+            rhs: rhs_index,
+            lhs_field: &join.lhs_field,
+        })
     }
 }
 
-impl<'a> Iterator for IndexJoin<'a> {
-    type Item = (Tuple<'a>, RowRef<'a>);
+impl<'a> Iterator for UniqueIxJoinLhs<'a> {
+    type Item = Tuple<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.tuple
+        self.lhs.find(|t| self.rhs.contains_any(&t.project(self.lhs_field)))
+    }
+}
+
+/// A right semijoin that uses a unique constraint index
+pub struct UniqueIxJoinRhs<'a> {
+    /// The lhs of the join
+    lhs: Box<Iter<'a>>,
+    /// The rhs index
+    rhs_index: &'a BTreeIndex,
+    /// A handle to the datastore
+    rhs_table: &'a Table,
+    /// A handle to the blobstore
+    blob_store: &'a dyn BlobStore,
+    /// The lhs probe field
+    lhs_field: &'a TupleField,
+}
+
+impl<'a> UniqueIxJoinRhs<'a> {
+    fn build_from<Tx>(join: &'a IxJoin, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(&join.lhs, tx)?;
+        let rhs_table = tx.table_or_err(join.rhs.table_id)?;
+        let rhs_index = rhs_table
+            .get_index(join.rhs_index)
+            .ok_or_else(|| anyhow!("IndexId `{}` does not exist", join.rhs_index))?;
+        Ok(Self {
+            lhs: Box::new(lhs),
+            rhs_index,
+            rhs_table,
+            blob_store: tx.blob_store(),
+            lhs_field: &join.lhs_field,
+        })
+    }
+}
+
+impl<'a> Iterator for UniqueIxJoinRhs<'a> {
+    type Item = Row<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.lhs.find_map(|tuple| {
+            self.rhs_index
+                .seek(&tuple.project(self.lhs_field))
+                .next()
+                .and_then(|ptr| self.rhs_table.get_row_ref(self.blob_store, ptr))
+                .map(Row::Ptr)
+        })
+    }
+}
+
+/// An index join that does not use a unique constraint index
+pub struct IxJoinIter<'a> {
+    /// The lhs of the join
+    lhs: Box<Iter<'a>>,
+    /// The current lhs tuple
+    lhs_tuple: Option<Tuple<'a>>,
+    /// The rhs index
+    rhs_index: &'a BTreeIndex,
+    /// The current rhs index cursor
+    rhs_index_cursor: Option<BTreeIndexRangeIter<'a>>,
+    /// A handle to the datastore
+    rhs_table: &'a Table,
+    /// A handle to the blobstore
+    blob_store: &'a dyn BlobStore,
+    /// The lhs probe field
+    lhs_field: &'a TupleField,
+}
+
+impl<'a> IxJoinIter<'a> {
+    fn build_from<Tx>(join: &'a IxJoin, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(&join.lhs, tx)?;
+        let rhs_table = tx.table_or_err(join.rhs.table_id)?;
+        let rhs_index = rhs_table
+            .get_index(join.rhs_index)
+            .ok_or_else(|| anyhow!("IndexId `{}` does not exist", join.rhs_index))?;
+        Ok(Self {
+            lhs: Box::new(lhs),
+            lhs_tuple: None,
+            rhs_index,
+            rhs_index_cursor: None,
+            rhs_table,
+            blob_store: tx.blob_store(),
+            lhs_field: &join.lhs_field,
+        })
+    }
+}
+
+impl<'a> Iterator for IxJoinIter<'a> {
+    type Item = (Tuple<'a>, Row<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.lhs_tuple
             .as_ref()
             .and_then(|tuple| {
-                self.index_cursor.as_mut().and_then(|cursor| {
+                self.rhs_index_cursor.as_mut().and_then(|cursor| {
                     cursor.next().and_then(|ptr| {
-                        self.table
+                        self.rhs_table
                             .get_row_ref(self.blob_store, ptr)
+                            .map(Row::Ptr)
                             .map(|ptr| (tuple.clone(), ptr))
                     })
                 })
             })
             .or_else(|| {
-                self.input.find_map(|tuple| {
-                    Some(self.index.seek(&self.projection.eval(&tuple))).and_then(|mut cursor| {
-                        cursor.next().and_then(|ptr| {
-                            self.table.get_row_ref(self.blob_store, ptr).map(|ptr| {
-                                self.tuple = Some(tuple.clone());
-                                self.index_cursor = Some(cursor);
+                self.lhs.find_map(|tuple| {
+                    let mut cursor = self.rhs_index.seek(&tuple.project(self.lhs_field));
+                    cursor.next().and_then(|ptr| {
+                        self.rhs_table
+                            .get_row_ref(self.blob_store, ptr)
+                            .map(Row::Ptr)
+                            .map(|ptr| {
+                                self.lhs_tuple = Some(tuple.clone());
+                                self.rhs_index_cursor = Some(cursor);
                                 (tuple, ptr)
                             })
-                        })
                     })
                 })
             })
     }
 }
 
-/// A nested loop join returns the cross product of its inputs
-pub struct NestedLoopJoin<'a> {
-    /// The lhs input
+/// A left semijoin that does not use a unique constraint index
+pub struct IxJoinLhs<'a> {
+    /// The lhs of the join
     lhs: Box<Iter<'a>>,
-    /// The rhs input
-    rhs: Box<Iter<'a>>,
-    /// The materialized rhs
-    build: Vec<Tuple<'a>>,
+    /// The rhs index
+    rhs_index: &'a BTreeIndex,
     /// The current lhs tuple
-    lhs_row: Option<Tuple<'a>>,
-    /// The current rhs tuple
-    rhs_ptr: usize,
+    lhs_tuple: Option<Tuple<'a>>,
+    /// The matching rhs row count
+    rhs_count: usize,
+    /// The lhs probe field
+    lhs_field: &'a TupleField,
 }
 
-impl<'a> NestedLoopJoin<'a> {
-    fn new(lhs: Iter<'a>, rhs: Iter<'a>) -> Self {
-        Self {
+impl<'a> IxJoinLhs<'a> {
+    fn build_from<Tx>(join: &'a IxJoin, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(&join.lhs, tx)?;
+        let rhs_table = tx.table_or_err(join.rhs.table_id)?;
+        let rhs_index = rhs_table
+            .get_index(join.rhs_index)
+            .ok_or_else(|| anyhow!("IndexId `{}` does not exist", join.rhs_index))?;
+        Ok(Self {
             lhs: Box::new(lhs),
-            rhs: Box::new(rhs),
-            build: vec![],
-            lhs_row: None,
-            rhs_ptr: 0,
+            lhs_tuple: None,
+            rhs_count: 0,
+            rhs_index,
+            lhs_field: &join.lhs_field,
+        })
+    }
+}
+
+impl<'a> Iterator for IxJoinLhs<'a> {
+    type Item = Tuple<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.rhs_count {
+            0 => self
+                .lhs
+                .find_map(|tuple| self.rhs_index.count(&tuple.project(self.lhs_field)).map(|n| (tuple, n)))
+                .map(|(tuple, n)| {
+                    self.rhs_count = n - 1;
+                    self.lhs_tuple = Some(tuple.clone());
+                    tuple
+                }),
+            _ => {
+                self.rhs_count -= 1;
+                self.lhs_tuple.clone()
+            }
         }
     }
 }
 
-impl<'a> Iterator for NestedLoopJoin<'a> {
-    type Item = (Tuple<'a>, Tuple<'a>);
+/// A right semijoin that does not use a unique constraint index
+pub struct IxJoinRhs<'a> {
+    /// The lhs of the join
+    lhs: Box<Iter<'a>>,
+    /// The rhs index
+    rhs_index: &'a BTreeIndex,
+    /// The current rhs index cursor
+    rhs_index_cursor: Option<BTreeIndexRangeIter<'a>>,
+    /// A handle to the datastore
+    rhs_table: &'a Table,
+    /// A handle to the blobstore
+    blob_store: &'a dyn BlobStore,
+    /// The lhs probe field
+    lhs_field: &'a TupleField,
+}
+
+impl<'a> IxJoinRhs<'a> {
+    fn build_from<Tx>(join: &'a IxJoin, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(&join.lhs, tx)?;
+        let rhs_table = tx.table_or_err(join.rhs.table_id)?;
+        let rhs_index = rhs_table
+            .get_index(join.rhs_index)
+            .ok_or_else(|| anyhow!("IndexId `{}` does not exist", join.rhs_index))?;
+        Ok(Self {
+            lhs: Box::new(lhs),
+            rhs_index,
+            rhs_index_cursor: None,
+            rhs_table,
+            blob_store: tx.blob_store(),
+            lhs_field: &join.lhs_field,
+        })
+    }
+}
+
+impl<'a> Iterator for IxJoinRhs<'a> {
+    type Item = Row<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        for t in self.rhs.as_mut() {
-            self.build.push(t);
+        self.rhs_index_cursor
+            .as_mut()
+            .and_then(|cursor| {
+                cursor
+                    .next()
+                    .and_then(|ptr| self.rhs_table.get_row_ref(self.blob_store, ptr))
+                    .map(Row::Ptr)
+            })
+            .or_else(|| {
+                self.lhs.find_map(|tuple| {
+                    let mut cursor = self.rhs_index.seek(&tuple.project(self.lhs_field));
+                    cursor.next().and_then(|ptr| {
+                        self.rhs_table
+                            .get_row_ref(self.blob_store, ptr)
+                            .map(Row::Ptr)
+                            .map(|ptr| {
+                                self.rhs_index_cursor = Some(cursor);
+                                ptr
+                            })
+                    })
+                })
+            })
+    }
+}
+
+/// A hash join that on each probe,
+/// returns at most one row from the hash table.
+pub struct UniqueHashJoin<'a> {
+    /// The lhs relation
+    lhs: Box<Iter<'a>>,
+    /// The rhs hash table
+    rhs: HashMap<AlgebraicValue, Row<'a>>,
+    /// The lhs probe field
+    lhs_field: &'a TupleField,
+}
+
+impl<'a> UniqueHashJoin<'a> {
+    /// Builds a hash table over the rhs
+    fn build_from<Tx>(join: &'a HashJoin, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(&join.lhs, tx)?;
+        let rhs = RowRefIter::build(&join.rhs, tx)?;
+        let rhs = rhs.map(|ptr| (ptr.project(&join.rhs_field), ptr)).collect();
+        Ok(Self {
+            lhs: Box::new(lhs),
+            rhs,
+            lhs_field: &join.lhs_field,
+        })
+    }
+}
+
+impl<'a> Iterator for UniqueHashJoin<'a> {
+    type Item = (Tuple<'a>, Row<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.lhs.find_map(|tuple| {
+            self.rhs
+                .get(&tuple.project(self.lhs_field))
+                .cloned()
+                .map(|ptr| (tuple, ptr))
+        })
+    }
+}
+
+/// A left hash semijoin that on each probe,
+/// returns at most one row from the hash table.
+pub struct UniqueHashJoinLhs<'a> {
+    /// The lhs relation
+    lhs: Box<Iter<'a>>,
+    /// The rhs hash table
+    rhs: HashSet<AlgebraicValue>,
+    /// The lhs probe field
+    lhs_field: &'a TupleField,
+}
+
+impl<'a> UniqueHashJoinLhs<'a> {
+    /// Builds a hash set over the rhs
+    fn build_from<Tx>(join: &'a HashJoin, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(&join.lhs, tx)?;
+        let rhs = RowRefIter::build(&join.rhs, tx)?;
+        let rhs = rhs.map(|ptr| ptr.project(&join.rhs_field)).collect();
+        Ok(Self {
+            lhs: Box::new(lhs),
+            rhs,
+            lhs_field: &join.lhs_field,
+        })
+    }
+}
+
+impl<'a> Iterator for UniqueHashJoinLhs<'a> {
+    type Item = Tuple<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.lhs.find(|t| self.rhs.contains(&t.project(self.lhs_field)))
+    }
+}
+
+/// A right hash join that on each probe,
+/// returns at most one row from the hash table.
+pub struct UniqueHashJoinRhs<'a> {
+    /// The lhs relation
+    lhs: Box<Iter<'a>>,
+    /// The rhs hash table
+    rhs: HashMap<AlgebraicValue, Row<'a>>,
+    /// The lhs probe field
+    lhs_field: &'a TupleField,
+}
+
+impl<'a> UniqueHashJoinRhs<'a> {
+    /// Builds a hash table over the rhs
+    fn build_from<Tx>(join: &'a HashJoin, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(&join.lhs, tx)?;
+        let rhs = RowRefIter::build(&join.rhs, tx)?;
+        let rhs = rhs.map(|ptr| (ptr.project(&join.rhs_field), ptr)).collect();
+        Ok(Self {
+            lhs: Box::new(lhs),
+            rhs,
+            lhs_field: &join.lhs_field,
+        })
+    }
+}
+
+impl<'a> Iterator for UniqueHashJoinRhs<'a> {
+    type Item = Row<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.lhs.find_map(|t| self.rhs.get(&t.project(self.lhs_field)).cloned())
+    }
+}
+
+/// A hash join that on each probe,
+/// may return many rows from the hash table.
+pub struct HashJoinIter<'a> {
+    /// The lhs relation
+    lhs: Box<Iter<'a>>,
+    /// The rhs hash table
+    rhs: HashMap<AlgebraicValue, Vec<Row<'a>>>,
+    /// The current lhs tuple
+    lhs_tuple: Option<Tuple<'a>>,
+    /// The current rhs row pointer
+    rhs_ptr: usize,
+    /// The lhs probe field
+    lhs_field: &'a TupleField,
+}
+
+impl<'a> HashJoinIter<'a> {
+    /// Builds a hash table over the rhs
+    fn build_from<Tx>(join: &'a HashJoin, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(&join.lhs, tx)?;
+        let rhs_iter = RowRefIter::build(&join.rhs, tx)?;
+        let mut rhs = HashMap::new();
+        for ptr in rhs_iter {
+            let val = ptr.project(&join.rhs_field);
+            match rhs.get_mut(&val) {
+                None => {
+                    rhs.insert(val, vec![ptr]);
+                }
+                Some(ptrs) => {
+                    ptrs.push(ptr);
+                }
+            }
         }
-        match self.build.get(self.rhs_ptr) {
+        Ok(Self {
+            lhs: Box::new(lhs),
+            rhs,
+            lhs_tuple: None,
+            rhs_ptr: 0,
+            lhs_field: &join.lhs_field,
+        })
+    }
+}
+
+impl<'a> Iterator for HashJoinIter<'a> {
+    type Item = (Tuple<'a>, Row<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.lhs_tuple
+            .as_ref()
+            .and_then(|tuple| {
+                self.rhs.get(&tuple.project(self.lhs_field)).and_then(|ptrs| {
+                    let i = self.rhs_ptr;
+                    self.rhs_ptr += 1;
+                    ptrs.get(i).map(|ptr| (tuple.clone(), ptr.clone()))
+                })
+            })
+            .or_else(|| {
+                self.lhs.find_map(|tuple| {
+                    self.rhs.get(&tuple.project(self.lhs_field)).and_then(|ptrs| {
+                        self.rhs_ptr = 1;
+                        self.lhs_tuple = Some(tuple.clone());
+                        ptrs.first().map(|ptr| (tuple, ptr.clone()))
+                    })
+                })
+            })
+    }
+}
+
+/// A left hash semijoin that on each probe,
+/// may return many rows from the hash table.
+pub struct HashJoinLhs<'a> {
+    /// The lhs relation
+    lhs: Box<Iter<'a>>,
+    /// The rhs hash table
+    rhs: HashMap<AlgebraicValue, usize>,
+    /// The current lhs tuple
+    lhs_tuple: Option<Tuple<'a>>,
+    /// The matching number of rhs rows
+    rhs_count: usize,
+    /// The lhs probe field
+    lhs_field: &'a TupleField,
+}
+
+impl<'a> HashJoinLhs<'a> {
+    /// Instantiates the iterator by building a hash table over the rhs
+    fn build_from<Tx>(join: &'a HashJoin, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(&join.lhs, tx)?;
+        let rhs_iter = RowRefIter::build(&join.rhs, tx)?;
+        let mut rhs = HashMap::new();
+        for ptr in rhs_iter {
+            rhs.entry(ptr.project(&join.rhs_field))
+                .and_modify(|n| *n += 1)
+                .or_insert_with(|| 1);
+        }
+        Ok(Self {
+            lhs: Box::new(lhs),
+            rhs,
+            lhs_tuple: None,
+            rhs_count: 0,
+            lhs_field: &join.lhs_field,
+        })
+    }
+}
+
+impl<'a> Iterator for HashJoinLhs<'a> {
+    type Item = Tuple<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.rhs_count {
+            0 => self.lhs.find_map(|tuple| {
+                self.rhs.get(&tuple.project(self.lhs_field)).map(|n| {
+                    self.rhs_count = *n - 1;
+                    self.lhs_tuple = Some(tuple.clone());
+                    tuple
+                })
+            }),
+            _ => {
+                self.rhs_count -= 1;
+                self.lhs_tuple.clone()
+            }
+        }
+    }
+}
+
+/// A right hash semijoin that on each probe,
+/// may return many rows from the hash table.
+pub struct HashJoinRhs<'a> {
+    /// The lhs relation
+    lhs: Box<Iter<'a>>,
+    /// The rhs hash table
+    rhs: HashMap<AlgebraicValue, Vec<Row<'a>>>,
+    /// The current lhs tuple
+    lhs_value: Option<AlgebraicValue>,
+    /// The current rhs row pointer
+    rhs_ptr: usize,
+    /// The lhs probe field
+    lhs_field: &'a TupleField,
+}
+
+impl<'a> HashJoinRhs<'a> {
+    /// Builds a hash table over the rhs
+    fn build_from<Tx>(join: &'a HashJoin, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(&join.lhs, tx)?;
+        let rhs_iter = RowRefIter::build(&join.rhs, tx)?;
+        let mut rhs = HashMap::new();
+        for ptr in rhs_iter {
+            let val = ptr.project(&join.rhs_field);
+            match rhs.get_mut(&val) {
+                None => {
+                    rhs.insert(val, vec![ptr]);
+                }
+                Some(ptrs) => {
+                    ptrs.push(ptr);
+                }
+            }
+        }
+        Ok(Self {
+            lhs: Box::new(lhs),
+            rhs,
+            lhs_value: None,
+            rhs_ptr: 0,
+            lhs_field: &join.lhs_field,
+        })
+    }
+}
+
+impl<'a> Iterator for HashJoinRhs<'a> {
+    type Item = Row<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.lhs_value
+            .as_ref()
+            .and_then(|value| {
+                self.rhs.get(value).and_then(|ptrs| {
+                    let i = self.rhs_ptr;
+                    self.rhs_ptr += 1;
+                    ptrs.get(i).cloned()
+                })
+            })
+            .or_else(|| {
+                self.lhs.find_map(|tuple| {
+                    let value = tuple.project(self.lhs_field);
+                    self.rhs.get(&value).and_then(|ptrs| {
+                        self.rhs_ptr = 1;
+                        self.lhs_value = Some(value.clone());
+                        ptrs.first().cloned()
+                    })
+                })
+            })
+    }
+}
+
+/// A nested loop join iterator
+pub struct NLJoin<'a> {
+    /// The lhs input
+    lhs: Box<Iter<'a>>,
+    /// The materialized rhs
+    rhs: Vec<Row<'a>>,
+    /// The current lhs tuple
+    lhs_tuple: Option<Tuple<'a>>,
+    /// The current rhs row pointer
+    rhs_ptr: usize,
+}
+
+impl<'a> NLJoin<'a> {
+    /// Instantiates the iterator by materializing the rhs
+    fn build_from<Tx>(lhs: &'a PhysicalPlan, rhs: &'a PhysicalPlan, tx: &'a Tx) -> Result<Self>
+    where
+        Tx: Datastore + DeltaStore,
+    {
+        let lhs = Iter::build(lhs, tx)?;
+        let rhs = RowRefIter::build(rhs, tx)?;
+        Ok(Self {
+            lhs: Box::new(lhs),
+            rhs: rhs.collect(),
+            lhs_tuple: None,
+            rhs_ptr: 0,
+        })
+    }
+}
+
+impl<'a> Iterator for NLJoin<'a> {
+    type Item = (Tuple<'a>, Row<'a>);
+
+    fn next(&mut self) -> Option<Self::Item> {
+        match self.rhs.get(self.rhs_ptr) {
             Some(v) => {
                 self.rhs_ptr += 1;
-                self.lhs_row.as_ref().map(|u| (u.clone(), v.clone()))
+                self.lhs_tuple.as_ref().map(|u| (u.clone(), v.clone()))
             }
             None => {
                 self.rhs_ptr = 1;
-                self.lhs_row = self.lhs.next();
-                self.lhs_row
+                self.lhs_tuple = self.lhs.next();
+                self.lhs_tuple
                     .as_ref()
-                    .zip(self.build.first())
+                    .zip(self.rhs.first())
                     .map(|(u, v)| (u.clone(), v.clone()))
             }
         }
@@ -543,205 +1050,23 @@ impl<'a> Iterator for NestedLoopJoin<'a> {
 }
 
 /// A tuple-at-a-time filter iterator
-pub struct Filter<'a> {
-    input: Box<Iter<'a>>,
-    program: ProgramEvaluator<'a>,
+pub struct Filter<'a, I> {
+    input: Box<I>,
+    expr: &'a PhysicalExpr,
 }
 
-impl<'a> Iterator for Filter<'a> {
+impl<'a> Iterator for Filter<'a, RowRefIter<'a>> {
+    type Item = Row<'a>;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.input.find(|ptr| self.expr.eval_bool(ptr))
+    }
+}
+
+impl<'a> Iterator for Filter<'a, Iter<'a>> {
     type Item = Tuple<'a>;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.input
-            .find(|tuple| self.program.eval(tuple).as_bool().is_some_and(|ok| *ok))
-    }
-}
-
-/// An opcode for a stack-based expression evaluator
-#[derive(Clone, Copy)]
-pub enum OpCode {
-    /// ==
-    Eq,
-    /// <>
-    Ne,
-    /// <
-    Lt,
-    /// >
-    Gt,
-    /// <=
-    Lte,
-    /// <=
-    Gte,
-    /// AND
-    And,
-    /// OR
-    Or,
-    /// 5
-    Const(u16),
-    /// ||
-    Concat(u16),
-    /// r.0 : [Row::Ptr]
-    PtrProj(u16),
-    /// r.0 : [Row::Ref]
-    RefProj(u16),
-    /// r.0.1 : [Row::Ptr]
-    TupPtrProj(u16),
-    /// r.0.1 : [Row::Ref]
-    TupRefProj(u16),
-}
-
-static_assert_size!(OpCode, 4);
-
-/// A program for evaluating a scalar expression
-pub struct ExprProgram<'a> {
-    /// The instructions or opcodes
-    ops: &'a [OpCode],
-    /// The constants in the original expression
-    constants: &'a [AlgebraicValue],
-}
-
-impl<'a> ExprProgram<'a> {
-    fn new(ops: &'a [OpCode], constants: &'a [AlgebraicValue]) -> Self {
-        Self { ops, constants }
-    }
-
-    /// Returns an interator over the opcodes
-    fn ops(&self) -> impl Iterator<Item = OpCode> + '_ {
-        self.ops.iter().copied()
-    }
-
-    /// Lookup a constant in the plan
-    fn constant(&self, i: u16) -> AlgebraicValue {
-        self.constants[i as usize].clone()
-    }
-}
-
-/// An evaluator for an [ExprProgram]
-pub struct ProgramEvaluator<'a> {
-    program: ExprProgram<'a>,
-    stack: Vec<AlgebraicValue>,
-}
-
-impl<'a> From<ExprProgram<'a>> for ProgramEvaluator<'a> {
-    fn from(program: ExprProgram<'a>) -> Self {
-        Self { program, stack: vec![] }
-    }
-}
-
-impl ProgramEvaluator<'_> {
-    pub fn eval(&mut self, tuple: &Tuple) -> AlgebraicValue {
-        for op in self.program.ops() {
-            match op {
-                OpCode::Const(i) => {
-                    self.stack.push(self.program.constant(i));
-                }
-                OpCode::Eq => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
-                    self.stack.push(AlgebraicValue::Bool(l == r));
-                }
-                OpCode::Ne => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
-                    self.stack.push(AlgebraicValue::Bool(l != r));
-                }
-                OpCode::Lt => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
-                    self.stack.push(AlgebraicValue::Bool(l < r));
-                }
-                OpCode::Gt => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
-                    self.stack.push(AlgebraicValue::Bool(l > r));
-                }
-                OpCode::Lte => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
-                    self.stack.push(AlgebraicValue::Bool(l <= r));
-                }
-                OpCode::Gte => {
-                    let r = self.stack.pop().unwrap();
-                    let l = self.stack.pop().unwrap();
-                    self.stack.push(AlgebraicValue::Bool(l >= r));
-                }
-                OpCode::And => {
-                    let r = *self.stack.pop().unwrap().as_bool().unwrap();
-                    let l = *self.stack.pop().unwrap().as_bool().unwrap();
-                    self.stack.push(AlgebraicValue::Bool(l && r));
-                }
-                OpCode::Or => {
-                    let r = *self.stack.pop().unwrap().as_bool().unwrap();
-                    let l = *self.stack.pop().unwrap().as_bool().unwrap();
-                    self.stack.push(AlgebraicValue::Bool(l || r));
-                }
-                OpCode::Concat(n) => {
-                    let mut elems = Vec::with_capacity(n as usize);
-                    // Pop args off stack
-                    for _ in 0..n {
-                        elems.push(self.stack.pop().unwrap());
-                    }
-                    // Concat and push on stack
-                    self.stack.push(AlgebraicValue::Product(ProductValue::from_iter(
-                        elems.into_iter().rev(),
-                    )));
-                }
-                OpCode::PtrProj(i) => {
-                    self.stack.push(
-                        tuple
-                            // Read field from row ref
-                            .expect_row()
-                            .expect_ptr()
-                            .read_col(i as usize)
-                            .unwrap(),
-                    );
-                }
-                OpCode::RefProj(i) => {
-                    self.stack.push(
-                        tuple
-                            // Read field from product ref
-                            .expect_row()
-                            .expect_ref()
-                            .elements[i as usize]
-                            .clone(),
-                    );
-                }
-                OpCode::TupPtrProj(i) => {
-                    let idx = *self
-                        // Pop index off stack
-                        .stack
-                        .pop()
-                        .unwrap()
-                        .as_u16()
-                        .unwrap();
-                    self.stack.push(
-                        tuple
-                            // Read field from row ref
-                            .expect_join()[idx as usize]
-                            .expect_ptr()
-                            .read_col(i as usize)
-                            .unwrap(),
-                    );
-                }
-                OpCode::TupRefProj(i) => {
-                    let idx = *self
-                        // Pop index off stack
-                        .stack
-                        .pop()
-                        .unwrap()
-                        .as_u16()
-                        .unwrap();
-                    self.stack.push(
-                        tuple
-                            // Read field from product ref
-                            .expect_join()[idx as usize]
-                            .expect_ptr()
-                            .read_col(i as usize)
-                            .unwrap(),
-                    );
-                }
-            }
-        }
-        self.stack.pop().unwrap()
+        self.input.find(|tuple| self.expr.eval_bool(tuple))
     }
 }

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -1,1 +1,176 @@
+use std::ops::RangeBounds;
+
+use anyhow::{anyhow, Result};
+use iter::PlanIter;
+use spacetimedb_lib::{
+    bsatn::{EncodeError, ToBsatn},
+    query::Delta,
+    ser::Serialize,
+    AlgebraicValue, ProductValue,
+};
+use spacetimedb_physical_plan::plan::{ProjectField, ProjectPlan, TupleField};
+use spacetimedb_primitives::{IndexId, TableId};
+use spacetimedb_table::{
+    blob_store::BlobStore,
+    static_assert_size,
+    table::{IndexScanIter, RowRef, Table, TableScanIter},
+};
+
 pub mod iter;
+
+/// The datastore interface required for building an executor
+pub trait Datastore {
+    fn table(&self, table_id: TableId) -> Option<&Table>;
+    fn blob_store(&self) -> &dyn BlobStore;
+
+    fn table_or_err(&self, table_id: TableId) -> Result<&Table> {
+        self.table(table_id)
+            .ok_or_else(|| anyhow!("TableId `{table_id}` does not exist"))
+    }
+
+    fn table_scan(&self, table_id: TableId) -> Result<TableScanIter> {
+        self.table(table_id)
+            .map(|table| table.scan_rows(self.blob_store()))
+            .ok_or_else(|| anyhow!("TableId `{table_id}` does not exist"))
+    }
+
+    fn index_scan(
+        &self,
+        table_id: TableId,
+        index_id: IndexId,
+        range: &impl RangeBounds<AlgebraicValue>,
+    ) -> Result<IndexScanIter> {
+        self.table(table_id)
+            .ok_or_else(|| anyhow!("TableId `{table_id}` does not exist"))
+            .and_then(|table| {
+                table
+                    .index_seek_by_id(self.blob_store(), index_id, range)
+                    .ok_or_else(|| anyhow!("IndexId `{index_id}` does not exist"))
+            })
+    }
+}
+
+pub trait DeltaStore {
+    fn has_inserts(&self, table_id: TableId) -> Option<Delta>;
+    fn has_deletes(&self, table_id: TableId) -> Option<Delta>;
+
+    fn inserts_for_table(&self, table_id: TableId) -> Option<std::slice::Iter<'_, ProductValue>>;
+    fn deletes_for_table(&self, table_id: TableId) -> Option<std::slice::Iter<'_, ProductValue>>;
+
+    fn delta_scan(&self, table_id: TableId, inserts: bool) -> Result<DeltaScanIter> {
+        match inserts {
+            true => self
+                .inserts_for_table(table_id)
+                .ok_or_else(|| anyhow!("TableId `{table_id}` does not exist"))
+                .map(|iter| DeltaScanIter { iter }),
+            false => self
+                .deletes_for_table(table_id)
+                .ok_or_else(|| anyhow!("TableId `{table_id}` does not exist"))
+                .map(|iter| DeltaScanIter { iter }),
+        }
+    }
+}
+
+#[derive(Clone, Serialize)]
+pub enum Row<'a> {
+    Ptr(RowRef<'a>),
+    Ref(&'a ProductValue),
+}
+
+impl ToBsatn for Row<'_> {
+    fn static_bsatn_size(&self) -> Option<u16> {
+        match self {
+            Self::Ptr(ptr) => ptr.static_bsatn_size(),
+            Self::Ref(val) => val.static_bsatn_size(),
+        }
+    }
+
+    fn to_bsatn_extend(&self, buf: &mut Vec<u8>) -> std::result::Result<(), EncodeError> {
+        match self {
+            Self::Ptr(ptr) => ptr.to_bsatn_extend(buf),
+            Self::Ref(val) => val.to_bsatn_extend(buf),
+        }
+    }
+
+    fn to_bsatn_vec(&self) -> std::result::Result<Vec<u8>, EncodeError> {
+        match self {
+            Self::Ptr(ptr) => ptr.to_bsatn_vec(),
+            Self::Ref(val) => val.to_bsatn_vec(),
+        }
+    }
+}
+
+impl ProjectField for Row<'_> {
+    fn project(&self, field: &TupleField) -> AlgebraicValue {
+        match self {
+            Self::Ptr(ptr) => ptr.read_col(field.field_pos).unwrap(),
+            Self::Ref(val) => val.elements.get(field.field_pos).unwrap().clone(),
+        }
+    }
+}
+
+/// Each query operator returns a tuple of [RowRef]s
+#[derive(Clone)]
+pub enum Tuple<'a> {
+    /// A pointer to a row in a base table
+    Row(Row<'a>),
+    /// A temporary returned by a join operator
+    Join(Vec<Row<'a>>),
+}
+
+static_assert_size!(Tuple, 40);
+
+impl ProjectField for Tuple<'_> {
+    fn project(&self, field: &TupleField) -> AlgebraicValue {
+        match self {
+            Self::Row(row) => row.project(field),
+            Self::Join(ptrs) => field
+                .label_pos
+                .and_then(|i| ptrs.get(i))
+                .map(|ptr| ptr.project(field))
+                .unwrap(),
+        }
+    }
+}
+
+impl<'a> Tuple<'a> {
+    /// Select the tuple element at position `i`
+    fn select(self, i: usize) -> Option<Row<'a>> {
+        match self {
+            Self::Row(_) => None,
+            Self::Join(mut ptrs) => Some(ptrs.swap_remove(i)),
+        }
+    }
+
+    /// Append a [Row] to a tuple
+    fn append(self, ptr: Row<'a>) -> Self {
+        match self {
+            Self::Row(row) => Self::Join(vec![row, ptr]),
+            Self::Join(mut rows) => {
+                rows.push(ptr);
+                Self::Join(rows)
+            }
+        }
+    }
+}
+
+pub struct DeltaScanIter<'a> {
+    iter: std::slice::Iter<'a, ProductValue>,
+}
+
+impl<'a> Iterator for DeltaScanIter<'a> {
+    type Item = &'a ProductValue;
+
+    fn next(&mut self) -> Option<Self::Item> {
+        self.iter.next()
+    }
+}
+
+/// Execute a query plan.
+/// The actual execution is driven by `f`.
+pub fn execute_plan<T, R>(plan: &ProjectPlan, tx: &T, f: impl Fn(PlanIter) -> R) -> Result<R>
+where
+    T: Datastore + DeltaStore,
+{
+    PlanIter::build(plan, tx).map(f)
+}

--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -2,9 +2,10 @@ use std::collections::HashMap;
 use std::ops::{Deref, DerefMut};
 use std::sync::Arc;
 
-use crate::expr::{Expr, Project};
+use crate::expr::{Expr, ProjectList, ProjectName, Relvar};
 use crate::{expr::LeftDeepJoin, statement::Statement};
 use spacetimedb_lib::AlgebraicType;
+use spacetimedb_primitives::TableId;
 use spacetimedb_schema::schema::TableSchema;
 use spacetimedb_sql_parser::ast::BinOp;
 use spacetimedb_sql_parser::{
@@ -23,7 +24,12 @@ pub type TypingResult<T> = core::result::Result<T, TypingError>;
 
 /// A view of the database schema
 pub trait SchemaView {
-    fn schema(&self, name: &str) -> Option<Arc<TableSchema>>;
+    fn table_id(&self, name: &str) -> Option<TableId>;
+    fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableSchema>>;
+
+    fn schema(&self, name: &str) -> Option<Arc<TableSchema>> {
+        self.table_id(name).and_then(|table_id| self.schema_for_table(table_id))
+    }
 }
 
 #[derive(Default)]
@@ -46,21 +52,29 @@ pub trait TypeChecker {
     type Ast;
     type Set;
 
-    fn type_ast(ast: Self::Ast, tx: &impl SchemaView) -> TypingResult<Project>;
+    fn type_ast(ast: Self::Ast, tx: &impl SchemaView) -> TypingResult<ProjectList>;
 
-    fn type_set(ast: Self::Set, vars: &mut Relvars, tx: &impl SchemaView) -> TypingResult<Project>;
+    fn type_set(ast: Self::Set, vars: &mut Relvars, tx: &impl SchemaView) -> TypingResult<ProjectList>;
 
     fn type_from(from: SqlFrom, vars: &mut Relvars, tx: &impl SchemaView) -> TypingResult<RelExpr> {
         match from {
             SqlFrom::Expr(SqlIdent(name), SqlIdent(alias)) => {
                 let schema = Self::type_relvar(tx, &name)?;
                 vars.insert(alias.clone(), schema.clone());
-                Ok(RelExpr::RelVar(schema, alias))
+                Ok(RelExpr::RelVar(Relvar {
+                    schema,
+                    alias,
+                    delta: None,
+                }))
             }
             SqlFrom::Join(SqlIdent(name), SqlIdent(alias), joins) => {
                 let schema = Self::type_relvar(tx, &name)?;
                 vars.insert(alias.clone(), schema.clone());
-                let mut join = RelExpr::RelVar(schema, alias);
+                let mut join = RelExpr::RelVar(Relvar {
+                    schema,
+                    alias,
+                    delta: None,
+                });
 
                 for SqlJoin {
                     var: SqlIdent(name),
@@ -73,23 +87,26 @@ pub trait TypeChecker {
                         return Err(DuplicateName(alias.into_string()).into());
                     }
 
-                    let rhs = Self::type_relvar(tx, &name)?;
                     let lhs = Box::new(join);
-                    let var = alias;
+                    let rhs = Relvar {
+                        schema: Self::type_relvar(tx, &name)?,
+                        alias,
+                        delta: None,
+                    };
 
-                    vars.insert(var.clone(), rhs.clone());
+                    vars.insert(rhs.alias.clone(), rhs.schema.clone());
 
                     if let Some(on) = on {
                         if let Expr::BinOp(BinOp::Eq, a, b) = type_expr(vars, on, Some(&AlgebraicType::Bool))? {
                             if let (Expr::Field(a), Expr::Field(b)) = (*a, *b) {
-                                join = RelExpr::EqJoin(LeftDeepJoin { lhs, rhs, var }, a, b);
+                                join = RelExpr::EqJoin(LeftDeepJoin { lhs, rhs }, a, b);
                                 continue;
                             }
                         }
                         unreachable!("Unreachability guaranteed by parser")
                     }
 
-                    join = RelExpr::LeftDeepJoin(LeftDeepJoin { lhs, rhs, var });
+                    join = RelExpr::LeftDeepJoin(LeftDeepJoin { lhs, rhs });
                 }
 
                 Ok(join)
@@ -111,11 +128,11 @@ impl TypeChecker for SubChecker {
     type Ast = SqlSelect;
     type Set = SqlSelect;
 
-    fn type_ast(ast: Self::Ast, tx: &impl SchemaView) -> TypingResult<Project> {
+    fn type_ast(ast: Self::Ast, tx: &impl SchemaView) -> TypingResult<ProjectList> {
         Self::type_set(ast, &mut Relvars::default(), tx)
     }
 
-    fn type_set(ast: Self::Set, vars: &mut Relvars, tx: &impl SchemaView) -> TypingResult<Project> {
+    fn type_set(ast: Self::Set, vars: &mut Relvars, tx: &impl SchemaView) -> TypingResult<ProjectList> {
         match ast {
             SqlSelect {
                 project,
@@ -138,26 +155,30 @@ impl TypeChecker for SubChecker {
 }
 
 /// Parse and type check a subscription query
-pub fn parse_and_type_sub(sql: &str, tx: &impl SchemaView) -> TypingResult<Project> {
+pub fn parse_and_type_sub(sql: &str, tx: &impl SchemaView) -> TypingResult<ProjectName> {
     expect_table_type(SubChecker::type_ast(parse_subscription(sql)?, tx)?)
+}
+
+/// Type check a subscription query
+pub fn type_subscription(ast: SqlSelect, tx: &impl SchemaView) -> TypingResult<ProjectName> {
+    expect_table_type(SubChecker::type_ast(ast, tx)?)
 }
 
 /// Parse and type check a *subscription* query into a `StatementCtx`
 pub fn compile_sql_sub<'a>(sql: &'a str, tx: &impl SchemaView) -> TypingResult<StatementCtx<'a>> {
-    let expr = parse_and_type_sub(sql, tx)?;
     Ok(StatementCtx {
-        statement: Statement::Select(expr),
+        statement: Statement::Select(ProjectList::Name(parse_and_type_sub(sql, tx)?)),
         sql,
         source: StatementSource::Subscription,
     })
 }
 
 /// Returns an error if the input type is not a table type or relvar
-fn expect_table_type(expr: Project) -> TypingResult<Project> {
-    if let Project::Fields(..) = expr {
-        return Err(Unsupported::ReturnType.into());
+fn expect_table_type(expr: ProjectList) -> TypingResult<ProjectName> {
+    match expr {
+        ProjectList::Name(proj) => Ok(proj),
+        ProjectList::List(..) => Err(Unsupported::ReturnType.into()),
     }
-    Ok(expr)
 }
 
 pub mod test_utils {
@@ -182,14 +203,24 @@ pub mod test_utils {
     pub struct SchemaViewer(pub ModuleDef);
 
     impl SchemaView for SchemaViewer {
-        fn schema(&self, name: &str) -> Option<Arc<TableSchema>> {
-            self.0.table(name).map(|def| {
-                Arc::new(TableSchema::from_module_def(
-                    &self.0,
-                    def,
-                    (),
-                    TableId(if *def.name == *"t" { 0 } else { 1 }),
-                ))
+        fn table_id(&self, name: &str) -> Option<TableId> {
+            match name {
+                "t" => Some(TableId(0)),
+                "s" => Some(TableId(1)),
+                _ => None,
+            }
+        }
+
+        fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableSchema>> {
+            match table_id.idx() {
+                0 => Some((TableId(0), "t")),
+                1 => Some((TableId(1), "s")),
+                _ => None,
+            }
+            .and_then(|(table_id, name)| {
+                self.0
+                    .table(name)
+                    .map(|def| Arc::new(TableSchema::from_module_def(&self.0, def, (), table_id)))
             })
         }
     }

--- a/crates/expr/src/statement.rs
+++ b/crates/expr/src/statement.rs
@@ -12,7 +12,7 @@ use spacetimedb_sql_parser::{
 };
 use thiserror::Error;
 
-use crate::{check::Relvars, expr::Project};
+use crate::{check::Relvars, expr::ProjectList};
 
 use super::{
     check::{SchemaView, TypeChecker, TypingResult},
@@ -22,7 +22,7 @@ use super::{
 };
 
 pub enum Statement {
-    Select(Project),
+    Select(ProjectList),
     Insert(TableInsert),
     Update(TableUpdate),
     Delete(TableDelete),
@@ -240,11 +240,11 @@ impl TypeChecker for SqlChecker {
     type Ast = SqlSelect;
     type Set = SqlSelect;
 
-    fn type_ast(ast: Self::Ast, tx: &impl SchemaView) -> TypingResult<Project> {
+    fn type_ast(ast: Self::Ast, tx: &impl SchemaView) -> TypingResult<ProjectList> {
         Self::type_set(ast, &mut Relvars::default(), tx)
     }
 
-    fn type_set(ast: Self::Set, vars: &mut Relvars, tx: &impl SchemaView) -> TypingResult<Project> {
+    fn type_set(ast: Self::Set, vars: &mut Relvars, tx: &impl SchemaView) -> TypingResult<ProjectList> {
         match ast {
             SqlSelect {
                 project,

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -11,6 +11,7 @@ pub mod db;
 pub mod error;
 pub mod identity;
 pub mod operator;
+pub mod query;
 pub mod relation;
 pub mod scheduler;
 pub mod version;

--- a/crates/lib/src/query.rs
+++ b/crates/lib/src/query.rs
@@ -1,0 +1,6 @@
+/// A type used by the query planner for incremental evaluation
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub enum Delta {
+    Inserts(usize),
+    Deletes(usize),
+}

--- a/crates/physical-plan/Cargo.toml
+++ b/crates/physical-plan/Cargo.toml
@@ -7,9 +7,14 @@ license-file = "LICENSE"
 description = "The physical query plan for the SpacetimeDB query engine"
 
 [dependencies]
+anyhow.workspace = true
 derive_more.workspace = true
 spacetimedb-lib.workspace = true
 spacetimedb-primitives.workspace = true
 spacetimedb-schema.workspace = true
 spacetimedb-expr.workspace = true
 spacetimedb-sql-parser.workspace = true
+spacetimedb-table.workspace = true
+
+[dev-dependencies]
+pretty_assertions.workspace = true

--- a/crates/physical-plan/src/compile.rs
+++ b/crates/physical-plan/src/compile.rs
@@ -2,8 +2,11 @@
 
 use std::collections::HashMap;
 
-use crate::plan::{HashJoin, Label, PhysicalCtx, PhysicalExpr, PhysicalPlan, PhysicalProject, ProjectField, Semi};
-use spacetimedb_expr::expr::{Expr, FieldProject, LeftDeepJoin, Project, RelExpr};
+use crate::plan::{
+    HashJoin, Label, PhysicalCtx, PhysicalExpr, PhysicalPlan, ProjectListPlan, ProjectPlan, Semi, TupleField,
+};
+
+use spacetimedb_expr::expr::{Expr, FieldProject, LeftDeepJoin, ProjectList, ProjectName, RelExpr, Relvar};
 use spacetimedb_expr::statement::Statement;
 use spacetimedb_expr::StatementCtx;
 
@@ -24,13 +27,12 @@ fn compile_expr(expr: Expr, var: &mut impl VarLabel) -> PhysicalExpr {
     }
 }
 
-fn compile_project(var: &mut impl VarLabel, expr: Project) -> PhysicalProject {
+fn compile_project_list(var: &mut impl VarLabel, expr: ProjectList) -> ProjectListPlan {
     match expr {
-        Project::None(input) => PhysicalProject::None(compile_rel_expr(var, input)),
-        Project::Relvar(input, name) => PhysicalProject::Relvar(compile_rel_expr(var, input), var.label(&name)),
-        Project::Fields(input, exprs) => PhysicalProject::Fields(
-            compile_rel_expr(var, input),
-            exprs
+        ProjectList::Name(proj) => ProjectListPlan::Name(compile_project_name(var, proj)),
+        ProjectList::List(proj, fields) => ProjectListPlan::List(
+            compile_rel_expr(var, proj),
+            fields
                 .into_iter()
                 .map(|(alias, expr)| (alias, compile_field_project(var, expr)))
                 .collect(),
@@ -38,54 +40,105 @@ fn compile_project(var: &mut impl VarLabel, expr: Project) -> PhysicalProject {
     }
 }
 
-fn compile_field_project(var: &mut impl VarLabel, expr: FieldProject) -> ProjectField {
-    ProjectField {
-        var: var.label(&expr.table),
-        pos: expr.field,
+fn compile_project_name(var: &mut impl VarLabel, proj: ProjectName) -> ProjectPlan {
+    match proj {
+        ProjectName::None(input) => ProjectPlan::None(compile_rel_expr(var, input)),
+        ProjectName::Some(input, name) => ProjectPlan::Name(compile_rel_expr(var, input), var.label(&name), None),
+    }
+}
+
+fn compile_field_project(var: &mut impl VarLabel, expr: FieldProject) -> TupleField {
+    TupleField {
+        label: var.label(&expr.table),
+        label_pos: None,
+        field_pos: expr.field,
     }
 }
 
 fn compile_rel_expr(var: &mut impl VarLabel, ast: RelExpr) -> PhysicalPlan {
     match ast {
-        RelExpr::RelVar(table, name) => {
-            let label = var.label(name.as_ref());
-            PhysicalPlan::TableScan(table, label)
+        RelExpr::RelVar(Relvar { schema, alias, delta }) => {
+            let label = var.label(alias.as_ref());
+            PhysicalPlan::TableScan(schema, label, delta)
         }
         RelExpr::Select(input, expr) => {
             let input = compile_rel_expr(var, *input);
             let input = Box::new(input);
             PhysicalPlan::Filter(input, compile_expr(expr, var))
         }
-        RelExpr::EqJoin(join, FieldProject { table: u, field: a, .. }, FieldProject { table: v, field: b, .. }) => {
-            PhysicalPlan::HashJoin(
-                HashJoin {
-                    lhs: Box::new(compile_rel_expr(var, *join.lhs)),
-                    rhs: Box::new(PhysicalPlan::TableScan(join.rhs, var.label(&join.var))),
-                    lhs_field: ProjectField {
-                        var: var.label(u.as_ref()),
-                        pos: a,
+        RelExpr::EqJoin(
+            LeftDeepJoin {
+                lhs,
+                rhs:
+                    Relvar {
+                        schema: rhs_schema,
+                        alias: rhs_alias,
+                        delta,
+                        ..
                     },
-                    rhs_field: ProjectField {
-                        var: var.label(v.as_ref()),
-                        pos: b,
-                    },
-                    unique: false,
+            },
+            FieldProject { table: u, field: a, .. },
+            FieldProject { table: v, field: b, .. },
+        ) => PhysicalPlan::HashJoin(
+            HashJoin {
+                lhs: Box::new(compile_rel_expr(var, *lhs)),
+                rhs: Box::new(PhysicalPlan::TableScan(rhs_schema, var.label(&rhs_alias), delta)),
+                lhs_field: TupleField {
+                    label: var.label(u.as_ref()),
+                    label_pos: None,
+                    field_pos: a,
                 },
-                Semi::All,
-            )
-        }
+                rhs_field: TupleField {
+                    label: var.label(v.as_ref()),
+                    label_pos: None,
+                    field_pos: b,
+                },
+                unique: false,
+            },
+            Semi::All,
+        ),
         RelExpr::LeftDeepJoin(LeftDeepJoin {
             lhs,
-            rhs,
-            var: rhs_name,
+            rhs:
+                Relvar {
+                    schema: rhs_schema,
+                    alias: rhs_alias,
+                    delta,
+                    ..
+                },
         }) => {
             let lhs = compile_rel_expr(var, *lhs);
-            let rhs = PhysicalPlan::TableScan(rhs, var.label(rhs_name.as_ref()));
+            let rhs = PhysicalPlan::TableScan(rhs_schema, var.label(&rhs_alias), delta);
             let lhs = Box::new(lhs);
             let rhs = Box::new(rhs);
             PhysicalPlan::NLJoin(lhs, rhs)
         }
     }
+}
+
+/// Compile a logical subscribe expression
+pub fn compile_project_plan(project: ProjectName) -> ProjectPlan {
+    struct Interner {
+        next: usize,
+        names: HashMap<String, usize>,
+    }
+    impl VarLabel for Interner {
+        fn label(&mut self, name: &str) -> Label {
+            if let Some(id) = self.names.get(name) {
+                return Label(*id);
+            }
+            self.next += 1;
+            self.names.insert(name.to_owned(), self.next);
+            self.next.into()
+        }
+    }
+    compile_project_name(
+        &mut Interner {
+            next: 0,
+            names: HashMap::new(),
+        },
+        project,
+    )
 }
 
 /// Compile a SQL statement into a physical plan.
@@ -109,7 +162,7 @@ pub fn compile(ast: StatementCtx<'_>) -> PhysicalCtx<'_> {
         }
     }
     let plan = match ast.statement {
-        Statement::Select(expr) => compile_project(
+        Statement::Select(expr) => compile_project_list(
             &mut Interner {
                 next: 0,
                 names: HashMap::new(),

--- a/crates/physical-plan/src/lib.rs
+++ b/crates/physical-plan/src/lib.rs
@@ -1,2 +1,3 @@
 pub mod compile;
 pub mod plan;
+pub mod rules;

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -1,52 +1,155 @@
-use std::{ops::Bound, sync::Arc};
+use std::{
+    borrow::Cow,
+    ops::{Bound, Deref, DerefMut},
+    sync::Arc,
+};
 
 use derive_more::From;
 use spacetimedb_expr::StatementSource;
-use spacetimedb_lib::AlgebraicValue;
+use spacetimedb_lib::{query::Delta, AlgebraicValue};
 use spacetimedb_primitives::{ColId, ColSet, IndexId};
 use spacetimedb_schema::schema::{IndexSchema, TableSchema};
 use spacetimedb_sql_parser::ast::{BinOp, LogOp};
+use spacetimedb_table::table::RowRef;
+
+use crate::rules::{
+    ComputePositions, HashToIxJoin, IxScanAnd, IxScanEq, IxScanEq2Col, IxScanEq3Col, PullFilterAboveHashJoin,
+    PushConstAnd, PushConstEq, ReorderDeltaJoinRhs, ReorderHashJoin, RewriteRule, UniqueHashJoinRule, UniqueIxJoinRule,
+};
 
 /// Table aliases are replaced with labels in the physical plan
 #[derive(Debug, Clone, Copy, PartialEq, Eq, From)]
 pub struct Label(pub usize);
 
-/// Physical query plans always terminate with a projection
-#[derive(Debug, PartialEq, Eq)]
-pub enum PhysicalProject {
+/// Physical plans always terminate with a projection.
+/// This type of projection returns row ids.
+///
+/// It can represent:
+///
+/// ```sql
+/// select * from t
+/// ```
+///
+/// and
+///
+/// ```sql
+/// select t.* from t join ...
+/// ```
+///
+/// but not
+///
+/// ```sql
+/// select a from t
+/// ```
+#[derive(Debug, Clone)]
+pub enum ProjectPlan {
     None(PhysicalPlan),
-    Relvar(PhysicalPlan, Label),
-    Fields(PhysicalPlan, Vec<(Box<str>, ProjectField)>),
+    Name(PhysicalPlan, Label, Option<usize>),
 }
 
-impl PhysicalProject {
+impl Deref for ProjectPlan {
+    type Target = PhysicalPlan;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::None(plan) | Self::Name(plan, ..) => plan,
+        }
+    }
+}
+
+impl DerefMut for ProjectPlan {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        match self {
+            Self::None(plan) | Self::Name(plan, ..) => plan,
+        }
+    }
+}
+
+impl ProjectPlan {
     pub fn optimize(self) -> Self {
         match self {
             Self::None(plan) => Self::None(plan.optimize(vec![])),
-            Self::Relvar(plan, var) => Self::None(plan.optimize(vec![var])),
-            Self::Fields(plan, fields) => {
-                Self::Fields(plan.optimize(fields.iter().map(|(_, proj)| proj.var).collect()), fields)
+            Self::Name(plan, label, _) => {
+                let plan = plan.optimize(vec![label]);
+                let n = plan.nfields();
+                let pos = plan.position(&label);
+                match n {
+                    1 => Self::None(plan),
+                    _ => Self::Name(plan, label, pos),
+                }
             }
         }
     }
 }
 
-#[derive(Debug, PartialEq, Eq)]
-pub struct ProjectField {
-    pub var: Label,
-    pub pos: usize,
+/// Physical plans always terminate with a projection.
+/// This type can project fields within a table.
+///
+/// That is, it can represent:
+///
+/// ```sql
+/// select a from t
+/// ```
+///
+/// as well as
+///
+/// ```sql
+/// select t.a, s.b from t join s ...
+/// ```
+#[derive(Debug)]
+pub enum ProjectListPlan {
+    Name(ProjectPlan),
+    List(PhysicalPlan, Vec<(Box<str>, TupleField)>),
+}
+
+impl ProjectListPlan {
+    pub fn optimize(self) -> Self {
+        match self {
+            Self::Name(plan) => Self::Name(plan.optimize()),
+            Self::List(plan, fields) => Self::List(
+                plan.optimize(
+                    fields
+                        .iter()
+                        .map(|(_, TupleField { label, .. })| label)
+                        .copied()
+                        .collect(),
+                ),
+                fields,
+            ),
+        }
+    }
+}
+
+/// Query operators return tuples of rows.
+/// And this type refers to a field of a row within a tuple.
+///
+/// Note that from the perspective of the optimizer,
+/// tuple elements have names or labels,
+/// so as to preserve query semantics across rewrites.
+///
+/// However from the perspective of the query engine,
+/// tuple elements are entirely positional.
+/// Hence the need for both `label` and `label_pos`.
+///
+/// The former is consistent across rewrites.
+/// The latter is only computed once after optimization.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TupleField {
+    pub label: Label,
+    pub label_pos: Option<usize>,
+    pub field_pos: usize,
 }
 
 /// A physical plan represents a concrete evaluation strategy.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PhysicalPlan {
     /// Scan a table row by row, returning row ids
-    TableScan(Arc<TableSchema>, Label),
+    TableScan(Arc<TableSchema>, Label, Option<Delta>),
     /// Fetch row ids from an index
     IxScan(IxScan, Label),
     /// An index join + projection
     IxJoin(IxJoin, Semi),
-    /// An hash join + projection
+    /// A hash join + projection
     HashJoin(HashJoin, Semi),
     /// A nested loop join
     NLJoin(Box<PhysicalPlan>, Box<PhysicalPlan>),
@@ -65,6 +168,21 @@ impl PhysicalPlan {
             Self::NLJoin(lhs, rhs) | Self::HashJoin(HashJoin { lhs, rhs, .. }, _) => {
                 lhs.visit(f);
                 rhs.visit(f);
+            }
+            _ => {}
+        }
+    }
+
+    /// Walks the plan tree and calls `f` on every op
+    pub fn visit_mut(&mut self, f: &mut impl FnMut(&mut Self)) {
+        f(self);
+        match self {
+            Self::IxJoin(IxJoin { lhs: input, .. }, _) | Self::Filter(input, _) => {
+                input.visit_mut(f);
+            }
+            Self::NLJoin(lhs, rhs) | Self::HashJoin(HashJoin { lhs, rhs, .. }, _) => {
+                lhs.visit_mut(f);
+                rhs.visit_mut(f);
             }
             _ => {}
         }
@@ -188,22 +306,29 @@ impl PhysicalPlan {
         plan
     }
 
-    /// Optimize a physical plan by applying rewrite rules.
+    /// Optimize a plan using the following rewrites:
     ///
-    /// First we canonicalize the plan.
-    /// Next we push filters to the leaves.
-    /// Then we try to turn those filters into index scans.
-    /// And finally we deterimine the index joins and semijoins.
+    /// 1. Canonicalize the plan
+    /// 2. Push filters to the leaves
+    /// 3. Turn filters into index scans if possible
+    /// 4. Determine index and semijoins
+    /// 5. Compute positions for tuple labels
     pub fn optimize(self, reqs: Vec<Label>) -> Self {
         self.map(&Self::canonicalize)
-            .apply_until::<PushConjunction>()
-            .apply_until::<PushEqFilter>()
-            .apply_rec::<EqToIxScan>()
-            .apply_rec::<ConjunctionToIxScan>()
+            .apply_until::<PushConstAnd>()
+            .apply_until::<PushConstEq>()
+            .apply_rec::<ReorderDeltaJoinRhs>()
+            .apply_rec::<PullFilterAboveHashJoin>()
+            .apply_rec::<IxScanEq3Col>()
+            .apply_rec::<IxScanEq2Col>()
+            .apply_rec::<IxScanEq>()
+            .apply_rec::<IxScanAnd>()
+            .apply_rec::<ReorderHashJoin>()
             .apply_rec::<HashToIxJoin>()
             .apply_rec::<UniqueIxJoinRule>()
             .apply_rec::<UniqueHashJoinRule>()
             .introduce_semijoins(reqs)
+            .apply_rec::<ComputePositions>()
     }
 
     /// The rewriter assumes a canonicalized plan.
@@ -258,7 +383,7 @@ impl PhysicalPlan {
                     unique,
                 },
                 semi,
-            ) if rhs.has_label(&lhs_field.var) || lhs.has_label(&rhs_field.var) => Self::HashJoin(
+            ) if rhs.has_label(&lhs_field.label) || lhs.has_label(&rhs_field.label) => Self::HashJoin(
                 HashJoin {
                     lhs,
                     rhs,
@@ -351,7 +476,7 @@ impl PhysicalPlan {
         match self {
             Self::Filter(input, expr) => {
                 expr.visit(&mut |expr| {
-                    if let PhysicalExpr::Field(ProjectField { var, .. }) = expr {
+                    if let PhysicalExpr::Field(TupleField { label: var, .. }) = expr {
                         if !reqs.contains(var) {
                             reqs.push(*var);
                         }
@@ -377,8 +502,8 @@ impl PhysicalPlan {
                 HashJoin {
                     lhs,
                     rhs,
-                    lhs_field: lhs_field @ ProjectField { var: u, .. },
-                    rhs_field: rhs_field @ ProjectField { var: v, .. },
+                    lhs_field: lhs_field @ TupleField { label: u, .. },
+                    rhs_field: rhs_field @ TupleField { label: v, .. },
                     unique,
                 },
                 Semi::All,
@@ -411,13 +536,13 @@ impl PhysicalPlan {
                 )
             }
             Self::IxJoin(join, Semi::All) if reqs.len() == 1 && join.rhs_label == reqs[0] => {
-                let lhs = join.lhs.introduce_semijoins(vec![join.lhs_probe_expr.var]);
+                let lhs = join.lhs.introduce_semijoins(vec![join.lhs_field.label]);
                 let lhs = Box::new(lhs);
                 Self::IxJoin(IxJoin { lhs, ..join }, Semi::Rhs)
             }
             Self::IxJoin(join, Semi::All) if reqs.iter().all(|var| *var != join.rhs_label) => {
-                if !reqs.contains(&join.lhs_probe_expr.var) {
-                    reqs.push(join.lhs_probe_expr.var);
+                if !reqs.contains(&join.lhs_field.label) {
+                    reqs.push(join.lhs_field.label);
                 }
                 let lhs = join.lhs.introduce_semijoins(reqs);
                 let lhs = Box::new(lhs);
@@ -434,10 +559,10 @@ impl PhysicalPlan {
     }
 
     // Does this plan return distinct values for these columns?
-    fn returns_distinct_values(&self, label: &Label, cols: &ColSet) -> bool {
+    pub(crate) fn returns_distinct_values(&self, label: &Label, cols: &ColSet) -> bool {
         match self {
             // Is there a unique constraint for these cols?
-            Self::TableScan(schema, var) => var == label && schema.is_unique(cols),
+            Self::TableScan(schema, var, _) => var == label && schema.is_unique(cols),
             // Is there a unique constraint for these cols + the index cols?
             Self::IxScan(
                 IxScan {
@@ -471,10 +596,11 @@ impl PhysicalPlan {
                 IxJoin {
                     lhs,
                     rhs,
-                    lhs_probe_expr:
-                        ProjectField {
-                            var: lhs_label,
-                            pos: lhs_field_pos,
+                    lhs_field:
+                        TupleField {
+                            label: lhs_label,
+                            field_pos: lhs_field_pos,
+                            ..
                         },
                     ..
                 },
@@ -492,9 +618,10 @@ impl PhysicalPlan {
                     lhs,
                     rhs,
                     rhs_field:
-                        ProjectField {
-                            var: rhs_label,
-                            pos: rhs_field_pos,
+                        TupleField {
+                            label: rhs_label,
+                            field_pos: rhs_field_pos,
+                            ..
                         },
                     ..
                 },
@@ -512,9 +639,10 @@ impl PhysicalPlan {
                     lhs,
                     rhs,
                     lhs_field:
-                        ProjectField {
-                            var: lhs_label,
-                            pos: lhs_field_pos,
+                        TupleField {
+                            label: lhs_label,
+                            field_pos: lhs_field_pos,
+                            ..
                         },
                     ..
                 },
@@ -532,8 +660,8 @@ impl PhysicalPlan {
                 expr.visit(&mut |plan| {
                     if let PhysicalExpr::BinOp(BinOp::Eq, expr, value) = plan {
                         if let (PhysicalExpr::Field(proj), PhysicalExpr::Value(..)) = (&**expr, &**value) {
-                            if proj.var == *label {
-                                cols.push(proj.pos.into());
+                            if proj.label == *label {
+                                cols.push(proj.field_pos.into());
                             }
                         }
                     }
@@ -544,19 +672,93 @@ impl PhysicalPlan {
         }
     }
 
+    pub fn index_on_field(&self, label: &Label, field: usize) -> bool {
+        self.any(&|plan| match plan {
+            Self::TableScan(schema, alias, _)
+            | Self::IxScan(IxScan { schema, .. }, alias)
+            | Self::IxJoin(
+                IxJoin {
+                    rhs: schema,
+                    rhs_label: alias,
+                    ..
+                },
+                _,
+            ) if alias == label => schema.indexes.iter().any(|IndexSchema { index_algorithm, .. }| {
+                index_algorithm
+                    .columns()
+                    .as_singleton()
+                    .is_some_and(|col_id| col_id.idx() == field)
+            }),
+            _ => false,
+        })
+    }
+
     /// Does this plan introduce this label?
     fn has_label(&self, label: &Label) -> bool {
         self.any(&|plan| match plan {
-            Self::TableScan(_, var) | Self::IxScan(_, var) | Self::IxJoin(IxJoin { rhs_label: var, .. }, _) => {
+            Self::TableScan(_, var, _) | Self::IxScan(_, var) | Self::IxJoin(IxJoin { rhs_label: var, .. }, _) => {
                 var == label
             }
             _ => false,
         })
     }
+
+    /// How many fields do the tuples returned by this plan have?
+    fn nfields(&self) -> usize {
+        match self {
+            Self::TableScan(..) | Self::IxScan(..) | Self::IxJoin(_, Semi::Rhs) => 1,
+            Self::Filter(input, _) => input.nfields(),
+            Self::IxJoin(join, Semi::Lhs) => join.lhs.nfields(),
+            Self::IxJoin(join, Semi::All) => join.lhs.nfields() + 1,
+            Self::HashJoin(join, Semi::Rhs) => join.rhs.nfields(),
+            Self::HashJoin(join, Semi::Lhs) => join.lhs.nfields(),
+            Self::HashJoin(join, Semi::All) => join.lhs.nfields() + join.rhs.nfields(),
+            Self::NLJoin(lhs, rhs) => lhs.nfields() + rhs.nfields(),
+        }
+    }
+
+    /// What is the position of this label in the return tuple?
+    pub(crate) fn position(&self, label: &Label) -> Option<usize> {
+        self.labels()
+            .into_iter()
+            .enumerate()
+            .find(|(_, name)| name == label)
+            .map(|(i, _)| i)
+    }
+
+    /// Returns the names of the relvars that this operation returns
+    fn labels(&self) -> Vec<Label> {
+        fn find(plan: &PhysicalPlan, labels: &mut Vec<Label>) {
+            match plan {
+                PhysicalPlan::TableScan(_, alias, _)
+                | PhysicalPlan::IxScan(_, alias)
+                | PhysicalPlan::IxJoin(IxJoin { rhs_label: alias, .. }, Semi::Rhs) => {
+                    labels.push(*alias);
+                }
+                PhysicalPlan::Filter(input, _)
+                | PhysicalPlan::IxJoin(IxJoin { lhs: input, .. }, Semi::Lhs)
+                | PhysicalPlan::HashJoin(HashJoin { lhs: input, .. }, Semi::Lhs)
+                | PhysicalPlan::HashJoin(HashJoin { rhs: input, .. }, Semi::Rhs) => {
+                    find(input, labels);
+                }
+                PhysicalPlan::IxJoin(IxJoin { lhs, rhs_label, .. }, Semi::All) => {
+                    find(lhs, labels);
+                    labels.push(*rhs_label);
+                }
+                PhysicalPlan::NLJoin(lhs, rhs) | PhysicalPlan::HashJoin(HashJoin { lhs, rhs, .. }, Semi::All) => {
+                    find(lhs, labels);
+                    find(rhs, labels);
+                }
+            }
+        }
+        let mut labels = vec![];
+        find(self, &mut labels);
+        labels
+    }
 }
 
 /// Fetch and return row ids from a btree index
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IxScan {
     /// The table on which this index is defined
     pub schema: Arc<TableSchema>,
@@ -569,31 +771,20 @@ pub struct IxScan {
 }
 
 /// An index [S]earch [arg]ument
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Sarg {
     Eq(ColId, AlgebraicValue),
     Range(ColId, Bound<AlgebraicValue>, Bound<AlgebraicValue>),
 }
 
-/// A hash join is potentially a bushy join.
-///
-/// ```text
-///      x
-///     / \
-///    /   \
-///   x     x
-///  / \   / \
-/// a   b c   d
-/// ```
-///
-/// It joins two relations by a single equality condition.
+/// A join of two relations on a single equality condition.
 /// It builds a hash table for the rhs and streams the lhs.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct HashJoin {
     pub lhs: Box<PhysicalPlan>,
     pub rhs: Box<PhysicalPlan>,
-    pub lhs_field: ProjectField,
-    pub rhs_field: ProjectField,
+    pub lhs_field: TupleField,
+    pub rhs_field: TupleField,
     pub unique: bool,
 }
 
@@ -601,7 +792,7 @@ pub struct HashJoin {
 /// where the lhs is a relation,
 /// and the rhs is a relvar or base table,
 /// whose rows are fetched using an index.
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct IxJoin {
     /// The lhs input used to probe the index
     pub lhs: Box<PhysicalPlan>,
@@ -618,23 +809,20 @@ pub struct IxJoin {
     /// The expression for computing probe values.
     /// Values are projected from the lhs,
     /// and used to probe the index on the rhs.
-    pub lhs_probe_expr: ProjectField,
+    pub lhs_field: TupleField,
 }
 
 /// Is this a semijoin?
 /// If so, which side is projected?
-#[derive(Debug, PartialEq, Eq)]
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
 pub enum Semi {
     Lhs,
     Rhs,
     All,
 }
 
-/// A physical scalar expression.
-///
-/// Types are encoded in the structure of the plan,
-/// rather than made explicit as for the logical plan.
-#[derive(Debug, PartialEq, Eq)]
+/// A physical scalar expression
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum PhysicalExpr {
     /// An n-ary logic expression
     LogOp(LogOp, Vec<PhysicalExpr>),
@@ -643,7 +831,21 @@ pub enum PhysicalExpr {
     /// A constant algebraic value
     Value(AlgebraicValue),
     /// A field projection expression
-    Field(ProjectField),
+    Field(TupleField),
+}
+
+/// A trait for projecting values from a tuple.
+/// This is needed because not all tuples are created equal.
+/// Some operators return [RowRef]s.
+/// Some joins return tuples of combined [RowRef]s.
+pub trait ProjectField {
+    fn project(&self, field: &TupleField) -> AlgebraicValue;
+}
+
+impl ProjectField for RowRef<'_> {
+    fn project(&self, field: &TupleField) -> AlgebraicValue {
+        self.read_col(field.field_pos).unwrap()
+    }
 }
 
 impl PhysicalExpr {
@@ -664,6 +866,23 @@ impl PhysicalExpr {
         }
     }
 
+    /// Walks the expression tree and calls `f` on every subexpression
+    pub fn visit_mut(&mut self, f: &mut impl FnMut(&mut Self)) {
+        f(self);
+        match self {
+            Self::BinOp(_, a, b) => {
+                a.visit_mut(f);
+                b.visit_mut(f);
+            }
+            Self::LogOp(_, exprs) => {
+                for expr in exprs {
+                    expr.visit_mut(f);
+                }
+            }
+            _ => {}
+        }
+    }
+
     /// Applies the transformation `f` to all subplans
     pub fn map(self, f: &impl Fn(Self) -> Self) -> Self {
         match f(self) {
@@ -671,6 +890,43 @@ impl PhysicalExpr {
             field @ Self::Field(..) => field,
             Self::BinOp(op, a, b) => Self::BinOp(op, Box::new(a.map(f)), Box::new(b.map(f))),
             Self::LogOp(op, exprs) => Self::LogOp(op, exprs.into_iter().map(|expr| expr.map(f)).collect()),
+        }
+    }
+
+    /// Evaluate this boolean expression over `row`
+    pub fn eval_bool(&self, row: &impl ProjectField) -> bool {
+        self.eval(row).as_bool().copied().unwrap_or(false)
+    }
+
+    /// Evaluate this expression over `row`
+    fn eval(&self, row: &impl ProjectField) -> Cow<'_, AlgebraicValue> {
+        fn eval_bin_op(op: BinOp, a: &AlgebraicValue, b: &AlgebraicValue) -> bool {
+            match op {
+                BinOp::Eq => a == b,
+                BinOp::Ne => a != b,
+                BinOp::Lt => a < b,
+                BinOp::Lte => a <= b,
+                BinOp::Gt => a > b,
+                BinOp::Gte => a >= b,
+            }
+        }
+        let into = |b| Cow::Owned(AlgebraicValue::Bool(b));
+        match self {
+            Self::BinOp(op, a, b) => into(eval_bin_op(*op, &a.eval(row), &b.eval(row))),
+            Self::LogOp(LogOp::And, exprs) => into(
+                exprs
+                    .iter()
+                    // ALL is equivalent to AND
+                    .all(|expr| expr.eval_bool(row)),
+            ),
+            Self::LogOp(LogOp::Or, exprs) => into(
+                exprs
+                    .iter()
+                    // ANY is equivalent to OR
+                    .any(|expr| expr.eval_bool(row)),
+            ),
+            Self::Field(field) => Cow::Owned(row.project(field)),
+            Self::Value(v) => Cow::Borrowed(v),
         }
     }
 
@@ -696,544 +952,17 @@ impl PhysicalExpr {
 
 /// A physical context for the result of a query compilation.
 pub struct PhysicalCtx<'a> {
-    pub plan: PhysicalProject,
+    pub plan: ProjectListPlan,
     pub sql: &'a str,
     pub source: StatementSource,
-}
-
-pub trait RewriteRule {
-    type Plan;
-    type Info;
-
-    fn matches(plan: &Self::Plan) -> Option<Self::Info>;
-    fn rewrite(plan: Self::Plan, info: Self::Info) -> Self::Plan;
-}
-
-/// Push equality conditions down to the leaves.
-///
-/// Example:
-///
-/// ```sql
-/// select b.*
-/// from a join b on a.id = b.id
-/// where a.x = 3
-/// ```
-///
-/// ... to ...
-///
-/// ```sql
-/// select b.*
-/// from (select * from a where x = 3) a
-/// join b on a.id = b.id
-/// ```
-///
-/// Example:
-///
-/// ```text
-///  s(a)
-///   |
-///   x
-///  / \
-/// a   b
-///
-/// ... to ...
-///
-///    x
-///   / \
-/// s(a) b
-///  |
-///  a
-/// ```
-struct PushEqFilter;
-
-impl RewriteRule for PushEqFilter {
-    type Plan = PhysicalPlan;
-    type Info = Label;
-
-    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, expr, value)) = plan {
-            if let (PhysicalExpr::Field(ProjectField { var, .. }), PhysicalExpr::Value(_)) = (&**expr, &**value) {
-                return match &**input {
-                    PhysicalPlan::TableScan(..) => None,
-                    input => input
-                        .any(&|plan| match plan {
-                            PhysicalPlan::TableScan(_, label) => label == var,
-                            _ => false,
-                        })
-                        .then_some(*var),
-                };
-            }
-        }
-        None
-    }
-
-    fn rewrite(plan: PhysicalPlan, relvar: Self::Info) -> PhysicalPlan {
-        if let PhysicalPlan::Filter(input, expr) = plan {
-            return input.map_if(
-                |scan, _| PhysicalPlan::Filter(Box::new(scan), expr),
-                |plan| match plan {
-                    PhysicalPlan::TableScan(_, var) if var == &relvar => Some(()),
-                    _ => None,
-                },
-            );
-        }
-        unreachable!()
-    }
-}
-
-/// Push conjunctions down to the leaves.
-///
-/// Example:
-///
-/// ```sql
-/// select b.*
-/// from a join b on a.id = b.id
-/// where a.x = 3 and a.y = 5
-/// ```
-///
-/// ... to ...
-///
-/// ```sql
-/// select b.*
-/// from (select * from a where x = 3 and y = 5) a
-/// join b on a.id = b.id
-/// ```
-///
-/// Example:
-///
-/// ```text
-///  s(a)
-///   |
-///   x
-///  / \
-/// a   b
-///
-/// ... to ...
-///
-///    x
-///   / \
-/// s(a) b
-///  |
-///  a
-/// ```
-struct PushConjunction;
-
-impl RewriteRule for PushConjunction {
-    type Plan = PhysicalPlan;
-    type Info = Label;
-
-    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan {
-            return exprs.iter().find_map(|expr| {
-                if let PhysicalExpr::BinOp(BinOp::Eq, expr, value) = expr {
-                    if let (PhysicalExpr::Field(ProjectField { var, .. }), PhysicalExpr::Value(_)) = (&**expr, &**value)
-                    {
-                        return match &**input {
-                            PhysicalPlan::TableScan(..) => None,
-                            input => input
-                                .any(&|plan| match plan {
-                                    PhysicalPlan::TableScan(_, label) => label == var,
-                                    _ => false,
-                                })
-                                .then_some(*var),
-                        };
-                    }
-                }
-                None
-            });
-        }
-        None
-    }
-
-    fn rewrite(plan: PhysicalPlan, relvar: Self::Info) -> PhysicalPlan {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan {
-            let mut leaf_exprs = vec![];
-            let mut root_exprs = vec![];
-            for expr in exprs {
-                if let PhysicalExpr::BinOp(BinOp::Eq, lhs, value) = &expr {
-                    if let (PhysicalExpr::Field(ProjectField { var, .. }), PhysicalExpr::Value(_)) = (&**lhs, &**value)
-                    {
-                        if var == &relvar {
-                            leaf_exprs.push(expr);
-                            continue;
-                        }
-                    }
-                }
-                root_exprs.push(expr);
-            }
-            // Match on table scan
-            let ok = |plan: &PhysicalPlan| match plan {
-                PhysicalPlan::TableScan(_, var) if var == &relvar => Some(()),
-                _ => None,
-            };
-            // Map scan to scan + filter
-            let f = |scan, _| {
-                PhysicalPlan::Filter(
-                    Box::new(scan),
-                    match leaf_exprs.len() {
-                        1 => leaf_exprs.swap_remove(0),
-                        _ => PhysicalExpr::LogOp(LogOp::And, leaf_exprs),
-                    },
-                )
-            };
-            // Remove top level filter if all conditions were pushable
-            if root_exprs.is_empty() {
-                return input.map_if(f, ok);
-            }
-            // Otherwise remove exprs from top level filter and push
-            return PhysicalPlan::Filter(
-                Box::new(input.map_if(f, ok)),
-                match root_exprs.len() {
-                    1 => root_exprs.swap_remove(0),
-                    _ => PhysicalExpr::LogOp(LogOp::And, root_exprs),
-                },
-            );
-        }
-        unreachable!()
-    }
-}
-
-/// Turn an equality predicate into a single column index scan
-struct EqToIxScan;
-
-struct IxScanInfo {
-    index_id: IndexId,
-    col_id: ColId,
-}
-
-impl RewriteRule for EqToIxScan {
-    type Plan = PhysicalPlan;
-    type Info = IxScanInfo;
-
-    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, expr, value)) = plan {
-            if let PhysicalPlan::TableScan(schema, _) = &**input {
-                if let (PhysicalExpr::Field(ProjectField { pos, .. }), PhysicalExpr::Value(_)) = (&**expr, &**value) {
-                    return schema
-                        .indexes
-                        .iter()
-                        .find_map(
-                            |IndexSchema {
-                                 index_id,
-                                 index_algorithm,
-                                 ..
-                             }| {
-                                index_algorithm
-                                    .columns()
-                                    .as_singleton()
-                                    .filter(|col_id| col_id.idx() == *pos)
-                                    .map(|col_id| IxScanInfo {
-                                        index_id: *index_id,
-                                        col_id,
-                                    })
-                            },
-                        )
-                        .or_else(|| {
-                            schema.indexes.iter().find_map(
-                                |IndexSchema {
-                                     index_id,
-                                     index_algorithm,
-                                     ..
-                                 }| {
-                                    index_algorithm
-                                        .columns()
-                                        .head()
-                                        .filter(|col_id| col_id.idx() == *pos)
-                                        .map(|col_id| IxScanInfo {
-                                            index_id: *index_id,
-                                            col_id,
-                                        })
-                                },
-                            )
-                        });
-                }
-            }
-        }
-        None
-    }
-
-    fn rewrite(plan: PhysicalPlan, info: Self::Info) -> PhysicalPlan {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, _, value)) = plan {
-            if let PhysicalPlan::TableScan(schema, var) = *input {
-                if let PhysicalExpr::Value(v) = *value {
-                    return PhysicalPlan::IxScan(
-                        IxScan {
-                            schema,
-                            index_id: info.index_id,
-                            prefix: vec![],
-                            arg: Sarg::Eq(info.col_id, v),
-                        },
-                        var,
-                    );
-                }
-            }
-        }
-        unreachable!()
-    }
-}
-
-/// Turn a conjunction into a single column index scan
-struct ConjunctionToIxScan;
-
-impl RewriteRule for ConjunctionToIxScan {
-    type Plan = PhysicalPlan;
-    type Info = (usize, IxScanInfo);
-
-    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan {
-            if let PhysicalPlan::TableScan(schema, _) = &**input {
-                return exprs.iter().enumerate().find_map(|(i, expr)| {
-                    if let PhysicalExpr::BinOp(BinOp::Eq, lhs, value) = expr {
-                        if let (PhysicalExpr::Field(ProjectField { pos, .. }), PhysicalExpr::Value(_)) =
-                            (&**lhs, &**value)
-                        {
-                            return schema
-                                .indexes
-                                .iter()
-                                .find_map(
-                                    |IndexSchema {
-                                         index_id,
-                                         index_algorithm,
-                                         ..
-                                     }| {
-                                        index_algorithm
-                                            .columns()
-                                            .as_singleton()
-                                            .filter(|col_id| col_id.idx() == *pos)
-                                            .map(|col_id| {
-                                                (
-                                                    i,
-                                                    IxScanInfo {
-                                                        index_id: *index_id,
-                                                        col_id,
-                                                    },
-                                                )
-                                            })
-                                    },
-                                )
-                                .or_else(|| {
-                                    schema.indexes.iter().find_map(
-                                        |IndexSchema {
-                                             index_id,
-                                             index_algorithm,
-                                             ..
-                                         }| {
-                                            index_algorithm
-                                                .columns()
-                                                .head()
-                                                .filter(|col_id| col_id.idx() == *pos)
-                                                .map(|col_id| {
-                                                    (
-                                                        i,
-                                                        IxScanInfo {
-                                                            index_id: *index_id,
-                                                            col_id,
-                                                        },
-                                                    )
-                                                })
-                                        },
-                                    )
-                                });
-                        }
-                    }
-                    None
-                });
-            }
-        }
-        None
-    }
-
-    fn rewrite(plan: PhysicalPlan, info: Self::Info) -> PhysicalPlan {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, mut exprs)) = plan {
-            if let PhysicalPlan::TableScan(schema, label) = *input {
-                let (i, IxScanInfo { index_id, col_id }) = info;
-                if let PhysicalExpr::BinOp(BinOp::Eq, _, value) = exprs.swap_remove(i) {
-                    if let PhysicalExpr::Value(v) = *value {
-                        return PhysicalPlan::Filter(
-                            Box::new(PhysicalPlan::IxScan(
-                                IxScan {
-                                    schema,
-                                    index_id,
-                                    prefix: vec![],
-                                    arg: Sarg::Eq(col_id, v),
-                                },
-                                label,
-                            )),
-                            match exprs.len() {
-                                1 => exprs.swap_remove(0),
-                                _ => PhysicalExpr::LogOp(LogOp::And, exprs),
-                            },
-                        );
-                    }
-                }
-            }
-        }
-        unreachable!()
-    }
-}
-
-/// Is this hash join a left deep join tree that can use an index?
-///
-/// ```text
-/// Notation:
-///
-/// x: index join
-/// hx: hash join
-///
-///     hx
-///    /  \
-///   x    c
-///  / \
-/// a   b
-///
-/// ... to ...
-///
-///     x
-///    / \
-///   x   c
-///  / \
-/// a   b
-/// ```
-struct HashToIxJoin;
-
-impl RewriteRule for HashToIxJoin {
-    type Plan = PhysicalPlan;
-    type Info = IxScanInfo;
-
-    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        if let PhysicalPlan::HashJoin(
-            HashJoin {
-                rhs,
-                rhs_field:
-                    ProjectField {
-                        var: rhs_var,
-                        pos: field_pos,
-                    },
-                ..
-            },
-            _,
-        ) = plan
-        {
-            return match &**rhs {
-                PhysicalPlan::TableScan(schema, var) if var == rhs_var => {
-                    // Is there a single column index on this field?
-                    schema.indexes.iter().find_map(|ix| {
-                        ix.index_algorithm
-                            .columns()
-                            .as_singleton()
-                            .filter(|col_id| col_id.idx() == *field_pos)
-                            .map(|col_id| IxScanInfo {
-                                index_id: ix.index_id,
-                                col_id,
-                            })
-                    })
-                }
-                _ => None,
-            };
-        }
-        None
-    }
-
-    fn rewrite(plan: PhysicalPlan, info: Self::Info) -> PhysicalPlan {
-        if let PhysicalPlan::HashJoin(join, semi) = plan {
-            if let PhysicalPlan::TableScan(rhs, rhs_label) = *join.rhs {
-                return PhysicalPlan::IxJoin(
-                    IxJoin {
-                        lhs: join.lhs,
-                        rhs,
-                        rhs_label,
-                        rhs_index: info.index_id,
-                        rhs_field: info.col_id,
-                        unique: false,
-                        lhs_probe_expr: join.lhs_field,
-                    },
-                    semi,
-                );
-            }
-        }
-        unreachable!()
-    }
-}
-
-/// Does this index join use a unique index?
-struct UniqueIxJoinRule;
-
-impl RewriteRule for UniqueIxJoinRule {
-    type Plan = PhysicalPlan;
-    type Info = ();
-
-    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        if let PhysicalPlan::IxJoin(
-            IxJoin {
-                unique: false,
-                rhs,
-                rhs_field,
-                ..
-            },
-            _,
-        ) = plan
-        {
-            return rhs
-                .constraints
-                .iter()
-                .filter_map(|cs| cs.data.unique_columns())
-                .filter_map(|cols| cols.as_singleton())
-                .find(|col_id| col_id == rhs_field)
-                .map(|_| ());
-        }
-        None
-    }
-
-    fn rewrite(mut plan: PhysicalPlan, _: Self::Info) -> PhysicalPlan {
-        if let PhysicalPlan::IxJoin(IxJoin { unique, .. }, _) = &mut plan {
-            *unique = true;
-        }
-        plan
-    }
-}
-
-/// Does probing the hash table return at most one element?
-struct UniqueHashJoinRule;
-
-impl RewriteRule for UniqueHashJoinRule {
-    type Plan = PhysicalPlan;
-    type Info = ();
-
-    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        if let PhysicalPlan::HashJoin(
-            HashJoin {
-                unique: false,
-                rhs,
-                rhs_field:
-                    ProjectField {
-                        var: rhs_label,
-                        pos: rhs_field_pos,
-                    },
-                ..
-            },
-            _,
-        ) = plan
-        {
-            return rhs
-                .returns_distinct_values(rhs_label, &ColSet::from(ColId(*rhs_field_pos as u16)))
-                .then_some(());
-        }
-        None
-    }
-
-    fn rewrite(mut plan: PhysicalPlan, _: Self::Info) -> PhysicalPlan {
-        if let PhysicalPlan::HashJoin(HashJoin { unique, .. }, _) = &mut plan {
-            *unique = true;
-        }
-        plan
-    }
 }
 
 #[cfg(test)]
 mod tests {
     use std::sync::Arc;
 
-    use spacetimedb_expr::check::{compile_sql_sub, SchemaView};
+    use pretty_assertions::assert_eq;
+    use spacetimedb_expr::check::{parse_and_type_sub, SchemaView};
     use spacetimedb_lib::{
         db::auth::{StAccess, StTableType},
         AlgebraicType, AlgebraicValue,
@@ -1246,22 +975,26 @@ mod tests {
     use spacetimedb_sql_parser::ast::BinOp;
 
     use crate::{
-        compile::compile,
-        plan::{HashJoin, IxJoin, IxScan, PhysicalPlan, PhysicalProject, ProjectField, Sarg, Semi},
+        compile::compile_project_plan,
+        plan::{HashJoin, IxJoin, IxScan, PhysicalPlan, Sarg, Semi, TupleField},
     };
 
-    use super::PhysicalExpr;
+    use super::{PhysicalExpr, ProjectPlan};
 
     struct SchemaViewer {
         schemas: Vec<Arc<TableSchema>>,
     }
 
     impl SchemaView for SchemaViewer {
-        fn schema(&self, name: &str) -> Option<Arc<TableSchema>> {
+        fn table_id(&self, name: &str) -> Option<TableId> {
             self.schemas
                 .iter()
                 .find(|schema| schema.table_name.as_ref() == name)
-                .cloned()
+                .map(|schema| schema.table_id)
+        }
+
+        fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableSchema>> {
+            self.schemas.iter().find(|schema| schema.table_id == table_id).cloned()
         }
     }
 
@@ -1338,11 +1071,11 @@ mod tests {
 
         let sql = "select * from t";
 
-        let lp = compile_sql_sub(sql, &db).unwrap();
-        let pp = compile(lp).plan.optimize();
+        let lp = parse_and_type_sub(sql, &db).unwrap();
+        let pp = compile_project_plan(lp).optimize();
 
         match pp {
-            PhysicalProject::None(PhysicalPlan::TableScan(schema, _)) => {
+            ProjectPlan::None(PhysicalPlan::TableScan(schema, _, _)) => {
                 assert_eq!(schema.table_id, t_id);
             }
             proj => panic!("unexpected project: {:#?}", proj),
@@ -1369,16 +1102,16 @@ mod tests {
 
         let sql = "select * from t where x = 5";
 
-        let lp = compile_sql_sub(sql, &db).unwrap();
-        let pp = compile(lp).plan.optimize();
+        let lp = parse_and_type_sub(sql, &db).unwrap();
+        let pp = compile_project_plan(lp).optimize();
 
         match pp {
-            PhysicalProject::None(PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, field, value))) => {
-                assert!(matches!(*field, PhysicalExpr::Field(ProjectField { pos: 1, .. })));
+            ProjectPlan::None(PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, field, value))) => {
+                assert!(matches!(*field, PhysicalExpr::Field(TupleField { field_pos: 1, .. })));
                 assert!(matches!(*value, PhysicalExpr::Value(AlgebraicValue::U64(5))));
 
                 match *input {
-                    PhysicalPlan::TableScan(schema, _) => {
+                    PhysicalPlan::TableScan(schema, _, _) => {
                         assert_eq!(schema.table_id, t_id);
                     }
                     plan => panic!("unexpected plan: {:#?}", plan),
@@ -1468,8 +1201,8 @@ mod tests {
             join b on q.entity_id = b.entity_id
             where u.identity = 5
         ";
-        let lp = compile_sql_sub(sql, &db).unwrap();
-        let pp = compile(lp).plan.optimize();
+        let lp = parse_and_type_sub(sql, &db).unwrap();
+        let pp = compile_project_plan(lp).optimize();
 
         // Plan:
         //         rx
@@ -1480,7 +1213,7 @@ mod tests {
         //    /  \
         // ix(u)  l
         let plan = match pp {
-            PhysicalProject::None(plan) => plan,
+            ProjectPlan::None(plan) => plan,
             proj => panic!("unexpected project: {:#?}", proj),
         };
 
@@ -1499,7 +1232,7 @@ mod tests {
                     rhs,
                     rhs_field: ColId(0),
                     unique: true,
-                    lhs_probe_expr: ProjectField { pos: 0, .. },
+                    lhs_field: TupleField { field_pos: 0, .. },
                     ..
                 },
                 Semi::Rhs,
@@ -1523,7 +1256,7 @@ mod tests {
                     rhs,
                     rhs_field: ColId(1),
                     unique: false,
-                    lhs_probe_expr: ProjectField { pos: 1, .. },
+                    lhs_field: TupleField { field_pos: 1, .. },
                     ..
                 },
                 Semi::Rhs,
@@ -1545,7 +1278,7 @@ mod tests {
                     rhs,
                     rhs_field: ColId(0),
                     unique: true,
-                    lhs_probe_expr: ProjectField { pos: 1, .. },
+                    lhs_field: TupleField { field_pos: 1, .. },
                     ..
                 },
                 Semi::Rhs,
@@ -1660,8 +1393,8 @@ mod tests {
             join p on p.id = v.project
             where 5 = m.employee and 5 = v.employee
         ";
-        let lp = compile_sql_sub(sql, &db).unwrap();
-        let pp = compile(lp).plan.optimize();
+        let lp = parse_and_type_sub(sql, &db).unwrap();
+        let pp = compile_project_plan(lp).optimize();
 
         // Plan:
         //           rx
@@ -1674,7 +1407,7 @@ mod tests {
         //    /  \
         // ix(m)  m
         let plan = match pp {
-            PhysicalProject::None(plan) => plan,
+            ProjectPlan::None(plan) => plan,
             proj => panic!("unexpected project: {:#?}", proj),
         };
 
@@ -1695,7 +1428,7 @@ mod tests {
                     rhs,
                     rhs_field: ColId(0),
                     unique: true,
-                    lhs_probe_expr: ProjectField { pos: 1, .. },
+                    lhs_field: TupleField { field_pos: 1, .. },
                     ..
                 },
                 Semi::Rhs,
@@ -1719,8 +1452,8 @@ mod tests {
                 HashJoin {
                     lhs,
                     rhs,
-                    lhs_field: ProjectField { pos: 1, .. },
-                    rhs_field: ProjectField { pos: 1, .. },
+                    lhs_field: TupleField { field_pos: 1, .. },
+                    rhs_field: TupleField { field_pos: 1, .. },
                     unique: true,
                 },
                 Semi::Rhs,
@@ -1758,7 +1491,7 @@ mod tests {
                     rhs,
                     rhs_field: ColId(0),
                     unique: false,
-                    lhs_probe_expr: ProjectField { pos: 0, .. },
+                    lhs_field: TupleField { field_pos: 0, .. },
                     ..
                 },
                 Semi::Rhs,
@@ -1780,7 +1513,7 @@ mod tests {
                     rhs,
                     rhs_field: ColId(1),
                     unique: false,
-                    lhs_probe_expr: ProjectField { pos: 1, .. },
+                    lhs_field: TupleField { field_pos: 1, .. },
                     ..
                 },
                 Semi::Rhs,
@@ -1807,5 +1540,121 @@ mod tests {
             }
             plan => panic!("unexpected plan: {:#?}", plan),
         }
+    }
+
+    /// Test single and multi-column index selections
+    #[test]
+    fn index_scans() {
+        let t_id = TableId(1);
+
+        let t = Arc::new(schema(
+            t_id,
+            "t",
+            &[
+                ("w", AlgebraicType::U8),
+                ("x", AlgebraicType::U8),
+                ("y", AlgebraicType::U8),
+                ("z", AlgebraicType::U8),
+            ],
+            &[&[1], &[2, 3], &[1, 2, 3]],
+            &[],
+            None,
+        ));
+
+        let db = SchemaViewer {
+            schemas: vec![t.clone()],
+        };
+
+        let sql = "select * from t where x = 3 and y = 4 and z = 5";
+        let lp = parse_and_type_sub(sql, &db).unwrap();
+        let pp = compile_project_plan(lp).optimize();
+
+        // Select index on (x, y, z)
+        match pp {
+            ProjectPlan::None(PhysicalPlan::IxScan(
+                IxScan {
+                    schema, prefix, arg, ..
+                },
+                _,
+            )) => {
+                assert_eq!(schema.table_id, t_id);
+                assert_eq!(arg, Sarg::Eq(ColId(3), AlgebraicValue::U8(5)));
+                assert_eq!(
+                    prefix,
+                    vec![(ColId(1), AlgebraicValue::U8(3)), (ColId(2), AlgebraicValue::U8(4))]
+                );
+            }
+            proj => panic!("unexpected plan: {:#?}", proj),
+        };
+
+        let sql = "select * from t where x = 3 and y = 4";
+        let lp = parse_and_type_sub(sql, &db).unwrap();
+        let pp = compile_project_plan(lp).optimize();
+
+        // Select index on x
+        let plan = match pp {
+            ProjectPlan::None(PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, field, value))) => {
+                assert!(matches!(*field, PhysicalExpr::Field(TupleField { field_pos: 2, .. })));
+                assert!(matches!(*value, PhysicalExpr::Value(AlgebraicValue::U8(4))));
+                *input
+            }
+            proj => panic!("unexpected plan: {:#?}", proj),
+        };
+
+        match plan {
+            PhysicalPlan::IxScan(
+                IxScan {
+                    schema, prefix, arg, ..
+                },
+                _,
+            ) => {
+                assert_eq!(schema.table_id, t_id);
+                assert_eq!(arg, Sarg::Eq(ColId(1), AlgebraicValue::U8(3)));
+                assert!(prefix.is_empty());
+            }
+            plan => panic!("unexpected plan: {:#?}", plan),
+        };
+
+        let sql = "select * from t where w = 5 and x = 4";
+        let lp = parse_and_type_sub(sql, &db).unwrap();
+        let pp = compile_project_plan(lp).optimize();
+
+        // Select index on x
+        let plan = match pp {
+            ProjectPlan::None(PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, field, value))) => {
+                assert!(matches!(*field, PhysicalExpr::Field(TupleField { field_pos: 0, .. })));
+                assert!(matches!(*value, PhysicalExpr::Value(AlgebraicValue::U8(5))));
+                *input
+            }
+            proj => panic!("unexpected plan: {:#?}", proj),
+        };
+
+        match plan {
+            PhysicalPlan::IxScan(
+                IxScan {
+                    schema, prefix, arg, ..
+                },
+                _,
+            ) => {
+                assert_eq!(schema.table_id, t_id);
+                assert_eq!(arg, Sarg::Eq(ColId(1), AlgebraicValue::U8(4)));
+                assert!(prefix.is_empty());
+            }
+            plan => panic!("unexpected plan: {:#?}", plan),
+        };
+
+        let sql = "select * from t where y = 1";
+        let lp = parse_and_type_sub(sql, &db).unwrap();
+        let pp = compile_project_plan(lp).optimize();
+
+        // Do not select index on (y, z)
+        match pp {
+            ProjectPlan::None(PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, field, value))) => {
+                assert!(matches!(*input, PhysicalPlan::TableScan(..)));
+                assert!(matches!(*field, PhysicalExpr::Field(TupleField { field_pos: 2, .. })));
+                assert!(matches!(*value, PhysicalExpr::Value(AlgebraicValue::U8(1))));
+            }
+            proj => panic!("unexpected plan: {:#?}", proj),
+        };
     }
 }

--- a/crates/physical-plan/src/rules.rs
+++ b/crates/physical-plan/src/rules.rs
@@ -1,0 +1,1085 @@
+//! This module defines the rewrite rules used for query optimization.
+//!
+//! These include:
+//!
+//! * [PushConstEq]  
+//!     Push down predicates of the form `x=1`
+//! * [PushConstAnd]  
+//!     Push down predicates of the form `x=1 and y=2`
+//! * [IxScanEq]  
+//!     Generate 1-column index scan for `x=1`
+//! * [IxScanAnd]  
+//!     Generate 1-column index scan for `x=1 and y=2`
+//! * [IxScanEq2Col]  
+//!     Generate 2-column index scan
+//! * [IxScanEq3Col]  
+//!     Generate 3-column index scan
+//! * [ReorderHashJoin]  
+//!     Reorder the sides of a hash join
+//! * [ReorderDeltaJoinRhs]
+//!     Reorder the sides of a hash join with delta tables
+//! * [PullFilterAboveHashJoin]
+//!     Pull a filter above a hash join with delta tables
+//! * [HashToIxJoin]  
+//!     Convert hash join to index join
+//! * [UniqueIxJoinRule]  
+//!     Mark index join as unique
+//! * [UniqueHashJoinRule]  
+//!     Mark hash join as unique
+use spacetimedb_primitives::{ColId, ColSet, IndexId};
+use spacetimedb_schema::schema::IndexSchema;
+use spacetimedb_sql_parser::ast::{BinOp, LogOp};
+
+use crate::plan::{HashJoin, IxJoin, IxScan, Label, PhysicalExpr, PhysicalPlan, Sarg, Semi, TupleField};
+
+pub trait RewriteRule {
+    type Plan;
+    type Info;
+
+    fn matches(plan: &Self::Plan) -> Option<Self::Info>;
+    fn rewrite(plan: Self::Plan, info: Self::Info) -> Self::Plan;
+}
+
+/// To preserve semantics while reordering operations,
+/// the physical plan assumes tuples with named labels.
+/// However positions are computed for them before execution.
+/// Note, this should always be the last rewrite.
+pub(crate) struct ComputePositions;
+
+impl RewriteRule for ComputePositions {
+    type Plan = PhysicalPlan;
+    type Info = Label;
+
+    fn matches(plan: &Self::Plan) -> Option<Self::Info> {
+        match plan {
+            PhysicalPlan::Filter(_, expr) => {
+                let mut label = None;
+                expr.visit(&mut |expr| {
+                    if let PhysicalExpr::Field(t @ TupleField { label_pos: None, .. }) = expr {
+                        label = Some(t.label);
+                    }
+                });
+                label
+            }
+            PhysicalPlan::IxJoin(
+                IxJoin {
+                    lhs_field: t @ TupleField { label_pos: None, .. },
+                    ..
+                },
+                _,
+            )
+            | PhysicalPlan::HashJoin(
+                HashJoin {
+                    lhs_field: t @ TupleField { label_pos: None, .. },
+                    ..
+                },
+                _,
+            )
+            | PhysicalPlan::HashJoin(
+                HashJoin {
+                    rhs_field: t @ TupleField { label_pos: None, .. },
+                    ..
+                },
+                _,
+            ) => Some(t.label),
+            _ => None,
+        }
+    }
+
+    fn rewrite(mut plan: Self::Plan, label: Self::Info) -> Self::Plan {
+        match &mut plan {
+            PhysicalPlan::Filter(input, expr) => {
+                if let Some(i) = input.position(&label) {
+                    expr.visit_mut(&mut |expr| match expr {
+                        PhysicalExpr::Field(t @ TupleField { label_pos: None, .. }) if t.label == label => {
+                            t.label_pos = Some(i);
+                        }
+                        _ => {}
+                    });
+                }
+            }
+            PhysicalPlan::IxJoin(
+                IxJoin {
+                    lhs: input,
+                    lhs_field: t @ TupleField { label_pos: None, .. },
+                    ..
+                },
+                _,
+            )
+            | PhysicalPlan::HashJoin(
+                HashJoin {
+                    lhs: input,
+                    lhs_field: t @ TupleField { label_pos: None, .. },
+                    ..
+                },
+                _,
+            )
+            | PhysicalPlan::HashJoin(
+                HashJoin {
+                    rhs: input,
+                    rhs_field: t @ TupleField { label_pos: None, .. },
+                    ..
+                },
+                _,
+            ) => {
+                if let Some(i) = input.position(&label) {
+                    t.label_pos = Some(i);
+                }
+            }
+            _ => {}
+        }
+        plan
+    }
+}
+
+/// Push constant comparisons down to the leaves.
+///
+/// Example:
+///
+/// ```sql
+/// select b.*
+/// from a join b on a.id = b.id
+/// where a.x = 3
+/// ```
+///
+/// ... to ...
+///
+/// ```sql
+/// select b.*
+/// from (select * from a where x = 3) a
+/// join b on a.id = b.id
+/// ```
+///
+/// Example:
+///
+/// ```text
+///  s(a)
+///   |
+///   x
+///  / \
+/// a   b
+///
+/// ... to ...
+///
+///    x
+///   / \
+/// s(a) b
+///  |
+///  a
+/// ```
+pub(crate) struct PushConstEq;
+
+impl RewriteRule for PushConstEq {
+    type Plan = PhysicalPlan;
+    type Info = Label;
+
+    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
+        if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(_, expr, value)) = plan {
+            if let (PhysicalExpr::Field(TupleField { label: var, .. }), PhysicalExpr::Value(_)) = (&**expr, &**value) {
+                return match &**input {
+                    PhysicalPlan::TableScan(..) => None,
+                    input => input
+                        .any(&|plan| match plan {
+                            PhysicalPlan::TableScan(_, label, _) => label == var,
+                            _ => false,
+                        })
+                        .then_some(*var),
+                };
+            }
+        }
+        None
+    }
+
+    fn rewrite(plan: PhysicalPlan, relvar: Self::Info) -> PhysicalPlan {
+        if let PhysicalPlan::Filter(input, expr) = plan {
+            return input.map_if(
+                |scan, _| PhysicalPlan::Filter(Box::new(scan), expr),
+                |plan| match plan {
+                    PhysicalPlan::TableScan(_, var, _) if var == &relvar => Some(()),
+                    _ => None,
+                },
+            );
+        }
+        unreachable!()
+    }
+}
+
+/// Push constant conjunctions down to the leaves.
+///
+/// Example:
+///
+/// ```sql
+/// select b.*
+/// from a join b on a.id = b.id
+/// where a.x = 3 and a.y = 5
+/// ```
+///
+/// ... to ...
+///
+/// ```sql
+/// select b.*
+/// from (select * from a where x = 3 and y = 5) a
+/// join b on a.id = b.id
+/// ```
+///
+/// Example:
+///
+/// ```text
+///  s(a)
+///   |
+///   x
+///  / \
+/// a   b
+///
+/// ... to ...
+///
+///    x
+///   / \
+/// s(a) b
+///  |
+///  a
+/// ```
+pub(crate) struct PushConstAnd;
+
+impl RewriteRule for PushConstAnd {
+    type Plan = PhysicalPlan;
+    type Info = Label;
+
+    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
+        if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan {
+            return exprs.iter().find_map(|expr| {
+                if let PhysicalExpr::BinOp(_, expr, value) = expr {
+                    if let (PhysicalExpr::Field(TupleField { label: var, .. }), PhysicalExpr::Value(_)) =
+                        (&**expr, &**value)
+                    {
+                        return match &**input {
+                            PhysicalPlan::TableScan(..) => None,
+                            input => input
+                                .any(&|plan| match plan {
+                                    PhysicalPlan::TableScan(_, label, _) => label == var,
+                                    _ => false,
+                                })
+                                .then_some(*var),
+                        };
+                    }
+                }
+                None
+            });
+        }
+        None
+    }
+
+    fn rewrite(plan: PhysicalPlan, relvar: Self::Info) -> PhysicalPlan {
+        if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan {
+            let mut leaf_exprs = vec![];
+            let mut root_exprs = vec![];
+            for expr in exprs {
+                if let PhysicalExpr::BinOp(_, lhs, value) = &expr {
+                    if let (PhysicalExpr::Field(TupleField { label: var, .. }), PhysicalExpr::Value(_)) =
+                        (&**lhs, &**value)
+                    {
+                        if var == &relvar {
+                            leaf_exprs.push(expr);
+                            continue;
+                        }
+                    }
+                }
+                root_exprs.push(expr);
+            }
+            // Match on table or delta scan
+            let ok = |plan: &PhysicalPlan| match plan {
+                PhysicalPlan::TableScan(_, var, _) if var == &relvar => Some(()),
+                _ => None,
+            };
+            // Map scan to scan + filter
+            let f = |scan, _| {
+                PhysicalPlan::Filter(
+                    Box::new(scan),
+                    match leaf_exprs.len() {
+                        1 => leaf_exprs.swap_remove(0),
+                        _ => PhysicalExpr::LogOp(LogOp::And, leaf_exprs),
+                    },
+                )
+            };
+            // Remove top level filter if all conditions were pushable
+            if root_exprs.is_empty() {
+                return input.map_if(f, ok);
+            }
+            // Otherwise remove exprs from top level filter and push
+            return PhysicalPlan::Filter(
+                Box::new(input.map_if(f, ok)),
+                match root_exprs.len() {
+                    1 => root_exprs.swap_remove(0),
+                    _ => PhysicalExpr::LogOp(LogOp::And, root_exprs),
+                },
+            );
+        }
+        unreachable!()
+    }
+}
+
+/// Match single field equality predicates such as:
+///
+/// ```sql
+/// select * from t where x = 1
+/// ```
+///
+/// Rewrite as an index scan if applicable.
+///
+/// NOTE: This rule does not consider multi-column indexes.
+pub(crate) struct IxScanEq;
+
+pub(crate) struct IxScanInfo {
+    index_id: IndexId,
+    cols: Vec<(usize, ColId)>,
+}
+
+impl RewriteRule for IxScanEq {
+    type Plan = PhysicalPlan;
+    type Info = (IndexId, ColId);
+
+    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
+        if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, expr, value)) = plan {
+            if let PhysicalPlan::TableScan(schema, _, None) = &**input {
+                if let (PhysicalExpr::Field(TupleField { field_pos: pos, .. }), PhysicalExpr::Value(_)) =
+                    (&**expr, &**value)
+                {
+                    return schema.indexes.iter().find_map(
+                        |IndexSchema {
+                             index_id,
+                             index_algorithm,
+                             ..
+                         }| {
+                            index_algorithm
+                                .columns()
+                                // TODO: Support prefix scans
+                                .as_singleton()
+                                .filter(|col_id| col_id.idx() == *pos)
+                                .map(|col_id| (*index_id, col_id))
+                        },
+                    );
+                }
+            }
+        }
+        None
+    }
+
+    fn rewrite(plan: PhysicalPlan, (index_id, col_id): Self::Info) -> PhysicalPlan {
+        if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, _, value)) = plan {
+            if let PhysicalPlan::TableScan(schema, var, None) = *input {
+                if let PhysicalExpr::Value(v) = *value {
+                    return PhysicalPlan::IxScan(
+                        IxScan {
+                            schema,
+                            index_id,
+                            prefix: vec![],
+                            arg: Sarg::Eq(col_id, v),
+                        },
+                        var,
+                    );
+                }
+            }
+        }
+        unreachable!()
+    }
+}
+
+/// Match multi-field equality predicates such as:
+///
+/// ```sql
+/// select * from t where x = 1 and y = 1
+/// ```
+///
+/// Create an index scan for one of the equality conditions.
+///
+/// NOTE: This rule does not consider multi-column indexes.
+pub(crate) struct IxScanAnd;
+
+impl RewriteRule for IxScanAnd {
+    type Plan = PhysicalPlan;
+    type Info = (IndexId, usize, ColId);
+
+    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
+        if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan {
+            if let PhysicalPlan::TableScan(schema, _, None) = &**input {
+                return exprs.iter().enumerate().find_map(|(i, expr)| {
+                    if let PhysicalExpr::BinOp(BinOp::Eq, lhs, value) = expr {
+                        if let (PhysicalExpr::Field(TupleField { field_pos: pos, .. }), PhysicalExpr::Value(_)) =
+                            (&**lhs, &**value)
+                        {
+                            return schema.indexes.iter().find_map(
+                                |IndexSchema {
+                                     index_id,
+                                     index_algorithm,
+                                     ..
+                                 }| {
+                                    index_algorithm
+                                        .columns()
+                                        // TODO: Support prefix scans
+                                        .as_singleton()
+                                        .filter(|col_id| col_id.idx() == *pos)
+                                        .map(|col_id| (*index_id, i, col_id))
+                                },
+                            );
+                        }
+                    }
+                    None
+                });
+            }
+        }
+        None
+    }
+
+    fn rewrite(plan: PhysicalPlan, (index_id, i, col_id): Self::Info) -> PhysicalPlan {
+        if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, mut exprs)) = plan {
+            if let PhysicalPlan::TableScan(schema, label, None) = *input {
+                if let PhysicalExpr::BinOp(BinOp::Eq, _, value) = exprs.swap_remove(i) {
+                    if let PhysicalExpr::Value(v) = *value {
+                        return PhysicalPlan::Filter(
+                            Box::new(PhysicalPlan::IxScan(
+                                IxScan {
+                                    schema,
+                                    index_id,
+                                    prefix: vec![],
+                                    arg: Sarg::Eq(col_id, v),
+                                },
+                                label,
+                            )),
+                            match exprs.len() {
+                                1 => exprs.swap_remove(0),
+                                _ => PhysicalExpr::LogOp(LogOp::And, exprs),
+                            },
+                        );
+                    }
+                }
+            }
+        }
+        unreachable!()
+    }
+}
+
+/// Match multi-field equality predicates such as:
+///
+/// ```sql
+/// select * from t where x = 1 and y = 1
+/// ```
+///
+/// Rewrite as a multi-column index scan if applicable.
+///
+/// NOTE: This rule does not consider indexes on 3 or more columns.
+pub(crate) struct IxScanEq2Col;
+
+impl RewriteRule for IxScanEq2Col {
+    type Plan = PhysicalPlan;
+    type Info = IxScanInfo;
+
+    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
+        if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan {
+            if let PhysicalPlan::TableScan(schema, _, None) = &**input {
+                for (i, a) in exprs.iter().enumerate() {
+                    for (j, b) in exprs.iter().enumerate().filter(|(j, _)| i != *j) {
+                        if let (PhysicalExpr::BinOp(BinOp::Eq, a, u), PhysicalExpr::BinOp(BinOp::Eq, b, v)) = (a, b) {
+                            if let (
+                                PhysicalExpr::Field(u),
+                                PhysicalExpr::Value(_),
+                                PhysicalExpr::Field(v),
+                                PhysicalExpr::Value(_),
+                            ) = (&**a, &**u, &**b, &**v)
+                            {
+                                return schema
+                                    .indexes
+                                    .iter()
+                                    .filter(|IndexSchema { index_algorithm, .. }| {
+                                        // TODO: Support prefix scans
+                                        index_algorithm.columns().len() == 2
+                                    })
+                                    .find_map(
+                                        |IndexSchema {
+                                             index_id,
+                                             index_algorithm,
+                                             ..
+                                         }| {
+                                            Some(IxScanInfo {
+                                                index_id: *index_id,
+                                                cols: vec![
+                                                    (
+                                                        i,
+                                                        index_algorithm
+                                                            .columns()
+                                                            .iter()
+                                                            .next()
+                                                            .filter(|col_id| col_id.idx() == u.field_pos)?,
+                                                    ),
+                                                    (
+                                                        j,
+                                                        index_algorithm
+                                                            .columns()
+                                                            .iter()
+                                                            .nth(1)
+                                                            .filter(|col_id| col_id.idx() == v.field_pos)?,
+                                                    ),
+                                                ],
+                                            })
+                                        },
+                                    );
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn rewrite(plan: PhysicalPlan, info: Self::Info) -> PhysicalPlan {
+        match info.cols.as_slice() {
+            [(i, a), (j, b)] => {
+                if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan {
+                    if let PhysicalPlan::TableScan(schema, label, None) = *input {
+                        if let (
+                            Some(PhysicalExpr::BinOp(BinOp::Eq, _, u)),
+                            Some(PhysicalExpr::BinOp(BinOp::Eq, _, v)),
+                        ) = (exprs.get(*i), exprs.get(*j))
+                        {
+                            if let (PhysicalExpr::Value(u), PhysicalExpr::Value(v)) = (&**u, &**v) {
+                                return match exprs.len() {
+                                    // If there are only 2 conditions in this filter,
+                                    // we replace the filter with an index scan.
+                                    2 => PhysicalPlan::IxScan(
+                                        IxScan {
+                                            schema,
+                                            index_id: info.index_id,
+                                            prefix: vec![(*a, u.clone())],
+                                            arg: Sarg::Eq(*b, v.clone()),
+                                        },
+                                        label,
+                                    ),
+                                    // If there are 3 conditions in this filter,
+                                    // we create an index scan from 2 of them.
+                                    // The original conjunction is no longer well defined,
+                                    // because it only has a single operand now.
+                                    // Hence we must replace it with its operand.
+                                    3 => PhysicalPlan::Filter(
+                                        Box::new(PhysicalPlan::IxScan(
+                                            IxScan {
+                                                schema,
+                                                index_id: info.index_id,
+                                                prefix: vec![(*a, u.clone())],
+                                                arg: Sarg::Eq(*b, v.clone()),
+                                            },
+                                            label,
+                                        )),
+                                        exprs
+                                            .into_iter()
+                                            .enumerate()
+                                            .find(|(pos, _)| pos != i && pos != j)
+                                            .map(|(_, expr)| expr)
+                                            .unwrap(),
+                                    ),
+                                    // If there are more than 3 conditions in this filter,
+                                    // we remove the 2 conditions used in the index scan.
+                                    // The remaining conditions still form a conjunction.
+                                    _ => PhysicalPlan::Filter(
+                                        Box::new(PhysicalPlan::IxScan(
+                                            IxScan {
+                                                schema,
+                                                index_id: info.index_id,
+                                                prefix: vec![(*a, u.clone())],
+                                                arg: Sarg::Eq(*b, v.clone()),
+                                            },
+                                            label,
+                                        )),
+                                        PhysicalExpr::LogOp(
+                                            LogOp::And,
+                                            exprs
+                                                .into_iter()
+                                                .enumerate()
+                                                .filter(|(pos, _)| pos != i && pos != j)
+                                                .map(|(_, expr)| expr)
+                                                .collect(),
+                                        ),
+                                    ),
+                                };
+                            }
+                        }
+                    }
+                }
+                unreachable!()
+            }
+            _ => plan,
+        }
+    }
+}
+
+/// Match multi-field equality predicates such as:
+///
+/// ```sql
+/// select * from t where x = 1 and y = 1 and z = 1
+/// ```
+///
+/// Rewrite as a multi-column index scan if applicable.
+///
+/// NOTE: This rule does not consider indexes on 4 or more columns.
+pub(crate) struct IxScanEq3Col;
+
+impl RewriteRule for IxScanEq3Col {
+    type Plan = PhysicalPlan;
+    type Info = IxScanInfo;
+
+    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
+        if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan {
+            if let PhysicalPlan::TableScan(schema, _, None) = &**input {
+                for (i, a) in exprs.iter().enumerate() {
+                    for (j, b) in exprs.iter().enumerate().filter(|(j, _)| i != *j) {
+                        for (k, c) in exprs.iter().enumerate().filter(|(k, _)| i != *k && j != *k) {
+                            if let (
+                                PhysicalExpr::BinOp(BinOp::Eq, a, u),
+                                PhysicalExpr::BinOp(BinOp::Eq, b, v),
+                                PhysicalExpr::BinOp(BinOp::Eq, c, w),
+                            ) = (a, b, c)
+                            {
+                                if let (
+                                    PhysicalExpr::Field(u),
+                                    PhysicalExpr::Value(_),
+                                    PhysicalExpr::Field(v),
+                                    PhysicalExpr::Value(_),
+                                    PhysicalExpr::Field(w),
+                                    PhysicalExpr::Value(_),
+                                ) = (&**a, &**u, &**b, &**v, &**c, &**w)
+                                {
+                                    return schema
+                                        .indexes
+                                        .iter()
+                                        .filter(|IndexSchema { index_algorithm, .. }| {
+                                            // TODO: Support prefix scans
+                                            index_algorithm.columns().len() == 3
+                                        })
+                                        .find_map(
+                                            |IndexSchema {
+                                                 index_id,
+                                                 index_algorithm,
+                                                 ..
+                                             }| {
+                                                Some(IxScanInfo {
+                                                    index_id: *index_id,
+                                                    cols: vec![
+                                                        (
+                                                            i,
+                                                            index_algorithm
+                                                                .columns()
+                                                                .iter()
+                                                                .next()
+                                                                .filter(|col_id| col_id.idx() == u.field_pos)?,
+                                                        ),
+                                                        (
+                                                            j,
+                                                            index_algorithm
+                                                                .columns()
+                                                                .iter()
+                                                                .nth(1)
+                                                                .filter(|col_id| col_id.idx() == v.field_pos)?,
+                                                        ),
+                                                        (
+                                                            k,
+                                                            index_algorithm
+                                                                .columns()
+                                                                .iter()
+                                                                .nth(2)
+                                                                .filter(|col_id| col_id.idx() == w.field_pos)?,
+                                                        ),
+                                                    ],
+                                                })
+                                            },
+                                        );
+                                }
+                            }
+                        }
+                    }
+                }
+            }
+        }
+        None
+    }
+
+    fn rewrite(plan: PhysicalPlan, info: Self::Info) -> PhysicalPlan {
+        match info.cols.as_slice() {
+            [(i, a), (j, b), (k, c)] => {
+                if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan {
+                    if let PhysicalPlan::TableScan(schema, label, None) = *input {
+                        if let (
+                            Some(PhysicalExpr::BinOp(BinOp::Eq, _, u)),
+                            Some(PhysicalExpr::BinOp(BinOp::Eq, _, v)),
+                            Some(PhysicalExpr::BinOp(BinOp::Eq, _, w)),
+                        ) = (exprs.get(*i), exprs.get(*j), exprs.get(*k))
+                        {
+                            if let (PhysicalExpr::Value(u), PhysicalExpr::Value(v), PhysicalExpr::Value(w)) =
+                                (&**u, &**v, &**w)
+                            {
+                                return match exprs.len() {
+                                    // If there are only 3 conditions in this filter,
+                                    // we replace the filter with an index scan.
+                                    3 => PhysicalPlan::IxScan(
+                                        IxScan {
+                                            schema,
+                                            index_id: info.index_id,
+                                            prefix: vec![(*a, u.clone()), (*b, v.clone())],
+                                            arg: Sarg::Eq(*c, w.clone()),
+                                        },
+                                        label,
+                                    ),
+                                    // If there are 4 conditions in this filter,
+                                    // we create an index scan from 3 of them.
+                                    // The original conjunction is no longer well defined,
+                                    // because it only has a single operand now.
+                                    // Hence we must replace it with its operand.
+                                    4 => PhysicalPlan::Filter(
+                                        Box::new(PhysicalPlan::IxScan(
+                                            IxScan {
+                                                schema,
+                                                index_id: info.index_id,
+                                                prefix: vec![(*a, u.clone()), (*b, v.clone())],
+                                                arg: Sarg::Eq(*c, w.clone()),
+                                            },
+                                            label,
+                                        )),
+                                        exprs
+                                            .into_iter()
+                                            .enumerate()
+                                            .find(|(pos, _)| pos != i && pos != j && pos != k)
+                                            .map(|(_, expr)| expr)
+                                            .unwrap(),
+                                    ),
+                                    // If there are more than 4 conditions in this filter,
+                                    // we remove the 3 conditions used in the index scan.
+                                    // The remaining conditions still form a conjunction.
+                                    _ => PhysicalPlan::Filter(
+                                        Box::new(PhysicalPlan::IxScan(
+                                            IxScan {
+                                                schema,
+                                                index_id: info.index_id,
+                                                prefix: vec![(*a, u.clone()), (*b, v.clone())],
+                                                arg: Sarg::Eq(*c, w.clone()),
+                                            },
+                                            label,
+                                        )),
+                                        PhysicalExpr::LogOp(
+                                            LogOp::And,
+                                            exprs
+                                                .into_iter()
+                                                .enumerate()
+                                                .filter(|(pos, _)| pos != i && pos != j && pos != k)
+                                                .map(|(_, expr)| expr)
+                                                .collect(),
+                                        ),
+                                    ),
+                                };
+                            }
+                        }
+                    }
+                }
+                unreachable!()
+            }
+            _ => plan,
+        }
+    }
+}
+
+/// Reorder hash joins so that selections are on the lhs.
+///
+/// ```text
+///   x
+///  / \
+/// a  s(b)
+///     |
+///     b
+///
+/// ... to ...
+///
+///    x
+///   / \
+/// s(b) a
+///  |
+///  b
+/// ```
+pub(crate) struct ReorderHashJoin;
+
+impl RewriteRule for ReorderHashJoin {
+    type Plan = PhysicalPlan;
+    type Info = ();
+
+    fn matches(plan: &Self::Plan) -> Option<Self::Info> {
+        match plan {
+            PhysicalPlan::HashJoin(HashJoin { lhs, rhs, .. }, Semi::All) => {
+                (matches!(&**lhs, PhysicalPlan::TableScan(..)) && !matches!(&**rhs, PhysicalPlan::TableScan(..)))
+                    .then_some(())
+            }
+            _ => None,
+        }
+    }
+
+    fn rewrite(plan: Self::Plan, _: Self::Info) -> Self::Plan {
+        match plan {
+            PhysicalPlan::HashJoin(join, Semi::All) => PhysicalPlan::HashJoin(
+                HashJoin {
+                    lhs: join.rhs,
+                    rhs: join.lhs,
+                    lhs_field: join.rhs_field,
+                    rhs_field: join.lhs_field,
+                    unique: false,
+                },
+                Semi::All,
+            ),
+            _ => plan,
+        }
+    }
+}
+
+/// Reorder a hash join if the rhs is a delta table.
+///
+/// ```text
+///    x
+///   / \
+/// s(b) a
+///  |
+///  b
+///
+/// ... to ...
+///
+///   x
+///  / \
+/// a  s(b)
+///     |
+///     b
+/// ```
+pub(crate) struct ReorderDeltaJoinRhs;
+
+impl RewriteRule for ReorderDeltaJoinRhs {
+    type Plan = PhysicalPlan;
+    type Info = ();
+
+    fn matches(plan: &Self::Plan) -> Option<Self::Info> {
+        if let PhysicalPlan::HashJoin(HashJoin { lhs, rhs, .. }, Semi::All) = plan {
+            if let PhysicalPlan::Filter(input, _) = &**lhs {
+                return (matches!(&**input, PhysicalPlan::TableScan(_, _, None))
+                    && matches!(&**rhs, PhysicalPlan::TableScan(_, _, Some(_))))
+                .then_some(());
+            }
+        }
+        None
+    }
+
+    fn rewrite(plan: Self::Plan, _: Self::Info) -> Self::Plan {
+        match plan {
+            PhysicalPlan::HashJoin(join, Semi::All) => PhysicalPlan::HashJoin(
+                HashJoin {
+                    lhs: join.rhs,
+                    rhs: join.lhs,
+                    ..join
+                },
+                Semi::All,
+            ),
+            _ => plan,
+        }
+    }
+}
+
+/// Pull a filter above a hash join if:
+///
+/// 1. The lhs is a delta table
+/// 2. The rhs has an index for the join
+///
+/// ```text
+///   x
+///  / \
+/// a  s(b)
+///     |
+///     b
+///
+/// ... to ...
+///
+///  s(b)
+///   |
+///   x
+///  / \
+/// a   b
+/// ```
+pub(crate) struct PullFilterAboveHashJoin;
+
+impl RewriteRule for PullFilterAboveHashJoin {
+    type Plan = PhysicalPlan;
+    type Info = ();
+
+    fn matches(plan: &Self::Plan) -> Option<Self::Info> {
+        if let PhysicalPlan::HashJoin(
+            HashJoin {
+                lhs, rhs, rhs_field, ..
+            },
+            Semi::All,
+        ) = plan
+        {
+            if let PhysicalPlan::Filter(input, _) = &**rhs {
+                if let PhysicalPlan::TableScan(schema, _, None) = &**input {
+                    return (matches!(&**lhs, PhysicalPlan::TableScan(_, _, Some(_)))
+                        && schema.indexes.iter().any(|schema| {
+                            schema
+                                .index_algorithm
+                                .columns()
+                                .as_singleton()
+                                .is_some_and(|col_id| col_id.idx() == rhs_field.field_pos)
+                        }))
+                    .then_some(());
+                }
+            }
+        }
+        None
+    }
+
+    fn rewrite(plan: Self::Plan, _: Self::Info) -> Self::Plan {
+        if let PhysicalPlan::HashJoin(join, semi) = plan {
+            if let PhysicalPlan::Filter(rhs, expr) = *join.rhs {
+                return PhysicalPlan::Filter(
+                    Box::new(PhysicalPlan::HashJoin(
+                        HashJoin {
+                            lhs: join.lhs,
+                            rhs,
+                            ..join
+                        },
+                        semi,
+                    )),
+                    expr,
+                );
+            }
+        }
+        unreachable!()
+    }
+}
+
+/// Always prefer an index join to a hash join
+pub(crate) struct HashToIxJoin;
+
+impl RewriteRule for HashToIxJoin {
+    type Plan = PhysicalPlan;
+    type Info = (IndexId, ColId);
+
+    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
+        if let PhysicalPlan::HashJoin(
+            HashJoin {
+                rhs,
+                rhs_field: TupleField { field_pos, .. },
+                ..
+            },
+            _,
+        ) = plan
+        {
+            return match &**rhs {
+                PhysicalPlan::TableScan(schema, _, None) => {
+                    // Is there a single column index on this field?
+                    schema.indexes.iter().find_map(|ix| {
+                        ix.index_algorithm
+                            .columns()
+                            .as_singleton()
+                            .filter(|col_id| col_id.idx() == *field_pos)
+                            .map(|col_id| (ix.index_id, col_id))
+                    })
+                }
+                _ => None,
+            };
+        }
+        None
+    }
+
+    fn rewrite(plan: PhysicalPlan, (rhs_index, rhs_field): Self::Info) -> PhysicalPlan {
+        if let PhysicalPlan::HashJoin(join, semi) = plan {
+            if let PhysicalPlan::TableScan(rhs, rhs_label, None) = *join.rhs {
+                return PhysicalPlan::IxJoin(
+                    IxJoin {
+                        lhs: join.lhs,
+                        rhs,
+                        rhs_label,
+                        rhs_index,
+                        rhs_field,
+                        unique: false,
+                        lhs_field: join.lhs_field,
+                    },
+                    semi,
+                );
+            }
+        }
+        unreachable!()
+    }
+}
+
+/// Does this index join use a unique index?
+pub(crate) struct UniqueIxJoinRule;
+
+impl RewriteRule for UniqueIxJoinRule {
+    type Plan = PhysicalPlan;
+    type Info = ();
+
+    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
+        if let PhysicalPlan::IxJoin(
+            IxJoin {
+                unique: false,
+                rhs,
+                rhs_field,
+                ..
+            },
+            _,
+        ) = plan
+        {
+            return rhs
+                .constraints
+                .iter()
+                .filter_map(|cs| cs.data.unique_columns())
+                .filter_map(|cols| cols.as_singleton())
+                .find(|col_id| col_id == rhs_field)
+                .map(|_| ());
+        }
+        None
+    }
+
+    fn rewrite(mut plan: PhysicalPlan, _: Self::Info) -> PhysicalPlan {
+        if let PhysicalPlan::IxJoin(IxJoin { unique, .. }, _) = &mut plan {
+            *unique = true;
+        }
+        plan
+    }
+}
+
+/// Does probing the hash table return at most one element?
+pub(crate) struct UniqueHashJoinRule;
+
+impl RewriteRule for UniqueHashJoinRule {
+    type Plan = PhysicalPlan;
+    type Info = ();
+
+    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
+        if let PhysicalPlan::HashJoin(
+            HashJoin {
+                unique: false,
+                rhs,
+                rhs_field:
+                    TupleField {
+                        label: rhs_label,
+                        field_pos: rhs_field_pos,
+                        ..
+                    },
+                ..
+            },
+            _,
+        ) = plan
+        {
+            return rhs
+                .returns_distinct_values(rhs_label, &ColSet::from(ColId(*rhs_field_pos as u16)))
+                .then_some(());
+        }
+        None
+    }
+
+    fn rewrite(mut plan: PhysicalPlan, _: Self::Info) -> PhysicalPlan {
+        if let PhysicalPlan::HashJoin(HashJoin { unique, .. }, _) = &mut plan {
+            *unique = true;
+        }
+        plan
+    }
+}

--- a/crates/query/Cargo.toml
+++ b/crates/query/Cargo.toml
@@ -1,16 +1,20 @@
 [package]
-name = "spacetimedb-execution"
+name = "spacetimedb-query"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
 license-file = "LICENSE"
-description = "The SpacetimeDB query engine"
+description = "Top level crate for invoking the query engine and optimizer"
 
 [dependencies]
 anyhow.workspace = true
+itertools.workspace = true
+rayon.workspace = true
+spacetimedb-client-api-messages.workspace = true
+spacetimedb-execution.workspace = true
 spacetimedb-expr.workspace = true
 spacetimedb-lib.workspace = true
-spacetimedb-physical-plan.workspace = true
 spacetimedb-primitives.workspace = true
+spacetimedb-physical-plan.workspace = true
 spacetimedb-sql-parser.workspace = true
 spacetimedb-table.workspace = true

--- a/crates/query/src/delta.rs
+++ b/crates/query/src/delta.rs
@@ -1,0 +1,451 @@
+use std::ops::Deref;
+
+use anyhow::{bail, Result};
+use itertools::Either;
+use spacetimedb_execution::{iter::ProjectIter, Datastore, DeltaStore, Row};
+use spacetimedb_expr::check::{type_subscription, SchemaView};
+use spacetimedb_lib::query::Delta;
+use spacetimedb_physical_plan::{
+    compile::compile_project_plan,
+    plan::{HashJoin, IxJoin, Label, PhysicalPlan, ProjectPlan},
+};
+use spacetimedb_primitives::TableId;
+use spacetimedb_sql_parser::parser::sub::parse_subscription;
+
+use crate::MAX_SQL_LENGTH;
+
+/// A delta plan performs incremental view maintenance
+#[derive(Debug)]
+pub enum DeltaPlan {
+    Join(JoinPlan),
+    Select(SelectPlan),
+}
+
+impl Deref for DeltaPlan {
+    type Target = ProjectPlan;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Join(JoinPlan { plan, .. }) | Self::Select(SelectPlan { plan, .. }) => plan,
+        }
+    }
+}
+
+impl DeltaPlan {
+    /// Compile a delta plan for incrementally maintaining a sql view
+    pub fn compile(sql: &str, tx: &impl SchemaView) -> Result<Self> {
+        if sql.len() > MAX_SQL_LENGTH {
+            bail!("SQL query exceeds maximum allowed length: \"{sql:.120}...\"")
+        }
+        let ast = parse_subscription(sql)?;
+        let sub = type_subscription(ast, tx)?;
+
+        let Some(table_id) = sub.table_id() else {
+            bail!("Failed to determine TableId for query")
+        };
+
+        let Some(table_name) = tx.schema_for_table(table_id).map(|schema| schema.table_name.clone()) else {
+            bail!("TableId `{table_id}` does not exist")
+        };
+
+        let plan = compile_project_plan(sub);
+
+        let mut ix_joins = true;
+        plan.visit(&mut |plan| match plan {
+            PhysicalPlan::IxJoin(IxJoin { lhs_field, .. }, _) => {
+                ix_joins = ix_joins && plan.index_on_field(&lhs_field.label, lhs_field.field_pos);
+            }
+            PhysicalPlan::HashJoin(
+                HashJoin {
+                    lhs_field, rhs_field, ..
+                },
+                _,
+            ) => {
+                ix_joins = ix_joins && plan.index_on_field(&lhs_field.label, lhs_field.field_pos);
+                ix_joins = ix_joins && plan.index_on_field(&rhs_field.label, rhs_field.field_pos);
+            }
+            _ => {}
+        });
+
+        if !ix_joins {
+            bail!("Subscriptions require indexes on join columns")
+        }
+
+        let mut labels = vec![];
+        plan.visit(&mut |plan| {
+            if let PhysicalPlan::TableScan(schema, label, None) = plan {
+                labels.push((schema.table_id, *label));
+            }
+        });
+
+        match labels.as_slice() {
+            [_] => Ok(Self::Select(SelectPlan {
+                table_id,
+                table_name,
+                plan,
+            })),
+            [(lhs_table, lhs_label), (rhs_table, rhs_label)] => Ok(Self::Join(JoinPlan {
+                table_id,
+                table_name,
+                lhs_label: *lhs_label,
+                rhs_label: *rhs_label,
+                lhs_table: *lhs_table,
+                rhs_table: *rhs_table,
+                plan,
+            })),
+            _ => bail!("Subscriptions cannot join more than 2 tables"),
+        }
+    }
+
+    /// Return all tables referenced in the plan
+    pub fn table_ids(&self) -> impl Iterator<Item = TableId> {
+        match self {
+            Self::Select(plan) => Either::Left(plan.table_ids()),
+            Self::Join(plan) => Either::Right(plan.table_ids()),
+        }
+    }
+
+    /// Delta plans always return rows from a single table
+    pub fn table_id(&self) -> TableId {
+        match self {
+            Self::Select(plan) => plan.table_id(),
+            Self::Join(plan) => plan.table_id(),
+        }
+    }
+
+    /// Delta plans always return rows from a single table
+    pub fn table_name(&self) -> Box<str> {
+        match self {
+            Self::Select(plan) => plan.table_name(),
+            Self::Join(plan) => plan.table_name(),
+        }
+    }
+
+    /// Return an evaluator for this delta plan
+    pub fn evaluator<Tx: Datastore + DeltaStore>(&self, tx: &Tx) -> DeltaPlanEvaluator {
+        match self {
+            Self::Select(plan) => plan.evaluator(tx),
+            Self::Join(plan) => plan.evaluator(tx),
+        }
+    }
+}
+
+/// An evaluator for a delta plan.
+/// It returns the rows that were added to the view,
+/// as well as the rows that were removed from it.
+pub struct DeltaPlanEvaluator {
+    is_join: bool,
+    insert_plans: Vec<ProjectPlan>,
+    delete_plans: Vec<ProjectPlan>,
+}
+
+impl DeltaPlanEvaluator {
+    pub fn eval_inserts<'a, Tx: Datastore + DeltaStore>(&'a self, tx: &'a Tx) -> Result<impl Iterator<Item = Row<'a>>> {
+        match self.insert_plans.len() {
+            1 => ProjectIter::build(&self.insert_plans[0], tx).map(Either::Left),
+            n => {
+                let mut iters = Vec::with_capacity(n);
+                for plan in &self.insert_plans {
+                    let iter = ProjectIter::build(plan, tx)?;
+                    iters.push(iter);
+                }
+                Ok(Either::Right(iters.into_iter().flatten()))
+            }
+        }
+    }
+
+    pub fn eval_deletes<'a, Tx: Datastore + DeltaStore>(&'a self, tx: &'a Tx) -> Result<impl Iterator<Item = Row<'a>>> {
+        match self.delete_plans.len() {
+            1 => ProjectIter::build(&self.delete_plans[0], tx).map(Either::Left),
+            n => {
+                let mut iters = Vec::with_capacity(n);
+                for plan in &self.delete_plans {
+                    let iter = ProjectIter::build(plan, tx)?;
+                    iters.push(iter);
+                }
+                Ok(Either::Right(iters.into_iter().flatten()))
+            }
+        }
+    }
+
+    pub fn is_join(&self) -> bool {
+        self.is_join
+    }
+
+    pub fn has_inserts(&self) -> bool {
+        !self.insert_plans.is_empty()
+    }
+
+    pub fn has_deletes(&self) -> bool {
+        !self.delete_plans.is_empty()
+    }
+}
+
+/// A delta plan for a single table select
+#[derive(Debug)]
+pub struct SelectPlan {
+    /// The table whose rows are returned
+    table_id: TableId,
+    /// The table whose rows are returned
+    table_name: Box<str>,
+    /// The query plan for the original view
+    plan: ProjectPlan,
+}
+
+impl SelectPlan {
+    /// Delta plans always return rows from a single table
+    pub fn table_id(&self) -> TableId {
+        self.table_id
+    }
+
+    /// Delta plans always return rows from a single table
+    pub fn table_name(&self) -> Box<str> {
+        self.table_name.clone()
+    }
+
+    /// Return all tables referenced in the plan
+    pub fn table_ids(&self) -> impl Iterator<Item = TableId> {
+        std::iter::once(self.table_id)
+    }
+
+    /// Returns an evaluator for computing the view delta
+    pub fn evaluator<Tx: Datastore + DeltaStore>(&self, tx: &Tx) -> DeltaPlanEvaluator {
+        /// Mutate a query plan by adding delta scans
+        fn delta_plan(plan: &ProjectPlan, table_id: TableId, delta: Delta) -> Vec<ProjectPlan> {
+            let mut plan = plan.clone();
+            plan.visit_mut(&mut |plan| match plan {
+                PhysicalPlan::TableScan(schema, _, is_delta @ None) if schema.table_id == table_id => {
+                    *is_delta = Some(delta);
+                }
+                _ => {}
+            });
+            vec![plan]
+        }
+        DeltaPlanEvaluator {
+            is_join: false,
+            insert_plans: tx
+                .has_inserts(self.table_id)
+                .map(|delta| delta_plan(&self.plan, self.table_id, delta))
+                .unwrap_or_default(),
+            delete_plans: tx
+                .has_deletes(self.table_id)
+                .map(|delta| delta_plan(&self.plan, self.table_id, delta))
+                .unwrap_or_default(),
+        }
+    }
+}
+
+/// A delta plan for a 2-way join.
+///
+/// Let `V`  denote the join between tables `R` and `S` at time `t`.
+/// Let `V'` denote the same join at time `t+1`.
+///
+/// We then have the following equality
+///
+/// ```text
+/// V' = V U dv
+/// ```
+///
+/// where `dv` is called the delta of `V`.
+///
+/// So how do we compute `dv` incrementally?
+/// That is, without evaluating `R' x S'`.
+/// and without access to the state at time `t`.
+///
+/// Given the following notation:
+///
+/// ```text
+/// x: The relational join operator
+/// U: union
+/// -: difference
+///
+/// dv: The difference or delta between V and V'
+///
+/// dv(+): Rows in V' that are not in V
+/// dv(-): Rows in V  that are not in V'
+/// ```
+///
+/// we derive the following equations
+///
+/// ```text
+/// V  = R x S
+///    = RS
+///
+/// V' = V  U dv
+///    = RS U dv
+///
+/// V' = R' x S'
+///    = (R U dr) x (S U ds)
+///    = RS U Rds U drS U drds
+///
+/// dv = Rds U drS U drds
+///    = (R' - dr)ds U dr(S' - ds) U drds
+///    = R'ds - drds U drS' - drds U drds
+///    = R'ds U drS' - drds
+///    = R'(ds(+) - ds(-)) U (dr(+) - dr(-))S' - (dr(+) - dr(-))(ds(+) - ds(-))
+///    = R'ds(+)
+///         - R'ds(-)
+///         U dr(+)S'
+///         - dr(-)S'
+///         U dr(+)dr(-)
+///         - dr(+)ds(+)
+///         U dr(-)ds(+)
+///         - dr(-)ds(-)
+///    = R'ds(+)
+///         U dr(+)S'
+///         U dr(+)dr(-)
+///         U dr(-)ds(+)
+///         - R'ds(-)
+///         - dr(-)S'
+///         - dr(+)ds(+)
+///         - dr(-)ds(-)
+///
+/// dv(+) = R'ds(+) U dr(+)S' U dr(+)dr(-) U dr(-)ds(+)
+/// dv(-) = R'ds(-) U dr(-)S' U dr(+)ds(+) U dr(-)ds(-)
+/// ```
+#[derive(Debug)]
+pub struct JoinPlan {
+    /// The table whose rows are returned
+    table_id: TableId,
+    /// The table whose rows are returned
+    table_name: Box<str>,
+    /// The label, or alias, for the lhs table
+    lhs_label: Label,
+    /// The label, or alias, for the rhs table
+    rhs_label: Label,
+    /// The id of the lhs table
+    lhs_table: TableId,
+    /// The id of the rhs table
+    rhs_table: TableId,
+    /// An unoptimized query plan for the original view
+    plan: ProjectPlan,
+}
+
+impl JoinPlan {
+    /// Delta plans always return rows from a single table
+    pub fn table_id(&self) -> TableId {
+        self.table_id
+    }
+
+    /// Delta plans always return rows from a single table
+    pub fn table_name(&self) -> Box<str> {
+        self.table_name.clone()
+    }
+
+    /// Return all tables referenced in the plan
+    pub fn table_ids(&self) -> impl Iterator<Item = TableId> {
+        std::iter::once(self.lhs_table).chain(std::iter::once(self.rhs_table))
+    }
+
+    /// Returns an evaluator for computing the view delta
+    pub fn evaluator<Tx: Datastore + DeltaStore>(&self, tx: &Tx) -> DeltaPlanEvaluator {
+        /// Mutate a query plan by adding delta scans
+        fn delta_plan(plan: &mut ProjectPlan, label: Label, delta: Delta) {
+            plan.visit_mut(&mut |plan| match plan {
+                PhysicalPlan::TableScan(_, var, is_delta @ None) if var == &label => {
+                    *is_delta = Some(delta);
+                }
+                _ => {}
+            });
+        }
+
+        /// Instantiate and optimize a delta plan
+        fn delta_plan_opt1(plan: &ProjectPlan, label: Label, delta: Delta) -> ProjectPlan {
+            let mut plan = plan.clone();
+            delta_plan(&mut plan, label, delta);
+            plan.optimize()
+        }
+
+        /// Instantiate and optimize a delta plan
+        fn delta_plan_opt2(plan: &ProjectPlan, lhs: Label, n: Delta, rhs: Label, m: Delta) -> ProjectPlan {
+            let mut plan = plan.clone();
+            delta_plan(&mut plan, lhs, n);
+            delta_plan(&mut plan, rhs, m);
+            plan.optimize()
+        }
+
+        // dr(+)S'
+        let dr_ins = tx
+            .has_inserts(self.lhs_table)
+            .map(|delta| delta_plan_opt1(&self.plan, self.lhs_label, delta))
+            .map(std::iter::once)
+            .map(Either::Left)
+            .unwrap_or_else(|| Either::Right(std::iter::empty()));
+
+        // dr(-)S'
+        let dr_del = tx
+            .has_deletes(self.lhs_table)
+            .map(|delta| delta_plan_opt1(&self.plan, self.lhs_label, delta))
+            .map(std::iter::once)
+            .map(Either::Left)
+            .unwrap_or_else(|| Either::Right(std::iter::empty()));
+
+        // R'ds(+)
+        let ds_ins = tx
+            .has_inserts(self.rhs_table)
+            .map(|delta| delta_plan_opt1(&self.plan, self.rhs_label, delta))
+            .map(std::iter::once)
+            .map(Either::Left)
+            .unwrap_or_else(|| Either::Right(std::iter::empty()));
+
+        // R'ds(-)
+        let ds_del = tx
+            .has_deletes(self.rhs_table)
+            .map(|delta| delta_plan_opt1(&self.plan, self.rhs_label, delta))
+            .map(std::iter::once)
+            .map(Either::Left)
+            .unwrap_or_else(|| Either::Right(std::iter::empty()));
+
+        // dr(+)ds(+)
+        let dr_ins_ds_ins = tx
+            .has_inserts(self.lhs_table)
+            .zip(tx.has_inserts(self.rhs_table))
+            .map(|(n, m)| delta_plan_opt2(&self.plan, self.lhs_label, n, self.rhs_label, m))
+            .map(std::iter::once)
+            .map(Either::Left)
+            .unwrap_or_else(|| Either::Right(std::iter::empty()));
+
+        // dr(+)ds(-)
+        let dr_ins_ds_del = tx
+            .has_inserts(self.lhs_table)
+            .zip(tx.has_deletes(self.rhs_table))
+            .map(|(n, m)| delta_plan_opt2(&self.plan, self.lhs_label, n, self.rhs_label, m))
+            .map(std::iter::once)
+            .map(Either::Left)
+            .unwrap_or_else(|| Either::Right(std::iter::empty()));
+
+        // dr(-)ds(+)
+        let dr_del_ds_ins = tx
+            .has_deletes(self.lhs_table)
+            .zip(tx.has_inserts(self.rhs_table))
+            .map(|(n, m)| delta_plan_opt2(&self.plan, self.lhs_label, n, self.rhs_label, m))
+            .map(std::iter::once)
+            .map(Either::Left)
+            .unwrap_or_else(|| Either::Right(std::iter::empty()));
+
+        // dr(-)ds(-)
+        let dr_del_ds_del = tx
+            .has_deletes(self.lhs_table)
+            .zip(tx.has_deletes(self.rhs_table))
+            .map(|(n, m)| delta_plan_opt2(&self.plan, self.lhs_label, n, self.rhs_label, m))
+            .map(std::iter::once)
+            .map(Either::Left)
+            .unwrap_or_else(|| Either::Right(std::iter::empty()));
+
+        DeltaPlanEvaluator {
+            is_join: true,
+            insert_plans: ds_ins
+                // R'ds(+) U dr(+)S' U dr(+)dr(-) U dr(-)ds(+)
+                .chain(dr_ins)
+                .chain(dr_ins_ds_del)
+                .chain(dr_del_ds_ins)
+                .collect(),
+            delete_plans: ds_del
+                // R'ds(-) U dr(-)S' U dr(+)ds(+) U dr(-)ds(-)
+                .chain(dr_del)
+                .chain(dr_ins_ds_ins)
+                .chain(dr_del_ds_del)
+                .collect(),
+        }
+    }
+}

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -1,0 +1,133 @@
+use std::ops::Deref;
+
+use anyhow::{bail, Result};
+use delta::DeltaPlan;
+use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
+use spacetimedb_client_api_messages::websocket::{
+    Compression, DatabaseUpdate, QueryUpdate, TableUpdate, WebsocketFormat,
+};
+use spacetimedb_execution::{execute_plan, iter::PlanIter, Datastore, DeltaStore};
+use spacetimedb_expr::check::{type_subscription, SchemaView};
+use spacetimedb_physical_plan::{compile::compile_project_plan, plan::ProjectPlan};
+use spacetimedb_primitives::TableId;
+use spacetimedb_sql_parser::parser::sub::parse_subscription;
+
+pub mod delta;
+
+/// DIRTY HACK ALERT: Maximum allowed length, in UTF-8 bytes, of SQL queries.
+/// Any query longer than this will be rejected.
+/// This prevents a stack overflow when compiling queries with deeply-nested `AND` and `OR` conditions.
+const MAX_SQL_LENGTH: usize = 50_000;
+
+/// A subscription query plan that is NOT used for incremental evaluation
+#[derive(Debug)]
+pub struct SubscribePlan {
+    /// The query plan
+    plan: ProjectPlan,
+    /// Table id of the returned rows
+    table_id: TableId,
+    /// Table name of the returned rows
+    table_name: Box<str>,
+}
+
+impl Deref for SubscribePlan {
+    type Target = ProjectPlan;
+
+    fn deref(&self) -> &Self::Target {
+        &self.plan
+    }
+}
+
+impl SubscribePlan {
+    /// Subscription queries always return rows from a single table
+    pub fn table_id(&self) -> TableId {
+        self.table_id
+    }
+
+    /// Subscription queries always return rows from a single table
+    pub fn table_name(&self) -> &str {
+        self.table_name.as_ref()
+    }
+
+    /// Delta plans are only materialized, and optimized, at runtime.
+    /// Hence we are free to instantiate a non-delta plans from them.
+    pub fn from_delta_plan(plan: &DeltaPlan) -> Self {
+        let table_id = plan.table_id();
+        let table_name = plan.table_name();
+        let plan = &**plan;
+        let plan = plan.clone().optimize();
+        Self {
+            plan,
+            table_id,
+            table_name,
+        }
+    }
+
+    /// Compile a subscription query for standard execution
+    pub fn compile(sql: &str, tx: &impl SchemaView) -> Result<Self> {
+        if sql.len() > MAX_SQL_LENGTH {
+            bail!("SQL query exceeds maximum allowed length: \"{sql:.120}...\"")
+        }
+        let ast = parse_subscription(sql)?;
+        let sub = type_subscription(ast, tx)?;
+
+        let Some(table_id) = sub.table_id() else {
+            bail!("Failed to determine TableId for query")
+        };
+
+        let Some(table_name) = tx.schema_for_table(table_id).map(|schema| schema.table_name.clone()) else {
+            bail!("TableId `{table_id}` does not exist")
+        };
+
+        let plan = compile_project_plan(sub);
+        let plan = plan.optimize();
+
+        Ok(Self {
+            plan,
+            table_id,
+            table_name,
+        })
+    }
+
+    /// Execute a subscription query
+    pub fn execute<Tx, F>(&self, tx: &Tx) -> Result<(F::List, u64)>
+    where
+        Tx: Datastore + DeltaStore,
+        F: WebsocketFormat,
+    {
+        execute_plan(&self.plan, tx, |iter| match iter {
+            PlanIter::Index(iter) => F::encode_list(iter),
+            PlanIter::Table(iter) => F::encode_list(iter),
+            PlanIter::Delta(iter) => F::encode_list(iter),
+            PlanIter::RowId(iter) => F::encode_list(iter),
+            PlanIter::Tuple(iter) => F::encode_list(iter),
+        })
+    }
+
+    /// Execute a subscription query and collect the results in a [TableUpdate]
+    pub fn collect_table_update<Tx, F>(&self, comp: Compression, tx: &Tx) -> Result<TableUpdate<F>>
+    where
+        Tx: Datastore + DeltaStore,
+        F: WebsocketFormat,
+    {
+        self.execute::<Tx, F>(tx).map(|(inserts, num_rows)| {
+            let deletes = F::List::default();
+            let qu = QueryUpdate { deletes, inserts };
+            let update = F::into_query_update(qu, comp);
+            TableUpdate::new(self.table_id, self.table_name.clone(), (update, num_rows))
+        })
+    }
+}
+
+/// Execute a collection of subscription queries in parallel
+pub fn execute_plans<Tx, F>(plans: Vec<SubscribePlan>, comp: Compression, tx: &Tx) -> Result<DatabaseUpdate<F>>
+where
+    Tx: Datastore + DeltaStore + Sync,
+    F: WebsocketFormat,
+{
+    plans
+        .par_iter()
+        .map(|plan| plan.collect_table_update(comp, tx))
+        .collect::<Result<_>>()
+        .map(|tables| DatabaseUpdate { tables })
+}

--- a/crates/table/src/btree_index.rs
+++ b/crates/table/src/btree_index.rs
@@ -710,6 +710,16 @@ impl BTreeIndex {
         self.seek(value).next().is_some()
     }
 
+    /// Returns the number of rows associated with this `value`.
+    /// Returns `None` if 0.
+    /// Returns `Some(1)` if the index is unique.
+    pub fn count(&self, value: &AlgebraicValue) -> Option<usize> {
+        match self.seek(value).count() {
+            0 => None,
+            n => Some(n),
+        }
+    }
+
     /// Returns an iterator over the [BTreeIndex] that yields all the `RowPointer`s
     /// that fall within the specified `range`.
     pub fn seek(&self, range: &impl RangeBounds<AlgebraicValue>) -> BTreeIndexRangeIter<'_> {

--- a/crates/vm/Cargo.toml
+++ b/crates/vm/Cargo.toml
@@ -7,6 +7,7 @@ description = "A VM for SpacetimeDB"
 
 [dependencies]
 spacetimedb-data-structures.workspace = true
+spacetimedb-execution.workspace = true
 spacetimedb-sats.workspace = true
 spacetimedb-lib.workspace = true
 spacetimedb-primitives.workspace = true

--- a/crates/vm/src/relation.rs
+++ b/crates/vm/src/relation.rs
@@ -1,4 +1,5 @@
 use core::hash::{Hash, Hasher};
+use spacetimedb_execution::Row;
 use spacetimedb_lib::db::auth::StAccess;
 use spacetimedb_lib::relation::{ColExpr, ColExprRef, Header};
 use spacetimedb_sats::bsatn::{ser::BsatnError, ToBsatn};
@@ -26,6 +27,15 @@ pub enum RelValue<'a> {
     /// However, for (lifetime) reasons, we cannot (yet) keep it as a `RowRef<'_>`
     /// and must convert that into a `ProductValue`.
     ProjRef(&'a ProductValue),
+}
+
+impl<'a> From<Row<'a>> for RelValue<'a> {
+    fn from(value: Row<'a>) -> Self {
+        match value {
+            Row::Ptr(ptr) => Self::Row(ptr),
+            Row::Ref(ptr) => Self::ProjRef(ptr),
+        }
+    }
 }
 
 impl Eq for RelValue<'_> {}


### PR DESCRIPTION
# Description of Changes

This patch integrates the new query engine into the query code path.

> What is implemented?

1. Instantiating tuple-at-a-time iterators from a physical plan
2. The addition of a new `query` crate which is the top level crate for invoking the query engine.
3. Invoking the new engine for initial subscriptions, one off queries, and incremental update
4. Benchmarks

# API and ABI breaking changes

n/a

# Expected complexity level and risk

4

The query engine is responsible for implementing the subscription logic, which is **the** only way to read data out of SpacetimeDB. As such, its correctness and performance is paramount.

# Testing

> Does the new engine preserve correctness? Does it also preserve performance?

We have already added tests to ensure we preserve semantics, with more being worked on currently. This patch updates the applicable benchmarks to ensure we maintain performance characteristics.

```
full-scan               time:   [10.988 ms 11.039 ms 11.098 ms]
                        change: [-24.628% -24.131% -23.622%] (p = 0.00 < 0.05)
                        Performance has improved.

full-join               time:   [92.660 µs 92.817 µs 92.976 µs]
                        change: [-34.859% -34.730% -34.595%] (p = 0.00 < 0.05)
                        Performance has improved.

query-indexes-multi     time:   [361.15 ns 361.59 ns 362.10 ns]
                        change: [-30.401% -30.266% -30.125%] (p = 0.00 < 0.05)
                        Performance has improved.
```