### PR TITLE
CLI - Confirm before publishing to non-local servers

### DIFF
--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -116,14 +116,7 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error
     };
     if server_address != "localhost" && server_address != "127.0.0.1" {
         println!("You are about to publish to a non-local server: {}", server_address);
-        if !y_or_n(
-            force,
-            format!(
-                "Are you sure you want to proceed with publishing to {}?",
-                server_address
-            )
-            .as_str(),
-        )? {
+        if !y_or_n(force, "Are you sure you want to proceed?")? {
             println!("Aborting");
             return Ok(());
         }

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -109,6 +109,26 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error
         build::exec_with_argstring(config.clone(), path_to_project, build_options).await?
     };
     let program_bytes = fs::read(path_to_wasm)?;
+
+    let server_address = {
+        let url = Url::parse(&database_host)?;
+        url.host_str().unwrap_or("<default>").to_string()
+    };
+    if server_address != "localhost" && server_address != "127.0.0.1" {
+        println!("You are about to publish to a non-local server: {}", server_address);
+        if !y_or_n(
+            force,
+            format!(
+                "Are you sure you want to proceed with publishing to {}?",
+                server_address
+            )
+            .as_str(),
+        )? {
+            println!("Aborting");
+            return Ok(());
+        }
+    }
+
     println!(
         "Uploading to {} => {}",
         server.unwrap_or(config.default_server_name().unwrap_or("<default>")),

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -181,8 +181,12 @@ class Smoketest(unittest.TestCase):
         publish_output = self.spacetime(
             "publish",
             *[domain] if domain is not None else [],
-            *["-c", "--yes"] if clear and domain is not None else [],
+            *["-c"] if clear and domain is not None else [],
             "--project-path", self.project_path,
+            # This is required if -c is provided, but is also required for SpacetimeDBPrivate's tests,
+            # because the server address is `node` which doesn't look like `localhost` or `127.0.0.1`
+            # and so the publish step prompts for confirmation.
+            "--yes",
             capture_stderr=capture_stderr,
         )
         self.resolved_identity = re.search(r"identity: ([0-9a-fA-F]+)", publish_output)[1]

--- a/smoketests/tests/permissions.py
+++ b/smoketests/tests/permissions.py
@@ -62,11 +62,12 @@ class Permissions(Smoketest):
         self.reset_config()
 
         with self.assertRaises(Exception):
+            # TODO: This raises for the wrong reason - `--clear-database` doesn't exist anymore!
             self.spacetime("publish", self.database_identity, "--project-path", self.project_path, "--clear-database", "--yes")
 
         # Check that this holds without `--clear-database`, too.
         with self.assertRaises(Exception):
-            self.spacetime("publish", self.database_identity, "--project-path", self.project_path)
+            self.spacetime("publish", self.database_identity, "--project-path", self.project_path, "--yes")
 
 
 class PrivateTablePermissions(Smoketest):


### PR DESCRIPTION
# Description of Changes

When publishing to a server besides `localhost` or `127.0.0.1`, prompt for confirmation.

# API and ABI breaking changes

Yes; this technically breaks the CLI API for publishing to non-local servers.

# Expected complexity level and risk

1

# Testing

- [x] Publishing to testnet prompts for confirmation; saying no exits
```
$ "$WORK"/SpacetimeDBPrivate/public/target/debug/spacetime publish -s testnet
checking crate with spacetimedb's clippy configuration
    Checking spacetime-module v0.1.0 (/mnt/nutera/work/my_new_project)
    Finished `release` profile [optimized] target(s) in 0.14s
    Finished `release` profile [optimized] target(s) in 0.11s
Optimising module with wasm-opt...
Could not find wasm-opt to optimise the module.
For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases.
Continuing with unoptimised module.
Build finished successfully.
You are about to publish to a non-local server: testnet.spacetimedb.com
Are you sure you want to proceed with publishing to testnet.spacetimedb.com? [y/N]N
Aborting
```

- [x] Publishing to testnet prompts for confirmation; saying yes proceeds
```
$ "$WORK"/SpacetimeDBPrivate/public/target/debug/spacetime publish -s testnet
checking crate with spacetimedb's clippy configuration
    Checking spacetime-module v0.1.0 (/mnt/nutera/work/my_new_project)
    Finished `release` profile [optimized] target(s) in 0.14s
    Finished `release` profile [optimized] target(s) in 0.07s
Optimising module with wasm-opt...
Could not find wasm-opt to optimise the module.
For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases.
Continuing with unoptimised module.
Build finished successfully.
You are about to publish to a non-local server: testnet.spacetimedb.com
Are you sure you want to proceed with publishing to testnet.spacetimedb.com? [y/N]y
Uploading to testnet => https://testnet.spacetimedb.com
Publishing module...
Created new database with identity: c20021c74f423a19aedc5fef2ab5adc66b4b5a556a031ee15c56e5ab6ff2f381
```

- [x] Publishing to local does not prompt for confirmation
```
$ "$WORK"/SpacetimeDBPrivate/public/target/debug/spacetime publish -s local
checking crate with spacetimedb's clippy configuration
    Checking spacetime-module v0.1.0 (/mnt/nutera/work/my_new_project)
    Finished `release` profile [optimized] target(s) in 0.14s
    Finished `release` profile [optimized] target(s) in 0.07s
Optimising module with wasm-opt...
Could not find wasm-opt to optimise the module.
For best performance install wasm-opt from https://github.com/WebAssembly/binaryen/releases.
Continuing with unoptimised module.
Build finished successfully.
Uploading to local => http://127.0.0.1:3000
Publishing module...
Created new database with identity: c2004b18ef1e1a3240db78883f52a588b1bb9ccd80692b8b1cccc913f32203ab
```