### PR TITLE
Use `println`/`eprintln` in the quickstart-chat client, not `log`

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,3 +7,6 @@ LICENSE.txt @cloutiertyler
 /crates/cli/src/ @bfops @cloutiertyler
 /crates/cli/src/subcommands/generate/ # No owners
 /crates/cli/src/subcommands/generate/mod.rs @bfops @cloutiertyler # These codeowners should be the same as the "root" CLI codeowners
+
+/crates/sdk/examples/quickstart-chat/ @gefjon
+/modules/quickstart-chat/ @gefjon

--- a/crates/sdk/examples/quickstart-chat/main.rs
+++ b/crates/sdk/examples/quickstart-chat/main.rs
@@ -45,7 +45,7 @@ fn creds_store() -> credentials::File {
 /// Our `on_connect` callback: save our credentials to a file.
 fn on_connected(_ctx: &DbConnection, identity: Identity, token: &str) {
     if let Err(e) = creds_store().save(identity, token) {
-        log::error!("Failed to save credentials: {:?}", e);
+        eprintln!("Failed to save credentials: {:?}", e);
     }
 }
 
@@ -54,7 +54,7 @@ fn on_connected(_ctx: &DbConnection, identity: Identity, token: &str) {
 /// Our `User::on_insert` callback: if the user is online, print a notification.
 fn on_user_inserted(_ctx: &EventContext, user: &User) {
     if user.online {
-        log::info!("User {} connected.", user_name_or_identity(user));
+        println!("User {} connected.", user_name_or_identity(user));
     }
 }
 
@@ -70,17 +70,17 @@ fn user_name_or_identity(user: &User) -> String {
 /// print a notification about name and status changes.
 fn on_user_updated(_ctx: &EventContext, old: &User, new: &User) {
     if old.name != new.name {
-        log::info!(
+        println!(
             "User {} renamed to {}.",
             user_name_or_identity(old),
             user_name_or_identity(new)
         );
     }
     if old.online && !new.online {
-        log::info!("User {} disconnected.", user_name_or_identity(new));
+        println!("User {} disconnected.", user_name_or_identity(new));
     }
     if !old.online && new.online {
-        log::info!("User {} connected.", user_name_or_identity(new));
+        println!("User {} connected.", user_name_or_identity(new));
     }
 }
 
@@ -101,7 +101,7 @@ fn print_message(ctx: &EventContext, message: &Message) {
         .find(&message.sender)
         .map(|u| user_name_or_identity(&u))
         .unwrap_or_else(|| "unknown".to_string());
-    log::info!("{}: {}", sender, message.text);
+    println!("{}: {}", sender, message.text);
 }
 
 // ## Print message backlog
@@ -126,7 +126,7 @@ fn on_name_set(ctx: &EventContext, name: &String) {
         ..
     }) = &ctx.event
     {
-        log::error!("Failed to change name to {:?}: {}", name, err);
+        eprintln!("Failed to change name to {:?}: {}", name, err);
     }
 }
 
@@ -139,7 +139,7 @@ fn on_message_sent(ctx: &EventContext, text: &String) {
         ..
     }) = &ctx.event
     {
-        log::error!("Failed to send message {:?}: {}", text, err);
+        eprintln!("Failed to send message {:?}: {}", text, err);
     }
 }
 
@@ -150,7 +150,7 @@ fn on_disconnected(_ctx: &DbConnection, err: Option<&anyhow::Error>) {
     if let Some(err) = err {
         panic!("Disconnected abnormally: {err}")
     } else {
-        log::info!("Disconnected normally.");
+        println!("Disconnected normally.");
         std::process::exit(0)
     }
 }


### PR DESCRIPTION
# Description of Changes

Likely by mistake, #1929 rewrote the `quickstart-chat` client to use `log::info!` and `log::error!` for output.
In addition to needlessly adding complexity to a quickstart project, this was broken because that program didn't install a logger, so it produced no output at all.

This commit reverts those changes, returning to `println`/`eprintln` output in the quickstart-chat client.
We could use `log::` macros and install a logger,
but then we'd have to explain installing a logger in the quickstart guide.

This commit also makes me a codeowner of the `quickstart-chat` project, both the module and the client.
I think extra scrutiny on these files is important because they're always supposed to exactly match the code presented in the tutorials, which prior to this commit they clearly did not.

# API and ABI breaking changes

N/a.

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Ran `quickstart-chat` locally, typed a few messages, set my name, saw output as expected.