### PR TITLE
Make automatic migrations deterministic

### DIFF
--- a/crates/lib/src/db/default_element_ordering.rs
+++ b/crates/lib/src/db/default_element_ordering.rs
@@ -3,6 +3,7 @@
 //! - In ABI version 8, the default ordering was not applied.
 //! - In ABI version 9, the default ordering is applied to all types in a spacetime module, unless they explicitly declare a custom ordering.
 
+use crate::is_sorted;
 use spacetimedb_sats::{ProductType, ProductTypeElement, SumType, SumTypeVariant};
 
 /// A label for a field of a `ProductType` or a variant of a `SumType`.
@@ -47,20 +48,6 @@ pub fn sum_type_has_default_ordering(ty: &SumType) -> bool {
 /// Not a recursive check.
 pub fn product_type_has_default_ordering(ty: &ProductType) -> bool {
     is_sorted(ty.elements.iter().enumerate().map(ElementLabel::from))
-}
-
-/// Check that an iterator is sorted.
-///
-/// TODO: remove this when [`Iterator`::is_sorted`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.is_sorted) is stabilized.
-fn is_sorted<T: Ord>(mut it: impl Iterator<Item = T>) -> bool {
-    let Some(mut curr) = it.next() else {
-        return true;
-    };
-    it.all(|next| {
-        let ordered = curr <= next;
-        curr = next;
-        ordered
-    })
 }
 
 #[cfg(test)]

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -374,3 +374,17 @@ pub fn resolved_type_via_v9<T: SpacetimeType>() -> AlgebraicType {
         .resolve_refs()
         .expect("recursive types not supported")
 }
+
+/// Check that an iterator is sorted.
+///
+/// TODO: remove this when [`Iterator`::is_sorted`](https://doc.rust-lang.org/std/iter/trait.Iterator.html#method.is_sorted) is stabilized.
+pub fn is_sorted<T: Ord>(mut it: impl Iterator<Item = T>) -> bool {
+    let Some(mut curr) = it.next() else {
+        return true;
+    };
+    it.all(|next| {
+        let ordered = curr <= next;
+        curr = next;
+        ordered
+    })
+}

--- a/crates/schema/src/auto_migrate.rs
+++ b/crates/schema/src/auto_migrate.rs
@@ -663,6 +663,8 @@ mod tests {
         let deliveries_schedule = "Deliveries_sched";
         let inspections_schedule = "Inspections_sched";
 
+        assert!(plan.prechecks.is_sorted());
+
         assert_eq!(plan.prechecks.len(), 1);
         assert_eq!(
             plan.prechecks[0],
@@ -677,6 +679,7 @@ mod tests {
         };
 
         let steps = &plan.steps[..];
+        assert!(steps.is_sorted());
 
         assert!(
             steps.contains(&AutoMigrateStep::RemoveSequence(apples_sequence)),

--- a/crates/schema/src/auto_migrate.rs
+++ b/crates/schema/src/auto_migrate.rs
@@ -52,13 +52,13 @@ pub struct AutoMigratePlan<'def> {
     /// There is also an implied check: that the schema in the database is compatible with the old ModuleDef.
     pub prechecks: Vec<AutoMigratePrecheck<'def>>,
     /// The migration steps to perform.
-    /// Order should not matter, as the steps are independent.
+    /// Order matters: `Remove`s of a particular `Def` must be ordered before `Add`s.
     pub steps: Vec<AutoMigrateStep<'def>>,
 }
 
 /// Checks that must be performed before performing an automatic migration.
 /// These checks can access table contents and other database state.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, PartialOrd, Ord)]
 pub enum AutoMigratePrecheck<'def> {
     /// Perform a check that adding a sequence is valid (the relevant column contains no values
     /// greater than the sequence's start value).
@@ -66,31 +66,50 @@ pub enum AutoMigratePrecheck<'def> {
 }
 
 /// A step in an automatic migration.
-#[derive(PartialEq, Eq, Debug)]
+#[derive(PartialEq, Eq, Debug, PartialOrd, Ord)]
 pub enum AutoMigrateStep<'def> {
+    // It is important FOR CORRECTNESS that `Remove` variants are declared before `Add` variants in this enum!
+    //
+    // The ordering is used to sort the steps of an auto-migration.
+    // If adds go before removes, and the user tries to remove an index and then re-add it with new configuration,
+    // the following can occur:
+    //
+    // 1. `AddIndex("indexname")`
+    // 2. `RemoveIndex("indexname")`
+    //
+    // This results in the index being added -- which, at time of writing, does nothing -- and then removed,
+    // resulting in the intended index not being created.
+    //
+    // For now, we just ensure that we declare all `Remove` variants before `Add` variants
+    // and let `#[derive(PartialOrd)]` take care of the rest.
+    // TODO: when this enum is made serializable, a more durable fix will be needed here.
+    // Probably we will want to have separate arrays of add and remove steps.
+    //
+    /// Remove an index.
+    RemoveIndex(<IndexDef as ModuleDefLookup>::Key<'def>),
+    /// Remove a constraint.
+    RemoveConstraint(<ConstraintDef as ModuleDefLookup>::Key<'def>),
+    /// Remove a sequence.
+    RemoveSequence(<SequenceDef as ModuleDefLookup>::Key<'def>),
+    /// Remove a schedule annotation from a table.
+    RemoveSchedule(<ScheduleDef as ModuleDefLookup>::Key<'def>),
+    /// Remove a row-level security query.
+    RemoveRowLevelSecurity(<RawRowLevelSecurityDefV9 as ModuleDefLookup>::Key<'def>),
+
     /// Add a table, including all indexes, constraints, and sequences.
     /// There will NOT be separate steps in the plan for adding indexes, constraints, and sequences.
     AddTable(<TableDef as ModuleDefLookup>::Key<'def>),
     /// Add an index.
     AddIndex(<IndexDef as ModuleDefLookup>::Key<'def>),
-    /// Remove an index.
-    RemoveIndex(<IndexDef as ModuleDefLookup>::Key<'def>),
-    /// Remove a constraint.
-    RemoveConstraint(<ConstraintDef as ModuleDefLookup>::Key<'def>),
     /// Add a sequence.
     AddSequence(<SequenceDef as ModuleDefLookup>::Key<'def>),
-    /// Remove a sequence.
-    RemoveSequence(<SequenceDef as ModuleDefLookup>::Key<'def>),
-    /// Change the access of a table.
-    ChangeAccess(<TableDef as ModuleDefLookup>::Key<'def>),
     /// Add a schedule annotation to a table.
     AddSchedule(<ScheduleDef as ModuleDefLookup>::Key<'def>),
-    /// Remove a schedule annotation from a table.
-    RemoveSchedule(<ScheduleDef as ModuleDefLookup>::Key<'def>),
     /// Add a row-level security query.
     AddRowLevelSecurity(<RawRowLevelSecurityDefV9 as ModuleDefLookup>::Key<'def>),
-    /// Remove a row-level security query.
-    RemoveRowLevelSecurity(<RawRowLevelSecurityDefV9 as ModuleDefLookup>::Key<'def>),
+
+    /// Change the access of a table.
+    ChangeAccess(<TableDef as ModuleDefLookup>::Key<'def>),
 }
 
 /// Something that might prevent an automatic migration.
@@ -180,6 +199,9 @@ pub fn ponder_auto_migrate<'def>(old: &'def ModuleDef, new: &'def ModuleDef) -> 
     let rls_ok = auto_migrate_row_level_security(&mut plan);
 
     let ((), (), (), (), ()) = (tables_ok, indexes_ok, sequences_ok, constraints_ok, rls_ok).combine_errors()?;
+
+    plan.steps.sort();
+    plan.prechecks.sort();
 
     Ok(plan)
 }

--- a/crates/schema/src/auto_migrate.rs
+++ b/crates/schema/src/auto_migrate.rs
@@ -77,11 +77,12 @@ pub enum AutoMigrateStep<'def> {
     // 1. `AddIndex("indexname")`
     // 2. `RemoveIndex("indexname")`
     //
-    // This results in the index being added -- which, at time of writing, does nothing -- and then removed,
+    // This results in the existing index being re-added -- which, at time of writing, does nothing -- and then removed,
     // resulting in the intended index not being created.
     //
     // For now, we just ensure that we declare all `Remove` variants before `Add` variants
     // and let `#[derive(PartialOrd)]` take care of the rest.
+    //
     // TODO: when this enum is made serializable, a more durable fix will be needed here.
     // Probably we will want to have separate arrays of add and remove steps.
     //

--- a/crates/schema/src/auto_migrate.rs
+++ b/crates/schema/src/auto_migrate.rs
@@ -457,7 +457,7 @@ fn auto_migrate_row_level_security(plan: &mut AutoMigratePlan) -> Result<()> {
 mod tests {
     use super::*;
     use spacetimedb_data_structures::expect_error_matching;
-    use spacetimedb_lib::{db::raw_def::*, AlgebraicType, ProductType, ScheduleAt};
+    use spacetimedb_lib::{db::raw_def::*, is_sorted, AlgebraicType, ProductType, ScheduleAt};
     use spacetimedb_primitives::{ColId, ColList};
     use v9::{RawIndexAlgorithm, RawModuleDefV9Builder, TableAccess};
     use validate::tests::expect_identifier;
@@ -663,7 +663,7 @@ mod tests {
         let deliveries_schedule = "Deliveries_sched";
         let inspections_schedule = "Inspections_sched";
 
-        assert!(plan.prechecks.is_sorted());
+        assert!(is_sorted(plan.prechecks.iter()));
 
         assert_eq!(plan.prechecks.len(), 1);
         assert_eq!(
@@ -679,7 +679,8 @@ mod tests {
         };
 
         let steps = &plan.steps[..];
-        assert!(steps.is_sorted());
+
+        assert!(is_sorted(steps.iter()));
 
         assert!(
             steps.contains(&AutoMigrateStep::RemoveSequence(apples_sequence)),

--- a/smoketests/tests/auto_migration.py
+++ b/smoketests/tests/auto_migration.py
@@ -75,11 +75,14 @@ spacetimedb::filter!("SELECT * FROM book");
         """This tests uploading a module with a schema change that should not require clearing the database."""
 
         # Check the row-level SQL filter is created correctly
-        self.assertSql("SELECT sql FROM st_row_level_security", """\
+        self.assertSql(
+            "SELECT sql FROM st_row_level_security",
+            """\
  sql
 ------------------------
  "SELECT * FROM person"
-""")
+""",
+        )
 
         logging.info("Initial publish complete")
         # initial module code is already published by test framework
@@ -103,12 +106,15 @@ spacetimedb::filter!("SELECT * FROM book");
         logging.info("Updated")
 
         # Check the row-level SQL filter is added correctly
-        self.assertSql("SELECT sql FROM st_row_level_security", """\
+        self.assertSql(
+            "SELECT sql FROM st_row_level_security",
+            """\
  sql
 ------------------------
- "SELECT * FROM person"
  "SELECT * FROM book"
-""")
+ "SELECT * FROM person"
+""",
+        )
 
         self.logs(100)
 


### PR DESCRIPTION
# Description of Changes

Fixes some bugs related to automatic migrations not being deterministic. Extracted from #2065

# API and ABI breaking changes

None

# Expected complexity level and risk

0

# Testing

Added sorted checks to the unit test. #2065 adds integration tests, but they rely on the new pretty-printing functionality to audit the migration plan, so I can't add those here.