### PR TITLE
Add `SubscriptionBuilder::subscribe_to_all_tables`

### DIFF
--- a/crates/sdk/src/subscription.rs
+++ b/crates/sdk/src/subscription.rs
@@ -126,6 +126,25 @@ impl<M: SpacetimeModule> SubscriptionBuilder<M> {
             .unwrap();
         M::SubscriptionHandle::new(SubscriptionHandleImpl { conn, sub_id })
     }
+
+    /// Subscribe to all rows from all tables.
+    ///
+    /// This method is intended as a convenience
+    /// for applications where client-side memory use and network bandwidth are not concerns.
+    /// Applications where these resources are a constraint
+    /// should register more precise queries via [`Self::subscribe`]
+    /// in order to replicate only the subset of data which the client needs to function.
+    ///
+    /// This method should not be combined with [`Self::subscribe`] on the same `DbConnection`.
+    /// A connection may either [`Self::subscribe`] to particular queries,
+    /// or [`Self::subscribe_to_all_tables`], but not both.
+    /// Attempting to call [`Self::subscribe`]
+    /// on a `DbConnection` that has previously used [`Self::subscribe_to_all_tables`],
+    /// or vice versa, may misbehave in any number of ways,
+    /// including dropping subscriptions, corrupting the client cache, or panicking.
+    pub fn subscribe_to_all_tables(self) {
+        self.subscribe(["SELECT * FROM *"]);
+    }
 }
 
 /// Types which specify a list of query strings.

--- a/crates/sdk/tests/test-client/src/main.rs
+++ b/crates/sdk/tests/test-client/src/main.rs
@@ -1563,8 +1563,8 @@ fn exec_caller_always_notified() {
     test_counter.wait_for_all();
 }
 
-/// Duplicates the test `insert_primitive`, but using the `SELECT * FROM *` sugar
-/// rather than an explicit query set.
+/// Duplicates the test `insert_primitive`,
+/// but using `SubscriptionBuilder::subscribe_to_all_tables` rather than an explicit query set.
 fn exec_subscribe_all_select_star() {
     let test_counter = TestCounter::new();
 
@@ -1602,7 +1602,7 @@ fn exec_subscribe_all_select_star() {
             }
         })
         .on_error(|_| panic!("Subscription error"))
-        .subscribe(["SELECT * FROM *"]);
+        .subscribe_to_all_tables();
 
     test_counter.wait_for_all();
 }


### PR DESCRIPTION
# Description of Changes

Rust client SDK analogue to [com.clockworklabs.spacetimedbsdk #211](https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/211).

Currently an abstraction over `SELECT * FROM *`, but that may change in the future. The new subscription API will be unable to cleanly support users supplying `SELECT * FROM *`, but this method we can continue supporting more easily.

# API and ABI breaking changes

Additive change only.

# Expected complexity level and risk

1.

# Testing

- [x] Amended an automated test that previously used `SELECT * FROM *` to use this instead.
