### PR TITLE
Rust SDK: `with_credentials` -> `with_token`

### DIFF
--- a/crates/sdk/examples/quickstart-chat/main.rs
+++ b/crates/sdk/examples/quickstart-chat/main.rs
@@ -43,8 +43,8 @@ fn creds_store() -> credentials::File {
 }
 
 /// Our `on_connect` callback: save our credentials to a file.
-fn on_connected(_ctx: &DbConnection, identity: Identity, token: &str) {
-    if let Err(e) = creds_store().save(identity, token) {
+fn on_connected(_ctx: &DbConnection, _identity: Identity, token: &str) {
+    if let Err(e) = creds_store().save(token) {
         eprintln!("Failed to save credentials: {:?}", e);
     }
 }
@@ -169,7 +169,7 @@ fn connect_to_db() -> DbConnection {
         .on_connect(on_connected)
         .on_connect_error(|err| panic!("Error while connecting: {err}"))
         .on_disconnect(on_disconnected)
-        .with_credentials(creds_store().load().expect("Error loading credentials"))
+        .with_token(creds_store().load().expect("Error loading credentials"))
         .with_module_name(DB_NAME)
         .with_uri(HOST)
         .with_compression(Compression::Gzip)

--- a/crates/sdk/src/db_connection.rs
+++ b/crates/sdk/src/db_connection.rs
@@ -35,6 +35,7 @@ use spacetimedb_client_api_messages::websocket as ws;
 use spacetimedb_client_api_messages::websocket::{BsatnFormat, CallReducerFlags, Compression};
 use spacetimedb_lib::{bsatn, ser::Serialize, Address, Identity};
 use std::{
+    borrow::Borrow,
     collections::HashMap,
     sync::{Arc, Mutex as StdMutex, OnceLock},
     time::{Duration, SystemTime},
@@ -640,7 +641,7 @@ pub struct DbConnectionBuilder<M: SpacetimeModule> {
 
     module_name: Option<String>,
 
-    credentials: Option<(Identity, String)>,
+    token: Option<String>,
 
     on_connect: Option<OnConnectCallback<M>>,
     on_connect_error: Option<OnConnectErrorCallback>,
@@ -734,7 +735,7 @@ but you must call one of them, or else the connection will never progress.
             handle.block_on(WsConnection::connect(
                 self.uri.unwrap(),
                 self.module_name.as_ref().unwrap(),
-                self.credentials.as_ref(),
+                self.token.as_deref(),
                 get_client_address(),
                 self.params,
             ))
@@ -769,7 +770,7 @@ but you must call one of them, or else the connection will never progress.
             recv: Arc::new(TokioMutex::new(parsed_recv_chan)),
             pending_mutations_send,
             pending_mutations_recv: Arc::new(TokioMutex::new(pending_mutations_recv)),
-            identity: Arc::new(StdMutex::new(self.credentials.as_ref().map(|creds| creds.0))),
+            identity: Arc::new(StdMutex::new(None)),
         };
 
         Ok(ctx_imp)
@@ -790,17 +791,18 @@ but you must call one of them, or else the connection will never progress.
         self
     }
 
-    /// Set the credentials with which to connect to the remote database.
+    /// Supply a token with which to authenticate with the remote database.
     ///
-    /// If `credentials` is `None` or this method is not invoked,
+    /// `token` should be an OpenID Connect compliant JSON Web Token.
+    ///
+    /// If this method is not invoked, or `None` is supplied,
     /// the SpacetimeDB host will generate a new anonymous `Identity`.
     ///
-    /// If the passed token is invalid, is not recognized by the host,
-    /// or does not authenticate as the passed `Identity`,
+    /// If the passed token is invalid or rejected by the host,
     /// the connection will fail asynchrnonously.
     // FIXME: currently this causes `disconnect` to be called rather than `on_connect_error`.
-    pub fn with_credentials(mut self, credentials: Option<(Identity, String)>) -> Self {
-        self.credentials = credentials;
+    pub fn with_token(mut self, token: Option<impl ToString>) -> Self {
+        self.token = token.map(|token| token.to_string());
         self
     }
 
@@ -831,10 +833,9 @@ but you must call one of them, or else the connection will never progress.
     /// The callback will receive three arguments:
     /// - The `DbConnection` which has successfully connected.
     /// - The `Identity` of the successful connection.
-    ///   If an identity and token were passed to [`Self::with_credentials`], this will be the same `Identity`.
     /// - The private access token which can be used to later re-authenticate as the same `Identity`.
-    ///   If an identity and token were passed to [`Self::with_credentials`],
-    ///   this may not be string-equal to the supplied token, but will authenticate as the same `Identity`.
+    ///   If a token was passed to [`Self::with_token`],
+    ///   this will be the same token.
     pub fn on_connect(mut self, callback: impl FnOnce(&M::DbConnection, Identity, &str) + Send + 'static) -> Self {
         if self.on_connect.is_some() {
             panic!(

--- a/crates/sdk/src/db_connection.rs
+++ b/crates/sdk/src/db_connection.rs
@@ -35,7 +35,6 @@ use spacetimedb_client_api_messages::websocket as ws;
 use spacetimedb_client_api_messages::websocket::{BsatnFormat, CallReducerFlags, Compression};
 use spacetimedb_lib::{bsatn, ser::Serialize, Address, Identity};
 use std::{
-    borrow::Borrow,
     collections::HashMap,
     sync::{Arc, Mutex as StdMutex, OnceLock},
     time::{Duration, SystemTime},
@@ -686,7 +685,7 @@ impl<M: SpacetimeModule> DbConnectionBuilder<M> {
         Self {
             uri: None,
             module_name: None,
-            credentials: None,
+            token: None,
             on_connect: None,
             on_connect_error: None,
             on_disconnect: None,

--- a/crates/sdk/src/websocket.rs
+++ b/crates/sdk/src/websocket.rs
@@ -12,7 +12,7 @@ use spacetimedb_client_api_messages::websocket::{
     SERVER_MSG_COMPRESSION_TAG_GZIP, SERVER_MSG_COMPRESSION_TAG_NONE,
 };
 use spacetimedb_client_api_messages::websocket::{ClientMessage, ServerMessage};
-use spacetimedb_lib::{bsatn, Address, Identity};
+use spacetimedb_lib::{bsatn, Address};
 use tokio::task::JoinHandle;
 use tokio::{net::TcpStream, runtime};
 use tokio_tungstenite::{

--- a/crates/sdk/src/websocket.rs
+++ b/crates/sdk/src/websocket.rs
@@ -182,7 +182,7 @@ impl WsConnection {
         )
         .await?;
         Ok(WsConnection { sock })
-    }n
+    }
 
     pub(crate) fn parse_response(bytes: &[u8]) -> Result<ServerMessage<BsatnFormat>> {
         let (compression, bytes) = bytes

--- a/crates/sdk/src/websocket.rs
+++ b/crates/sdk/src/websocket.rs
@@ -104,7 +104,7 @@ where
 fn make_request<Host>(
     host: Host,
     db_name: &str,
-    credentials: Option<&(Identity, String)>,
+    token: Option<&str>,
     client_address: Address,
     params: WsParams,
 ) -> Result<http::Request<()>>
@@ -115,7 +115,7 @@ where
     let uri = make_uri(host, db_name, client_address, params)?;
     let mut req = IntoClientRequest::into_client_request(uri)?;
     request_insert_protocol_header(&mut req);
-    request_insert_auth_header(&mut req, credentials);
+    request_insert_auth_header(&mut req, token);
     Ok(req)
 }
 
@@ -137,9 +137,9 @@ fn request_insert_protocol_header(req: &mut http::Request<()>) {
 
 const AUTH_HEADER_KEY: &str = "Authorization";
 
-fn request_insert_auth_header(req: &mut http::Request<()>, credentials: Option<&(Identity, String)>) {
+fn request_insert_auth_header(req: &mut http::Request<()>, token: Option<&str>) {
     // TODO: figure out how the token is supposed to be encoded in the request
-    if let Some((_, token)) = credentials {
+    if let Some(token) = token {
         use base64::Engine;
 
         let auth_bytes = format!("token:{}", token);
@@ -159,7 +159,7 @@ impl WsConnection {
     pub(crate) async fn connect<Host>(
         host: Host,
         db_name: &str,
-        credentials: Option<&(Identity, String)>,
+        token: Option<&str>,
         client_address: Address,
         params: WsParams,
     ) -> Result<Self>
@@ -167,7 +167,7 @@ impl WsConnection {
         Host: TryInto<Uri>,
         <Host as TryInto<Uri>>::Error: std::error::Error + Send + Sync + 'static,
     {
-        let req = make_request(host, db_name, credentials, client_address, params)?;
+        let req = make_request(host, db_name, token, client_address, params)?;
         let (sock, _): (WebSocketStream<MaybeTlsStream<TcpStream>>, _) = connect_async_with_config(
             req,
             // TODO(kim): In order to be able to replicate module WASM blobs,
@@ -182,7 +182,7 @@ impl WsConnection {
         )
         .await?;
         Ok(WsConnection { sock })
-    }
+    }n
 
     pub(crate) fn parse_response(bytes: &[u8]) -> Result<ServerMessage<BsatnFormat>> {
         let (compression, bytes) = bytes

--- a/crates/sdk/tests/test-client/src/main.rs
+++ b/crates/sdk/tests/test-client/src/main.rs
@@ -1471,7 +1471,7 @@ fn exec_reauth_part_2() {
         })
         .on_connect_error(|e| panic!("Connect failed: {e:?}"))
         .with_module_name(name)
-        .with_credentials(Some((identity, token)))
+        .with_token(Some(token))
         .with_uri(LOCALHOST)
         .build()
         .unwrap()

--- a/crates/sdk/tests/test-client/src/main.rs
+++ b/crates/sdk/tests/test-client/src/main.rs
@@ -1431,8 +1431,8 @@ fn exec_reauth_part_1() {
     let save_result = test_counter.add_test("save-credentials");
 
     DbConnection::builder()
-        .on_connect(|_, identity, token| {
-            save_result(creds_store().save(identity, token));
+        .on_connect(|_, _identity, token| {
+            save_result(creds_store().save(token));
         })
         .on_connect_error(|e| panic!("Connect failed: {e:?}"))
         .with_module_name(name)
@@ -1455,14 +1455,13 @@ fn exec_reauth_part_2() {
 
     let creds_match_result = test_counter.add_test("creds-match");
 
-    let (identity, token) = creds_store().load().unwrap().unwrap();
+    let token = creds_store().load().unwrap().unwrap();
 
     DbConnection::builder()
         .on_connect({
             let token = token.clone();
-            move |_, recv_identity, recv_token| {
+            move |_, _recv_identity, recv_token| {
                 let run_checks = || {
-                    assert_eq_or_bail!(identity, recv_identity);
                     assert_eq_or_bail!(token, recv_token);
                     Ok(())
                 };


### PR DESCRIPTION
# Description of Changes

See discussion on https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/212

This PR replaces `DbConnectionBuilder::with_credentials` with `::with_token`, which does not require an `Identity` as argument. It also amends our machinery for saving and loading credentials to and from disk to suit the new API.

# API and ABI breaking changes

Yep!

# Expected complexity level and risk

1.

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] I believe automated tests to be sufficient.