### PR TITLE
Fix wording in `ReplayVisitor::visit_insert`

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -888,7 +888,7 @@ impl<F: FnMut(u64)> spacetimedb_commitlog::payload::txdata::Visitor for ReplayVi
             .replay_insert(table_id, &schema, &row)
             .with_context(|| {
                 format!(
-                    "Error deleting row {:?} during transaction {:?} playback",
+                    "Error inserting row {:?} during transaction {:?} playback",
                     row, self.committed_state.next_tx_offset
                 )
             })?;


### PR DESCRIPTION
# Description of Changes

Fixes a typo in `ReplayVisitor::visit_insert`: s/deleting/inserting

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Covered by existing tests / nothing important to test.