### PR TITLE
Add new crates to `publish-crates.sh` script

### DIFF
--- a/tools/publish-crates.sh
+++ b/tools/publish-crates.sh
@@ -23,7 +23,7 @@ if [ $DRY_RUN != 1 ] ; then
 fi
 
 BASEDIR=$(pwd)
-declare -a CRATES=("metrics" "primitives" "bindings-macro" "bindings-sys" "data-structures" "sats" "lib" "schema" "bindings" "table" "vm" "client-api-messages" "commitlog" "durability" "fs-utils" "snapshot" "core" "client-api" "standalone" "cli" "sdk")
+declare -a CRATES=("metrics" "primitives" "sql-parser" "bindings-macro" "bindings-sys" "data-structures" "sats" "lib" "schema" "bindings" "table" "vm" "client-api-messages" "paths" "commitlog" "durability" "fs-utils" "snapshot" "expr" "core" "client-api" "standalone" "cli" "sdk")
 
 for crate in "${CRATES[@]}" ; do
 	if [ ! -d "${BASEDIR}/crates/${crate}" ] ; then


### PR DESCRIPTION
# Description of Changes

We had several crates that were missing from the `publish-crates.sh` script, meaning that manual intervention was required for it to run properly.

# API and ABI breaking changes

No code changes

# Expected complexity level and risk

1

# Testing

I believe this is where I added them in order to successfully publish to crates.io, but it's hard to re-test after the fact :shrug: Unfortunately the `--dry-run` option doesn't "just work" the way we'd want.

We'd have to set up our own temporary package repository in order to test this comprehensively.

The worst case is that we have to make further corrections next time we publish, which is the same state we're in without this PR.