### PR TITLE
Query execution updates for cpu metrics

### DIFF
--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -5,7 +5,7 @@ use iter::PlanIter;
 use spacetimedb_lib::{
     bsatn::{EncodeError, ToBsatn},
     query::Delta,
-    ser::Serialize,
+    sats::impl_serialize,
     AlgebraicValue, ProductValue,
 };
 use spacetimedb_physical_plan::plan::{ProjectField, ProjectPlan, TupleField};
@@ -17,6 +17,7 @@ use spacetimedb_table::{
 };
 
 pub mod iter;
+pub mod pipelined;
 
 /// The datastore interface required for building an executor
 pub trait Datastore {
@@ -72,11 +73,16 @@ pub trait DeltaStore {
     }
 }
 
-#[derive(Clone, Serialize)]
+#[derive(Clone)]
 pub enum Row<'a> {
     Ptr(RowRef<'a>),
     Ref(&'a ProductValue),
 }
+
+impl_serialize!(['a] Row<'a>, (self, ser) => match self {
+    Self::Ptr(row) => row.serialize(ser),
+    Self::Ref(row) => row.serialize(ser),
+});
 
 impl ToBsatn for Row<'_> {
     fn static_bsatn_size(&self) -> Option<u16> {
@@ -104,8 +110,8 @@ impl ToBsatn for Row<'_> {
 impl ProjectField for Row<'_> {
     fn project(&self, field: &TupleField) -> AlgebraicValue {
         match self {
-            Self::Ptr(ptr) => ptr.read_col(field.field_pos).unwrap(),
-            Self::Ref(val) => val.elements.get(field.field_pos).unwrap().clone(),
+            Self::Ptr(ptr) => ptr.project(field),
+            Self::Ref(val) => val.project(field),
         }
     }
 }
@@ -151,6 +157,13 @@ impl<'a> Tuple<'a> {
                 rows.push(ptr);
                 Self::Join(rows)
             }
+        }
+    }
+
+    fn join(self, with: Self) -> Self {
+        match with {
+            Self::Row(ptr) => self.append(ptr),
+            Self::Join(ptrs) => ptrs.into_iter().fold(self, |tup, ptr| tup.append(ptr)),
         }
     }
 }

--- a/crates/execution/src/pipelined.rs
+++ b/crates/execution/src/pipelined.rs
@@ -1,0 +1,656 @@
+use std::{
+    collections::{HashMap, HashSet},
+    ops::Bound,
+};
+
+use anyhow::{anyhow, Result};
+use spacetimedb_lib::{query::Delta, AlgebraicValue, ProductValue};
+use spacetimedb_physical_plan::plan::{
+    HashJoin, IxJoin, IxScan, PhysicalExpr, PhysicalPlan, ProjectField, ProjectPlan, Sarg, Semi, TupleField,
+};
+use spacetimedb_primitives::{ColId, IndexId, TableId};
+
+use crate::{Datastore, DeltaStore, Row, Tuple};
+
+/// Implements a projection on top of a pipelined executor
+pub enum PipelinedProject {
+    None(PipelinedExecutor),
+    Some(PipelinedExecutor, usize),
+}
+
+impl From<ProjectPlan> for PipelinedProject {
+    fn from(plan: ProjectPlan) -> Self {
+        match plan {
+            ProjectPlan::None(plan) => Self::None(plan.into()),
+            ProjectPlan::Name(plan, _, None) => Self::None(plan.into()),
+            ProjectPlan::Name(plan, _, Some(i)) => Self::Some(plan.into(), i),
+        }
+    }
+}
+
+impl PipelinedProject {
+    pub fn execute<'a, Tx: Datastore + DeltaStore>(
+        &self,
+        tx: &'a Tx,
+        f: &mut dyn FnMut(Row<'a>) -> Result<()>,
+    ) -> Result<()> {
+        match self {
+            Self::None(plan) => {
+                // No explicit projection.
+                // This means the input does not return tuples.
+                // It returns either row ids or product values.
+                plan.execute(tx, &mut |t| {
+                    if let Tuple::Row(row) = t {
+                        f(row)?;
+                    }
+                    Ok(())
+                })
+            }
+            Self::Some(plan, i) => {
+                // The contrary is true for explicit projections.
+                // They return a tuple of row ids or product values.
+                plan.execute(tx, &mut |t| {
+                    if let Some(row) = t.select(*i) {
+                        f(row)?;
+                    }
+                    Ok(())
+                })
+            }
+        }
+    }
+}
+
+/// Executes a query plan in a streaming fashion.
+/// Avoids materializing intermediate results when possible.
+/// Note that unlike a tuple at a time iterator,
+/// the caller has no way to interrupt its forward progress.
+pub enum PipelinedExecutor {
+    TableScan(PipelinedScan),
+    IxScan(PipelinedIxScan),
+    IxJoin(PipelinedIxJoin),
+    HashJoin(BlockingHashJoin),
+    NLJoin(BlockingNLJoin),
+    Filter(PipelinedFilter),
+}
+
+impl From<PhysicalPlan> for PipelinedExecutor {
+    fn from(plan: PhysicalPlan) -> Self {
+        match plan {
+            PhysicalPlan::TableScan(schema, _, delta) => Self::TableScan(PipelinedScan {
+                table: schema.table_id,
+                delta,
+            }),
+            PhysicalPlan::IxScan(scan, _) => Self::IxScan(scan.into()),
+            PhysicalPlan::IxJoin(
+                IxJoin {
+                    lhs,
+                    rhs,
+                    rhs_index,
+                    rhs_field,
+                    unique,
+                    lhs_field,
+                    ..
+                },
+                semijoin,
+            ) => Self::IxJoin(PipelinedIxJoin {
+                lhs: Box::new(Self::from(*lhs)),
+                rhs_table: rhs.table_id,
+                rhs_index,
+                rhs_field,
+                lhs_field,
+                unique,
+                semijoin,
+            }),
+            PhysicalPlan::HashJoin(
+                HashJoin {
+                    lhs,
+                    rhs,
+                    lhs_field,
+                    rhs_field,
+                    unique,
+                },
+                semijoin,
+            ) => Self::HashJoin(BlockingHashJoin {
+                lhs: Box::new(PipelinedExecutor::from(*lhs)),
+                rhs: Box::new(PipelinedExecutor::from(*rhs)),
+                lhs_field,
+                rhs_field,
+                unique,
+                semijoin,
+            }),
+            PhysicalPlan::NLJoin(lhs, rhs) => Self::NLJoin(BlockingNLJoin {
+                lhs: Box::new(PipelinedExecutor::from(*lhs)),
+                rhs: Box::new(PipelinedExecutor::from(*rhs)),
+            }),
+            PhysicalPlan::Filter(input, expr) => Self::Filter(PipelinedFilter {
+                input: Box::new(PipelinedExecutor::from(*input)),
+                expr,
+            }),
+        }
+    }
+}
+
+impl PipelinedExecutor {
+    pub fn execute<'a, Tx: Datastore + DeltaStore>(
+        &self,
+        tx: &'a Tx,
+        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
+    ) -> Result<()> {
+        match self {
+            Self::TableScan(scan) => scan.execute(tx, f),
+            Self::IxScan(scan) => scan.execute(tx, f),
+            Self::IxJoin(join) => join.execute(tx, f),
+            Self::HashJoin(join) => join.execute(tx, f),
+            Self::NLJoin(join) => join.execute(tx, f),
+            Self::Filter(filter) => filter.execute(tx, f),
+        }
+    }
+}
+
+/// A pipelined executor for scanning both physical and delta tables
+pub struct PipelinedScan {
+    pub table: TableId,
+    pub delta: Option<Delta>,
+}
+
+impl PipelinedScan {
+    pub fn execute<'a, Tx: Datastore + DeltaStore>(
+        &self,
+        tx: &'a Tx,
+        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
+    ) -> Result<()> {
+        match self.delta {
+            None => {
+                for tuple in tx
+                    // Open an row id iterator
+                    .table_scan(self.table)?
+                    .map(Row::Ptr)
+                    .map(Tuple::Row)
+                {
+                    f(tuple)?;
+                }
+            }
+            Some(Delta::Inserts(_)) => {
+                for tuple in tx
+                    // Open a product value iterator
+                    .delta_scan(self.table, true)?
+                    .map(Row::Ref)
+                    .map(Tuple::Row)
+                {
+                    f(tuple)?;
+                }
+            }
+            Some(Delta::Deletes(_)) => {
+                for tuple in tx
+                    // Open a product value iterator
+                    .delta_scan(self.table, false)?
+                    .map(Row::Ref)
+                    .map(Tuple::Row)
+                {
+                    f(tuple)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A pipelined executor for scanning an index
+pub struct PipelinedIxScan {
+    /// The table id
+    pub table_id: TableId,
+    /// The index id
+    pub index_id: IndexId,
+    /// An equality prefix for multi-column scans
+    pub prefix: Vec<AlgebraicValue>,
+    /// The lower index bound
+    pub lower: Bound<AlgebraicValue>,
+    /// The upper index bound
+    pub upper: Bound<AlgebraicValue>,
+}
+
+impl From<IxScan> for PipelinedIxScan {
+    fn from(scan: IxScan) -> Self {
+        match scan {
+            IxScan {
+                schema,
+                index_id,
+                prefix,
+                arg: Sarg::Eq(_, v),
+            } => Self {
+                table_id: schema.table_id,
+                index_id,
+                prefix: prefix.into_iter().map(|(_, v)| v).collect(),
+                lower: Bound::Included(v.clone()),
+                upper: Bound::Included(v),
+            },
+            IxScan {
+                schema,
+                index_id,
+                prefix,
+                arg: Sarg::Range(_, lower, upper),
+            } => Self {
+                table_id: schema.table_id,
+                index_id,
+                prefix: prefix.into_iter().map(|(_, v)| v).collect(),
+                lower,
+                upper,
+            },
+        }
+    }
+}
+
+impl PipelinedIxScan {
+    pub fn execute<'a, Tx: Datastore + DeltaStore>(
+        &self,
+        tx: &'a Tx,
+        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
+    ) -> Result<()> {
+        match self.prefix.as_slice() {
+            [] => {
+                for ptr in tx
+                    .index_scan(
+                        self.table_id,
+                        self.index_id,
+                        &(self.lower.as_ref(), self.upper.as_ref()),
+                    )?
+                    .map(Row::Ptr)
+                    .map(Tuple::Row)
+                {
+                    f(ptr)?;
+                }
+            }
+            prefix => {
+                for ptr in tx
+                    .index_scan(
+                        self.table_id,
+                        self.index_id,
+                        &(
+                            self.lower
+                                .as_ref()
+                                .map(std::iter::once)
+                                .map(|iter| prefix.iter().chain(iter))
+                                .map(|iter| iter.cloned())
+                                .map(ProductValue::from_iter)
+                                .map(AlgebraicValue::Product),
+                            self.upper
+                                .as_ref()
+                                .map(std::iter::once)
+                                .map(|iter| prefix.iter().chain(iter))
+                                .map(|iter| iter.cloned())
+                                .map(ProductValue::from_iter)
+                                .map(AlgebraicValue::Product),
+                        ),
+                    )?
+                    .map(Row::Ptr)
+                    .map(Tuple::Row)
+                {
+                    f(ptr)?;
+                }
+            }
+        }
+        Ok(())
+    }
+}
+
+/// A pipelined index join executor
+pub struct PipelinedIxJoin {
+    /// The executor for the lhs of the join
+    pub lhs: Box<PipelinedExecutor>,
+    /// The rhs table
+    pub rhs_table: TableId,
+    /// The rhs index
+    pub rhs_index: IndexId,
+    /// The rhs join field
+    pub rhs_field: ColId,
+    /// The lhs join field
+    pub lhs_field: TupleField,
+    /// Is the index unique?
+    pub unique: bool,
+    /// Is this a semijoin?
+    pub semijoin: Semi,
+}
+
+impl PipelinedIxJoin {
+    pub fn execute<'a, Tx: Datastore + DeltaStore>(
+        &self,
+        tx: &'a Tx,
+        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
+    ) -> Result<()> {
+        let blob_store = tx.blob_store();
+        let rhs_table = tx.table_or_err(self.rhs_table)?;
+        let rhs_index = rhs_table
+            .get_index_by_id(self.rhs_index)
+            .ok_or_else(|| anyhow!("IndexId `{0}` does not exist", self.rhs_index))?;
+
+        match self {
+            Self {
+                lhs,
+                lhs_field,
+                unique: true,
+                semijoin: Semi::Lhs,
+                ..
+            } => {
+                // Should we evaluate the lhs tuple?
+                // Probe the index to see if there is a matching row.
+                lhs.execute(tx, &mut |u| {
+                    if rhs_index.contains_any(&u.project(lhs_field)) {
+                        f(u)?;
+                    }
+                    Ok(())
+                })
+            }
+            Self {
+                lhs,
+                lhs_field,
+                unique: true,
+                semijoin: Semi::Rhs,
+                ..
+            } => {
+                // Probe the index and evaluate the matching rhs row
+                lhs.execute(tx, &mut |u| {
+                    if let Some(v) = rhs_index
+                        .seek(&u.project(lhs_field))
+                        .next()
+                        .and_then(|ptr| rhs_table.get_row_ref(blob_store, ptr))
+                        .map(Row::Ptr)
+                        .map(Tuple::Row)
+                    {
+                        f(v)?;
+                    }
+                    Ok(())
+                })
+            }
+            Self {
+                lhs,
+                lhs_field,
+                unique: true,
+                semijoin: Semi::All,
+                ..
+            } => {
+                // Probe the index and evaluate the matching rhs row
+                lhs.execute(tx, &mut |u| {
+                    if let Some(v) = rhs_index
+                        .seek(&u.project(lhs_field))
+                        .next()
+                        .and_then(|ptr| rhs_table.get_row_ref(blob_store, ptr))
+                        .map(Row::Ptr)
+                        .map(Tuple::Row)
+                    {
+                        f(u.join(v))?;
+                    }
+                    Ok(())
+                })
+            }
+            Self {
+                lhs,
+                lhs_field,
+                unique: false,
+                semijoin: Semi::Lhs,
+                ..
+            } => {
+                // How many times should we evaluate the lhs tuple?
+                // Probe the index for the number of matching rows.
+                lhs.execute(tx, &mut |u| {
+                    if let Some(n) = rhs_index.count(&u.project(lhs_field)) {
+                        for _ in 0..n {
+                            f(u.clone())?;
+                        }
+                    }
+                    Ok(())
+                })
+            }
+            Self {
+                lhs,
+                lhs_field,
+                unique: false,
+                semijoin: Semi::Rhs,
+                ..
+            } => {
+                // Probe the index and evaluate the matching rhs rows
+                lhs.execute(tx, &mut |u| {
+                    for v in rhs_index
+                        .seek(&u.project(lhs_field))
+                        .filter_map(|ptr| rhs_table.get_row_ref(blob_store, ptr))
+                        .map(Row::Ptr)
+                        .map(Tuple::Row)
+                    {
+                        f(v)?;
+                    }
+                    Ok(())
+                })
+            }
+            Self {
+                lhs,
+                lhs_field,
+                unique: false,
+                semijoin: Semi::All,
+                ..
+            } => {
+                // Probe the index and evaluate the matching rhs rows
+                lhs.execute(tx, &mut |u| {
+                    for v in rhs_index
+                        .seek(&u.project(lhs_field))
+                        .filter_map(|ptr| rhs_table.get_row_ref(blob_store, ptr))
+                        .map(Row::Ptr)
+                        .map(Tuple::Row)
+                    {
+                        f(u.clone().join(v.clone()))?;
+                    }
+                    Ok(())
+                })
+            }
+        }
+    }
+}
+
+/// An executor for a hash join.
+/// Note, this executor is a pipeline breaker,
+/// because it must fully materialize the rhs.
+pub struct BlockingHashJoin {
+    pub lhs: Box<PipelinedExecutor>,
+    pub rhs: Box<PipelinedExecutor>,
+    pub lhs_field: TupleField,
+    pub rhs_field: TupleField,
+    pub unique: bool,
+    pub semijoin: Semi,
+}
+
+impl BlockingHashJoin {
+    pub fn execute<'a, Tx: Datastore + DeltaStore>(
+        &self,
+        tx: &'a Tx,
+        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
+    ) -> Result<()> {
+        match self {
+            Self {
+                lhs,
+                rhs,
+                lhs_field,
+                rhs_field,
+                unique: true,
+                semijoin: Semi::Lhs,
+            } => {
+                let mut rhs_table = HashSet::new();
+                rhs.execute(tx, &mut |v| {
+                    rhs_table.insert(v.project(rhs_field));
+                    Ok(())
+                })?;
+                lhs.execute(tx, &mut |u| {
+                    if rhs_table.contains(&u.project(lhs_field)) {
+                        f(u)?;
+                    }
+                    Ok(())
+                })
+            }
+            Self {
+                lhs,
+                rhs,
+                lhs_field,
+                rhs_field,
+                unique: true,
+                semijoin: Semi::Rhs,
+            } => {
+                let mut rhs_table = HashMap::new();
+                rhs.execute(tx, &mut |v| {
+                    rhs_table.insert(v.project(rhs_field), v);
+                    Ok(())
+                })?;
+                lhs.execute(tx, &mut |u| {
+                    if let Some(v) = rhs_table.get(&u.project(lhs_field)) {
+                        f(v.clone())?;
+                    }
+                    Ok(())
+                })
+            }
+            Self {
+                lhs,
+                rhs,
+                lhs_field,
+                rhs_field,
+                unique: true,
+                semijoin: Semi::All,
+            } => {
+                let mut rhs_table = HashMap::new();
+                rhs.execute(tx, &mut |v| {
+                    rhs_table.insert(v.project(rhs_field), v);
+                    Ok(())
+                })?;
+                lhs.execute(tx, &mut |u| {
+                    if let Some(v) = rhs_table.get(&u.project(lhs_field)) {
+                        f(u.clone().join(v.clone()))?;
+                    }
+                    Ok(())
+                })
+            }
+            Self {
+                lhs,
+                rhs,
+                lhs_field,
+                rhs_field,
+                unique: false,
+                semijoin: Semi::Lhs,
+            } => {
+                let mut rhs_table = HashMap::new();
+                rhs.execute(tx, &mut |v| {
+                    rhs_table
+                        .entry(v.project(rhs_field))
+                        .and_modify(|n| *n += 1)
+                        .or_insert(1);
+                    Ok(())
+                })?;
+                lhs.execute(tx, &mut |u| {
+                    if let Some(n) = rhs_table.get(&u.project(lhs_field)).copied() {
+                        for _ in 0..n {
+                            f(u.clone())?;
+                        }
+                    }
+                    Ok(())
+                })
+            }
+            Self {
+                lhs,
+                rhs,
+                lhs_field,
+                rhs_field,
+                unique: false,
+                semijoin: Semi::Rhs,
+            } => {
+                let mut rhs_table: HashMap<AlgebraicValue, Vec<_>> = HashMap::new();
+                rhs.execute(tx, &mut |v| {
+                    let key = v.project(rhs_field);
+                    if let Some(tuples) = rhs_table.get_mut(&key) {
+                        tuples.push(v);
+                    } else {
+                        rhs_table.insert(key, vec![v]);
+                    }
+                    Ok(())
+                })?;
+                lhs.execute(tx, &mut |u| {
+                    if let Some(rhs_tuples) = rhs_table.get(&u.project(lhs_field)) {
+                        for v in rhs_tuples {
+                            f(v.clone())?;
+                        }
+                    }
+                    Ok(())
+                })
+            }
+            Self {
+                lhs,
+                rhs,
+                lhs_field,
+                rhs_field,
+                unique: false,
+                semijoin: Semi::All,
+            } => {
+                let mut rhs_table: HashMap<AlgebraicValue, Vec<_>> = HashMap::new();
+                rhs.execute(tx, &mut |v| {
+                    let key = v.project(rhs_field);
+                    if let Some(tuples) = rhs_table.get_mut(&key) {
+                        tuples.push(v);
+                    } else {
+                        rhs_table.insert(key, vec![v]);
+                    }
+                    Ok(())
+                })?;
+                lhs.execute(tx, &mut |u| {
+                    if let Some(rhs_tuples) = rhs_table.get(&u.project(lhs_field)) {
+                        for v in rhs_tuples {
+                            f(u.clone().join(v.clone()))?;
+                        }
+                    }
+                    Ok(())
+                })
+            }
+        }
+    }
+}
+
+/// An executor for a nested loop join.
+/// Note, this is a pipeline breaker,
+/// because it fully materializes the rhs.
+pub struct BlockingNLJoin {
+    pub lhs: Box<PipelinedExecutor>,
+    pub rhs: Box<PipelinedExecutor>,
+}
+
+impl BlockingNLJoin {
+    pub fn execute<'a, Tx: Datastore + DeltaStore>(
+        &self,
+        tx: &'a Tx,
+        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
+    ) -> Result<()> {
+        let mut rhs = vec![];
+        self.rhs.execute(tx, &mut |t| {
+            rhs.push(t);
+            Ok(())
+        })?;
+        self.lhs.execute(tx, &mut |u| {
+            for v in rhs.iter() {
+                f(u.clone().join(v.clone()))?;
+            }
+            Ok(())
+        })
+    }
+}
+
+/// A pipelined filter executor
+pub struct PipelinedFilter {
+    pub input: Box<PipelinedExecutor>,
+    pub expr: PhysicalExpr,
+}
+
+impl PipelinedFilter {
+    pub fn execute<'a, Tx: Datastore + DeltaStore>(
+        &self,
+        tx: &'a Tx,
+        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
+    ) -> Result<()> {
+        self.input.execute(tx, &mut |t| {
+            if self.expr.eval_bool(&t) {
+                f(t)?;
+            }
+            Ok(())
+        })
+    }
+}

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -6,7 +6,7 @@ use std::{
 
 use derive_more::From;
 use spacetimedb_expr::StatementSource;
-use spacetimedb_lib::{query::Delta, AlgebraicValue};
+use spacetimedb_lib::{query::Delta, AlgebraicValue, ProductValue};
 use spacetimedb_primitives::{ColId, ColSet, IndexId};
 use spacetimedb_schema::schema::{IndexSchema, TableSchema};
 use spacetimedb_sql_parser::ast::{BinOp, LogOp};
@@ -845,6 +845,12 @@ pub trait ProjectField {
 impl ProjectField for RowRef<'_> {
     fn project(&self, field: &TupleField) -> AlgebraicValue {
         self.read_col(field.field_pos).unwrap()
+    }
+}
+
+impl ProjectField for &'_ ProductValue {
+    fn project(&self, field: &TupleField) -> AlgebraicValue {
+        self.elements[field.field_pos].clone()
     }
 }
 


### PR DESCRIPTION
# Description of Changes

This patch is a prerequisite for computing query cpu metrics.

> Why is a new executor needed?

Tuple at a time iterators are not well suited to gathering per operator metrics.

# API and ABI breaking changes

None

# Expected complexity level and risk

2

Adding new query executors is relatively straightforward since they work off of the same physical plan. We can rely on our current test coverage to catch any issues.

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

No new tests have been added. We already have correctness tests for the query and subscription code that are executor agnostic.
