### PR TITLE
Cache whether a `Table` is a scheduler table, avoiding fetching the schema

### DIFF
--- a/crates/core/src/db/datastore/traits.rs
+++ b/crates/core/src/db/datastore/traits.rs
@@ -345,6 +345,19 @@ impl Program {
     }
 }
 
+/// Additional information about an insert operation.
+pub struct InsertFlags {
+    /// Is the table a scheduler table?
+    pub is_scheduler_table: bool,
+}
+
+/// Additional information about an update operation.
+// TODO(centril): consider fusing this with `InsertFlags`.
+pub struct UpdateFlags {
+    /// Is the table a scheduler table?
+    pub is_scheduler_table: bool,
+}
+
 pub trait TxDatastore: DataRow + Tx {
     type IterTx<'a>: Iterator<Item = Self::RowRef<'a>>
     where
@@ -486,30 +499,34 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     ///
     /// Returns the list of columns with sequence-trigger values that were replaced with generated ones
     /// and a reference to the row as a [`RowRef`].
+    /// Also returns any additional insert flags.
     ///
     /// Generated columns are columns with an auto-inc sequence
     /// and where the column was `0` in `row`.
+    // TODO(centril): consider making the tuple into a struct.
     fn insert_mut_tx<'a>(
         &'a self,
         tx: &'a mut Self::MutTx,
         table_id: TableId,
         row: &[u8],
-    ) -> Result<(ColList, RowRef<'a>)>;
+    ) -> Result<(ColList, RowRef<'a>, InsertFlags)>;
     /// Updates a row to `row`, encoded in BSATN, into the table identified by `table_id`
     /// using the index identified by `index_id`.
     ///
     /// Returns the list of columns with sequence-trigger values that were replaced with generated ones
     /// and a reference to the row as a [`RowRef`].
+    /// Also returns any additional update flags.
     ///
     /// Generated columns are columns with an auto-inc sequence
     /// and where the column was `0` in `row`.
+    // TODO(centril): consider making the tuple into a struct.
     fn update_mut_tx<'a>(
         &'a self,
         tx: &'a mut Self::MutTx,
         table_id: TableId,
         index_id: IndexId,
         row: &[u8],
-    ) -> Result<(ColList, RowRef<'a>)>;
+    ) -> Result<(ColList, RowRef<'a>, UpdateFlags)>;
 
     /// Obtain the [`Metadata`] for this datastore.
     ///

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -4,7 +4,8 @@ use super::datastore::locking_tx_datastore::state_view::{
 };
 use super::datastore::system_tables::ST_MODULE_ID;
 use super::datastore::traits::{
-    IsolationLevel, Metadata, MutTx as _, MutTxDatastore, Program, RowTypeForTable, Tx as _, TxDatastore,
+    InsertFlags, IsolationLevel, Metadata, MutTx as _, MutTxDatastore, Program, RowTypeForTable, Tx as _, TxDatastore,
+    UpdateFlags,
 };
 use super::datastore::{
     locking_tx_datastore::{
@@ -1130,7 +1131,7 @@ impl RelationalDB {
         tx: &'a mut MutTx,
         table_id: TableId,
         row: &[u8],
-    ) -> Result<(ColList, RowRef<'a>), DBError> {
+    ) -> Result<(ColList, RowRef<'a>, InsertFlags), DBError> {
         self.inner.insert_mut_tx(tx, table_id, row)
     }
 
@@ -1140,7 +1141,7 @@ impl RelationalDB {
         table_id: TableId,
         index_id: IndexId,
         row: &[u8],
-    ) -> Result<(ColList, RowRef<'a>), DBError> {
+    ) -> Result<(ColList, RowRef<'a>, UpdateFlags), DBError> {
         self.inner.update_mut_tx(tx, table_id, index_id, row)
     }
 
@@ -1563,7 +1564,7 @@ pub mod tests_utils {
         table_id: TableId,
         row: &T,
     ) -> Result<(AlgebraicValue, RowRef<'a>), DBError> {
-        let (gen_cols, row_ref) = db.insert(tx, table_id, &to_vec(row).unwrap())?;
+        let (gen_cols, row_ref, _) = db.insert(tx, table_id, &to_vec(row).unwrap())?;
         let gen_cols = row_ref.project(&gen_cols).unwrap();
         Ok((gen_cols, row_ref))
     }

--- a/crates/primitives/src/col_list.rs
+++ b/crates/primitives/src/col_list.rs
@@ -387,9 +387,9 @@ impl From<&ColList> for ColSet {
     }
 }
 
-impl From<ColId> for ColSet {
-    fn from(id: ColId) -> Self {
-        Self::from(ColList::new(id))
+impl<C: Into<ColId>> From<C> for ColSet {
+    fn from(value: C) -> Self {
+        Self::from(ColList::new(value.into()))
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Fixes https://github.com/clockworklabs/SpacetimeDB/issues/2021.

Does 2 things:

1. changes `fn {insert,update}_mut_tx` to `traits.rs` to return whether the table was a scheduler table.
2. adds `Table::is_scheduler` so `datastore_{insert, update}_bsatn` don't have to fetch the schema.

Perf before:

```
for i in {1..5}; do spacetime call basics update_positions_by_collect -s local; done

2025-01-21T04:14:53.970948Z  INFO: : Timing span "update_positions_by_collect": 664.876291ms
2025-01-21T04:14:55.258220Z  INFO: : Timing span "update_positions_by_collect": 651.551835ms
2025-01-21T04:14:56.600896Z  INFO: : Timing span "update_positions_by_collect": 667.1316ms
2025-01-21T04:14:57.722544Z  INFO: : Timing span "update_positions_by_collect": 638.108509ms
2025-01-21T04:14:58.980541Z  INFO: : Timing span "update_positions_by_collect": 642.46669ms
```

Perf after:
```
for i in {1..5}; do spacetime call basics update_positions_by_collect -s local; done

2025-01-22T15:21:00.033248Z  INFO: : Timing span "update_positions_by_collect": 663.533985ms
2025-01-22T15:21:01.290030Z  INFO: : Timing span "update_positions_by_collect": 617.702017ms
2025-01-22T15:21:02.417180Z  INFO: : Timing span "update_positions_by_collect": 622.391745ms
2025-01-22T15:21:03.643441Z  INFO: : Timing span "update_positions_by_collect": 618.93754ms
2025-01-22T15:21:04.785486Z  INFO: : Timing span "update_positions_by_collect": 626.819507ms
```

This means we go from an average 653 ms to 630 ms, which is about an average 23 ms speedup.
This was the expected speedup based on % of samples in the update ABI PR flamegraph.

# API and ABI breaking changes

None

# Expected complexity level and risk

1, fairly simple and contained change.

# Testing

A test of the caching behavior is added in `datastore.rs`: `fn test_scheduled_table_insert_and_update`.