### PR TITLE
Set `tracing` static level for binaries only

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4745,6 +4745,7 @@ dependencies = [
  "tokio-tungstenite",
  "toml 0.8.19",
  "toml_edit",
+ "tracing",
  "walkdir",
  "wasmbin",
  "wasmtime",
@@ -5287,6 +5288,7 @@ dependencies = [
  "tokio",
  "toml 0.8.19",
  "tower-http",
+ "tracing",
 ]
 
 [[package]]
@@ -5347,6 +5349,7 @@ dependencies = [
  "clap 4.5.20",
  "semver",
  "spacetimedb-paths",
+ "tracing",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -245,7 +245,7 @@ tokio-util = { version = "0.7.4", features = ["time"] }
 toml = "0.8"
 toml_edit = "0.22.22"
 tower-http = { version = "0.5", features = ["cors"] }
-tracing = { version = "0.1.37", features = ["release_max_level_off"] }
+tracing = "0.1.37"
 tracing-appender = "0.2.2"
 tracing-core = "0.1.31"
 tracing-flame = "0.2.0"

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -63,6 +63,7 @@ tokio.workspace = true
 tokio-tungstenite.workspace = true
 toml.workspace = true
 toml_edit.workspace = true
+tracing = { workspace = true, features = ["release_max_level_off"] }
 walkdir.workspace = true
 wasmbin.workspace = true
 wasmtime.workspace = true

--- a/crates/core/src/database_logger.rs
+++ b/crates/core/src/database_logger.rs
@@ -132,7 +132,7 @@ impl DatabaseLogger {
         Self { inner, tx }
     }
 
-    #[tracing::instrument(name = "DatabaseLogger::size", skip(self), err)]
+    #[tracing::instrument(level = "trace", name = "DatabaseLogger::size", skip(self), err)]
     pub fn size(&self) -> io::Result<u64> {
         Ok(self.inner.lock().file.metadata()?.len())
     }

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -578,7 +578,7 @@ impl RelationalDB {
     /// **Note**: this call **must** be paired with [`Self::rollback_mut_tx`] or
     /// [`Self::commit_tx`], otherwise the database will be left in an invalid
     /// state. See also [`Self::with_auto_commit`].
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn begin_mut_tx(&self, isolation_level: IsolationLevel, workload: Workload) -> MutTx {
         log::trace!("BEGIN MUT TX");
         let r = self.inner.begin_mut_tx(isolation_level, workload);
@@ -586,7 +586,7 @@ impl RelationalDB {
         r
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn begin_tx(&self, workload: Workload) -> Tx {
         log::trace!("BEGIN TX");
         let r = self.inner.begin_tx(workload);
@@ -594,25 +594,25 @@ impl RelationalDB {
         r
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn rollback_mut_tx(&self, tx: MutTx) {
         log::trace!("ROLLBACK MUT TX");
         self.inner.rollback_mut_tx(tx)
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn rollback_mut_tx_downgrade(&self, tx: MutTx, workload: Workload) -> Tx {
         log::trace!("ROLLBACK MUT TX");
         self.inner.rollback_mut_tx_downgrade(tx, workload)
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn release_tx(&self, tx: Tx) {
         log::trace!("RELEASE TX");
         self.inner.release_tx(tx)
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn commit_tx(&self, tx: MutTx) -> Result<Option<TxData>, DBError> {
         log::trace!("COMMIT MUT TX");
 
@@ -631,7 +631,7 @@ impl RelationalDB {
         Ok(Some(tx_data))
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn commit_tx_downgrade(&self, tx: MutTx, workload: Workload) -> Result<Option<(TxData, Tx)>, DBError> {
         log::trace!("COMMIT MUT TX");
 

--- a/crates/core/src/host/disk_storage.rs
+++ b/crates/core/src/host/disk_storage.rs
@@ -27,7 +27,7 @@ impl DiskStorage {
         path
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub async fn get(&self, key: &Hash) -> io::Result<Option<Box<[u8]>>> {
         let path = self.object_path(key);
         match fs::read(path).await {
@@ -48,7 +48,7 @@ impl DiskStorage {
         }
     }
 
-    #[tracing::instrument(skip(self, value))]
+    #[tracing::instrument(level = "trace", skip(self, value))]
     pub async fn put(&self, value: &[u8]) -> io::Result<Hash> {
         let h = hash_bytes(value);
         let path = self.object_path(&h);
@@ -68,7 +68,7 @@ impl DiskStorage {
         Ok(h)
     }
 
-    #[tracing::instrument(skip(self))]
+    #[tracing::instrument(level = "trace", skip(self))]
     pub async fn prune(&self, key: &Hash) -> anyhow::Result<()> {
         Ok(fs::remove_file(self.object_path(key)).await?)
     }

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -107,7 +107,7 @@ impl InstanceEnv {
         self.tx.get()
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn console_log(&self, level: LogLevel, record: &Record, bt: &dyn BacktraceProvider) {
         self.replica_ctx.logger.write(level, record, bt);
         log::trace!(
@@ -186,7 +186,7 @@ impl InstanceEnv {
         Ok(todo!())
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn datastore_delete_by_btree_scan_bsatn(
         &self,
         index_id: IndexId,
@@ -215,7 +215,7 @@ impl InstanceEnv {
     /// - not in a transaction.
     /// - the table didn't exist.
     /// - a row couldn't be decoded to the table schema type.
-    #[tracing::instrument(skip(self, relation))]
+    #[tracing::instrument(level = "trace", skip(self, relation))]
     pub fn datastore_delete_all_by_eq_bsatn(&self, table_id: TableId, relation: &[u8]) -> Result<u32, NodesError> {
         let stdb = &*self.replica_ctx.relational_db;
         let tx = &mut *self.get_tx()?;
@@ -234,7 +234,7 @@ impl InstanceEnv {
     ///
     /// Errors with `GetTxError` if not in a transaction
     /// and `TableNotFound` if the table does not exist.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn table_id_from_name(&self, table_name: &str) -> Result<TableId, NodesError> {
         let stdb = &*self.replica_ctx.relational_db;
         let tx = &mut *self.get_tx()?;
@@ -248,7 +248,7 @@ impl InstanceEnv {
     ///
     /// Errors with `GetTxError` if not in a transaction
     /// and `IndexNotFound` if the index does not exist.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn index_id_from_name(&self, index_name: &str) -> Result<IndexId, NodesError> {
         let stdb = &*self.replica_ctx.relational_db;
         let tx = &mut *self.get_tx()?;
@@ -262,7 +262,7 @@ impl InstanceEnv {
     ///
     /// Errors with `GetTxError` if not in a transaction
     /// and `TableNotFound` if the table does not exist.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn datastore_table_row_count(&self, table_id: TableId) -> Result<u64, NodesError> {
         let stdb = &*self.replica_ctx.relational_db;
         let tx = &mut *self.get_tx()?;
@@ -271,7 +271,7 @@ impl InstanceEnv {
         stdb.table_row_count_mut(tx, table_id).ok_or(NodesError::TableNotFound)
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn datastore_table_scan_bsatn_chunks(
         &self,
         pool: &mut ChunkPool,
@@ -284,7 +284,7 @@ impl InstanceEnv {
         Ok(chunks)
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn datastore_btree_scan_bsatn_chunks(
         &self,
         pool: &mut ChunkPool,

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -816,7 +816,7 @@ impl ModuleHost {
         )
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn one_off_query<F: WebsocketFormat>(
         &self,
         caller_identity: Identity,

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -258,7 +258,12 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
         self.trapped
     }
 
-    #[tracing::instrument(skip_all, fields(db_id = self.instance.instance_env().replica_ctx.id))]
+    #[tracing::instrument(
+        level = "debug",
+        skip_all,
+        err
+        fields(db_id = self.instance.instance_env().replica_ctx.id),
+    )]
     fn init_database(&mut self, program: Program) -> anyhow::Result<Option<ReducerCallResult>> {
         log::debug!("init database");
         let timestamp = Timestamp::now();
@@ -328,7 +333,7 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
         Ok(rcr)
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     fn update_database(
         &mut self,
         program: Program,
@@ -389,7 +394,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
     /// The method also performs various measurements and records energy usage,
     /// as well as broadcasting a [`ModuleEvent`] containg information about
     /// the outcome of the call.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     fn call_reducer_with_tx(&mut self, tx: Option<MutTxId>, params: CallReducerParams) -> ReducerCallResult {
         let CallReducerParams {
             timestamp,

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -303,7 +303,7 @@ impl WasmInstanceEnv {
     ///
     /// - `NOT_IN_TRANSACTION`, when called outside of a transaction.
     /// - `NO_SUCH_TABLE`, when `name` is not the name of a table.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn table_id_from_name(
         caller: Caller<'_, Self>,
         name: WasmPtr<u8>,
@@ -338,7 +338,7 @@ impl WasmInstanceEnv {
     ///
     /// - `NOT_IN_TRANSACTION`, when called outside of a transaction.
     /// - `NO_SUCH_INDEX`, when `name` is not the name of an index.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn index_id_from_name(
         caller: Caller<'_, Self>,
         name: WasmPtr<u8>,
@@ -368,7 +368,7 @@ impl WasmInstanceEnv {
     ///
     /// - `NOT_IN_TRANSACTION`, when called outside of a transaction.
     /// - `NO_SUCH_TABLE`, when `table_id` is not a known ID of a table.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn datastore_table_row_count(caller: Caller<'_, Self>, table_id: u32, out: WasmPtr<u64>) -> RtResult<u32> {
         Self::cvt_ret::<u64>(caller, AbiCall::DatastoreTableRowCount, out, |caller| {
             let (_, env) = Self::mem_env(caller);
@@ -391,7 +391,7 @@ impl WasmInstanceEnv {
     ///
     /// - `NOT_IN_TRANSACTION`, when called outside of a transaction.
     /// - `NO_SUCH_TABLE`, when `table_id` is not a known ID of a table.
-    // #[tracing::instrument(skip_all)]
+    // #[tracing::instrument(level = "trace", skip_all)]
     pub fn datastore_table_scan_bsatn(
         caller: Caller<'_, Self>,
         table_id: u32,
@@ -541,7 +541,7 @@ impl WasmInstanceEnv {
     /// - `BUFFER_TOO_SMALL`, when there are rows left but they cannot fit in `buffer`.
     ///   When this occurs, `buffer_len` is set to the size of the next item in the iterator.
     ///   To make progress, the caller should reallocate the buffer to at least that size and try again.
-    // #[tracing::instrument(skip_all)]
+    // #[tracing::instrument(level = "trace", skip_all)]
     pub fn row_iter_bsatn_advance(
         caller: Caller<'_, Self>,
         iter: u32,
@@ -612,7 +612,7 @@ impl WasmInstanceEnv {
     /// Returns an error:
     ///
     /// - `NO_SUCH_ITER`, when `iter` is not a valid iterator.
-    // #[tracing::instrument(skip_all)]
+    // #[tracing::instrument(level = "trace", skip_all)]
     pub fn row_iter_bsatn_close(caller: Caller<'_, Self>, iter: u32) -> RtResult<u32> {
         let row_iter_idx = RowIterIdx(iter);
         Self::cvt_custom(caller, AbiCall::RowIterBsatnClose, |caller| {
@@ -660,7 +660,7 @@ impl WasmInstanceEnv {
     ///   typed at the `ProductType` the table's schema specifies.
     /// - `UNIQUE_ALREADY_EXISTS`, when inserting `row` would violate a unique constraint.
     /// - `SCHEDULE_AT_DELAY_TOO_LONG`, when the delay specified in the row was too long.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn datastore_insert_bsatn(
         caller: Caller<'_, Self>,
         table_id: u32,
@@ -723,7 +723,7 @@ impl WasmInstanceEnv {
     /// - `NO_SUCH_ROW`, when the row was not found in the unique index.
     /// - `UNIQUE_ALREADY_EXISTS`, when inserting `row` would violate a unique constraint.
     /// - `SCHEDULE_AT_DELAY_TOO_LONG`, when the delay specified in the row was too long.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn datastore_update_bsatn(
         caller: Caller<'_, Self>,
         table_id: u32,
@@ -844,7 +844,7 @@ impl WasmInstanceEnv {
     /// - `NO_SUCH_TABLE`, when `table_id` is not a known ID of a table.
     /// - `BSATN_DECODE_ERROR`, when `rel` cannot be decoded to `Vec<ProductValue>`
     ///   where each `ProductValue` is typed at the `ProductType` the table's schema specifies.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn datastore_delete_all_by_eq_bsatn(
         caller: Caller<'_, Self>,
         table_id: u32,
@@ -1052,7 +1052,7 @@ impl WasmInstanceEnv {
     /// - `message` is not NULL and `message_ptr[..message_len]` is not in bounds of WASM memory.
     ///
     /// [target]: https://docs.rs/log/latest/log/struct.Record.html#method.target
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn console_log(
         caller: Caller<'_, Self>,
         level: u32,

--- a/crates/core/src/host/wasmtime/wasmtime_module.rs
+++ b/crates/core/src/host/wasmtime/wasmtime_module.rs
@@ -181,7 +181,7 @@ impl module_host_actor::WasmInstance for WasmtimeInstance {
 
     type Trap = anyhow::Error;
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     fn call_reducer(
         &mut self,
         op: ReducerOp<'_>,

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -207,7 +207,7 @@ impl ExecutionUnit {
     }
 
     /// Evaluate this execution unit against the database using the specified format.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn eval<F: WebsocketFormat>(
         &self,
         db: &RelationalDB,

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -73,7 +73,7 @@ impl ModuleSubscriptions {
         })
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn add_subscription(
         &self,
         sender: Arc<ClientConnectionSender>,
@@ -182,7 +182,7 @@ impl ModuleSubscriptions {
 
     /// Add a subscriber to the module. NOTE: this function is blocking.
     /// This is used for the legacy subscription API which uses a set of queries.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn add_legacy_subscriber(
         &self,
         sender: Arc<ClientConnectionSender>,

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -238,7 +238,7 @@ impl SubscriptionManager {
     ///
     /// If a query is not already indexed,
     /// its table ids added to the inverted index.
-    // #[tracing::instrument(skip_all)]
+    // #[tracing::instrument(level = "trace", skip_all)]
     pub fn set_legacy_subscription(&mut self, client: Client, queries: impl IntoIterator<Item = Query>) {
         let client_id = (client.id.identity, client.id.address);
         // First, remove any existing legacy subscriptions.
@@ -281,7 +281,7 @@ impl SubscriptionManager {
     /// Removes a client from the subscriber mapping.
     /// If a query no longer has any subscribers,
     /// it is removed from the index along with its table ids.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn remove_all_subscriptions(&mut self, client: &ClientId) {
         self.remove_legacy_subscriptions(client);
         let Some(client_info) = self.clients.get(client) else {
@@ -309,7 +309,7 @@ impl SubscriptionManager {
     /// This method takes a set of delta tables,
     /// evaluates only the necessary queries for those delta tables,
     /// and then sends the results to each client.
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn eval_updates(&self, tx: &DeltaTx, event: Arc<ModuleEvent>, caller: Option<&ClientConnectionSender>) {
         use FormatSwitch::{Bsatn, Json};
 

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -529,7 +529,7 @@ impl ExecutionSet {
         ws::DatabaseUpdate { tables }
     }
 
-    #[tracing::instrument(skip_all)]
+    #[tracing::instrument(level = "trace", skip_all)]
     pub fn eval_incr_for_test<'a>(
         &'a self,
 

--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -25,7 +25,7 @@ pub const fn const_unwrap<T: Copy>(o: Option<T>) -> T {
     }
 }
 
-#[tracing::instrument(skip_all)]
+#[tracing::instrument(level = "trace", skip_all)]
 pub fn spawn_rayon<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) -> impl Future<Output = R> {
     let span = tracing::Span::current();
     let (tx, rx) = oneshot::channel();

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -42,6 +42,7 @@ thiserror.workspace = true
 tokio.workspace = true
 tower-http.workspace = true
 toml.workspace = true
+tracing = { workspace = true, features = ["release_max_level_debug"] }
 
 [dev-dependencies]
 once_cell.workspace = true

--- a/crates/update/Cargo.toml
+++ b/crates/update/Cargo.toml
@@ -10,3 +10,4 @@ spacetimedb-paths.workspace = true
 anyhow.workspace = true
 clap.workspace = true
 semver.workspace = true
+tracing = { workspace = true, features = ["release_max_level_off"] }


### PR DESCRIPTION
Disabling tracing (`features = ["release_max_level_off"]`) at the
workspace level prevents library users from using tracing at all.
Instead, set the feature for each binary individually.

Also change all but one `#[instrument]` macros to be at "trace" level,
which will prevent code gen unless the static level is at trace. This is
because most of them were introduced for `tracy` tracing, and may be at
"hot" code locations.

Fixes: #2117

# Expected complexity level and risk

1

# Testing

Build the proprietary edition with this patch and confirm logs emitted via the
`tracing` crate's macros are output. Both from public and proprietary code.
