### PR TITLE
NFC: simplify C# FFI definitions

### DIFF
--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#FFI.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#FFI.verified.cs
@@ -1001,7 +1001,7 @@ static class ModuleRegistration
 
     [UnmanagedCallersOnly(EntryPoint = "__call_reducer__")]
     public static SpacetimeDB.Internal.Errno __call_reducer__(
-        uint id,
+        int id,
         ulong sender_0,
         ulong sender_1,
         ulong sender_2,

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#FFI.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#FFI.verified.cs
@@ -1149,7 +1149,7 @@ static class ModuleRegistration
 
     [UnmanagedCallersOnly(EntryPoint = "__call_reducer__")]
     public static SpacetimeDB.Internal.Errno __call_reducer__(
-        uint id,
+        int id,
         ulong sender_0,
         ulong sender_1,
         ulong sender_2,

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -876,7 +876,7 @@ public class Module : IIncrementalGenerator
 
                         [UnmanagedCallersOnly(EntryPoint = "__call_reducer__")]
                         public static SpacetimeDB.Internal.Errno __call_reducer__(
-                            uint id,
+                            int id,
                             ulong sender_0,
                             ulong sender_1,
                             ulong sender_2,

--- a/crates/bindings-csharp/Runtime/Internal/FFI.cs
+++ b/crates/bindings-csharp/Runtime/Internal/FFI.cs
@@ -128,14 +128,14 @@ internal static partial class FFI
 
     [LibraryImport(StdbNamespace)]
     public static partial CheckedStatus table_id_from_name(
-        [In] byte[] name,
+        ReadOnlySpan<byte> name,
         uint name_len,
         out TableId out_
     );
 
     [LibraryImport(StdbNamespace)]
     public static partial CheckedStatus index_id_from_name(
-        [In] byte[] name,
+        ReadOnlySpan<byte> name,
         uint name_len,
         out IndexId out_
     );
@@ -165,7 +165,7 @@ internal static partial class FFI
     [LibraryImport(StdbNamespace)]
     public static partial Errno row_iter_bsatn_advance(
         RowIter iter_handle,
-        [MarshalUsing(CountElementName = nameof(buffer_len))] [Out] byte[] buffer,
+        Span<byte> buffer,
         ref uint buffer_len
     );
 
@@ -195,7 +195,7 @@ internal static partial class FFI
     [LibraryImport(StdbNamespace)]
     public static partial CheckedStatus datastore_delete_all_by_eq_bsatn(
         TableId table_id,
-        [In] byte[] relation,
+        ReadOnlySpan<byte> relation,
         uint relation_len,
         out uint out_
     );
@@ -227,12 +227,12 @@ internal static partial class FFI
     [LibraryImport(StdbNamespace)]
     public static partial void console_log(
         LogLevel level,
-        [In] byte[] target,
+        ReadOnlySpan<byte> target,
         uint target_len,
-        [In] byte[] filename,
+        ReadOnlySpan<byte> filename,
         uint filename_len,
         uint line_number,
-        [In] byte[] message,
+        ReadOnlySpan<byte> message,
         uint message_len
     );
 
@@ -262,16 +262,19 @@ internal static partial class FFI
     }
 
     [LibraryImport(StdbNamespace)]
-    public static partial ConsoleTimerId console_timer_start([In] byte[] name, uint name_len);
+    public static partial ConsoleTimerId console_timer_start(
+        ReadOnlySpan<byte> name,
+        uint name_len
+    );
 
     [LibraryImport(StdbNamespace)]
     public static partial CheckedStatus console_timer_end(ConsoleTimerId stopwatch_id);
 
     [LibraryImport(StdbNamespace)]
     public static partial void volatile_nonatomic_schedule_immediate(
-        [In] byte[] name,
+        ReadOnlySpan<byte> name,
         uint name_len,
-        [In] byte[] args,
+        ReadOnlySpan<byte> args,
         uint args_len
     );
 

--- a/crates/bindings-csharp/Runtime/Internal/FFI.cs
+++ b/crates/bindings-csharp/Runtime/Internal/FFI.cs
@@ -129,14 +129,14 @@ internal static partial class FFI
     [LibraryImport(StdbNamespace)]
     public static partial CheckedStatus table_id_from_name(
         ReadOnlySpan<byte> name,
-        uint name_len,
+        int name_len,
         out TableId out_
     );
 
     [LibraryImport(StdbNamespace)]
     public static partial CheckedStatus index_id_from_name(
         ReadOnlySpan<byte> name,
-        uint name_len,
+        int name_len,
         out IndexId out_
     );
 
@@ -153,12 +153,12 @@ internal static partial class FFI
     public static partial CheckedStatus datastore_btree_scan_bsatn(
         IndexId index_id,
         ReadOnlySpan<byte> prefix,
-        uint prefix_len,
+        int prefix_len,
         ColId prefix_elems,
         ReadOnlySpan<byte> rstart,
-        uint rstart_len,
+        int rstart_len,
         ReadOnlySpan<byte> rend,
-        uint rend_len,
+        int rend_len,
         out RowIter out_
     );
 
@@ -166,7 +166,7 @@ internal static partial class FFI
     public static partial Errno row_iter_bsatn_advance(
         RowIter iter_handle,
         Span<byte> buffer,
-        ref uint buffer_len
+        ref int buffer_len
     );
 
     [LibraryImport(StdbNamespace)]
@@ -176,19 +176,19 @@ internal static partial class FFI
     public static partial CheckedStatus datastore_insert_bsatn(
         TableId table_id,
         Span<byte> row,
-        ref uint row_len
+        ref int row_len
     );
 
     [LibraryImport(StdbNamespace)]
     public static partial CheckedStatus datastore_delete_by_btree_scan_bsatn(
         IndexId index_id,
         ReadOnlySpan<byte> prefix,
-        uint prefix_len,
+        int prefix_len,
         ColId prefix_elems,
         ReadOnlySpan<byte> rstart,
-        uint rstart_len,
+        int rstart_len,
         ReadOnlySpan<byte> rend,
-        uint rend_len,
+        int rend_len,
         out uint out_
     );
 
@@ -196,7 +196,7 @@ internal static partial class FFI
     public static partial CheckedStatus datastore_delete_all_by_eq_bsatn(
         TableId table_id,
         ReadOnlySpan<byte> relation,
-        uint relation_len,
+        int relation_len,
         out uint out_
     );
 
@@ -204,14 +204,14 @@ internal static partial class FFI
     public static partial Errno bytes_source_read(
         BytesSource source,
         Span<byte> buffer,
-        ref uint buffer_len
+        ref int buffer_len
     );
 
     [LibraryImport(StdbNamespace)]
     public static partial CheckedStatus bytes_sink_write(
         BytesSink sink,
         ReadOnlySpan<byte> buffer,
-        ref uint buffer_len
+        ref int buffer_len
     );
 
     public enum LogLevel : byte
@@ -228,12 +228,12 @@ internal static partial class FFI
     public static partial void console_log(
         LogLevel level,
         ReadOnlySpan<byte> target,
-        uint target_len,
+        int target_len,
         ReadOnlySpan<byte> filename,
-        uint filename_len,
+        int filename_len,
         uint line_number,
         ReadOnlySpan<byte> message,
-        uint message_len
+        int message_len
     );
 
     [NativeMarshalling(typeof(ConsoleTimerIdMarshaller))]
@@ -262,10 +262,7 @@ internal static partial class FFI
     }
 
     [LibraryImport(StdbNamespace)]
-    public static partial ConsoleTimerId console_timer_start(
-        ReadOnlySpan<byte> name,
-        uint name_len
-    );
+    public static partial ConsoleTimerId console_timer_start(ReadOnlySpan<byte> name, int name_len);
 
     [LibraryImport(StdbNamespace)]
     public static partial CheckedStatus console_timer_end(ConsoleTimerId stopwatch_id);
@@ -273,9 +270,9 @@ internal static partial class FFI
     [LibraryImport(StdbNamespace)]
     public static partial void volatile_nonatomic_schedule_immediate(
         ReadOnlySpan<byte> name,
-        uint name_len,
+        int name_len,
         ReadOnlySpan<byte> args,
-        uint args_len
+        int args_len
     );
 
     // Note #1: our Identity type has the same layout as a fixed-size 32-byte little-endian buffer,

--- a/crates/bindings-csharp/Runtime/Internal/IIndex.cs
+++ b/crates/bindings-csharp/Runtime/Internal/IIndex.cs
@@ -11,7 +11,7 @@ public abstract class IndexBase<Row>
     public IndexBase(string name)
     {
         var name_bytes = System.Text.Encoding.UTF8.GetBytes(name);
-        FFI.index_id_from_name(name_bytes, (uint)name_bytes.Length, out indexId);
+        FFI.index_id_from_name(name_bytes, name_bytes.Length, out indexId);
     }
 
     private static void ToParams<Bounds>(
@@ -50,12 +50,12 @@ public abstract class IndexBase<Row>
         FFI.datastore_delete_by_btree_scan_bsatn(
             indexId,
             prefix,
-            (uint)prefix.Length,
+            prefix.Length,
             prefixElems,
             rstart,
-            (uint)rstart.Length,
+            rstart.Length,
             rend,
-            (uint)rend.Length,
+            rend.Length,
             out var out_
         );
         return out_;
@@ -70,12 +70,12 @@ public abstract class IndexBase<Row>
             FFI.datastore_btree_scan_bsatn(
                 indexId,
                 prefix,
-                (uint)prefix.Length,
+                prefix.Length,
                 prefixElems,
                 rstart,
-                (uint)rstart.Length,
+                rstart.Length,
                 rend,
-                (uint)rend.Length,
+                rend.Length,
                 out handle
             );
         }

--- a/crates/bindings-csharp/Runtime/Internal/IReducer.cs
+++ b/crates/bindings-csharp/Runtime/Internal/IReducer.cs
@@ -26,9 +26,9 @@ public interface IReducer
 
         FFI.volatile_nonatomic_schedule_immediate(
             name_bytes,
-            (uint)name_bytes.Length,
+            name_bytes.Length,
             args_bytes,
-            (uint)args_bytes.Length
+            args_bytes.Length
         );
     }
 }

--- a/crates/bindings-csharp/Runtime/Internal/ITable.cs
+++ b/crates/bindings-csharp/Runtime/Internal/ITable.cs
@@ -17,10 +17,9 @@ internal abstract class RawTableIterBase<T>
                 return false;
             }
 
-            uint buffer_len;
             while (true)
             {
-                buffer_len = (uint)buffer.Length;
+                var buffer_len = buffer.Length;
                 var ret = FFI.row_iter_bsatn_advance(handle, buffer, ref buffer_len);
                 if (ret == Errno.EXHAUSTED)
                 {
@@ -116,7 +115,7 @@ public interface ITableView<View, T>
         new(() =>
         {
             var name_bytes = System.Text.Encoding.UTF8.GetBytes(tableName);
-            FFI.table_id_from_name(name_bytes, (uint)name_bytes.Length, out var out_);
+            FFI.table_id_from_name(name_bytes, name_bytes.Length, out var out_);
             return out_;
         });
 
@@ -142,11 +141,11 @@ public interface ITableView<View, T>
     {
         // Insert the row.
         var bytes = IStructuralReadWrite.ToBytes(row);
-        var bytes_len = (uint)bytes.Length;
+        var bytes_len = bytes.Length;
         FFI.datastore_insert_bsatn(tableId, bytes, ref bytes_len);
 
         // Write back any generated column values.
-        using var stream = new MemoryStream(bytes, 0, (int)bytes_len);
+        using var stream = new MemoryStream(bytes, 0, bytes_len);
         using var reader = new BinaryReader(stream);
         return View.ReadGenFields(reader, row);
     }
@@ -154,7 +153,7 @@ public interface ITableView<View, T>
     protected static bool DoDelete(T row)
     {
         var bytes = IStructuralReadWrite.ToBytes(row);
-        FFI.datastore_delete_all_by_eq_bsatn(tableId, bytes, (uint)bytes.Length, out var out_);
+        FFI.datastore_delete_all_by_eq_bsatn(tableId, bytes, bytes.Length, out var out_);
         return out_ > 0;
     }
 

--- a/crates/bindings-csharp/Runtime/Internal/Module.cs
+++ b/crates/bindings-csharp/Runtime/Internal/Module.cs
@@ -180,11 +180,9 @@ public static class Module
         try
         {
             var senderIdentity = Identity.From(
-                MemoryMarshal.AsBytes([sender_0, sender_1, sender_2, sender_3]).ToArray()
+                MemoryMarshal.AsBytes([sender_0, sender_1, sender_2, sender_3])
             );
-            var senderAddress = Address.From(
-                MemoryMarshal.AsBytes([address_0, address_1]).ToArray()
-            );
+            var senderAddress = Address.From(MemoryMarshal.AsBytes([address_0, address_1]));
             var random = new Random((int)timestamp.MicrosecondsSinceEpoch);
             var time = timestamp.ToStd();
 

--- a/crates/bindings-csharp/Runtime/Log.cs
+++ b/crates/bindings-csharp/Runtime/Log.cs
@@ -168,12 +168,12 @@ public static class Log
         FFI.console_log(
             level,
             target_bytes,
-            (uint)target_bytes.Length,
+            target_bytes.Length,
             filename_bytes,
-            (uint)filename_bytes.Length,
+            filename_bytes.Length,
             lineNumber,
             text_bytes,
-            (uint)text_bytes.Length
+            text_bytes.Length
         );
     }
 }

--- a/crates/bindings-csharp/Runtime/LogStopwatch.cs
+++ b/crates/bindings-csharp/Runtime/LogStopwatch.cs
@@ -11,7 +11,7 @@ public sealed class LogStopwatch : IDisposable
     public LogStopwatch(string name)
     {
         var name_bytes = Encoding.UTF8.GetBytes(name);
-        StopwatchId = FFI.console_timer_start(name_bytes, (uint)name_bytes.Length);
+        StopwatchId = FFI.console_timer_start(name_bytes, name_bytes.Length);
     }
 
     void IDisposable.Dispose()


### PR DESCRIPTION
# Description of Changes

This is non-functional change, just aligning FFI definitions closer to the language conventions.

C# uses `int` everywhere for positons and lengths in standard APIs.

Our manual conversions from Rust `uint` to C# `int` do the same bitcast anyway, so we might as well change the FFI definitions instead for cleaner code and fewer casts.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Ran `dotnet test`, waiting for CI for the rest.
