### PR TITLE
Relax dotnet version requirements

### DIFF
--- a/crates/bindings-csharp/global.json
+++ b/crates/bindings-csharp/global.json
@@ -1,0 +1,1 @@
+../../modules/global.json

--- a/crates/cli/src/subcommands/project/csharp/global._json
+++ b/crates/cli/src/subcommands/project/csharp/global._json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0",
+    "version": "8.0.0",
     "rollForward": "latestMinor"
   }
 }

--- a/crates/cli/src/subcommands/project/csharp/global._json
+++ b/crates/cli/src/subcommands/project/csharp/global._json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "8.0",
     "rollForward": "latestMinor"
   }
 }

--- a/crates/cli/src/subcommands/project/csharp/global._json
+++ b/crates/cli/src/subcommands/project/csharp/global._json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "8.0.000",
     "rollForward": "latestMinor"
   }
 }

--- a/crates/cli/src/subcommands/project/csharp/global._json
+++ b/crates/cli/src/subcommands/project/csharp/global._json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.000",
+    "version": "8.0.0",
     "rollForward": "latestMinor"
   }
 }

--- a/modules/global.json
+++ b/modules/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0",
+    "version": "8.0.0",
     "rollForward": "latestMinor"
   }
 }

--- a/modules/global.json
+++ b/modules/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.400",
+    "version": "8.0",
     "rollForward": "latestMinor"
   }
 }

--- a/modules/global.json
+++ b/modules/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "8.0.000",
     "rollForward": "latestMinor"
   }
 }

--- a/modules/global.json
+++ b/modules/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.000",
+    "version": "8.0.0",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
Verion 8.0.400 is not necessarily available in Linux package repositories, causing the `csharp_module.py` smoketest to fail (including on CI).

Until and unless a specific issue arises, allow any 8.0 minor version.

# Expected complexity level and risk

1

# Testing

Fixes a smoketest.