### PR TITLE
[C#] Reuse buffers in table iterations

### DIFF
--- a/crates/bindings-csharp/Runtime/Internal/FFI.cs
+++ b/crates/bindings-csharp/Runtime/Internal/FFI.cs
@@ -52,8 +52,33 @@ internal static partial class FFI
 #endif
     ;
 
+    public static void Check(this Errno status)
+    {
+        if (status == Errno.OK)
+        {
+            return;
+        }
+        throw status switch
+        {
+            Errno.NOT_IN_TRANSACTION => new NotInTransactionException(),
+            Errno.BSATN_DECODE_ERROR => new BsatnDecodeException(),
+            Errno.NO_SUCH_TABLE => new NoSuchTableException(),
+            Errno.NO_SUCH_INDEX => new NoSuchIndexException(),
+            Errno.NO_SUCH_ITER => new NoSuchIterException(),
+            Errno.NO_SUCH_CONSOLE_TIMER => new NoSuchLogStopwatch(),
+            Errno.NO_SUCH_BYTES => new NoSuchBytesException(),
+            Errno.NO_SPACE => new NoSpaceException(),
+            Errno.BUFFER_TOO_SMALL => new BufferTooSmallException(),
+            Errno.UNIQUE_ALREADY_EXISTS => new UniqueConstraintViolationException(),
+            Errno.SCHEDULE_AT_DELAY_TOO_LONG => new ScheduleAtDelayTooLongException(),
+            Errno.INDEX_NOT_UNIQUE => new IndexNotUniqueException(),
+            Errno.NO_SUCH_ROW => new NoSuchRowException(),
+            _ => new UnknownException(status),
+        };
+    }
+
     [NativeMarshalling(typeof(Marshaller))]
-    public struct CheckedStatus
+    internal struct CheckedStatus
     {
         // This custom marshaller takes care of checking the status code
         // returned from the host and throwing an exception if it's not 0.
@@ -69,27 +94,8 @@ internal static partial class FFI
         {
             public static CheckedStatus ConvertToManaged(Errno status)
             {
-                if (status == 0)
-                {
-                    return default;
-                }
-                throw status switch
-                {
-                    Errno.NOT_IN_TRANSACTION => new NotInTransactionException(),
-                    Errno.BSATN_DECODE_ERROR => new BsatnDecodeException(),
-                    Errno.NO_SUCH_TABLE => new NoSuchTableException(),
-                    Errno.NO_SUCH_INDEX => new NoSuchIndexException(),
-                    Errno.NO_SUCH_ITER => new NoSuchIterException(),
-                    Errno.NO_SUCH_CONSOLE_TIMER => new NoSuchLogStopwatch(),
-                    Errno.NO_SUCH_BYTES => new NoSuchBytesException(),
-                    Errno.NO_SPACE => new NoSpaceException(),
-                    Errno.BUFFER_TOO_SMALL => new BufferTooSmallException(),
-                    Errno.UNIQUE_ALREADY_EXISTS => new UniqueConstraintViolationException(),
-                    Errno.SCHEDULE_AT_DELAY_TOO_LONG => new ScheduleAtDelayTooLongException(),
-                    Errno.INDEX_NOT_UNIQUE => new IndexNotUniqueException(),
-                    Errno.NO_SUCH_ROW => new NoSuchRowException(),
-                    _ => new UnknownException(status),
-                };
+                status.Check();
+                return default;
             }
         }
     }

--- a/crates/bindings-csharp/Runtime/Internal/IIndex.cs
+++ b/crates/bindings-csharp/Runtime/Internal/IIndex.cs
@@ -41,7 +41,7 @@ public abstract class IndexBase<Row>
     }
 
     protected IEnumerable<Row> DoFilter<Bounds>(Bounds bounds)
-        where Bounds : IBTreeIndexBounds => new RawTableIter<Bounds>(indexId, bounds).Parse();
+        where Bounds : IBTreeIndexBounds => new RawTableIter<Bounds>(indexId, bounds);
 
     protected uint DoDelete<Bounds>(Bounds bounds)
         where Bounds : IBTreeIndexBounds

--- a/crates/bindings-csharp/Runtime/Internal/ITable.cs
+++ b/crates/bindings-csharp/Runtime/Internal/ITable.cs
@@ -42,9 +42,6 @@ internal abstract class RawTableIterBase<T> : IEnumerable<T>
                         }
                         break;
                     }
-                    // Couldn't find the iterator, error!
-                    case Errno.NO_SUCH_ITER:
-                        throw new NoSuchIterException();
                     // The scratch `buffer` is too small to fit a row / chunk.
                     // Grow `buffer` and try again.
                     // The `buffer_len` will have been updated with the necessary size.
@@ -52,7 +49,8 @@ internal abstract class RawTableIterBase<T> : IEnumerable<T>
                         ArrayPool<byte>.Shared.Return(buffer);
                         break;
                     default:
-                        throw new UnknownException(ret);
+                        ret.Check();
+                        break;
                 }
             }
         }

--- a/crates/bindings-csharp/Runtime/Internal/ITable.cs
+++ b/crates/bindings-csharp/Runtime/Internal/ITable.cs
@@ -47,6 +47,7 @@ internal abstract class RawTableIterBase<T> : IEnumerable<T>
                     // The `buffer_len` will have been updated with the necessary size.
                     case Errno.BUFFER_TOO_SMALL:
                         ArrayPool<byte>.Shared.Return(buffer);
+                        buffer = ArrayPool<byte>.Shared.Rent((int)buffer_len);
                         break;
                     default:
                         ret.Check();

--- a/crates/bindings-csharp/Runtime/Internal/Module.cs
+++ b/crates/bindings-csharp/Runtime/Internal/Module.cs
@@ -124,11 +124,8 @@ public static class Module
                 // The host will likely not trigger this branch (current host doesn't),
                 // but a module should be prepared for it.
                 case Errno.OK:
+                    ret.Check();
                     break;
-                case Errno.NO_SUCH_BYTES:
-                    throw new NoSuchBytesException();
-                default:
-                    throw new UnknownException(ret);
             }
         }
     }


### PR DESCRIPTION
# Description of Changes

This is one of the branches I had for a while, but never submitted as a PR as it wasn't a priority. Still might be nice to have eventually.

Benchmark comparisons:

| Group                                                                                  | Speedup | Master Timing         | Reuse-C#-Buffers-Iter Timing |
|----------------------------------------------------------------------------------------|---------|-----------------------|------------------------------|
| special/db_game/csharp/circles/load=10                                                 | 1.50    | 1528.5±31.20ms        | 1015.9±13.92ms              |
| special/db_game/csharp/circles/load=100                                                | 1.48    | 1522.5±21.20ms        | 1027.5±15.85ms              |
| special/db_game/csharp/ia_loop/load=10                                                 | 1.83    | 242.8±5.78ms          | 132.3±3.28ms                |
| special/db_game/csharp/ia_loop/load=100                                                | 2.16    | 624.8±15.15ms         | 289.7±3.82ms                |
| stdb_module/csharp/mem/filter/string/index/load=2048/count=256                         | 1.09    | 865.0±29.83µs         | 790.6±29.09µs               |
| stdb_module/csharp/mem/filter/u64/index/load=2048/count=256                            | 1.16    | 525.3±9.86µs          | 452.1±6.28µs                |
| stdb_module/csharp/mem/insert_bulk/u32_u64_u64/btree_each_column/load=2048/count=256   | 1.07    | 2.0±0.12ms            | 1900.5±104.00µs             |
| stdb_module/csharp/mem/iterate/u32_u64_str/unique_0/count=256                          | 1.06    | 790.5±46.63µs         | 746.3±13.33µs               |
| stdb_module/csharp/mem/iterate/u32_u64_u64/unique_0/count=256                          | 1.10    | 475.0±26.96µs         | 432.1±11.19µs               |


That is, the difference is fairly marginal in microbenchmarks, but really shines in integration ones which are arguably more representative of real-world scenarios.

In those, the speedup ranges from 1.5x to 2.1x.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] Ran SDK tests for C#.
- [x] Ran `dotnet test`.