### PR TITLE
Fix autocomplete issues in bindings crate

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3539,9 +3539,9 @@ dependencies = [
 
 [[package]]
 name = "proc-macro2"
-version = "1.0.89"
+version = "1.0.93"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f139b0662de085916d1fb67d2b4169d1addddda1919e696f3252b740b629986e"
+checksum = "60946a68e5f9d28b0dc1c21bb8a97ee7d018a8b322fa57838ba31cc878e22d99"
 dependencies = [
  "unicode-ident",
 ]
@@ -4678,7 +4678,6 @@ dependencies = [
 name = "spacetimedb-bindings-macro"
 version = "1.0.0-rc3"
 dependencies = [
- "bitflags 2.6.0",
  "heck 0.4.1",
  "humantime",
  "proc-macro2",

--- a/crates/bindings-macro/Cargo.toml
+++ b/crates/bindings-macro/Cargo.toml
@@ -14,7 +14,6 @@ bench = false
 [dependencies]
 spacetimedb-primitives.workspace = true
 
-bitflags.workspace = true
 humantime.workspace = true
 proc-macro2.workspace = true
 quote.workspace = true

--- a/crates/bindings/src/table.rs
+++ b/crates/bindings/src/table.rs
@@ -257,30 +257,22 @@ impl MaybeError for AutoIncOverflow {
 }
 
 pub trait Column {
-    type Row;
-    type ColType;
+    type Table: Table;
+    type ColType: SpacetimeType + Serialize + DeserializeOwned;
     const COLUMN_NAME: &'static str;
-    fn get_field(row: &Self::Row) -> &Self::ColType;
+    fn get_field(row: &<Self::Table as Table>::Row) -> &Self::ColType;
 }
 
-pub struct UniqueColumn<Tbl: Table, ColType, Col>
-where
-    ColType: SpacetimeType + Serialize + DeserializeOwned,
-    Col: Index + Column<Row = Tbl::Row, ColType = ColType>,
-{
-    _marker: PhantomData<(Tbl, Col)>,
+pub struct UniqueColumn<Tbl, ColType, Col> {
+    _marker: PhantomData<(Tbl, ColType, Col)>,
 }
 
-impl<Tbl: Table, ColType, Col> UniqueColumn<Tbl, ColType, Col>
-where
-    ColType: SpacetimeType + Serialize + DeserializeOwned,
-    Col: Index + Column<Row = Tbl::Row, ColType = ColType>,
-{
+impl<Tbl: Table, Col: Index + Column<Table = Tbl>> UniqueColumn<Tbl, Col::ColType, Col> {
     #[doc(hidden)]
     pub const __NEW: Self = Self { _marker: PhantomData };
 
     #[inline]
-    fn get_args(&self, col_val: &ColType) -> BTreeScanArgs {
+    fn get_args(&self, col_val: &Col::ColType) -> BTreeScanArgs {
         BTreeScanArgs {
             data: IterBuf::serialize(&std::ops::Bound::Included(col_val)).unwrap(),
             prefix_elems: 0,
@@ -298,11 +290,11 @@ where
     // whereas by-ref makes passing `!Copy` fields more performant.
     // Can we do something smart with `std::borrow::Borrow`?
     #[inline]
-    pub fn find(&self, col_val: impl Borrow<ColType>) -> Option<Tbl::Row> {
+    pub fn find(&self, col_val: impl Borrow<Col::ColType>) -> Option<Tbl::Row> {
         self._find(col_val.borrow())
     }
 
-    fn _find(&self, col_val: &ColType) -> Option<Tbl::Row> {
+    fn _find(&self, col_val: &Col::ColType) -> Option<Tbl::Row> {
         // Find the row with a match.
         let index_id = Col::index_id();
         let args = self.get_args(col_val);
@@ -330,11 +322,11 @@ where
     /// May panic if deleting the row would violate a constraint,
     /// though as of proposing no such constraints exist.
     #[inline]
-    pub fn delete(&self, col_val: impl Borrow<ColType>) -> bool {
+    pub fn delete(&self, col_val: impl Borrow<Col::ColType>) -> bool {
         self._delete(col_val.borrow()).0
     }
 
-    fn _delete(&self, col_val: &ColType) -> (bool, IterBuf) {
+    fn _delete(&self, col_val: &Col::ColType) -> (bool, IterBuf) {
         let index_id = Col::index_id();
         let args = self.get_args(col_val);
         let (prefix, prefix_elems, rstart, rend) = args.args_for_syscall();

--- a/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
+++ b/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
@@ -37,7 +37,6 @@ spacetimedb
 │   └── rand_core (*)
 ├── scoped_tls
 ├── spacetimedb_bindings_macro
-│   ├── bitflags
 │   ├── heck
 │   ├── humantime
 │   ├── proc_macro2 (*)


### PR DESCRIPTION
# Description of Changes

Fixes 2 specific issues:
- invalid syntax (namely, at least, an incomplete if block: `if foo`) in a reducer body would cause autocomplete to break.
  - This is fixed by upgrading the `proc-macro2` dependency.
- No completions for methods on unique columns.
  - This is fixed by fiddling around with the bounds on the `impl` block for `UniqueColumn`. Best I can tell is that this was hitting some poorly-handled edge case in chalk, related to evaluating bounds that are too dependent on each other (?)

# Expected complexity level and risk

1

# Testing

- [x] Both cases now provide autocomplete with rust-analyzer.
