### PR TITLE
Don't create indexes during bootstrapping; wait until after replay

### DIFF
--- a/crates/commitlog/Cargo.toml
+++ b/crates/commitlog/Cargo.toml
@@ -10,7 +10,7 @@ description = "Implementation of the SpacetimeDB commitlog."
 [features]
 default = ["serde"]
 # Enable types + impls useful for testing
-test = []
+test = ["dep:env_logger"]
 
 [dependencies]
 bitflags.workspace = true
@@ -24,6 +24,9 @@ spacetimedb-paths.workspace = true
 spacetimedb-sats.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
+
+# For the 'test' feature
+env_logger = { workspace = true, optional = true }
 
 [dev-dependencies]
 env_logger.workspace = true

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -24,8 +24,8 @@ pub use crate::{
 pub mod error;
 pub mod payload;
 
-#[cfg(test)]
-mod tests;
+#[cfg(any(test, feature = "test"))]
+pub mod tests;
 
 /// [`Commitlog`] options.
 #[derive(Clone, Copy, Debug)]

--- a/crates/commitlog/src/tests.rs
+++ b/crates/commitlog/src/tests.rs
@@ -1,4 +1,6 @@
+#[cfg(test)]
 mod bitflip;
+#[cfg(test)]
 mod partial;
 
 pub mod helpers;

--- a/crates/commitlog/src/tests/helpers.rs
+++ b/crates/commitlog/src/tests/helpers.rs
@@ -38,6 +38,17 @@ where
     total_txs
 }
 
+pub fn fill_log_with<R, T>(log: &mut commitlog::Generic<R, T>, txes: impl IntoIterator<Item = T>)
+where
+    R: Repo,
+    T: Debug + Encode,
+{
+    for tx in txes {
+        log.append(tx).unwrap();
+    }
+    log.commit().unwrap();
+}
+
 pub fn enable_logging() {
     let _ = env_logger::builder()
         .filter_level(log::LevelFilter::Trace)

--- a/crates/commitlog/src/tests/helpers.rs
+++ b/crates/commitlog/src/tests/helpers.rs
@@ -38,6 +38,9 @@ where
     total_txs
 }
 
+/// Put the `txes` into a single commit within `log`.
+///
+/// Panics if `txes` does not fit within a single commit within `log`.
 pub fn fill_log_with<R, T>(log: &mut commitlog::Generic<R, T>, txes: impl IntoIterator<Item = T>)
 where
     R: Repo,

--- a/crates/commitlog/src/tests/helpers.rs
+++ b/crates/commitlog/src/tests/helpers.rs
@@ -38,9 +38,9 @@ where
     total_txs
 }
 
-/// Put the `txes` into a single commit within `log`.
+/// Put the `txes` into `log`.
 ///
-/// Panics if `txes` does not fit within a single commit within `log`.
+/// Each TX from `txes` will be placed in its own commit within `log`.
 pub fn fill_log_with<R, T>(log: &mut commitlog::Generic<R, T>, txes: impl IntoIterator<Item = T>)
 where
     R: Repo,
@@ -48,8 +48,8 @@ where
 {
     for tx in txes {
         log.append(tx).unwrap();
+        log.commit().unwrap();
     }
-    log.commit().unwrap();
 }
 
 pub fn enable_logging() {

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -122,6 +122,7 @@ test = []
 [dev-dependencies]
 spacetimedb-lib = { path = "../lib", features = ["proptest"] }
 spacetimedb-sats = { path = "../sats", features = ["proptest"] }
+spacetimedb-commitlog = { workspace = true, features = ["test"] }
 
 criterion.workspace = true
 # Also as dev-dependencies for use in _this_ crate's tests.

--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -319,9 +319,8 @@ impl CommittedState {
             .get_mut(&table_id)
             .ok_or_else(|| TableError::IdNotFoundState(table_id))?;
         let blob_store = &mut self.blob_store;
-        let skip_index_update = true;
         table
-            .delete_equal_row(blob_store, rel, skip_index_update)
+            .delete_equal_row(blob_store, rel)
             .map_err(TableError::Insert)?
             .ok_or_else(|| anyhow!("Delete for non-existent row when replaying transaction"))?;
         Ok(())
@@ -334,7 +333,7 @@ impl CommittedState {
         row: &ProductValue,
     ) -> Result<()> {
         let (table, blob_store) = self.get_table_and_blob_store_or_create(table_id, schema);
-        table.insert_for_replay(blob_store, row).map_err(TableError::Insert)?;
+        table.insert(blob_store, row).map_err(TableError::Insert)?;
         Ok(())
     }
 

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -115,7 +115,10 @@ impl Locking {
         // The database tables are now initialized with the correct data.
         // Now we have to build our in memory structures.
         commit_state.build_sequence_state(&mut datastore.sequence_state.lock())?;
-        commit_state.build_indexes()?;
+        // We don't want to build indexes here; we'll build those later,
+        // in `rebuild_state_after_replay`.
+        // We actively do not want indexes to exist during replay,
+        // as they break replaying TX 0.
 
         log::trace!("DATABASE:BOOTSTRAPPING SYSTEM TABLES DONE");
         Ok(datastore)

--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -905,7 +905,7 @@ impl From<StModuleRow> for ProductValue {
 /// identity                                                                                | address
 /// -----------------------------------------------------------------------------------------+--------------------------------------------------------
 ///  (__identity_bytes = 0x7452047061ea2502003412941d85a42f89b0702588b823ab55fc4f12e9ea8363) | (__address_bytes = 0x6bdea3ab517f5857dc9b1b5fe99e1b14)
-#[derive(Clone, Debug, Eq, PartialEq, SpacetimeType)]
+#[derive(Clone, Copy, Debug, Eq, PartialEq, SpacetimeType)]
 #[sats(crate = spacetimedb_lib)]
 pub struct StClientRow {
     pub(crate) identity: IdentityViaU256,


### PR DESCRIPTION
# Description of Changes

This PR fixes a bug where replaying databases without a snapshot of TX 0, i.e. using the entire commitlog,
would fail when replaying deletes on `st_client`.

This is because `st_client` was in the unique (*) position of:
- Being a system table,
- with a unique index,
- which is mutated after bootstrapping.

(*) Other system tables meet all three criteria in edge cases with schema-changing publishes, but only `st_client` meets them in everyday testing.

In this case, when replaying the entire commitlog, we create the indexes on the system tables during bootstrapping before replay. (I theorize, but have not checked,
that when restoring from a snapshot we do not create these indexes so eagerly, instead waiting for after replaying the commitlog suffix to create them.)

However, we cannot update or use indexes during bootstrapping, at least currently, because doing so causes unique constraint violations. Prior to this commit, we had a bunch of complicated code which avoided updating indexes during replay.

PR #2092, aka commit f667f65b159f0ffbd00a3bdb24afee79c0084070, introduced a case where we would use an index during replay: when replaying a delete for a table which had an index, and therefore had no pointer map.
Prior to that commit, we would never use an index during replay, even if it existed.

This all came together to mean that `st_client` had an empty index, and no pointer map, and so calls to `replay_delete_by_rel` on that table would always fail. I theorize that no one noticed this sooner
because it did not manifest when restoring from a snapshot, and there is always a snapshot of TX 0 unless you manually delete it, as Kim did during his testing.

The fix is simple: we do not construct indexes on the system tables during bootstrapping before replaying the commitlog, instead waiting until after replay like we do for user-defined indexes. This allows us to rip out all the aforementioned fiddly code for dodging indexes during replay,
since now there will not be any indexes and therefore we will never update them.

This PR also includes some new testing infra in `relational_db.rs`, and exports some test helpers from the `commitlog` crate under its `test` feature.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

4: I don't feel like I understand our bootstrapping process terribly well, it is quite fiddly, and I cannot explain why we were previously constructing system table indexes before replay. It may have been important in some way I do not realize.

# Testing

- [x] Replayed a commitlog containing a conn/disconn pair after deleting snapshot 0, and saw that it successfully reconstructed the (or at least an) in-memory state.
  - I did not do any more work to verify that the reconstructed state was correct.
- [x] Did the same thing with a commitlog with snapshot 0 still intact, to make sure I didn't somehow break that.
- [x] Wrote a cool new regression test, `replay_delete_from_st_client`, which fails on master but passes on this branch.