### PR TITLE
Fix ScheduleAt in C#

### DIFF
--- a/crates/bindings-csharp/BSATN.Runtime.Tests/Tests.cs
+++ b/crates/bindings-csharp/BSATN.Runtime.Tests/Tests.cs
@@ -139,4 +139,16 @@ public static class BSATNRuntimeTests
             () => Address.FromHexString("these are not hex characters....")
         );
     }
+
+    [Fact]
+    public static void TimestampConversionChecks()
+    {
+        ulong us = 1737582793990639;
+        var time = ScheduleAt.DateTimeOffsetFromMicrosSinceUnixEpoch(us);
+
+        Assert.Equal(ScheduleAt.ToMicrosecondsSinceUnixEpoch(time), us);
+
+        var interval = ScheduleAt.TimeSpanFromMicroseconds(us);
+        Assert.Equal(ScheduleAt.ToMicroseconds(interval), us);
+    }
 }

--- a/crates/bindings-csharp/BSATN.Runtime/Repr.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/Repr.cs
@@ -11,17 +11,17 @@ using System.Runtime.InteropServices;
 [SpacetimeDB.Type] // we should be able to encode it to BSATN too
 public partial struct DateTimeOffsetRepr(DateTimeOffset time)
 {
-    public ulong MicrosecondsSinceEpoch = (ulong)time.Ticks / 10;
+    public ulong MicrosecondsSinceEpoch = ScheduleAt.ToMicrosecondsSinceUnixEpoch(time);
 
     public readonly DateTimeOffset ToStd() =>
-        DateTimeOffset.UnixEpoch.AddTicks(10 * (long)MicrosecondsSinceEpoch);
+        ScheduleAt.DateTimeOffsetFromMicrosSinceUnixEpoch(MicrosecondsSinceEpoch);
 }
 
 [StructLayout(LayoutKind.Sequential)] // we should be able to use it in FFI
 [SpacetimeDB.Type] // we should be able to encode it to BSATN too
 public partial struct TimeSpanRepr(TimeSpan duration)
 {
-    public ulong Microseconds = (ulong)duration.Ticks / 10;
+    public ulong Microseconds = ScheduleAt.ToMicroseconds(duration);
 
-    public readonly TimeSpan ToStd() => TimeSpan.FromTicks(10 * (long)Microseconds);
+    public readonly TimeSpan ToStd() => ScheduleAt.TimeSpanFromMicroseconds(Microseconds);
 }


### PR DESCRIPTION
# Description of Changes

Fix the implementation of C# timestamps. While addressing issues on blackholio I noticed these were incorrect. The specific issue was a missed subtraction of DateTimeOffset.UnixEpoch when converting from DateTimeOffset to milliseconds.

A fix is needed if the C# server version of Blackholio is to work.

https://github.com/clockworklabs/SpacetimeDB/pull/1836 is a larger change that will rework Timestamp in C#, that will want to be rebased onto this.

# API and ABI breaking changes

Added APIs in the C# SDK.

# Expected complexity level and risk

0

# Testing

Added a unit test.