### PR TITLE
Fix sending of subscription errors.

### DIFF
--- a/crates/client-api-messages/src/websocket.rs
+++ b/crates/client-api-messages/src/websocket.rs
@@ -343,6 +343,9 @@ pub struct SubscriptionError {
     /// Provided by the client via a [`Subscribe`] or [`Unsubscribe`] message.
     /// [`None`] if this occurred as the result of a [`TransactionUpdate`].
     pub request_id: Option<u32>,
+    /// Provided by the client via a [`Subscribe`] or [`Unsubscribe`] message.
+    /// [`None`] if this occurred as the result of a [`TransactionUpdate`].
+    pub query_id: Option<u32>,
     /// The return table of the query in question.
     /// The server is not required to set this field.
     /// It has been added to avoid a breaking change post 1.0.

--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -390,7 +390,8 @@ impl ToProtocol for SubscriptionMessage {
             SubscriptionResult::Error(error) => {
                 let msg = ws::SubscriptionError {
                     total_host_execution_duration_micros,
-                    request_id: self.request_id, // Pass Option through
+                    request_id: self.request_id,           // Pass Option through
+                    query_id: self.query_id.map(|x| x.id), // Pass Option through
                     table_id: error.table_id,
                     error: error.message,
                 };


### PR DESCRIPTION
# Description of Changes

This is pulling out the server side changes that were originally in https://github.com/clockworklabs/SpacetimeDB/pull/2111.

Previously the code was not sending subscription errors for invalid queries (because we were treating those errors as generic internal errors). This fixes that. It also adds the query id to those subscription error messages, so that the clients aren't forced to track the request ids.


# Expected complexity level and risk

1

# Testing

This change is covered with some end-to-end tests in https://github.com/clockworklabs/SpacetimeDB/pull/2111.

Adding unit tests in the future would be good.

