### PR TITLE
Remove the client from subscription manager on a disconnect

### DIFF
--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -516,6 +516,7 @@ impl ModuleHost {
     }
 
     pub async fn disconnect_client(&self, client_id: ClientActorId) {
+        log::trace!("disconnecting client {}", client_id);
         let this = self.clone();
         let _ = tokio::task::spawn_blocking(move || {
             this.subscriptions().remove_subscriber(client_id);


### PR DESCRIPTION
# Description of Changes

This is fixing an obvious bug in the subscription manager. When a client disconnects, we are removing the queries, but not removing our record of the client. This is a memory leak (and would be an issue if clients reused their connection ids).

@kim this should fix the logs you were seeing when shutting down a worker.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

# Testing

Unit tests are now asserting that we remove the clients.
