### PR TITLE
Bump version to `1.0.0-rc4`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -815,7 +815,7 @@ dependencies = [
 
 [[package]]
 name = "connect_disconnect_client"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "spacetimedb-sdk",
@@ -4616,7 +4616,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "bytemuck",
  "derive_more",
@@ -4634,7 +4634,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bench"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "anymap",
@@ -4676,7 +4676,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-macro"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "heck 0.4.1",
  "humantime",
@@ -4688,14 +4688,14 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-sys"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "spacetimedb-primitives",
 ]
 
 [[package]]
 name = "spacetimedb-cli"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4753,7 +4753,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4797,7 +4797,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api-messages"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "brotli",
  "bytes",
@@ -4821,7 +4821,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-commitlog"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "bitflags 2.6.0",
  "crc32c",
@@ -4844,7 +4844,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-core"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -4952,7 +4952,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-data-structures"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "ahash 0.8.11",
  "hashbrown 0.15.1",
@@ -4964,7 +4964,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-durability"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -4978,7 +4978,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-execution"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "spacetimedb-expr",
@@ -4991,7 +4991,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-expr"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "derive_more",
  "spacetimedb-lib",
@@ -5005,7 +5005,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-fs-utils"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "hex",
@@ -5045,7 +5045,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-lib"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5073,7 +5073,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-metrics"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "arrayvec",
  "itertools 0.12.1",
@@ -5083,7 +5083,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-paths"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5099,7 +5099,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-physical-plan"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -5114,7 +5114,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-primitives"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "bitflags 2.6.0",
  "either",
@@ -5125,7 +5125,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-query"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5150,7 +5150,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sats"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "ahash 0.8.11",
  "arrayvec",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-schema"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "enum-as-inner",
@@ -5208,7 +5208,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sdk"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "anymap",
@@ -5234,7 +5234,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-snapshot"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "blake3",
  "hex",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sql-parser"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "derive_more",
  "sqlparser",
@@ -5260,7 +5260,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-standalone"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5293,7 +5293,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-table"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "ahash 0.8.11",
  "blake3",
@@ -5317,7 +5317,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-testing"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -5343,7 +5343,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-update"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -5354,7 +5354,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-vm"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -5445,7 +5445,7 @@ dependencies = [
 
 [[package]]
 name = "sqltest"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5792,7 +5792,7 @@ dependencies = [
 
 [[package]]
 name = "test-client"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -5803,7 +5803,7 @@ dependencies = [
 
 [[package]]
 name = "test-counter"
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
  "spacetimedb-data-structures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -85,38 +85,38 @@ inherits = "release"
 debug = true
 
 [workspace.package]
-version = "1.0.0-rc3"
+version = "1.0.0-rc4"
 edition = "2021"
 # update rust-toolchain.toml too!
 rust-version = "1.78.0"
 
 [workspace.dependencies]
-spacetimedb = { path = "crates/bindings", version = "1.0.0-rc3" }
-spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.0.0-rc3" }
-spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.0.0-rc3" }
-spacetimedb-cli = { path = "crates/cli", version = "1.0.0-rc3" }
-spacetimedb-client-api = { path = "crates/client-api", version = "1.0.0-rc3" }
-spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.0.0-rc3" }
-spacetimedb-commitlog = { path = "crates/commitlog", version = "1.0.0-rc3" }
-spacetimedb-core = { path = "crates/core", version = "1.0.0-rc3" }
-spacetimedb-data-structures = { path = "crates/data-structures", version = "1.0.0-rc3" }
-spacetimedb-durability = { path = "crates/durability", version = "1.0.0-rc3" }
-spacetimedb-execution = { path = "crates/execution", version = "1.0.0-rc3" }
-spacetimedb-expr = { path = "crates/expr", version = "1.0.0-rc3" }
-spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.0.0-rc3" }
-spacetimedb-metrics = { path = "crates/metrics", version = "1.0.0-rc3" }
-spacetimedb-paths = { path = "crates/paths", version = "1.0.0-rc3" }
-spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.0.0-rc3" }
-spacetimedb-primitives = { path = "crates/primitives", version = "1.0.0-rc3" }
-spacetimedb-query = { path = "crates/query", version = "1.0.0-rc3" }
-spacetimedb-sats = { path = "crates/sats", version = "1.0.0-rc3" }
-spacetimedb-schema = { path = "crates/schema", version = "1.0.0-rc3" }
-spacetimedb-standalone = { path = "crates/standalone", version = "1.0.0-rc3" }
-spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.0.0-rc3" }
-spacetimedb-table = { path = "crates/table", version = "1.0.0-rc3" }
-spacetimedb-vm = { path = "crates/vm", version = "1.0.0-rc3" }
-spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.0.0-rc3" }
-spacetimedb-snapshot = { path = "crates/snapshot", version = "1.0.0-rc3" }
+spacetimedb = { path = "crates/bindings", version = "1.0.0-rc4" }
+spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.0.0-rc4" }
+spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.0.0-rc4" }
+spacetimedb-cli = { path = "crates/cli", version = "1.0.0-rc4" }
+spacetimedb-client-api = { path = "crates/client-api", version = "1.0.0-rc4" }
+spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.0.0-rc4" }
+spacetimedb-commitlog = { path = "crates/commitlog", version = "1.0.0-rc4" }
+spacetimedb-core = { path = "crates/core", version = "1.0.0-rc4" }
+spacetimedb-data-structures = { path = "crates/data-structures", version = "1.0.0-rc4" }
+spacetimedb-durability = { path = "crates/durability", version = "1.0.0-rc4" }
+spacetimedb-execution = { path = "crates/execution", version = "1.0.0-rc4" }
+spacetimedb-expr = { path = "crates/expr", version = "1.0.0-rc4" }
+spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.0.0-rc4" }
+spacetimedb-metrics = { path = "crates/metrics", version = "1.0.0-rc4" }
+spacetimedb-paths = { path = "crates/paths", version = "1.0.0-rc4" }
+spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.0.0-rc4" }
+spacetimedb-primitives = { path = "crates/primitives", version = "1.0.0-rc4" }
+spacetimedb-query = { path = "crates/query", version = "1.0.0-rc4" }
+spacetimedb-sats = { path = "crates/sats", version = "1.0.0-rc4" }
+spacetimedb-schema = { path = "crates/schema", version = "1.0.0-rc4" }
+spacetimedb-standalone = { path = "crates/standalone", version = "1.0.0-rc4" }
+spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.0.0-rc4" }
+spacetimedb-table = { path = "crates/table", version = "1.0.0-rc4" }
+spacetimedb-vm = { path = "crates/vm", version = "1.0.0-rc4" }
+spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.0.0-rc4" }
+spacetimedb-snapshot = { path = "crates/snapshot", version = "1.0.0-rc4" }
 
 ahash = "0.8"
 anyhow = "1.0.68"

--- a/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
+++ b/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Codegen</AssemblyName>
-    <Version>1.0.0-rc3</Version>
+    <Version>1.0.0-rc4</Version>
     <Title>SpacetimeDB BSATN Codegen</Title>
     <Description>The SpacetimeDB BSATN Codegen implements the Roslyn incremental generators for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Runtime</AssemblyName>
-    <Version>1.0.0-rc3</Version>
+    <Version>1.0.0-rc4</Version>
     <Title>SpacetimeDB BSATN Runtime</Title>
     <Description>The SpacetimeDB BSATN Runtime implements APIs for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Codegen</AssemblyName>
-    <Version>1.0.0-rc3</Version>
+    <Version>1.0.0-rc4</Version>
     <Title>SpacetimeDB Module Codegen</Title>
     <Description>The SpacetimeDB Codegen implements the Roslyn incremental generators for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Runtime/Runtime.csproj
+++ b/crates/bindings-csharp/Runtime/Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Runtime</AssemblyName>
-    <Version>1.0.0-rc3</Version>
+    <Version>1.0.0-rc4</Version>
     <Title>SpacetimeDB Module Runtime</Title>
     <Description>The SpacetimeDB Runtime implements the database runtime bindings for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="1.0.0-rc3" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="1.0.0-rc4" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/rust/Cargo._toml
+++ b/crates/cli/src/subcommands/project/rust/Cargo._toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "1.0.0-rc3"
+spacetimedb = "1.0.0-rc4"
 log = "0.4"


### PR DESCRIPTION
# Description of Changes

We have released `v1.0.0-rc3`. This PR bumps us to the next RC version. (Hotfixes will happen on cherrypicked branches, and will therefore not include this PR).

# API and ABI breaking changes

No, just a version bump.

# Expected complexity level and risk

1

# Testing

None. This just bumps the version.