### PR TITLE
Switch `DeleteTable` impl to one based on `FixedBitSet`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1661,9 +1661,9 @@ checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
 name = "foldhash"
-version = "0.1.3"
+version = "0.1.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f81ec6369c545a7d40e4589b5597581fa1c441fe1cce96dd1de43159910a36a2"
+checksum = "a0d2fde1f7b3d48b8395d5f2de76c18a528bd6a9cdde438df747bfcba3e05d6f"
 
 [[package]]
 name = "foreign-types"
@@ -4641,6 +4641,7 @@ dependencies = [
  "byte-unit",
  "clap 4.5.20",
  "criterion",
+ "foldhash",
  "futures",
  "iai-callgrind",
  "iai-callgrind-macros",
@@ -4655,6 +4656,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serial_test",
+ "smallvec",
  "spacetimedb-client-api",
  "spacetimedb-core",
  "spacetimedb-data-structures",

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -21,6 +21,10 @@ harness = false
 name = "subscription"
 harness = false
 
+[[bench]]
+name = "delete_table"
+harness = false
+
 [[bin]]
 name = "summarize"
 
@@ -57,11 +61,13 @@ rusqlite.workspace = true
 serde.workspace = true
 serde_json.workspace = true
 serial_test.workspace = true
+smallvec.workspace = true
 tempdir.workspace = true
 tokio.workspace = true
 tracing-subscriber.workspace = true
 walkdir.workspace = true
 itertools.workspace = true
+foldhash = "0.1.4"
 
 [target.'cfg(target_os = "linux")'.dependencies]
 # only try to build these on linux

--- a/crates/bench/benches/delete_table.rs
+++ b/crates/bench/benches/delete_table.rs
@@ -1,0 +1,435 @@
+use core::{cmp::Ordering, iter::repeat_with, time::Duration};
+use criterion::{
+    black_box, criterion_group, criterion_main,
+    measurement::{Measurement as _, WallTime},
+    BenchmarkGroup, Criterion,
+};
+use itertools::Itertools;
+use rand::{prelude::*, seq::SliceRandom};
+use smallvec::SmallVec;
+use spacetimedb::db::datastore::locking_tx_datastore::delete_table;
+use spacetimedb_data_structures::map::HashSet;
+use spacetimedb_table::indexes::{PageIndex, PageOffset, RowPointer, Size, SquashedOffset};
+use std::collections::BTreeSet;
+
+fn time<R>(body: impl FnOnce() -> R) -> Duration {
+    let start = WallTime.start();
+    let ret = body();
+    let end = WallTime.end(start);
+    black_box(ret);
+    end
+}
+
+const FIXED_ROW_SIZE: Size = Size(4 * 4);
+
+fn gen_row_pointers(iters: u64) -> impl Iterator<Item = RowPointer> {
+    let mut page_index = PageIndex(0);
+    let mut page_offset = PageOffset(0);
+    let iter = repeat_with(move || {
+        page_offset += FIXED_ROW_SIZE;
+        if page_offset >= PageOffset::PAGE_END {
+            // Consumed the page, let's use a new page.
+            page_index.0 += 1;
+            page_offset = PageOffset(0);
+        }
+
+        black_box(RowPointer::new(
+            false,
+            page_index,
+            page_offset,
+            SquashedOffset::COMMITTED_STATE,
+        ))
+    });
+    iter.take(iters as usize)
+}
+
+fn bench_custom(g: &mut BenchmarkGroup<'_, WallTime>, name: &str, run: impl Fn(u64) -> Duration) {
+    g.bench_function(name, |b| b.iter_custom(&run));
+}
+
+fn bench_delete_table<DT: DeleteTable>(c: &mut Criterion) {
+    let name = DT::NAME;
+    let mut g = c.benchmark_group(name);
+    let row_size = black_box(FIXED_ROW_SIZE);
+    let new_dt = || DT::new(row_size);
+    bench_custom(&mut g, "mixed", |i| {
+        let mut dt = new_dt();
+        gen_row_pointers(i)
+            .map(|ptr| time(|| dt.contains(ptr)) + time(|| dt.insert(ptr)))
+            .sum()
+    });
+    bench_custom(&mut g, "mixed_random", |i| {
+        let mut dt = new_dt();
+        let mut ptrs = gen_row_pointers(i).collect_vec();
+        let mut rng = ThreadRng::default();
+        ptrs.shuffle(&mut rng);
+        ptrs.into_iter()
+            .map(|ptr| time(|| dt.contains(ptr)) + time(|| dt.insert(ptr)))
+            .sum()
+    });
+    bench_custom(&mut g, "insert", |i| {
+        let mut dt = new_dt();
+        gen_row_pointers(i).map(|ptr| time(|| dt.insert(ptr))).sum()
+    });
+    bench_custom(&mut g, "contains_for_half", |i| {
+        let mut dt = new_dt();
+        gen_row_pointers(i)
+            .enumerate()
+            .map(|(i, ptr)| {
+                if i % 2 == 0 {
+                    black_box(dt.insert(ptr));
+                }
+                time(|| dt.contains(ptr))
+            })
+            .sum()
+    });
+    bench_custom(&mut g, "contains_for_full", |i| {
+        let mut dt = new_dt();
+        gen_row_pointers(i)
+            .map(|ptr| {
+                black_box(dt.insert(ptr));
+                time(|| dt.contains(ptr))
+            })
+            .sum()
+    });
+    bench_custom(&mut g, "remove", |i| {
+        let mut dt = new_dt();
+        for ptr in gen_row_pointers(i) {
+            black_box(dt.insert(ptr));
+        }
+        gen_row_pointers(i).map(|ptr| time(|| dt.remove(ptr))).sum()
+    });
+    bench_custom(&mut g, "iter", |i| {
+        let mut dt = new_dt();
+        for ptr in gen_row_pointers(i) {
+            black_box(dt.insert(ptr));
+        }
+        time(|| dt.iter().count())
+    });
+    g.finish();
+}
+
+trait DeleteTable {
+    const NAME: &'static str;
+    fn new(fixed_row_size: Size) -> Self;
+    fn contains(&self, ptr: RowPointer) -> bool;
+    fn insert(&mut self, ptr: RowPointer) -> bool;
+    fn remove(&mut self, ptr: RowPointer) -> bool;
+    fn iter(&self) -> impl Iterator<Item = RowPointer>;
+    #[allow(unused)]
+    fn len(&self) -> usize;
+}
+
+struct DTBTree(BTreeSet<RowPointer>);
+
+impl DeleteTable for DTBTree {
+    const NAME: &'static str = "DTBTree";
+    fn new(_: Size) -> Self {
+        Self(<_>::default())
+    }
+    fn contains(&self, ptr: RowPointer) -> bool {
+        self.0.contains(&ptr)
+    }
+    fn insert(&mut self, ptr: RowPointer) -> bool {
+        self.0.insert(ptr)
+    }
+    fn remove(&mut self, ptr: RowPointer) -> bool {
+        self.0.remove(&ptr)
+    }
+    fn iter(&self) -> impl Iterator<Item = RowPointer> {
+        self.0.iter().copied()
+    }
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+struct DTHashSet(HashSet<RowPointer>);
+
+impl DeleteTable for DTHashSet {
+    const NAME: &'static str = "DTHashSet";
+    fn new(_: Size) -> Self {
+        Self(<_>::default())
+    }
+    fn contains(&self, ptr: RowPointer) -> bool {
+        self.0.contains(&ptr)
+    }
+    fn insert(&mut self, ptr: RowPointer) -> bool {
+        self.0.insert(ptr)
+    }
+    fn remove(&mut self, ptr: RowPointer) -> bool {
+        self.0.remove(&ptr)
+    }
+    fn iter(&self) -> impl Iterator<Item = RowPointer> {
+        self.0.iter().copied()
+    }
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+struct DTHashSetFH(foldhash::HashSet<RowPointer>);
+
+impl DeleteTable for DTHashSetFH {
+    const NAME: &'static str = "DTHashSetFH";
+    fn new(_: Size) -> Self {
+        Self(<_>::default())
+    }
+    fn contains(&self, ptr: RowPointer) -> bool {
+        self.0.contains(&ptr)
+    }
+    fn insert(&mut self, ptr: RowPointer) -> bool {
+        self.0.insert(ptr)
+    }
+    fn remove(&mut self, ptr: RowPointer) -> bool {
+        self.0.remove(&ptr)
+    }
+    fn iter(&self) -> impl Iterator<Item = RowPointer> {
+        self.0.iter().copied()
+    }
+    fn len(&self) -> usize {
+        self.0.len()
+    }
+}
+
+type DTPageAndBitSet = delete_table::DeleteTable;
+
+impl DeleteTable for DTPageAndBitSet {
+    const NAME: &'static str = "DTPageAndBitSet";
+    fn new(fixed_row_size: Size) -> Self {
+        Self::new(fixed_row_size)
+    }
+    fn contains(&self, ptr: RowPointer) -> bool {
+        self.contains(ptr)
+    }
+    fn insert(&mut self, ptr: RowPointer) -> bool {
+        self.insert(ptr)
+    }
+    fn remove(&mut self, ptr: RowPointer) -> bool {
+        self.remove(ptr)
+    }
+    fn iter(&self) -> impl Iterator<Item = RowPointer> {
+        self.iter()
+    }
+    fn len(&self) -> usize {
+        self.len()
+    }
+}
+
+#[derive(Clone, Copy)]
+struct OffsetRange {
+    start: PageOffset,
+    end: PageOffset,
+}
+impl OffsetRange {
+    fn point(offset: PageOffset) -> Self {
+        Self {
+            start: offset,
+            end: offset,
+        }
+    }
+}
+type OffsetRanges = SmallVec<[OffsetRange; 4]>;
+struct DTPageAndOffsetRanges {
+    deleted: Vec<OffsetRanges>,
+    len: usize,
+    fixed_row_size: Size,
+}
+
+fn cmp_start_end<T: Ord>(start: &T, end: &T, needle: &T) -> Ordering {
+    match (start.cmp(needle), end.cmp(needle)) {
+        // start = needle or start < offset <= end => we have a match.
+        (Ordering::Less, Ordering::Equal | Ordering::Greater) | (Ordering::Equal, _) => Ordering::Equal,
+        // start <= end < needle => no match.
+        (Ordering::Less, Ordering::Less) => Ordering::Less,
+        // start <= end > needle => no match.
+        (Ordering::Greater, _) => Ordering::Greater,
+    }
+}
+
+#[inline]
+fn find_range_to_insert_offset(
+    ranges: &OffsetRanges,
+    offset: PageOffset,
+    fixed_row_size: Size,
+) -> Result<(bool, bool, usize), usize> {
+    let mut extend_end = true;
+    let mut exists = false;
+    ranges
+        .binary_search_by(|&OffsetRange { start, end }| {
+            extend_end = true;
+            exists = false;
+            match end.cmp(&offset) {
+                // `end + row_size = offset` => we can just extend `end = offset`.
+                Ordering::Less if end.0 + fixed_row_size.0 == offset.0 => Ordering::Equal,
+                // Cannot extend this range, so let's not find it.
+                Ordering::Less => Ordering::Less,
+                // `offset` is already covered, so don't do anything,
+                // but `end = offset` is a no-op.
+                Ordering::Equal => {
+                    exists = true;
+                    Ordering::Equal
+                }
+                // `end` is greater, but we may be covered by `start` instead.
+                Ordering::Greater => match start.cmp(&offset) {
+                    // `offset` is within the range, so don't do anything.
+                    Ordering::Less | Ordering::Equal => {
+                        exists = true;
+                        Ordering::Equal
+                    }
+                    // `start - row_size = offset` => we can just extend `start = offset`.
+                    Ordering::Greater if start.0 - fixed_row_size.0 == offset.0 => {
+                        extend_end = false;
+                        Ordering::Equal
+                    }
+                    // Range is entirely greater than offset.
+                    Ordering::Greater => Ordering::Greater,
+                },
+            }
+        })
+        .map(|idx| (extend_end, exists, idx))
+}
+
+impl DeleteTable for DTPageAndOffsetRanges {
+    const NAME: &'static str = "DTPageAndOffsetRanges";
+    fn new(fixed_row_size: Size) -> Self {
+        Self {
+            deleted: <_>::default(),
+            len: 0,
+            fixed_row_size,
+        }
+    }
+    fn contains(&self, ptr: RowPointer) -> bool {
+        let page_idx = ptr.page_index().idx();
+        let page_offset = ptr.page_offset();
+        match self.deleted.get(page_idx) {
+            Some(ranges) => ranges
+                .binary_search_by(|r| cmp_start_end(&r.start, &r.end, &page_offset))
+                .is_ok(),
+            _ => false,
+        }
+    }
+    fn insert(&mut self, ptr: RowPointer) -> bool {
+        let fixed_row_size = self.fixed_row_size;
+        let page_idx = ptr.page_index().idx();
+        let page_offset = ptr.page_offset();
+
+        let Some(ranges) = self.deleted.get_mut(page_idx) else {
+            let pages = self.deleted.len();
+            let after = 1 + page_idx;
+            self.deleted.reserve(after - pages);
+            for _ in pages..after {
+                self.deleted.push(SmallVec::new());
+            }
+            self.deleted[page_idx].push(OffsetRange::point(page_offset));
+            self.len += 1;
+            return true;
+        };
+
+        let (extend_end, exists, range_idx) = match find_range_to_insert_offset(ranges, page_offset, fixed_row_size) {
+            Err(range_idx) => {
+                // Not found, so add a point range.
+                ranges.insert(range_idx, OffsetRange::point(page_offset));
+                self.len += 1;
+                return true;
+            }
+            Ok(x) => x,
+        };
+
+        if extend_end {
+            let next = range_idx + 1;
+            let new_end = if let Some(r) = ranges
+                .get(next)
+                .copied()
+                .filter(|r| r.start.0 - fixed_row_size.0 == page_offset.0)
+            {
+                ranges.remove(next);
+                r.end
+            } else {
+                page_offset
+            };
+            ranges[range_idx].end = new_end;
+        } else {
+            let prev = range_idx.saturating_sub(1);
+            if let Some(r) = ranges
+                .get(prev)
+                .copied()
+                .filter(|r| r.end.0 + fixed_row_size.0 == page_offset.0)
+            {
+                ranges[range_idx].start = r.start;
+                ranges.remove(prev);
+            } else {
+                ranges[range_idx].start = page_offset;
+            };
+        }
+
+        let added = !exists;
+        if added {
+            self.len += 1;
+        }
+        added
+    }
+    fn remove(&mut self, ptr: RowPointer) -> bool {
+        let fixed_row_size = self.fixed_row_size;
+        let page_idx = ptr.page_index().idx();
+        let page_offset = ptr.page_offset();
+
+        let Some(ranges) = self.deleted.get_mut(page_idx) else {
+            return false;
+        };
+        let Ok(idx) = ranges.binary_search_by(|r| cmp_start_end(&r.start, &r.end, &page_offset)) else {
+            return false;
+        };
+
+        self.len -= 1;
+
+        let range = &mut ranges[idx];
+        let is_start = range.start == page_offset;
+        let is_end = range.end == page_offset;
+        match (is_start, is_end) {
+            // Remove the point range.
+            (true, true) => drop(ranges.remove(idx)),
+            // Narrow the start.
+            (true, false) => range.start += fixed_row_size,
+            // Narrow the end.
+            (false, true) => range.end -= fixed_row_size,
+            // Split the range.
+            (false, false) => {
+                // Derive the second range, to the right of the hole.
+                let end = range.end;
+                let start = PageOffset(page_offset.0 + fixed_row_size.0);
+                let new = OffsetRange { start, end };
+                // Adjust the first range, to the left of the hole.
+                range.end.0 = page_offset.0 - fixed_row_size.0;
+                // Add the second range.
+                ranges.insert(idx + 1, new);
+            }
+        }
+        true
+    }
+    fn iter(&self) -> impl Iterator<Item = RowPointer> {
+        (0..)
+            .map(PageIndex)
+            .zip(self.deleted.iter())
+            .flat_map(move |(pi, ranges)| {
+                ranges
+                    .iter()
+                    .flat_map(|range| (range.start.0..=range.end.0).step_by(self.fixed_row_size.0 as usize))
+                    .map(PageOffset)
+                    .map(move |po| RowPointer::new(false, pi, po, SquashedOffset::COMMITTED_STATE))
+            })
+    }
+    fn len(&self) -> usize {
+        self.len
+    }
+}
+
+criterion_group!(
+    delete_table,
+    bench_delete_table::<DTBTree>,
+    bench_delete_table::<DTHashSet>,
+    bench_delete_table::<DTHashSetFH>,
+    bench_delete_table::<DTPageAndBitSet>,
+    bench_delete_table::<DTPageAndOffsetRanges>, // best so far.
+);
+criterion_main!(delete_table);

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -119,7 +119,7 @@ default = ["unindexed_iter_by_col_range_warn"]
 # Enable timing for wasm ABI calls
 spacetimedb-wasm-instance-env-times = []
 # Enable test helpers and utils
-test = []
+test = ["spacetimedb-commitlog/test"]
 
 [dev-dependencies]
 spacetimedb-lib = { path = "../lib", features = ["proptest"] }

--- a/crates/core/proptest-regressions/db/datastore/locking_tx_datastore/delete_table.txt
+++ b/crates/core/proptest-regressions/db/datastore/locking_tx_datastore/delete_table.txt
@@ -1,0 +1,7 @@
+# Seeds for failure cases proptest has generated in the past. It is
+# automatically read and these particular cases re-run before any
+# novel cases are generated.
+#
+# It is recommended to check this file in to source control so that
+# everyone who runs the test benefits from these saved cases.
+cc 9d74a36309d35ba5b09bd33cbc24f72f95a498152b469caeeeb8c2adf712974c # shrinks to (size, [ptr_a, ptr_b]) = (Size(2), [RowPointer(r: 0, pi: 0, po: 0, so: 1), RowPointer(r: 0, pi: 0, po: 0, so: 1)])

--- a/crates/core/src/db/datastore/locking_tx_datastore/delete_table.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/delete_table.rs
@@ -1,0 +1,310 @@
+use spacetimedb_table::{
+    fixed_bit_set::FixedBitSet,
+    indexes::{max_rows_in_page, PageIndex, PageOffset, RowPointer, Size, SquashedOffset},
+};
+
+/// A table recording which rows of a table in the [`CommittedState`] that have been deleted.
+pub struct DeleteTable {
+    /// Keeps track of all the deleted row pointers.
+    deleted: Vec<Option<FixedBitSet>>,
+    /// The number of deleted row pointers.
+    ///
+    /// This is stored for efficiency, but can be derived from `self.deleted` otherwise.
+    len: usize,
+    /// The size of a row in the table.
+    fixed_row_size: Size,
+}
+
+impl DeleteTable {
+    /// Returns a new deletion table where the rows have `fixed_row_size`.
+    ///
+    /// The table is initially empty.
+    pub fn new(fixed_row_size: Size) -> Self {
+        Self {
+            deleted: <_>::default(),
+            len: 0,
+            fixed_row_size,
+        }
+    }
+
+    /// Returns whether `ptr`, belonging to a table in [`CommittedState`], is recorded as deleted.
+    pub fn contains(&self, ptr: RowPointer) -> bool {
+        let page_idx = ptr.page_index().idx();
+        match self.deleted.get(page_idx) {
+            Some(Some(set)) => set.get(ptr.page_offset() / self.fixed_row_size),
+            _ => false,
+        }
+    }
+
+    /// Marks `ptr`, belonging to a table in [`CommittedState`], as deleted.
+    ///
+    /// Returns `true` if `ptr` was not previously marked.
+    pub fn insert(&mut self, ptr: RowPointer) -> bool {
+        let fixed_row_size = self.fixed_row_size;
+        let page_idx = ptr.page_index().idx();
+        let bitset_idx = ptr.page_offset() / fixed_row_size;
+
+        let new_set = || {
+            let mut bs = FixedBitSet::new(max_rows_in_page(fixed_row_size));
+            bs.set(bitset_idx, true);
+            bs
+        };
+
+        match self.deleted.get_mut(page_idx) {
+            // Already got a bitset for this page, just set the bit.
+            Some(Some(set)) => {
+                let added = !set.get(bitset_idx);
+                set.set(bitset_idx, true);
+                if added {
+                    self.len += 1;
+                }
+                added
+            }
+            // No bitset yet, initialize the slot with a new one.
+            Some(slot) => {
+                *slot = Some(new_set());
+                self.len += 1;
+                true
+            }
+            // We haven't reached this page index before,
+            // Make uninitialized slots for all the pages before this one
+            // that do not have bitsets.
+            // Add an initialized bitset for this page index.
+            None => {
+                let pages = self.deleted.len();
+                let after = 1 + page_idx;
+                self.deleted.reserve(after - pages);
+                for _ in pages..page_idx {
+                    self.deleted.push(None);
+                }
+                self.deleted.push(Some(new_set()));
+                self.len += 1;
+                true
+            }
+        }
+    }
+
+    /// Un-marks `ptr`, belonging to a table in [`CommittedState`], as deleted.
+    pub fn remove(&mut self, ptr: RowPointer) -> bool {
+        let fixed_row_size = self.fixed_row_size;
+        let page_idx = ptr.page_index().idx();
+        let bitset_idx = ptr.page_offset() / fixed_row_size;
+        if let Some(Some(set)) = self.deleted.get_mut(page_idx) {
+            let removed = set.get(bitset_idx);
+            if removed {
+                self.len -= 1;
+            }
+            set.set(bitset_idx, false);
+            removed
+        } else {
+            false
+        }
+    }
+
+    /// Yields all the row pointers marked in this table.
+    pub fn iter(&self) -> impl '_ + Iterator<Item = RowPointer> {
+        (0..)
+            .map(PageIndex)
+            .zip(self.deleted.iter())
+            .filter_map(|(pi, set)| Some((pi, set.as_ref()?)))
+            .flat_map(move |(pi, set)| {
+                set.iter_set().map(move |idx| {
+                    let po = PageOffset(idx as u16 * self.fixed_row_size.0);
+                    // It's a committed state pointer that has been deleted.
+                    RowPointer::new(false, pi, po, SquashedOffset::COMMITTED_STATE)
+                })
+            })
+    }
+
+    /// Returns the number of rows marked for deletion.
+    pub fn len(&self) -> usize {
+        self.len
+    }
+
+    /// Returns whether there are any rows to delete.
+    pub fn is_empty(&self) -> bool {
+        self.len == 0
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use core::cmp::Ordering;
+    use proptest::array::uniform;
+    use proptest::collection::vec;
+    use proptest::prelude::*;
+    use std::collections::BTreeSet;
+
+    #[derive(Copy, Clone, Eq, PartialEq, Debug)]
+    struct OrdRowPtr(RowPointer);
+    impl Ord for OrdRowPtr {
+        fn cmp(&self, other: &Self) -> Ordering {
+            self.0
+                .page_index()
+                .cmp(&other.0.page_index())
+                .then_with(|| self.0.page_offset().cmp(&other.0.page_offset()))
+        }
+    }
+    impl PartialOrd for OrdRowPtr {
+        fn partial_cmp(&self, other: &Self) -> Option<Ordering> {
+            Some(self.cmp(other))
+        }
+    }
+    impl PartialEq<OrdRowPtr> for RowPointer {
+        fn eq(&self, other: &OrdRowPtr) -> bool {
+            *self == other.0
+        }
+    }
+
+    /// The `DeleteTable` is really just a set specialized for `RowPointer`.
+    /// To harden the tests, we mirror the operations with a `BTreeSet`
+    /// and assert equivalent observable results.
+    ///
+    /// The setup here can cause some redundancy in our checks,
+    /// but that's fine, as testing is not perf sensitive.
+    struct TestDT {
+        dt: DeleteTable,
+        bs: BTreeSet<OrdRowPtr>,
+    }
+
+    impl TestDT {
+        fn new(fixed_row_size: Size) -> Self {
+            let dt = DeleteTable::new(fixed_row_size);
+            let bs = BTreeSet::new();
+            Self { dt, bs }
+        }
+        fn contains(&self, ptr: RowPointer) -> bool {
+            let dt = self.dt.contains(ptr);
+            let bs = self.bs.contains(&OrdRowPtr(ptr));
+            assert_eq!(dt, bs);
+            dt
+        }
+        fn insert(&mut self, ptr: RowPointer) -> bool {
+            let dt = self.dt.insert(ptr);
+            let bs = self.bs.insert(OrdRowPtr(ptr));
+            assert_eq!(dt, bs);
+            self.check_state();
+            dt
+        }
+        fn remove(&mut self, ptr: RowPointer) -> bool {
+            let dt = self.dt.remove(ptr);
+            let bs = self.bs.remove(&OrdRowPtr(ptr));
+            assert_eq!(dt, bs);
+            self.check_state();
+            dt
+        }
+        fn iter(&self) -> impl Iterator<Item = RowPointer> {
+            let dt = self.dt.iter().collect::<Vec<_>>();
+            let bs = self.bs.iter().copied().collect::<Vec<_>>();
+            assert_eq!(dt, bs);
+            assert_eq!(self.len(), bs.len());
+            dt.into_iter()
+        }
+        fn check_state(&self) {
+            let _ = self.iter();
+        }
+        fn len(&self) -> usize {
+            let dt = self.dt.len();
+            let bs = self.bs.len();
+            assert_eq!(dt, bs);
+            dt
+        }
+        fn is_empty(&self) -> bool {
+            let dt = self.dt.is_empty();
+            let bs = self.bs.is_empty();
+            assert_eq!(dt, bs);
+            dt
+        }
+    }
+
+    fn gen_size() -> impl Strategy<Value = Size> {
+        (2..100u16).prop_map(Size)
+    }
+
+    fn gen_ptr(row_size: Size) -> impl Strategy<Value = RowPointer> {
+        let page_offset = (0..100u16).prop_map(move |num| PageOffset(row_size.0 * num));
+        let page_index = (0..100u64).prop_map(PageIndex);
+        (page_index, page_offset).prop_map(|(pi, po)| RowPointer::new(false, pi, po, SquashedOffset::COMMITTED_STATE))
+    }
+
+    fn gen_size_and_ptrs<const N: usize>() -> impl Strategy<Value = (Size, [RowPointer; N])> {
+        gen_size().prop_flat_map(|s| uniform(gen_ptr(s)).prop_map(move |ptr| (s, ptr)))
+    }
+
+    fn gen_two_ptr_vecs() -> impl Strategy<Value = (Size, [Vec<RowPointer>; 2])> {
+        gen_size().prop_flat_map(|s| uniform(vec(gen_ptr(s), 0..100)).prop_map(move |vs| (s, vs)))
+    }
+
+    proptest! {
+        #[test]
+        fn insertion_entails_contained((size, [ptr_a, ptr_b]) in gen_size_and_ptrs()) {
+            let mut dt = TestDT::new(size);
+
+            // Initially we have nothing.
+            prop_assert!(dt.is_empty());
+            prop_assert!(!dt.contains(ptr_a));
+            prop_assert!(!dt.contains(ptr_b));
+
+            // Add `ptr_a` and expect it but not `ptr_b`.
+            prop_assert!(dt.insert(ptr_a));
+            prop_assert!(!dt.is_empty());
+            prop_assert!(dt.contains(ptr_a));
+            prop_assert!(!dt.contains(ptr_b));
+        }
+
+        #[test]
+        fn insertion_is_state_idempotent((size, [ptr_a]) in gen_size_and_ptrs()) {
+            let mut dt = TestDT::new(size);
+
+            prop_assert!(dt.insert(ptr_a));
+            prop_assert!(dt.contains(ptr_a));
+
+            prop_assert!(!dt.insert(ptr_a)); // Idempotence.
+            prop_assert!(dt.contains(ptr_a));
+        }
+
+        #[test]
+        fn deleting_non_existent_does_nothing((size, [ptr_a, ptr_b]) in gen_size_and_ptrs()) {
+            let mut dt = TestDT::new(size);
+            prop_assert!(!dt.remove(ptr_b));
+            prop_assert!(dt.insert(ptr_a));
+            prop_assert!(!dt.remove(ptr_b));
+        }
+
+        #[test]
+        fn insertion_followed_by_deletion_is_no_op((size, [ptr_a]) in gen_size_and_ptrs()) {
+            let mut dt = TestDT::new(size);
+
+            prop_assert!(dt.insert(ptr_a));
+            prop_assert!(dt.contains(ptr_a));
+
+            prop_assert!(dt.remove(ptr_a));
+            prop_assert!(!dt.contains(ptr_a));
+        }
+
+        #[test]
+        fn set_intersection_behaves((size, [ptrs_a, ptrs_b]) in gen_two_ptr_vecs()) {
+            let mut dt_a = TestDT::new(size);
+            let mut dt_b = TestDT::new(size);
+
+            // Fill first set.
+            for ptr in ptrs_a {
+                dt_a.insert(ptr);
+            }
+            // Fill second set.
+            for ptr in ptrs_b {
+                dt_b.insert(ptr);
+            }
+
+            // Intersect first and second sets.
+            let expected_intersection = dt_a.bs.intersection(&dt_b.bs).copied().collect::<BTreeSet<_>>();
+            for ptr in dt_a.iter() {
+                if !dt_b.contains(ptr) {
+                    prop_assert!(dt_a.remove(ptr));
+                }
+            }
+            prop_assert_eq!(dt_a.iter().collect::<Vec<_>>(), expected_intersection.into_iter().collect::<Vec<_>>());
+        }
+    }
+}

--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -7,6 +7,7 @@ pub use mut_tx::MutTxId;
 mod sequence;
 pub mod state_view;
 pub use state_view::{IterByColEqTx, IterByColRangeTx};
+pub mod delete_table;
 pub(crate) mod tx;
 mod tx_state;
 

--- a/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/state_view.rs
@@ -1,8 +1,4 @@
-use super::{
-    committed_state::CommittedState,
-    datastore::Result,
-    tx_state::{DeleteTable, TxState},
-};
+use super::{committed_state::CommittedState, datastore::Result, delete_table::DeleteTable, tx_state::TxState};
 use crate::db::datastore::locking_tx_datastore::committed_state::CommittedIndexIterWithDeletedMutTx;
 use crate::{
     db::datastore::system_tables::{
@@ -261,7 +257,7 @@ impl<'a> Iterator for IterMutTx<'a> {
                     //
                     // As a result, in MVCC, this branch will need to check if the `row_ref`
                     // also exists in the `tx_state.insert_tables` and ensure it is yielded only once.
-                    if let next @ Some(_) = iter.find(|row_ref| !del_tables.contains(&row_ref.pointer())) {
+                    if let next @ Some(_) = iter.find(|row_ref| !del_tables.contains(row_ref.pointer())) {
                         return next;
                     }
                 }
@@ -358,7 +354,7 @@ impl<'a> Iterator for IndexSeekIterIdWithDeletedMutTx<'a> {
             //
             // As a result, in MVCC, this branch will need to check if the `row_ref`
             // also exists in the `tx_state.insert_tables` and ensure it is yielded only once.
-            .and_then(|i| i.find(|row_ref| !self.del_table.contains(&row_ref.pointer())))
+            .and_then(|i| i.find(|row_ref| !self.del_table.contains(row_ref.pointer())))
         {
             // TODO(metrics): This doesn't actually fetch a row.
             // Move this counter to `RowRef::read_row`.

--- a/crates/table/src/indexes.rs
+++ b/crates/table/src/indexes.rs
@@ -202,9 +202,15 @@ impl fmt::LowerHex for PageOffset {
     }
 }
 
+/// Returns the maximum number of rows with `fixed_row_size` that a page can hold.
+#[inline]
+pub fn max_rows_in_page(fixed_row_size: Size) -> usize {
+    PageOffset::PAGE_END.idx().div_ceil(fixed_row_size.len())
+}
+
 /// The index of a [`Page`] within a [`Pages`].
 #[cfg_attr(any(test, feature = "proptest"), derive(proptest_derive::Arbitrary))]
-#[derive(Clone, Copy, PartialEq, Eq, Debug)]
+#[derive(Clone, Copy, PartialEq, Eq, PartialOrd, Ord, Debug)]
 pub struct PageIndex(#[cfg_attr(any(test, feature = "proptest"), proptest(strategy = "0..MASK_PI"))] pub u64);
 
 impl MemoryUsage for PageIndex {}

--- a/crates/table/src/lib.rs
+++ b/crates/table/src/lib.rs
@@ -12,7 +12,7 @@ pub mod blob_store;
 pub mod btree_index;
 pub mod eq;
 mod eq_to_pv;
-mod fixed_bit_set;
+pub mod fixed_bit_set;
 pub mod indexes;
 pub mod layout;
 pub mod page;

--- a/crates/table/src/page.rs
+++ b/crates/table/src/page.rs
@@ -39,7 +39,7 @@ use super::{
     layout::MIN_ROW_SIZE,
     var_len::{is_granule_offset_aligned, VarLenGranule, VarLenGranuleHeader, VarLenMembers, VarLenRef},
 };
-use crate::{fixed_bit_set::IterSet, static_assert_size, table::BlobNumBytes, MemoryUsage};
+use crate::{fixed_bit_set::IterSet, indexes::max_rows_in_page, static_assert_size, table::BlobNumBytes, MemoryUsage};
 use core::{mem, ops::ControlFlow};
 use spacetimedb_lib::{de::Deserialize, ser::Serialize};
 use thiserror::Error;
@@ -185,7 +185,7 @@ impl FixedHeader {
             // Points one after the last allocated fixed-length row, or `NULL` for an empty page.
             last: PageOffset::VAR_LEN_NULL,
             num_rows: 0,
-            present_rows: FixedBitSet::new(PageOffset::PAGE_END.idx().div_ceil(fixed_row_size.len())),
+            present_rows: FixedBitSet::new(max_rows_in_page(fixed_row_size)),
         }
     }
 

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -1655,8 +1655,8 @@ impl Table {
     }
 
     /// Returns the row size for a row in the table.
-    fn row_size(&self) -> Size {
-        self.inner.row_layout.size()
+    pub fn row_size(&self) -> Size {
+        self.row_layout().size()
     }
 
     /// Returns the layout for a row in the table.


### PR DESCRIPTION
# Description of Changes

Fixes https://github.com/clockworklabs/SpacetimeDB/issues/2147.
Changes the implementation of `DeleteTable` to be based on grouping by page.
To be more specific, each page (`PageIndex`) is assigned its own `FixedBitSet`, which tracks which `PageOffset`s, converted to indices using `fixed_row_size`, is contained.

Based on micro benchmarks, this brings us to from about 172 ns per iteration (`BTreeSet<RowPointer>`), to about 40 ns.
Using `FixedBitSet` performs better in all cases, including `contains`, `insert`, `remove`, `iter`. The only drawback is that it uses more space for small tables, but it should use significantly less space as the initial cost becomes negligible.

The micro benchmarks are added in the PR, but no effort is made to test and document all the other implementations.

```
Using DTPageAndOffsetRanges (average = 502 ms):
2025-01-28T23:34:33.505986Z  INFO: : Timing span "update_positions_by_collect": 471.953969ms
2025-01-28T23:34:34.383674Z  INFO: : Timing span "update_positions_by_collect": 505.608822ms
2025-01-28T23:34:35.447897Z  INFO: : Timing span "update_positions_by_collect": 512.471063ms
2025-01-28T23:34:36.498788Z  INFO: : Timing span "update_positions_by_collect": 510.634443ms
2025-01-28T23:34:37.534776Z  INFO: : Timing span "update_positions_by_collect": 511.801253ms

Using DTPageAndBitSet (average = 498 ms -- I've gotten higher averages too)
2025-01-28T23:48:26.766216Z  INFO: : Timing span "update_positions_by_collect": 467.907743ms
2025-01-28T23:48:27.785888Z  INFO: : Timing span "update_positions_by_collect": 510.477257ms
2025-01-28T23:48:28.716523Z  INFO: : Timing span "update_positions_by_collect": 502.43078ms
2025-01-28T23:48:29.725186Z  INFO: : Timing span "update_positions_by_collect": 511.856229ms
2025-01-28T23:48:30.714442Z  INFO: : Timing span "update_positions_by_collect": 497.093745ms
```

# API and ABI breaking changes

None.

# Expected complexity level and risk

2, not very complex, but it does touch the datastore.
However, the new code is well tested.

# Testing

Proptests are added that assert that `DeleteTable` behaves correctly as a set, including by checking that it behaves observably as `BTreeSet`.