### PR TITLE
Meter wasm memory usage

### DIFF
--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -77,6 +77,7 @@ pub struct ExecutionTimings {
 pub struct ExecuteResult<E> {
     pub energy: EnergyStats,
     pub timings: ExecutionTimings,
+    pub memory_allocation: usize,
     pub call_result: Result<Result<(), Box<str>>, E>,
 }
 
@@ -193,6 +194,8 @@ impl<T: WasmModule> WasmModuleHostActor<T> {
             instance,
             info: self.info.clone(),
             energy_monitor: self.energy_monitor.clone(),
+            // will be updated on the first reducer call
+            allocated_memory: 0,
             trapped: false,
         }
     }
@@ -236,6 +239,7 @@ pub struct WasmModuleInstance<T: WasmInstance> {
     instance: T,
     info: Arc<ModuleInfo>,
     energy_monitor: Arc<dyn EnergyMonitor>,
+    allocated_memory: usize,
     trapped: bool,
 }
 
@@ -410,7 +414,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
 
         let replica_ctx = self.replica_context();
         let stdb = &*replica_ctx.relational_db.clone();
-        let address = replica_ctx.database_identity;
+        let database_identity = replica_ctx.database_identity;
         let reducer_def = self.info.module_def.reducer_by_id(reducer_id);
         let reducer_name = &*reducer_def.name;
 
@@ -446,7 +450,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         });
         let _guard = WORKER_METRICS
             .reducer_plus_query_duration
-            .with_label_values(&address, op.name)
+            .with_label_values(&database_identity, op.name)
             .with_timer(tx.timer);
 
         let mut tx_slot = self.instance.instance_env().tx.clone();
@@ -466,11 +470,19 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         let ExecuteResult {
             energy,
             timings,
+            memory_allocation,
             call_result,
         } = result;
 
         self.energy_monitor
             .record_reducer(&energy_fingerprint, energy.used, timings.total_duration);
+        if self.allocated_memory != memory_allocation {
+            WORKER_METRICS
+                .wasm_memory_bytes
+                .with_label_values(&database_identity)
+                .set(memory_allocation as i64);
+            self.allocated_memory = memory_allocation;
+        }
 
         reducer_span
             .record("timings.total_duration", tracing::field::debug(timings.total_duration))

--- a/crates/core/src/host/wasmtime/wasmtime_module.rs
+++ b/crates/core/src/host/wasmtime/wasmtime_module.rs
@@ -228,10 +228,12 @@ impl module_host_actor::WasmInstance for WasmtimeInstance {
             used: (budget - remaining).into(),
             remaining,
         };
+        let memory_allocation = store.data().get_mem().memory.data_size(&store);
 
         module_host_actor::ExecuteResult {
             energy,
             timings,
+            memory_allocation,
             call_result,
         }
     }

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -85,6 +85,11 @@ metrics_group!(
         #[labels(caller_identity: Identity, module_hash: Hash, caller_address: Address, reducer_symbol: str)]
         pub wasm_instance_errors: IntCounterVec,
 
+        #[name = spacetime_worker_wasm_memory_bytes]
+        #[help = "The number of bytes of linear memory allocated by the database's WASM module instance"]
+        #[labels(database_identity: Identity)]
+        pub wasm_memory_bytes: IntGaugeVec,
+
         #[name = spacetime_active_queries]
         #[help = "The number of active subscription queries"]
         #[labels(database_identity: Identity)]


### PR DESCRIPTION
# Description of Changes

Add a `record_reducer_allocated_memory` method to `EnergyMonitor`, and call it after every reducer run. The `EnergyMonitor` implementation can decide how much it wants to debounce the event.

# Expected complexity level and risk

1

# Testing

This just adds a new hook, but there's not yet an implementation of that hook to test.