### PR TITLE
Track compute metrics for sql dml with new engine

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4987,6 +4987,7 @@ dependencies = [
  "spacetimedb-lib",
  "spacetimedb-physical-plan",
  "spacetimedb-primitives",
+ "spacetimedb-sats",
  "spacetimedb-sql-parser",
  "spacetimedb-table",
 ]

--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -6,13 +6,11 @@ use http::StatusCode;
 
 use spacetimedb::client::ClientActorIndex;
 use spacetimedb::energy::{EnergyBalance, EnergyQuanta};
-use spacetimedb::execution_context::Workload;
 use spacetimedb::host::{HostController, ModuleHost, NoSuchModule, UpdateDatabaseResult};
 use spacetimedb::identity::{AuthCtx, Identity};
 use spacetimedb::json::client_api::StmtResultJson;
 use spacetimedb::messages::control_db::{Database, HostType, Node, Replica};
 use spacetimedb::sql;
-use spacetimedb::sql::execute::translate_col;
 use spacetimedb_client_api_messages::name::{DomainName, InsertDomainResult, RegisterTldResult, Tld};
 use spacetimedb_lib::ProductTypeElement;
 use spacetimedb_paths::server::ModuleLogsDir;
@@ -82,37 +80,34 @@ impl Host {
                 self.replica_id,
                 move |db| -> axum::response::Result<_, (StatusCode, String)> {
                     tracing::info!(sql = body);
-                    let results =
-                        sql::execute::run(db, &body, auth, Some(&module_host.info().subscriptions)).map_err(|e| {
-                            log::warn!("{}", e);
-                            if let Some(auth_err) = e.get_auth_error() {
-                                (StatusCode::UNAUTHORIZED, auth_err.to_string())
-                            } else {
-                                (StatusCode::BAD_REQUEST, e.to_string())
-                            }
-                        })?;
 
-                    let json = db.with_read_only(Workload::Sql, |tx| {
-                        results
-                            .into_iter()
-                            .map(|result| {
-                                let rows = result.data;
-                                let schema = result
-                                    .head
-                                    .fields
-                                    .iter()
-                                    .map(|x| {
-                                        let ty = x.algebraic_type.clone();
-                                        let name = translate_col(tx, x.field);
-                                        ProductTypeElement::new(ty, name)
-                                    })
-                                    .collect();
-                                StmtResultJson { schema, rows }
-                            })
-                            .collect::<Vec<_>>()
-                    });
+                    // We need a header for query results
+                    let mut header = vec![];
 
-                    Ok(json)
+                    let rows = sql::execute::run(
+                        // Returns an empty result set for mutations
+                        db,
+                        &body,
+                        auth,
+                        Some(&module_host.info().subscriptions),
+                        &mut header,
+                    )
+                    .map_err(|e| {
+                        log::warn!("{}", e);
+                        if let Some(auth_err) = e.get_auth_error() {
+                            (StatusCode::UNAUTHORIZED, auth_err.to_string())
+                        } else {
+                            (StatusCode::BAD_REQUEST, e.to_string())
+                        }
+                    })?;
+
+                    // Turn the header into a `ProductType`
+                    let schema = header
+                        .into_iter()
+                        .map(|(col_name, col_type)| ProductTypeElement::new(col_type, Some(col_name)))
+                        .collect();
+
+                    Ok(vec![StmtResultJson { schema, rows }])
                 },
             )
             .await

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -318,11 +318,13 @@ impl Tx for Locking {
         let committed_state_shared_lock = self.committed_state.read_arc();
         let lock_wait_time = timer.elapsed();
         let ctx = ExecutionContext::with_workload(self.database_identity, workload);
+        let metrics = ExecutionMetrics::default();
         Self::Tx {
             committed_state_shared_lock,
             lock_wait_time,
             timer,
             ctx,
+            metrics,
         }
     }
 
@@ -639,7 +641,7 @@ pub(super) fn record_tx_metrics(
     committed: bool,
     tx_data: Option<&TxData>,
     committed_state: Option<&CommittedState>,
-    metrics: Option<ExecutionMetrics>,
+    metrics: ExecutionMetrics,
 ) {
     let workload = &ctx.workload();
     let db = &ctx.database_identity();
@@ -666,9 +668,7 @@ pub(super) fn record_tx_metrics(
         .with_label_values(workload, db, reducer)
         .observe(elapsed_time);
 
-    if let Some(metrics) = metrics {
-        record_exec_metrics(workload, db, metrics);
-    }
+    record_exec_metrics(workload, db, metrics);
 
     /// Update table rows and table size gauges,
     /// and sets them to zero if no table is present.
@@ -1004,10 +1004,10 @@ mod tests {
     use crate::db::datastore::system_tables::{
         system_tables, StColumnRow, StConstraintData, StConstraintFields, StConstraintRow, StIndexAlgorithm,
         StIndexFields, StIndexRow, StRowLevelSecurityFields, StScheduledFields, StSequenceFields, StSequenceRow,
-        StTableRow, StVarFields, StVarValue, ST_CLIENT_NAME, ST_COLUMN_ID, ST_COLUMN_NAME, ST_CONSTRAINT_ID,
-        ST_CONSTRAINT_NAME, ST_INDEX_ID, ST_INDEX_NAME, ST_MODULE_NAME, ST_RESERVED_SEQUENCE_RANGE,
-        ST_ROW_LEVEL_SECURITY_ID, ST_ROW_LEVEL_SECURITY_NAME, ST_SCHEDULED_ID, ST_SCHEDULED_NAME, ST_SEQUENCE_ID,
-        ST_SEQUENCE_NAME, ST_TABLE_NAME, ST_VAR_ID, ST_VAR_NAME,
+        StTableRow, StVarFields, ST_CLIENT_NAME, ST_COLUMN_ID, ST_COLUMN_NAME, ST_CONSTRAINT_ID, ST_CONSTRAINT_NAME,
+        ST_INDEX_ID, ST_INDEX_NAME, ST_MODULE_NAME, ST_RESERVED_SEQUENCE_RANGE, ST_ROW_LEVEL_SECURITY_ID,
+        ST_ROW_LEVEL_SECURITY_NAME, ST_SCHEDULED_ID, ST_SCHEDULED_NAME, ST_SEQUENCE_ID, ST_SEQUENCE_NAME,
+        ST_TABLE_NAME, ST_VAR_ID, ST_VAR_NAME,
     };
     use crate::db::datastore::traits::{IsolationLevel, MutTx};
     use crate::db::datastore::Result;
@@ -1018,6 +1018,7 @@ mod tests {
     use pretty_assertions::{assert_eq, assert_matches};
     use spacetimedb_lib::db::auth::{StAccess, StTableType};
     use spacetimedb_lib::error::ResultTest;
+    use spacetimedb_lib::st_var::StVarValue;
     use spacetimedb_lib::{resolved_type_via_v9, ScheduleAt};
     use spacetimedb_primitives::{col_list, ColId, ScheduleId};
     use spacetimedb_sats::algebraic_value::ser::value_serialize;

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx.rs
@@ -8,6 +8,7 @@ use super::{
 use crate::db::datastore::locking_tx_datastore::state_view::IterTx;
 use crate::execution_context::ExecutionContext;
 use spacetimedb_execution::Datastore;
+use spacetimedb_lib::metrics::ExecutionMetrics;
 use spacetimedb_primitives::{ColList, TableId};
 use spacetimedb_sats::AlgebraicValue;
 use spacetimedb_schema::schema::TableSchema;
@@ -25,6 +26,7 @@ pub struct TxId {
     pub(super) lock_wait_time: Duration,
     pub(super) timer: Instant,
     pub(crate) ctx: ExecutionContext,
+    pub(crate) metrics: ExecutionMetrics,
 }
 
 impl Datastore for TxId {
@@ -86,7 +88,15 @@ impl StateView for TxId {
 
 impl TxId {
     pub(super) fn release(self) {
-        record_tx_metrics(&self.ctx, self.timer, self.lock_wait_time, true, None, None, None);
+        record_tx_metrics(
+            &self.ctx,
+            self.timer,
+            self.lock_wait_time,
+            true,
+            None,
+            None,
+            self.metrics,
+        );
     }
 
     /// The Number of Distinct Values (NDV) for a column or list of columns,

--- a/crates/core/src/db/datastore/system_tables.rs
+++ b/crates/core/src/db/datastore/system_tables.rs
@@ -13,21 +13,19 @@
 
 use crate::db::relational_db::RelationalDB;
 use crate::error::DBError;
-use derive_more::From;
 use spacetimedb_lib::db::auth::{StAccess, StTableType};
 use spacetimedb_lib::db::raw_def::v9::{RawIndexAlgorithm, RawSql};
 use spacetimedb_lib::db::raw_def::*;
 use spacetimedb_lib::de::{Deserialize, DeserializeOwned, Error};
 use spacetimedb_lib::ser::Serialize;
+use spacetimedb_lib::st_var::StVarValue;
 use spacetimedb_lib::{Address, Identity, ProductValue, SpacetimeType};
 use spacetimedb_primitives::*;
 use spacetimedb_sats::algebraic_type::fmt::fmt_algebraic_type;
 use spacetimedb_sats::algebraic_value::ser::value_serialize;
 use spacetimedb_sats::hash::Hash;
 use spacetimedb_sats::product_value::InvalidFieldError;
-use spacetimedb_sats::{
-    impl_deserialize, impl_serialize, impl_st, u256, AlgebraicType, AlgebraicValue, ArrayValue, SumValue,
-};
+use spacetimedb_sats::{impl_deserialize, impl_serialize, impl_st, u256, AlgebraicType, AlgebraicValue, ArrayValue};
 use spacetimedb_schema::def::{BTreeAlgorithm, ConstraintData, IndexAlgorithm, ModuleDef, UniqueConstraintData};
 use spacetimedb_schema::schema::{
     ColumnSchema, ConstraintSchema, IndexSchema, RowLevelSecuritySchema, ScheduleSchema, Schema, SequenceSchema,
@@ -1094,146 +1092,6 @@ impl StVarName {
             | StVarName::SlowQryThreshold
             | StVarName::SlowSubThreshold
             | StVarName::SlowIncThreshold => AlgebraicType::U64,
-        }
-    }
-}
-
-/// The value of a system variable in `st_var`
-#[derive(Debug, Clone, From, SpacetimeType)]
-#[sats(crate = spacetimedb_lib)]
-pub enum StVarValue {
-    Bool(bool),
-    I8(i8),
-    U8(u8),
-    I16(i16),
-    U16(u16),
-    I32(i32),
-    U32(u32),
-    I64(i64),
-    U64(u64),
-    I128(i128),
-    U128(u128),
-    // No support for u/i256 added here as it seems unlikely to be useful.
-    F32(f32),
-    F64(f64),
-    String(Box<str>),
-}
-
-impl StVarValue {
-    pub fn try_from_primitive(value: AlgebraicValue) -> Result<Self, AlgebraicValue> {
-        match value {
-            AlgebraicValue::Bool(v) => Ok(StVarValue::Bool(v)),
-            AlgebraicValue::I8(v) => Ok(StVarValue::I8(v)),
-            AlgebraicValue::U8(v) => Ok(StVarValue::U8(v)),
-            AlgebraicValue::I16(v) => Ok(StVarValue::I16(v)),
-            AlgebraicValue::U16(v) => Ok(StVarValue::U16(v)),
-            AlgebraicValue::I32(v) => Ok(StVarValue::I32(v)),
-            AlgebraicValue::U32(v) => Ok(StVarValue::U32(v)),
-            AlgebraicValue::I64(v) => Ok(StVarValue::I64(v)),
-            AlgebraicValue::U64(v) => Ok(StVarValue::U64(v)),
-            AlgebraicValue::I128(v) => Ok(StVarValue::I128(v.0)),
-            AlgebraicValue::U128(v) => Ok(StVarValue::U128(v.0)),
-            AlgebraicValue::F32(v) => Ok(StVarValue::F32(v.into_inner())),
-            AlgebraicValue::F64(v) => Ok(StVarValue::F64(v.into_inner())),
-            AlgebraicValue::String(v) => Ok(StVarValue::String(v)),
-            _ => Err(value),
-        }
-    }
-
-    pub fn try_from_sum(value: AlgebraicValue) -> Result<Self, AlgebraicValue> {
-        value.into_sum()?.try_into()
-    }
-}
-
-impl TryFrom<SumValue> for StVarValue {
-    type Error = AlgebraicValue;
-
-    fn try_from(sum: SumValue) -> Result<Self, Self::Error> {
-        match sum.tag {
-            0 => Ok(StVarValue::Bool(sum.value.into_bool()?)),
-            1 => Ok(StVarValue::I8(sum.value.into_i8()?)),
-            2 => Ok(StVarValue::U8(sum.value.into_u8()?)),
-            3 => Ok(StVarValue::I16(sum.value.into_i16()?)),
-            4 => Ok(StVarValue::U16(sum.value.into_u16()?)),
-            5 => Ok(StVarValue::I32(sum.value.into_i32()?)),
-            6 => Ok(StVarValue::U32(sum.value.into_u32()?)),
-            7 => Ok(StVarValue::I64(sum.value.into_i64()?)),
-            8 => Ok(StVarValue::U64(sum.value.into_u64()?)),
-            9 => Ok(StVarValue::I128(sum.value.into_i128()?.0)),
-            10 => Ok(StVarValue::U128(sum.value.into_u128()?.0)),
-            11 => Ok(StVarValue::F32(sum.value.into_f32()?.into_inner())),
-            12 => Ok(StVarValue::F64(sum.value.into_f64()?.into_inner())),
-            13 => Ok(StVarValue::String(sum.value.into_string()?)),
-            _ => Err(*sum.value),
-        }
-    }
-}
-
-impl From<StVarValue> for AlgebraicValue {
-    fn from(value: StVarValue) -> Self {
-        AlgebraicValue::Sum(value.into())
-    }
-}
-
-impl From<StVarValue> for SumValue {
-    fn from(value: StVarValue) -> Self {
-        match value {
-            StVarValue::Bool(v) => SumValue {
-                tag: 0,
-                value: Box::new(AlgebraicValue::Bool(v)),
-            },
-            StVarValue::I8(v) => SumValue {
-                tag: 1,
-                value: Box::new(AlgebraicValue::I8(v)),
-            },
-            StVarValue::U8(v) => SumValue {
-                tag: 2,
-                value: Box::new(AlgebraicValue::U8(v)),
-            },
-            StVarValue::I16(v) => SumValue {
-                tag: 3,
-                value: Box::new(AlgebraicValue::I16(v)),
-            },
-            StVarValue::U16(v) => SumValue {
-                tag: 4,
-                value: Box::new(AlgebraicValue::U16(v)),
-            },
-            StVarValue::I32(v) => SumValue {
-                tag: 5,
-                value: Box::new(AlgebraicValue::I32(v)),
-            },
-            StVarValue::U32(v) => SumValue {
-                tag: 6,
-                value: Box::new(AlgebraicValue::U32(v)),
-            },
-            StVarValue::I64(v) => SumValue {
-                tag: 7,
-                value: Box::new(AlgebraicValue::I64(v)),
-            },
-            StVarValue::U64(v) => SumValue {
-                tag: 8,
-                value: Box::new(AlgebraicValue::U64(v)),
-            },
-            StVarValue::I128(v) => SumValue {
-                tag: 9,
-                value: Box::new(AlgebraicValue::I128(v.into())),
-            },
-            StVarValue::U128(v) => SumValue {
-                tag: 10,
-                value: Box::new(AlgebraicValue::U128(v.into())),
-            },
-            StVarValue::F32(v) => SumValue {
-                tag: 11,
-                value: Box::new(AlgebraicValue::F32(v.into())),
-            },
-            StVarValue::F64(v) => SumValue {
-                tag: 12,
-                value: Box::new(AlgebraicValue::F64(v.into())),
-            },
-            StVarValue::String(v) => SumValue {
-                tag: 13,
-                value: Box::new(AlgebraicValue::String(v)),
-            },
         }
     }
 }

--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -372,7 +372,6 @@ mod tests {
         );
         run_for_testing(&db, sql)?;
 
-        let tx = db.begin_tx(Workload::ForTests);
         // Compile query, check for both hex formats and it to be case-insensitive...
         let sql = &format!(
             "select * from test where identity = {} AND identity_mix = x'93dda09db9a56d8fa6c024d843e805D8262191db3b4bA84c5efcd1ad451fed4e' AND address = x'{}' AND address = {}",
@@ -383,6 +382,7 @@ mod tests {
 
         let rows = run_for_testing(&db, sql)?;
 
+        let tx = db.begin_tx(Workload::ForTests);
         let CrudExpr::Query(QueryExpr {
             source: _,
             query: mut ops,
@@ -398,7 +398,7 @@ mod tests {
             panic!("Expected Select");
         };
 
-        assert_eq!(rows[0].data, vec![row]);
+        assert_eq!(rows, vec![row]);
 
         Ok(())
     }

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -199,7 +199,7 @@ pub fn run(
             });
 
             // Compute the header for the result set
-            stmt.iter_return_fields(|col_name, col_type| {
+            stmt.for_each_return_field(|col_name, col_type| {
                 head.push((col_name.into(), col_type.clone()));
             });
 

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -1,23 +1,28 @@
 use std::time::Duration;
 
-use super::compiler::compile_sql;
+use super::ast::SchemaViewer;
 use crate::db::datastore::locking_tx_datastore::state_view::StateView;
 use crate::db::datastore::system_tables::StVarTable;
 use crate::db::datastore::traits::IsolationLevel;
 use crate::db::relational_db::{RelationalDB, Tx};
 use crate::energy::EnergyQuanta;
 use crate::error::DBError;
+use crate::estimation::estimate_rows_scanned;
 use crate::execution_context::Workload;
 use crate::host::module_host::{DatabaseTableUpdate, DatabaseUpdate, EventStatus, ModuleEvent, ModuleFunctionCall};
 use crate::host::ArgsTuple;
 use crate::subscription::module_subscription_actor::{ModuleSubscriptions, WriteConflict};
+use crate::subscription::tx::DeltaTx;
 use crate::util::slow::SlowQueryLogger;
-use crate::vm::{DbProgram, TxMode};
-use itertools::Either;
+use crate::vm::{check_row_limit, DbProgram, TxMode};
+use anyhow::anyhow;
 use spacetimedb_client_api_messages::timestamp::Timestamp;
+use spacetimedb_expr::statement::Statement;
 use spacetimedb_lib::identity::AuthCtx;
+use spacetimedb_lib::metrics::ExecutionMetrics;
 use spacetimedb_lib::relation::FieldName;
-use spacetimedb_lib::{ProductType, ProductValue};
+use spacetimedb_lib::{AlgebraicType, ProductType, ProductValue};
+use spacetimedb_query::{compile_sql_stmt, execute_dml_stmt, execute_select_stmt};
 use spacetimedb_vm::eval::run_ast;
 use spacetimedb_vm::expr::{CodeResult, CrudExpr, Expr};
 use spacetimedb_vm::relation::MemTable;
@@ -172,30 +177,93 @@ pub fn run(
     sql_text: &str,
     auth: AuthCtx,
     subs: Option<&ModuleSubscriptions>,
-) -> Result<Vec<MemTable>, DBError> {
-    let result = db.with_read_only(Workload::Sql, |tx| {
-        let ast = compile_sql(db, &AuthCtx::for_testing(), tx, sql_text)?;
-        if CrudExpr::is_reads(&ast) {
-            let mut updates = Vec::new();
-            let result = execute(
-                &mut DbProgram::new(db, &mut TxMode::Tx(tx), auth),
-                ast,
-                sql_text,
-                &mut updates,
-            )?;
-            Ok::<_, DBError>(Either::Left(result))
-        } else {
-            // hehe. right. write.
-            Ok(Either::Right(ast))
-        }
+    head: &mut Vec<(Box<str>, AlgebraicType)>,
+) -> Result<Vec<ProductValue>, DBError> {
+    // We parse the sql statement in a mutable transation.
+    // If it turns out to be a query, we downgrade the tx.
+    let (tx, stmt) = db.with_auto_rollback(db.begin_mut_tx(IsolationLevel::Serializable, Workload::Sql), |tx| {
+        compile_sql_stmt(sql_text, &SchemaViewer::new(tx, &auth))
     })?;
-    match result {
-        Either::Left(result) => Ok(result),
-        // TODO: this should perhaps be an upgradable_read upgrade? or we should try
-        //       and figure out if we can detect the mutablility of the query before we take
-        //       the tx? once we have migrations we probably don't want to have stale
-        //       sql queries after a database schema have been updated.
-        Either::Right(ast) => execute_sql(db, sql_text, ast, auth, subs),
+
+    let mut metrics = ExecutionMetrics::default();
+
+    match stmt {
+        Statement::Select(stmt) => {
+            // Up to this point, the tx has been read-only,
+            // and hence there are no deltas to process.
+            let (_, tx) = tx.commit_downgrade(Workload::Sql);
+
+            // Release the tx on drop, so that we record metrics
+            let mut tx = scopeguard::guard(tx, |tx| {
+                db.release_tx(tx);
+            });
+
+            // Compute the header for the result set
+            stmt.iter_return_fields(|col_name, col_type| {
+                head.push((col_name.into(), col_type.clone()));
+            });
+
+            // Evaluate the query
+            let rows = execute_select_stmt(stmt, &DeltaTx::from(&*tx), &mut metrics, |plan| {
+                check_row_limit(&plan, db, &tx, |plan, tx| estimate_rows_scanned(tx, plan), &auth)?;
+                Ok(plan)
+            })?;
+
+            // Update transaction metrics
+            tx.metrics.merge(metrics);
+
+            Ok(rows)
+        }
+        Statement::DML(stmt) => {
+            // An extra layer of auth is required for DML
+            if auth.caller != auth.owner {
+                return Err(anyhow!("Only owners are authorized to run SQL DML statements").into());
+            }
+
+            // Evaluate the mutation
+            let (mut tx, _) = db.with_auto_rollback(tx, |tx| execute_dml_stmt(stmt, tx, &mut metrics))?;
+
+            // Update transaction metrics
+            tx.metrics.merge(metrics);
+
+            // Commit the tx if there are no deltas to process
+            if subs.is_none() {
+                return db.commit_tx(tx).map(|_| vec![]);
+            }
+
+            // Otherwise downgrade the tx and process the deltas.
+            // Note, we get the delta by downgrading the tx.
+            // Hence we just pass a default `DatabaseUpdate` here.
+            // It will ultimately be replaced with the correct one.
+            match subs
+                .unwrap()
+                .commit_and_broadcast_event(
+                    None,
+                    ModuleEvent {
+                        timestamp: Timestamp::now(),
+                        caller_identity: auth.caller,
+                        caller_address: None,
+                        function_call: ModuleFunctionCall {
+                            reducer: String::new(),
+                            reducer_id: u32::MAX.into(),
+                            args: ArgsTuple::default(),
+                        },
+                        status: EventStatus::Committed(DatabaseUpdate::default()),
+                        energy_quanta_used: EnergyQuanta::ZERO,
+                        host_execution_duration: Duration::ZERO,
+                        request_id: None,
+                        timer: None,
+                    },
+                    tx,
+                )
+                .unwrap()
+            {
+                Err(WriteConflict) => {
+                    todo!("See module_host_actor::call_reducer_with_tx")
+                }
+                Ok(_) => Ok(vec![]),
+            }
+        }
     }
 }
 
@@ -218,12 +286,11 @@ pub(crate) mod tests {
     use pretty_assertions::assert_eq;
     use spacetimedb_lib::db::auth::{StAccess, StTableType};
     use spacetimedb_lib::error::{ResultTest, TestError};
-    use spacetimedb_lib::relation::ColExpr;
     use spacetimedb_lib::relation::Header;
     use spacetimedb_lib::{AlgebraicValue, Identity};
     use spacetimedb_primitives::{col_list, ColId};
     use spacetimedb_sats::{product, AlgebraicType, ArrayValue, ProductType};
-    use spacetimedb_vm::eval::test_helpers::{create_game_data, mem_table, mem_table_without_table_name};
+    use spacetimedb_vm::eval::test_helpers::create_game_data;
     use std::sync::Arc;
 
     pub(crate) fn execute_for_testing(
@@ -236,9 +303,9 @@ pub(crate) mod tests {
     }
 
     /// Short-cut for simplify test execution
-    pub(crate) fn run_for_testing(db: &RelationalDB, sql_text: &str) -> Result<Vec<MemTable>, DBError> {
+    pub(crate) fn run_for_testing(db: &RelationalDB, sql_text: &str) -> Result<Vec<ProductValue>, DBError> {
         let subs = ModuleSubscriptions::new(Arc::new(db.clone()), Identity::ZERO);
-        run(db, sql_text, AuthCtx::for_testing(), Some(&subs))
+        run(db, sql_text, AuthCtx::for_testing(), Some(&subs), &mut vec![])
     }
 
     fn create_data(total_rows: u64) -> ResultTest<(TestDB, MemTable)> {
@@ -263,14 +330,7 @@ pub(crate) mod tests {
 
         let result = run_for_testing(&db, "SELECT * FROM inventory")?;
 
-        assert_eq!(result.len(), 1, "Not return results");
-        let result = result.first().unwrap().clone();
-
-        assert_eq!(
-            mem_table_without_table_name(&result),
-            mem_table_without_table_name(&input),
-            "Inventory"
-        );
+        assert_eq!(result, input.data, "Inventory");
         Ok(())
     }
 
@@ -279,31 +339,15 @@ pub(crate) mod tests {
         let (db, input) = create_data(1)?;
 
         let result = run_for_testing(&db, "SELECT inventory.* FROM inventory")?;
-        assert_eq!(result.len(), 1, "Not return results");
-        let result = result.first().unwrap().clone();
 
-        assert_eq!(
-            mem_table_without_table_name(&result),
-            mem_table_without_table_name(&input),
-            "Inventory"
-        );
+        assert_eq!(result, input.data, "Inventory");
 
         let result = run_for_testing(
             &db,
             "SELECT inventory.inventory_id FROM inventory WHERE inventory.inventory_id = 1",
         )?;
-        assert_eq!(result.len(), 1, "Not return results");
-        let result = result.first().unwrap().clone();
 
-        let head = ProductType::from([("inventory_id", AlgebraicType::U64)]);
-        let row = product!(1u64);
-        let input = mem_table(input.head.table_id, head, vec![row]);
-
-        assert_eq!(
-            mem_table_without_table_name(&result),
-            mem_table_without_table_name(&input),
-            "Inventory"
-        );
+        assert_eq!(result, vec![product!(1u64)], "Inventory");
 
         Ok(())
     }
@@ -313,7 +357,6 @@ pub(crate) mod tests {
         let (db, _) = create_data(1)?;
 
         let tx = db.begin_tx(Workload::ForTests);
-        let schema = db.schema_for_table(&tx, ST_TABLE_ID).unwrap();
         db.release_tx(tx);
 
         let result = run_for_testing(
@@ -321,8 +364,6 @@ pub(crate) mod tests {
             &format!("SELECT * FROM {} WHERE table_id = {}", ST_TABLE_NAME, ST_TABLE_ID),
         )?;
 
-        assert_eq!(result.len(), 1, "Not return results");
-        let result = result.first().unwrap().clone();
         let pk_col_id: ColId = StTableFields::TableId.into();
         let row = product![
             ST_TABLE_ID,
@@ -331,108 +372,62 @@ pub(crate) mod tests {
             StAccess::Public.as_str(),
             Some(AlgebraicValue::Array(ArrayValue::U16(vec![pk_col_id.0].into()))),
         ];
-        let input = MemTable::new(Header::from(&*schema).into(), schema.table_access, vec![row]);
 
-        assert_eq!(
-            mem_table_without_table_name(&result),
-            mem_table_without_table_name(&input),
-            "st_table"
-        );
+        assert_eq!(result, vec![row], "st_table");
         Ok(())
     }
 
     #[test]
     fn test_select_column() -> ResultTest<()> {
-        let (db, table) = create_data(1)?;
+        let (db, _) = create_data(1)?;
 
         let result = run_for_testing(&db, "SELECT inventory_id FROM inventory")?;
 
-        assert_eq!(result.len(), 1, "Not return results");
-        let result = result.first().unwrap().clone();
-        // The expected result.
-        let inv = table.head.project(&[ColExpr::Col(0.into())]).unwrap();
-
         let row = product![1u64];
-        let input = MemTable::new(inv.into(), table.table_access, vec![row]);
 
-        assert_eq!(
-            mem_table_without_table_name(&result),
-            mem_table_without_table_name(&input),
-            "Inventory"
-        );
+        assert_eq!(result, vec![row], "Inventory");
         Ok(())
     }
 
     #[test]
     fn test_where() -> ResultTest<()> {
-        let (db, table) = create_data(1)?;
+        let (db, _) = create_data(1)?;
 
         let result = run_for_testing(&db, "SELECT inventory_id FROM inventory WHERE inventory_id = 1")?;
 
-        assert_eq!(result.len(), 1, "Not return results");
-        let result = result.first().unwrap().clone();
-
-        // The expected result.
-        let inv = table.head.project(&[ColExpr::Col(0.into())]).unwrap();
-
         let row = product![1u64];
-        let input = MemTable::new(inv.into(), table.table_access, vec![row]);
 
-        assert_eq!(
-            mem_table_without_table_name(&result),
-            mem_table_without_table_name(&input),
-            "Inventory"
-        );
+        assert_eq!(result, vec![row], "Inventory");
         Ok(())
     }
 
     #[test]
     fn test_or() -> ResultTest<()> {
-        let (db, table) = create_data(2)?;
+        let (db, _) = create_data(2)?;
 
-        let result = run_for_testing(
+        let mut result = run_for_testing(
             &db,
             "SELECT inventory_id FROM inventory WHERE inventory_id = 1 OR inventory_id = 2",
         )?;
 
-        assert_eq!(result.len(), 1, "Not return results");
-        let mut result = result.first().unwrap().clone();
-        result.data.sort();
-        //The expected result
-        let inv = table.head.project(&[ColExpr::Col(0.into())]).unwrap();
+        result.sort();
 
-        let input = MemTable::new(inv.into(), table.table_access, vec![product![1u64], product![2u64]]);
-
-        assert_eq!(
-            mem_table_without_table_name(&result),
-            mem_table_without_table_name(&input),
-            "Inventory"
-        );
+        assert_eq!(result, vec![product![1u64], product![2u64]], "Inventory");
         Ok(())
     }
 
     #[test]
     fn test_nested() -> ResultTest<()> {
-        let (db, table) = create_data(2)?;
+        let (db, _) = create_data(2)?;
 
-        let result = run_for_testing(
+        let mut result = run_for_testing(
             &db,
             "SELECT inventory_id FROM inventory WHERE (inventory_id = 1 OR inventory_id = 2 AND (true))",
         )?;
 
-        assert_eq!(result.len(), 1, "Not return results");
-        let mut result = result.first().unwrap().clone();
-        result.data.sort();
-        // The expected result.
-        let inv = table.head.project(&[ColExpr::Col(0.into())]).unwrap();
+        result.sort();
 
-        let input = MemTable::new(inv.into(), table.table_access, vec![product![1u64], product![2u64]]);
-
-        assert_eq!(
-            mem_table_without_table_name(&result),
-            mem_table_without_table_name(&input),
-            "Inventory"
-        );
+        assert_eq!(result, vec![product![1u64], product![2u64]], "Inventory");
         Ok(())
     }
 
@@ -442,7 +437,7 @@ pub(crate) mod tests {
 
         let db = TestDB::durable()?;
 
-        let (p_schema, inv_schema) = db.with_auto_commit::<_, _, TestError>(Workload::ForTests, |tx| {
+        db.with_auto_commit::<_, _, TestError>(Workload::ForTests, |tx| {
             let i = create_table_with_rows(&db, tx, "Inventory", data.inv_ty, &data.inv.data, StAccess::Public)?;
             let p = create_table_with_rows(&db, tx, "Player", data.player_ty, &data.player.data, StAccess::Public)?;
             create_table_with_rows(
@@ -456,7 +451,7 @@ pub(crate) mod tests {
             Ok((p, i))
         })?;
 
-        let result = &run_for_testing(
+        let result = run_for_testing(
             &db,
             "SELECT
         Player.*
@@ -465,18 +460,13 @@ pub(crate) mod tests {
         JOIN Location
         ON Location.entity_id = Player.entity_id
         WHERE Location.x > 0 AND Location.x <= 32 AND Location.z > 0 AND Location.z <= 32",
-        )?[0];
+        )?;
 
         let row1 = product!(100u64, 1u64);
-        let input = MemTable::new(Header::from(&*p_schema).into(), p_schema.table_access, [row1].into());
 
-        assert_eq!(
-            mem_table_without_table_name(result),
-            mem_table_without_table_name(&input),
-            "Player JOIN Location"
-        );
+        assert_eq!(result, vec![row1], "Player JOIN Location");
 
-        let result = &run_for_testing(
+        let result = run_for_testing(
             &db,
             "SELECT
         Inventory.*
@@ -487,20 +477,11 @@ pub(crate) mod tests {
         JOIN Location
         ON Player.entity_id = Location.entity_id
         WHERE Location.x > 0 AND Location.x <= 32 AND Location.z > 0 AND Location.z <= 32",
-        )?[0];
+        )?;
 
         let row1 = product!(1u64, "health");
-        let input = MemTable::new(
-            Header::from(&*inv_schema).into(),
-            inv_schema.table_access,
-            [row1].into(),
-        );
 
-        assert_eq!(
-            mem_table_without_table_name(result),
-            mem_table_without_table_name(&input),
-            "Inventory JOIN Player JOIN Location"
-        );
+        assert_eq!(result, vec![row1], "Inventory JOIN Player JOIN Location");
         Ok(())
     }
 
@@ -512,20 +493,13 @@ pub(crate) mod tests {
 
         assert_eq!(result.len(), 0, "Return results");
 
-        let result = run_for_testing(&db, "SELECT * FROM inventory")?;
-
-        assert_eq!(result.len(), 1, "Not return results");
-        let mut result = result.first().unwrap().clone();
+        let mut result = run_for_testing(&db, "SELECT * FROM inventory")?;
 
         input.data.push(product![2u64, "test"]);
         input.data.sort();
-        result.data.sort();
+        result.sort();
 
-        assert_eq!(
-            mem_table_without_table_name(&result),
-            mem_table_without_table_name(&input),
-            "Inventory"
-        );
+        assert_eq!(result, input.data, "Inventory");
 
         Ok(())
     }
@@ -538,29 +512,17 @@ pub(crate) mod tests {
         run_for_testing(&db, "INSERT INTO inventory (inventory_id, name) VALUES (3, 't3')")?;
 
         let result = run_for_testing(&db, "SELECT * FROM inventory")?;
-        assert_eq!(
-            result.iter().map(|x| x.data.len()).sum::<usize>(),
-            3,
-            "Not return results"
-        );
+        assert_eq!(result.len(), 3, "Not return results");
 
         run_for_testing(&db, "DELETE FROM inventory WHERE inventory.inventory_id = 3")?;
 
         let result = run_for_testing(&db, "SELECT * FROM inventory")?;
-        assert_eq!(
-            result.iter().map(|x| x.data.len()).sum::<usize>(),
-            2,
-            "Not delete correct row?"
-        );
+        assert_eq!(result.len(), 2, "Not delete correct row?");
 
         run_for_testing(&db, "DELETE FROM inventory")?;
 
         let result = run_for_testing(&db, "SELECT * FROM inventory")?;
-        assert_eq!(
-            result.iter().map(|x| x.data.len()).sum::<usize>(),
-            0,
-            "Not delete all rows"
-        );
+        assert_eq!(result.len(), 0, "Not delete all rows");
 
         Ok(())
     }
@@ -576,17 +538,11 @@ pub(crate) mod tests {
 
         let result = run_for_testing(&db, "SELECT * FROM inventory WHERE inventory_id = 2")?;
 
-        let result = result.first().unwrap().clone();
-
         let mut change = input;
         change.data.clear();
         change.data.push(product![2u64, "c2"]);
 
-        assert_eq!(
-            mem_table_without_table_name(&change),
-            mem_table_without_table_name(&result),
-            "Update Inventory 2"
-        );
+        assert_eq!(result, change.data, "Update Inventory 2");
 
         run_for_testing(&db, "UPDATE inventory SET name = 'c3'")?;
 
@@ -594,14 +550,9 @@ pub(crate) mod tests {
 
         let updated: Vec<_> = result
             .into_iter()
-            .map(|x| {
-                x.data
-                    .into_iter()
-                    .map(|x| x.field_as_str(1, None).unwrap().to_string())
-                    .collect::<Vec<_>>()
-            })
+            .map(|x| x.field_as_str(1, None).unwrap().to_string())
             .collect();
-        assert_eq!(vec![vec!["c3"; 3]], updated);
+        assert_eq!(vec!["c3"; 3], updated);
 
         Ok(())
     }
@@ -624,8 +575,7 @@ pub(crate) mod tests {
 
         let result = run_for_testing(&db, "select * from test where b = 1 and a = 1")?;
 
-        let result = result.first().unwrap().clone();
-        assert_eq!(result.data, vec![product![1, 1, 1, 1]]);
+        assert_eq!(result, vec![product![1, 1, 1, 1]]);
 
         Ok(())
     }
@@ -672,20 +622,13 @@ pub(crate) mod tests {
         .unwrap();
 
         let result = run_for_testing(&db, "select * from test where x > 5 and x < 5").unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].data.is_empty());
+        assert!(result.is_empty());
 
         let result = run_for_testing(&db, "select * from test where x >= 5 and x < 4").unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(
-            result[0].data.is_empty(),
-            "Expected no rows but found {:#?}",
-            result[0].data
-        );
+        assert!(result.is_empty(), "Expected no rows but found {:#?}", result);
 
         let result = run_for_testing(&db, "select * from test where x > 5 and x <= 4").unwrap();
-        assert_eq!(result.len(), 1);
-        assert!(result[0].data.is_empty());
+        assert!(result.is_empty());
         Ok(())
     }
 
@@ -703,8 +646,7 @@ pub(crate) mod tests {
 
         let result = run_for_testing(&db, "select * from test where a >= 3 and a <= 5 and b >= 3 and b <= 5")?;
 
-        let result = result.first().unwrap().clone();
-        assert_eq!(result.data, []);
+        assert!(result.is_empty());
 
         Ok(())
     }
@@ -726,6 +668,8 @@ pub(crate) mod tests {
 
         let internal_auth = AuthCtx::new(server, server);
         let external_auth = AuthCtx::new(server, client);
+
+        let run = |db, sql, auth, subs| run(db, sql, auth, subs, &mut vec![]);
 
         // No row limit, both queries pass.
         assert!(run(&db, "SELECT * FROM T", internal_auth, None).is_ok());

--- a/crates/core/src/sql/parser.rs
+++ b/crates/core/src/sql/parser.rs
@@ -22,7 +22,7 @@ impl RowLevelExpr {
 
         Ok(Self {
             def: RowLevelSecuritySchema {
-                table_id: sql.table_id().unwrap(),
+                table_id: sql.return_table_id().unwrap(),
                 sql: rls.sql.clone(),
             },
             sql,

--- a/crates/core/src/util/slow.rs
+++ b/crates/core/src/util/slow.rs
@@ -49,11 +49,12 @@ mod tests {
     use super::*;
 
     use crate::db::datastore::system_tables::ST_VARNAME_SLOW_QRY;
-    use crate::db::datastore::system_tables::{StVarName, StVarValue, ST_VARNAME_SLOW_INC, ST_VARNAME_SLOW_SUB};
+    use crate::db::datastore::system_tables::{StVarName, ST_VARNAME_SLOW_INC, ST_VARNAME_SLOW_SUB};
     use crate::sql::compiler::compile_sql;
     use crate::sql::execute::tests::execute_for_testing;
     use spacetimedb_lib::error::ResultTest;
     use spacetimedb_lib::identity::AuthCtx;
+    use spacetimedb_lib::st_var::StVarValue;
     use spacetimedb_lib::ProductValue;
 
     use crate::db::relational_db::tests_utils::{insert, TestDB};

--- a/crates/execution/Cargo.toml
+++ b/crates/execution/Cargo.toml
@@ -10,6 +10,7 @@ description = "The SpacetimeDB query engine"
 anyhow.workspace = true
 spacetimedb-expr.workspace = true
 spacetimedb-lib.workspace = true
+spacetimedb-sats.workspace = true
 spacetimedb-physical-plan.workspace = true
 spacetimedb-primitives.workspace = true
 spacetimedb-sql-parser.workspace = true

--- a/crates/execution/src/dml.rs
+++ b/crates/execution/src/dml.rs
@@ -1,0 +1,152 @@
+use anyhow::Result;
+use spacetimedb_lib::{metrics::ExecutionMetrics, AlgebraicValue, ProductValue};
+use spacetimedb_physical_plan::dml::{DeletePlan, InsertPlan, MutationPlan, UpdatePlan};
+use spacetimedb_primitives::{ColId, TableId};
+use spacetimedb_sats::size_of::SizeOf;
+
+use crate::{pipelined::PipelinedProject, Datastore, DeltaStore};
+
+/// A mutable datastore can read as well as insert and delete rows
+pub trait MutDatastore: Datastore + DeltaStore {
+    fn insert_product_value(&mut self, table_id: TableId, row: &ProductValue) -> Result<()>;
+    fn delete_product_value(&mut self, table_id: TableId, row: &ProductValue) -> Result<()>;
+}
+
+/// Executes a physical mutation plan
+pub enum MutExecutor {
+    Insert(InsertExecutor),
+    Delete(DeleteExecutor),
+    Update(UpdateExecutor),
+}
+
+impl From<MutationPlan> for MutExecutor {
+    fn from(plan: MutationPlan) -> Self {
+        match plan {
+            MutationPlan::Insert(plan) => Self::Insert(plan.into()),
+            MutationPlan::Delete(plan) => Self::Delete(plan.into()),
+            MutationPlan::Update(plan) => Self::Update(plan.into()),
+        }
+    }
+}
+
+impl MutExecutor {
+    pub fn execute<Tx: MutDatastore>(&self, tx: &mut Tx, metrics: &mut ExecutionMetrics) -> Result<()> {
+        match self {
+            Self::Insert(exec) => exec.execute(tx, metrics),
+            Self::Delete(exec) => exec.execute(tx, metrics),
+            Self::Update(exec) => exec.execute(tx, metrics),
+        }
+    }
+}
+
+/// Executes row insertions
+pub struct InsertExecutor {
+    table_id: TableId,
+    rows: Vec<ProductValue>,
+}
+
+impl From<InsertPlan> for InsertExecutor {
+    fn from(plan: InsertPlan) -> Self {
+        Self {
+            rows: plan.rows,
+            table_id: plan.table.table_id,
+        }
+    }
+}
+
+impl InsertExecutor {
+    fn execute<Tx: MutDatastore>(&self, tx: &mut Tx, metrics: &mut ExecutionMetrics) -> Result<()> {
+        for row in &self.rows {
+            tx.insert_product_value(self.table_id, row)?;
+        }
+        // TODO: It would be better to get this metric from the bsatn buffer.
+        // But we haven't been concerned with optimizing DML up to this point.
+        metrics.bytes_written += self.rows.iter().map(|row| row.size_of()).sum::<usize>();
+        Ok(())
+    }
+}
+
+/// Executes row deletions
+pub struct DeleteExecutor {
+    table_id: TableId,
+    filter: PipelinedProject,
+}
+
+impl From<DeletePlan> for DeleteExecutor {
+    fn from(plan: DeletePlan) -> Self {
+        Self {
+            table_id: plan.table.table_id,
+            filter: plan.filter.into(),
+        }
+    }
+}
+
+impl DeleteExecutor {
+    fn execute<Tx: MutDatastore>(&self, tx: &mut Tx, metrics: &mut ExecutionMetrics) -> Result<()> {
+        // TODO: Delete by row id instead of product value
+        let mut deletes = vec![];
+        self.filter.execute(tx, metrics, &mut |row| {
+            deletes.push(row.to_product_value());
+            Ok(())
+        })?;
+        // TODO: This metric should be updated inline when we serialize.
+        // Note, that we don't update bytes written,
+        // because deletes don't actually write out any bytes.
+        metrics.bytes_scanned += deletes.iter().map(|row| row.size_of()).sum::<usize>();
+        for row in &deletes {
+            tx.delete_product_value(self.table_id, row)?;
+        }
+        Ok(())
+    }
+}
+
+/// Executes row updates
+pub struct UpdateExecutor {
+    table_id: TableId,
+    columns: Vec<(ColId, AlgebraicValue)>,
+    filter: PipelinedProject,
+}
+
+impl From<UpdatePlan> for UpdateExecutor {
+    fn from(plan: UpdatePlan) -> Self {
+        Self {
+            columns: plan.columns,
+            table_id: plan.table.table_id,
+            filter: plan.filter.into(),
+        }
+    }
+}
+
+impl UpdateExecutor {
+    fn execute<Tx: MutDatastore>(&self, tx: &mut Tx, metrics: &mut ExecutionMetrics) -> Result<()> {
+        let mut deletes = vec![];
+        self.filter.execute(tx, metrics, &mut |row| {
+            deletes.push(row.to_product_value());
+            Ok(())
+        })?;
+        for row in &deletes {
+            tx.delete_product_value(self.table_id, row)?;
+        }
+        // TODO: This metric should be updated inline when we serialize.
+        metrics.bytes_scanned = deletes.iter().map(|row| row.size_of()).sum::<usize>();
+        for row in &deletes {
+            let row = ProductValue::from_iter(
+                row
+                    // Update the deleted rows with the new field values
+                    .into_iter()
+                    .cloned()
+                    .enumerate()
+                    .map(|(i, elem)| {
+                        self.columns
+                            .iter()
+                            .find(|(col_id, _)| i == col_id.idx())
+                            .map(|(_, value)| value.clone())
+                            .unwrap_or_else(|| elem)
+                    }),
+            );
+            tx.insert_product_value(self.table_id, &row)?;
+            metrics.bytes_written += row.size_of();
+        }
+        Ok(())
+    }
+}

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -16,6 +16,7 @@ use spacetimedb_table::{
     table::{IndexScanIter, RowRef, Table, TableScanIter},
 };
 
+pub mod dml;
 pub mod iter;
 pub mod pipelined;
 
@@ -77,6 +78,15 @@ pub trait DeltaStore {
 pub enum Row<'a> {
     Ptr(RowRef<'a>),
     Ref(&'a ProductValue),
+}
+
+impl Row<'_> {
+    pub fn to_product_value(&self) -> ProductValue {
+        match self {
+            Self::Ptr(ptr) => ptr.to_product_value(),
+            Self::Ref(val) => (*val).clone(),
+        }
+    }
 }
 
 impl_serialize!(['a] Row<'a>, (self, ser) => match self {

--- a/crates/expr/src/expr.rs
+++ b/crates/expr/src/expr.rs
@@ -47,7 +47,7 @@ impl ProjectName {
     }
 
     /// Iterate over the returned column names and types
-    pub fn iter_return_fields(&self, mut f: impl FnMut(&str, &AlgebraicType)) {
+    pub fn for_each_return_field(&self, mut f: impl FnMut(&str, &AlgebraicType)) {
         if let Some(schema) = self.return_table() {
             for schema in schema.columns() {
                 f(&schema.col_name, &schema.col_type);
@@ -98,10 +98,10 @@ impl ProjectList {
     }
 
     /// Iterate over the projected column names and types
-    pub fn iter_return_fields(&self, mut f: impl FnMut(&str, &AlgebraicType)) {
+    pub fn for_each_return_field(&self, mut f: impl FnMut(&str, &AlgebraicType)) {
         match self {
             Self::Name(project) => {
-                project.iter_return_fields(f);
+                project.for_each_return_field(f);
             }
             Self::List(_, fields) => {
                 for (name, FieldProject { ty, .. }) in fields {

--- a/crates/expr/src/expr.rs
+++ b/crates/expr/src/expr.rs
@@ -26,11 +26,32 @@ pub enum ProjectName {
 }
 
 impl ProjectName {
-    /// What is the [TableId] for this projection?
-    pub fn table_id(&self) -> Option<TableId> {
+    /// The [TableSchema] of the returned rows.
+    /// Note this expression returns rows from a relvar.
+    /// Hence it this method should never return [None].
+    pub fn return_table(&self) -> Option<&TableSchema> {
         match self {
-            Self::None(input) => input.table_id(None),
-            Self::Some(input, var) => input.table_id(Some(var.as_ref())),
+            Self::None(input) => input.return_table(),
+            Self::Some(input, alias) => input.find_table_schema(alias),
+        }
+    }
+
+    /// The [TableId] of the returned rows.
+    /// Note this expression returns rows from a relvar.
+    /// Hence it this method should never return [None].
+    pub fn return_table_id(&self) -> Option<TableId> {
+        match self {
+            Self::None(input) => input.return_table_id(),
+            Self::Some(input, alias) => input.find_table_id(alias),
+        }
+    }
+
+    /// Iterate over the returned column names and types
+    pub fn iter_return_fields(&self, mut f: impl FnMut(&str, &AlgebraicType)) {
+        if let Some(schema) = self.return_table() {
+            for schema in schema.columns() {
+                f(&schema.col_name, &schema.col_type);
+            }
         }
     }
 }
@@ -56,11 +77,37 @@ pub enum ProjectList {
 }
 
 impl ProjectList {
-    /// What is the [TableId] for this projection?
-    pub fn table_id(&self) -> Option<TableId> {
+    /// Does this expression project a single relvar?
+    /// If so, we return it's [TableSchema].
+    /// If not, it projects a list of columns, so we return [None].
+    pub fn return_table(&self) -> Option<&TableSchema> {
         match self {
+            Self::Name(project) => project.return_table(),
             Self::List(..) => None,
-            Self::Name(proj) => proj.table_id(),
+        }
+    }
+
+    /// Does this expression project a single relvar?
+    /// If so, we return it's [TableId].
+    /// If not, it projects a list of columns, so we return [None].
+    pub fn return_table_id(&self) -> Option<TableId> {
+        match self {
+            Self::Name(project) => project.return_table_id(),
+            Self::List(..) => None,
+        }
+    }
+
+    /// Iterate over the projected column names and types
+    pub fn iter_return_fields(&self, mut f: impl FnMut(&str, &AlgebraicType)) {
+        match self {
+            Self::Name(project) => {
+                project.iter_return_fields(f);
+            }
+            Self::List(_, fields) => {
+                for (name, FieldProject { ty, .. }) in fields {
+                    f(name, ty);
+                }
+            }
         }
     }
 }
@@ -108,22 +155,38 @@ impl RelExpr {
         }
     }
 
-    /// What is the [TableId] for this expression or relvar?
-    pub fn table_id(&self, var: Option<&str>) -> Option<TableId> {
-        match (self, var) {
-            (Self::RelVar(Relvar { schema, .. }), None) => Some(schema.table_id),
-            (Self::RelVar(Relvar { schema, alias, .. }), Some(var)) if alias.as_ref() == var => Some(schema.table_id),
-            (Self::RelVar(Relvar { schema, .. }), Some(_)) => Some(schema.table_id),
-            (Self::Select(input, _), _) => input.table_id(var),
-            (Self::LeftDeepJoin(..) | Self::EqJoin(..), None) => None,
-            (Self::LeftDeepJoin(join) | Self::EqJoin(join, ..), Some(name)) => {
-                if join.rhs.alias.as_ref() == name {
-                    Some(join.rhs.schema.table_id)
-                } else {
-                    join.lhs.table_id(var)
-                }
-            }
+    /// Return the [TableSchema] for a relvar in the expression
+    pub fn find_table_schema(&self, alias: &str) -> Option<&TableSchema> {
+        match self {
+            Self::RelVar(relvar) if relvar.alias.as_ref() == alias => Some(&relvar.schema),
+            Self::Select(input, _) => input.find_table_schema(alias),
+            Self::EqJoin(LeftDeepJoin { rhs, .. }, ..) if rhs.alias.as_ref() == alias => Some(&rhs.schema),
+            Self::EqJoin(LeftDeepJoin { lhs, .. }, ..) => lhs.find_table_schema(alias),
+            Self::LeftDeepJoin(LeftDeepJoin { rhs, .. }) if rhs.alias.as_ref() == alias => Some(&rhs.schema),
+            Self::LeftDeepJoin(LeftDeepJoin { lhs, .. }) => lhs.find_table_schema(alias),
+            _ => None,
         }
+    }
+
+    /// Return the [TableId] for a relvar in the expression
+    pub fn find_table_id(&self, alias: &str) -> Option<TableId> {
+        self.find_table_schema(alias).map(|schema| schema.table_id)
+    }
+
+    /// Does this expression return a single relvar?
+    /// If so, return it's [TableSchema], otherwise return [None].
+    pub fn return_table(&self) -> Option<&TableSchema> {
+        match self {
+            Self::RelVar(Relvar { schema, .. }) => Some(schema),
+            Self::Select(input, _) => input.return_table(),
+            _ => None,
+        }
+    }
+
+    /// Does this expression return a single relvar?
+    /// If so, return it's [TableId], otherwise return [None].
+    pub fn return_table_id(&self) -> Option<TableId> {
+        self.return_table().map(|schema| schema.table_id)
     }
 }
 

--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -1,4 +1,4 @@
-use std::collections::HashSet;
+use std::{collections::HashSet, ops::Deref};
 
 use crate::statement::Statement;
 use check::{Relvars, TypingResult};
@@ -61,7 +61,7 @@ pub(crate) fn type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&Algebra
             Ok(Expr::Value(parse(v.into_string(), ty)?, ty.clone()))
         }
         (SqlExpr::Field(SqlIdent(table), SqlIdent(field)), None) => {
-            let table_type = vars.get(&table).ok_or_else(|| Unresolved::var(&table))?;
+            let table_type = vars.deref().get(&table).ok_or_else(|| Unresolved::var(&table))?;
             let ColumnSchema { col_pos, col_type, .. } = table_type
                 .get_column_by_name(&field)
                 .ok_or_else(|| Unresolved::var(&field))?;
@@ -72,8 +72,9 @@ pub(crate) fn type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&Algebra
             }))
         }
         (SqlExpr::Field(SqlIdent(table), SqlIdent(field)), Some(ty)) => {
-            let table_type = vars.get(&table).ok_or_else(|| Unresolved::var(&table))?;
+            let table_type = vars.deref().get(&table).ok_or_else(|| Unresolved::var(&table))?;
             let ColumnSchema { col_pos, col_type, .. } = table_type
+                .as_ref()
                 .get_column_by_name(&field)
                 .ok_or_else(|| Unresolved::var(&field))?;
             if col_type != ty {

--- a/crates/expr/src/statement.rs
+++ b/crates/expr/src/statement.rs
@@ -315,6 +315,8 @@ pub fn type_and_rewrite_show(show: SqlShow, tx: &impl SchemaView) -> TypingResul
     // -------------------------------------------
     let var_name_field = Expr::Field(FieldProject {
         table: ST_VAR_NAME.into(),
+        // TODO: Avoid hard coding the field position.
+        // See `StVarFields` for the schema of `st_var`.
         field: 0,
         ty: AlgebraicType::String,
     });
@@ -333,6 +335,8 @@ pub fn type_and_rewrite_show(show: SqlShow, tx: &impl SchemaView) -> TypingResul
         VALUE_COLUMN.into(),
         FieldProject {
             table: ST_VAR_NAME.into(),
+            // TODO: Avoid hard coding the field position.
+            // See `StVarFields` for the schema of `st_var`.
             field: 1,
             ty: value_col_ty.clone(),
         },

--- a/crates/expr/src/statement.rs
+++ b/crates/expr/src/statement.rs
@@ -1,18 +1,22 @@
 use std::sync::Arc;
 
-use spacetimedb_lib::{AlgebraicType, AlgebraicValue};
-use spacetimedb_primitives::ColId;
+use spacetimedb_lib::{st_var::StVarValue, AlgebraicType, AlgebraicValue, ProductValue};
+use spacetimedb_primitives::{ColId, TableId};
 use spacetimedb_schema::schema::{ColumnSchema, TableSchema};
 use spacetimedb_sql_parser::{
     ast::{
         sql::{SqlAst, SqlDelete, SqlInsert, SqlSelect, SqlSet, SqlShow, SqlUpdate},
-        SqlIdent, SqlLiteral,
+        BinOp, SqlIdent, SqlLiteral,
     },
     parser::sql::parse_sql,
 };
 use thiserror::Error;
 
-use crate::{check::Relvars, expr::ProjectList};
+use crate::{
+    check::Relvars,
+    errors::InvalidLiteral,
+    expr::{FieldProject, ProjectList, RelExpr, Relvar},
+};
 
 use super::{
     check::{SchemaView, TypeChecker, TypingResult},
@@ -23,29 +27,49 @@ use super::{
 
 pub enum Statement {
     Select(ProjectList),
+    DML(DML),
+}
+
+pub enum DML {
     Insert(TableInsert),
     Update(TableUpdate),
     Delete(TableDelete),
-    Set(SetVar),
-    Show(ShowVar),
 }
 
-/// A resolved row of literal values for an insert
-pub type Row = Box<[AlgebraicValue]>;
+impl DML {
+    /// Returns the schema of the table on which this mutation applies
+    pub fn table_schema(&self) -> &TableSchema {
+        match self {
+            Self::Insert(insert) => &insert.table,
+            Self::Delete(delete) => &delete.table,
+            Self::Update(update) => &update.table,
+        }
+    }
+
+    /// Returns the id of the table on which this mutation applies
+    pub fn table_id(&self) -> TableId {
+        self.table_schema().table_id
+    }
+
+    /// Returns the name of the table on which this mutation applies
+    pub fn table_name(&self) -> Box<str> {
+        self.table_schema().table_name.clone()
+    }
+}
 
 pub struct TableInsert {
-    pub into: Arc<TableSchema>,
-    pub rows: Box<[Row]>,
+    pub table: Arc<TableSchema>,
+    pub rows: Box<[ProductValue]>,
 }
 
 pub struct TableDelete {
-    pub from: Arc<TableSchema>,
-    pub expr: Option<Expr>,
+    pub table: Arc<TableSchema>,
+    pub filter: Option<Expr>,
 }
 
 pub struct TableUpdate {
-    pub schema: Arc<TableSchema>,
-    pub values: Box<[(ColId, AlgebraicValue)]>,
+    pub table: Arc<TableSchema>,
+    pub columns: Box<[(ColId, AlgebraicValue)]>,
     pub filter: Option<Expr>,
 }
 
@@ -92,10 +116,13 @@ pub fn type_insert(insert: SqlInsert, tx: &impl SchemaView) -> TypingResult<Tabl
             }));
         }
         let mut values = Vec::new();
-        for (value, ty) in row
-            .into_iter()
-            .zip(schema.columns().iter().map(|ColumnSchema { col_type, .. }| col_type))
-        {
+        for (value, ty) in row.into_iter().zip(
+            schema
+                .as_ref()
+                .columns()
+                .iter()
+                .map(|ColumnSchema { col_type, .. }| col_type),
+        ) {
             match (value, ty) {
                 (SqlLiteral::Bool(v), AlgebraicType::Bool) => {
                     values.push(AlgebraicValue::Bool(v));
@@ -114,11 +141,11 @@ pub fn type_insert(insert: SqlInsert, tx: &impl SchemaView) -> TypingResult<Tabl
                 }
             }
         }
-        rows.push(values.into_boxed_slice());
+        rows.push(ProductValue::from(values));
     }
     let into = schema;
     let rows = rows.into_boxed_slice();
-    Ok(TableInsert { into, rows })
+    Ok(TableInsert { table: into, rows })
 }
 
 /// Type check a DELETE statement
@@ -136,7 +163,10 @@ pub fn type_delete(delete: SqlDelete, tx: &impl SchemaView) -> TypingResult<Tabl
     let expr = filter
         .map(|expr| type_expr(&vars, expr, Some(&AlgebraicType::Bool)))
         .transpose()?;
-    Ok(TableDelete { from, expr })
+    Ok(TableDelete {
+        table: from,
+        filter: expr,
+    })
 }
 
 /// Type check an UPDATE statement
@@ -157,6 +187,7 @@ pub fn type_update(update: SqlUpdate, tx: &impl SchemaView) -> TypingResult<Tabl
             col_type: ty,
             ..
         } = schema
+            .as_ref()
             .get_column_by_name(&field)
             .ok_or_else(|| Unresolved::field(&table_name, &field))?;
         match (lit, ty) {
@@ -183,7 +214,11 @@ pub fn type_update(update: SqlUpdate, tx: &impl SchemaView) -> TypingResult<Tabl
     let filter = filter
         .map(|expr| type_expr(&vars, expr, Some(&AlgebraicType::Bool)))
         .transpose()?;
-    Ok(TableUpdate { schema, values, filter })
+    Ok(TableUpdate {
+        table: schema,
+        columns: values,
+        filter,
+    })
 }
 
 #[derive(Error, Debug)]
@@ -201,36 +236,132 @@ fn is_var_valid(var: &str) -> bool {
     var == VAR_ROW_LIMIT || var == VAR_SLOW_QUERY || var == VAR_SLOW_UPDATE || var == VAR_SLOW_SUB
 }
 
-pub fn type_set(set: SqlSet) -> TypingResult<SetVar> {
-    let SqlSet(SqlIdent(name), lit) = set;
-    if !is_var_valid(&name) {
+const ST_VAR_NAME: &str = "st_var";
+const VALUE_COLUMN: &str = "value";
+
+/// The concept of `SET` only exists in the ast.
+/// We translate it here to an `INSERT` on the `st_var` system table.
+/// That is:
+///
+/// ```sql
+/// SET var TO ...
+/// ```
+///
+/// is rewritten as
+///
+/// ```sql
+/// INSERT INTO st_var (name, value) VALUES ('var', ...)
+/// ```
+pub fn type_and_rewrite_set(set: SqlSet, tx: &impl SchemaView) -> TypingResult<TableInsert> {
+    let SqlSet(SqlIdent(var_name), lit) = set;
+    if !is_var_valid(&var_name) {
         return Err(InvalidVar {
-            name: name.into_string(),
+            name: var_name.into_string(),
         }
         .into());
     }
+
     match lit {
         SqlLiteral::Bool(_) => Err(UnexpectedType::new(&AlgebraicType::U64, &AlgebraicType::Bool).into()),
         SqlLiteral::Str(_) => Err(UnexpectedType::new(&AlgebraicType::U64, &AlgebraicType::String).into()),
         SqlLiteral::Hex(_) => Err(UnexpectedType::new(&AlgebraicType::U64, &AlgebraicType::bytes()).into()),
-        SqlLiteral::Num(n) => Ok(SetVar {
-            name: name.into_string(),
-            value: parse(n.into_string(), &AlgebraicType::U64)?,
-        }),
+        SqlLiteral::Num(n) => {
+            let table = tx.schema(ST_VAR_NAME).ok_or_else(|| Unresolved::table(ST_VAR_NAME))?;
+            let var_name = AlgebraicValue::String(var_name);
+            let sum_value = StVarValue::try_from_primitive(parse(n.clone().into_string(), &AlgebraicType::U64)?)
+                .map_err(|_| InvalidLiteral::new(n.into_string(), &AlgebraicType::U64))?
+                .into();
+            Ok(TableInsert {
+                table,
+                rows: Box::new([ProductValue::from_iter([var_name, sum_value])]),
+            })
+        }
     }
 }
 
-pub fn type_show(show: SqlShow) -> TypingResult<ShowVar> {
-    let SqlShow(SqlIdent(name)) = show;
-    if !is_var_valid(&name) {
+/// The concept of `SHOW` only exists in the ast.
+/// We translate it here to a `SELECT` on the `st_var` system table.
+/// That is:
+///
+/// ```sql
+/// SHOW var
+/// ```
+///
+/// is rewritten as
+///
+/// ```sql
+/// SELECT value FROM st_var WHERE name = 'var'
+/// ```
+pub fn type_and_rewrite_show(show: SqlShow, tx: &impl SchemaView) -> TypingResult<ProjectList> {
+    let SqlShow(SqlIdent(var_name)) = show;
+    if !is_var_valid(&var_name) {
         return Err(InvalidVar {
-            name: name.into_string(),
+            name: var_name.into_string(),
         }
         .into());
     }
-    Ok(ShowVar {
-        name: name.into_string(),
-    })
+
+    let table_schema = tx.schema(ST_VAR_NAME).ok_or_else(|| Unresolved::table(ST_VAR_NAME))?;
+
+    let value_col_ty = table_schema
+        .as_ref()
+        .get_column(1)
+        .map(|ColumnSchema { col_type, .. }| col_type)
+        .ok_or_else(|| Unresolved::field(ST_VAR_NAME, VALUE_COLUMN))?;
+
+    // -------------------------------------------
+    // SELECT value FROM st_var WHERE name = 'var'
+    //                                ^^^^
+    // -------------------------------------------
+    let var_name_field = Expr::Field(FieldProject {
+        table: ST_VAR_NAME.into(),
+        field: 0,
+        ty: AlgebraicType::String,
+    });
+
+    // -------------------------------------------
+    // SELECT value FROM st_var WHERE name = 'var'
+    //                                        ^^^
+    // -------------------------------------------
+    let var_name_value = Expr::Value(AlgebraicValue::String(var_name), AlgebraicType::String);
+
+    // -------------------------------------------
+    // SELECT value FROM st_var WHERE name = 'var'
+    //        ^^^^^
+    // -------------------------------------------
+    let column_list = vec![(
+        VALUE_COLUMN.into(),
+        FieldProject {
+            table: ST_VAR_NAME.into(),
+            field: 1,
+            ty: value_col_ty.clone(),
+        },
+    )];
+
+    // -------------------------------------------
+    // SELECT value FROM st_var WHERE name = 'var'
+    //                   ^^^^^^
+    // -------------------------------------------
+    let relvar = RelExpr::RelVar(Relvar {
+        schema: table_schema,
+        alias: ST_VAR_NAME.into(),
+        delta: None,
+    });
+
+    let filter = Expr::BinOp(
+        // -------------------------------------------
+        // SELECT value FROM st_var WHERE name = 'var'
+        //                                    ^^^
+        // -------------------------------------------
+        BinOp::Eq,
+        Box::new(var_name_field),
+        Box::new(var_name_value),
+    );
+
+    Ok(ProjectList::List(
+        RelExpr::Select(Box::new(relvar), filter),
+        column_list,
+    ))
 }
 
 /// Type-checker for regular `SQL` queries
@@ -266,14 +397,14 @@ impl TypeChecker for SqlChecker {
     }
 }
 
-fn parse_and_type_sql(sql: &str, tx: &impl SchemaView) -> TypingResult<Statement> {
+pub fn parse_and_type_sql(sql: &str, tx: &impl SchemaView) -> TypingResult<Statement> {
     match parse_sql(sql)? {
-        SqlAst::Insert(insert) => Ok(Statement::Insert(type_insert(insert, tx)?)),
-        SqlAst::Delete(delete) => Ok(Statement::Delete(type_delete(delete, tx)?)),
-        SqlAst::Update(update) => Ok(Statement::Update(type_update(update, tx)?)),
         SqlAst::Select(ast) => Ok(Statement::Select(SqlChecker::type_ast(ast, tx)?)),
-        SqlAst::Set(set) => Ok(Statement::Set(type_set(set)?)),
-        SqlAst::Show(show) => Ok(Statement::Show(type_show(show)?)),
+        SqlAst::Insert(insert) => Ok(Statement::DML(DML::Insert(type_insert(insert, tx)?))),
+        SqlAst::Delete(delete) => Ok(Statement::DML(DML::Delete(type_delete(delete, tx)?))),
+        SqlAst::Update(update) => Ok(Statement::DML(DML::Update(type_update(update, tx)?))),
+        SqlAst::Set(set) => Ok(Statement::DML(DML::Insert(type_and_rewrite_set(set, tx)?))),
+        SqlAst::Show(show) => Ok(Statement::Select(type_and_rewrite_show(show, tx)?)),
     }
 }
 

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -15,6 +15,7 @@ pub mod operator;
 pub mod query;
 pub mod relation;
 pub mod scheduler;
+pub mod st_var;
 pub mod version;
 
 pub mod type_def {

--- a/crates/lib/src/st_var.rs
+++ b/crates/lib/src/st_var.rs
@@ -1,0 +1,143 @@
+use derive_more::From;
+use spacetimedb_sats::{AlgebraicValue, SpacetimeType, SumValue};
+
+/// The value of a system variable in `st_var`.
+/// Defined here because it is used in both the datastore and query.
+#[derive(Debug, Clone, From, SpacetimeType)]
+#[sats(crate = spacetimedb_lib)]
+pub enum StVarValue {
+    Bool(bool),
+    I8(i8),
+    U8(u8),
+    I16(i16),
+    U16(u16),
+    I32(i32),
+    U32(u32),
+    I64(i64),
+    U64(u64),
+    I128(i128),
+    U128(u128),
+    // No support for u/i256 added here as it seems unlikely to be useful.
+    F32(f32),
+    F64(f64),
+    String(Box<str>),
+}
+
+impl StVarValue {
+    pub fn try_from_primitive(value: AlgebraicValue) -> Result<Self, AlgebraicValue> {
+        match value {
+            AlgebraicValue::Bool(v) => Ok(StVarValue::Bool(v)),
+            AlgebraicValue::I8(v) => Ok(StVarValue::I8(v)),
+            AlgebraicValue::U8(v) => Ok(StVarValue::U8(v)),
+            AlgebraicValue::I16(v) => Ok(StVarValue::I16(v)),
+            AlgebraicValue::U16(v) => Ok(StVarValue::U16(v)),
+            AlgebraicValue::I32(v) => Ok(StVarValue::I32(v)),
+            AlgebraicValue::U32(v) => Ok(StVarValue::U32(v)),
+            AlgebraicValue::I64(v) => Ok(StVarValue::I64(v)),
+            AlgebraicValue::U64(v) => Ok(StVarValue::U64(v)),
+            AlgebraicValue::I128(v) => Ok(StVarValue::I128(v.0)),
+            AlgebraicValue::U128(v) => Ok(StVarValue::U128(v.0)),
+            AlgebraicValue::F32(v) => Ok(StVarValue::F32(v.into_inner())),
+            AlgebraicValue::F64(v) => Ok(StVarValue::F64(v.into_inner())),
+            AlgebraicValue::String(v) => Ok(StVarValue::String(v)),
+            _ => Err(value),
+        }
+    }
+
+    pub fn try_from_sum(value: AlgebraicValue) -> Result<Self, AlgebraicValue> {
+        value.into_sum()?.try_into()
+    }
+}
+
+impl TryFrom<SumValue> for StVarValue {
+    type Error = AlgebraicValue;
+
+    fn try_from(sum: SumValue) -> Result<Self, Self::Error> {
+        match sum.tag {
+            0 => Ok(StVarValue::Bool(sum.value.into_bool()?)),
+            1 => Ok(StVarValue::I8(sum.value.into_i8()?)),
+            2 => Ok(StVarValue::U8(sum.value.into_u8()?)),
+            3 => Ok(StVarValue::I16(sum.value.into_i16()?)),
+            4 => Ok(StVarValue::U16(sum.value.into_u16()?)),
+            5 => Ok(StVarValue::I32(sum.value.into_i32()?)),
+            6 => Ok(StVarValue::U32(sum.value.into_u32()?)),
+            7 => Ok(StVarValue::I64(sum.value.into_i64()?)),
+            8 => Ok(StVarValue::U64(sum.value.into_u64()?)),
+            9 => Ok(StVarValue::I128(sum.value.into_i128()?.0)),
+            10 => Ok(StVarValue::U128(sum.value.into_u128()?.0)),
+            11 => Ok(StVarValue::F32(sum.value.into_f32()?.into_inner())),
+            12 => Ok(StVarValue::F64(sum.value.into_f64()?.into_inner())),
+            13 => Ok(StVarValue::String(sum.value.into_string()?)),
+            _ => Err(*sum.value),
+        }
+    }
+}
+
+impl From<StVarValue> for AlgebraicValue {
+    fn from(value: StVarValue) -> Self {
+        AlgebraicValue::Sum(value.into())
+    }
+}
+
+impl From<StVarValue> for SumValue {
+    fn from(value: StVarValue) -> Self {
+        match value {
+            StVarValue::Bool(v) => SumValue {
+                tag: 0,
+                value: Box::new(AlgebraicValue::Bool(v)),
+            },
+            StVarValue::I8(v) => SumValue {
+                tag: 1,
+                value: Box::new(AlgebraicValue::I8(v)),
+            },
+            StVarValue::U8(v) => SumValue {
+                tag: 2,
+                value: Box::new(AlgebraicValue::U8(v)),
+            },
+            StVarValue::I16(v) => SumValue {
+                tag: 3,
+                value: Box::new(AlgebraicValue::I16(v)),
+            },
+            StVarValue::U16(v) => SumValue {
+                tag: 4,
+                value: Box::new(AlgebraicValue::U16(v)),
+            },
+            StVarValue::I32(v) => SumValue {
+                tag: 5,
+                value: Box::new(AlgebraicValue::I32(v)),
+            },
+            StVarValue::U32(v) => SumValue {
+                tag: 6,
+                value: Box::new(AlgebraicValue::U32(v)),
+            },
+            StVarValue::I64(v) => SumValue {
+                tag: 7,
+                value: Box::new(AlgebraicValue::I64(v)),
+            },
+            StVarValue::U64(v) => SumValue {
+                tag: 8,
+                value: Box::new(AlgebraicValue::U64(v)),
+            },
+            StVarValue::I128(v) => SumValue {
+                tag: 9,
+                value: Box::new(AlgebraicValue::I128(v.into())),
+            },
+            StVarValue::U128(v) => SumValue {
+                tag: 10,
+                value: Box::new(AlgebraicValue::U128(v.into())),
+            },
+            StVarValue::F32(v) => SumValue {
+                tag: 11,
+                value: Box::new(AlgebraicValue::F32(v.into())),
+            },
+            StVarValue::F64(v) => SumValue {
+                tag: 12,
+                value: Box::new(AlgebraicValue::F64(v.into())),
+            },
+            StVarValue::String(v) => SumValue {
+                tag: 13,
+                value: Box::new(AlgebraicValue::String(v)),
+            },
+        }
+    }
+}

--- a/crates/physical-plan/src/dml.rs
+++ b/crates/physical-plan/src/dml.rs
@@ -1,0 +1,111 @@
+use std::sync::Arc;
+
+use spacetimedb_expr::{
+    expr::{ProjectName, RelExpr, Relvar},
+    statement::{TableDelete, TableInsert, TableUpdate},
+};
+use spacetimedb_lib::{AlgebraicValue, ProductValue};
+use spacetimedb_primitives::ColId;
+use spacetimedb_schema::schema::TableSchema;
+
+use crate::{compile::compile_select, plan::ProjectPlan};
+
+/// A plan for mutating a table in the database
+pub enum MutationPlan {
+    Insert(InsertPlan),
+    Delete(DeletePlan),
+    Update(UpdatePlan),
+}
+
+impl MutationPlan {
+    /// Optimizes the filters in updates and deletes
+    pub fn optimize(self) -> Self {
+        match self {
+            Self::Insert(..) => self,
+            Self::Delete(plan) => Self::Delete(plan.optimize()),
+            Self::Update(plan) => Self::Update(plan.optimize()),
+        }
+    }
+}
+
+/// A plan for inserting rows into a table
+pub struct InsertPlan {
+    pub table: Arc<TableSchema>,
+    pub rows: Vec<ProductValue>,
+}
+
+impl From<TableInsert> for InsertPlan {
+    fn from(insert: TableInsert) -> Self {
+        let TableInsert { table, rows } = insert;
+        let rows = rows.into_vec();
+        Self { table, rows }
+    }
+}
+
+/// A plan for deleting rows from a table
+pub struct DeletePlan {
+    pub table: Arc<TableSchema>,
+    pub filter: ProjectPlan,
+}
+
+impl DeletePlan {
+    /// Optimize the filter part of the delete
+    fn optimize(self) -> Self {
+        let Self { table, filter } = self;
+        let filter = filter.optimize();
+        Self { table, filter }
+    }
+
+    /// Logical to physical conversion
+    pub(crate) fn compile(delete: TableDelete) -> Self {
+        let TableDelete { table, filter } = delete;
+        let schema = table.clone();
+        let alias = table.table_name.clone();
+        let relvar = RelExpr::RelVar(Relvar {
+            schema,
+            alias,
+            delta: None,
+        });
+        let project = match filter {
+            None => ProjectName::None(relvar),
+            Some(expr) => ProjectName::None(RelExpr::Select(Box::new(relvar), expr)),
+        };
+        let filter = compile_select(project);
+        Self { table, filter }
+    }
+}
+
+/// A plan for updating rows in a table
+pub struct UpdatePlan {
+    pub table: Arc<TableSchema>,
+    pub columns: Vec<(ColId, AlgebraicValue)>,
+    pub filter: ProjectPlan,
+}
+
+impl UpdatePlan {
+    /// Optimize the filter part of the update
+    fn optimize(self) -> Self {
+        let Self { table, columns, filter } = self;
+        let filter = filter.optimize();
+        Self { columns, table, filter }
+    }
+
+    /// Logical to physical conversion
+    pub(crate) fn compile(update: TableUpdate) -> Self {
+        let TableUpdate { table, columns, filter } = update;
+        let schema = table.clone();
+        let alias = table.table_name.clone();
+        let relvar = RelExpr::RelVar(Relvar {
+            schema,
+            alias,
+            delta: None,
+        });
+        let project = match filter {
+            None => ProjectName::None(relvar),
+            Some(expr) => ProjectName::None(RelExpr::Select(Box::new(relvar), expr)),
+        };
+        let filter = compile_select(project);
+        let columns = columns.into_vec();
+        Self { columns, table, filter }
+    }
+}

--- a/crates/physical-plan/src/lib.rs
+++ b/crates/physical-plan/src/lib.rs
@@ -1,3 +1,4 @@
 pub mod compile;
+pub mod dml;
 pub mod plan;
 pub mod rules;

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -99,7 +99,18 @@ impl ProjectPlan {
 #[derive(Debug)]
 pub enum ProjectListPlan {
     Name(ProjectPlan),
-    List(PhysicalPlan, Vec<(Box<str>, TupleField)>),
+    List(PhysicalPlan, Vec<TupleField>),
+}
+
+impl Deref for ProjectListPlan {
+    type Target = PhysicalPlan;
+
+    fn deref(&self) -> &Self::Target {
+        match self {
+            Self::Name(plan) => plan,
+            Self::List(plan, ..) => plan,
+        }
+    }
 }
 
 impl ProjectListPlan {
@@ -107,13 +118,7 @@ impl ProjectListPlan {
         match self {
             Self::Name(plan) => Self::Name(plan.optimize()),
             Self::List(plan, fields) => Self::List(
-                plan.optimize(
-                    fields
-                        .iter()
-                        .map(|(_, TupleField { label, .. })| label)
-                        .copied()
-                        .collect(),
-                ),
+                plan.optimize(fields.iter().map(|TupleField { label, .. }| label).copied().collect()),
                 fields,
             ),
         }
@@ -560,7 +565,7 @@ impl PhysicalPlan {
     pub(crate) fn returns_distinct_values(&self, label: &Label, cols: &ColSet) -> bool {
         match self {
             // Is there a unique constraint for these cols?
-            Self::TableScan(schema, var, _) => var == label && schema.is_unique(cols),
+            Self::TableScan(schema, var, _) => var == label && schema.as_ref().is_unique(cols),
             // Is there a unique constraint for these cols + the index cols?
             Self::IxScan(
                 IxScan {
@@ -572,7 +577,7 @@ impl PhysicalPlan {
                 var,
             ) => {
                 var == label
-                    && schema.is_unique(&ColSet::from_iter(
+                    && schema.as_ref().is_unique(&ColSet::from_iter(
                         cols.iter()
                             .chain(prefix.iter().map(|(col_id, _)| *col_id))
                             .chain(vec![*col]),
@@ -605,7 +610,7 @@ impl PhysicalPlan {
                 _,
             ) => {
                 lhs.returns_distinct_values(lhs_label, &ColSet::from(ColId(*lhs_field_pos as u16)))
-                    && rhs.is_unique(cols)
+                    && rhs.as_ref().is_unique(cols)
             }
             // If the table in question is on the lhs,
             // and if the lhs returns distinct values,
@@ -1000,7 +1005,7 @@ mod tests {
     use spacetimedb_sql_parser::ast::BinOp;
 
     use crate::{
-        compile::compile_project_plan,
+        compile::compile_select,
         plan::{HashJoin, IxJoin, IxScan, PhysicalPlan, Sarg, Semi, TupleField},
     };
 
@@ -1097,7 +1102,7 @@ mod tests {
         let sql = "select * from t";
 
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_project_plan(lp).optimize();
+        let pp = compile_select(lp).optimize();
 
         match pp {
             ProjectPlan::None(PhysicalPlan::TableScan(schema, _, _)) => {
@@ -1128,7 +1133,7 @@ mod tests {
         let sql = "select * from t where x = 5";
 
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_project_plan(lp).optimize();
+        let pp = compile_select(lp).optimize();
 
         match pp {
             ProjectPlan::None(PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, field, value))) => {
@@ -1227,7 +1232,7 @@ mod tests {
             where u.identity = 5
         ";
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_project_plan(lp).optimize();
+        let pp = compile_select(lp).optimize();
 
         // Plan:
         //         rx
@@ -1419,7 +1424,7 @@ mod tests {
             where 5 = m.employee and 5 = v.employee
         ";
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_project_plan(lp).optimize();
+        let pp = compile_select(lp).optimize();
 
         // Plan:
         //           rx
@@ -1592,7 +1597,7 @@ mod tests {
 
         let sql = "select * from t where x = 3 and y = 4 and z = 5";
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_project_plan(lp).optimize();
+        let pp = compile_select(lp).optimize();
 
         // Select index on (x, y, z)
         match pp {
@@ -1614,7 +1619,7 @@ mod tests {
 
         let sql = "select * from t where x = 3 and y = 4";
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_project_plan(lp).optimize();
+        let pp = compile_select(lp).optimize();
 
         // Select index on x
         let plan = match pp {
@@ -1642,7 +1647,7 @@ mod tests {
 
         let sql = "select * from t where w = 5 and x = 4";
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_project_plan(lp).optimize();
+        let pp = compile_select(lp).optimize();
 
         // Select index on x
         let plan = match pp {
@@ -1670,7 +1675,7 @@ mod tests {
 
         let sql = "select * from t where y = 1";
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_project_plan(lp).optimize();
+        let pp = compile_select(lp).optimize();
 
         // Do not select index on (y, z)
         match pp {

--- a/crates/query/src/delta.rs
+++ b/crates/query/src/delta.rs
@@ -6,7 +6,7 @@ use spacetimedb_execution::{pipelined::PipelinedProject, Datastore, DeltaStore, 
 use spacetimedb_expr::check::{type_subscription, SchemaView};
 use spacetimedb_lib::{metrics::ExecutionMetrics, query::Delta};
 use spacetimedb_physical_plan::{
-    compile::compile_project_plan,
+    compile::compile_select,
     plan::{HashJoin, IxJoin, Label, PhysicalPlan, ProjectPlan},
 };
 use spacetimedb_primitives::TableId;
@@ -40,7 +40,7 @@ impl DeltaPlan {
         let ast = parse_subscription(sql)?;
         let sub = type_subscription(ast, tx)?;
 
-        let Some(table_id) = sub.table_id() else {
+        let Some(table_id) = sub.return_table_id() else {
             bail!("Failed to determine TableId for query")
         };
 
@@ -48,7 +48,7 @@ impl DeltaPlan {
             bail!("TableId `{table_id}` does not exist")
         };
 
-        let plan = compile_project_plan(sub);
+        let plan = compile_select(sub);
 
         let mut ix_joins = true;
         plan.visit(&mut |plan| match plan {


### PR DESCRIPTION
# Description of Changes

DML was still using the old engine. This patch updates it to use the new engine.

NOTE: Internal tests are failing due to a new dependency in core. Hence this pr will merge with internal tests failing, but they will be fixed immediately afterwards.

# API and ABI breaking changes

None

# Expected complexity level and risk

3

There are a few non-trivial changes:

1. `SET` and `SHOW` statements are rewritten as `INSERT` and `SELECT` respectively
2. We have to parse the query to determine if it is a dml statement and therefore whether it should be executed in a mutable or read-only transaction

# Testing

All previous tests still apply
