### PR TITLE
`prop_assume!(a != b)` in some tests to fix spurious failures

### DIFF
--- a/crates/core/proptest-regressions/db/datastore/locking_tx_datastore/delete_table.txt
+++ b/crates/core/proptest-regressions/db/datastore/locking_tx_datastore/delete_table.txt
@@ -5,3 +5,4 @@
 # It is recommended to check this file in to source control so that
 # everyone who runs the test benefits from these saved cases.
 cc 9d74a36309d35ba5b09bd33cbc24f72f95a498152b469caeeeb8c2adf712974c # shrinks to (size, [ptr_a, ptr_b]) = (Size(2), [RowPointer(r: 0, pi: 0, po: 0, so: 1), RowPointer(r: 0, pi: 0, po: 0, so: 1)])
+cc daf4d4880192b4f6d95f928ed49d80465b48ff4fde4ae31aea5cfea3996cdbc6 # shrinks to minimal failing input: (size, [ptr_a, ptr_b]) = (Size(23), [RowPointer(r: 0, pi: 75, po: 828, so: 1), RowPointer(r: 0, pi: 75, po: 828, so: 1)])

--- a/crates/core/src/db/datastore/locking_tx_datastore/delete_table.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/delete_table.rs
@@ -239,6 +239,8 @@ mod test {
     proptest! {
         #[test]
         fn insertion_entails_contained((size, [ptr_a, ptr_b]) in gen_size_and_ptrs()) {
+            prop_assume!(ptr_a != ptr_b);
+
             let mut dt = TestDT::new(size);
 
             // Initially we have nothing.
@@ -266,7 +268,10 @@ mod test {
 
         #[test]
         fn deleting_non_existent_does_nothing((size, [ptr_a, ptr_b]) in gen_size_and_ptrs()) {
+            prop_assume!(ptr_a != ptr_b);
+
             let mut dt = TestDT::new(size);
+
             prop_assert!(!dt.remove(ptr_b));
             prop_assert!(dt.insert(ptr_a));
             prop_assert!(!dt.remove(ptr_b));


### PR DESCRIPTION
# Description of Changes

A rare-ish edge case in a few of our proptests caused spurious failures when the runner generated two equal row pointers. The test was intended to verify behavior with non-equal pointers, and so was not equipped to handle this case. A simple `prop_assume!` call tells the runner to ignore that case.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

- [x] Added proptest regression that exercises this case.