### PR TITLE
Return errors for invariant violations during query planning

### DIFF
--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -59,7 +59,7 @@ impl ModuleSubscriptions {
         auth: &AuthCtx,
     ) -> Result<(SubscriptionUpdate, ExecutionMetrics), DBError> {
         let comp = sender.config.compression;
-        let plan = SubscribePlan::from_delta_plan(&query);
+        let plan = SubscribePlan::from_delta_plan(&query)?;
 
         check_row_limit(
             &plan,
@@ -264,7 +264,7 @@ impl ModuleSubscriptions {
             .iter()
             .map(|plan| &***plan)
             .map(SubscribePlan::from_delta_plan)
-            .collect::<Vec<_>>();
+            .collect::<Result<Vec<_>, _>>()?;
 
         fn rows_scanned(tx: &TxId, plans: &[SubscribePlan]) -> u64 {
             plans

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -82,7 +82,7 @@ pub fn compile_read_only_query(auth: &AuthCtx, tx: &Tx, input: &str) -> Result<P
     let plan = DeltaPlan::compile(&input, &tx)?;
     let hash = QueryHash::from_string(&input);
 
-    Ok(Plan::new(plan, hash))
+    Ok(Plan::new(plan, hash, input.into_owned()))
 }
 
 /// The kind of [`QueryExpr`] currently supported for incremental evaluation.
@@ -752,7 +752,7 @@ mod tests {
         let table_id = plan.table_id();
         let table_name = plan.table_name();
         let tx = DeltaTx::new(&tx, &data);
-        let evaluator = plan.evaluator(&tx);
+        let evaluator = plan.evaluator(&tx).unwrap();
         let updates = eval_delta(&tx, metrics, &evaluator).unwrap();
 
         let inserts = updates

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -621,7 +621,7 @@ pub(crate) fn get_all(relational_db: &RelationalDB, tx: &Tx, auth: &AuthCtx) -> 
         .map(|schema| {
             let sql = format!("SELECT * FROM {}", schema.table_name);
             let hash = QueryHash::from_string(&sql);
-            DeltaPlan::compile(&sql, &SchemaViewer::new(tx, auth)).map(|plan| Plan::new(plan, hash))
+            DeltaPlan::compile(&sql, &SchemaViewer::new(tx, auth)).map(|plan| Plan::new(plan, hash, sql))
         })
         .collect::<Result<_, _>>()?)
 }

--- a/crates/physical-plan/src/dml.rs
+++ b/crates/physical-plan/src/dml.rs
@@ -1,5 +1,6 @@
 use std::sync::Arc;
 
+use anyhow::Result;
 use spacetimedb_expr::{
     expr::{ProjectName, RelExpr, Relvar},
     statement::{TableDelete, TableInsert, TableUpdate},
@@ -19,11 +20,11 @@ pub enum MutationPlan {
 
 impl MutationPlan {
     /// Optimizes the filters in updates and deletes
-    pub fn optimize(self) -> Self {
+    pub fn optimize(self) -> Result<Self> {
         match self {
-            Self::Insert(..) => self,
-            Self::Delete(plan) => Self::Delete(plan.optimize()),
-            Self::Update(plan) => Self::Update(plan.optimize()),
+            Self::Insert(..) => Ok(self),
+            Self::Delete(plan) => Ok(Self::Delete(plan.optimize()?)),
+            Self::Update(plan) => Ok(Self::Update(plan.optimize()?)),
         }
     }
 }
@@ -50,10 +51,10 @@ pub struct DeletePlan {
 
 impl DeletePlan {
     /// Optimize the filter part of the delete
-    fn optimize(self) -> Self {
+    fn optimize(self) -> Result<Self> {
         let Self { table, filter } = self;
-        let filter = filter.optimize();
-        Self { table, filter }
+        let filter = filter.optimize()?;
+        Ok(Self { table, filter })
     }
 
     /// Logical to physical conversion
@@ -84,10 +85,10 @@ pub struct UpdatePlan {
 
 impl UpdatePlan {
     /// Optimize the filter part of the update
-    fn optimize(self) -> Self {
+    fn optimize(self) -> Result<Self> {
         let Self { table, columns, filter } = self;
-        let filter = filter.optimize();
-        Self { columns, table, filter }
+        let filter = filter.optimize()?;
+        Ok(Self { columns, table, filter })
     }
 
     /// Logical to physical conversion

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -4,6 +4,7 @@ use std::{
     sync::Arc,
 };
 
+use anyhow::Result;
 use derive_more::From;
 use spacetimedb_expr::StatementSource;
 use spacetimedb_lib::{query::Delta, sats::size_of::SizeOf, AlgebraicValue, ProductValue};
@@ -66,17 +67,17 @@ impl DerefMut for ProjectPlan {
 }
 
 impl ProjectPlan {
-    pub fn optimize(self) -> Self {
+    pub fn optimize(self) -> Result<Self> {
         match self {
-            Self::None(plan) => Self::None(plan.optimize(vec![])),
+            Self::None(plan) => Ok(Self::None(plan.optimize(vec![])?)),
             Self::Name(plan, label, _) => {
-                let plan = plan.optimize(vec![label]);
+                let plan = plan.optimize(vec![label])?;
                 let n = plan.nfields();
                 let pos = plan.position(&label);
-                match n {
+                Ok(match n {
                     1 => Self::None(plan),
                     _ => Self::Name(plan, label, pos),
-                }
+                })
             }
         }
     }
@@ -114,13 +115,13 @@ impl Deref for ProjectListPlan {
 }
 
 impl ProjectListPlan {
-    pub fn optimize(self) -> Self {
+    pub fn optimize(self) -> Result<Self> {
         match self {
-            Self::Name(plan) => Self::Name(plan.optimize()),
-            Self::List(plan, fields) => Self::List(
-                plan.optimize(fields.iter().map(|TupleField { label, .. }| label).copied().collect()),
+            Self::Name(plan) => Ok(Self::Name(plan.optimize()?)),
+            Self::List(plan, fields) => Ok(Self::List(
+                plan.optimize(fields.iter().map(|TupleField { label, .. }| label).copied().collect())?,
                 fields,
-            ),
+            )),
         }
     }
 }
@@ -228,7 +229,11 @@ impl PhysicalPlan {
 
     /// Applies `f` to a subplan if `ok` returns a match.
     /// Recurses until an `ok` match is found.
-    pub fn map_if<Info>(self, f: impl FnOnce(Self, Info) -> Self, ok: impl Fn(&Self) -> Option<Info>) -> Self {
+    pub fn map_if<Info>(
+        self,
+        f: impl FnOnce(Self, Info) -> Result<Self>,
+        ok: impl Fn(&Self) -> Option<Info>,
+    ) -> Result<Self> {
         if let Some(info) = ok(&self) {
             return f(self, info);
         }
@@ -236,56 +241,56 @@ impl PhysicalPlan {
             // Does `ok` match a subplan?
             plan.any(&|plan| ok(plan).is_some())
         };
-        match self {
+        Ok(match self {
             Self::NLJoin(lhs, rhs) if matches(&lhs) => {
                 // Replace the lhs subtree
-                Self::NLJoin(Box::new(lhs.map_if(f, ok)), rhs)
+                Self::NLJoin(Box::new(lhs.map_if(f, ok)?), rhs)
             }
             Self::NLJoin(lhs, rhs) if matches(&rhs) => {
                 // Replace the rhs subtree
-                Self::NLJoin(lhs, Box::new(rhs.map_if(f, ok)))
+                Self::NLJoin(lhs, Box::new(rhs.map_if(f, ok)?))
             }
             Self::HashJoin(join, semi) if matches(&join.lhs) => Self::HashJoin(
                 HashJoin {
-                    lhs: Box::new(join.lhs.map_if(f, ok)),
+                    lhs: Box::new(join.lhs.map_if(f, ok)?),
                     ..join
                 },
                 semi,
             ),
             Self::HashJoin(join, semi) if matches(&join.rhs) => Self::HashJoin(
                 HashJoin {
-                    rhs: Box::new(join.rhs.map_if(f, ok)),
+                    rhs: Box::new(join.rhs.map_if(f, ok)?),
                     ..join
                 },
                 semi,
             ),
             Self::IxJoin(join, semi) if matches(&join.lhs) => Self::IxJoin(
                 IxJoin {
-                    lhs: Box::new(join.lhs.map_if(f, ok)),
+                    lhs: Box::new(join.lhs.map_if(f, ok)?),
                     ..join
                 },
                 semi,
             ),
             Self::Filter(input, expr) if matches(&input) => {
                 // Replace the input only if there is a match
-                Self::Filter(Box::new(input.map_if(f, ok)), expr)
+                Self::Filter(Box::new(input.map_if(f, ok)?), expr)
             }
             _ => self,
-        }
+        })
     }
 
     /// Applies a rewrite rule once to this plan.
     /// Updates indicator variable if plan was modified.
-    pub fn apply_once<R: RewriteRule<Plan = PhysicalPlan>>(self, ok: &mut bool) -> Self {
+    pub fn apply_once<R: RewriteRule<Plan = PhysicalPlan>>(self, ok: &mut bool) -> Result<Self> {
         if let Some(info) = R::matches(&self) {
             *ok = true;
             return R::rewrite(self, info);
         }
-        self
+        Ok(self)
     }
 
     /// Recursively apply a rule to all subplans until a fixedpoint is reached.
-    pub fn apply_rec<R: RewriteRule<Plan = PhysicalPlan>>(self) -> Self {
+    pub fn apply_rec<R: RewriteRule<Plan = PhysicalPlan>>(self) -> Result<Self> {
         let mut ok = false;
         let plan = self.map_if(
             |plan, info| {
@@ -293,22 +298,22 @@ impl PhysicalPlan {
                 R::rewrite(plan, info)
             },
             R::matches,
-        );
+        )?;
         if ok {
             return plan.apply_rec::<R>();
         }
-        plan
+        Ok(plan)
     }
 
     /// Repeatedly apply a rule until a fixedpoint is reached.
     /// It does not apply rule recursively to subplans.
-    pub fn apply_until<R: RewriteRule<Plan = PhysicalPlan>>(self) -> Self {
+    pub fn apply_until<R: RewriteRule<Plan = PhysicalPlan>>(self) -> Result<Self> {
         let mut ok = false;
-        let plan = self.apply_once::<R>(&mut ok);
+        let plan = self.apply_once::<R>(&mut ok)?;
         if ok {
             return plan.apply_until::<R>();
         }
-        plan
+        Ok(plan)
     }
 
     /// Optimize a plan using the following rewrites:
@@ -318,20 +323,20 @@ impl PhysicalPlan {
     /// 3. Turn filters into index scans if possible
     /// 4. Determine index and semijoins
     /// 5. Compute positions for tuple labels
-    pub fn optimize(self, reqs: Vec<Label>) -> Self {
+    pub fn optimize(self, reqs: Vec<Label>) -> Result<Self> {
         self.map(&Self::canonicalize)
-            .apply_until::<PushConstAnd>()
-            .apply_until::<PushConstEq>()
-            .apply_rec::<ReorderDeltaJoinRhs>()
-            .apply_rec::<PullFilterAboveHashJoin>()
-            .apply_rec::<IxScanEq3Col>()
-            .apply_rec::<IxScanEq2Col>()
-            .apply_rec::<IxScanEq>()
-            .apply_rec::<IxScanAnd>()
-            .apply_rec::<ReorderHashJoin>()
-            .apply_rec::<HashToIxJoin>()
-            .apply_rec::<UniqueIxJoinRule>()
-            .apply_rec::<UniqueHashJoinRule>()
+            .apply_until::<PushConstAnd>()?
+            .apply_until::<PushConstEq>()?
+            .apply_rec::<ReorderDeltaJoinRhs>()?
+            .apply_rec::<PullFilterAboveHashJoin>()?
+            .apply_rec::<IxScanEq3Col>()?
+            .apply_rec::<IxScanEq2Col>()?
+            .apply_rec::<IxScanEq>()?
+            .apply_rec::<IxScanAnd>()?
+            .apply_rec::<ReorderHashJoin>()?
+            .apply_rec::<HashToIxJoin>()?
+            .apply_rec::<UniqueIxJoinRule>()?
+            .apply_rec::<UniqueHashJoinRule>()?
             .introduce_semijoins(reqs)
             .apply_rec::<ComputePositions>()
     }
@@ -1102,7 +1107,7 @@ mod tests {
         let sql = "select * from t";
 
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_select(lp).optimize();
+        let pp = compile_select(lp).optimize().unwrap();
 
         match pp {
             ProjectPlan::None(PhysicalPlan::TableScan(schema, _, _)) => {
@@ -1133,7 +1138,7 @@ mod tests {
         let sql = "select * from t where x = 5";
 
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_select(lp).optimize();
+        let pp = compile_select(lp).optimize().unwrap();
 
         match pp {
             ProjectPlan::None(PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, field, value))) => {
@@ -1232,7 +1237,7 @@ mod tests {
             where u.identity = 5
         ";
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_select(lp).optimize();
+        let pp = compile_select(lp).optimize().unwrap();
 
         // Plan:
         //         rx
@@ -1424,7 +1429,7 @@ mod tests {
             where 5 = m.employee and 5 = v.employee
         ";
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_select(lp).optimize();
+        let pp = compile_select(lp).optimize().unwrap();
 
         // Plan:
         //           rx
@@ -1597,7 +1602,7 @@ mod tests {
 
         let sql = "select * from t where x = 3 and y = 4 and z = 5";
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_select(lp).optimize();
+        let pp = compile_select(lp).optimize().unwrap();
 
         // Select index on (x, y, z)
         match pp {
@@ -1619,7 +1624,7 @@ mod tests {
 
         let sql = "select * from t where x = 3 and y = 4";
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_select(lp).optimize();
+        let pp = compile_select(lp).optimize().unwrap();
 
         // Select index on x
         let plan = match pp {
@@ -1647,7 +1652,7 @@ mod tests {
 
         let sql = "select * from t where w = 5 and x = 4";
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_select(lp).optimize();
+        let pp = compile_select(lp).optimize().unwrap();
 
         // Select index on x
         let plan = match pp {
@@ -1675,7 +1680,7 @@ mod tests {
 
         let sql = "select * from t where y = 1";
         let lp = parse_and_type_sub(sql, &db).unwrap();
-        let pp = compile_select(lp).optimize();
+        let pp = compile_select(lp).optimize().unwrap();
 
         // Do not select index on (y, z)
         match pp {


### PR DESCRIPTION
# Description of Changes

Instead of invoking `unreachable!` in the query rewrite code, now we return an error. An error means we have an internal logic bug, but we don't want the server to panic in that case. Instead we just log the error. There's a TODO for handling the error appropriately in the subscription code.

# API and ABI breaking changes

None

# Expected complexity level and risk

2

Just a return type change and updating callers.

# Testing

A simple refactor so no new tests added.
