### PR TITLE
Register data size metrics for standalone.

### DIFF
--- a/crates/core/src/energy.rs
+++ b/crates/core/src/energy.rs
@@ -24,6 +24,7 @@ pub trait EnergyMonitor: Send + Sync + 'static {
     fn record_memory_usage(&self, database: &Database, replica_id: u64, mem_usage: u64, period: Duration);
 }
 
+// The null energy monitor records nothing and always returns the default budget.
 #[derive(Default)]
 pub struct NullEnergyMonitor;
 

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -12,6 +12,7 @@ use clap::{ArgMatches, Command};
 use energy_monitor::StandaloneEnergyMonitor;
 use spacetimedb::client::ClientActorIndex;
 use spacetimedb::config::{CertificateAuthority, MetadataFile};
+use spacetimedb::db::db_metrics::data_size::DATA_SIZE_METRICS;
 use spacetimedb::db::relational_db::{self, Durability, Txdata};
 use spacetimedb::db::{db_metrics::DB_METRICS, Config};
 use spacetimedb::energy::{EnergyBalance, EnergyQuanta};
@@ -82,6 +83,7 @@ impl StandaloneEnv {
         let metrics_registry = prometheus::Registry::new();
         metrics_registry.register(Box::new(&*WORKER_METRICS)).unwrap();
         metrics_registry.register(Box::new(&*DB_METRICS)).unwrap();
+        metrics_registry.register(Box::new(&*DATA_SIZE_METRICS)).unwrap();
 
         Ok(Arc::new(Self {
             control_db,


### PR DESCRIPTION
# Description of Changes

This registers the recently added datasize metrics with our other prometheus stats.

There is also a random one-line comment in a different part of the code that wasn't worth its own PR.

# Expected complexity level and risk

1

# Testing

If you wanted to verify this manually, you could run a standalone instance with data, curl the `/metrics` endpoint, and look for the data size metrics.
