### PR TITLE
Add metrics for fuel usage and reducer runtime totals.

### DIFF
--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -90,6 +90,21 @@ metrics_group!(
         #[help = "The number of bytes in a table with the precision of a page size"]
         #[labels(db: Identity, table_id: u32, table_name: str)]
         pub rdb_table_size: IntGaugeVec,
+
+        #[name = reducer_wasmtime_fuel_used]
+        #[help = "The total wasmtime fuel used"]
+        #[labels(db: Identity, reducer: str)]
+        pub reducer_wasmtime_fuel_used: IntCounterVec,
+
+        #[name = reducer_wasm_time_usec]
+        #[help = "The total runtime of reducer calls"]
+        #[labels(db: Identity, reducer: str)]
+        pub reducer_duration_usec: IntCounterVec,
+
+        #[name = reducer_abi_time_usec]
+        #[help = "The total time spent in reducer ABI calls"]
+        #[labels(db: Identity, reducer: str)]
+        pub reducer_abi_time_usec: IntCounterVec,
     }
 );
 

--- a/crates/core/src/host/wasm_common/instrumentation.rs
+++ b/crates/core/src/host/wasm_common/instrumentation.rs
@@ -104,6 +104,10 @@ impl CallTimes {
         self.times[span.call] += span.duration;
     }
 
+    pub fn sum(&self) -> Duration {
+        self.times.values().sum()
+    }
+
     /// Taking the record of call times gives a copy of the
     /// current values and resets the values to zero.
     ///

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -14,6 +14,7 @@ use crate::database_logger::{self, SystemLogger};
 use crate::db::datastore::locking_tx_datastore::MutTxId;
 use crate::db::datastore::system_tables::{StClientRow, ST_CLIENT_ID};
 use crate::db::datastore::traits::{IsolationLevel, Program};
+use crate::db::db_metrics::DB_METRICS;
 use crate::energy::{EnergyMonitor, EnergyQuanta, ReducerBudget, ReducerFingerprint};
 use crate::execution_context::{self, ReducerContext, Workload};
 use crate::host::instance_env::InstanceEnv;
@@ -65,6 +66,7 @@ pub trait WasmInstance: Send + Sync + 'static {
 
 pub struct EnergyStats {
     pub used: EnergyQuanta,
+    pub wasmtime_fuel_used: u64,
     pub remaining: ReducerBudget,
 }
 
@@ -474,6 +476,18 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
             call_result,
         } = result;
 
+        DB_METRICS
+            .reducer_wasmtime_fuel_used
+            .with_label_values(&database_identity, reducer_name)
+            .inc_by(energy.wasmtime_fuel_used);
+        DB_METRICS
+            .reducer_duration_usec
+            .with_label_values(&database_identity, reducer_name)
+            .inc_by(timings.total_duration.as_micros() as u64);
+        DB_METRICS
+            .reducer_abi_time_usec
+            .with_label_values(&database_identity, reducer_name)
+            .inc_by(timings.wasm_instance_env_call_times.sum().as_micros() as u64);
         self.energy_monitor
             .record_reducer(&energy_fingerprint, energy.used, timings.total_duration);
         if self.allocated_memory != memory_allocation {

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -72,7 +72,6 @@ pub struct EnergyStats {
 
 pub struct ExecutionTimings {
     pub total_duration: Duration,
-    #[expect(unused)] // TODO: do we want to do something with this?
     pub wasm_instance_env_call_times: CallTimes,
 }
 
@@ -488,6 +487,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
             .reducer_abi_time_usec
             .with_label_values(&database_identity, reducer_name)
             .inc_by(timings.wasm_instance_env_call_times.sum().as_micros() as u64);
+
         self.energy_monitor
             .record_reducer(&energy_fingerprint, energy.used, timings.total_duration);
         if self.allocated_memory != memory_allocation {

--- a/crates/core/src/host/wasmtime/wasmtime_module.rs
+++ b/crates/core/src/host/wasmtime/wasmtime_module.rs
@@ -192,6 +192,7 @@ impl module_host_actor::WasmInstance for WasmtimeInstance {
         // EnergyQuanta at the end of this function, from_energy_quanta clamps it to a u64 range.
         // otherwise, we'd return something like `used: i128::MAX - u64::MAX`, which is inaccurate.
         set_store_fuel(store, budget.into());
+        let original_fuel = get_store_fuel(store);
 
         // Prepare sender identity and address, as LITTLE-ENDIAN byte arrays.
         let [sender_0, sender_1, sender_2, sender_3] = bytemuck::must_cast(op.caller_identity.to_byte_array());
@@ -223,9 +224,12 @@ impl module_host_actor::WasmInstance for WasmtimeInstance {
 
         let call_result = call_result.map(|code| handle_error_sink_code(code, error));
 
-        let remaining: ReducerBudget = get_store_fuel(store).into();
+        let remaining_fuel = get_store_fuel(store);
+
+        let remaining: ReducerBudget = remaining_fuel.into();
         let energy = module_host_actor::EnergyStats {
             used: (budget - remaining).into(),
+            wasmtime_fuel_used: original_fuel.0 - remaining_fuel.0,
             remaining,
         };
         let memory_allocation = store.data().get_mem().memory.data_size(&store);


### PR DESCRIPTION
# Description of Changes

This adds some metrics for reducer runtime and wasmtime fuel usage.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1

# Testing

I manually tested a version of this on a different branch. By running some reducers and looking at the stats.
