### PR TITLE
CLI - Better module language inference

### DIFF
--- a/crates/cli/src/tasks/mod.rs
+++ b/crates/cli/src/tasks/mod.rs
@@ -8,7 +8,7 @@ use crate::tasks::rust::build_rust;
 use duct::cmd;
 
 pub fn build(project_path: &Path, lint_dir: Option<&Path>, build_debug: bool) -> anyhow::Result<PathBuf> {
-    let lang = util::detect_module_language(project_path);
+    let lang = util::detect_module_language(project_path)?;
     let mut wasm_path = match lang {
         ModuleLanguage::Rust => build_rust(project_path, lint_dir, build_debug),
         ModuleLanguage::Csharp => build_csharp(project_path, build_debug),

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -209,13 +209,19 @@ impl clap::ValueEnum for ModuleLanguage {
     }
 }
 
-pub fn detect_module_language(path_to_project: &Path) -> ModuleLanguage {
+pub fn detect_module_language(path_to_project: &Path) -> anyhow::Result<ModuleLanguage> {
     // TODO: Possible add a config file durlng spacetime init with the language
     // check for Cargo.toml
     if path_to_project.join("Cargo.toml").exists() {
-        ModuleLanguage::Rust
+        Ok(ModuleLanguage::Rust)
+    } else if path_to_project
+        .read_dir()
+        .unwrap()
+        .any(|entry| entry.unwrap().path().extension() == Some("csproj".as_ref()))
+    {
+        Ok(ModuleLanguage::Csharp)
     } else {
-        ModuleLanguage::Csharp
+        anyhow::bail!("Could not detect the language of the module. Are you in a SpacetimeDB project directory?")
     }
 }
 


### PR DESCRIPTION
# Description of Changes

We used to assume a project was a rust project if it had a `Cargo.toml`, and otherwise assume that it's a .NET project. Now we do something _slightly_ smarter, where we only assume it's a .NET project if there's a `*.csproj` file (and error otherwise).

Fixes #2136 .

# API and ABI breaking changes

No, not for projects that are in any format we expect.

# Expected complexity level and risk

1

# Testing

- [x] No `Cargo.toml` or `*.csproj` causes an error:
```
$ mkdir test-project && cd test-project
$ spacetimedb-cli publish -s local foo
Error: Could not detect the language of the module. Are you in a SpacetimeDB project directory?
```

- [x] A `.csproj` file causes the project to be treated as .NET
```
$ mkdir test-project && cd test-project
$ touch Foo.csproj
$ spacetimedb-cli publish -s local foo
MSBuild version 17.8.5+b5265ef37 for .NET
/mnt/nutera/work/foo/Foo.csproj : error MSB4025: The project file could not be loaded. Root element is missing.
Error: command ["dotnet", "publish", "-c", "Release", "-v", "quiet"] exited with code 1
```

- [x] A `Cargo.toml` causes the project to be treated as Rust:
```
$ mkdir test-project && cd test-project
$ touch Cargo.toml && mkdir src
$ spacetimedb-cli publish -s local foo
error: failed to parse manifest at `/mnt/nutera/work/foo/Cargo.toml`

Caused by:
  manifest is missing either a `[package]` or a `[workspace]`
Error: command ["cargo", "build", "--config=net.git-fetch-with-cli=true", "--target=wasm32-unknown-unknown", "--release", "--message-format=json-render-diagnostics"] exited with code 101
```