### PR TITLE
CLI - Clarify helptext for `spacetime login`

### DIFF
--- a/crates/cli/src/subcommands/login.rs
+++ b/crates/cli/src/subcommands/login.rs
@@ -31,7 +31,7 @@ pub fn cli() -> Command {
                 .group("login-method")
                 .help("Bypass the login flow and use a login token directly"),
         )
-        .about("Log the CLI in to SpacetimeDB")
+        .about("Manage your login to the SpacetimeDB CLI")
 }
 
 fn get_subcommands() -> Vec<Command> {


### PR DESCRIPTION
# Description of Changes

The helptext used to just say "log in to spacetimedb" which conflicted with e.g. `spacetime login show` which just displayed login info.

# API and ABI breaking changes

No

# Expected complexity level and risk

1

# Testing

```
$ cargo run -- login help
Manage your login to the SpacetimeDB CLI

Usage: spacetimedb-cli login [OPTIONS]
       spacetimedb-cli login <COMMAND>

Commands:
  show  Show the current login info
  help  Print this message or the help of the given subcommand(s)

Options:
      --auth-host <auth-host>         Fetch login token from a different host [default: https://spacetimedb.com]
      --server-issued-login <server>  Log in to a SpacetimeDB server directly, without going through a global auth server
      --token <spacetimedb-token>     Bypass the login flow and use a login token directly
  -h, --help                          Print help
```