### PR TITLE
Error handling for incremental evaluation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5654,6 +5654,7 @@ dependencies = [
  "futures",
  "glob",
  "itertools 0.12.1",
+ "parking_lot 0.12.3",
  "postgres-types",
  "quick-junit",
  "rusqlite",

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -12,12 +12,13 @@ use crate::messages::control_db::{Database, HostType};
 use crate::module_host_context::ModuleCreationContext;
 use crate::replica_context::ReplicaContext;
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
+use crate::subscription::module_subscription_manager::SubscriptionManager;
 use crate::util::spawn_rayon;
 use anyhow::{anyhow, ensure, Context};
 use async_trait::async_trait;
 use durability::{Durability, EmptyHistory};
 use log::{info, trace, warn};
-use parking_lot::Mutex;
+use parking_lot::{Mutex, RwLock};
 use serde::Serialize;
 use spacetimedb_data_structures::map::IntMap;
 use spacetimedb_durability as durability;
@@ -532,7 +533,24 @@ async fn make_replica_ctx(
     relational_db: Arc<RelationalDB>,
 ) -> anyhow::Result<ReplicaContext> {
     let logger = tokio::task::block_in_place(move || Arc::new(DatabaseLogger::open_today(path.module_logs())));
-    let subscriptions = ModuleSubscriptions::new(relational_db.clone(), database.owner_identity);
+    let subscriptions = Arc::new(RwLock::new(SubscriptionManager::default()));
+    let manager = subscriptions.clone();
+    let subscriptions = ModuleSubscriptions::new(relational_db.clone(), subscriptions, database.owner_identity);
+
+    // If an error occurs when evaluating a subscription,
+    // we mark each client that was affected,
+    // and we remove those clients from the manager async.
+    tokio::spawn(async move {
+        loop {
+            tokio::time::sleep(Duration::from_secs(10)).await;
+            let subscriptions = manager.clone();
+            tokio::task::spawn_blocking(move || {
+                subscriptions.write().remove_dropped_clients();
+            })
+            .await
+            .unwrap();
+        }
+    });
 
     Ok(ReplicaContext {
         database,

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -437,6 +437,7 @@ mod test {
     use std::{ops::Bound, sync::Arc};
 
     use anyhow::{anyhow, Result};
+    use parking_lot::RwLock;
     use spacetimedb_lib::{bsatn::to_vec, AlgebraicType, AlgebraicValue, Hash, Identity, ProductValue};
     use spacetimedb_paths::{server::ModuleLogsDir, FromPathUnchecked};
     use spacetimedb_primitives::{IndexId, TableId};
@@ -453,7 +454,9 @@ mod test {
         host::Scheduler,
         messages::control_db::{Database, HostType},
         replica_context::ReplicaContext,
-        subscription::module_subscription_actor::ModuleSubscriptions,
+        subscription::{
+            module_subscription_actor::ModuleSubscriptions, module_subscription_manager::SubscriptionManager,
+        },
     };
 
     use super::{ChunkPool, InstanceEnv, TxSlot};
@@ -468,7 +471,11 @@ mod test {
 
     /// An `InstanceEnv` requires `ModuleSubscriptions`
     fn subscription_actor(relational_db: Arc<RelationalDB>) -> ModuleSubscriptions {
-        ModuleSubscriptions::new(relational_db, Identity::ZERO)
+        ModuleSubscriptions::new(
+            relational_db,
+            Arc::new(RwLock::new(SubscriptionManager::default())),
+            Identity::ZERO,
+        )
     }
 
     /// An `InstanceEnv` requires a `ReplicaContext`.

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -282,7 +282,9 @@ pub(crate) mod tests {
     use super::*;
     use crate::db::datastore::system_tables::{StTableFields, ST_TABLE_ID, ST_TABLE_NAME};
     use crate::db::relational_db::tests_utils::{insert, TestDB};
+    use crate::subscription::module_subscription_manager::SubscriptionManager;
     use crate::vm::tests::create_table_with_rows;
+    use parking_lot::RwLock;
     use pretty_assertions::assert_eq;
     use spacetimedb_lib::db::auth::{StAccess, StTableType};
     use spacetimedb_lib::error::{ResultTest, TestError};
@@ -298,13 +300,21 @@ pub(crate) mod tests {
         sql_text: &str,
         q: Vec<CrudExpr>,
     ) -> Result<Vec<MemTable>, DBError> {
-        let subs = ModuleSubscriptions::new(Arc::new(db.clone()), Identity::ZERO);
+        let subs = ModuleSubscriptions::new(
+            Arc::new(db.clone()),
+            Arc::new(RwLock::new(SubscriptionManager::default())),
+            Identity::ZERO,
+        );
         execute_sql(db, sql_text, q, AuthCtx::for_testing(), Some(&subs))
     }
 
     /// Short-cut for simplify test execution
     pub(crate) fn run_for_testing(db: &RelationalDB, sql_text: &str) -> Result<Vec<ProductValue>, DBError> {
-        let subs = ModuleSubscriptions::new(Arc::new(db.clone()), Identity::ZERO);
+        let subs = ModuleSubscriptions::new(
+            Arc::new(db.clone()),
+            Arc::new(RwLock::new(SubscriptionManager::default())),
+            Identity::ZERO,
+        );
         run(db, sql_text, AuthCtx::for_testing(), Some(&subs), &mut vec![])
     }
 

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -43,10 +43,10 @@ type AssertTxFn = Arc<dyn Fn(&Tx)>;
 type SubscriptionUpdate = FormatSwitch<TableUpdate<BsatnFormat>, TableUpdate<JsonFormat>>;
 
 impl ModuleSubscriptions {
-    pub fn new(relational_db: Arc<RelationalDB>, owner_identity: Identity) -> Self {
+    pub fn new(relational_db: Arc<RelationalDB>, subscriptions: Subscriptions, owner_identity: Identity) -> Self {
         Self {
             relational_db,
-            subscriptions: Arc::new(RwLock::new(SubscriptionManager::default())),
+            subscriptions,
             owner_identity,
         }
     }
@@ -429,6 +429,8 @@ mod tests {
     use crate::db::relational_db::RelationalDB;
     use crate::error::DBError;
     use crate::execution_context::Workload;
+    use crate::subscription::module_subscription_manager::SubscriptionManager;
+    use parking_lot::RwLock;
     use spacetimedb_client_api_messages::websocket::Subscribe;
     use spacetimedb_lib::db::auth::StAccess;
     use spacetimedb_lib::{error::ResultTest, AlgebraicType, Identity};
@@ -442,7 +444,8 @@ mod tests {
         let client = ClientActorId::for_test(Identity::ZERO);
         let config = ClientConfig::for_test();
         let sender = Arc::new(ClientConnectionSender::dummy(client, config));
-        let module_subscriptions = ModuleSubscriptions::new(db.clone(), owner);
+        let module_subscriptions =
+            ModuleSubscriptions::new(db.clone(), Arc::new(RwLock::new(SubscriptionManager::default())), owner);
 
         let subscribe = Subscribe {
             query_strings: [sql.into()].into(),

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -424,16 +424,22 @@ pub struct WriteConflict;
 #[cfg(test)]
 mod tests {
     use super::{AssertTxFn, ModuleSubscriptions};
+    use crate::client::messages::{SerializableMessage, SubscriptionMessage, SubscriptionResult};
     use crate::client::{ClientActorId, ClientConfig, ClientConnectionSender};
+    use crate::db::datastore::traits::IsolationLevel;
     use crate::db::relational_db::tests_utils::{insert, TestDB};
     use crate::db::relational_db::RelationalDB;
     use crate::error::DBError;
     use crate::execution_context::Workload;
+    use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent, ModuleFunctionCall};
     use crate::subscription::module_subscription_manager::SubscriptionManager;
     use parking_lot::RwLock;
-    use spacetimedb_client_api_messages::websocket::Subscribe;
+    use spacetimedb_client_api_messages::energy::EnergyQuanta;
+    use spacetimedb_client_api_messages::websocket::{QueryId, Subscribe, SubscribeSingle, Unsubscribe};
     use spacetimedb_lib::db::auth::StAccess;
+    use spacetimedb_lib::{bsatn, Timestamp};
     use spacetimedb_lib::{error::ResultTest, AlgebraicType, Identity};
+    use spacetimedb_primitives::{IndexId, TableId};
     use spacetimedb_sats::product;
     use std::time::Instant;
     use std::{sync::Arc, time::Duration};
@@ -452,6 +458,217 @@ mod tests {
             request_id: 0,
         };
         module_subscriptions.add_legacy_subscriber(sender, subscribe, Instant::now(), assert)
+    }
+
+    /// An in-memory `RelationalDB` for testing
+    fn relational_db() -> anyhow::Result<Arc<RelationalDB>> {
+        let TestDB { db, .. } = TestDB::in_memory()?;
+        Ok(Arc::new(db))
+    }
+
+    /// Initialize a module [SubscriptionManager]
+    fn module_subscriptions(db: Arc<RelationalDB>) -> ModuleSubscriptions {
+        ModuleSubscriptions::new(
+            db,
+            Arc::new(RwLock::new(SubscriptionManager::default())),
+            Identity::ZERO,
+        )
+    }
+
+    /// Return a client connection for testing
+    fn sender_with_rx() -> (Arc<ClientConnectionSender>, mpsc::Receiver<SerializableMessage>) {
+        let client = ClientActorId::for_test(Identity::ZERO);
+        let config = ClientConfig::for_test();
+        let (sender, rx) = ClientConnectionSender::dummy_with_channel(client, config);
+        (Arc::new(sender), rx)
+    }
+
+    /// A [SubscribeSingle] message for testing
+    fn single_subscribe(sql: &str, query_id: u32) -> SubscribeSingle {
+        SubscribeSingle {
+            query: sql.into(),
+            request_id: 0,
+            query_id: QueryId::new(query_id),
+        }
+    }
+
+    /// An [Unsubscribe] message for testing
+    fn single_unsubscribe(query_id: u32) -> Unsubscribe {
+        Unsubscribe {
+            request_id: 0,
+            query_id: QueryId::new(query_id),
+        }
+    }
+
+    /// A dummy [ModuleEvent] for testing
+    fn module_event() -> ModuleEvent {
+        ModuleEvent {
+            timestamp: Timestamp::now(),
+            caller_identity: Identity::ZERO,
+            caller_address: None,
+            function_call: ModuleFunctionCall::default(),
+            status: EventStatus::Committed(DatabaseUpdate::default()),
+            energy_quanta_used: EnergyQuanta { quanta: 0 },
+            host_execution_duration: Duration::from_millis(0),
+            request_id: None,
+            timer: None,
+        }
+    }
+
+    /// Creates a single row, single column table with an index
+    fn create_table_with_index(db: &RelationalDB, name: &str) -> anyhow::Result<(TableId, IndexId)> {
+        let table_id = db.create_table_for_test(name, &[("id", AlgebraicType::U64)], &[0.into()])?;
+        let index_id = db.with_read_only(Workload::ForTests, |tx| {
+            db.schema_for_table(tx, table_id)?
+                .indexes
+                .iter()
+                .find(|schema| {
+                    schema
+                        .index_algorithm
+                        .columns()
+                        .as_singleton()
+                        .is_some_and(|col_id| col_id.idx() == 0)
+                })
+                .map(|schema| schema.index_id)
+                .ok_or_else(|| anyhow::anyhow!("Index not found for ColId `{}`", 0))
+        })?;
+        db.with_auto_commit(Workload::ForTests, |tx| {
+            db.insert(tx, table_id, &bsatn::to_vec(&product![1_u64])?)?;
+            Ok((table_id, index_id))
+        })
+    }
+
+    #[tokio::test]
+    async fn subscribe_error() -> anyhow::Result<()> {
+        let (sender, mut rx) = sender_with_rx();
+        let db = relational_db()?;
+        let subs = module_subscriptions(db.clone());
+
+        // Create a table `t` with index on `id`
+        create_table_with_index(&db, "t")?;
+
+        let subscribe = || -> anyhow::Result<()> {
+            // Invalid query: t does not have a field x
+            let sql = "select * from t where x = 1";
+            subs.add_subscription(sender.clone(), single_subscribe(sql, 0), Instant::now(), None)?;
+            Ok(())
+        };
+
+        subscribe()?;
+
+        assert!(matches!(
+            rx.recv().await,
+            Some(SerializableMessage::Subscription(SubscriptionMessage {
+                result: SubscriptionResult::Error(..),
+                ..
+            }))
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn unsubscribe_error() -> anyhow::Result<()> {
+        let (sender, mut rx) = sender_with_rx();
+        let db = relational_db()?;
+        let subs = module_subscriptions(db.clone());
+
+        // Create a table `t` with an index on `id`
+        let (_, index_id) = create_table_with_index(&db, "t")?;
+
+        let subscribe = || -> anyhow::Result<()> {
+            let sql = "select * from t where id = 1";
+            subs.add_subscription(sender.clone(), single_subscribe(sql, 0), Instant::now(), None)?;
+            Ok(())
+        };
+
+        let unsubscribe = || -> anyhow::Result<()> {
+            subs.remove_subscription(sender.clone(), single_unsubscribe(0), Instant::now())?;
+            Ok(())
+        };
+
+        subscribe()?;
+
+        // The initial subscription should succeed
+        assert!(matches!(
+            rx.recv().await,
+            Some(SerializableMessage::Subscription(SubscriptionMessage {
+                result: SubscriptionResult::Subscribe(..),
+                ..
+            }))
+        ));
+
+        // Remove the index from `id`
+        db.with_auto_commit(Workload::ForTests, |tx| db.drop_index(tx, index_id))?;
+
+        unsubscribe()?;
+
+        // Why does the unsubscribe fail?
+        // This relies on some knowledge of the underlying implementation.
+        // Specifically that we do not recompile queries on unsubscribe.
+        // We execute the cached plan which in this case is an index scan.
+        // The index no longer exists, and therefore it fails.
+        assert!(matches!(
+            rx.recv().await,
+            Some(SerializableMessage::Subscription(SubscriptionMessage {
+                result: SubscriptionResult::Error(..),
+                ..
+            }))
+        ));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn tx_update_error() -> anyhow::Result<()> {
+        let (sender, mut rx) = sender_with_rx();
+        let db = relational_db()?;
+        let subs = module_subscriptions(db.clone());
+
+        // Create two tables `t` and `s` with indexes on their `id` columns
+        let (table_id, _index_id) = create_table_with_index(&db, "t")?;
+        let (_table_id, index_id) = create_table_with_index(&db, "s")?;
+
+        let subscribe = || -> anyhow::Result<()> {
+            let sql = "select t.* from t join s on t.id = s.id";
+            subs.add_subscription(sender.clone(), single_subscribe(sql, 0), Instant::now(), None)?;
+            Ok(())
+        };
+
+        subscribe()?;
+
+        // The initial subscription should succeed
+        assert!(matches!(
+            rx.recv().await,
+            Some(SerializableMessage::Subscription(SubscriptionMessage {
+                result: SubscriptionResult::Subscribe(..),
+                ..
+            }))
+        ));
+
+        // Remove the index from `s`
+        db.with_auto_commit(Workload::ForTests, |tx| db.drop_index(tx, index_id))?;
+
+        // Start a new transaction and insert a new row into `t`
+        let mut tx = db.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
+        db.insert(&mut tx, table_id, &bsatn::to_vec(&product![2_u64])?)?;
+
+        assert!(matches!(
+            subs.commit_and_broadcast_event(None, module_event(), tx),
+            Ok(Ok(_))
+        ));
+
+        // Why does the update fail?
+        // This relies on some knowledge of the underlying implementation.
+        // Specifically, plans are cached on the initial subscribe.
+        // Hence we execute a cached plan which happens to be an index join.
+        // We've removed the index on `s`, and therefore it fails.
+        assert!(matches!(
+            rx.recv().await,
+            Some(SerializableMessage::Subscription(SubscriptionMessage {
+                result: SubscriptionResult::Error(..),
+                ..
+            }))
+        ));
+        Ok(())
     }
 
     /// Asserts that a subscription holds a tx handle for the entire length of its evaluation.

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -203,6 +203,17 @@ impl SubscriptionManager {
         }
     }
 
+    /// Remove any clients that have been marked for removal
+    pub fn remove_dropped_clients(&mut self) {
+        for id in self.clients.keys().copied().collect::<Vec<_>>() {
+            if let Some(client) = self.clients.get(&id) {
+                if client.dropped.load(Ordering::Relaxed) {
+                    self.remove_all_subscriptions(&id);
+                }
+            }
+        }
+    }
+
     /// Remove a single subscription for a client.
     /// This will return an error if the client does not have a subscription with the given query id.
     pub fn remove_subscription(&mut self, client_id: ClientId, query_id: ClientQueryId) -> Result<Query, DBError> {

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -143,6 +143,10 @@ impl SubscriptionManager {
         self.queries.get(hash).map(|state| state.query.clone())
     }
 
+    /// Return all clients that are subscribed to a particular query.
+    /// Note this method filters out clients that have been dropped.
+    /// If you need all clients currently maintained by the manager,
+    /// regardless of drop status, do not use this method.
     pub fn clients_for_query(&self, hash: &QueryHash) -> impl Iterator<Item = &ClientId> {
         self.queries
             .get(hash)

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -1,6 +1,9 @@
 use super::execution_unit::QueryHash;
 use super::tx::DeltaTx;
-use crate::client::messages::{SubscriptionUpdateMessage, TransactionUpdateMessage};
+use crate::client::messages::{
+    SerializableMessage, SubscriptionError, SubscriptionMessage, SubscriptionResult, SubscriptionUpdateMessage,
+    TransactionUpdateMessage,
+};
 use crate::client::{ClientConnectionSender, Protocol};
 use crate::error::DBError;
 use crate::execution_context::WorkloadType;
@@ -9,16 +12,18 @@ use crate::messages::websocket::{self as ws, TableUpdate};
 use crate::subscription::delta::eval_delta;
 use crate::subscription::record_exec_metrics;
 use hashbrown::hash_map::OccupiedError;
+use hashbrown::{HashMap, HashSet};
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use spacetimedb_client_api_messages::websocket::{
     BsatnFormat, CompressableQueryUpdate, FormatSwitch, JsonFormat, QueryId, QueryUpdate, WebsocketFormat,
 };
-use spacetimedb_data_structures::map::{Entry, HashCollectionExt, HashMap, HashSet, IntMap};
+use spacetimedb_data_structures::map::{Entry, IntMap};
 use spacetimedb_lib::metrics::ExecutionMetrics;
 use spacetimedb_lib::{Address, Identity};
 use spacetimedb_primitives::TableId;
 use spacetimedb_subscription::SubscriptionPlan;
 use std::ops::Deref;
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
 /// Clients are uniquely identified by their Identity and Address.
@@ -66,6 +71,9 @@ struct ClientInfo {
     subscriptions: HashMap<SubscriptionId, QueryHash>,
     // This should be removed when we migrate to SubscribeSingle.
     legacy_subscriptions: HashSet<QueryHash>,
+    // This flag is set if an error occurs during a tx update.
+    // It will be cleaned up async or on resubscribe.
+    dropped: AtomicBool,
 }
 
 impl ClientInfo {
@@ -74,6 +82,7 @@ impl ClientInfo {
             outbound_ref,
             subscriptions: HashMap::default(),
             legacy_subscriptions: HashSet::default(),
+            dropped: AtomicBool::new(false),
         }
     }
 }
@@ -134,6 +143,18 @@ impl SubscriptionManager {
         self.queries.get(hash).map(|state| state.query.clone())
     }
 
+    pub fn clients_for_query(&self, hash: &QueryHash) -> impl Iterator<Item = &ClientId> {
+        self.queries
+            .get(hash)
+            .into_iter()
+            .flat_map(|query| query.all_clients())
+            .filter(|id| {
+                self.clients
+                    .get(*id)
+                    .is_some_and(|info| !info.dropped.load(Ordering::Acquire))
+            })
+    }
+
     pub fn num_unique_queries(&self) -> usize {
         self.queries.len()
     }
@@ -189,7 +210,9 @@ impl SubscriptionManager {
         let Some(ci) = self.clients.get_mut(&client_id) else {
             return Err(anyhow::anyhow!("Client not found: {:?}", client_id).into());
         };
-
+        if ci.dropped.load(Ordering::Acquire) {
+            return Err(anyhow::anyhow!("Client not found: {:?}", client_id).into());
+        }
         let Some(query_hash) = ci.subscriptions.remove(&subscription_id) else {
             return Err(anyhow::anyhow!("Subscription not found: {:?}", subscription_id).into());
         };
@@ -209,6 +232,16 @@ impl SubscriptionManager {
     /// Adds a single subscription for a client.
     pub fn add_subscription(&mut self, client: Client, query: Query, query_id: ClientQueryId) -> Result<(), DBError> {
         let client_id = (client.id.identity, client.id.address);
+
+        // Clean up any dropped subscriptions
+        if self
+            .clients
+            .get(&client_id)
+            .is_some_and(|ci| ci.dropped.load(Ordering::Acquire))
+        {
+            self.remove_all_subscriptions(&client_id);
+        }
+
         let ci = self
             .clients
             .entry(client_id)
@@ -333,7 +366,7 @@ impl SubscriptionManager {
         // Put the main work on a rayon compute thread.
         rayon::scope(|_| {
             let span = tracing::info_span!("eval_incr").entered();
-            let (updates, metrics) = tables
+            let (updates, errs, metrics) = tables
                 .iter()
                 .filter(|table| !table.inserts.is_empty() || !table.deletes.is_empty())
                 .map(|DatabaseTableUpdate { table_id, .. }| table_id)
@@ -385,26 +418,19 @@ impl SubscriptionManager {
                         (update, num_rows)
                     }
 
-                    let delta_updates_opt = match eval_delta(tx, &mut metrics, plan) {
-                        Ok(delta_updates) => Some(delta_updates),
-                        Err(err) => {
-                            // TODO: Handle errors instead of just logging them
+                    let updates = eval_delta(tx, &mut metrics, plan)
+                        .map_err(|err| {
                             tracing::error!(
                                 message = "Query errored during tx update",
                                 sql = plan.sql,
                                 reason = ?err,
                             );
-                            None
-                        }
-                    };
-
-                    let updates = delta_updates_opt
-                        .filter(|delta_updates| delta_updates.has_updates())
+                            self.clients_for_query(hash)
+                                .map(|id| (id, err.to_string().into_boxed_str()))
+                                .collect::<Vec<_>>()
+                        })
                         .map(|delta_updates| {
-                            self.queries
-                                .get(hash)
-                                .into_iter()
-                                .flat_map(|query| query.all_clients())
+                            self.clients_for_query(hash)
                                 .map(|id| {
                                     let client = &self.clients[id].outbound_ref;
                                     let update = match client.config.protocol {
@@ -424,24 +450,41 @@ impl SubscriptionManager {
                                     (id, table_id, table_name.clone(), update)
                                 })
                                 .collect::<Vec<_>>()
-                        })
-                        .unwrap_or_default();
+                        });
 
                     (updates, metrics)
                 })
-                .reduce(
-                    || (vec![], ExecutionMetrics::default()),
-                    |(mut updates, mut aggregated_metrics), (table_upates, metrics)| {
-                        updates.extend(table_upates);
-                        aggregated_metrics.merge(metrics);
-                        (updates, aggregated_metrics)
+                .fold(
+                    || (vec![], vec![], ExecutionMetrics::default()),
+                    |(mut rows, mut errs, mut agg_metrics), (result, metrics)| {
+                        match result {
+                            Ok(x) => {
+                                rows.extend(x);
+                            }
+                            Err(x) => {
+                                errs.extend(x);
+                            }
+                        }
+                        agg_metrics.merge(metrics);
+                        (rows, errs, agg_metrics)
                     },
-                );
+                )
+                .reduce_with(|(mut acc_rows, mut acc_errs, mut acc_metrics), (rows, errs, metrics)| {
+                    acc_rows.extend(rows);
+                    acc_errs.extend(errs);
+                    acc_metrics.merge(metrics);
+                    (acc_rows, acc_errs, acc_metrics)
+                })
+                .unwrap_or_default();
 
             record_exec_metrics(&WorkloadType::Update, database_identity, metrics);
 
+            let clients_with_errors = errs.iter().map(|(id, _)| id).collect::<HashSet<_>>();
+
             let mut eval = updates
                 .into_iter()
+                // Filter out clients whose subscriptions failed
+                .filter(|(id, ..)| !clients_with_errors.contains(id))
                 // For each subscriber, aggregate all the updates for the same table.
                 // That is, we build a map `(subscriber_id, table_id) -> updates`.
                 // A particular subscriber uses only one format,
@@ -482,6 +525,8 @@ impl SubscriptionManager {
                         updates
                     },
                 );
+
+            drop(clients_with_errors);
             drop(span);
 
             let _span = tracing::info_span!("eval_send").entered();
@@ -493,33 +538,53 @@ impl SubscriptionManager {
             // is a full tx update, rather than a light one.
             // That is, in the case of the caller, we don't respect the light setting.
             if let Some((caller, addr)) = caller.zip(event.caller_address) {
-                let update = eval
+                let database_update = eval
                     .remove(&(event.caller_identity, addr))
                     .map(|update| SubscriptionUpdateMessage::from_event_and_update(&event, update))
                     .unwrap_or_else(|| {
                         SubscriptionUpdateMessage::default_for_protocol(caller.config.protocol, event.request_id)
                     });
-                send_to_client(caller, Some(event.clone()), update);
+                let message = TransactionUpdateMessage {
+                    event: Some(event.clone()),
+                    database_update,
+                };
+                send_to_client(caller, message);
             }
 
             // Send all the other updates.
             for (id, update) in eval {
-                let message = SubscriptionUpdateMessage::from_event_and_update(&event, update);
+                let database_update = SubscriptionUpdateMessage::from_event_and_update(&event, update);
                 let client = self.client(id);
                 // Conditionally send out a full update or a light one otherwise.
                 let event = client.config.tx_update_full.then(|| event.clone());
-                send_to_client(&client, event, message);
+                let message = TransactionUpdateMessage { event, database_update };
+                send_to_client(&client, message);
+            }
+
+            // Send error messages and mark clients for removal
+            for (id, message) in errs {
+                if let Some(client) = self.clients.get(id) {
+                    client.dropped.store(true, Ordering::Release);
+                    send_to_client(
+                        &client.outbound_ref,
+                        SubscriptionMessage {
+                            request_id: None,
+                            query_id: None,
+                            timer: None,
+                            result: SubscriptionResult::Error(SubscriptionError {
+                                table_id: None,
+                                message,
+                            }),
+                        },
+                    );
+                }
             }
         })
     }
 }
 
-fn send_to_client(
-    client: &ClientConnectionSender,
-    event: Option<Arc<ModuleEvent>>,
-    database_update: SubscriptionUpdateMessage,
-) {
-    if let Err(e) = client.send_message(TransactionUpdateMessage { event, database_update }) {
+fn send_to_client(client: &ClientConnectionSender, message: impl Into<SerializableMessage>) {
+    if let Err(e) = client.send_message(message) {
         tracing::warn!(%client.id, "failed to send update message to client: {e}")
     }
 }

--- a/crates/sqltest/Cargo.toml
+++ b/crates/sqltest/Cargo.toml
@@ -21,6 +21,7 @@ fs-err.workspace = true
 futures.workspace = true
 glob.workspace = true
 itertools.workspace = true
+parking_lot.workspace = true
 postgres-types.workspace = true
 quick-junit.workspace = true
 rusqlite.workspace = true

--- a/crates/sqltest/src/space.rs
+++ b/crates/sqltest/src/space.rs
@@ -1,11 +1,13 @@
 use crate::db::DBRunner;
 use async_trait::async_trait;
+use parking_lot::RwLock;
 use spacetimedb::db::relational_db::tests_utils::TestDB;
 use spacetimedb::error::DBError;
 use spacetimedb::execution_context::Workload;
 use spacetimedb::sql::compiler::compile_sql;
 use spacetimedb::sql::execute::execute_sql;
 use spacetimedb::subscription::module_subscription_actor::ModuleSubscriptions;
+use spacetimedb::subscription::module_subscription_manager::SubscriptionManager;
 use spacetimedb::Identity;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_sats::algebraic_value::Packed;
@@ -71,7 +73,11 @@ impl SpaceDb {
     pub(crate) fn run_sql(&self, sql: &str) -> anyhow::Result<Vec<MemTable>> {
         self.conn.with_read_only(Workload::Sql, |tx| {
             let ast = compile_sql(&self.conn, &AuthCtx::for_testing(), tx, sql)?;
-            let subs = ModuleSubscriptions::new(Arc::new(self.conn.db.clone()), Identity::ZERO);
+            let subs = ModuleSubscriptions::new(
+                Arc::new(self.conn.db.clone()),
+                Arc::new(RwLock::new(SubscriptionManager::default())),
+                Identity::ZERO,
+            );
             let result = execute_sql(&self.conn, sql, ast, self.auth, Some(&subs))?;
             //remove comments to see which SQL worked. Can't collect it outside from lack of a hook in the external `sqllogictest` crate... :(
             //append_file(&std::path::PathBuf::from(".ok.sql"), sql)?;


### PR DESCRIPTION
# Description of Changes

When an error occurs during a tx update (subscription evaluation), we will now:

1. Send a `SubscriptionError` to the relevant clients
2. Drop the full set of subscriptions for each such client

To drop the subscriptions, we mark the affected clients when the error occurs (see eval_updates), and an async task will periodically remove them from the mapping.

> Why not drop them when the error occurs (in eval_updates)?

This would require holding a write lock on the `SubscriptionManager` preventing other read only transactions from running.

# API and ABI breaking changes

None

# Expected complexity level and risk

4

Not a big change, but touches concurrency related code.

# Testing

Added the following new tests:

1. Subscribing with an invalid query returns an error to the client
2. Removing an index and unsubscribing from a query that relied on that index also returns an error to the client
3. A tx update that fails due to a removed index returns an error to the client
