### PR TITLE
CLI - Warn when using an unstable command

### DIFF
--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -1,7 +1,7 @@
 use crate::common_args;
 use crate::config::Config;
 use crate::edit_distance::{edit_distance, find_best_match_for_name};
-use crate::util::{self, print_unstable_warning, UNSTABLE_HELPTEXT};
+use crate::util::{self, UNSTABLE_HELPTEXT};
 use crate::util::{add_auth_header_opt, database_identity, get_auth_header};
 use anyhow::{bail, Context, Error};
 use clap::{Arg, ArgMatches};
@@ -38,7 +38,7 @@ pub fn cli() -> clap::Command {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), Error> {
-    print_unstable_warning();
+    println!("{}", UNSTABLE_HELPTEXT);
     let database = args.get_one::<String>("database").unwrap();
     let reducer_name = args.get_one::<String>("reducer_name").unwrap();
     let arguments = args.get_many::<String>("arguments");

--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -38,7 +38,7 @@ pub fn cli() -> clap::Command {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), Error> {
-    println!("{}\n", UNSTABLE_WARNING);
+    eprintln!("{}\n", UNSTABLE_WARNING);
     let database = args.get_one::<String>("database").unwrap();
     let reducer_name = args.get_one::<String>("reducer_name").unwrap();
     let arguments = args.get_many::<String>("arguments");

--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -1,7 +1,7 @@
 use crate::common_args;
 use crate::config::Config;
 use crate::edit_distance::{edit_distance, find_best_match_for_name};
-use crate::util::{self, UNSTABLE_HELPTEXT};
+use crate::util::{self, UNSTABLE_WARNING};
 use crate::util::{add_auth_header_opt, database_identity, get_auth_header};
 use anyhow::{bail, Context, Error};
 use clap::{Arg, ArgMatches};
@@ -18,7 +18,7 @@ pub fn cli() -> clap::Command {
     clap::Command::new("call")
         .about(format!(
             "Invokes a reducer function in a database.\n\n{}",
-            UNSTABLE_HELPTEXT
+            UNSTABLE_WARNING
         ))
         .arg(
             Arg::new("database")
@@ -38,7 +38,7 @@ pub fn cli() -> clap::Command {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), Error> {
-    println!("{}", UNSTABLE_HELPTEXT);
+    println!("{}", UNSTABLE_WARNING);
     let database = args.get_one::<String>("database").unwrap();
     let reducer_name = args.get_one::<String>("reducer_name").unwrap();
     let arguments = args.get_many::<String>("arguments");

--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -38,7 +38,7 @@ pub fn cli() -> clap::Command {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), Error> {
-    println!("{}", UNSTABLE_WARNING);
+    println!("{}\n", UNSTABLE_WARNING);
     let database = args.get_one::<String>("database").unwrap();
     let reducer_name = args.get_one::<String>("reducer_name").unwrap();
     let arguments = args.get_many::<String>("arguments");

--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -1,7 +1,7 @@
 use crate::common_args;
 use crate::config::Config;
 use crate::edit_distance::{edit_distance, find_best_match_for_name};
-use crate::util;
+use crate::util::{self, print_unstable_warning, UNSTABLE_HELPTEXT};
 use crate::util::{add_auth_header_opt, database_identity, get_auth_header};
 use anyhow::{bail, Context, Error};
 use clap::{Arg, ArgMatches};
@@ -16,7 +16,10 @@ use std::iter;
 
 pub fn cli() -> clap::Command {
     clap::Command::new("call")
-        .about("Invokes a reducer function in a database")
+        .about(format!(
+            "Invokes a reducer function in a database.\n\n{}",
+            UNSTABLE_HELPTEXT
+        ))
         .arg(
             Arg::new("database")
                 .required(true)
@@ -35,6 +38,7 @@ pub fn cli() -> clap::Command {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), Error> {
+    print_unstable_warning();
     let database = args.get_one::<String>("database").unwrap();
     let reducer_name = args.get_one::<String>("reducer_name").unwrap();
     let arguments = args.get_many::<String>("arguments");

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -31,7 +31,7 @@ pub fn cli() -> clap::Command {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}", UNSTABLE_WARNING);
+    println!("{}\n", UNSTABLE_WARNING);
 
     let database = args.get_one::<String>("database").unwrap();
     let entity_name = args.get_one::<String>("entity_name");

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -1,6 +1,6 @@
 use crate::common_args;
 use crate::config::Config;
-use crate::util::{add_auth_header_opt, database_identity, get_auth_header, print_unstable_warning, UNSTABLE_HELPTEXT};
+use crate::util::{add_auth_header_opt, database_identity, get_auth_header, UNSTABLE_HELPTEXT};
 use clap::{Arg, ArgMatches};
 
 pub fn cli() -> clap::Command {
@@ -31,7 +31,7 @@ pub fn cli() -> clap::Command {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    print_unstable_warning();
+    println!("{}", UNSTABLE_HELPTEXT);
 
     let database = args.get_one::<String>("database").unwrap();
     let entity_name = args.get_one::<String>("entity_name");

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -1,13 +1,13 @@
 use crate::common_args;
 use crate::config::Config;
-use crate::util::{add_auth_header_opt, database_identity, get_auth_header, UNSTABLE_HELPTEXT};
+use crate::util::{add_auth_header_opt, database_identity, get_auth_header, UNSTABLE_WARNING};
 use clap::{Arg, ArgMatches};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("describe")
         .about(format!(
             "Describe the structure of a database or entities within it.\n\n{}",
-            UNSTABLE_HELPTEXT
+            UNSTABLE_WARNING
         ))
         .arg(
             Arg::new("database")
@@ -31,7 +31,7 @@ pub fn cli() -> clap::Command {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}", UNSTABLE_HELPTEXT);
+    println!("{}", UNSTABLE_WARNING);
 
     let database = args.get_one::<String>("database").unwrap();
     let entity_name = args.get_one::<String>("entity_name");

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -31,7 +31,7 @@ pub fn cli() -> clap::Command {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}\n", UNSTABLE_WARNING);
+    eprintln!("{}\n", UNSTABLE_WARNING);
 
     let database = args.get_one::<String>("database").unwrap();
     let entity_name = args.get_one::<String>("entity_name");

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -1,11 +1,14 @@
 use crate::common_args;
 use crate::config::Config;
-use crate::util::{add_auth_header_opt, database_identity, get_auth_header};
+use crate::util::{add_auth_header_opt, database_identity, get_auth_header, print_unstable_warning, UNSTABLE_HELPTEXT};
 use clap::{Arg, ArgMatches};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("describe")
-        .about("Describe the structure of a database or entities within it")
+        .about(format!(
+            "Describe the structure of a database or entities within it.\n\n{}",
+            UNSTABLE_HELPTEXT
+        ))
         .arg(
             Arg::new("database")
                 .required(true)
@@ -28,6 +31,8 @@ pub fn cli() -> clap::Command {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+    print_unstable_warning();
+
     let database = args.get_one::<String>("database").unwrap();
     let entity_name = args.get_one::<String>("entity_name");
     let entity_type = args.get_one::<String>("entity_type");

--- a/crates/cli/src/subcommands/energy.rs
+++ b/crates/cli/src/subcommands/energy.rs
@@ -42,7 +42,7 @@ async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Result
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let (cmd, subcommand_args) = args.subcommand().expect("Subcommand required");
-    println!("{}\n", UNSTABLE_WARNING);
+    eprintln!("{}\n", UNSTABLE_WARNING);
     exec_subcommand(config, cmd, subcommand_args).await
 }
 

--- a/crates/cli/src/subcommands/energy.rs
+++ b/crates/cli/src/subcommands/energy.rs
@@ -42,7 +42,7 @@ async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Result
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let (cmd, subcommand_args) = args.subcommand().expect("Subcommand required");
-    println!("{}", UNSTABLE_WARNING);
+    println!("{}\n", UNSTABLE_WARNING);
     exec_subcommand(config, cmd, subcommand_args).await
 }
 

--- a/crates/cli/src/subcommands/energy.rs
+++ b/crates/cli/src/subcommands/energy.rs
@@ -3,7 +3,7 @@ use crate::common_args;
 use clap::ArgMatches;
 
 use crate::config::Config;
-use crate::util::{self, get_login_token_or_log_in, print_unstable_warning, UNSTABLE_HELPTEXT};
+use crate::util::{self, get_login_token_or_log_in, UNSTABLE_HELPTEXT};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("energy")
@@ -42,7 +42,7 @@ async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Result
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let (cmd, subcommand_args) = args.subcommand().expect("Subcommand required");
-    print_unstable_warning();
+    println!("{}", UNSTABLE_HELPTEXT);
     exec_subcommand(config, cmd, subcommand_args).await
 }
 

--- a/crates/cli/src/subcommands/energy.rs
+++ b/crates/cli/src/subcommands/energy.rs
@@ -3,13 +3,13 @@ use crate::common_args;
 use clap::ArgMatches;
 
 use crate::config::Config;
-use crate::util::{self, get_login_token_or_log_in, UNSTABLE_HELPTEXT};
+use crate::util::{self, get_login_token_or_log_in, UNSTABLE_WARNING};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("energy")
         .about(format!(
             "Invokes commands related to database budgets.\n\n{}",
-            UNSTABLE_HELPTEXT
+            UNSTABLE_WARNING
         ))
         .args_conflicts_with_subcommands(true)
         .subcommand_required(true)
@@ -42,7 +42,7 @@ async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Result
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let (cmd, subcommand_args) = args.subcommand().expect("Subcommand required");
-    println!("{}", UNSTABLE_HELPTEXT);
+    println!("{}", UNSTABLE_WARNING);
     exec_subcommand(config, cmd, subcommand_args).await
 }
 

--- a/crates/cli/src/subcommands/energy.rs
+++ b/crates/cli/src/subcommands/energy.rs
@@ -3,11 +3,14 @@ use crate::common_args;
 use clap::ArgMatches;
 
 use crate::config::Config;
-use crate::util::{self, get_login_token_or_log_in};
+use crate::util::{self, get_login_token_or_log_in, print_unstable_warning, UNSTABLE_HELPTEXT};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("energy")
-        .about("Invokes commands related to database budgets")
+        .about(format!(
+            "Invokes commands related to database budgets.\n\n{}",
+            UNSTABLE_HELPTEXT
+        ))
         .args_conflicts_with_subcommands(true)
         .subcommand_required(true)
         .subcommands(get_energy_subcommands())
@@ -39,6 +42,7 @@ async fn exec_subcommand(config: Config, cmd: &str, args: &ArgMatches) -> Result
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let (cmd, subcommand_args) = args.subcommand().expect("Subcommand required");
+    print_unstable_warning();
     exec_subcommand(config, cmd, subcommand_args).await
 }
 

--- a/crates/cli/src/subcommands/init.rs
+++ b/crates/cli/src/subcommands/init.rs
@@ -1,6 +1,6 @@
 use crate::util::ModuleLanguage;
 use crate::Config;
-use crate::{detect::find_executable, util::UNSTABLE_HELPTEXT};
+use crate::{detect::find_executable, util::UNSTABLE_WARNING};
 use anyhow::Context;
 use clap::{Arg, ArgMatches};
 use colored::Colorize;
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("init")
-        .about(format!("Initializes a new spacetime project.\n\n{}", UNSTABLE_HELPTEXT))
+        .about(format!("Initializes a new spacetime project.\n\n{}", UNSTABLE_WARNING))
         .arg(
             Arg::new("project-path")
                 .value_parser(clap::value_parser!(PathBuf))
@@ -114,7 +114,7 @@ fn check_for_git() -> bool {
 }
 
 pub async fn exec(_config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}", UNSTABLE_HELPTEXT);
+    println!("{}", UNSTABLE_WARNING);
 
     let project_path = args.get_one::<PathBuf>("project-path").unwrap();
     let project_lang = *args.get_one::<ModuleLanguage>("lang").unwrap();

--- a/crates/cli/src/subcommands/init.rs
+++ b/crates/cli/src/subcommands/init.rs
@@ -1,6 +1,6 @@
-use crate::detect::find_executable;
-use crate::util::ModuleLanguage;
+use crate::util::{print_unstable_warning, ModuleLanguage};
 use crate::Config;
+use crate::{detect::find_executable, util::UNSTABLE_HELPTEXT};
 use anyhow::Context;
 use clap::{Arg, ArgMatches};
 use colored::Colorize;
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("init")
-        .about("Initializes a new spacetime project")
+        .about(format!("Initializes a new spacetime project.\n\n{}", UNSTABLE_HELPTEXT))
         .arg(
             Arg::new("project-path")
                 .value_parser(clap::value_parser!(PathBuf))
@@ -114,6 +114,8 @@ fn check_for_git() -> bool {
 }
 
 pub async fn exec(_config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+    print_unstable_warning();
+
     let project_path = args.get_one::<PathBuf>("project-path").unwrap();
     let project_lang = *args.get_one::<ModuleLanguage>("lang").unwrap();
 

--- a/crates/cli/src/subcommands/init.rs
+++ b/crates/cli/src/subcommands/init.rs
@@ -114,7 +114,7 @@ fn check_for_git() -> bool {
 }
 
 pub async fn exec(_config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}", UNSTABLE_WARNING);
+    println!("{}\n", UNSTABLE_WARNING);
 
     let project_path = args.get_one::<PathBuf>("project-path").unwrap();
     let project_lang = *args.get_one::<ModuleLanguage>("lang").unwrap();

--- a/crates/cli/src/subcommands/init.rs
+++ b/crates/cli/src/subcommands/init.rs
@@ -1,4 +1,4 @@
-use crate::util::{print_unstable_warning, ModuleLanguage};
+use crate::util::ModuleLanguage;
 use crate::Config;
 use crate::{detect::find_executable, util::UNSTABLE_HELPTEXT};
 use anyhow::Context;
@@ -114,7 +114,7 @@ fn check_for_git() -> bool {
 }
 
 pub async fn exec(_config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    print_unstable_warning();
+    println!("{}", UNSTABLE_HELPTEXT);
 
     let project_path = args.get_one::<PathBuf>("project-path").unwrap();
     let project_lang = *args.get_one::<ModuleLanguage>("lang").unwrap();

--- a/crates/cli/src/subcommands/init.rs
+++ b/crates/cli/src/subcommands/init.rs
@@ -114,7 +114,7 @@ fn check_for_git() -> bool {
 }
 
 pub async fn exec(_config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}\n", UNSTABLE_WARNING);
+    eprintln!("{}\n", UNSTABLE_WARNING);
 
     let project_path = args.get_one::<PathBuf>("project-path").unwrap();
     let project_lang = *args.get_one::<ModuleLanguage>("lang").unwrap();

--- a/crates/cli/src/subcommands/list.rs
+++ b/crates/cli/src/subcommands/list.rs
@@ -1,7 +1,6 @@
 use crate::common_args;
 use crate::util;
 use crate::util::get_login_token_or_log_in;
-use crate::util::print_unstable_warning;
 use crate::util::UNSTABLE_HELPTEXT;
 use crate::Config;
 use clap::{ArgMatches, Command};
@@ -35,7 +34,7 @@ struct IdentityRow {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    print_unstable_warning();
+    println!("{}", UNSTABLE_HELPTEXT);
 
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
     let force = args.get_flag("force");

--- a/crates/cli/src/subcommands/list.rs
+++ b/crates/cli/src/subcommands/list.rs
@@ -1,6 +1,8 @@
 use crate::common_args;
 use crate::util;
 use crate::util::get_login_token_or_log_in;
+use crate::util::print_unstable_warning;
+use crate::util::UNSTABLE_HELPTEXT;
 use crate::Config;
 use clap::{ArgMatches, Command};
 use reqwest::StatusCode;
@@ -13,7 +15,10 @@ use tabled::{
 
 pub fn cli() -> Command {
     Command::new("list")
-        .about("Lists the databases attached to an identity")
+        .about(format!(
+            "Lists the databases attached to an identity.\n\n{}",
+            UNSTABLE_HELPTEXT
+        ))
         .arg(common_args::server().help("The nickname, host name or URL of the server from which to list databases"))
         .arg(common_args::yes())
 }
@@ -30,6 +35,8 @@ struct IdentityRow {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+    print_unstable_warning();
+
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
     let force = args.get_flag("force");
     let token = get_login_token_or_log_in(&mut config, server, !force).await?;

--- a/crates/cli/src/subcommands/list.rs
+++ b/crates/cli/src/subcommands/list.rs
@@ -34,7 +34,7 @@ struct IdentityRow {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}\n", UNSTABLE_WARNING);
+    eprintln!("{}\n", UNSTABLE_WARNING);
 
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
     let force = args.get_flag("force");

--- a/crates/cli/src/subcommands/list.rs
+++ b/crates/cli/src/subcommands/list.rs
@@ -1,7 +1,7 @@
 use crate::common_args;
 use crate::util;
 use crate::util::get_login_token_or_log_in;
-use crate::util::UNSTABLE_HELPTEXT;
+use crate::util::UNSTABLE_WARNING;
 use crate::Config;
 use clap::{ArgMatches, Command};
 use reqwest::StatusCode;
@@ -16,7 +16,7 @@ pub fn cli() -> Command {
     Command::new("list")
         .about(format!(
             "Lists the databases attached to an identity.\n\n{}",
-            UNSTABLE_HELPTEXT
+            UNSTABLE_WARNING
         ))
         .arg(common_args::server().help("The nickname, host name or URL of the server from which to list databases"))
         .arg(common_args::yes())
@@ -34,7 +34,7 @@ struct IdentityRow {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}", UNSTABLE_HELPTEXT);
+    println!("{}", UNSTABLE_WARNING);
 
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
     let force = args.get_flag("force");

--- a/crates/cli/src/subcommands/list.rs
+++ b/crates/cli/src/subcommands/list.rs
@@ -34,7 +34,7 @@ struct IdentityRow {
 }
 
 pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}", UNSTABLE_WARNING);
+    println!("{}\n", UNSTABLE_WARNING);
 
     let server = args.get_one::<String>("server").map(|s| s.as_ref());
     let force = args.get_flag("force");

--- a/crates/cli/src/subcommands/server.rs
+++ b/crates/cli/src/subcommands/server.rs
@@ -1,6 +1,9 @@
 use crate::{
     common_args,
-    util::{host_or_url_to_host_and_protocol, spacetime_server_fingerprint, y_or_n, VALID_PROTOCOLS},
+    util::{
+        host_or_url_to_host_and_protocol, print_unstable_warning, spacetime_server_fingerprint, y_or_n,
+        UNSTABLE_HELPTEXT, VALID_PROTOCOLS,
+    },
     Config,
 };
 use anyhow::Context;
@@ -16,7 +19,10 @@ pub fn cli() -> Command {
         .args_conflicts_with_subcommands(true)
         .subcommand_required(true)
         .subcommands(get_subcommands())
-        .about("Manage the connection to the SpacetimeDB server")
+        .about(format!(
+            "Manage the connection to the SpacetimeDB server.\n\n{}",
+            UNSTABLE_HELPTEXT
+        ))
 }
 
 fn get_subcommands() -> Vec<Command> {
@@ -113,6 +119,7 @@ fn get_subcommands() -> Vec<Command> {
 
 pub async fn exec(config: Config, paths: &SpacetimePaths, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let (cmd, subcommand_args) = args.subcommand().expect("Subcommand required");
+    print_unstable_warning();
     exec_subcommand(config, paths, cmd, subcommand_args).await
 }
 

--- a/crates/cli/src/subcommands/server.rs
+++ b/crates/cli/src/subcommands/server.rs
@@ -116,7 +116,7 @@ fn get_subcommands() -> Vec<Command> {
 
 pub async fn exec(config: Config, paths: &SpacetimePaths, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let (cmd, subcommand_args) = args.subcommand().expect("Subcommand required");
-    println!("{}", UNSTABLE_WARNING);
+    println!("{}\n", UNSTABLE_WARNING);
     exec_subcommand(config, paths, cmd, subcommand_args).await
 }
 

--- a/crates/cli/src/subcommands/server.rs
+++ b/crates/cli/src/subcommands/server.rs
@@ -1,8 +1,7 @@
 use crate::{
     common_args,
     util::{
-        host_or_url_to_host_and_protocol, print_unstable_warning, spacetime_server_fingerprint, y_or_n,
-        UNSTABLE_HELPTEXT, VALID_PROTOCOLS,
+        host_or_url_to_host_and_protocol, spacetime_server_fingerprint, y_or_n, UNSTABLE_HELPTEXT, VALID_PROTOCOLS,
     },
     Config,
 };
@@ -119,7 +118,7 @@ fn get_subcommands() -> Vec<Command> {
 
 pub async fn exec(config: Config, paths: &SpacetimePaths, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let (cmd, subcommand_args) = args.subcommand().expect("Subcommand required");
-    print_unstable_warning();
+    println!("{}", UNSTABLE_HELPTEXT);
     exec_subcommand(config, paths, cmd, subcommand_args).await
 }
 

--- a/crates/cli/src/subcommands/server.rs
+++ b/crates/cli/src/subcommands/server.rs
@@ -116,7 +116,7 @@ fn get_subcommands() -> Vec<Command> {
 
 pub async fn exec(config: Config, paths: &SpacetimePaths, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let (cmd, subcommand_args) = args.subcommand().expect("Subcommand required");
-    println!("{}\n", UNSTABLE_WARNING);
+    eprintln!("{}\n", UNSTABLE_WARNING);
     exec_subcommand(config, paths, cmd, subcommand_args).await
 }
 

--- a/crates/cli/src/subcommands/server.rs
+++ b/crates/cli/src/subcommands/server.rs
@@ -1,8 +1,6 @@
 use crate::{
     common_args,
-    util::{
-        host_or_url_to_host_and_protocol, spacetime_server_fingerprint, y_or_n, UNSTABLE_HELPTEXT, VALID_PROTOCOLS,
-    },
+    util::{host_or_url_to_host_and_protocol, spacetime_server_fingerprint, y_or_n, UNSTABLE_WARNING, VALID_PROTOCOLS},
     Config,
 };
 use anyhow::Context;
@@ -20,7 +18,7 @@ pub fn cli() -> Command {
         .subcommands(get_subcommands())
         .about(format!(
             "Manage the connection to the SpacetimeDB server.\n\n{}",
-            UNSTABLE_HELPTEXT
+            UNSTABLE_WARNING
         ))
 }
 
@@ -118,7 +116,7 @@ fn get_subcommands() -> Vec<Command> {
 
 pub async fn exec(config: Config, paths: &SpacetimePaths, args: &ArgMatches) -> Result<(), anyhow::Error> {
     let (cmd, subcommand_args) = args.subcommand().expect("Subcommand required");
-    println!("{}", UNSTABLE_HELPTEXT);
+    println!("{}", UNSTABLE_WARNING);
     exec_subcommand(config, paths, cmd, subcommand_args).await
 }
 

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -130,7 +130,7 @@ fn stmt_result_to_table(stmt_result: &StmtResultJson) -> anyhow::Result<tabled::
 }
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}\n", UNSTABLE_WARNING);
+    eprintln!("{}\n", UNSTABLE_WARNING);
     let interactive = args.get_one::<bool>("interactive").unwrap_or(&false);
     if *interactive {
         let con = parse_req(config, args).await?;

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -11,7 +11,7 @@ use tabled::settings::Style;
 
 use crate::config::Config;
 use crate::errors::error_for_status;
-use crate::util::{database_identity, get_auth_header, print_unstable_warning, UNSTABLE_HELPTEXT};
+use crate::util::{database_identity, get_auth_header, UNSTABLE_HELPTEXT};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("sql")
@@ -130,7 +130,7 @@ fn stmt_result_to_table(stmt_result: &StmtResultJson) -> anyhow::Result<tabled::
 }
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    print_unstable_warning();
+    println!("{}", UNSTABLE_HELPTEXT);
     let interactive = args.get_one::<bool>("interactive").unwrap_or(&false);
     if *interactive {
         let con = parse_req(config, args).await?;

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -11,11 +11,11 @@ use tabled::settings::Style;
 
 use crate::config::Config;
 use crate::errors::error_for_status;
-use crate::util::{database_identity, get_auth_header, UNSTABLE_HELPTEXT};
+use crate::util::{database_identity, get_auth_header, UNSTABLE_WARNING};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("sql")
-        .about(format!("Runs a SQL query on the database.\n\n{}", UNSTABLE_HELPTEXT))
+        .about(format!("Runs a SQL query on the database.\n\n{}", UNSTABLE_WARNING))
         .arg(
             Arg::new("database")
                 .required(true)
@@ -130,7 +130,7 @@ fn stmt_result_to_table(stmt_result: &StmtResultJson) -> anyhow::Result<tabled::
 }
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}", UNSTABLE_HELPTEXT);
+    println!("{}", UNSTABLE_WARNING);
     let interactive = args.get_one::<bool>("interactive").unwrap_or(&false);
     if *interactive {
         let con = parse_req(config, args).await?;

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -11,11 +11,11 @@ use tabled::settings::Style;
 
 use crate::config::Config;
 use crate::errors::error_for_status;
-use crate::util::{database_identity, get_auth_header};
+use crate::util::{database_identity, get_auth_header, print_unstable_warning, UNSTABLE_HELPTEXT};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("sql")
-        .about("Runs a SQL query on the database.")
+        .about(format!("Runs a SQL query on the database.\n\n{}", UNSTABLE_HELPTEXT))
         .arg(
             Arg::new("database")
                 .required(true)
@@ -130,6 +130,7 @@ fn stmt_result_to_table(stmt_result: &StmtResultJson) -> anyhow::Result<tabled::
 }
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+    print_unstable_warning();
     let interactive = args.get_one::<bool>("interactive").unwrap_or(&false);
     if *interactive {
         let con = parse_req(config, args).await?;

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -130,7 +130,7 @@ fn stmt_result_to_table(stmt_result: &StmtResultJson) -> anyhow::Result<tabled::
 }
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}", UNSTABLE_WARNING);
+    println!("{}\n", UNSTABLE_WARNING);
     let interactive = args.get_one::<bool>("interactive").unwrap_or(&false);
     if *interactive {
         let con = parse_req(config, args).await?;

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -125,7 +125,7 @@ struct SubscriptionTable {
 }
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}", UNSTABLE_WARNING);
+    println!("{}\n", UNSTABLE_WARNING);
 
     let queries = args.get_many::<String>("query").unwrap();
     let num = args.get_one::<u32>("num-updates").copied();

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -125,7 +125,7 @@ struct SubscriptionTable {
 }
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}\n", UNSTABLE_WARNING);
+    eprintln!("{}\n", UNSTABLE_WARNING);
 
     let queries = args.get_many::<String>("query").unwrap();
     let num = args.get_one::<u32>("num-updates").copied();

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -17,14 +17,14 @@ use tokio_tungstenite::tungstenite::Message as WsMessage;
 use crate::api::ClientApi;
 use crate::common_args;
 use crate::sql::parse_req;
-use crate::util::UNSTABLE_HELPTEXT;
+use crate::util::UNSTABLE_WARNING;
 use crate::Config;
 
 pub fn cli() -> clap::Command {
     clap::Command::new("subscribe")
         .about(format!(
             "Subscribe to SQL queries on the database.\n\n{}",
-            UNSTABLE_HELPTEXT
+            UNSTABLE_WARNING
         ))
         .arg(
             Arg::new("database")
@@ -125,7 +125,7 @@ struct SubscriptionTable {
 }
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
-    println!("{}", UNSTABLE_HELPTEXT);
+    println!("{}", UNSTABLE_WARNING);
 
     let queries = args.get_many::<String>("query").unwrap();
     let num = args.get_one::<u32>("num-updates").copied();

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -17,11 +17,15 @@ use tokio_tungstenite::tungstenite::Message as WsMessage;
 use crate::api::ClientApi;
 use crate::common_args;
 use crate::sql::parse_req;
+use crate::util::UNSTABLE_HELPTEXT;
 use crate::Config;
 
 pub fn cli() -> clap::Command {
     clap::Command::new("subscribe")
-        .about("Subscribe to SQL queries on the database.")
+        .about(format!(
+            "Subscribe to SQL queries on the database.\n\n{}",
+            UNSTABLE_HELPTEXT
+        ))
         .arg(
             Arg::new("database")
                 .required(true)
@@ -121,6 +125,8 @@ struct SubscriptionTable {
 }
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
+    println!("{}", UNSTABLE_HELPTEXT);
+
     let queries = args.get_many::<String>("query").unwrap();
     let num = args.get_one::<u32>("num-updates").copied();
     let timeout = args.get_one::<u32>("timeout").copied();

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -15,7 +15,7 @@ use std::path::Path;
 use crate::config::Config;
 use crate::login::{spacetimedb_login_force, DEFAULT_AUTH_HOST};
 
-pub const UNSTABLE_HELPTEXT: &str = "WARNING: This command is UNSTABLE and subject to breaking changes.";
+pub const UNSTABLE_WARNING: &str = "WARNING: This command is UNSTABLE and subject to breaking changes.";
 
 /// Determine the identity of the `database`.
 pub async fn database_identity(

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -15,6 +15,12 @@ use std::path::Path;
 use crate::config::Config;
 use crate::login::{spacetimedb_login_force, DEFAULT_AUTH_HOST};
 
+pub const UNSTABLE_HELPTEXT: &str = "This command is UNSTABLE and subject to breaking changes.";
+
+pub fn print_unstable_warning() {
+    println!("WARNING: {}", UNSTABLE_HELPTEXT);
+}
+
 /// Determine the identity of the `database`.
 pub async fn database_identity(
     config: &Config,

--- a/crates/cli/src/util.rs
+++ b/crates/cli/src/util.rs
@@ -15,11 +15,7 @@ use std::path::Path;
 use crate::config::Config;
 use crate::login::{spacetimedb_login_force, DEFAULT_AUTH_HOST};
 
-pub const UNSTABLE_HELPTEXT: &str = "This command is UNSTABLE and subject to breaking changes.";
-
-pub fn print_unstable_warning() {
-    println!("WARNING: {}", UNSTABLE_HELPTEXT);
-}
+pub const UNSTABLE_HELPTEXT: &str = "WARNING: This command is UNSTABLE and subject to breaking changes.";
 
 /// Determine the identity of the `database`.
 pub async fn database_identity(


### PR DESCRIPTION
# Description of Changes

Addresses https://github.com/clockworklabs/SpacetimeDB/issues/1820.

- [x] Print a warning when using unstable subcommands or args
- [x] Unstable commands also have unstable markers in their `--help` text

Note: I only added this text to the CLI commands list. I did not add it to other binaries, especially `spacetimedb-update`.

# API and ABI breaking changes

Not API/ABI breaking.

# Expected complexity level and risk

1

# Testing

- [x] Helptext contains the warning

```
$ cargo run -pspacetimedb-cli -- init --help
   Compiling spacetimedb-cli v1.0.0-rc4 (/home/lead/work/clockwork-localhd/SpacetimeDBPrivate/public/crates/cli)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 17.35s
     Running `target/debug/spacetimedb-cli init --help`
Initializes a new spacetime project.

WARNING: This command is UNSTABLE and subject to breaking changes.

Usage: spacetimedb-cli init --lang <lang> [project-path]

Arguments:
  [project-path]  The path where we will create the spacetime project [default: .]

Options:
  -l, --lang <lang>  The spacetime module language. [possible values: csharp, rust]
  -h, --help         Print help
```

- [x] Using an unstable command shows the warning
```
$ cargo run -pspacetimedb-cli -- list
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.26s
     Running `target/debug/spacetimedb-cli list`
WARNING: This command is UNSTABLE and subject to breaking changes.

Associated database identities for c20058f5a5bbcbfd65110416110492e91d5ab64054640deb456bd5fa8a2ab9d5:

 db_identity                                                      
------------------------------------------------------------------
 c200bff0b7ec3b9af7247886265bc8a831b3f3067b9f32263fcf954d03e98088 
 c200b0e6eda45da7e3c702b2c5e1412517842c34cf06200ed8733551fd624ea0 
 c20001583eb7da147b40500c64d590089c1bb5e112be31eba202c8c50d63baf4 
```

- [x] Using a subcommand of an unstable command also shows the warning
```
$ cargo run -pspacetimedb-cli -- server list
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.25s
     Running `target/debug/spacetimedb-cli server list`
WARNING: This command is UNSTABLE and subject to breaking changes.

 DEFAULT  HOSTNAME                           PROTOCOL  NICKNAME              
          foo.com                            https     foo-test-bad-server   
     ***  127.0.0.1:3000                     http      local                 
          testnet.spacetimedb.com            https     testnet               
          foo2.com                           https     foo-test-bad-server-2 
          maincloud.staging.spacetimedb.com  https     maincloud-staging     
          testnet.staging.spacetimedb.com    https     staging   
```