### PR TITLE
Added context types to DBConnectionBuilder

### DIFF
--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -574,11 +574,11 @@ fn print_db_connection(_module: &ModuleDef, out: &mut Indenter) {
         "export class DBConnection extends DBConnectionImpl<RemoteTables, RemoteReducers, SetReducerFlags> {{"
     );
     out.indent(1);
-    writeln!(out, "static builder = (): DBConnectionBuilder<DBConnection>  => {{");
+    writeln!(out, "static builder = (): DBConnectionBuilder<DBConnection, ErrorContext, SubscriptionEventContext>  => {{");
     out.indent(1);
     writeln!(
         out,
-        "return new DBConnectionBuilder<DBConnection>(REMOTE_MODULE, (imp: DBConnectionImpl) => imp as DBConnection);"
+        "return new DBConnectionBuilder<DBConnection, ErrorContext, SubscriptionEventContext>(REMOTE_MODULE, (imp: DBConnectionImpl) => imp as DBConnection);"
     );
     out.dedent(1);
     writeln!(out, "}}");


### PR DESCRIPTION
# Description of Changes

Just updated TypeScript code gen to pass in a few more generics params.

# API and ABI breaking changes

Technically a breaking change since the expected error types on `.onConnectError` and `.onDisconnect` are now different.

# Expected complexity level and risk

1

# Testing

I generated the types for the TypeScript quick start and verified that it was still working.