### PR TITLE
Add metrics for index inserts and deletes

### DIFF
--- a/crates/cli/examples/regen-csharp-moduledef.rs
+++ b/crates/cli/examples/regen-csharp-moduledef.rs
@@ -36,8 +36,7 @@ fn main() -> anyhow::Result<()> {
             namespace: "SpacetimeDB.Internal",
         },
     )?
-    .into_iter()
-    .map(|(filename, code)| {
+    .into_iter().try_for_each(|(filename, code)| {
         // Skip anything but raw types (in particular, this will skip top-level SpacetimeDBClient.g.cs which we don't need).
         let Some(filename) = filename.strip_prefix("Types/") else {
             return Ok(());
@@ -64,8 +63,7 @@ fn main() -> anyhow::Result<()> {
         );
 
         fs::write(dir.join(filename), code.as_ref())
-    })
-    .collect::<std::io::Result<()>>()?;
+    })?;
 
     Ok(())
 }

--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -20,10 +20,20 @@ metrics_group!(
         #[labels(txn_type: WorkloadType, db: Identity, reducer_or_query: str, table_id: u32, table_name: str)]
         pub rdb_num_rows_inserted: IntCounterVec,
 
+        #[name = spacetime_num_index_rows_inserted_total]
+        #[help = "The cumulative number of index entries inserted. Does not count schema changes."]
+        #[labels(txn_type: WorkloadType, db: Identity, reducer_or_query: str, table_id: u32, table_name: str)]
+        pub rdb_num_index_entries_inserted: IntCounterVec,
+
         #[name = spacetime_num_rows_deleted_total]
         #[help = "The cumulative number of rows deleted from a table"]
         #[labels(txn_type: WorkloadType, db: Identity, reducer_or_query: str, table_id: u32, table_name: str)]
         pub rdb_num_rows_deleted: IntCounterVec,
+
+        #[name = spacetime_num_index_rows_deleted_total]
+        #[help = "The cumulative number of index entries deleted. Does not count schema changes."]
+        #[labels(txn_type: WorkloadType, db: Identity, reducer_or_query: str, table_id: u32, table_name: str)]
+        pub rdb_num_index_entries_deleted: IntCounterVec,
 
         #[name = spacetime_num_rows_scanned_total]
         #[help = "The cumulative number of rows scanned from the database"]


### PR DESCRIPTION
# Description of Changes

This adds metrics for index insertions and deletions. It relies on the fact that we don't have sparse indexes.

Note that we don't count index insertions for newly added indexes, which we may want to add in the future.


# Expected complexity level and risk

1

# Testing

Not tested, but seems very low risk, since it mostly uses the row insertion tracking.
