### PR TITLE
CLI - Default config lists maincloud, not testnet

### DIFF
--- a/crates/cli/src/config.rs
+++ b/crates/cli/src/config.rs
@@ -163,15 +163,15 @@ impl RawConfig {
             nickname: Some("local".to_string()),
             ecdsa_public_key: None,
         };
-        let testnet = ServerConfig {
-            host: "testnet.spacetimedb.com".to_string(),
+        let maincloud = ServerConfig {
+            host: "maincloud.spacetimedb.com".to_string(),
             protocol: "https".to_string(),
-            nickname: Some("testnet".to_string()),
+            nickname: Some("maincloud".to_string()),
             ecdsa_public_key: None,
         };
         RawConfig {
             default_server: local.nickname.clone(),
-            server_configs: vec![local, testnet],
+            server_configs: vec![local, maincloud],
             web_session_token: None,
             spacetimedb_token: None,
         }


### PR DESCRIPTION
# Description of Changes

Replaced testnet with maincloud in the default config file.

I did **not** replace it in any of our tests, since those test config files don't actually need to be synced with our real config files. I can replace there too if that's preferred.

# API and ABI breaking changes

Not breaking.

# Expected complexity level and risk

1

# Testing

- [x] Remove config file, run a CLI command, see that maincloud is in the config file now
```
$ rm ~/.config/spacetime/cli.toml

$ cargo run -p spacetimedb-cli -- server add foo --url https://foo.spacetimedb.com --no-fingerprint
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 0.24s
     Running `target/debug/spacetimedb-cli server add foo --url 'https://foo.spacetimedb.com' --no-fingerprint`
Saving config to /home/lead/.config/spacetime/cli.toml.
WARNING: This command is UNSTABLE and subject to breaking changes.

Host: foo.spacetimedb.com
Protocol: https
Saving config to /home/lead/.config/spacetime/cli.toml.

$ cat ~/.config/spacetime/cli.toml
default_server = "local"

[[server_configs]]
nickname = "local"
host = "127.0.0.1:3000"
protocol = "http"

[[server_configs]]
nickname = "maincloud"
host = "maincloud.spacetimedb.com"
protocol = "https"

[[server_configs]]
nickname = "foo"
host = "foo.spacetimedb.com"
protocol = "https"
```