### PR TITLE
Support RFC 3339 timestamp values in sql

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5257,6 +5257,7 @@ dependencies = [
  "bitflags 2.6.0",
  "blake3",
  "bytes",
+ "chrono",
  "derive_more",
  "enum-as-inner",
  "enum-map",
@@ -5351,12 +5352,14 @@ name = "spacetimedb-sats"
 version = "1.0.0"
 dependencies = [
  "ahash 0.8.11",
+ "anyhow",
  "arrayvec",
  "bitflags 2.6.0",
  "blake3",
  "bytemuck",
  "bytes",
  "bytestring",
+ "chrono",
  "decorum",
  "derive_more",
  "enum-as-inner",

--- a/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
+++ b/crates/bindings/tests/snapshots/deps__spacetimedb_bindings_dependencies.snap
@@ -2,7 +2,7 @@
 source: crates/bindings/tests/deps.rs
 expression: "cargo tree -p spacetimedb -f {lib} -e no-dev"
 ---
-total crates: 67
+total crates: 68
 spacetimedb
 ├── bytemuck
 ├── derive_more
@@ -61,6 +61,10 @@ spacetimedb
 │   │   [build-dependencies]
 │   │   └── cc
 │   │       └── shlex
+│   ├── chrono
+│   │   └── num_traits
+│   │       [build-dependencies]
+│   │       └── autocfg
 │   ├── derive_more (*)
 │   ├── enum_as_inner
 │   │   ├── heck
@@ -90,15 +94,15 @@ spacetimedb
 │   │           └── syn (*)
 │   ├── spacetimedb_primitives (*)
 │   ├── spacetimedb_sats
+│   │   ├── anyhow
 │   │   ├── arrayvec
 │   │   ├── bitflags
 │   │   ├── bytemuck
 │   │   ├── bytes
+│   │   ├── chrono (*)
 │   │   ├── decorum
 │   │   │   ├── approx
-│   │   │   │   └── num_traits
-│   │   │   │       [build-dependencies]
-│   │   │   │       └── autocfg
+│   │   │   │   └── num_traits (*)
 │   │   │   └── num_traits (*)
 │   │   ├── derive_more (*)
 │   │   ├── enum_as_inner (*)

--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -240,6 +240,7 @@ mod tests {
             (
                 "t",
                 ProductType::from([
+                    ("ts", AlgebraicType::timestamp()),
                     ("i8", AlgebraicType::I8),
                     ("u8", AlgebraicType::U8),
                     ("i16", AlgebraicType::I16),
@@ -321,9 +322,29 @@ mod tests {
                 sql: "select * from t where u256 = 1e40",
                 msg: "u256",
             },
+            TestCase {
+                sql: "select * from t where ts = '2025-02-10T15:45:30Z'",
+                msg: "timestamp",
+            },
+            TestCase {
+                sql: "select * from t where ts = '2025-02-10T15:45:30.123Z'",
+                msg: "timestamp ms",
+            },
+            TestCase {
+                sql: "select * from t where ts = '2025-02-10T15:45:30.123456789Z'",
+                msg: "timestamp ns",
+            },
+            TestCase {
+                sql: "select * from t where ts = '2025-02-10 15:45:30+02:00'",
+                msg: "timestamp with timezone",
+            },
+            TestCase {
+                sql: "select * from t where ts = '2025-02-10 15:45:30.123+02:00'",
+                msg: "timestamp ms with timezone",
+            },
         ] {
             let result = parse_and_type_sub(sql, &tx);
-            assert!(result.is_ok(), "{msg}");
+            assert!(result.is_ok(), "name: {}, error: {}", msg, result.unwrap_err());
         }
     }
 

--- a/crates/lib/Cargo.toml
+++ b/crates/lib/Cargo.toml
@@ -33,6 +33,7 @@ spacetimedb-data-structures.workspace = true
 
 anyhow.workspace = true
 bitflags.workspace = true
+chrono.workspace = true
 derive_more.workspace = true
 enum-as-inner.workspace = true
 hex.workspace = true

--- a/crates/sats/Cargo.toml
+++ b/crates/sats/Cargo.toml
@@ -30,11 +30,13 @@ spacetimedb-bindings-macro.workspace = true
 spacetimedb-primitives.workspace = true
 spacetimedb-metrics = { workspace = true, optional = true }
 
+anyhow.workspace = true
 arrayvec.workspace = true
 bitflags.workspace = true
 bytes.workspace = true
 bytemuck.workspace = true
 bytestring = { workspace = true, optional = true }
+chrono.workspace = true
 decorum.workspace = true
 derive_more.workspace = true
 enum-as-inner.workspace = true

--- a/crates/sats/src/timestamp.rs
+++ b/crates/sats/src/timestamp.rs
@@ -1,3 +1,6 @@
+use anyhow::Context;
+use chrono::DateTime;
+
 use crate::{de::Deserialize, impl_st, ser::Serialize, time_duration::TimeDuration, AlgebraicType};
 use std::fmt;
 use std::ops::Add;
@@ -126,6 +129,15 @@ impl Timestamp {
             .to_micros_since_unix_epoch()
             .checked_sub(earlier.to_micros_since_unix_epoch())?;
         Some(TimeDuration::from_micros(delta))
+    }
+
+    /// Parses an RFC 3339 formated timestamp string
+    pub fn parse_from_str(str: &str) -> anyhow::Result<Timestamp> {
+        DateTime::parse_from_rfc3339(str)
+            .map_err(|err| anyhow::anyhow!(err))
+            .with_context(|| "Invalid timestamp format. Expected RFC 3339 format (e.g. '2025-02-10 15:45:30').")
+            .map(|dt| dt.timestamp_micros())
+            .map(Timestamp::from_micros_since_unix_epoch)
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Adds RFC 3339 formatted timestamps to sql. This only required updates to the type system.

Note this does not introduce any new optimizations. Timestamp columns can be indexed and so all current optimizations related to indexed columns still apply.

# API and ABI breaking changes

None

# Expected complexity level and risk

1.5

Just added timestamp parsing and expanded a typing constraint to allow timestamp values in comparison expressions.

# Testing

New typing tests
