### PR TITLE
CI - Update `actions/cache@v2` -> `@v4`

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -34,7 +34,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}
@@ -95,7 +95,7 @@ jobs:
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Cache Docker layers
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: /tmp/.buildx-cache
           key: ${{ runner.os }}-buildx-${{ github.sha }}


### PR DESCRIPTION
# Description of Changes

The old version is becoming deprecated, is currently going through brownout periods, and will become entirely nonfunctional as of March 1, 2025.

See https://github.com/actions/cache/discussions/1510.

# API and ABI breaking changes

No breaking changes. CI only.

# Expected complexity level and risk

1

# Testing

This has been tested elsewhere (contact @bfops for more details).