### PR TITLE
Only support bearer auth

### DIFF
--- a/crates/client-api/src/auth.rs
+++ b/crates/client-api/src/auth.rs
@@ -67,15 +67,9 @@ impl SpacetimeCreds {
     fn from_request_parts(parts: &request::Parts) -> Result<Option<Self>, headers::Error> {
         let header = parts
             .headers
-            .typed_try_get::<headers::Authorization<authorization::Bearer>>()
-            .map(|x| x.map(|auth| auth.token().to_owned()))
-            .or_else(|_| {
-                Ok(parts
-                    .headers
-                    .typed_try_get::<headers::Authorization<Self>>()?
-                    .map(|auth| auth.0.token))
-            })?;
-        if let Some(token) = header {
+            .typed_try_get::<headers::Authorization<authorization::Bearer>>()?;
+        if let Some(headers::Authorization(bearer)) = header {
+            let token = bearer.token().to_owned();
             return Ok(Some(SpacetimeCreds { token }));
         }
         if let Ok(Query(creds)) = Query::<Self>::try_from_uri(&parts.uri) {


### PR DESCRIPTION
# Description of Changes

Follow up to #2181. If a client somehow can send basic auth but not bearer, they can also just use the `?token` param.

# API and ABI breaking changes

Breaks http api - not sure what the counts as. Nothing needed from users besides upgrading, though.

# Expected complexity level and risk

1: this is covered by tests, and all the relevant client sdks have been updated to use bearer auth instead of basic.

# Testing

- [x] I'm confident this is covered by smoketests.