### PR TITLE
C# SDK - Emit Event.UnknownTransaction rather than throwing on unknown reducer (#2241)

### DIFF
--- a/crates/cli/src/subcommands/generate/csharp.rs
+++ b/crates/cli/src/subcommands/generate/csharp.rs
@@ -426,8 +426,6 @@ impl Lang for Csharp<'_> {
         indented_block(&mut output, |output| {
             // Prevent instantiation of this class from outside.
             writeln!(output, "private Reducer() {{ }}");
-            writeln!(output);
-            writeln!(output, "public sealed class StdbNone : Reducer {{}}");
         });
         writeln!(output);
 
@@ -462,8 +460,6 @@ impl Lang for Csharp<'_> {
                             "\"{reducer_str_name}\" => BSATNHelpers.Decode<Reducer.{reducer_name}>(encodedArgs),"
                         );
                     }
-                    // Note: "" is a special case for transactions from CLI commands.
-                    writeln!(output, "\"<none>\" or \"\" => new Reducer.StdbNone(),");
                     writeln!(
                         output,
                         r#"var reducer => throw new ArgumentOutOfRangeException("Reducer", $"Unknown reducer {{reducer}}")"#
@@ -516,7 +512,6 @@ impl Lang for Csharp<'_> {
                             "Reducer.{reducer_name} args => Reducers.Invoke{reducer_name}(eventContext, args),"
                         );
                     }
-                    writeln!(output, "Reducer.StdbNone => true,");
                     writeln!(
                         output,
                         r#"_ => throw new ArgumentOutOfRangeException("Reducer", $"Unknown reducer {{reducer}}")"#

--- a/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_csharp.snap
@@ -938,8 +938,6 @@ namespace SpacetimeDB
     public abstract partial class Reducer
     {
         private Reducer() { }
-
-        public sealed class StdbNone : Reducer {}
     }
 
     public sealed class DbConnection : DbConnectionBase<DbConnection, RemoteTables, Reducer>
@@ -972,7 +970,6 @@ namespace SpacetimeDB
                 "say_hello" => BSATNHelpers.Decode<Reducer.SayHello>(encodedArgs),
                 "test" => BSATNHelpers.Decode<Reducer.Test>(encodedArgs),
                 "test_btree_index_args" => BSATNHelpers.Decode<Reducer.TestBtreeIndexArgs>(encodedArgs),
-                "<none>" or "" => new Reducer.StdbNone(),
                 var reducer => throw new ArgumentOutOfRangeException("Reducer", $"Unknown reducer {reducer}")
             };
         }
@@ -1007,7 +1004,6 @@ namespace SpacetimeDB
                 Reducer.SayHello args => Reducers.InvokeSayHello(eventContext, args),
                 Reducer.Test args => Reducers.InvokeTest(eventContext, args),
                 Reducer.TestBtreeIndexArgs args => Reducers.InvokeTestBtreeIndexArgs(eventContext, args),
-                Reducer.StdbNone => true,
                 _ => throw new ArgumentOutOfRangeException("Reducer", $"Unknown reducer {reducer}")
             };
         }


### PR DESCRIPTION

# Description of Changes

Same as https://github.com/clockworklabs/SpacetimeDB/pull/2241 but that was mistakenly based on the wrong branch and was not merged into master ;-;

# API and ABI breaking changes

none
# Expected complexity level and risk

0
# Testing

- [x] quickstart
- [x] blackholio