### PR TITLE
CI - Fix the `SDK Tests` CI job after branch rename

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -142,7 +142,7 @@ jobs:
         uses: actions/checkout@v4
         with:
           repository: clockworklabs/spacetimedb-csharp-sdk
-          ref: staging
+          ref: master
           path: spacetimedb-csharp-sdk
 
       - name: Setup NuGet override for C# SDK


### PR DESCRIPTION
# Description of Changes

https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/issues/226 renamed the branches in the C# SDK repo.

This PR updates our CI to use the new branch name.

# API and ABI breaking changes

No breaking changes.

# Expected complexity level and risk

1

# Testing

The CI passes on this PR (specifically, the `SDK Tests` job passes, which was no longer the case without this change).