### PR TITLE
Upload spacetimedb-update as its own release artifact

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - master
       - release/*
-      - noa/package-update-bin-itself
 
 jobs:
   build-cli:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - release/*
+      - noa/package-update-bin-itself
 
 jobs:
   build-cli:
@@ -45,6 +46,7 @@ jobs:
         run: |
           mkdir build
           cd target/${{matrix.target}}/release
+          cp spacetimedb-update ../../../build/spacetimedb-update-${{matrix.target}}
           tar -czf ../../../build/spacetime-${{matrix.target}}.tar.gz spacetimedb-{cli,standalone,update}
 
       - name: Package (windows)
@@ -52,6 +54,7 @@ jobs:
         run: |
           mkdir build
           cd target/${{matrix.target}}/release
+          cp spacetimedb-update.exe ../../../build/spacetimedb-update-${{matrix.target}}.exe
           7z a ../../../build/spacetime-${{matrix.target}}.zip spacetimedb-cli.exe spacetimedb-standalone.exe spacetimedb-update.exe
 
       - name: Extract branch name


### PR DESCRIPTION
# Description of Changes

This makes it so that the install script doesn't have to do as much.

# Expected complexity level and risk

1

# Testing

- [x] The first commit has the package job enabled