### PR TITLE
keynote-benchmarks: measure the hot latency in 'roundtrip'

### DIFF
--- a/modules/keynote-benchmarks/src/lib.rs
+++ b/modules/keynote-benchmarks/src/lib.rs
@@ -70,6 +70,13 @@ fn update_positions_by_collect(ctx: &ReducerContext) {
 
 #[reducer]
 fn roundtrip(ctx: &ReducerContext) {
+    // Warmup the index.
+    let id = ctx.db().velocity().id();
+    for x in 0..10_000 {
+        id.find(x);
+    }
+
+    // Measures the hot latency.
     let _stopwatch = LogStopwatch::new("index_roundtrip");
-    ctx.db().velocity().id().find(333_333);
+    id.find(10_001);
 }


### PR DESCRIPTION
# Description of Changes

When priming the index first before taking a measurement, the hot latency becomes around 550 ns on my machine.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

This is tweaking a test.