### PR TITLE
Update install script

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -46,7 +46,7 @@ jobs:
           mkdir build
           cd target/${{matrix.target}}/release
           cp spacetimedb-update ../../../build/spacetimedb-update-${{matrix.target}}
-          tar -czf ../../../build/spacetime-${{matrix.target}}.tar.gz spacetimedb-{cli,standalone,update}
+          tar -czf ../../../build/spacetime-${{matrix.target}}.tar.gz spacetimedb-{cli,standalone}
 
       - name: Package (windows)
         if: ${{ runner.os == 'Windows' }}
@@ -54,7 +54,7 @@ jobs:
           mkdir build
           cd target/${{matrix.target}}/release
           cp spacetimedb-update.exe ../../../build/spacetimedb-update-${{matrix.target}}.exe
-          7z a ../../../build/spacetime-${{matrix.target}}.zip spacetimedb-cli.exe spacetimedb-standalone.exe spacetimedb-update.exe
+          7z a ../../../build/spacetime-${{matrix.target}}.zip spacetimedb-cli.exe spacetimedb-standalone.exe
 
       - name: Extract branch name
         shell: bash

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - master
       - release/*
-      - noa/package-update-bin-itself
 
 jobs:
   build-cli:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - release/*
+      - noa/package-update-bin-itself
 
 jobs:
   build-cli:
@@ -45,6 +46,7 @@ jobs:
         run: |
           mkdir build
           cd target/${{matrix.target}}/release
+          cp spacetimedb-update ../../../build/spacetimedb-update-${{matrix.target}}
           tar -czf ../../../build/spacetime-${{matrix.target}}.tar.gz spacetimedb-{cli,standalone,update}
 
       - name: Package (windows)
@@ -52,6 +54,7 @@ jobs:
         run: |
           mkdir build
           cd target/${{matrix.target}}/release
+          cp spacetimedb-update.exe ../../../build/spacetimedb-update-${{matrix.target}}.exe
           7z a ../../../build/spacetime-${{matrix.target}}.zip spacetimedb-cli.exe spacetimedb-standalone.exe spacetimedb-update.exe
 
       - name: Extract branch name

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5547,6 +5547,7 @@ dependencies = [
  "serde",
  "spacetimedb-paths",
  "tar",
+ "tempfile",
  "tokio",
  "toml 0.8.19",
  "tracing",

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -194,6 +194,18 @@ impl RootDir {
     pub fn data_dir(&self) -> server::ServerDataDir {
         server::ServerDataDir(self.0.join("data"))
     }
+
+    fn from_paths(paths: &SpacetimePaths) -> Option<Self> {
+        let SpacetimePaths {
+            cli_config_dir,
+            cli_bin_file,
+            cli_bin_dir,
+            data_dir,
+        } = paths;
+        let parent = cli_config_dir.0.parent()?;
+        let parents = [cli_bin_file.0.parent()?, cli_bin_dir.0.parent()?, data_dir.0.parent()?];
+        parents.iter().all(|x| *x == parent).then(|| Self(parent.to_owned()))
+    }
 }
 
 #[derive(Clone, Debug)]
@@ -247,6 +259,10 @@ impl SpacetimePaths {
             cli_bin_dir: dir.cli_bin_dir(),
             data_dir: dir.data_dir(),
         }
+    }
+
+    pub fn to_root_dir(&self) -> Option<RootDir> {
+        RootDir::from_paths(self)
     }
 }
 

--- a/crates/update/Cargo.toml
+++ b/crates/update/Cargo.toml
@@ -18,6 +18,7 @@ reqwest.workspace = true
 semver = { workspace = true, features = ["serde"] }
 serde.workspace = true
 tar.workspace = true
+tempfile.workspace = true
 tokio.workspace = true
 toml.workspace = true
 tracing = { workspace = true, features = ["release_max_level_off"] }

--- a/crates/update/spacetime-install.ps1
+++ b/crates/update/spacetime-install.ps1
@@ -1,0 +1,52 @@
+Param(
+    [Parameter(Mandatory=$false)]
+    [Switch]$Nightly
+)
+
+function Install {
+    $ErrorActionPreference = 'Stop'
+    [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
+
+    $DownloadUrl = "https://github.com/clockworklabs/SpacetimeDB/releases/latest/download/spacetime.exe"
+    Write-Output "Installing spacetimedb..."
+
+    function UpdatePathIfNotExists {
+        param (
+            [string]$DirectoryToAdd
+        )
+        $currentPath = [Environment]::GetEnvironmentVariable("Path", "User")
+        if (-not $currentPath.Contains($DirectoryToAdd)) {
+            [Environment]::SetEnvironmentVariable("Path", $currentPath + ";" + $DirectoryToAdd, "User")
+        }
+    }
+
+    try {
+        $Directory = Join-Path "C:" "Program Files"
+        $Directory = Join-Path $Directory "SpacetimeDB"
+        $Executable = Join-Path $Directory "spacetime.exe"
+        New-Item $Directory -Force -ItemType Directory | Out-Null
+        Invoke-WebRequest $DownloadUrl -OutFile $Executable -UseBasicParsing
+        UpdatePathIfNotExists $Directory
+
+        Write-Output "We have added spacetimedb to your Path. You may have to logout and log back in to reload your environment."
+    } catch {
+
+        Write-Output "Failed to install into C:, we will try to install in your home directory."
+        Write-Output "*If you want to install globally, run powershell as admin*"
+        $Directory = Join-Path $HOME "SpacetimeDB"
+        $Executable = Join-Path $Directory "spacetime.exe"
+        New-Item $Directory -Force -ItemType Directory | Out-Null
+        Invoke-WebRequest $DownloadUrl -OutFile $Executable -UseBasicParsing
+        UpdatePathIfNotExists $Directory
+    }
+    
+    Write-Output ""
+    Write-Output "spacetime is installed into $Executable"
+    Write-Output "The install process is complete, head over to our quickstart guide to get started!"
+    Write-Output "  https://spacetimedb.com/docs/quick-start"
+    Write-Output ""
+    Write-Output "NOTE: You may have to start a new powershell process to get spacetime to work."
+}
+
+Install
+

--- a/crates/update/spacetime-install.ps1
+++ b/crates/update/spacetime-install.ps1
@@ -7,8 +7,8 @@ function Install {
     $ErrorActionPreference = 'Stop'
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
-    $DownloadUrl = "https://github.com/clockworklabs/SpacetimeDB/releases/latest/download/spacetime.exe"
-    Write-Output "Installing spacetimedb..."
+    $DownloadUrl = "https://github.com/clockworklabs/SpacetimeDB/releases/latest/download/spacetimedb-update-x86_64-pc-windows-msvc.exe"
+    Write-Output "Downloading installer..."
 
     function UpdatePathIfNotExists {
         param (
@@ -19,33 +19,15 @@ function Install {
             [Environment]::SetEnvironmentVariable("Path", $currentPath + ";" + $DirectoryToAdd, "User")
         }
     }
-
-    try {
-        $Directory = Join-Path "C:" "Program Files"
-        $Directory = Join-Path $Directory "SpacetimeDB"
-        $Executable = Join-Path $Directory "spacetime.exe"
-        New-Item $Directory -Force -ItemType Directory | Out-Null
-        Invoke-WebRequest $DownloadUrl -OutFile $Executable -UseBasicParsing
-        UpdatePathIfNotExists $Directory
-
-        Write-Output "We have added spacetimedb to your Path. You may have to logout and log back in to reload your environment."
-    } catch {
-
-        Write-Output "Failed to install into C:, we will try to install in your home directory."
-        Write-Output "*If you want to install globally, run powershell as admin*"
-        $Directory = Join-Path $HOME "SpacetimeDB"
-        $Executable = Join-Path $Directory "spacetime.exe"
-        New-Item $Directory -Force -ItemType Directory | Out-Null
-        Invoke-WebRequest $DownloadUrl -OutFile $Executable -UseBasicParsing
-        UpdatePathIfNotExists $Directory
-    }
     
-    Write-Output ""
-    Write-Output "spacetime is installed into $Executable"
-    Write-Output "The install process is complete, head over to our quickstart guide to get started!"
-    Write-Output "  https://spacetimedb.com/docs/quick-start"
-    Write-Output ""
-    Write-Output "NOTE: You may have to start a new powershell process to get spacetime to work."
+    $Executable = Join-Path ([System.IO.Path]::GetTempPath()) "spacetime-install.exe"
+    Invoke-WebRequest $DownloadUrl -OutFile $Executable -UseBasicParsing
+    & $Executable
+
+    # TODO: do this in spacetimedb-update
+    $InstallDir = Join-Path ([Environment]::GetSpecialFolder("LocalApplicationData")) "SpacetimeDB"
+    UpdatePathIfNotExists $InstallDir
+    Write-Output "We have added spacetimedb to your Path. You may have to logout and log back in to reload your environment."
 }
 
 Install

--- a/crates/update/spacetime-install.ps1
+++ b/crates/update/spacetime-install.ps1
@@ -8,6 +8,7 @@ function Install {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
     $DownloadUrl = "https://github.com/clockworklabs/SpacetimeDB/releases/latest/download/spacetimedb-update-x86_64-pc-windows-msvc.exe"
+    $DownloadUrl = "http://localhost:8000/spacetimedb-update-x86_64-pc-windows-msvc.exe"
     Write-Output "Downloading installer..."
 
     function UpdatePathIfNotExists {
@@ -25,7 +26,7 @@ function Install {
     & $Executable
 
     # TODO: do this in spacetimedb-update
-    $InstallDir = Join-Path ([Environment]::GetSpecialFolder("LocalApplicationData")) "SpacetimeDB"
+    $InstallDir = Join-Path ([Environment]::GetFolderPath("LocalApplicationData")) "SpacetimeDB"
     UpdatePathIfNotExists $InstallDir
     Write-Output "We have added spacetimedb to your Path. You may have to logout and log back in to reload your environment."
 }

--- a/crates/update/spacetime-install.ps1
+++ b/crates/update/spacetime-install.ps1
@@ -8,7 +8,6 @@ function Install {
     [Net.ServicePointManager]::SecurityProtocol = [Net.SecurityProtocolType]::Tls12
 
     $DownloadUrl = "https://github.com/clockworklabs/SpacetimeDB/releases/latest/download/spacetimedb-update-x86_64-pc-windows-msvc.exe"
-    $DownloadUrl = "http://localhost:8000/spacetimedb-update-x86_64-pc-windows-msvc.exe"
     Write-Output "Downloading installer..."
 
     function UpdatePathIfNotExists {

--- a/crates/update/spacetime-install.sh
+++ b/crates/update/spacetime-install.sh
@@ -1,0 +1,110 @@
+#!/usr/bin/env sh
+
+set -u
+
+if command -v curl >/dev/null 2>&1; then
+  _downloader=curl
+elif command -v wget >/dev/null 2>&1; then
+  _downloader=wget
+else
+  echo "Error: you need to have either 'curl' or 'wget' installed and in your path"
+  exit 1
+fi
+
+# First make sure all config is valid, we don't want to end up with
+# a partial install.
+
+# Detect the OS and arch
+_oss="$(uname -s)"
+_cpu="$(uname -m)"
+
+case "$_oss" in
+Linux) _oss=linux ;;
+Darwin) _oss=darwin ;;
+*) err "Error: unsupported operating system: $_oss" ;;
+esac
+
+case "$_cpu" in
+arm64 | aarch64) _cpu=arm64 ;;
+x86_64 | x86-64 | x64 | amd64) _cpu=amd64 ;;
+*) err "Error: unsupported CPU architecture: $_cpu" ;;
+esac
+
+_arc="${_oss}-${_cpu}"
+
+# Compute the download file extension type
+case "$_oss" in
+linux) _ext=linux ;;
+darwin) _ext=macos ;;
+*) echo "Invalid OSS: $_oss" && exit 1 ;;
+esac
+
+# Define the latest SpacetimeDB download url
+printf "This script will install the spacetimedb-cli command line tool. platform=%s os=%s\n" "$_arc" "$_oss"
+# echo "Our EULA for spacetimedb-cli can be found here: https://eula.spacetimedb.com"
+# read -p "Press [enter] to agree to the EULA"
+printf "Press [enter] to install the spacetimedb-cli binary. Use Ctrl-C now to exit.\n\n"
+read -r ans
+
+# We can now install the binary
+_download_file="$(mktemp)"
+rm -f "$_download_file"
+_download_file="${_download_file}.tar.gz"
+_extract_dir="$(mktemp -d)"
+_url="https://github.com/clockworklabs/SpacetimeDB/releases/latest/download/spacetime.$_arc.tar.gz"
+if [ "$_downloader" = curl ]; then
+  echo "Downloading from https://install.spacetimedb.com..."
+  curl -L -sSf --progress-bar "$_url" -o "$_download_file"
+elif [ "$_downloader" = wget ]; then
+  echo "Downloading from https://install.spacetimedb.com..."
+  wget -O - "$_url" >"$_download_file"
+fi
+
+echo "Extracting..."
+tar xf "$_download_file" -C "$_extract_dir"
+rm -f "$_download_file"
+_bin_file="$_extract_dir/spacetime"
+
+# Note: We would like to install globally if we can, however some users may not have sudo access.
+if [ "$_oss" = linux ]; then
+  echo "Default: /usr/bin/spacetime"
+  if [ ! -z ${USER:-} ]; then
+    echo "If you do not have sudo access for your computer, we recommend using /home/$USER/bin/spacetime"
+  fi
+  printf "Press enter or provide the full install path you would like to use: "
+  read -r _install_path
+
+  if [ "$_install_path" = "" ]; then
+    _install_path="/usr/bin/spacetime"
+  fi
+elif [ "$_oss" = darwin ]; then
+  echo "Default: /usr/local/bin/spacetime"
+  if [ ! -z "${USER:-}" ]; then
+    echo "If you do not have sudo access for your computer, we recommend using $HOME/bin/spacetime"
+  fi
+  read -p "Press enter or provide the full install path you would like to use: " _install_path
+
+  if [ "$_install_path" = "" ]; then
+    _install_path="/usr/local/bin/spacetime"
+  fi
+fi
+
+_install_dir="$(dirname $_install_path)"
+if [ ! -d "$_install_dir" ]; then
+  if ! mkdir -pv "$_install_dir"; then
+    sudo mkdir -pv "$_install_dir"
+    if ! [ -d "$_install_dir" ]; then
+      echo "Fatal Error: Failed to create installation direction."
+      exit 1
+    fi
+  fi
+fi
+
+chmod +x "$_bin_file"
+if ! mv -v "$_bin_file" "$_install_path"; then
+  sudo mv -v "$_bin_file" "$_install_path"
+fi
+
+printf "\nspacetime is installed into %s Note: we recommend making sure that this executable is in your PATH.\n" "$_install_path"
+printf "The install process is complete, head over to our quickstart guide to get started!\n\n"
+printf "\thttps://spacetimedb.com/docs/quick-start\n\n"

--- a/crates/update/spacetime-install.sh
+++ b/crates/update/spacetime-install.sh
@@ -1,110 +1,438 @@
-#!/usr/bin/env sh
+#!/bin/sh
 
 set -u
 
-if command -v curl >/dev/null 2>&1; then
-  _downloader=curl
-elif command -v wget >/dev/null 2>&1; then
-  _downloader=wget
-else
-  echo "Error: you need to have either 'curl' or 'wget' installed and in your path"
+err() {
+  echo "$1" >&2
   exit 1
-fi
+}
 
-# First make sure all config is valid, we don't want to end up with
-# a partial install.
+# NOTICE: If you change anything here, please make the same changes in self_install.rs
+usage() {
+    cat <<EOF
+Install the SpacetimeDB CLI
 
-# Detect the OS and arch
-_oss="$(uname -s)"
-_cpu="$(uname -m)"
+Usage: spacetime-install[EXE] [OPTIONS]
 
-case "$_oss" in
-Linux) _oss=linux ;;
-Darwin) _oss=darwin ;;
-*) err "Error: unsupported operating system: $_oss" ;;
-esac
+Options:
+      --root-dir <ROOT_DIR>
+          The directory to locally install SpacetimeDB into. If unspecified, uses platform defaults
 
-case "$_cpu" in
-arm64 | aarch64) _cpu=arm64 ;;
-x86_64 | x86-64 | x64 | amd64) _cpu=amd64 ;;
-*) err "Error: unsupported CPU architecture: $_cpu" ;;
-esac
+  -y, --yes
+          Skip the confirmation dialog
 
-_arc="${_oss}-${_cpu}"
+  -h, --help
+          Print help
+EOF
+}
 
-# Compute the download file extension type
-case "$_oss" in
-linux) _ext=linux ;;
-darwin) _ext=macos ;;
-*) echo "Invalid OSS: $_oss" && exit 1 ;;
-esac
+SPACETIME_DOWNLOAD_ROOT="${SPACETIME_DOWNLOAD_ROOT:-https://github.com/clockworklabs/SpacetimeDB/releases/latest/download}"
 
-# Define the latest SpacetimeDB download url
-printf "This script will install the spacetimedb-cli command line tool. platform=%s os=%s\n" "$_arc" "$_oss"
-# echo "Our EULA for spacetimedb-cli can be found here: https://eula.spacetimedb.com"
-# read -p "Press [enter] to agree to the EULA"
-printf "Press [enter] to install the spacetimedb-cli binary. Use Ctrl-C now to exit.\n\n"
-read -r ans
-
-# We can now install the binary
-_download_file="$(mktemp)"
-rm -f "$_download_file"
-_download_file="${_download_file}.tar.gz"
-_extract_dir="$(mktemp -d)"
-_url="https://github.com/clockworklabs/SpacetimeDB/releases/latest/download/spacetime.$_arc.tar.gz"
-if [ "$_downloader" = curl ]; then
-  echo "Downloading from https://install.spacetimedb.com..."
-  curl -L -sSf --progress-bar "$_url" -o "$_download_file"
-elif [ "$_downloader" = wget ]; then
-  echo "Downloading from https://install.spacetimedb.com..."
-  wget -O - "$_url" >"$_download_file"
-fi
-
-echo "Extracting..."
-tar xf "$_download_file" -C "$_extract_dir"
-rm -f "$_download_file"
-_bin_file="$_extract_dir/spacetime"
-
-# Note: We would like to install globally if we can, however some users may not have sudo access.
-if [ "$_oss" = linux ]; then
-  echo "Default: /usr/bin/spacetime"
-  if [ ! -z ${USER:-} ]; then
-    echo "If you do not have sudo access for your computer, we recommend using /home/$USER/bin/spacetime"
-  fi
-  printf "Press enter or provide the full install path you would like to use: "
-  read -r _install_path
-
-  if [ "$_install_path" = "" ]; then
-    _install_path="/usr/bin/spacetime"
-  fi
-elif [ "$_oss" = darwin ]; then
-  echo "Default: /usr/local/bin/spacetime"
-  if [ ! -z "${USER:-}" ]; then
-    echo "If you do not have sudo access for your computer, we recommend using $HOME/bin/spacetime"
-  fi
-  read -p "Press enter or provide the full install path you would like to use: " _install_path
-
-  if [ "$_install_path" = "" ]; then
-    _install_path="/usr/local/bin/spacetime"
-  fi
-fi
-
-_install_dir="$(dirname $_install_path)"
-if [ ! -d "$_install_dir" ]; then
-  if ! mkdir -pv "$_install_dir"; then
-    sudo mkdir -pv "$_install_dir"
-    if ! [ -d "$_install_dir" ]; then
-      echo "Fatal Error: Failed to create installation direction."
-      exit 1
+main() {
+    # First make sure all config is valid, we don't want to end up with
+    # a partial install.
+    local _downloader
+    if check_cmd curl; then
+        _downloader=curl
+    elif check_cmd wget; then
+        _downloader=wget
+    else
+        err "need 'curl' or 'wget' (command not found)"
     fi
-  fi
-fi
+    need_cmd chmod
+    need_cmd rm
+    need_cmd rmdir
+    need_cmd mktemp
 
-chmod +x "$_bin_file"
-if ! mv -v "$_bin_file" "$_install_path"; then
-  sudo mv -v "$_bin_file" "$_install_path"
-fi
+    # Detect the OS and arch
+    get_architecture || return 1
+    local _host="$RETVAL"
+    [ -z "$_host" ] && err "failed to get architecture"
 
-printf "\nspacetime is installed into %s Note: we recommend making sure that this executable is in your PATH.\n" "$_install_path"
-printf "The install process is complete, head over to our quickstart guide to get started!\n\n"
-printf "\thttps://spacetimedb.com/docs/quick-start\n\n"
+    local _ext=""
+    case "$_host" in
+        *windows*) _ext=".exe" ;;
+    esac
+
+    # We can now install the binary
+    local _tmpdir
+    _tmpdir="$(ensure mktemp -d)" || exit 1
+    local _download_file="$_tmpdir/spacetime-install$_ext"
+
+    check_for_help_flag "$@"
+
+    # Define the latest SpacetimeDB download url
+    local _url="$SPACETIME_DOWNLOAD_ROOT/spacetimedb-update-$_host$_ext"
+    echo "Downloading installer..."
+    if [ "$_downloader" = curl ]; then
+        local _httpstatus
+        if ! _httpstatus="$(curl -sSfL -w '%{http_code}' --progress-bar "$_url" -o "$_download_file")"; then
+            if [ "$_httpstatus" = 404 ]; then
+                err "It seems like we may not have prebuilt binaries for your platform."
+            fi
+            exit 1
+        fi
+    elif [ "$_downloader" = wget ]; then
+        wget "$_url" -O "$_download_file" || exit 1
+    fi
+
+    ensure chmod u+x "$_download_file"
+    if [ ! -x "$_download_file" ]; then
+        printf '%s\n' "Cannot execute $_download_file (likely because of mounting /tmp as noexec)." 1>&2
+        printf '%s\n' "Please copy the file to a location where you can execute binaries and run ./spacetime-install${_ext}." 1>&2
+        exit 1
+    fi
+
+    "$_download_file" "$@"
+    local _retval=$?
+
+    rm -f "$_download_file"
+    rmdir "$_tmpdir"
+
+    return "$_retval"
+}
+
+check_for_help_flag() {
+    for arg in "$@"; do
+        case "$arg" in
+            --help)
+                usage
+                exit 0
+                ;;
+            *)
+                OPTIND=1
+                if [ "${arg%%--*}" = "" ]; then
+                    # Long option (other than --help);
+                    # don't attempt to interpret it.
+                    continue
+                fi
+                while getopts :hy sub_arg "$arg"; do
+                    case "$sub_arg" in
+                        h)
+                            usage
+                            exit 0
+                            ;;
+                        *)
+                            ;;
+                        esac
+                done
+                ;;
+        esac
+    done
+}
+
+
+# The following functions are from rustup-init.sh of the Rust project:
+# get_architecture, get_endianness, need_cmd, check_cmd, ensure
+# Licensed under the MIT license:
+## Copyright (c) 2016 The Rust Project Developers
+## 
+## Permission is hereby granted, free of charge, to any
+## person obtaining a copy of this software and associated
+## documentation files (the "Software"), to deal in the
+## Software without restriction, including without
+## limitation the rights to use, copy, modify, merge,
+## publish, distribute, sublicense, and/or sell copies of
+## the Software, and to permit persons to whom the Software
+## is furnished to do so, subject to the following
+## conditions:
+## 
+## The above copyright notice and this permission notice
+## shall be included in all copies or substantial portions
+## of the Software.
+## 
+## THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF
+## ANY KIND, EXPRESS OR IMPLIED, INCLUDING BUT NOT LIMITED
+## TO THE WARRANTIES OF MERCHANTABILITY, FITNESS FOR A
+## PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT
+## SHALL THE AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY
+## CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER IN AN ACTION
+## OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR
+## IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER
+## DEALINGS IN THE SOFTWARE.
+get_architecture() {
+    local _ostype _cputype _bitness _arch _clibtype
+    _ostype="$(uname -s)"
+    _cputype="$(uname -m)"
+    _clibtype="gnu"
+
+    if [ "$_ostype" = Linux ]; then
+        if [ "$(uname -o)" = Android ]; then
+            _ostype=Android
+        fi
+        if ldd --version 2>&1 | grep -q 'musl'; then
+            _clibtype="musl"
+        fi
+    fi
+
+    if [ "$_ostype" = Darwin ]; then
+        # Darwin `uname -m` can lie due to Rosetta shenanigans. If you manage to
+        # invoke a native shell binary and then a native uname binary, you can
+        # get the real answer, but that's hard to ensure, so instead we use
+        # `sysctl` (which doesn't lie) to check for the actual architecture.
+        if [ "$_cputype" = i386 ]; then
+            # Handling i386 compatibility mode in older macOS versions (<10.15)
+            # running on x86_64-based Macs.
+            # Starting from 10.15, macOS explicitly bans all i386 binaries from running.
+            # See: <https://support.apple.com/en-us/HT208436>
+
+            # Avoid `sysctl: unknown oid` stderr output and/or non-zero exit code.
+            if sysctl hw.optional.x86_64 2> /dev/null || true | grep -q ': 1'; then
+                _cputype=x86_64
+            fi
+        elif [ "$_cputype" = x86_64 ]; then
+            # Handling x86-64 compatibility mode (a.k.a. Rosetta 2)
+            # in newer macOS versions (>=11) running on arm64-based Macs.
+            # Rosetta 2 is built exclusively for x86-64 and cannot run i386 binaries.
+
+            # Avoid `sysctl: unknown oid` stderr output and/or non-zero exit code.
+            if sysctl hw.optional.arm64 2> /dev/null || true | grep -q ': 1'; then
+                _cputype=arm64
+            fi
+        fi
+    fi
+
+    if [ "$_ostype" = SunOS ]; then
+        # Both Solaris and illumos presently announce as "SunOS" in "uname -s"
+        # so use "uname -o" to disambiguate.  We use the full path to the
+        # system uname in case the user has coreutils uname first in PATH,
+        # which has historically sometimes printed the wrong value here.
+        if [ "$(/usr/bin/uname -o)" = illumos ]; then
+            _ostype=illumos
+        fi
+
+        # illumos systems have multi-arch userlands, and "uname -m" reports the
+        # machine hardware name; e.g., "i86pc" on both 32- and 64-bit x86
+        # systems.  Check for the native (widest) instruction set on the
+        # running kernel:
+        if [ "$_cputype" = i86pc ]; then
+            _cputype="$(isainfo -n)"
+        fi
+    fi
+
+    case "$_ostype" in
+
+        Android)
+            _ostype=linux-android
+            ;;
+
+        Linux)
+            check_proc
+            _ostype=unknown-linux-$_clibtype
+            _bitness=$(get_bitness)
+            ;;
+
+        FreeBSD)
+            _ostype=unknown-freebsd
+            ;;
+
+        NetBSD)
+            _ostype=unknown-netbsd
+            ;;
+
+        DragonFly)
+            _ostype=unknown-dragonfly
+            ;;
+
+        Darwin)
+            _ostype=apple-darwin
+            ;;
+
+        illumos)
+            _ostype=unknown-illumos
+            ;;
+
+        MINGW* | MSYS* | CYGWIN* | Windows_NT)
+            _ostype=pc-windows-gnu
+            ;;
+
+        *)
+            err "unrecognized OS type: $_ostype"
+            ;;
+
+    esac
+
+    case "$_cputype" in
+
+        i386 | i486 | i686 | i786 | x86)
+            _cputype=i686
+            ;;
+
+        xscale | arm)
+            _cputype=arm
+            if [ "$_ostype" = "linux-android" ]; then
+                _ostype=linux-androideabi
+            fi
+            ;;
+
+        armv6l)
+            _cputype=arm
+            if [ "$_ostype" = "linux-android" ]; then
+                _ostype=linux-androideabi
+            else
+                _ostype="${_ostype}eabihf"
+            fi
+            ;;
+
+        armv7l | armv8l)
+            _cputype=armv7
+            if [ "$_ostype" = "linux-android" ]; then
+                _ostype=linux-androideabi
+            else
+                _ostype="${_ostype}eabihf"
+            fi
+            ;;
+
+        aarch64 | arm64)
+            _cputype=aarch64
+            ;;
+
+        x86_64 | x86-64 | x64 | amd64)
+            _cputype=x86_64
+            ;;
+
+        mips)
+            _cputype=$(get_endianness mips '' el)
+            ;;
+
+        mips64)
+            if [ "$_bitness" -eq 64 ]; then
+                # only n64 ABI is supported for now
+                _ostype="${_ostype}abi64"
+                _cputype=$(get_endianness mips64 '' el)
+            fi
+            ;;
+
+        ppc)
+            _cputype=powerpc
+            ;;
+
+        ppc64)
+            _cputype=powerpc64
+            ;;
+
+        ppc64le)
+            _cputype=powerpc64le
+            ;;
+
+        s390x)
+            _cputype=s390x
+            ;;
+        riscv64)
+            _cputype=riscv64gc
+            ;;
+        loongarch64)
+            _cputype=loongarch64
+            ensure_loongarch_uapi
+            ;;
+        *)
+            err "unknown CPU type: $_cputype"
+
+    esac
+
+    # Detect 64-bit linux with 32-bit userland
+    if [ "${_ostype}" = unknown-linux-gnu ] && [ "${_bitness}" -eq 32 ]; then
+        case $_cputype in
+            x86_64)
+                _cputype=i686
+                ;;
+            mips64)
+                _cputype=$(get_endianness mips '' el)
+                ;;
+            powerpc64)
+                _cputype=powerpc
+                ;;
+            aarch64)
+                _cputype=armv7
+                if [ "$_ostype" = "linux-android" ]; then
+                    _ostype=linux-androideabi
+                else
+                    _ostype="${_ostype}eabihf"
+                fi
+                ;;
+            riscv64gc)
+                err "riscv64 with 32-bit userland unsupported"
+                ;;
+        esac
+    fi
+
+    # Detect armv7 but without the CPU features Rust needs in that build,
+    # and fall back to arm.
+    # See https://github.com/rust-lang/rustup.rs/issues/587.
+    if [ "$_ostype" = "unknown-linux-gnueabihf" ] && [ "$_cputype" = armv7 ]; then
+        if ensure grep '^Features' /proc/cpuinfo | grep -E -q -v 'neon|simd'; then
+            # At least one processor does not have NEON (which is asimd on armv8+).
+            _cputype=arm
+        fi
+    fi
+
+    _arch="${_cputype}-${_ostype}"
+
+    RETVAL="$_arch"
+}
+
+check_proc() {
+    # Check for /proc by looking for the /proc/self/exe link
+    # This is only run on Linux
+    if ! test -L /proc/self/exe ; then
+        err "fatal: Unable to find /proc/self/exe.  Is /proc mounted?  Installation cannot proceed without /proc."
+    fi
+}
+
+get_bitness() {
+    need_cmd head
+    # Architecture detection without dependencies beyond coreutils.
+    # ELF files start out "\x7fELF", and the following byte is
+    #   0x01 for 32-bit and
+    #   0x02 for 64-bit.
+    # The printf builtin on some shells like dash only supports octal
+    # escape sequences, so we use those.
+    local _current_exe_head
+    _current_exe_head=$(head -c 5 /proc/self/exe )
+    if [ "$_current_exe_head" = "$(printf '\177ELF\001')" ]; then
+        echo 32
+    elif [ "$_current_exe_head" = "$(printf '\177ELF\002')" ]; then
+        echo 64
+    else
+        err "unknown platform bitness"
+    fi
+}
+
+get_endianness() {
+    local cputype=$1
+    local suffix_eb=$2
+    local suffix_el=$3
+
+    # detect endianness without od/hexdump, like get_bitness() does.
+    need_cmd head
+    need_cmd tail
+
+    local _current_exe_endianness
+    _current_exe_endianness="$(head -c 6 /proc/self/exe | tail -c 1)"
+    if [ "$_current_exe_endianness" = "$(printf '\001')" ]; then
+        echo "${cputype}${suffix_el}"
+    elif [ "$_current_exe_endianness" = "$(printf '\002')" ]; then
+        echo "${cputype}${suffix_eb}"
+    else
+        err "unknown platform endianness"
+    fi
+}
+
+need_cmd() {
+    if ! check_cmd "$1"; then
+        err "need '$1' (command not found)"
+    fi
+}
+
+check_cmd() {
+    command -v "$1" > /dev/null 2>&1
+}
+
+# Run a command that should never fail. If the command fails execution
+# will immediately terminate with an error showing the failing
+# command.
+ensure() {
+    if ! "$@"; then err "command failed: $*"; fi
+}
+
+main "$@" || exit 1

--- a/crates/update/src/cli.rs
+++ b/crates/update/src/cli.rs
@@ -4,15 +4,17 @@ use std::ffi::OsString;
 use std::future::Future;
 use std::process::ExitCode;
 
-use anyhow::Context;
 use spacetimedb_paths::{RootDir, SpacetimePaths};
 
 mod install;
 mod link;
 mod list;
+mod self_install;
 mod uninstall;
 mod upgrade;
 mod r#use;
+
+pub use self_install::SelfInstall;
 
 /// Manage installed spacetime versions
 #[derive(clap::Parser)]
@@ -38,26 +40,7 @@ impl Args {
                 crate::proxy::run_cli(Some(&paths), None, cli_args)
             }
             Subcommand::Version(version) => version.exec(&paths).map(|()| ExitCode::SUCCESS),
-            Subcommand::SelfInstall { install_latest } => {
-                let current_exe = std::env::current_exe().context("could not get current exe")?;
-                let suppress_eexists = |r: std::io::Result<()>| {
-                    r.or_else(|e| (e.kind() == std::io::ErrorKind::AlreadyExists).then_some(()).ok_or(e))
-                };
-                suppress_eexists(paths.cli_bin_dir.create()).context("could not create bin dir")?;
-                suppress_eexists(paths.cli_config_dir.create()).context("could not create config dir")?;
-                suppress_eexists(paths.data_dir.create()).context("could not create data dir")?;
-                paths
-                    .cli_bin_file
-                    .create_parent()
-                    .and_then(|()| std::fs::copy(&current_exe, &paths.cli_bin_file))
-                    .context("could not install binary")?;
-
-                if install_latest {
-                    upgrade::Upgrade {}.exec(&paths)?;
-                }
-
-                Ok(ExitCode::SUCCESS)
-            }
+            Subcommand::SelfInstall(self_install) => self_install.exec(),
         }
     }
 }
@@ -70,11 +53,7 @@ enum Subcommand {
         #[clap(allow_hyphen_values = true)]
         args: Vec<OsString>,
     },
-    SelfInstall {
-        /// Download and install the latest CLI version after self-installing.
-        #[arg(long)]
-        install_latest: bool,
-    },
+    SelfInstall(SelfInstall),
 }
 
 #[derive(clap::Args)]
@@ -119,7 +98,7 @@ fn tokio_block_on<Fut: Future>(fut: Fut) -> anyhow::Result<Fut::Output> {
     Ok(tokio::runtime::Runtime::new()?.block_on(fut))
 }
 
-#[derive(clap::Args)]
+#[derive(clap::Args, Copy, Clone)]
 struct ForceYes {
     /// Skip the confirmation dialog.
     #[arg(long, short)]
@@ -127,12 +106,15 @@ struct ForceYes {
 }
 
 impl ForceYes {
-    fn confirm(self, prompt: String) -> anyhow::Result<bool> {
+    fn confirm_with_default(self, prompt: String, default: bool) -> anyhow::Result<bool> {
         let yes = self.yes
             || dialoguer::Confirm::new()
                 .with_prompt(prompt)
-                .default(false)
+                .default(default)
                 .interact()?;
         Ok(yes)
+    }
+    fn confirm(self, prompt: String) -> anyhow::Result<bool> {
+        self.confirm_with_default(prompt, false)
     }
 }

--- a/crates/update/src/cli/install.rs
+++ b/crates/update/src/cli/install.rs
@@ -39,7 +39,7 @@ impl Install {
                 "can only install spacetimedb-standalone at the moment"
             );
             let client = super::reqwest_client()?;
-            let version = download_and_install(&client, Some(self.version), self.artifact_name, paths).await?;
+            let (version, _) = download_and_install(&client, Some(self.version), self.artifact_name, paths).await?;
             if self.r#use {
                 paths.cli_bin_dir.set_current_version(&version.to_string())?;
             }
@@ -48,19 +48,23 @@ impl Install {
     }
 }
 
+pub(super) fn make_progress_bar() -> ProgressBar {
+    let pb = ProgressBar::new(0).with_style(ProgressStyle::with_template("{spinner} {prefix}{msg}").unwrap());
+    pb.enable_steady_tick(std::time::Duration::from_millis(60));
+    pb
+}
+
 pub(super) async fn download_and_install(
     client: &reqwest::Client,
     version: Option<semver::Version>,
     artifact_name: Option<String>,
     paths: &SpacetimePaths,
-) -> anyhow::Result<semver::Version> {
+) -> anyhow::Result<(semver::Version, Release)> {
     let custom_artifact = artifact_name.is_some();
     let download_name = artifact_name.as_deref().unwrap_or(DOWNLOAD_NAME);
     let artifact_type = ArtifactType::deduce(download_name).context("Unknown archive type")?;
 
-    let pb_style = ProgressStyle::with_template("{spinner} {prefix}{msg}").unwrap();
-    let pb = ProgressBar::new(0).with_style(pb_style.clone());
-    pb.enable_steady_tick(std::time::Duration::from_millis(60));
+    let pb = make_progress_bar();
 
     pb.set_message("Resolving version...");
     let releases_url = "https://api.github.com/repos/clockworklabs/SpacetimeDB/releases";
@@ -101,12 +105,10 @@ pub(super) async fn download_and_install(
             }
         })?;
 
-    pb.set_style(ProgressStyle::with_template("{spinner} {prefix}{msg} {bytes}/{total_bytes} ({eta})").unwrap());
     pb.set_prefix(format!("Installing v{release_version}: "));
     pb.set_message("downloading...");
     let archive = download_with_progress(&pb, client, &asset.browser_download_url).await?;
 
-    pb.set_style(pb_style);
     pb.set_message("unpacking...");
 
     let version_dir = paths.cli_bin_dir.version_dir(&release_version.to_string());
@@ -124,7 +126,7 @@ pub(super) async fn download_and_install(
 
     pb.finish_with_message("done!");
 
-    Ok(release_version)
+    Ok((release_version, release))
 }
 
 enum ArtifactType {
@@ -155,15 +157,15 @@ pub(super) async fn available_releases(client: &reqwest::Client) -> anyhow::Resu
 }
 
 #[derive(Deserialize)]
-struct ReleaseAsset {
-    name: String,
-    browser_download_url: String,
+pub(super) struct ReleaseAsset {
+    pub(super) name: String,
+    pub(super) browser_download_url: String,
 }
 
 #[derive(Deserialize)]
-struct Release {
+pub(super) struct Release {
     tag_name: String,
-    assets: Vec<ReleaseAsset>,
+    pub(super) assets: Vec<ReleaseAsset>,
 }
 
 impl Release {
@@ -173,13 +175,16 @@ impl Release {
     }
 }
 
-async fn download_with_progress(
+pub(super) async fn download_with_progress(
     pb: &ProgressBar,
     client: &reqwest::Client,
     url: &str,
 ) -> Result<http_body_util::Collected<Bytes>, anyhow::Error> {
     let response = client.get(url).send().await?.error_for_status()?;
 
+    let pb_style = pb.style();
+
+    pb.set_style(ProgressStyle::with_template("{spinner} {prefix}{msg} {bytes}/{total_bytes} ({eta})").unwrap());
     pb.set_length(response.content_length().unwrap_or(0));
 
     let body = reqwest::Body::from(response)
@@ -191,6 +196,8 @@ async fn download_with_progress(
         })
         .collect()
         .await?;
+
+    pb.set_style(pb_style);
 
     Ok(body)
 }

--- a/crates/update/src/cli/self_install.rs
+++ b/crates/update/src/cli/self_install.rs
@@ -1,0 +1,117 @@
+use std::process::ExitCode;
+
+use anyhow::Context;
+use spacetimedb_paths::{RootDir, SpacetimePaths};
+
+use crate::cli::ForceYes;
+
+/// Install the SpacetimeDB CLI.
+// NOTICE: If you change anything here, please make the same changes in spacetime-install.sh
+#[derive(clap::Parser)]
+#[command(bin_name = "spacetime-install[EXE]")]
+pub struct SelfInstall {
+    /// The directory to locally install SpacetimeDB into. If unspecified, uses platform defaults.
+    #[arg(long)]
+    root_dir: Option<RootDir>,
+
+    #[command(flatten)]
+    yes: ForceYes,
+}
+
+impl SelfInstall {
+    pub fn exec(self) -> anyhow::Result<ExitCode> {
+        let paths = match &self.root_dir {
+            Some(root_dir) => SpacetimePaths::from_root_dir(root_dir),
+            None => SpacetimePaths::platform_defaults()?,
+        };
+
+        let SpacetimePaths {
+            cli_config_dir,
+            cli_bin_file,
+            cli_bin_dir,
+            data_dir,
+        } = &paths;
+
+        eprintln!("Our EULA for spacetimedb-cli can be found here: <https://spacetimedb.com/eula>");
+        if self.yes.yes {
+            eprintln!("By continuing, you agree to the EULA.");
+        } else if !self.yes.confirm_with_default("Agree to the EULA?".to_owned(), true)? {
+            return Ok(ExitCode::FAILURE);
+        }
+
+        let root_dir = self.root_dir.or_else(|| paths.to_root_dir());
+        eprint!("The SpacetimeDB command line tool will now be installed");
+        if let Some(root_dir) = &root_dir {
+            eprintln!(" into {}", root_dir.display());
+        } else {
+            eprintln!(":");
+            eprintln!("\tCLI configuration directory: {}", cli_config_dir.display());
+            eprintln!("\t`spacetime` binary: {}", cli_bin_file.display());
+            eprintln!(
+                "\tdirectory for installed SpacetimeDB versions: {}",
+                cli_bin_dir.display()
+            );
+            eprintln!("\tdatabase directory: {}", data_dir.display());
+        }
+        if !self
+            .yes
+            .confirm_with_default("Would you like to continue?".to_owned(), true)?
+        {
+            eprintln!("Exiting.");
+            return Ok(ExitCode::FAILURE);
+        }
+
+        let current_exe = std::env::current_exe().context("could not get current exe")?;
+        let suppress_eexists = |r: std::io::Result<()>| {
+            r.or_else(|e| (e.kind() == std::io::ErrorKind::AlreadyExists).then_some(()).ok_or(e))
+        };
+        suppress_eexists(cli_bin_dir.create()).context("could not create bin dir")?;
+        suppress_eexists(cli_config_dir.create()).context("could not create config dir")?;
+        suppress_eexists(data_dir.create()).context("could not create data dir")?;
+        cli_bin_file
+            .create_parent()
+            .and_then(|()| std::fs::copy(&current_exe, cli_bin_file))
+            .context("could not install binary")?;
+
+        eprintln!("Downloading latest version...");
+        let res = super::upgrade::Upgrade {}
+            .exec(&paths)
+            .context("failed to download and install latest SpacetimeDB version");
+        if let Err(err) = &res {
+            eprintln!("Error: {err:#}\n")
+        }
+
+        eprintln!(
+            "\
+The `spacetime` command has been installed as {cli_bin_file}
+Note: we recommend making sure that this executable is in your PATH variable.
+
+The install process is complete; check out our quickstart guide to get started!
+	<https://spacetimedb.com/docs/quick-start>",
+            cli_bin_file = cli_bin_file.display()
+        );
+
+        Ok(ExitCode::SUCCESS)
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use clap::CommandFactory;
+
+    use super::*;
+
+    #[test]
+    fn ensure_script_help_is_up_to_date() {
+        let help_text = SelfInstall::command().render_long_help().to_string();
+        let script = std::fs::read_to_string(concat!(env!("CARGO_MANIFEST_DIR"), "/spacetime-install.sh")).unwrap();
+        let (_, heredoc) = script
+            .split_once("usage() {\n    cat <<EOF\n")
+            .expect("couldn't find usage function");
+        let (heredoc, _) = heredoc.split_once("EOF").expect("couldn't find end of heredoc");
+        assert!(
+            help_text == heredoc,
+            "the usage text in spacetime-install.sh is out of date from the CLI. it should be:\n{help_text}"
+        );
+    }
+}

--- a/crates/update/src/cli/upgrade.rs
+++ b/crates/update/src/cli/upgrade.rs
@@ -1,4 +1,10 @@
+use std::io::Write;
+
+use anyhow::Context;
+use bytes::Buf;
 use spacetimedb_paths::SpacetimePaths;
+
+use super::install::{download_and_install, download_with_progress, make_progress_bar};
 
 /// Upgrade and switch to the latest available version of SpacetimeDB.
 #[derive(clap::Args)]
@@ -8,20 +14,41 @@ impl Upgrade {
     pub(super) fn exec(self, paths: &SpacetimePaths) -> anyhow::Result<()> {
         super::tokio_block_on(async {
             let client = super::reqwest_client()?;
-            let version = super::install::download_and_install(&client, None, None, paths).await?;
+            let (version, release) = download_and_install(&client, None, None, paths).await?;
             paths.cli_bin_dir.set_current_version(&version.to_string())?;
 
             let cur_version = semver::Version::parse(env!("CARGO_PKG_VERSION")).unwrap();
             if version > cur_version {
-                let mut new_update_binary = paths
-                    .cli_bin_dir
-                    .version_dir(&version.to_string())
-                    .0
-                    .join("spacetimedb-update");
-                new_update_binary.set_extension(std::env::consts::EXE_EXTENSION);
-                if new_update_binary.exists() {
-                    tokio::fs::copy(new_update_binary, &paths.cli_bin_file).await?;
-                    eprintln!("Self-updated `spacetime version` command")
+                if let Some(asset) = release.assets.iter().find(|asset| asset.name == UPDATE_BIN_NAME) {
+                    let pb = make_progress_bar().with_prefix("Self-updating `spacetime version`: ");
+                    pb.set_message("downloading...");
+                    let bin = download_with_progress(&pb, &client, &asset.browser_download_url).await?;
+                    pb.set_message("installing...");
+                    let cli_bin_file = paths.cli_bin_file.clone();
+                    tokio::task::spawn_blocking(move || {
+                        let mut file = tempfile::NamedTempFile::with_prefix_in(
+                            ".spacetimedb-update-tmp",
+                            cli_bin_file.0.parent().unwrap(),
+                        )?;
+                        #[cfg(unix)]
+                        file.as_file_mut()
+                            .set_permissions(std::os::unix::fs::PermissionsExt::from_mode(0o755))?;
+                        // TODO(noa): write_all_vectored once stabilized
+                        let mut bin = bin.aggregate();
+                        while bin.has_remaining() {
+                            let chunk = bin.chunk();
+                            file.write_all(chunk)?;
+                            bin.advance(chunk.len());
+                        }
+                        file.persist(cli_bin_file)
+                            .map_err(|e| e.error)
+                            .context("failed to overwrite existing spacetime binary")
+                    })
+                    .await??;
+
+                    pb.finish_with_message("done!");
+                } else {
+                    eprintln!("Tried to self-update `spacetime version`, but no release asset was found.");
                 }
             }
 
@@ -29,3 +56,9 @@ impl Upgrade {
         })?
     }
 }
+
+const UPDATE_BIN_NAME: &str = if cfg!(windows) {
+    concat!("spacetimedb-update-", env!("BUILD_TARGET"), ".exe")
+} else {
+    concat!("spacetimedb-update-", env!("BUILD_TARGET"))
+};

--- a/crates/update/src/main.rs
+++ b/crates/update/src/main.rs
@@ -26,6 +26,8 @@ fn main() -> anyhow::Result<ExitCode> {
         } else {
             proxy::run_cli(None, Some(argv0.as_os_str()), args)
         }
+    } else if cmd == "spacetime-install" {
+        cli::SelfInstall::parse().exec()
     } else {
         anyhow::bail!(
             "unknown command name for spacetimedb-update multicall binary: {}",


### PR DESCRIPTION
# Description of Changes

Based on #2263, might make more sense to combine them as one PR.

This has a couple changes beyond just updating for the new spacetimedb-update functionality, mostly taken from looking at how `rustup-init.sh` does things:
- Uses the `get_architecture` function from `rustup-init.sh`, since it's existing well-tested code that gives us the rust/llvm target tuple, and platform detection code is horrible to write.
- checks for flags passed to the installer:
  - if `-h` or `--help` is passed, prints the help text of the installer without having to download and execute it.
- If the download fails, check whether it was because of a 404 and give a good error message ("It seems like we may not have prebuilt binaries for your platform.")
- check for the case `chmod +x` doesn't actually set the executable bit and give an error message (from `rustup-init.sh`)

# Expected complexity level and risk

2: lotta shell code, but a lot was just taken from rustup's `rustup-init.sh`, which is already well-tested

# Testing

- [x] Tested that spacetime-install.sh works in a fresh docker image
- [x] Need to test on windows.
