### PR TITLE
C#: *BTreeIndexBounds => *IndexScanRangeBounds

### DIFF
--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#FFI.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#FFI.verified.cs
@@ -295,28 +295,28 @@ namespace SpacetimeDB
             {
                 public IEnumerable<global::TestIndexIssues> Filter(int SelfIndexingColumn) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<int, SpacetimeDB.BSATN.I32>(
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<int, SpacetimeDB.BSATN.I32>(
                             SelfIndexingColumn
                         )
                     );
 
                 public ulong Delete(int SelfIndexingColumn) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<int, SpacetimeDB.BSATN.I32>(
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<int, SpacetimeDB.BSATN.I32>(
                             SelfIndexingColumn
                         )
                     );
 
                 public IEnumerable<global::TestIndexIssues> Filter(Bound<int> SelfIndexingColumn) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<int, SpacetimeDB.BSATN.I32>(
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<int, SpacetimeDB.BSATN.I32>(
                             SelfIndexingColumn
                         )
                     );
 
                 public ulong Delete(Bound<int> SelfIndexingColumn) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<int, SpacetimeDB.BSATN.I32>(
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<int, SpacetimeDB.BSATN.I32>(
                             SelfIndexingColumn
                         )
                     );

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#FFI.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#FFI.verified.cs
@@ -100,27 +100,27 @@ namespace SpacetimeDB
             {
                 public IEnumerable<global::BTreeMultiColumn> Filter(uint X) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<uint, SpacetimeDB.BSATN.U32>(X)
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<uint, SpacetimeDB.BSATN.U32>(X)
                     );
 
                 public ulong Delete(uint X) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<uint, SpacetimeDB.BSATN.U32>(X)
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<uint, SpacetimeDB.BSATN.U32>(X)
                     );
 
                 public IEnumerable<global::BTreeMultiColumn> Filter(Bound<uint> X) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<uint, SpacetimeDB.BSATN.U32>(X)
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<uint, SpacetimeDB.BSATN.U32>(X)
                     );
 
                 public ulong Delete(Bound<uint> X) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<uint, SpacetimeDB.BSATN.U32>(X)
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<uint, SpacetimeDB.BSATN.U32>(X)
                     );
 
                 public IEnumerable<global::BTreeMultiColumn> Filter((uint X, uint Y) f) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<
                             uint,
                             SpacetimeDB.BSATN.U32,
                             uint,
@@ -130,7 +130,7 @@ namespace SpacetimeDB
 
                 public ulong Delete((uint X, uint Y) f) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<
                             uint,
                             SpacetimeDB.BSATN.U32,
                             uint,
@@ -140,7 +140,7 @@ namespace SpacetimeDB
 
                 public IEnumerable<global::BTreeMultiColumn> Filter((uint X, Bound<uint> Y) f) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<
                             uint,
                             SpacetimeDB.BSATN.U32,
                             uint,
@@ -150,7 +150,7 @@ namespace SpacetimeDB
 
                 public ulong Delete((uint X, Bound<uint> Y) f) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<
                             uint,
                             SpacetimeDB.BSATN.U32,
                             uint,
@@ -160,7 +160,7 @@ namespace SpacetimeDB
 
                 public IEnumerable<global::BTreeMultiColumn> Filter((uint X, uint Y, uint Z) f) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<
                             uint,
                             SpacetimeDB.BSATN.U32,
                             uint,
@@ -172,7 +172,7 @@ namespace SpacetimeDB
 
                 public ulong Delete((uint X, uint Y, uint Z) f) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<
                             uint,
                             SpacetimeDB.BSATN.U32,
                             uint,
@@ -186,7 +186,7 @@ namespace SpacetimeDB
                     (uint X, uint Y, Bound<uint> Z) f
                 ) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<
                             uint,
                             SpacetimeDB.BSATN.U32,
                             uint,
@@ -198,7 +198,7 @@ namespace SpacetimeDB
 
                 public ulong Delete((uint X, uint Y, Bound<uint> Z) f) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<
                             uint,
                             SpacetimeDB.BSATN.U32,
                             uint,
@@ -302,27 +302,27 @@ namespace SpacetimeDB
             {
                 public IEnumerable<global::BTreeViews> Filter(uint X) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<uint, SpacetimeDB.BSATN.U32>(X)
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<uint, SpacetimeDB.BSATN.U32>(X)
                     );
 
                 public ulong Delete(uint X) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<uint, SpacetimeDB.BSATN.U32>(X)
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<uint, SpacetimeDB.BSATN.U32>(X)
                     );
 
                 public IEnumerable<global::BTreeViews> Filter(Bound<uint> X) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<uint, SpacetimeDB.BSATN.U32>(X)
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<uint, SpacetimeDB.BSATN.U32>(X)
                     );
 
                 public ulong Delete(Bound<uint> X) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<uint, SpacetimeDB.BSATN.U32>(X)
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<uint, SpacetimeDB.BSATN.U32>(X)
                     );
 
                 public IEnumerable<global::BTreeViews> Filter((uint X, uint Y) f) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<
                             uint,
                             SpacetimeDB.BSATN.U32,
                             uint,
@@ -332,7 +332,7 @@ namespace SpacetimeDB
 
                 public ulong Delete((uint X, uint Y) f) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<
                             uint,
                             SpacetimeDB.BSATN.U32,
                             uint,
@@ -342,7 +342,7 @@ namespace SpacetimeDB
 
                 public IEnumerable<global::BTreeViews> Filter((uint X, Bound<uint> Y) f) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<
                             uint,
                             SpacetimeDB.BSATN.U32,
                             uint,
@@ -352,7 +352,7 @@ namespace SpacetimeDB
 
                 public ulong Delete((uint X, Bound<uint> Y) f) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<
                             uint,
                             SpacetimeDB.BSATN.U32,
                             uint,
@@ -368,28 +368,28 @@ namespace SpacetimeDB
             {
                 public IEnumerable<global::BTreeViews> Filter(string Faction) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<string, SpacetimeDB.BSATN.String>(
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<string, SpacetimeDB.BSATN.String>(
                             Faction
                         )
                     );
 
                 public ulong Delete(string Faction) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<string, SpacetimeDB.BSATN.String>(
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<string, SpacetimeDB.BSATN.String>(
                             Faction
                         )
                     );
 
                 public IEnumerable<global::BTreeViews> Filter(Bound<string> Faction) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<string, SpacetimeDB.BSATN.String>(
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<string, SpacetimeDB.BSATN.String>(
                             Faction
                         )
                     );
 
                 public ulong Delete(Bound<string> Faction) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<string, SpacetimeDB.BSATN.String>(
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<string, SpacetimeDB.BSATN.String>(
                             Faction
                         )
                     );
@@ -490,28 +490,28 @@ namespace SpacetimeDB
             {
                 public IEnumerable<global::MultiTableRow> Filter(string Name) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<string, SpacetimeDB.BSATN.String>(
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<string, SpacetimeDB.BSATN.String>(
                             Name
                         )
                     );
 
                 public ulong Delete(string Name) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<string, SpacetimeDB.BSATN.String>(
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<string, SpacetimeDB.BSATN.String>(
                             Name
                         )
                     );
 
                 public IEnumerable<global::MultiTableRow> Filter(Bound<string> Name) =>
                     DoFilter(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<string, SpacetimeDB.BSATN.String>(
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<string, SpacetimeDB.BSATN.String>(
                             Name
                         )
                     );
 
                 public ulong Delete(Bound<string> Name) =>
                     DoDelete(
-                        new SpacetimeDB.Internal.BTreeIndexBounds<string, SpacetimeDB.BSATN.String>(
+                        new SpacetimeDB.Internal.IndexScanRangeBounds<string, SpacetimeDB.BSATN.String>(
                             Name
                         )
                     );

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -420,17 +420,17 @@ record TableDeclaration : BaseTypeDeclaration<ColumnDeclaration>
 
                 yield return $$"""
                         public IEnumerable<{{globalName}}> Filter({{argsScalar}}) =>
-                            DoFilter(new SpacetimeDB.Internal.BTreeIndexBounds<{{types}}>({{argName}}));
+                            DoFilter(new SpacetimeDB.Internal.IndexScanRangeBounds<{{types}}>({{argName}}));
 
                         public ulong Delete({{argsScalar}}) =>
-                            DoDelete(new SpacetimeDB.Internal.BTreeIndexBounds<{{types}}>({{argName}}));
+                            DoDelete(new SpacetimeDB.Internal.IndexScanRangeBounds<{{types}}>({{argName}}));
 
                         public IEnumerable<{{globalName}}> Filter({{argsBounds}}) =>
-                            DoFilter(new SpacetimeDB.Internal.BTreeIndexBounds<{{types}}>({{argName}}));
+                            DoFilter(new SpacetimeDB.Internal.IndexScanRangeBounds<{{types}}>({{argName}}));
 
                         public ulong Delete({{argsBounds}}) =>
-                            DoDelete(new SpacetimeDB.Internal.BTreeIndexBounds<{{types}}>({{argName}}));
-                    
+                            DoDelete(new SpacetimeDB.Internal.IndexScanRangeBounds<{{types}}>({{argName}}));
+
                     """;
             }
 

--- a/crates/bindings-csharp/Runtime/Internal/Bounds.cs
+++ b/crates/bindings-csharp/Runtime/Internal/Bounds.cs
@@ -9,7 +9,7 @@ enum BoundVariant : byte
     Unbounded,
 }
 
-public interface IBTreeIndexBounds
+public interface IIndexScanRangeBounds
 {
     ushort PrefixElems { get; }
     void Prefix(BinaryWriter w);
@@ -28,7 +28,7 @@ public readonly struct Bound<T>(T min, T max)
     public static implicit operator Bound<T>((T min, T max) span) => new(span.min, span.max);
 }
 
-public readonly struct BTreeIndexBounds<T, TRW>(Bound<T> t) : IBTreeIndexBounds
+public readonly struct IndexScanRangeBounds<T, TRW>(Bound<T> t) : IIndexScanRangeBounds
     where T : IEquatable<T>
     where TRW : struct, IReadWrite<T>
 {
@@ -49,7 +49,7 @@ public readonly struct BTreeIndexBounds<T, TRW>(Bound<T> t) : IBTreeIndexBounds
     }
 }
 
-public readonly struct BTreeIndexBounds<T, TRW, U, URW>((T t, Bound<U> u) b) : IBTreeIndexBounds
+public readonly struct IndexScanRangeBounds<T, TRW, U, URW>((T t, Bound<U> u) b) : IIndexScanRangeBounds
     where U : IEquatable<U>
     where TRW : struct, IReadWrite<T>
     where URW : struct, IReadWrite<U>
@@ -74,8 +74,8 @@ public readonly struct BTreeIndexBounds<T, TRW, U, URW>((T t, Bound<U> u) b) : I
     }
 }
 
-public readonly struct BTreeIndexBounds<T, TRW, U, URW, V, VRW>((T t, U u, Bound<V> v) b)
-    : IBTreeIndexBounds
+public readonly struct IndexScanRangeBounds<T, TRW, U, URW, V, VRW>((T t, U u, Bound<V> v) b)
+    : IIndexScanRangeBounds
     where V : IEquatable<V>
     where TRW : struct, IReadWrite<T>
     where URW : struct, IReadWrite<U>
@@ -102,9 +102,9 @@ public readonly struct BTreeIndexBounds<T, TRW, U, URW, V, VRW>((T t, U u, Bound
     }
 }
 
-public readonly struct BTreeIndexBounds<T, TRW, U, URW, V, VRW, W, WRW>(
+public readonly struct IndexScanRangeBounds<T, TRW, U, URW, V, VRW, W, WRW>(
     (T t, U u, V v, Bound<W> w) b
-) : IBTreeIndexBounds
+) : IIndexScanRangeBounds
     where W : IEquatable<W>
     where TRW : struct, IReadWrite<T>
     where URW : struct, IReadWrite<U>
@@ -133,9 +133,9 @@ public readonly struct BTreeIndexBounds<T, TRW, U, URW, V, VRW, W, WRW>(
     }
 }
 
-public readonly struct BTreeIndexBounds<T, TRW, U, URW, V, VRW, W, WRW, X, XRW>(
+public readonly struct IndexScanRangeBounds<T, TRW, U, URW, V, VRW, W, WRW, X, XRW>(
     (T t, U u, V v, W w, Bound<X> x) b
-) : IBTreeIndexBounds
+) : IIndexScanRangeBounds
     where X : IEquatable<X>
     where TRW : struct, IReadWrite<T>
     where URW : struct, IReadWrite<U>
@@ -166,9 +166,9 @@ public readonly struct BTreeIndexBounds<T, TRW, U, URW, V, VRW, W, WRW, X, XRW>(
     }
 }
 
-public readonly struct BTreeIndexBounds<T, TRW, U, URW, V, VRW, W, WRW, X, XRW, Y, YRW>(
+public readonly struct IndexScanRangeBounds<T, TRW, U, URW, V, VRW, W, WRW, X, XRW, Y, YRW>(
     (T t, U u, V v, W w, X x, Bound<Y> y) b
-) : IBTreeIndexBounds
+) : IIndexScanRangeBounds
     where Y : IEquatable<Y>
     where TRW : struct, IReadWrite<T>
     where URW : struct, IReadWrite<U>
@@ -201,9 +201,9 @@ public readonly struct BTreeIndexBounds<T, TRW, U, URW, V, VRW, W, WRW, X, XRW, 
     }
 }
 
-public readonly struct BTreeIndexBounds<T, TRW, U, URW, V, VRW, W, WRW, X, XRW, Y, YRW, Z, ZRW>(
+public readonly struct IndexScanRangeBounds<T, TRW, U, URW, V, VRW, W, WRW, X, XRW, Y, YRW, Z, ZRW>(
     (T t, U u, V v, W w, X x, Y y, Bound<Z> z) b
-) : IBTreeIndexBounds
+) : IIndexScanRangeBounds
     where Z : IEquatable<Z>
     where TRW : struct, IReadWrite<T>
     where URW : struct, IReadWrite<U>
@@ -238,7 +238,7 @@ public readonly struct BTreeIndexBounds<T, TRW, U, URW, V, VRW, W, WRW, X, XRW, 
     }
 }
 
-public readonly struct BTreeIndexBounds<
+public readonly struct IndexScanRangeBounds<
     T,
     TRW,
     U,
@@ -255,7 +255,7 @@ public readonly struct BTreeIndexBounds<
     ZRW,
     A,
     ARW
->((T t, U u, V v, W w, X x, Y y, Z z, Bound<A> a) b) : IBTreeIndexBounds
+>((T t, U u, V v, W w, X x, Y y, Z z, Bound<A> a) b) : IIndexScanRangeBounds
     where A : IEquatable<A>
     where TRW : struct, IReadWrite<T>
     where URW : struct, IReadWrite<U>
@@ -292,7 +292,7 @@ public readonly struct BTreeIndexBounds<
     }
 }
 
-public readonly struct BTreeIndexBounds<
+public readonly struct IndexScanRangeBounds<
     T,
     TRW,
     U,
@@ -311,7 +311,7 @@ public readonly struct BTreeIndexBounds<
     ARW,
     B,
     BRW
->((T t, U u, V v, W w, X x, Y y, Z z, A a, Bound<B> b) b) : IBTreeIndexBounds
+>((T t, U u, V v, W w, X x, Y y, Z z, A a, Bound<B> b) b) : IIndexScanRangeBounds
     where B : IEquatable<B>
     where TRW : struct, IReadWrite<T>
     where URW : struct, IReadWrite<U>
@@ -350,7 +350,7 @@ public readonly struct BTreeIndexBounds<
     }
 }
 
-public readonly struct BTreeIndexBounds<
+public readonly struct IndexScanRangeBounds<
     T,
     TRW,
     U,
@@ -371,7 +371,7 @@ public readonly struct BTreeIndexBounds<
     BRW,
     C,
     CRW
->((T t, U u, V v, W w, X x, Y y, Z z, A a, B b, Bound<C> c) b) : IBTreeIndexBounds
+>((T t, U u, V v, W w, X x, Y y, Z z, A a, B b, Bound<C> c) b) : IIndexScanRangeBounds
     where C : IEquatable<C>
     where TRW : struct, IReadWrite<T>
     where URW : struct, IReadWrite<U>

--- a/crates/bindings-csharp/Runtime/Internal/IIndex.cs
+++ b/crates/bindings-csharp/Runtime/Internal/IIndex.cs
@@ -21,7 +21,7 @@ public abstract class IndexBase<Row>
         out ReadOnlySpan<byte> rstart,
         out ReadOnlySpan<byte> rend
     )
-        where Bounds : IBTreeIndexBounds
+        where Bounds : IIndexScanRangeBounds
     {
         prefixElems = new FFI.ColId(bounds.PrefixElems);
 
@@ -41,10 +41,10 @@ public abstract class IndexBase<Row>
     }
 
     protected IEnumerable<Row> DoFilter<Bounds>(Bounds bounds)
-        where Bounds : IBTreeIndexBounds => new RawTableIter<Bounds>(indexId, bounds).Parse();
+        where Bounds : IIndexScanRangeBounds => new RawTableIter<Bounds>(indexId, bounds).Parse();
 
     protected uint DoDelete<Bounds>(Bounds bounds)
-        where Bounds : IBTreeIndexBounds
+        where Bounds : IIndexScanRangeBounds
     {
         ToParams(bounds, out var prefixElems, out var prefix, out var rstart, out var rend);
         FFI.datastore_delete_by_index_scan_range_bsatn(
@@ -62,7 +62,7 @@ public abstract class IndexBase<Row>
     }
 
     private class RawTableIter<Bounds>(FFI.IndexId indexId, Bounds bounds) : RawTableIterBase<Row>
-        where Bounds : IBTreeIndexBounds
+        where Bounds : IIndexScanRangeBounds
     {
         protected override void IterStart(out FFI.RowIter handle)
         {
@@ -89,7 +89,7 @@ public abstract class UniqueIndex<Handle, Row, T, RW>(Handle table, string name)
     where T : IEquatable<T>
     where RW : struct, BSATN.IReadWrite<T>
 {
-    private static BTreeIndexBounds<T, RW> ToBounds(T key) => new(key);
+    private static IndexScanRangeBounds<T, RW> ToBounds(T key) => new(key);
 
     protected IEnumerable<Row> DoFilter(T key) => DoFilter(ToBounds(key));
 


### PR DESCRIPTION
# Description of Changes

In C# bindings, rename `*BTreeIndexBounds` to `*IndexScanRangeBounds` to be consistent with the Rust bindings.

# API and ABI breaking changes

These were marked as `Internal`, so arguably not.

# Expected complexity level and risk

2

# Testing

Existing tests are amended to fit the rename.