### PR TITLE
Send delete updates for unsubscribes

### DIFF
--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -5,10 +5,10 @@ use spacetimedb::host::module_host::DatabaseTableUpdate;
 use spacetimedb::identity::AuthCtx;
 use spacetimedb::messages::websocket::BsatnFormat;
 use spacetimedb::sql::ast::SchemaViewer;
-use spacetimedb::subscription::collect_table_update;
 use spacetimedb::subscription::query::compile_read_only_queryset;
 use spacetimedb::subscription::subscription::ExecutionSet;
 use spacetimedb::subscription::tx::DeltaTx;
+use spacetimedb::subscription::{collect_table_update, TableUpdateType};
 use spacetimedb::{db::relational_db::RelationalDB, messages::websocket::Compression};
 use spacetimedb_bench::database::BenchDatabase as _;
 use spacetimedb_bench::spacetime_raw::SpacetimeRaw;
@@ -129,6 +129,7 @@ fn eval(c: &mut Criterion) {
                     table_name.clone(),
                     Compression::None,
                     &tx,
+                    TableUpdateType::Subscribe,
                 )))
             })
         });

--- a/crates/core/src/subscription/mod.rs
+++ b/crates/core/src/subscription/mod.rs
@@ -63,6 +63,14 @@ where
     Ok((list, n, metrics))
 }
 
+/// When collecting a table update are we inserting or deleting rows?
+/// For unsubscribe operations, we need to delete rows.
+#[derive(Debug, Clone, Copy)]
+pub enum TableUpdateType {
+    Subscribe,
+    Unsubscribe,
+}
+
 /// Execute a subscription query and collect the results in a [TableUpdate]
 pub fn collect_table_update<Tx, F>(
     plan: &PipelinedProject,
@@ -70,14 +78,25 @@ pub fn collect_table_update<Tx, F>(
     table_name: Box<str>,
     comp: Compression,
     tx: &Tx,
+    update_type: TableUpdateType,
 ) -> Result<(TableUpdate<F>, ExecutionMetrics)>
 where
     Tx: Datastore + DeltaStore,
     F: WebsocketFormat,
 {
-    execute_plan::<Tx, F>(plan, tx).map(|(inserts, num_rows, metrics)| {
-        let deletes = F::List::default();
-        let qu = QueryUpdate { deletes, inserts };
+    execute_plan::<Tx, F>(plan, tx).map(|(rows, num_rows, metrics)| {
+        let empty = F::List::default();
+        let qu = match update_type {
+            TableUpdateType::Subscribe => QueryUpdate {
+                deletes: empty,
+                inserts: rows,
+            },
+            TableUpdateType::Unsubscribe => QueryUpdate {
+                deletes: rows,
+                inserts: empty,
+            },
+        };
+        // let qu = QueryUpdate { deletes, inserts };
         let update = F::into_query_update(qu, comp);
         (TableUpdate::new(table_id, table_name, (update, num_rows)), metrics)
     })
@@ -88,6 +107,7 @@ pub fn execute_plans<Tx, F>(
     plans: &[Arc<Plan>],
     comp: Compression,
     tx: &Tx,
+    update_type: TableUpdateType,
 ) -> Result<(DatabaseUpdate<F>, ExecutionMetrics)>
 where
     Tx: Datastore + DeltaStore + Sync,
@@ -101,7 +121,7 @@ where
                 .clone()
                 .optimize()
                 .map(PipelinedProject::from)
-                .and_then(|plan| collect_table_update(&plan, table_id, table_name.into(), comp, tx))
+                .and_then(|plan| collect_table_update(&plan, table_id, table_name.into(), comp, tx, update_type))
         })
         .collect::<Result<Vec<_>>>()
         .map(|table_updates_with_metrics| {


### PR DESCRIPTION
# Description of Changes

We were sending row insert operations in `Unsubscribe` messages, so clients aren't actually removing the rows. This adds a way to invert query results for `Unsubscribe` operations.

This means unsubscribe is currently not removing the data...

cc @gefjon @kazimuth 

# Expected complexity level and risk

1

# Testing

I extended the existing unsubscribe test so that the query actually returns something.
