### PR TITLE
CLI - Remove newlines from command helptext

### DIFF
--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -18,7 +18,7 @@ use super::sql::parse_req;
 pub fn cli() -> clap::Command {
     clap::Command::new("call")
         .about(format!(
-            "Invokes a reducer function in a database.\n\n{}",
+            "Invokes a reducer function in a database. {}",
             UNSTABLE_WARNING
         ))
         .arg(

--- a/crates/cli/src/subcommands/describe.rs
+++ b/crates/cli/src/subcommands/describe.rs
@@ -10,7 +10,7 @@ use spacetimedb_lib::sats;
 pub fn cli() -> clap::Command {
     clap::Command::new("describe")
         .about(format!(
-            "Describe the structure of a database or entities within it.\n\n{}",
+            "Describe the structure of a database or entities within it. {}",
             UNSTABLE_WARNING
         ))
         .arg(

--- a/crates/cli/src/subcommands/energy.rs
+++ b/crates/cli/src/subcommands/energy.rs
@@ -8,7 +8,7 @@ use crate::util::{self, get_login_token_or_log_in, UNSTABLE_WARNING};
 pub fn cli() -> clap::Command {
     clap::Command::new("energy")
         .about(format!(
-            "Invokes commands related to database budgets.\n\n{}",
+            "Invokes commands related to database budgets. {}",
             UNSTABLE_WARNING
         ))
         .args_conflicts_with_subcommands(true)

--- a/crates/cli/src/subcommands/init.rs
+++ b/crates/cli/src/subcommands/init.rs
@@ -8,7 +8,7 @@ use std::path::{Path, PathBuf};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("init")
-        .about(format!("Initializes a new spacetime project.\n\n{}", UNSTABLE_WARNING))
+        .about(format!("Initializes a new spacetime project. {}", UNSTABLE_WARNING))
         .arg(
             Arg::new("project-path")
                 .value_parser(clap::value_parser!(PathBuf))

--- a/crates/cli/src/subcommands/list.rs
+++ b/crates/cli/src/subcommands/list.rs
@@ -16,7 +16,7 @@ use tabled::{
 pub fn cli() -> Command {
     Command::new("list")
         .about(format!(
-            "Lists the databases attached to an identity.\n\n{}",
+            "Lists the databases attached to an identity. {}",
             UNSTABLE_WARNING
         ))
         .arg(common_args::server().help("The nickname, host name or URL of the server from which to list databases"))

--- a/crates/cli/src/subcommands/server.rs
+++ b/crates/cli/src/subcommands/server.rs
@@ -17,7 +17,7 @@ pub fn cli() -> Command {
         .subcommand_required(true)
         .subcommands(get_subcommands())
         .about(format!(
-            "Manage the connection to the SpacetimeDB server.\n\n{}",
+            "Manage the connection to the SpacetimeDB server. {}",
             UNSTABLE_WARNING
         ))
 }

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -15,7 +15,7 @@ use crate::util::{database_identity, get_auth_header, ResponseExt, UNSTABLE_WARN
 
 pub fn cli() -> clap::Command {
     clap::Command::new("sql")
-        .about(format!("Runs a SQL query on the database.\n\n{}", UNSTABLE_WARNING))
+        .about(format!("Runs a SQL query on the database. {}", UNSTABLE_WARNING))
         .arg(
             Arg::new("database")
                 .required(true)

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -23,7 +23,7 @@ use crate::Config;
 pub fn cli() -> clap::Command {
     clap::Command::new("subscribe")
         .about(format!(
-            "Subscribe to SQL queries on the database.\n\n{}",
+            "Subscribe to SQL queries on the database. {}",
             UNSTABLE_WARNING
         ))
         .arg(


### PR DESCRIPTION
# Description of Changes

These were causing issues when we rendered the helptext into markdown in https://github.com/clockworklabs/spacetime-docs/pull/168:

![image](https://github.com/user-attachments/assets/3f5f5d32-4a60-4f42-a6f1-c9560211aca3)

They also looked a bit weird when doing `spacetime help`:
```
Usage:
spacetimedb-cli [OPTIONS] <COMMAND>

Options:
      --root-dir <root_dir>        The root directory to store all spacetime files in.
      --config-path <config_path>  The path to the cli.toml config file
  -h, --help                       Print help
  -V, --version                    Print version

Commands:
  publish    Create and update a SpacetimeDB database
  delete     Deletes a SpacetimeDB database
  logs       Prints logs from a SpacetimeDB database
  call       Invokes a reducer function in a database.
             
             WARNING: This command is UNSTABLE and subject to breaking changes.
  describe   Describe the structure of a database or entities within it.
             
             WARNING: This command is UNSTABLE and subject to breaking changes.
  energy     Invokes commands related to database budgets.
             
             WARNING: This command is UNSTABLE and subject to breaking changes.
  sql        Runs a SQL query on the database.
             
             WARNING: This command is UNSTABLE and subject to breaking changes.
  rename     Rename a database
  generate   Generate client files for a spacetime module.
  list       Lists the databases attached to an identity.
             
             WARNING: This command is UNSTABLE and subject to breaking changes.
  login      Manage your login to the SpacetimeDB CLI
  logout     
  init       Initializes a new spacetime project.
             
             WARNING: This command is UNSTABLE and subject to breaking changes.
  build      Builds a spacetime module.
  server     Manage the connection to the SpacetimeDB server.
             
             WARNING: This command is UNSTABLE and subject to breaking changes.
  subscribe  Subscribe to SQL queries on the database.
             
             WARNING: This command is UNSTABLE and subject to breaking changes.
  start      Start a local SpacetimeDB instance
  version    Manage installed spacetime versions
  help       Print this message or the help of the given subcommand(s)
```

# API and ABI breaking changes

No breaking changes.

# Expected complexity level and risk

1

# Testing

- [x] New toplevel helptext looks reasonable:
```
Usage:
spacetimedb-cli [OPTIONS] <COMMAND>

Options:
      --root-dir <root_dir>        The root directory to store all spacetime files in.
      --config-path <config_path>  The path to the cli.toml config file
  -h, --help                       Print help
  -V, --version                    Print version

Commands:
  publish    Create and update a SpacetimeDB database
  delete     Deletes a SpacetimeDB database
  logs       Prints logs from a SpacetimeDB database
  call       Invokes a reducer function in a database. WARNING: This command is UNSTABLE and subject to breaking changes.
  describe   Describe the structure of a database or entities within it. WARNING: This command is UNSTABLE and subject to breaking changes.
  energy     Invokes commands related to database budgets. WARNING: This command is UNSTABLE and subject to breaking changes.
  sql        Runs a SQL query on the database. WARNING: This command is UNSTABLE and subject to breaking changes.
  rename     Rename a database
  generate   Generate client files for a spacetime module.
  list       Lists the databases attached to an identity. WARNING: This command is UNSTABLE and subject to breaking changes.
  login      Manage your login to the SpacetimeDB CLI
  logout     
  init       Initializes a new spacetime project. WARNING: This command is UNSTABLE and subject to breaking changes.
  build      Builds a spacetime module.
  server     Manage the connection to the SpacetimeDB server. WARNING: This command is UNSTABLE and subject to breaking changes.
  subscribe  Subscribe to SQL queries on the database. WARNING: This command is UNSTABLE and subject to breaking changes.
  start      Start a local SpacetimeDB instance
  version    Manage installed spacetime versions
  help       Print this message or the help of the given subcommand(s)
```
- [x] An arbitrary command's help text seems reasonable too:
```
Subscribe to SQL queries on the database. WARNING: This command is UNSTABLE and subject to breaking changes.

Usage: spacetimedb-cli subscribe [OPTIONS] <database> <query>...

Arguments:
  <database>  The name or identity of the database you would like to query
  <query>...  The SQL query to execute

Options:
  -n, --num-updates <num-updates>  The number of subscription updates to receive before exiting
  -t, --timeout <timeout>          The timeout, in seconds, after which to disconnect and stop receiving subscription messages. If `-n` is specified, it will stop after whichever
                                                        one comes first.
      --print-initial-update       Print the initial update for the queries.
      --anonymous                  Perform this action with an anonymous identity
  -y, --yes                        Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with
                                   spacetimedb.com).
  -s, --server <server>            The nickname, host name or URL of the server hosting the database
  -h, --help                       Print help
```