### PR TITLE
Add support for LIMIT

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5173,6 +5173,7 @@ name = "spacetimedb-execution"
 version = "1.0.0-rc4"
 dependencies = [
  "anyhow",
+ "itertools 0.12.1",
  "spacetimedb-expr",
  "spacetimedb-lib",
  "spacetimedb-physical-plan",

--- a/crates/core/src/estimation.rs
+++ b/crates/core/src/estimation.rs
@@ -1,6 +1,6 @@
 use crate::db::{datastore::locking_tx_datastore::state_view::StateView as _, relational_db::Tx};
 use spacetimedb_lib::query::Delta;
-use spacetimedb_physical_plan::plan::{HashJoin, IxJoin, IxScan, PhysicalPlan, Sarg};
+use spacetimedb_physical_plan::plan::{HashJoin, IxJoin, IxScan, PhysicalPlan, Sarg, TableScan};
 use spacetimedb_primitives::{ColList, TableId};
 use spacetimedb_vm::expr::{Query, QueryExpr, SourceExpr};
 
@@ -14,6 +14,7 @@ pub fn estimate_rows_scanned(tx: &Tx, plan: &PhysicalPlan) -> u64 {
     match plan {
         PhysicalPlan::TableScan(..) | PhysicalPlan::IxScan(..) => row_estimate(tx, plan),
         PhysicalPlan::Filter(input, _) => estimate_rows_scanned(tx, input).saturating_add(row_estimate(tx, input)),
+        PhysicalPlan::Limit(input, n) => estimate_rows_scanned(tx, input).saturating_add(*n),
         PhysicalPlan::NLJoin(lhs, rhs) => estimate_rows_scanned(tx, lhs)
             .saturating_add(estimate_rows_scanned(tx, rhs))
             .saturating_add(row_estimate(tx, lhs).saturating_mul(row_estimate(tx, rhs))),
@@ -48,9 +49,24 @@ pub fn estimate_rows_scanned(tx: &Tx, plan: &PhysicalPlan) -> u64 {
 pub fn row_estimate(tx: &Tx, plan: &PhysicalPlan) -> u64 {
     match plan {
         // Table scans return the number of rows in the table
-        PhysicalPlan::TableScan(schema, _, None) => tx.table_row_count(schema.table_id).unwrap_or_default(),
+        PhysicalPlan::TableScan(TableScan { limit: Some(n), .. }, _) => *n,
+        PhysicalPlan::TableScan(
+            TableScan {
+                schema,
+                limit: None,
+                delta: None,
+            },
+            _,
+        ) => tx.table_row_count(schema.table_id).unwrap_or_default(),
         // We don't estimate the cardinality of delta scans currently
-        PhysicalPlan::TableScan(_, _, Some(Delta::Inserts | Delta::Deletes)) => 0,
+        PhysicalPlan::TableScan(
+            TableScan {
+                limit: None,
+                delta: Some(Delta::Inserts | Delta::Deletes),
+                ..
+            },
+            _,
+        ) => 0,
         // The selectivity of a single column index scan is 1 / NDV,
         // where NDV is the Number of Distinct Values of a column.
         // Note, this assumes a uniform distribution of column values.
@@ -65,6 +81,7 @@ pub fn row_estimate(tx: &Tx, plan: &PhysicalPlan) -> u64 {
         PhysicalPlan::IxScan(IxScan { schema, .. }, _) => tx.table_row_count(schema.table_id).unwrap_or_default(),
         // Same for filters
         PhysicalPlan::Filter(input, _) => row_estimate(tx, input),
+        PhysicalPlan::Limit(_, n) => *n,
         // Nested loop joins are cross joins
         PhysicalPlan::NLJoin(lhs, rhs) => row_estimate(tx, lhs).saturating_mul(row_estimate(tx, rhs)),
         // Unique joins return a maximal estimation.

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -345,6 +345,18 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_limit() -> ResultTest<()> {
+        let (db, _) = create_data(5)?;
+
+        let result = run_for_testing(&db, "SELECT * FROM inventory limit 2")?;
+
+        let (_, input) = create_data(2)?;
+
+        assert_eq!(result, input.data, "Inventory");
+        Ok(())
+    }
+
+    #[test]
     fn test_select_star_table() -> ResultTest<()> {
         let (db, input) = create_data(1)?;
 

--- a/crates/execution/Cargo.toml
+++ b/crates/execution/Cargo.toml
@@ -8,6 +8,7 @@ description = "The SpacetimeDB query engine"
 
 [dependencies]
 anyhow.workspace = true
+itertools.workspace = true
 spacetimedb-expr.workspace = true
 spacetimedb-lib.workspace = true
 spacetimedb-sats.workspace = true

--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -485,6 +485,10 @@ mod tests {
                 sql: "select t.* from t join s on t.u32 = r.u32 join s as r",
                 msg: "Alias r is not in scope when it is referenced",
             },
+            TestCase {
+                sql: "select * from t limit 5",
+                msg: "Subscriptions do not support limit",
+            },
         ] {
             let result = parse_and_type_sub(sql, &tx);
             assert!(result.is_err(), "{msg}");

--- a/crates/expr/src/expr.rs
+++ b/crates/expr/src/expr.rs
@@ -123,6 +123,8 @@ pub enum RelExpr {
     LeftDeepJoin(LeftDeepJoin),
     /// A left deep binary equi-join
     EqJoin(LeftDeepJoin, FieldProject, FieldProject),
+    /// A limiting operator for the number of rows
+    Limit(Box<RelExpr>, u64),
 }
 
 /// A table reference
@@ -140,7 +142,7 @@ impl RelExpr {
         match self {
             Self::RelVar(..) => 1,
             Self::LeftDeepJoin(join) | Self::EqJoin(join, ..) => join.lhs.nfields() + 1,
-            Self::Select(input, _) => input.nfields(),
+            Self::Select(input, _) | Self::Limit(input, ..) => input.nfields(),
         }
     }
 
@@ -151,7 +153,7 @@ impl RelExpr {
             Self::LeftDeepJoin(join) | Self::EqJoin(join, ..) => {
                 join.rhs.alias.as_ref() == field || join.lhs.has_field(field)
             }
-            Self::Select(input, _) => input.has_field(field),
+            Self::Select(input, _) | Self::Limit(input, ..) => input.has_field(field),
         }
     }
 

--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -29,6 +29,19 @@ pub(crate) fn type_select(input: RelExpr, expr: SqlExpr, vars: &Relvars) -> Typi
     ))
 }
 
+/// Type check a LIMIT clause
+pub(crate) fn type_limit(input: RelExpr, limit: &str) -> TypingResult<RelExpr> {
+    Ok(
+        parse_int(limit, AlgebraicType::U64, BigDecimal::to_u64, AlgebraicValue::U64)
+            .map_err(|_| InvalidLiteral::new(limit.to_owned(), &AlgebraicType::U64))
+            .and_then(|n| {
+                n.into_u64()
+                    .map_err(|_| InvalidLiteral::new(limit.to_owned(), &AlgebraicType::U64))
+            })
+            .map(|n| RelExpr::Limit(Box::new(input), n))?,
+    )
+}
+
 /// Type check and lower a [ast::Project]
 pub(crate) fn type_proj(input: RelExpr, proj: ast::Project, vars: &Relvars) -> TypingResult<ProjectList> {
     match proj {

--- a/crates/expr/src/statement.rs
+++ b/crates/expr/src/statement.rs
@@ -16,6 +16,7 @@ use crate::{
     check::Relvars,
     errors::InvalidLiteral,
     expr::{FieldProject, ProjectList, RelExpr, Relvar},
+    type_limit,
 };
 
 use super::{
@@ -391,6 +392,7 @@ impl TypeChecker for SqlChecker {
                 project,
                 from,
                 filter: None,
+                limit: None,
             } => {
                 let input = Self::type_from(from, vars, tx)?;
                 type_proj(input, project, vars)
@@ -398,10 +400,29 @@ impl TypeChecker for SqlChecker {
             SqlSelect {
                 project,
                 from,
+                filter: None,
+                limit: Some(n),
+            } => {
+                let input = Self::type_from(from, vars, tx)?;
+                type_proj(type_limit(input, &n)?, project, vars)
+            }
+            SqlSelect {
+                project,
+                from,
                 filter: Some(expr),
+                limit: None,
             } => {
                 let input = Self::type_from(from, vars, tx)?;
                 type_proj(type_select(input, expr, vars)?, project, vars)
+            }
+            SqlSelect {
+                project,
+                from,
+                filter: Some(expr),
+                limit: Some(n),
+            } => {
+                let input = Self::type_from(from, vars, tx)?;
+                type_proj(type_limit(type_select(input, expr, vars)?, &n)?, project, vars)
             }
         }
     }
@@ -469,6 +490,7 @@ mod tests {
             "select str from t",
             "select str, arr from t",
             "select t.str, arr from t",
+            "select * from t limit 5",
         ] {
             let result = parse_and_type_sql(sql, &tx);
             assert!(result.is_ok());
@@ -479,9 +501,14 @@ mod tests {
     fn invalid() {
         let tx = SchemaViewer(module_def());
 
-        // Unqualified columns in a join
-        let sql = "select id, str from s join t";
-        let result = parse_and_type_sql(sql, &tx);
-        assert!(result.is_err());
+        for sql in [
+            // Unqualified columns in a join
+            "select id, str from s join t",
+            // Wrong type for limit
+            "select * from t limit '5'",
+        ] {
+            let result = parse_and_type_sql(sql, &tx);
+            assert!(result.is_err());
+        }
     }
 }

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -38,6 +38,10 @@ pub fn compile_subscription(sql: &str, tx: &impl SchemaView) -> Result<(ProjectP
 
     let plan = compile_select(plan);
 
+    if plan.has_limit() {
+        bail!("LIMIT is not supported in subscriptions")
+    }
+
     Ok((plan, return_id, return_name))
 }
 

--- a/crates/sql-parser/src/ast/sql.rs
+++ b/crates/sql-parser/src/ast/sql.rs
@@ -54,6 +54,7 @@ pub struct SqlSelect {
     pub project: Project,
     pub from: SqlFrom,
     pub filter: Option<SqlExpr>,
+    pub limit: Option<Box<str>>,
 }
 
 impl SqlSelect {
@@ -62,7 +63,7 @@ impl SqlSelect {
             SqlFrom::Expr(_, alias) => Self {
                 project: self.project.qualify_vars(alias.clone()),
                 filter: self.filter.map(|expr| expr.qualify_vars(alias.clone())),
-                from: self.from,
+                ..self
             },
             SqlFrom::Join(..) => self,
         }


### PR DESCRIPTION
# Description of Changes

Adds LIMIT to the sql api.

# API and ABI breaking changes

None

# Expected complexity level and risk

2

Changes include:

1. A simple addition to the parser
2. A rewrite rule for merging with a table scan (needed for non-tuple-at-a-time iterators)
3. A new execution stage

# Testing

Additional tests for both typing and executing a `LIMIT` clause
