### PR TITLE
Bump Rust and C# package versions to 1.0.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "connect_disconnect_client"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "spacetimedb-sdk",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "bytemuck",
  "derive_more",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bench"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "anymap",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-macro"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "heck 0.4.1",
  "humantime",
@@ -4883,14 +4883,14 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-sys"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "spacetimedb-primitives",
 ]
 
 [[package]]
 name = "spacetimedb-cli"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api-messages"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "brotli",
  "bytes",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-commitlog"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "bitflags 2.6.0",
  "crc32c",
@@ -5046,7 +5046,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-core"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-data-structures"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "ahash 0.8.11",
  "hashbrown 0.15.1",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-durability"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-execution"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-expr"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-fs-utils"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-lib"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5279,7 +5279,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-metrics"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "arrayvec",
  "itertools 0.12.1",
@@ -5289,7 +5289,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-paths"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5305,7 +5305,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-physical-plan"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -5320,7 +5320,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-primitives"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "bitflags 2.6.0",
  "either",
@@ -5331,7 +5331,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-query"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5348,7 +5348,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sats"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "ahash 0.8.11",
  "arrayvec",
@@ -5378,7 +5378,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-schema"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "enum-as-inner",
@@ -5406,7 +5406,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sdk"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anymap",
  "base64 0.21.7",
@@ -5435,7 +5435,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-snapshot"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "blake3",
  "hex",
@@ -5452,7 +5452,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sql-parser"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "derive_more",
  "sqlparser",
@@ -5461,7 +5461,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-standalone"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5494,7 +5494,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-subscription"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "spacetimedb-execution",
@@ -5507,7 +5507,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-table"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "ahash 0.8.11",
  "blake3",
@@ -5531,7 +5531,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-testing"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -5557,7 +5557,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-update"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5582,7 +5582,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-vm"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -5673,7 +5673,7 @@ dependencies = [
 
 [[package]]
 name = "sqltest"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6010,7 +6010,7 @@ dependencies = [
 
 [[package]]
 name = "test-client"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -6021,7 +6021,7 @@ dependencies = [
 
 [[package]]
 name = "test-counter"
-version = "1.0.0-rc4"
+version = "1.0.0"
 dependencies = [
  "anyhow",
  "spacetimedb-data-structures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,39 +86,39 @@ inherits = "release"
 debug = true
 
 [workspace.package]
-version = "1.0.0-rc4"
+version = "1.0.0"
 edition = "2021"
 # update rust-toolchain.toml too!
 rust-version = "1.84.0"
 
 [workspace.dependencies]
-spacetimedb = { path = "crates/bindings", version = "1.0.0-rc4" }
-spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.0.0-rc4" }
-spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.0.0-rc4" }
-spacetimedb-cli = { path = "crates/cli", version = "1.0.0-rc4" }
-spacetimedb-client-api = { path = "crates/client-api", version = "1.0.0-rc4" }
-spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.0.0-rc4" }
-spacetimedb-commitlog = { path = "crates/commitlog", version = "1.0.0-rc4" }
-spacetimedb-core = { path = "crates/core", version = "1.0.0-rc4" }
-spacetimedb-data-structures = { path = "crates/data-structures", version = "1.0.0-rc4" }
-spacetimedb-durability = { path = "crates/durability", version = "1.0.0-rc4" }
-spacetimedb-execution = { path = "crates/execution", version = "1.0.0-rc4" }
-spacetimedb-expr = { path = "crates/expr", version = "1.0.0-rc4" }
-spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.0.0-rc4" }
-spacetimedb-metrics = { path = "crates/metrics", version = "1.0.0-rc4" }
-spacetimedb-paths = { path = "crates/paths", version = "1.0.0-rc4" }
-spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.0.0-rc4" }
-spacetimedb-primitives = { path = "crates/primitives", version = "1.0.0-rc4" }
-spacetimedb-query = { path = "crates/query", version = "1.0.0-rc4" }
-spacetimedb-sats = { path = "crates/sats", version = "1.0.0-rc4" }
-spacetimedb-schema = { path = "crates/schema", version = "1.0.0-rc4" }
-spacetimedb-standalone = { path = "crates/standalone", version = "1.0.0-rc4" }
-spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.0.0-rc4" }
-spacetimedb-table = { path = "crates/table", version = "1.0.0-rc4" }
-spacetimedb-vm = { path = "crates/vm", version = "1.0.0-rc4" }
-spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.0.0-rc4" }
-spacetimedb-snapshot = { path = "crates/snapshot", version = "1.0.0-rc4" }
-spacetimedb-subscription = { path = "crates/subscription", version = "1.0.0-rc4" }
+spacetimedb = { path = "crates/bindings", version = "1.0.0" }
+spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.0.0" }
+spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.0.0" }
+spacetimedb-cli = { path = "crates/cli", version = "1.0.0" }
+spacetimedb-client-api = { path = "crates/client-api", version = "1.0.0" }
+spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.0.0" }
+spacetimedb-commitlog = { path = "crates/commitlog", version = "1.0.0" }
+spacetimedb-core = { path = "crates/core", version = "1.0.0" }
+spacetimedb-data-structures = { path = "crates/data-structures", version = "1.0.0" }
+spacetimedb-durability = { path = "crates/durability", version = "1.0.0" }
+spacetimedb-execution = { path = "crates/execution", version = "1.0.0" }
+spacetimedb-expr = { path = "crates/expr", version = "1.0.0" }
+spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.0.0" }
+spacetimedb-metrics = { path = "crates/metrics", version = "1.0.0" }
+spacetimedb-paths = { path = "crates/paths", version = "1.0.0" }
+spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.0.0" }
+spacetimedb-primitives = { path = "crates/primitives", version = "1.0.0" }
+spacetimedb-query = { path = "crates/query", version = "1.0.0" }
+spacetimedb-sats = { path = "crates/sats", version = "1.0.0" }
+spacetimedb-schema = { path = "crates/schema", version = "1.0.0" }
+spacetimedb-standalone = { path = "crates/standalone", version = "1.0.0" }
+spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.0.0" }
+spacetimedb-table = { path = "crates/table", version = "1.0.0" }
+spacetimedb-vm = { path = "crates/vm", version = "1.0.0" }
+spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.0.0" }
+spacetimedb-snapshot = { path = "crates/snapshot", version = "1.0.0" }
+spacetimedb-subscription = { path = "crates/subscription", version = "1.0.0" }
 
 ahash = "0.8"
 anyhow = "1.0.68"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Clockwork Laboratories, Inc.
-Licensed Work:        SpacetimeDB 1.0.0-rc1
+Licensed Work:        SpacetimeDB 1.0.0
                       The Licensed Work is
                       (c) 2023 Clockwork Laboratories, Inc.
                       

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -21,7 +21,7 @@ Additional Use Grant: You may make use of the Licensed Work provided your
                       Licensed Work by creating tables whose schemas are
                       controlled by such third parties.
 
-Change Date:          2029-08-12
+Change Date:          2030-02-26
 
 Change License:       GNU Affero General Public License v3.0 with a linking
                       exception

--- a/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
+++ b/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Codegen</AssemblyName>
-    <Version>1.0.0-rc4</Version>
+    <Version>1.0.0</Version>
     <Title>SpacetimeDB BSATN Codegen</Title>
     <Description>The SpacetimeDB BSATN Codegen implements the Roslyn incremental generators for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Runtime</AssemblyName>
-    <Version>1.0.0-rc4</Version>
+    <Version>1.0.0</Version>
     <Title>SpacetimeDB BSATN Runtime</Title>
     <Description>The SpacetimeDB BSATN Runtime implements APIs for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Codegen</AssemblyName>
-    <Version>1.0.0-rc4</Version>
+    <Version>1.0.0</Version>
     <Title>SpacetimeDB Module Codegen</Title>
     <Description>The SpacetimeDB Codegen implements the Roslyn incremental generators for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Runtime/Runtime.csproj
+++ b/crates/bindings-csharp/Runtime/Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Runtime</AssemblyName>
-    <Version>1.0.0-rc4</Version>
+    <Version>1.0.0</Version>
     <Title>SpacetimeDB Module Runtime</Title>
     <Description>The SpacetimeDB Runtime implements the database runtime bindings for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings/README.md
+++ b/crates/bindings/README.md
@@ -101,7 +101,7 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "1.0.0-rc2"
+spacetimedb = "1.0.0"
 log = "0.4"
 ```
 <!-- TODO: update `spacetimedb` version there. -->

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="1.0.0-rc4" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="1.0.0" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/rust/Cargo._toml
+++ b/crates/cli/src/subcommands/project/rust/Cargo._toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "1.0.0-rc4"
+spacetimedb = "1.0.0"
 log = "0.4"


### PR DESCRIPTION
# Description of Changes

I'm bumping these versions to 1.0.0 in preparation for the release.

**Note:** For some reason, `LICENSE.txt` hasn't been getting updated since `1.0.0-rc1`. I didn't investigate why.

# API and ABI breaking changes

None,

# Expected complexity level and risk

1

# Testing

None. This just bumps package versions.