### PR TITLE
Add support for COUNT

### DIFF
--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -357,6 +357,20 @@ pub(crate) mod tests {
     }
 
     #[test]
+    fn test_count() -> ResultTest<()> {
+        let (db, _) = create_data(5)?;
+
+        let result = run_for_testing(&db, "SELECT count(*) as n FROM inventory")?;
+
+        assert_eq!(result, vec![product![5u64]], "Inventory");
+
+        let result = run_for_testing(&db, "SELECT count(*) as n FROM inventory limit 2")?;
+
+        assert_eq!(result, vec![product![5u64]], "Inventory");
+        Ok(())
+    }
+
+    #[test]
     fn test_select_star_table() -> ResultTest<()> {
         let (db, input) = create_data(1)?;
 

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -360,13 +360,17 @@ pub(crate) mod tests {
     fn test_count() -> ResultTest<()> {
         let (db, _) = create_data(5)?;
 
-        let result = run_for_testing(&db, "SELECT count(*) as n FROM inventory")?;
-
+        let sql = "SELECT count(*) as n FROM inventory";
+        let result = run_for_testing(&db, sql)?;
         assert_eq!(result, vec![product![5u64]], "Inventory");
 
-        let result = run_for_testing(&db, "SELECT count(*) as n FROM inventory limit 2")?;
-
+        let sql = "SELECT count(*) as n FROM inventory limit 2";
+        let result = run_for_testing(&db, sql)?;
         assert_eq!(result, vec![product![5u64]], "Inventory");
+
+        let sql = "SELECT count(*) as n FROM inventory WHERE inventory_id = 4 or inventory_id = 5";
+        let result = run_for_testing(&db, sql)?;
+        assert_eq!(result, vec![product![2u64]], "Inventory");
         Ok(())
     }
 

--- a/crates/execution/src/iter.rs
+++ b/crates/execution/src/iter.rs
@@ -103,7 +103,6 @@ impl<'a> Iter<'a> {
                     .map(|input| Filter { input, expr })
                     .map(Iter::Filter)
             }
-            PhysicalPlan::Limit(..) => unimplemented!(),
             PhysicalPlan::NLJoin(lhs, rhs) => {
                 // Build a nested loop join iterator
                 NLJoin::build_from(lhs, rhs, tx)

--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -177,7 +177,8 @@ pub fn compile_sql_sub<'a>(sql: &'a str, tx: &impl SchemaView) -> TypingResult<S
 fn expect_table_type(expr: ProjectList) -> TypingResult<ProjectName> {
     match expr {
         ProjectList::Name(proj) => Ok(proj),
-        ProjectList::List(..) => Err(Unsupported::ReturnType.into()),
+        ProjectList::Limit(input, _) => expect_table_type(*input),
+        ProjectList::List(..) | ProjectList::Agg(..) => Err(Unsupported::ReturnType.into()),
     }
 }
 

--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -10,6 +10,7 @@ use check::{Relvars, TypingResult};
 use errors::{DuplicateName, InvalidLiteral, InvalidOp, InvalidWildcard, UnexpectedType, Unresolved};
 use ethnum::i256;
 use ethnum::u256;
+use expr::AggType;
 use expr::{Expr, FieldProject, ProjectList, ProjectName, RelExpr};
 use spacetimedb_lib::{from_hex_pad, AlgebraicType, AlgebraicValue, ConnectionId, Identity};
 use spacetimedb_sats::algebraic_type::fmt::fmt_algebraic_type;
@@ -30,7 +31,7 @@ pub(crate) fn type_select(input: RelExpr, expr: SqlExpr, vars: &Relvars) -> Typi
 }
 
 /// Type check a LIMIT clause
-pub(crate) fn type_limit(input: RelExpr, limit: &str) -> TypingResult<RelExpr> {
+pub(crate) fn type_limit(input: ProjectList, limit: &str) -> TypingResult<ProjectList> {
     Ok(
         parse_int(limit, AlgebraicType::U64, BigDecimal::to_u64, AlgebraicValue::U64)
             .map_err(|_| InvalidLiteral::new(limit.to_owned(), &AlgebraicType::U64))
@@ -38,7 +39,7 @@ pub(crate) fn type_limit(input: RelExpr, limit: &str) -> TypingResult<RelExpr> {
                 n.into_u64()
                     .map_err(|_| InvalidLiteral::new(limit.to_owned(), &AlgebraicType::U64))
             })
-            .map(|n| RelExpr::Limit(Box::new(input), n))?,
+            .map(|n| ProjectList::Limit(Box::new(input), n))?,
     )
 }
 
@@ -51,6 +52,7 @@ pub(crate) fn type_proj(input: RelExpr, proj: ast::Project, vars: &Relvars) -> T
             Ok(ProjectList::Name(ProjectName::Some(input, var)))
         }
         ast::Project::Star(Some(SqlIdent(var))) => Err(Unresolved::var(&var).into()),
+        ast::Project::Count(SqlIdent(alias)) => Ok(ProjectList::Agg(input, AggType::Count, alias, AlgebraicType::U64)),
         ast::Project::Exprs(elems) => {
             let mut projections = vec![];
             let mut names = HashSet::new();

--- a/crates/expr/src/statement.rs
+++ b/crates/expr/src/statement.rs
@@ -393,37 +393,36 @@ impl TypeChecker for SqlChecker {
                 from,
                 filter: None,
                 limit: None,
-            } => {
-                let input = Self::type_from(from, vars, tx)?;
-                type_proj(input, project, vars)
-            }
+            } => type_proj(Self::type_from(from, vars, tx)?, project, vars),
             SqlSelect {
                 project,
                 from,
                 filter: None,
                 limit: Some(n),
-            } => {
-                let input = Self::type_from(from, vars, tx)?;
-                type_proj(type_limit(input, &n)?, project, vars)
-            }
+            } => type_limit(type_proj(Self::type_from(from, vars, tx)?, project, vars)?, &n),
             SqlSelect {
                 project,
                 from,
                 filter: Some(expr),
                 limit: None,
-            } => {
-                let input = Self::type_from(from, vars, tx)?;
-                type_proj(type_select(input, expr, vars)?, project, vars)
-            }
+            } => type_proj(
+                type_select(Self::type_from(from, vars, tx)?, expr, vars)?,
+                project,
+                vars,
+            ),
             SqlSelect {
                 project,
                 from,
                 filter: Some(expr),
                 limit: Some(n),
-            } => {
-                let input = Self::type_from(from, vars, tx)?;
-                type_proj(type_limit(type_select(input, expr, vars)?, &n)?, project, vars)
-            }
+            } => type_limit(
+                type_proj(
+                    type_select(Self::type_from(from, vars, tx)?, expr, vars)?,
+                    project,
+                    vars,
+                )?,
+                &n,
+            ),
         }
     }
 }

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -38,10 +38,6 @@ pub fn compile_subscription(sql: &str, tx: &impl SchemaView) -> Result<(ProjectP
 
     let plan = compile_select(plan);
 
-    if plan.has_limit() {
-        bail!("LIMIT is not supported in subscriptions")
-    }
-
     Ok((plan, return_id, return_name))
 }
 

--- a/crates/sql-parser/src/ast/mod.rs
+++ b/crates/sql-parser/src/ast/mod.rs
@@ -79,12 +79,14 @@ pub enum Project {
     Star(Option<SqlIdent>),
     /// SELECT a, b
     Exprs(Vec<ProjectElem>),
+    /// SELECT COUNT(*)
+    Count(SqlIdent),
 }
 
 impl Project {
     pub fn qualify_vars(self, with: SqlIdent) -> Self {
         match self {
-            Self::Star(..) => self,
+            Self::Star(..) | Self::Count(..) => self,
             Self::Exprs(elems) => Self::Exprs(elems.into_iter().map(|elem| elem.qualify_vars(with.clone())).collect()),
         }
     }

--- a/crates/sql-parser/src/parser/errors.rs
+++ b/crates/sql-parser/src/parser/errors.rs
@@ -1,7 +1,10 @@
 use std::fmt::Display;
 
 use sqlparser::{
-    ast::{BinaryOperator, Expr, ObjectName, Query, Select, SelectItem, SetExpr, TableFactor, TableWithJoins, Value},
+    ast::{
+        BinaryOperator, Expr, Function, ObjectName, Query, Select, SelectItem, SetExpr, TableFactor, TableWithJoins,
+        Value,
+    },
     parser::ParserError,
 };
 use thiserror::Error;
@@ -36,6 +39,10 @@ pub enum SqlUnsupported {
     Projection(SelectItem),
     #[error("Unsupported projection expression: {0}")]
     ProjectionExpr(Expr),
+    #[error("Unsupported aggregate function: {0}")]
+    Aggregate(Function),
+    #[error("Aggregate expressions must have column aliases")]
+    AggregateWithoutAlias,
     #[error("Unsupported FROM expression: {0}")]
     From(TableFactor),
     #[error("Unsupported set operation: {0}")]

--- a/crates/sql-parser/src/parser/sql.rs
+++ b/crates/sql-parser/src/parser/sql.rs
@@ -439,6 +439,8 @@ mod tests {
     fn supported() {
         for sql in [
             "select a from t",
+            "select count(*) as n from t",
+            "select count(*) as n from t join s on t.id = s.id where s.x = 1",
             "insert into t values (1, 2)",
             "delete from t",
             "delete from t where a = 1",
@@ -460,6 +462,8 @@ mod tests {
             "select a from t where",
             // Empty GROUP BY
             "select a, count(*) from t group by",
+            // Aggregate without alias
+            "select count(*) from t",
             // Empty statement
             "",
             " ",


### PR DESCRIPTION
# Description of Changes

Support count queries such as `SELECT COUNT(*) AS n FROM t`

# API and ABI breaking changes

None

# Expected complexity level and risk

1

Note, there is a better way of supporting agg, but that required a larger diff, so I left a descriptive TODO in the code instead.

# Testing

Parsing, optimization, and execution tests added
