### PR TITLE
Fix docker container for standalone

### DIFF
--- a/crates/standalone/Dockerfile
+++ b/crates/standalone/Dockerfile
@@ -40,5 +40,5 @@ FROM env-${CARGO_PROFILE}
 EXPOSE 3000
 
 ENV RUST_BACKTRACE=1
-ENTRYPOINT ["spacetimedb-standalone", "--data-dir=/stdb/data", "--jwt-pub-key-path=/etc/spacetimedb/id_ecdsa.pub", "--jwt-priv-key-path=/etc/spacetimedb/id_ecdsa"]
-CMD ["start"]
+ENTRYPOINT ["spacetimedb-standalone"]
+CMD ["start", "--data-dir=/stdb/data", "--jwt-pub-key-path=/etc/spacetimedb/id_ecdsa.pub", "--jwt-priv-key-path=/etc/spacetimedb/id_ecdsa"]


### PR DESCRIPTION
## Update

We're going to merge this so that the docker-compose setup in this repository works again but we're going to be shipping a separate docker container for the website that uses all of the spacetimedb binaries (update, cli, standalone) instead of only standalone. This decision came from a conversation in discord with Tyler.

For those curious we're talking about the docker container described here: https://spacetimedb.com/install

# Description of Changes

Binary split PR: https://github.com/clockworklabs/SpacetimeDB/pull/2011

Before the binary split the standalone command worked like this:

```
spacetimedb-standalone --data-dir ... --jwt-token ... start
```

After the binary split we've changed it so that now the command needs to be composed like this:
```
spacetimedb-standalone start --data-dir ... --jwt-token ...
```

You'll see that the arguments need to go after start instead of before it. This has broken the standalone docker container on the website. If you try it currently it looks like this:
```
boppy@ubuntu-22-lts-server:~$ docker run --rm --pull always -p 3000:3000 clockworklabs/spacetimedb start
latest: Pulling from clockworklabs/spacetimedb
Digest: sha256:c800f48bee874daf05ab594d772d03cc5014c22ce57908bcf0818c4747598f51
Status: Image is up to date for clockworklabs/spacetimedb:latest
error: unexpected argument '--data-dir' found

  tip: 'start --data-dir' exists

Usage: spacetimedb
       spacetimedb <COMMAND>

For more information, try '--help'.
```

Like I said, this is because `--data-dir` no longer goes with the `spacetimedb-standalone` command but goes with the `start` subcommand instead.

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

0 - this was broken before and it is fixed now. This didn't change our APIs or affect any other functionality, only the Dockerfile.

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

The docker container didn't work before but it works now.

```
boppy@ubuntu-22-lts-server:~/SpacetimeDB$ docker compose build --no-cache
WARN[0000] /home/boppy/SpacetimeDB/docker-compose.yml: `version` is obsolete
[+] Building 86.0s (18/18) FINISHED                                                                      docker:default
 => [node internal] load build definition from Dockerfile                                                          0.0s
 => => transferring dockerfile: 1.41kB                                                                             0.0s
 => [node internal] load metadata for docker.io/library/rust:1.84.0                                                0.4s
 => [node internal] load .dockerignore                                                                             0.0s
 => => transferring context: 120B                                                                                  0.0s
 => CACHED [node chef 1/4] FROM docker.io/library/rust:1.84.0@sha256:e6e40c05cfe7dd55ad13794333d31b6d0818f0c60868  0.0s
 => [node internal] load build context                                                                             0.1s
 => => transferring context: 7.71MB                                                                                0.1s
 => [node chef 2/4] RUN rust_target=$(rustc -vV | awk '/^host:/{ print $2 }') &&   curl https://github.com/cargo-  0.8s
 => [node chef 3/4] RUN cargo binstall -y cargo-chef@0.1.70                                                        1.7s
 => [node chef 4/4] WORKDIR /usr/src/app                                                                           0.1s
 => [node planner 1/2] COPY . .                                                                                    0.4s
 => [node builder 1/6] RUN cargo binstall -y cargo-watch@8.4.0                                                     1.4s
 => [node planner 2/2] RUN cargo chef prepare --recipe-path recipe.json                                            0.3s
 => [node builder 2/6] RUN cargo binstall -y flamegraph@0.6.2                                                      1.8s
 => [node builder 3/6] COPY --from=planner /usr/src/app/recipe.json .                                              0.1s
 => [node builder 4/6] RUN cargo chef cook -p spacetimedb-standalone --profile=dev                                41.2s
 => [node builder 5/6] COPY . .                                                                                    0.2s
 => [node builder 6/6] RUN cargo build -p spacetimedb-standalone --profile=dev --locked                           26.4s
 => [node env-dev 1/1] RUN mkdir -p /stdb/data && ln -s /usr/src/app/crates/standalone/config.toml /stdb/data/con  0.2s
 => [node] exporting to image                                                                                     11.5s
 => => exporting layers                                                                                           11.5s
 => => writing image sha256:ba0c338061ebfc7675edb19c969ca61e7c740c9fb2d1d7d1aeaf57cdcc061488                       0.0s
 => => naming to docker.io/library/spacetimedb-node                                                                0.0s
boppy@ubuntu-22-lts-server:~/SpacetimeDB$ docker run -p 3000:3000 spacetimedb-node

┌───────────────────────────────────────────────────────────────────────────────────────────────────────┐
│                                                                                                       │
│                                                                                                       │
│                                                                              ⢀⠔⠁                      │
│                                                                            ⣠⡞⠁                        │
│                                              ⣀⣀⣤⣤⣤⣤⣤⣤⣤⣤⣤⣤⣀⣀⣀⣀⣀⣀⣀⣤⣤⡴⠒    ⢀⣠⡾⠋                          │
│                                         ⢀⣤⣶⣾88888888888888888888⠿⠋    ⢀⣴8⡟⠁                           │
│                                      ⢀⣤⣾88888⡿⠿⠛⠛⠛⠛⠛⠛⠛⠛⠻⠿88888⠟⠁    ⣠⣾88⡟                             │
│                                    ⢀⣴88888⠟⠋⠁ ⣀⣤⠤⠶⠶⠶⠶⠶⠤⣤⣀ ⠉⠉⠉    ⢀⣴⣾888⡟                              │
│                                   ⣠88888⠋  ⣠⠶⠋⠉         ⠉⠙⠶⣄   ⢀⣴888888⠃                              │
│                                  ⣰8888⡟⠁ ⣰⠟⠁               ⠈⠻⣆ ⠈⢿888888                               │
│                                 ⢠8888⡟  ⡼⠁                   ⠈⢧ ⠈⢿8888⡿                               │
│                                 ⣼8888⠁ ⢸⠇                     ⠸⡇ ⠘8888⣷                               │
│                                 88888  8                       8  88888                               │
│                                 ⢿8888⡄ ⢸⡆                     ⢰⡇ ⢀8888⡟                               │
│                                 ⣾8888⣷⡀ ⢳⡀                   ⢀⡞  ⣼8888⠃                               │
│                                 888888⣷⡀ ⠹⣦⡀               ⢀⣴⠏ ⢀⣼8888⠏                                │
│                                ⢠888888⠟⠁   ⠙⠶⣄⣀         ⣀⣠⠶⠋  ⣠88888⠋                                 │
│                                ⣼888⡿⠟⠁    ⣀⣀⣀ ⠉⠛⠒⠶⠶⠶⠶⠶⠒⠛⠉ ⢀⣠⣴88888⠟⠁                                  │
│                               ⣼88⡿⠋    ⢀⣴88888⣶⣦⣤⣤⣤⣤⣤⣤⣤⣤⣶⣾88888⡿⠛⠁                                    │
│                             ⢀⣼8⠟⠁    ⣠⣶88888888888888888888⡿⠿⠛⠁                                       │
│                            ⣠⡾⠋⠁    ⠤⠞⠛⠛⠉⠉⠉⠉⠉⠉⠉⠛⠛⠛⠛⠛⠛⠛⠛⠛⠛⠉⠉                                            │
│                          ⢀⡼⠋                                                                          │
│                        ⢀⠔⠁                                                                            │
│                                                                                                       │
│                                                                                                       │
│  .d8888b.                                     888    d8b                        8888888b.  888888b.   │
│ d88P  Y88b                                    888    Y8P                        888  "Y88b 888  "88b  │
│ Y88b.                                         888                               888    888 888  .88P  │
│  "Y888b.   88888b.   8888b.   .d8888b .d88b.  888888 888 88888b.d88b.   .d88b.  888    888 8888888K.  │
│     "Y88b. 888 "88b     "88b d88P"   d8P  Y8b 888    888 888 "888 "88b d8P  Y8b 888    888 888  "Y88b │
│       "888 888  888 .d888888 888     88888888 888    888 888  888  888 88888888 888    888 888    888 │
│ Y88b  d88P 888 d88P 888  888 Y88b.   Y8b.     Y88b.  888 888  888  888 Y8b.     888  .d88P 888   d88P │
│  "Y8888P"  88888P"  "Y888888  "Y8888P "Y8888   "Y888 888 888  888  888  "Y8888  8888888P"  8888888P"  │
│            888                                                                                        │
│            888                                                                                        │
│            888                                                                                        │
│                                  "Multiplayer at the speed of light"                                  │
└───────────────────────────────────────────────────────────────────────────────────────────────────────┘

spacetimedb-standalone version: 1.0.0-rc4
spacetimedb-standalone path: /usr/src/app/target/debug/spacetimedb-standalone
database running in data directory /stdb/data
2025-02-21T07:49:04.010437Z DEBUG /usr/src/app/crates/standalone/src/subcommands/start.rs:145: Starting SpacetimeDB listening on 0.0.0.0:3000
```
