### PR TITLE
Fix self-replace on windows

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4482,6 +4482,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "self-replace"
+version = "1.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "03ec815b5eab420ab893f63393878d89c90fdd94c0bcc44c07abb8ad95552fb7"
+dependencies = [
+ "fastrand",
+ "tempfile",
+ "windows-sys 0.52.0",
+]
+
+[[package]]
 name = "semver"
 version = "1.0.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5554,6 +5565,7 @@ dependencies = [
  "http-body-util",
  "indicatif",
  "reqwest 0.12.9",
+ "self-replace",
  "semver",
  "serde",
  "spacetimedb-paths",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,6 +219,7 @@ rustyline = { version = "12.0.0", features = [] }
 scoped-tls = "1.0.1"
 scopeguard = "1.1.0"
 second-stack = "0.3"
+self-replace = "1.5"
 semver = "1"
 serde = { version = "1.0.136", features = ["derive"] }
 serde_json = { version = "1.0.128", features = ["raw_value", "arbitrary_precision"] }

--- a/crates/paths/src/cli.rs
+++ b/crates/paths/src/cli.rs
@@ -95,6 +95,7 @@ impl VersionBinDir {
         #[cfg(windows)]
         {
             junction::delete(self).ok();
+            std::fs::remove_dir(self).ok();
             // We won't be able to create a junction if the fs isn't NTFS, so fall back to trying
             // to make a symlink.
             junction::create(path, self)

--- a/crates/update/Cargo.toml
+++ b/crates/update/Cargo.toml
@@ -15,6 +15,7 @@ flate2.workspace = true
 http-body-util = "0.1.2"
 indicatif.workspace = true
 reqwest.workspace = true
+self-replace.workspace = true
 semver = { workspace = true, features = ["serde"] }
 serde.workspace = true
 tar.workspace = true


### PR DESCRIPTION
# Description of Changes

Windows doesn't let you overwrite an exe file that's currently running. Thankfully, the [`self-update`](https://docs.rs/self-update) crate has an implementation for this.

# Expected complexity level and risk

1: can't get more broken that it already is! and we're just using someone else's code :)

# Testing

- [ ] Need to test on windows.