### PR TITLE
fix: join order rewrite rule

### DIFF
--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -352,6 +352,25 @@ mod tests {
     }
 
     #[test]
+    fn test_compile_incr_plan() -> ResultTest<()> {
+        let db = TestDB::durable()?;
+
+        let schema = &[("n", AlgebraicType::U64), ("data", AlgebraicType::U64)];
+        let indexes = &[0.into()];
+        db.create_table_for_test("a", schema, indexes)?;
+
+        let schema = &[("n", AlgebraicType::U64), ("data", AlgebraicType::U64)];
+        let indexes = &[0.into()];
+        db.create_table_for_test("b", schema, indexes)?;
+
+        let tx = db.begin_tx(Workload::ForTests);
+        let sql = "SELECT b.* FROM b JOIN a ON b.n = a.n WHERE b.data > 200";
+        let result = compile_read_only_query(&AuthCtx::for_testing(), &tx, sql);
+        assert!(result.is_ok());
+        Ok(())
+    }
+
+    #[test]
     fn test_eval_incr_for_index_scan() -> ResultTest<()> {
         let db = TestDB::durable()?;
 

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -708,6 +708,261 @@ mod tests {
     }
 
     #[test]
+    /// TODO: This test is a slight modifaction of [test_eval_incr_for_index_join].
+    /// Essentially the WHERE condition is on different tables.
+    /// Should refactor to reduce duplicate logic between the two tests.
+    fn test_eval_incr_for_left_semijoin() -> ResultTest<()> {
+        fn compile_query(db: &RelationalDB) -> ResultTest<SubscriptionPlan> {
+            db.with_read_only(Workload::ForTests, |tx| {
+                let auth = AuthCtx::for_testing();
+                let tx = SchemaViewer::new(tx, &auth);
+                // Should be answered using an index semijion
+                let sql = "select lhs.* from lhs join rhs on lhs.id = rhs.id where lhs.x >= 5 and lhs.x <= 7";
+                Ok(SubscriptionPlan::compile(sql, &tx).unwrap())
+            })
+        }
+
+        // Case 1:
+        // Delete a row inside the region of lhs,
+        // Insert a row inside the region of lhs.
+        fn index_join_case_1(db: &RelationalDB) -> ResultTest<()> {
+            let _ = create_lhs_table_for_eval_incr(db)?;
+            let rhs_id = create_rhs_table_for_eval_incr(db)?;
+            let query = compile_query(db)?;
+
+            let r1 = product!(10, 0, 2);
+            let r2 = product!(10, 0, 3);
+
+            let mut metrics = ExecutionMetrics::default();
+
+            let result = eval_incr(db, &mut metrics, &query, vec![(rhs_id, r1, false), (rhs_id, r2, true)])?;
+
+            // No updates to report
+            assert!(result.is_empty());
+            Ok(())
+        }
+
+        // Case 2:
+        // Delete a row outside the region of lhs,
+        // Insert a row outside the region of lhs.
+        fn index_join_case_2(db: &RelationalDB) -> ResultTest<()> {
+            let _ = create_lhs_table_for_eval_incr(db)?;
+            let rhs_id = create_rhs_table_for_eval_incr(db)?;
+            let query = compile_query(db)?;
+
+            let r1 = product!(13, 3, 5);
+            let r2 = product!(13, 4, 6);
+
+            let mut metrics = ExecutionMetrics::default();
+
+            let result = eval_incr(db, &mut metrics, &query, vec![(rhs_id, r1, false), (rhs_id, r2, true)])?;
+
+            // No updates to report
+            assert!(result.is_empty());
+            Ok(())
+        }
+
+        // Case 3:
+        // Delete a row inside  the region of lhs,
+        // Insert a row outside the region of lhs.
+        fn index_join_case_3(db: &RelationalDB) -> ResultTest<()> {
+            let lhs_id = create_lhs_table_for_eval_incr(db)?;
+            let rhs_id = create_rhs_table_for_eval_incr(db)?;
+            let query = compile_query(db)?;
+
+            let r1 = product!(10, 0, 2);
+            let r2 = product!(10, 3, 5);
+
+            let mut metrics = ExecutionMetrics::default();
+
+            let result = eval_incr(db, &mut metrics, &query, vec![(rhs_id, r1, false), (rhs_id, r2, true)])?;
+
+            // A single delete from lhs
+            assert_eq!(result.tables.len(), 1);
+            assert_eq!(result.tables[0], delete_op(lhs_id, "lhs", product!(0, 5)));
+            Ok(())
+        }
+
+        // Case 4:
+        // Delete a row outside the region of lhs,
+        // Insert a row inside  the region of lhs.
+        fn index_join_case_4(db: &RelationalDB) -> ResultTest<()> {
+            let lhs_id = create_lhs_table_for_eval_incr(db)?;
+            let rhs_id = create_rhs_table_for_eval_incr(db)?;
+            let query = compile_query(db)?;
+
+            let r1 = product!(13, 3, 5);
+            let r2 = product!(13, 2, 4);
+
+            let mut metrics = ExecutionMetrics::default();
+
+            let result = eval_incr(db, &mut metrics, &query, vec![(rhs_id, r1, false), (rhs_id, r2, true)])?;
+
+            // A single insert into lhs
+            assert_eq!(result.tables.len(), 1);
+            assert_eq!(result.tables[0], insert_op(lhs_id, "lhs", product!(2, 7)));
+            Ok(())
+        }
+
+        // Case 5:
+        // Insert row into rhs,
+        // Insert matching row inside the region of lhs.
+        fn index_join_case_5(db: &RelationalDB) -> ResultTest<()> {
+            let lhs_id = create_lhs_table_for_eval_incr(db)?;
+            let rhs_id = create_rhs_table_for_eval_incr(db)?;
+            let query = compile_query(db)?;
+
+            let lhs_row = product!(5, 6);
+            let rhs_row = product!(20, 5, 3);
+
+            let mut metrics = ExecutionMetrics::default();
+
+            let result = eval_incr(
+                db,
+                &mut metrics,
+                &query,
+                vec![(lhs_id, lhs_row, true), (rhs_id, rhs_row, true)],
+            )?;
+
+            // A single insert into lhs
+            assert_eq!(result.tables.len(), 1);
+            assert_eq!(result.tables[0], insert_op(lhs_id, "lhs", product!(5, 6)));
+            Ok(())
+        }
+
+        // Case 6:
+        // Insert row into rhs,
+        // Insert matching row outside the region of lhs.
+        fn index_join_case_6(db: &RelationalDB) -> ResultTest<()> {
+            let lhs_id = create_lhs_table_for_eval_incr(db)?;
+            let rhs_id = create_rhs_table_for_eval_incr(db)?;
+            let query = compile_query(db)?;
+
+            let lhs_row = product!(5, 10);
+            let rhs_row = product!(20, 5, 5);
+
+            let mut metrics = ExecutionMetrics::default();
+
+            let result = eval_incr(
+                db,
+                &mut metrics,
+                &query,
+                vec![(lhs_id, lhs_row, true), (rhs_id, rhs_row, true)],
+            )?;
+
+            // No updates to report
+            assert_eq!(result.tables.len(), 0);
+            Ok(())
+        }
+
+        // Case 7:
+        // Delete row from rhs,
+        // Delete matching row inside the region of lhs.
+        fn index_join_case_7(db: &RelationalDB) -> ResultTest<()> {
+            let lhs_id = create_lhs_table_for_eval_incr(db)?;
+            let rhs_id = create_rhs_table_for_eval_incr(db)?;
+            let query = compile_query(db)?;
+
+            let lhs_row = product!(0, 5);
+            let rhs_row = product!(10, 0, 2);
+
+            let mut metrics = ExecutionMetrics::default();
+
+            let result = eval_incr(
+                db,
+                &mut metrics,
+                &query,
+                vec![(lhs_id, lhs_row, false), (rhs_id, rhs_row, false)],
+            )?;
+
+            // A single delete from lhs
+            assert_eq!(result.tables.len(), 1);
+            assert_eq!(result.tables[0], delete_op(lhs_id, "lhs", product!(0, 5)));
+            Ok(())
+        }
+
+        // Case 8:
+        // Delete row from rhs,
+        // Delete matching row outside the region of lhs.
+        fn index_join_case_8(db: &RelationalDB) -> ResultTest<()> {
+            let lhs_id = create_lhs_table_for_eval_incr(db)?;
+            let rhs_id = create_rhs_table_for_eval_incr(db)?;
+            let query = compile_query(db)?;
+
+            let lhs_row = product!(3, 8);
+            let rhs_row = product!(13, 3, 5);
+
+            let mut metrics = ExecutionMetrics::default();
+
+            let result = eval_incr(
+                db,
+                &mut metrics,
+                &query,
+                vec![(lhs_id, lhs_row, false), (rhs_id, rhs_row, false)],
+            )?;
+
+            // No updates to report
+            assert_eq!(result.tables.len(), 0);
+            Ok(())
+        }
+
+        // Case 9:
+        // Update row from rhs,
+        // Update matching row inside the region of lhs.
+        fn index_join_case_9(db: &RelationalDB) -> ResultTest<()> {
+            let lhs_id = create_lhs_table_for_eval_incr(db)?;
+            let rhs_id = create_rhs_table_for_eval_incr(db)?;
+            let query = compile_query(db)?;
+
+            let lhs_old = product!(1, 6);
+            let lhs_new = product!(1, 7);
+            let rhs_old = product!(11, 1, 3);
+            let rhs_new = product!(11, 1, 4);
+
+            let mut metrics = ExecutionMetrics::default();
+
+            let result = eval_incr(
+                db,
+                &mut metrics,
+                &query,
+                vec![
+                    (lhs_id, lhs_old, false),
+                    (rhs_id, rhs_old, false),
+                    (lhs_id, lhs_new, true),
+                    (rhs_id, rhs_new, true),
+                ],
+            )?;
+
+            let lhs_old = product!(1, 6);
+            let lhs_new = product!(1, 7);
+
+            // A delete and an insert into lhs
+            assert_eq!(result.tables.len(), 1);
+            assert_eq!(
+                result.tables[0],
+                DatabaseTableUpdate {
+                    table_id: lhs_id,
+                    table_name: "lhs".into(),
+                    deletes: [lhs_old].into(),
+                    inserts: [lhs_new].into(),
+                },
+            );
+            Ok(())
+        }
+
+        run_eval_incr_test(index_join_case_1)?;
+        run_eval_incr_test(index_join_case_2)?;
+        run_eval_incr_test(index_join_case_3)?;
+        run_eval_incr_test(index_join_case_4)?;
+        run_eval_incr_test(index_join_case_5)?;
+        run_eval_incr_test(index_join_case_6)?;
+        run_eval_incr_test(index_join_case_7)?;
+        run_eval_incr_test(index_join_case_8)?;
+        run_eval_incr_test(index_join_case_9)?;
+        Ok(())
+    }
+
+    #[test]
     fn test_eval_incr_for_index_join() -> ResultTest<()> {
         // Case 1:
         // Delete a row inside the region of rhs,

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -358,9 +358,6 @@ mod tests {
         let schema = &[("n", AlgebraicType::U64), ("data", AlgebraicType::U64)];
         let indexes = &[0.into()];
         db.create_table_for_test("a", schema, indexes)?;
-
-        let schema = &[("n", AlgebraicType::U64), ("data", AlgebraicType::U64)];
-        let indexes = &[0.into()];
         db.create_table_for_test("b", schema, indexes)?;
 
         let tx = db.begin_tx(Workload::ForTests);

--- a/crates/physical-plan/src/rules.rs
+++ b/crates/physical-plan/src/rules.rs
@@ -57,60 +57,28 @@ pub(crate) struct ComputePositions;
 
 impl RewriteRule for ComputePositions {
     type Plan = PhysicalPlan;
-    type Info = Label;
+    type Info = (Label, usize);
 
     fn matches(plan: &Self::Plan) -> Option<Self::Info> {
         match plan {
-            PhysicalPlan::Filter(_, expr) => {
-                let mut label = None;
+            PhysicalPlan::Filter(input, expr) => {
+                let mut name_and_position = None;
                 expr.visit(&mut |expr| {
-                    if let PhysicalExpr::Field(t @ TupleField { label_pos: None, .. }) = expr {
-                        label = Some(t.label);
+                    if let PhysicalExpr::Field(TupleField {
+                        label, label_pos: None, ..
+                    }) = expr
+                    {
+                        name_and_position = input.position(label).map(|i| (*label, i));
                     }
                 });
-                label
-            }
-            PhysicalPlan::IxJoin(
-                IxJoin {
-                    lhs_field: t @ TupleField { label_pos: None, .. },
-                    ..
-                },
-                _,
-            )
-            | PhysicalPlan::HashJoin(
-                HashJoin {
-                    lhs_field: t @ TupleField { label_pos: None, .. },
-                    ..
-                },
-                _,
-            )
-            | PhysicalPlan::HashJoin(
-                HashJoin {
-                    rhs_field: t @ TupleField { label_pos: None, .. },
-                    ..
-                },
-                _,
-            ) => Some(t.label),
-            _ => None,
-        }
-    }
-
-    fn rewrite(mut plan: Self::Plan, label: Self::Info) -> Result<Self::Plan> {
-        match &mut plan {
-            PhysicalPlan::Filter(input, expr) => {
-                if let Some(i) = input.position(&label) {
-                    expr.visit_mut(&mut |expr| match expr {
-                        PhysicalExpr::Field(t @ TupleField { label_pos: None, .. }) if t.label == label => {
-                            t.label_pos = Some(i);
-                        }
-                        _ => {}
-                    });
-                }
+                name_and_position
             }
             PhysicalPlan::IxJoin(
                 IxJoin {
                     lhs: input,
-                    lhs_field: t @ TupleField { label_pos: None, .. },
+                    lhs_field: TupleField {
+                        label, label_pos: None, ..
+                    },
                     ..
                 },
                 _,
@@ -118,7 +86,9 @@ impl RewriteRule for ComputePositions {
             | PhysicalPlan::HashJoin(
                 HashJoin {
                     lhs: input,
-                    lhs_field: t @ TupleField { label_pos: None, .. },
+                    lhs_field: TupleField {
+                        label, label_pos: None, ..
+                    },
                     ..
                 },
                 _,
@@ -126,14 +96,49 @@ impl RewriteRule for ComputePositions {
             | PhysicalPlan::HashJoin(
                 HashJoin {
                     rhs: input,
+                    rhs_field: TupleField {
+                        label, label_pos: None, ..
+                    },
+                    ..
+                },
+                _,
+            ) => input.position(label).map(|i| (*label, i)),
+            _ => None,
+        }
+    }
+
+    fn rewrite(mut plan: Self::Plan, (name, pos): Self::Info) -> Result<Self::Plan> {
+        match &mut plan {
+            PhysicalPlan::Filter(_, expr) => {
+                expr.visit_mut(&mut |expr| match expr {
+                    PhysicalExpr::Field(t @ TupleField { label_pos: None, .. }) if t.label == name => {
+                        t.label_pos = Some(pos);
+                    }
+                    _ => {}
+                });
+            }
+            PhysicalPlan::IxJoin(
+                IxJoin {
+                    lhs_field: t @ TupleField { label_pos: None, .. },
+                    ..
+                },
+                _,
+            )
+            | PhysicalPlan::HashJoin(
+                HashJoin {
+                    lhs_field: t @ TupleField { label_pos: None, .. },
+                    ..
+                },
+                _,
+            )
+            | PhysicalPlan::HashJoin(
+                HashJoin {
                     rhs_field: t @ TupleField { label_pos: None, .. },
                     ..
                 },
                 _,
             ) => {
-                if let Some(i) = input.position(&label) {
-                    t.label_pos = Some(i);
-                }
+                t.label_pos = Some(pos);
             }
             _ => {}
         }

--- a/crates/physical-plan/src/rules.rs
+++ b/crates/physical-plan/src/rules.rs
@@ -920,7 +920,7 @@ impl RewriteRule for ReorderHashJoin {
                     rhs: join.lhs,
                     lhs_field: join.rhs_field,
                     rhs_field: join.lhs_field,
-                    unique: false,
+                    unique: join.unique,
                 },
                 Semi::All,
             )),
@@ -969,7 +969,9 @@ impl RewriteRule for ReorderDeltaJoinRhs {
                 HashJoin {
                     lhs: join.rhs,
                     rhs: join.lhs,
-                    ..join
+                    lhs_field: join.rhs_field,
+                    rhs_field: join.lhs_field,
+                    unique: join.unique,
                 },
                 Semi::All,
             )),

--- a/crates/physical-plan/src/rules.rs
+++ b/crates/physical-plan/src/rules.rs
@@ -917,6 +917,7 @@ impl RewriteRule for ReorderHashJoin {
         }
     }
 
+    // Swaps both the inputs and the fields
     fn rewrite(plan: Self::Plan, _: Self::Info) -> Result<Self::Plan> {
         match plan {
             PhysicalPlan::HashJoin(join, Semi::All) => Ok(PhysicalPlan::HashJoin(
@@ -968,6 +969,7 @@ impl RewriteRule for ReorderDeltaJoinRhs {
         None
     }
 
+    // Swaps both the inputs and the fields
     fn rewrite(plan: Self::Plan, _: Self::Info) -> Result<Self::Plan> {
         match plan {
             PhysicalPlan::HashJoin(join, Semi::All) => Ok(PhysicalPlan::HashJoin(


### PR DESCRIPTION
# Description of Changes

After swapping the left and right hand sides of a delta join, we were not updating the left and right hand side join fields.

This resulted in a stack overflow when applying a different rewrite rule for translating named arguments into positional ones.

As part of this patch I also modified the rewrite that stack overflowed to error if an invariant is not met.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Added basic regression test that stack overflowed before this change.

Added an incremental evaluation test similar to the ones we currently have. The current tests we have did not exercise this particular rewrite (left vs right join), and so did not catch this bug.
