### PR TITLE
Added in a SQL execution time calculation

### DIFF
--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -1,3 +1,5 @@
+use std::time::Duration;
+
 use crate::auth::{
     anon_auth_middleware, SpacetimeAuth, SpacetimeEnergyUsed, SpacetimeExecutionDurationMicros, SpacetimeIdentity,
     SpacetimeIdentityToken,
@@ -385,7 +387,12 @@ where
         .ok_or(StatusCode::NOT_FOUND)?;
     let json = host.exec_sql(auth, database, body).await?;
 
-    Ok(axum::Json(json))
+    let total_duration = json.iter().fold(0, |acc, x| acc + x.total_duration_micros);
+
+    Ok((
+        TypedHeader(SpacetimeExecutionDurationMicros(Duration::from_micros(total_duration))),
+        axum::Json(json),
+    ))
 }
 
 #[derive(Deserialize)]

--- a/crates/core/src/json/client_api.rs
+++ b/crates/core/src/json/client_api.rs
@@ -5,4 +5,5 @@ use spacetimedb_lib::{ProductType, ProductValue};
 pub struct StmtResultJson {
     pub schema: ProductType,
     pub rows: Vec<ProductValue>,
+    pub total_duration_micros: u64,
 }


### PR DESCRIPTION
# Description of Changes

Now returning the execution duration of SQL queries. The changes include adding timing measurements and updating the API response structure to include the total duration of SQL execution.

Closes https://github.com/clockworklabs/spacetime-web/issues/478#issue-2645325773

AFAIK this should not require a change to the internal stuff.

# API and ABI breaking changes

This is an additive change to the SQL endpoint API.

# Expected complexity level and risk

1

# Testing

I ran and tested this locally using a local build of SpacetimeDB and checked that it worked against my local build of the website.
