### PR TITLE
`MutTxId::update`: consider deleted commited row when replacing tx row

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -2348,7 +2348,7 @@ mod tests {
         // We should now have a committed row `row` marked as deleted and a row `row_prime`.
         // These share `KEY`.
         insert(&datastore, &mut tx, table_id, row_prime)?;
-        // 3. update `row` -> `row_prime`.
+        // 3. update `row_prime` -> `row`.
         // Because `row` exists in the committed state but was marked as deleted,
         // it should be undeleted, without a new row being added to the tx state.
         let (_, row_ref) = update(&datastore, &mut tx, table_id, index_id, row)?;

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -1566,7 +1566,7 @@ impl MutTxId {
                     .get_index_by_id_with_table(table_id, index_id)
                     .and_then(|index| find_old_row(tx_row_ref, index).0.map(|ptr| (index, ptr)))
                     .filter(|&(_, ptr)| {
-                        // Was committed row was deleted?
+                        // Was committed row previously deleted in this TX?
                         let deleted = del_table.contains(ptr);
                         // If so, remember it in case it was identical to the new row.
                         old_commit_del_ptr = deleted.then_some(ptr);


### PR DESCRIPTION
# Description of Changes

Fixes #2296.

In `MutTxId::update`: If there was a deleted committed row (`row`), this fact is recorded. Later, when updating a `row_prime`, resident in the tx state and sharing a `key` with `row`, if `row_prime` it's to be replaced with `row`'s contents, we revert the insertion of the and instead un-delete `row`.

# API and ABI breaking changes

None

# Expected complexity level and risk

2?

# Testing

- A regression test `test_update_brings_back_deleted_commit_row_repro_2296` is added.
- The repro in https://github.com/clockworklabs/SpacetimeDB/issues/2296#issuecomment-2676480573 was tested manually against the new impl and the database was successfully restarted.