### PR TITLE
sdk: Client ping on idle connections

### DIFF
--- a/crates/client-api/src/routes/subscribe.rs
+++ b/crates/client-api/src/routes/subscribe.rs
@@ -382,7 +382,8 @@ async fn ws_client_actor_inner(
             }
             Item::Message(ClientMessage::Ping(_message)) => {
                 log::trace!("Received ping from client {}", client.id);
-                // TODO: should we respond with a `Pong`?
+                // No need to explicitly respond with a `Pong`, as tungstenite handles this automatically.
+                // See [https://github.com/snapview/tokio-tungstenite/issues/88].
             }
             Item::Message(ClientMessage::Pong(_message)) => {
                 log::trace!("Received heartbeat from client {}", client.id);

--- a/crates/sdk/src/websocket.rs
+++ b/crates/sdk/src/websocket.rs
@@ -358,6 +358,9 @@ impl WsConnection {
                         log::trace!("received ping");
                         idle = false;
                         record_metrics(payload.len());
+                        // No need to explicitly respond with a `Pong`,
+                        // as tungstenite handles this automatically.
+                        // See [https://github.com/snapview/tokio-tungstenite/issues/88].
                     },
 
                     Ok(Some(WebSocketMessage::Pong(payload))) => {


### PR DESCRIPTION
Make the websocket loop send a `Ping` frame when the connection is idle for a while. "idle" includes missing server-side pings.

Writing to the socket will detect if the remote end went away, but FIN / RST went missing for some reason. This is not detected by only reading.

--- 

I haven't touched the scary server-side websocket loop, but we may consider to also make it send pings only if it doesn't have anything else to send.

# Expected complexity level and risk

2

# Testing

The situation can be approximated by inducing a 100% packet loss scenario.
This can be done in various ways. A convenient one is `docker compose disconnect`, which disables the virtual interface of a container.

Without this patch, you'll see the server timing out the connection after a while (as it did not receive pong), while the client keeps thinking that something may eventually arrive.
With this patch, both ends eventually close the connection.