### PR TITLE
Update comment to reflect the new internals of the subscription api

### DIFF
--- a/crates/sdk/src/subscription.rs
+++ b/crates/sdk/src/subscription.rs
@@ -236,14 +236,6 @@ impl<M: SpacetimeModule> SubscriptionBuilder<M> {
     /// Applications where these resources are a constraint
     /// should register more precise queries via [`Self::subscribe`]
     /// in order to replicate only the subset of data which the client needs to function.
-    ///
-    /// This method should not be combined with [`Self::subscribe`] on the same `DbConnection`.
-    /// A connection may either [`Self::subscribe`] to particular queries,
-    /// or [`Self::subscribe_to_all_tables`], but not both.
-    /// Attempting to call [`Self::subscribe`]
-    /// on a `DbConnection` that has previously used [`Self::subscribe_to_all_tables`],
-    /// or vice versa, may misbehave in any number of ways,
-    /// including dropping subscriptions, corrupting the client cache, or panicking.
     pub fn subscribe_to_all_tables(self) {
         static NEXT_SUB_ID: AtomicU32 = AtomicU32::new(0);
 


### PR DESCRIPTION
# Description of Changes

Invoking `subscribe_to_all_tables` will no longer result in undefined behavior. Updated doc comment to reflect that.

# API and ABI breaking changes

None

# Expected complexity level and risk

0

# Testing

No code changes.
