### PR TITLE
Add readmes to all implementation crates specifying that they do not …

### DIFF
--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
 description = "Bench library/utility for SpacetimeDB"
+publish = false
 
 [[bench]]
 name = "special"

--- a/crates/bench/README.md
+++ b/crates/bench/README.md
@@ -1,4 +1,9 @@
 # spacetimedb-bench
+
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.
+
 Benchmarking suite for SpacetimeDB using [Criterion](https://github.com/bheisler/criterion.rs) and [Callgrind](https://valgrind.org/docs/manual/cl-manual.html) (via [iai-callgrind](https://github.com/clockworklabs/iai-callgrind)). Provides comparisons between the underlying spacetime datastore, spacetime modules, and sqlite.
 
 To run the criterion benchmarks:

--- a/crates/bindings-macro/README.md
+++ b/crates/bindings-macro/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Unstable Crate** ⚠️
+>
+> No provide stability guarantees. It is **not** stable and may change without notice.

--- a/crates/bindings-sys/README.md
+++ b/crates/bindings-sys/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Unstable Crate** ⚠️
+>
+> No provide stability guarantees. It is **not** stable and may change without notice.

--- a/crates/client-api-messages/README.md
+++ b/crates/client-api-messages/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Unstable Crate** ⚠️
+>
+> No provide stability guarantees. It is **not** stable and may change without notice.

--- a/crates/client-api/README.md
+++ b/crates/client-api/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/commitlog/README.md
+++ b/crates/commitlog/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/core/README.md
+++ b/crates/core/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Unstable Crate** ⚠️
+>
+> No provide stability guarantees. It is **not** stable and may change without notice.

--- a/crates/data-structures/README.md
+++ b/crates/data-structures/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/durability/README.md
+++ b/crates/durability/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/execution/README.md
+++ b/crates/execution/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/expr/README.md
+++ b/crates/expr/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/fs-utils/README.md
+++ b/crates/fs-utils/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/lib/README.md
+++ b/crates/lib/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Unstable Crate** ⚠️
+>
+> No provide stability guarantees. It is **not** stable and may change without notice.

--- a/crates/metrics/README.md
+++ b/crates/metrics/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/paths/README.md
+++ b/crates/paths/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/physical-plan/README.md
+++ b/crates/physical-plan/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/primitives/README.md
+++ b/crates/primitives/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/query/README.md
+++ b/crates/query/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/sats/README.md
+++ b/crates/sats/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/schema/README.md
+++ b/crates/schema/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/snapshot/README.md
+++ b/crates/snapshot/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/sqltest/Cargo.toml
+++ b/crates/sqltest/Cargo.toml
@@ -4,6 +4,7 @@ version.workspace = true
 edition.workspace = true
 description = "Sql integration test for SpacetimeDB"
 license-file = "LICENSE"
+publish = false
 
 [dependencies]
 spacetimedb-lib.workspace = true

--- a/crates/sqltest/README.md
+++ b/crates/sqltest/README.md
@@ -1,5 +1,9 @@
 This crate check the conformance of SpacetimeDB to SQL:2016
 
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.
+
 # Setup PG
 
 Create a database called `TestSpace`

--- a/crates/standalone/README.md
+++ b/crates/standalone/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Unstable Crate** ⚠️
+>
+> No provide stability guarantees. It is **not** stable and may change without notice.

--- a/crates/subscription/README.md
+++ b/crates/subscription/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Unstable Crate** ⚠️
+>
+> No provide stability guarantees. It is **not** stable and may change without notice.

--- a/crates/table/README.md
+++ b/crates/table/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -2,6 +2,7 @@
 name = "spacetimedb-testing"
 version.workspace = true
 edition.workspace = true
+publish = false
 
 [dependencies]
 spacetimedb-cli.workspace = true

--- a/crates/testing/README.md
+++ b/crates/testing/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/update/Cargo.toml
+++ b/crates/update/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-update"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+publish = false
 
 [dependencies]
 spacetimedb-paths.workspace = true

--- a/crates/update/README.md
+++ b/crates/update/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.

--- a/crates/vm/README.md
+++ b/crates/vm/README.md
@@ -1,0 +1,3 @@
+> ⚠️ **Internal Crate** ⚠️
+>
+> This crate is intended for internal use only. It is **not** stable and may change without notice.


### PR DESCRIPTION
…offer stable interfaces

# Description of Changes

Closes private [#1156](https://github.com/clockworklabs/SpacetimeDBPrivate/issues/1156).

Notes to reviewer:

* Binaries are not documented, so I don't put the readme there
* It could be desirable to use `doc = false`, but it need judgments here, like it could be nice to see what `sats` are or see at the internal documentation of the `core`.
* I not decided if should add the same note to the `lib.rs` so is visible in `docs.rs`. Should I?

* `Readme`'s with `**Internal Crate**` are distinct from `**Unstable Crate**` for what I think the later is useful for the public to see and know, but is still in flux.

# API and ABI breaking changes

It could change what is seen in `crates.rs`/`docs/rs`, that is intentional.

# Expected complexity level and risk

1

# Testing

- [x] *Attempt to run* `cargo +nightly publish -Z package-workspace --allow-dirty --dry-run --workspace --exclude ...`, but it failed in weird ways, so this depends on manual inspection.
