### PR TITLE
Install dotnet-sdk-8 instead of 9 in Dockerfile

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -4,7 +4,8 @@ RUN curl -sSfLO https://packages.microsoft.com/config/debian/12/packages-microso
       dpkg -i packages-microsoft-prod.deb && \
       rm packages-microsoft-prod.deb && \
       apt-get update && \
-      apt-get install -y dotnet-sdk-9.0 binaryen && \
+      apt-get install -y dotnet-sdk-8.0 binaryen && \
+      rm -rf /var/lib/apt/lists/* && \
       dotnet workload install wasi-experimental
 
 RUN rustup target add wasm32-unknown-unknown


### PR DESCRIPTION
# Description of Changes

`spacetime init` generates a global.json with dotnet 8, so install 8 instead of 9 in the image. Also `rm /var/lib/apt/lists/*`, which is what `apt update` downloads, since that's unnecessary to package when the user can just run `apt update` themselves if they really need to.

# Expected complexity level and risk

1

# Testing

The rust module generated by `spacetime init` works (including publish, call, logs, etc), since I was able to use a git dependency because rc4 isn't published to crates.io yet, but I couldn't figure out how to use a git dependency in dotnet. 

The invocations for using the image are:

```sh
# start it up, using the current directory as the module to publish
docker run --init --name mydb -v $PWD:/app spacetime start
docker exec -ti mydb spacetime <init,publish,call,logs,etc>
```