### PR TITLE
Remove errant backslash that got into the 'please add to path' message

### DIFF
--- a/crates/update/src/cli/self_install.rs
+++ b/crates/update/src/cli/self_install.rs
@@ -85,12 +85,12 @@ impl SelfInstall {
             let bin_dir = cli_bin_file.0.parent().unwrap();
             if !std::env::split_paths(&path_var).any(|p| p == bin_dir) {
                 eprintln!(
-                    r#"\
+                    "\
 It seems like this directory is not in your `PATH` variable. Please add the
 following line to your shell configuration and open a new shell session:
 
-    export PATH="{}:$PATH"
-"#,
+    export PATH=\"{}:$PATH\"
+",
                     bin_dir.display()
                 )
             }


### PR DESCRIPTION
# Description of Changes

Because it was a raw string, the `\` wasn't treated as an escape:

```
Downloading installer...
The SpacetimeDB command line tool will now be installed:
    CLI configuration directory: /home/spacetime/.config/spacetime/
    `spacetime` binary: /home/spacetime/.local/bin/spacetime
    directory for installed SpacetimeDB versions: /home/spacetime/.local/share/spacetime/bin
    database directory: /home/spacetime/.local/share/spacetime/data
Downloading latest version...
The `spacetime` command has been installed as /home/spacetime/.local/bin/spacetime

\
It seems like this directory is not in your `PATH` variable. Please add the
following line to your shell configuration and open a new shell session:

    export PATH="/home/spacetime/.local/bin:$PATH"

The install process is complete; check out our quickstart guide to get started!
    <https://spacetimedb.com/docs/quick-start>
```

# Expected complexity level and risk

1

# Testing

- [x] Ran install script without `~/.local/bin` in PATH.