### PR TITLE
Make the `tools/merge-docker-images.sh` script more generic

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Merge images
         run: |
-          ./tools/merge-docker-images.sh clockworklabs/spacetimedb $GITHUB_SHA
+          ./tools/merge-docker-images.sh clockworklabs/spacetimedb commit-${GITHUB_SHA:0:7} ${GITHUB_SHA:0:7}-full
 
         # This ugly bit is necessary if you don't want your cache to grow forever
         # until it hits GitHub's limit of 5GB.
@@ -120,7 +120,7 @@ jobs:
 
       - name: Merge images
         run: |
-          ./tools/merge-docker-images.sh clockworklabs/spacetimedb $GITHUB_SHA
+          ./tools/merge-docker-images.sh clockworklabs/spacetimedb "commit-${GITHUB_SHA:0:7}" "${GITHUB_SHA:0:7}-full"
 
         # This ugly bit is necessary if you don't want your cache to grow forever
         # until it hits GitHub's limit of 5GB.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Merge images
         run: |
-          ./tools/merge-docker-images.sh $GITHUB_SHA
+          ./tools/merge-docker-images.sh clockworklabs/spacetimedb $GITHUB_SHA
 
         # This ugly bit is necessary if you don't want your cache to grow forever
         # until it hits GitHub's limit of 5GB.
@@ -120,7 +120,7 @@ jobs:
 
       - name: Merge images
         run: |
-          ./tools/merge-docker-images.sh $GITHUB_SHA
+          ./tools/merge-docker-images.sh clockworklabs/spacetimedb $GITHUB_SHA
 
         # This ugly bit is necessary if you don't want your cache to grow forever
         # until it hits GitHub's limit of 5GB.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -59,7 +59,7 @@ jobs:
 
       - name: Merge images
         run: |
-          ./tools/merge-docker-images.sh clockworklabs/spacetimedb commit-${GITHUB_SHA:0:7} ${GITHUB_SHA:0:7}-full
+          ./tools/merge-docker-images.sh clockworklabs/spacetimedb "commit-${GITHUB_SHA:0:7}" "${GITHUB_SHA:0:7}-full"
 
         # This ugly bit is necessary if you don't want your cache to grow forever
         # until it hits GitHub's limit of 5GB.

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,6 @@ on:
       - master
       - staging
       - dev
-      - bfops/align-merge-script
     tags:
       - 'v*'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
       - master
       - staging
       - dev
+      - bfops/align-merge-script
     tags:
       - 'v*'
 

--- a/tools/merge-docker-images.sh
+++ b/tools/merge-docker-images.sh
@@ -34,10 +34,13 @@ docker manifest annotate "${IMAGE_NAME}":$FULL_TAG \
 docker manifest annotate "${IMAGE_NAME}":$FULL_TAG \
   "${IMAGE_NAME}"@$AMD64_DIGEST --os linux --arch amd64
 
-# Push the manifest
 docker manifest push "${IMAGE_NAME}":$FULL_TAG
 
-# re-tag the manifeast with a tag
+# re-tag the manifest with the GitHub ref
+echo '${GITHUB_REF}' is "${GITHUB_REF}"
 ORIGINAL_VERSION=${GITHUB_REF#refs/*/}
 VERSION=$(sanitize_docker_ref "$ORIGINAL_VERSION")
+echo "Tagging image with sanitized GITHUB_REF: $VERSION (original: $ORIGINAL_VERSION)"
 docker buildx imagetools create "${IMAGE_NAME}":$FULL_TAG --tag "${IMAGE_NAME}":$VERSION
+
+echo "Image merging and tagging completed successfully."

--- a/tools/merge-docker-images.sh
+++ b/tools/merge-docker-images.sh
@@ -6,9 +6,10 @@ sanitize_docker_ref() {
 }
 
 IMAGE_NAME="$1"
-# Shorten the first argument (commit sha) to 7 chars
-SHORT_SHA=${2:0:7}
-TAG="commit-$SHORT_SHA"
+# Docker tag to use for platform-specific images
+TAG="$2"
+# Docker tag to use for the "universal" image
+FULL_TAG="$3"
 
 # Check if images for both amd64 and arm64 exist
 if docker pull "${IMAGE_NAME}":$TAG-amd64 --platform amd64 >/dev/null 2>&1 && docker pull "${IMAGE_NAME}":$TAG-arm64 --platform arm64 >/dev/null 2>&1; then
@@ -21,8 +22,6 @@ fi
 # Extract digests
 AMD64_DIGEST=$(docker manifest inspect "${IMAGE_NAME}":$TAG-amd64 | jq -r '.manifests[0].digest')
 ARM64_DIGEST=$(docker manifest inspect "${IMAGE_NAME}":$TAG-arm64 | jq -r '.manifests[0].digest')
-
-FULL_TAG="$SHORT_SHA-full"
 
 # Create a new manifest using extracted digests
 docker manifest create "${IMAGE_NAME}":$FULL_TAG \

--- a/tools/merge-docker-images.sh
+++ b/tools/merge-docker-images.sh
@@ -37,7 +37,7 @@ docker manifest annotate "${IMAGE_NAME}":$FULL_TAG \
 docker manifest push "${IMAGE_NAME}":$FULL_TAG
 
 # re-tag the manifest with the GitHub ref
-echo '${GITHUB_REF}' is "${GITHUB_REF}"
+echo "GITHUB_REF is ${GITHUB_REF}"
 ORIGINAL_VERSION=${GITHUB_REF#refs/*/}
 VERSION=$(sanitize_docker_ref "$ORIGINAL_VERSION")
 echo "Tagging image with sanitized GITHUB_REF: $VERSION (original: $ORIGINAL_VERSION)"

--- a/tools/merge-docker-images.sh
+++ b/tools/merge-docker-images.sh
@@ -1,6 +1,10 @@
 #!/bin/bash
 set -e
 
+sanitize_docker_ref() {
+  echo "$1" | tr '[:upper:]' '[:lower:]' | sed -e 's/[^a-z0-9._-]/-/g' -e 's/^[.-]//g' -e 's/[.-]$//g'
+}
+
 # Shorten the first argument (commit sha) to 7 chars
 SHORT_SHA=${1:0:7}
 TAG="commit-$SHORT_SHA"
@@ -34,5 +38,6 @@ docker manifest annotate clockworklabs/spacetimedb:$FULL_TAG \
 docker manifest push clockworklabs/spacetimedb:$FULL_TAG
 
 # re-tag the manifeast with a tag
-VERSION=${GITHUB_REF#refs/*/}
+ORIGINAL_VERSION=${GITHUB_REF#refs/*/}
+VERSION=$(sanitize_docker_ref "$ORIGINAL_VERSION")
 docker buildx imagetools create clockworklabs/spacetimedb:$FULL_TAG --tag clockworklabs/spacetimedb:$VERSION

--- a/tools/merge-docker-images.sh
+++ b/tools/merge-docker-images.sh
@@ -1,5 +1,6 @@
 #!/bin/bash
 set -e
+set -u
 
 sanitize_docker_ref() {
   echo "$1" | tr '[:upper:]' '[:lower:]' | sed -e 's/[^a-z0-9._-]/-/g' -e 's/^[.-]//g' -e 's/[.-]$//g'
@@ -36,6 +37,8 @@ docker manifest annotate "${IMAGE_NAME}":$FULL_TAG \
 
 docker manifest push "${IMAGE_NAME}":$FULL_TAG
 
+# if undefined, use the empty string
+GITHUB_REF="${GITHUB_REF-}"
 # re-tag the manifest with the GitHub ref
 echo "GITHUB_REF is ${GITHUB_REF}"
 ORIGINAL_VERSION=${GITHUB_REF#refs/*/}

--- a/tools/merge-docker-images.sh
+++ b/tools/merge-docker-images.sh
@@ -5,12 +5,13 @@ sanitize_docker_ref() {
   echo "$1" | tr '[:upper:]' '[:lower:]' | sed -e 's/[^a-z0-9._-]/-/g' -e 's/^[.-]//g' -e 's/[.-]$//g'
 }
 
+IMAGE_NAME="$1"
 # Shorten the first argument (commit sha) to 7 chars
-SHORT_SHA=${1:0:7}
+SHORT_SHA=${2:0:7}
 TAG="commit-$SHORT_SHA"
 
 # Check if images for both amd64 and arm64 exist
-if docker pull clockworklabs/spacetimedb:$TAG-amd64 --platform amd64 >/dev/null 2>&1 && docker pull clockworklabs/spacetimedb:$TAG-arm64 --platform arm64 >/dev/null 2>&1; then
+if docker pull "${IMAGE_NAME}":$TAG-amd64 --platform amd64 >/dev/null 2>&1 && docker pull "${IMAGE_NAME}":$TAG-arm64 --platform arm64 >/dev/null 2>&1; then
   echo "Both images exist, preparing the merged manifest"
 else
   echo "One or both images do not exist. Exiting"
@@ -18,26 +19,26 @@ else
 fi
 
 # Extract digests
-AMD64_DIGEST=$(docker manifest inspect clockworklabs/spacetimedb:$TAG-amd64 | jq -r '.manifests[0].digest')
-ARM64_DIGEST=$(docker manifest inspect clockworklabs/spacetimedb:$TAG-arm64 | jq -r '.manifests[0].digest')
+AMD64_DIGEST=$(docker manifest inspect "${IMAGE_NAME}":$TAG-amd64 | jq -r '.manifests[0].digest')
+ARM64_DIGEST=$(docker manifest inspect "${IMAGE_NAME}":$TAG-arm64 | jq -r '.manifests[0].digest')
 
 FULL_TAG="$SHORT_SHA-full"
 
 # Create a new manifest using extracted digests
-docker manifest create clockworklabs/spacetimedb:$FULL_TAG \
-  clockworklabs/spacetimedb@$AMD64_DIGEST \
-  clockworklabs/spacetimedb@$ARM64_DIGEST
+docker manifest create "${IMAGE_NAME}":$FULL_TAG \
+  "${IMAGE_NAME}"@$AMD64_DIGEST \
+  "${IMAGE_NAME}"@$ARM64_DIGEST
 
 # Annotate the manifest with with proper platforms
-docker manifest annotate clockworklabs/spacetimedb:$FULL_TAG \
-  clockworklabs/spacetimedb@$ARM64_DIGEST --os linux --arch arm64
-docker manifest annotate clockworklabs/spacetimedb:$FULL_TAG \
-  clockworklabs/spacetimedb@$AMD64_DIGEST --os linux --arch amd64
+docker manifest annotate "${IMAGE_NAME}":$FULL_TAG \
+  "${IMAGE_NAME}"@$ARM64_DIGEST --os linux --arch arm64
+docker manifest annotate "${IMAGE_NAME}":$FULL_TAG \
+  "${IMAGE_NAME}"@$AMD64_DIGEST --os linux --arch amd64
 
 # Push the manifest
-docker manifest push clockworklabs/spacetimedb:$FULL_TAG
+docker manifest push "${IMAGE_NAME}":$FULL_TAG
 
 # re-tag the manifeast with a tag
 ORIGINAL_VERSION=${GITHUB_REF#refs/*/}
 VERSION=$(sanitize_docker_ref "$ORIGINAL_VERSION")
-docker buildx imagetools create clockworklabs/spacetimedb:$FULL_TAG --tag clockworklabs/spacetimedb:$VERSION
+docker buildx imagetools create "${IMAGE_NAME}":$FULL_TAG --tag "${IMAGE_NAME}":$VERSION


### PR DESCRIPTION
# Description of Changes

This is a **non-functional change** to make the `tools/merge-docker-images.sh` script more generic/flexible.

This PR is a series of small (stacking) changes:
- [add `sanitize_docker_ref`](https://github.com/clockworklabs/SpacetimeDB/commit/0c3e82dbb74d0e6d7beb2f2dfaeb3eabc907194d#diff-420ad3305b9234b763ba2d2a77c973be716716a4384fe4c1bc14977839855c8b)
- [add IMAGE_NAME param](https://github.com/clockworklabs/SpacetimeDB/commit/1a0ba34f4baa53eb09616f61c11a6ec3fca58166#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94)
- [make TAG and FULL_TAG into params](https://github.com/clockworklabs/SpacetimeDB/commit/f6bcb63a1d0bbe670631970a03015dc37f29da95#diff-3f5366f6d6df3ec1179e5efadc6f350bfa88eebf4e2da589b4d94ccb85ae5e94)
- [tweak output and comments](https://github.com/clockworklabs/SpacetimeDB/commit/333061c13b9f07174a328b0394f13c2e386e090f)
- [add `set -u`](https://github.com/clockworklabs/SpacetimeDB/pull/2334/commits/bd85d27d4635b6c40ce96f81d906942e57c0653e)

# API and ABI breaking changes

This does not change code.

# Expected complexity level and risk

1

# Testing

- [x] When I make the CI run on this branch, we successfully get all the docker tags (platform-specified, unified, and ref-tagged)
    - [AMD64](https://github.com/clockworklabs/SpacetimeDB/actions/runs/13647155987/job/38148018251?pr=2334)
    - [ARM64](https://github.com/clockworklabs/SpacetimeDB/actions/runs/13647155987/job/38148018043?pr=2334) (this one merges the images)