### PR TITLE
CI - Only tag extra docker images on tag refs

### DIFF
--- a/tools/merge-docker-images.sh
+++ b/tools/merge-docker-images.sh
@@ -38,9 +38,11 @@ docker manifest push "${IMAGE_NAME}":$FULL_TAG
 
 # re-tag the manifest with the GitHub ref
 echo '${GITHUB_REF}' is "${GITHUB_REF}"
-ORIGINAL_VERSION=${GITHUB_REF#refs/*/}
-VERSION=$(sanitize_docker_ref "$ORIGINAL_VERSION")
-echo "Tagging image with sanitized GITHUB_REF: $VERSION (original: $ORIGINAL_VERSION)"
-docker buildx imagetools create "${IMAGE_NAME}":$FULL_TAG --tag "${IMAGE_NAME}":$VERSION
+if [[ "${GITHUB_REF}" == refs/tags/* ]]; then
+  ORIGINAL_VERSION=${GITHUB_REF#refs/*/}
+  VERSION=$(sanitize_docker_ref "$ORIGINAL_VERSION")
+  echo "Tagging image with sanitized GITHUB_REF: $VERSION (original: $ORIGINAL_VERSION)"
+  docker buildx imagetools create "${IMAGE_NAME}":$FULL_TAG --tag "${IMAGE_NAME}":$VERSION
+fi
 
 echo "Image merging and tagging completed successfully."


### PR DESCRIPTION
# Description of Changes

Previously, we would create an extra docker image for every git ref that was pushed. Now, we only do it for tags.

We had intended to remove the docker tags for git branches a long time ago, because it was cumbersome to map between "we're using the docker image of $BRANCH" and figuring out which exact commit was deployed. However, this `merge-docker-images.sh` script slipped through the cracks.

# API and ABI breaking changes

No code changes.

# Expected complexity level and risk

1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Write a test you've completed here.*
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
