### PR TITLE
commitlog: Use `fdatasync`

### DIFF
--- a/crates/commitlog/src/segment.rs
+++ b/crates/commitlog/src/segment.rs
@@ -204,7 +204,7 @@ pub trait FileLike {
 
 impl FileLike for File {
     fn fsync(&mut self) -> io::Result<()> {
-        self.sync_all()
+        self.sync_data()
     }
 
     fn ftruncate(&mut self, _tx_offset: u64, size: u64) -> io::Result<()> {


### PR DESCRIPTION
`fdatasync` is sufficient and faster. Even though the documentation for
`sync_all` doesn't describe POSIX semantics, the implementation for *nix
systems (except apple's) is indeed `fdatasync`. Others will get `fsync`.

# Expected complexity level and risk

1

# Testing

Semantics preserving.
