### PR TITLE
Fix quickstart link

### DIFF
--- a/crates/update/src/cli/self_install.rs
+++ b/crates/update/src/cli/self_install.rs
@@ -99,7 +99,7 @@ following line to your shell configuration and open a new shell session:
         eprintln!(
             "\
 The install process is complete; check out our quickstart guide to get started!
-	<https://spacetimedb.com/docs/quick-start>"
+	<https://spacetimedb.com/docs/getting-started>"
         );
 
         Ok(ExitCode::SUCCESS)


### PR DESCRIPTION
# Description of Changes

Our current CLI outputs this when installing or upgrading:
```
The install process is complete; check out our quickstart guide to get started!
        <https://spacetimedb.com/docs/quick-start>
```

This link 404s, it should be:

```
The install process is complete; check out our quickstart guide to get started!
        <https://spacetimedb.com/docs/getting-started>
```

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

Not breaking

# Expected complexity level and risk

*How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.*

*This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.*

*If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.*

0

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

I downgraded the version of SpacetimeDB on this branch via:

```
Boppy@JASKIER MINGW64 ~/clockwork/SpacetimeDB/tools/upgrade-version (jdetter/fix-quickstart-link)
$ cargo run 1.0.0-rc7
```

Then I built the new update binary:
```
Boppy@JASKIER MINGW64 ~/clockwork/SpacetimeDB (jdetter/fix-quickstart-link)
$ cargo build --release -p spacetimedb-update
   Compiling smallvec v1.13.2
   Compiling scopeguard v1.2.0
   Compiling serde v1.0.215
...
```

Then I manually ran the update process:
```
Boppy@JASKIER MINGW64 ~/clockwork/SpacetimeDB/target/release (jdetter/fix-quickstart-link)
$ ./spacetimedb-update.exe self-install
The SpacetimeDB command line tool will now be installed into C:\Users\Boppy\AppData\Local\SpacetimeDB
Would you like to continue? yes
Downloading latest version...
  Installing v1.0.0: done!
  Self-updating `spacetime version`: done!
The `spacetime` command has been installed as C:\Users\Boppy\AppData\Local\SpacetimeDB\spacetime.exe

The install process is complete; check out our quickstart guide to get started!
        <https://spacetimedb.com/docs/getting-started>
```

(see the updated URL)