### PR TITLE
CLI - Fix helptext for `--build-options`

### DIFF
--- a/crates/cli/src/subcommands/generate/mod.rs
+++ b/crates/cli/src/subcommands/generate/mod.rs
@@ -91,7 +91,7 @@ pub fn cli() -> clap::Command {
                 .alias("build-opts")
                 .action(Set)
                 .default_value("")
-                .help("Options to pass to the build command, for example --build-options='--skip-println-checks'"),
+                .help("Options to pass to the build command, for example --build-options='--lint-dir='"),
         )
         .arg(common_args::yes())
         .after_help("Run `spacetime help publish` for more detailed information.")

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -29,7 +29,7 @@ pub fn cli() -> clap::Command {
                 .alias("build-opts")
                 .action(Set)
                 .default_value("")
-                .help("Options to pass to the build command, for example --build-options='--skip-println-checks'")
+                .help("Options to pass to the build command, for example --build-options='--lint-dir='")
         )
         .arg(
             Arg::new("project_path")


### PR DESCRIPTION
# Description of Changes

We (I) changed `--skip-println-checks` into `--lint-dir` in #1928 , but didn't update this helptext.

Fixes #2347 .

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] Running `spacetime publish --build-options='--lint-dir='` publishes without println checks