### PR TITLE
Add @jdetter back to CLI codeowners

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -4,9 +4,9 @@
 LICENSE.txt @cloutiertyler
 /crates/client-api-messages/src/websocket.rs @centril @gefjon
 
-/crates/cli/src/ @bfops @cloutiertyler
+/crates/cli/src/ @bfops @cloutiertyler @jdetter
 /crates/cli/src/subcommands/generate/ # No owners
-/crates/cli/src/subcommands/generate/mod.rs @bfops @cloutiertyler # These codeowners should be the same as the "root" CLI codeowners
+/crates/cli/src/subcommands/generate/mod.rs @bfops @cloutiertyler @jdetter # These codeowners should be the same as the "root" CLI codeowners
 
 /crates/sdk/examples/quickstart-chat/ @gefjon
 /modules/quickstart-chat/ @gefjon


### PR DESCRIPTION
# Description of Changes

We removed @jdetter from CLI codeowners because he was out. He's back now, so adding him back.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None