### PR TITLE
 Implements `IComparable` for `Identity` and `ConnectionId`

### DIFF
--- a/crates/bindings-csharp/BSATN.Runtime.Tests/Tests.cs
+++ b/crates/bindings-csharp/BSATN.Runtime.Tests/Tests.cs
@@ -183,17 +183,17 @@ public static class BSATNRuntimeTests
         var str = "00112233445566778899AABBCCDDEEFF";
         var strHigh = "00001111222233334444555566667777";
         var strLow = "FFFFEEEEDDDDCCCCBBBBAAAA99998888";
-        
+
         var connIdA = ConnectionId.FromHexString(str);
         var connIdB = ConnectionId.FromHexString(str);
         var connIdHigh = ConnectionId.FromHexString(strHigh);
         var connIdLow = ConnectionId.FromHexString(strLow);
-        
+
         Assert.NotNull(connIdA);
         Assert.NotNull(connIdB);
         Assert.NotNull(connIdHigh);
         Assert.NotNull(connIdLow);
-        
+
         Assert.Equal(0, connIdA.Value.CompareTo(connIdB.Value));
         Assert.Equal(+1, connIdA.Value.CompareTo(connIdHigh.Value));
         Assert.Equal(-1, connIdA.Value.CompareTo(connIdLow.Value));
@@ -209,7 +209,7 @@ public static class BSATNRuntimeTests
         var str = "00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF";
         var strHigh = "0000111122223333444455556666777788889999AAAABBBBCCCCDDDDEEEEFFFF";
         var strLow = "FFFFEEEEDDDDCCCCBBBBAAAA9999888877776666555544443333222211110000";
-        
+
         var identityA = Identity.FromHexString(str);
         var identityB = Identity.FromHexString(str);
         var identityHigh = Identity.FromHexString(strHigh);

--- a/crates/bindings-csharp/BSATN.Runtime.Tests/Tests.cs
+++ b/crates/bindings-csharp/BSATN.Runtime.Tests/Tests.cs
@@ -176,4 +176,51 @@ public static class BSATNRuntimeTests
         Assert.Equal(-1, stamp.CompareTo(laterStamp));
         Assert.Equal(+1, laterStamp.CompareTo(stamp));
     }
+
+    [Fact]
+    public static void ConnectionIdComparableChecks()
+    {
+        var str = "00112233445566778899AABBCCDDEEFF";
+        var strHigh = "00001111222233334444555566667777";
+        var strLow = "FFFFEEEEDDDDCCCCBBBBAAAA99998888";
+        
+        var connIdA = ConnectionId.FromHexString(str);
+        var connIdB = ConnectionId.FromHexString(str);
+        var connIdHigh = ConnectionId.FromHexString(strHigh);
+        var connIdLow = ConnectionId.FromHexString(strLow);
+        
+        Assert.NotNull(connIdA);
+        Assert.NotNull(connIdB);
+        Assert.NotNull(connIdHigh);
+        Assert.NotNull(connIdLow);
+        
+        Assert.Equal(0, connIdA.Value.CompareTo(connIdB.Value));
+        Assert.Equal(+1, connIdA.Value.CompareTo(connIdHigh.Value));
+        Assert.Equal(-1, connIdA.Value.CompareTo(connIdLow.Value));
+
+        var notAConnId = new uint();
+
+        Assert.ThrowsAny<Exception>(() => connIdA.Value.CompareTo(notAConnId));
+    }
+
+    [Fact]
+    public static void IdentityComparableChecks()
+    {
+        var str = "00112233445566778899AABBCCDDEEFF00112233445566778899AABBCCDDEEFF";
+        var strHigh = "0000111122223333444455556666777788889999AAAABBBBCCCCDDDDEEEEFFFF";
+        var strLow = "FFFFEEEEDDDDCCCCBBBBAAAA9999888877776666555544443333222211110000";
+        
+        var identityA = Identity.FromHexString(str);
+        var identityB = Identity.FromHexString(str);
+        var identityHigh = Identity.FromHexString(strHigh);
+        var identityLow = Identity.FromHexString(strLow);
+
+        Assert.Equal(0, identityA.CompareTo(identityB));
+        Assert.Equal(+1, identityA.CompareTo(identityHigh));
+        Assert.Equal(-1, identityA.CompareTo(identityLow));
+
+        var notAnIdentity = new uint();
+
+        Assert.ThrowsAny<Exception>(() => identityA.CompareTo(notAnIdentity));
+    }
 }

--- a/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
@@ -118,7 +118,10 @@ public readonly partial struct Unit
 }
 
 [StructLayout(LayoutKind.Sequential)]
-public readonly record struct ConnectionId : IEquatable<ConnectionId>, IComparable, IComparable<ConnectionId>
+public readonly record struct ConnectionId
+    : IEquatable<ConnectionId>,
+        IComparable,
+        IComparable<ConnectionId>
 {
     private readonly U128 value;
 
@@ -305,7 +308,7 @@ public readonly record struct Identity : IEquatable<Identity>, IComparable, ICom
 
     // This must be explicitly implemented, otherwise record will generate a new implementation.
     public override string ToString() => Util.ToHexBigEndian(value);
-    
+
     /// <inheritdoc cref="IComparable.CompareTo(object)" />
     public int CompareTo(object? value)
     {

--- a/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
@@ -220,21 +220,7 @@ public readonly record struct ConnectionId
     }
 
     /// <inheritdoc cref="IComparable{T}.CompareTo(T)" />
-    public int CompareTo(ConnectionId connectionId)
-    {
-        if (this.value < connectionId.value)
-        {
-            return -1;
-        }
-        else if (this.value > connectionId.value)
-        {
-            return 1;
-        }
-        else
-        {
-            return 0;
-        }
-    }
+    public int CompareTo(ConnectionId connectionId) => this.value.CompareTo(connectionId.value);
 }
 
 [StructLayout(LayoutKind.Sequential)]
@@ -327,21 +313,7 @@ public readonly record struct Identity : IEquatable<Identity>, IComparable, ICom
     }
 
     /// <inheritdoc cref="IComparable{T}.CompareTo(T)" />
-    public int CompareTo(Identity identity)
-    {
-        if (this.value < identity.value)
-        {
-            return -1;
-        }
-        else if (this.value > identity.value)
-        {
-            return 1;
-        }
-        else
-        {
-            return 0;
-        }
-    }
+    public int CompareTo(Identity identity) => this.value.CompareTo(identity.value);
 }
 
 /// <summary>

--- a/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
@@ -118,7 +118,7 @@ public readonly partial struct Unit
 }
 
 [StructLayout(LayoutKind.Sequential)]
-public readonly record struct ConnectionId
+public readonly record struct ConnectionId : IEquatable<ConnectionId>, IComparable, IComparable<ConnectionId>
 {
     private readonly U128 value;
 
@@ -198,10 +198,44 @@ public readonly record struct ConnectionId
     }
 
     public override string ToString() => Util.ToHexBigEndian(value);
+
+    /// <inheritdoc cref="IComparable.CompareTo(object)" />
+    public int CompareTo(object? value)
+    {
+        if (value is ConnectionId other)
+        {
+            return CompareTo(other);
+        }
+        else if (value is null)
+        {
+            return 1;
+        }
+        else
+        {
+            throw new ArgumentException("Argument must be a ConnectionId", nameof(value));
+        }
+    }
+
+    /// <inheritdoc cref="IComparable{T}.CompareTo(T)" />
+    public int CompareTo(ConnectionId connectionId)
+    {
+        if (this.value < connectionId.value)
+        {
+            return -1;
+        }
+        else if (this.value > connectionId.value)
+        {
+            return 1;
+        }
+        else
+        {
+            return 0;
+        }
+    }
 }
 
 [StructLayout(LayoutKind.Sequential)]
-public readonly record struct Identity
+public readonly record struct Identity : IEquatable<Identity>, IComparable, IComparable<Identity>
 {
     private readonly U256 value;
 
@@ -271,6 +305,40 @@ public readonly record struct Identity
 
     // This must be explicitly implemented, otherwise record will generate a new implementation.
     public override string ToString() => Util.ToHexBigEndian(value);
+    
+    /// <inheritdoc cref="IComparable.CompareTo(object)" />
+    public int CompareTo(object? value)
+    {
+        if (value is Identity other)
+        {
+            return CompareTo(other);
+        }
+        else if (value is null)
+        {
+            return 1;
+        }
+        else
+        {
+            throw new ArgumentException("Argument must be a Identity", nameof(value));
+        }
+    }
+
+    /// <inheritdoc cref="IComparable{T}.CompareTo(T)" />
+    public int CompareTo(Identity identity)
+    {
+        if (this.value < identity.value)
+        {
+            return -1;
+        }
+        else if (this.value > identity.value)
+        {
+            return 1;
+        }
+        else
+        {
+            return 0;
+        }
+    }
 }
 
 /// <summary>


### PR DESCRIPTION
# Description of Changes

 Implements `IComparable` for `Identity` and `ConnectionId`

This relates to the following issue:
https://github.com/clockworklabs/SpacetimeDB/issues/2348

# API and ABI breaking changes

Not a breaking change. Adds functionality and fixes bug.

# Expected complexity level and risk

1

# Testing

1. Created a test project with a Rust server defining a table with a `btree` index like:
```
#[index(btree)]
pub identity: Identity,
```
and another where a table was defined with:
```#[spacetimedb::table(name = period_timer, scheduled(period, at = scheduled_at), index(name = identity, btree(columns = [identity])))]```
2. Published the server.
3. Created a C# client and generated the bindings.
4. Confirmed issue existed prior to change: IDE reports an error in the table definition of `The type 'SpacetimeDB.Identity' must be convertible to 'System.IComparable<SpacetimeDB.Identity>' in order to use it as parameter 'Column' in the generic class 'SpacetimeDB.RemoteTableHandle<EventContext,Row>.BTreeIndexBase<Column>'`
5. Made change contained in this PR.
6. Rebuilt SpacetimeDB executables, and C# SDK NuGet files.
7. Tested again by republishing and regenerating bindings.
8. Observed IDE no longer reports issue.

- [x] Tested IDE no longer reports error after change.
