### PR TITLE
CLI - Fix `sql --interactive` case where returned rows are 0

### DIFF
--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -94,6 +94,7 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool
             if with_stats {
                 // The `tabled::count_rows` add the header as a row, so subtract it.
                 let row_count = table.count_rows().wrapping_sub(1);
+                // For some reason, `table.with(...)` crashes if the row count is 0.
                 if row_count > 0 {
                     let row_count = print_row_count(row_count);
                     table.with(tabled::settings::panel::Footer::new(row_count));

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -92,11 +92,11 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool
         .map(|stmt_result| {
             let mut table = stmt_result_to_table(stmt_result)?;
             if with_stats {
+                // The `tabled::count_rows` add the header as a row, so subtract it.
                 let row_count = table.count_rows().wrapping_sub(1);
                 if row_count > 0 {
-                    // The `tabled::count_rows` add the header as a row, so subtract it.
-                    let string_row_count = print_row_count(row_count);
-                    table.with(tabled::settings::panel::Footer::new(string_row_count));
+                    let row_count = print_row_count(row_count);
+                    table.with(tabled::settings::panel::Footer::new(row_count));
                 }
             }
             anyhow::Ok(table)

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -92,9 +92,12 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool
         .map(|stmt_result| {
             let mut table = stmt_result_to_table(stmt_result)?;
             if with_stats {
-                // The `tabled::count_rows` add the header as a row, so subtract it.
-                let row_count = print_row_count(table.count_rows().wrapping_sub(1));
-                table.with(tabled::settings::panel::Footer::new(row_count));
+                let row_count = table.count_rows().wrapping_sub(1);
+                if row_count > 0 {
+                    // The `tabled::count_rows` add the header as a row, so subtract it.
+                    let string_row_count = print_row_count(row_count);
+                    table.with(tabled::settings::panel::Footer::new(string_row_count));
+                }
             }
             anyhow::Ok(table)
         })


### PR DESCRIPTION
# Description of Changes

See https://github.com/clockworklabs/SpacetimeDB/issues/2358 for more context on this issue and why this was needed.

I think we recently removed the functionality where we return row counts for `update` and `delete` statements. This means that the CLI can no longer say things like "N rows updated".

# API and ABI breaking changes

No.

# Expected complexity level and risk

1

# Testing

- [x] No longer crashes when running `update` or `delete` commands in interactive mode:
```
$ "$WORK"/SpacetimeDBPrivate/public/target/debug/spacetimedb-cli sql -s local test-project --interactive
WARNING: This command is UNSTABLE and subject to breaking changes.

┌──────────────────────────────────────────────────────────┐
│ .exit: Exit the REPL                                     │
│ .clear: Clear the Screen                                 │
│                                                          │
│ Give us feedback in our Discord server:                  │
│    https://discord.gg/w2DVqNZXdN                         │
└──────────────────────────────────────────────────────────┘
🪐test-project>update person set name='foo'

Time: 1.28ms
🪐test-project>delete from person

Time: 1.34ms
🪐test-project>
```