### PR TITLE
Update PR template

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,27 +1,28 @@
 # Description of Changes
 
-Please describe your change, mention any related tickets, and so on here.
+<!-- Please describe your change, mention any related tickets, and so on here. -->
 
 # API and ABI breaking changes
 
-If this is an API or ABI breaking change, please apply the
-corresponding GitHub label.
+<!-- If this is an API or ABI breaking change, please apply the
+corresponding GitHub label. -->
 
 # Expected complexity level and risk
 
-*How complicated do you think these changes are? Grade on a scale from 1 to 5,
-where 1 is a trivial change, and 5 is a deep-reaching and complex change.*
+<!--
+How complicated do you think these changes are? Grade on a scale from 1 to 5,
+where 1 is a trivial change, and 5 is a deep-reaching and complex change.
 
-*This complexity rating applies not only to the complexity apparent in the diff,
-but also to its interactions with existing and future code.*
+This complexity rating applies not only to the complexity apparent in the diff,
+but also to its interactions with existing and future code.
 
-*If you answered more than a 2, explain what is complex about the PR,
-and what other components it interacts with in potentially concerning ways.*
+If you answered more than a 2, explain what is complex about the PR,
+and what other components it interacts with in potentially concerning ways.  -->
 
 # Testing
 
-*Describe any testing you've done, and any testing you'd like your reviewers to do,
-so that you're confident that all the changes work as expected!*
+<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
+so that you're confident that all the changes work as expected! -->
 
-- [x] *Write a test you've completed here.*
-- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
+- [ ] <!-- maybe a test you want to do -->
+- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->


### PR DESCRIPTION
# Description of Changes

This has been annoying me for months haha. This turns the instructions for each section into `<!-- comments -->`, so that they don't show up in the rendered description if they're not removed. Also removed the default X from the testing checkbox, so that the PR author has to actually check it to show they've done it.

# Testing

- [x] Tested how it renders. The below is the new template, rendered but unedited:


# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
