### PR TITLE
When generating for typescript, convert the primary key to camel case.

### DIFF
--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -323,7 +323,7 @@ removeOnUpdate = (cb: (ctx: EventContext, onRow: {row_type}, newRow: {row_type})
             writeln!(out, "tableName: \"{}\",", table.name);
             writeln!(out, "rowType: {row_type}.getTypeScriptAlgebraicType(),");
             if let Some(pk) = schema.pk() {
-                writeln!(out, "primaryKey: \"{}\",", pk.col_name);
+                writeln!(out, "primaryKey: \"{}\",", pk.col_name.to_string().to_case(Case::Camel));
             }
             out.dedent(1);
             writeln!(out, "}},");

--- a/crates/cli/tests/snapshots/codegen__codegen_typescript.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_typescript.snap
@@ -884,7 +884,7 @@ const REMOTE_MODULE = {
     repeating_test_arg: {
       tableName: "repeating_test_arg",
       rowType: RepeatingTestArg.getTypeScriptAlgebraicType(),
-      primaryKey: "scheduled_id",
+      primaryKey: "scheduledId",
     },
     test_a: {
       tableName: "test_a",


### PR DESCRIPTION
# Description of Changes

Currently if the primary key column is named in snake case, the typescript client won't be able to find it, because it converts the fields to camel case, but doesn't convert the primary key name.


# Expected complexity level and risk

1

# Testing

I manually tested with the typescript quickstart.
