### PR TITLE
Bump versions to 1.0.1

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -882,7 +882,7 @@ dependencies = [
 
 [[package]]
 name = "connect_disconnect_client"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "spacetimedb-sdk",
@@ -4809,7 +4809,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bytemuck",
  "derive_more",
@@ -4827,7 +4827,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bench"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "anymap",
@@ -4871,7 +4871,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-macro"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "heck 0.4.1",
  "humantime",
@@ -4883,14 +4883,14 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-sys"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "spacetimedb-primitives",
 ]
 
 [[package]]
 name = "spacetimedb-cli"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4951,7 +4951,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -4998,7 +4998,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api-messages"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "brotli",
  "bytes",
@@ -5023,7 +5023,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-commitlog"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bitflags 2.6.0",
  "crc32c",
@@ -5046,7 +5046,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-core"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -5154,7 +5154,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-data-structures"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ahash 0.8.11",
  "hashbrown 0.15.1",
@@ -5166,7 +5166,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-durability"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5180,7 +5180,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-execution"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5195,7 +5195,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-expr"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -5211,7 +5211,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-fs-utils"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "hex",
@@ -5251,7 +5251,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-lib"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5280,7 +5280,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-metrics"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "arrayvec",
  "itertools 0.12.1",
@@ -5290,7 +5290,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-paths"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5306,7 +5306,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-physical-plan"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -5321,7 +5321,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-primitives"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "bitflags 2.6.0",
  "either",
@@ -5332,7 +5332,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-query"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5349,7 +5349,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sats"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -5381,7 +5381,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-schema"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "enum-as-inner",
@@ -5409,7 +5409,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sdk"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anymap",
  "base64 0.21.7",
@@ -5438,7 +5438,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-snapshot"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "blake3",
  "hex",
@@ -5455,7 +5455,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sql-parser"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "derive_more",
  "sqlparser",
@@ -5464,7 +5464,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-standalone"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5497,7 +5497,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-subscription"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "spacetimedb-execution",
@@ -5510,7 +5510,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-table"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "ahash 0.8.11",
  "blake3",
@@ -5534,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-testing"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -5560,7 +5560,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-update"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5585,7 +5585,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-vm"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -5676,7 +5676,7 @@ dependencies = [
 
 [[package]]
 name = "sqltest"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6013,7 +6013,7 @@ dependencies = [
 
 [[package]]
 name = "test-client"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -6024,7 +6024,7 @@ dependencies = [
 
 [[package]]
 name = "test-counter"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
  "anyhow",
  "spacetimedb-data-structures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,39 +86,39 @@ inherits = "release"
 debug = true
 
 [workspace.package]
-version = "1.0.0"
+version = "1.0.1"
 edition = "2021"
 # update rust-toolchain.toml too!
 rust-version = "1.84.0"
 
 [workspace.dependencies]
-spacetimedb = { path = "crates/bindings", version = "1.0.0" }
-spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.0.0" }
-spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.0.0" }
-spacetimedb-cli = { path = "crates/cli", version = "1.0.0" }
-spacetimedb-client-api = { path = "crates/client-api", version = "1.0.0" }
-spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.0.0" }
-spacetimedb-commitlog = { path = "crates/commitlog", version = "1.0.0" }
-spacetimedb-core = { path = "crates/core", version = "1.0.0" }
-spacetimedb-data-structures = { path = "crates/data-structures", version = "1.0.0" }
-spacetimedb-durability = { path = "crates/durability", version = "1.0.0" }
-spacetimedb-execution = { path = "crates/execution", version = "1.0.0" }
-spacetimedb-expr = { path = "crates/expr", version = "1.0.0" }
-spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.0.0" }
-spacetimedb-metrics = { path = "crates/metrics", version = "1.0.0" }
-spacetimedb-paths = { path = "crates/paths", version = "1.0.0" }
-spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.0.0" }
-spacetimedb-primitives = { path = "crates/primitives", version = "1.0.0" }
-spacetimedb-query = { path = "crates/query", version = "1.0.0" }
-spacetimedb-sats = { path = "crates/sats", version = "1.0.0" }
-spacetimedb-schema = { path = "crates/schema", version = "1.0.0" }
-spacetimedb-standalone = { path = "crates/standalone", version = "1.0.0" }
-spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.0.0" }
-spacetimedb-table = { path = "crates/table", version = "1.0.0" }
-spacetimedb-vm = { path = "crates/vm", version = "1.0.0" }
-spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.0.0" }
-spacetimedb-snapshot = { path = "crates/snapshot", version = "1.0.0" }
-spacetimedb-subscription = { path = "crates/subscription", version = "1.0.0" }
+spacetimedb = { path = "crates/bindings", version = "1.0.1" }
+spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.0.1" }
+spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.0.1" }
+spacetimedb-cli = { path = "crates/cli", version = "1.0.1" }
+spacetimedb-client-api = { path = "crates/client-api", version = "1.0.1" }
+spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.0.1" }
+spacetimedb-commitlog = { path = "crates/commitlog", version = "1.0.1" }
+spacetimedb-core = { path = "crates/core", version = "1.0.1" }
+spacetimedb-data-structures = { path = "crates/data-structures", version = "1.0.1" }
+spacetimedb-durability = { path = "crates/durability", version = "1.0.1" }
+spacetimedb-execution = { path = "crates/execution", version = "1.0.1" }
+spacetimedb-expr = { path = "crates/expr", version = "1.0.1" }
+spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.0.1" }
+spacetimedb-metrics = { path = "crates/metrics", version = "1.0.1" }
+spacetimedb-paths = { path = "crates/paths", version = "1.0.1" }
+spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.0.1" }
+spacetimedb-primitives = { path = "crates/primitives", version = "1.0.1" }
+spacetimedb-query = { path = "crates/query", version = "1.0.1" }
+spacetimedb-sats = { path = "crates/sats", version = "1.0.1" }
+spacetimedb-schema = { path = "crates/schema", version = "1.0.1" }
+spacetimedb-standalone = { path = "crates/standalone", version = "1.0.1" }
+spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.0.1" }
+spacetimedb-table = { path = "crates/table", version = "1.0.1" }
+spacetimedb-vm = { path = "crates/vm", version = "1.0.1" }
+spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.0.1" }
+spacetimedb-snapshot = { path = "crates/snapshot", version = "1.0.1" }
+spacetimedb-subscription = { path = "crates/subscription", version = "1.0.1" }
 
 ahash = "0.8"
 anyhow = "1.0.68"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Clockwork Laboratories, Inc.
-Licensed Work:        SpacetimeDB 1.0.0
+Licensed Work:        SpacetimeDB 1.0.1
                       The Licensed Work is
                       (c) 2023 Clockwork Laboratories, Inc.
                       
@@ -21,7 +21,7 @@ Additional Use Grant: You may make use of the Licensed Work provided your
                       Licensed Work by creating tables whose schemas are
                       controlled by such third parties.
 
-Change Date:          2030-02-26
+Change Date:          2030-03-11
 
 Change License:       GNU Affero General Public License v3.0 with a linking
                       exception

--- a/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
+++ b/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Codegen</AssemblyName>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Title>SpacetimeDB BSATN Codegen</Title>
     <Description>The SpacetimeDB BSATN Codegen implements the Roslyn incremental generators for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Runtime</AssemblyName>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Title>SpacetimeDB BSATN Runtime</Title>
     <Description>The SpacetimeDB BSATN Runtime implements APIs for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Codegen</AssemblyName>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Title>SpacetimeDB Module Codegen</Title>
     <Description>The SpacetimeDB Codegen implements the Roslyn incremental generators for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Runtime/Runtime.csproj
+++ b/crates/bindings-csharp/Runtime/Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Runtime</AssemblyName>
-    <Version>1.0.0</Version>
+    <Version>1.0.1</Version>
     <Title>SpacetimeDB Module Runtime</Title>
     <Description>The SpacetimeDB Runtime implements the database runtime bindings for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/cli/src/subcommands/project/rust/Cargo._toml
+++ b/crates/cli/src/subcommands/project/rust/Cargo._toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "1.0.0"
+spacetimedb = "1.0.1"
 log = "0.4"


### PR DESCRIPTION
# Description of Changes

Bumped Rust and C# versions to 1.0.1.

# API and ABI breaking changes

None. Just a version bump.

# Expected complexity level and risk

1

# Testing

None