### PR TITLE
Fix typescript primary key

### DIFF
--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -323,7 +323,7 @@ removeOnUpdate = (cb: (ctx: EventContext, onRow: {row_type}, newRow: {row_type})
             writeln!(out, "tableName: \"{}\",", table.name);
             writeln!(out, "rowType: {row_type}.getTypeScriptAlgebraicType(),");
             if let Some(pk) = schema.pk() {
-                writeln!(out, "primaryKey: \"{}\",", pk.col_name);
+                writeln!(out, "primaryKey: \"{}\",", pk.col_name.deref().to_case(Case::Camel));
             }
             out.dedent(1);
             writeln!(out, "}},");

--- a/crates/cli/tests/snapshots/codegen__codegen_typescript.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_typescript.snap
@@ -884,7 +884,7 @@ const REMOTE_MODULE = {
     repeating_test_arg: {
       tableName: "repeating_test_arg",
       rowType: RepeatingTestArg.getTypeScriptAlgebraicType(),
-      primaryKey: "scheduled_id",
+      primaryKey: "scheduledId",
     },
     test_a: {
       tableName: "test_a",


### PR DESCRIPTION
# Description of Changes

While we generate primary key with `snake_case` but data was deserialize as json `camelCase` there is no way to get key from data , So it will use `undefined` as key for this line https://github.com/clockworklabs/spacetimedb-typescript-sdk/blob/main/packages/sdk/src/table_cache.ts#L69 and keep raising error `Updating a row that was not present in the cache` on browser console

This can re-produce by create table contains `snake_case` id
```
#[table(name = entity_player, public)]
#[derive(Debug)]
pub struct EntityPlayer {
    #[primary_key]
    pub entity_id: u32,
    #[index(btree)]
    pub player_id: u32,
}
```

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

Complexity Level: 1

# Testing

*Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected!*

- [x] *Generate typescript with table contains `snake_case` id, no more error on browser console*