### PR TITLE
Print back the # of rows affected (ins, upd, del, scanned) with timings

### DIFF
--- a/crates/cli/src/api.rs
+++ b/crates/cli/src/api.rs
@@ -1,7 +1,11 @@
+use std::iter::Sum;
+use std::ops::Add;
+
 use reqwest::{header, Client, RequestBuilder};
 use serde::Deserialize;
 use serde_json::value::RawValue;
 
+use spacetimedb::json::client_api::StmtStatsJson;
 use spacetimedb_lib::db::raw_def::v9::RawModuleDefV9;
 use spacetimedb_lib::de::serde::DeserializeWrapper;
 use spacetimedb_lib::sats::ProductType;
@@ -82,11 +86,59 @@ impl ClientApi {
     }
 }
 
+// Sync with spacetimedb::json::client_api::StmtResultJson
 #[derive(Debug, Clone, Deserialize)]
 pub struct StmtResultJson<'a> {
     pub schema: ProductType,
     #[serde(borrow)]
     pub rows: Vec<&'a RawValue>,
+    pub total_duration_micros: u64,
+    #[serde(default)]
+    pub stats: StmtStatsJson,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct StmtStats {
+    pub total_duration_micros: u64,
+    pub rows_inserted: u64,
+    pub rows_updated: u64,
+    pub rows_deleted: u64,
+    pub rows_scanned: u64,
+    pub total_rows: usize,
+}
+
+impl Sum<StmtStats> for StmtStats {
+    fn sum<I: Iterator<Item = StmtStats>>(iter: I) -> Self {
+        iter.fold(StmtStats::default(), Add::add)
+    }
+}
+
+impl Add for StmtStats {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            total_duration_micros: self.total_duration_micros + rhs.total_duration_micros,
+            rows_inserted: self.rows_inserted + rhs.rows_inserted,
+            rows_deleted: self.rows_deleted + rhs.rows_deleted,
+            rows_updated: self.rows_updated + rhs.rows_updated,
+            rows_scanned: self.rows_scanned + rhs.rows_scanned,
+            total_rows: self.total_rows + rhs.total_rows,
+        }
+    }
+}
+
+impl From<&StmtResultJson<'_>> for StmtStats {
+    fn from(value: &StmtResultJson<'_>) -> Self {
+        Self {
+            total_duration_micros: value.total_duration_micros,
+            rows_inserted: value.stats.rows_inserted,
+            rows_deleted: value.stats.rows_deleted,
+            rows_updated: value.stats.rows_updated,
+            rows_scanned: value.stats.rows_scanned,
+            total_rows: value.rows.len(),
+        }
+    }
 }
 
 pub fn from_json_seed<'de, T: serde::de::DeserializeSeed<'de>>(

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -1,7 +1,10 @@
+use std::fmt;
 use std::time::Instant;
 
-use crate::api::{from_json_seed, ClientApi, Connection, StmtResultJson};
+use crate::api::{from_json_seed, ClientApi, Connection, StmtResultJson, StmtStats};
 use crate::common_args;
+use crate::config::Config;
+use crate::util::{database_identity, get_auth_header, ResponseExt, UNSTABLE_WARNING};
 use anyhow::Context;
 use clap::{Arg, ArgAction, ArgMatches};
 use itertools::Itertools;
@@ -9,9 +12,6 @@ use reqwest::RequestBuilder;
 use spacetimedb_lib::de::serde::SeedWrapper;
 use spacetimedb_lib::sats::{satn, Typespace};
 use tabled::settings::Style;
-
-use crate::config::Config;
-use crate::util::{database_identity, get_auth_header, ResponseExt, UNSTABLE_WARNING};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("sql")
@@ -54,18 +54,53 @@ pub(crate) async fn parse_req(mut config: Config, args: &ArgMatches) -> Result<C
     })
 }
 
-// Need to report back timings from each query from the backend instead of infer here...
-fn print_row_count(rows: usize) -> String {
-    let txt = if rows == 1 { "row" } else { "rows" };
-    format!("({rows} {txt})")
+struct StmtResult {
+    table: tabled::Table,
+    stats: Option<StmtStats>,
+    time_client: Instant,
 }
 
-fn print_timings(now: Instant) {
-    println!("Time: {:.2?}", now.elapsed());
+impl fmt::Display for StmtResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        if !self.table.is_empty() {
+            writeln!(f, "{}", self.table)?;
+        }
+
+        if let Some(stats) = &self.stats {
+            let txt = if stats.total_rows == 1 { "row" } else { "rows" };
+
+            let result = format!("({} {txt})", stats.total_rows);
+            let mut info = Vec::new();
+            if stats.rows_scanned != 0 {
+                info.push(format!("scan: {}", stats.rows_scanned));
+            }
+            if stats.rows_inserted != 0 {
+                info.push(format!("ins: {}", stats.rows_inserted));
+            }
+            if stats.rows_deleted != 0 {
+                info.push(format!("del: {}", stats.rows_deleted));
+            }
+            if stats.rows_updated != 0 {
+                info.push(format!("upd: {}", stats.rows_updated));
+            }
+            info.push(format!(
+                "server: {:.2?}",
+                std::time::Duration::from_micros(stats.total_duration_micros)
+            ));
+            info.push(format!("client: {:.2?}", self.time_client.elapsed()));
+
+            if !info.is_empty() {
+                write!(f, "{result} [{info}]", info = info.join(", "))?;
+            } else {
+                write!(f, "{result}")?;
+            };
+        };
+        writeln!(f)
+    }
 }
 
 pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool) -> Result<(), anyhow::Error> {
-    let now = Instant::now();
+    let mut now = Instant::now();
 
     let json = builder
         .body(sql.to_owned())
@@ -77,12 +112,19 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool
         .await?;
 
     let stmt_result_json: Vec<StmtResultJson> = serde_json::from_str(&json).context("malformed sql response")?;
+    let stats = stmt_result_json.iter().map(StmtStats::from).sum::<StmtStats>();
 
     // Print only `OK for empty tables as it's likely a command like `INSERT`.
     if stmt_result_json.is_empty() {
-        if with_stats {
-            print_timings(now);
-        }
+        println!(
+            "{}",
+            StmtResult {
+                stats: if with_stats { Some(stats) } else { None },
+                table: tabled::Table::new([""]),
+                time_client: now,
+            }
+        );
+
         println!("OK");
         return Ok(());
     };
@@ -90,28 +132,24 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool
     stmt_result_json
         .iter()
         .map(|stmt_result| {
-            let mut table = stmt_result_to_table(stmt_result)?;
-            if with_stats {
-                // The `tabled::count_rows` add the header as a row, so subtract it.
-                let row_count = table.count_rows().wrapping_sub(1);
-                // For some reason, `table.with(...)` crashes if the row count is 0.
-                if row_count > 0 {
-                    let row_count = print_row_count(row_count);
-                    table.with(tabled::settings::panel::Footer::new(row_count));
-                }
-            }
-            anyhow::Ok(table)
+            let (stats, table) = stmt_result_to_table(stmt_result)?;
+
+            let time_client = now;
+            now = Instant::now();
+            anyhow::Ok(StmtResult {
+                stats: if with_stats { Some(stats) } else { None },
+                table,
+                time_client,
+            })
         })
         .process_results(|it| println!("{}", it.format("\n\n")))?;
-    if with_stats {
-        print_timings(now);
-    }
 
     Ok(())
 }
 
-fn stmt_result_to_table(stmt_result: &StmtResultJson) -> anyhow::Result<tabled::Table> {
-    let StmtResultJson { schema, rows } = stmt_result;
+fn stmt_result_to_table(stmt_result: &StmtResultJson) -> anyhow::Result<(StmtStats, tabled::Table)> {
+    let stats = StmtStats::from(stmt_result);
+    let StmtResultJson { schema, rows, .. } = stmt_result;
 
     let mut builder = tabled::builder::Builder::default();
     builder.set_header(
@@ -134,7 +172,7 @@ fn stmt_result_to_table(stmt_result: &StmtResultJson) -> anyhow::Result<tabled::
     let mut table = builder.build();
     table.with(Style::psql());
 
-    Ok(table)
+    Ok((stats, table))
 }
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {

--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -8,7 +8,7 @@ use spacetimedb::client::ClientActorIndex;
 use spacetimedb::energy::{EnergyBalance, EnergyQuanta};
 use spacetimedb::host::{HostController, ModuleHost, NoSuchModule, UpdateDatabaseResult};
 use spacetimedb::identity::{AuthCtx, Identity};
-use spacetimedb::json::client_api::StmtResultJson;
+use spacetimedb::json::client_api::{StmtResultJson, StmtStatsJson};
 use spacetimedb::messages::control_db::{Database, HostType, Node, Replica};
 use spacetimedb::sql;
 use spacetimedb_client_api_messages::name::{DomainName, InsertDomainResult, RegisterTldResult, SetDomainsResult, Tld};
@@ -88,7 +88,7 @@ impl Host {
                     let sql_span =
                         tracing::trace_span!("execute_sql", total_duration = tracing::field::Empty,).entered();
 
-                    let rows = sql::execute::run(
+                    let result = sql::execute::run(
                         // Returns an empty result set for mutations
                         db,
                         &body,
@@ -116,8 +116,14 @@ impl Host {
 
                     Ok(vec![StmtResultJson {
                         schema,
-                        rows,
+                        rows: result.rows,
                         total_duration_micros: total_duration.as_micros() as u64,
+                        stats: StmtStatsJson {
+                            rows_inserted: result.metrics.rows_inserted,
+                            rows_deleted: result.metrics.rows_deleted,
+                            rows_updated: result.metrics.rows_updated,
+                            rows_scanned: result.metrics.rows_scanned as u64,
+                        },
                     }])
                 },
             )

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -102,14 +102,15 @@ impl DeltaStore for MutTxId {
 }
 
 impl MutDatastore for MutTxId {
-    fn insert_product_value(&mut self, table_id: TableId, row: &ProductValue) -> anyhow::Result<()> {
-        self.insert_via_serialize_bsatn(table_id, row)?;
-        Ok(())
+    fn insert_product_value(&mut self, table_id: TableId, row: &ProductValue) -> anyhow::Result<bool> {
+        Ok(match self.insert_via_serialize_bsatn(table_id, row)?.1 {
+            RowRefInsertion::Inserted(_) => true,
+            RowRefInsertion::Existed(_) => false,
+        })
     }
 
-    fn delete_product_value(&mut self, table_id: TableId, row: &ProductValue) -> anyhow::Result<()> {
-        self.delete_by_row_value(table_id, row)?;
-        Ok(())
+    fn delete_product_value(&mut self, table_id: TableId, row: &ProductValue) -> anyhow::Result<bool> {
+        Ok(self.delete_by_row_value(table_id, row)?)
     }
 }
 

--- a/crates/core/src/json/client_api.rs
+++ b/crates/core/src/json/client_api.rs
@@ -1,9 +1,19 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use spacetimedb_lib::{ProductType, ProductValue};
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct StmtStatsJson {
+    pub rows_inserted: u64,
+    pub rows_deleted: u64,
+    pub rows_updated: u64,
+    pub rows_scanned: u64,
+}
+
+// Sync with spacetimedb_cli::api::StmtResultJson
 #[derive(Debug, Clone, Serialize)]
 pub struct StmtResultJson {
     pub schema: ProductType,
     pub rows: Vec<ProductValue>,
     pub total_duration_micros: u64,
+    pub stats: StmtStatsJson,
 }

--- a/crates/lib/src/metrics.rs
+++ b/crates/lib/src/metrics.rs
@@ -1,5 +1,5 @@
 /// Metrics collected during the course of a transaction
-#[derive(Default)]
+#[derive(Default, Copy, Clone)]
 pub struct ExecutionMetrics {
     /// How many times is an index probed?
     ///
@@ -40,6 +40,12 @@ pub struct ExecutionMetrics {
     ///
     /// In general, these are BSATN bytes, but JSON is also possible.
     pub bytes_sent_to_clients: usize,
+    /// How many rows were inserted?
+    pub rows_inserted: u64,
+    /// How many rows were deleted?
+    pub rows_deleted: u64,
+    /// How many rows were updated?
+    pub rows_updated: u64,
 }
 
 impl ExecutionMetrics {
@@ -51,6 +57,9 @@ impl ExecutionMetrics {
             bytes_scanned,
             bytes_written,
             bytes_sent_to_clients,
+            rows_inserted,
+            rows_deleted,
+            rows_updated,
         }: ExecutionMetrics,
     ) {
         self.index_seeks += index_seeks;
@@ -58,6 +67,9 @@ impl ExecutionMetrics {
         self.bytes_scanned += bytes_scanned;
         self.bytes_written += bytes_written;
         self.bytes_sent_to_clients += bytes_sent_to_clients;
+        self.rows_inserted += rows_inserted;
+        self.rows_deleted += rows_deleted;
+        self.rows_updated += rows_updated;
     }
 }
 
@@ -75,6 +87,9 @@ mod tests {
             bytes_scanned: 1,
             bytes_written: 1,
             bytes_sent_to_clients: 1,
+            rows_inserted: 1,
+            rows_deleted: 1,
+            rows_updated: 1,
         });
 
         assert_eq!(a.index_seeks, 1);
@@ -82,5 +97,7 @@ mod tests {
         assert_eq!(a.bytes_scanned, 1);
         assert_eq!(a.bytes_written, 1);
         assert_eq!(a.bytes_sent_to_clients, 1);
+        assert_eq!(a.rows_inserted, 1);
+        assert_eq!(a.rows_deleted, 1);
     }
 }


### PR DESCRIPTION
# Description of Changes

Closes #2430.


# API and ABI breaking changes

It change the  returning `json` for `sql` route (spacetimedb::json::client_api::StmtResultJson), with added field for stats.


# Expected complexity level and risk
 
1

# Testing

- [x] *Added test that confirm the number of stats for `ins, del, upd`*
- [x] *Manual testing of the `cli` output using the module `keynote-benchmarks`*

```bash
🪐quickstart>delete from position;
(0 rows) [scan: 2000000, del: 1000000, server: 3.49s, client: 3.50s]

🪐quickstart>select * from position;
 id | x | y | z
----+---+---+---
(0 rows) [server: 1.98ms, client: 9.42ms]

🪐quickstart>delete from position;
(0 rows) [server: 1.29ms, client: 8.32ms]

🪐quickstart>INSERT INTO position (id, x, y, z) VALUES (1000011, 10.0, 20.0, 30.0);
(0 rows) [ins: 1, server: 1.99ms, client: 7.02ms]

🪐quickstart>select * from position;
 id      | x  | y  | z
---------+----+----+----
 1000011 | 10 | 20 | 30
(1 row) [scan: 3, server: 1.41ms, client: 7.07ms]

🪐quickstart>update position set x = 1.0;
(0 rows) [scan: 2, upd: 1, server: 3.08ms, client: 8.96ms]
```
