### PR TITLE
Print back the # of rows affected (ins, upd, del) with timings

### DIFF
--- a/crates/cli/src/api.rs
+++ b/crates/cli/src/api.rs
@@ -103,7 +103,6 @@ pub struct StmtStats {
     pub rows_inserted: u64,
     pub rows_updated: u64,
     pub rows_deleted: u64,
-    pub rows_scanned: u64,
     pub total_rows: usize,
 }
 
@@ -122,7 +121,6 @@ impl Add for StmtStats {
             rows_inserted: self.rows_inserted + rhs.rows_inserted,
             rows_deleted: self.rows_deleted + rhs.rows_deleted,
             rows_updated: self.rows_updated + rhs.rows_updated,
-            rows_scanned: self.rows_scanned + rhs.rows_scanned,
             total_rows: self.total_rows + rhs.total_rows,
         }
     }
@@ -135,7 +133,6 @@ impl From<&StmtResultJson<'_>> for StmtStats {
             rows_inserted: value.stats.rows_inserted,
             rows_deleted: value.stats.rows_deleted,
             rows_updated: value.stats.rows_updated,
-            rows_scanned: value.stats.rows_scanned,
             total_rows: value.rows.len(),
         }
     }

--- a/crates/cli/src/api.rs
+++ b/crates/cli/src/api.rs
@@ -1,7 +1,11 @@
+use std::iter::Sum;
+use std::ops::Add;
+
 use reqwest::{header, Client, RequestBuilder};
 use serde::Deserialize;
 use serde_json::value::RawValue;
 
+use spacetimedb::json::client_api::StmtStatsJson;
 use spacetimedb_lib::db::raw_def::v9::RawModuleDefV9;
 use spacetimedb_lib::de::serde::DeserializeWrapper;
 use spacetimedb_lib::sats::ProductType;
@@ -82,11 +86,59 @@ impl ClientApi {
     }
 }
 
+// Sync with spacetimedb::json::client_api::StmtResultJson
 #[derive(Debug, Clone, Deserialize)]
 pub struct StmtResultJson<'a> {
     pub schema: ProductType,
     #[serde(borrow)]
     pub rows: Vec<&'a RawValue>,
+    pub total_duration_micros: u64,
+    #[serde(default)]
+    pub stats: StmtStatsJson,
+}
+
+#[derive(Debug, Clone, Deserialize, Default)]
+pub struct StmtStats {
+    pub total_duration_micros: u64,
+    pub rows_inserted: u64,
+    pub rows_updated: u64,
+    pub rows_deleted: u64,
+    pub rows_scanned: u64,
+    pub total_rows: usize,
+}
+
+impl Sum<StmtStats> for StmtStats {
+    fn sum<I: Iterator<Item = StmtStats>>(iter: I) -> Self {
+        iter.fold(StmtStats::default(), Add::add)
+    }
+}
+
+impl Add for StmtStats {
+    type Output = Self;
+
+    fn add(self, rhs: Self) -> Self::Output {
+        Self {
+            total_duration_micros: self.total_duration_micros + rhs.total_duration_micros,
+            rows_inserted: self.rows_inserted + rhs.rows_inserted,
+            rows_deleted: self.rows_deleted + rhs.rows_deleted,
+            rows_updated: self.rows_updated + rhs.rows_updated,
+            rows_scanned: self.rows_scanned + rhs.rows_scanned,
+            total_rows: self.total_rows + rhs.total_rows,
+        }
+    }
+}
+
+impl From<&StmtResultJson<'_>> for StmtStats {
+    fn from(value: &StmtResultJson<'_>) -> Self {
+        Self {
+            total_duration_micros: value.total_duration_micros,
+            rows_inserted: value.stats.rows_inserted,
+            rows_deleted: value.stats.rows_deleted,
+            rows_updated: value.stats.rows_updated,
+            rows_scanned: value.stats.rows_scanned,
+            total_rows: value.rows.len(),
+        }
+    }
 }
 
 pub fn from_json_seed<'de, T: serde::de::DeserializeSeed<'de>>(

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -123,7 +123,7 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool
         println!(
             "{}",
             StmtResult {
-                stats: if with_stats { Some(stats) } else { None },
+                stats: with_stats.then_some(stats),
                 table: tabled::Table::new([""]),
                 time_client: now,
             }
@@ -141,7 +141,7 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool
             let time_client = now;
             now = Instant::now();
             anyhow::Ok(StmtResult {
-                stats: if with_stats { Some(stats) } else { None },
+                stats: with_stats.then_some(stats),
                 table,
                 time_client,
             })

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -1,5 +1,6 @@
 use std::fmt;
-use std::time::Instant;
+use std::fmt::Write;
+use std::time::{Duration, Instant};
 
 use crate::api::{from_json_seed, ClientApi, Connection, StmtResultJson, StmtStats};
 use crate::common_args;
@@ -7,7 +8,6 @@ use crate::config::Config;
 use crate::util::{database_identity, get_auth_header, ResponseExt, UNSTABLE_WARNING};
 use anyhow::Context;
 use clap::{Arg, ArgAction, ArgMatches};
-use itertools::Itertools;
 use reqwest::RequestBuilder;
 use spacetimedb_lib::de::serde::SeedWrapper;
 use spacetimedb_lib::sats::{satn, Typespace};
@@ -57,7 +57,6 @@ pub(crate) async fn parse_req(mut config: Config, args: &ArgMatches) -> Result<C
 struct StmtResult {
     table: tabled::Table,
     stats: Option<StmtStats>,
-    time_client: Instant,
 }
 
 impl fmt::Display for StmtResult {
@@ -75,23 +74,19 @@ impl fmt::Display for StmtResult {
 
             let result = format!("({} {txt})", stats.total_rows);
             let mut info = Vec::new();
-            if stats.rows_scanned != 0 {
-                info.push(format!("scan: {}", stats.rows_scanned));
-            }
             if stats.rows_inserted != 0 {
-                info.push(format!("ins: {}", stats.rows_inserted));
+                info.push(format!("inserted: {}", stats.rows_inserted));
             }
             if stats.rows_deleted != 0 {
-                info.push(format!("del: {}", stats.rows_deleted));
+                info.push(format!("deleted: {}", stats.rows_deleted));
             }
             if stats.rows_updated != 0 {
-                info.push(format!("upd: {}", stats.rows_updated));
+                info.push(format!("updated: {}", stats.rows_updated));
             }
             info.push(format!(
                 "server: {:.2?}",
                 std::time::Duration::from_micros(stats.total_duration_micros)
             ));
-            info.push(format!("client: {:.2?}", self.time_client.elapsed()));
 
             if !info.is_empty() {
                 write!(f, "{result} [{info}]", info = info.join(", "))?;
@@ -103,8 +98,46 @@ impl fmt::Display for StmtResult {
     }
 }
 
+fn print_stmt_result(
+    stmt_results: &[StmtResultJson],
+    with_stats: Option<Duration>,
+    f: &mut String,
+) -> anyhow::Result<()> {
+    let if_empty: Option<anyhow::Result<StmtResult>> = stmt_results.is_empty().then_some(anyhow::Ok(StmtResult {
+        stats: with_stats.is_some().then_some(StmtStats::default()),
+        table: tabled::Table::new([""]),
+    }));
+    let total = stmt_results.len();
+    for (pos, result) in if_empty
+        .into_iter()
+        .chain(stmt_results.iter().map(|stmt_result| {
+            let (stats, table) = stmt_result_to_table(stmt_result)?;
+
+            anyhow::Ok(StmtResult {
+                stats: with_stats.is_some().then_some(stats),
+                table,
+            })
+        }))
+        .enumerate()
+    {
+        let result = result?;
+        f.write_str(&format!("{result}"))?;
+        if pos + 1 < total {
+            f.write_char('\n')?;
+            f.write_char('\n')?;
+        }
+    }
+
+    if let Some(with_stats) = with_stats {
+        f.write_char('\n')?;
+        f.write_str(&format!("Roundtrip time: {:.2?}", with_stats))?;
+        f.write_char('\n')?;
+    }
+    Ok(())
+}
+
 pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool) -> Result<(), anyhow::Error> {
-    let mut now = Instant::now();
+    let now = Instant::now();
 
     let json = builder
         .body(sql.to_owned())
@@ -116,37 +149,10 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool
         .await?;
 
     let stmt_result_json: Vec<StmtResultJson> = serde_json::from_str(&json).context("malformed sql response")?;
-    let stats = stmt_result_json.iter().map(StmtStats::from).sum::<StmtStats>();
 
-    // Print only `OK for empty tables as it's likely a command like `INSERT`.
-    if stmt_result_json.is_empty() {
-        println!(
-            "{}",
-            StmtResult {
-                stats: with_stats.then_some(stats),
-                table: tabled::Table::new([""]),
-                time_client: now,
-            }
-        );
-
-        println!("OK");
-        return Ok(());
-    };
-
-    stmt_result_json
-        .iter()
-        .map(|stmt_result| {
-            let (stats, table) = stmt_result_to_table(stmt_result)?;
-
-            let time_client = now;
-            now = Instant::now();
-            anyhow::Ok(StmtResult {
-                stats: with_stats.then_some(stats),
-                table,
-                time_client,
-            })
-        })
-        .process_results(|it| println!("{}", it.format("\n\n")))?;
+    let mut out = String::new();
+    print_stmt_result(&stmt_result_json, with_stats.then_some(now.elapsed()), &mut out)?;
+    println!("{}", out);
 
     Ok(())
 }
@@ -195,4 +201,222 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error
         run_sql(api.sql(), query, false).await?;
     }
     Ok(())
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use itertools::Itertools;
+    use serde_json::value::RawValue;
+    use spacetimedb::json::client_api::StmtStatsJson;
+    use spacetimedb_lib::sats::ProductType;
+    use spacetimedb_lib::{AlgebraicType, AlgebraicValue};
+
+    fn make_row(row: &[AlgebraicValue]) -> Result<Box<RawValue>, serde_json::Error> {
+        let json = serde_json::json!(row);
+        RawValue::from_string(json.to_string())
+    }
+
+    fn check_outputs(
+        result: &[StmtResultJson],
+        duration: Option<Duration>,
+        expect: &str,
+    ) -> Result<String, anyhow::Error> {
+        let mut out = String::new();
+        print_stmt_result(result, duration, &mut out)?;
+
+        // Need to trim the output to because rustfmt remove the `expect` spaces
+        let out = out.lines().map(|line| line.trim_end()).join("\n");
+        assert_eq!(out, expect,);
+
+        Ok(out)
+    }
+
+    fn check_output(
+        schema: ProductType,
+        rows: Vec<&RawValue>,
+        stats: StmtStatsJson,
+        duration: Option<Duration>,
+        expect: &str,
+    ) -> Result<String, anyhow::Error> {
+        let table = StmtResultJson {
+            schema: schema.clone(),
+            rows,
+            total_duration_micros: 1000,
+            stats: stats.clone(),
+        };
+
+        let mut out = String::new();
+        print_stmt_result(&[table], duration, &mut out)?;
+
+        // Need to trim the output to because rustfmt remove the `expect` spaces
+        let out = out.lines().map(|line| line.trim_end()).join("\n");
+        assert_eq!(out, expect,);
+
+        Ok(out)
+    }
+
+    #[test]
+    fn test_output() -> Result<(), anyhow::Error> {
+        let duration = Duration::from_micros(1000);
+        let schema = ProductType::from([("a", AlgebraicType::I32), ("b", AlgebraicType::I64)]);
+        let row = make_row(&[AlgebraicValue::I32(1), AlgebraicValue::I64(2)])?;
+        // Verify with and without stats
+        check_output(
+            schema.clone(),
+            vec![&row],
+            StmtStatsJson {
+                rows_inserted: 1,
+                rows_deleted: 1,
+                rows_updated: 1,
+            },
+            None,
+            r#" a | b
+---+---
+ 1 | 2"#,
+        )?;
+
+        check_output(
+            schema.clone(),
+            vec![&row],
+            StmtStatsJson {
+                rows_inserted: 1,
+                rows_deleted: 1,
+                rows_updated: 1,
+            },
+            Some(duration),
+            r#" a | b
+---+---
+ 1 | 2
+(1 row) [inserted: 1, deleted: 1, updated: 1, server: 1.00ms]
+Roundtrip time: 1.00ms"#,
+        )?;
+
+        // Only a query result
+        check_output(
+            schema.clone(),
+            vec![&row],
+            StmtStatsJson {
+                rows_inserted: 0,
+                rows_deleted: 0,
+                rows_updated: 0,
+            },
+            Some(duration),
+            r#" a | b
+---+---
+ 1 | 2
+(1 row) [server: 1.00ms]
+Roundtrip time: 1.00ms"#,
+        )?;
+
+        // Empty table
+        check_output(
+            schema.clone(),
+            vec![],
+            StmtStatsJson {
+                rows_inserted: 0,
+                rows_deleted: 0,
+                rows_updated: 0,
+            },
+            Some(duration),
+            r#" a | b
+---+---
+(0 rows) [server: 1.00ms]
+Roundtrip time: 1.00ms"#,
+        )?;
+
+        // DML
+        check_output(
+            schema.clone(),
+            vec![],
+            StmtStatsJson {
+                rows_inserted: 1,
+                rows_deleted: 0,
+                rows_updated: 0,
+            },
+            Some(duration),
+            r#" a | b
+---+---
+(0 rows) [inserted: 1, server: 1.00ms]
+Roundtrip time: 1.00ms"#,
+        )?;
+
+        check_output(
+            schema.clone(),
+            vec![],
+            StmtStatsJson {
+                rows_inserted: 0,
+                rows_deleted: 1,
+                rows_updated: 0,
+            },
+            Some(duration),
+            r#" a | b
+---+---
+(0 rows) [deleted: 1, server: 1.00ms]
+Roundtrip time: 1.00ms"#,
+        )?;
+
+        check_output(
+            schema.clone(),
+            vec![],
+            StmtStatsJson {
+                rows_inserted: 0,
+                rows_deleted: 0,
+                rows_updated: 1,
+            },
+            Some(duration),
+            r#" a | b
+---+---
+(0 rows) [updated: 1, server: 1.00ms]
+Roundtrip time: 1.00ms"#,
+        )?;
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_multiple_output() -> Result<(), anyhow::Error> {
+        let duration = Duration::from_micros(1000);
+        let schema = ProductType::from([("a", AlgebraicType::I32), ("b", AlgebraicType::I64)]);
+        let row = make_row(&[AlgebraicValue::I32(1), AlgebraicValue::I64(2)])?;
+
+        // Verify with and without stats
+        check_outputs(
+            &[
+                StmtResultJson {
+                    schema: schema.clone(),
+                    rows: vec![&row],
+                    total_duration_micros: 1000,
+                    stats: StmtStatsJson {
+                        rows_inserted: 1,
+                        rows_deleted: 1,
+                        rows_updated: 1,
+                    },
+                },
+                StmtResultJson {
+                    schema: schema.clone(),
+                    rows: vec![&row],
+                    total_duration_micros: 1000,
+                    stats: StmtStatsJson {
+                        rows_inserted: 1,
+                        rows_deleted: 1,
+                        rows_updated: 1,
+                    },
+                },
+            ],
+            Some(duration),
+            r#" a | b
+---+---
+ 1 | 2
+(1 row) [inserted: 1, deleted: 1, updated: 1, server: 1.00ms]
+
+ a | b
+---+---
+ 1 | 2
+(1 row) [inserted: 1, deleted: 1, updated: 1, server: 1.00ms]
+Roundtrip time: 1.00ms"#,
+        )?;
+
+        Ok(())
+    }
 }

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -1,7 +1,10 @@
+use std::fmt;
 use std::time::Instant;
 
-use crate::api::{from_json_seed, ClientApi, Connection, StmtResultJson};
+use crate::api::{from_json_seed, ClientApi, Connection, StmtResultJson, StmtStats};
 use crate::common_args;
+use crate::config::Config;
+use crate::util::{database_identity, get_auth_header, ResponseExt, UNSTABLE_WARNING};
 use anyhow::Context;
 use clap::{Arg, ArgAction, ArgMatches};
 use itertools::Itertools;
@@ -9,9 +12,6 @@ use reqwest::RequestBuilder;
 use spacetimedb_lib::de::serde::SeedWrapper;
 use spacetimedb_lib::sats::{satn, Typespace};
 use tabled::settings::Style;
-
-use crate::config::Config;
-use crate::util::{database_identity, get_auth_header, ResponseExt, UNSTABLE_WARNING};
 
 pub fn cli() -> clap::Command {
     clap::Command::new("sql")
@@ -54,18 +54,57 @@ pub(crate) async fn parse_req(mut config: Config, args: &ArgMatches) -> Result<C
     })
 }
 
-// Need to report back timings from each query from the backend instead of infer here...
-fn print_row_count(rows: usize) -> String {
-    let txt = if rows == 1 { "row" } else { "rows" };
-    format!("({rows} {txt})")
+struct StmtResult {
+    table: tabled::Table,
+    stats: Option<StmtStats>,
+    time_client: Instant,
 }
 
-fn print_timings(now: Instant) {
-    println!("Time: {:.2?}", now.elapsed());
+impl fmt::Display for StmtResult {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        let has_table = !self.table.is_empty();
+        if has_table {
+            write!(f, "{}", self.table)?;
+        }
+
+        if let Some(stats) = &self.stats {
+            if has_table {
+                writeln!(f)?;
+            }
+            let txt = if stats.total_rows == 1 { "row" } else { "rows" };
+
+            let result = format!("({} {txt})", stats.total_rows);
+            let mut info = Vec::new();
+            if stats.rows_scanned != 0 {
+                info.push(format!("scan: {}", stats.rows_scanned));
+            }
+            if stats.rows_inserted != 0 {
+                info.push(format!("ins: {}", stats.rows_inserted));
+            }
+            if stats.rows_deleted != 0 {
+                info.push(format!("del: {}", stats.rows_deleted));
+            }
+            if stats.rows_updated != 0 {
+                info.push(format!("upd: {}", stats.rows_updated));
+            }
+            info.push(format!(
+                "server: {:.2?}",
+                std::time::Duration::from_micros(stats.total_duration_micros)
+            ));
+            info.push(format!("client: {:.2?}", self.time_client.elapsed()));
+
+            if !info.is_empty() {
+                write!(f, "{result} [{info}]", info = info.join(", "))?;
+            } else {
+                write!(f, "{result}")?;
+            };
+        };
+        Ok(())
+    }
 }
 
 pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool) -> Result<(), anyhow::Error> {
-    let now = Instant::now();
+    let mut now = Instant::now();
 
     let json = builder
         .body(sql.to_owned())
@@ -77,12 +116,19 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool
         .await?;
 
     let stmt_result_json: Vec<StmtResultJson> = serde_json::from_str(&json).context("malformed sql response")?;
+    let stats = stmt_result_json.iter().map(StmtStats::from).sum::<StmtStats>();
 
     // Print only `OK for empty tables as it's likely a command like `INSERT`.
     if stmt_result_json.is_empty() {
-        if with_stats {
-            print_timings(now);
-        }
+        println!(
+            "{}",
+            StmtResult {
+                stats: if with_stats { Some(stats) } else { None },
+                table: tabled::Table::new([""]),
+                time_client: now,
+            }
+        );
+
         println!("OK");
         return Ok(());
     };
@@ -90,28 +136,24 @@ pub(crate) async fn run_sql(builder: RequestBuilder, sql: &str, with_stats: bool
     stmt_result_json
         .iter()
         .map(|stmt_result| {
-            let mut table = stmt_result_to_table(stmt_result)?;
-            if with_stats {
-                // The `tabled::count_rows` add the header as a row, so subtract it.
-                let row_count = table.count_rows().wrapping_sub(1);
-                // For some reason, `table.with(...)` crashes if the row count is 0.
-                if row_count > 0 {
-                    let row_count = print_row_count(row_count);
-                    table.with(tabled::settings::panel::Footer::new(row_count));
-                }
-            }
-            anyhow::Ok(table)
+            let (stats, table) = stmt_result_to_table(stmt_result)?;
+
+            let time_client = now;
+            now = Instant::now();
+            anyhow::Ok(StmtResult {
+                stats: if with_stats { Some(stats) } else { None },
+                table,
+                time_client,
+            })
         })
         .process_results(|it| println!("{}", it.format("\n\n")))?;
-    if with_stats {
-        print_timings(now);
-    }
 
     Ok(())
 }
 
-fn stmt_result_to_table(stmt_result: &StmtResultJson) -> anyhow::Result<tabled::Table> {
-    let StmtResultJson { schema, rows } = stmt_result;
+fn stmt_result_to_table(stmt_result: &StmtResultJson) -> anyhow::Result<(StmtStats, tabled::Table)> {
+    let stats = StmtStats::from(stmt_result);
+    let StmtResultJson { schema, rows, .. } = stmt_result;
 
     let mut builder = tabled::builder::Builder::default();
     builder.set_header(
@@ -134,7 +176,7 @@ fn stmt_result_to_table(stmt_result: &StmtResultJson) -> anyhow::Result<tabled::
     let mut table = builder.build();
     table.with(Style::psql());
 
-    Ok(table)
+    Ok((stats, table))
 }
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {

--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -122,7 +122,6 @@ impl Host {
                             rows_inserted: result.metrics.rows_inserted,
                             rows_deleted: result.metrics.rows_deleted,
                             rows_updated: result.metrics.rows_updated,
-                            rows_scanned: result.metrics.rows_scanned as u64,
                         },
                     }])
                 },

--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -8,7 +8,7 @@ use spacetimedb::client::ClientActorIndex;
 use spacetimedb::energy::{EnergyBalance, EnergyQuanta};
 use spacetimedb::host::{HostController, ModuleHost, NoSuchModule, UpdateDatabaseResult};
 use spacetimedb::identity::{AuthCtx, Identity};
-use spacetimedb::json::client_api::StmtResultJson;
+use spacetimedb::json::client_api::{StmtResultJson, StmtStatsJson};
 use spacetimedb::messages::control_db::{Database, HostType, Node, Replica};
 use spacetimedb::sql;
 use spacetimedb_client_api_messages::name::{DomainName, InsertDomainResult, RegisterTldResult, SetDomainsResult, Tld};
@@ -88,7 +88,7 @@ impl Host {
                     let sql_span =
                         tracing::trace_span!("execute_sql", total_duration = tracing::field::Empty,).entered();
 
-                    let rows = sql::execute::run(
+                    let result = sql::execute::run(
                         // Returns an empty result set for mutations
                         db,
                         &body,
@@ -116,8 +116,14 @@ impl Host {
 
                     Ok(vec![StmtResultJson {
                         schema,
-                        rows,
+                        rows: result.rows,
                         total_duration_micros: total_duration.as_micros() as u64,
+                        stats: StmtStatsJson {
+                            rows_inserted: result.metrics.rows_inserted,
+                            rows_deleted: result.metrics.rows_deleted,
+                            rows_updated: result.metrics.rows_updated,
+                            rows_scanned: result.metrics.rows_scanned as u64,
+                        },
                     }])
                 },
             )

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -102,14 +102,15 @@ impl DeltaStore for MutTxId {
 }
 
 impl MutDatastore for MutTxId {
-    fn insert_product_value(&mut self, table_id: TableId, row: &ProductValue) -> anyhow::Result<()> {
-        self.insert_via_serialize_bsatn(table_id, row)?;
-        Ok(())
+    fn insert_product_value(&mut self, table_id: TableId, row: &ProductValue) -> anyhow::Result<bool> {
+        Ok(match self.insert_via_serialize_bsatn(table_id, row)?.1 {
+            RowRefInsertion::Inserted(_) => true,
+            RowRefInsertion::Existed(_) => false,
+        })
     }
 
-    fn delete_product_value(&mut self, table_id: TableId, row: &ProductValue) -> anyhow::Result<()> {
-        self.delete_by_row_value(table_id, row)?;
-        Ok(())
+    fn delete_product_value(&mut self, table_id: TableId, row: &ProductValue) -> anyhow::Result<bool> {
+        Ok(self.delete_by_row_value(table_id, row)?)
     }
 }
 

--- a/crates/core/src/json/client_api.rs
+++ b/crates/core/src/json/client_api.rs
@@ -1,9 +1,19 @@
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use spacetimedb_lib::{ProductType, ProductValue};
 
+#[derive(Debug, Clone, Serialize, Deserialize, Default)]
+pub struct StmtStatsJson {
+    pub rows_inserted: u64,
+    pub rows_deleted: u64,
+    pub rows_updated: u64,
+    pub rows_scanned: u64,
+}
+
+// Sync with spacetimedb_cli::api::StmtResultJson
 #[derive(Debug, Clone, Serialize)]
 pub struct StmtResultJson {
     pub schema: ProductType,
     pub rows: Vec<ProductValue>,
     pub total_duration_micros: u64,
+    pub stats: StmtStatsJson,
 }

--- a/crates/core/src/json/client_api.rs
+++ b/crates/core/src/json/client_api.rs
@@ -6,7 +6,6 @@ pub struct StmtStatsJson {
     pub rows_inserted: u64,
     pub rows_deleted: u64,
     pub rows_updated: u64,
-    pub rows_scanned: u64,
 }
 
 // Sync with spacetimedb_cli::api::StmtResultJson

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -171,6 +171,11 @@ pub fn execute_sql_tx<'a>(
     execute(&mut DbProgram::new(db, &mut tx, auth), ast, sql, &mut updates).map(Some)
 }
 
+pub struct SqlResult {
+    pub rows: Vec<ProductValue>,
+    pub metrics: ExecutionMetrics,
+}
+
 /// Run the `SQL` string using the `auth` credentials
 pub fn run(
     db: &RelationalDB,
@@ -178,7 +183,7 @@ pub fn run(
     auth: AuthCtx,
     subs: Option<&ModuleSubscriptions>,
     head: &mut Vec<(Box<str>, AlgebraicType)>,
-) -> Result<Vec<ProductValue>, DBError> {
+) -> Result<SqlResult, DBError> {
     // We parse the sql statement in a mutable transation.
     // If it turns out to be a query, we downgrade the tx.
     let (tx, stmt) = db.with_auto_rollback(db.begin_mut_tx(IsolationLevel::Serializable, Workload::Sql), |tx| {
@@ -212,7 +217,10 @@ pub fn run(
             // Update transaction metrics
             tx.metrics.merge(metrics);
 
-            Ok(rows)
+            Ok(SqlResult {
+                rows,
+                metrics: tx.metrics,
+            })
         }
         Statement::DML(stmt) => {
             // An extra layer of auth is required for DML
@@ -228,7 +236,8 @@ pub fn run(
 
             // Commit the tx if there are no deltas to process
             if subs.is_none() {
-                return db.commit_tx(tx).map(|_| vec![]);
+                let metrics = tx.metrics;
+                return db.commit_tx(tx).map(|_| SqlResult { rows: vec![], metrics });
             }
 
             // Otherwise downgrade the tx and process the deltas.
@@ -261,7 +270,7 @@ pub fn run(
                 Err(WriteConflict) => {
                     todo!("See module_host_actor::call_reducer_with_tx")
                 }
-                Ok(_) => Ok(vec![]),
+                Ok(_) => Ok(SqlResult { rows: vec![], metrics }),
             }
         }
     }
@@ -315,7 +324,7 @@ pub(crate) mod tests {
             Arc::new(RwLock::new(SubscriptionManager::default())),
             Identity::ZERO,
         );
-        run(db, sql_text, AuthCtx::for_testing(), Some(&subs), &mut vec![])
+        run(db, sql_text, AuthCtx::for_testing(), Some(&subs), &mut vec![]).map(|x| x.rows)
     }
 
     fn create_data(total_rows: u64) -> ResultTest<(TestDB, MemTable)> {
@@ -771,6 +780,59 @@ pub(crate) mod tests {
         // Both queries pass.
         assert!(run(&db, "SELECT * FROM T", internal_auth, None).is_ok());
         assert!(run(&db, "SELECT * FROM T", external_auth, None).is_ok());
+
+        Ok(())
+    }
+
+    // Verify we don't return rows on DML
+    #[test]
+    fn test_row_dml() -> ResultTest<()> {
+        let db = TestDB::durable()?;
+
+        let table_id = db.create_table_for_test("T", &[("a", AlgebraicType::U8)], &[])?;
+        db.with_auto_commit(Workload::ForTests, |tx| -> Result<_, DBError> {
+            for i in 0..4u8 {
+                insert(&db, tx, table_id, &product!(i))?;
+            }
+            Ok(())
+        })?;
+
+        let server = Identity::from_claims("issuer", "server");
+
+        let internal_auth = AuthCtx::new(server, server);
+
+        let run = |db, sql, auth, subs| run(db, sql, auth, subs, &mut vec![]);
+
+        let check = |db, sql, auth, metrics: ExecutionMetrics| {
+            let result = run(db, sql, auth, None)?;
+            assert_eq!(result.rows, vec![]);
+            assert_eq!(result.metrics.rows_inserted, metrics.rows_inserted);
+            assert_eq!(result.metrics.rows_deleted, metrics.rows_deleted);
+            assert_eq!(result.metrics.rows_updated, metrics.rows_updated);
+
+            Ok::<(), DBError>(())
+        };
+
+        let ins = ExecutionMetrics {
+            rows_inserted: 1,
+            ..ExecutionMetrics::default()
+        };
+        let upd = ExecutionMetrics {
+            rows_updated: 5,
+            ..ExecutionMetrics::default()
+        };
+        let del = ExecutionMetrics {
+            rows_deleted: 1,
+            ..ExecutionMetrics::default()
+        };
+
+        check(&db, "INSERT INTO T (a) VALUES (5)", internal_auth, ins)?;
+        check(&db, "UPDATE T SET a = 2", internal_auth, upd)?;
+        assert_eq!(
+            run(&db, "SELECT * FROM T", internal_auth, None)?.rows,
+            vec![product!(2u8)]
+        );
+        check(&db, "DELETE FROM T", internal_auth, del)?;
 
         Ok(())
     }

--- a/crates/lib/src/metrics.rs
+++ b/crates/lib/src/metrics.rs
@@ -1,5 +1,5 @@
 /// Metrics collected during the course of a transaction
-#[derive(Default)]
+#[derive(Default, Copy, Clone)]
 pub struct ExecutionMetrics {
     /// How many times is an index probed?
     ///
@@ -40,6 +40,12 @@ pub struct ExecutionMetrics {
     ///
     /// In general, these are BSATN bytes, but JSON is also possible.
     pub bytes_sent_to_clients: usize,
+    /// How many rows were inserted?
+    pub rows_inserted: u64,
+    /// How many rows were deleted?
+    pub rows_deleted: u64,
+    /// How many rows were updated?
+    pub rows_updated: u64,
 }
 
 impl ExecutionMetrics {
@@ -51,6 +57,9 @@ impl ExecutionMetrics {
             bytes_scanned,
             bytes_written,
             bytes_sent_to_clients,
+            rows_inserted,
+            rows_deleted,
+            rows_updated,
         }: ExecutionMetrics,
     ) {
         self.index_seeks += index_seeks;
@@ -58,6 +67,9 @@ impl ExecutionMetrics {
         self.bytes_scanned += bytes_scanned;
         self.bytes_written += bytes_written;
         self.bytes_sent_to_clients += bytes_sent_to_clients;
+        self.rows_inserted += rows_inserted;
+        self.rows_deleted += rows_deleted;
+        self.rows_updated += rows_updated;
     }
 }
 
@@ -75,6 +87,9 @@ mod tests {
             bytes_scanned: 1,
             bytes_written: 1,
             bytes_sent_to_clients: 1,
+            rows_inserted: 1,
+            rows_deleted: 1,
+            rows_updated: 1,
         });
 
         assert_eq!(a.index_seeks, 1);
@@ -82,5 +97,7 @@ mod tests {
         assert_eq!(a.bytes_scanned, 1);
         assert_eq!(a.bytes_written, 1);
         assert_eq!(a.bytes_sent_to_clients, 1);
+        assert_eq!(a.rows_inserted, 1);
+        assert_eq!(a.rows_deleted, 1);
     }
 }


### PR DESCRIPTION
# Description of Changes

Closes #2430.


# API and ABI breaking changes

It change the  returning `json` for `sql` route (spacetimedb::json::client_api::StmtResultJson), with added field for stats.


# Expected complexity level and risk
 
1

# Testing

- [x] *Added test that confirm the number of stats for `ins, del, upd`*
- [x] *Added unit test for the output of the `sql` cli with and without stats* 
- [x] *Manual testing of the `cli` output using the module `keynote-benchmarks`*

```bash
🪐quickstart>delete from position;
(0 rows) [deleted: 1000000, server: 3.71s]
Roundtrip time: 3.72s

🪐quickstart>select * from position;
 id | x | y | z
----+---+---+---
(0 rows) [server: 1.32ms]
Roundtrip time: 6.46ms

🪐quickstart>delete from position;
(0 rows) [server: 1.47ms]
Roundtrip time: 7.69ms

🪐quickstart>INSERT INTO position (id, x, y, z) VALUES (1000011, 10.0, 20.0, 30.0);
(0 rows) [inserted: 1, server: 2.82ms]
Roundtrip time: 7.13ms

🪐quickstart>select * from position;
 id      | x  | y  | z
---------+----+----+----
 1000011 | 10 | 20 | 30
(1 row) [server: 1.29ms]
Roundtrip time: 5.49ms

🪐quickstart>update position set x = 1.0;
(0 rows) [updated: 1, server: 1.96ms]
Roundtrip time: 4.50ms

```
