### PR TITLE
CI - Fix docker jobs failing

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,6 @@ on:
       - master
       - staging
       - dev
-      - bfops/fix-docker-maybe
     tags:
       - 'v*'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
       - master
       - staging
       - dev
+      - bfops/fix-docker-maybe
     tags:
       - 'v*'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -11,7 +11,7 @@ on:
 
 jobs:
   docker-amd64:
-    runs-on: bare-metal
+    runs-on: ubuntu-latest
     name: Build DockerHub AMD64 Container
     steps:
       - name: Install jq

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -16,10 +16,10 @@ jobs:
     steps:
       - name: Install jq
         run: sudo apt-get install jq -y
-      - name: Prune stale references
-        run: git remote prune origin
       - name: Checkout
         uses: actions/checkout@v3
+      - name: Prune stale references
+        run: git remote prune origin
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -14,12 +14,8 @@ jobs:
     runs-on: ubuntu-latest
     name: Build DockerHub AMD64 Container
     steps:
-      - name: Install jq
-        run: sudo apt-get install jq -y
       - name: Checkout
         uses: actions/checkout@v3
-      - name: Prune stale references
-        run: git remote prune origin
       - name: Docker meta
         id: meta
         uses: docker/metadata-action@v4


### PR DESCRIPTION
# Description of Changes

We're having some confusing issue where our docker jobs fail due to permission denied errors.

We can and should investigate this, but for now i'm just moving them to run on `ubuntu-latest`.

# API and ABI breaking changes

No. CI only.

# Expected complexity level and risk

1

# Testing

- [ ] The docker job passes when we run it on this branch (see https://github.com/clockworklabs/SpacetimeDB/actions/runs/13862695461/job/38794769978).