### PR TITLE
Use jemalloc in standalone and add stats.

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4864,6 +4864,8 @@ dependencies = [
  "spacetimedb-table",
  "spacetimedb-testing",
  "tempdir",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tracing-subscriber",
  "walkdir",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5493,6 +5493,7 @@ dependencies = [
  "spacetimedb-paths",
  "tempfile",
  "thiserror 1.0.69",
+ "tikv-jemallocator",
  "tokio",
  "toml 0.8.19",
  "tower-http",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4937,6 +4937,8 @@ dependencies = [
  "tempfile",
  "termcolor",
  "thiserror 1.0.69",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tokio-tungstenite",
  "toml 0.8.19",
@@ -5134,6 +5136,8 @@ dependencies = [
  "tempfile",
  "thin-vec",
  "thiserror 1.0.69",
+ "tikv-jemalloc-ctl",
+ "tikv-jemallocator",
  "tokio",
  "tokio-stream",
  "tokio-util",
@@ -6100,6 +6104,37 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d050e60b33d41c19108b32cea32164033a9013fe3b46cbd4457559bfbf77afaa"
 dependencies = [
  "num_cpus",
+]
+
+[[package]]
+name = "tikv-jemalloc-ctl"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f21f216790c8df74ce3ab25b534e0718da5a1916719771d3fec23315c99e468b"
+dependencies = [
+ "libc",
+ "paste",
+ "tikv-jemalloc-sys",
+]
+
+[[package]]
+name = "tikv-jemalloc-sys"
+version = "0.6.0+5.3.0-1-ge13ca993e8ccb9ba9847cc330696e02839f328f7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cd3c60906412afa9c2b5b5a48ca6a5abe5736aec9eb48ad05037a677e52e4e2d"
+dependencies = [
+ "cc",
+ "libc",
+]
+
+[[package]]
+name = "tikv-jemallocator"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4cec5ff18518d81584f477e9bfdf957f5bb0979b0bac3af4ca30b5b3ae2d2865"
+dependencies = [
+ "libc",
+ "tikv-jemalloc-sys",
 ]
 
 [[package]]

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5493,6 +5493,7 @@ dependencies = [
  "spacetimedb-paths",
  "tempfile",
  "thiserror 1.0.69",
+ "tikv-jemalloc-ctl",
  "tikv-jemallocator",
  "tokio",
  "toml 0.8.19",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -273,6 +273,8 @@ wasmbin = "0.6"
 webbrowser = "1.0.2"
 windows-sys = "0.59"
 xdg = "2.5"
+tikv-jemallocator = { version = "0.6.0", features = ["profiling", "stats"] }
+tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"]}
 
 # Vendor the openssl we rely on, rather than depend on a
 # potentially very old system version.

--- a/crates/bench/Cargo.toml
+++ b/crates/bench/Cargo.toml
@@ -74,6 +74,10 @@ tracing-subscriber.workspace = true
 walkdir.workspace = true
 itertools.workspace = true
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true }
+
 [target.'cfg(target_os = "linux")'.dependencies]
 # only try to build these on linux
 

--- a/crates/bench/benches/generic.rs
+++ b/crates/bench/benches/generic.rs
@@ -4,7 +4,6 @@ use criterion::{
     Bencher, BenchmarkGroup, Criterion,
 };
 use lazy_static::lazy_static;
-use mimalloc::MiMalloc;
 use spacetimedb_bench::{
     database::BenchDatabase,
     schemas::{create_sequential, u32_u64_str, u32_u64_u64, BenchTable, IndexStrategy, RandomTable},
@@ -14,8 +13,16 @@ use spacetimedb_lib::sats::AlgebraicType;
 use spacetimedb_primitives::ColId;
 use spacetimedb_testing::modules::{Csharp, Rust};
 
+#[cfg(target_env = "msvc")]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
+
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 lazy_static! {
     static ref RUN_ONE_MILLION: bool = std::env::var("RUN_ONE_MILLION").is_ok();

--- a/crates/bench/benches/special.rs
+++ b/crates/bench/benches/special.rs
@@ -1,6 +1,5 @@
 use criterion::async_executor::AsyncExecutor;
 use criterion::{criterion_group, criterion_main, Criterion, SamplingMode};
-use mimalloc::MiMalloc;
 use spacetimedb_bench::{
     database::BenchDatabase,
     schemas::{create_sequential, u32_u64_str, u32_u64_u64, u64_u64_u32, BenchTable, RandomTable},
@@ -13,8 +12,16 @@ use spacetimedb_testing::modules::{Csharp, ModuleLanguage, Rust};
 use std::sync::Arc;
 use std::sync::OnceLock;
 
+#[cfg(target_env = "msvc")]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
+
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
 
 fn criterion_benchmark(c: &mut Criterion) {
     serialize_benchmarks::<u32_u64_str>(c);

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -76,8 +76,8 @@ webbrowser.workspace = true
 clap-markdown.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6.0", features = ["profiling", "stats"] }
-tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"]}
+tikv-jemallocator = { workspace = true }
+tikv-jemalloc-ctl = { workspace = true }
 
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_System_Console"] }

--- a/crates/cli/Cargo.toml
+++ b/crates/cli/Cargo.toml
@@ -75,6 +75,10 @@ wasmtime.workspace = true
 webbrowser.workspace = true
 clap-markdown.workspace = true
 
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6.0", features = ["profiling", "stats"] }
+tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"]}
+
 [target.'cfg(windows)'.dependencies]
 windows-sys = { workspace = true, features = ["Win32_System_Console"] }
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -5,6 +5,8 @@ use spacetimedb_cli::*;
 use spacetimedb_paths::cli::CliTomlPath;
 use spacetimedb_paths::{RootDir, SpacetimePaths};
 
+// Note that the standalone server is invoked through standaline/src/main.rs, so you will
+// also want to set the allocator there.
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;
 

--- a/crates/cli/src/main.rs
+++ b/crates/cli/src/main.rs
@@ -1,11 +1,21 @@
 use std::process::ExitCode;
 
 use clap::{Arg, Command};
-use mimalloc::MiMalloc;
 use spacetimedb_cli::*;
 use spacetimedb_paths::cli::CliTomlPath;
 use spacetimedb_paths::{RootDir, SpacetimePaths};
 
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
+#[cfg(target_env = "msvc")]
+use mimalloc::MiMalloc;
+
+#[cfg(target_env = "msvc")]
 #[global_allocator]
 static GLOBAL: MiMalloc = MiMalloc;
 

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -110,6 +110,9 @@ wasmtime.workspace = true
 jwks = { package = "spacetimedb-jwks", version = "0.1.3" }
 async_cache = "0.3.1"
 faststr = "0.2.23"
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = { version = "0.6.0", features = ["profiling", "stats"] }
+tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"]}
 
 [features]
 # Print a warning when doing an unindexed `iter_by_col_range` on a large table.

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -110,9 +110,10 @@ wasmtime.workspace = true
 jwks = { package = "spacetimedb-jwks", version = "0.1.3" }
 async_cache = "0.3.1"
 faststr = "0.2.23"
+
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
-tikv-jemallocator = { version = "0.6.0", features = ["profiling", "stats"] }
-tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"]}
+tikv-jemallocator = {workspace = true}
+tikv-jemalloc-ctl = {workspace = true}
 
 [features]
 # Print a warning when doing an unindexed `iter_by_col_range` on a large table.

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -37,6 +37,7 @@ scopeguard.workspace = true
 serde_json.workspace = true
 sled.workspace = true
 socket2.workspace = true
+tikv-jemallocator = { version = "0.6.0", features = ["profiling", "stats"] }
 thiserror.workspace = true
 tokio.workspace = true
 tower-http.workspace = true

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -37,12 +37,15 @@ scopeguard.workspace = true
 serde_json.workspace = true
 sled.workspace = true
 socket2.workspace = true
-tikv-jemallocator = { version = "0.6.0", features = ["profiling", "stats"] }
 thiserror.workspace = true
 tokio.workspace = true
 tower-http.workspace = true
 toml.workspace = true
 tracing = { workspace = true, features = ["release_max_level_debug"] }
+
+[target.'cfg(not(target_env = "msvc"))'.dependencies]
+tikv-jemallocator = {workspace = true}
+tikv-jemalloc-ctl = {workspace = true}
 
 [dev-dependencies]
 once_cell.workspace = true

--- a/crates/standalone/src/main.rs
+++ b/crates/standalone/src/main.rs
@@ -39,6 +39,13 @@ Example usage:
         )
 }
 
+#[cfg(not(target_env = "msvc"))]
+use tikv_jemallocator::Jemalloc;
+
+#[cfg(not(target_env = "msvc"))]
+#[global_allocator]
+static GLOBAL: Jemalloc = Jemalloc;
+
 fn main() -> anyhow::Result<()> {
     // take_hook() returns the default hook in case when a custom one is not set
     let orig_hook = panic::take_hook();

--- a/crates/standalone/src/subcommands/start.rs
+++ b/crates/standalone/src/subcommands/start.rs
@@ -8,6 +8,7 @@ use clap::{Arg, ArgMatches};
 use spacetimedb::config::{CertificateAuthority, ConfigFile};
 use spacetimedb::db::{Config, Storage};
 use spacetimedb::startup::{self, TracingOptions};
+use spacetimedb::worker_metrics;
 use spacetimedb_client_api::routes::database::DatabaseRoutes;
 use spacetimedb_client_api::routes::router;
 use spacetimedb_paths::cli::{PrivKeyPath, PubKeyPath};
@@ -133,6 +134,7 @@ pub async fn exec(args: &ArgMatches) -> anyhow::Result<()> {
 
     let data_dir = Arc::new(data_dir.clone());
     let ctx = StandaloneEnv::init(db_config, &certs, data_dir).await?;
+    worker_metrics::spawn_jemalloc_stats(listen_addr.clone());
 
     let mut db_routes = DatabaseRoutes::default();
     db_routes.root_post = db_routes.root_post.layer(DefaultBodyLimit::disable());


### PR DESCRIPTION
# Description of Changes

This uses jemalloc in standalone instead of mimalloc, unless the target env is msvc. The main reason is that jemalloc exposes better stats, and has a way to do heap profiling. This PR doesn't set up profiling, but it does add stats on jemalloc's memory usage.

# Expected complexity level and risk

2. The risk here is that there could be an issue on some platforms. 

# Testing

This works on mac and at least some linux platforms.
