### PR TITLE
smoketests: Test database deletion

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,7 +60,8 @@ jobs:
         with: { python-version: '3.12' }
         if: runner.os == 'Windows'
       - name: Run smoketests
-        run: python -m smoketests ${{ matrix.smoketest_args }}
+        # Note: test_publish_clear_database only works in private
+        run: python -m smoketests ${{ matrix.smoketest_args }} -x test_publish_clear_database
       - name: Stop containers (Linux)
         if: always() && runner.os == 'Linux'
         run: docker compose down

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -60,8 +60,8 @@ jobs:
         with: { python-version: '3.12' }
         if: runner.os == 'Windows'
       - name: Run smoketests
-        # Note: test_publish_clear_database only works in private
-        run: python -m smoketests ${{ matrix.smoketest_args }} -x test_publish_clear_database
+        # Note: clear_database only works in private
+        run: python -m smoketests ${{ matrix.smoketest_args }} -x clear_database
       - name: Stop containers (Linux)
         if: always() && runner.os == 'Linux'
         run: docker compose down

--- a/smoketests/tests/clear_database.py
+++ b/smoketests/tests/clear_database.py
@@ -1,0 +1,71 @@
+from .. import Smoketest, random_string
+import time
+
+class ClearDatabase(Smoketest):
+    AUTOPUBLISH = False
+
+    MODULE_CODE = """
+use spacetimedb::{ReducerContext, Table, duration};
+
+#[spacetimedb::table(name = counter, public)]
+pub struct Counter {
+    #[primary_key]
+    id: u64,
+    val: u64
+}
+
+#[spacetimedb::table(name = scheduled_counter, public, scheduled(inc, at = sched_at))]
+pub struct ScheduledCounter {
+    #[primary_key]
+    #[auto_inc]
+    scheduled_id: u64,
+    sched_at: spacetimedb::ScheduleAt,
+}
+
+#[spacetimedb::reducer]
+pub fn inc(ctx: &ReducerContext, arg: ScheduledCounter) {
+    if let Some(mut counter) = ctx.db.counter().id().find(arg.scheduled_id) {
+        counter.val += 1;
+        ctx.db.counter().id().update(counter);
+    } else {
+        ctx.db.counter().insert(Counter {
+            id: arg.scheduled_id,
+            val: 1,
+        });
+    }
+}
+
+#[spacetimedb::reducer(init)]
+pub fn init(ctx: &ReducerContext) {
+    ctx.db.scheduled_counter().insert(ScheduledCounter {
+        scheduled_id: 0,
+        sched_at: duration!(100ms).into(),
+    });
+}
+"""
+
+    def test_publish_clear_database(self):
+        """
+        Test that publishing with the clear flag stops the old module.
+        This relies on private control database internals.
+        """
+
+        name = random_string()
+        self.publish_module(name, clear = False)
+        time.sleep(1)
+        self.publish_module(name, clear = True)
+        time.sleep(1)
+        self.spacetime("delete", name)
+
+        deleted_replicas = self.query_control(f"select id from deleted_replica where database_identity = '0x{self.resolved_identity}'")
+        state_filter = f'replica_id = {" OR replica_id = ".join(deleted_replicas)}'
+        states = self.query_control(f"select lifecycle from replica_state where {state_filter}")
+        # All replicas should have state 'Deleted'.
+        all_deleted = all([x == "(Deleted = ())" for x in states])
+        assert all_deleted
+
+    def query_control(self, sql):
+        out = self.spacetime("sql", "spacetime-control", sql)
+        out = [line.strip() for line in out.splitlines()]
+        out = out[2:] # Remove header
+        return out

--- a/smoketests/tests/clear_database.py
+++ b/smoketests/tests/clear_database.py
@@ -55,6 +55,8 @@ pub fn init(ctx: &ReducerContext) {
         self.spacetime("delete", name)
 
         deleted_replicas = self.query_control(f"select id from deleted_replica where database_identity = '0x{self.resolved_identity}'")
+        # Both clear = True and delete should leave a deleted replica
+        self.assertEqual(len(deleted_replicas), 2)
         state_filter = f'replica_id = {" OR replica_id = ".join(deleted_replicas)}'
         states = self.query_control(f"select lifecycle from replica_state where {state_filter}")
         # All replicas should have state 'Deleted'.

--- a/smoketests/tests/clear_database.py
+++ b/smoketests/tests/clear_database.py
@@ -1,5 +1,4 @@
 from .. import Smoketest, random_string
-import time
 
 class ClearDatabase(Smoketest):
     AUTOPUBLISH = False
@@ -52,9 +51,7 @@ pub fn init(ctx: &ReducerContext) {
 
         name = random_string()
         self.publish_module(name, clear = False)
-        time.sleep(1)
         self.publish_module(name, clear = True)
-        time.sleep(1)
         self.spacetime("delete", name)
 
         deleted_replicas = self.query_control(f"select id from deleted_replica where database_identity = '0x{self.resolved_identity}'")

--- a/smoketests/tests/delete_database.py
+++ b/smoketests/tests/delete_database.py
@@ -1,0 +1,63 @@
+from .. import Smoketest, random_string
+import time
+
+class DeleteDatabase(Smoketest):
+    AUTOPUBLISH = False
+
+    MODULE_CODE = """
+use spacetimedb::{ReducerContext, Table, duration};
+
+#[spacetimedb::table(name = counter, public)]
+pub struct Counter {
+    #[primary_key]
+    id: u64,
+    val: u64
+}
+
+#[spacetimedb::table(name = scheduled_counter, public, scheduled(inc, at = sched_at))]
+pub struct ScheduledCounter {
+    #[primary_key]
+    #[auto_inc]
+    scheduled_id: u64,
+    sched_at: spacetimedb::ScheduleAt,
+}
+
+#[spacetimedb::reducer]
+pub fn inc(ctx: &ReducerContext, arg: ScheduledCounter) {
+    if let Some(mut counter) = ctx.db.counter().id().find(arg.scheduled_id) {
+        counter.val += 1;
+        ctx.db.counter().id().update(counter);
+    } else {
+        ctx.db.counter().insert(Counter {
+            id: arg.scheduled_id,
+            val: 1,
+        });
+    }
+}
+
+#[spacetimedb::reducer(init)]
+pub fn init(ctx: &ReducerContext) {
+    ctx.db.scheduled_counter().insert(ScheduledCounter {
+        scheduled_id: 0,
+        sched_at: duration!(100ms).into(),
+    });
+}
+"""
+
+    def test_delete_database(self):
+        """
+        Test that deleting a database stops the module.
+        The module is considered stopped if its scheduled reducer stops
+        producing update events.
+        """
+
+        name = random_string()
+        self.publish_module(name, clear = False)
+        sub = self.subscribe("select * from counter", n = 1000)
+        time.sleep(2)
+        self.spacetime("delete", name)
+
+        updates = sub()
+        # At a rate of 100ms, we shouldn't have more than 20 updates in 2secs.
+        # But let's say 50, in case the delete gets delayed for some reason.
+        assert len(updates) <= 50


### PR DESCRIPTION
Add tests checking that a module stops running when its database is deleted or re-published using the `--clear-database` flag.

Depends on private internals and time.