### PR TITLE
Add sql support for `:sender` parameter 

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5458,6 +5458,7 @@ name = "spacetimedb-sql-parser"
 version = "1.0.1"
 dependencies = [
  "derive_more",
+ "spacetimedb-lib",
  "sqlparser",
  "thiserror 1.0.69",
 ]

--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -118,7 +118,7 @@ fn eval(c: &mut Criterion) {
             let tx = raw.db.begin_tx(Workload::Subscribe);
             let auth = AuthCtx::for_testing();
             let schema_viewer = &SchemaViewer::new(&tx, &auth);
-            let (plan, table_id, table_name) = compile_subscription(sql, schema_viewer).unwrap();
+            let (plan, table_id, table_name) = compile_subscription(sql, schema_viewer, &auth).unwrap();
             let plan = plan.optimize().map(PipelinedProject::from).unwrap();
             let tx = DeltaTx::from(&tx);
 

--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -118,7 +118,7 @@ fn eval(c: &mut Criterion) {
             let tx = raw.db.begin_tx(Workload::Subscribe);
             let auth = AuthCtx::for_testing();
             let schema_viewer = &SchemaViewer::new(&tx, &auth);
-            let (plan, table_id, table_name) = compile_subscription(sql, schema_viewer, &auth).unwrap();
+            let (plan, table_id, table_name, _) = compile_subscription(sql, schema_viewer, &auth).unwrap();
             let plan = plan.optimize().map(PipelinedProject::from).unwrap();
             let tx = DeltaTx::from(&tx);
 

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -67,7 +67,7 @@ pub use spacetimedb_bindings_macro::duration;
 /// const PLAYERS_SEE_ENTITIES_IN_SAME_CHUNK: Filter = Filter::Sql("
 ///     SELECT * FROM LocationState WHERE chunk_index IN (
 ///         SELECT chunk_index FROM LocationState WHERE entity_id IN (
-///             SELECT entity_id FROM UserState WHERE identity = @sender
+///             SELECT entity_id FROM UserState WHERE identity = :sender
 ///         )
 ///     )
 /// ");

--- a/crates/core/src/estimation.rs
+++ b/crates/core/src/estimation.rs
@@ -193,7 +193,7 @@ mod tests {
         let auth = AuthCtx::for_testing();
         let tx = db.begin_tx(Workload::ForTests);
         let tx = SchemaViewer::new(&tx, &auth);
-        let plan = compile_subscription(sql, &tx)
+        let plan = compile_subscription(sql, &tx, &auth)
             .and_then(|(plan, ..)| plan.optimize())
             .expect("failed to compile sql query");
         row_estimate(&tx, &plan)

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -830,7 +830,7 @@ impl ModuleHost {
 
         let (rows, metrics) = db.with_read_only(Workload::Sql, |tx| {
             let tx = SchemaViewer::new(tx, &auth);
-            let (plan, _, table_name) = compile_subscription(&query, &tx)?;
+            let (plan, _, table_name) = compile_subscription(&query, &tx, &auth)?;
             let plan = plan.optimize()?;
             check_row_limit(&plan, db, &tx, |plan, tx| estimate_rows_scanned(tx, plan), &auth)?;
             execute_plan::<_, F>(&plan.into(), &DeltaTx::from(&*tx))

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -830,7 +830,7 @@ impl ModuleHost {
 
         let (rows, metrics) = db.with_read_only(Workload::Sql, |tx| {
             let tx = SchemaViewer::new(tx, &auth);
-            let (plan, _, table_name) = compile_subscription(&query, &tx, &auth)?;
+            let (plan, _, table_name, _) = compile_subscription(&query, &tx, &auth)?;
             let plan = plan.optimize()?;
             check_row_limit(&plan, db, &tx, |plan, tx| estimate_rows_scanned(tx, plan), &auth)?;
             execute_plan::<_, F>(&plan.into(), &DeltaTx::from(&*tx))

--- a/crates/core/src/sql/ast.rs
+++ b/crates/core/src/sql/ast.rs
@@ -977,7 +977,7 @@ pub(crate) fn compile_to_ast<T: TableSchemaView + StateView>(
 ) -> Result<Vec<SqlAst>, DBError> {
     // NOTE: The following ensures compliance with the 1.0 sql api.
     // Come 1.0, it will have replaced the current compilation stack.
-    compile_sql_stmt(sql_text, &SchemaViewer::new(tx, auth))?;
+    compile_sql_stmt(sql_text, &SchemaViewer::new(tx, auth), auth)?;
 
     let dialect = PostgreSqlDialect {};
     let ast = Parser::parse_sql(&dialect, sql_text).map_err(|error| DBError::SqlParser {

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -182,7 +182,7 @@ pub fn run(
     // We parse the sql statement in a mutable transation.
     // If it turns out to be a query, we downgrade the tx.
     let (tx, stmt) = db.with_auto_rollback(db.begin_mut_tx(IsolationLevel::Serializable, Workload::Sql), |tx| {
-        compile_sql_stmt(sql_text, &SchemaViewer::new(tx, &auth))
+        compile_sql_stmt(sql_text, &SchemaViewer::new(tx, &auth), &auth)
     })?;
 
     let mut metrics = ExecutionMetrics::default();
@@ -334,6 +334,19 @@ pub(crate) mod tests {
         Ok((stdb, MemTable::new(header, schema.table_access, rows)))
     }
 
+    fn create_identity_table(table_name: &str) -> ResultTest<(TestDB, MemTable)> {
+        let stdb = TestDB::durable()?;
+        let head = ProductType::from([("identity", AlgebraicType::identity())]);
+        let rows = vec![product!(Identity::ZERO), product!(Identity::ONE)];
+
+        let schema = stdb.with_auto_commit(Workload::ForTests, |tx| {
+            create_table_with_rows(&stdb, tx, table_name, head.clone(), &rows, StAccess::Public)
+        })?;
+        let header = Header::from(&*schema).into();
+
+        Ok((stdb, MemTable::new(header, schema.table_access, rows)))
+    }
+
     #[test]
     fn test_select_star() -> ResultTest<()> {
         let (db, input) = create_data(1)?;
@@ -371,6 +384,35 @@ pub(crate) mod tests {
         let sql = "SELECT count(*) as n FROM inventory WHERE inventory_id = 4 or inventory_id = 5";
         let result = run_for_testing(&db, sql)?;
         assert_eq!(result, vec![product![2u64]], "Inventory");
+        Ok(())
+    }
+
+    /// Test the evaluation of SELECT, UPDATE, and DELETE parameterized with `@sender`
+    #[test]
+    fn test_sender_param() -> ResultTest<()> {
+        let (db, _) = create_identity_table("user")?;
+
+        const SELECT_ALL: &str = "SELECT * FROM user";
+
+        let sql = "SELECT * FROM user WHERE identity = @sender";
+        let result = run_for_testing(&db, sql)?;
+        assert_eq!(result, vec![product![Identity::ZERO]]);
+
+        let sql = "DELETE FROM user WHERE identity = @sender";
+        run_for_testing(&db, sql)?;
+        let result = run_for_testing(&db, SELECT_ALL)?;
+        assert_eq!(result, vec![product![Identity::ONE]]);
+
+        let zero = "0".repeat(64);
+        let one = "0".repeat(63) + "1";
+
+        let sql = format!("UPDATE user SET identity = 0x{zero}");
+        run_for_testing(&db, &sql)?;
+        let sql = format!("UPDATE user SET identity = 0x{one} WHERE identity = @sender");
+        run_for_testing(&db, &sql)?;
+        let result = run_for_testing(&db, SELECT_ALL)?;
+        assert_eq!(result, vec![product![Identity::ONE]]);
+
         Ok(())
     }
 

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -387,18 +387,18 @@ pub(crate) mod tests {
         Ok(())
     }
 
-    /// Test the evaluation of SELECT, UPDATE, and DELETE parameterized with `@sender`
+    /// Test the evaluation of SELECT, UPDATE, and DELETE parameterized with `:sender`
     #[test]
     fn test_sender_param() -> ResultTest<()> {
         let (db, _) = create_identity_table("user")?;
 
         const SELECT_ALL: &str = "SELECT * FROM user";
 
-        let sql = "SELECT * FROM user WHERE identity = @sender";
+        let sql = "SELECT * FROM user WHERE identity = :sender";
         let result = run_for_testing(&db, sql)?;
         assert_eq!(result, vec![product![Identity::ZERO]]);
 
-        let sql = "DELETE FROM user WHERE identity = @sender";
+        let sql = "DELETE FROM user WHERE identity = :sender";
         run_for_testing(&db, sql)?;
         let result = run_for_testing(&db, SELECT_ALL)?;
         assert_eq!(result, vec![product![Identity::ONE]]);
@@ -408,7 +408,7 @@ pub(crate) mod tests {
 
         let sql = format!("UPDATE user SET identity = 0x{zero}");
         run_for_testing(&db, &sql)?;
-        let sql = format!("UPDATE user SET identity = 0x{one} WHERE identity = @sender");
+        let sql = format!("UPDATE user SET identity = 0x{one} WHERE identity = :sender");
         run_for_testing(&db, &sql)?;
         let result = run_for_testing(&db, SELECT_ALL)?;
         assert_eq!(result, vec![product![Identity::ONE]]);

--- a/crates/core/src/sql/parser.rs
+++ b/crates/core/src/sql/parser.rs
@@ -18,7 +18,7 @@ impl RowLevelExpr {
         auth_ctx: &AuthCtx,
         rls: &RawRowLevelSecurityDefV9,
     ) -> Result<Self, TypingError> {
-        let sql = parse_and_type_sub(&rls.sql, &SchemaViewer::new(tx, auth_ctx))?;
+        let sql = parse_and_type_sub(&rls.sql, &SchemaViewer::new(tx, auth_ctx), auth_ctx)?;
 
         Ok(Self {
             def: RowLevelSecuritySchema {

--- a/crates/core/src/sql/parser.rs
+++ b/crates/core/src/sql/parser.rs
@@ -18,7 +18,7 @@ impl RowLevelExpr {
         auth_ctx: &AuthCtx,
         rls: &RawRowLevelSecurityDefV9,
     ) -> Result<Self, TypingError> {
-        let sql = parse_and_type_sub(&rls.sql, &SchemaViewer::new(tx, auth_ctx), auth_ctx)?;
+        let (sql, _) = parse_and_type_sub(&rls.sql, &SchemaViewer::new(tx, auth_ctx), auth_ctx)?;
 
         Ok(Self {
             def: RowLevelSecuritySchema {

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -60,6 +60,21 @@ impl QueryHash {
     pub fn from_string(str: &str) -> Self {
         Self::from_bytes(str.as_bytes())
     }
+
+    /// If a query is parameterized with `@sender`, we must use the value of `@sender`,
+    /// i.e. the identity of the caller, when hashing the query text,
+    /// so that two identical queries from different clients aren't hashed to the same value.
+    ///
+    /// TODO: Once we have RLS, this hash must computed after name resolution.
+    /// It can no longer be computed from the source text.
+    pub fn from_string_and_identity(str: &str, identity: Identity) -> Self {
+        let mut hasher = blake3::Hasher::new();
+        hasher.update(str.as_bytes());
+        hasher.update(&identity.to_byte_array());
+        Self {
+            data: hasher.finalize().into(),
+        }
+    }
 }
 
 #[derive(Debug)]

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -57,7 +57,11 @@ impl QueryHash {
         }
     }
 
-    pub fn from_string(str: &str) -> Self {
+    /// Generate a hash from a query string
+    pub fn from_string(str: &str, identity: Identity, has_param: bool) -> Self {
+        if has_param {
+            return Self::from_string_and_identity(str, identity);
+        }
         Self::from_bytes(str.as_bytes())
     }
 

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -65,7 +65,7 @@ impl QueryHash {
         Self::from_bytes(str.as_bytes())
     }
 
-    /// If a query is parameterized with `@sender`, we must use the value of `@sender`,
+    /// If a query is parameterized with `:sender`, we must use the value of `:sender`,
     /// i.e. the identity of the caller, when hashing the query text,
     /// so that two identical queries from different clients aren't hashed to the same value.
     ///

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -15,6 +15,7 @@ use crate::estimation::estimate_rows_scanned;
 use crate::execution_context::{Workload, WorkloadType};
 use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent};
 use crate::messages::websocket::Subscribe;
+use crate::sql::ast::SchemaViewer;
 use crate::subscription::execute_plans;
 use crate::vm::check_row_limit;
 use crate::worker_metrics::WORKER_METRICS;
@@ -24,6 +25,7 @@ use spacetimedb_client_api_messages::websocket::{
     UnsubscribeMulti,
 };
 use spacetimedb_execution::pipelined::PipelinedProject;
+use spacetimedb_expr::check::parse_and_type_sub;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::metrics::ExecutionMetrics;
 use spacetimedb_lib::Identity;
@@ -43,6 +45,27 @@ pub struct ModuleSubscriptions {
 type AssertTxFn = Arc<dyn Fn(&Tx)>;
 type SubscriptionUpdate = FormatSwitch<TableUpdate<BsatnFormat>, TableUpdate<JsonFormat>>;
 type FullSubscriptionUpdate = FormatSwitch<ws::DatabaseUpdate<BsatnFormat>, ws::DatabaseUpdate<JsonFormat>>;
+
+/// A utility for sending an error message to a client and returning early
+macro_rules! return_on_err {
+    ($expr:expr, $handler:expr) => {
+        match $expr {
+            Ok(val) => val,
+            Err(e) => {
+                // TODO: Handle errors sending messages.
+                let _ = $handler(e.to_string().into());
+                return Ok(());
+            }
+        }
+    };
+}
+
+/// Hash a sql query, using the caller's identity if necessary
+fn hash_query(sql: &str, tx: &TxId, auth: &AuthCtx) -> Result<QueryHash, DBError> {
+    parse_and_type_sub(sql, &SchemaViewer::new(tx, auth), auth)
+        .map_err(DBError::from)
+        .map(|(_, has_param)| QueryHash::from_string(sql, auth.caller, has_param))
+}
 
 impl ModuleSubscriptions {
     pub fn new(relational_db: Arc<RelationalDB>, subscriptions: Subscriptions, owner_identity: Identity) -> Self {
@@ -130,22 +153,6 @@ impl ModuleSubscriptions {
         timer: Instant,
         _assert: Option<AssertTxFn>,
     ) -> Result<(), DBError> {
-        let tx = scopeguard::guard(self.relational_db.begin_tx(Workload::Subscribe), |tx| {
-            self.relational_db.release_tx(tx);
-        });
-        let auth = AuthCtx::new(self.owner_identity, sender.id.identity);
-        let query = super::query::WHITESPACE.replace_all(&request.query, " ");
-        let sql = query.trim();
-        let hash = QueryHash::from_string(sql);
-        let existing_query = {
-            let guard = self.subscriptions.read();
-            guard.query(&hash)
-        };
-        let query: Result<Arc<Plan>, DBError> = existing_query.map(Ok).unwrap_or_else(|| {
-            let compiled = compile_read_only_query(&auth, &tx, sql)?;
-            Ok(Arc::new(compiled))
-        });
-
         // Send an error message to the client
         let send_err_msg = |message| {
             sender.send_message(SubscriptionMessage {
@@ -159,28 +166,31 @@ impl ModuleSubscriptions {
             })
         };
 
-        // If compile error, send to client
-        let query = match query {
-            Ok(query) => query,
-            Err(e) => {
-                // Apparently we ignore errors sending messages.
-                let _ = send_err_msg(e.to_string().into());
-                return Ok(());
-            }
+        let tx = scopeguard::guard(self.relational_db.begin_tx(Workload::Subscribe), |tx| {
+            self.relational_db.release_tx(tx);
+        });
+        let auth = AuthCtx::new(self.owner_identity, sender.id.identity);
+        let query = super::query::WHITESPACE.replace_all(&request.query, " ");
+        let sql = query.trim();
+
+        let hash = return_on_err!(hash_query(sql, &tx, &auth), send_err_msg);
+
+        let existing_query = {
+            let guard = self.subscriptions.read();
+            guard.query(&hash)
         };
 
-        let eval_result =
-            self.evaluate_initial_subscription(sender.clone(), query.clone(), &tx, &auth, TableUpdateType::Subscribe);
+        let query = return_on_err!(
+            existing_query
+                .map(Ok)
+                .unwrap_or_else(|| compile_read_only_query(&auth, &tx, sql).map(Arc::new)),
+            send_err_msg
+        );
 
-        // If execution error, send to client
-        let (table_rows, metrics) = match eval_result {
-            Ok(ok) => ok,
-            Err(e) => {
-                // Apparently we ignore errors sending messages.
-                let _ = send_err_msg(e.to_string().into());
-                return Ok(());
-            }
-        };
+        let (table_rows, metrics) = return_on_err!(
+            self.evaluate_initial_subscription(sender.clone(), query.clone(), &tx, &auth, TableUpdateType::Subscribe),
+            send_err_msg
+        );
 
         record_exec_metrics(
             &WorkloadType::Subscribe,
@@ -423,17 +433,13 @@ impl ModuleSubscriptions {
                 );
                 continue;
             }
-            let hash = QueryHash::from_string(sql);
+
+            let hash = return_on_err!(hash_query(sql, &tx, &auth), send_err_msg);
+
             if let Some(unit) = guard.query(&hash) {
                 queries.push(unit);
             } else {
-                let compiled = match compile_read_only_query(&auth, &tx, sql) {
-                    Ok(compiled) => compiled,
-                    Err(e) => {
-                        send_err_msg(e.to_string().into());
-                        return Ok(());
-                    }
-                };
+                let compiled = return_on_err!(compile_read_only_query(&auth, &tx, sql), send_err_msg);
                 queries.push(Arc::new(compiled));
             }
         }
@@ -522,7 +528,8 @@ impl ModuleSubscriptions {
                 );
                 continue;
             }
-            let hash = QueryHash::from_string(sql);
+
+            let hash = hash_query(sql, &tx, &auth)?;
             if let Some(unit) = guard.query(&hash) {
                 queries.push(unit);
             } else {
@@ -666,29 +673,36 @@ pub struct WriteConflict;
 #[cfg(test)]
 mod tests {
     use super::{AssertTxFn, ModuleSubscriptions};
-    use crate::client::messages::{SerializableMessage, SubscriptionMessage, SubscriptionResult};
-    use crate::client::{ClientActorId, ClientConfig, ClientConnectionSender};
+    use crate::client::messages::{
+        SerializableMessage, SubscriptionMessage, SubscriptionResult, SubscriptionUpdateMessage,
+        TransactionUpdateMessage,
+    };
+    use crate::client::{ClientActorId, ClientConfig, ClientConnectionSender, ClientName, Protocol};
     use crate::db::datastore::traits::IsolationLevel;
     use crate::db::relational_db::tests_utils::{insert, TestDB};
     use crate::db::relational_db::RelationalDB;
     use crate::error::DBError;
     use crate::execution_context::Workload;
     use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent, ModuleFunctionCall};
+    use crate::messages::websocket as ws;
     use crate::subscription::module_subscription_manager::SubscriptionManager;
     use crate::subscription::query::compile_read_only_query;
     use crate::subscription::TableUpdateType;
     use parking_lot::RwLock;
     use spacetimedb_client_api_messages::energy::EnergyQuanta;
-    use spacetimedb_client_api_messages::websocket::{QueryId, Subscribe, SubscribeSingle, Unsubscribe};
+    use spacetimedb_client_api_messages::websocket::{
+        CompressableQueryUpdate, Compression, FormatSwitch, QueryId, RowListLen, Subscribe, SubscribeMulti,
+        SubscribeSingle, Unsubscribe,
+    };
     use spacetimedb_lib::db::auth::StAccess;
     use spacetimedb_lib::identity::AuthCtx;
-    use spacetimedb_lib::{bsatn, Timestamp};
+    use spacetimedb_lib::{bsatn, ConnectionId, ProductType, ProductValue, Timestamp};
     use spacetimedb_lib::{error::ResultTest, AlgebraicType, Identity};
     use spacetimedb_primitives::{IndexId, TableId};
-    use spacetimedb_sats::product;
+    use spacetimedb_sats::{product, u256};
     use std::time::Instant;
     use std::{sync::Arc, time::Duration};
-    use tokio::sync::mpsc;
+    use tokio::sync::mpsc::{self, Receiver};
 
     fn add_subscriber(db: Arc<RelationalDB>, sql: &str, assert: Option<AssertTxFn>) -> Result<(), DBError> {
         let owner = Identity::from_byte_array([1; 32]);
@@ -732,6 +746,18 @@ mod tests {
     fn single_subscribe(sql: &str, query_id: u32) -> SubscribeSingle {
         SubscribeSingle {
             query: sql.into(),
+            request_id: 0,
+            query_id: QueryId::new(query_id),
+        }
+    }
+
+    /// A [SubscribeMulti] message for testing
+    fn multi_subscribe(query_strings: &[&'static str], query_id: u32) -> SubscribeMulti {
+        SubscribeMulti {
+            query_strings: query_strings
+                .iter()
+                .map(|sql| String::from(*sql).into_boxed_str())
+                .collect(),
             request_id: 0,
             query_id: QueryId::new(query_id),
         }
@@ -946,6 +972,114 @@ mod tests {
                 ..
             }))
         ));
+        Ok(())
+    }
+
+    /// In this test we have two clients issue parameterized subscriptions.
+    /// These subscriptions are identical syntactically but not semantically,
+    /// because they are parameterized by `@sender` - the caller's identity.
+    #[tokio::test]
+    async fn test_parameterized_subscription() -> anyhow::Result<()> {
+        let client_0_identity = Identity::from_u256(u256::MAX);
+        let client_1_identity = Identity::from_u256(u256::ONE);
+        let client_0_config = ClientConfig {
+            protocol: Protocol::Binary,
+            compression: Compression::None,
+            tx_update_full: true,
+        };
+        let client_1_config = ClientConfig {
+            protocol: Protocol::Binary,
+            compression: Compression::None,
+            tx_update_full: true,
+        };
+        let client_0 = ClientActorId {
+            identity: client_0_identity,
+            connection_id: ConnectionId::from_u128(0),
+            name: ClientName(0),
+        };
+        let client_1 = ClientActorId {
+            identity: client_1_identity,
+            connection_id: ConnectionId::from_u128(1),
+            name: ClientName(1),
+        };
+        let (sender_0, mut rx_0) = ClientConnectionSender::dummy_with_channel(client_0, client_0_config);
+        let (sender_1, mut rx_1) = ClientConnectionSender::dummy_with_channel(client_1, client_1_config);
+        let db = relational_db()?;
+        let subs = module_subscriptions(db.clone());
+
+        // Create an empty table with an `Identity` column
+        let table_id = db.create_table_for_test("t", &[("identity", AlgebraicType::identity())], &[])?;
+
+        let subscribe = |sender, query_id| -> anyhow::Result<()> {
+            let sql = "select * from t where identity = @sender";
+            subs.add_multi_subscription(sender, multi_subscribe(&[sql], query_id), Instant::now(), None)?;
+            Ok(())
+        };
+
+        let client_0_query_id = 1;
+        let client_1_query_id = 2;
+
+        subscribe(Arc::new(sender_0), client_0_query_id)?;
+        subscribe(Arc::new(sender_1), client_1_query_id)?;
+
+        /// Wait for the initial subscription
+        async fn wait(rx: &mut Receiver<SerializableMessage>) {
+            assert!(matches!(rx.recv().await, Some(SerializableMessage::Subscription(_))))
+        }
+
+        // Wait for both subscriptions
+        wait(&mut rx_0).await;
+        wait(&mut rx_1).await;
+
+        // Insert two identities - one for each caller - into the table
+        let mut tx = db.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
+        db.insert(&mut tx, table_id, &bsatn::to_vec(&product![client_0_identity])?)?;
+        db.insert(&mut tx, table_id, &bsatn::to_vec(&product![client_1_identity])?)?;
+
+        assert!(matches!(
+            subs.commit_and_broadcast_event(None, module_event(), tx),
+            Ok(Ok(_))
+        ));
+
+        /// Assert that we get the expected identity from the receiver
+        async fn assert_identity(table_id: TableId, identity: Identity, rx: &mut Receiver<SerializableMessage>) {
+            match rx.recv().await {
+                Some(SerializableMessage::TxUpdate(TransactionUpdateMessage {
+                    database_update:
+                        SubscriptionUpdateMessage {
+                            database_update: FormatSwitch::Bsatn(ws::DatabaseUpdate { mut tables }),
+                            ..
+                        },
+                    ..
+                })) => {
+                    assert_eq!(tables.len(), 1);
+                    let mut table_update = tables.pop().unwrap();
+
+                    assert_eq!(table_update.table_id, table_id);
+                    assert_eq!(table_update.num_rows, 1);
+                    assert_eq!(table_update.updates.len(), 1);
+
+                    let CompressableQueryUpdate::Uncompressed(table_update) = table_update.updates.pop().unwrap()
+                    else {
+                        panic!("expected an uncompressed table update")
+                    };
+
+                    assert!(table_update.deletes.is_empty());
+                    assert_eq!(table_update.inserts.len(), 1);
+
+                    let typ = ProductType::from([AlgebraicType::identity()]);
+                    let raw = table_update.inserts.into_iter().next().unwrap();
+                    let row = ProductValue::decode(&typ, &mut &*raw).unwrap();
+
+                    assert_eq!(row, product![identity]);
+                }
+                _ => panic!("expected a transaction update"),
+            }
+        }
+
+        // Assert that each connection receives the correct update
+        assert_identity(table_id, client_0_identity, &mut rx_0).await;
+        assert_identity(table_id, client_1_identity, &mut rx_1).await;
         Ok(())
     }
 

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -977,7 +977,7 @@ mod tests {
 
     /// In this test we have two clients issue parameterized subscriptions.
     /// These subscriptions are identical syntactically but not semantically,
-    /// because they are parameterized by `@sender` - the caller's identity.
+    /// because they are parameterized by `:sender` - the caller's identity.
     #[tokio::test]
     async fn test_parameterized_subscription() -> anyhow::Result<()> {
         let client_0_identity = Identity::from_u256(u256::MAX);
@@ -1011,7 +1011,7 @@ mod tests {
         let table_id = db.create_table_for_test("t", &[("identity", AlgebraicType::identity())], &[])?;
 
         let subscribe = |sender, query_id| -> anyhow::Result<()> {
-            let sql = "select * from t where identity = @sender";
+            let sql = "select * from t where identity = :sender";
             subs.add_multi_subscription(sender, multi_subscribe(&[sql], query_id), Instant::now(), None)?;
             Ok(())
         };

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -728,14 +728,7 @@ mod tests {
             let auth = AuthCtx::for_testing();
             let tx = SchemaViewer::new(&*tx, &auth);
             let (plan, has_param) = SubscriptionPlan::compile(sql, &tx, &auth).unwrap();
-            let hash = if has_param {
-                // If the query plan is parameterized,
-                // we must use the value of the parameter to compute the query hash.
-                // See the comment on `from_string_and_identity` for details.
-                QueryHash::from_string_and_identity(sql, auth.caller)
-            } else {
-                QueryHash::from_string(sql)
-            };
+            let hash = QueryHash::from_string(sql, auth.caller, has_param);
             Ok(Arc::new(Plan::new(plan, hash, sql.into())))
         })
     }

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -728,7 +728,7 @@ mod tests {
             let auth = AuthCtx::for_testing();
             let tx = SchemaViewer::new(&*tx, &auth);
             let hash = QueryHash::from_string(sql);
-            let plan = SubscriptionPlan::compile(sql, &tx).unwrap();
+            let plan = SubscriptionPlan::compile(sql, &tx, &auth).unwrap();
             Ok(Arc::new(Plan::new(plan, hash, sql.into())))
         })
     }

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -80,15 +80,7 @@ pub fn compile_read_only_query(auth: &AuthCtx, tx: &Tx, input: &str) -> Result<P
 
     let tx = SchemaViewer::new(tx, auth);
     let (plan, has_param) = SubscriptionPlan::compile(&input, &tx, auth)?;
-
-    let hash = if has_param {
-        // If the query plan is parameterized,
-        // we must use the value of the parameter to compute the query hash.
-        // See the comment on `from_string_and_identity` for details.
-        QueryHash::from_string_and_identity(&input, auth.caller)
-    } else {
-        QueryHash::from_string(&input)
-    };
+    let hash = QueryHash::from_string(&input, auth.caller, has_param);
 
     Ok(Plan::new(plan, hash, input.into_owned()))
 }

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -79,7 +79,7 @@ pub fn compile_read_only_query(auth: &AuthCtx, tx: &Tx, input: &str) -> Result<P
     let input = WHITESPACE.replace_all(input, " ");
 
     let tx = SchemaViewer::new(tx, auth);
-    let plan = SubscriptionPlan::compile(&input, &tx)?;
+    let plan = SubscriptionPlan::compile(&input, &tx, auth)?;
     let hash = QueryHash::from_string(&input);
 
     Ok(Plan::new(plan, hash, input.into_owned()))
@@ -698,7 +698,7 @@ mod tests {
             let tx = SchemaViewer::new(tx, &auth);
             // Should be answered using an index semijion
             let sql = "select lhs.* from lhs join rhs on lhs.id = rhs.id where rhs.y >= 2 and rhs.y <= 4";
-            Ok(SubscriptionPlan::compile(sql, &tx).unwrap())
+            Ok(SubscriptionPlan::compile(sql, &tx, &auth).unwrap())
         })
     }
 
@@ -718,7 +718,7 @@ mod tests {
                 let tx = SchemaViewer::new(tx, &auth);
                 // Should be answered using an index semijion
                 let sql = "select lhs.* from lhs join rhs on lhs.id = rhs.id where lhs.x >= 5 and lhs.x <= 7";
-                Ok(SubscriptionPlan::compile(sql, &tx).unwrap())
+                Ok(SubscriptionPlan::compile(sql, &tx, &auth).unwrap())
             })
         }
 

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -620,8 +620,10 @@ pub(crate) fn get_all(relational_db: &RelationalDB, tx: &Tx, auth: &AuthCtx) -> 
         })
         .map(|schema| {
             let sql = format!("SELECT * FROM {}", schema.table_name);
+            // TODO: Once we have RLS, we must compute this hash after name resolution.
             let hash = QueryHash::from_string(&sql);
-            SubscriptionPlan::compile(&sql, &SchemaViewer::new(tx, auth), auth).map(|plan| Plan::new(plan, hash, sql))
+            SubscriptionPlan::compile(&sql, &SchemaViewer::new(tx, auth), auth)
+                .map(|(plan, _)| Plan::new(plan, hash, sql))
         })
         .collect::<Result<_, _>>()?)
 }

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -621,7 +621,7 @@ pub(crate) fn get_all(relational_db: &RelationalDB, tx: &Tx, auth: &AuthCtx) -> 
         .map(|schema| {
             let sql = format!("SELECT * FROM {}", schema.table_name);
             // TODO: Once we have RLS, we must compute this hash after name resolution.
-            let hash = QueryHash::from_string(&sql);
+            let hash = QueryHash::from_string(&sql, auth.caller, false);
             SubscriptionPlan::compile(&sql, &SchemaViewer::new(tx, auth), auth)
                 .map(|(plan, _)| Plan::new(plan, hash, sql))
         })

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -621,7 +621,7 @@ pub(crate) fn get_all(relational_db: &RelationalDB, tx: &Tx, auth: &AuthCtx) -> 
         .map(|schema| {
             let sql = format!("SELECT * FROM {}", schema.table_name);
             let hash = QueryHash::from_string(&sql);
-            SubscriptionPlan::compile(&sql, &SchemaViewer::new(tx, auth)).map(|plan| Plan::new(plan, hash, sql))
+            SubscriptionPlan::compile(&sql, &SchemaViewer::new(tx, auth), auth).map(|plan| Plan::new(plan, hash, sql))
         })
         .collect::<Result<_, _>>()?)
 }

--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -4,6 +4,7 @@ use std::sync::Arc;
 
 use crate::expr::{Expr, ProjectList, ProjectName, Relvar};
 use crate::{expr::LeftDeepJoin, statement::Statement};
+use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::AlgebraicType;
 use spacetimedb_primitives::TableId;
 use spacetimedb_schema::schema::TableSchema;
@@ -155,8 +156,10 @@ impl TypeChecker for SubChecker {
 }
 
 /// Parse and type check a subscription query
-pub fn parse_and_type_sub(sql: &str, tx: &impl SchemaView) -> TypingResult<ProjectName> {
-    expect_table_type(SubChecker::type_ast(parse_subscription(sql)?, tx)?)
+pub fn parse_and_type_sub(sql: &str, tx: &impl SchemaView, auth: &AuthCtx) -> TypingResult<ProjectName> {
+    let ast = parse_subscription(sql)?;
+    let ast = ast.resolve_sender(auth.caller);
+    expect_table_type(SubChecker::type_ast(ast, tx)?)
 }
 
 /// Type check a subscription query
@@ -165,9 +168,9 @@ pub fn type_subscription(ast: SqlSelect, tx: &impl SchemaView) -> TypingResult<P
 }
 
 /// Parse and type check a *subscription* query into a `StatementCtx`
-pub fn compile_sql_sub<'a>(sql: &'a str, tx: &impl SchemaView) -> TypingResult<StatementCtx<'a>> {
+pub fn compile_sql_sub<'a>(sql: &'a str, tx: &impl SchemaView, auth: &AuthCtx) -> TypingResult<StatementCtx<'a>> {
     Ok(StatementCtx {
-        statement: Statement::Select(ProjectList::Name(parse_and_type_sub(sql, tx)?)),
+        statement: Statement::Select(ProjectList::Name(parse_and_type_sub(sql, tx, auth)?)),
         sql,
         source: StatementSource::Subscription,
     })
@@ -229,11 +232,14 @@ pub mod test_utils {
 
 #[cfg(test)]
 mod tests {
-    use crate::check::test_utils::{build_module_def, SchemaViewer};
-    use spacetimedb_lib::{AlgebraicType, ProductType};
+    use crate::{
+        check::test_utils::{build_module_def, SchemaViewer},
+        expr::ProjectName,
+    };
+    use spacetimedb_lib::{identity::AuthCtx, AlgebraicType, ProductType};
     use spacetimedb_schema::def::ModuleDef;
 
-    use super::parse_and_type_sub;
+    use super::{SchemaView, TypingResult};
 
     fn module_def() -> ModuleDef {
         build_module_def(vec![
@@ -270,6 +276,11 @@ mod tests {
                 ]),
             ),
         ])
+    }
+
+    /// A wrapper around [super::parse_and_type_sub] that takes a dummy [AuthCtx]
+    fn parse_and_type_sub(sql: &str, tx: &impl SchemaView) -> TypingResult<ProjectName> {
+        super::parse_and_type_sub(sql, tx, &AuthCtx::for_testing())
     }
 
     #[test]
@@ -424,6 +435,14 @@ mod tests {
                 msg: "Can leave columns unqualified when unambiguous",
             },
             TestCase {
+                sql: "select * from s where id = @sender",
+                msg: "Can use @sender as an Identity",
+            },
+            TestCase {
+                sql: "select * from s where bytes = @sender",
+                msg: "Can use @sender as a byte array",
+            },
+            TestCase {
                 sql: "select * from t where t.u32 = 1 or t.str = ''",
                 msg: "Type OR with qualified column references",
             },
@@ -466,6 +485,10 @@ mod tests {
             TestCase {
                 sql: "select * from r",
                 msg: "Table r does not exist",
+            },
+            TestCase {
+                sql: "select * from t where arr = @sender",
+                msg: "The @sender param is an identity",
             },
             TestCase {
                 sql: "select * from t where t.a = 1",

--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -437,12 +437,12 @@ mod tests {
                 msg: "Can leave columns unqualified when unambiguous",
             },
             TestCase {
-                sql: "select * from s where id = @sender",
-                msg: "Can use @sender as an Identity",
+                sql: "select * from s where id = :sender",
+                msg: "Can use :sender as an Identity",
             },
             TestCase {
-                sql: "select * from s where bytes = @sender",
-                msg: "Can use @sender as a byte array",
+                sql: "select * from s where bytes = :sender",
+                msg: "Can use :sender as a byte array",
             },
             TestCase {
                 sql: "select * from t where t.u32 = 1 or t.str = ''",
@@ -489,8 +489,8 @@ mod tests {
                 msg: "Table r does not exist",
             },
             TestCase {
-                sql: "select * from t where arr = @sender",
-                msg: "The @sender param is an identity",
+                sql: "select * from t where arr = :sender",
+                msg: "The :sender param is an identity",
             },
             TestCase {
                 sql: "select * from t where t.a = 1",

--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -129,7 +129,9 @@ pub(crate) fn type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&Algebra
             }
         },
         (SqlExpr::Bin(..) | SqlExpr::Log(..), Some(ty)) => Err(UnexpectedType::new(&AlgebraicType::Bool, ty).into()),
-        (SqlExpr::Var(_), _) => unreachable!(),
+        // Both unqualified names as well as parameters are syntactic constructs.
+        // Unqualified names are qualified and parameters are resolved before type checking.
+        (SqlExpr::Var(_) | SqlExpr::Param(_), _) => unreachable!(),
     }
 }
 

--- a/crates/lib/src/identity.rs
+++ b/crates/lib/src/identity.rs
@@ -64,7 +64,11 @@ impl spacetimedb_metrics::typed_prometheus::AsPrometheusLabel for Identity {
 }
 
 impl Identity {
+    /// The 0x0 `Identity`
     pub const ZERO: Self = Self::from_u256(u256::ZERO);
+
+    /// The 0x1 `Identity`
+    pub const ONE: Self = Self::from_u256(u256::ONE);
 
     /// Create an `Identity` from a LITTLE-ENDIAN byte array.
     ///

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -1119,11 +1119,13 @@ mod tests {
 
     use pretty_assertions::assert_eq;
     use spacetimedb_expr::{
-        check::{parse_and_type_sub, SchemaView},
+        check::{SchemaView, TypingResult},
+        expr::ProjectName,
         statement::{parse_and_type_sql, Statement},
     };
     use spacetimedb_lib::{
         db::auth::{StAccess, StTableType},
+        identity::AuthCtx,
         AlgebraicType, AlgebraicValue,
     };
     use spacetimedb_primitives::{ColId, ColList, ColSet, TableId};
@@ -1208,6 +1210,11 @@ mod tests {
             None,
             primary_key.map(ColId::from),
         )
+    }
+
+    /// A wrapper around [spacetimedb_expr::check::parse_and_type_sub] that takes a dummy [AuthCtx]
+    fn parse_and_type_sub(sql: &str, tx: &impl SchemaView) -> TypingResult<ProjectName> {
+        spacetimedb_expr::check::parse_and_type_sub(sql, tx, &AuthCtx::for_testing())
     }
 
     /// No rewrites applied to a simple table scan
@@ -1923,7 +1930,7 @@ mod tests {
         };
 
         let compile = |sql| {
-            let stmt = parse_and_type_sql(sql, &db).unwrap();
+            let stmt = parse_and_type_sql(sql, &db, &AuthCtx::for_testing()).unwrap();
             let Statement::Select(select) = stmt else {
                 unreachable!()
             };

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -1214,7 +1214,7 @@ mod tests {
 
     /// A wrapper around [spacetimedb_expr::check::parse_and_type_sub] that takes a dummy [AuthCtx]
     fn parse_and_type_sub(sql: &str, tx: &impl SchemaView) -> TypingResult<ProjectName> {
-        spacetimedb_expr::check::parse_and_type_sub(sql, tx, &AuthCtx::for_testing())
+        spacetimedb_expr::check::parse_and_type_sub(sql, tx, &AuthCtx::for_testing()).map(|(plan, _)| plan)
     }
 
     /// No rewrites applied to a simple table scan

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -25,12 +25,12 @@ pub fn compile_subscription(
     sql: &str,
     tx: &impl SchemaView,
     auth: &AuthCtx,
-) -> Result<(ProjectPlan, TableId, Box<str>)> {
+) -> Result<(ProjectPlan, TableId, Box<str>, bool)> {
     if sql.len() > MAX_SQL_LENGTH {
         bail!("SQL query exceeds maximum allowed length: \"{sql:.120}...\"")
     }
 
-    let plan = parse_and_type_sub(sql, tx, auth)?;
+    let (plan, has_param) = parse_and_type_sub(sql, tx, auth)?;
 
     let Some(return_id) = plan.return_table_id() else {
         bail!("Failed to determine TableId for query")
@@ -42,7 +42,7 @@ pub fn compile_subscription(
 
     let plan = compile_select(plan);
 
-    Ok((plan, return_id, return_name))
+    Ok((plan, return_id, return_name, has_param))
 }
 
 /// A utility for parsing and type checking a sql statement

--- a/crates/sdk/tests/test-client/src/main.rs
+++ b/crates/sdk/tests/test-client/src/main.rs
@@ -2234,7 +2234,7 @@ fn exec_two_different_compression_algos() {
 
 /// In this test we have two clients issue parameterized subscriptions.
 /// These subscriptions are identical syntactically but not semantically,
-/// because they are parameterized by `@sender` - the caller's identity.
+/// because they are parameterized by `:sender` - the caller's identity.
 fn test_parameterized_subscription() {
     let ctr_for_test = TestCounter::new();
     let ctr_for_subs = TestCounter::new();
@@ -2257,7 +2257,7 @@ fn test_parameterized_subscription() {
         connect_with_then(&ctr_for_test, test_name, |builder| builder, {
             move |ctx| {
                 let sender = ctx.identity();
-                subscribe_these_then(ctx, &["SELECT * FROM pk_identity WHERE i = @sender"], move |ctx| {
+                subscribe_these_then(ctx, &["SELECT * FROM pk_identity WHERE i = :sender"], move |ctx| {
                     put_result(&mut record_sub, Ok(()));
                     // Wait to insert until both client connections have been made
                     ctr_for_subs.wait_for_all();

--- a/crates/sdk/tests/test-client/src/main.rs
+++ b/crates/sdk/tests/test-client/src/main.rs
@@ -124,6 +124,7 @@ fn main() {
         "row-deduplication-r-join-s-and-r-joint" => exec_row_deduplication_r_join_s_and_r_join_t(),
         "test-intra-query-bag-semantics-for-join" => test_intra_query_bag_semantics_for_join(),
         "two-different-compression-algos" => exec_two_different_compression_algos(),
+        "test-parameterized-subscription" => test_parameterized_subscription(),
         _ => panic!("Unknown test: {}", test),
     }
 }
@@ -2229,4 +2230,69 @@ fn exec_two_different_compression_algos() {
     connect_with_compression(&test_counter, "gzip", Gzip, got_gzip, &barrier, &bytes);
     connect_with_compression(&test_counter, "none", None, got_none, &barrier, &bytes);
     test_counter.wait_for_all();
+}
+
+/// In this test we have two clients issue parameterized subscriptions.
+/// These subscriptions are identical syntactically but not semantically,
+/// because they are parameterized by `@sender` - the caller's identity.
+fn test_parameterized_subscription() {
+    let ctr_for_test = TestCounter::new();
+    let ctr_for_subs = TestCounter::new();
+    let sub_0 = Some(ctr_for_subs.add_test("sub_0"));
+    let sub_1 = Some(ctr_for_subs.add_test("sub_1"));
+    let insert_0 = Some(ctr_for_test.add_test("insert_0"));
+    let insert_1 = Some(ctr_for_test.add_test("insert_1"));
+    let update_0 = Some(ctr_for_test.add_test("update_0"));
+    let update_1 = Some(ctr_for_test.add_test("update_1"));
+
+    fn subscribe_and_update(
+        test_name: &str,
+        old: i32,
+        new: i32,
+        waiters: [Arc<TestCounter>; 2],
+        senders: [Option<ResultRecorder>; 3],
+    ) {
+        let [ctr_for_test, ctr_for_subs] = waiters;
+        let [mut record_sub, mut record_ins, mut record_upd] = senders;
+        connect_with_then(&ctr_for_test, test_name, |builder| builder, {
+            move |ctx| {
+                let sender = ctx.identity();
+                subscribe_these_then(ctx, &["SELECT * FROM pk_identity WHERE i = @sender"], move |ctx| {
+                    put_result(&mut record_sub, Ok(()));
+                    // Wait to insert until both client connections have been made
+                    ctr_for_subs.wait_for_all();
+                    PkIdentity::insert(ctx, sender, old);
+                    PkIdentity::update(ctx, sender, new);
+                });
+                PkIdentity::on_insert(ctx, move |_, row| {
+                    assert_eq!(row.i, sender);
+                    assert_eq!(row.data, old);
+                    put_result(&mut record_ins, Ok(()));
+                });
+                PkIdentity::on_update(ctx, move |_, old_row, new_row| {
+                    assert_eq!(old_row.i, sender);
+                    assert_eq!(new_row.i, sender);
+                    assert_eq!(old_row.data, old);
+                    assert_eq!(new_row.data, new);
+                    put_result(&mut record_upd, Ok(()));
+                });
+            }
+        });
+    }
+
+    subscribe_and_update(
+        "client_0",
+        1,
+        2,
+        [ctr_for_test.clone(), ctr_for_subs.clone()],
+        [sub_0, insert_0, update_0],
+    );
+    subscribe_and_update(
+        "client_1",
+        3,
+        4,
+        [ctr_for_test.clone(), ctr_for_subs.clone()],
+        [sub_1, insert_1, update_1],
+    );
+    ctr_for_test.wait_for_all();
 }

--- a/crates/sdk/tests/test.rs
+++ b/crates/sdk/tests/test.rs
@@ -225,6 +225,11 @@ macro_rules! declare_tests_with_suffix {
             fn two_different_compression_algos() {
                 make_test("two-different-compression-algos").run();
             }
+
+            #[test]
+            fn test_parameterized_subscription() {
+                make_test("test-parameterized-subscription").run();
+            }
         }
     };
 }

--- a/crates/sql-parser/Cargo.toml
+++ b/crates/sql-parser/Cargo.toml
@@ -10,3 +10,4 @@ description = "The SpacetimeDB SQL AST and Parser"
 derive_more.workspace = true
 sqlparser.workspace = true
 thiserror.workspace = true
+spacetimedb-lib.workspace = true

--- a/crates/sql-parser/src/ast/mod.rs
+++ b/crates/sql-parser/src/ast/mod.rs
@@ -1,5 +1,6 @@
 use std::fmt::{Display, Formatter};
 
+use spacetimedb_lib::Identity;
 use sqlparser::ast::Ident;
 
 pub mod sql;
@@ -108,6 +109,8 @@ pub enum SqlExpr {
     Lit(SqlLiteral),
     /// Unqualified column ref
     Var(SqlIdent),
+    /// A parameter prefixed with `@`
+    Param(Parameter),
     /// Qualified column ref
     Field(SqlIdent, SqlIdent),
     /// A binary infix expression
@@ -120,7 +123,7 @@ impl SqlExpr {
     pub fn qualify_vars(self, with: SqlIdent) -> Self {
         match self {
             Self::Var(name) => Self::Field(with, name),
-            Self::Lit(..) | Self::Field(..) => self,
+            Self::Lit(..) | Self::Field(..) | Self::Param(..) => self,
             Self::Bin(a, b, op) => Self::Bin(
                 Box::new(a.qualify_vars(with.clone())),
                 Box::new(b.qualify_vars(with)),
@@ -141,6 +144,34 @@ impl SqlExpr {
             _ => false,
         }
     }
+
+    /// Replace the `@sender` parameter with the [Identity] it represents
+    pub fn resolve_sender(self, sender_identity: Identity) -> Self {
+        match self {
+            Self::Lit(_) | Self::Var(_) | Self::Field(..) => self,
+            Self::Param(Parameter::Sender) => {
+                Self::Lit(SqlLiteral::Hex(String::from(sender_identity.to_hex()).into_boxed_str()))
+            }
+
+            Self::Bin(a, b, op) => Self::Bin(
+                Box::new(a.resolve_sender(sender_identity)),
+                Box::new(b.resolve_sender(sender_identity)),
+                op,
+            ),
+            Self::Log(a, b, op) => Self::Log(
+                Box::new(a.resolve_sender(sender_identity)),
+                Box::new(b.resolve_sender(sender_identity)),
+                op,
+            ),
+        }
+    }
+}
+
+/// A named parameter prefixed with `@`
+#[derive(Debug)]
+pub enum Parameter {
+    /// @sender
+    Sender,
 }
 
 /// A SQL identifier or named reference.

--- a/crates/sql-parser/src/ast/mod.rs
+++ b/crates/sql-parser/src/ast/mod.rs
@@ -148,7 +148,11 @@ impl SqlExpr {
     /// Is this AST parameterized?
     /// We need to know in order to hash subscription queries correctly.
     pub fn has_parameter(&self) -> bool {
-        matches!(self, Self::Param(Parameter::Sender))
+        match self {
+            Self::Lit(_) | Self::Var(_) | Self::Field(..) => false,
+            Self::Param(Parameter::Sender) => true,
+            Self::Bin(a, b, _) | Self::Log(a, b, _) => a.has_parameter() || b.has_parameter(),
+        }
     }
 
     /// Replace the `@sender` parameter with the [Identity] it represents

--- a/crates/sql-parser/src/ast/mod.rs
+++ b/crates/sql-parser/src/ast/mod.rs
@@ -109,7 +109,7 @@ pub enum SqlExpr {
     Lit(SqlLiteral),
     /// Unqualified column ref
     Var(SqlIdent),
-    /// A parameter prefixed with `@`
+    /// A parameter prefixed with `:`
     Param(Parameter),
     /// Qualified column ref
     Field(SqlIdent, SqlIdent),
@@ -155,7 +155,7 @@ impl SqlExpr {
         }
     }
 
-    /// Replace the `@sender` parameter with the [Identity] it represents
+    /// Replace the `:sender` parameter with the [Identity] it represents
     pub fn resolve_sender(self, sender_identity: Identity) -> Self {
         match self {
             Self::Lit(_) | Self::Var(_) | Self::Field(..) => self,
@@ -177,10 +177,10 @@ impl SqlExpr {
     }
 }
 
-/// A named parameter prefixed with `@`
+/// A named parameter prefixed with `:`
 #[derive(Debug)]
 pub enum Parameter {
-    /// @sender
+    /// :sender
     Sender,
 }
 

--- a/crates/sql-parser/src/ast/mod.rs
+++ b/crates/sql-parser/src/ast/mod.rs
@@ -145,6 +145,12 @@ impl SqlExpr {
         }
     }
 
+    /// Is this AST parameterized?
+    /// We need to know in order to hash subscription queries correctly.
+    pub fn has_parameter(&self) -> bool {
+        matches!(self, Self::Param(Parameter::Sender))
+    }
+
     /// Replace the `@sender` parameter with the [Identity] it represents
     pub fn resolve_sender(self, sender_identity: Identity) -> Self {
         match self {

--- a/crates/sql-parser/src/ast/sql.rs
+++ b/crates/sql-parser/src/ast/sql.rs
@@ -49,7 +49,7 @@ impl SqlAst {
         }
     }
 
-    /// Replace the `@sender` parameter with the [Identity] it represents
+    /// Replace the `:sender` parameter with the [Identity] it represents
     pub fn resolve_sender(self, sender_identity: Identity) -> Self {
         match self {
             Self::Select(select) => Self::Select(select.resolve_sender(sender_identity)),
@@ -91,7 +91,7 @@ impl SqlSelect {
         Ok(self)
     }
 
-    /// Replace the `@sender` parameter with the [Identity] it represents
+    /// Replace the `:sender` parameter with the [Identity] it represents
     pub fn resolve_sender(self, sender_identity: Identity) -> Self {
         Self {
             filter: self.filter.map(|expr| expr.resolve_sender(sender_identity)),
@@ -121,7 +121,7 @@ pub struct SqlUpdate {
 }
 
 impl SqlUpdate {
-    /// Replace the `@sender` parameter with the [Identity] it represents
+    /// Replace the `:sender` parameter with the [Identity] it represents
     fn resolve_sender(self, sender_identity: Identity) -> Self {
         Self {
             filter: self.filter.map(|expr| expr.resolve_sender(sender_identity)),
@@ -138,7 +138,7 @@ pub struct SqlDelete {
 }
 
 impl SqlDelete {
-    /// Replace the `@sender` parameter with the [Identity] it represents
+    /// Replace the `:sender` parameter with the [Identity] it represents
     fn resolve_sender(self, sender_identity: Identity) -> Self {
         Self {
             filter: self.filter.map(|expr| expr.resolve_sender(sender_identity)),

--- a/crates/sql-parser/src/ast/sql.rs
+++ b/crates/sql-parser/src/ast/sql.rs
@@ -1,3 +1,5 @@
+use spacetimedb_lib::Identity;
+
 use crate::parser::{errors::SqlUnsupported, SqlParseResult};
 
 use super::{Project, SqlExpr, SqlFrom, SqlIdent, SqlLiteral};
@@ -46,6 +48,16 @@ impl SqlAst {
             _ => Ok(self),
         }
     }
+
+    /// Replace the `@sender` parameter with the [Identity] it represents
+    pub fn resolve_sender(self, sender_identity: Identity) -> Self {
+        match self {
+            Self::Select(select) => Self::Select(select.resolve_sender(sender_identity)),
+            Self::Update(update) => Self::Update(update.resolve_sender(sender_identity)),
+            Self::Delete(delete) => Self::Delete(delete.resolve_sender(sender_identity)),
+            _ => self,
+        }
+    }
 }
 
 /// A SELECT statement in the SQL query language
@@ -78,6 +90,14 @@ impl SqlSelect {
         }
         Ok(self)
     }
+
+    /// Replace the `@sender` parameter with the [Identity] it represents
+    pub fn resolve_sender(self, sender_identity: Identity) -> Self {
+        Self {
+            filter: self.filter.map(|expr| expr.resolve_sender(sender_identity)),
+            ..self
+        }
+    }
 }
 
 /// INSERT INTO table cols VALUES literals
@@ -100,11 +120,31 @@ pub struct SqlUpdate {
     pub filter: Option<SqlExpr>,
 }
 
+impl SqlUpdate {
+    /// Replace the `@sender` parameter with the [Identity] it represents
+    fn resolve_sender(self, sender_identity: Identity) -> Self {
+        Self {
+            filter: self.filter.map(|expr| expr.resolve_sender(sender_identity)),
+            ..self
+        }
+    }
+}
+
 /// DELETE FROM table [ WHERE predicate ]
 #[derive(Debug)]
 pub struct SqlDelete {
     pub table: SqlIdent,
     pub filter: Option<SqlExpr>,
+}
+
+impl SqlDelete {
+    /// Replace the `@sender` parameter with the [Identity] it represents
+    fn resolve_sender(self, sender_identity: Identity) -> Self {
+        Self {
+            filter: self.filter.map(|expr| expr.resolve_sender(sender_identity)),
+            ..self
+        }
+    }
 }
 
 /// SET var '=' literal

--- a/crates/sql-parser/src/ast/sub.rs
+++ b/crates/sql-parser/src/ast/sub.rs
@@ -40,7 +40,7 @@ impl SqlSelect {
         self.filter.as_ref().is_some_and(|expr| expr.has_parameter())
     }
 
-    /// Replace the `@sender` parameter with the [Identity] it represents
+    /// Replace the `:sender` parameter with the [Identity] it represents
     pub fn resolve_sender(self, sender_identity: Identity) -> Self {
         Self {
             filter: self.filter.map(|expr| expr.resolve_sender(sender_identity)),

--- a/crates/sql-parser/src/ast/sub.rs
+++ b/crates/sql-parser/src/ast/sub.rs
@@ -1,8 +1,11 @@
+use spacetimedb_lib::Identity;
+
 use crate::parser::{errors::SqlUnsupported, SqlParseResult};
 
 use super::{Project, SqlExpr, SqlFrom};
 
 /// A SELECT statement in the SQL subscription language
+#[derive(Debug)]
 pub struct SqlSelect {
     pub project: Project,
     pub from: SqlFrom,
@@ -29,5 +32,13 @@ impl SqlSelect {
             return Err(SqlUnsupported::UnqualifiedNames.into());
         }
         Ok(self)
+    }
+
+    /// Replace the `@sender` parameter with the [Identity] it represents
+    pub fn resolve_sender(self, sender_identity: Identity) -> Self {
+        Self {
+            filter: self.filter.map(|expr| expr.resolve_sender(sender_identity)),
+            ..self
+        }
     }
 }

--- a/crates/sql-parser/src/ast/sub.rs
+++ b/crates/sql-parser/src/ast/sub.rs
@@ -34,6 +34,12 @@ impl SqlSelect {
         Ok(self)
     }
 
+    /// Is this AST parameterized?
+    /// We need to know in order to hash subscription queries correctly.
+    pub fn has_parameter(&self) -> bool {
+        self.filter.as_ref().is_some_and(|expr| expr.has_parameter())
+    }
+
     /// Replace the `@sender` parameter with the [Identity] it represents
     pub fn resolve_sender(self, sender_identity: Identity) -> Self {
         Self {

--- a/crates/sql-parser/src/parser/mod.rs
+++ b/crates/sql-parser/src/parser/mod.rs
@@ -5,7 +5,9 @@ use sqlparser::ast::{
     WildcardAdditionalOptions,
 };
 
-use crate::ast::{BinOp, LogOp, Project, ProjectElem, ProjectExpr, SqlExpr, SqlFrom, SqlIdent, SqlJoin, SqlLiteral};
+use crate::ast::{
+    BinOp, LogOp, Parameter, Project, ProjectElem, ProjectExpr, SqlExpr, SqlFrom, SqlIdent, SqlJoin, SqlLiteral,
+};
 
 pub mod errors;
 pub mod sql;
@@ -211,6 +213,7 @@ pub(crate) fn parse_expr(expr: Expr) -> SqlParseResult<SqlExpr> {
     }
     match expr {
         Expr::Nested(expr) => parse_expr(*expr),
+        Expr::Value(Value::Placeholder(param)) if &param == "@sender" => Ok(SqlExpr::Param(Parameter::Sender)),
         Expr::Value(v) => Ok(SqlExpr::Lit(parse_literal(v)?)),
         Expr::UnaryOp {
             op: UnaryOperator::Plus,

--- a/crates/sql-parser/src/parser/mod.rs
+++ b/crates/sql-parser/src/parser/mod.rs
@@ -213,7 +213,7 @@ pub(crate) fn parse_expr(expr: Expr) -> SqlParseResult<SqlExpr> {
     }
     match expr {
         Expr::Nested(expr) => parse_expr(*expr),
-        Expr::Value(Value::Placeholder(param)) if &param == "@sender" => Ok(SqlExpr::Param(Parameter::Sender)),
+        Expr::Value(Value::Placeholder(param)) if &param == ":sender" => Ok(SqlExpr::Param(Parameter::Sender)),
         Expr::Value(v) => Ok(SqlExpr::Lit(parse_literal(v)?)),
         Expr::UnaryOp {
             op: UnaryOperator::Plus,

--- a/crates/sql-parser/src/parser/sql.rs
+++ b/crates/sql-parser/src/parser/sql.rs
@@ -132,7 +132,7 @@ use sqlparser::{
         Assignment, Expr, GroupByExpr, ObjectName, Query, Select, SetExpr, Statement, TableFactor, TableWithJoins,
         Value, Values,
     },
-    dialect::AnsiDialect,
+    dialect::PostgreSqlDialect,
     parser::Parser,
 };
 
@@ -148,7 +148,7 @@ use super::{
 
 /// Parse a SQL string
 pub fn parse_sql(sql: &str) -> SqlParseResult<SqlAst> {
-    let mut stmts = Parser::parse_sql(&AnsiDialect {}, sql)?;
+    let mut stmts = Parser::parse_sql(&PostgreSqlDialect {}, sql)?;
     if stmts.len() > 1 {
         return Err(SqlUnsupported::MultiStatement.into());
     }
@@ -439,16 +439,16 @@ mod tests {
     fn supported() {
         for sql in [
             "select a from t",
-            "select a from t where x = @sender",
+            "select a from t where x = :sender",
             "select count(*) as n from t",
             "select count(*) as n from t join s on t.id = s.id where s.x = 1",
             "insert into t values (1, 2)",
             "delete from t",
             "delete from t where a = 1",
-            "delete from t where x = @sender",
+            "delete from t where x = :sender",
             "update t set a = 1, b = 2",
             "update t set a = 1, b = 2 where c = 3",
-            "update t set a = 1, b = 2 where x = @sender",
+            "update t set a = 1, b = 2 where x = :sender",
         ] {
             assert!(parse_sql(sql).is_ok());
         }

--- a/crates/sql-parser/src/parser/sql.rs
+++ b/crates/sql-parser/src/parser/sql.rs
@@ -132,7 +132,7 @@ use sqlparser::{
         Assignment, Expr, GroupByExpr, ObjectName, Query, Select, SetExpr, Statement, TableFactor, TableWithJoins,
         Value, Values,
     },
-    dialect::PostgreSqlDialect,
+    dialect::AnsiDialect,
     parser::Parser,
 };
 
@@ -148,7 +148,7 @@ use super::{
 
 /// Parse a SQL string
 pub fn parse_sql(sql: &str) -> SqlParseResult<SqlAst> {
-    let mut stmts = Parser::parse_sql(&PostgreSqlDialect {}, sql)?;
+    let mut stmts = Parser::parse_sql(&AnsiDialect {}, sql)?;
     if stmts.len() > 1 {
         return Err(SqlUnsupported::MultiStatement.into());
     }
@@ -439,13 +439,16 @@ mod tests {
     fn supported() {
         for sql in [
             "select a from t",
+            "select a from t where x = @sender",
             "select count(*) as n from t",
             "select count(*) as n from t join s on t.id = s.id where s.x = 1",
             "insert into t values (1, 2)",
             "delete from t",
             "delete from t where a = 1",
+            "delete from t where x = @sender",
             "update t set a = 1, b = 2",
             "update t set a = 1, b = 2 where c = 3",
+            "update t set a = 1, b = 2 where x = @sender",
         ] {
             assert!(parse_sql(sql).is_ok());
         }

--- a/crates/sql-parser/src/parser/sub.rs
+++ b/crates/sql-parser/src/parser/sub.rs
@@ -55,7 +55,7 @@
 
 use sqlparser::{
     ast::{GroupByExpr, Query, Select, SetExpr, Statement},
-    dialect::AnsiDialect,
+    dialect::PostgreSqlDialect,
     parser::Parser,
 };
 
@@ -68,7 +68,7 @@ use super::{
 
 /// Parse a SQL string
 pub fn parse_subscription(sql: &str) -> SqlParseResult<SqlSelect> {
-    let mut stmts = Parser::parse_sql(&AnsiDialect {}, sql)?;
+    let mut stmts = Parser::parse_sql(&PostgreSqlDialect {}, sql)?;
     match stmts.len() {
         0 => Err(SqlUnsupported::Empty.into()),
         1 => parse_statement(stmts.swap_remove(0))
@@ -177,7 +177,7 @@ mod tests {
             "select t.* from t join s",
             "select t.* from t join s on t.c = s.d",
             "select a.* from t as a join s as b on a.c = b.d",
-            "select * from t where x = @sender",
+            "select * from t where x = :sender",
         ] {
             assert!(parse_subscription(sql).is_ok());
         }

--- a/crates/sql-parser/src/parser/sub.rs
+++ b/crates/sql-parser/src/parser/sub.rs
@@ -55,7 +55,7 @@
 
 use sqlparser::{
     ast::{GroupByExpr, Query, Select, SetExpr, Statement},
-    dialect::PostgreSqlDialect,
+    dialect::AnsiDialect,
     parser::Parser,
 };
 
@@ -68,7 +68,7 @@ use super::{
 
 /// Parse a SQL string
 pub fn parse_subscription(sql: &str) -> SqlParseResult<SqlSelect> {
-    let mut stmts = Parser::parse_sql(&PostgreSqlDialect {}, sql)?;
+    let mut stmts = Parser::parse_sql(&AnsiDialect {}, sql)?;
     match stmts.len() {
         0 => Err(SqlUnsupported::Empty.into()),
         1 => parse_statement(stmts.swap_remove(0))
@@ -177,6 +177,7 @@ mod tests {
             "select t.* from t join s",
             "select t.* from t join s on t.c = s.d",
             "select a.* from t as a join s as b on a.c = b.d",
+            "select * from t where x = @sender",
         ] {
             assert!(parse_subscription(sql).is_ok());
         }

--- a/crates/subscription/src/lib.rs
+++ b/crates/subscription/src/lib.rs
@@ -1,7 +1,7 @@
 use anyhow::{bail, Result};
 use spacetimedb_execution::{pipelined::PipelinedProject, Datastore, DeltaStore, Row};
 use spacetimedb_expr::check::SchemaView;
-use spacetimedb_lib::{metrics::ExecutionMetrics, query::Delta};
+use spacetimedb_lib::{identity::AuthCtx, metrics::ExecutionMetrics, query::Delta};
 use spacetimedb_physical_plan::plan::{HashJoin, IxJoin, Label, PhysicalPlan, ProjectPlan, TableScan};
 use spacetimedb_primitives::TableId;
 use spacetimedb_query::compile_subscription;
@@ -279,8 +279,8 @@ impl SubscriptionPlan {
     }
 
     /// Generate a plan for incrementally maintaining a subscription
-    pub fn compile(sql: &str, tx: &impl SchemaView) -> Result<Self> {
-        let (plan, return_id, return_name) = compile_subscription(sql, tx)?;
+    pub fn compile(sql: &str, tx: &impl SchemaView, auth: &AuthCtx) -> Result<Self> {
+        let (plan, return_id, return_name) = compile_subscription(sql, tx, auth)?;
 
         let mut ix_joins = true;
         plan.visit(&mut |plan| match plan {

--- a/crates/subscription/src/lib.rs
+++ b/crates/subscription/src/lib.rs
@@ -279,8 +279,8 @@ impl SubscriptionPlan {
     }
 
     /// Generate a plan for incrementally maintaining a subscription
-    pub fn compile(sql: &str, tx: &impl SchemaView, auth: &AuthCtx) -> Result<Self> {
-        let (plan, return_id, return_name) = compile_subscription(sql, tx, auth)?;
+    pub fn compile(sql: &str, tx: &impl SchemaView, auth: &AuthCtx) -> Result<(Self, bool)> {
+        let (plan, return_id, return_name, has_param) = compile_subscription(sql, tx, auth)?;
 
         let mut ix_joins = true;
         plan.visit(&mut |plan| match plan {
@@ -323,12 +323,15 @@ impl SubscriptionPlan {
 
         let fragments = Fragments::compile_from_plan(&plan, &table_aliases)?;
 
-        Ok(Self {
-            return_id,
-            return_name,
-            table_ids,
-            plan,
-            fragments,
-        })
+        Ok((
+            Self {
+                return_id,
+                return_name,
+                table_ids,
+                plan,
+                fragments,
+            },
+            has_param,
+        ))
     }
 }


### PR DESCRIPTION
# Description of Changes

Adds sql and subscriptions support for the `:sender` parameter which resolves to the caller identity.

Note that we resolve `:sender` before we type check. Hence right now it is purely a syntactic construct. Ultimately though we'll want to have parameters represented in the physical plan.

# API and ABI breaking changes

None

# Expected complexity level and risk

2

Mostly a straightforward change. The only change that might be unexpected is that now we must explicitly take the `:sender` identity into account when compiling a subscription. This was not automatically handled for us because we don't hash the AST directly.

# Testing

- [x] Parsing tests
- [x] Type checking tests
- [x] Query evaluation tests
- [x] Subscription evaluation tests
- [x] Multiple clients, same subscription test