### PR TITLE
commitlog: Streaming

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -207,6 +207,28 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
+name = "async-stream"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0b5a71a6f37880a80d1d7f19efd781e4b5de42c88f0722cc13bcb6cc2cfe8476"
+dependencies = [
+ "async-stream-impl",
+ "futures-core",
+ "pin-project-lite",
+]
+
+[[package]]
+name = "async-stream-impl"
+version = "0.3.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c7c24de15d275a1ecfd47a380fb4d5ec9bfe0933f309ed5e705b775596a3574d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.87",
+]
+
+[[package]]
 name = "async-trait"
 version = "0.1.83"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -594,9 +616,9 @@ checksum = "1fd0f2584146f6f2ef48085050886acf353beff7305ebd1ae69500e27c67f64b"
 
 [[package]]
 name = "bytes"
-version = "1.8.0"
+version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9ac0150caa2ae65ca5bd83f25c7de183dea78d4d366469f148435e2acfbad0da"
+checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
 
 [[package]]
 name = "bytestring"
@@ -5029,9 +5051,12 @@ dependencies = [
 name = "spacetimedb-commitlog"
 version = "1.0.1"
 dependencies = [
+ "async-stream",
  "bitflags 2.6.0",
+ "bytes",
  "crc32c",
  "env_logger",
+ "futures",
  "itertools 0.12.1",
  "log",
  "memmap2",
@@ -5041,11 +5066,15 @@ dependencies = [
  "proptest-derive",
  "rand 0.8.5",
  "serde",
+ "spacetimedb-commitlog",
  "spacetimedb-paths",
  "spacetimedb-primitives",
  "spacetimedb-sats",
  "tempfile",
  "thiserror 1.0.69",
+ "tokio",
+ "tokio-stream",
+ "tokio-util",
 ]
 
 [[package]]
@@ -6288,9 +6317,9 @@ dependencies = [
 
 [[package]]
 name = "tokio-stream"
-version = "0.1.16"
+version = "0.1.17"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4f4e6ce100d0eb49a2734f8c0812bcd324cf357d21810932c5df6b96ef2b86f1"
+checksum = "eca58d7bba4a75707817a2c44174253f9236b2d5fbd055602e9d5c07c139a047"
 dependencies = [
  "futures-core",
  "pin-project-lite",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -124,6 +124,7 @@ ahash = "0.8"
 anyhow = "1.0.68"
 anymap = "0.12"
 arrayvec = "0.7.2"
+async-stream = "0.3.6"
 async-trait = "0.1.68"
 axum = { version = "0.7", features = ["tracing"] }
 axum-extra = { version = "0.9", features = ["typed-header"] }
@@ -135,7 +136,7 @@ blake3 = "1.5.1"
 brotli = "3.5"
 byte-unit = "4.0.18"
 bytemuck = { version = "1.16.2", features = ["must_cast"] }
-bytes = "1.2.1"
+bytes = "1.10.1"
 bytestring = { version = "1.2.0", features = ["serde"] }
 cargo_metadata = "0.17.0"
 chrono = { version = "0.4.24", default-features = false }

--- a/crates/commitlog/Cargo.toml
+++ b/crates/commitlog/Cargo.toml
@@ -9,26 +9,36 @@ description = "Implementation of the SpacetimeDB commitlog."
 
 [features]
 default = ["serde"]
+streaming = ["dep:async-stream", "dep:bytes", "dep:futures", "dep:tokio", "dep:tokio-util"]
 # Enable types + impls useful for testing
 test = ["dep:env_logger"]
 
 [dependencies]
+async-stream = { workspace = true, optional = true }
 bitflags.workspace = true
+bytes= { workspace = true, optional = true }
 crc32c.workspace = true
+futures = { workspace = true, optional = true}
 itertools.workspace = true
 log.workspace = true
 memmap2 = "0.9.4"
 serde = { workspace = true, optional = true }
-spacetimedb-primitives.workspace = true
 spacetimedb-paths.workspace = true
+spacetimedb-primitives.workspace = true
 spacetimedb-sats.workspace = true
 tempfile.workspace = true
 thiserror.workspace = true
+tokio = { workspace = true, optional = true }
+tokio-util = { workspace = true, optional = true, features = ["io-util"] }
 
 # For the 'test' feature
 env_logger = { workspace = true, optional = true }
 
 [dev-dependencies]
+# Enable streaming in tests
+# Also enable 'test' feature, so integration tests can use the helpers.
+spacetimedb-commitlog = { path = ".", features = ["test", "streaming"] }
+
 env_logger.workspace = true
 once_cell.workspace = true
 pretty_assertions = { workspace = true, features = ["unstable"] }
@@ -36,3 +46,4 @@ proptest-derive.workspace = true
 proptest.workspace = true
 rand.workspace = true
 tempfile.workspace = true
+tokio-stream = { version = "0.1.17", features = ["fs"] }

--- a/crates/commitlog/src/commit.rs
+++ b/crates/commitlog/src/commit.rs
@@ -7,8 +7,10 @@ use crc32c::{Crc32cReader, Crc32cWriter};
 use spacetimedb_sats::buffer::{BufReader, Cursor, DecodeError};
 
 use crate::{
-    error::ChecksumMismatch, payload::Decoder, segment::CHECKSUM_ALGORITHM_CRC32C, Transaction,
-    DEFAULT_LOG_FORMAT_VERSION,
+    error::ChecksumMismatch,
+    payload::Decoder,
+    segment::{CHECKSUM_ALGORITHM_CRC32C, CHECKSUM_CRC32C_LEN},
+    Transaction, DEFAULT_LOG_FORMAT_VERSION,
 };
 
 #[derive(Default)]
@@ -139,8 +141,9 @@ pub struct Commit {
 impl Commit {
     pub const DEFAULT_EPOCH: u64 = 0;
 
-    pub const FRAMING_LEN: usize = Header::LEN + /* crc32 */ 4;
+    pub const FRAMING_LEN: usize = Header::LEN + Self::CHECKSUM_LEN;
     pub const CHECKSUM_ALGORITHM: u8 = CHECKSUM_ALGORITHM_CRC32C;
+    pub const CHECKSUM_LEN: usize = CHECKSUM_CRC32C_LEN;
 
     /// The range of transaction offsets contained in this commit.
     pub fn tx_range(&self) -> Range<u64> {

--- a/crates/commitlog/src/commitlog.rs
+++ b/crates/commitlog/src/commitlog.rs
@@ -9,7 +9,7 @@ use crate::{
     payload::Decoder,
     repo::{self, Repo},
     segment::{self, FileLike, Transaction, Writer},
-    Commit, Encode, Options,
+    Commit, Encode, Options, DEFAULT_LOG_FORMAT_VERSION,
 };
 
 pub use crate::segment::Committed;

--- a/crates/commitlog/src/error.rs
+++ b/crates/commitlog/src/error.rs
@@ -62,7 +62,7 @@ pub struct Append<T> {
 pub struct ChecksumMismatch;
 
 #[derive(Debug, Error)]
-pub(crate) enum SegmentMetadata {
+pub enum SegmentMetadata {
     #[error("invalid commit encountered")]
     InvalidCommit {
         sofar: segment::Metadata,

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -433,6 +433,32 @@ impl<T: Encode> Commitlog<T> {
     }
 }
 
+/// Extract the most recently written [`segment::Metadata`] from the commitlog
+/// in `repo`.
+///
+/// Returns `None` if the commitlog is empty.
+///
+/// Note that this function validates the most recent segment, which entails
+/// traversing it from the start.
+///
+/// The function can be used instead of the pattern:
+///
+/// ```ignore
+/// let log = Commitlog::open(..)?;
+/// let max_offset = log.max_committed_offset();
+/// ```
+///
+/// like so:
+///
+/// ```ignore
+/// let max_offset = committed_meta(..)?.map(|meta| meta.tx_range.end);
+/// ```
+///
+/// Unlike `open`, no segment will be created in an empty `repo`.
+pub fn committed_meta(root: CommitLogDir) -> Result<Option<segment::Metadata>, error::SegmentMetadata> {
+    commitlog::committed_meta(repo::Fs::new(root)?)
+}
+
 /// Obtain an iterator which traverses the commitlog located at the `root`
 /// directory from the start, yielding [`StoredCommit`]s.
 ///

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -24,6 +24,9 @@ pub use crate::{
 pub mod error;
 pub mod payload;
 
+#[cfg(feature = "streaming")]
+pub mod stream;
+
 #[cfg(any(test, feature = "test"))]
 pub mod tests;
 

--- a/crates/commitlog/src/stream.rs
+++ b/crates/commitlog/src/stream.rs
@@ -1,0 +1,8 @@
+mod writer;
+pub use writer::{OnTrailingData, StreamWriter};
+
+mod reader;
+pub use reader::{commits, retain_range};
+
+mod common;
+pub use common::{AsyncLen, IntoAsyncSegment, RangeFromMaybeToInclusive};

--- a/crates/commitlog/src/stream/common.rs
+++ b/crates/commitlog/src/stream/common.rs
@@ -1,0 +1,201 @@
+use std::{
+    future::Future,
+    io,
+    ops::{Bound, RangeBounds},
+};
+
+use tokio::io::{
+    AsyncBufRead, AsyncBufReadExt as _, AsyncRead, AsyncReadExt as _, AsyncSeek, AsyncSeekExt, AsyncWrite,
+};
+
+use crate::commit;
+
+/// How to convert [`crate::repo::Segment`]s into async I/O types.
+pub trait IntoAsyncSegment {
+    type AsyncSegmentReader: AsyncBufRead + AsyncSeek + Unpin + Send;
+    type AsyncSegmentWriter: AsyncWrite + AsyncFsync + AsyncLen + Unpin + Send;
+
+    fn into_async_reader(self) -> Self::AsyncSegmentReader;
+    fn into_async_writer(self) -> Self::AsyncSegmentWriter;
+}
+
+impl IntoAsyncSegment for std::fs::File {
+    type AsyncSegmentReader = tokio::io::BufReader<tokio::fs::File>;
+    type AsyncSegmentWriter = tokio::io::BufWriter<tokio::fs::File>;
+
+    fn into_async_reader(self) -> Self::AsyncSegmentReader {
+        tokio::io::BufReader::new(tokio::fs::File::from_std(self))
+    }
+
+    fn into_async_writer(self) -> Self::AsyncSegmentWriter {
+        tokio::io::BufWriter::new(tokio::fs::File::from_std(self))
+    }
+}
+
+#[cfg(any(test, feature = "test"))]
+impl IntoAsyncSegment for crate::repo::mem::Segment {
+    type AsyncSegmentReader = tokio::io::BufReader<crate::repo::mem::Segment>;
+    type AsyncSegmentWriter = tokio::io::BufWriter<crate::repo::mem::Segment>;
+
+    fn into_async_reader(self) -> Self::AsyncSegmentReader {
+        tokio::io::BufReader::new(self)
+    }
+
+    fn into_async_writer(self) -> Self::AsyncSegmentWriter {
+        tokio::io::BufWriter::new(self)
+    }
+}
+
+pub trait AsyncFsync {
+    fn fsync(&self) -> impl Future<Output = ()> + Send;
+}
+
+impl<T: AsyncWrite + AsyncFsync + Send + Sync> AsyncFsync for tokio::io::BufWriter<T> {
+    async fn fsync(&self) {
+        self.get_ref().fsync().await
+    }
+}
+
+impl AsyncFsync for tokio::fs::File {
+    async fn fsync(&self) {
+        self.sync_data().await.expect("fsync failed")
+    }
+}
+
+#[cfg(any(test, feature = "test"))]
+impl AsyncFsync for crate::repo::mem::Segment {
+    async fn fsync(&self) {}
+}
+
+pub trait AsyncLen {
+    fn segment_len(&mut self) -> impl Future<Output = io::Result<u64>> + Send;
+}
+
+impl<T: AsyncWrite + AsyncLen + Send> AsyncLen for tokio::io::BufWriter<T> {
+    async fn segment_len(&mut self) -> io::Result<u64> {
+        self.get_mut().segment_len().await
+    }
+}
+
+impl<T: AsyncRead + AsyncLen + Send> AsyncLen for tokio::io::BufReader<T> {
+    async fn segment_len(&mut self) -> io::Result<u64> {
+        self.get_mut().segment_len().await
+    }
+}
+
+impl AsyncLen for tokio::fs::File {
+    async fn segment_len(&mut self) -> io::Result<u64> {
+        let old_pos = self.stream_position().await?;
+        let len = self.seek(io::SeekFrom::End(0)).await?;
+        // If we're already at the end of the file, avoid seeking.
+        if old_pos != len {
+            self.seek(io::SeekFrom::Start(old_pos)).await?;
+        }
+
+        Ok(len)
+    }
+}
+
+#[cfg(any(test, feature = "test"))]
+impl AsyncLen for crate::repo::mem::Segment {
+    async fn segment_len(&mut self) -> io::Result<u64> {
+        crate::repo::Segment::segment_len(self)
+    }
+}
+
+/// An optionally half-open range.
+///
+/// Can express both `start..=end` and `start..`.
+#[derive(Clone, Copy, Debug)]
+pub struct RangeFromMaybeToInclusive {
+    /// The start of the range, inclusive.
+    pub start: u64,
+    /// The end of the range, inclusive, or unbounded if `None`.
+    pub end: Option<u64>,
+}
+
+impl RangeFromMaybeToInclusive {
+    pub fn from_range_bounds(b: impl RangeBounds<u64>) -> Self {
+        let start = match b.start_bound() {
+            Bound::Unbounded => 0,
+            Bound::Included(start) => *start,
+            Bound::Excluded(start) => start + 1,
+        };
+        let end = match b.end_bound() {
+            Bound::Unbounded => None,
+            Bound::Included(end) => Some((*end).max(start)),
+            Bound::Excluded(end) => Some(end.saturating_sub(1).max(start)),
+        };
+
+        Self { start, end }
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.end.is_some_and(|end| end <= self.start)
+    }
+
+    pub fn contains(&self, item: &u64) -> bool {
+        item >= &self.start
+            && match &self.end {
+                None => true,
+                Some(end) => item <= end,
+            }
+    }
+}
+
+impl RangeBounds<u64> for RangeFromMaybeToInclusive {
+    fn start_bound(&self) -> Bound<&u64> {
+        Bound::Included(&self.start)
+    }
+
+    fn end_bound(&self) -> Bound<&u64> {
+        self.end.as_ref().map(Bound::Included).unwrap_or(Bound::Unbounded)
+    }
+}
+
+#[derive(Default)]
+pub(super) struct CommitBuf {
+    pub header: [u8; commit::Header::LEN],
+    pub body: Vec<u8>,
+}
+
+impl CommitBuf {
+    pub fn as_buf(&self) -> impl bytes::Buf + '_ {
+        bytes::Buf::chain(&self.header[..], &self.body[..])
+    }
+
+    pub fn as_reader(&self) -> impl io::Read + '_ {
+        io::Read::chain(&self.header[..], &self.body[..])
+    }
+
+    pub fn filled_len(&self) -> usize {
+        self.header.len() + self.body.len()
+    }
+}
+
+pub(super) enum DidReadExact {
+    All,
+    Eof,
+}
+
+impl DidReadExact {
+    pub fn is_eof(&self) -> bool {
+        matches!(self, Self::Eof)
+    }
+}
+
+pub(super) async fn read_exact(src: &mut (impl AsyncRead + Unpin), buf: &mut [u8]) -> io::Result<DidReadExact> {
+    src.read_exact(buf).await.map(|_| DidReadExact::All).or_else(|e| {
+        if e.kind() == io::ErrorKind::UnexpectedEof {
+            Ok(DidReadExact::Eof)
+        } else {
+            Err(e)
+        }
+    })
+}
+
+/// Get a reference to the [`AsyncBufRead`]'s buffer, filling it if necessary.
+pub(super) async fn peek_buf(src: &mut (impl AsyncBufRead + Unpin)) -> io::Result<Option<&[u8]>> {
+    let buf = src.fill_buf().await?;
+    Ok(if buf.is_empty() { None } else { Some(buf) })
+}

--- a/crates/commitlog/src/stream/reader.rs
+++ b/crates/commitlog/src/stream/reader.rs
@@ -1,0 +1,228 @@
+use std::{
+    io::{self, SeekFrom},
+    ops::RangeBounds,
+};
+
+use async_stream::try_stream;
+use bytes::{Buf as _, Bytes};
+use futures::Stream;
+use log::{debug, info, trace, warn};
+use tokio::{
+    io::{AsyncBufRead, AsyncReadExt as _, AsyncSeek, AsyncSeekExt as _},
+    task::spawn_blocking,
+};
+use tokio_util::io::SyncIoBridge;
+
+use crate::{
+    commit,
+    repo::Repo,
+    segment::{self, seek_to_offset, CHECKSUM_LEN},
+};
+
+use super::{
+    common::{read_exact, CommitBuf},
+    IntoAsyncSegment, RangeFromMaybeToInclusive,
+};
+
+/// Stream the `range` of transaction offsets from the commitlog in `repo` as
+/// raw commitlog data.
+///
+/// The stream contains segment headers as they are encountered scanning the
+/// `range`.
+///
+/// Only whole [`commit::StoredCommit`]s are yielded, so a `range` that doesn't
+/// fall on commit boundaries may yield extra data.
+///
+/// Only the headers of the source commitlog are inspected (in order to be able
+/// to satisfy the `range` predicate), so no guarantees are made about the
+/// integrity of the log.
+///
+/// If the commitlog is empty, that is does not contain any commits, the
+/// returned stream yields nothing.
+pub fn commits<R>(repo: R, range: impl RangeBounds<u64>) -> impl Stream<Item = io::Result<Bytes>>
+where
+    R: Repo + Send + 'static,
+    R::Segment: IntoAsyncSegment,
+{
+    let mut range = RangeFromMaybeToInclusive::from_range_bounds(range);
+    let retain = move |segments: Vec<_>| retain_range(&segments, range);
+    try_stream! {
+        let segments = repo.existing_offsets().map(retain)?;
+        for segment_offset in segments {
+            if range.start < segment_offset {
+                range.start = segment_offset;
+            }
+            trace!("segment: segment={} start={}", segment_offset, range.start);
+
+            let segment = spawn_blocking({
+                let repo = repo.clone();
+                move || repo.open_segment(segment_offset)
+            })
+            .await
+            .unwrap()?
+            .into_async_reader();
+
+            for await chunk in read_segment(repo.clone(), segment, segment_offset, range) {
+                yield chunk.inspect_err(|e| warn!("error reading segment {}: {}", segment_offset, e))?;
+            }
+        }
+    }
+}
+
+fn read_segment(
+    repo: impl Repo + Send + 'static,
+    mut segment: impl AsyncBufRead + AsyncSeek + Unpin + Send + 'static,
+    segment_start: u64,
+    range: RangeFromMaybeToInclusive,
+) -> impl Stream<Item = io::Result<Bytes>> {
+    try_stream! {
+        info!("reading segment {segment_start}");
+        let (segment_header, segment_header_bytes) = {
+            let mut buf = [0u8; segment::Header::LEN];
+            segment.read_exact(&mut buf).await?;
+            let header = segment::Header::decode(&buf[..])?;
+            (header, Bytes::from_owner(buf))
+        };
+        let mut send_segment_header = Some(segment_header_bytes);
+
+        // Try to seek to the starting offset
+        // if it doesn't fall on the segment boundary.
+        if range.start > segment_start {
+            // Don't send a segment header if we're not reading from the start.
+            send_segment_header = None;
+            segment = spawn_blocking(move || {
+                let mut segment = SyncIoBridge::new(segment);
+                if let Ok(offset_index) = repo.get_offset_index(segment_start) {
+                    debug!("seek_to_offset segment={} start={}", segment_start, range.start);
+                    seek_to_offset(&mut segment, &offset_index, range.start)
+                        .inspect_err(|e| {
+                            warn!(
+                                "error seeking to offset {} in segment {}: {}",
+                                range.start, segment_start, e
+                            )
+                        })
+                        .ok();
+                }
+                segment.into_inner()
+            })
+            .await
+            .unwrap();
+        }
+
+        let checksum_len = CHECKSUM_LEN[segment_header.checksum_algorithm as usize];
+        let mut commit_buf = CommitBuf::default();
+        loop {
+            if read_exact(&mut segment, &mut commit_buf.header).await?.is_eof() {
+                trace!("eof reading commit header");
+                break;
+            }
+            let Some(hdr) = commit::Header::decode(&commit_buf.header[..])? else {
+                warn!("all-zeroes commit header");
+                break;
+            };
+            // Skip the commit if we're not at `range.start`.
+            if hdr.min_tx_offset < range.start {
+                segment.seek(SeekFrom::Current(hdr.len as i64 + checksum_len as i64)).await?;
+            // Stop if we're past the range end.
+            } else if range.end.is_some_and(|end| hdr.min_tx_offset > end) {
+                break
+            } else {
+                commit_buf.body.resize(hdr.len as usize + checksum_len, 0);
+                segment.read_exact(&mut commit_buf.body).await?;
+
+                // Send segment header if not sent already.
+                if let Some(header_bytes) = send_segment_header.take() {
+                    trace!("sending segment header");
+                    yield header_bytes;
+                }
+
+                trace!("sending commit {}", hdr.min_tx_offset);
+                yield commit_buf.as_buf().copy_to_bytes(commit_buf.filled_len());
+            }
+        }
+    }
+}
+
+/// Given a list of (segment) offsets, retain those which fall into the `range`.
+pub fn retain_range(offsets: &[u64], range: RangeFromMaybeToInclusive) -> Vec<u64> {
+    if range.is_empty() {
+        return vec![];
+    }
+    offsets
+        .iter()
+        .zip(offsets.iter().skip(1).chain([&u64::MAX]))
+        .filter_map(|(&start, &end)| {
+            let in_start = range.start >= start && range.start < end;
+            (in_start || range.contains(&start)).then_some(start)
+        })
+        .collect()
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use proptest::prelude::*;
+
+    fn retain_range(offsets: &[u64], range: impl RangeBounds<u64>) -> Vec<u64> {
+        super::retain_range(offsets, RangeFromMaybeToInclusive::from_range_bounds(range))
+    }
+
+    #[test]
+    fn test_slice_segments_on_boundary() {
+        let offsets = vec![0, 10, 20, 30];
+
+        for (i, start) in offsets.iter().enumerate() {
+            let retained = retain_range(&offsets, start..);
+            assert_eq!(&retained, &offsets[i..]);
+        }
+    }
+
+    #[test]
+    fn test_slice_segments_between_boundary() {
+        let offsets = vec![0, 10, 20, 30];
+
+        let ranges = vec![5, 11, 29];
+        for (i, start) in ranges.into_iter().enumerate() {
+            let retained = retain_range(&offsets, start..);
+            assert_eq!(&retained, &offsets[i..]);
+        }
+    }
+
+    #[test]
+    fn test_slice_segments_with_upper_bound() {
+        let offsets = vec![0, 10, 20, 30];
+        let retained = retain_range(&offsets, 11..29);
+        assert_eq!(&retained, &[10, 20]);
+    }
+
+    proptest! {
+        #[test]
+        fn prop_offset_at_or_after_last_segment_yields_last(start in 30u64..) {
+            let offsets = vec![0, 10, 20, 30];
+            let retained = retain_range(&offsets, start..);
+            prop_assert_eq!(&retained, &[30]);
+        }
+
+        #[test]
+        fn prop_empty_input_gives_empty_output(start in any::<u64>()) {
+            let retained = retain_range(&[], start..);
+            prop_assert_eq!(&retained, &[] as &[u64]);
+        }
+
+        #[test]
+        fn prop_empty_range_retains_nothing(start in any::<u64>()) {
+            let offsets = vec![0, 10, 20, 30];
+            let range = start..start;
+            prop_assert!(range.is_empty(), "expected range to be empty: {range:?}");
+            let retained = retain_range(&offsets, range);
+            prop_assert_eq!(&retained, &[] as &[u64]);
+        }
+
+        #[test]
+        fn prop_offset_at_or_after_last_with_upper_bound_yields_last(start in 30u64..) {
+            let offsets = vec![0, 10, 20, 30];
+            let retained = retain_range(&offsets, start..start + 16);
+            prop_assert_eq!(&retained, &[30]);
+        }
+    }
+}

--- a/crates/commitlog/src/stream/writer.rs
+++ b/crates/commitlog/src/stream/writer.rs
@@ -1,0 +1,428 @@
+use std::{
+    io::{self, Seek as _},
+    ops::Range,
+};
+
+use log::{debug, error, trace, warn};
+use tokio::{
+    io::{AsyncBufRead, AsyncBufReadExt as _, AsyncReadExt as _, AsyncWriteExt},
+    task::spawn_blocking,
+};
+
+use crate::{
+    commit, error,
+    repo::{self, Repo, Segment},
+    segment::{self, FileLike as _, OffsetIndexWriter, CHECKSUM_LEN, DEFAULT_CHECKSUM_ALGORITHM},
+    stream::common::{read_exact, AsyncFsync},
+    Options, StoredCommit, DEFAULT_LOG_FORMAT_VERSION,
+};
+
+use super::{
+    common::{peek_buf, AsyncLen as _, CommitBuf},
+    IntoAsyncSegment,
+};
+
+/// Progress reporting for [`StreamWriter::write_all`].
+pub trait Progress {
+    /// Report that the transaction range `tx_range` was written to the
+    /// destination commitlog.
+    ///
+    /// The method is called after each commit written, so should be cheap to
+    /// call and never block. A call does not imply that the commit is already
+    /// flushed to disk.
+    fn range_written(&mut self, tx_range: Range<u64>);
+}
+
+impl<T: FnMut(Range<u64>)> Progress for T {
+    fn range_written(&mut self, tx_range: Range<u64>) {
+        (self)(tx_range)
+    }
+}
+
+/// Write a raw byte stream of commitlog data to a local commitlog.
+///
+/// Intended for mirroring commitlogs over the network.
+///
+/// The source stream is expected to contain the raw commitlog data, including
+/// segment headers.
+///
+/// Whenever a segment header is encountered in the stream, a new segment is
+/// created locally. The stream data is decoded as a series of [commits],
+/// without inspecting their payload. The checksum of each commit is verified,
+/// and it is checked that the commit offsets are contiguous.
+///
+/// Apart from this **no further validation is performed**, it is assumed that
+/// the source is trusted.
+///
+/// [commits]: crate::commit::StoredCommit
+pub struct StreamWriter<R>
+where
+    R: Repo,
+    R::Segment: IntoAsyncSegment,
+{
+    repo: R,
+    commitlog_options: Options,
+
+    last_written_tx_range: Option<Range<u64>>,
+    current_segment: Option<CurrentSegment<<R::Segment as IntoAsyncSegment>::AsyncSegmentWriter>>,
+    commit_buf: CommitBuf,
+}
+
+impl<R> StreamWriter<R>
+where
+    R: Repo + Send + 'static,
+    R::Segment: IntoAsyncSegment,
+{
+    /// Create a new [`StreamWriter`] from the commitlog in `repo`.
+    ///
+    /// Opens the latest segment of the commitlog for writing.
+    /// If the commitlog is empty, no segment is created and [`Self::append_all`]
+    /// expects that the source stream starts with a segment header.
+    ///
+    /// The method traverses the most recent segment to ensure it contains valid
+    /// data, and to ensure [`Self::append_all`] can only write consecutive
+    /// commits. The `on_trailing` parameter an be used to trim the segment if
+    /// it contains trailing invalid data (i.e. due to a partial write).
+    pub fn create(repo: R, commitlog_options: Options, on_trailing: OnTrailingData) -> io::Result<Self> {
+        let Some(last) = repo.existing_offsets()?.pop() else {
+            return Ok(Self {
+                repo,
+                commitlog_options,
+                last_written_tx_range: None,
+                current_segment: None,
+                commit_buf: <_>::default(),
+            });
+        };
+
+        let mut segment = repo.open_segment(last)?;
+        let mut offset_index = repo::create_offset_index_writer(&repo, last, commitlog_options);
+        let segment::Metadata {
+            header,
+            tx_range,
+            size_in_bytes: _,
+            max_epoch: _,
+        } = segment::Metadata::extract(last, &mut segment).or_else(|e| match e {
+            error::SegmentMetadata::InvalidCommit { sofar, source } => match on_trailing {
+                OnTrailingData::Error => Err(io::Error::new(io::ErrorKind::InvalidData, source)),
+                OnTrailingData::Trim => {
+                    if let Some(idx) = offset_index.as_mut() {
+                        idx.ftruncate(sofar.tx_range.end, sofar.size_in_bytes)
+                            .inspect_err(|e| {
+                                error!(
+                                    "failed to truncate offset index for segment {} containing trailing data: {}",
+                                    last, e
+                                )
+                            })?;
+                    }
+                    segment.ftruncate(sofar.tx_range.end, sofar.size_in_bytes)?;
+                    segment.seek(io::SeekFrom::End(0))?;
+
+                    Ok(sofar)
+                }
+            },
+            error::SegmentMetadata::Io(err) => Err(err),
+        })?;
+        header
+            .ensure_compatible(DEFAULT_LOG_FORMAT_VERSION, DEFAULT_CHECKSUM_ALGORITHM)
+            .map_err(|e| io::Error::new(io::ErrorKind::InvalidData, e))?;
+
+        let current_segment = CurrentSegment {
+            header,
+            segment: segment.into_async_writer(),
+            offset_index,
+        };
+
+        Ok(Self {
+            repo,
+            commitlog_options,
+            last_written_tx_range: Some(tx_range),
+            current_segment: Some(current_segment),
+            commit_buf: <_>::default(),
+        })
+    }
+
+    /// Consume `stream` and append it to the local commitog.
+    ///
+    /// The `stream` should be the suffix after the commitlog already present
+    /// in the local [`Repo`]. The method checks that commit offsets are
+    /// contiguous.
+    ///
+    /// Segments are created whenever the stream yields a segment header.
+    /// If the stream doesn't start with a segment header, the data is appended
+    /// to the latest segment found when the writer was created.
+    ///
+    /// An offset index is maintained locally per segment according to the
+    /// [`Options`] used for [`Self::create`]ing the writer.
+    ///
+    /// Writing data to the commitlog incrementally by calling `append_all`
+    /// repeatedly is supported. However, I/O errors may leave the local
+    /// commitlog in an inconsistent state. To prevent further appends, this
+    /// method consumes `self`, and returns it back if the input `stream` was
+    /// consumed successfully. In case of errors, the caller must re-open the
+    /// writer via [`Self::create`] in order to perform consistency checks.
+    pub async fn append_all(
+        mut self,
+        mut stream: impl AsyncBufRead + Unpin,
+        mut progress: impl Progress,
+    ) -> io::Result<Self> {
+        loop {
+            let Some(buf) = peek_buf(&mut stream).await? else {
+                break;
+            };
+
+            let mut current_segment = if buf.starts_with(&segment::MAGIC) {
+                // Ensure the previous segment, if any, is fsync'ed.
+                self.close_current_segment().await?;
+                // Ensure we actually have a valid segment header.
+                let header =
+                    segment::Header::decode(buf).inspect_err(|e| warn!("failed to decode segment header: {e}"))?;
+                trace!(
+                    "create segment at {}",
+                    self.last_written_tx_range
+                        .as_ref()
+                        .map(|range| range.end)
+                        .unwrap_or_default()
+                );
+                let (mut segment, index) = spawn_blocking({
+                    let repo = self.repo.clone();
+                    let last_written_tx_range = self.last_written_tx_range.clone();
+                    let commitlog_options = self.commitlog_options;
+                    move || create_segment(repo, last_written_tx_range, commitlog_options)
+                })
+                .await
+                .unwrap()
+                .map(|(segment, index)| (segment.into_async_writer(), index))?;
+
+                segment.write_all(&buf[..segment::Header::LEN]).await?;
+                stream.consume(segment::Header::LEN as _);
+
+                CurrentSegment {
+                    header,
+                    segment,
+                    offset_index: index,
+                }
+            } else if let Some(current_segment) = self.current_segment.take() {
+                current_segment
+            } else {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    "no current segment, expected segment header",
+                ));
+            };
+
+            // What follows is commits to be written to `current_segment`,
+            // until we encounter EOF or a segment marker.
+            let res = self
+                .append_all_inner(&mut stream, &mut current_segment, &mut progress)
+                .await;
+            // Ensure we flush application buffers (BufWriter).
+            // `fsync` can be delayed until we either open a new segment,
+            // or the stream is exhausted and we break the loop.
+            // If there are errors writing to the segment, there's no point in
+            // syncing.
+            current_segment.segment.flush().await?;
+            let maybe_eof = res?;
+            // Put back segment, so it gets closed if we break the loop.
+            self.current_segment = Some(current_segment);
+            match maybe_eof {
+                AppendInnerResult::StreamExhausted => break,
+                AppendInnerResult::SegmentMarker => continue,
+            }
+        }
+
+        if let Some(current_segment) = self.current_segment.as_mut() {
+            current_segment.flush_and_sync().await?;
+        }
+
+        Ok(self)
+    }
+
+    async fn append_all_inner(
+        &mut self,
+        stream: &mut (impl AsyncBufRead + Unpin),
+        current_segment: &mut CurrentSegment<<R::Segment as IntoAsyncSegment>::AsyncSegmentWriter>,
+        progress: &mut impl Progress,
+    ) -> io::Result<AppendInnerResult> {
+        let mut bytes_written = current_segment
+            .segment
+            .segment_len()
+            .await?
+            // We may not have flushed the segment header yet,
+            // but the offset index needs to be offset by the header length.
+            .max(segment::Header::LEN as _);
+
+        loop {
+            let Some(buf) = peek_buf(stream).await? else {
+                // The stream is exhausted, break the outer loop.
+                trace!("eof");
+                return Ok(AppendInnerResult::StreamExhausted);
+            };
+            if buf.starts_with(&segment::MAGIC) {
+                // New segment, break inner loop.
+                trace!("segment marker");
+                return Ok(AppendInnerResult::SegmentMarker);
+            }
+
+            // Read the header, so we can determine the size of the commit.
+            if read_exact(stream, &mut self.commit_buf.header).await?.is_eof() {
+                return Ok(AppendInnerResult::StreamExhausted);
+            }
+            let Some(commit_header) = commit::Header::decode(&self.commit_buf.header[..])
+                .inspect_err(|e| warn!("failed to decode commit header: {e}"))?
+            else {
+                // Nb. eof handled above.
+                return Err(io::Error::new(io::ErrorKind::InvalidData, "all-zeroes commit header"));
+            };
+
+            // Read the rest of the commit.
+            self.commit_buf.body.resize(
+                commit_header.len as usize + CHECKSUM_LEN[current_segment.header.checksum_algorithm as usize],
+                0,
+            );
+            stream
+                .read_exact(&mut self.commit_buf.body)
+                .await
+                .inspect_err(|e| warn!("failed to read commit body: {e}"))?;
+            // Decode the commit and verify its checksum.
+            let commit = StoredCommit::decode(self.commit_buf.as_reader())
+                .inspect_err(|e| warn!("failed to decode commit: {e}"))?
+                .expect("commit decode cannot return `None` because we already decoded the header");
+
+            // Check that the commit offset is what we expect.
+            let expected_offset = self
+                .last_written_tx_range
+                .as_ref()
+                .map(|range| range.end)
+                .unwrap_or_default();
+            if commit.min_tx_offset != expected_offset {
+                return Err(io::Error::new(
+                    io::ErrorKind::InvalidData,
+                    format!(
+                        "expected commit offset {} but encountered {}",
+                        expected_offset, commit.min_tx_offset
+                    ),
+                ));
+            }
+            trace!("received commit {commit:?}");
+
+            // Write the commit and report progress.
+            current_segment
+                .segment
+                .write_all_buf(&mut self.commit_buf.as_buf())
+                .await?;
+            let written_range = commit.min_tx_offset..(commit.min_tx_offset + commit.n as u64);
+            self.last_written_tx_range = Some(written_range.clone());
+            progress.range_written(written_range);
+
+            let commit_len = (self.commit_buf.header.len() + self.commit_buf.body.len()) as u64;
+
+            // Update to offset index if we have one.
+            if let Some(offset_index) = current_segment.offset_index.as_mut() {
+                debug!(
+                    "append_after_commit min_tx_offset={} bytes_written={} commit_len={}",
+                    commit.min_tx_offset, bytes_written, commit_len
+                );
+                offset_index
+                    .append_after_commit(commit.min_tx_offset, bytes_written, commit_len)
+                    .inspect_err(|e| warn!("failed to append to offset index: {e}"))
+                    .ok();
+            }
+
+            bytes_written += commit_len;
+        }
+    }
+
+    async fn close_current_segment(&mut self) -> io::Result<()> {
+        if let Some(current_segment) = self.current_segment.take() {
+            trace!("closing current segment");
+            current_segment.close().await?;
+        }
+
+        Ok(())
+    }
+}
+
+/// What to do when [`StreamWriter::create`] detects trailing (invalid) data
+/// in the commitlog.
+#[derive(Default)]
+pub enum OnTrailingData {
+    /// Return an error. This is the default.
+    #[default]
+    Error,
+    /// Remove the suffix of the log after the last valid commit.
+    Trim,
+}
+
+enum AppendInnerResult {
+    StreamExhausted,
+    SegmentMarker,
+}
+
+struct CurrentSegment<W> {
+    header: segment::Header,
+    segment: W,
+    offset_index: Option<OffsetIndexWriter>,
+}
+
+impl<W: AsyncWriteExt + AsyncFsync + Unpin> CurrentSegment<W> {
+    async fn close(mut self) -> io::Result<()> {
+        self.flush_and_sync().await
+    }
+
+    async fn flush_and_sync(&mut self) -> io::Result<()> {
+        self.segment.flush().await?;
+        self.segment.fsync().await;
+        if let Some(mut index) = self.offset_index.take() {
+            let index = spawn_blocking(move || {
+                index
+                    .fsync()
+                    .inspect_err(|e| warn!("offset index fsync failed: {e}"))
+                    .ok();
+                index
+            })
+            .await
+            .unwrap();
+            self.offset_index = Some(index);
+        }
+
+        Ok(())
+    }
+}
+
+/// Create a new segment at offset `last_written_tx_range.end`.
+///
+/// If the segment file already exists but has a size equal to or smaller than
+/// a segment header, the file is truncated. Otherwise, an already existing
+/// segment is an error.
+fn create_segment<R: Repo>(
+    repo: R,
+    last_written_tx_range: Option<Range<u64>>,
+    commitlog_options: Options,
+) -> io::Result<(R::Segment, Option<OffsetIndexWriter>)> {
+    let segment_offset = last_written_tx_range
+        .as_ref()
+        .map(|range| range.end)
+        .unwrap_or_default();
+    let segment = repo.create_segment(segment_offset).or_else(|e| {
+        if e.kind() == io::ErrorKind::AlreadyExists {
+            trace!("segment already exists");
+            let mut s = repo.open_segment(segment_offset)?;
+            let len = s.segment_len()?;
+            trace!("segment len: {len}");
+            if len <= segment::Header::LEN as _ {
+                trace!("overwriting existing segment");
+                s.ftruncate(0, 0)?;
+                return Ok(s);
+            }
+        }
+
+        Err(e)
+    })?;
+    let index_writer = repo
+        .create_offset_index(segment_offset, commitlog_options.offset_index_len())
+        .inspect_err(|e| warn!("unable to create offset index segment={segment_offset} err={e:?}"))
+        .map(|index| OffsetIndexWriter::new(index, commitlog_options))
+        .ok();
+
+    Ok((segment, index_writer))
+}

--- a/crates/commitlog/src/tests/bitflip.rs
+++ b/crates/commitlog/src/tests/bitflip.rs
@@ -118,7 +118,7 @@ proptest! {
 
         let Inputs {
             log,
-            mut segment,
+            segment,
             byte_pos,
             bit_mask,
 

--- a/crates/commitlog/src/tests/helpers.rs
+++ b/crates/commitlog/src/tests/helpers.rs
@@ -1,5 +1,7 @@
 use std::fmt::Debug;
 
+use env_logger::Env;
+
 use crate::{
     commitlog,
     repo::{self, Repo},
@@ -53,8 +55,7 @@ where
 }
 
 pub fn enable_logging() {
-    let _ = env_logger::builder()
-        .filter_level(log::LevelFilter::Trace)
+    let _ = env_logger::Builder::from_env(Env::default().default_filter_or("trace"))
         .format_timestamp(None)
         .is_test(true)
         .try_init();

--- a/crates/commitlog/tests/io.rs
+++ b/crates/commitlog/tests/io.rs
@@ -1,1 +1,4 @@
 mod random_payload;
+
+#[cfg(feature = "streaming")]
+mod streaming;

--- a/crates/commitlog/tests/random_payload/mod.rs
+++ b/crates/commitlog/tests/random_payload/mod.rs
@@ -6,7 +6,7 @@ use spacetimedb_paths::server::CommitLogDir;
 use spacetimedb_paths::FromPathUnchecked;
 use tempfile::tempdir;
 
-fn gen_payload() -> [u8; 256] {
+pub fn gen_payload() -> [u8; 256] {
     let mut rng = rand::thread_rng();
     let mut buf = [0u8; 256];
     rng.fill(&mut buf);

--- a/crates/commitlog/tests/streaming/mod.rs
+++ b/crates/commitlog/tests/streaming/mod.rs
@@ -39,7 +39,13 @@ async fn copy_all() {
         .expect("failed to create stream writer");
     let reader = create_reader(&src, ..);
     pin!(reader);
-    writer.append_all(reader, |_| ()).await.unwrap();
+    writer
+        .append_all(reader, |_| ())
+        .await
+        .unwrap()
+        .sync_all()
+        .await
+        .unwrap();
 
     assert_equal_dirs(&src, &dst).await
 }
@@ -62,6 +68,7 @@ async fn copy_ranges() {
         pin!(reader);
         writer = writer.append_all(reader, |_| ()).await.unwrap();
     }
+    writer.sync_all().await.unwrap();
 
     assert_equal_dirs(&src, &dst).await
 }
@@ -81,6 +88,7 @@ async fn copy_invalid_range() {
         let reader = create_reader(&src, ..50);
         pin!(reader);
         writer = writer.append_all(reader, |_| ()).await.unwrap();
+        writer.sync_all().await.unwrap();
     }
     {
         info!("appending `75..`");
@@ -139,7 +147,13 @@ async fn trim_garbage() {
     .expect("failed to create stream writer");
     let reader = create_reader(&src, 99..);
     pin!(reader);
-    writer.append_all(reader, |_| ()).await.unwrap();
+    writer
+        .append_all(reader, |_| ())
+        .await
+        .unwrap()
+        .sync_all()
+        .await
+        .unwrap();
 
     assert_equal_dirs(&src, &dst).await
 }

--- a/crates/commitlog/tests/streaming/mod.rs
+++ b/crates/commitlog/tests/streaming/mod.rs
@@ -1,0 +1,217 @@
+use std::{
+    io,
+    num::{NonZeroU16, NonZeroU64},
+    ops::RangeBounds,
+    path::{Path, PathBuf},
+};
+
+use futures::StreamExt as _;
+use log::info;
+use spacetimedb_commitlog::{
+    repo::{self, Repo, Segment},
+    stream::{self, OnTrailingData, StreamWriter},
+    tests::helpers::enable_logging,
+    Commitlog, Options,
+};
+use spacetimedb_paths::{server::CommitLogDir, FromPathUnchecked as _};
+use tempfile::tempdir;
+use tokio::{
+    fs,
+    io::{AsyncBufRead, AsyncReadExt, BufReader},
+    pin,
+    task::spawn_blocking,
+};
+use tokio_stream::wrappers::ReadDirStream;
+use tokio_util::io::StreamReader;
+
+use super::random_payload;
+
+#[tokio::test]
+async fn copy_all() {
+    enable_logging();
+
+    let root = tempdir().unwrap();
+    let (src, dst) = create_dirs(root.path()).await;
+    fill_log(src.clone()).await;
+
+    let writer = create_writer(dst.clone())
+        .await
+        .expect("failed to create stream writer");
+    let reader = create_reader(&src, ..);
+    pin!(reader);
+    writer.append_all(reader, |_| ()).await.unwrap();
+
+    assert_equal_dirs(&src, &dst).await
+}
+
+#[tokio::test]
+async fn copy_ranges() {
+    enable_logging();
+
+    let root = tempdir().unwrap();
+    let (src, dst) = create_dirs(root.path()).await;
+    fill_log(src.clone()).await;
+
+    let mut writer = create_writer(dst.clone())
+        .await
+        .expect("failed to create stream writer");
+
+    for (start, end) in [(0, 25), (25, 50), (50, 75), (75, 101)] {
+        info!("appending range {start}..{end}");
+        let reader = create_reader(&src, start..end);
+        pin!(reader);
+        writer = writer.append_all(reader, |_| ()).await.unwrap();
+    }
+
+    assert_equal_dirs(&src, &dst).await
+}
+
+#[tokio::test]
+async fn copy_invalid_range() {
+    enable_logging();
+
+    let root = tempdir().unwrap();
+    let (src, dst) = create_dirs(root.path()).await;
+    fill_log(src.clone()).await;
+
+    let mut writer = create_writer(dst.clone()).await.expect("failed to create writer");
+
+    {
+        info!("appending `..50`");
+        let reader = create_reader(&src, ..50);
+        pin!(reader);
+        writer = writer.append_all(reader, |_| ()).await.unwrap();
+    }
+    {
+        info!("appending `75..`");
+        let reader = create_reader(&src, 75..);
+        pin!(reader);
+        pretty_assertions::assert_matches!(
+            writer.append_all(reader, |_| ()).await.map(drop),
+            Err(e) if e.kind() == io::ErrorKind::InvalidData
+        );
+    }
+}
+
+#[tokio::test]
+async fn trim_garbage() {
+    enable_logging();
+
+    let root = tempdir().unwrap();
+    let (src, dst) = create_dirs(root.path()).await;
+    fill_log(src.clone()).await;
+
+    {
+        let writer = create_writer(dst.clone())
+            .await
+            .expect("failed to create stream writer");
+        let reader = create_reader(&src, ..);
+        pin!(reader);
+        writer.append_all(reader, |_| ()).await.unwrap();
+        assert_equal_dirs(&src, &dst).await
+    }
+
+    // Truncate the destination log so the last commit is broken.
+    spawn_blocking({
+        let repo = repo(&dst);
+        move || {
+            let last_segment_offset = repo.existing_offsets().unwrap().pop().unwrap();
+            let mut segment = repo.open_segment(last_segment_offset).unwrap();
+            let len = segment.segment_len().unwrap();
+            segment.set_len(len - 128).unwrap();
+        }
+    })
+    .await
+    .unwrap();
+    // The default is to return an error.
+    pretty_assertions::assert_matches!(
+        create_writer(dst.clone()).await.map(drop),
+        Err(e) if e.kind() == io::ErrorKind::InvalidData
+    );
+
+    // With `Trim`, we can retry from commit 99.
+    let writer = spawn_blocking({
+        let path = dst.clone();
+        move || StreamWriter::create(repo(&path), default_options(), OnTrailingData::Trim)
+    })
+    .await
+    .unwrap()
+    .expect("failed to create stream writer");
+    let reader = create_reader(&src, 99..);
+    pin!(reader);
+    writer.append_all(reader, |_| ()).await.unwrap();
+
+    assert_equal_dirs(&src, &dst).await
+}
+
+async fn assert_equal_dirs(src: &Path, dst: &Path) {
+    let mut src_dir = fs::read_dir(src).await.map(ReadDirStream::new).unwrap();
+    let mut buf_a = vec![];
+    let mut buf_b = vec![];
+    while let Some(entry) = src_dir.next().await.map(Result::unwrap) {
+        if entry.file_type().await.unwrap().is_file() {
+            let src_path = entry.path();
+            let dst_path = dst.join(src_path.file_name().unwrap());
+
+            let mut src_file = fs::File::open(&src_path).await.unwrap();
+            let mut dst_file = fs::File::open(&dst_path).await.unwrap();
+
+            src_file.read_to_end(&mut buf_a).await.unwrap();
+            dst_file.read_to_end(&mut buf_b).await.unwrap();
+
+            assert_eq!(buf_a, buf_b, "{} and {} differ", src_path.display(), dst_path.display());
+        }
+        buf_a.clear();
+        buf_b.clear();
+    }
+}
+
+fn default_options() -> Options {
+    Options {
+        max_segment_size: 8 * 1024,
+        max_records_in_commit: NonZeroU16::MIN,
+        // Write an index entry for every commit.
+        offset_index_interval_bytes: NonZeroU64::new(256).unwrap(),
+        offset_index_require_segment_fsync: false,
+        ..Options::default()
+    }
+}
+
+async fn fill_log(path: PathBuf) {
+    spawn_blocking(move || {
+        let clog = Commitlog::open(CommitLogDir::from_path_unchecked(path), default_options()).unwrap();
+        let payload = random_payload::gen_payload();
+        for _ in 0..100 {
+            clog.append_maybe_flush(payload).unwrap();
+        }
+        clog.flush_and_sync().unwrap();
+    })
+    .await
+    .unwrap();
+}
+
+async fn create_writer(path: PathBuf) -> io::Result<StreamWriter<repo::Fs>> {
+    spawn_blocking(move || StreamWriter::create(repo(&path), default_options(), OnTrailingData::Error))
+        .await
+        .unwrap()
+}
+
+fn repo(at: &Path) -> repo::Fs {
+    repo::Fs::new(CommitLogDir::from_path_unchecked(at)).unwrap()
+}
+
+fn create_reader(path: &Path, range: impl RangeBounds<u64>) -> impl AsyncBufRead {
+    BufReader::new(StreamReader::new(stream::commits(
+        repo::Fs::new(CommitLogDir::from_path_unchecked(path)).unwrap(),
+        range,
+    )))
+}
+
+async fn create_dirs(root: &Path) -> (PathBuf, PathBuf) {
+    let src = root.join("a");
+    let dst = root.join("b");
+    fs::create_dir(&src).await.unwrap();
+    fs::create_dir(&dst).await.unwrap();
+
+    (src, dst)
+}


### PR DESCRIPTION
Moves support for streaming (network) transfer of raw commitlog data to the
`commitlog` crate proper, along with some improvements.

Also adds free-standing functions to determine the commitlog metadata and for
truncation. This allows to bypass `open`ing the commitlog in some cases, which
can be both convenient and avoids implicit creation of a segment when the
commitlog is empty.

# API and ABI breaking changes

None

# Expected complexity level and risk

2

Complexity is in diffing against the previous implementation, which lives in a
different repo. Risk is zero, as the code is not used in a released version.

# Testing

Adds tests.
