### PR TITLE
Commitlog compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5188,6 +5188,7 @@ dependencies = [
  "rand 0.8.5",
  "serde",
  "spacetimedb-commitlog",
+ "spacetimedb-fs-utils",
  "spacetimedb-paths",
  "spacetimedb-primitives",
  "spacetimedb-sats",
@@ -5196,6 +5197,7 @@ dependencies = [
  "tokio",
  "tokio-stream",
  "tokio-util",
+ "zstd-framed",
 ]
 
 [[package]]
@@ -5374,6 +5376,8 @@ dependencies = [
  "rand 0.8.5",
  "tempdir",
  "thiserror 1.0.69",
+ "tokio",
+ "zstd-framed",
 ]
 
 [[package]]
@@ -7940,6 +7944,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "fcf2b778a664581e31e389454a7072dab1647606d44f7feea22cd5abb9c9f3f9"
 dependencies = [
  "zstd-safe",
+]
+
+[[package]]
+name = "zstd-framed"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c62b9e3ab74fc13257dfb915a4410efab52f336b52ee99b7c11a89d76dc80ca4"
+dependencies = [
+ "pin-project-lite",
+ "thiserror 1.0.69",
+ "tokio",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -277,6 +277,7 @@ xdg = "2.5"
 tikv-jemallocator = { version = "0.6.0", features = ["profiling", "stats"] }
 tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"]}
 jemalloc_pprof = { version = "0.7", features = ["symbolize", "flamegraph"] }
+zstd-framed = { version = "0.1.1", features = ["tokio"] }
 
 # Vendor the openssl we rely on, rather than depend on a
 # potentially very old system version.

--- a/crates/commitlog/Cargo.toml
+++ b/crates/commitlog/Cargo.toml
@@ -23,6 +23,7 @@ itertools.workspace = true
 log.workspace = true
 memmap2 = "0.9.4"
 serde = { workspace = true, optional = true }
+spacetimedb-fs-utils.workspace = true
 spacetimedb-paths.workspace = true
 spacetimedb-primitives.workspace = true
 spacetimedb-sats.workspace = true
@@ -30,6 +31,7 @@ tempfile.workspace = true
 thiserror.workspace = true
 tokio = { workspace = true, optional = true }
 tokio-util = { workspace = true, optional = true, features = ["io-util"] }
+zstd-framed.workspace = true
 
 # For the 'test' feature
 env_logger = { workspace = true, optional = true }

--- a/crates/commitlog/src/repo/fs.rs
+++ b/crates/commitlog/src/repo/fs.rs
@@ -1,10 +1,14 @@
 use std::fs::{self, File};
-use std::io::{self, Seek};
+use std::io;
 
 use log::{debug, warn};
+use spacetimedb_fs_utils::compression::{new_zstd_writer, CompressReader};
 use spacetimedb_paths::server::{CommitLogDir, SegmentFile};
+use tempfile::NamedTempFile;
 
-use super::{Repo, Segment, TxOffset, TxOffsetIndex, TxOffsetIndexMut};
+use crate::segment::FileLike;
+
+use super::{Repo, SegmentLen, TxOffset, TxOffsetIndex, TxOffsetIndexMut};
 
 const SEGMENT_FILE_EXT: &str = ".stdb.log";
 
@@ -57,23 +61,23 @@ impl Fs {
     }
 }
 
-impl Segment for File {
-    fn segment_len(&mut self) -> io::Result<u64> {
-        let old_pos = self.stream_position()?;
-        let len = self.seek(io::SeekFrom::End(0))?;
-        // If we're already at the end of the file, avoid seeking.
-        if old_pos != len {
-            self.seek(io::SeekFrom::Start(old_pos))?;
-        }
+impl SegmentLen for File {}
 
-        Ok(len)
+impl FileLike for NamedTempFile {
+    fn fsync(&mut self) -> io::Result<()> {
+        self.as_file_mut().fsync()
+    }
+
+    fn ftruncate(&mut self, tx_offset: u64, size: u64) -> io::Result<()> {
+        self.as_file_mut().ftruncate(tx_offset, size)
     }
 }
 
 impl Repo for Fs {
-    type Segment = File;
+    type SegmentWriter = File;
+    type SegmentReader = CompressReader;
 
-    fn create_segment(&self, offset: u64) -> io::Result<Self::Segment> {
+    fn create_segment(&self, offset: u64) -> io::Result<Self::SegmentWriter> {
         File::options()
             .read(true)
             .append(true)
@@ -82,7 +86,7 @@ impl Repo for Fs {
             .or_else(|e| {
                 if e.kind() == io::ErrorKind::AlreadyExists {
                     debug!("segment {offset} already exists");
-                    let file = self.open_segment(offset)?;
+                    let file = self.open_segment_writer(offset)?;
                     if file.metadata()?.len() == 0 {
                         debug!("segment {offset} is empty");
                         return Ok(file);
@@ -93,8 +97,13 @@ impl Repo for Fs {
             })
     }
 
-    fn open_segment(&self, offset: u64) -> io::Result<Self::Segment> {
+    fn open_segment_writer(&self, offset: u64) -> io::Result<Self::SegmentWriter> {
         File::options().read(true).append(true).open(self.segment_path(offset))
+    }
+
+    fn open_segment_reader(&self, offset: u64) -> io::Result<Self::SegmentReader> {
+        let file = File::open(self.segment_path(offset))?;
+        CompressReader::new(file)
     }
 
     fn remove_segment(&self, offset: u64) -> io::Result<()> {
@@ -102,6 +111,25 @@ impl Repo for Fs {
             warn!("failed to remove offset index for segment {offset}, error: {e}");
         });
         fs::remove_file(self.segment_path(offset))
+    }
+
+    fn compress_segment(&self, offset: u64) -> io::Result<()> {
+        let src = self.open_segment_reader(offset)?;
+        // if it's already compressed, leave it be
+        let CompressReader::None(mut src) = src else {
+            return Ok(());
+        };
+
+        let mut dst = NamedTempFile::new_in(&self.root)?;
+        // bytes per frame. in the future, it might be worth looking into putting
+        // every commit into its own frame, to make seeking more efficient.
+        let max_frame_size = 0x1000;
+        let mut writer = new_zstd_writer(&mut dst, max_frame_size)?;
+        io::copy(&mut src, &mut writer)?;
+        writer.shutdown()?;
+        drop(writer);
+        dst.persist(self.segment_path(offset))?;
+        Ok(())
     }
 
     fn existing_offsets(&self) -> io::Result<Vec<u64>> {
@@ -138,5 +166,18 @@ impl Repo for Fs {
 
     fn get_offset_index(&self, offset: TxOffset) -> io::Result<TxOffsetIndex> {
         TxOffsetIndex::open_index_file(&self.root.index(offset))
+    }
+}
+
+impl SegmentLen for CompressReader {}
+
+#[cfg(feature = "streaming")]
+impl crate::stream::AsyncRepo for Fs {
+    type AsyncSegmentWriter = tokio::io::BufWriter<tokio::fs::File>;
+    type AsyncSegmentReader = spacetimedb_fs_utils::compression::AsyncCompressReader<tokio::fs::File>;
+
+    async fn open_segment_reader_async(&self, offset: u64) -> io::Result<Self::AsyncSegmentReader> {
+        let file = tokio::fs::File::open(self.segment_path(offset)).await?;
+        spacetimedb_fs_utils::compression::AsyncCompressReader::new(file).await
     }
 }

--- a/crates/commitlog/src/repo/mod.rs
+++ b/crates/commitlog/src/repo/mod.rs
@@ -22,7 +22,7 @@ pub type TxOffset = u64;
 pub type TxOffsetIndexMut = IndexFileMut<TxOffset>;
 pub type TxOffsetIndex = IndexFile<TxOffset>;
 
-pub trait Segment: FileLike + io::Read + io::Write + io::Seek + Send + Sync {
+pub trait SegmentLen: io::Seek {
     /// Determine the length in bytes of the segment.
     ///
     /// This method does not rely on metadata `fsync`, and may use up to three
@@ -32,10 +32,27 @@ pub trait Segment: FileLike + io::Read + io::Write + io::Seek + Send + Sync {
     /// restored. However, if it returns an error, the seek position is
     /// unspecified.
     //
-    // TODO: Replace with `Seek::stream_len` if / when stabilized:
+    // TODO: Remove trait and replace with `Seek::stream_len` if / when stabilized:
     // https://github.com/rust-lang/rust/issues/59359
-    fn segment_len(&mut self) -> io::Result<u64>;
+    fn segment_len(&mut self) -> io::Result<u64> {
+        let old_pos = self.stream_position()?;
+        let len = self.seek(io::SeekFrom::End(0))?;
+
+        // Avoid seeking a third time when we were already at the end of the
+        // stream. The branch is usually way cheaper than a seek operation.
+        if old_pos != len {
+            self.seek(io::SeekFrom::Start(old_pos))?;
+        }
+
+        Ok(len)
+    }
 }
+
+pub trait SegmentReader: io::BufRead + SegmentLen + Send + Sync {}
+impl<T: io::BufRead + SegmentLen + Send + Sync> SegmentReader for T {}
+
+pub trait SegmentWriter: FileLike + io::Read + io::Write + SegmentLen + Send + Sync {}
+impl<T: FileLike + io::Read + io::Write + SegmentLen + Send + Sync> SegmentWriter for T {}
 
 /// A repository of log segments.
 ///
@@ -43,7 +60,8 @@ pub trait Segment: FileLike + io::Read + io::Write + io::Seek + Send + Sync {
 /// representation.
 pub trait Repo: Clone {
     /// The type of log segments managed by this repo, which must behave like a file.
-    type Segment: Segment + 'static;
+    type SegmentWriter: SegmentWriter + 'static;
+    type SegmentReader: SegmentReader + 'static;
 
     /// Create a new segment with the minimum transaction offset `offset`.
     ///
@@ -53,7 +71,7 @@ pub trait Repo: Clone {
     /// It is permissible, however, to successfully return the new segment if
     /// it is completely empty (i.e. [`create_segment_writer`] did not previously
     /// succeed in writing the segment header).
-    fn create_segment(&self, offset: u64) -> io::Result<Self::Segment>;
+    fn create_segment(&self, offset: u64) -> io::Result<Self::SegmentWriter>;
 
     /// Open an existing segment at the minimum transaction offset `offset`.
     ///
@@ -61,14 +79,25 @@ pub trait Repo: Clone {
     /// `offset` does not exist.
     ///
     /// The method does not guarantee that the segment is non-empty -- this case
-    /// will be caught by [`resume_segment_writer`] and [`open_segment_reader`]
-    /// respectively.
-    fn open_segment(&self, offset: u64) -> io::Result<Self::Segment>;
+    /// will be caught by [`open_segment_reader`].
+    fn open_segment_reader(&self, offset: u64) -> io::Result<Self::SegmentReader>;
+
+    /// Open an existing segment at the minimum transaction offset `offset`.
+    ///
+    /// Must return [`io::ErrorKind::NotFound`] if a segment with the given
+    /// `offset` does not exist.
+    ///
+    /// The method does not guarantee that the segment is non-empty -- this case
+    /// will be caught by [`resume_segment_writer`].
+    fn open_segment_writer(&self, offset: u64) -> io::Result<Self::SegmentWriter>;
 
     /// Remove the segment at the minimum transaction offset `offset`.
     ///
     /// Return [`io::ErrorKind::NotFound`] if no such segment exists.
     fn remove_segment(&self, offset: u64) -> io::Result<()>;
+
+    /// Compress a segment in storage, marking it as immutable.
+    fn compress_segment(&self, offset: u64) -> io::Result<()>;
 
     /// Traverse all segments in this repository and return list of their
     /// offsets, sorted in ascending order.
@@ -92,22 +121,37 @@ pub trait Repo: Clone {
 }
 
 impl<T: Repo> Repo for &T {
-    type Segment = T::Segment;
+    type SegmentWriter = T::SegmentWriter;
+    type SegmentReader = T::SegmentReader;
 
-    fn create_segment(&self, offset: u64) -> io::Result<Self::Segment> {
+    fn create_segment(&self, offset: u64) -> io::Result<Self::SegmentWriter> {
         T::create_segment(self, offset)
     }
 
-    fn open_segment(&self, offset: u64) -> io::Result<Self::Segment> {
-        T::open_segment(self, offset)
+    fn open_segment_reader(&self, offset: u64) -> io::Result<Self::SegmentReader> {
+        T::open_segment_reader(self, offset)
+    }
+
+    fn open_segment_writer(&self, offset: u64) -> io::Result<Self::SegmentWriter> {
+        T::open_segment_writer(self, offset)
     }
 
     fn remove_segment(&self, offset: u64) -> io::Result<()> {
         T::remove_segment(self, offset)
     }
 
+    fn compress_segment(&self, offset: u64) -> io::Result<()> {
+        T::compress_segment(self, offset)
+    }
+
     fn existing_offsets(&self) -> io::Result<Vec<u64>> {
         T::existing_offsets(self)
+    }
+}
+
+impl<T: SegmentLen> SegmentLen for io::BufReader<T> {
+    fn segment_len(&mut self) -> io::Result<u64> {
+        SegmentLen::segment_len(self.get_mut())
     }
 }
 
@@ -131,7 +175,7 @@ pub fn create_segment_writer<R: Repo>(
     opts: Options,
     epoch: u64,
     offset: u64,
-) -> io::Result<Writer<R::Segment>> {
+) -> io::Result<Writer<R::SegmentWriter>> {
     let mut storage = repo.create_segment(offset)?;
     Header {
         log_format_version: opts.log_format_version,
@@ -177,8 +221,8 @@ pub fn resume_segment_writer<R: Repo>(
     repo: &R,
     opts: Options,
     offset: u64,
-) -> io::Result<Result<Writer<R::Segment>, Metadata>> {
-    let mut storage = repo.open_segment(offset)?;
+) -> io::Result<Result<Writer<R::SegmentWriter>, Metadata>> {
+    let mut storage = repo.open_segment_writer(offset)?;
     let Metadata {
         header,
         tx_range,
@@ -234,8 +278,8 @@ pub fn open_segment_reader<R: Repo>(
     repo: &R,
     max_log_format_version: u8,
     offset: u64,
-) -> io::Result<Reader<R::Segment>> {
+) -> io::Result<Reader<R::SegmentReader>> {
     debug!("open segment reader at {offset}");
-    let storage = repo.open_segment(offset)?;
+    let storage = repo.open_segment_reader(offset)?;
     Reader::new(max_log_format_version, offset, storage)
 }

--- a/crates/commitlog/src/segment.rs
+++ b/crates/commitlog/src/segment.rs
@@ -359,11 +359,11 @@ impl<R: io::Read + io::Seek> Reader<R> {
     }
 }
 
-impl<R: io::Read + io::Seek> Reader<R> {
+impl<R: io::BufRead + io::Seek> Reader<R> {
     pub fn commits(self) -> Commits<R> {
         Commits {
             header: self.header,
-            reader: io::BufReader::new(self.inner),
+            reader: self.inner,
         }
     }
 
@@ -393,7 +393,7 @@ impl<R: io::Read + io::Seek> Reader<R> {
 
     #[cfg(test)]
     pub(crate) fn metadata(self) -> Result<Metadata, error::SegmentMetadata> {
-        Metadata::with_header(self.min_tx_offset, self.header, io::BufReader::new(self.inner))
+        Metadata::with_header(self.min_tx_offset, self.header, self.inner)
     }
 }
 
@@ -465,10 +465,10 @@ pub struct Transaction<T> {
 
 pub struct Commits<R> {
     pub header: Header,
-    reader: io::BufReader<R>,
+    reader: R,
 }
 
-impl<R: io::Read> Iterator for Commits<R> {
+impl<R: io::BufRead> Iterator for Commits<R> {
     type Item = io::Result<StoredCommit>;
 
     fn next(&mut self) -> Option<Self::Item> {
@@ -477,7 +477,7 @@ impl<R: io::Read> Iterator for Commits<R> {
 }
 
 #[cfg(test)]
-impl<R: io::Read> Commits<R> {
+impl<R: io::BufRead> Commits<R> {
     pub fn with_log_format_version(self) -> impl Iterator<Item = io::Result<(u8, StoredCommit)>> {
         CommitsWithVersion { inner: self }
     }
@@ -489,7 +489,7 @@ struct CommitsWithVersion<R> {
 }
 
 #[cfg(test)]
-impl<R: io::Read> Iterator for CommitsWithVersion<R> {
+impl<R: io::BufRead> Iterator for CommitsWithVersion<R> {
     type Item = io::Result<(u8, StoredCommit)>;
 
     fn next(&mut self) -> Option<Self::Item> {

--- a/crates/commitlog/src/stream.rs
+++ b/crates/commitlog/src/stream.rs
@@ -5,4 +5,4 @@ mod reader;
 pub use reader::{commits, retain_range};
 
 mod common;
-pub use common::{AsyncLen, IntoAsyncSegment, RangeFromMaybeToInclusive};
+pub use common::{AsyncFsync, AsyncLen, AsyncRepo, IntoAsyncWriter, RangeFromMaybeToInclusive};

--- a/crates/commitlog/src/stream/reader.rs
+++ b/crates/commitlog/src/stream/reader.rs
@@ -1,16 +1,11 @@
-use std::{
-    io::{self, SeekFrom},
-    ops::RangeBounds,
-};
+use std::ops::RangeBounds;
 
 use async_stream::try_stream;
 use bytes::{Buf as _, Bytes};
 use futures::Stream;
 use log::{debug, info, trace, warn};
-use tokio::{
-    io::{AsyncBufRead, AsyncReadExt as _, AsyncSeek, AsyncSeekExt as _},
-    task::spawn_blocking,
-};
+use tokio::io::{self, AsyncBufRead, AsyncReadExt as _, AsyncSeek, AsyncSeekExt as _, SeekFrom};
+use tokio::task::spawn_blocking;
 use tokio_util::io::SyncIoBridge;
 
 use crate::{
@@ -20,8 +15,8 @@ use crate::{
 };
 
 use super::{
-    common::{read_exact, CommitBuf},
-    IntoAsyncSegment, RangeFromMaybeToInclusive,
+    common::{read_exact, AsyncRepo, CommitBuf},
+    RangeFromMaybeToInclusive,
 };
 
 /// Stream the `range` of transaction offsets from the commitlog in `repo` as
@@ -41,8 +36,7 @@ use super::{
 /// returned stream yields nothing.
 pub fn commits<R>(repo: R, range: impl RangeBounds<u64>) -> impl Stream<Item = io::Result<Bytes>>
 where
-    R: Repo + Send + 'static,
-    R::Segment: IntoAsyncSegment,
+    R: AsyncRepo + Send + 'static,
 {
     let mut range = RangeFromMaybeToInclusive::from_range_bounds(range);
     let retain = move |segments: Vec<_>| retain_range(&segments, range);
@@ -54,13 +48,7 @@ where
             }
             trace!("segment: segment={} start={}", segment_offset, range.start);
 
-            let segment = spawn_blocking({
-                let repo = repo.clone();
-                move || repo.open_segment(segment_offset)
-            })
-            .await
-            .unwrap()?
-            .into_async_reader();
+            let segment = repo.open_segment_reader_async(segment_offset).await?;
 
             for await chunk in read_segment(repo.clone(), segment, segment_offset, range) {
                 yield chunk.inspect_err(|e| warn!("error reading segment {}: {}", segment_offset, e))?;

--- a/crates/commitlog/src/tests/bitflip.rs
+++ b/crates/commitlog/src/tests/bitflip.rs
@@ -77,7 +77,7 @@ impl Inputs {
                 // and generate a byte position where we want a bit to be
                 // flipped.
                 .prop_flat_map(move |segment_offset| {
-                    let segment = log.repo.open_segment(segment_offset).unwrap();
+                    let segment = log.repo.open_segment_writer(segment_offset).unwrap();
                     let byte_pos = byte_position(segment.len());
                     (Just(log.clone()), Just(segment), Just(segment_offset), byte_pos)
                 }),

--- a/crates/commitlog/tests/streaming/mod.rs
+++ b/crates/commitlog/tests/streaming/mod.rs
@@ -8,7 +8,7 @@ use std::{
 use futures::StreamExt as _;
 use log::info;
 use spacetimedb_commitlog::{
-    repo::{self, Repo, Segment},
+    repo::{self, Repo, SegmentLen},
     stream::{self, OnTrailingData, StreamWriter},
     tests::helpers::enable_logging,
     Commitlog, Options,
@@ -124,7 +124,7 @@ async fn trim_garbage() {
         let repo = repo(&dst);
         move || {
             let last_segment_offset = repo.existing_offsets().unwrap().pop().unwrap();
-            let mut segment = repo.open_segment(last_segment_offset).unwrap();
+            let mut segment = repo.open_segment_writer(last_segment_offset).unwrap();
             let len = segment.segment_len().unwrap();
             segment.set_len(len - 128).unwrap();
         }

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -26,7 +26,6 @@ use futures::channel::mpsc;
 use futures::StreamExt;
 use parking_lot::RwLock;
 use spacetimedb_commitlog as commitlog;
-pub use spacetimedb_durability::Durability;
 use spacetimedb_durability::{self as durability, TxOffset};
 use spacetimedb_lib::db::auth::StAccess;
 use spacetimedb_lib::db::raw_def::v9::{btree, RawModuleDefV9Builder, RawSql};
@@ -49,6 +48,7 @@ use std::io;
 use std::ops::RangeBounds;
 use std::path::Path;
 use std::sync::Arc;
+use tokio::sync::watch;
 
 pub type MutTx = <Locking as super::datastore::traits::MutTx>::MutTx;
 pub type Tx = <Locking as super::datastore::traits::Tx>::Tx;
@@ -83,14 +83,16 @@ pub const ONLY_MODULE_VERSION: &str = "0.0.1";
 /// for each entry in [`ConnectedClients`].
 pub type ConnectedClients = HashSet<(Identity, ConnectionId)>;
 
+pub type Durability = dyn durability::Durability<TxData = Txdata>;
+
 #[derive(Clone)]
 pub struct RelationalDB {
     database_identity: Identity,
     owner_identity: Identity,
 
     inner: Locking,
-    durability: Option<Arc<dyn Durability<TxData = Txdata>>>,
-    snapshot_worker: Option<Arc<SnapshotWorker>>,
+    durability: Option<Arc<Durability>>,
+    snapshot_worker: Option<SnapshotWorker>,
 
     row_count_fn: RowCountFn,
     /// Function to determine the durable size on disk.
@@ -104,63 +106,83 @@ pub struct RelationalDB {
     _lock: LockFile,
 }
 
+#[derive(Clone)]
 struct SnapshotWorker {
-    _handle: tokio::task::JoinHandle<()>,
     /// Send end of the [`Self::snapshot_loop`]'s `trigger` receiver.
     ///
     /// Send a message along this queue to request that the `snapshot_loop` asynchronously capture a snapshot.
     request_snapshot: mpsc::UnboundedSender<()>,
+    /// An rx we keep around so that users can subscribe to snapshot updates.
+    notify_rx: watch::Receiver<TxOffset>,
 }
 
 impl SnapshotWorker {
     fn new(committed_state: Arc<RwLock<CommittedState>>, repo: Arc<SnapshotRepository>) -> Self {
         let (request_snapshot, trigger) = mpsc::unbounded();
-        let handle = tokio::spawn(Self::snapshot_loop(trigger, committed_state, repo));
+        let latest_snapshot = repo.latest_snapshot().ok().flatten().unwrap_or(0);
+        let (notify_tx, notify_rx) = watch::channel(latest_snapshot);
+        tokio::spawn(
+            SnapshotWorkerActor {
+                trigger,
+                committed_state,
+                repo,
+                notify_tx,
+            }
+            .run(),
+        );
         SnapshotWorker {
-            _handle: handle,
             request_snapshot,
+            notify_rx,
+        }
+    }
+}
+
+struct SnapshotWorkerActor {
+    trigger: mpsc::UnboundedReceiver<()>,
+    committed_state: Arc<RwLock<CommittedState>>,
+    repo: Arc<SnapshotRepository>,
+    notify_tx: watch::Sender<TxOffset>,
+}
+
+impl SnapshotWorkerActor {
+    /// The snapshot loop takes a snapshot after each `trigger` message received.
+    async fn run(mut self) {
+        while let Some(()) = self.trigger.next().await {
+            self.take_snapshot().await
         }
     }
 
-    /// The snapshot loop takes a snapshot after each `trigger` message received.
-    async fn snapshot_loop(
-        mut trigger: mpsc::UnboundedReceiver<()>,
-        committed_state: Arc<RwLock<CommittedState>>,
-        repo: Arc<SnapshotRepository>,
-    ) {
-        while let Some(()) = trigger.next().await {
-            let committed_state = committed_state.clone();
-            let repo = repo.clone();
-            tokio::task::spawn_blocking(move || Self::take_snapshot(&committed_state, &repo))
+    async fn take_snapshot(&self) {
+        let start_time = std::time::Instant::now();
+        let committed_state = self.committed_state.clone();
+        let snapshot_repo = self.repo.clone();
+        let res =
+            tokio::task::spawn_blocking(move || Locking::take_snapshot_internal(&committed_state, &snapshot_repo))
                 .await
                 .unwrap();
-        }
-    }
-
-    fn take_snapshot(committed_state: &RwLock<CommittedState>, snapshot_repo: &SnapshotRepository) {
-        let start_time = std::time::Instant::now();
-        match Locking::take_snapshot_internal(committed_state, snapshot_repo) {
+        match res {
             Err(e) => {
                 log::error!(
                     "Error capturing snapshot of database {:?}: {e:?}",
-                    snapshot_repo.database_identity()
+                    self.repo.database_identity()
                 );
             }
 
             Ok(None) => {
                 log::warn!(
                     "SnapshotWorker::take_snapshot: refusing to take snapshot of database {} at TX offset -1",
-                    snapshot_repo.database_identity()
+                    self.repo.database_identity()
                 );
             }
 
             Ok(Some((tx_offset, _path))) => {
                 log::info!(
                     "Captured snapshot of database {:?} at TX offset {} in {:?}",
-                    snapshot_repo.database_identity(),
+                    self.repo.database_identity(),
                     tx_offset,
                     start_time.elapsed()
                 );
+                self.notify_tx.send_replace(tx_offset);
             }
         }
     }
@@ -189,12 +211,12 @@ impl RelationalDB {
         database_identity: Identity,
         owner_identity: Identity,
         inner: Locking,
-        durability: Option<(Arc<dyn Durability<TxData = Txdata>>, DiskSizeFn)>,
+        durability: Option<(Arc<Durability>, DiskSizeFn)>,
         snapshot_repo: Option<Arc<SnapshotRepository>>,
     ) -> Self {
         let (durability, disk_size_fn) = durability.unzip();
         let snapshot_worker =
-            snapshot_repo.map(|repo| Arc::new(SnapshotWorker::new(inner.committed_state.clone(), repo.clone())));
+            snapshot_repo.map(|repo| SnapshotWorker::new(inner.committed_state.clone(), repo.clone()));
         Self {
             inner,
             durability,
@@ -293,7 +315,7 @@ impl RelationalDB {
         database_identity: Identity,
         owner_identity: Identity,
         history: impl durability::History<TxData = Txdata>,
-        durability: Option<(Arc<dyn Durability<TxData = Txdata>>, DiskSizeFn)>,
+        durability: Option<(Arc<Durability>, DiskSizeFn)>,
         snapshot_repo: Option<Arc<SnapshotRepository>>,
     ) -> Result<(Self, ConnectedClients), DBError> {
         log::trace!("[{}] DATABASE: OPEN", database_identity);
@@ -663,11 +685,7 @@ impl RelationalDB {
     /// has already decided based on the reducer and operations whether the transaction should be appended;
     /// this method is responsible only for reading its decision out of the `tx_data`
     /// and calling `durability.append_tx`.
-    fn do_durability(
-        durability: &dyn Durability<TxData = Txdata>,
-        reducer_context: Option<&ReducerContext>,
-        tx_data: &TxData,
-    ) {
+    fn do_durability(durability: &Durability, reducer_context: Option<&ReducerContext>, tx_data: &TxData) {
         use commitlog::payload::{
             txdata::{Mutations, Ops},
             Txdata,
@@ -736,6 +754,15 @@ impl RelationalDB {
                 }
             }
         }
+    }
+
+    /// Subscribe to a channel of snapshot offsets.
+    ///
+    /// If a `snapshot_repo` was provided when this database was opened, this method
+    /// returns a `watch::Receiver` that updates with the latest [`TxOffset`] a snapshot
+    /// was taken at.
+    pub fn subscribe_to_snapshots(&self) -> Option<watch::Receiver<TxOffset>> {
+        self.snapshot_worker.as_ref().map(|snap| snap.notify_rx.clone())
     }
 
     /// Run a fallible function in a transaction.
@@ -1516,7 +1543,7 @@ pub mod tests_utils {
         ) -> Result<(RelationalDB, Arc<durability::Local<ProductValue>>), DBError> {
             let (local, disk_size_fn) = rt.block_on(local_durability(root.commit_log()))?;
             let history = local.clone();
-            let durability = local.clone() as Arc<dyn Durability<TxData = Txdata>>;
+            let durability = local.clone() as Arc<Durability>;
             let snapshot_repo = open_snapshot_repo(root.snapshots(), Identity::ZERO, 0)?;
             let db = Self::open_db(root, history, Some((durability, disk_size_fn)), Some(snapshot_repo), 0)?;
 
@@ -1526,7 +1553,7 @@ pub mod tests_utils {
         fn open_db(
             root: &ReplicaDir,
             history: impl durability::History<TxData = Txdata>,
-            durability: Option<(Arc<dyn Durability<TxData = Txdata>>, DiskSizeFn)>,
+            durability: Option<(Arc<Durability>, DiskSizeFn)>,
             snapshot_repo: Option<Arc<SnapshotRepository>>,
             expected_num_clients: usize,
         ) -> Result<RelationalDB, DBError> {

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -20,7 +20,7 @@ use durability::{Durability, EmptyHistory};
 use log::{info, trace, warn};
 use parking_lot::{Mutex, RwLock};
 use spacetimedb_data_structures::map::IntMap;
-use spacetimedb_durability as durability;
+use spacetimedb_durability::{self as durability, TxOffset};
 use spacetimedb_lib::hash_bytes;
 use spacetimedb_paths::server::{ReplicaDir, ServerDataDir};
 use spacetimedb_sats::hash::Hash;
@@ -43,9 +43,11 @@ type Hosts = Arc<Mutex<IntMap<u64, HostCell>>>;
 
 pub type ExternalDurability = (Arc<dyn Durability<TxData = Txdata>>, DiskSizeFn);
 
+pub type StartSnapshotWatcher = Box<dyn FnOnce(watch::Receiver<TxOffset>)>;
+
 #[async_trait]
 pub trait DurabilityProvider: Send + Sync + 'static {
-    async fn durability(&self, replica_id: u64) -> anyhow::Result<ExternalDurability>;
+    async fn durability(&self, replica_id: u64) -> anyhow::Result<(ExternalDurability, Option<StartSnapshotWatcher>)>;
 }
 
 #[async_trait]
@@ -709,16 +711,21 @@ impl Host {
                 let snapshot_repo =
                     relational_db::open_snapshot_repo(replica_dir.snapshots(), database.database_identity, replica_id)?;
                 let (history, _) = relational_db::local_durability(replica_dir.commit_log()).await?;
-                let durability = durability.durability(replica_id).await?;
+                let (durability, start_snapshot_watcher) = durability.durability(replica_id).await?;
 
-                RelationalDB::open(
+                let (db, clients) = RelationalDB::open(
                     &replica_dir,
                     database.database_identity,
                     database.owner_identity,
                     history,
                     Some(durability),
                     Some(snapshot_repo),
-                )?
+                )?;
+                if let Some(start_snapshot_watcher) = start_snapshot_watcher {
+                    let watcher = db.subscribe_to_snapshots().expect("we passed snapshot_repo");
+                    start_snapshot_watcher(watcher)
+                }
+                (db, clients)
             }
         };
         let (program, program_needs_init) = match db.program()? {

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -23,7 +23,7 @@ mod wasm_common;
 pub use disk_storage::DiskStorage;
 pub use host_controller::{
     DurabilityProvider, ExternalDurability, ExternalStorage, HostController, ProgramStorage, ReducerCallResult,
-    ReducerOutcome,
+    ReducerOutcome, StartSnapshotWatcher,
 };
 pub use module_host::{ModuleHost, NoSuchModule, ReducerCallError, UpdateDatabaseResult};
 pub use scheduler::Scheduler;

--- a/crates/durability/src/imp/local.rs
+++ b/crates/durability/src/imp/local.rs
@@ -144,6 +144,16 @@ impl<T: Encode + Send + Sync + 'static> Local<T> {
         self.clog.commits_from(offset).map_ok(Commit::from)
     }
 
+    /// Get a list of segment offsets, sorted in ascending order.
+    pub fn existing_segment_offsets(&self) -> io::Result<Vec<TxOffset>> {
+        self.clog.existing_segment_offsets()
+    }
+
+    /// Compress the segments at the offsets provded, marking them as immutable.
+    pub fn compress_segments(&self, offsets: &[TxOffset]) -> io::Result<()> {
+        self.clog.compress_segments(offsets)
+    }
+
     /// Apply all outstanding transactions to the [`Commitlog`] and flush it
     /// to disk.
     ///

--- a/crates/fs-utils/Cargo.toml
+++ b/crates/fs-utils/Cargo.toml
@@ -11,6 +11,8 @@ anyhow.workspace = true
 thiserror.workspace = true
 hex.workspace = true
 rand.workspace = true
+tokio.workspace = true
+zstd-framed.workspace = true
 
 [dev-dependencies]
 tempdir.workspace = true

--- a/crates/fs-utils/src/compression.rs
+++ b/crates/fs-utils/src/compression.rs
@@ -1,0 +1,205 @@
+use std::fs::File;
+use std::io;
+use std::io::{BufReader, Read, Seek, SeekFrom};
+use zstd_framed;
+use zstd_framed::{ZstdReader, ZstdWriter};
+
+const ZSTD_MAGIC_BYTES: [u8; 4] = [0x28, 0xB5, 0x2F, 0xFD];
+
+/// Helper struct to keep track of the number of files compressed using each algorithm
+#[derive(Debug, Copy, Clone, PartialEq, Default)]
+pub struct CompressCount {
+    pub none: usize,
+    pub zstd: usize,
+}
+
+/// Compression type
+///
+/// if `None`, the file is not compressed, otherwise it will be compressed using the specified algorithm.
+#[derive(Debug, Copy, Clone, PartialEq)]
+pub enum CompressType {
+    None,
+    Zstd,
+}
+
+/// A reader that can read compressed files
+pub enum CompressReader {
+    None(BufReader<File>),
+    Zstd(Box<ZstdReader<'static, BufReader<File>>>),
+}
+
+impl CompressReader {
+    /// Create a new CompressReader from a File
+    ///
+    /// It will detect the compression type using `magic bytes` and return the appropriate reader.
+    ///
+    /// **Note**: The reader will be return to the original position after detecting the compression type.
+    pub fn new(mut inner: File) -> io::Result<Self> {
+        let current_pos = inner.stream_position()?;
+
+        let mut magic_bytes = [0u8; 4];
+        let bytes_read = inner.read(&mut magic_bytes)?;
+
+        // Restore the original position
+        inner.seek(SeekFrom::Start(current_pos))?;
+
+        // Determine compression type
+        Ok(if bytes_read == 4 {
+            match magic_bytes {
+                ZSTD_MAGIC_BYTES => {
+                    let table = zstd_framed::table::read_seek_table(&mut inner)?;
+                    let mut builder = ZstdReader::builder(inner);
+                    if let Some(table) = table {
+                        builder = builder.with_seek_table(table);
+                    }
+                    CompressReader::Zstd(Box::new(builder.build()?))
+                }
+                _ => CompressReader::None(BufReader::new(inner)),
+            }
+        } else {
+            CompressReader::None(BufReader::new(inner))
+        })
+    }
+
+    pub fn file_size(&self) -> io::Result<usize> {
+        Ok(match self {
+            Self::None(inner) => inner.get_ref().metadata()?.len() as usize,
+            //TODO: Can't see how to get the file size from ZstdReader
+            Self::Zstd(_inner) => 0,
+        })
+    }
+
+    pub fn compress_type(&self) -> CompressType {
+        match self {
+            CompressReader::None(_) => CompressType::None,
+            CompressReader::Zstd(_) => CompressType::Zstd,
+        }
+    }
+}
+
+impl Read for CompressReader {
+    fn read(&mut self, buf: &mut [u8]) -> io::Result<usize> {
+        match self {
+            CompressReader::None(inner) => inner.read(buf),
+            CompressReader::Zstd(inner) => inner.read(buf),
+        }
+    }
+}
+
+impl io::BufRead for CompressReader {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        match self {
+            CompressReader::None(inner) => inner.fill_buf(),
+            CompressReader::Zstd(inner) => inner.fill_buf(),
+        }
+    }
+
+    fn consume(&mut self, amt: usize) {
+        match self {
+            CompressReader::None(inner) => inner.consume(amt),
+            CompressReader::Zstd(inner) => inner.consume(amt),
+        }
+    }
+}
+
+impl Seek for CompressReader {
+    fn seek(&mut self, pos: SeekFrom) -> io::Result<u64> {
+        match self {
+            CompressReader::None(inner) => inner.seek(pos),
+            CompressReader::Zstd(inner) => inner.seek(pos),
+        }
+    }
+}
+
+pub fn new_zstd_writer<'a, W: io::Write>(inner: W, max_frame_size: u32) -> io::Result<ZstdWriter<'a, W>> {
+    ZstdWriter::builder(inner)
+        .with_compression_level(0)
+        .with_seek_table(max_frame_size)
+        .build()
+}
+
+pub use async_impls::AsyncCompressReader;
+
+mod async_impls {
+    use super::*;
+    use std::pin::Pin;
+    use std::task::{Context, Poll};
+    use tokio::io::{self, AsyncBufRead, AsyncRead, AsyncReadExt, AsyncSeek, AsyncSeekExt};
+    use zstd_framed::{AsyncZstdReader, AsyncZstdSeekableReader};
+
+    pub enum AsyncCompressReader<R> {
+        None(io::BufReader<R>),
+        Zstd(Box<AsyncZstdSeekableReader<'static, io::BufReader<R>>>),
+    }
+
+    impl<R: AsyncRead + AsyncSeek + Unpin> AsyncCompressReader<R> {
+        /// Create a new AsyncCompressReader from a reader
+        ///
+        /// It will detect the compression type using `magic bytes` and return the appropriate reader.
+        ///
+        /// **Note**: The reader will be return to the start after detecting the compression type.
+        pub async fn new(mut inner: R) -> io::Result<Self> {
+            let mut magic_bytes = [0u8; 4];
+            let magic_bytes = match inner.read_exact(&mut magic_bytes).await {
+                Ok(_) => Some(magic_bytes),
+                Err(e) if e.kind() == io::ErrorKind::UnexpectedEof => None,
+                Err(e) => return Err(e),
+            };
+
+            // Restore the original position
+            inner.seek(io::SeekFrom::Start(0)).await?;
+
+            // Determine compression type
+            Ok(match magic_bytes {
+                Some(ZSTD_MAGIC_BYTES) => {
+                    let table = zstd_framed::table::tokio::read_seek_table(&mut inner).await?;
+                    let mut builder = AsyncZstdReader::builder_tokio(inner);
+                    if let Some(table) = table {
+                        builder = builder.with_seek_table(table);
+                    }
+                    AsyncCompressReader::Zstd(Box::new(builder.build()?.seekable()))
+                }
+                _ => AsyncCompressReader::None(io::BufReader::new(inner)),
+            })
+        }
+
+        pub fn compress_type(&self) -> CompressType {
+            match self {
+                AsyncCompressReader::None(_) => CompressType::None,
+                AsyncCompressReader::Zstd(_) => CompressType::Zstd,
+            }
+        }
+    }
+
+    macro_rules! forward_reader {
+    ($self:ident.$method:ident($($args:expr),*)) => {
+        match $self.get_mut() {
+            AsyncCompressReader::None(r) => Pin::new(r).$method($($args),*),
+            AsyncCompressReader::Zstd(r) => Pin::new(r).$method($($args),*),
+        }
+    };
+}
+    impl<R: AsyncRead + AsyncSeek + Unpin> AsyncRead for AsyncCompressReader<R> {
+        fn poll_read(self: Pin<&mut Self>, cx: &mut Context<'_>, buf: &mut io::ReadBuf<'_>) -> Poll<io::Result<()>> {
+            forward_reader!(self.poll_read(cx, buf))
+        }
+    }
+    impl<R: AsyncRead + AsyncSeek + Unpin> AsyncBufRead for AsyncCompressReader<R> {
+        fn poll_fill_buf(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<&[u8]>> {
+            forward_reader!(self.poll_fill_buf(cx))
+        }
+
+        fn consume(self: Pin<&mut Self>, amt: usize) {
+            forward_reader!(self.consume(amt))
+        }
+    }
+    impl<R: AsyncRead + AsyncSeek + Unpin> AsyncSeek for AsyncCompressReader<R> {
+        fn start_seek(self: Pin<&mut Self>, position: SeekFrom) -> std::io::Result<()> {
+            forward_reader!(self.start_seek(position))
+        }
+
+        fn poll_complete(self: Pin<&mut Self>, cx: &mut Context<'_>) -> Poll<std::io::Result<u64>> {
+            forward_reader!(self.poll_complete(cx))
+        }
+    }
+}

--- a/crates/fs-utils/src/lib.rs
+++ b/crates/fs-utils/src/lib.rs
@@ -2,6 +2,7 @@ use rand::Rng;
 use std::io::Write;
 use std::path::Path;
 
+pub mod compression;
 pub mod dir_trie;
 pub mod lockfile;
 


### PR DESCRIPTION
# Description of Changes

Resolves #1592. Takes `fs-utils/compression` from #2034.

# API and ABI breaking changes

Not sure which label applies, but this is a change that is not forwards-compatible once you upgrade.

# Expected complexity level and risk

3 - this is a bit tricky but I'm pretty confident in this implementation.

# Testing

- [x] commits are properly compressed to zstd format when a snapshot is taken.
- [ ] *Write a test you want a reviewer to do here, so they can check it off when they're satisfied.*
