### PR TITLE
Bump versions to 1.1.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -904,7 +904,7 @@ dependencies = [
 
 [[package]]
 name = "connect_disconnect_client"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "spacetimedb-sdk",
@@ -4831,7 +4831,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "bytemuck",
  "derive_more",
@@ -4849,7 +4849,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bench"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "anymap",
@@ -4895,7 +4895,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-macro"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "heck 0.4.1",
  "humantime",
@@ -4907,14 +4907,14 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-sys"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "spacetimedb-primitives",
 ]
 
 [[package]]
 name = "spacetimedb-cli"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -4977,7 +4977,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5024,7 +5024,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api-messages"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "brotli",
  "bytes",
@@ -5049,7 +5049,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-commitlog"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "async-stream",
  "bitflags 2.6.0",
@@ -5079,7 +5079,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-core"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -5189,7 +5189,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-data-structures"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "ahash 0.8.11",
  "hashbrown 0.15.1",
@@ -5201,7 +5201,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-durability"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5215,7 +5215,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-execution"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5230,7 +5230,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-expr"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -5246,7 +5246,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-fs-utils"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -5286,7 +5286,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-lib"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "bitflags 2.6.0",
@@ -5315,7 +5315,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-metrics"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "arrayvec",
  "itertools 0.12.1",
@@ -5325,7 +5325,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-paths"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5341,7 +5341,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-physical-plan"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -5356,7 +5356,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-primitives"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "bitflags 2.6.0",
  "either",
@@ -5367,7 +5367,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-query"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5384,7 +5384,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sats"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "ahash 0.8.11",
  "anyhow",
@@ -5416,7 +5416,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-schema"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "enum-as-inner",
@@ -5430,7 +5430,6 @@ dependencies = [
  "serde_json",
  "serial_test",
  "smallvec",
- "spacetimedb-cli",
  "spacetimedb-data-structures",
  "spacetimedb-lib",
  "spacetimedb-primitives",
@@ -5444,7 +5443,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sdk"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anymap",
  "base64 0.21.7",
@@ -5473,7 +5472,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-snapshot"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "blake3",
  "hex",
@@ -5490,7 +5489,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sql-parser"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "derive_more",
  "spacetimedb-lib",
@@ -5500,7 +5499,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-standalone"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5535,7 +5534,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-subscription"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "spacetimedb-execution",
@@ -5548,7 +5547,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-table"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "ahash 0.8.11",
  "blake3",
@@ -5572,7 +5571,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-testing"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "clap 4.5.20",
@@ -5598,7 +5597,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-update"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5623,7 +5622,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-vm"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -5714,7 +5713,7 @@ dependencies = [
 
 [[package]]
 name = "sqltest"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6051,7 +6050,7 @@ dependencies = [
 
 [[package]]
 name = "test-client"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "env_logger",
@@ -6063,7 +6062,7 @@ dependencies = [
 
 [[package]]
 name = "test-counter"
-version = "1.0.1"
+version = "1.1.0"
 dependencies = [
  "anyhow",
  "spacetimedb-data-structures",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5430,6 +5430,7 @@ dependencies = [
  "serde_json",
  "serial_test",
  "smallvec",
+ "spacetimedb-cli",
  "spacetimedb-data-structures",
  "spacetimedb-lib",
  "spacetimedb-primitives",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -86,39 +86,39 @@ inherits = "release"
 debug = true
 
 [workspace.package]
-version = "1.0.1"
+version = "1.1.0"
 edition = "2021"
 # update rust-toolchain.toml too!
 rust-version = "1.84.0"
 
 [workspace.dependencies]
-spacetimedb = { path = "crates/bindings", version = "1.0.1" }
-spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.0.1" }
-spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.0.1" }
-spacetimedb-cli = { path = "crates/cli", version = "1.0.1" }
-spacetimedb-client-api = { path = "crates/client-api", version = "1.0.1" }
-spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.0.1" }
-spacetimedb-commitlog = { path = "crates/commitlog", version = "1.0.1" }
-spacetimedb-core = { path = "crates/core", version = "1.0.1" }
-spacetimedb-data-structures = { path = "crates/data-structures", version = "1.0.1" }
-spacetimedb-durability = { path = "crates/durability", version = "1.0.1" }
-spacetimedb-execution = { path = "crates/execution", version = "1.0.1" }
-spacetimedb-expr = { path = "crates/expr", version = "1.0.1" }
-spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.0.1" }
-spacetimedb-metrics = { path = "crates/metrics", version = "1.0.1" }
-spacetimedb-paths = { path = "crates/paths", version = "1.0.1" }
-spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.0.1" }
-spacetimedb-primitives = { path = "crates/primitives", version = "1.0.1" }
-spacetimedb-query = { path = "crates/query", version = "1.0.1" }
-spacetimedb-sats = { path = "crates/sats", version = "1.0.1" }
-spacetimedb-schema = { path = "crates/schema", version = "1.0.1" }
-spacetimedb-standalone = { path = "crates/standalone", version = "1.0.1" }
-spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.0.1" }
-spacetimedb-table = { path = "crates/table", version = "1.0.1" }
-spacetimedb-vm = { path = "crates/vm", version = "1.0.1" }
-spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.0.1" }
-spacetimedb-snapshot = { path = "crates/snapshot", version = "1.0.1" }
-spacetimedb-subscription = { path = "crates/subscription", version = "1.0.1" }
+spacetimedb = { path = "crates/bindings", version = "1.1.0" }
+spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.1.0" }
+spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.1.0" }
+spacetimedb-cli = { path = "crates/cli", version = "1.1.0" }
+spacetimedb-client-api = { path = "crates/client-api", version = "1.1.0" }
+spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.1.0" }
+spacetimedb-commitlog = { path = "crates/commitlog", version = "1.1.0" }
+spacetimedb-core = { path = "crates/core", version = "1.1.0" }
+spacetimedb-data-structures = { path = "crates/data-structures", version = "1.1.0" }
+spacetimedb-durability = { path = "crates/durability", version = "1.1.0" }
+spacetimedb-execution = { path = "crates/execution", version = "1.1.0" }
+spacetimedb-expr = { path = "crates/expr", version = "1.1.0" }
+spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.1.0" }
+spacetimedb-metrics = { path = "crates/metrics", version = "1.1.0" }
+spacetimedb-paths = { path = "crates/paths", version = "1.1.0" }
+spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.1.0" }
+spacetimedb-primitives = { path = "crates/primitives", version = "1.1.0" }
+spacetimedb-query = { path = "crates/query", version = "1.1.0" }
+spacetimedb-sats = { path = "crates/sats", version = "1.1.0" }
+spacetimedb-schema = { path = "crates/schema", version = "1.1.0" }
+spacetimedb-standalone = { path = "crates/standalone", version = "1.1.0" }
+spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.1.0" }
+spacetimedb-table = { path = "crates/table", version = "1.1.0" }
+spacetimedb-vm = { path = "crates/vm", version = "1.1.0" }
+spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.1.0" }
+spacetimedb-snapshot = { path = "crates/snapshot", version = "1.1.0" }
+spacetimedb-subscription = { path = "crates/subscription", version = "1.1.0" }
 
 ahash = "0.8"
 anyhow = "1.0.68"

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Clockwork Laboratories, Inc.
-Licensed Work:        SpacetimeDB 1.0.1
+Licensed Work:        SpacetimeDB 1.1.0
                       The Licensed Work is
                       (c) 2023 Clockwork Laboratories, Inc.
                       
@@ -21,7 +21,7 @@ Additional Use Grant: You may make use of the Licensed Work provided your
                       Licensed Work by creating tables whose schemas are
                       controlled by such third parties.
 
-Change Date:          2030-03-11
+Change Date:          2030-03-27
 
 Change License:       GNU Affero General Public License v3.0 with a linking
                       exception

--- a/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
+++ b/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Codegen</AssemblyName>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Title>SpacetimeDB BSATN Codegen</Title>
     <Description>The SpacetimeDB BSATN Codegen implements the Roslyn incremental generators for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Runtime</AssemblyName>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Title>SpacetimeDB BSATN Runtime</Title>
     <Description>The SpacetimeDB BSATN Runtime implements APIs for BSATN serialization/deserialization in C#.</Description>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Codegen</AssemblyName>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Title>SpacetimeDB Module Codegen</Title>
     <Description>The SpacetimeDB Codegen implements the Roslyn incremental generators for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Runtime/Runtime.csproj
+++ b/crates/bindings-csharp/Runtime/Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Runtime</AssemblyName>
-    <Version>1.0.1</Version>
+    <Version>1.1.0</Version>
     <Title>SpacetimeDB Module Runtime</Title>
     <Description>The SpacetimeDB Runtime implements the database runtime bindings for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/cli/src/subcommands/project/rust/Cargo._toml
+++ b/crates/cli/src/subcommands/project/rust/Cargo._toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "1.0.1"
+spacetimedb = "1.1.0"
 log = "0.4"

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -235,30 +235,4 @@ mod tests {
             .check_compatibility_and_update(mkmeta(1, 3, 5))
             .unwrap_err();
     }
-
-    // this will start failing once we bump to v1.1.0 - that's fine, it can just be removed.
-    #[test]
-    fn check_v1_0_0_compatibility() {
-        // this is the function v1.0.0 uses to check compatibility
-        let version_compatible_with = |this: &MetadataFile, version: &semver::Version| {
-            semver::Comparator {
-                op: semver::Op::Caret,
-                major: this.version.major,
-                minor: Some(this.version.minor),
-                patch: Some(this.version.minor),
-                pre: Default::default(),
-            }
-            .matches(version)
-        };
-        let default_v1_0_0_meta_file = MetadataFile {
-            version: mkver(1, 0, 0),
-            edition: "standalone".to_owned(),
-            client_connection_id: None,
-        };
-        let meta_file_from_v1_0_x = MetadataFile::new("standalone");
-        assert!(version_compatible_with(
-            &meta_file_from_v1_0_x,
-            &default_v1_0_0_meta_file.version,
-        ));
-    }
 }


### PR DESCRIPTION
# Description of Changes

Bumped the Rust and C# versions to 1.1.0.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None. Existing CI only.