### PR TITLE
Add utility for rls resolution

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5357,6 +5357,7 @@ dependencies = [
  "bigdecimal",
  "derive_more",
  "ethnum",
+ "pretty_assertions",
  "spacetimedb-lib",
  "spacetimedb-primitives",
  "spacetimedb-sats",

--- a/crates/expr/Cargo.toml
+++ b/crates/expr/Cargo.toml
@@ -19,4 +19,5 @@ spacetimedb-schema.workspace = true
 spacetimedb-sql-parser.workspace = true
 
 [dev-dependencies]
+pretty_assertions.workspace = true
 spacetimedb-lib.workspace = true

--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -27,6 +27,7 @@ pub type TypingResult<T> = core::result::Result<T, TypingError>;
 pub trait SchemaView {
     fn table_id(&self, name: &str) -> Option<TableId>;
     fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableSchema>>;
+    fn rls_rules_for_table(&self, table_id: TableId) -> anyhow::Result<Vec<Box<str>>>;
 
     fn schema(&self, name: &str) -> Option<Arc<TableSchema>> {
         self.table_id(name).and_then(|table_id| self.schema_for_table(table_id))
@@ -228,6 +229,10 @@ pub mod test_utils {
                     .table(name)
                     .map(|def| Arc::new(TableSchema::from_module_def(&self.0, def, (), table_id)))
             })
+        }
+
+        fn rls_rules_for_table(&self, _: TableId) -> anyhow::Result<Vec<Box<str>>> {
+            Ok(vec![])
         }
     }
 }

--- a/crates/expr/src/expr.rs
+++ b/crates/expr/src/expr.rs
@@ -19,7 +19,7 @@ use spacetimedb_sql_parser::ast::{BinOp, LogOp};
 /// ```sql
 /// select t.* from t join s ...
 /// ```
-#[derive(Debug)]
+#[derive(Debug, PartialEq, Eq)]
 pub enum ProjectName {
     None(RelExpr),
     Some(RelExpr, Box<str>),
@@ -142,7 +142,7 @@ impl ProjectList {
 }
 
 /// A logical relational expression
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum RelExpr {
     /// A relvar or table reference
     RelVar(Relvar),
@@ -155,7 +155,7 @@ pub enum RelExpr {
 }
 
 /// A table reference
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct Relvar {
     /// The table schema of this relvar
     pub schema: Arc<TableSchema>,
@@ -258,7 +258,7 @@ impl RelExpr {
 }
 
 /// A left deep binary cross product
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct LeftDeepJoin {
     /// The lhs is recursive
     pub lhs: Box<RelExpr>,
@@ -267,7 +267,7 @@ pub struct LeftDeepJoin {
 }
 
 /// A typed scalar expression
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub enum Expr {
     /// A binary expression
     BinOp(BinOp, Box<Expr>, Box<Expr>),
@@ -324,7 +324,7 @@ impl Expr {
 }
 
 /// A typed qualified field projection
-#[derive(Debug, Clone)]
+#[derive(Debug, Clone, PartialEq, Eq)]
 pub struct FieldProject {
     pub table: Box<str>,
     pub field: usize,

--- a/crates/expr/src/expr.rs
+++ b/crates/expr/src/expr.rs
@@ -26,6 +26,22 @@ pub enum ProjectName {
 }
 
 impl ProjectName {
+    /// Unwrap the outer projection, returning the inner expression
+    pub fn unwrap(self) -> RelExpr {
+        match self {
+            Self::None(expr) | Self::Some(expr, _) => expr,
+        }
+    }
+
+    /// What is the name of the return table?
+    /// This is either the table name itself or its alias.
+    pub fn return_name(&self) -> Option<&str> {
+        match self {
+            Self::None(input) => input.return_name(),
+            Self::Some(_, name) => Some(name.as_ref()),
+        }
+    }
+
     /// The [TableSchema] of the returned rows.
     /// Note this expression returns rows from a relvar.
     /// Hence it this method should never return [None].
@@ -126,7 +142,7 @@ impl ProjectList {
 }
 
 /// A logical relational expression
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum RelExpr {
     /// A relvar or table reference
     RelVar(Relvar),
@@ -139,15 +155,43 @@ pub enum RelExpr {
 }
 
 /// A table reference
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct Relvar {
+    /// The table schema of this relvar
     pub schema: Arc<TableSchema>,
+    /// The name of this relvar
     pub alias: Box<str>,
     /// Does this relvar represent a delta table?
     pub delta: Option<Delta>,
 }
 
 impl RelExpr {
+    /// Walk the expression tree and call `f` on each node
+    pub fn visit(&self, f: &mut impl FnMut(&Self)) {
+        f(self);
+        match self {
+            Self::Select(lhs, _)
+            | Self::LeftDeepJoin(LeftDeepJoin { lhs, .. })
+            | Self::EqJoin(LeftDeepJoin { lhs, .. }, ..) => {
+                lhs.visit(f);
+            }
+            Self::RelVar(..) => {}
+        }
+    }
+
+    /// Walk the expression tree and call `f` on each node
+    pub fn visit_mut(&mut self, f: &mut impl FnMut(&mut Self)) {
+        f(self);
+        match self {
+            Self::Select(lhs, _)
+            | Self::LeftDeepJoin(LeftDeepJoin { lhs, .. })
+            | Self::EqJoin(LeftDeepJoin { lhs, .. }, ..) => {
+                lhs.visit_mut(f);
+            }
+            Self::RelVar(..) => {}
+        }
+    }
+
     /// The number of fields this expression returns
     pub fn nfields(&self) -> usize {
         match self {
@@ -201,10 +245,20 @@ impl RelExpr {
     pub fn return_table_id(&self) -> Option<TableId> {
         self.return_table().map(|schema| schema.table_id)
     }
+
+    /// Does this expression return a single relvar?
+    /// If so, return its name or equivalently its alias.
+    pub fn return_name(&self) -> Option<&str> {
+        match self {
+            Self::RelVar(Relvar { alias, .. }) => Some(alias.as_ref()),
+            Self::Select(input, _) => input.return_name(),
+            _ => None,
+        }
+    }
 }
 
 /// A left deep binary cross product
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct LeftDeepJoin {
     /// The lhs is recursive
     pub lhs: Box<RelExpr>,
@@ -213,7 +267,7 @@ pub struct LeftDeepJoin {
 }
 
 /// A typed scalar expression
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum Expr {
     /// A binary expression
     BinOp(BinOp, Box<Expr>, Box<Expr>),
@@ -226,6 +280,30 @@ pub enum Expr {
 }
 
 impl Expr {
+    /// Walk the expression tree and call `f` on each node
+    pub fn visit(&self, f: &impl Fn(&Self)) {
+        f(self);
+        match self {
+            Self::BinOp(_, a, b) | Self::LogOp(_, a, b) => {
+                a.visit(f);
+                b.visit(f);
+            }
+            Self::Value(..) | Self::Field(..) => {}
+        }
+    }
+
+    /// Walk the expression tree and call `f` on each node
+    pub fn visit_mut(&mut self, f: &mut impl FnMut(&mut Self)) {
+        f(self);
+        match self {
+            Self::BinOp(_, a, b) | Self::LogOp(_, a, b) => {
+                a.visit_mut(f);
+                b.visit_mut(f);
+            }
+            Self::Value(..) | Self::Field(..) => {}
+        }
+    }
+
     /// A literal boolean value
     pub const fn bool(v: bool) -> Self {
         Self::Value(AlgebraicValue::Bool(v), AlgebraicType::Bool)
@@ -246,7 +324,7 @@ impl Expr {
 }
 
 /// A typed qualified field projection
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub struct FieldProject {
     pub table: Box<str>,
     pub field: usize,

--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -23,6 +23,7 @@ use spacetimedb_sql_parser::ast::{self, BinOp, ProjectElem, SqlExpr, SqlIdent, S
 pub mod check;
 pub mod errors;
 pub mod expr;
+pub mod rls;
 pub mod statement;
 
 /// Type check and lower a [SqlExpr]

--- a/crates/expr/src/rls.rs
+++ b/crates/expr/src/rls.rs
@@ -1,0 +1,407 @@
+use std::rc::Rc;
+
+use spacetimedb_lib::identity::AuthCtx;
+use spacetimedb_primitives::TableId;
+use spacetimedb_sql_parser::ast::BinOp;
+
+use crate::{
+    check::{parse_and_type_sub, SchemaView},
+    expr::{Expr, FieldProject, LeftDeepJoin, ProjectName, RelExpr, Relvar},
+};
+
+/// This utility is responsible for implementing view resolution.
+///
+/// What is view resolution and why do we need it?
+///
+/// A view is a named query that can be referenced as though it were just a regular table.
+/// In SpacetimeDB, Row Level Security (RLS) is implemented using views.
+/// We must resolve/expand these views in order to guarantee the correct access controls.
+///
+/// How is it implemented?
+///
+/// Take the following join tree for example:
+/// ```text
+///     x
+///    / \
+///   x   c
+///  / \
+/// a   b
+/// ```
+///
+/// Let's assume b is a view with the following structure:
+/// ```text
+///     x
+///    / \
+///   x   f
+///  / \
+/// d   e
+/// ```
+///
+/// Logically we just want to expand the tree like so:
+/// ```text
+///     x
+///    / \
+///   x   c
+///  / \
+/// a   x
+///    / \
+///   x   f
+///  / \
+/// d   e
+/// ```
+///
+/// However the join trees at this level are left deep.
+/// To maintain this invariant, the correct expansion would be:
+/// ```text
+///         x
+///        / \
+///       x   c
+///      / \
+///     x   f
+///    / \
+///   x   e
+///  / \
+/// a   d
+/// ```
+///
+/// That is, the subtree whose root is the left sibling of the node being expanded,
+/// i.e. the subtree rooted at `a` in the above example,
+/// must be pushed below the leftmost leaf node of the view expansion.
+pub fn resolve_views(
+    tx: &impl SchemaView,
+    expr: ProjectName,
+    auth: &AuthCtx,
+    has_param: &mut bool,
+) -> anyhow::Result<Vec<ProjectName>> {
+    // RLS does not apply to the database owner
+    if auth.caller == auth.owner {
+        return Ok(vec![expr]);
+    }
+
+    let Some(return_name) = expr.return_name().map(|name| name.to_owned().into_boxed_str()) else {
+        anyhow::bail!("Could not determine return type during RLS resolution")
+    };
+
+    // Unwrap the underlying `RelExpr`
+    let expr = match expr {
+        ProjectName::None(expr) | ProjectName::Some(expr, _) => expr,
+    };
+
+    resolve_views_for_expr(
+        tx,
+        expr,
+        // Do not ignore the return table when checking for RLS rules
+        None,
+        // Resolve list is empty as we are not yet resolving any RLS rules
+        Rc::new(ResolveList::None),
+        has_param,
+        &mut 0,
+        auth,
+    )
+    .map(|fragments| {
+        fragments
+            .into_iter()
+            // The expanded fragments could be join trees,
+            // so wrap each of them in an outer project.
+            .map(|expr| ProjectName::Some(expr, return_name.clone()))
+            .collect()
+    })
+}
+
+/// A list for detecting cycles during RLS resolution.
+enum ResolveList {
+    None,
+    Some(TableId, Rc<ResolveList>),
+}
+
+impl ResolveList {
+    fn new(table_id: TableId, list: Rc<Self>) -> Rc<Self> {
+        Rc::new(Self::Some(table_id, list))
+    }
+
+    fn contains(&self, table_id: &TableId) -> bool {
+        match self {
+            Self::None => false,
+            Self::Some(id, suffix) if id != table_id => suffix.contains(table_id),
+            Self::Some(..) => true,
+        }
+    }
+}
+
+/// The main driver for view resolution. See [resolve_views] for details.
+///
+/// But first, a word on the `return_table_id` parameter.
+///
+/// Why do we care about it?
+/// What does it mean for it to be `None`?
+///
+/// If this IS NOT a user query, it must be a view definition.
+/// In SpacetimeDB this means we're expanding an RLS filter.
+/// RLS filters cannot be self-referential, meaning that within a filter,
+/// we cannot recursively expand references to its return table.
+///
+/// However, a `None` value implies that this expression is a user query,
+/// and so we should attempt to expand references to the return table.
+fn resolve_views_for_expr(
+    tx: &impl SchemaView,
+    view: RelExpr,
+    return_table_id: Option<TableId>,
+    resolving: Rc<ResolveList>,
+    has_param: &mut bool,
+    suffix: &mut usize,
+    auth: &AuthCtx,
+) -> anyhow::Result<Vec<RelExpr>> {
+    let is_return_table = |relvar: &Relvar| return_table_id.is_some_and(|id| relvar.schema.table_id == id);
+
+    // Collect the table ids queried by this view.
+    // Ignore the id of the return table, since RLS views cannot be recursive.
+    let mut names = vec![];
+    view.visit(&mut |expr| match expr {
+        RelExpr::RelVar(rhs)
+        | RelExpr::LeftDeepJoin(LeftDeepJoin { rhs, .. })
+        | RelExpr::EqJoin(LeftDeepJoin { rhs, .. }, ..)
+            if !is_return_table(rhs) =>
+        {
+            names.push((rhs.schema.table_id, rhs.alias.clone()));
+        }
+        _ => {}
+    });
+
+    // Are we currently resolving any of them?
+    if let Some(table_id) = names
+        .iter()
+        .map(|(table_id, _)| table_id)
+        .find(|table_id| resolving.contains(table_id))
+    {
+        anyhow::bail!("Discovered cyclic dependency when resolving RLS rules for table id `{table_id}`");
+    }
+
+    let return_name = |expr: &ProjectName| {
+        expr.return_name()
+            .map(|name| name.to_owned())
+            .ok_or_else(|| anyhow::anyhow!("Could not resolve table reference in RLS filter"))
+    };
+
+    let mut view_def_fragments = vec![];
+
+    for (table_id, alias) in names {
+        let mut view_fragments = vec![];
+
+        for sql in tx.rls_rules_for_table(table_id)? {
+            // Parse and type check the RLS filter
+            let (expr, is_parameterized) = parse_and_type_sub(&sql, tx, auth)?;
+
+            // Are any of the RLS rules parameterized?
+            *has_param = *has_param || is_parameterized;
+
+            // We need to know which relvar is being returned for alpha-renaming
+            let return_name = return_name(&expr)?;
+
+            // Resolve views within the RLS filter itself
+            let fragments = resolve_views_for_expr(
+                tx,
+                expr.unwrap(),
+                Some(table_id),
+                ResolveList::new(table_id, resolving.clone()),
+                has_param,
+                suffix,
+                auth,
+            )?;
+
+            // Run alpha conversion on each view definition
+            alpha_rename_fragments(
+                // The revlar returned from the inner expression
+                &return_name,
+                // Its corresponding alias in the outer expression
+                &alias,
+                fragments,
+                &mut view_fragments,
+                suffix,
+            );
+        }
+
+        if !view_fragments.is_empty() {
+            view_def_fragments.push((table_id, alias, view_fragments));
+        }
+    }
+
+    /// After we collect all the necessary view definitions and run alpha conversion,
+    /// this function handles the actual replacement of the view with its definition.
+    fn expand_views(expr: RelExpr, view_def_fragments: &[(TableId, Box<str>, Vec<RelExpr>)], out: &mut Vec<RelExpr>) {
+        match view_def_fragments {
+            [] => out.push(expr),
+            [(table_id, alias, fragments), view_def_fragments @ ..] => {
+                for fragment in fragments {
+                    let expanded = expand_leaf(expr.clone(), *table_id, alias, fragment);
+                    expand_views(expanded, view_def_fragments, out);
+                }
+            }
+        }
+    }
+
+    let mut resolved = vec![];
+    expand_views(view, &view_def_fragments, &mut resolved);
+    Ok(resolved)
+}
+
+/// This is the main driver of alpha conversion.
+///
+/// For each expression that we alpha convert,
+/// we append a unique suffix to the names in that expression,
+/// with the one exception being the name of the return table.
+/// The return table is aliased in the outer expression,
+/// and so we use the same alias in the inner expression.
+///
+/// Ex.
+///
+/// Let `v` be a view defined as:
+/// ```sql
+/// SELECT r.* FROM r JOIN s ON r.id = s.id
+/// ```
+///
+/// Take the following user query:
+/// ```sql
+/// SELECT t.* FROM v JOIN t ON v.id = t.id WHERE v.x = 0
+/// ```
+///
+/// After alpha conversion, the expansion becomes:
+/// ```sql
+/// SELECT t.*
+/// FROM r AS v
+/// JOIN s AS s_1 ON v.id = s_1.id
+/// JOIN t AS t   ON t.id = v.id WHERE v.x = 0
+/// ```
+fn alpha_rename_fragments(
+    return_name: &str,
+    outer_alias: &str,
+    inputs: Vec<RelExpr>,
+    output: &mut Vec<RelExpr>,
+    suffix: &mut usize,
+) {
+    for mut fragment in inputs {
+        *suffix += 1;
+        alpha_rename(&mut fragment, &mut |name: &str| {
+            if name == return_name {
+                return outer_alias.to_owned().into_boxed_str();
+            }
+            (name.to_owned() + "_" + &suffix.to_string()).into_boxed_str()
+        });
+        output.push(fragment);
+    }
+}
+
+/// When expanding a view, we must do an alpha conversion on the view definition.
+/// This involves renaming the table aliases before replacing the view reference.
+fn alpha_rename(expr: &mut RelExpr, f: &mut impl FnMut(&str) -> Box<str>) {
+    /// Helper for renaming a relvar
+    fn rename(relvar: &mut Relvar, f: &mut impl FnMut(&str) -> Box<str>) {
+        relvar.alias = f(&relvar.alias);
+    }
+    /// Helper for renaming a field reference
+    fn rename_field(field: &mut FieldProject, f: &mut impl FnMut(&str) -> Box<str>) {
+        field.table = f(&field.table);
+    }
+    expr.visit_mut(&mut |expr| match expr {
+        RelExpr::RelVar(rhs) | RelExpr::LeftDeepJoin(LeftDeepJoin { rhs, .. }) => {
+            rename(rhs, f);
+        }
+        RelExpr::EqJoin(LeftDeepJoin { rhs, .. }, a, b) => {
+            rename(rhs, f);
+            rename_field(a, f);
+            rename_field(b, f);
+        }
+        RelExpr::Select(_, expr) => {
+            expr.visit_mut(&mut |expr| {
+                if let Expr::Field(field) = expr {
+                    rename_field(field, f);
+                }
+            });
+        }
+    });
+}
+
+/// Extends a left deep join tree with another.
+///
+/// Ex.
+///
+/// Assume `expr` is given by:
+/// ```text
+///     x
+///    / \
+///   x   f
+///  / \
+/// d   e
+/// ```
+///
+/// Assume `with` is given by:
+/// ```text
+///     x
+///    / \
+///   x   c
+///  / \
+/// a   b
+/// ```
+///
+/// This function extends `expr` by pushing `with` to the left-most leaf node:
+/// ```text
+///           x
+///          / \
+///         x   f
+///        / \
+///       x   e
+///      / \
+///     x   d
+///    / \
+///   x   c
+///  / \
+/// a   b
+/// ```
+fn extend_lhs(expr: RelExpr, with: RelExpr) -> RelExpr {
+    match expr {
+        RelExpr::RelVar(rhs) => RelExpr::LeftDeepJoin(LeftDeepJoin {
+            lhs: Box::new(with),
+            rhs,
+        }),
+        RelExpr::Select(input, expr) => RelExpr::Select(Box::new(extend_lhs(*input, with)), expr),
+        RelExpr::LeftDeepJoin(join) => RelExpr::LeftDeepJoin(LeftDeepJoin {
+            lhs: Box::new(extend_lhs(*join.lhs, with)),
+            ..join
+        }),
+        RelExpr::EqJoin(join, a, b) => RelExpr::EqJoin(
+            LeftDeepJoin {
+                lhs: Box::new(extend_lhs(*join.lhs, with)),
+                ..join
+            },
+            a,
+            b,
+        ),
+    }
+}
+
+/// Replaces the leaf node determined by `table_id` and `alias` with the subtree `with`.
+/// Ensures the expanded tree stays left deep.
+fn expand_leaf(expr: RelExpr, table_id: TableId, alias: &str, with: &RelExpr) -> RelExpr {
+    let ok = |relvar: &Relvar| relvar.schema.table_id == table_id && relvar.alias.as_ref() == alias;
+    match expr {
+        RelExpr::RelVar(relvar, ..) if ok(&relvar) => with.clone(),
+        RelExpr::RelVar(..) => expr,
+        RelExpr::Select(input, expr) => RelExpr::Select(Box::new(expand_leaf(*input, table_id, alias, with)), expr),
+        RelExpr::LeftDeepJoin(join) if ok(&join.rhs) => extend_lhs(with.clone(), *join.lhs),
+        RelExpr::LeftDeepJoin(LeftDeepJoin { lhs, rhs }) => RelExpr::LeftDeepJoin(LeftDeepJoin {
+            lhs: Box::new(expand_leaf(*lhs, table_id, alias, with)),
+            rhs,
+        }),
+        RelExpr::EqJoin(join, a, b) if ok(&join.rhs) => RelExpr::Select(
+            Box::new(extend_lhs(with.clone(), *join.lhs)),
+            Expr::BinOp(BinOp::Eq, Box::new(Expr::Field(a)), Box::new(Expr::Field(b))),
+        ),
+        RelExpr::EqJoin(LeftDeepJoin { lhs, rhs }, a, b) => RelExpr::EqJoin(
+            LeftDeepJoin {
+                lhs: Box::new(expand_leaf(*lhs, table_id, alias, with)),
+                rhs,
+            },
+            a,
+            b,
+        ),
+    }
+}

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -1157,6 +1157,10 @@ mod tests {
         fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableSchema>> {
             self.schemas.iter().find(|schema| schema.table_id == table_id).cloned()
         }
+
+        fn rls_rules_for_table(&self, _: TableId) -> anyhow::Result<Vec<Box<str>>> {
+            Ok(vec![])
+        }
     }
 
     fn schema(


### PR DESCRIPTION
# Description of Changes

This is the first of several patches that will close/implement #2442. This one in particular adds a utility for expanding or resolving RLS rules in a logical query expression, but it does not integrate it into compiler. That will happen in a follow on patch along with integration tests.

# API and ABI breaking changes

None

# Expected complexity level and risk

2.5

The logic is straightforward. There are a few parts that may be non-obvious like tree rotations and alpha conversion. I've tried to add ample documentation around those parts.

# Testing

Integration tests will be added with in the integration patch.
