### PR TITLE
Feature gate #[client_visibility_filter]

### DIFF
--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -17,6 +17,7 @@ bench = false
 default = ["rand"]
 rand = ["dep:rand", "dep:getrandom"]
 unstable = ["spacetimedb-bindings-sys/unstable"]
+rls = []
 
 [dependencies]
 spacetimedb-bindings-sys.workspace = true

--- a/crates/bindings/Cargo.toml
+++ b/crates/bindings/Cargo.toml
@@ -17,7 +17,6 @@ bench = false
 default = ["rand"]
 rand = ["dep:rand", "dep:getrandom"]
 unstable = ["spacetimedb-bindings-sys/unstable"]
-rls = []
 
 [dependencies]
 spacetimedb-bindings-sys.workspace = true

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -78,7 +78,7 @@ pub use spacetimedb_bindings_macro::duration;
 /// until they are processed by the SpacetimeDB host.
 /// This means that errors in queries, such as syntax errors, type errors or unknown tables,
 /// will be reported during `spacetime publish`, not at compile time.
-#[cfg(feature = "rls")]
+#[cfg(feature = "unstable")]
 #[doc(inline, hidden)] // TODO: RLS filters are currently unimplemented, and are not enforced.
 pub use spacetimedb_bindings_macro::client_visibility_filter;
 

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -78,6 +78,7 @@ pub use spacetimedb_bindings_macro::duration;
 /// until they are processed by the SpacetimeDB host.
 /// This means that errors in queries, such as syntax errors, type errors or unknown tables,
 /// will be reported during `spacetime publish`, not at compile time.
+#[cfg(feature = "rls")]
 #[doc(inline, hidden)] // TODO: RLS filters are currently unimplemented, and are not enforced.
 pub use spacetimedb_bindings_macro::client_visibility_filter;
 

--- a/modules/sdk-test/Cargo.toml
+++ b/modules/sdk-test/Cargo.toml
@@ -16,4 +16,4 @@ paste.workspace = true
 
 [dependencies.spacetimedb]
 workspace = true
-features = ["rls"]
+features = ["unstable"]

--- a/modules/sdk-test/Cargo.toml
+++ b/modules/sdk-test/Cargo.toml
@@ -10,7 +10,10 @@ license-file = "LICENSE"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb.workspace = true
 log.workspace = true
 anyhow.workspace = true
 paste.workspace = true
+
+[dependencies.spacetimedb]
+workspace = true
+features = ["rls"]

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -150,7 +150,7 @@ def new_identity(config_path):
 class Smoketest(unittest.TestCase):
     MODULE_CODE = TEMPLATE_LIB_RS
     AUTOPUBLISH = True
-    BINDINGS_FEATURES = ["rls"]
+    BINDINGS_FEATURES = ["unstable"]
     EXTRA_DEPS = ""
 
     @classmethod

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -150,7 +150,7 @@ def new_identity(config_path):
 class Smoketest(unittest.TestCase):
     MODULE_CODE = TEMPLATE_LIB_RS
     AUTOPUBLISH = True
-    BINDINGS_FEATURES = []
+    BINDINGS_FEATURES = ["rls"]
     EXTRA_DEPS = ""
 
     @classmethod


### PR DESCRIPTION
# Description of Changes

Adds the `rls` cargo feature to the SpacetimeDB bindings crate and gates the `client_visibility_filter` proc macro with it.

# API and ABI breaking changes

None

# Expected complexity level and risk

0

# Testing

I enabled the `rls` feature in the `sdk-test` module as well as the smoketests.
Both were already using `#[client_visibility_filter]` but it was, and still is, a noop.
