### PR TITLE
CI - Make Test Suite check for dirty `git diff`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,6 +101,9 @@ jobs:
       - name: Run cargo test
         run: cargo test --all
 
+      - name: Check that the test outputs are up-to-date
+        run: git diff --exit-code
+
       - name: Ensure C# autogen bindings are up-to-date
         run: |
           cargo run --example regen-csharp-moduledef

--- a/crates/sdk/tests/test-client/src/module_bindings/mod.rs
+++ b/crates/sdk/tests/test-client/src/module_bindings/mod.rs
@@ -292,7 +292,6 @@ pub mod unique_u_64_type;
 pub mod unique_u_8_table;
 pub mod unique_u_8_type;
 pub mod unit_struct_type;
-pub mod update_btree_u_32_reducer;
 pub mod update_pk_bool_reducer;
 pub mod update_pk_connection_id_reducer;
 pub mod update_pk_i_128_reducer;
@@ -797,7 +796,6 @@ pub use unique_u_64_type::UniqueU64;
 pub use unique_u_8_table::*;
 pub use unique_u_8_type::UniqueU8;
 pub use unit_struct_type::UnitStruct;
-pub use update_btree_u_32_reducer::{set_flags_for_update_btree_u_32, update_btree_u_32, UpdateBtreeU32CallbackId};
 pub use update_pk_bool_reducer::{set_flags_for_update_pk_bool, update_pk_bool, UpdatePkBoolCallbackId};
 pub use update_pk_connection_id_reducer::{
     set_flags_for_update_pk_connection_id, update_pk_connection_id, UpdatePkConnectionIdCallbackId,
@@ -1404,10 +1402,6 @@ pub enum Reducer {
     SendScheduledMessage {
         arg: ScheduledTable,
     },
-    UpdateBtreeU32 {
-        inserts: Vec<BTreeU32>,
-        deletes: Vec<BTreeU32>,
-    },
     UpdatePkBool {
         b: bool,
         data: i32,
@@ -1691,7 +1685,6 @@ impl __sdk::Reducer for Reducer {
             Reducer::InsertVecUnitStruct { .. } => "insert_vec_unit_struct",
             Reducer::NoOpSucceeds => "no_op_succeeds",
             Reducer::SendScheduledMessage { .. } => "send_scheduled_message",
-            Reducer::UpdateBtreeU32 { .. } => "update_btree_u32",
             Reducer::UpdatePkBool { .. } => "update_pk_bool",
             Reducer::UpdatePkConnectionId { .. } => "update_pk_connection_id",
             Reducer::UpdatePkI128 { .. } => "update_pk_i128",
@@ -2494,13 +2487,6 @@ impl TryFrom<__ws::ReducerCallInfo<__ws::BsatnFormat>> for Reducer {
                 send_scheduled_message_reducer::SendScheduledMessageArgs,
             >("send_scheduled_message", &value.args)?
             .into()),
-            "update_btree_u32" => Ok(
-                __sdk::parse_reducer_args::<update_btree_u_32_reducer::UpdateBtreeU32Args>(
-                    "update_btree_u32",
-                    &value.args,
-                )?
-                .into(),
-            ),
             "update_pk_bool" => Ok(__sdk::parse_reducer_args::<update_pk_bool_reducer::UpdatePkBoolArgs>(
                 "update_pk_bool",
                 &value.args,


### PR DESCRIPTION
# Description of Changes

It is possible to have a diff after running `cargo test --all`, e.g. in `crates/sdk/tests/test-client/src/module_bindings/`. This PR adds a `git diff` check into the CI so that, if any PRs affect this output, they are required to regenerate the bindings.

# API and ABI breaking changes

No breaking changes.

# Expected complexity level and risk

1

# Testing

- [x] Adding this revealed that the current bindings are already stale
- [x] CI passes after regenerating the bindings