### PR TITLE
Update data size metrics periodically, not on every transaction.

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/committed_state.rs
@@ -679,7 +679,7 @@ impl CommittedState {
         (table, blob_store)
     }
 
-    pub(super) fn report_data_size(&self, database_identity: Identity) {
+    pub fn report_data_size(&self, database_identity: Identity) {
         use crate::db::db_metrics::data_size::DATA_SIZE_METRICS;
 
         for (_, table) in &self.tables {

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -726,12 +726,6 @@ pub(super) fn record_tx_metrics(
             }
         }
     }
-
-    if let Some(committed_state) = committed_state {
-        // TODO(cleanliness,bikeshedding): Consider inlining `report_data_size` here,
-        // or moving the above metric writes into it, for consistency of organization.
-        committed_state.report_data_size(*db);
-    }
 }
 
 impl MutTx for Locking {

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -509,6 +509,13 @@ impl RelationalDB {
         self.inner.heap_usage()
     }
 
+    /// Update data size metrics.
+    pub fn update_data_size_metrics(&self) {
+        let cs = self.inner.committed_state.read();
+
+        cs.report_data_size(self.database_identity)
+    }
+
     pub fn encode_row(row: &ProductValue, bytes: &mut Vec<u8>) {
         // TODO: large file storage of the row elements
         row.encode(bytes);

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -771,7 +771,7 @@ impl Host {
         }
 
         scheduler_starter.start(&module_host)?;
-        let metrics_task = tokio::spawn(storage_monitor(replica_ctx.clone(), energy_monitor.clone())).abort_handle();
+        let metrics_task = tokio::spawn(metric_reporter(replica_ctx.clone())).abort_handle();
 
         Ok(Host {
             module: watch::Sender::new(module_host),
@@ -843,23 +843,14 @@ impl Drop for Host {
     }
 }
 
-const STORAGE_METERING_INTERVAL: Duration = Duration::from_secs(5);
+const STORAGE_METERING_INTERVAL: Duration = Duration::from_secs(15);
 
-/// Periodically collect the disk usage of `replica_ctx` and update metrics as well as
-/// the `energy_monitor` accordingly.
-async fn storage_monitor(replica_ctx: Arc<ReplicaContext>, energy_monitor: Arc<dyn EnergyMonitor>) {
-    let mut interval = tokio::time::interval(STORAGE_METERING_INTERVAL);
-    // We don't care about happening precisely every 5 seconds - it just matters
-    // that the time between ticks is accurate.
-    interval.set_missed_tick_behavior(tokio::time::MissedTickBehavior::Delay);
-
-    let mut prev_disk_usage = tokio::task::block_in_place(|| replica_ctx.total_disk_usage());
-    let mut prev_tick = interval.tick().await;
+/// Periodically collect gauge stats and update prometheus metrics.
+async fn metric_reporter(replica_ctx: Arc<ReplicaContext>) {
+    // TODO: Consider adding a metric for heap usage.
     loop {
-        let tick = interval.tick().await;
-        let dt = tick - prev_tick;
-        let (disk_usage, mem_usage) =
-            tokio::task::block_in_place(|| (replica_ctx.total_disk_usage(), replica_ctx.mem_usage()));
+        let disk_usage = tokio::task::block_in_place(|| replica_ctx.total_disk_usage());
+        replica_ctx.update_data_size_metrics();
         if let Some(num_bytes) = disk_usage.durability {
             DB_METRICS
                 .message_log_size
@@ -872,10 +863,6 @@ async fn storage_monitor(replica_ctx: Arc<ReplicaContext>, energy_monitor: Arc<d
                 .with_label_values(&replica_ctx.database_identity)
                 .set(num_bytes as i64);
         }
-        let disk_usage = disk_usage.or(prev_disk_usage);
-        energy_monitor.record_disk_usage(&replica_ctx.database, replica_ctx.replica_id, disk_usage.sum(), dt);
-        energy_monitor.record_memory_usage(&replica_ctx.database, replica_ctx.replica_id, mem_usage as u64, dt);
-        prev_disk_usage = disk_usage;
-        prev_tick = tick;
+        tokio::time::sleep(STORAGE_METERING_INTERVAL).await;
     }
 }

--- a/crates/core/src/replica_context.rs
+++ b/crates/core/src/replica_context.rs
@@ -46,6 +46,11 @@ impl ReplicaContext {
     pub fn mem_usage(&self) -> usize {
         self.relational_db.size_in_memory()
     }
+
+    /// Update data size stats.
+    pub fn update_data_size_metrics(&self) {
+        self.relational_db.update_data_size_metrics();
+    }
 }
 
 impl Deref for ReplicaContext {


### PR DESCRIPTION
# Description of Changes

Instead of updating data-size-related gauges after each transaction, we report the metrics every 15 seconds. This should reduce overhead for databases with high traffic. 

# API and ABI breaking changes

If this is an API or ABI breaking change, please apply the
corresponding GitHub label.

# Expected complexity level and risk

1. The main risk here is extra overhead if there are a large number of idle databases. We could mitigate that in the future by returning the `next_tx_offset` and skipping reports if it hasn't changed.

# Testing

I ran a standalone instance and checked that:
 1. We report data size metrics right after a module is loaded.
 2. The size metrics change if I add data.

I haven't really looking into writing unit tests for it, since this is tied in with the module lifecycle logic.


