### PR TITLE
Fix C# SDK Tests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -153,6 +153,10 @@ jobs:
         working-directory: spacetimedb-csharp-sdk
         run: |
           dotnet pack ../crates/bindings-csharp/BSATN.Runtime
+          # The SDK package overrides the following crate for use in their tests.
+          # Even though it doesn't actually depend on it, we still need to pack it
+          # so dotnet doesn't complain.
+          dotnet pack ../crates/bindings-csharp/Runtime
           ./tools~/write-nuget-config.sh ..
 
           # clear package caches, so we get fresh ones even if version numbers haven't changed


### PR DESCRIPTION
# Description of Changes

A recent change in the C# SDK repo broke these, this fixes them.

# API and ABI breaking changes

None

# Expected complexity level and risk

0

# Testing

CI