### PR TITLE
commitlog: Derive serde for `Commit`

### DIFF
--- a/crates/commitlog/src/commit.rs
+++ b/crates/commitlog/src/commit.rs
@@ -111,6 +111,7 @@ impl Header {
 
 /// Entry type of a [`crate::Commitlog`].
 #[derive(Clone, Debug, Default, PartialEq)]
+#[cfg_attr(feature = "serde", derive(serde::Serialize, serde::Deserialize))]
 pub struct Commit {
     /// The offset of the first record in this commit.
     ///


### PR DESCRIPTION
For replication purposes.

# Expected complexity level and risk

1

# Testing

Trivial derive.