### PR TITLE
Rip Rayon out of reducer execution and query evaluation

### DIFF
--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -462,9 +462,9 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         )
         .entered();
 
-        // run the call_reducer call in rayon. it's important that we don't acquire a lock inside a rayon task,
-        // as that can lead to deadlock.
-        let (mut tx, result) = rayon::scope(|_| tx_slot.set(tx, || self.instance.call_reducer(op, budget)));
+        // FOR BENCHMARKING: Just run the reducer on whatever thread we're already on,
+        // instead of bouncing to a Rayon thread.
+        let (mut tx, result) = tx_slot.set(tx, || self.instance.call_reducer(op, budget));
 
         let ExecuteResult {
             energy,

--- a/crates/core/src/subscription/mod.rs
+++ b/crates/core/src/subscription/mod.rs
@@ -2,7 +2,6 @@ use std::sync::Arc;
 
 use anyhow::Result;
 use module_subscription_manager::Plan;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use spacetimedb_client_api_messages::websocket::{
     ByteListLen, Compression, DatabaseUpdate, QueryUpdate, TableUpdate, WebsocketFormat,
 };
@@ -112,8 +111,9 @@ where
     Tx: Datastore + DeltaStore + Sync,
     F: WebsocketFormat,
 {
+    // FOR TESTING: Just evaluate sequentially.
     plans
-        .par_iter()
+        .iter()
         .map(|plan| (plan, plan.subscribed_table_id(), plan.subscribed_table_name()))
         .map(|(plan, table_id, table_name)| {
             plan.physical_plan()

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -32,7 +32,6 @@ use crate::sql::ast::SchemaViewer;
 use crate::vm::{build_query, TxMode};
 use anyhow::Context;
 use itertools::Either;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use spacetimedb_client_api_messages::websocket::{Compression, WebsocketFormat};
 use spacetimedb_data_structures::map::HashSet;
 use spacetimedb_lib::db::auth::{StAccess, StTableType};
@@ -519,11 +518,11 @@ impl ExecutionSet {
         slow_query_threshold: Option<Duration>,
         compression: Compression,
     ) -> ws::DatabaseUpdate<F> {
-        // evaluate each of the execution units in this ExecutionSet in parallel
+        // FOR TESTING: Just do sequential execution.
         let tables = self
             .exec_units
             // if you need eval to run single-threaded for debugging, change this to .iter()
-            .par_iter()
+            .iter()
             .filter_map(|unit| unit.eval(db, tx, &unit.sql, slow_query_threshold, compression))
             .collect();
         ws::DatabaseUpdate { tables }


### PR DESCRIPTION
For testing/benchmarking purposes. One theory about our performance is that we're spending a lot of time context-switching between Tokio and Rayon threads. This build will be used in the first of a series of experiments to investigate that overhead. In this patch, we just do sequential evaluation on the Tokio worker threads where the rest of our code runs, instead of sending stuff to Rayon. Rayon use is mostly, but not entirely, removed from Core.

The two next steps I am interested in:
- Use parallelism, but on Tokio workers rather than Rayon threads. I.e. replace `par_iter`, `fold` and `reduce_with` calls with Tokio-isms, instead of this patch's `std::iter::Iterator` versions.
- (Not discussed in meeting) continue using `par_iter` and friends, but invoke the "outer loop" from Tokio threads. I.e. retain use of `par_iter`, `fold` and `reduce_with`, but remove calls to `rayon::scope` or `rayon::spawn`.
