### PR TITLE
Add CI job to run `cargo doc` on the bindings crate

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -191,6 +191,19 @@ jobs:
           dotnet tool restore
           dotnet csharpier --check .
 
+      - name: Run `cargo doc` for bindings crate
+        # `bindings` is the only crate we care strongly about documenting,
+        # since we link to its docs.rs from our website.
+        # We won't pass `--no-deps`, though,
+        # since we want everything reachable through it to also work.
+        # This includes `sats` and `lib`.
+        working-directory: crates/bindings
+        env:
+          # Make `cargo doc` exit with error on warnings, most notably broken links
+          RUSTDOCFLAGS: '--deny warnings'
+        run: |
+          cargo doc
+
   wasm_bindings:
     name: Build and test wasm bindings
     runs-on: spacetimedb-runner

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -1,6 +1,7 @@
 #![doc = include_str!("../README.md")]
 // ^ if you are working on docs, go read the top comment of README.md please.
 
+#[cfg(feature = "unstable")]
 mod client_visibility_filter;
 pub mod log_stopwatch;
 mod logger;
@@ -18,7 +19,7 @@ pub use log;
 #[cfg(feature = "rand")]
 pub use rand;
 
-#[doc(hidden)]
+#[cfg(feature = "unstable")]
 pub use client_visibility_filter::Filter;
 #[cfg(feature = "rand")]
 pub use rng::StdbRng;

--- a/crates/sats/src/product_type.rs
+++ b/crates/sats/src/product_type.rs
@@ -121,22 +121,22 @@ impl ProductType {
         self.is_i64_newtype(TIME_DURATION_TAG)
     }
 
-    /// Returns whether this is the special tag of [`Identity`].
+    /// Returns whether this is the special tag of `Identity`.
     pub fn is_identity_tag(tag_name: &str) -> bool {
         tag_name == IDENTITY_TAG
     }
 
-    /// Returns whether this is the special tag of [`ConnectionId`].
+    /// Returns whether this is the special tag of `ConnectionId`.
     pub fn is_connection_id_tag(tag_name: &str) -> bool {
         tag_name == CONNECTION_ID_TAG
     }
 
-    /// Returns whether this is the special tag of [`Timestamp`].
+    /// Returns whether this is the special tag of [`crate::timestamp::Timestamp`].
     pub fn is_timestamp_tag(tag_name: &str) -> bool {
         tag_name == TIMESTAMP_TAG
     }
 
-    /// Returns whether this is the special tag of [`TimeDuration`].
+    /// Returns whether this is the special tag of [`crate::time_duration::TimeDuration`].
     pub fn is_time_duration_tag(tag_name: &str) -> bool {
         tag_name == TIME_DURATION_TAG
     }


### PR DESCRIPTION
# Description of Changes

Like the title says. I noticed we had some broken links in doc comments while working on #2547 , and thought it would be wise to detect them in CI.

# API and ABI breaking changes

N/a.

# Expected complexity level and risk

1.

# Testing

- [x] Ran this commands by hand and saw that it rejected broken links.
- [x] [Failed in CI the first time because we had broken docs links in master](https://github.com/clockworklabs/SpacetimeDB/actions/runs/14246191034/job/39927673298?pr=2548).
- [x] I'll push a new commit which fixes the broken links, and then it will pass.
