### PR TITLE
Feature gate [ClientVisibilityFilter] in C#

### DIFF
--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/Lib.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/Lib.cs
@@ -1,7 +1,5 @@
 using SpacetimeDB;
 
-#pragma warning disable STDB_UNSTABLE // Enable experimental SpacetimeDB features
-
 public enum LocalEnum { }
 
 [SpacetimeDB.Type]
@@ -412,6 +410,8 @@ public partial struct TestScheduleIssues
 
 public partial class Module
 {
+#pragma warning disable STDB_UNSTABLE // Enable ClientVisibilityFilter
+
     // Invalid: not public static readonly
     [SpacetimeDB.ClientVisibilityFilter]
     private Filter MY_FILTER = new Filter.Sql("SELECT * FROM TestAutoIncNotInteger");
@@ -423,4 +423,12 @@ public partial class Module
     // Invalid: not a Filter
     [SpacetimeDB.ClientVisibilityFilter]
     public static readonly string MY_THIRD_FILTER = "SELECT * FROM TestAutoIncNotInteger";
+
+#pragma warning restore STDB_UNSTABLE // Disable ClientVisibilityFilter
+
+    // Valid Filter, but [ClientVisibilityFilter] is disabled
+    [SpacetimeDB.ClientVisibilityFilter]
+    public static readonly Filter MY_FOURTH_FILTER = new Filter.Sql(
+        "SELECT * FROM TestAutoIncNotInteger"
+    );
 }

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/Lib.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/Lib.cs
@@ -1,5 +1,7 @@
 using SpacetimeDB;
 
+#pragma warning disable STDB_UNSTABLE // Enable experimental SpacetimeDB features
+
 public enum LocalEnum { }
 
 [SpacetimeDB.Type]

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/ExtraCompilationErrors.verified.txt
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/ExtraCompilationErrors.verified.txt
@@ -23,6 +23,29 @@
     }
   },
   {/*
+    // Valid Filter, but [ClientVisibilityFilter] is disabled
+    [SpacetimeDB.ClientVisibilityFilter]
+     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+    public static readonly Filter MY_FOURTH_FILTER = new Filter.Sql(
+*/
+    Message: 'SpacetimeDB.ClientVisibilityFilterAttribute' is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.,
+    Severity: Error,
+    Descriptor: {
+      Id: STDB_UNSTABLE,
+      Title: Type is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS9204),
+      MessageFormat: '{0}' is for evaluation purposes only and is subject to change or removal in future updates. Suppress this diagnostic to proceed.,
+      Category: Compiler,
+      DefaultSeverity: Warning,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        CustomObsolete
+      ]
+    }
+  },
+  {/*
     {
         return Field.GetHashCode();
                ^^^^^
@@ -162,7 +185,7 @@ partial struct TestTypeParams<T>  : System.IEquatable<TestTypeParams>, Spacetime
 SpacetimeDB.Internal.Module.RegisterTable<global::TestUniqueNotEquatable, SpacetimeDB.Internal.TableHandles.TestUniqueNotEquatable>();
         SpacetimeDB.Internal.Module.RegisterClientVisibilityFilter(global::Module.MY_FILTER);
                                                                                   ^^^^^^^^^
-SpacetimeDB.Internal.Module.RegisterClientVisibilityFilter(global::Module.MY_SECOND_FILTER);
+SpacetimeDB.Internal.Module.RegisterClientVisibilityFilter(global::Module.MY_FOURTH_FILTER);
 */
     Message: 'Module.MY_FILTER' is inaccessible due to its protection level,
     Severity: Error,

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#FFI.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#FFI.verified.cs
@@ -991,6 +991,7 @@ static class ModuleRegistration
             SpacetimeDB.Internal.TableHandles.TestUniqueNotEquatable
         >();
         SpacetimeDB.Internal.Module.RegisterClientVisibilityFilter(global::Module.MY_FILTER);
+        SpacetimeDB.Internal.Module.RegisterClientVisibilityFilter(global::Module.MY_FOURTH_FILTER);
         SpacetimeDB.Internal.Module.RegisterClientVisibilityFilter(global::Module.MY_SECOND_FILTER);
         SpacetimeDB.Internal.Module.RegisterClientVisibilityFilter(global::Module.MY_THIRD_FILTER);
     }

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module.verified.txt
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module.verified.txt
@@ -415,7 +415,7 @@ public partial struct TestScheduleIssues
     [SpacetimeDB.ClientVisibilityFilter]
     public static readonly string MY_THIRD_FILTER = "SELECT * FROM TestAutoIncNotInteger";
                                   ^^^^^^^^^^^^^^^
-}
+
 */
       Message: Field MY_THIRD_FILTER is marked as ClientVisibilityFilter but it has type string which is not SpacetimeDB.Filter,
       Severity: Error,

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -833,7 +833,9 @@ public class Module : IIncrementalGenerator
 
         var rlsFilters = context
             .SyntaxProvider.ForAttributeWithMetadataName(
+#pragma warning disable STDB_UNSTABLE
                 fullyQualifiedMetadataName: typeof(ClientVisibilityFilterAttribute).FullName,
+#pragma warning restore STDB_UNSTABLE
                 predicate: (node, ct) => true,
                 transform: (context, ct) =>
                     context.ParseWithDiags(diag => new ClientVisibilityFilterDeclaration(

--- a/crates/bindings-csharp/Runtime/Attrs.cs
+++ b/crates/bindings-csharp/Runtime/Attrs.cs
@@ -33,6 +33,8 @@
     ///
     /// The query follows the same syntax as a subscription query.
     /// See the <see href="https://spacetimedb.com/docs/sql">SQL reference</see> for more information.
+    ///
+    /// This is an experimental feature and subject to change in the future.
     /// </summary>
     [System.Diagnostics.CodeAnalysis.Experimental("STDB_UNSTABLE")]
     [AttributeUsage(AttributeTargets.Field)]

--- a/crates/bindings-csharp/Runtime/Attrs.cs
+++ b/crates/bindings-csharp/Runtime/Attrs.cs
@@ -34,6 +34,7 @@
     /// The query follows the same syntax as a subscription query.
     /// See the <see href="https://spacetimedb.com/docs/sql">SQL reference</see> for more information.
     /// </summary>
+    [System.Diagnostics.CodeAnalysis.Experimental("STDB_UNSTABLE")]
     [AttributeUsage(AttributeTargets.Field)]
     public sealed class ClientVisibilityFilterAttribute : Attribute { }
 

--- a/modules/sdk-test-cs/Lib.cs
+++ b/modules/sdk-test-cs/Lib.cs
@@ -2,6 +2,8 @@ namespace SpacetimeDB.Sdk.Test;
 
 using SpacetimeDB;
 
+#pragma warning disable STDB_UNSTABLE // Enable experimental SpacetimeDB features
+
 public static partial class Module
 {
     [SpacetimeDB.Type]


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Places the `[ClientVisibilityFilter]` behind the `STDB_UNSTABLE` experimental feature flag. Will emit a compiler warning unless the following is added to the module file
```csharp
#pragma warning disable STDB_UNSTABLE // Enable experimental SpacetimeDB features
```

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

0

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

The build failed until I enabled `STDB_UNSTABLE` in the `sdk-test-cs` module.