### PR TITLE
Return error for unqualified columns instead of panic

### DIFF
--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -528,6 +528,10 @@ mod tests {
                 sql: "select * from t limit 5",
                 msg: "Subscriptions do not support limit",
             },
+            TestCase {
+                sql: "select t.* from t join s on t.u32 = s.u32 where bytes = 0xABCD",
+                msg: "Columns must be qualified in join expressions",
+            },
         ] {
             let result = parse_and_type_sub(sql, &tx);
             assert!(result.is_err(), "{msg}");

--- a/crates/expr/src/statement.rs
+++ b/crates/expr/src/statement.rs
@@ -512,6 +512,8 @@ mod tests {
             "select id, str from s join t",
             // Wrong type for limit
             "select * from t limit '5'",
+            // Unqualified name in join expression
+            "select t.* from t join s on t.u32 = s.u32 where bytes = 0xABCD",
         ] {
             let result = parse_and_type_sql(sql, &tx);
             assert!(result.is_err());

--- a/crates/sql-parser/src/ast/sql.rs
+++ b/crates/sql-parser/src/ast/sql.rs
@@ -88,6 +88,11 @@ impl SqlSelect {
         if self.project.has_unqualified_vars() {
             return Err(SqlUnsupported::UnqualifiedNames.into());
         }
+        if let Some(expr) = &self.filter {
+            if expr.has_unqualified_vars() {
+                return Err(SqlUnsupported::UnqualifiedNames.into());
+            }
+        }
         Ok(self)
     }
 

--- a/crates/sql-parser/src/ast/sub.rs
+++ b/crates/sql-parser/src/ast/sub.rs
@@ -31,6 +31,11 @@ impl SqlSelect {
         if self.project.has_unqualified_vars() {
             return Err(SqlUnsupported::UnqualifiedNames.into());
         }
+        if let Some(expr) = &self.filter {
+            if expr.has_unqualified_vars() {
+                return Err(SqlUnsupported::UnqualifiedNames.into());
+            }
+        }
         Ok(self)
     }
 


### PR DESCRIPTION
# Description of Changes

Fixes an issue where we would panic on unqualified column names in join expressions. Now we return an error.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

Added a test to the type checker that previously panicked
