### PR TITLE
fix expression canonicalization

### DIFF
--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -517,7 +517,14 @@ impl PhysicalPlan {
                     PhysicalExpr::BinOp(op, value, expr)
                         if matches!(&*value, PhysicalExpr::Value(_)) && matches!(&*expr, PhysicalExpr::Field(..)) =>
                     {
-                        PhysicalExpr::BinOp(op, expr, value)
+                        match op {
+                            BinOp::Eq => PhysicalExpr::BinOp(BinOp::Eq, expr, value),
+                            BinOp::Ne => PhysicalExpr::BinOp(BinOp::Ne, expr, value),
+                            BinOp::Lt => PhysicalExpr::BinOp(BinOp::Gt, expr, value),
+                            BinOp::Gt => PhysicalExpr::BinOp(BinOp::Lt, expr, value),
+                            BinOp::Lte => PhysicalExpr::BinOp(BinOp::Gte, expr, value),
+                            BinOp::Gte => PhysicalExpr::BinOp(BinOp::Lte, expr, value),
+                        }
                     }
                     _ => expr,
                 };

--- a/crates/sdk/tests/test.rs
+++ b/crates/sdk/tests/test.rs
@@ -217,6 +217,16 @@ macro_rules! declare_tests_with_suffix {
             }
 
             #[test]
+            fn test_lhs_join_update() {
+                make_test("test-lhs-join-update").run()
+            }
+
+            #[test]
+            fn test_lhs_join_update_disjoint_queries() {
+                make_test("test-lhs-join-update-disjoint-queries").run()
+            }
+
+            #[test]
             fn test_intra_query_bag_semantics_for_join() {
                 make_test("test-intra-query-bag-semantics-for-join").run()
             }


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Was doing an investigation into subscription updates and discovered a bug that reordered `<` and `>` comparison expressions incorrectly.

I added subscription update tests for exercising the fix.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Server side subscription test
- [x] SDK subscription test
