### PR TITLE
Impose limits on the heap usage of `ChunkPool`

### DIFF
--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -51,8 +51,8 @@ const MAX_CHUNKS_IN_POOL: usize = 32;
 /// This, together with [`MAX_CHUNKS_IN_POOL`],
 /// prevents the heap usage of a [`ChunkPool`] from growing without bound.
 ///
-/// This number chosen completely arbitrarily by pgoldman 2025-04-10.
-const MAX_CHUNK_SIZE_IN_BYTES: usize = 1024;
+/// We switch to a new chunk when we pass ROW_ITER_CHUNK_SIZE, so this adds a buffer of 4x.
+const MAX_CHUNK_SIZE_IN_BYTES: usize = spacetimedb_primitives::ROW_ITER_CHUNK_SIZE * 4;
 
 /// A pool of available unused chunks.
 ///

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -97,7 +97,10 @@ impl ChunkPool {
     }
 }
 
-#[derive(Default)]
+/// Construct a new `ChunkedWriter` using [`Self::new`].
+/// Do not impl `Default` for this struct or construct it manually;
+/// it is important that all allocated chunks are taken from the [`ChunkPool`],
+/// rather than directly from the global allocator.
 struct ChunkedWriter {
     /// Chunks collected thus far.
     chunks: Vec<Vec<u8>>,

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -81,6 +81,11 @@ impl ChunkPool {
     ///
     /// These limits place an upper bound on the memory usage of a single [`ChunkPool`].
     pub fn put(&mut self, mut chunk: Vec<u8>) {
+        log::trace!(
+            "put: chunk of capacity {} into pool of {} chunks",
+            chunk.capacity(),
+            self.free_chunks.len()
+        );
         if chunk.capacity() > MAX_CHUNK_SIZE_IN_BYTES {
             return;
         }

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -115,6 +115,14 @@ impl ChunkedWriter {
         }
     }
 
+    /// Creates a new `ChunkedWriter` with an empty chunk allocated from the pool.
+    fn new(pool: &mut ChunkPool) -> Self {
+        Self {
+            chunks: Vec::new(),
+            curr: pool.take(),
+        }
+    }
+
     /// Finalises the writer and returns all the chunks.
     fn into_chunks(mut self) -> Vec<Vec<u8>> {
         if !self.curr.is_empty() {
@@ -129,7 +137,7 @@ impl ChunkedWriter {
         rows_scanned: &mut usize,
         bytes_scanned: &mut usize,
     ) -> Vec<Vec<u8>> {
-        let mut chunked_writer = Self::default();
+        let mut chunked_writer = Self::new(pool);
         // Consume the iterator, serializing each `item`,
         // while allowing a chunk to be created at boundaries.
         for item in iter {


### PR DESCRIPTION
# Description of Changes

Heap profiling performed by @jsdt revealed that we had a memory leak in `InstanceEnv::datastore_index_scan_range_bsatn_chunks`. A bit of spelunking pointed to `ChunkPool`, a pool of buffers, which prior to this commit was allowed to grow without limit. `ChunkPool` is per-database, and so it is easy to imagine a scenario in which a large number of databases each occasionally allocate, use and never free very large chunks, resulting in the overall system's memory usage increasing over time.

This commit adds some very simple limits on the heap usage of a `ChunkPool`. Specifically, we introduce two constants,
`MAX_CHUNKS_IN_POOL` and `MAX_CHUNK_SIZE_IN_BYTES`, and when returning a chunk to the pool, we free it if it violates these limits. The values of these constants, 32 and `4xROW_ITER_CHUNK_SIZE` respectively, were chosen entirely arbitrarily. Using a global pool would be helpful here.

This also makes a change to use the `ChunkPool` when creating a new `ChunkedWriter`. Before this, we were allocating a fresh chunk every time, which would eventually go into the chunkpool. That is probably why the chunk pool was growing so quickly.

In the future we should at least add some metrics around the size of this pool.

# API and ABI breaking changes

None.

# Expected complexity level and risk

2 ish? Seems possible that my chosen values for the two constants are somehow pathologically bad, and this PR regresses performance.

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Run a BitCraft bot test and observe that performance is not significantly reduced.
- [x] Run heap profiling and observe that we no longer leak memory.
