### PR TITLE
CI - Fix the external contributor check

### DIFF
--- a/.github/workflows/contributor_check.yml
+++ b/.github/workflows/contributor_check.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Verify author is contributor
         env:
-          GITHUB_TOKEN: ${{ secrets.ORG_READ_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           CONTRIB_ORG: clockworklabs
           PR_AUTHOR: ${{ github.event.pull_request.user.login || (github.event_name == 'merge_group' && github.event.sender.login) || null }}
         run: |


### PR DESCRIPTION
# Description of Changes

This was using a GH token that was not passed to external CI, so the contributor check would always fail. This was originally broken in https://github.com/clockworklabs/SpacetimeDB/pull/194.

I just switched it to using the `GITHUB_TOKEN` secret, which _is_ passed to CI on external PRs (see https://docs.github.com/en/actions/security-for-github-actions/security-guides/using-secrets-in-github-actions#using-secrets-in-a-workflow).

**We will also have to update the `GITHUB_TOKEN` token to have permissions to list org members**.

# API and ABI breaking changes

None. CI-only change.

# Expected complexity level and risk

1

# Testing

None, because I don't want to create a whole new GitHub account and repo just to open a test PR.

I say we merge this and test with one of the many open PRs, e.g. https://github.com/clockworklabs/SpacetimeDB/pull/2416 (where the author _has_ signed the CLA).