### PR TITLE
Bump a missed version

### DIFF
--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="1.0.0" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="1.1.0" />
   </ItemGroup>
 
 </Project>


### PR DESCRIPTION
# Description of Changes

I missed bumping the SpacetimeDB lib version in the C# template project used by the CLI.

I've added this step to our release checklist as well.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1

# Testing

None