### PR TITLE
Typescript Generation: Wrap union types in parens if for arrays

### DIFF
--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -999,10 +999,15 @@ pub fn write_type<W: Write>(
             if matches!(&**elem_ty, AlgebraicTypeUse::Primitive(PrimitiveType::U8)) {
                 return write!(out, "Uint8Array");
             }
+            let needs_parens = matches!(&**elem_ty, AlgebraicTypeUse::Option(_));
             // We wrap the inner type in parentheses to avoid ambiguity with the [] binding.
-            write!(out,"(")?;
+            if needs_parens {
+                write!(out, "(")?;
+            }
             write_type(module, out, elem_ty, ref_prefix)?;
-            write!(out,")")?;
+            if needs_parens {
+                write!(out, ")")?;
+            }
             write!(out, "[]")?;
         }
         AlgebraicTypeUse::Ref(r) => {

--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -999,7 +999,10 @@ pub fn write_type<W: Write>(
             if matches!(&**elem_ty, AlgebraicTypeUse::Primitive(PrimitiveType::U8)) {
                 return write!(out, "Uint8Array");
             }
+            // We wrap the inner type in parentheses to avoid ambiguity with the [] binding.
+            write!(out,"(")?;
             write_type(module, out, elem_ty, ref_prefix)?;
+            write!(out,")")?;
             write!(out, "[]")?;
         }
         AlgebraicTypeUse::Ref(r) => {


### PR DESCRIPTION
# Description of Changes

When generating typescript types, if we have an array of unions, we wrap the inner type in parens, to fix https://github.com/clockworklabs/SpacetimeDB/issues/2541.

# API and ABI breaking changes

This should only change the generated code in places that would have been a bug.

# Expected complexity level and risk

1.

# Testing

I didn't see a good place to add full tests for the typescript generation. We will want to do that at some point.

For this change I created a module with some more complex array types and inspected the generated code.
