### PR TITLE
Count bytes_written for updates

### DIFF
--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -795,9 +795,9 @@ mod test {
             Ok(())
         };
         let tx = db.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests);
-        let (tx, delete_result) = tx_slot.set(tx, f);
+        let (tx, res) = tx_slot.set(tx, f);
 
-        delete_result?;
+        res?;
 
         assert_eq!(new_row_len, tx.metrics.bytes_written);
         Ok(())

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -295,6 +295,7 @@ impl InstanceEnv {
         if update_flags.is_scheduler_table {
             self.schedule_row(stdb, tx, table_id, row_ptr)?;
         }
+        tx.metrics.bytes_written += row_len;
 
         Ok(row_len)
     }


### PR DESCRIPTION
# Description of Changes

Previously we weren't counting bytes_written inside of `update` (only `insert`). This updates the appropriate execution metrics inside of `InstanceEnv::update`.

# Expected complexity level and risk

1.

# Testing

I added one unit basic test.
