### PR TITLE
CI - Fix job that packages the CLI for release

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - release/*
+      - bfops/fix-packaging
 
 jobs:
   build-cli:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - master
       - release/*
-      - bfops/fix-packaging
 
 jobs:
   build-cli:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: x86_64 Linux, target: x86_64-unknown-linux-gnu, runner: bare-metal, container: debian:bookworm }
+          - { name: x86_64 Linux, target: x86_64-unknown-linux-gnu, runner: bare-metal, container: 'debian:bookworm' }
           - { name: aarch64 Linux, target: aarch64-unknown-linux-gnu, runner: arm-runner }
           - { name: x86_64 Linux musl, target: x86_64-unknown-linux-musl, runner: bare-metal, container: alpine }
           # FIXME: arm musl build. "JavaScript Actions in Alpine containers are only supported on x64 Linux runners"


### PR DESCRIPTION
# Description of Changes

This was broken in https://github.com/clockworklabs/SpacetimeDB/pull/2466. Apparently it was not tested after changing to use `debian:bookworm`, which needs to be wrapped in a string.

# API and ABI breaking changes

CI-only change.

# Expected complexity level and risk

1

# Testing

- [x] CI job did not immediately fail when I added this branch to the workflow file: https://github.com/clockworklabs/SpacetimeDB/actions/runs/14479917277/job/40614448449?pr=2617