### PR TITLE
Fix building and publishing the auth crate

### DIFF
--- a/crates/auth/Cargo.toml
+++ b/crates/auth/Cargo.toml
@@ -3,9 +3,11 @@ name = "spacetimedb-auth"
 version.workspace = true
 edition.workspace = true
 rust-version.workspace = true
+license-file = "LICENSE"
+description = "Auth helpers for SpacetimeDB"
 
 [dependencies]
-spacetimedb-lib.workspace = true
+spacetimedb-lib = { workspace = true, features = ["serde"] }
 
 anyhow.workspace = true
 serde.workspace = true


### PR DESCRIPTION
# Description of Changes

This PR fixes publishing the `auth` crate by:
- Adding a `LICENSE`
- Adding a `description`
- Adding the `serde` feature to `spacetimedb-lib`, so that the crate builds successfully in isolation

# API and ABI breaking changes

No

# Expected complexity level and risk

1

# Testing
- [x] This published successfully as part of the 1.1.0 release