### PR TITLE
Housekeeping: Split macro code in input and output region

### DIFF
--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -157,8 +157,9 @@ pub fn table(args: StdTokenStream, item: StdTokenStream) -> StdTokenStream {
             derive_input.attrs.push(derive_table_helper);
         }
 
-        let args = table::TableArgs::parse(args.into(), &derive_input.ident)?;
-        let generated = table::table_impl(args, &derive_input)?;
+        let table = table::TableArgs::parse(args.into(), &derive_input)?;
+        let columns = table::ColumnArgs::parse(&table.indices, &derive_input)?;
+        let generated = table::table_impl(table, columns, &derive_input)?;
         Ok(TokenStream::from_iter([quote!(#derive_input), generated]))
     })
 }

--- a/crates/bindings-macro/src/table.rs
+++ b/crates/bindings-macro/src/table.rs
@@ -14,6 +14,8 @@ use syn::punctuated::Punctuated;
 use syn::spanned::Spanned;
 use syn::{parse_quote, Ident, Path, Token};
 
+//region Input
+
 pub(crate) struct TableArgs {
     access: Option<TableAccess>,
     scheduled: Option<ScheduledArg>,
@@ -234,7 +236,12 @@ impl IndexArg {
         let name = field.clone();
         Ok(IndexArg::new(name, kind))
     }
+}
 
+//endregion Input
+//region Output
+
+impl IndexArg {
     fn validate<'a>(&'a self, table_name: &str, cols: &'a [Column<'a>]) -> syn::Result<ValidatedIndex<'a>> {
         let find_column = |ident| find_column(cols, ident);
         let kind = match &self.kind {
@@ -806,3 +813,5 @@ pub(crate) fn table_impl(mut args: TableArgs, item: &syn::DeriveInput) -> syn::R
 
     Ok(emission)
 }
+
+//endregion Output

--- a/crates/bindings-macro/src/table.rs
+++ b/crates/bindings-macro/src/table.rs
@@ -28,18 +28,6 @@ enum TableAccess {
     Private(Span),
 }
 
-impl TableAccess {
-    fn to_value(&self) -> TokenStream {
-        let (TableAccess::Public(span) | TableAccess::Private(span)) = *self;
-        let name = match self {
-            TableAccess::Public(_) => "Public",
-            TableAccess::Private(_) => "Private",
-        };
-        let ident = Ident::new(name, span);
-        quote_spanned!(span => spacetimedb::table::TableAccess::#ident)
-    }
-}
-
 struct ScheduledArg {
     span: Span,
     reducer: Path,
@@ -240,6 +228,18 @@ impl IndexArg {
 
 //endregion Input
 //region Output
+
+impl TableAccess {
+    fn to_value(&self) -> TokenStream {
+        let (TableAccess::Public(span) | TableAccess::Private(span)) = *self;
+        let name = match self {
+            TableAccess::Public(_) => "Public",
+            TableAccess::Private(_) => "Private",
+        };
+        let ident = Ident::new(name, span);
+        quote_spanned!(span => spacetimedb::table::TableAccess::#ident)
+    }
+}
 
 impl IndexArg {
     fn validate<'a>(&'a self, table_name: &str, cols: &'a [Column<'a>]) -> syn::Result<ValidatedIndex<'a>> {

--- a/crates/bindings-macro/src/table.rs
+++ b/crates/bindings-macro/src/table.rs
@@ -226,6 +226,14 @@ impl IndexArg {
     }
 }
 
+#[derive(Copy, Clone)]
+struct Column<'a> {
+    index: u16,
+    vis: &'a syn::Visibility,
+    ident: &'a syn::Ident,
+    ty: &'a syn::Type,
+}
+
 //endregion Input
 //region Output
 
@@ -456,14 +464,6 @@ fn superize_vis(vis: &syn::Visibility) -> Cow<'_, syn::Visibility> {
         }
         syn::Visibility::Inherited => Cow::Owned(parse_quote!(pub(super))),
     }
-}
-
-#[derive(Copy, Clone)]
-struct Column<'a> {
-    index: u16,
-    vis: &'a syn::Visibility,
-    ident: &'a syn::Ident,
-    ty: &'a syn::Type,
 }
 
 fn try_find_column<'a, 'b, T: ?Sized>(cols: &'a [Column<'b>], name: &T) -> Option<&'a Column<'b>>


### PR DESCRIPTION
# Description of Changes

I've splitted the rust macro code into an input and output region so that it can be unterstood better. No changes to code logic was made. The best way to review this is per commit because I made them as atomic as possible.

# API and ABI breaking changes

None

# Expected complexity level and risk

1