### PR TITLE
`spacetimedb-update self-install` fails if the install fails.

### DIFF
--- a/crates/update/src/cli/self_install.rs
+++ b/crates/update/src/cli/self_install.rs
@@ -67,7 +67,7 @@ impl SelfInstall {
             .context("could not install binary")?;
 
         eprintln!("Downloading latest version...");
-        let res = super::upgrade::Upgrade {}
+        super::upgrade::Upgrade {}
             .exec(&paths)
             .context("failed to download and install latest SpacetimeDB version")?;
 

--- a/crates/update/src/cli/self_install.rs
+++ b/crates/update/src/cli/self_install.rs
@@ -69,10 +69,7 @@ impl SelfInstall {
         eprintln!("Downloading latest version...");
         let res = super::upgrade::Upgrade {}
             .exec(&paths)
-            .context("failed to download and install latest SpacetimeDB version");
-        if let Err(err) = &res {
-            eprintln!("Error: {err:#}\n")
-        }
+            .context("failed to download and install latest SpacetimeDB version")?;
 
         eprintln!(
             "The `spacetime` command has been installed as {}",


### PR DESCRIPTION
# Description of Changes

Prior to this PR, when the call to `upgrade` (which installs the latest version) failed, `self-install` would print the error and then go on to print a success message.

This PR updates the logic so that we fail if the version installation fails.

Previous behavior:
```
The SpacetimeDB command line tool will now be installed into /var/folders/qn/7t0vq3ts721cmgt0tgrtgzl80000gn/T/tmp.OEcKoBCvjL
Downloading latest version...
Error: failed to download and install latest SpacetimeDB version: Could not fetch release info: HTTP status client error (403 Forbidden) for url (https://api.github.com/repos/clockworklabs/SpacetimeDB/releases/latest)

The `spacetime` command has been installed as /var/folders/qn/7t0vq3ts721cmgt0tgrtgzl80000gn/T/tmp.OEcKoBCvjL/spacetime

The install process is complete; check out our quickstart guide to get started!
	<https://spacetimedb.com/docs/getting-started>
```

New behavior:
```
The SpacetimeDB command line tool will now be installed into /var/folders/qn/7t0vq3ts721cmgt0tgrtgzl80000gn/T/tmp.b0ab4mKN8T
Downloading latest version...
Error: failed to download and install latest SpacetimeDB version

Caused by:
    0: Could not fetch release info
    1: HTTP status client error (403 Forbidden) for url (https://api.github.com/repos/clockworklabs/SpacetimeDB/releases/latest)
```

# API and ABI breaking changes

No API/ABI breaking changes.

# Expected complexity level and risk

1

# Testing

- [x] The installer now exits after saying "failed to download and install latest SpacetimeDB version", rather than continuing to a success message.