### PR TITLE
Do not publish RLS rules on private tables

### DIFF
--- a/crates/core/src/sql/parser.rs
+++ b/crates/core/src/sql/parser.rs
@@ -1,8 +1,9 @@
+use crate::db::datastore::locking_tx_datastore::state_view::StateView;
 use crate::db::datastore::locking_tx_datastore::MutTxId;
 use crate::sql::ast::SchemaViewer;
 use spacetimedb_expr::check::parse_and_type_sub;
-use spacetimedb_expr::errors::TypingError;
 use spacetimedb_expr::expr::ProjectName;
+use spacetimedb_lib::db::auth::StAccess;
 use spacetimedb_lib::db::raw_def::v9::RawRowLevelSecurityDefV9;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_schema::schema::RowLevelSecuritySchema;
@@ -17,15 +18,26 @@ impl RowLevelExpr {
         tx: &mut MutTxId,
         auth_ctx: &AuthCtx,
         rls: &RawRowLevelSecurityDefV9,
-    ) -> Result<Self, TypingError> {
+    ) -> anyhow::Result<Self> {
         let (sql, _) = parse_and_type_sub(&rls.sql, &SchemaViewer::new(tx, auth_ctx), auth_ctx)?;
+        let table_id = sql.return_table_id().unwrap();
+        let schema = tx.schema_for_table(table_id)?;
 
-        Ok(Self {
-            def: RowLevelSecuritySchema {
-                table_id: sql.return_table_id().unwrap(),
-                sql: rls.sql.clone(),
-            },
-            sql,
-        })
+        match schema.table_access {
+            StAccess::Private => {
+                anyhow::bail!(
+                    "Cannot define RLS rule on private table: {}. \
+                        Please make table public if you wish to restrict access using RLS.",
+                    schema.table_name
+                )
+            }
+            StAccess::Public => Ok(Self {
+                def: RowLevelSecuritySchema {
+                    table_id,
+                    sql: rls.sql.clone(),
+                },
+                sql,
+            }),
+        }
     }
 }

--- a/smoketests/tests/auto_migration.py
+++ b/smoketests/tests/auto_migration.py
@@ -7,7 +7,7 @@ class AddTableAutoMigration(Smoketest):
     MODULE_CODE = """
 use spacetimedb::{log, ReducerContext, Table, SpacetimeType};
 
-#[spacetimedb::table(name = person)]
+#[spacetimedb::table(name = person, public)]
 pub struct Person {
     name: String,
 }
@@ -44,7 +44,7 @@ const PERSON_VISIBLE: spacetimedb::Filter = spacetimedb::Filter::Sql("SELECT * F
     MODULE_CODE_UPDATED = (
         MODULE_CODE
         + """
-#[spacetimedb::table(name = book)]
+#[spacetimedb::table(name = book, public)]
 pub struct Book {
     isbn: String,
 }

--- a/smoketests/tests/fail_initial_publish.py
+++ b/smoketests/tests/fail_initial_publish.py
@@ -7,7 +7,7 @@ class FailInitialPublish(Smoketest):
     MODULE_CODE_BROKEN = """
 use spacetimedb::{client_visibility_filter, Filter};
 
-#[spacetimedb::table(name = person)]
+#[spacetimedb::table(name = person, public)]
 pub struct Person {
     name: String,
 }
@@ -20,7 +20,7 @@ const HIDE_PEOPLE_EXCEPT_ME: Filter = Filter::Sql("SELECT * FROM Person WHERE na
     MODULE_CODE_FIXED = """
 use spacetimedb::{client_visibility_filter, Filter};
 
-#[spacetimedb::table(name = person)]
+#[spacetimedb::table(name = person, public)]
 pub struct Person {
     name: String,
 }

--- a/smoketests/tests/rls.py
+++ b/smoketests/tests/rls.py
@@ -1,6 +1,6 @@
-from .. import Smoketest
+from .. import Smoketest, random_string
 
-class SqlFormat(Smoketest):
+class Rls(Smoketest):
     MODULE_CODE = """
 use spacetimedb::{Identity, ReducerContext, Table};
 
@@ -53,3 +53,28 @@ pub fn add_user(ctx: &ReducerContext, name: String) {
  name
 ------
 """)
+
+class BrokenRls(Smoketest):
+    AUTOPUBLISH = False
+
+    MODULE_CODE_BROKEN = """
+use spacetimedb::{client_visibility_filter, Filter};
+
+#[spacetimedb::table(name = user)]
+pub struct User {
+    identity: Identity,
+}
+
+#[client_visibility_filter]
+const PERSON_FILTER: Filter = Filter::Sql("SELECT * FROM \"user\" WHERE identity = :sender");
+"""
+
+    def test_publish_fails_for_rls_on_private_table(self):
+        """This tests that publishing an RLS rule on a private table fails"""
+
+        name = random_string()
+
+        self.write_module_code(self.MODULE_CODE_BROKEN)
+
+        with self.assertRaises(Exception):
+            self.publish_module(name)


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

This patch disallows RLS on private tables. Attempting to publish such a module will now fail.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None.

This was always just a no-op since RLS doesn't doesn't apply to module owners, and non-owners cannot query private tables.

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] smoketest
