### PR TITLE
Fixed compile errors and warnings on Windows

### DIFF
--- a/crates/bench/benches/generic.rs
+++ b/crates/bench/benches/generic.rs
@@ -15,7 +15,7 @@ use spacetimedb_testing::modules::{Csharp, Rust};
 
 #[cfg(target_env = "msvc")]
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;

--- a/crates/bench/benches/special.rs
+++ b/crates/bench/benches/special.rs
@@ -15,7 +15,7 @@ use std::sync::OnceLock;
 
 #[cfg(target_env = "msvc")]
 #[global_allocator]
-static GLOBAL: MiMalloc = MiMalloc;
+static GLOBAL: mimalloc::MiMalloc = mimalloc::MiMalloc;
 
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemallocator::Jemalloc;

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1939,6 +1939,7 @@ mod tests {
     use spacetimedb_sats::buffer::BufReader;
     use spacetimedb_sats::product;
     use spacetimedb_schema::schema::RowLevelSecuritySchema;
+    #[cfg(unix)]
     use spacetimedb_snapshot::Snapshot;
     use spacetimedb_table::read_column::ReadColumn;
     use spacetimedb_table::table::RowRef;
@@ -2909,6 +2910,7 @@ mod tests {
         let (dir, repo) = make_snapshot(root.clone(), Identity::ZERO, 0, CompressType::None, true);
         stdb.take_snapshot(&repo)?;
 
+        #[cfg(unix)]
         let total_objects = repo.size_on_disk()?.object_count;
         // Another snapshots that will hardlink part of the first one
         for i in 0..2 {

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -265,14 +265,15 @@ pub static WORKER_METRICS: Lazy<WorkerMetrics> = Lazy::new(WorkerMetrics::new);
 #[cfg(not(target_env = "msvc"))]
 use tikv_jemalloc_ctl::{epoch, stats};
 
+#[cfg(not(target_env = "msvc"))]
 static SPAWN_JEMALLOC_GUARD: Once = Once::new();
-pub fn spawn_jemalloc_stats(node_id: String) {
+pub fn spawn_jemalloc_stats(_node_id: String) {
     #[cfg(not(target_env = "msvc"))]
     SPAWN_JEMALLOC_GUARD.call_once(|| {
         spawn(async move {
-            let allocated_bytes = WORKER_METRICS.jemalloc_allocated_bytes.with_label_values(&node_id);
-            let resident_bytes = WORKER_METRICS.jemalloc_resident_bytes.with_label_values(&node_id);
-            let active_bytes = WORKER_METRICS.jemalloc_active_bytes.with_label_values(&node_id);
+            let allocated_bytes = WORKER_METRICS.jemalloc_allocated_bytes.with_label_values(&_node_id);
+            let resident_bytes = WORKER_METRICS.jemalloc_resident_bytes.with_label_values(&_node_id);
+            let active_bytes = WORKER_METRICS.jemalloc_active_bytes.with_label_values(&_node_id);
 
             let e = epoch::mib().unwrap();
             loop {

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -268,13 +268,14 @@ impl SpacetimePaths {
 
 #[cfg(test)]
 mod tests {
-    use std::ffi::{OsStr, OsString};
     use std::path::Path;
 
     use super::*;
 
+    #[cfg(not(windows))]
     mod vars {
         use super::*;
+        use std::ffi::{OsStr, OsString};
         struct ResetVar<'a>(&'a str, Option<OsString>);
         impl Drop for ResetVar<'_> {
             fn drop(&mut self) {

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -273,7 +273,6 @@ mod tests {
 
     #[cfg(not(windows))]
     mod vars {
-        use super::*;
         use std::ffi::{OsStr, OsString};
         struct ResetVar<'a>(&'a str, Option<OsString>);
         impl Drop for ResetVar<'_> {

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -270,8 +270,6 @@ impl SpacetimePaths {
 mod tests {
     use std::path::Path;
 
-    use super::*;
-
     #[cfg(not(windows))]
     mod vars {
         use super::*;
@@ -317,6 +315,9 @@ mod tests {
         assert_eq!(paths.cli_bin_dir.0, p("/__data_home/spacetime/bin"));
         assert_eq!(paths.data_dir.0, p("/__data_home/spacetime/data"));
     }
+
+    #[cfg(windows)]
+    use super::*;
 
     #[cfg(windows)]
     #[test]

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -269,6 +269,7 @@ impl SpacetimePaths {
 #[cfg(test)]
 mod tests {
     use std::path::Path;
+    use crate::{PathBufExt, RootDir, SpacetimePaths};
 
     #[cfg(not(windows))]
     mod vars {
@@ -317,11 +318,10 @@ mod tests {
     }
 
     #[cfg(windows)]
-    use super::*;
-
-    #[cfg(windows)]
     #[test]
     fn windows() {
+        use crate::SpacetimePaths;
+
         let paths = SpacetimePaths::platform_defaults().unwrap();
         let appdata_local = dirs::data_local_dir().unwrap();
         assert_eq!(paths.cli_config_dir.0, appdata_local.join("config"));

--- a/crates/paths/src/lib.rs
+++ b/crates/paths/src/lib.rs
@@ -268,8 +268,8 @@ impl SpacetimePaths {
 
 #[cfg(test)]
 mod tests {
-    use std::path::Path;
     use crate::{PathBufExt, RootDir, SpacetimePaths};
+    use std::path::Path;
 
     #[cfg(not(windows))]
     mod vars {

--- a/crates/update/src/proxy.rs
+++ b/crates/update/src/proxy.rs
@@ -9,7 +9,7 @@ use std::process::ExitCode;
 
 pub(crate) fn run_cli(
     paths: Option<&SpacetimePaths>,
-    argv0: Option<&OsStr>,
+    _argv0: Option<&OsStr>,
     args: Vec<OsString>,
 ) -> anyhow::Result<ExitCode> {
     let parse_args = || PartialCliArgs::parse(&args);
@@ -44,8 +44,8 @@ pub(crate) fn run_cli(
     #[cfg(unix)]
     {
         use std::os::unix::process::CommandExt;
-        if let Some(argv0) = argv0 {
-            cmd.arg0(argv0);
+        if let Some(_argv0) = _argv0 {
+            cmd.arg0(_argv0);
         }
     };
     let exec_result = exec_replace(&mut cmd).with_context(|| format!("exec failed for {}", cli_path.display()));


### PR DESCRIPTION
# Description of Changes

SpacetimeDB doesn't actually compile on Windows because of bit rot of our various `cfg` flags. This fixes that issue.

It further fixes warnings caused by unused variables that are `cfg`'d out.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

No testing beyond automated testing. No functionality should be changed.
