### PR TITLE
Fix filter pushdowns in the presence of rls

### DIFF
--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -553,6 +553,112 @@ pub(crate) mod tests {
         assert_query_results(
             &db,
             // Should only return the orders for sender "a"
+            "select * from users where identity = :sender",
+            &auth_for_a,
+            [product![id_for_a]],
+        );
+        assert_query_results(
+            &db,
+            // Should only return the orders for sender "b"
+            "select * from users where identity = :sender",
+            &auth_for_b,
+            [product![id_for_b]],
+        );
+        assert_query_results(
+            &db,
+            // Should only return the orders for sender "a"
+            &format!("select * from users where identity = 0x{}", id_for_a.to_hex()),
+            &auth_for_a,
+            [product![id_for_a]],
+        );
+        assert_query_results(
+            &db,
+            // Should only return the orders for sender "b"
+            &format!("select * from users where identity = 0x{}", id_for_b.to_hex()),
+            &auth_for_b,
+            [product![id_for_b]],
+        );
+        assert_query_results(
+            &db,
+            // Should only return the orders for sender "a"
+            &format!(
+                "select * from users where identity = :sender and identity = 0x{}",
+                id_for_a.to_hex()
+            ),
+            &auth_for_a,
+            [product![id_for_a]],
+        );
+        assert_query_results(
+            &db,
+            // Should only return the orders for sender "b"
+            &format!(
+                "select * from users where identity = :sender and identity = 0x{}",
+                id_for_b.to_hex()
+            ),
+            &auth_for_b,
+            [product![id_for_b]],
+        );
+        assert_query_results(
+            &db,
+            // Should only return the orders for sender "a"
+            &format!(
+                "select * from users where identity = :sender or identity = 0x{}",
+                id_for_b.to_hex()
+            ),
+            &auth_for_a,
+            [product![id_for_a]],
+        );
+        assert_query_results(
+            &db,
+            // Should only return the orders for sender "b"
+            &format!(
+                "select * from users where identity = :sender or identity = 0x{}",
+                id_for_a.to_hex()
+            ),
+            &auth_for_b,
+            [product![id_for_b]],
+        );
+        assert_query_results(
+            &db,
+            // Should not return any rows.
+            // Querying as sender "a", but filtering on sender "b".
+            &format!("select * from users where identity = 0x{}", id_for_b.to_hex()),
+            &auth_for_a,
+            [],
+        );
+        assert_query_results(
+            &db,
+            // Should not return any rows.
+            // Querying as sender "b", but filtering on sender "a".
+            &format!("select * from users where identity = 0x{}", id_for_a.to_hex()),
+            &auth_for_b,
+            [],
+        );
+        assert_query_results(
+            &db,
+            // Should not return any rows.
+            // Querying as sender "a", but filtering on sender "b".
+            &format!(
+                "select * from users where identity = :sender and identity = 0x{}",
+                id_for_b.to_hex()
+            ),
+            &auth_for_a,
+            [],
+        );
+        assert_query_results(
+            &db,
+            // Should not return any rows.
+            // Querying as sender "b", but filtering on sender "a".
+            &format!(
+                "select * from users where identity = :sender and identity = 0x{}",
+                id_for_a.to_hex()
+            ),
+            &auth_for_b,
+            [],
+        );
+        assert_query_results(
+            &db,
+            // Should only return the orders for sender "a"
             "select * from sales",
             &auth_for_a,
             [product![1u64, id_for_a], product![3u64, id_for_a]],
@@ -561,6 +667,34 @@ pub(crate) mod tests {
             &db,
             // Should only return the orders for sender "b"
             "select * from sales",
+            &auth_for_b,
+            [product![2u64, id_for_b], product![4u64, id_for_b]],
+        );
+        assert_query_results(
+            &db,
+            // Should only return the orders for sender "a"
+            "select s.* from users u join sales s on u.identity = s.customer",
+            &auth_for_a,
+            [product![1u64, id_for_a], product![3u64, id_for_a]],
+        );
+        assert_query_results(
+            &db,
+            // Should only return the orders for sender "b"
+            "select s.* from users u join sales s on u.identity = s.customer",
+            &auth_for_b,
+            [product![2u64, id_for_b], product![4u64, id_for_b]],
+        );
+        assert_query_results(
+            &db,
+            // Should only return the orders for sender "a"
+            "select s.* from users u join sales s on u.identity = s.customer where u.identity = :sender",
+            &auth_for_a,
+            [product![1u64, id_for_a], product![3u64, id_for_a]],
+        );
+        assert_query_results(
+            &db,
+            // Should only return the orders for sender "b"
+            "select s.* from users u join sales s on u.identity = s.customer where u.identity = :sender",
             &auth_for_b,
             [product![2u64, id_for_b], product![4u64, id_for_b]],
         );


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

After the introduction of RLS, the filter pushdown rule was no longer guaranteed to reach a fixed point due to the presence of nested filter operations. This patch updates the rule to check if a plan has already been optimized before applying the rule.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Execution tests for nested filters with RLS
