### PR TITLE
Remove redundant rows from subscription updates

### DIFF
--- a/crates/core/src/db/db_metrics/mod.rs
+++ b/crates/core/src/db/db_metrics/mod.rs
@@ -126,6 +126,16 @@ metrics_group!(
         #[labels(db: Identity)]
         pub delta_queries_matched: IntCounterVec,
 
+        #[name = spacetime_num_duplicate_rows_evaluated]
+        #[help = "The number of times we evaluate the same row in a subscription update"]
+        #[labels(db: Identity)]
+        pub duplicate_rows_evaluated: IntCounterVec,
+
+        #[name = spacetime_num_duplicate_rows_sent]
+        #[help = "The number of duplicate rows we send in a subscription update"]
+        #[labels(db: Identity)]
+        pub duplicate_rows_sent: IntCounterVec,
+
         #[name = spacetime_subscription_connections]
         #[help = "Number of connections with active subscriptions"]
         #[labels(database_identity: Identity)]

--- a/crates/core/src/subscription/delta.rs
+++ b/crates/core/src/subscription/delta.rs
@@ -30,12 +30,9 @@ pub fn eval_delta<'a, Tx: Datastore + DeltaStore>(
     let mut duplicate_rows_evaluated = 0;
     let mut duplicate_rows_sent = 0;
 
-    // Query plans for joins may return redundant rows,
-    // but we track row counts to avoid sending them to clients.
-    //
-    // Single table plans will never return redundant rows,
-    // so there's no need to track row counts.
     if !plan.is_join() {
+        // Single table plans will never return redundant rows,
+        // so there's no need to track row counts.
         plan.for_each_insert(tx, metrics, &mut |row| {
             inserts.push(row.into());
             Ok(())
@@ -46,6 +43,8 @@ pub fn eval_delta<'a, Tx: Datastore + DeltaStore>(
             Ok(())
         })?;
     } else {
+        // Query plans for joins may return redundant rows.
+        // We track row counts to avoid sending them to clients.
         let mut insert_counts = HashMap::new();
         let mut delete_counts = HashMap::new();
 

--- a/crates/core/src/subscription/delta.rs
+++ b/crates/core/src/subscription/delta.rs
@@ -24,34 +24,82 @@ pub fn eval_delta<'a, Tx: Datastore + DeltaStore>(
 ) -> Result<Option<UpdatesRelValue<'a>>> {
     metrics.delta_queries_evaluated += 1;
 
-    let mut insert_counts = HashMap::new();
-    let mut delete_counts = HashMap::new();
-
-    plan.for_each_insert(tx, metrics, &mut |row| {
-        *insert_counts.entry(row).or_default() += 1;
-        Ok(())
-    })?;
-
-    plan.for_each_delete(tx, metrics, &mut |row| {
-        match insert_counts.get_mut(&row) {
-            None | Some(0) => {
-                *delete_counts.entry(row).or_default() += 1;
-            }
-            Some(n) => {
-                *n -= 1;
-            }
-        }
-        Ok(())
-    })?;
-
     let mut inserts = vec![];
     let mut deletes = vec![];
 
-    for (row, n) in insert_counts.into_iter().filter(|(_, n)| *n > 0) {
-        inserts.extend(std::iter::repeat_n(row, n).map(RelValue::from));
-    }
-    for (row, n) in delete_counts.into_iter().filter(|(_, n)| *n > 0) {
-        deletes.extend(std::iter::repeat_n(row, n).map(RelValue::from));
+    let mut duplicate_rows_evaluated = 0;
+    let mut duplicate_rows_sent = 0;
+
+    // Query plans for joins may return redundant rows,
+    // but we track row counts to avoid sending them to clients.
+    //
+    // Single table plans will never return redundant rows,
+    // so there's no need to track row counts.
+    if !plan.is_join() {
+        plan.for_each_insert(tx, metrics, &mut |row| {
+            inserts.push(row.into());
+            Ok(())
+        })?;
+
+        plan.for_each_delete(tx, metrics, &mut |row| {
+            deletes.push(row.into());
+            Ok(())
+        })?;
+    } else {
+        let mut insert_counts = HashMap::new();
+        let mut delete_counts = HashMap::new();
+
+        plan.for_each_insert(tx, metrics, &mut |row| {
+            let n = insert_counts.entry(row).or_default();
+            if *n > 0 {
+                duplicate_rows_evaluated += 1;
+            }
+            *n += 1;
+            Ok(())
+        })?;
+
+        plan.for_each_delete(tx, metrics, &mut |row| {
+            match insert_counts.get_mut(&row) {
+                // We have not seen an insert for this row.
+                // If we have seen a delete, increment the metric.
+                // Always increment the delete_count.
+                None => {
+                    let n = delete_counts.entry(row).or_default();
+                    if *n > 0 {
+                        duplicate_rows_evaluated += 1;
+                    }
+                    *n += 1;
+                }
+                // We have already seen an insert for this row.
+                // This is a duplicate, so increment the metric.
+                //
+                // There are no more inserts for this row,
+                // so increment the delete_count as well.
+                Some(0) => {
+                    duplicate_rows_evaluated += 1;
+                    *delete_counts.entry(row).or_default() += 1;
+                }
+                // We have already seen an insert for this row.
+                // This is a duplicate, so increment the metric.
+                //
+                // There are still more inserts for this row,
+                // so don't increment the delete_count.
+                Some(n) => {
+                    duplicate_rows_evaluated += 1;
+                    *n -= 1;
+                }
+            }
+            Ok(())
+        })?;
+
+        for (row, n) in insert_counts.into_iter().filter(|(_, n)| *n > 0) {
+            duplicate_rows_sent += n as u64 - 1;
+            inserts.extend(std::iter::repeat_n(row, n).map(RelValue::from));
+        }
+        for (row, n) in delete_counts.into_iter().filter(|(_, n)| *n > 0) {
+            duplicate_rows_sent += n as u64 - 1;
+            deletes.extend(std::iter::repeat_n(row, n).map(RelValue::from));
+        }
     }
 
     // Return `None` for empty updates
@@ -60,5 +108,8 @@ pub fn eval_delta<'a, Tx: Datastore + DeltaStore>(
     }
 
     metrics.delta_queries_matched += 1;
+    metrics.duplicate_rows_evaluated += duplicate_rows_evaluated;
+    metrics.duplicate_rows_sent += duplicate_rows_sent;
+
     Ok(Some(UpdatesRelValue { inserts, deletes }))
 }

--- a/crates/core/src/subscription/mod.rs
+++ b/crates/core/src/subscription/mod.rs
@@ -66,6 +66,18 @@ pub(crate) fn record_exec_metrics(workload: &WorkloadType, db: &Identity, metric
             .with_label_values(db)
             .inc_by(metrics.delta_queries_evaluated);
     }
+    if metrics.duplicate_rows_evaluated > 0 {
+        DB_METRICS
+            .duplicate_rows_evaluated
+            .with_label_values(db)
+            .inc_by(metrics.duplicate_rows_evaluated);
+    }
+    if metrics.duplicate_rows_sent > 0 {
+        DB_METRICS
+            .duplicate_rows_sent
+            .with_label_values(db)
+            .inc_by(metrics.duplicate_rows_sent);
+    }
 }
 
 /// Execute a subscription query

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -1788,7 +1788,7 @@ mod tests {
 
         // We should only have evaluated a single query
         assert_eq!(metrics.delta_queries_evaluated, 1);
-        assert_eq!(metrics.delta_queries_matched, 1);
+        assert_eq!(metrics.delta_queries_matched, 0);
 
         // Insert a new row into `v`
         let metrics = commit_tx(&db, &subs, [], [(v_id, product![2u64, 6u64, 6u64])])?;

--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -1,4 +1,7 @@
-use std::ops::RangeBounds;
+use std::{
+    hash::{Hash, Hasher},
+    ops::RangeBounds,
+};
 
 use anyhow::{anyhow, Result};
 use iter::PlanIter;
@@ -95,10 +98,19 @@ pub trait DeltaStore {
     }
 }
 
-#[derive(Clone)]
+#[derive(Clone, PartialEq, Eq)]
 pub enum Row<'a> {
     Ptr(RowRef<'a>),
     Ref(&'a ProductValue),
+}
+
+impl Hash for Row<'_> {
+    fn hash<H: Hasher>(&self, state: &mut H) {
+        match self {
+            Self::Ptr(x) => x.hash(state),
+            Self::Ref(x) => x.hash(state),
+        }
+    }
 }
 
 impl Row<'_> {

--- a/crates/lib/src/metrics.rs
+++ b/crates/lib/src/metrics.rs
@@ -50,6 +50,10 @@ pub struct ExecutionMetrics {
     pub delta_queries_evaluated: u64,
     /// How many subscriptions had some updates?
     pub delta_queries_matched: u64,
+    /// How many times do we evaluate the same row in a subscription update?
+    pub duplicate_rows_evaluated: u64,
+    /// How many duplicate rows do we send in a subscription update?
+    pub duplicate_rows_sent: u64,
 }
 
 impl ExecutionMetrics {
@@ -66,6 +70,8 @@ impl ExecutionMetrics {
             rows_updated,
             delta_queries_evaluated,
             delta_queries_matched,
+            duplicate_rows_evaluated,
+            duplicate_rows_sent,
         }: ExecutionMetrics,
     ) {
         self.index_seeks += index_seeks;
@@ -78,6 +84,8 @@ impl ExecutionMetrics {
         self.rows_updated += rows_updated;
         self.delta_queries_evaluated += delta_queries_evaluated;
         self.delta_queries_matched += delta_queries_matched;
+        self.duplicate_rows_evaluated += duplicate_rows_evaluated;
+        self.duplicate_rows_sent += duplicate_rows_sent;
     }
 }
 
@@ -100,6 +108,8 @@ mod tests {
             rows_updated: 1,
             delta_queries_evaluated: 2,
             delta_queries_matched: 3,
+            duplicate_rows_evaluated: 4,
+            duplicate_rows_sent: 2,
         });
 
         assert_eq!(a.index_seeks, 1);
@@ -111,5 +121,7 @@ mod tests {
         assert_eq!(a.rows_deleted, 1);
         assert_eq!(a.delta_queries_evaluated, 2);
         assert_eq!(a.delta_queries_matched, 3);
+        assert_eq!(a.duplicate_rows_evaluated, 4);
+        assert_eq!(a.duplicate_rows_sent, 2);
     }
 }

--- a/crates/subscription/src/lib.rs
+++ b/crates/subscription/src/lib.rs
@@ -230,6 +230,11 @@ pub struct SubscriptionPlan {
 }
 
 impl SubscriptionPlan {
+    /// Is this a plan for a join?
+    pub fn is_join(&self) -> bool {
+        self.fragments.insert_plans.len() > 1 && self.fragments.delete_plans.len() > 1
+    }
+
     /// To which table does this plan subscribe?
     pub fn subscribed_table_id(&self) -> TableId {
         self.return_id


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Avoids sending trivially empty subscription updates to clients. That is, if a row is inserted `n` times and deleted `n` times, we remove it from the result set to avoid network and client side deserialization costs.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Current regression tests pass
- [x] Bot test
