### PR TITLE
Add the primary key type to typescript's `TableRuntimeTypeInfo`

### DIFF
--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -325,11 +325,20 @@ removeOnUpdate = (cb: (ctx: EventContext, onRow: {row_type}, newRow: {row_type})
             writeln!(out, "tableName: \"{}\",", table.name);
             writeln!(out, "rowType: {row_type}.getTypeScriptAlgebraicType(),");
             if let Some(pk) = schema.pk() {
-                writeln!(out, "primaryKey: {{");
+                // This is left here so we can release the codegen change before releasing a new
+                // version of the SDK.
+                //
+                // Eventually we can remove this and only generate use the `primaryKeyInfo` field.
+                writeln!(out, "primaryKey: \"{}\",", pk.col_name.to_string().to_case(Case::Camel));
+
+                writeln!(out, "primaryKeyInfo: {{");
                 out.indent(1);
                 writeln!(out, "colName: \"{}\",", pk.col_name.to_string().to_case(Case::Camel));
-                // The position is added a way to look up the type.
-                writeln!(out, "colPosition: {},", pk.col_pos.0);
+                writeln!(
+                    out,
+                    "colType: {row_type}.getTypeScriptAlgebraicType().product.elements[{}],",
+                    pk.col_pos.0
+                );
                 out.dedent(1);
                 writeln!(out, "}},");
             }

--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -325,7 +325,13 @@ removeOnUpdate = (cb: (ctx: EventContext, onRow: {row_type}, newRow: {row_type})
             writeln!(out, "tableName: \"{}\",", table.name);
             writeln!(out, "rowType: {row_type}.getTypeScriptAlgebraicType(),");
             if let Some(pk) = schema.pk() {
-                writeln!(out, "primaryKey: \"{}\",", pk.col_name.to_string().to_case(Case::Camel));
+                writeln!(out, "primaryKey: {{");
+                out.indent(1);
+                writeln!(out, "colName: \"{}\",", pk.col_name.to_string().to_case(Case::Camel));
+                // The position is added a way to look up the type.
+                writeln!(out, "colPosition: {},", pk.col_pos.0);
+                out.dedent(1);
+                writeln!(out, "}},");
             }
             out.dedent(1);
             writeln!(out, "}},");

--- a/crates/cli/src/subcommands/generate/typescript.rs
+++ b/crates/cli/src/subcommands/generate/typescript.rs
@@ -336,7 +336,7 @@ removeOnUpdate = (cb: (ctx: EventContext, onRow: {row_type}, newRow: {row_type})
                 writeln!(out, "colName: \"{}\",", pk.col_name.to_string().to_case(Case::Camel));
                 writeln!(
                     out,
-                    "colType: {row_type}.getTypeScriptAlgebraicType().product.elements[{}],",
+                    "colType: {row_type}.getTypeScriptAlgebraicType().product.elements[{}].algebraicType,",
                     pk.col_pos.0
                 );
                 out.dedent(1);

--- a/crates/cli/tests/snapshots/codegen__codegen_typescript.snap
+++ b/crates/cli/tests/snapshots/codegen__codegen_typescript.snap
@@ -857,21 +857,37 @@ const REMOTE_MODULE = {
       tableName: "logged_out_player",
       rowType: Player.getTypeScriptAlgebraicType(),
       primaryKey: "identity",
+      primaryKeyInfo: {
+        colName: "identity",
+        colType: Player.getTypeScriptAlgebraicType().product.elements[0].algebraicType,
+      },
     },
     person: {
       tableName: "person",
       rowType: Person.getTypeScriptAlgebraicType(),
       primaryKey: "id",
+      primaryKeyInfo: {
+        colName: "id",
+        colType: Person.getTypeScriptAlgebraicType().product.elements[0].algebraicType,
+      },
     },
     pk_multi_identity: {
       tableName: "pk_multi_identity",
       rowType: PkMultiIdentity.getTypeScriptAlgebraicType(),
       primaryKey: "id",
+      primaryKeyInfo: {
+        colName: "id",
+        colType: PkMultiIdentity.getTypeScriptAlgebraicType().product.elements[0].algebraicType,
+      },
     },
     player: {
       tableName: "player",
       rowType: Player.getTypeScriptAlgebraicType(),
       primaryKey: "identity",
+      primaryKeyInfo: {
+        colName: "identity",
+        colType: Player.getTypeScriptAlgebraicType().product.elements[0].algebraicType,
+      },
     },
     points: {
       tableName: "points",
@@ -885,6 +901,10 @@ const REMOTE_MODULE = {
       tableName: "repeating_test_arg",
       rowType: RepeatingTestArg.getTypeScriptAlgebraicType(),
       primaryKey: "scheduledId",
+      primaryKeyInfo: {
+        colName: "scheduledId",
+        colType: RepeatingTestArg.getTypeScriptAlgebraicType().product.elements[0].algebraicType,
+      },
     },
     test_a: {
       tableName: "test_a",
@@ -898,6 +918,10 @@ const REMOTE_MODULE = {
       tableName: "test_e",
       rowType: TestE.getTypeScriptAlgebraicType(),
       primaryKey: "id",
+      primaryKeyInfo: {
+        colName: "id",
+        colType: TestE.getTypeScriptAlgebraicType().product.elements[0].algebraicType,
+      },
     },
     test_f: {
       tableName: "test_f",


### PR DESCRIPTION
# Description of Changes

The [TableRuntimeTypeInfo](https://github.com/clockworklabs/spacetimedb-typescript-sdk/blob/46e3fbd5515fe1d709670270cccc50659f8dee1c/packages/sdk/src/spacetime_module.ts#L7) that we have in the typescript SDK currently has the name of the primary key (if it exists), and the type of the rows. That is technically enough to figure out the `AlgebraicType` of the primary key with something like `rowType.product.elements.find( (element: ProductTypeElement) => {element.name === primaryKey})?.algebraicType`, but it's more convenient to have it generated for us.

This adds a field that looks like:
```
      primaryKeyInfo: {
        colName: "id",
        colType: Person.getTypeScriptAlgebraicType().product.elements[0].algebraicType,
      },
```

We are still generating `primaryKey` field, so we don't need to release a new TS SDK version and CLI version at the same time, but eventually we can get rid of it.

<!-- Please describe your change, mention any related tickets, and so on here. -->

# API and ABI breaking changes

This is just adding a field in generated typescript code, which shouldn't break anything.

# Expected complexity level and risk

1.

# Testing

I've tested the current TS sdk with the newly generated code to ensure it doesn't break, and I'm working on a TS PR that will use the new field. I have enough of the new code working that I have tested the newly generated fields.
