### PR TITLE
Fix `spacetime version list` not showing current version

### DIFF
--- a/crates/update/src/cli/list.rs
+++ b/crates/update/src/cli/list.rs
@@ -1,4 +1,5 @@
 use spacetimedb_paths::SpacetimePaths;
+use std::path::Path;
 
 /// List installed SpacetimeDB versions.
 #[derive(clap::Args)]
@@ -10,7 +11,16 @@ pub(super) struct List {
 
 impl List {
     pub(super) fn exec(self, paths: &SpacetimePaths) -> anyhow::Result<()> {
-        let current = paths.cli_bin_dir.current_version()?;
+        let current = match paths.cli_bin_dir.current_version()? {
+            None => None,
+            Some(path_str) => {
+                let file_name = Path::new(&path_str)
+                    .file_name()
+                    .and_then(|f| f.to_str())
+                    .ok_or(anyhow::anyhow!("Could not extract current version"))?;
+                Some(file_name.to_string())
+            }
+        };
         let versions = if self.all {
             let client = super::reqwest_client()?;
             super::tokio_block_on(super::install::available_releases(&client))??


### PR DESCRIPTION
# Description of Changes

See https://github.com/clockworklabs/SpacetimeDB/issues/2679.

At some point, this code was changed so that `current` contains an entire path, rather than just the version string itself, so the comparison between `ver` and `current` was always failing.

# API and ABI breaking changes

Not a breaking change.

# Expected complexity level and risk

1
# Testing

- [x] It works now!
```
$ cargo run -pspacetimedb-update -- version list
   Compiling spacetimedb-update v1.1.1 (/home/lead/work/clockwork-localhd/SpacetimeDBPrivate/public/crates/update)
    Finished `dev` profile [unoptimized + debuginfo] target(s) in 3.63s
     Running `target/debug/spacetimedb-update version list`
1.1.1
1.1.0 (current)
```

I could be convinced to add a smoketest for this.