### PR TITLE
CI - Publishable crates check also checks for license file

### DIFF
--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -3,6 +3,7 @@ name = "spacetimedb-schema"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
+description = "Schema library for SpacetimeDB"
 rust-version.workspace = true
 
 [features]
@@ -32,7 +33,7 @@ enum-map.workspace = true
 [dev-dependencies]
 spacetimedb-lib = { path = "../lib", features = ["test"] }
 # these are circular dependencies, but only in tests, so it's fine
-spacetimedb-testing.workspace = true
+spacetimedb-testing = { path = "../testing" }
 spacetimedb-codegen = { path = "../codegen" }
 
 proptest.workspace = true

--- a/crates/schema/Cargo.toml
+++ b/crates/schema/Cargo.toml
@@ -3,7 +3,6 @@ name = "spacetimedb-schema"
 version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
-description = "Schema library for SpacetimeDB"
 rust-version.workspace = true
 
 [features]
@@ -33,7 +32,7 @@ enum-map.workspace = true
 [dev-dependencies]
 spacetimedb-lib = { path = "../lib", features = ["test"] }
 # these are circular dependencies, but only in tests, so it's fine
-spacetimedb-testing = { path = "../testing" }
+spacetimedb-testing.workspace = true
 spacetimedb-codegen = { path = "../codegen" }
 
 proptest.workspace = true

--- a/tools/crate-publish-checks.py
+++ b/tools/crate-publish-checks.py
@@ -3,7 +3,7 @@ import argparse
 import sys
 from pathlib import Path
 
-def check_deps(dev_deps):
+def check_deps(dev_deps, cargo_toml_path):
     non_path_spacetimedb = []
     for name, details in dev_deps.items():
         if not name.startswith("spacetimedb"):
@@ -16,7 +16,7 @@ def check_deps(dev_deps):
             # String dependency = version from crates.io
             non_path_spacetimedb.append(name)
     if non_path_spacetimedb:
-        print(f"❌ These dev-dependencies must be converted to use `path` in order to not impede crate publishing:")
+        print(f"❌ These dev-dependencies in {cargo_toml_path} must be converted to use `path` in order to not impede crate publishing:")
         for dep in non_path_spacetimedb:
             print(f"  - {dep}")
         return False
@@ -27,18 +27,18 @@ def check_package_metadata(package, cargo_toml_path):
 
     # Accept either license OR license-file
     if "license" not in package and "license-file" not in package:
-        print(f"❌ Missing required field: license/license-file")
+        print(f"❌ Missing required field in {cargo_toml_path}: license/license-file")
         has_errors = True
 
     if "license-file" in package:
         license_file = package["license-file"]
         license_path = cargo_toml_path.parent / license_file
         if not license_path.exists():
-            print(f"❌ License file '{license_file}' specified in Cargo.toml does not exist")
+            print(f"❌ License file '{license_file}' specified in {cargo_toml_path} does not exist")
             has_errors = True
 
     if "description" not in package:
-        print(f"❌ Missing required field: description")
+        print(f"❌ Missing required field in {cargo_toml_path}: description")
         has_errors = True
 
     return not has_errors

--- a/tools/crate-publish-checks.py
+++ b/tools/crate-publish-checks.py
@@ -30,16 +30,16 @@ def check_package_metadata(package, cargo_toml_path):
         print(f"❌ Missing required field in {cargo_toml_path}: license/license-file")
         has_errors = True
 
+    if "description" not in package:
+        print(f"❌ Missing required field in {cargo_toml_path}: description")
+        has_errors = True
+
     if "license-file" in package:
         license_file = package["license-file"]
         license_path = cargo_toml_path.parent / license_file
         if not license_path.exists():
             print(f"❌ License file '{license_file}' specified in {cargo_toml_path} does not exist")
             has_errors = True
-
-    if "description" not in package:
-        print(f"❌ Missing required field in {cargo_toml_path}: description")
-        has_errors = True
 
     return not has_errors
 
@@ -58,7 +58,9 @@ if __name__ == "__main__":
 
         dev_deps = data.get('dev-dependencies', {})
         package = data.get('package', {})
-        if check_deps(dev_deps, cargo_toml_path) and check_package_metadata(package, cargo_toml_path):
+        deps_pass = check_deps(dev_deps, cargo_toml_path)
+        package_passes = check_package_metadata(package, cargo_toml_path)
+        if deps_pass and package_passes:
             print(f"✅ {cargo_toml_path} passed all checks.")
         else:
             sys.exit(1)

--- a/tools/crate-publish-checks.py
+++ b/tools/crate-publish-checks.py
@@ -3,7 +3,7 @@ import argparse
 import sys
 from pathlib import Path
 
-def check_deps(dev_deps, cargo_toml_path):
+def find_non_path_spacetimedb_deps(dev_deps, cargo_toml_path):
     non_path_spacetimedb = []
     for name, details in dev_deps.items():
         if not name.startswith("spacetimedb"):
@@ -18,7 +18,7 @@ def check_deps(dev_deps, cargo_toml_path):
     success = not non_path_spacetimedb
     return success, non_path_spacetimedb
 
-def check_package_metadata(package, cargo_toml_path):
+def check_cargo_metadata(package, cargo_toml_path):
     missing_fields = []
 
     # Accept either license OR license-file
@@ -43,11 +43,11 @@ def run_checks(data, cargo_toml_path):
         "success": True,
     }
 
-    success, bad_deps = check_deps(data.get("dev-dependencies", {}), cargo_toml_path)
+    success, bad_deps = find_non_path_spacetimedb_deps(data.get("dev-dependencies", {}), cargo_toml_path)
     result["success"] = result["success"] and success
     result["bad_deps"] = bad_deps
 
-    success, missing_fields, missing_license_file = check_package_metadata(data.get("package", {}), cargo_toml_path)
+    success, missing_fields, missing_license_file = check_cargo_metadata(data.get("package", {}), cargo_toml_path)
     result["missing_fields"] = missing_fields
     result["missing_license_file"] = missing_license_file
     result["success"] = result["success"] and success

--- a/tools/crate-publish-checks.py
+++ b/tools/crate-publish-checks.py
@@ -3,7 +3,7 @@ import argparse
 import sys
 from pathlib import Path
 
-def find_non_path_spacetimedb_deps(dev_deps):
+def check_deps(dev_deps):
     non_path_spacetimedb = []
     for name, details in dev_deps.items():
         if not name.startswith("spacetimedb"):
@@ -15,20 +15,33 @@ def find_non_path_spacetimedb_deps(dev_deps):
         else:
             # String dependency = version from crates.io
             non_path_spacetimedb.append(name)
-    return non_path_spacetimedb
+    if non_path_spacetimedb:
+        print(f"❌ These dev-dependencies must be converted to use `path` in order to not impede crate publishing:")
+        for dep in non_path_spacetimedb:
+            print(f"  - {dep}")
+        return False
+    return True
 
-def check_cargo_metadata(data):
-    package = data.get("package", {})
-    missing_fields = []
+def check_package_metadata(package, cargo_toml_path):
+    has_errors = False
 
     # Accept either license OR license-file
     if "license" not in package and "license-file" not in package:
-        missing_fields.append("license/license-file")
+        print(f"❌ Missing required field: license/license-file")
+        has_errors = True
+
+    if "license-file" in package:
+        license_file = package["license-file"]
+        license_path = cargo_toml_path.parent / license_file
+        if not license_path.exists():
+            print(f"❌ License file '{license_file}' specified in Cargo.toml does not exist")
+            has_errors = True
 
     if "description" not in package:
-        missing_fields.append("description")
+        print(f"❌ Missing required field: description")
+        has_errors = True
 
-    return missing_fields
+    return not has_errors
 
 if __name__ == "__main__":
     parser = argparse.ArgumentParser(description="Check Cargo.toml for metadata and dev-dependencies.")
@@ -43,29 +56,12 @@ if __name__ == "__main__":
 
         data = toml.load(cargo_toml_path)
 
-        # Check dev-dependencies
-        dev_deps = data.get("dev-dependencies", {})
-        bad_deps = find_non_path_spacetimedb_deps(dev_deps)
-
-        # Check license/license-file and description
-        missing_fields = check_cargo_metadata(data)
-
-        exit_code = 0
-
-        if bad_deps:
-            print(f"❌ These dev-dependencies in {cargo_toml_path} must be converted to use `path` in order to not impede crate publishing:")
-            for dep in bad_deps:
-                print(f"  - {dep}")
-            exit_code = 1
-
-        if missing_fields:
-            print(f"❌ Missing required fields in [package] of {cargo_toml_path}: {', '.join(missing_fields)}")
-            exit_code = 1
-
-        if exit_code == 0:
+        dev_deps = data.get('dev-dependencies', {})
+        package = data.get('package', {})
+        if check_deps(dev_deps) and check_package_metadata(package, cargo_toml_path):
             print(f"✅ {cargo_toml_path} passed all checks.")
-
-        sys.exit(exit_code)
+        else:
+            sys.exit(1)
 
     except Exception as e:
         print(f"⚠️ Error: {e}")

--- a/tools/crate-publish-checks.py
+++ b/tools/crate-publish-checks.py
@@ -58,7 +58,7 @@ if __name__ == "__main__":
 
         dev_deps = data.get('dev-dependencies', {})
         package = data.get('package', {})
-        if check_deps(dev_deps) and check_package_metadata(package, cargo_toml_path):
+        if check_deps(dev_deps, cargo_toml_path) and check_package_metadata(package, cargo_toml_path):
             print(f"✅ {cargo_toml_path} passed all checks.")
         else:
             sys.exit(1)


### PR DESCRIPTION
# Description of Changes

https://github.com/clockworklabs/SpacetimeDB/pull/2593 merged without adding a LICENSE file, so I'm adding that to the CI check.

# API and ABI breaking changes

None. CI only.

# Expected complexity level and risk

2.

# Testing

- [x] CI complains about the missing LICENSE file (https://github.com/clockworklabs/SpacetimeDB/actions/runs/14739699799/job/41374381968?pr=2681)
- [x] CI complains about dev dependencies not being path (https://github.com/clockworklabs/SpacetimeDB/actions/runs/14739699799/job/41374381968?pr=2681)
- [x] CI complains about missing description field (https://github.com/clockworklabs/SpacetimeDB/actions/runs/14739699799/job/41374381968?pr=2681)
- [x] CI passes once the missing LICENSE file is added