### PR TITLE
Reduce allocations in C# when deserializing lists and arrays

### DIFF
--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
@@ -403,8 +403,18 @@ public readonly struct Array<Element, ElementRW> : IReadWrite<Element[]>
     where ElementRW : IReadWrite<Element>, new()
 {
     private static readonly Enumerable<Element, ElementRW> enumerable = new();
+    private static readonly ElementRW elementRW = new();
 
-    public Element[] Read(BinaryReader reader) => enumerable.Read(reader).ToArray();
+    public Element[] Read(BinaryReader reader)
+    {
+        var count = reader.ReadInt32();
+        var result = new Element[count];
+        for (var i = 0; i < count; i++)
+        {
+            result[i] = elementRW.Read(reader);
+        }
+        return result;
+    }
 
     public void Write(BinaryWriter writer, Element[] value) => enumerable.Write(writer, value);
 
@@ -446,8 +456,18 @@ public readonly struct List<Element, ElementRW> : IReadWrite<List<Element>>
     where ElementRW : IReadWrite<Element>, new()
 {
     private static readonly Enumerable<Element, ElementRW> enumerable = new();
+    private static readonly ElementRW elementRW = new();
 
-    public List<Element> Read(BinaryReader reader) => enumerable.Read(reader).ToList();
+    public List<Element> Read(BinaryReader reader)
+    {
+        var count = reader.ReadInt32();
+        var result = new List<Element>(count);
+        for (var i = 0; i < count; i++)
+        {
+            result.Add(elementRW.Read(reader));
+        }
+        return result;
+    }
 
     public void Write(BinaryWriter writer, List<Element> value) => enumerable.Write(writer, value);
 

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
@@ -407,6 +407,7 @@ public readonly struct Array<Element, ElementRW> : IReadWrite<Element[]>
 
     public Element[] Read(BinaryReader reader)
     {
+        // Don't use IEnumerable here: save an allocation and pre-allocate the output.
         var count = reader.ReadInt32();
         var result = new Element[count];
         for (var i = 0; i < count; i++)
@@ -460,6 +461,7 @@ public readonly struct List<Element, ElementRW> : IReadWrite<List<Element>>
 
     public List<Element> Read(BinaryReader reader)
     {
+        // Don't use IEnumerable here: save an allocation and pre-allocate the output.
         var count = reader.ReadInt32();
         var result = new List<Element>(count);
         for (var i = 0; i < count; i++)

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
@@ -407,7 +407,7 @@ public readonly struct Array<Element, ElementRW> : IReadWrite<Element[]>
 
     public Element[] Read(BinaryReader reader)
     {
-        // Don't use IEnumerable here: save an allocation and pre-allocate the output.
+        // Don't use Enumerable here: save an allocation and pre-allocate the output.
         var count = reader.ReadInt32();
         var result = new Element[count];
         for (var i = 0; i < count; i++)
@@ -461,7 +461,7 @@ public readonly struct List<Element, ElementRW> : IReadWrite<List<Element>>
 
     public List<Element> Read(BinaryReader reader)
     {
-        // Don't use IEnumerable here: save an allocation and pre-allocate the output.
+        // Don't use Enumerable here: save an allocation and pre-allocate the output.
         var count = reader.ReadInt32();
         var result = new List<Element>(count);
         for (var i = 0; i < count; i++)


### PR DESCRIPTION
# Description of Changes

Since we know the size of lists and arrays, we can allocate them up-front. This also skips allocating an `IEnumerable`.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

0

# Testing

Automated tests should break immediately if this is wrong