### PR TITLE
Disable reducer arg broadcast

### DIFF
--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -46,6 +46,7 @@ impl StandaloneEnv {
         config: Config,
         certs: &CertificateAuthority,
         data_dir: Arc<ServerDataDir>,
+        disable_reducer_args: bool,
     ) -> anyhow::Result<Arc<Self>> {
         let _pid_file = data_dir.pid_file()?;
         let meta_path = data_dir.metadata_toml();
@@ -68,6 +69,7 @@ impl StandaloneEnv {
             program_store.clone(),
             energy_monitor,
             durability_provider,
+            disable_reducer_args,
         );
         let client_actor_index = ClientActorIndex::new();
         let jwt_keys = certs.get_or_create_keys()?;
@@ -513,9 +515,9 @@ mod tests {
             page_pool_max_size: None,
         };
 
-        let _env = StandaloneEnv::init(config, &ca, data_dir.clone()).await?;
+        let _env = StandaloneEnv::init(config, &ca, data_dir.clone(), false).await?;
         // Ensure that we have a lock.
-        assert!(StandaloneEnv::init(config, &ca, data_dir.clone()).await.is_err());
+        assert!(StandaloneEnv::init(config, &ca, data_dir.clone(), false).await.is_err());
 
         Ok(())
     }


### PR DESCRIPTION
# Description of Changes

By default, reducer callbacks are broadcasted to all clients of the module. This PR adds a command line flag to `spacetime start` that when given, disables reducer arguments from being sent along with the reducer callback. It does so by swapping out the Args struct to the null version of it.

Potentially solves #1837 or at least it could temporarily.

# API and ABI breaking changes

None; adds an optional command line flag to `spacetime start` to enable new behavior. `--no-reducer-args`

# Expected complexity level and risk

Level is about 2. The change is pretty trivial, however the depth of that change to make it command line configurable adds a bit of complexity. There may be some unknowns that I am not aware of by not broadcasting the full args of reducers to other clients. This is mostly why I didn't make a more substantive change.

# Testing

Successfully ran the repo test suite.

Additional tests against existing projects and a project to specifically to demonstrate the corrected behavior via extracting passwords from third party reducer args was done by @lethalchip. See below images:

## Setup
![image](https://github.com/user-attachments/assets/e2b5228c-d547-4701-a224-66db8b225375)
![image](https://github.com/user-attachments/assets/6a6ab727-12ce-406e-90ce-041cacba2ab6)

## Use Case

![image](https://github.com/user-attachments/assets/413e6de1-2ae3-4ed3-b1e2-f0529a7bd823)

## Results

![image](https://github.com/user-attachments/assets/0b708116-e887-4997-a1f4-d34e9eff37d1)
![image](https://github.com/user-attachments/assets/feb902c6-43ab-4624-9f76-6c431ec8851d)

