### PR TITLE
Make `Timestamp` and `TimeDuration` implement `FilterableValue`

### DIFF
--- a/crates/lib/src/filterable_value.rs
+++ b/crates/lib/src/filterable_value.rs
@@ -1,6 +1,8 @@
 use crate::{ConnectionId, Identity};
 use core::ops;
 use spacetimedb_sats::bsatn;
+use spacetimedb_sats::time_duration::TimeDuration;
+use spacetimedb_sats::timestamp::Timestamp;
 use spacetimedb_sats::{hash::Hash, i256, u256, Serialize};
 
 /// Types which can appear as an argument to an index filtering operation
@@ -96,6 +98,9 @@ impl_filterable_value! {
     Identity: Copy,
     ConnectionId: Copy,
     Hash: Copy,
+
+    Timestamp: Copy,
+    TimeDuration: Copy,
 
     // Some day we will likely also want to support `Vec<u8>` and `[u8]`,
     // as they have trivial portable equality and ordering,

--- a/modules/module-test/src/lib.rs
+++ b/modules/module-test/src/lib.rs
@@ -89,6 +89,22 @@ pub enum TestF {
     Baz(String),
 }
 
+#[spacetimedb::table(
+    name = test_g,
+    index(name = created_at_index, btree(columns = [name, created_at])),
+)]
+#[derive(Debug)]
+pub struct TestG {
+    #[primary_key]
+    #[auto_inc]
+    id: u64,
+
+    name: String,
+
+    #[index(btree)]
+    created_at: Timestamp,
+}
+
 // // All tables are private by default.
 const _: () = assert!(matches!(get_table_access(test_e::test_e), TableAccess::Private));
 
@@ -362,6 +378,9 @@ fn test_btree_index_args(ctx: &ReducerContext) {
 
     ctx.db.test_e().name().delete(&string);
     ctx.db.test_e().name().delete("str");
+
+    // Testing if it compiles with a range of timestamps.
+    let _ = ctx.db.test_g().created_at().filter(..ctx.timestamp);
 
     // ctx.db.test_e().name().delete(string); // SHOULD FAIL
 

--- a/modules/sdk-test-cs/Lib.cs
+++ b/modules/sdk-test-cs/Lib.cs
@@ -320,6 +320,7 @@ public static partial class Module
     [SpacetimeDB.Table(Name = "one_timestamp", Public = true)]
     public partial struct OneTimestamp
     {
+        [SpacetimeDB.Index.BTree]
         public Timestamp t;
     }
 
@@ -327,6 +328,8 @@ public static partial class Module
     public static void insert_one_timestamp(ReducerContext ctx, Timestamp t)
     {
         ctx.Db.one_timestamp.Insert(new OneTimestamp { t = t });
+
+        var _count = ctx.Db.one_timestamp.t.Filter((t, ctx.Timestamp)).Count();
     }
 
     [SpacetimeDB.Table(Name = "one_simple_enum", Public = true)]


### PR DESCRIPTION
# Description of Changes

Making `Timestamp` and `TimeDuration` implement `FilterableValue`.

This resolves https://github.com/clockworklabs/SpacetimeDB/issues/2650

# API and ABI breaking changes
API change is additive in this case, I'm not marking this as unstable because the `FilterableValue` implementation is already stabilized.

# Expected complexity level and risk
Complexity 1.

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
