### PR TITLE
Fix subscription manager metadata for joins

### DIFF
--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -1802,6 +1802,34 @@ mod tests {
         assert_eq!(metrics.delta_queries_evaluated, 1);
         assert_eq!(metrics.delta_queries_matched, 1);
 
+        // Modify a matching row in `u`
+        let metrics = commit_tx(
+            &db,
+            &subs,
+            [(u_id, product![1u64, 2u64, 2u64])],
+            [(u_id, product![1u64, 2u64, 3u64])],
+        )?;
+
+        assert_tx_update_for_table(
+            &mut rx_for_b,
+            u_id,
+            &ProductType::from([AlgebraicType::U64, AlgebraicType::U64, AlgebraicType::U64]),
+            [product![1u64, 2u64, 3u64]],
+            [product![1u64, 2u64, 2u64]],
+        )
+        .await;
+
+        // We should have evaluated all of the queries
+        assert_eq!(metrics.delta_queries_evaluated, 4);
+        assert_eq!(metrics.delta_queries_matched, 1);
+
+        // Insert a non-matching row in `u`
+        let metrics = commit_tx(&db, &subs, [], [(u_id, product![3u64, 0u64, 0u64])])?;
+
+        // We should have evaluated all of the queries
+        assert_eq!(metrics.delta_queries_evaluated, 4);
+        assert_eq!(metrics.delta_queries_matched, 0);
+
         Ok(())
     }
 

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -1519,7 +1519,7 @@ mod tests {
     }
 
     #[test]
-    fn test_lookup_queries_for_search_arg() -> ResultTest<()> {
+    fn test_search_args_for_selects() -> ResultTest<()> {
         let db = TestDB::durable()?;
 
         let table_id = create_table(&db, "t")?;
@@ -1577,6 +1577,75 @@ mod tests {
 
         assert!(hashes.len() == 1);
         assert!(hashes.contains(&&hash_for_5));
+
+        Ok(())
+    }
+
+    #[test]
+    fn test_search_args_for_join() -> ResultTest<()> {
+        let db = TestDB::durable()?;
+
+        let schema = [("id", AlgebraicType::U8), ("a", AlgebraicType::U8)];
+
+        let t_id = db.create_table_for_test("t", &schema, &[0.into()])?;
+        let s_id = db.create_table_for_test("s", &schema, &[0.into()])?;
+
+        let client = Arc::new(client(0));
+        let mut subscriptions = SubscriptionManager::default();
+
+        let plan = compile_plan(&db, "select t.* from t join s on t.id = s.id where s.a = 1")?;
+        let hash = plan.hash;
+
+        subscriptions.add_subscription_multi(client.clone(), vec![plan], QueryId::new(0))?;
+
+        // Do we need to evaluate the above join query for this table update?
+        // Yes, because the above query does not filter on `t`.
+        // Therefore we must evaluate it for any update on `t`.
+        let table_update = DatabaseTableUpdate {
+            table_id: t_id,
+            table_name: "t".into(),
+            inserts: [product![0u8, 0u8]].into(),
+            deletes: [].into(),
+        };
+
+        let hashes = subscriptions
+            .queries_for_table_update(&table_update)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert_eq!(hashes, vec![hash]);
+
+        // Do we need to evaluate the above join query for this table update?
+        // Yes, because `s.a = 1`.
+        let table_update = DatabaseTableUpdate {
+            table_id: s_id,
+            table_name: "s".into(),
+            inserts: [product![0u8, 1u8]].into(),
+            deletes: [].into(),
+        };
+
+        let hashes = subscriptions
+            .queries_for_table_update(&table_update)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert_eq!(hashes, vec![hash]);
+
+        // Do we need to evaluate the above join query for this table update?
+        // No, because `s.a != 1`.
+        let table_update = DatabaseTableUpdate {
+            table_id: s_id,
+            table_name: "s".into(),
+            inserts: [product![0u8, 2u8]].into(),
+            deletes: [].into(),
+        };
+
+        let hashes = subscriptions
+            .queries_for_table_update(&table_update)
+            .cloned()
+            .collect::<Vec<_>>();
+
+        assert!(hashes.is_empty());
 
         Ok(())
     }

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -621,7 +621,7 @@ impl SubscriptionManager {
     }
 
     // Update the mapping from table id to related queries by inserting the given query.
-    // If this query has search arguments, that mapping is updated instead.
+    // Also add any search arguments the query may have.
     // This takes a ref to the table map instead of `self` to avoid borrowing issues.
     fn insert_query(
         tables: &mut IntMap<TableId, HashSet<QueryHash>>,
@@ -636,6 +636,8 @@ impl SubscriptionManager {
                 table_ids.remove(&table_id);
                 search_args.insert_query(table_id, col_id, arg, hash);
             }
+            // Update the `tables` map if this query reads from a table,
+            // but does not have a search argument for that table.
             for table_id in table_ids {
                 tables.entry(table_id).or_default().insert(hash);
             }


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Fixes a bug where the subscription manager would not update its metadata for tables that did not have a filter in a join query.
This resulted in row updates not being sent to clients for those tables.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Regression tests
- [x] Bot test
