### PR TITLE
ci: Update dependencies for the `wasm_bindings` job

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -225,9 +225,8 @@ jobs:
       - name: Build module-test
         run: cargo run -p spacetimedb-cli -- build --project-path modules/module-test
 
-      # TODO(kim): What does this have to do with bindgen?
       - name: Run bindgen tests
-        run: cargo test -p spacetimedb-cli
+        run: cargo test -p spacetimedb-codegen
 
   publish_checks:
     name: Check that packages are publishable

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -213,9 +213,19 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - run: echo ::add-matcher::.github/workflows/rust_matcher.json
 
+      # Make sure the `Cargo.lock` file reflects the latest available versions.
+      # This is what users would end up with on a fresh module, so we want to
+      # catch any compile errors arising from a different transitive closure
+      # of dependencies than what is in the workspace lock file.
+      #
+      # For context see also: https://github.com/clockworklabs/SpacetimeDB/pull/2714
+      - name: Update dependencies
+        run: cargo update
+
       - name: Build module-test
         run: cargo run -p spacetimedb-cli -- build --project-path modules/module-test
 
+      # TODO(kim): What does this have to do with bindgen?
       - name: Run bindgen tests
         run: cargo test -p spacetimedb-cli
 


### PR DESCRIPTION
Make sure the `Cargo.lock` file of the `wasm_bindings` job reflects the
latest available versions. This is what users would end up with on a
fresh module, so we want to catch any compile errors arising from a
different transitive closure of dependencies than what is in the
workspace lock file.

Follup-up for: https://github.com/clockworklabs/SpacetimeDB/pull/2714


# Expected complexity level and risk

1

# Testing

- [x] yes
