### PR TITLE
Log instead of panicking when missing a row from st_client

### DIFF
--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -677,7 +677,7 @@ impl ModuleHost {
                 .replica_ctx()
                 .relational_db
                 .with_auto_commit(workload, |mut_tx| {
-                    mut_tx.delete_st_client(caller_identity, caller_connection_id)
+                    mut_tx.delete_st_client(caller_identity, caller_connection_id, self.info.database_identity)
                 })
                 .inspect_err(|e| {
                     log::error!(

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -558,7 +558,9 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
             Ok(Ok(())) => {
                 let res = match reducer_def.lifecycle {
                     Some(Lifecycle::OnConnect) => tx.insert_st_client(caller_identity, caller_connection_id),
-                    Some(Lifecycle::OnDisconnect) => tx.delete_st_client(caller_identity, caller_connection_id),
+                    Some(Lifecycle::OnDisconnect) => {
+                        tx.delete_st_client(caller_identity, caller_connection_id, database_identity)
+                    }
                     _ => Ok(()),
                 };
                 match res {


### PR DESCRIPTION
# Description of Changes

We've observed this panic multiple times, somehow. It doesn't have to be a hard error, it's just surprising and not something we thought was possible. This PR drops it down to be an error log instead of a panic, and also adds the database identity to the log.
My hope is that, the next time we see this happen, we can find the replica dir and commitlog for the database with the inconsistent `st_table`, and use that to debug how we reached the unexpected state.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1.

# Testing

None. We totally don't know how to reproduce this (that's kind of the point).
