### PR TITLE
Reduce reflection use in generated C# code

### DIFF
--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
@@ -44,7 +44,7 @@ public interface IStructuralReadWrite
     /// Using the resulting serializer rather than <c>Read&lt;T&gt;</c> is usually faster in Mono/IL2CPP.
     /// This is because we manually monomorphise the code to read rows in our automatically-generated
     /// implementation of IReadWrite. This allows rows to be initialized with new() rather than reflection
-    /// in the generated code.
+    /// in the compiled code.
     /// </summary>
     /// <returns>An <c>IReadWrite&lt;T&gt;</c> for <c>T : IStructuralReadWrite</c>.</returns>
     object GetSerializer();

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
@@ -5,7 +5,6 @@ using System.Text;
 /// <summary>
 /// Implemented by product types marked with [SpacetimeDB.Type].
 /// All rows in SpacetimeDB are product types, so this is also implemented by all row types.
-///
 /// </summary>
 public interface IStructuralReadWrite
 {
@@ -118,6 +117,12 @@ public interface IReadWrite<T>
     AlgebraicType GetAlgebraicType(ITypeRegistrar registrar);
 }
 
+/// <summary>
+/// Present for backwards-compatibility reasons, but no longer used.
+/// The auto-generated serialization code for enum now reads/writes
+/// the tag byte directly to the wire. This avoids calling into reflective code.
+/// </summary>
+/// <typeparam name="T"></typeparam>
 public readonly struct Enum<T> : IReadWrite<T>
     where T : struct, Enum
 {
@@ -139,6 +144,9 @@ public readonly struct Enum<T> : IReadWrite<T>
         // However, enum values are guaranteed to be sequential and zero based.
         // Hence we only ever need to do an upper bound check.
         // See `SpacetimeDB.Type.ParseEnum` for the syntax analysis.
+
+        // Later note: this STILL uses reflection. We've deprecated this class entirely
+        // because of this.
         if (Convert.ToUInt64(value) >= NumVariants)
         {
             throw new ArgumentOutOfRangeException(

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
@@ -2,12 +2,61 @@ namespace SpacetimeDB.BSATN;
 
 using System.Text;
 
+/// <summary>
+/// Implemented by product types marked with [SpacetimeDB.Type].
+/// All rows in SpacetimeDB are product types, so this is also implemented by all row types.
+///
+/// </summary>
 public interface IStructuralReadWrite
 {
+    /// <summary>
+    /// Initialize this value from the reader.
+    /// The reader is assumed to store a <see href="https://spacetimedb.com/docs/bsatn">BSATN-encoded</see>
+    /// value of this type.
+    /// Advances the reader to the first byte past the end of the read value.
+    /// Throws an exception if this would advance past the end of the reader.
+    /// </summary>
+    /// <param name="reader"></param>
     void ReadFields(BinaryReader reader);
 
+    /// <summary>
+    /// Write the fields of this type to the writer.
+    /// Throws an exception if the underlying writer throws.
+    /// Throws if this value is malformed (i.e. has null values for fields that
+    /// are not explicitly marked nullable.)
+    /// </summary>
+    /// <param name="writer"></param>
     void WriteFields(BinaryWriter writer);
 
+    /// <summary>
+    /// Get an IReadWrite implementation that can read values of this type.
+    /// In Rust, this would return <c>IReadWrite&lt;Self&gt;</c>, but the C# type system
+    /// has no equivalent Self type -- that is, you can't use the implementing type in type signatures
+    /// in an interface. So, you have to manually downcast.
+    /// A typical invocation looks like: <c>(IReadWrite&lt;Row&gt;) new Row().GetSerializer()</c>
+    ///
+    /// This is an instance method because of limitations of C# interfaces.
+    /// (C# 11 has static virtual interface members, but Unity does not support C# 11.)
+    /// This method always works, whether or not the row it is called on is correctly initialized.
+    /// The returned serializer has nothing to do with the row GetSerializer is called on -- it returns
+    /// new rows and does not modify or interact with the original row.
+    ///
+    /// Using the resulting serializer rather than <c>Read&lt;T&gt;</c> is usually faster in Mono/IL2CPP.
+    /// This is because we manually monomorphise the code to read rows in our automatically-generated
+    /// implementation of IReadWrite. This allows rows to be initialized with new() rather than reflection
+    /// in the generated code.
+    /// </summary>
+    /// <returns>An <c>IReadWrite&lt;T&gt;</c> for <c>T : IStructuralReadWrite</c>.</returns>
+    object GetSerializer();
+
+    /// <summary>
+    /// Read a row from the reader.
+    /// This method usually uses Activator.CreateInstance to create the resulting row;
+    /// if this is too slow, prefer using GetSerializer.
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="reader"></param>
+    /// <returns></returns>
     static T Read<T>(BinaryReader reader)
         where T : IStructuralReadWrite, new()
     {
@@ -38,12 +87,34 @@ public interface IStructuralReadWrite
     }
 }
 
+/// <summary>
+/// Interface for types that know how to serialize another type.
+/// We auto-generate an implementation of <c>IReadWrite&lt;T&gt;</c> for all
+/// types marked with <c>[SpacetimeDB.Type]</c>. For a type <c>T</c>, this implementation
+/// is accessible at <c>T.BSATN</c>. The implementation is always a zero-sized struct.
+/// </summary>
+/// <typeparam name="T"></typeparam>
 public interface IReadWrite<T>
 {
+    /// <summary>
+    /// Read a BSATN-encoded value of type T from the reader.
+    /// Throws on end-of-stream or if the stream is malformed.
+    /// Advances the reader to the first byte past the end of the encoded value.
+    /// </summary>
+    /// <param name="reader"></param>
+    /// <returns></returns>
     T Read(BinaryReader reader);
 
+    /// <summary>
+    /// Write a BSATN-encoded value of type T to the writer.
+    /// </summary>
     void Write(BinaryWriter writer, T value);
 
+    /// <summary>
+    /// Get metadata for this type. Used in module initialization.
+    /// </summary>
+    /// <param name="registrar"></param>
+    /// <returns></returns>
     AlgebraicType GetAlgebraicType(ITypeRegistrar registrar);
 }
 

--- a/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
@@ -392,6 +392,11 @@ public record struct Timestamp(long MicrosecondsSinceUnixEpoch)
         BSATN.MicrosecondsSinceUnixEpoch.Write(writer, MicrosecondsSinceUnixEpoch);
     }
 
+    readonly object IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public readonly partial struct BSATN : IReadWrite<Timestamp>
     {
         internal static readonly I64 MicrosecondsSinceUnixEpoch = new();
@@ -461,6 +466,11 @@ public record struct TimeDuration(long Microseconds) : IStructuralReadWrite
     public readonly void WriteFields(BinaryWriter writer)
     {
         BSATN.__time_duration_micros__.Write(writer, Microseconds);
+    }
+
+    readonly object IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
     }
 
     public readonly partial struct BSATN : IReadWrite<TimeDuration>

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/client/snapshots/Type#CustomClass.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/client/snapshots/Type#CustomClass.verified.cs
@@ -16,6 +16,11 @@ partial struct CustomClass : System.IEquatable<CustomClass>, SpacetimeDB.BSATN.I
         BSATN.StringField.Write(writer, StringField);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"CustomClass {{ IntField = {SpacetimeDB.BSATN.StringUtil.GenericToString(IntField)}, StringField = {SpacetimeDB.BSATN.StringUtil.GenericToString(StringField)} }}";
 
@@ -24,8 +29,12 @@ partial struct CustomClass : System.IEquatable<CustomClass>, SpacetimeDB.BSATN.I
         internal static readonly SpacetimeDB.BSATN.I32 IntField = new();
         internal static readonly SpacetimeDB.BSATN.String StringField = new();
 
-        public CustomClass Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<CustomClass>(reader);
+        public CustomClass Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new CustomClass();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, CustomClass value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/client/snapshots/Type#CustomStruct.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/client/snapshots/Type#CustomStruct.verified.cs
@@ -18,6 +18,11 @@ partial struct CustomStruct
         BSATN.StringField.Write(writer, StringField);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"CustomStruct {{ IntField = {SpacetimeDB.BSATN.StringUtil.GenericToString(IntField)}, StringField = {SpacetimeDB.BSATN.StringUtil.GenericToString(StringField)} }}";
 
@@ -26,8 +31,12 @@ partial struct CustomStruct
         internal static readonly SpacetimeDB.BSATN.I32 IntField = new();
         internal static readonly SpacetimeDB.BSATN.String StringField = new();
 
-        public CustomStruct Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<CustomStruct>(reader);
+        public CustomStruct Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new CustomStruct();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, CustomStruct value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/client/snapshots/Type#CustomTaggedEnum.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/client/snapshots/Type#CustomTaggedEnum.verified.cs
@@ -4,14 +4,6 @@
 
 partial record CustomTaggedEnum : System.IEquatable<CustomTaggedEnum>
 {
-    private CustomTaggedEnum() { }
-
-    internal enum @enum : byte
-    {
-        IntVariant,
-        StringVariant
-    }
-
     public sealed record IntVariant(int IntVariant_) : CustomTaggedEnum
     {
         public override string ToString() =>
@@ -26,31 +18,32 @@ partial record CustomTaggedEnum : System.IEquatable<CustomTaggedEnum>
 
     public readonly partial struct BSATN : SpacetimeDB.BSATN.IReadWrite<CustomTaggedEnum>
     {
-        internal static readonly SpacetimeDB.BSATN.Enum<@enum> __enumTag = new();
         internal static readonly SpacetimeDB.BSATN.I32 IntVariant = new();
         internal static readonly SpacetimeDB.BSATN.String StringVariant = new();
 
-        public CustomTaggedEnum Read(System.IO.BinaryReader reader) =>
-            __enumTag.Read(reader) switch
+        public CustomTaggedEnum Read(System.IO.BinaryReader reader)
+        {
+            return reader.ReadByte() switch
             {
-                @enum.IntVariant => new IntVariant(IntVariant.Read(reader)),
-                @enum.StringVariant => new StringVariant(StringVariant.Read(reader)),
+                0 => new IntVariant(IntVariant.Read(reader)),
+                1 => new StringVariant(StringVariant.Read(reader)),
                 _
                     => throw new System.InvalidOperationException(
                         "Invalid tag value, this state should be unreachable."
                     )
             };
+        }
 
         public void Write(System.IO.BinaryWriter writer, CustomTaggedEnum value)
         {
             switch (value)
             {
                 case IntVariant(var inner):
-                    __enumTag.Write(writer, @enum.IntVariant);
+                    writer.Write((byte)0);
                     IntVariant.Write(writer, inner);
                     break;
                 case StringVariant(var inner):
-                    __enumTag.Write(writer, @enum.StringVariant);
+                    writer.Write((byte)1);
                     StringVariant.Write(writer, inner);
                     break;
             }

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/client/snapshots/Type#PublicTable.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/client/snapshots/Type#PublicTable.verified.cs
@@ -62,6 +62,11 @@ partial struct PublicTable : System.IEquatable<PublicTable>, SpacetimeDB.BSATN.I
         BSATN.NullableReferenceField.Write(writer, NullableReferenceField);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"PublicTable {{ ByteField = {SpacetimeDB.BSATN.StringUtil.GenericToString(ByteField)}, UshortField = {SpacetimeDB.BSATN.StringUtil.GenericToString(UshortField)}, UintField = {SpacetimeDB.BSATN.StringUtil.GenericToString(UintField)}, UlongField = {SpacetimeDB.BSATN.StringUtil.GenericToString(UlongField)}, U128Field = {SpacetimeDB.BSATN.StringUtil.GenericToString(U128Field)}, U256Field = {SpacetimeDB.BSATN.StringUtil.GenericToString(U256Field)}, SbyteField = {SpacetimeDB.BSATN.StringUtil.GenericToString(SbyteField)}, ShortField = {SpacetimeDB.BSATN.StringUtil.GenericToString(ShortField)}, IntField = {SpacetimeDB.BSATN.StringUtil.GenericToString(IntField)}, LongField = {SpacetimeDB.BSATN.StringUtil.GenericToString(LongField)}, I128Field = {SpacetimeDB.BSATN.StringUtil.GenericToString(I128Field)}, I256Field = {SpacetimeDB.BSATN.StringUtil.GenericToString(I256Field)}, BoolField = {SpacetimeDB.BSATN.StringUtil.GenericToString(BoolField)}, FloatField = {SpacetimeDB.BSATN.StringUtil.GenericToString(FloatField)}, DoubleField = {SpacetimeDB.BSATN.StringUtil.GenericToString(DoubleField)}, StringField = {SpacetimeDB.BSATN.StringUtil.GenericToString(StringField)}, IdentityField = {SpacetimeDB.BSATN.StringUtil.GenericToString(IdentityField)}, ConnectionIdField = {SpacetimeDB.BSATN.StringUtil.GenericToString(ConnectionIdField)}, CustomStructField = {SpacetimeDB.BSATN.StringUtil.GenericToString(CustomStructField)}, CustomClassField = {SpacetimeDB.BSATN.StringUtil.GenericToString(CustomClassField)}, CustomEnumField = {SpacetimeDB.BSATN.StringUtil.GenericToString(CustomEnumField)}, CustomTaggedEnumField = {SpacetimeDB.BSATN.StringUtil.GenericToString(CustomTaggedEnumField)}, ListField = {SpacetimeDB.BSATN.StringUtil.GenericToString(ListField)}, NullableValueField = {SpacetimeDB.BSATN.StringUtil.GenericToString(NullableValueField)}, NullableReferenceField = {SpacetimeDB.BSATN.StringUtil.GenericToString(NullableReferenceField)} }}";
 
@@ -100,8 +105,12 @@ partial struct PublicTable : System.IEquatable<PublicTable>, SpacetimeDB.BSATN.I
             SpacetimeDB.BSATN.String
         > NullableReferenceField = new();
 
-        public PublicTable Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<PublicTable>(reader);
+        public PublicTable Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new PublicTable();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, PublicTable value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#InAnotherNamespace.TestDuplicateTableName.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#InAnotherNamespace.TestDuplicateTableName.verified.cs
@@ -12,15 +12,22 @@ partial class InAnotherNamespace
 
         public void WriteFields(System.IO.BinaryWriter writer) { }
 
+        object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+        {
+            return new BSATN();
+        }
+
         public override string ToString() => $"TestDuplicateTableName {{  }}";
 
         public readonly partial struct BSATN
             : SpacetimeDB.BSATN.IReadWrite<InAnotherNamespace.TestDuplicateTableName>
         {
-            public InAnotherNamespace.TestDuplicateTableName Read(System.IO.BinaryReader reader) =>
-                SpacetimeDB.BSATN.IStructuralReadWrite.Read<InAnotherNamespace.TestDuplicateTableName>(
-                    reader
-                );
+            public InAnotherNamespace.TestDuplicateTableName Read(System.IO.BinaryReader reader)
+            {
+                var ___result = new InAnotherNamespace.TestDuplicateTableName();
+                ___result.ReadFields(reader);
+                return ___result;
+            }
 
             public void Write(
                 System.IO.BinaryWriter writer,

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestAutoIncNotInteger.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestAutoIncNotInteger.verified.cs
@@ -18,6 +18,11 @@ partial struct TestAutoIncNotInteger
         BSATN.IdentityField.Write(writer, IdentityField);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"TestAutoIncNotInteger {{ AutoIncField = {SpacetimeDB.BSATN.StringUtil.GenericToString(AutoIncField)}, IdentityField = {SpacetimeDB.BSATN.StringUtil.GenericToString(IdentityField)} }}";
 
@@ -26,8 +31,12 @@ partial struct TestAutoIncNotInteger
         internal static readonly SpacetimeDB.BSATN.F32 AutoIncField = new();
         internal static readonly SpacetimeDB.BSATN.String IdentityField = new();
 
-        public TestAutoIncNotInteger Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<TestAutoIncNotInteger>(reader);
+        public TestAutoIncNotInteger Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new TestAutoIncNotInteger();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, TestAutoIncNotInteger value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestDuplicateTableName.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestDuplicateTableName.verified.cs
@@ -10,12 +10,21 @@ partial struct TestDuplicateTableName
 
     public void WriteFields(System.IO.BinaryWriter writer) { }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() => $"TestDuplicateTableName {{  }}";
 
     public readonly partial struct BSATN : SpacetimeDB.BSATN.IReadWrite<TestDuplicateTableName>
     {
-        public TestDuplicateTableName Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<TestDuplicateTableName>(reader);
+        public TestDuplicateTableName Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new TestDuplicateTableName();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, TestDuplicateTableName value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestIndexIssues.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestIndexIssues.verified.cs
@@ -16,6 +16,11 @@ partial struct TestIndexIssues
         BSATN.SelfIndexingColumn.Write(writer, SelfIndexingColumn);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"TestIndexIssues {{ SelfIndexingColumn = {SpacetimeDB.BSATN.StringUtil.GenericToString(SelfIndexingColumn)} }}";
 
@@ -23,8 +28,12 @@ partial struct TestIndexIssues
     {
         internal static readonly SpacetimeDB.BSATN.I32 SelfIndexingColumn = new();
 
-        public TestIndexIssues Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<TestIndexIssues>(reader);
+        public TestIndexIssues Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new TestIndexIssues();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, TestIndexIssues value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestScheduleIssues.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestScheduleIssues.verified.cs
@@ -22,6 +22,11 @@ partial struct TestScheduleIssues
         BSATN.ScheduleAtCorrectType.Write(writer, ScheduleAtCorrectType);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"TestScheduleIssues {{ IdWrongType = {SpacetimeDB.BSATN.StringUtil.GenericToString(IdWrongType)}, IdCorrectType = {SpacetimeDB.BSATN.StringUtil.GenericToString(IdCorrectType)}, ScheduleAtWrongType = {SpacetimeDB.BSATN.StringUtil.GenericToString(ScheduleAtWrongType)}, ScheduleAtCorrectType = {SpacetimeDB.BSATN.StringUtil.GenericToString(ScheduleAtCorrectType)} }}";
 
@@ -32,8 +37,12 @@ partial struct TestScheduleIssues
         internal static readonly SpacetimeDB.BSATN.I32 ScheduleAtWrongType = new();
         internal static readonly SpacetimeDB.ScheduleAt.BSATN ScheduleAtCorrectType = new();
 
-        public TestScheduleIssues Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<TestScheduleIssues>(reader);
+        public TestScheduleIssues Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new TestScheduleIssues();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, TestScheduleIssues value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestTableTaggedEnum.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestTableTaggedEnum.verified.cs
@@ -4,14 +4,6 @@
 
 partial record TestTableTaggedEnum : System.IEquatable<TestTableTaggedEnum>
 {
-    private TestTableTaggedEnum() { }
-
-    internal enum @enum : byte
-    {
-        X,
-        Y
-    }
-
     public sealed record X(int X_) : TestTableTaggedEnum
     {
         public override string ToString() =>
@@ -26,31 +18,32 @@ partial record TestTableTaggedEnum : System.IEquatable<TestTableTaggedEnum>
 
     public readonly partial struct BSATN : SpacetimeDB.BSATN.IReadWrite<TestTableTaggedEnum>
     {
-        internal static readonly SpacetimeDB.BSATN.Enum<@enum> __enumTag = new();
         internal static readonly SpacetimeDB.BSATN.I32 X = new();
         internal static readonly SpacetimeDB.BSATN.I32 Y = new();
 
-        public TestTableTaggedEnum Read(System.IO.BinaryReader reader) =>
-            __enumTag.Read(reader) switch
+        public TestTableTaggedEnum Read(System.IO.BinaryReader reader)
+        {
+            return reader.ReadByte() switch
             {
-                @enum.X => new X(X.Read(reader)),
-                @enum.Y => new Y(Y.Read(reader)),
+                0 => new X(X.Read(reader)),
+                1 => new Y(Y.Read(reader)),
                 _
                     => throw new System.InvalidOperationException(
                         "Invalid tag value, this state should be unreachable."
                     )
             };
+        }
 
         public void Write(System.IO.BinaryWriter writer, TestTableTaggedEnum value)
         {
             switch (value)
             {
                 case X(var inner):
-                    __enumTag.Write(writer, @enum.X);
+                    writer.Write((byte)0);
                     X.Write(writer, inner);
                     break;
                 case Y(var inner):
-                    __enumTag.Write(writer, @enum.Y);
+                    writer.Write((byte)1);
                     Y.Write(writer, inner);
                     break;
             }

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestUniqueNotEquatable.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestUniqueNotEquatable.verified.cs
@@ -18,6 +18,11 @@ partial struct TestUniqueNotEquatable
         BSATN.PrimaryKeyField.Write(writer, PrimaryKeyField);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"TestUniqueNotEquatable {{ UniqueField = {SpacetimeDB.BSATN.StringUtil.GenericToString(UniqueField)}, PrimaryKeyField = {SpacetimeDB.BSATN.StringUtil.GenericToString(PrimaryKeyField)} }}";
 
@@ -30,8 +35,12 @@ partial struct TestUniqueNotEquatable
         internal static readonly SpacetimeDB.BSATN.Enum<TestEnumWithExplicitValues> PrimaryKeyField =
             new();
 
-        public TestUniqueNotEquatable Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<TestUniqueNotEquatable>(reader);
+        public TestUniqueNotEquatable Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new TestUniqueNotEquatable();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, TestUniqueNotEquatable value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Type#TestTaggedEnumField.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Type#TestTaggedEnumField.verified.cs
@@ -4,14 +4,6 @@
 
 partial record TestTaggedEnumField : System.IEquatable<TestTaggedEnumField>
 {
-    private TestTaggedEnumField() { }
-
-    internal enum @enum : byte
-    {
-        X,
-        Y
-    }
-
     public sealed record X(int X_) : TestTaggedEnumField
     {
         public override string ToString() =>
@@ -26,31 +18,32 @@ partial record TestTaggedEnumField : System.IEquatable<TestTaggedEnumField>
 
     public readonly partial struct BSATN : SpacetimeDB.BSATN.IReadWrite<TestTaggedEnumField>
     {
-        internal static readonly SpacetimeDB.BSATN.Enum<@enum> __enumTag = new();
         internal static readonly SpacetimeDB.BSATN.I32 X = new();
         internal static readonly SpacetimeDB.BSATN.I32 Y = new();
 
-        public TestTaggedEnumField Read(System.IO.BinaryReader reader) =>
-            __enumTag.Read(reader) switch
+        public TestTaggedEnumField Read(System.IO.BinaryReader reader)
+        {
+            return reader.ReadByte() switch
             {
-                @enum.X => new X(X.Read(reader)),
-                @enum.Y => new Y(Y.Read(reader)),
+                0 => new X(X.Read(reader)),
+                1 => new Y(Y.Read(reader)),
                 _
                     => throw new System.InvalidOperationException(
                         "Invalid tag value, this state should be unreachable."
                     )
             };
+        }
 
         public void Write(System.IO.BinaryWriter writer, TestTaggedEnumField value)
         {
             switch (value)
             {
                 case X(var inner):
-                    __enumTag.Write(writer, @enum.X);
+                    writer.Write((byte)0);
                     X.Write(writer, inner);
                     break;
                 case Y(var inner):
-                    __enumTag.Write(writer, @enum.Y);
+                    writer.Write((byte)1);
                     Y.Write(writer, inner);
                     break;
             }

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Type#TestTaggedEnumInlineTuple.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Type#TestTaggedEnumInlineTuple.verified.cs
@@ -4,13 +4,6 @@
 
 partial record TestTaggedEnumInlineTuple : System.IEquatable<TestTaggedEnumInlineTuple>
 {
-    private TestTaggedEnumInlineTuple() { }
-
-    internal enum @enum : byte
-    {
-        Item1
-    }
-
     public sealed record Item1(int Item1_) : TestTaggedEnumInlineTuple
     {
         public override string ToString() =>
@@ -19,25 +12,26 @@ partial record TestTaggedEnumInlineTuple : System.IEquatable<TestTaggedEnumInlin
 
     public readonly partial struct BSATN : SpacetimeDB.BSATN.IReadWrite<TestTaggedEnumInlineTuple>
     {
-        internal static readonly SpacetimeDB.BSATN.Enum<@enum> __enumTag = new();
         internal static readonly SpacetimeDB.BSATN.I32 Item1 = new();
 
-        public TestTaggedEnumInlineTuple Read(System.IO.BinaryReader reader) =>
-            __enumTag.Read(reader) switch
+        public TestTaggedEnumInlineTuple Read(System.IO.BinaryReader reader)
+        {
+            return reader.ReadByte() switch
             {
-                @enum.Item1 => new Item1(Item1.Read(reader)),
+                0 => new Item1(Item1.Read(reader)),
                 _
                     => throw new System.InvalidOperationException(
                         "Invalid tag value, this state should be unreachable."
                     )
             };
+        }
 
         public void Write(System.IO.BinaryWriter writer, TestTaggedEnumInlineTuple value)
         {
             switch (value)
             {
                 case Item1(var inner):
-                    __enumTag.Write(writer, @enum.Item1);
+                    writer.Write((byte)0);
                     Item1.Write(writer, inner);
                     break;
             }

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Type#TestTypeParams_T_.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Type#TestTypeParams_T_.verified.cs
@@ -16,6 +16,11 @@ partial struct TestTypeParams<T>
         BSATN.Field.Write(writer, Field);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"TestTypeParams {{ Field = {SpacetimeDB.BSATN.StringUtil.GenericToString(Field)} }}";
 
@@ -23,8 +28,12 @@ partial struct TestTypeParams<T>
     {
         internal static readonly TRW Field = new();
 
-        public TestTypeParams<T> Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<TestTypeParams<T>>(reader);
+        public TestTypeParams<T> Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new TestTypeParams<T>();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, TestTypeParams<T> value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Type#TestUnsupportedType.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Type#TestUnsupportedType.verified.cs
@@ -22,6 +22,11 @@ partial struct TestUnsupportedType
         BSATN.UnsupportedEnum.Write(writer, UnsupportedEnum);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"TestUnsupportedType {{ UnsupportedSpecialType = {SpacetimeDB.BSATN.StringUtil.GenericToString(UnsupportedSpecialType)}, UnsupportedSystemType = {SpacetimeDB.BSATN.StringUtil.GenericToString(UnsupportedSystemType)}, UnresolvedType = {SpacetimeDB.BSATN.StringUtil.GenericToString(UnresolvedType)}, UnsupportedEnum = {SpacetimeDB.BSATN.StringUtil.GenericToString(UnsupportedEnum)} }}";
 
@@ -34,8 +39,12 @@ partial struct TestUnsupportedType
         internal static readonly SpacetimeDB.BSATN.Unsupported<object> UnresolvedType = new();
         internal static readonly SpacetimeDB.BSATN.Unsupported<LocalEnum> UnsupportedEnum = new();
 
-        public TestUnsupportedType Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<TestUnsupportedType>(reader);
+        public TestUnsupportedType Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new TestUnsupportedType();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, TestUnsupportedType value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#BTreeMultiColumn.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#BTreeMultiColumn.verified.cs
@@ -20,6 +20,11 @@ partial struct BTreeMultiColumn
         BSATN.Z.Write(writer, Z);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"BTreeMultiColumn {{ X = {SpacetimeDB.BSATN.StringUtil.GenericToString(X)}, Y = {SpacetimeDB.BSATN.StringUtil.GenericToString(Y)}, Z = {SpacetimeDB.BSATN.StringUtil.GenericToString(Z)} }}";
 
@@ -29,8 +34,12 @@ partial struct BTreeMultiColumn
         internal static readonly SpacetimeDB.BSATN.U32 Y = new();
         internal static readonly SpacetimeDB.BSATN.U32 Z = new();
 
-        public BTreeMultiColumn Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<BTreeMultiColumn>(reader);
+        public BTreeMultiColumn Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new BTreeMultiColumn();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, BTreeMultiColumn value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#BTreeViews.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#BTreeViews.verified.cs
@@ -20,6 +20,11 @@ partial struct BTreeViews : System.IEquatable<BTreeViews>, SpacetimeDB.BSATN.ISt
         BSATN.Faction.Write(writer, Faction);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"BTreeViews {{ Id = {SpacetimeDB.BSATN.StringUtil.GenericToString(Id)}, X = {SpacetimeDB.BSATN.StringUtil.GenericToString(X)}, Y = {SpacetimeDB.BSATN.StringUtil.GenericToString(Y)}, Faction = {SpacetimeDB.BSATN.StringUtil.GenericToString(Faction)} }}";
 
@@ -30,8 +35,12 @@ partial struct BTreeViews : System.IEquatable<BTreeViews>, SpacetimeDB.BSATN.ISt
         internal static readonly SpacetimeDB.BSATN.U32 Y = new();
         internal static readonly SpacetimeDB.BSATN.String Faction = new();
 
-        public BTreeViews Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<BTreeViews>(reader);
+        public BTreeViews Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new BTreeViews();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, BTreeViews value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#MultiTableRow.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#MultiTableRow.verified.cs
@@ -20,6 +20,11 @@ partial struct MultiTableRow
         BSATN.Bar.Write(writer, Bar);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"MultiTableRow {{ Name = {SpacetimeDB.BSATN.StringUtil.GenericToString(Name)}, Foo = {SpacetimeDB.BSATN.StringUtil.GenericToString(Foo)}, Bar = {SpacetimeDB.BSATN.StringUtil.GenericToString(Bar)} }}";
 
@@ -29,8 +34,12 @@ partial struct MultiTableRow
         internal static readonly SpacetimeDB.BSATN.U32 Foo = new();
         internal static readonly SpacetimeDB.BSATN.U32 Bar = new();
 
-        public MultiTableRow Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<MultiTableRow>(reader);
+        public MultiTableRow Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new MultiTableRow();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, MultiTableRow value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PrivateTable.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PrivateTable.verified.cs
@@ -8,12 +8,21 @@ partial class PrivateTable : System.IEquatable<PrivateTable>, SpacetimeDB.BSATN.
 
     public void WriteFields(System.IO.BinaryWriter writer) { }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() => $"PrivateTable {{  }}";
 
     public readonly partial struct BSATN : SpacetimeDB.BSATN.IReadWrite<PrivateTable>
     {
-        public PrivateTable Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<PrivateTable>(reader);
+        public PrivateTable Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new PrivateTable();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, PrivateTable value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PublicTable.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PublicTable.verified.cs
@@ -68,6 +68,11 @@ partial struct PublicTable : System.IEquatable<PublicTable>, SpacetimeDB.BSATN.I
         BSATN.NullableReferenceField.Write(writer, NullableReferenceField);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"PublicTable {{ Id = {SpacetimeDB.BSATN.StringUtil.GenericToString(Id)}, ByteField = {SpacetimeDB.BSATN.StringUtil.GenericToString(ByteField)}, UshortField = {SpacetimeDB.BSATN.StringUtil.GenericToString(UshortField)}, UintField = {SpacetimeDB.BSATN.StringUtil.GenericToString(UintField)}, UlongField = {SpacetimeDB.BSATN.StringUtil.GenericToString(UlongField)}, UInt128Field = {SpacetimeDB.BSATN.StringUtil.GenericToString(UInt128Field)}, U128Field = {SpacetimeDB.BSATN.StringUtil.GenericToString(U128Field)}, U256Field = {SpacetimeDB.BSATN.StringUtil.GenericToString(U256Field)}, SbyteField = {SpacetimeDB.BSATN.StringUtil.GenericToString(SbyteField)}, ShortField = {SpacetimeDB.BSATN.StringUtil.GenericToString(ShortField)}, IntField = {SpacetimeDB.BSATN.StringUtil.GenericToString(IntField)}, LongField = {SpacetimeDB.BSATN.StringUtil.GenericToString(LongField)}, Int128Field = {SpacetimeDB.BSATN.StringUtil.GenericToString(Int128Field)}, I128Field = {SpacetimeDB.BSATN.StringUtil.GenericToString(I128Field)}, I256Field = {SpacetimeDB.BSATN.StringUtil.GenericToString(I256Field)}, BoolField = {SpacetimeDB.BSATN.StringUtil.GenericToString(BoolField)}, FloatField = {SpacetimeDB.BSATN.StringUtil.GenericToString(FloatField)}, DoubleField = {SpacetimeDB.BSATN.StringUtil.GenericToString(DoubleField)}, StringField = {SpacetimeDB.BSATN.StringUtil.GenericToString(StringField)}, IdentityField = {SpacetimeDB.BSATN.StringUtil.GenericToString(IdentityField)}, ConnectionIdField = {SpacetimeDB.BSATN.StringUtil.GenericToString(ConnectionIdField)}, CustomStructField = {SpacetimeDB.BSATN.StringUtil.GenericToString(CustomStructField)}, CustomClassField = {SpacetimeDB.BSATN.StringUtil.GenericToString(CustomClassField)}, CustomEnumField = {SpacetimeDB.BSATN.StringUtil.GenericToString(CustomEnumField)}, CustomTaggedEnumField = {SpacetimeDB.BSATN.StringUtil.GenericToString(CustomTaggedEnumField)}, ListField = {SpacetimeDB.BSATN.StringUtil.GenericToString(ListField)}, NullableValueField = {SpacetimeDB.BSATN.StringUtil.GenericToString(NullableValueField)}, NullableReferenceField = {SpacetimeDB.BSATN.StringUtil.GenericToString(NullableReferenceField)} }}";
 
@@ -109,8 +114,12 @@ partial struct PublicTable : System.IEquatable<PublicTable>, SpacetimeDB.BSATN.I
             SpacetimeDB.BSATN.String
         > NullableReferenceField = new();
 
-        public PublicTable Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<PublicTable>(reader);
+        public PublicTable Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new PublicTable();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, PublicTable value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#RegressionMultipleUniqueIndexesHadSameName.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#RegressionMultipleUniqueIndexesHadSameName.verified.cs
@@ -18,6 +18,11 @@ partial struct RegressionMultipleUniqueIndexesHadSameName
         BSATN.Unique2.Write(writer, Unique2);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"RegressionMultipleUniqueIndexesHadSameName {{ Unique1 = {SpacetimeDB.BSATN.StringUtil.GenericToString(Unique1)}, Unique2 = {SpacetimeDB.BSATN.StringUtil.GenericToString(Unique2)} }}";
 
@@ -27,10 +32,12 @@ partial struct RegressionMultipleUniqueIndexesHadSameName
         internal static readonly SpacetimeDB.BSATN.U32 Unique1 = new();
         internal static readonly SpacetimeDB.BSATN.U32 Unique2 = new();
 
-        public RegressionMultipleUniqueIndexesHadSameName Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<RegressionMultipleUniqueIndexesHadSameName>(
-                reader
-            );
+        public RegressionMultipleUniqueIndexesHadSameName Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new RegressionMultipleUniqueIndexesHadSameName();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(
             System.IO.BinaryWriter writer,

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#Timers.SendMessageTimer.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#Timers.SendMessageTimer.verified.cs
@@ -22,6 +22,11 @@ partial class Timers
             BSATN.Text.Write(writer, Text);
         }
 
+        object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+        {
+            return new BSATN();
+        }
+
         public override string ToString() =>
             $"SendMessageTimer {{ ScheduledId = {SpacetimeDB.BSATN.StringUtil.GenericToString(ScheduledId)}, ScheduledAt = {SpacetimeDB.BSATN.StringUtil.GenericToString(ScheduledAt)}, Text = {SpacetimeDB.BSATN.StringUtil.GenericToString(Text)} }}";
 
@@ -31,8 +36,12 @@ partial class Timers
             internal static readonly SpacetimeDB.ScheduleAt.BSATN ScheduledAt = new();
             internal static readonly SpacetimeDB.BSATN.String Text = new();
 
-            public Timers.SendMessageTimer Read(System.IO.BinaryReader reader) =>
-                SpacetimeDB.BSATN.IStructuralReadWrite.Read<Timers.SendMessageTimer>(reader);
+            public Timers.SendMessageTimer Read(System.IO.BinaryReader reader)
+            {
+                var ___result = new Timers.SendMessageTimer();
+                ___result.ReadFields(reader);
+                return ___result;
+            }
 
             public void Write(System.IO.BinaryWriter writer, Timers.SendMessageTimer value)
             {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#ContainsNestedLists.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#ContainsNestedLists.verified.cs
@@ -30,6 +30,11 @@ partial class ContainsNestedLists
         BSATN.StringListListArray.Write(writer, StringListListArray);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"ContainsNestedLists {{ IntList = {SpacetimeDB.BSATN.StringUtil.GenericToString(IntList)}, StringList = {SpacetimeDB.BSATN.StringUtil.GenericToString(StringList)}, IntArray = {SpacetimeDB.BSATN.StringUtil.GenericToString(IntArray)}, StringArray = {SpacetimeDB.BSATN.StringUtil.GenericToString(StringArray)}, IntArrayArrayList = {SpacetimeDB.BSATN.StringUtil.GenericToString(IntArrayArrayList)}, IntListListArray = {SpacetimeDB.BSATN.StringUtil.GenericToString(IntListListArray)}, StringArrayArrayList = {SpacetimeDB.BSATN.StringUtil.GenericToString(StringArrayArrayList)}, StringListListArray = {SpacetimeDB.BSATN.StringUtil.GenericToString(StringListListArray)} }}";
 
@@ -72,8 +77,12 @@ partial class ContainsNestedLists
             >
         > StringListListArray = new();
 
-        public ContainsNestedLists Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<ContainsNestedLists>(reader);
+        public ContainsNestedLists Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new ContainsNestedLists();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, ContainsNestedLists value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#CustomClass.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#CustomClass.verified.cs
@@ -20,6 +20,11 @@ partial class CustomClass : System.IEquatable<CustomClass>, SpacetimeDB.BSATN.IS
         BSATN.NullableStringField.Write(writer, NullableStringField);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"CustomClass {{ IntField = {SpacetimeDB.BSATN.StringUtil.GenericToString(IntField)}, StringField = {SpacetimeDB.BSATN.StringUtil.GenericToString(StringField)}, NullableIntField = {SpacetimeDB.BSATN.StringUtil.GenericToString(NullableIntField)}, NullableStringField = {SpacetimeDB.BSATN.StringUtil.GenericToString(NullableStringField)} }}";
 
@@ -36,8 +41,12 @@ partial class CustomClass : System.IEquatable<CustomClass>, SpacetimeDB.BSATN.IS
             SpacetimeDB.BSATN.String
         > NullableStringField = new();
 
-        public CustomClass Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<CustomClass>(reader);
+        public CustomClass Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new CustomClass();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, CustomClass value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#CustomNestedClass.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#CustomNestedClass.verified.cs
@@ -30,6 +30,11 @@ partial class CustomNestedClass
         BSATN.NestedNullableCustomRecord.Write(writer, NestedNullableCustomRecord);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"CustomNestedClass {{ NestedClass = {SpacetimeDB.BSATN.StringUtil.GenericToString(NestedClass)}, NestedNullableClass = {SpacetimeDB.BSATN.StringUtil.GenericToString(NestedNullableClass)}, NestedEnum = {SpacetimeDB.BSATN.StringUtil.GenericToString(NestedEnum)}, NestedNullableEnum = {SpacetimeDB.BSATN.StringUtil.GenericToString(NestedNullableEnum)}, NestedTaggedEnum = {SpacetimeDB.BSATN.StringUtil.GenericToString(NestedTaggedEnum)}, NestedNullableTaggedEnum = {SpacetimeDB.BSATN.StringUtil.GenericToString(NestedNullableTaggedEnum)}, NestedCustomRecord = {SpacetimeDB.BSATN.StringUtil.GenericToString(NestedCustomRecord)}, NestedNullableCustomRecord = {SpacetimeDB.BSATN.StringUtil.GenericToString(NestedNullableCustomRecord)} }}";
 
@@ -56,8 +61,12 @@ partial class CustomNestedClass
             CustomRecord.BSATN
         > NestedNullableCustomRecord = new();
 
-        public CustomNestedClass Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<CustomNestedClass>(reader);
+        public CustomNestedClass Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new CustomNestedClass();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, CustomNestedClass value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#CustomRecord.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#CustomRecord.verified.cs
@@ -20,6 +20,11 @@ partial class CustomRecord : System.IEquatable<CustomRecord>, SpacetimeDB.BSATN.
         BSATN.NullableStringField.Write(writer, NullableStringField);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"CustomRecord {{ IntField = {SpacetimeDB.BSATN.StringUtil.GenericToString(IntField)}, StringField = {SpacetimeDB.BSATN.StringUtil.GenericToString(StringField)}, NullableIntField = {SpacetimeDB.BSATN.StringUtil.GenericToString(NullableIntField)}, NullableStringField = {SpacetimeDB.BSATN.StringUtil.GenericToString(NullableStringField)} }}";
 
@@ -36,8 +41,12 @@ partial class CustomRecord : System.IEquatable<CustomRecord>, SpacetimeDB.BSATN.
             SpacetimeDB.BSATN.String
         > NullableStringField = new();
 
-        public CustomRecord Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<CustomRecord>(reader);
+        public CustomRecord Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new CustomRecord();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, CustomRecord value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#CustomStruct.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#CustomStruct.verified.cs
@@ -22,6 +22,11 @@ partial struct CustomStruct
         BSATN.NullableStringField.Write(writer, NullableStringField);
     }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() =>
         $"CustomStruct {{ IntField = {SpacetimeDB.BSATN.StringUtil.GenericToString(IntField)}, StringField = {SpacetimeDB.BSATN.StringUtil.GenericToString(StringField)}, NullableIntField = {SpacetimeDB.BSATN.StringUtil.GenericToString(NullableIntField)}, NullableStringField = {SpacetimeDB.BSATN.StringUtil.GenericToString(NullableStringField)} }}";
 
@@ -38,8 +43,12 @@ partial struct CustomStruct
             SpacetimeDB.BSATN.String
         > NullableStringField = new();
 
-        public CustomStruct Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<CustomStruct>(reader);
+        public CustomStruct Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new CustomStruct();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, CustomStruct value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#CustomTaggedEnum.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#CustomTaggedEnum.verified.cs
@@ -4,16 +4,6 @@
 
 partial record CustomTaggedEnum : System.IEquatable<CustomTaggedEnum>
 {
-    private CustomTaggedEnum() { }
-
-    internal enum @enum : byte
-    {
-        IntVariant,
-        StringVariant,
-        NullableIntVariant,
-        NullableStringVariant
-    }
-
     public sealed record IntVariant(int IntVariant_) : CustomTaggedEnum
     {
         public override string ToString() =>
@@ -40,7 +30,6 @@ partial record CustomTaggedEnum : System.IEquatable<CustomTaggedEnum>
 
     public readonly partial struct BSATN : SpacetimeDB.BSATN.IReadWrite<CustomTaggedEnum>
     {
-        internal static readonly SpacetimeDB.BSATN.Enum<@enum> __enumTag = new();
         internal static readonly SpacetimeDB.BSATN.I32 IntVariant = new();
         internal static readonly SpacetimeDB.BSATN.String StringVariant = new();
         internal static readonly SpacetimeDB.BSATN.ValueOption<
@@ -52,38 +41,39 @@ partial record CustomTaggedEnum : System.IEquatable<CustomTaggedEnum>
             SpacetimeDB.BSATN.String
         > NullableStringVariant = new();
 
-        public CustomTaggedEnum Read(System.IO.BinaryReader reader) =>
-            __enumTag.Read(reader) switch
+        public CustomTaggedEnum Read(System.IO.BinaryReader reader)
+        {
+            return reader.ReadByte() switch
             {
-                @enum.IntVariant => new IntVariant(IntVariant.Read(reader)),
-                @enum.StringVariant => new StringVariant(StringVariant.Read(reader)),
-                @enum.NullableIntVariant => new NullableIntVariant(NullableIntVariant.Read(reader)),
-                @enum.NullableStringVariant
-                    => new NullableStringVariant(NullableStringVariant.Read(reader)),
+                0 => new IntVariant(IntVariant.Read(reader)),
+                1 => new StringVariant(StringVariant.Read(reader)),
+                2 => new NullableIntVariant(NullableIntVariant.Read(reader)),
+                3 => new NullableStringVariant(NullableStringVariant.Read(reader)),
                 _
                     => throw new System.InvalidOperationException(
                         "Invalid tag value, this state should be unreachable."
                     )
             };
+        }
 
         public void Write(System.IO.BinaryWriter writer, CustomTaggedEnum value)
         {
             switch (value)
             {
                 case IntVariant(var inner):
-                    __enumTag.Write(writer, @enum.IntVariant);
+                    writer.Write((byte)0);
                     IntVariant.Write(writer, inner);
                     break;
                 case StringVariant(var inner):
-                    __enumTag.Write(writer, @enum.StringVariant);
+                    writer.Write((byte)1);
                     StringVariant.Write(writer, inner);
                     break;
                 case NullableIntVariant(var inner):
-                    __enumTag.Write(writer, @enum.NullableIntVariant);
+                    writer.Write((byte)2);
                     NullableIntVariant.Write(writer, inner);
                     break;
                 case NullableStringVariant(var inner):
-                    __enumTag.Write(writer, @enum.NullableStringVariant);
+                    writer.Write((byte)3);
                     NullableStringVariant.Write(writer, inner);
                     break;
             }

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#EmptyClass.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#EmptyClass.verified.cs
@@ -8,12 +8,21 @@ partial class EmptyClass : System.IEquatable<EmptyClass>, SpacetimeDB.BSATN.IStr
 
     public void WriteFields(System.IO.BinaryWriter writer) { }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() => $"EmptyClass {{  }}";
 
     public readonly partial struct BSATN : SpacetimeDB.BSATN.IReadWrite<EmptyClass>
     {
-        public EmptyClass Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<EmptyClass>(reader);
+        public EmptyClass Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new EmptyClass();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, EmptyClass value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#EmptyRecord.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#EmptyRecord.verified.cs
@@ -8,12 +8,21 @@ partial record EmptyRecord : System.IEquatable<EmptyRecord>, SpacetimeDB.BSATN.I
 
     public void WriteFields(System.IO.BinaryWriter writer) { }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() => $"EmptyRecord {{  }}";
 
     public readonly partial struct BSATN : SpacetimeDB.BSATN.IReadWrite<EmptyRecord>
     {
-        public EmptyRecord Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<EmptyRecord>(reader);
+        public EmptyRecord Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new EmptyRecord();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, EmptyRecord value)
         {

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#EmptyStruct.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#EmptyStruct.verified.cs
@@ -8,12 +8,21 @@ partial struct EmptyStruct : System.IEquatable<EmptyStruct>, SpacetimeDB.BSATN.I
 
     public void WriteFields(System.IO.BinaryWriter writer) { }
 
+    object SpacetimeDB.BSATN.IStructuralReadWrite.GetSerializer()
+    {
+        return new BSATN();
+    }
+
     public override string ToString() => $"EmptyStruct {{  }}";
 
     public readonly partial struct BSATN : SpacetimeDB.BSATN.IReadWrite<EmptyStruct>
     {
-        public EmptyStruct Read(System.IO.BinaryReader reader) =>
-            SpacetimeDB.BSATN.IStructuralReadWrite.Read<EmptyStruct>(reader);
+        public EmptyStruct Read(System.IO.BinaryReader reader)
+        {
+            var ___result = new EmptyStruct();
+            ___result.ReadFields(reader);
+            return ___result;
+        }
 
         public void Write(System.IO.BinaryWriter writer, EmptyStruct value)
         {


### PR DESCRIPTION
# Description of Changes

Directly allocates results for some operations and avoids the usage of reflection for enum serialization.
This should hopefully speed up (de)serialization to some extent.
Needs to be paired with an upcoming C# SDK PR to speed these up further.

# API and ABI breaking changes

Adds a method to IStructuralReadWrite, which will break anyone who manually implements it. However, nobody should be manually implementing it. I've checked, and Bitcraft doesn't.

# Expected complexity level and risk

0

# Testing

- [ ] Blackholio
- [ ] Bitcraft
