### PR TITLE
Fix index scan rewrite rule

### DIFF
--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -495,6 +495,39 @@ pub(crate) mod tests {
         );
     }
 
+    /// Test a query that uses a multi-column index
+    #[test]
+    fn test_multi_column_index() -> anyhow::Result<()> {
+        let db = TestDB::in_memory()?;
+
+        let schema = [
+            ("a", AlgebraicType::U64),
+            ("b", AlgebraicType::U64),
+            ("c", AlgebraicType::U64),
+        ];
+
+        let table_id = db.create_table_for_test_multi_column("t", &schema, [1, 2].into())?;
+
+        insert_rows(
+            &db,
+            table_id,
+            vec![
+                product![0_u64, 1_u64, 2_u64],
+                product![1_u64, 2_u64, 1_u64],
+                product![2_u64, 2_u64, 2_u64],
+            ],
+        )?;
+
+        assert_query_results(
+            &db,
+            "select * from t where c = 1 and b = 2",
+            &AuthCtx::for_testing(),
+            [product![1_u64, 2_u64, 1_u64]],
+        );
+
+        Ok(())
+    }
+
     /// Test querying a table with RLS rules
     #[test]
     fn test_rls_rules() -> anyhow::Result<()> {

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -1830,10 +1830,10 @@ mod tests {
                 _,
             )) => {
                 assert_eq!(schema.table_id, t_id);
-                assert_eq!(arg, Sarg::Eq(ColId(1), AlgebraicValue::U8(3)));
+                assert_eq!(arg, Sarg::Eq(ColId(3), AlgebraicValue::U8(5)));
                 assert_eq!(
                     prefix,
-                    vec![(ColId(3), AlgebraicValue::U8(5)), (ColId(2), AlgebraicValue::U8(4))]
+                    vec![(ColId(1), AlgebraicValue::U8(3)), (ColId(2), AlgebraicValue::U8(4))]
                 );
             }
             proj => panic!("unexpected plan: {:#?}", proj),
@@ -1941,8 +1941,8 @@ mod tests {
                 _,
             )) => {
                 assert_eq!(schema.table_id, t_id);
-                assert_eq!(arg, Sarg::Eq(ColId(2), AlgebraicValue::U8(1)));
-                assert_eq!(prefix, vec![(ColId(3), AlgebraicValue::U8(2))]);
+                assert_eq!(arg, Sarg::Eq(ColId(3), AlgebraicValue::U8(2)));
+                assert_eq!(prefix, vec![(ColId(2), AlgebraicValue::U8(1))]);
             }
             proj => panic!("unexpected plan: {:#?}", proj),
         };

--- a/crates/physical-plan/src/rules.rs
+++ b/crates/physical-plan/src/rules.rs
@@ -622,13 +622,20 @@ impl RewriteRule for IxScanEq2Col {
                     .indexes
                     .iter()
                     .filter(|idx| idx.index_algorithm.columns().len() == 2) // TODO: Support prefix scans
-                    .find_map(|idx| {
+                    .map(|idx| (idx.index_id, idx.index_algorithm.columns()))
+                    .find_map(|(index_id, columns)| {
+                        let mut columns = columns.iter();
+                        let x = columns.next()?;
+                        if x.idx() != u.field_pos {
+                            return None;
+                        }
+                        let y = columns.next()?;
+                        if y.idx() != v.field_pos {
+                            return None;
+                        }
                         Some(IxScanInfo {
-                            index_id: idx.index_id,
-                            cols: vec![
-                                (i, idx.index_algorithm.find_col_index(u.field_pos)?),
-                                (j, idx.index_algorithm.find_col_index(v.field_pos)?),
-                            ],
+                            index_id,
+                            cols: vec![(i, x), (j, y)],
                         })
                     })
                 {
@@ -795,14 +802,24 @@ impl RewriteRule for IxScanEq3Col {
                         .indexes
                         .iter()
                         .filter(|idx| idx.index_algorithm.columns().len() == 3)
-                        .find_map(|idx| {
+                        .map(|idx| (idx.index_id, idx.index_algorithm.columns()))
+                        .find_map(|(index_id, columns)| {
+                            let mut columns = columns.iter();
+                            let x = columns.next()?;
+                            if x.idx() != u.field_pos {
+                                return None;
+                            }
+                            let y = columns.next()?;
+                            if y.idx() != v.field_pos {
+                                return None;
+                            }
+                            let z = columns.next()?;
+                            if z.idx() != w.field_pos {
+                                return None;
+                            }
                             Some(IxScanInfo {
-                                index_id: idx.index_id,
-                                cols: vec![
-                                    (i, idx.index_algorithm.find_col_index(u.field_pos)?),
-                                    (j, idx.index_algorithm.find_col_index(v.field_pos)?),
-                                    (k, idx.index_algorithm.find_col_index(w.field_pos)?),
-                                ],
+                                index_id,
+                                cols: vec![(i, x), (j, y), (k, z)],
                             })
                         })
                     {


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Fixes a bug introduced in https://github.com/clockworklabs/SpacetimeDB/pull/2208 that used the wrong value for multi-column index scans.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

Updated query planner tests that incorrectly asserted on the wrong values and added a new functional test.
