### PR TITLE
 Use spawn_blocking for the fallback commit in identity_dis/connected 

### DIFF
--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -9,6 +9,7 @@ use crate::error::DBError;
 use crate::host::module_host::ClientConnectedError;
 use crate::host::{ModuleHost, NoSuchModule, ReducerArgs, ReducerCallError, ReducerCallResult};
 use crate::messages::websocket::Subscribe;
+use crate::util::asyncify;
 use crate::util::prometheus_handle::IntGaugeExt;
 use crate::worker_metrics::WORKER_METRICS;
 use bytes::Bytes;
@@ -301,57 +302,52 @@ impl ClientConnection {
 
     pub async fn subscribe_single(&self, subscription: SubscribeSingle, timer: Instant) -> Result<(), DBError> {
         let me = self.clone();
-        tokio::task::spawn_blocking(move || {
+        asyncify(move || {
             me.module
                 .subscriptions()
                 .add_single_subscription(me.sender, subscription, timer, None)
         })
         .await
-        .unwrap() // TODO: is unwrapping right here?
     }
 
     pub async fn unsubscribe(&self, request: Unsubscribe, timer: Instant) -> Result<(), DBError> {
         let me = self.clone();
-        tokio::task::spawn_blocking(move || {
+        asyncify(move || {
             me.module
                 .subscriptions()
                 .remove_single_subscription(me.sender, request, timer)
         })
         .await
-        .unwrap() // TODO: is unwrapping right here?
     }
 
     pub async fn subscribe_multi(&self, request: SubscribeMulti, timer: Instant) -> Result<(), DBError> {
         let me = self.clone();
-        tokio::task::spawn_blocking(move || {
+        asyncify(move || {
             me.module
                 .subscriptions()
                 .add_multi_subscription(me.sender, request, timer, None)
         })
         .await
-        .unwrap() // TODO: is unwrapping right here?
     }
 
     pub async fn unsubscribe_multi(&self, request: UnsubscribeMulti, timer: Instant) -> Result<(), DBError> {
         let me = self.clone();
-        tokio::task::spawn_blocking(move || {
+        asyncify(move || {
             me.module
                 .subscriptions()
                 .remove_multi_subscription(me.sender, request, timer)
         })
         .await
-        .unwrap() // TODO: is unwrapping right here?
     }
 
     pub async fn subscribe(&self, subscription: Subscribe, timer: Instant) -> Result<(), DBError> {
         let me = self.clone();
-        tokio::task::spawn_blocking(move || {
+        asyncify(move || {
             me.module
                 .subscriptions()
                 .add_legacy_subscriber(me.sender, subscription, timer, None)
         })
         .await
-        .unwrap()
     }
 
     pub fn one_off_query_json(&self, query: &str, message_id: &[u8], timer: Instant) -> Result<(), anyhow::Error> {

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -19,7 +19,7 @@ use crate::db::datastore::system_tables::{StModuleRow, WASM_MODULE};
 use crate::error::{DBError, DatabaseError, TableError};
 use crate::execution_context::{ReducerContext, Workload};
 use crate::messages::control_db::HostType;
-use crate::util::spawn_rayon;
+use crate::util::{asyncify, spawn_rayon};
 use anyhow::{anyhow, Context};
 use fs2::FileExt;
 use futures::channel::mpsc;
@@ -157,15 +157,14 @@ impl SnapshotWorkerActor {
         let start_time = std::time::Instant::now();
         let committed_state = self.committed_state.clone();
         let snapshot_repo = self.repo.clone();
-        let res = tokio::task::spawn_blocking(move || {
+        let res = asyncify(move || {
             Locking::take_snapshot_internal(&committed_state, &snapshot_repo).inspect(|opts| {
                 if let Some(opts) = opts {
                     Locking::compress_older_snapshot_internal(&snapshot_repo, opts.0);
                 }
             })
         })
-        .await
-        .unwrap();
+        .await;
         match res {
             Err(e) => {
                 log::error!(

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -536,10 +536,7 @@ impl ModuleHost {
     pub async fn disconnect_client(&self, client_id: ClientActorId) {
         log::trace!("disconnecting client {}", client_id);
         let this = self.clone();
-        let _ = tokio::task::spawn_blocking(move || {
-            this.subscriptions().remove_subscriber(client_id);
-        })
-        .await;
+        asyncify(move || this.subscriptions().remove_subscriber(client_id)).await;
         // ignore NoSuchModule; if the module's already closed, that's fine
         if let Err(e) = self
             .call_identity_disconnected(client_id.identity, client_id.connection_id)

--- a/crates/core/src/util/mod.rs
+++ b/crates/core/src/util/mod.rs
@@ -32,6 +32,23 @@ pub fn spawn_rayon<R: Send + 'static>(f: impl FnOnce() -> R + Send + 'static) ->
     rx.map(|res| res.unwrap().unwrap_or_else(|err| std::panic::resume_unwind(err)))
 }
 
+/// Ergonomic wrapper for `tokio::task::spawn_blocking(f).await`.
+///
+/// If `f` panics, it will be bubbled up to the calling task.
+pub async fn asyncify<F, R>(f: F) -> R
+where
+    F: FnOnce() -> R + Send + 'static,
+    R: Send + 'static,
+{
+    tokio::task::spawn_blocking(f)
+        .await
+        .unwrap_or_else(|e| match e.try_into_panic() {
+            Ok(panic_payload) => std::panic::resume_unwind(panic_payload),
+            // the only other variant is cancelled, which shouldn't happen because we don't cancel it.
+            Err(e) => panic!("Unexpected JoinError: {e}"),
+        })
+}
+
 /// Await `fut`, while also polling `also`.
 pub async fn also_poll<Fut: Future>(fut: Fut, also: impl Future<Output = ()>) -> Fut::Output {
     let mut also = pin!(also.fuse());


### PR DESCRIPTION
# Description of Changes

`with_auto_commit` takes a lock, which we shouldn't be doing in a tokio task. The second commit uses the utility wrapper in more places around `core`, which makes the callsites clearer.


# Expected complexity level and risk

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->
Not sure exactly what a test for this would look like, but this is clearly more correct than before.

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
