### PR TITLE
commitlog: Include latest commit offset in segment metadata

### DIFF
--- a/crates/commitlog/src/repo/mod.rs
+++ b/crates/commitlog/src/repo/mod.rs
@@ -243,6 +243,7 @@ pub fn resume_segment_writer<R: Repo>(
         tx_range,
         size_in_bytes,
         max_epoch,
+        max_commit_offset: _,
     } = match Metadata::extract(offset, &mut storage, offset_index.as_ref()) {
         Err(error::SegmentMetadata::InvalidCommit { sofar, source }) => {
             warn!("invalid commit in segment {offset}: {source}");


### PR DESCRIPTION
# Description of Changes

The segment metadata, obtained e.g. via `committed_meta`, will now include the start offset of the last commit read from the segment.

# API and ABI breaking changes

No 

# Expected complexity level and risk

1

# Testing

- [x] yes
