### PR TITLE
Handle snapshot restore more robustly

### DIFF
--- a/crates/commitlog/src/commitlog.rs
+++ b/crates/commitlog/src/commitlog.rs
@@ -182,6 +182,15 @@ impl<R: Repo, T> Generic<R, T> {
         self.head.next_tx_offset().checked_sub(1)
     }
 
+    /// The first transaction offset written to disk, or `None` if nothing has
+    /// been written yet.
+    pub fn min_committed_offset(&self) -> Option<u64> {
+        self.tail
+            .first()
+            .copied()
+            .or_else(|| (!self.head.is_empty()).then(|| self.head.min_tx_offset()))
+    }
+
     // Helper to obtain a list of the segment offsets which include transaction
     // offset `offset`.
     //

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -131,6 +131,13 @@ impl<T> Commitlog<T> {
         self.inner.read().unwrap().max_committed_offset()
     }
 
+    /// Determine the minimum transaction offset in the log.
+    ///
+    /// The offset is `None` if the log hasn't been flushed to disk yet.
+    pub fn min_committed_offset(&self) -> Option<u64> {
+        self.inner.read().unwrap().min_committed_offset()
+    }
+
     /// Get the current epoch.
     ///
     /// See also: [`Commit::epoch`].

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -532,7 +532,7 @@ impl RelationalDB {
                     break;
                 }
                 if let Ok(datastore) =
-                    try_restore_napshot(snapshot_repo, snapshot_offset, database_identity, page_pool.clone())
+                    try_restore_snapshot(snapshot_repo, snapshot_offset, database_identity, page_pool.clone())
                 {
                     return Ok(datastore);
                 } else {

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -534,7 +534,7 @@ impl RelationalDB {
                         break;
                     }
                     if let Ok(datastore) =
-                        try_restore_napshot(snapshot_repo, snapshot_offset, database_identity, page_pool.clone())
+                        try_restore_snapshot(snapshot_repo, snapshot_offset, database_identity, page_pool.clone())
                     {
                         return Ok(datastore);
                     } else {

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -466,7 +466,7 @@ impl RelationalDB {
         min_commitlog_offset: TxOffset,
         page_pool: PagePool,
     ) -> Result<Locking, RestoreSnapshotError> {
-        fn try_restore_napshot(
+        fn try_restore_snapshot(
             snapshot_repo: &SnapshotRepository,
             snapshot_offset: TxOffset,
             database_identity: Identity,

--- a/crates/durability/src/imp/local.rs
+++ b/crates/durability/src/imp/local.rs
@@ -345,7 +345,10 @@ impl<T: Encode + 'static> History for Local<T> {
         self.clog.transactions_from(offset, decoder)
     }
 
-    fn max_tx_offset(&self) -> Option<TxOffset> {
-        self.clog.max_committed_offset()
+    fn tx_range_hint(&self) -> (TxOffset, Option<TxOffset>) {
+        let min = self.clog.min_committed_offset().unwrap_or_default();
+        let max = self.clog.max_committed_offset();
+
+        (min, max)
     }
 }

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -82,10 +82,10 @@ pub trait History {
     ///
     /// Callers should thus only rely on it for informational purposes.
     ///
-    /// The default implementation returns `None`, which is correct for any
+    /// The default implementation returns `(0, None)`, which is correct for any
     /// history implementation.
-    fn max_tx_offset(&self) -> Option<TxOffset> {
-        None
+    fn tx_range_hint(&self) -> (TxOffset, Option<TxOffset>) {
+        (0, None)
     }
 }
 
@@ -113,8 +113,8 @@ impl<T: History> History for Arc<T> {
         (**self).transactions_from(offset, decoder)
     }
 
-    fn max_tx_offset(&self) -> Option<TxOffset> {
-        (**self).max_tx_offset()
+    fn tx_range_hint(&self) -> (TxOffset, Option<TxOffset>) {
+        (**self).tx_range_hint()
     }
 }
 
@@ -153,7 +153,7 @@ impl<T> History for EmptyHistory<T> {
         iter::empty()
     }
 
-    fn max_tx_offset(&self) -> Option<TxOffset> {
-        Some(0)
+    fn tx_range_hint(&self) -> (TxOffset, Option<TxOffset>) {
+        (0, Some(0))
     }
 }


### PR DESCRIPTION
Snapshots may be corrupted on disk or incomplete where the lock file is gone,
but the snapshot file was not written (it is written last after all objects).

This patch handles both cases by ignoring snapshots without a snapshot file when
listing the available snapshots, and trying older snapshots if the latest one
cannot be restored from (for any reason).

It also takes into account that the prefix of the local commitlog could have
been archived.

# API and ABI breaking changes

No

# Expected complexity level and risk

2

# Testing

- [x] added
