### PR TITLE
Fix row count stats for multi subscription responses.

### DIFF
--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -297,10 +297,19 @@ fn num_rows_in(rows: &SubscriptionRows) -> usize {
     }
 }
 
+fn subscription_data_rows(rows: &SubscriptionData) -> usize {
+    match &rows.data {
+        FormatSwitch::Bsatn(x) => x.num_rows(),
+        FormatSwitch::Json(x) => x.num_rows(),
+    }
+}
+
 impl SubscriptionMessage {
     fn num_rows(&self) -> usize {
         match &self.result {
             SubscriptionResult::Subscribe(x) => num_rows_in(x),
+            SubscriptionResult::SubscribeMulti(x) => subscription_data_rows(x),
+            SubscriptionResult::UnsubscribeMulti(x) => subscription_data_rows(x),
             SubscriptionResult::Unsubscribe(x) => num_rows_in(x),
             _ => 0,
         }


### PR DESCRIPTION
# Description of Changes

This fixes our outgoing row count metrics for (un)subscribemulti calls.
