### PR TITLE
Follow-up: use asyncify in ModuleHost::call

### DIFF
--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -588,8 +588,13 @@ impl ModuleHost {
             self.inner.get_instance(self.info.database_identity).await?
         };
 
-        // Spawning a task allows to catch panics without proving to the
-        // compiler that `dyn ModuleInstance` is unwind safe.
+        // Operations on module instances (e.g. calling reducers) is blocking,
+        // partially because the computation can potentialyl take a long time
+        // and partially because interacting with the database requires taking
+        // a blocking lock. So, we run `f` inside of `asyncify()`, which runs
+        // the provided closure in a tokio blocking task, and bubbles up any
+        // panic that may occur.
+
         // If a reducer call panics, we **must** ensure to call `self.on_panic`
         // so that the module is discarded by the host controller.
         scopeguard::defer_on_unwind!({

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -592,13 +592,11 @@ impl ModuleHost {
         // compiler that `dyn ModuleInstance` is unwind safe.
         // If a reducer call panics, we **must** ensure to call `self.on_panic`
         // so that the module is discarded by the host controller.
-        let result = tokio::task::spawn_blocking(move || f(&mut *inst))
-            .await
-            .unwrap_or_else(|e| {
-                log::warn!("reducer {reducer} panicked");
-                (self.on_panic)();
-                std::panic::resume_unwind(e.into_panic());
-            });
+        scopeguard::defer_on_unwind!({
+            log::warn!("reducer {reducer} panicked");
+            (self.on_panic)();
+        });
+        let result = asyncify(move || f(&mut *inst)).await;
         Ok(result)
     }
 


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->
Follow-up to #2737. I added this utility function in #2730, and it makes the logic of these kinds of `spawn_blocking` uses clearer.

# Expected complexity level and risk
1
<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->
n/a - the code is equivalent.
- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
