### PR TITLE
Add counters for client connections spawned and aborted.

### DIFF
--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -209,6 +209,8 @@ impl ClientConnection {
             let Ok(fut) = fut_rx.await else { return };
 
             let _gauge_guard = WORKER_METRICS.connected_clients.with_label_values(&db).inc_scope();
+            WORKER_METRICS.ws_clients_spawned.with_label_values(&db).inc();
+            scopeguard::defer!(WORKER_METRICS.ws_clients_aborted.with_label_values(&db).inc());
 
             fut.await
         })

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -15,6 +15,16 @@ metrics_group!(
         #[labels(database_identity: Identity)]
         pub connected_clients: IntGaugeVec,
 
+        #[name = spacetime_worker_ws_clients_spawned]
+        #[help = "Number of new ws client connections spawned. Counted after any on_connect reducers are run."]
+        #[labels(database_identity: Identity)]
+        pub ws_clients_spawned: IntGaugeVec,
+
+        #[name = spacetime_worker_ws_clients_aborted]
+        #[help = "Number of ws client connections aborted"]
+        #[labels(database_identity: Identity)]
+        pub ws_clients_aborted: IntGaugeVec,
+
         #[name = spacetime_websocket_requests_total]
         #[help = "The cumulative number of websocket request messages"]
         #[labels(replica_id: u64, protocol: str)]


### PR DESCRIPTION
# Description of Changes

This adds two new metrics to track how often websocket clients connect and disconnect (`spacetime_worker_ws_clients_spawned`, and `spacetime_worker_ws_clients_aborted`).

Note that this isn't tracking at the tcp connection level, rather it only counts clients that have gone through any client lifecycle reducers.

Adding a metric for rejected clients (meaning the on_connect reducer failed) in the future could be useful.

# API and ABI breaking changes

This is purely a metrics change.

1.

