### PR TITLE
`merge_apply_inserts`: merge via BFLATN -> BFLATN instead of PVs

### DIFF
--- a/crates/table/benches/page.rs
+++ b/crates/table/benches/page.rs
@@ -463,6 +463,7 @@ fn copy_filter_into_fixed_len_keep_ratio<Row: FixedLenRow>(b: &mut Bencher, keep
                 &visitor,
                 None::<&mut Box<dyn FnMut(_)>>,
                 |_page, _row| rng.random_bool(*keep_ratio),
+                |_, _| {},
             )
         };
     });

--- a/crates/table/benches/page.rs
+++ b/crates/table/benches/page.rs
@@ -461,7 +461,7 @@ fn copy_filter_into_fixed_len_keep_ratio<Row: FixedLenRow>(b: &mut Bencher, keep
                 target_page,
                 row_size_for_type::<Row>(),
                 &visitor,
-                &mut NullBlobStore,
+                None::<&mut Box<dyn FnMut(_)>>,
                 |_page, _row| rng.random_bool(*keep_ratio),
             )
         };

--- a/crates/table/benches/page_manager.rs
+++ b/crates/table/benches/page_manager.rs
@@ -460,7 +460,7 @@ fn copy_filter_fixed_len(c: &mut Criterion) {
             group.bench_function(keep_ratio.to_string(), |b| {
                 b.iter_with_large_drop(|| unsafe {
                     let mut keep_iter = keep_seq.iter().copied();
-                    black_box(&pages).copy_filter(visitor, row_size, &mut NullBlobStore, |_, _| {
+                    black_box(&pages).copy_filter(visitor, row_size, None::<&mut Box<dyn FnMut(_)>>, |_, _| {
                         black_box(keep_iter.next().unwrap_or_default())
                     })
                 });

--- a/crates/table/src/blob_store.rs
+++ b/crates/table/src/blob_store.rs
@@ -12,6 +12,7 @@
 //!   It is not optimize and is mainly intended for testing purposes.
 
 use blake3::hash;
+use core::mem;
 use spacetimedb_data_structures::map::{hash_map::Entry, HashMap};
 use spacetimedb_lib::{de::Deserialize, ser::Serialize};
 use spacetimedb_memory_usage::MemoryUsage;
@@ -233,15 +234,20 @@ impl BlobStore for HashMapBlobStore {
     }
 }
 
+impl HashMapBlobStore {
+    /// Merge `src_bs` into `self`.
+    pub fn merge_from(&mut self, src_bs: Self) {
+        for (hash, mut obj) in src_bs.map {
+            let uses = mem::take(&mut obj.uses);
+            self.map.entry(hash).or_insert(obj).uses += uses;
+        }
+    }
+}
+
 #[cfg(test)]
 impl HashMapBlobStore {
-    /// Returns an iterator over the (hash, usage count, blob bytes) triple.
-    fn iter(&self) -> impl Iterator<Item = (&BlobHash, usize, &[u8])> + '_ {
-        self.map.iter().map(|(hash, obj)| (hash, obj.uses, &*obj.blob))
-    }
-
     /// Returns a map relating blob hashes to the usage count in this blob store.
     pub fn usage_counter(&self) -> HashMap<BlobHash, usize> {
-        self.iter().map(|(hash, uses, _)| (*hash, uses)).collect()
+        self.iter_blobs().map(|(hash, uses, _)| (*hash, uses)).collect()
     }
 }

--- a/crates/table/src/page.rs
+++ b/crates/table/src/page.rs
@@ -33,12 +33,14 @@
 //!   for a discussion on safety and validity invariants.
 
 use super::{
-    blob_store::BlobStore,
+    blob_store::{BlobHash, BlobStore},
     fixed_bit_set::FixedBitSet,
-    indexes::{Byte, Bytes, PageOffset, PAGE_HEADER_SIZE, PAGE_SIZE},
+    fixed_bit_set::IterSet,
+    indexes::{max_rows_in_page, Byte, Bytes, PageOffset, PAGE_HEADER_SIZE, PAGE_SIZE},
+    static_assert_size,
+    table::BlobNumBytes,
     var_len::{is_granule_offset_aligned, VarLenGranule, VarLenGranuleHeader, VarLenMembers, VarLenRef},
 };
-use crate::{fixed_bit_set::IterSet, indexes::max_rows_in_page, static_assert_size, table::BlobNumBytes};
 use core::{mem, ops::ControlFlow};
 use spacetimedb_sats::layout::{Size, MIN_ROW_SIZE};
 use spacetimedb_sats::memory_usage::MemoryUsage;
@@ -1640,7 +1642,7 @@ impl Page {
         dst: &mut Page,
         fixed_row_size: Size,
         var_len_visitor: &impl VarLenMembers,
-        blob_store: &mut dyn BlobStore,
+        mut blob_policy: Option<&mut impl FnMut(BlobHash)>,
         mut filter: impl FnMut(&Page, PageOffset) -> bool,
     ) -> ControlFlow<(), PageOffset> {
         for row_offset in self
@@ -1648,11 +1650,12 @@ impl Page {
             // Only copy rows satisfying the predicate `filter`.
             .filter(|o| filter(self, *o))
         {
+            let blob_policy = blob_policy.as_mut();
             // SAFETY:
             // - `starting_from` points to a valid row and thus `row_offset` also does.
             // - `var_len_visitor` will visit the right `VarLenRef`s and is consistent with other calls.
             // - `fixed_row_size` is consistent with `var_len_visitor` and `self`.
-            if !unsafe { self.copy_row_into(row_offset, dst, fixed_row_size, var_len_visitor, blob_store) } {
+            if !unsafe { self.copy_row_into(row_offset, dst, fixed_row_size, var_len_visitor, blob_policy) } {
                 // Target doesn't have enough space for row;
                 // stop here and return the offset of the uncopied row
                 // so a later call to `copy_filter_into` can start there.
@@ -1684,7 +1687,7 @@ impl Page {
         dst: &mut Page,
         fixed_row_size: Size,
         var_len_visitor: &impl VarLenMembers,
-        blob_store: &mut dyn BlobStore,
+        mut blob_policy: Option<&mut impl FnMut(BlobHash)>,
     ) -> bool {
         // SAFETY: Caller promised that `starting_from` points to a valid row
         // consistent with `fixed_row_size` which was also
@@ -1717,6 +1720,7 @@ impl Page {
         // SAFETY: forward our requirement on `var_len_visitor` to `visit_var_len_mut`.
         let target_vlr_iter = unsafe { var_len_visitor.visit_var_len_mut(dst_row) };
         for (src_vlr, target_vlr_slot) in src_vlr_iter.zip(target_vlr_iter) {
+            let blob_policy = blob_policy.as_mut();
             // SAFETY:
             //
             // - requirements of `visit_var_len_assume_init` were met,
@@ -1724,7 +1728,7 @@ impl Page {
             //
             // - the call to `dst.has_space_for_row` above ensures
             //   that the allocation will not fail part-way through.
-            let target_vlr_fixup = unsafe { self.copy_var_len_into(*src_vlr, &mut dst_var, blob_store) }
+            let target_vlr_fixup = unsafe { self.copy_var_len_into(*src_vlr, &mut dst_var, blob_policy) }
                 .expect("Failed to allocate var-len object in dst page after checking for available space");
 
             *target_vlr_slot = target_vlr_fixup;
@@ -1751,7 +1755,7 @@ impl Page {
         &self,
         src_vlr: VarLenRef,
         dst_var: &mut VarView<'_>,
-        blob_store: &mut dyn BlobStore,
+        blob_policy: Option<&mut impl FnMut(BlobHash)>,
     ) -> Result<VarLenRef, Error> {
         // SAFETY: Caller promised that `src_vlr.first_granule` points to a valid granule is be NULL.
         let mut iter = unsafe { self.iter_var_len_object(src_vlr.first_granule) };
@@ -1803,12 +1807,12 @@ impl Page {
         //    or was `next_dst_chunk` in the previous iteration and hasn't been written to yet.
         unsafe { dst_var.write_chunk_to_granule(data, data.len(), dst_chunk, PageOffset::VAR_LEN_NULL) };
 
-        // For a large blob object,
-        // notify the `blob_store` that we've taken a reference to the blob hash.
-        if src_vlr.is_large_blob() {
-            blob_store
-                .clone_blob(&src_chunk.blob_hash())
-                .expect("blob_store could not mark hash as used");
+        // For a large blob object, run the blob policy, if we have one.
+        // This could, for example:
+        // - increment the refcount in the blob store
+        // - clone the blob object and the bytes to a new blob store.
+        if let Some(blob_policy) = blob_policy.filter(|_| src_vlr.is_large_blob()) {
+            blob_policy(src_chunk.blob_hash());
         }
 
         Ok(VarLenRef {

--- a/crates/table/src/page.rs
+++ b/crates/table/src/page.rs
@@ -1625,6 +1625,10 @@ impl Page {
     /// If the entirety of `self` is processed, return `Break`.
     /// `dst` may or may not be full in this case, but is likely not full.
     ///
+    /// When a row is copied over,
+    /// `notify` is called with first the source row offset
+    /// and then the destination row offset.
+    ///
     /// # Safety
     ///
     /// The `var_len_visitor` must visit the same set of `VarLenRef`s in the row
@@ -1636,6 +1640,7 @@ impl Page {
     /// The `starting_from` offset must point to a valid starting offset
     /// consistent with `fixed_row_size`.
     /// That is, it must not point into the middle of a row.
+    #[allow(clippy::too_many_arguments)]
     pub unsafe fn copy_filter_into(
         &self,
         starting_from: PageOffset,
@@ -1644,6 +1649,7 @@ impl Page {
         var_len_visitor: &impl VarLenMembers,
         mut blob_policy: Option<&mut impl FnMut(BlobHash)>,
         mut filter: impl FnMut(&Page, PageOffset) -> bool,
+        mut notify: impl FnMut(PageOffset, PageOffset),
     ) -> ControlFlow<(), PageOffset> {
         for row_offset in self
             .iter_fixed_len_from(fixed_row_size, starting_from)
@@ -1655,11 +1661,13 @@ impl Page {
             // - `starting_from` points to a valid row and thus `row_offset` also does.
             // - `var_len_visitor` will visit the right `VarLenRef`s and is consistent with other calls.
             // - `fixed_row_size` is consistent with `var_len_visitor` and `self`.
-            if !unsafe { self.copy_row_into(row_offset, dst, fixed_row_size, var_len_visitor, blob_policy) } {
+            let res = unsafe { self.copy_row_into(row_offset, dst, fixed_row_size, var_len_visitor, blob_policy) };
+            match res {
+                Some(inserted_offset) => notify(row_offset, inserted_offset),
                 // Target doesn't have enough space for row;
                 // stop here and return the offset of the uncopied row
                 // so a later call to `copy_filter_into` can start there.
-                return ControlFlow::Continue(row_offset);
+                None => return ControlFlow::Continue(row_offset),
             }
         }
 
@@ -1670,7 +1678,8 @@ impl Page {
     }
 
     /// Copies the row at `row_offset` from `self` into `dst`
-    /// or returns `false` otherwise if `dst` has no space for the row.
+    /// and returns the new offset in `dst`.
+    /// Returns `None` if `dst` has no space for the row.
     ///
     /// # Safety
     ///
@@ -1688,14 +1697,14 @@ impl Page {
         fixed_row_size: Size,
         var_len_visitor: &impl VarLenMembers,
         mut blob_policy: Option<&mut impl FnMut(BlobHash)>,
-    ) -> bool {
+    ) -> Option<PageOffset> {
         // SAFETY: Caller promised that `starting_from` points to a valid row
         // consistent with `fixed_row_size` which was also
         // claimed to be consistent with `var_len_visitor` and `self`.
         let required_granules = unsafe { self.row_total_granules(row_offset, fixed_row_size, var_len_visitor) };
         if !dst.has_space_for_row(fixed_row_size, required_granules) {
             // Target doesn't have enough space for row.
-            return false;
+            return None;
         };
 
         let src_row = self.get_row_data(row_offset, fixed_row_size);
@@ -1734,7 +1743,7 @@ impl Page {
             *target_vlr_slot = target_vlr_fixup;
         }
 
-        true
+        Some(inserted_offset)
     }
 
     /// Copy a var-len object `src_vlr` from `self` into `dst_var`,

--- a/crates/table/src/pages.rs
+++ b/crates/table/src/pages.rs
@@ -1,6 +1,6 @@
 //! Provides [`Pages`], a page manager dealing with [`Page`]s as a collection.
 
-use super::blob_store::BlobStore;
+use super::blob_store::{BlobHash, BlobStore};
 use super::indexes::{Bytes, PageIndex, PageOffset, RowPointer};
 use super::page::Page;
 use super::page_pool::PagePool;
@@ -264,7 +264,7 @@ impl Pages {
         &self,
         var_len_visitor: &impl VarLenMembers,
         fixed_row_size: Size,
-        blob_store: &mut dyn BlobStore,
+        mut blob_policy: Option<&mut impl FnMut(BlobHash)>,
         mut filter: impl FnMut(&Page, PageOffset) -> bool,
     ) -> Self {
         // Build a new container to hold the materialized view.
@@ -311,7 +311,7 @@ impl Pages {
                         &mut to_page,
                         fixed_row_size,
                         var_len_visitor,
-                        blob_store,
+                        blob_policy.as_mut(),
                         &mut filter,
                     )
                 };

--- a/crates/table/src/pages.rs
+++ b/crates/table/src/pages.rs
@@ -1,7 +1,7 @@
 //! Provides [`Pages`], a page manager dealing with [`Page`]s as a collection.
 
 use super::blob_store::{BlobHash, BlobStore};
-use super::indexes::{Bytes, PageIndex, PageOffset, RowPointer};
+use super::indexes::{Bytes, PageIndex, PageOffset, RowPointer, SquashedOffset};
 use super::page::Page;
 use super::page_pool::PagePool;
 use super::table::BlobNumBytes;
@@ -120,7 +120,7 @@ impl Pages {
     /// add it to the non-full set so that later insertions can access it.
     pub fn maybe_mark_page_non_full(&mut self, page_index: PageIndex, fixed_row_size: Size) {
         if !self[page_index].is_full(fixed_row_size) {
-            self.non_full_pages.push(page_index);
+            self.mark_page_non_full(page_index);
         }
     }
 
@@ -251,6 +251,125 @@ impl Pages {
         blob_store_deleted_bytes
     }
 
+    /// Moves over all pages in `src` to `self`.
+    ///
+    /// This consumes `src` and either frees pages or moves them to `self`.
+    //  TODO(perf, centril): Currently we just copy pages over and free the source pages,
+    //  figure out some clever heuristic as to when we can move pages instead.
+    ///
+    /// # Safety
+    ///
+    /// - The `var_len_visitor` will visit the same set of `VarLenRef`s in the row
+    ///   as the visitor provided to all other methods on `self` and `src`.
+    ///
+    /// - The `fixed_row_size` is consistent with the `var_len_visitor`
+    ///   and is equal to the value provided to all other methods on `self` and `src`.
+    #[allow(clippy::too_many_arguments)]
+    pub unsafe fn take_pages_of(
+        &mut self,
+        src: Pages,
+        src_so: SquashedOffset,
+        dst_so: SquashedOffset,
+        pool: &PagePool,
+        var_len_visitor: &impl VarLenMembers,
+        fixed_row_size: Size,
+        mut notify: impl FnMut(RowPointer, RowPointer),
+    ) -> Result<(), Error> {
+        let dst = self;
+
+        // A destination page that was not filled entirely,
+        // or `None` if we need to find a page in `dst`.
+        let mut partial_page = None;
+
+        // Copy each page.
+        for (src_page, src_page_index) in src.pages.into_iter().zip(0..) {
+            let src_page_index = PageIndex(src_page_index);
+
+            // You may require multiple calls to `Page::copy_starting_from`
+            // if `partial_page` fills up;
+            // the first call starts from 0.
+            let mut copy_starting_from = Some(PageOffset(0));
+
+            // While there are unprocessed rows in `src_page`,
+            while let Some(next_offset) = copy_starting_from.take() {
+                // Grab the `partial_page` or grab a new one from `dst`.
+                // The `dst` will allocate a new one if necessary.
+                if partial_page.is_none() {
+                    // SAFETY:
+                    // - Still processing `src_page`, so `next_offset` is a valid offset in it.
+                    // - Caller promised that `fixed_row_size` is consistent with `var_len_visitor`
+                    //   and as `src_page` is part of `src`,
+                    //   it follows that `fixed_row_size` is equal to the size used for `src_page`.
+                    let required_granules =
+                        unsafe { src_page.row_total_granules(next_offset, fixed_row_size, var_len_visitor) };
+                    let dst_page_index = dst.find_page_with_space_for_row(pool, fixed_row_size, required_granules)?;
+                    partial_page = Some((dst_page_index, &mut dst[dst_page_index]));
+                }
+                let dst_page_and_index = partial_page.take();
+                // SAFETY: if `partial_page` was `None` the `if` made it `Some`.
+                let (dst_page_index, dst_page) = unsafe { dst_page_and_index.unwrap_unchecked() };
+
+                // Copy as many rows as will fit in `dst_page`.
+                //
+                // SAFETY:
+                //
+                // - The `var_len_visitor` will visit the same set of `VarLenRef`s in the row
+                //   as the visitor provided to all other methods on `dst`.
+                //   The `dst_page` uses the same visitor as the `src_page`.
+                //
+                // - The `fixed_row_size` is consistent with the `var_len_visitor`
+                //   and is equal to the value provided to all other methods on `dst` and `src`,
+                //   as promised by the caller,
+                //   and thus `dst_page` and `src_page`
+                //
+                // - The `next_offset` is either 0,
+                //   which is always a valid starting offset for any row size,
+                //   or it came from `copy_filter_into` in a previous iteration,
+                //   which, given that `fixed_row_size` was valid,
+                //   always returns a valid starting offset in case of `Continue(_)`.
+                let cfi_ret = unsafe {
+                    src_page.copy_filter_into(
+                        next_offset,
+                        dst_page,
+                        fixed_row_size,
+                        var_len_visitor,
+                        // No blob policy. We will merge the blob stores wholesale instead.
+                        None::<&mut &mut dyn FnMut(_)>,
+                        // Copy all rows.
+                        |_, _| true,
+                        // Add a translation entry for indices.
+                        |src_offset, dst_offset| {
+                            let src_ptr = RowPointer::new(false, src_page_index, src_offset, src_so);
+                            let dst_ptr = RowPointer::new(false, dst_page_index, dst_offset, dst_so);
+                            notify(src_ptr, dst_ptr);
+                        },
+                    )
+                };
+                // If `dst_page` couldn't fit all of `src_page` (`Continue`),
+                // repeat the `while_let` loop to copy the rest.
+                // If `dst_page` fit all of `src_page`, we can move on.
+                copy_starting_from = cfi_ret.continue_value();
+
+                // If `src_page` finished copying into `dst_page`, then `dst_page` may have extra room.
+                //
+                // If `copy_filter_into` returns `Continue`,
+                // that means at least one row didn't have space in `dst_page`,
+                // so we must consider `dst_page` full.
+                //
+                // Note that this is distinct from `Page::is_full`,
+                // as that method considers the optimistic case of a row with no var-len members.
+                if copy_starting_from.is_none() {
+                    partial_page = Some((dst_page_index, dst_page));
+                }
+            }
+
+            // We're done with `src_page`, so return it to the pool.
+            pool.put(src_page);
+        }
+
+        Ok(())
+    }
+
     /// Materialize a view of rows in `self` for which the  `filter` returns `true`.
     ///
     /// # Safety
@@ -313,6 +432,7 @@ impl Pages {
                         var_len_visitor,
                         blob_policy.as_mut(),
                         &mut filter,
+                        |_, _| {},
                     )
                 };
                 copy_starting_from = if let ControlFlow::Continue(continue_point) = cfi_ret {

--- a/crates/table/src/pointer_map.rs
+++ b/crates/table/src/pointer_map.rs
@@ -194,10 +194,15 @@ impl PointerMap {
 
     /// Returns the row pointers associated with the given row `hash`.
     pub fn pointers_for(&self, hash: RowHash) -> &[RowPointer] {
-        self.map.get(&hash).map_or(&[], |poc| match poc.unpack() {
+        self.map.get(&hash).map_or(&[], |poc| self.poc_pointers(poc))
+    }
+
+    /// Returns the row pointers for `poc`.
+    fn poc_pointers<'a>(&'a self, poc: &'a PtrOrCollider) -> &'a [RowPointer] {
+        match poc.unpack() {
             MapSlotRef::Pointer(ro) => slice::from_ref(ro),
             MapSlotRef::Collider(ci) => &self.colliders[ci.idx()],
-        })
+        }
     }
 
     /// Returns the row pointers associated with the given row `hash`.
@@ -312,6 +317,23 @@ impl PointerMap {
         };
 
         ret
+    }
+
+    /// Returns an iterator over all row hash x row pointer pairs.
+    pub fn iter(&self) -> impl '_ + Iterator<Item = (RowHash, RowPointer)> {
+        self.map
+            .iter()
+            .flat_map(|(hash, poc)| self.poc_pointers(poc).iter().map(|&ptr| (*hash, ptr)))
+    }
+
+    /// Merges `translate(src_pm)` into `self`.
+    ///
+    /// For every `(hash, ptr)` in `src_pm`,
+    /// inserts `(hash, translate(ptr))` into `self`.
+    pub fn merge_from(&mut self, src_pm: PointerMap, translate: impl Fn(RowPointer) -> RowPointer) {
+        for (hash, ptr) in src_pm.iter() {
+            self.insert(hash, translate(ptr));
+        }
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Change `merge_apply_inserts`, so that merging into `CommittedState` is done via `Table::merge_from`, added in this PR, rather than depending on creating PVs. This means that we do BFLATN -> BFLATN copying instead.

PVs are however still made to produce `TxData`. I've added TODOs to eventually remove that too in favor of not using PVs in subscriptions and serializing into and storing BSATN in `TxData`.

Only the last commit ([merge_apply_inserts: merge tables and blob stores directly, not via PV](https://github.com/clockworklabs/SpacetimeDB/pull/2744/changes/945a0d2a9a8a4343638e6ff29b6ec0c323f69775)) is from this PR, which is the last in the stack.

# API and ABI breaking changes

None

# Expected complexity level and risk

4, fairly complex change touching critical datastore bits.

# Testing

Covered by existing tests.