### PR TITLE
Add `ws_schema.json` to gitignore

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -216,3 +216,6 @@ new.json
 # Keys
 *.pem
 .ok.sql
+
+# Intermediate file generated when updating the external client SDKs' WS format bindings
+crates/client-api-messages/ws_schema.json


### PR DESCRIPTION
# Description of Changes

Gitignore a file that's an intermediate artifact of updating the external client SDKs when the WS protocol gets extended.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

0

# Testing

N/a
