### PR TITLE
Reject clients who match an existing `st_client` row

### DIFF
--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -694,9 +694,10 @@ impl ModuleHost {
             });
 
             let stdb = self.inner.replica_ctx().relational_db.clone();
+            let database_identity = self.info().database_identity;
             asyncify(move || {
                 stdb.with_auto_commit(workload, |mut_tx| {
-                    mut_tx.insert_st_client(caller_identity, caller_connection_id)
+                    mut_tx.insert_st_client(caller_identity, caller_connection_id, database_identity)
                 })
             })
             .await

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -478,7 +478,9 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
             // and conversely removing from `st_clients` on disconnect.
             Ok(Ok(())) => {
                 let res = match reducer_def.lifecycle {
-                    Some(Lifecycle::OnConnect) => tx.insert_st_client(caller_identity, caller_connection_id),
+                    Some(Lifecycle::OnConnect) => {
+                        tx.insert_st_client(caller_identity, caller_connection_id, database_identity)
+                    }
                     Some(Lifecycle::OnDisconnect) => {
                         tx.delete_st_client(caller_identity, caller_connection_id, database_identity)
                     }


### PR DESCRIPTION
# Description of Changes

At various places in our codebase, we assume that client connections are unique by `(identity, connection_id)` pair,
but we never actually enforced this prior to now.
It was difficult, but not impossible, to accidentally connect with an already-present `(identity, connection_id)` pair. The easiest way was to open two `DbConnection`s in parallel from within a single Rust client SDK process,
due to a misbehavior in that SDK which I intend to fix in a separate PR.

This commit modifies `MutTxId::insert_st_client` to return an error if the row to be inserted is already resident in the database. It's still possible for a database owner to delete from `st_client` manually via a SQL `delete` statement, which will cause strange misbehaviors, but it should no longer be possible for an unprivileged client to accidentally put the database into a state that's intended to be impossible.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Manually tested with [a modified `quickstart-chat` client](https://github.com/user-attachments/files/20257695/quickstart-chat-two-connections.patch.txt).
  - Prior to this commit, the host accepts both connections, sends responses only to the first one, and shows the error log introduced by #2722 when the second disconnects. (Or maybe when the first disconnects? Timing unclear.)
  - With this commit, the host rejects the second connection, and so none of the misbehavior is reachable.
- [ ] Write automated tests somehow.
