### PR TITLE
Bump rust-toolchain to rust 1.87

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -183,7 +183,7 @@ jobs:
     runs-on: ubuntu-latest
     timeout-minutes: 20 # on a successful run, runs in 8 minutes
     container:
-      image: rust:1.83.0
+      image: rust:1.87.0
       options: --privileged
     # filter for a comment containing 'benchmarks please'
     if: ${{ github.event_name != 'issue_comment' || (github.event.issue.pull_request && contains(github.event.comment.body, 'benchmarks please')) }}

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -89,7 +89,8 @@ debug = true
 [workspace.package]
 version = "1.1.1"
 edition = "2021"
-# update rust-toolchain.toml too!
+# This is the rust-version for the bindings crate, but not necessarily
+# the database (core, standalone, etc)
 rust-version = "1.84.0"
 
 [workspace.dependencies]

--- a/crates/bench/Dockerfile
+++ b/crates/bench/Dockerfile
@@ -3,7 +3,7 @@
 # See the README for commands to run.
 
 # sync with: ../../rust-toolchain.toml
-FROM rust:1.84.0
+FROM rust:1.87.0
 
 RUN apt-get update && \
     apt-get install -y valgrind bash && \

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -4,7 +4,6 @@ version.workspace = true
 edition.workspace = true
 license-file = "LICENSE"
 description = "The core library for SpacetimeDB"
-rust-version.workspace = true
 
 # See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
 [lib]

--- a/crates/standalone/Dockerfile
+++ b/crates/standalone/Dockerfile
@@ -1,7 +1,7 @@
 ARG CARGO_PROFILE=release
 
 
-FROM rust:1.84.0 AS chef
+FROM rust:1.87.0 AS chef
 RUN rust_target=$(rustc -vV | awk '/^host:/{ print $2 }') && \
   curl https://github.com/cargo-bins/cargo-binstall/releases/latest/download/cargo-binstall-$rust_target.tgz -fL | tar xz -C $CARGO_HOME/bin
 RUN cargo binstall -y cargo-chef@0.1.70

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,6 +1,7 @@
 [toolchain]
-# change crates/{standalone,bench}/Dockerfile and rust-version in Cargo.toml too!
-# also the docker image tag in .github/workflows/benchmarks.yml:jobs/callgrind_benchmark/container/image
-channel = "1.84.0"
+# change crates/{standalone,bench}/Dockerfile, and the docker image tag in
+# .github/workflows/benchmarks.yml:jobs/callgrind_benchmark/container/image
+# maybe also the rust-version in Cargo.toml
+channel = "1.87.0"
 profile = "default"
 targets = ["wasm32-unknown-unknown"]


### PR DESCRIPTION
# Description of Changes

This bumps our rust-toolchain in the file to 1.87, but doesn't bump the MSRV of the bindings crate and its dependents. We could, if we wanted to, but we don't really have an MSRV policy in place. This is necessary because the `v8` crate has a fairly aggressive MSRV and I'd like to not fall too far behind from their latest version, since that's also the version of V8 itself.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->
2 - rust version changes can cause problems but it's very rare

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
