### PR TITLE
Add `client_connection_incoming_queue_length` metric

### DIFF
--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -257,6 +257,11 @@ metrics_group!(
         #[help = "The cumulative number of bytes sent to clients"]
         #[labels(txn_type: WorkloadType, db: Identity)]
         pub bytes_sent_to_clients: IntCounterVec,
+
+        #[name = spacetime_client_connection_incoming_queue_length]
+        #[help = "The number of client -> server WebSocket messages waiting in a client connection's incoming queue"]
+        #[labels(db: Identity, client_identity: Identity, connection_id: ConnectionId)]
+        pub client_connection_incoming_queue_length: IntGaugeVec,
     }
 );
 


### PR DESCRIPTION
# Description of Changes

It's a metric that tracks the size of the incoming per-client `message_queue`. We've been concerned about not having visibility into this queue's length, as currently we only have the length of the per-database reducer queue, but each client can only have a single reducer in that queue, and may have additional messages waiting in its per-client queue.

The new metric, `spacetime_client_connection_incoming_queue_length`, is an `IntGaugeVec` with the labels:
`db: Identity, client_identity: Identity, connection_id: ConnectionId`. My theory is that in our viewer we can inspect the average and the sum per database, and it also may be interesting to be able to look at individual clients, as e.g. the BitCraft mob monitor may be a notable outlier. This is not the same pattern as most of our other metrics, though, which tend to only offer per-database granularity. It's possible that this new metric should also have the last two labels removed, and be labeled only on `db: Identity`.

# API and ABI breaking changes

N/a, as we don't (AFAIK) offer stability guarantees for our metrics.

# Expected complexity level and risk

2ish: see above question about granularity.

# Testing

I am not sure how to test this.

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
