### PR TITLE
core: Fix error handling when restoring snapshot

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -2974,7 +2974,7 @@ mod tests {
         try_restore(1, 0)?;
         // But not if the commitlog starts after the previous snapshot
         assert_matches!(
-            try_restore(1, 1).map(drop),
+            try_restore(1, 2).map(drop),
             Err(RestoreSnapshotError::NoConnectedSnapshot { .. })
         );
 

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -557,7 +557,7 @@ impl RelationalDB {
                 else {
                     break;
                 };
-                if min_commitlog_offset > 0 && min_commitlog_offset + 1 > snapshot_offset {
+                if min_commitlog_offset > 0 && min_commitlog_offset > snapshot_offset + 1 {
                     log::debug!(
                         "snapshot_offset={} min_commitlog_offset={}",
                         snapshot_offset,

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -549,7 +549,12 @@ impl RelationalDB {
                 else {
                     break;
                 };
-                if min_commitlog_offset + 1 > snapshot_offset {
+                if min_commitlog_offset > 0 && min_commitlog_offset + 1 > snapshot_offset {
+                    log::debug!(
+                        "snapshot_offset={} min_commitlog_offset={}",
+                        snapshot_offset,
+                        min_commitlog_offset
+                    );
                     break;
                 }
                 match try_load_snapshot(snapshot_repo, snapshot_offset, database_identity, &page_pool) {

--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -426,4 +426,10 @@ pub enum RestoreSnapshotError {
     Bootstrap(#[source] Box<DBError>),
     #[error("No connected snapshot found, commitlog starts at {min_commitlog_offset}")]
     NoConnectedSnapshot { min_commitlog_offset: TxOffset },
+    #[error("Failed to invalidate snapshots at or newer than {offset}")]
+    Invalidate {
+        offset: TxOffset,
+        #[source]
+        source: Box<SnapshotError>,
+    },
 }


### PR DESCRIPTION
- `Locking::restore_from_snapshot` should not be retried, as it is not
  idempotent
- Non-transient errors (i.e. hash mismatch, deserialization) should
  invalide the snapshot

# Expected complexity level and risk

2

# Testing

