### PR TITLE
Improve serialization speed of enums without data in C#

### DIFF
--- a/crates/bindings-csharp/BSATN.Codegen/Type.cs
+++ b/crates/bindings-csharp/BSATN.Codegen/Type.cs
@@ -73,7 +73,11 @@ public abstract record TypeUse(string Name, string BSATNName)
                     Parse(member, named.TypeArguments[0], diag)
                 ),
                 _ => named.IsValueType
-                    ? (named.TypeKind == Microsoft.CodeAnalysis.TypeKind.Enum ? new EnumUse(type, typeInfo) : new ValueUse(type, typeInfo))
+                    ? (
+                        named.TypeKind == Microsoft.CodeAnalysis.TypeKind.Enum
+                            ? new EnumUse(type, typeInfo)
+                            : new ValueUse(type, typeInfo)
+                    )
                     : new ReferenceUse(type, typeInfo),
             },
             _ => throw new InvalidOperationException($"Unsupported type {type}"),

--- a/crates/bindings-csharp/BSATN.Codegen/Type.cs
+++ b/crates/bindings-csharp/BSATN.Codegen/Type.cs
@@ -73,7 +73,7 @@ public abstract record TypeUse(string Name, string BSATNName)
                     Parse(member, named.TypeArguments[0], diag)
                 ),
                 _ => named.IsValueType
-                    ? new ValueUse(type, typeInfo)
+                    ? (named.TypeKind == Microsoft.CodeAnalysis.TypeKind.Enum ? new EnumUse(type, typeInfo) : new ValueUse(type, typeInfo))
                     : new ReferenceUse(type, typeInfo),
             },
             _ => throw new InvalidOperationException($"Unsupported type {type}"),
@@ -113,7 +113,32 @@ public abstract record TypeUse(string Name, string BSATNName)
 }
 
 /// <summary>
-/// A use of a value type.
+/// A use of an enum type.
+/// (This is a C# enum, not one of our tagged enums.)
+/// </summary>
+/// <param name="Type"></param>
+/// <param name="TypeInfo"></param>
+public record EnumUse(string Type, string TypeInfo) : TypeUse(Type, TypeInfo)
+{
+    // We just use `==` here, rather than `.Equals`, because
+    // C# enums don't provide a `bool Equals(Self other)`, and
+    // using `.Equals(object other)` allocates, which we want to avoid.
+    // 
+    // We could instead generate custom .Equals for enums -- except that requires
+    // partial enums, and I'm not sure such things exist.
+    public override string EqualsStatement(
+        string inVar1,
+        string inVar2,
+        string outVar,
+        int level = 0
+    ) => $"var {outVar} = {inVar1} == {inVar2};";
+
+    public override string GetHashCodeStatement(string inVar, string outVar, int level = 0) =>
+        $"var {outVar} = {inVar}.GetHashCode();";
+}
+
+/// <summary>
+/// A use of a value type (that is not an enum).
 /// </summary>
 /// <param name="Type"></param>
 /// <param name="TypeInfo"></param>

--- a/crates/bindings-csharp/BSATN.Codegen/Type.cs
+++ b/crates/bindings-csharp/BSATN.Codegen/Type.cs
@@ -123,7 +123,7 @@ public record EnumUse(string Type, string TypeInfo) : TypeUse(Type, TypeInfo)
     // We just use `==` here, rather than `.Equals`, because
     // C# enums don't provide a `bool Equals(Self other)`, and
     // using `.Equals(object other)` allocates, which we want to avoid.
-    // 
+    //
     // We could instead generate custom .Equals for enums -- except that requires
     // partial enums, and I'm not sure such things exist.
     public override string EqualsStatement(

--- a/crates/bindings-csharp/BSATN.Runtime.Tests/Tests.cs
+++ b/crates/bindings-csharp/BSATN.Runtime.Tests/Tests.cs
@@ -444,7 +444,8 @@ public static partial class BSATNRuntimeTests
             BasicDataClass U,
             BasicDataStruct V,
             BasicDataRecord W
-        )> { }
+        )>
+    { }
 
     static readonly Gen<BasicEnum> GenBasicEnum = Gen.SelectMany<int, BasicEnum>(
         Gen.Int[0, 7],
@@ -669,6 +670,7 @@ public static partial class BSATNRuntimeTests
         PisangRaja,
     }
 
+
     [Fact]
     public static void EnumSerializationWorks()
     {
@@ -819,5 +821,38 @@ public static partial class BSATNRuntimeTests
             ).ToString()
         );
 #pragma warning restore CS8625 // Cannot convert null literal to non-nullable reference type.
+    }
+
+    [Type]
+    partial struct ContainsEnum
+    {
+        public Banana TheBanana;
+        public int BananaCount;
+    }
+
+    static readonly Gen<(Banana, int)> GenContainsEnum = Gen.Select(Gen.Enum<Banana>(), Gen.Int[0, 3]);
+    static readonly Gen<((Banana, int), (Banana, int))> GenTwoContainsEnum = Gen.Select(GenContainsEnum, GenContainsEnum);
+
+    [Fact]
+    public static void GeneratedEnumEqualsWorks()
+    {
+        GenTwoContainsEnum.Sample(example =>
+        {
+            var ((b1, c1), (b2, c2)) = example;
+            var struct1 = new ContainsEnum { TheBanana = b1, BananaCount = c1 };
+            var struct2 = new ContainsEnum { TheBanana = b2, BananaCount = c2 };
+
+            if ((b1, c1) == (b2, c2))
+            {
+                Assert.True(struct1.Equals(struct2));
+                Assert.Equal(struct1, struct2);
+            }
+            else
+            {
+                Assert.False(struct1.Equals(struct2));
+                Assert.NotEqual(struct1, struct2);
+            }
+
+        }, iter: 10_000);
     }
 }

--- a/crates/bindings-csharp/BSATN.Runtime.Tests/Tests.cs
+++ b/crates/bindings-csharp/BSATN.Runtime.Tests/Tests.cs
@@ -656,6 +656,51 @@ public static partial class BSATNRuntimeTests
         }
     }
 
+    [Type]
+    enum Banana
+    {
+        Cavendish,
+        LadyFinger,
+        RedBanana,
+        Manzano,
+        BlueJava,
+        GreenPlantain,
+        YellowPlantain,
+        PisangRaja,
+    }
+
+    [Fact]
+    public static void EnumSerializationWorks()
+    {
+        var serializer = new Enum<Banana>();
+        var bananas = new Banana[]
+        {
+            Banana.Cavendish,
+            Banana.LadyFinger,
+            Banana.RedBanana,
+            Banana.Manzano,
+            Banana.BlueJava,
+            Banana.GreenPlantain,
+            Banana.YellowPlantain,
+            Banana.PisangRaja,
+        };
+        for (var i = 0; i < bananas.Length; i++)
+        {
+            var stream = new MemoryStream();
+            var writer = new BinaryWriter(stream);
+            var banana = bananas[i];
+            serializer.Write(writer, banana);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var tag = new BinaryReader(stream).ReadByte();
+            Assert.Equal(tag, i);
+
+            stream.Seek(0, SeekOrigin.Begin);
+            var newBanana = serializer.Read(new BinaryReader(stream));
+            Assert.Equal(banana, newBanana);
+        }
+    }
+
     [Fact]
     public static void GeneratedNestedListEqualsWorks()
     {

--- a/crates/bindings-csharp/BSATN.Runtime.Tests/Tests.cs
+++ b/crates/bindings-csharp/BSATN.Runtime.Tests/Tests.cs
@@ -444,8 +444,7 @@ public static partial class BSATNRuntimeTests
             BasicDataClass U,
             BasicDataStruct V,
             BasicDataRecord W
-        )>
-    { }
+        )> { }
 
     static readonly Gen<BasicEnum> GenBasicEnum = Gen.SelectMany<int, BasicEnum>(
         Gen.Int[0, 7],
@@ -670,7 +669,6 @@ public static partial class BSATNRuntimeTests
         PisangRaja,
     }
 
-
     [Fact]
     public static void EnumSerializationWorks()
     {
@@ -830,29 +828,37 @@ public static partial class BSATNRuntimeTests
         public int BananaCount;
     }
 
-    static readonly Gen<(Banana, int)> GenContainsEnum = Gen.Select(Gen.Enum<Banana>(), Gen.Int[0, 3]);
-    static readonly Gen<((Banana, int), (Banana, int))> GenTwoContainsEnum = Gen.Select(GenContainsEnum, GenContainsEnum);
+    static readonly Gen<(Banana, int)> GenContainsEnum = Gen.Select(
+        Gen.Enum<Banana>(),
+        Gen.Int[0, 3]
+    );
+    static readonly Gen<((Banana, int), (Banana, int))> GenTwoContainsEnum = Gen.Select(
+        GenContainsEnum,
+        GenContainsEnum
+    );
 
     [Fact]
     public static void GeneratedEnumEqualsWorks()
     {
-        GenTwoContainsEnum.Sample(example =>
-        {
-            var ((b1, c1), (b2, c2)) = example;
-            var struct1 = new ContainsEnum { TheBanana = b1, BananaCount = c1 };
-            var struct2 = new ContainsEnum { TheBanana = b2, BananaCount = c2 };
-
-            if ((b1, c1) == (b2, c2))
+        GenTwoContainsEnum.Sample(
+            example =>
             {
-                Assert.True(struct1.Equals(struct2));
-                Assert.Equal(struct1, struct2);
-            }
-            else
-            {
-                Assert.False(struct1.Equals(struct2));
-                Assert.NotEqual(struct1, struct2);
-            }
+                var ((b1, c1), (b2, c2)) = example;
+                var struct1 = new ContainsEnum { TheBanana = b1, BananaCount = c1 };
+                var struct2 = new ContainsEnum { TheBanana = b2, BananaCount = c2 };
 
-        }, iter: 10_000);
+                if ((b1, c1) == (b2, c2))
+                {
+                    Assert.True(struct1.Equals(struct2));
+                    Assert.Equal(struct1, struct2);
+                }
+                else
+                {
+                    Assert.False(struct1.Equals(struct2));
+                    Assert.NotEqual(struct1, struct2);
+                }
+            },
+            iter: 10_000
+        );
     }
 }

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
@@ -157,10 +157,13 @@ public readonly struct Enum<T> : IReadWrite<T>
         // However, enum values are guaranteed to be sequential and zero based.
         // Hence we only ever need to do an upper bound check.
         // See `SpacetimeDB.Type.ParseEnum` for the syntax analysis.
+        //
+        // Note: this actually still uses reflection and allocates.
+        // It's hard to figure out how to avoid this without custom-generating a writer for each enum type.
         var tag = Convert.ToByte(value);
         if (tag < TagToValue.Length)
         {
-            writer.Write(Convert.ToByte(tag));
+            writer.Write(tag);
         }
         else
         {

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
@@ -165,7 +165,7 @@ public readonly struct Enum<T> : IReadWrite<T>
         else
         {
             throw new ArgumentOutOfRangeException(
-                $"Enum {value} is malformed for type {typeof(T).Name}"
+                $"Value {value} is out of range for enum {typeof(T).Name}"
             );
         }
     }

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN/Runtime.cs
@@ -118,24 +118,37 @@ public interface IReadWrite<T>
 }
 
 /// <summary>
-/// Present for backwards-compatibility reasons, but no longer used.
-/// The auto-generated serialization code for enum now reads/writes
-/// the tag byte directly to the wire. This avoids calling into reflective code.
+/// Serializer for enums.
 /// </summary>
 /// <typeparam name="T"></typeparam>
 public readonly struct Enum<T> : IReadWrite<T>
     where T : struct, Enum
 {
-    private static readonly ulong NumVariants;
+    /// <summary>
+    /// Map from tag -> value, implemented as an array.
+    /// Note: the [Type] macro rejects enums with explicitly set values (see Codegen.Tests),
+    /// so this array is guaranteed to be continuous and indexed starting from 0.
+    /// </summary>
+    private static readonly T[] TagToValue = Enum.GetValues(typeof(T)).Cast<T>().ToArray();
 
-    static Enum()
+    public T Read(BinaryReader reader)
     {
-        NumVariants = (ulong)Enum.GetValues(typeof(T)).Length;
+        var tag = reader.ReadByte();
+        try
+        {
+            return TagToValue[tag];
+        }
+        catch
+        {
+            throw new ArgumentOutOfRangeException(
+                $"Tag {tag} is out of range of enum {typeof(T).Name}"
+            );
+        }
     }
 
-    private static T Validate(T value)
+    public void Write(BinaryWriter writer, T value)
     {
-        // Previously this was: `if (!Enum.IsDefined(typeof(T), value))`.
+        // Previously this was: `if (Enum.IsDefined(typeof(T), value))`.
         // This was quite expensive because:
         //   1. It uses reflection
         //   2. It allocates
@@ -144,23 +157,18 @@ public readonly struct Enum<T> : IReadWrite<T>
         // However, enum values are guaranteed to be sequential and zero based.
         // Hence we only ever need to do an upper bound check.
         // See `SpacetimeDB.Type.ParseEnum` for the syntax analysis.
-
-        // Later note: this STILL uses reflection. We've deprecated this class entirely
-        // because of this.
-        if (Convert.ToUInt64(value) >= NumVariants)
+        var tag = Convert.ToByte(value);
+        if (tag < TagToValue.Length)
+        {
+            writer.Write(Convert.ToByte(tag));
+        }
+        else
         {
             throw new ArgumentOutOfRangeException(
-                nameof(value),
-                $"Value {value} is out of range of enum {typeof(T).Name}"
+                $"Enum {value} is malformed for type {typeof(T).Name}"
             );
         }
-        return value;
     }
-
-    public T Read(BinaryReader reader) => Validate((T)Enum.ToObject(typeof(T), reader.ReadByte()));
-
-    public void Write(BinaryWriter writer, T value) =>
-        writer.Write(Convert.ToByte(Validate(value)));
 
     public AlgebraicType GetAlgebraicType(ITypeRegistrar registrar) =>
         registrar.RegisterType<T>(

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/client/snapshots/Type#PublicTable.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/client/snapshots/Type#PublicTable.verified.cs
@@ -255,7 +255,7 @@ partial struct PublicTable : System.IEquatable<PublicTable>, SpacetimeDB.BSATN.I
         var ___eqConnectionIdField = this.ConnectionIdField.Equals(that.ConnectionIdField);
         var ___eqCustomStructField = this.CustomStructField.Equals(that.CustomStructField);
         var ___eqCustomClassField = this.CustomClassField.Equals(that.CustomClassField);
-        var ___eqCustomEnumField = this.CustomEnumField.Equals(that.CustomEnumField);
+        var ___eqCustomEnumField = this.CustomEnumField == that.CustomEnumField;
         var ___eqCustomTaggedEnumField =
             this.CustomTaggedEnumField == null
                 ? that.CustomTaggedEnumField == null

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestUniqueNotEquatable.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Module#TestUniqueNotEquatable.verified.cs
@@ -76,7 +76,7 @@ partial struct TestUniqueNotEquatable
     public bool Equals(TestUniqueNotEquatable that)
     {
         var ___eqUniqueField = this.UniqueField.Equals(that.UniqueField);
-        var ___eqPrimaryKeyField = this.PrimaryKeyField.Equals(that.PrimaryKeyField);
+        var ___eqPrimaryKeyField = this.PrimaryKeyField == that.PrimaryKeyField;
         return ___eqUniqueField && ___eqPrimaryKeyField;
     }
 

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Type#TestUnsupportedType.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/Type#TestUnsupportedType.verified.cs
@@ -104,7 +104,7 @@ partial struct TestUnsupportedType
             this.UnresolvedType == null
                 ? that.UnresolvedType == null
                 : this.UnresolvedType.Equals(that.UnresolvedType);
-        var ___eqUnsupportedEnum = this.UnsupportedEnum.Equals(that.UnsupportedEnum);
+        var ___eqUnsupportedEnum = this.UnsupportedEnum == that.UnsupportedEnum;
         return ___eqUnsupportedSpecialType
             && ___eqUnsupportedSystemType
             && ___eqUnresolvedType

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PublicTable.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Module#PublicTable.verified.cs
@@ -279,7 +279,7 @@ partial struct PublicTable : System.IEquatable<PublicTable>, SpacetimeDB.BSATN.I
             this.CustomClassField == null
                 ? that.CustomClassField == null
                 : this.CustomClassField.Equals(that.CustomClassField);
-        var ___eqCustomEnumField = this.CustomEnumField.Equals(that.CustomEnumField);
+        var ___eqCustomEnumField = this.CustomEnumField == that.CustomEnumField;
         var ___eqCustomTaggedEnumField =
             this.CustomTaggedEnumField == null
                 ? that.CustomTaggedEnumField == null

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#CustomNestedClass.verified.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/snapshots/Type#CustomNestedClass.verified.cs
@@ -152,7 +152,7 @@ partial class CustomNestedClass
             this.NestedNullableClass == null
                 ? that.NestedNullableClass == null
                 : this.NestedNullableClass.Equals(that.NestedNullableClass);
-        var ___eqNestedEnum = this.NestedEnum.Equals(that.NestedEnum);
+        var ___eqNestedEnum = this.NestedEnum == that.NestedEnum;
         var ___eqNestedNullableEnum = this.NestedNullableEnum.Equals(that.NestedNullableEnum);
         var ___eqNestedTaggedEnum =
             this.NestedTaggedEnum == null


### PR DESCRIPTION
# Description of Changes

I was looking at a bitcraft profile and it was still spending a lot of time in reflection when deserializing enums without data -- plain-old-enums. Turns out the code I thought was dead was not. So, I changed it to be as fast as possible (indexing into an array!) This should save a few more allocations and some deserialization time. I also changed the generated .Equals for `[SpacetimeDB.Type]`s containing enums to avoid an allocation.

# API and ABI breaking changes

# Expected complexity level and risk

0

# Testing
I am planning to test:

- [x] Bitcraft
- [x] Blackholio
