### PR TITLE
Make connection metrics keyed on database identity, not replica ID

### DIFF
--- a/crates/core/src/client/message_handlers.rs
+++ b/crates/core/src/client/message_handlers.rs
@@ -28,8 +28,7 @@ pub enum MessageHandleError {
 }
 
 pub async fn handle(client: &ClientConnection, message: DataMessage, timer: Instant) -> Result<(), MessageHandleError> {
-    client.metrics.websocket_request_msg_size.observe(message.len() as f64);
-    client.metrics.websocket_requests.inc();
+    client.observe_websocket_request_message(&message);
 
     let message = match message {
         DataMessage::Text(text) => {

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -27,12 +27,12 @@ metrics_group!(
 
         #[name = spacetime_websocket_requests_total]
         #[help = "The cumulative number of websocket request messages"]
-        #[labels(replica_id: u64, protocol: str)]
+        #[labels(database_identity: Identity, protocol: str)]
         pub websocket_requests: IntCounterVec,
 
         #[name = spacetime_websocket_request_msg_size]
         #[help = "The size of messages received on connected sessions"]
-        #[labels(replica_id: u64, protocol: str)]
+        #[labels(database_identity: Identity, protocol: str)]
         pub websocket_request_msg_size: HistogramVec,
 
         #[name = jemalloc_active_bytes]


### PR DESCRIPTION
# Description of Changes

This commit changes two metrics, `spacetime_websocket_requests_total` and `spacetime_websocket_request_msg_size`, to be labeled by the database `Identity` of the connection, rather than the replica ID.

# API and ABI breaking changes

Changes metric labels, but we don't offer stability guarantees about our metrics.

# Expected complexity level and risk

1 - I'm reasonably sure we don't even use these metrics.

# Testing

None - I am unsure how to test metrics.