### PR TITLE
Commitlog: handle empty offset index lookup

### DIFF
--- a/crates/commitlog/Cargo.toml
+++ b/crates/commitlog/Cargo.toml
@@ -35,6 +35,7 @@ zstd-framed.workspace = true
 
 # For the 'test' feature
 env_logger = { workspace = true, optional = true }
+pretty_assertions.workspace = true
 
 [dev-dependencies]
 # Enable streaming in tests

--- a/crates/commitlog/src/segment.rs
+++ b/crates/commitlog/src/segment.rs
@@ -431,9 +431,9 @@ pub fn seek_to_offset<R: io::Read + io::Seek>(
 ) -> Result<(), IndexError> {
     let (index_key, byte_offset) = index_file.key_lookup(start_tx_offset)?;
 
-    // If the index_key is 0, it means the index file is empty, no need to seek
+    // If the index_key is 0, it means the index file is empty, return error without seeking
     if index_key == 0 {
-        return Ok(());
+        return Err(IndexError::KeyNotFound);
     }
     debug!("index lookup for key={start_tx_offset}: found key={index_key} at byte-offset={byte_offset}");
     // returned `index_key` should never be greater than `start_tx_offset`


### PR DESCRIPTION
# Description of Changes
fix: Offset index, key lookup returns `(0,0)` key and byte offset pair if it is empty.
fix:`seek_to_offset` was returning `Ok` for key 0. when asked to validate 0th commit at 0 byte offset.
Resulting `reset_to_internal` to miscalculate commit offset and truncating in middle of first commit. Its calculation was shorter by `segment::HEADER::len`


# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
