### PR TITLE
`commit_and_broadcast_event`: `read_tx.merge(update_metrics)`

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -858,8 +858,8 @@ pub fn report_tx_metricses(
     reducer: &str,
     db: &RelationalDB,
     tx_data: Option<&TxData>,
-    metrics_mut: Option<TxMetrics>,
-    metrics_read: TxMetrics,
+    metrics_mut: Option<&TxMetrics>,
+    metrics_read: &TxMetrics,
 ) {
     if let Some(metrics_mut) = metrics_mut {
         metrics_mut.report_with_db(reducer, db, tx_data);

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -972,7 +972,7 @@ impl RelationalDB {
         let mut tx = self.begin_tx(workload);
         let res = f(&mut tx);
         let (tx_metics, reducer) = self.release_tx(tx);
-        report_tx_metricses(&reducer, self, None, None, tx_metics);
+        report_tx_metricses(&reducer, self, None, None, &tx_metics);
         res
     }
 

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -174,7 +174,8 @@ pub fn execute_sql_tx<'a>(
 
 pub struct SqlResult {
     pub rows: Vec<ProductValue>,
-    /// Should not be reported!
+    /// These metrics will be reported via `report_tx_metrics`.
+    /// They should not be reported separately to avoid double counting.
     pub metrics: ExecutionMetrics,
 }
 

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -645,7 +645,8 @@ impl ModuleSubscriptions {
 
     /// Commit a transaction and broadcast its ModuleEvent to all interested subscribers.
     ///
-    /// The returned [`ExecutionMetrics`] are meant for testing purposes and should not be reported.
+    /// The returned [`ExecutionMetrics`] are reported in this method via `report_tx_metrics`.
+    /// They are returned for testing purposes but should not be reported separately.
     pub fn commit_and_broadcast_event(
         &self,
         caller: Option<&ClientConnectionSender>,
@@ -710,7 +711,7 @@ impl ModuleSubscriptions {
             EventStatus::OutOfEnergy => {} // ?
         }
 
-        // Merge in the pdate evaluation metrics.
+        // Merge in the subscription evaluation metrics.
         read_tx.metrics.merge(update_metrics);
 
         Ok(Ok((event, update_metrics)))


### PR DESCRIPTION
# Description of Changes

Fixes a bug noticed by @joshua-spacetime where we didn't actually merge in the update stats.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [ ] Check against prometheus that the stats are back.
