### PR TITLE
Seperate type imports and class imports for typescript client binding…

### DIFF
--- a/crates/codegen/src/typescript.rs
+++ b/crates/codegen/src/typescript.rs
@@ -623,6 +623,15 @@ fn print_reducer_enum_defn(module: &ModuleDef, out: &mut Indenter) {
 
 fn print_spacetimedb_imports(out: &mut Indenter) {
     let mut types = [
+        "CallReducerFlags",
+        "EventContextInterface",
+        "ReducerEventContextInterface",
+        "SubscriptionEventContextInterface",
+        "ErrorContextInterface",
+        "DbContext",
+        "Event",
+    ];
+    let mut classes = [
         "AlgebraicType",
         "ProductType",
         "ProductTypeElement",
@@ -636,20 +645,21 @@ fn print_spacetimedb_imports(out: &mut Indenter) {
         "DbConnectionBuilder",
         "TableCache",
         "BinaryWriter",
-        "type CallReducerFlags",
-        "type EventContextInterface",
-        "type ReducerEventContextInterface",
-        "type SubscriptionEventContextInterface",
-        "type ErrorContextInterface",
         "SubscriptionBuilderImpl",
         "BinaryReader",
         "DbConnectionImpl",
-        "type DbContext",
-        "type Event",
         "deepEqual",
     ];
     types.sort();
+    classes.sort();
     writeln!(out, "import {{");
+    out.indent(1);
+    for cl in &classes {
+        writeln!(out, "{cl},");
+    }
+    out.dedent(1);
+    writeln!(out, "}} from \"@clockworklabs/spacetimedb-sdk\";");
+    writeln!(out, "import type {{");
     out.indent(1);
     for ty in &types {
         writeln!(out, "{ty},");


### PR DESCRIPTION
Seperate type imports and class imports for typescript client bindings codegen

# Description of Changes

Currently the code generation works fine following the typescript client setup tutorial in the documentation if you select Typescript+SWC as the variant in the vite template menu 
![image](https://github.com/user-attachments/assets/5b8b16d2-9dbc-4b0e-b35d-5d6623c6dc95)
However if you select typescript only, the bindings generated by spacetimedb will not be bundled correctly by vite. This is described in vite's documentation here:
![image](https://github.com/user-attachments/assets/a0dc34d4-42a3-441b-a779-33af01ebc0f5)
The end result is a client side error of trying to import a type from a JS file:
![image](https://github.com/user-attachments/assets/5d225f14-8a55-48fa-8b13-383e7f7497ae)

This fix separates the type imports from the class imports in the generated typescript code, turning:
```ts
import {
  AlgebraicType,
  AlgebraicValue,
  BinaryReader,
  BinaryWriter,
  CallReducerFlags,
  ConnectionId,
  DbConnectionBuilder,
  DbConnectionImpl,
  DbContext,
  ErrorContextInterface,
  Event,
  EventContextInterface,
  Identity,
  ProductType,
  ProductTypeElement,
  ReducerEventContextInterface,
  SubscriptionBuilderImpl,
  SubscriptionEventContextInterface,
  SumType,
  SumTypeVariant,
  TableCache,
  TimeDuration,
  Timestamp,
  deepEqual,
} from "@clockworklabs/spacetimedb-sdk";
```
into
```ts
import {
  AlgebraicType,
  AlgebraicValue,
  BinaryReader,
  BinaryWriter,
  ConnectionId,
  DbConnectionBuilder,
  DbConnectionImpl,
  Identity,
  ProductType,
  ProductTypeElement,
  SubscriptionBuilderImpl,
  SumType,
  SumTypeVariant,
  TableCache,
  TimeDuration,
  Timestamp,
  deepEqual,
} from "@clockworklabs/spacetimedb-sdk";
import type {
  CallReducerFlags,
  DbContext,
  ErrorContextInterface,
  Event,
  EventContextInterface,
  ReducerEventContextInterface,
  SubscriptionEventContextInterface,
} from "@clockworklabs/spacetimedb-sdk";
```
solving the problem.

## Relevant issues

https://github.com/clockworklabs/spacetimedb-typescript-sdk/issues/167
https://github.com/clockworklabs/SpacetimeDB/issues/2661

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->
This is not a breaking change

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->
1

# Testing

- [x] Repository compiles
- [x] Typescript codegen generates correct typescript code
- [x] Typescript code generated by typescript codegen works in the plain Typescript variant of vite.