### PR TITLE
commitlog: Reduce log noise when offset index cannot be used

### DIFF
--- a/crates/commitlog/src/error.rs
+++ b/crates/commitlog/src/error.rs
@@ -72,3 +72,17 @@ pub enum SegmentMetadata {
     #[error(transparent)]
     Io(#[from] io::Error),
 }
+
+/// Recursively concatenate `e.source()`, separated by ": ".
+pub(crate) fn source_chain(e: &impl std::error::Error) -> String {
+    let mut s = String::new();
+    let mut source = e.source();
+    while let Some(cause) = source {
+        s.push(':');
+        s.push(' ');
+        s.push_str(&cause.to_string());
+        source = cause.source()
+    }
+
+    s
+}


### PR DESCRIPTION
# Description of Changes

Much noise is e.g. created when the index is empty. Also consolidate the logic a bit.

# Expected complexity level and risk

1.5

# Testing

- [x] Inspect log output
