### PR TITLE
Aggregate and broadcast `DbUpdate`s off the main thread

### DIFF
--- a/crates/client-api-messages/src/websocket.rs
+++ b/crates/client-api-messages/src/websocket.rs
@@ -623,7 +623,7 @@ pub struct TableUpdate<F: WebsocketFormat> {
 }
 
 impl<F: WebsocketFormat> TableUpdate<F> {
-    pub fn new(table_id: TableId, table_name: Box<str>, (update, num_rows): (F::QueryUpdate, u64)) -> Self {
+    pub fn new(table_id: TableId, table_name: Box<str>, update: F::QueryUpdate, num_rows: u64) -> Self {
         Self {
             table_id,
             table_name,
@@ -641,7 +641,7 @@ impl<F: WebsocketFormat> TableUpdate<F> {
         }
     }
 
-    pub fn push(&mut self, (update, num_rows): (F::QueryUpdate, u64)) {
+    pub fn push(&mut self, update: F::QueryUpdate, num_rows: u64) {
         self.updates.push(update);
         self.num_rows += num_rows;
     }

--- a/crates/client-api-messages/src/websocket.rs
+++ b/crates/client-api-messages/src/websocket.rs
@@ -622,13 +622,19 @@ pub struct TableUpdate<F: WebsocketFormat> {
     pub updates: SmallVec<[F::QueryUpdate; 1]>,
 }
 
+/// Computed update for a single query, annotated with the number of matching rows.
+pub struct SingleQueryUpdate<F: WebsocketFormat> {
+    pub update: F::QueryUpdate,
+    pub num_rows: u64,
+}
+
 impl<F: WebsocketFormat> TableUpdate<F> {
-    pub fn new(table_id: TableId, table_name: Box<str>, update: F::QueryUpdate, num_rows: u64) -> Self {
+    pub fn new(table_id: TableId, table_name: Box<str>, update: SingleQueryUpdate<F>) -> Self {
         Self {
             table_id,
             table_name,
-            num_rows,
-            updates: [update].into(),
+            num_rows: update.num_rows,
+            updates: [update.update].into(),
         }
     }
 
@@ -641,9 +647,9 @@ impl<F: WebsocketFormat> TableUpdate<F> {
         }
     }
 
-    pub fn push(&mut self, update: F::QueryUpdate, num_rows: u64) {
-        self.updates.push(update);
-        self.num_rows += num_rows;
+    pub fn push(&mut self, update: SingleQueryUpdate<F>) {
+        self.updates.push(update.update);
+        self.num_rows += update.num_rows;
     }
 
     pub fn num_rows(&self) -> usize {

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -12,6 +12,7 @@ use crate::messages::control_db::{Database, HostType};
 use crate::module_host_context::ModuleCreationContext;
 use crate::replica_context::ReplicaContext;
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
+use crate::subscription::module_subscription_manager::SubscriptionManager;
 use crate::util::{asyncify, spawn_rayon};
 use anyhow::{anyhow, ensure, Context};
 use async_trait::async_trait;
@@ -523,7 +524,9 @@ async fn make_replica_ctx(
     relational_db: Arc<RelationalDB>,
 ) -> anyhow::Result<ReplicaContext> {
     let logger = tokio::task::block_in_place(move || Arc::new(DatabaseLogger::open_today(path.module_logs())));
-    let subscriptions = <_>::default();
+    let subscriptions = Arc::new(parking_lot::RwLock::new(SubscriptionManager::for_database(
+        database.database_identity,
+    )));
     let downgraded = Arc::downgrade(&subscriptions);
     let subscriptions = ModuleSubscriptions::new(relational_db.clone(), subscriptions, database.owner_identity);
 

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -534,6 +534,9 @@ mod test {
 
     /// An `InstanceEnv` requires `ModuleSubscriptions`
     fn subscription_actor(relational_db: Arc<RelationalDB>) -> ModuleSubscriptions {
+        // Create and enter a Tokio runtime to run the `ModuleSubscriptions`' background workers in parallel.
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
         ModuleSubscriptions::new(relational_db, <_>::default(), Identity::ZERO)
     }
 

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -514,7 +514,9 @@ mod test {
         host::Scheduler,
         messages::control_db::{Database, HostType},
         replica_context::ReplicaContext,
-        subscription::module_subscription_actor::ModuleSubscriptions,
+        subscription::{
+            module_subscription_actor::ModuleSubscriptions, module_subscription_manager::SubscriptionManager,
+        },
     };
     use anyhow::{anyhow, Result};
     use spacetimedb_lib::db::auth::StAccess;
@@ -537,7 +539,11 @@ mod test {
         // Create and enter a Tokio runtime to run the `ModuleSubscriptions`' background workers in parallel.
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let _rt = runtime.enter();
-        ModuleSubscriptions::new(relational_db, <_>::default(), Identity::ZERO)
+        ModuleSubscriptions::new(
+            relational_db,
+            SubscriptionManager::for_test_without_metrics_arc_rwlock(),
+            Identity::ZERO,
+        )
     }
 
     /// An `InstanceEnv` requires a `ReplicaContext`.

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -534,31 +534,39 @@ mod test {
 
     /// An `InstanceEnv` requires a `ReplicaContext`.
     /// For our purposes this is just a wrapper for `RelationalDB`.
-    fn replica_ctx(relational_db: Arc<RelationalDB>) -> Result<ReplicaContext> {
-        Ok(ReplicaContext {
-            database: Database {
-                id: 0,
-                database_identity: Identity::ZERO,
-                owner_identity: Identity::ZERO,
-                host_type: HostType::Wasm,
-                initial_program: Hash::ZERO,
+    fn replica_ctx(relational_db: Arc<RelationalDB>) -> Result<(ReplicaContext, tokio::runtime::Runtime)> {
+        let (subs, runtime) = ModuleSubscriptions::for_test_new_runtime(relational_db.clone());
+        Ok((
+            ReplicaContext {
+                database: Database {
+                    id: 0,
+                    database_identity: Identity::ZERO,
+                    owner_identity: Identity::ZERO,
+                    host_type: HostType::Wasm,
+                    initial_program: Hash::ZERO,
+                },
+                replica_id: 0,
+                logger: Arc::new(temp_logger()?),
+                subscriptions: subs,
+                relational_db,
             },
-            replica_id: 0,
-            logger: Arc::new(temp_logger()?),
-            subscriptions: ModuleSubscriptions::for_test_new_runtime(relational_db.clone()),
-            relational_db,
-        })
+            runtime,
+        ))
     }
 
     /// An `InstanceEnv` used for testing the database syscalls.
-    fn instance_env(db: Arc<RelationalDB>) -> Result<InstanceEnv> {
+    fn instance_env(db: Arc<RelationalDB>) -> Result<(InstanceEnv, tokio::runtime::Runtime)> {
         let (scheduler, _) = Scheduler::open(db.clone());
-        Ok(InstanceEnv {
-            replica_ctx: Arc::new(replica_ctx(db)?),
-            scheduler,
-            tx: TxSlot::default(),
-            start_time: Timestamp::now(),
-        })
+        let (replica_context, runtime) = replica_ctx(db)?;
+        Ok((
+            InstanceEnv {
+                replica_ctx: Arc::new(replica_context),
+                scheduler,
+                tx: TxSlot::default(),
+                start_time: Timestamp::now(),
+            },
+            runtime,
+        ))
     }
 
     /// An in-memory `RelationalDB` for testing.
@@ -657,7 +665,7 @@ mod test {
     #[test]
     fn table_scan_metrics() -> Result<()> {
         let db = relational_db()?;
-        let env = instance_env(db.clone())?;
+        let (env, _runtime) = instance_env(db.clone())?;
 
         let (table_id, _) = create_table_with_index(&db)?;
 
@@ -689,7 +697,7 @@ mod test {
     #[test]
     fn index_scan_metrics() -> Result<()> {
         let db = relational_db()?;
-        let env = instance_env(db.clone())?;
+        let (env, _runtime) = instance_env(db.clone())?;
 
         let (_, index_id) = create_table_with_index(&db)?;
 
@@ -741,7 +749,7 @@ mod test {
     #[test]
     fn insert_metrics() -> Result<()> {
         let db = relational_db()?;
-        let env = instance_env(db.clone())?;
+        let (env, _runtime) = instance_env(db.clone())?;
 
         let (table_id, _) = create_table_with_index(&db)?;
 
@@ -778,7 +786,7 @@ mod test {
     #[test]
     fn update_metrics() -> Result<()> {
         let db = relational_db()?;
-        let env = instance_env(db.clone())?;
+        let (env, _runtime) = instance_env(db.clone())?;
 
         let (table_id, index_id) = create_table_with_unique_index(&db)?;
 
@@ -805,7 +813,7 @@ mod test {
     #[test]
     fn delete_by_index_metrics() -> Result<()> {
         let db = relational_db()?;
-        let env = instance_env(db.clone())?;
+        let (env, _runtime) = instance_env(db.clone())?;
 
         let (_, index_id) = create_table_with_index(&db)?;
 
@@ -833,7 +841,7 @@ mod test {
     #[test]
     fn delete_by_value_metrics() -> Result<()> {
         let db = relational_db()?;
-        let env = instance_env(db.clone())?;
+        let (env, _runtime) = instance_env(db.clone())?;
 
         let (table_id, _) = create_table_with_index(&db)?;
 

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -512,7 +512,7 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         let (event, _) = match self
             .info
             .subscriptions
-            .commit_and_broadcast_event(client.as_deref(), event, tx)
+            .commit_and_broadcast_event(client, event, tx)
             .unwrap()
         {
             Ok(ev) => ev,

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -332,12 +332,18 @@ pub(crate) mod tests {
         sql_text: &str,
         q: Vec<CrudExpr>,
     ) -> Result<Vec<MemTable>, DBError> {
+        // Create and enter a Tokio runtime to run the `ModuleSubscriptions`' background workers in parallel.
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
         let subs = ModuleSubscriptions::new(Arc::new(db.clone()), <_>::default(), Identity::ZERO);
         execute_sql(db, sql_text, q, AuthCtx::for_testing(), Some(&subs))
     }
 
     /// Short-cut for simplify test execution
     pub(crate) fn run_for_testing(db: &RelationalDB, sql_text: &str) -> Result<Vec<ProductValue>, DBError> {
+        // Create and enter a Tokio runtime to run the `ModuleSubscriptions`' background workers in parallel.
+        let rt = tokio::runtime::Runtime::new().unwrap();
+        let _guard = rt.enter();
         let subs = ModuleSubscriptions::new(Arc::new(db.clone()), <_>::default(), Identity::ZERO);
         run(db, sql_text, AuthCtx::for_testing(), Some(&subs), &mut vec![]).map(|x| x.rows)
     }

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -333,13 +333,13 @@ pub(crate) mod tests {
         sql_text: &str,
         q: Vec<CrudExpr>,
     ) -> Result<Vec<MemTable>, DBError> {
-        let subs = ModuleSubscriptions::for_test_new_runtime(Arc::new(db.clone()));
+        let (subs, _runtime) = ModuleSubscriptions::for_test_new_runtime(Arc::new(db.clone()));
         execute_sql(db, sql_text, q, AuthCtx::for_testing(), Some(&subs))
     }
 
     /// Short-cut for simplify test execution
     pub(crate) fn run_for_testing(db: &RelationalDB, sql_text: &str) -> Result<Vec<ProductValue>, DBError> {
-        let subs = ModuleSubscriptions::for_test_new_runtime(Arc::new(db.clone()));
+        let (subs, _runtime) = ModuleSubscriptions::for_test_new_runtime(Arc::new(db.clone()));
         run(db, sql_text, AuthCtx::for_testing(), Some(&subs), &mut vec![]).map(|x| x.rows)
     }
 

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -8,7 +8,9 @@ use crate::host::module_host::{DatabaseTableUpdate, DatabaseTableUpdateRelValue,
 use crate::messages::websocket::TableUpdate;
 use crate::util::slow::SlowQueryLogger;
 use crate::vm::{build_query, TxMode};
-use spacetimedb_client_api_messages::websocket::{Compression, QueryUpdate, RowListLen as _, WebsocketFormat};
+use spacetimedb_client_api_messages::websocket::{
+    Compression, QueryUpdate, RowListLen as _, SingleQueryUpdate, WebsocketFormat,
+};
 use spacetimedb_lib::db::error::AuthError;
 use spacetimedb_lib::relation::DbTable;
 use spacetimedb_lib::{Identity, ProductValue};
@@ -254,7 +256,11 @@ impl ExecutionUnit {
             let deletes = F::List::default();
             let qu = QueryUpdate { deletes, inserts };
             let update = F::into_query_update(qu, compression);
-            TableUpdate::new(self.return_table(), self.return_name(), update, num_rows)
+            TableUpdate::new(
+                self.return_table(),
+                self.return_name(),
+                SingleQueryUpdate { update, num_rows },
+            )
         })
     }
 

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -254,7 +254,7 @@ impl ExecutionUnit {
             let deletes = F::List::default();
             let qu = QueryUpdate { deletes, inserts };
             let update = F::into_query_update(qu, compression);
-            TableUpdate::new(self.return_table(), self.return_name(), (update, num_rows))
+            TableUpdate::new(self.return_table(), self.return_name(), update, num_rows)
         })
     }
 

--- a/crates/core/src/subscription/mod.rs
+++ b/crates/core/src/subscription/mod.rs
@@ -142,7 +142,7 @@ where
         // after we release the tx lock.
         // There's no need to compress the inner table update too.
         let update = F::into_query_update(qu, Compression::None);
-        (TableUpdate::new(table_id, table_name, (update, num_rows)), metrics)
+        (TableUpdate::new(table_id, table_name, update, num_rows), metrics)
     })
 }
 
@@ -171,7 +171,7 @@ where
                 .clone()
                 .optimize()
                 .map(|plan| (sql, PipelinedProject::from(plan)))
-                .and_then(|(_, plan)| collect_table_update(&[plan], table_id, table_name.into(), tx, update_type))
+                .and_then(|(_, plan)| collect_table_update(&[plan], table_id, (&**table_name).into(), tx, update_type))
                 .map_err(|err| DBError::WithSql {
                     sql: sql.into(),
                     error: Box::new(DBError::Other(err)),

--- a/crates/core/src/subscription/mod.rs
+++ b/crates/core/src/subscription/mod.rs
@@ -5,7 +5,7 @@ use module_subscription_manager::Plan;
 use prometheus::IntCounter;
 use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use spacetimedb_client_api_messages::websocket::{
-    ByteListLen, Compression, DatabaseUpdate, QueryUpdate, TableUpdate, WebsocketFormat,
+    ByteListLen, Compression, DatabaseUpdate, QueryUpdate, SingleQueryUpdate, TableUpdate, WebsocketFormat,
 };
 use spacetimedb_execution::{pipelined::PipelinedProject, Datastore, DeltaStore};
 use spacetimedb_lib::{metrics::ExecutionMetrics, Identity};
@@ -142,7 +142,10 @@ where
         // after we release the tx lock.
         // There's no need to compress the inner table update too.
         let update = F::into_query_update(qu, Compression::None);
-        (TableUpdate::new(table_id, table_name, update, num_rows), metrics)
+        (
+            TableUpdate::new(table_id, table_name, SingleQueryUpdate { update, num_rows }),
+            metrics,
+        )
     })
 }
 

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -696,7 +696,7 @@ impl ModuleSubscriptions {
 
         match &event.status {
             EventStatus::Committed(_) => {
-                update_metrics = subscriptions.eval_updates(&delta_read_tx, event.clone(), caller);
+                update_metrics = subscriptions.eval_updates_sequential(&delta_read_tx, event.clone(), caller);
             }
             EventStatus::Failed(_) => {
                 if let Some(client) = caller {

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -148,10 +148,10 @@ impl ModuleSubscriptions {
 
     /// Construct a new [`ModuleSubscriptions`] for use in testing,
     /// creating a new [`tokio::runtime::Runtime`] to run its send worker.
-    pub fn for_test_new_runtime(db: Arc<RelationalDB>) -> ModuleSubscriptions {
+    pub fn for_test_new_runtime(db: Arc<RelationalDB>) -> (ModuleSubscriptions, tokio::runtime::Runtime) {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let _rt = runtime.enter();
-        Self::for_test_enclosing_runtime(db)
+        (Self::for_test_enclosing_runtime(db), runtime)
     }
 
     /// Construct a new [`ModuleSubscriptions`] for use in testing,
@@ -1073,7 +1073,7 @@ mod tests {
         let (sender, _) = client_connection(client_id);
 
         let db = relational_db()?;
-        let subs = ModuleSubscriptions::for_test_new_runtime(db.clone());
+        let (subs, _runtime) = ModuleSubscriptions::for_test_new_runtime(db.clone());
 
         // Create a table `t` with index on `id`
         let table_id = db.create_table_for_test("t", &[("id", AlgebraicType::U64)], &[0.into()])?;

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -737,6 +737,7 @@ mod tests {
     use crate::error::DBError;
     use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent, ModuleFunctionCall};
     use crate::messages::websocket as ws;
+    use crate::subscription::module_subscription_manager::SubscriptionManager;
     use crate::subscription::query::compile_read_only_query;
     use crate::subscription::TableUpdateType;
     use hashbrown::HashMap;
@@ -768,7 +769,11 @@ mod tests {
         let client = ClientActorId::for_test(Identity::ZERO);
         let config = ClientConfig::for_test();
         let sender = Arc::new(ClientConnectionSender::dummy(client, config));
-        let module_subscriptions = ModuleSubscriptions::new(db.clone(), <_>::default(), owner);
+        let module_subscriptions = ModuleSubscriptions::new(
+            db.clone(),
+            SubscriptionManager::for_test_without_metrics_arc_rwlock(),
+            owner,
+        );
 
         let subscribe = Subscribe {
             query_strings: [sql.into()].into(),
@@ -791,7 +796,11 @@ mod tests {
     fn module_subscriptions(db: Arc<RelationalDB>) -> ModuleSubscriptions {
         let runtime = tokio::runtime::Runtime::new().unwrap();
         let _rt = runtime.enter();
-        ModuleSubscriptions::new(db, <_>::default(), Identity::ZERO)
+        ModuleSubscriptions::new(
+            db,
+            SubscriptionManager::for_test_without_metrics_arc_rwlock(),
+            Identity::ZERO,
+        )
     }
 
     /// Initialize a [`ModuleSubscriptions`] manager.
@@ -799,7 +808,11 @@ mod tests {
     /// Must be called from within a multi-threaded Tokio runtime,
     /// so that the manager's background tasks can run in parallel.
     fn module_subscriptions_async(db: Arc<RelationalDB>) -> ModuleSubscriptions {
-        ModuleSubscriptions::new(db, <_>::default(), Identity::ZERO)
+        ModuleSubscriptions::new(
+            db,
+            SubscriptionManager::for_test_without_metrics_arc_rwlock(),
+            Identity::ZERO,
+        )
     }
 
     /// A [SubscribeSingle] message for testing

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -20,7 +20,7 @@ use spacetimedb_data_structures::map::{Entry, IntMap};
 use spacetimedb_lib::metrics::ExecutionMetrics;
 use spacetimedb_lib::{AlgebraicValue, ConnectionId, Identity, ProductValue};
 use spacetimedb_primitives::{ColId, TableId};
-use spacetimedb_subscription::SubscriptionPlan;
+use spacetimedb_subscription::{SubscriptionPlan, TableName};
 use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
@@ -363,7 +363,7 @@ struct ClientQueryUpdate<F: WebsocketFormat> {
 struct ClientUpdate {
     id: ClientId,
     table_id: TableId,
-    table_name: Arc<str>,
+    table_name: TableName,
     update: FormatSwitch<ClientQueryUpdate<BsatnFormat>, ClientQueryUpdate<JsonFormat>>,
 }
 
@@ -842,7 +842,7 @@ impl SubscriptionManager {
             // which involves cloning BSATN (binary) or product values (json).
             .fold(FoldState::default(), |mut acc, (qstate, plan)| {
                 let table_id = plan.subscribed_table_id();
-                let table_name = Arc::clone(plan.subscribed_table_name());
+                let table_name = plan.subscribed_table_name().clone();
                 // Store at most one copy for both the serialization to BSATN and JSON.
                 // Each subscriber gets to pick which of these they want,
                 // but we only fill `ops_bin_uncompressed` and `ops_json` at most once.

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -405,7 +405,10 @@ impl SubscriptionManager {
     }
 
     pub fn for_test_without_metrics() -> Self {
-        let clean_up_metric = scopeguard::guard((), |_| {});
+        let clean_up_metric = scopeguard::guard((), |_| {
+            let bt = std::backtrace::Backtrace::force_capture();
+            println!("Exiting test send_worker at {bt}");
+        });
         Self::with_metric(None, clean_up_metric)
     }
 

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -12,6 +12,7 @@ use crate::subscription::delta::eval_delta;
 use hashbrown::hash_map::OccupiedError;
 use hashbrown::{HashMap, HashSet};
 use itertools::Itertools;
+use parking_lot::RwLock;
 use spacetimedb_client_api_messages::websocket::{
     BsatnFormat, CompressableQueryUpdate, FormatSwitch, JsonFormat, QueryId, QueryUpdate, WebsocketFormat,
 };
@@ -23,6 +24,7 @@ use spacetimedb_subscription::SubscriptionPlan;
 use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
+use tokio::sync::mpsc;
 
 /// Clients are uniquely identified by their Identity and ConnectionId.
 /// Identity is insufficient because different ConnectionIds can use the same Identity.
@@ -37,6 +39,10 @@ type SwitchedDbUpdate = FormatSwitch<ws::DatabaseUpdate<BsatnFormat>, ws::Databa
 type ClientQueryId = QueryId;
 /// SubscriptionId is a globally unique identifier for a subscription.
 type SubscriptionId = (ClientId, ClientQueryId);
+
+// Type aliases that oddly aren't included in parking_lot...
+type ArcRwLockReadGuard<T> = parking_lot::ArcRwLockReadGuard<parking_lot::RawRwLock, T>;
+type ArcRwLockWriteGuard<T> = parking_lot::ArcRwLockWriteGuard<parking_lot::RawRwLock, T>;
 
 #[derive(Debug)]
 pub struct Plan {
@@ -293,15 +299,20 @@ impl SearchArguments {
     }
 }
 
+type ClientsMap = HashMap<ClientId, ClientInfo>;
+
 /// Responsible for the efficient evaluation of subscriptions.
 /// It performs basic multi-query optimization,
 /// in that if a query has N subscribers,
 /// it is only executed once,
 /// with the results copied to the N receivers.
-#[derive(Debug, Default)]
+#[derive(Debug)]
 pub struct SubscriptionManager {
-    // State for each client.
-    clients: HashMap<ClientId, ClientInfo>,
+    /// State for each client.
+    ///
+    /// Protected by an `Arc<RwLock>` because the [`Self::send_worker`] needs to read from it
+    /// in order to dispatch messages to clients.
+    clients: Arc<RwLock<ClientsMap>>,
 
     // Queries for which there is at least one subscriber.
     queries: HashMap<QueryHash, QueryState>,
@@ -315,6 +326,53 @@ pub struct SubscriptionManager {
     // and has a simple equality filter on that table,
     // we map the filter values to the query in this lookup table.
     search_args: SearchArguments,
+
+    /// Transmit side of a channel to the manager's [`Self::send_worker`] task.
+    ///
+    /// The send worker runs in parallel and pops [`ComputedQueries`]es out in order,
+    /// aggregates each client's full set of updates,
+    /// then passes them to the clients' websocket workers.
+    /// This allows transaction processing to proceed on the main thread
+    /// ahead of post-processing and broadcasting updates
+    /// while still ensuring that those updates are sent in the correct serial order.
+    /// Additionally, it avoids starving the next reducer request of Tokio workers,
+    /// as it imposes a delay between unlocking the datastore
+    /// and waking the many per-client sender Tokio tasks.
+    send_worker_tx: mpsc::UnboundedSender<ComputedQueries>,
+}
+
+impl Default for SubscriptionManager {
+    fn default() -> Self {
+        let (send_worker_tx, rx) = mpsc::unbounded_channel();
+        tokio::spawn(Self::send_worker(rx));
+        Self {
+            clients: Default::default(),
+            queries: Default::default(),
+            tables: Default::default(),
+            search_args: Default::default(),
+            send_worker_tx,
+        }
+    }
+}
+
+struct ClientQueryUpdate<F: WebsocketFormat> {
+    update: F::QueryUpdate,
+    num_rows: u64,
+}
+
+struct ClientUpdate {
+    id: ClientId,
+    table_id: TableId,
+    table_name: Arc<str>,
+    update: FormatSwitch<ClientQueryUpdate<BsatnFormat>, ClientQueryUpdate<JsonFormat>>,
+}
+
+struct ComputedQueries {
+    updates: Vec<ClientUpdate>,
+    errs: Vec<(ClientId, Box<str>)>,
+    event: Arc<ModuleEvent>,
+    caller: Option<Arc<ClientConnectionSender>>,
+    clients: ArcRwLockReadGuard<ClientsMap>,
 }
 
 // Tracks some gauges related to subscriptions.
@@ -333,7 +391,7 @@ pub struct SubscriptionGaugeStats {
 
 impl SubscriptionManager {
     pub fn client(&self, id: &ClientId) -> Client {
-        self.clients[id].outbound_ref.clone()
+        self.clients.read()[id].outbound_ref.clone()
     }
 
     pub fn query(&self, hash: &QueryHash) -> Option<Query> {
@@ -341,12 +399,12 @@ impl SubscriptionManager {
     }
 
     pub fn calculate_gauge_stats(&self) -> SubscriptionGaugeStats {
+        let clients = self.clients.read();
         let num_queries = self.queries.len();
-        let num_connections = self.clients.len();
+        let num_connections = clients.len();
         let num_query_subscriptions = self.queries.values().map(|state| state.subscriptions.len()).sum();
-        let num_subscription_sets = self.clients.values().map(|ci| ci.subscriptions.len()).sum();
-        let num_legacy_subscriptions = self
-            .clients
+        let num_subscription_sets = clients.values().map(|ci| ci.subscriptions.len()).sum();
+        let num_legacy_subscriptions = clients
             .values()
             .filter(|ci| !ci.legacy_subscriptions.is_empty())
             .count();
@@ -371,7 +429,7 @@ impl SubscriptionManager {
 
     #[cfg(test)]
     fn contains_client(&self, subscriber: &ClientId) -> bool {
-        self.clients.contains_key(subscriber)
+        self.clients.read().contains_key(subscriber)
     }
 
     #[cfg(test)]
@@ -400,8 +458,8 @@ impl SubscriptionManager {
             .any(|id| id == col_id)
     }
 
-    fn remove_legacy_subscriptions(&mut self, client: &ClientId) {
-        if let Some(ci) = self.clients.get_mut(client) {
+    fn remove_legacy_subscriptions(&mut self, clients: &mut ArcRwLockWriteGuard<ClientsMap>, client: &ClientId) {
+        if let Some(ci) = clients.get_mut(client) {
             let mut queries_to_remove = Vec::new();
             for query_hash in ci.legacy_subscriptions.iter() {
                 let Some(query_state) = self.queries.get_mut(query_hash) else {
@@ -428,10 +486,11 @@ impl SubscriptionManager {
 
     /// Remove any clients that have been marked for removal
     pub fn remove_dropped_clients(&mut self) {
-        for id in self.clients.keys().copied().collect::<Vec<_>>() {
-            if let Some(client) = self.clients.get(&id) {
+        let mut clients = self.clients.write_arc();
+        for id in clients.keys().copied().collect::<Vec<_>>() {
+            if let Some(client) = clients.get(&id) {
                 if client.dropped.load(Ordering::Relaxed) {
-                    self.remove_all_subscriptions(&id);
+                    self.remove_all_subscriptions_inner(&mut clients, &id);
                 }
             }
         }
@@ -440,9 +499,9 @@ impl SubscriptionManager {
     /// Remove a single subscription for a client.
     /// This will return an error if the client does not have a subscription with the given query id.
     pub fn remove_subscription(&mut self, client_id: ClientId, query_id: ClientQueryId) -> Result<Vec<Query>, DBError> {
+        let mut clients = self.clients.write();
         let subscription_id = (client_id, query_id);
-        let Some(ci) = self
-            .clients
+        let Some(ci) = clients
             .get_mut(&client_id)
             .filter(|ci| !ci.dropped.load(Ordering::Acquire))
         else {
@@ -502,19 +561,19 @@ impl SubscriptionManager {
         queries: Vec<Query>,
         query_id: ClientQueryId,
     ) -> Result<Vec<Query>, DBError> {
+        let mut clients = self.clients.write_arc();
+
         let client_id = (client.id.identity, client.id.connection_id);
 
         // Clean up any dropped subscriptions
-        if self
-            .clients
+        if clients
             .get(&client_id)
             .is_some_and(|ci| ci.dropped.load(Ordering::Acquire))
         {
-            self.remove_all_subscriptions(&client_id);
+            self.remove_all_subscriptions_inner(&mut clients, &client_id);
         }
 
-        let ci = self
-            .clients
+        let ci = clients
             .entry(client_id)
             .or_insert_with(|| ClientInfo::new(client.clone()));
         #[cfg(test)]
@@ -576,13 +635,14 @@ impl SubscriptionManager {
     /// its table ids added to the inverted index.
     // #[tracing::instrument(level = "trace", skip_all)]
     pub fn set_legacy_subscription(&mut self, client: Client, queries: impl IntoIterator<Item = Query>) {
+        let mut clients = self.clients.write_arc();
+
         let client_id = (client.id.identity, client.id.connection_id);
         // First, remove any existing legacy subscriptions.
-        self.remove_legacy_subscriptions(&client_id);
+        self.remove_legacy_subscriptions(&mut clients, &client_id);
 
         // Now, add the new subscriptions.
-        let ci = self
-            .clients
+        let ci = clients
             .entry(client_id)
             .or_insert_with(|| ClientInfo::new(client.clone()));
         for unit in queries {
@@ -641,13 +701,15 @@ impl SubscriptionManager {
         }
     }
 
-    /// Removes a client from the subscriber mapping.
-    /// If a query no longer has any subscribers,
-    /// it is removed from the index along with its table ids.
-    #[tracing::instrument(level = "trace", skip_all)]
-    pub fn remove_all_subscriptions(&mut self, client: &ClientId) {
-        self.remove_legacy_subscriptions(client);
-        let Some(client_info) = self.clients.remove(client) else {
+    /// Remove all subscriptions for `client` from `clients` and `self`,
+    /// when the caller already has a lock on `self.clients`.
+    ///
+    /// Dirty hack alert! This method takes an `ArcRwLockWriteGuard`
+    /// to the `clients` which is inside of `self`.
+    /// We take the `Arc` version to avoid borrowck complaining about multiple borrows on `self` coexisting.
+    fn remove_all_subscriptions_inner(&mut self, clients: &mut ArcRwLockWriteGuard<ClientsMap>, client: &ClientId) {
+        self.remove_legacy_subscriptions(clients, client);
+        let Some(client_info) = clients.remove(client) else {
             return;
         };
         debug_assert!(client_info.legacy_subscriptions.is_empty());
@@ -671,6 +733,15 @@ impl SubscriptionManager {
         for query_hash in queries_to_remove {
             self.queries.remove(&query_hash);
         }
+    }
+
+    /// Removes a client from the subscriber mapping.
+    /// If a query no longer has any subscribers,
+    /// it is removed from the index along with its table ids.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub fn remove_all_subscriptions(&mut self, client: &ClientId) {
+        let mut clients = self.clients.write_arc();
+        self.remove_all_subscriptions_inner(&mut clients, client);
     }
 
     /// Find the queries that need to be evaluated for this table update.
@@ -732,26 +803,20 @@ impl SubscriptionManager {
         &self,
         tx: &DeltaTx,
         event: Arc<ModuleEvent>,
-        caller: Option<&ClientConnectionSender>,
+        caller: Option<Arc<ClientConnectionSender>>,
     ) -> ExecutionMetrics {
         use FormatSwitch::{Bsatn, Json};
+
+        let clients = self.clients.read_arc();
 
         let tables = &event.status.database_update().unwrap().tables;
 
         let span = tracing::info_span!("eval_incr").entered();
 
-        type ClientQueryUpdate<F> = (<F as WebsocketFormat>::QueryUpdate, /* num_rows */ u64);
-        struct ClientUpdate<'a> {
-            id: &'a ClientId,
-            table_id: TableId,
-            table_name: &'a str,
-            update: FormatSwitch<ClientQueryUpdate<BsatnFormat>, ClientQueryUpdate<JsonFormat>>,
-        }
-
         #[derive(Default)]
-        struct FoldState<'a> {
-            updates: Vec<ClientUpdate<'a>>,
-            errs: Vec<(&'a ClientId, Box<str>)>,
+        struct FoldState {
+            updates: Vec<ClientUpdate>,
+            errs: Vec<(ClientId, Box<str>)>,
             metrics: ExecutionMetrics,
         }
 
@@ -777,7 +842,7 @@ impl SubscriptionManager {
             // which involves cloning BSATN (binary) or product values (json).
             .fold(FoldState::default(), |mut acc, (qstate, plan)| {
                 let table_id = plan.subscribed_table_id();
-                let table_name = plan.subscribed_table_name();
+                let table_name = Arc::clone(plan.subscribed_table_name());
                 // Store at most one copy for both the serialization to BSATN and JSON.
                 // Each subscriber gets to pick which of these they want,
                 // but we only fill `ops_bin_uncompressed` and `ops_json` at most once.
@@ -805,7 +870,7 @@ impl SubscriptionManager {
                     updates: &UpdatesRelValue<'_>,
                     memory: &mut Option<(F::QueryUpdate, u64, usize)>,
                     metrics: &mut ExecutionMetrics,
-                ) -> (F::QueryUpdate, u64) {
+                ) -> ClientQueryUpdate<F> {
                     let (update, num_rows, num_bytes) = memory
                         .get_or_insert_with(|| {
                             let encoded = updates.encode::<F>();
@@ -821,12 +886,12 @@ impl SubscriptionManager {
                     // Therefore every time we call this function,
                     // we update the `bytes_sent_to_clients` metric.
                     metrics.bytes_sent_to_clients += num_bytes;
-                    (update, num_rows)
+                    ClientQueryUpdate { update, num_rows }
                 }
 
                 // filter out clients that've dropped
                 let clients_for_query = qstate.all_clients().filter(|id| {
-                    self.clients
+                    clients
                         .get(*id)
                         .is_some_and(|info| !info.dropped.load(Ordering::Acquire))
                 });
@@ -845,14 +910,14 @@ impl SubscriptionManager {
                         .to_string()
                         .into_boxed_str();
 
-                        acc.errs.extend(clients_for_query.map(|id| (id, err.clone())))
+                        acc.errs.extend(clients_for_query.map(|id| (*id, err.clone())))
                     }
                     // The query didn't return any rows to update
                     Ok(None) => {}
                     // The query did return updates - process them and add them to the accumulator
                     Ok(Some(delta_updates)) => {
                         let row_iter = clients_for_query.map(|id| {
-                            let client = &self.clients[id].outbound_ref;
+                            let client = &clients[id].outbound_ref;
                             let update = match client.config.protocol {
                                 Protocol::Binary => Bsatn(memo_encode::<BsatnFormat>(
                                     &delta_updates,
@@ -866,9 +931,9 @@ impl SubscriptionManager {
                                 )),
                             };
                             ClientUpdate {
-                                id,
+                                id: *id,
                                 table_id,
-                                table_name,
+                                table_name: table_name.clone(),
                                 update,
                             }
                         });
@@ -879,108 +944,154 @@ impl SubscriptionManager {
                 acc
             });
 
-        let clients_with_errors = errs.iter().map(|(id, _)| *id).collect::<HashSet<_>>();
+        // We've now finished all of the work which needs to read from the datastore,
+        // so get this work off the main thread and over to the `send_worker`,
+        // then return ASAP in order to unlock the datastore and start running the next transaction.
+        // See comment on the `send_worker_tx` field in [`SubscriptionManager`] for more motivation.
+        self.send_worker_tx
+            .send(ComputedQueries {
+                updates,
+                errs,
+                event,
+                caller,
+                clients,
+            })
+            .expect("send worker has panicked, or otherwise dropped its recv queue!");
 
-        let mut eval = updates
-            .into_iter()
-            // Filter out clients whose subscriptions failed
-            .filter(|upd| !clients_with_errors.contains(upd.id))
-            // For each subscriber, aggregate all the updates for the same table.
-            // That is, we build a map `(subscriber_id, table_id) -> updates`.
-            // A particular subscriber uses only one format,
-            // so their `TableUpdate` will contain either JSON (`Protocol::Text`)
-            // or BSATN (`Protocol::Binary`).
-            .fold(
-                HashMap::<(&ClientId, TableId), SwitchedTableUpdate>::new(),
-                |mut tables, upd| {
-                    match tables.entry((upd.id, upd.table_id)) {
-                        Entry::Occupied(mut entry) => match entry.get_mut().zip_mut(upd.update) {
-                            Bsatn((tbl_upd, update)) => tbl_upd.push(update),
-                            Json((tbl_upd, update)) => tbl_upd.push(update),
-                        },
-                        Entry::Vacant(entry) => drop(entry.insert(match upd.update {
-                            Bsatn(update) => Bsatn(TableUpdate::new(upd.table_id, upd.table_name.into(), update)),
-                            Json(update) => Json(TableUpdate::new(upd.table_id, upd.table_name.into(), update)),
-                        })),
-                    }
-                    tables
-                },
-            )
-            .into_iter()
-            // Each client receives a single list of updates per transaction.
-            // So before sending the updates to each client,
-            // we must stitch together the `TableUpdate*`s into an aggregated list.
-            .fold(
-                HashMap::<&ClientId, SwitchedDbUpdate>::new(),
-                |mut updates, ((id, _), update)| {
-                    let entry = updates.entry(id);
-                    let entry = entry.or_insert_with(|| match &update {
-                        Bsatn(_) => Bsatn(<_>::default()),
-                        Json(_) => Json(<_>::default()),
-                    });
-                    match entry.zip_mut(update) {
-                        Bsatn((list, elem)) => list.tables.push(elem),
-                        Json((list, elem)) => list.tables.push(elem),
-                    }
-                    updates
-                },
-            );
-
-        drop(clients_with_errors);
         drop(span);
 
-        let _span = tracing::info_span!("eval_send").entered();
+        metrics
+    }
 
-        // We might have a known caller that hasn't been hidden from here..
-        // This caller may have subscribed to some query.
-        // If they haven't, we'll send them an empty update.
-        // Regardless, the update that we send to the caller, if we send any,
-        // is a full tx update, rather than a light one.
-        // That is, in the case of the caller, we don't respect the light setting.
-        if let Some((caller, conn_id)) = caller.zip(event.caller_connection_id) {
-            let database_update = eval
-                .remove(&(event.caller_identity, conn_id))
-                .map(|update| SubscriptionUpdateMessage::from_event_and_update(&event, update))
-                .unwrap_or_else(|| {
-                    SubscriptionUpdateMessage::default_for_protocol(caller.config.protocol, event.request_id)
-                });
-            let message = TransactionUpdateMessage {
-                event: Some(event.clone()),
-                database_update,
-            };
-            send_to_client(caller, message);
-        }
+    /// Asynchronous background worker which aggregates each of the clients' updates from a [`ComputedQueries`]
+    /// into `DbUpdate`s and then sends them to the clients' WebSocket workers.
+    ///
+    /// See comment on the `send_worker_tx` field in [`SubscriptionManager`] for motivation.
+    async fn send_worker(mut rx: mpsc::UnboundedReceiver<ComputedQueries>) {
+        use FormatSwitch::{Bsatn, Json};
 
-        // Send all the other updates.
-        for (id, update) in eval {
-            let database_update = SubscriptionUpdateMessage::from_event_and_update(&event, update);
-            let client = self.client(id);
-            // Conditionally send out a full update or a light one otherwise.
-            let event = client.config.tx_update_full.then(|| event.clone());
-            let message = TransactionUpdateMessage { event, database_update };
-            send_to_client(&client, message);
-        }
+        while let Some(ComputedQueries {
+            updates,
+            errs,
+            event,
+            caller,
+            clients,
+        }) = rx.recv().await
+        {
+            let clients_with_errors = errs.iter().map(|(id, _)| id).collect::<HashSet<_>>();
 
-        // Send error messages and mark clients for removal
-        for (id, message) in errs {
-            if let Some(client) = self.clients.get(id) {
-                client.dropped.store(true, Ordering::Release);
-                send_to_client(
-                    &client.outbound_ref,
-                    SubscriptionMessage {
-                        request_id: None,
-                        query_id: None,
-                        timer: None,
-                        result: SubscriptionResult::Error(SubscriptionError {
-                            table_id: None,
-                            message,
-                        }),
+            let span = tracing::info_span!("eval_incr_group_messages_by_client");
+
+            let mut eval = updates
+                .into_iter()
+                // Filter out clients whose subscriptions failed
+                .filter(|upd| !clients_with_errors.contains(&upd.id))
+                // For each subscriber, aggregate all the updates for the same table.
+                // That is, we build a map `(subscriber_id, table_id) -> updates`.
+                // A particular subscriber uses only one format,
+                // so their `TableUpdate` will contain either JSON (`Protocol::Text`)
+                // or BSATN (`Protocol::Binary`).
+                .fold(
+                    HashMap::<(ClientId, TableId), SwitchedTableUpdate>::new(),
+                    |mut tables, upd| {
+                        match tables.entry((upd.id, upd.table_id)) {
+                            Entry::Occupied(mut entry) => match entry.get_mut().zip_mut(upd.update) {
+                                Bsatn((tbl_upd, update)) => tbl_upd.push(update.update, update.num_rows),
+                                Json((tbl_upd, update)) => tbl_upd.push(update.update, update.num_rows),
+                            },
+                            Entry::Vacant(entry) => drop(entry.insert(match upd.update {
+                                Bsatn(update) => Bsatn(TableUpdate::new(
+                                    upd.table_id,
+                                    (&*upd.table_name).into(),
+                                    update.update,
+                                    update.num_rows,
+                                )),
+                                Json(update) => Json(TableUpdate::new(
+                                    upd.table_id,
+                                    (&*upd.table_name).into(),
+                                    update.update,
+                                    update.num_rows,
+                                )),
+                            })),
+                        }
+                        tables
+                    },
+                )
+                .into_iter()
+                // Each client receives a single list of updates per transaction.
+                // So before sending the updates to each client,
+                // we must stitch together the `TableUpdate*`s into an aggregated list.
+                .fold(
+                    HashMap::<ClientId, SwitchedDbUpdate>::new(),
+                    |mut updates, ((id, _), update)| {
+                        let entry = updates.entry(id);
+                        let entry = entry.or_insert_with(|| match &update {
+                            Bsatn(_) => Bsatn(<_>::default()),
+                            Json(_) => Json(<_>::default()),
+                        });
+                        match entry.zip_mut(update) {
+                            Bsatn((list, elem)) => list.tables.push(elem),
+                            Json((list, elem)) => list.tables.push(elem),
+                        }
+                        updates
                     },
                 );
+
+            drop(clients_with_errors);
+            drop(span);
+
+            let _span = tracing::info_span!("eval_send").entered();
+
+            // We might have a known caller that hasn't been hidden from here..
+            // This caller may have subscribed to some query.
+            // If they haven't, we'll send them an empty update.
+            // Regardless, the update that we send to the caller, if we send any,
+            // is a full tx update, rather than a light one.
+            // That is, in the case of the caller, we don't respect the light setting.
+            if let Some(caller) = caller {
+                let caller_id = (caller.id.identity, caller.id.connection_id);
+                let database_update = eval
+                    .remove(&caller_id)
+                    .map(|update| SubscriptionUpdateMessage::from_event_and_update(&event, update))
+                    .unwrap_or_else(|| {
+                        SubscriptionUpdateMessage::default_for_protocol(caller.config.protocol, event.request_id)
+                    });
+                let message = TransactionUpdateMessage {
+                    event: Some(event.clone()),
+                    database_update,
+                };
+                send_to_client(&caller, message);
+            }
+
+            // Send all the other updates.
+            for (id, update) in eval {
+                let database_update = SubscriptionUpdateMessage::from_event_and_update(&event, update);
+                let client = clients[&id].outbound_ref.clone();
+                // Conditionally send out a full update or a light one otherwise.
+                let event = client.config.tx_update_full.then(|| event.clone());
+                let message = TransactionUpdateMessage { event, database_update };
+                send_to_client(&client, message);
+            }
+
+            // Send error messages and mark clients for removal
+            for (id, message) in errs {
+                if let Some(client) = clients.get(&id) {
+                    client.dropped.store(true, Ordering::Release);
+                    send_to_client(
+                        &client.outbound_ref,
+                        SubscriptionMessage {
+                            request_id: None,
+                            query_id: None,
+                            timer: None,
+                            result: SubscriptionResult::Error(SubscriptionError {
+                                table_id: None,
+                                message,
+                            }),
+                        },
+                    );
+                }
             }
         }
-
-        metrics
     }
 }
 
@@ -1060,6 +1171,9 @@ mod tests {
         let id = id(0);
         let client = Arc::new(client(0));
 
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.set_legacy_subscription(client.clone(), [plan.clone()]);
 
@@ -1082,6 +1196,10 @@ mod tests {
         let client = Arc::new(client(0));
 
         let query_id: ClientQueryId = QueryId::new(1);
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.add_subscription(client.clone(), plan.clone(), query_id)?;
         assert!(subscriptions.query_reads_from_table(&hash, &table_id));
@@ -1101,6 +1219,10 @@ mod tests {
         let client = Arc::new(client(0));
 
         let query_id: ClientQueryId = QueryId::new(1);
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.add_subscription(client.clone(), plan.clone(), query_id)?;
         assert!(subscriptions.query_reads_from_table(&hash, &table_id));
@@ -1123,6 +1245,10 @@ mod tests {
         let client = Arc::new(client(0));
 
         let query_id: ClientQueryId = QueryId::new(1);
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.add_subscription(client.clone(), plan.clone(), query_id)?;
 
@@ -1144,6 +1270,10 @@ mod tests {
         let client = Arc::new(client(0));
 
         let query_id: ClientQueryId = QueryId::new(1);
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.add_subscription(client.clone(), plan.clone(), query_id)?;
         subscriptions.add_subscription(client.clone(), plan.clone(), QueryId::new(2))?;
@@ -1169,6 +1299,10 @@ mod tests {
         let client = Arc::new(client(0));
 
         let query_id: ClientQueryId = QueryId::new(1);
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         let added_query = subscriptions.add_subscription_multi(client.clone(), vec![plan.clone()], query_id)?;
         assert!(added_query.len() == 1);
@@ -1203,6 +1337,10 @@ mod tests {
 
         // All of the clients are using the same query id.
         let query_id: ClientQueryId = QueryId::new(1);
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.add_subscription(clients[0].clone(), plan.clone(), query_id)?;
         subscriptions.add_subscription(clients[1].clone(), plan.clone(), query_id)?;
@@ -1240,6 +1378,10 @@ mod tests {
 
         // All of the clients are using the same query id.
         let query_id: ClientQueryId = QueryId::new(1);
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.add_subscription(clients[0].clone(), plan.clone(), query_id)?;
         subscriptions.add_subscription(clients[1].clone(), plan.clone(), query_id)?;
@@ -1284,6 +1426,10 @@ mod tests {
             .collect::<ResultTest<Vec<_>>>()?;
 
         let client = Arc::new(client(0));
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.add_subscription(client.clone(), queries[0].clone(), QueryId::new(1))?;
         subscriptions.add_subscription(client.clone(), queries[1].clone(), QueryId::new(2))?;
@@ -1325,6 +1471,10 @@ mod tests {
             .collect::<ResultTest<Vec<_>>>()?;
 
         let client = Arc::new(client(0));
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         let added = subscriptions.add_subscription_multi(client.clone(), vec![queries[0].clone()], QueryId::new(1))?;
         assert_eq!(added.len(), 1);
@@ -1365,6 +1515,10 @@ mod tests {
         let table_id = create_table(&db, "t")?;
 
         let client = Arc::new(client(0));
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
 
         // Subscribe to queries that have search arguments
@@ -1434,6 +1588,10 @@ mod tests {
         let table_id = create_table(&db, "t")?;
 
         let client = Arc::new(client(0));
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
 
         let queries = (0u8..5)
@@ -1500,6 +1658,10 @@ mod tests {
         let s_id = db.create_table_for_test("s", &schema, &[0.into()])?;
 
         let client = Arc::new(client(0));
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
 
         let plan = compile_plan(&db, "select t.* from t join s on t.id = s.id where s.a = 1")?;
@@ -1570,6 +1732,10 @@ mod tests {
         let client = Arc::new(client(0));
 
         let query_id: ClientQueryId = QueryId::new(1);
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.add_subscription(client.clone(), plan.clone(), query_id)?;
 
@@ -1591,6 +1757,10 @@ mod tests {
         let client = Arc::new(client(0));
 
         let query_id: ClientQueryId = QueryId::new(1);
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         let result = subscriptions.add_subscription_multi(client.clone(), vec![plan.clone()], query_id)?;
         assert_eq!(result[0].hash, plan.hash);
@@ -1614,6 +1784,9 @@ mod tests {
         let id = id(0);
         let client = Arc::new(client(0));
 
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
+
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.set_legacy_subscription(client, [plan]);
         subscriptions.remove_all_subscriptions(&id);
@@ -1636,6 +1809,9 @@ mod tests {
 
         let id = id(0);
         let client = Arc::new(client(0));
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
 
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.set_legacy_subscription(client.clone(), [plan.clone()]);
@@ -1668,6 +1844,9 @@ mod tests {
 
         let id1 = id(1);
         let client1 = Arc::new(client(1));
+
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
 
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.set_legacy_subscription(client0, [plan.clone()]);
@@ -1714,6 +1893,8 @@ mod tests {
         let id1 = id(1);
         let client1 = Arc::new(client(1));
 
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
         let mut subscriptions = SubscriptionManager::default();
         subscriptions.set_legacy_subscription(client0, [plan_scan.clone(), plan_select0.clone()]);
         subscriptions.set_legacy_subscription(client1, [plan_scan.clone(), plan_select1.clone()]);
@@ -1771,6 +1952,8 @@ mod tests {
         let config = ClientConfig::for_test();
         let (client0, mut rx) = ClientConnectionSender::dummy_with_channel(client0, config);
 
+        let runtime = tokio::runtime::Runtime::new().unwrap();
+        let _rt = runtime.enter();
         let subscriptions = SubscriptionManager::default();
 
         let event = Arc::new(ModuleEvent {
@@ -1790,20 +1973,16 @@ mod tests {
         });
 
         db.with_read_only(Workload::Update, |tx| {
-            subscriptions.eval_updates_sequential(&(&*tx).into(), event, Some(&client0))
+            subscriptions.eval_updates_sequential(&(&*tx).into(), event, Some(Arc::new(client0)))
         });
 
-        tokio::runtime::Builder::new_current_thread()
-            .enable_time()
-            .build()
-            .unwrap()
-            .block_on(async move {
-                tokio::time::timeout(Duration::from_millis(20), async move {
-                    rx.recv().await.expect("Expected at least one message");
-                })
-                .await
-                .expect("Timed out waiting for a message to the client");
-            });
+        runtime.block_on(async move {
+            tokio::time::timeout(Duration::from_millis(20), async move {
+                rx.recv().await.expect("Expected at least one message");
+            })
+            .await
+            .expect("Timed out waiting for a message to the client");
+        });
 
         Ok(())
     }

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -12,7 +12,6 @@ use crate::subscription::delta::eval_delta;
 use hashbrown::hash_map::OccupiedError;
 use hashbrown::{HashMap, HashSet};
 use itertools::Itertools;
-use rayon::iter::{IntoParallelIterator, ParallelIterator};
 use spacetimedb_client_api_messages::websocket::{
     BsatnFormat, CompressableQueryUpdate, FormatSwitch, JsonFormat, QueryId, QueryUpdate, WebsocketFormat,
 };
@@ -21,7 +20,7 @@ use spacetimedb_lib::metrics::ExecutionMetrics;
 use spacetimedb_lib::{AlgebraicValue, ConnectionId, Identity, ProductValue};
 use spacetimedb_primitives::{ColId, TableId};
 use spacetimedb_subscription::SubscriptionPlan;
-use std::collections::{BTreeSet, LinkedList};
+use std::collections::BTreeSet;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::Arc;
 
@@ -723,8 +722,13 @@ impl SubscriptionManager {
     /// This method takes a set of delta tables,
     /// evaluates only the necessary queries for those delta tables,
     /// and then sends the results to each client.
+    ///
+    /// This previously used rayon to parallelize subscription evaluation.
+    /// However, in order to optimize for the common case of small updates,
+    /// we removed rayon and switched to a single-threaded execution,
+    /// which removed significant overhead associated with thread switching.
     #[tracing::instrument(level = "trace", skip_all)]
-    pub fn eval_updates(
+    pub fn eval_updates_sequential(
         &self,
         tx: &DeltaTx,
         event: Arc<ModuleEvent>,
@@ -734,349 +738,255 @@ impl SubscriptionManager {
 
         let tables = &event.status.database_update().unwrap().tables;
 
-        // Put the main work on a rayon compute thread.
-        rayon::scope(|_| {
-            let span = tracing::info_span!("eval_incr").entered();
+        let span = tracing::info_span!("eval_incr").entered();
 
-            type ClientQueryUpdate<F> = (<F as WebsocketFormat>::QueryUpdate, /* num_rows */ u64);
-            struct ClientUpdate<'a> {
-                id: &'a ClientId,
-                table_id: TableId,
-                table_name: &'a str,
-                update: FormatSwitch<ClientQueryUpdate<BsatnFormat>, ClientQueryUpdate<JsonFormat>>,
-            }
+        type ClientQueryUpdate<F> = (<F as WebsocketFormat>::QueryUpdate, /* num_rows */ u64);
+        struct ClientUpdate<'a> {
+            id: &'a ClientId,
+            table_id: TableId,
+            table_name: &'a str,
+            update: FormatSwitch<ClientQueryUpdate<BsatnFormat>, ClientQueryUpdate<JsonFormat>>,
+        }
 
-            // rayon has a fold-reduce idiom, which we use here. First, rayon splits
-            // the task onto a number of worker threads, and then on each thread, we *fold*
-            // each item of the iterator into an accumulator. This is that accumulator
-            // state; we use vecs because we're only ever going to be appending onto the
-            // end, so reallocation is more or less amortized.
-            #[derive(Default)]
-            struct FoldState<'a> {
-                updates: Vec<ClientUpdate<'a>>,
-                errs: Vec<(&'a ClientId, Box<str>)>,
-                metrics: ExecutionMetrics,
-            }
+        #[derive(Default)]
+        struct FoldState<'a> {
+            updates: Vec<ClientUpdate<'a>>,
+            errs: Vec<(&'a ClientId, Box<str>)>,
+            metrics: ExecutionMetrics,
+        }
 
-            // Next, we *reduce* the result of multiple threads into one final output.
-            // This is the accumulator for that; we use `VecList`s here because they
-            // have good characteristics for this use case, namely cheap appension
-            // of the result of each thread.
-            #[derive(Default)]
-            struct ReduceState<'a> {
-                updates: VecList<ClientUpdate<'a>>,
-                errs: VecList<(&'a ClientId, Box<str>)>,
-                metrics: ExecutionMetrics,
-            }
-            impl<'a> ReduceState<'a> {
-                /// Convert the result of a single-thread fold to get ready for a multi-thread reduce.
-                fn from_fold(acc: FoldState<'a>) -> Self {
-                    Self {
-                        updates: acc.updates.into(),
-                        errs: acc.errs.into(),
-                        metrics: acc.metrics,
-                    }
+        let FoldState { updates, errs, metrics } = tables
+            .iter()
+            .filter(|table| !table.inserts.is_empty() || !table.deletes.is_empty())
+            .flat_map(|table_update| self.queries_for_table_update(table_update))
+            // deduplicate queries by their hash
+            .filter({
+                let mut seen = HashSet::new();
+                // (HashSet::insert returns true for novel elements)
+                move |&hash| seen.insert(hash)
+            })
+            .flat_map(|hash| {
+                let qstate = &self.queries[hash];
+                qstate
+                    .query
+                    .plans_fragments()
+                    .map(move |plan_fragment| (qstate, plan_fragment))
+            })
+            // If N clients are subscribed to a query,
+            // we copy the DatabaseTableUpdate N times,
+            // which involves cloning BSATN (binary) or product values (json).
+            .fold(FoldState::default(), |mut acc, (qstate, plan)| {
+                let table_id = plan.subscribed_table_id();
+                let table_name = plan.subscribed_table_name();
+                // Store at most one copy for both the serialization to BSATN and JSON.
+                // Each subscriber gets to pick which of these they want,
+                // but we only fill `ops_bin_uncompressed` and `ops_json` at most once.
+                // The former will be `Some(_)` if some subscriber uses `Protocol::Binary`
+                // and the latter `Some(_)` if some subscriber uses `Protocol::Text`.
+                //
+                // Previously we were compressing each `QueryUpdate` within a `TransactionUpdate`.
+                // The reason was simple - many clients can subscribe to the same query.
+                // If we compress `TransactionUpdate`s independently for each client,
+                // we could be doing a lot of redundant compression.
+                //
+                // However the risks associated with this approach include:
+                //   1. We have to hold the tx lock when compressing
+                //   2. A potentially worse compression ratio
+                //   3. Extra decompression overhead on the client
+                //
+                // Because transaction processing is currently single-threaded,
+                // the risks of holding the tx lock for longer than necessary,
+                // as well as additional the message processing overhead on the client,
+                // outweighed the benefit of reduced cpu with the former approach.
+                let mut ops_bin_uncompressed: Option<(CompressableQueryUpdate<BsatnFormat>, _, _)> = None;
+                let mut ops_json: Option<(QueryUpdate<JsonFormat>, _, _)> = None;
+
+                fn memo_encode<F: WebsocketFormat>(
+                    updates: &UpdatesRelValue<'_>,
+                    memory: &mut Option<(F::QueryUpdate, u64, usize)>,
+                    metrics: &mut ExecutionMetrics,
+                ) -> (F::QueryUpdate, u64) {
+                    let (update, num_rows, num_bytes) = memory
+                        .get_or_insert_with(|| {
+                            let encoded = updates.encode::<F>();
+                            // The first time we insert into this map, we call encode.
+                            // This is when we serialize the rows to BSATN/JSON.
+                            // Hence this is where we increment `bytes_scanned`.
+                            metrics.bytes_scanned += encoded.2;
+                            encoded
+                        })
+                        .clone();
+                    // We call this function for each query,
+                    // and for each client subscribed to it.
+                    // Therefore every time we call this function,
+                    // we update the `bytes_sent_to_clients` metric.
+                    metrics.bytes_sent_to_clients += num_bytes;
+                    (update, num_rows)
                 }
-                /// Concatenate this `ReduceState` with another one.
-                ///
-                /// This is a cheap operation, since `LinkedList::append` is `O(1)`.
-                fn append(mut self, rhs: Self) -> Self {
-                    self.updates.append(rhs.updates);
-                    self.errs.append(rhs.errs);
-                    self.metrics.merge(rhs.metrics);
-                    self
-                }
-            }
 
-            let plans = tables
-                .iter()
-                .filter(|table| !table.inserts.is_empty() || !table.deletes.is_empty())
-                .flat_map(|table_update| self.queries_for_table_update(table_update))
-                // deduplicate queries by their hash
-                .filter({
-                    let mut seen = HashSet::new();
-                    // (HashSet::insert returns true for novel elements)
-                    move |&hash| seen.insert(hash)
-                })
-                .flat_map(|hash| {
-                    let qstate = &self.queries[hash];
-                    qstate
-                        .query
-                        .plans_fragments()
-                        .map(move |plan_fragment| (qstate, plan_fragment))
-                })
-                // collect all plan fragments we want to do work on into a
-                // single vec, which is more efficient for rayon to work with.
-                .collect::<Vec<_>>();
+                // filter out clients that've dropped
+                let clients_for_query = qstate.all_clients().filter(|id| {
+                    self.clients
+                        .get(*id)
+                        .is_some_and(|info| !info.dropped.load(Ordering::Acquire))
+                });
 
-            let ReduceState { updates, errs, metrics } = plans
-                .into_par_iter()
-                // If N clients are subscribed to a query,
-                // we copy the DatabaseTableUpdate N times,
-                // which involves cloning BSATN (binary) or product values (json).
-                .fold(FoldState::default, |mut acc, (qstate, plan)| {
-                    let table_id = plan.subscribed_table_id();
-                    let table_name = plan.subscribed_table_name();
-                    // Store at most one copy for both the serialization to BSATN and JSON.
-                    // Each subscriber gets to pick which of these they want,
-                    // but we only fill `ops_bin_uncompressed` and `ops_json` at most once.
-                    // The former will be `Some(_)` if some subscriber uses `Protocol::Binary`
-                    // and the latter `Some(_)` if some subscriber uses `Protocol::Text`.
-                    //
-                    // Previously we were compressing each `QueryUpdate` within a `TransactionUpdate`.
-                    // The reason was simple - many clients can subscribe to the same query.
-                    // If we compress `TransactionUpdate`s independently for each client,
-                    // we could be doing a lot of redundant compression.
-                    //
-                    // However the risks associated with this approach include:
-                    //   1. We have to hold the tx lock when compressing
-                    //   2. A potentially worse compression ratio
-                    //   3. Extra decompression overhead on the client
-                    //
-                    // Because transaction processing is currently single-threaded,
-                    // the risks of holding the tx lock for longer than necessary,
-                    // as well as the additional message processing overhead on the client,
-                    // outweighed the benefit of reduced cpu with the former approach.
-                    let mut ops_bin_uncompressed: Option<(CompressableQueryUpdate<BsatnFormat>, _, _)> = None;
-                    let mut ops_json: Option<(QueryUpdate<JsonFormat>, _, _)> = None;
+                match eval_delta(tx, &mut acc.metrics, plan) {
+                    Err(err) => {
+                        tracing::error!(
+                            message = "Query errored during tx update",
+                            sql = qstate.query.sql,
+                            reason = ?err,
+                        );
+                        let err = DBError::WithSql {
+                            sql: qstate.query.sql.as_str().into(),
+                            error: Box::new(err.into()),
+                        }
+                        .to_string()
+                        .into_boxed_str();
 
-                    fn memo_encode<F: WebsocketFormat>(
-                        updates: &UpdatesRelValue<'_>,
-                        memory: &mut Option<(F::QueryUpdate, u64, usize)>,
-                        metrics: &mut ExecutionMetrics,
-                    ) -> (F::QueryUpdate, u64) {
-                        let (update, num_rows, num_bytes) = memory
-                            .get_or_insert_with(|| {
-                                let encoded = updates.encode::<F>();
-                                // The first time we insert into this map, we call encode.
-                                // This is when we serialize the rows to BSATN/JSON.
-                                // Hence this is where we increment `bytes_scanned`.
-                                metrics.bytes_scanned += encoded.2;
-                                encoded
-                            })
-                            .clone();
-                        // We call this function for each query,
-                        // and for each client subscribed to it.
-                        // Therefore every time we call this function,
-                        // we update the `bytes_sent_to_clients` metric.
-                        metrics.bytes_sent_to_clients += num_bytes;
-                        (update, num_rows)
+                        acc.errs.extend(clients_for_query.map(|id| (id, err.clone())))
                     }
-
-                    // filter out clients that've dropped
-                    let clients_for_query = qstate.all_clients().filter(|id| {
-                        self.clients
-                            .get(*id)
-                            .is_some_and(|info| !info.dropped.load(Ordering::Acquire))
-                    });
-
-                    match eval_delta(tx, &mut acc.metrics, plan) {
-                        Err(err) => {
-                            tracing::error!(
-                                message = "Query errored during tx update",
-                                sql = qstate.query.sql,
-                                reason = ?err,
-                            );
-                            let err = DBError::WithSql {
-                                sql: qstate.query.sql.as_str().into(),
-                                error: Box::new(err.into()),
+                    // The query didn't return any rows to update
+                    Ok(None) => {}
+                    // The query did return updates - process them and add them to the accumulator
+                    Ok(Some(delta_updates)) => {
+                        let row_iter = clients_for_query.map(|id| {
+                            let client = &self.clients[id].outbound_ref;
+                            let update = match client.config.protocol {
+                                Protocol::Binary => Bsatn(memo_encode::<BsatnFormat>(
+                                    &delta_updates,
+                                    &mut ops_bin_uncompressed,
+                                    &mut acc.metrics,
+                                )),
+                                Protocol::Text => Json(memo_encode::<JsonFormat>(
+                                    &delta_updates,
+                                    &mut ops_json,
+                                    &mut acc.metrics,
+                                )),
+                            };
+                            ClientUpdate {
+                                id,
+                                table_id,
+                                table_name,
+                                update,
                             }
-                            .to_string()
-                            .into_boxed_str();
-
-                            acc.errs.extend(clients_for_query.map(|id| (id, err.clone())))
-                        }
-                        // The query didn't return any rows to update
-                        Ok(None) => {}
-                        // The query did return updates - process them and add them to the accumulator
-                        Ok(Some(delta_updates)) => {
-                            let row_iter = clients_for_query.map(|id| {
-                                let client = &self.clients[id].outbound_ref;
-                                let update = match client.config.protocol {
-                                    Protocol::Binary => Bsatn(memo_encode::<BsatnFormat>(
-                                        &delta_updates,
-                                        &mut ops_bin_uncompressed,
-                                        &mut acc.metrics,
-                                    )),
-                                    Protocol::Text => Json(memo_encode::<JsonFormat>(
-                                        &delta_updates,
-                                        &mut ops_json,
-                                        &mut acc.metrics,
-                                    )),
-                                };
-                                ClientUpdate {
-                                    id,
-                                    table_id,
-                                    table_name,
-                                    update,
-                                }
-                            });
-                            acc.updates.extend(row_iter);
-                        }
-                    }
-
-                    acc
-                })
-                // it would be nice to use `.collect_into_vec()` here, and reap the
-                // benefits of having an `IndexedParallelIterator`, but we actually
-                // produce many elements per `SubscriptionPlan` and would need to
-                // `flatten` them, meaning it effectively becomes unindexed.
-                .map(ReduceState::from_fold)
-                .reduce(ReduceState::default, ReduceState::append);
-
-            let clients_with_errors = errs.iter().map(|(id, _)| *id).collect::<HashSet<_>>();
-
-            let mut eval = updates
-                .into_iter()
-                // Filter out clients whose subscriptions failed
-                .filter(|upd| !clients_with_errors.contains(upd.id))
-                // For each subscriber, aggregate all the updates for the same table.
-                // That is, we build a map `(subscriber_id, table_id) -> updates`.
-                // A particular subscriber uses only one format,
-                // so their `TableUpdate` will contain either JSON (`Protocol::Text`)
-                // or BSATN (`Protocol::Binary`).
-                .fold(
-                    HashMap::<(&ClientId, TableId), SwitchedTableUpdate>::new(),
-                    |mut tables, upd| {
-                        match tables.entry((upd.id, upd.table_id)) {
-                            Entry::Occupied(mut entry) => match entry.get_mut().zip_mut(upd.update) {
-                                Bsatn((tbl_upd, update)) => tbl_upd.push(update),
-                                Json((tbl_upd, update)) => tbl_upd.push(update),
-                            },
-                            Entry::Vacant(entry) => drop(entry.insert(match upd.update {
-                                Bsatn(update) => Bsatn(TableUpdate::new(upd.table_id, upd.table_name.into(), update)),
-                                Json(update) => Json(TableUpdate::new(upd.table_id, upd.table_name.into(), update)),
-                            })),
-                        }
-                        tables
-                    },
-                )
-                .into_iter()
-                // Each client receives a single list of updates per transaction.
-                // So before sending the updates to each client,
-                // we must stitch together the `TableUpdate*`s into an aggregated list.
-                .fold(
-                    HashMap::<&ClientId, SwitchedDbUpdate>::new(),
-                    |mut updates, ((id, _), update)| {
-                        let entry = updates.entry(id);
-                        let entry = entry.or_insert_with(|| match &update {
-                            Bsatn(_) => Bsatn(<_>::default()),
-                            Json(_) => Json(<_>::default()),
                         });
-                        match entry.zip_mut(update) {
-                            Bsatn((list, elem)) => list.tables.push(elem),
-                            Json((list, elem)) => list.tables.push(elem),
-                        }
-                        updates
+                        acc.updates.extend(row_iter);
+                    }
+                }
+
+                acc
+            });
+
+        let clients_with_errors = errs.iter().map(|(id, _)| *id).collect::<HashSet<_>>();
+
+        let mut eval = updates
+            .into_iter()
+            // Filter out clients whose subscriptions failed
+            .filter(|upd| !clients_with_errors.contains(upd.id))
+            // For each subscriber, aggregate all the updates for the same table.
+            // That is, we build a map `(subscriber_id, table_id) -> updates`.
+            // A particular subscriber uses only one format,
+            // so their `TableUpdate` will contain either JSON (`Protocol::Text`)
+            // or BSATN (`Protocol::Binary`).
+            .fold(
+                HashMap::<(&ClientId, TableId), SwitchedTableUpdate>::new(),
+                |mut tables, upd| {
+                    match tables.entry((upd.id, upd.table_id)) {
+                        Entry::Occupied(mut entry) => match entry.get_mut().zip_mut(upd.update) {
+                            Bsatn((tbl_upd, update)) => tbl_upd.push(update),
+                            Json((tbl_upd, update)) => tbl_upd.push(update),
+                        },
+                        Entry::Vacant(entry) => drop(entry.insert(match upd.update {
+                            Bsatn(update) => Bsatn(TableUpdate::new(upd.table_id, upd.table_name.into(), update)),
+                            Json(update) => Json(TableUpdate::new(upd.table_id, upd.table_name.into(), update)),
+                        })),
+                    }
+                    tables
+                },
+            )
+            .into_iter()
+            // Each client receives a single list of updates per transaction.
+            // So before sending the updates to each client,
+            // we must stitch together the `TableUpdate*`s into an aggregated list.
+            .fold(
+                HashMap::<&ClientId, SwitchedDbUpdate>::new(),
+                |mut updates, ((id, _), update)| {
+                    let entry = updates.entry(id);
+                    let entry = entry.or_insert_with(|| match &update {
+                        Bsatn(_) => Bsatn(<_>::default()),
+                        Json(_) => Json(<_>::default()),
+                    });
+                    match entry.zip_mut(update) {
+                        Bsatn((list, elem)) => list.tables.push(elem),
+                        Json((list, elem)) => list.tables.push(elem),
+                    }
+                    updates
+                },
+            );
+
+        drop(clients_with_errors);
+        drop(span);
+
+        let _span = tracing::info_span!("eval_send").entered();
+
+        // We might have a known caller that hasn't been hidden from here..
+        // This caller may have subscribed to some query.
+        // If they haven't, we'll send them an empty update.
+        // Regardless, the update that we send to the caller, if we send any,
+        // is a full tx update, rather than a light one.
+        // That is, in the case of the caller, we don't respect the light setting.
+        if let Some((caller, conn_id)) = caller.zip(event.caller_connection_id) {
+            let database_update = eval
+                .remove(&(event.caller_identity, conn_id))
+                .map(|update| SubscriptionUpdateMessage::from_event_and_update(&event, update))
+                .unwrap_or_else(|| {
+                    SubscriptionUpdateMessage::default_for_protocol(caller.config.protocol, event.request_id)
+                });
+            let message = TransactionUpdateMessage {
+                event: Some(event.clone()),
+                database_update,
+            };
+            send_to_client(caller, message);
+        }
+
+        // Send all the other updates.
+        for (id, update) in eval {
+            let database_update = SubscriptionUpdateMessage::from_event_and_update(&event, update);
+            let client = self.client(id);
+            // Conditionally send out a full update or a light one otherwise.
+            let event = client.config.tx_update_full.then(|| event.clone());
+            let message = TransactionUpdateMessage { event, database_update };
+            send_to_client(&client, message);
+        }
+
+        // Send error messages and mark clients for removal
+        for (id, message) in errs {
+            if let Some(client) = self.clients.get(id) {
+                client.dropped.store(true, Ordering::Release);
+                send_to_client(
+                    &client.outbound_ref,
+                    SubscriptionMessage {
+                        request_id: None,
+                        query_id: None,
+                        timer: None,
+                        result: SubscriptionResult::Error(SubscriptionError {
+                            table_id: None,
+                            message,
+                        }),
                     },
                 );
-
-            drop(clients_with_errors);
-            drop(span);
-
-            let _span = tracing::info_span!("eval_send").entered();
-
-            // We might have a known caller that hasn't been hidden from here..
-            // This caller may have subscribed to some query.
-            // If they haven't, we'll send them an empty update.
-            // Regardless, the update that we send to the caller, if we send any,
-            // is a full tx update, rather than a light one.
-            // That is, in the case of the caller, we don't respect the light setting.
-            if let Some((caller, conn_id)) = caller.zip(event.caller_connection_id) {
-                let database_update = eval
-                    .remove(&(event.caller_identity, conn_id))
-                    .map(|update| SubscriptionUpdateMessage::from_event_and_update(&event, update))
-                    .unwrap_or_else(|| {
-                        SubscriptionUpdateMessage::default_for_protocol(caller.config.protocol, event.request_id)
-                    });
-                let message = TransactionUpdateMessage {
-                    event: Some(event.clone()),
-                    database_update,
-                };
-                send_to_client(caller, message);
             }
+        }
 
-            // Send all the other updates.
-            for (id, update) in eval {
-                let database_update = SubscriptionUpdateMessage::from_event_and_update(&event, update);
-                let client = self.client(id);
-                // Conditionally send out a full update or a light one otherwise.
-                let event = client.config.tx_update_full.then(|| event.clone());
-                let message = TransactionUpdateMessage { event, database_update };
-                send_to_client(&client, message);
-            }
-
-            // Send error messages and mark clients for removal
-            for (id, message) in errs {
-                if let Some(client) = self.clients.get(id) {
-                    client.dropped.store(true, Ordering::Release);
-                    send_to_client(
-                        &client.outbound_ref,
-                        SubscriptionMessage {
-                            request_id: None,
-                            query_id: None,
-                            timer: None,
-                            result: SubscriptionResult::Error(SubscriptionError {
-                                table_id: None,
-                                message,
-                            }),
-                        },
-                    );
-                }
-            }
-
-            metrics
-        })
+        metrics
     }
 }
 
 fn send_to_client(client: &ClientConnectionSender, message: impl Into<SerializableMessage>) {
     if let Err(e) = client.send_message(message) {
         tracing::warn!(%client.id, "failed to send update message to client: {e}")
-    }
-}
-
-/// A linked list of vecs.
-///
-/// To quote the docs for [`ParallelIterator::collect_vec_list`] (which I (Noa) also wrote):
-///
-/// > This is useful when you need to condense a parallel iterator into a
-/// > collection, but have no specific requirements for what that collection
-/// > should be. [...] This is a very efficient way to collect an unindexed
-/// > parallel iterator, without much intermediate data movement.
-struct VecList<T>(LinkedList<Vec<T>>);
-
-impl<T> Default for VecList<T> {
-    fn default() -> Self {
-        Self(Default::default())
-    }
-}
-impl<T> From<Vec<T>> for VecList<T> {
-    fn from(vec: Vec<T>) -> Self {
-        let mut list = LinkedList::new();
-        if !vec.is_empty() {
-            list.push_back(vec);
-        }
-        Self(list)
-    }
-}
-impl<T> VecList<T> {
-    /// Append another `VecList` onto this one.
-    ///
-    /// This operation is `O(1)`.
-    fn append(&mut self, mut other: Self) {
-        self.0.append(&mut other.0)
-    }
-    /// Iterate over the individual elements of this `VecList`.
-    fn iter(&self) -> impl Iterator<Item = &T> {
-        self.0.iter().flatten()
-    }
-}
-impl<T> IntoIterator for VecList<T> {
-    type Item = T;
-    type IntoIter = std::iter::Flatten<std::collections::linked_list::IntoIter<Vec<T>>>;
-    fn into_iter(self) -> Self::IntoIter {
-        self.0.into_iter().flatten()
     }
 }
 
@@ -1880,7 +1790,7 @@ mod tests {
         });
 
         db.with_read_only(Workload::Update, |tx| {
-            subscriptions.eval_updates(&(&*tx).into(), event, Some(&client0))
+            subscriptions.eval_updates_sequential(&(&*tx).into(), event, Some(&client0))
         });
 
         tokio::runtime::Builder::new_current_thread()

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -405,10 +405,7 @@ impl SubscriptionManager {
     }
 
     pub fn for_test_without_metrics() -> Self {
-        let clean_up_metric = scopeguard::guard((), |_| {
-            let bt = std::backtrace::Backtrace::force_capture();
-            println!("Exiting test send_worker at {bt}");
-        });
+        let clean_up_metric = scopeguard::guard((), |_| {});
         Self::with_metric(None, clean_up_metric)
     }
 

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -1079,7 +1079,8 @@ mod tests {
 
         let (data, _, tx) = tx.commit_downgrade(Workload::ForTests);
         let table_id = plan.subscribed_table_id();
-        let table_name = plan.subscribed_table_name().into();
+        // This awful construction to convert `Arc<str>` into `Box<str>`.
+        let table_name = (&**plan.subscribed_table_name()).into();
         let tx = DeltaTx::new(&tx, &data);
 
         // IMPORTANT: FOR TESTING ONLY!

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -257,6 +257,11 @@ metrics_group!(
         #[help = "The cumulative number of bytes sent to clients"]
         #[labels(txn_type: WorkloadType, db: Identity)]
         pub bytes_sent_to_clients: IntCounterVec,
+
+        #[name = spacetime_subscription_send_queue_length]
+        #[help = "The number of `ComputedQueries` waiting in the queue to be aggregated and broadcast by the `send_worker`"]
+        #[labels(database_identity: Identity)]
+        pub subscription_send_queue_length: IntGaugeVec,
     }
 );
 

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -61,6 +61,7 @@ pub struct TableSchema {
     pub table_id: TableId,
 
     /// The name of the table.
+    // TODO(perf): This should likely be an `Arc<str>`, not a `Box<str>`, as we `Clone` it somewhat frequently.
     pub table_name: Box<str>,
 
     /// The columns of the table.

--- a/crates/sqltest/src/space.rs
+++ b/crates/sqltest/src/space.rs
@@ -6,7 +6,6 @@ use spacetimedb::execution_context::Workload;
 use spacetimedb::sql::compiler::compile_sql;
 use spacetimedb::sql::execute::execute_sql;
 use spacetimedb::subscription::module_subscription_actor::ModuleSubscriptions;
-use spacetimedb::Identity;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_sats::algebraic_value::Packed;
 use spacetimedb_sats::meta_type::MetaType;
@@ -71,7 +70,7 @@ impl SpaceDb {
     pub(crate) fn run_sql(&self, sql: &str) -> anyhow::Result<Vec<MemTable>> {
         self.conn.with_read_only(Workload::Sql, |tx| {
             let ast = compile_sql(&self.conn, &AuthCtx::for_testing(), tx, sql)?;
-            let subs = ModuleSubscriptions::new(Arc::new(self.conn.db.clone()), <_>::default(), Identity::ZERO);
+            let subs = ModuleSubscriptions::for_test_new_runtime(Arc::new(self.conn.db.clone()));
             let result = execute_sql(&self.conn, sql, ast, self.auth, Some(&subs))?;
             //remove comments to see which SQL worked. Can't collect it outside from lack of a hook in the external `sqllogictest` crate... :(
             //append_file(&std::path::PathBuf::from(".ok.sql"), sql)?;

--- a/crates/sqltest/src/space.rs
+++ b/crates/sqltest/src/space.rs
@@ -70,7 +70,7 @@ impl SpaceDb {
     pub(crate) fn run_sql(&self, sql: &str) -> anyhow::Result<Vec<MemTable>> {
         self.conn.with_read_only(Workload::Sql, |tx| {
             let ast = compile_sql(&self.conn, &AuthCtx::for_testing(), tx, sql)?;
-            let subs = ModuleSubscriptions::for_test_new_runtime(Arc::new(self.conn.db.clone()));
+            let (subs, _runtime) = ModuleSubscriptions::for_test_new_runtime(Arc::new(self.conn.db.clone()));
             let result = execute_sql(&self.conn, sql, ast, self.auth, Some(&subs))?;
             //remove comments to see which SQL worked. Can't collect it outside from lack of a hook in the external `sqllogictest` crate... :(
             //append_file(&std::path::PathBuf::from(".ok.sql"), sql)?;

--- a/crates/subscription/src/lib.rs
+++ b/crates/subscription/src/lib.rs
@@ -1,3 +1,5 @@
+use std::sync::Arc;
+
 use anyhow::{bail, Result};
 use spacetimedb_execution::{pipelined::PipelinedProject, Datastore, DeltaStore, Row};
 use spacetimedb_expr::check::SchemaView;
@@ -215,7 +217,7 @@ pub struct SubscriptionPlan {
     /// To which table are we subscribed?
     return_id: TableId,
     /// To which table are we subscribed?
-    return_name: Box<str>,
+    return_name: Arc<str>,
     /// A subscription can read from multiple tables.
     /// From which tables do we read?
     table_ids: Vec<TableId>,
@@ -241,7 +243,7 @@ impl SubscriptionPlan {
     }
 
     /// To which table does this plan subscribe?
-    pub fn subscribed_table_name(&self) -> &str {
+    pub fn subscribed_table_name(&self) -> &Arc<str> {
         &self.return_name
     }
 
@@ -331,6 +333,8 @@ impl SubscriptionPlan {
 
         let mut subscriptions = vec![];
 
+        let return_name = Arc::<str>::from(return_name);
+
         for plan in plans {
             if has_non_index_join(&plan) {
                 bail!("Subscriptions require indexes on join columns")
@@ -342,7 +346,7 @@ impl SubscriptionPlan {
 
             subscriptions.push(Self {
                 return_id,
-                return_name: return_name.clone(),
+                return_name: Arc::clone(&return_name),
                 table_ids,
                 plan,
                 fragments,

--- a/crates/subscription/src/lib.rs
+++ b/crates/subscription/src/lib.rs
@@ -211,13 +211,56 @@ impl Fragments {
     }
 }
 
+/// Newtype wrapper for table names.
+///
+/// Uses an `Arc` internally, so `Clone` is cheap.
+#[derive(Debug, Clone, PartialEq, Eq, PartialOrd, Ord, Hash)]
+pub struct TableName(Arc<str>);
+
+impl From<Arc<str>> for TableName {
+    fn from(name: Arc<str>) -> Self {
+        TableName(name)
+    }
+}
+
+impl From<Box<str>> for TableName {
+    fn from(name: Box<str>) -> Self {
+        TableName(name.into())
+    }
+}
+
+impl From<String> for TableName {
+    fn from(name: String) -> Self {
+        TableName(name.into())
+    }
+}
+
+impl std::ops::Deref for TableName {
+    type Target = str;
+    fn deref(&self) -> &Self::Target {
+        &*self.0
+    }
+}
+
+impl TableName {
+    pub fn from_str(name: &str) -> Self {
+        TableName(name.into())
+    }
+}
+
+impl std::fmt::Display for TableName {
+    fn fmt(&self, f: &mut std::fmt::Formatter) -> std::fmt::Result {
+        self.0.fmt(f)
+    }
+}
+
 /// A subscription defines a view over a table
 #[derive(Debug)]
 pub struct SubscriptionPlan {
     /// To which table are we subscribed?
     return_id: TableId,
     /// To which table are we subscribed?
-    return_name: Arc<str>,
+    return_name: TableName,
     /// A subscription can read from multiple tables.
     /// From which tables do we read?
     table_ids: Vec<TableId>,
@@ -243,7 +286,7 @@ impl SubscriptionPlan {
     }
 
     /// To which table does this plan subscribe?
-    pub fn subscribed_table_name(&self) -> &Arc<str> {
+    pub fn subscribed_table_name(&self) -> &TableName {
         &self.return_name
     }
 
@@ -333,7 +376,7 @@ impl SubscriptionPlan {
 
         let mut subscriptions = vec![];
 
-        let return_name = Arc::<str>::from(return_name);
+        let return_name = TableName::from(return_name);
 
         for plan in plans {
             if has_non_index_join(&plan) {
@@ -346,7 +389,7 @@ impl SubscriptionPlan {
 
             subscriptions.push(Self {
                 return_id,
-                return_name: Arc::clone(&return_name),
+                return_name: return_name.clone(),
                 table_ids,
                 plan,
                 fragments,


### PR DESCRIPTION
# Description of Changes

and after releasing the datastore lock.

This commit moves some amount of work off the main `eval_updates_sequential` task and into a new background worker, the `send_worker`. The actual work performed is unchanged, it's just that some of it is moved to a different function which runs asynchronously after releasing the datastore lock. We expect two benefits from this:

1. Most obviously, we're now doing less work while holding the lock, reducing the size of our critical section.
2. We suspect that we had a thundering herd problem where we wake each client's WebSocket worker just before waking the next reducer task, making it wait in the Tokio task queue until all the client messages have been sent. This change should cause the reducer task to wake first, improving transaction throughput.

Moving the aggregation and broadcast to a separate task required enclosing the `SubscriptionManager`'s client map in an `Arc<RwLock>`. There's some amount of tricky code in there, with comments, that has to go out of its way to avoid deadlocks.

I also chose to change the `table_name` to be an `Arc<str>` rather than a `Box<str>`, as it needed to be cloned from `eval_updates_sequential` into the `send_worker`, where previously it was just borrowed within `eval_updates_sequential`. We could further reduce cloning by threading the change from `Box` to `Arc` further through our code, but I chose to keep the change relatively contained within the subscription-related code.

Additionally, while reworking the `SubscriptionManger`'s code, I changed from using tuples to structs in a few places. This leaked out a bit, and I changed some methods which used to take `(args: (T, U))` to instead take  `arg_t: T, arg_u: U`.
The only callers outside of `module_subscription_manager.rs` (the ones I was changing anyways) were constructing the tuple in the call anyways, and so now look cleaner.

Many tests are changed to now require a Tokio runtime, so that the `SubscriptionManager` can `tokio::spawn` its `Self::send_worker` future. Some tests which previously had a single-threaded runtime now require a multi-threaded one. This is mildly painful.

A new metric, `subscription_send_queue_length`, is also added. It is incremented by `eval_updates_sequential` before pushing into the new queue, and decremented by the `send_worker` after popping.

Because the metric is labeled with `database_identity: Identity`, the `SubscriptionManager` now needs to know its `Identity`, and so cannot be `Default`. Methods are added to make constructing one in tests easier.


# API and ABI breaking changes

N/a

# Expected complexity level and risk

3, some risk of deadlock due to added synchronization with the client map.

# Testing

- [x] I believe automated testing is sufficient to validate semantics.
- [x] Would like a bot test to observe hopefully-improved performance.