### PR TITLE
Datastore Extraction: TxMetrics refactor, small non-functional change to make datastore extraction easier

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -6,16 +6,13 @@ use super::{
     tx::TxId,
     tx_state::TxState,
 };
+use crate::execution_context::{Workload, WorkloadType};
 use crate::{
     db::datastore::{
         locking_tx_datastore::state_view::{IterByColRangeMutTx, IterMutTx, IterTx},
         traits::{InsertFlags, UpdateFlags},
     },
     subscription::ExecutionCounters,
-};
-use crate::{
-    db::relational_db::RelationalDB,
-    execution_context::{Workload, WorkloadType},
 };
 use crate::{
     db::{
@@ -848,22 +845,6 @@ impl TxMetrics {
             }
         }
     }
-}
-
-/// Reports the `TxMetrics`s passed.
-///
-/// Should only be called after the tx lock has been fully released.
-pub fn report_tx_metricses(
-    reducer: &str,
-    db: &RelationalDB,
-    tx_data: Option<&TxData>,
-    metrics_mut: Option<&TxMetrics>,
-    metrics_read: &TxMetrics,
-) {
-    if let Some(metrics_mut) = metrics_mut {
-        db.report(reducer, metrics_mut, tx_data);
-    }
-    db.report(reducer, metrics_read, None);
 }
 
 impl MutTx for Locking {

--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -6,14 +6,11 @@ use super::{
     tx::TxId,
     tx_state::TxState,
 };
-use crate::execution_context::{Workload, WorkloadType};
-use crate::{
-    db::datastore::{
-        locking_tx_datastore::state_view::{IterByColRangeMutTx, IterMutTx, IterTx},
-        traits::{InsertFlags, UpdateFlags},
-    },
-    subscription::ExecutionCounters,
+use crate::db::datastore::{
+    locking_tx_datastore::state_view::{IterByColRangeMutTx, IterMutTx, IterTx},
+    traits::{InsertFlags, UpdateFlags},
 };
+use crate::execution_context::{Workload, WorkloadType};
 use crate::{
     db::{
         datastore::{
@@ -33,7 +30,6 @@ use crate::{
 };
 use anyhow::{anyhow, Context};
 use core::{cell::RefCell, ops::RangeBounds};
-use enum_map::EnumMap;
 use parking_lot::{Mutex, RwLock};
 use spacetimedb_commitlog::payload::{txdata, Txdata};
 use spacetimedb_data_structures::map::{HashCollectionExt, HashMap};
@@ -71,9 +67,6 @@ pub struct Locking {
     sequence_state: Arc<Mutex<SequencesState>>,
     /// The identity of this database.
     pub(crate) database_identity: Identity,
-
-    /// A map from workload types to their cached prometheus counters.
-    workload_type_to_exec_counters: Arc<EnumMap<WorkloadType, ExecutionCounters>>,
 }
 
 impl MemoryUsage for Locking {
@@ -82,7 +75,6 @@ impl MemoryUsage for Locking {
             committed_state,
             sequence_state,
             database_identity,
-            workload_type_to_exec_counters: _,
         } = self;
         std::mem::size_of_val(&**committed_state)
             + committed_state.read().heap_usage()
@@ -94,14 +86,10 @@ impl MemoryUsage for Locking {
 
 impl Locking {
     pub fn new(database_identity: Identity, page_pool: PagePool) -> Self {
-        let workload_type_to_exec_counters =
-            Arc::new(EnumMap::from_fn(|ty| ExecutionCounters::new(&ty, &database_identity)));
-
         Self {
             committed_state: Arc::new(RwLock::new(CommittedState::new(page_pool))),
             sequence_state: <_>::default(),
             database_identity,
-            workload_type_to_exec_counters,
         }
     }
 
@@ -317,10 +305,6 @@ impl Locking {
             .ok_or_else(|| TableError::NotFound(name.into()))?;
 
         tx.alter_table_access(table_id, access)
-    }
-
-    pub(crate) fn exec_counters_for(&self, workload_type: WorkloadType) -> &ExecutionCounters {
-        &self.workload_type_to_exec_counters[workload_type]
     }
 }
 

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -364,7 +364,7 @@ fn init_database(
     let rcr = match module_def.lifecycle_reducer(Lifecycle::Init) {
         None => {
             if let Some((tx_data, tx_metrics, reducer)) = stdb.commit_tx(tx)? {
-                tx_metrics.report_with_db(&reducer, stdb, Some(&tx_data));
+                stdb.report(&reducer, &tx_metrics, Some(&tx_data));
             }
             None
         }

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -290,12 +290,12 @@ impl<T: WasmInstance> ModuleInstance for WasmModuleInstance<T> {
                 log::warn!("Database update failed: {} @ {}", e, stdb.database_identity());
                 self.system_logger().warn(&format!("Database update failed: {e}"));
                 let (tx_metrics, reducer) = stdb.rollback_mut_tx(tx);
-                tx_metrics.report_with_db(&reducer, stdb, None);
+                stdb.report(&reducer, &tx_metrics, None);
                 Ok(UpdateDatabaseResult::ErrorExecutingMigration(e))
             }
             Ok(()) => {
                 if let Some((tx_data, tx_metrics, reducer)) = stdb.commit_tx(tx)? {
-                    tx_metrics.report_with_db(&reducer, stdb, Some(&tx_data));
+                    stdb.report(&reducer, &tx_metrics, Some(&tx_data));
                 }
                 self.system_logger().info("Database updated");
                 log::info!("Database updated, {}", stdb.database_identity());

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -1,7 +1,6 @@
 use std::time::Duration;
 
 use super::ast::SchemaViewer;
-use crate::db::datastore::locking_tx_datastore::datastore::report_tx_metricses;
 use crate::db::datastore::locking_tx_datastore::state_view::StateView;
 use crate::db::datastore::system_tables::StVarTable;
 use crate::db::datastore::traits::IsolationLevel;
@@ -204,13 +203,7 @@ pub fn run(
             // Release the tx on drop, so that we record metrics.
             let mut tx = scopeguard::guard(tx, |tx| {
                 let (tx_metrics_downgrade, reducer) = db.release_tx(tx);
-                report_tx_metricses(
-                    &reducer,
-                    db,
-                    Some(&tx_data),
-                    Some(&tx_metrics_mut),
-                    &tx_metrics_downgrade,
-                );
+                db.report_tx_metricses(&reducer, Some(&tx_data), Some(&tx_metrics_mut), &tx_metrics_downgrade);
             });
 
             // Compute the header for the result set

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -255,7 +255,7 @@ pub fn run(
                 let metrics = tx.metrics;
                 return db.commit_tx(tx).map(|tx_opt| {
                     if let Some((tx_data, tx_metrics, reducer)) = tx_opt {
-                        tx_metrics.report_with_db(&reducer, db, Some(&tx_data));
+                        db.report(&reducer, &tx_metrics, Some(&tx_data));
                     }
                     SqlResult { rows: vec![], metrics }
                 });

--- a/crates/core/src/subscription/mod.rs
+++ b/crates/core/src/subscription/mod.rs
@@ -12,7 +12,10 @@ use spacetimedb_lib::{metrics::ExecutionMetrics, Identity};
 use spacetimedb_primitives::TableId;
 
 use crate::{
-    db::db_metrics::DB_METRICS, error::DBError, execution_context::WorkloadType, worker_metrics::WORKER_METRICS,
+    db::{datastore::locking_tx_datastore::datastore::MetricsRecorder, db_metrics::DB_METRICS},
+    error::DBError,
+    execution_context::WorkloadType,
+    worker_metrics::WORKER_METRICS,
 };
 
 pub mod delta;
@@ -81,6 +84,12 @@ impl ExecutionCounters {
         if metrics.duplicate_rows_sent > 0 {
             self.duplicate_rows_sent.inc_by(metrics.duplicate_rows_sent);
         }
+    }
+}
+
+impl MetricsRecorder for ExecutionCounters {
+    fn record(&self, metrics: &ExecutionMetrics) {
+        self.record(metrics);
     }
 }
 

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -264,7 +264,7 @@ impl ModuleSubscriptions {
 
         let tx = scopeguard::guard(self.relational_db.begin_tx(Workload::Subscribe), |tx| {
             let (tx_metrics, reducer) = self.relational_db.release_tx(tx);
-            tx_metrics.report_with_db(&reducer, &self.relational_db, None);
+            self.relational_db.report(&reducer, &tx_metrics, None);
         });
 
         let existing_query = {
@@ -357,7 +357,7 @@ impl ModuleSubscriptions {
 
         let tx = scopeguard::guard(self.relational_db.begin_tx(Workload::Unsubscribe), |tx| {
             let (tx_metrics, reducer) = self.relational_db.release_tx(tx);
-            tx_metrics.report_with_db(&reducer, &self.relational_db, None);
+            self.relational_db.report(&reducer, &tx_metrics, None);
         });
         let auth = AuthCtx::new(self.owner_identity, sender.id.identity);
         let (table_rows, metrics) = return_on_err_with_sql!(
@@ -403,7 +403,7 @@ impl ModuleSubscriptions {
         // Always lock the db before the subscription lock to avoid deadlocks.
         let tx = scopeguard::guard(self.relational_db.begin_tx(Workload::Unsubscribe), |tx| {
             let (tx_metrics, reducer) = self.relational_db.release_tx(tx);
-            tx_metrics.report_with_db(&reducer, &self.relational_db, None);
+            self.relational_db.report(&reducer, &tx_metrics, None);
         });
 
         let removed_queries = {
@@ -475,7 +475,7 @@ impl ModuleSubscriptions {
         // We always get the db lock before the subscription lock to avoid deadlocks.
         let tx = scopeguard::guard(self.relational_db.begin_tx(Workload::Subscribe), |tx| {
             let (tx_metrics, reducer) = self.relational_db.release_tx(tx);
-            tx_metrics.report_with_db(&reducer, &self.relational_db, None);
+            self.relational_db.report(&reducer, &tx_metrics, None);
         });
         let guard = self.subscriptions.read();
 
@@ -536,7 +536,7 @@ impl ModuleSubscriptions {
         );
         let tx = scopeguard::guard(tx, |tx| {
             let (tx_metrics, reducer) = self.relational_db.release_tx(tx);
-            tx_metrics.report_with_db(&reducer, &self.relational_db, None);
+            self.relational_db.report(&reducer, &tx_metrics, None);
         });
 
         // We minimize locking so that other clients can add subscriptions concurrently.
@@ -592,7 +592,7 @@ impl ModuleSubscriptions {
         let (queries, auth, tx) = self.compile_queries(sender.id.identity, subscription.query_strings, num_queries)?;
         let tx = scopeguard::guard(tx, |tx| {
             let (tx_metrics, reducer) = self.relational_db.release_tx(tx);
-            tx_metrics.report_with_db(&reducer, &self.relational_db, None);
+            self.relational_db.report(&reducer, &tx_metrics, None);
         });
 
         check_row_limit(


### PR DESCRIPTION
# Description of Changes

This removes the dependency of the `TxMetrics` struct on `ExecutionCounters` which is deeply tied to things in the `core` crate that should not be in a potential future `datastore` crate.

This is in the furtherance of making it easier to separate the `datastore` crate.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None beyond automated. This is a non-functional change.
