### PR TITLE
Datastore Extraction: Remove reference to WORKER_METRICS inside db_metrics

### DIFF
--- a/crates/core/src/db/db_metrics/data_size.rs
+++ b/crates/core/src/db/db_metrics/data_size.rs
@@ -3,8 +3,6 @@ use prometheus::IntGaugeVec;
 use spacetimedb_lib::Identity;
 use spacetimedb_metrics::metrics_group;
 
-use crate::worker_metrics::WORKER_METRICS;
-
 metrics_group!(
     #[non_exhaustive]
     pub struct DbDataSize {
@@ -42,32 +40,3 @@ metrics_group!(
 );
 
 pub static DATA_SIZE_METRICS: Lazy<DbDataSize> = Lazy::new(DbDataSize::new);
-
-// Remove all gauges associated with a database.
-// This is useful if a database is being deleted.
-pub fn remove_database_gauges<'a, I>(db: &Identity, table_names: I)
-where
-    I: IntoIterator<Item = &'a str>,
-{
-    // Remove the per-table gauges.
-    for table_name in table_names {
-        let _ = DATA_SIZE_METRICS
-            .data_size_table_num_rows
-            .remove_label_values(db, table_name);
-        let _ = DATA_SIZE_METRICS
-            .data_size_table_bytes_used_by_rows
-            .remove_label_values(db, table_name);
-        let _ = DATA_SIZE_METRICS
-            .data_size_table_num_rows_in_indexes
-            .remove_label_values(db, table_name);
-        let _ = DATA_SIZE_METRICS
-            .data_size_table_bytes_used_by_index_keys
-            .remove_label_values(db, table_name);
-    }
-    // Remove the per-db gauges.
-    let _ = DATA_SIZE_METRICS.data_size_blob_store_num_blobs.remove_label_values(db);
-    let _ = DATA_SIZE_METRICS
-        .data_size_blob_store_bytes_used_by_blobs
-        .remove_label_values(db);
-    let _ = WORKER_METRICS.wasm_memory_bytes.remove_label_values(db);
-}

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -4,15 +4,17 @@ use super::wasmtime::WasmtimeRuntime;
 use super::{Scheduler, UpdateDatabaseResult};
 use crate::database_logger::DatabaseLogger;
 use crate::db::datastore::traits::Program;
+use crate::db::db_metrics::data_size::DATA_SIZE_METRICS;
 use crate::db::db_metrics::DB_METRICS;
 use crate::db::relational_db::{self, DiskSizeFn, RelationalDB, Txdata};
-use crate::db::{self, db_metrics};
+use crate::db::{self};
 use crate::energy::{EnergyMonitor, EnergyQuanta, NullEnergyMonitor};
 use crate::messages::control_db::{Database, HostType};
 use crate::module_host_context::ModuleCreationContext;
 use crate::replica_context::ReplicaContext;
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
 use crate::util::{asyncify, spawn_rayon};
+use crate::worker_metrics::WORKER_METRICS;
 use anyhow::{anyhow, ensure, Context};
 use async_trait::async_trait;
 use durability::{Durability, EmptyHistory};
@@ -441,7 +443,7 @@ impl HostController {
                 let module = host.module.borrow().clone();
                 module.exit().await;
                 let table_names = module.info().module_def.tables().map(|t| t.name.deref());
-                db_metrics::data_size::remove_database_gauges(&module.info().database_identity, table_names);
+                remove_database_gauges(&module.info().database_identity, table_names);
             }
         }
 
@@ -980,4 +982,33 @@ pub async fn extract_schema(program_bytes: Box<[u8]>, host_type: HostType) -> an
     let module_info = Arc::into_inner(module_info).unwrap();
 
     Ok(module_info.module_def)
+}
+
+// Remove all gauges associated with a database.
+// This is useful if a database is being deleted.
+pub fn remove_database_gauges<'a, I>(db: &Identity, table_names: I)
+where
+    I: IntoIterator<Item = &'a str>,
+{
+    // Remove the per-table gauges.
+    for table_name in table_names {
+        let _ = DATA_SIZE_METRICS
+            .data_size_table_num_rows
+            .remove_label_values(db, table_name);
+        let _ = DATA_SIZE_METRICS
+            .data_size_table_bytes_used_by_rows
+            .remove_label_values(db, table_name);
+        let _ = DATA_SIZE_METRICS
+            .data_size_table_num_rows_in_indexes
+            .remove_label_values(db, table_name);
+        let _ = DATA_SIZE_METRICS
+            .data_size_table_bytes_used_by_index_keys
+            .remove_label_values(db, table_name);
+    }
+    // Remove the per-db gauges.
+    let _ = DATA_SIZE_METRICS.data_size_blob_store_num_blobs.remove_label_values(db);
+    let _ = DATA_SIZE_METRICS
+        .data_size_blob_store_bytes_used_by_blobs
+        .remove_label_values(db);
+    let _ = WORKER_METRICS.wasm_memory_bytes.remove_label_values(db);
 }


### PR DESCRIPTION
# Description of Changes

This is a non-functional change that removes a reference to `WORKER_METRICS` inside of `db_metrics` which will have to be moved into the datastore crate.

# API and ABI breaking changes

None

# Expected complexity level and risk

1 it's trivial

# Testing

None
