### PR TITLE
Fix typo in the log config toml file

### DIFF
--- a/crates/standalone/config.toml
+++ b/crates/standalone/config.toml
@@ -1,5 +1,5 @@
 # [certificate-authority]
-# jwt-priv-key-path = "~/.config/spacetime/id_ecdsas"
+# jwt-priv-key-path = "~/.config/spacetime/id_ecdsa"
 # jwt-pub-key-path = "~/.config/spacetime/id_ecdsa.pub"
 
 [logs]


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

There is a typo in the config.toml file which is loaded by spacetimedb-standalone. The line that has a typo is commented out by default but if a user uncomments this line without fixing the typo then it will cause an issue.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

0

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

This shouldn't require any testing outside of the testsuite, this is just a typo fix in a config file.
