### PR TITLE
`Page::reset_for`: stop zeroing pages

### DIFF
--- a/crates/table/src/page.rs
+++ b/crates/table/src/page.rs
@@ -1837,8 +1837,16 @@ impl Page {
     /// The reset page supports `max_rows_in_page` at most.
     pub fn reset_for(&mut self, max_rows_in_page: usize) {
         self.header.reset_for(max_rows_in_page);
-        // SAFETY: We just reset the page header.
-        unsafe { self.zero_data() };
+
+        // NOTE(centril): We previously zeroed pages when resetting.
+        // This had an adverse performance impact.
+        // The reason why we previously zeroed was for security under a multi-tenant setup
+        // when exposing a module ABI that allows modules to memcpy whole pages over.
+        // However, we have no such ABI for the time being, so we can soundly avoid zeroing.
+        // If we ever decide to add such an ABI, we must start zeroing again.
+        //
+        // // SAFETY: We just reset the page header.
+        // unsafe { self.zero_data() };
     }
 
     /// Sets the header and the row data.


### PR DESCRIPTION
# Description of Changes

Fixes https://github.com/clockworklabs/SpacetimeDB/issues/2803.

# API and ABI breaking changes

None

# Expected complexity level and risk

The main risk here is that if we continue doing this, we have to give up 

# Testing

Any semantically meaningful logic should be covered by existing tests.