### PR TITLE
smoketests: Bring containers back up in tear down of replication tests

### DIFF
--- a/smoketests/tests/replication.py
+++ b/smoketests/tests/replication.py
@@ -219,6 +219,11 @@ fn send_message(ctx: &ReducerContext, text: String) {
         super().setUpClass()
         cls.root_config = cls.project_path / "root_config"
 
+    def tearDown(self):
+        # Ensure containers that were brought down during a test are back up.
+        self.docker.compose("up", "-d")
+        super().tearDown()
+
     def __init__(self, *args, **kwargs):
         super().__init__(*args, **kwargs)
 


### PR DESCRIPTION
Needed to ensure subsequent tests that don't inherit from `ReplicationTest` have a functioning cluster, and allows deletion of test database.

# Expected complexity level and risk

1

# Testing

- [x] Yes
