### PR TITLE
client-api: Don't debug-print dropped outgoing Ws messages at info

### DIFF
--- a/crates/client-api/src/routes/subscribe.rs
+++ b/crates/client-api/src/routes/subscribe.rs
@@ -296,7 +296,8 @@ async fn ws_client_actor_inner(
                     // TODO: this isn't great. when we receive a close request from the peer,
                     //       tungstenite doesn't let us send any new messages on the socket,
                     //       even though the websocket RFC allows it. should we fork tungstenite?
-                    log::info!("dropping messages due to ws already being closed: {:?}", &rx_buf[..n]);
+                    log::info!("dropping {n} messages due to ws already being closed");
+                    log::debug!("dropped messages: {:?}", &rx_buf[..n]);
                 } else {
                 let send_all = async {
                     for msg in rx_buf.drain(..n) {


### PR DESCRIPTION
It's not impossible for a client to disconnect while there are outstanding subscription messages (e.g. `st_client` updates), and printing them all to the log at info level just creates a lot of data with limited value.

Print them at debug level instead.

# Expected complexity level and risk

1

# Testing

Just a log verbosity change.