### PR TITLE
Invoke __identity_connected__ for sql http requests

### DIFF
--- a/smoketests/tests/client_connected_error_rejects_connection.py
+++ b/smoketests/tests/client_connected_error_rejects_connection.py
@@ -17,6 +17,7 @@ pub fn init(ctx: &ReducerContext) {
 }
 """
 
+
 class ClientConnectedErrorRejectsConnection(Smoketest):
     MODULE_CODE = MODULE_HEADER + """
 
@@ -33,11 +34,12 @@ pub fn identity_disconnected(_ctx: &ReducerContext) {
 
     def test_client_connected_error_rejects_connection(self):
         with self.assertRaises(Exception):
-            self.subscribe("select * from all_u8s", n = 0)()
+            self.subscribe("select * from all_u8s", n=0)()
 
         logs = self.logs(100)
         self.assertIn('Rejecting connection from client', logs)
         self.assertNotIn('This should never be called, since we reject all connections!', logs)
+
 
 class ClientDisconnectedErrorStillDeletesStClient(Smoketest):
     MODULE_CODE = MODULE_HEADER + """
@@ -53,13 +55,12 @@ pub fn identity_disconnected(_ctx: &ReducerContext) {
 """
 
     def test_client_disconnected_error_still_deletes_st_client(self):
-        self.subscribe("select * from all_u8s", n = 0)()
+        self.subscribe("select * from all_u8s", n=0)()
 
         logs = self.logs(100)
         self.assertIn('This should be called, but the `st_client` row should still be deleted', logs)
 
         sql_out = self.spacetime("sql", self.database_identity, "select * from st_client")
-
         self.assertMultiLineEqual(sql_out, """ identity | connection_id 
 ----------+---------------
 """)

--- a/smoketests/tests/client_connected_error_rejects_connection.py
+++ b/smoketests/tests/client_connected_error_rejects_connection.py
@@ -55,12 +55,19 @@ pub fn identity_disconnected(_ctx: &ReducerContext) {
 """
 
     def test_client_disconnected_error_still_deletes_st_client(self):
+        # The st_client table should only have the data of the current connection
         self.subscribe("select * from all_u8s", n=0)()
 
         logs = self.logs(100)
         self.assertIn('This should be called, but the `st_client` row should still be deleted', logs)
 
         sql_out = self.spacetime("sql", self.database_identity, "select * from st_client")
-        self.assertMultiLineEqual(sql_out, """ identity | connection_id 
-----------+---------------
-""")
+        row = []
+        # Get only the rows with numeric data
+        # identity                                                                      | connection_id
+        # ------------------------------------------------------------------------------+-----------------------------------------
+        for x in sql_out.splitlines()[1:]:
+            x = x.split("|")[0].strip()
+            if x.isdigit():
+                row.append(x)
+        self.assertEqual(len(row), 1)

--- a/smoketests/tests/connect_disconnect_from_cli.py
+++ b/smoketests/tests/connect_disconnect_from_cli.py
@@ -21,7 +21,7 @@ pub fn say_hello(_ctx: &ReducerContext) {
 }
 """
 
-    def test_conn_disconn(self):
+    def test_conn_disconn_cli(self):
         """
         Ensure that the connect and disconnect functions are called when invoking a reducer from the CLI
         """
@@ -31,3 +31,12 @@ pub fn say_hello(_ctx: &ReducerContext) {
         self.assertIn('_connect called', logs)
         self.assertIn('disconnect called', logs)
         self.assertIn('Hello, World!', logs)
+
+    def test_conn_disconn_sql(self):
+        """
+        Ensure that the connect and disconnect functions are called when invoking a sql from the CLI
+        """
+        self.spacetime("sql", self.database_identity, "select * from st_client")
+        logs = self.logs(10)
+        self.assertIn('_connect called', logs)
+        self.assertIn('disconnect called', logs)


### PR DESCRIPTION
# Description of Changes

Closes #2802

We invoke __identity_connected__ for reducer calls over http but not for sql. This is a problem since __identity_connected__ can have access control logic.

# API and ABI breaking changes

Minor: It will run the `on_connect and on_disconnect` so in could reject calls that before run.

# Expected complexity level and risk

1

# Testing

- [x] Add smoke test
