### PR TITLE
Bump versions to 1.2.0

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -910,7 +910,7 @@ dependencies = [
 
 [[package]]
 name = "connect_disconnect_client"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "spacetimedb-sdk",
@@ -5151,7 +5151,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "bytemuck",
  "derive_more",
@@ -5169,7 +5169,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-auth"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "serde",
@@ -5181,7 +5181,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bench"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "anymap",
@@ -5227,7 +5227,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-macro"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "heck 0.4.1",
  "humantime",
@@ -5239,14 +5239,14 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-bindings-sys"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "spacetimedb-primitives",
 ]
 
 [[package]]
 name = "spacetimedb-cli"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "base64 0.21.7",
@@ -5307,7 +5307,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5355,7 +5355,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-client-api-messages"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "brotli",
  "bytes",
@@ -5380,7 +5380,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-codegen"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "convert_case 0.6.0",
@@ -5397,7 +5397,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-commitlog"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "async-stream",
  "bitflags 2.9.0",
@@ -5429,7 +5429,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-core"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -5542,7 +5542,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-data-structures"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "ahash 0.8.12",
  "hashbrown 0.15.3",
@@ -5554,7 +5554,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-durability"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5568,7 +5568,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-execution"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5583,7 +5583,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-expr"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "bigdecimal",
@@ -5601,7 +5601,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-fs-utils"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "hex",
@@ -5643,7 +5643,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-lib"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "bitflags 2.9.0",
@@ -5671,7 +5671,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-metrics"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "arrayvec",
  "itertools 0.12.1",
@@ -5681,7 +5681,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-paths"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "chrono",
@@ -5697,7 +5697,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-physical-plan"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "derive_more",
@@ -5713,7 +5713,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-primitives"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "bitflags 2.9.0",
  "either",
@@ -5724,7 +5724,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-query"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "itertools 0.12.1",
@@ -5741,7 +5741,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sats"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "ahash 0.8.12",
  "anyhow",
@@ -5773,7 +5773,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-schema"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "enum-as-inner",
@@ -5800,7 +5800,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sdk"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anymap",
  "base64 0.21.7",
@@ -5829,7 +5829,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-snapshot"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "blake3",
@@ -5861,7 +5861,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-sql-parser"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "derive_more",
  "spacetimedb-lib",
@@ -5871,7 +5871,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-standalone"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -5908,7 +5908,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-subscription"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "spacetimedb-execution",
@@ -5921,7 +5921,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-table"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "ahash 0.8.12",
  "blake3",
@@ -5946,7 +5946,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-testing"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "clap 4.5.37",
@@ -5973,7 +5973,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-update"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "bytes",
@@ -5998,7 +5998,7 @@ dependencies = [
 
 [[package]]
 name = "spacetimedb-vm"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "arrayvec",
@@ -6089,7 +6089,7 @@ dependencies = [
 
 [[package]]
 name = "sqltest"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "async-trait",
@@ -6426,7 +6426,7 @@ dependencies = [
 
 [[package]]
 name = "test-client"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "env_logger 0.10.2",
@@ -6438,7 +6438,7 @@ dependencies = [
 
 [[package]]
 name = "test-counter"
-version = "1.1.3"
+version = "1.2.0"
 dependencies = [
  "anyhow",
  "spacetimedb-data-structures",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -87,41 +87,41 @@ inherits = "release"
 debug = true
 
 [workspace.package]
-version = "1.1.3"
+version = "1.2.0"
 edition = "2021"
 # update rust-toolchain.toml too!
 rust-version = "1.84.0"
 
 [workspace.dependencies]
-spacetimedb = { path = "crates/bindings", version = "1.1.3" }
-spacetimedb-auth = { path = "crates/auth", version = "1.1.3" }
-spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.1.3" }
-spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.1.3" }
-spacetimedb-cli = { path = "crates/cli", version = "1.1.3" }
-spacetimedb-client-api = { path = "crates/client-api", version = "1.1.3" }
-spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.1.3" }
-spacetimedb-codegen = { path = "crates/codegen", version = "1.1.3" }
-spacetimedb-commitlog = { path = "crates/commitlog", version = "1.1.3" }
-spacetimedb-core = { path = "crates/core", version = "1.1.3" }
-spacetimedb-data-structures = { path = "crates/data-structures", version = "1.1.3" }
-spacetimedb-durability = { path = "crates/durability", version = "1.1.3" }
-spacetimedb-execution = { path = "crates/execution", version = "1.1.3" }
-spacetimedb-expr = { path = "crates/expr", version = "1.1.3" }
-spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.1.3" }
-spacetimedb-metrics = { path = "crates/metrics", version = "1.1.3" }
-spacetimedb-paths = { path = "crates/paths", version = "1.1.3" }
-spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.1.3" }
-spacetimedb-primitives = { path = "crates/primitives", version = "1.1.3" }
-spacetimedb-query = { path = "crates/query", version = "1.1.3" }
-spacetimedb-sats = { path = "crates/sats", version = "1.1.3" }
-spacetimedb-schema = { path = "crates/schema", version = "1.1.3" }
-spacetimedb-standalone = { path = "crates/standalone", version = "1.1.3" }
-spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.1.3" }
-spacetimedb-table = { path = "crates/table", version = "1.1.3" }
-spacetimedb-vm = { path = "crates/vm", version = "1.1.3" }
-spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.1.3" }
-spacetimedb-snapshot = { path = "crates/snapshot", version = "1.1.3" }
-spacetimedb-subscription = { path = "crates/subscription", version = "1.1.3" }
+spacetimedb = { path = "crates/bindings", version = "1.2.0" }
+spacetimedb-auth = { path = "crates/auth", version = "1.2.0" }
+spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.2.0" }
+spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.2.0" }
+spacetimedb-cli = { path = "crates/cli", version = "1.2.0" }
+spacetimedb-client-api = { path = "crates/client-api", version = "1.2.0" }
+spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.2.0" }
+spacetimedb-codegen = { path = "crates/codegen", version = "1.2.0" }
+spacetimedb-commitlog = { path = "crates/commitlog", version = "1.2.0" }
+spacetimedb-core = { path = "crates/core", version = "1.2.0" }
+spacetimedb-data-structures = { path = "crates/data-structures", version = "1.2.0" }
+spacetimedb-durability = { path = "crates/durability", version = "1.2.0" }
+spacetimedb-execution = { path = "crates/execution", version = "1.2.0" }
+spacetimedb-expr = { path = "crates/expr", version = "1.2.0" }
+spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.2.0" }
+spacetimedb-metrics = { path = "crates/metrics", version = "1.2.0" }
+spacetimedb-paths = { path = "crates/paths", version = "1.2.0" }
+spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.2.0" }
+spacetimedb-primitives = { path = "crates/primitives", version = "1.2.0" }
+spacetimedb-query = { path = "crates/query", version = "1.2.0" }
+spacetimedb-sats = { path = "crates/sats", version = "1.2.0" }
+spacetimedb-schema = { path = "crates/schema", version = "1.2.0" }
+spacetimedb-standalone = { path = "crates/standalone", version = "1.2.0" }
+spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.2.0" }
+spacetimedb-table = { path = "crates/table", version = "1.2.0" }
+spacetimedb-vm = { path = "crates/vm", version = "1.2.0" }
+spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.2.0" }
+spacetimedb-snapshot = { path = "crates/snapshot", version = "1.2.0" }
+spacetimedb-subscription = { path = "crates/subscription", version = "1.2.0" }
 
 # Prevent `ahash` from pulling in `getrandom` by disabling default features.
 # Modules use `getrandom02` and we need to prevent an incompatible version

--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Clockwork Laboratories, Inc.
-Licensed Work:        SpacetimeDB 1.1.3
+Licensed Work:        SpacetimeDB 1.2.0
                       The Licensed Work is
                       (c) 2023 Clockwork Laboratories, Inc.
                       

--- a/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
+++ b/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Codegen</AssemblyName>
-    <Version>1.1.2</Version>
+    <Version>1.2.0</Version>
     <Title>SpacetimeDB BSATN Codegen</Title>
     <Description>The SpacetimeDB BSATN Codegen implements the Roslyn incremental generators for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Runtime</AssemblyName>
-    <Version>1.1.2</Version>
+    <Version>1.2.0</Version>
     <Title>SpacetimeDB BSATN Runtime</Title>
     <Description>The SpacetimeDB BSATN Runtime implements APIs for BSATN serialization/deserialization in C#.</Description>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Codegen</AssemblyName>
-    <Version>1.1.2</Version>
+    <Version>1.2.0</Version>
     <Title>SpacetimeDB Module Codegen</Title>
     <Description>The SpacetimeDB Codegen implements the Roslyn incremental generators for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Runtime/Runtime.csproj
+++ b/crates/bindings-csharp/Runtime/Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Runtime</AssemblyName>
-    <Version>1.1.2</Version>
+    <Version>1.2.0</Version>
     <Title>SpacetimeDB Module Runtime</Title>
     <Description>The SpacetimeDB Runtime implements the database runtime bindings for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
+++ b/crates/cli/src/subcommands/project/csharp/StdbModule._csproj
@@ -8,7 +8,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="1.1.*" />
+    <PackageReference Include="SpacetimeDB.Runtime" Version="1.2.*" />
   </ItemGroup>
 
 </Project>

--- a/crates/cli/src/subcommands/project/rust/Cargo._toml
+++ b/crates/cli/src/subcommands/project/rust/Cargo._toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "1.1.3"
+spacetimedb = "1.2.0"
 log = "0.4"


### PR DESCRIPTION
# Description of Changes

It turns out that we have merged at least one PR that requires a minor version bump (https://github.com/clockworklabs/SpacetimeDB/pull/2711), but there are some others that maybe deserve that as well:

- https://github.com/clockworklabs/SpacetimeDB/pull/2725
- https://github.com/clockworklabs/SpacetimeDB/pull/2678

As such, I'm retroactively bumping the version number.

# API and ABI breaking changes

None, just a version bump

# Expected complexity level and risk

1

# Testing

None beyond CI