### PR TITLE
Implemented value tuple literal in SQL

### DIFF
--- a/crates/expr/src/expr.rs
+++ b/crates/expr/src/expr.rs
@@ -322,6 +322,8 @@ pub enum Expr {
     LogOp(LogOp, Box<Expr>, Box<Expr>),
     /// A typed literal expression
     Value(AlgebraicValue, AlgebraicType),
+    /// A typed literal tuple expression
+    Tuple(Box<[AlgebraicValue]>, AlgebraicType),
     /// A field projection
     Field(FieldProject),
 }
@@ -335,7 +337,7 @@ impl Expr {
                 a.visit(f);
                 b.visit(f);
             }
-            Self::Value(..) | Self::Field(..) => {}
+            Self::Value(..) | Self::Tuple(..) | Self::Field(..) => {}
         }
     }
 
@@ -347,7 +349,7 @@ impl Expr {
                 a.visit_mut(f);
                 b.visit_mut(f);
             }
-            Self::Value(..) | Self::Field(..) => {}
+            Self::Value(..) | Self::Tuple(..) | Self::Field(..) => {}
         }
     }
 
@@ -365,7 +367,7 @@ impl Expr {
     pub fn ty(&self) -> &AlgebraicType {
         match self {
             Self::BinOp(..) | Self::LogOp(..) => &AlgebraicType::Bool,
-            Self::Value(_, ty) | Self::Field(FieldProject { ty, .. }) => ty,
+            Self::Value(_, ty) | Self::Tuple(_, ty) | Self::Field(FieldProject { ty, .. }) => ty,
         }
     }
 }

--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -14,7 +14,7 @@ use expr::AggType;
 use expr::{Expr, FieldProject, ProjectList, ProjectName, RelExpr};
 use spacetimedb_lib::ser::Serialize;
 use spacetimedb_lib::Timestamp;
-use spacetimedb_lib::{from_hex_pad, AlgebraicType, AlgebraicValue, ConnectionId, Identity};
+use spacetimedb_lib::{from_hex_pad, AlgebraicType, AlgebraicValue, ConnectionId, Identity, ProductType, ProductTypeElement};
 use spacetimedb_sats::algebraic_type::fmt::fmt_algebraic_type;
 use spacetimedb_sats::algebraic_value::ser::ValueSerializer;
 use spacetimedb_schema::schema::ColumnSchema;
@@ -90,6 +90,31 @@ pub(crate) fn type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&Algebra
             parse(&v, ty).map_err(|_| InvalidLiteral::new(v.into_string(), ty))?,
             ty.clone(),
         )),
+        (SqlExpr::Tup(_), None) => {
+            Err(Unresolved::Literal.into())
+        }
+        (SqlExpr::Tup(t), Some(&AlgebraicType::Product(ref pty))) => Ok(Expr::Tuple(
+            t.iter().zip(pty.elements.iter()).map(|(lit, ty)| {
+                match (lit, ty) {
+                    (SqlLiteral::Bool(v), ProductTypeElement {
+                        algebraic_type: AlgebraicType::Bool,
+                        ..
+                    }) => Ok(AlgebraicValue::Bool(*v)),
+                    (SqlLiteral::Bool(_), ProductTypeElement {
+                        algebraic_type: ty,
+                        ..
+                    }) => Err(UnexpectedType::new(&AlgebraicType::Bool, ty).into()),
+                    (SqlLiteral::Str(v) | SqlLiteral::Num(v) | SqlLiteral::Hex(v), ProductTypeElement {
+                        algebraic_type: ty,
+                        ..
+                    }) => Ok(parse(&v, ty).map_err(|_| InvalidLiteral::new(v.clone().into_string(), ty))?),
+                }
+            }).collect::<TypingResult<Box<[AlgebraicValue]>>>()?,
+            AlgebraicType::Product(pty.clone()),
+        )),
+        (SqlExpr::Tup(_), Some(ty)) => {
+            Err(UnexpectedType::new(&AlgebraicType::Product(ProductType::unit()), ty).into())
+        }
         (SqlExpr::Field(SqlIdent(table), SqlIdent(field)), None) => {
             let table_type = vars.deref().get(&table).ok_or_else(|| Unresolved::var(&table))?;
             let ColumnSchema { col_pos, col_type, .. } = table_type
@@ -145,15 +170,19 @@ pub(crate) fn type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&Algebra
 }
 
 /// Is this type compatible with this binary operator?
-fn op_supports_type(_op: BinOp, t: &AlgebraicType) -> bool {
-    t.is_bool()
-        || t.is_integer()
-        || t.is_float()
-        || t.is_string()
-        || t.is_bytes()
-        || t.is_identity()
-        || t.is_connection_id()
-        || t.is_timestamp()
+fn op_supports_type(op: BinOp, ty: &AlgebraicType) -> bool {
+    match (ty, op) {
+        (AlgebraicType::Product(_), BinOp::Eq | BinOp::Ne) => true,
+        _ if ty.is_bool() => true,
+        _ if ty.is_integer() => true,
+        _ if ty.is_float() => true,
+        _ if ty.is_string() => true,
+        _ if ty.is_bytes() => true,
+        _ if ty.is_identity() => true,
+        _ if ty.is_connection_id() => true,
+        _ if ty.is_timestamp() => true,
+        _ => false,
+    }
 }
 
 /// Parse an integer literal into an [AlgebraicValue]

--- a/crates/physical-plan/src/compile.rs
+++ b/crates/physical-plan/src/compile.rs
@@ -23,6 +23,7 @@ fn compile_expr(expr: Expr, var: &mut impl VarLabel) -> PhysicalExpr {
             PhysicalExpr::BinOp(op, a, b)
         }
         Expr::Value(v, _) => PhysicalExpr::Value(v),
+        Expr::Tuple(t, _) => PhysicalExpr::Tuple(t),
         Expr::Field(proj) => PhysicalExpr::Field(compile_field_project(var, proj)),
     }
 }

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -1031,6 +1031,8 @@ pub enum PhysicalExpr {
     BinOp(BinOp, Box<PhysicalExpr>, Box<PhysicalExpr>),
     /// A constant algebraic value
     Value(AlgebraicValue),
+    /// A tuple of constant algebraic values
+    Tuple(Box<[AlgebraicValue]>),
     /// A field projection expression
     Field(TupleField),
 }
@@ -1094,6 +1096,7 @@ impl PhysicalExpr {
     pub fn map(self, f: &impl Fn(Self) -> Self) -> Self {
         match f(self) {
             value @ Self::Value(..) => value,
+            values @ Self::Tuple(..) => values,
             field @ Self::Field(..) => field,
             Self::BinOp(op, a, b) => Self::BinOp(op, Box::new(a.map(f)), Box::new(b.map(f))),
             Self::LogOp(op, exprs) => Self::LogOp(op, exprs.into_iter().map(|expr| expr.map(f)).collect()),
@@ -1155,6 +1158,7 @@ impl PhysicalExpr {
                 Cow::Owned(value)
             }
             Self::Value(v) => Cow::Borrowed(v),
+            Self::Tuple(t) => Cow::Owned(AlgebraicValue::Product(ProductValue {elements: t.clone()})),
         }
     }
 
@@ -1173,7 +1177,7 @@ impl PhysicalExpr {
                     .collect(),
             ),
             Self::BinOp(op, a, b) => Self::BinOp(op, Box::new(a.flatten()), Box::new(b.flatten())),
-            Self::Field(..) | Self::Value(..) => self,
+            Self::Field(..) | Self::Value(..) | Self::Tuple(..) => self,
         }
     }
 }

--- a/crates/sql-parser/src/parser/mod.rs
+++ b/crates/sql-parser/src/parser/mod.rs
@@ -215,6 +215,12 @@ pub(crate) fn parse_expr(expr: Expr) -> SqlParseResult<SqlExpr> {
         Expr::Nested(expr) => parse_expr(*expr),
         Expr::Value(Value::Placeholder(param)) if &param == ":sender" => Ok(SqlExpr::Param(Parameter::Sender)),
         Expr::Value(v) => Ok(SqlExpr::Lit(parse_literal(v)?)),
+        Expr::Tuple(ref t) => Ok(SqlExpr::Tup(t.iter().map(|x| {
+            match x {
+                Expr::Value(v) => parse_literal(v.clone()),
+                _ => Err(SqlUnsupported::Expr(expr.clone()).into()),
+            }
+        }).collect::<SqlParseResult<Vec<_>>>()?)),
         Expr::UnaryOp {
             op: UnaryOperator::Plus,
             expr,


### PR DESCRIPTION
# Description of Changes

There's been no way to use product types like this:
```rust
struct Position<T: geo::CoordNum = Coord> {
	lat: T,
	lon: T,
}

#[table(name=point)]
struct Point {
	pos: Position,
}
```
because SQL queries containing tuples:
```sql
SELECT * FROM point WHERE pos = (0, 0);
```
would fail with:
`Error: Unsupported expression: (0, 0)`

This PR implements tuple support for `=` and `!=` operators (subject to further expansion).

# API and ABI breaking changes

None.

# Expected complexity level and risk

### 2.

# Testing

- [x] Manual testing using custom `struct` columns.
- [ ] Needs unit tests. I leave this open for contributions or as an exercise to the employees.