### PR TITLE
Implemented SQL simple enum string literal parsing

### DIFF
--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -158,16 +158,20 @@ pub(crate) fn type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&Algebra
 }
 
 /// Is this type compatible with this binary operator?
-fn op_supports_type(_op: BinOp, t: &AlgebraicType) -> bool {
-    t.is_bool()
-        || t.is_integer()
-        || t.is_float()
-        || t.is_string()
-        || t.is_bytes()
-        || t.is_identity()
-        || t.is_connection_id()
-        || t.is_timestamp()
-        || t.is_uuid()
+fn op_supports_type(op: BinOp, ty: &AlgebraicType) -> bool {
+    match (ty, op) {
+        (AlgebraicType::Sum(st), BinOp::Eq | BinOp::Ne) if st.is_simple_enum() => true,
+        _ if ty.is_bool() => true,
+        _ if ty.is_integer() => true,
+        _ if ty.is_float() => true,
+        _ if ty.is_string() => true,
+        _ if ty.is_bytes() => true,
+        _ if ty.is_identity() => true,
+        _ if ty.is_connection_id() => true,
+        _ if ty.is_timestamp() => true,
+        _ if ty.is_uuid() => true,
+        _ => false,
+    }
 }
 
 /// Parse an integer literal into an [AlgebraicValue]
@@ -240,6 +244,14 @@ pub(crate) fn parse(value: &str, ty: &AlgebraicType) -> anyhow::Result<Algebraic
         Uuid::parse_str(value)
             .map(AlgebraicValue::from)
             .map_err(|err| anyhow!(err))
+    };
+    let to_simple_enum = || {
+        Ok(AlgebraicValue::enum_simple(
+            match ty {
+                AlgebraicType::Sum(st) => st.get_variant_simple(value).ok_or_else(|| anyhow!("{value} is not a valid {}", fmt_algebraic_type(&ty)))?.0,
+                _ => unreachable!("ty.is_simple_enum() is true"),
+            }
+        ))
     };
     let to_i256 = |decimal: &BigDecimal| {
         i256::from_str_radix(
@@ -362,6 +374,7 @@ pub(crate) fn parse(value: &str, ty: &AlgebraicType) -> anyhow::Result<Algebraic
         t if t.is_identity() => to_identity(),
         t if t.is_connection_id() => to_connection_id(),
         t if t.is_uuid() => to_uuid(),
+        t if t.is_simple_enum() => to_simple_enum(),
         t => bail!("Literal values for type {} are not supported", fmt_algebraic_type(t)),
     }
 }

--- a/crates/sats/src/algebraic_type.rs
+++ b/crates/sats/src/algebraic_type.rs
@@ -207,6 +207,11 @@ impl AlgebraicType {
         matches!(self, Self::Sum(p) if p.is_empty())
     }
 
+    /// Returns whether this type is a simple enum type.
+    pub fn is_simple_enum(&self) -> bool {
+        matches!(self, Self::Sum(p) if p.is_simple_enum())
+    }
+
     /// Returns whether this type is an option type.
     pub fn is_option(&self) -> bool {
         matches!(self, Self::Sum(p) if p.is_option())


### PR DESCRIPTION
# Description of Changes

Ditto #2843.
```rust
enum TestKind {
	OptionA,
	OptionB,
}

#[table(name=test)]
struct Test {
	kind: TestKind,
}
```
```sql
SELECT * FROM test WHERE kind = 'OptionB';
```

This PR implements simple enum support for = and != operators (subject to further expansion).

_Note: still doesn't work with [enum_stringify](https://docs.rs/enum_stringify/latest/enum_stringify) case conversion OOTB. No clue how to implement that yet._

# API and ABI breaking changes

None.

# Expected complexity level and risk

### 1.

# Testing

- [x] Manual testing using custom `enum` columns.
- [ ] Needs unit tests. I leave this open for contributions or as an exercise to the employees.