### PR TITLE
Implemented `FilterableValue` for `Timestamp` & `TimeDuration`

### DIFF
--- a/crates/lib/src/filterable_value.rs
+++ b/crates/lib/src/filterable_value.rs
@@ -1,4 +1,4 @@
-use crate::{ConnectionId, Identity};
+use crate::{ConnectionId, Identity, TimeDuration, Timestamp};
 use core::ops;
 use spacetimedb_sats::bsatn;
 use spacetimedb_sats::{hash::Hash, i256, u256, Serialize};
@@ -95,6 +95,8 @@ impl_filterable_value! {
 
     Identity: Copy,
     ConnectionId: Copy,
+    Timestamp: Copy,
+    TimeDuration: Copy,
     Hash: Copy,
 
     // Some day we will likely also want to support `Vec<u8>` and `[u8]`,


### PR DESCRIPTION
Without this:
```rust
some_table.some_index().filter((ctx.sender, ctx.timestamp));
                        ------ ^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `IndexScanRangeBounds<(spacetimedb::Identity, spacetimedb::Timestamp), _>` is not implemented for `(spacetimedb::Identity, spacetimedb::Timestamp)`
```
Same goes for `.delete()`.

# API and ABI breaking changes

None.

# Expected complexity level and risk

### 1.

# Testing

- [x] Compiles.
- [x] Allows compiling the case.
- [ ] Why hasn't this already been implemented?