### PR TITLE
Add Zstd compression to the websocket messages

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -5399,6 +5399,7 @@ dependencies = [
  "spacetimedb-sats",
  "strum",
  "thiserror 1.0.69",
+ "zstd",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -290,6 +290,7 @@ xdg = "2.5"
 tikv-jemallocator = { version = "0.6.0", features = ["profiling", "stats"] }
 tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"] }
 jemalloc_pprof = { version = "0.7", features = ["symbolize", "flamegraph"] }
+zstd = "0.13"
 zstd-framed = { version = "0.1.1", features = ["tokio"] }
 
 # Vendor the openssl we rely on, rather than depend on a

--- a/crates/client-api-messages/Cargo.toml
+++ b/crates/client-api-messages/Cargo.toml
@@ -13,6 +13,7 @@ spacetimedb-sats = { workspace = true, features = ["bytestring"] }
 bytes.workspace = true
 bytestring.workspace = true
 brotli.workspace = true
+zstd.workspace = true
 chrono = { workspace = true, features = ["serde"] }
 enum-as-inner.workspace = true
 flate2.workspace = true

--- a/crates/client-api-messages/src/websocket.rs
+++ b/crates/client-api-messages/src/websocket.rs
@@ -306,13 +306,13 @@ pub struct OneOffQuery {
 /// The tag recognized by the host and SDKs to mean no compression of a [`ServerMessage`].
 pub const SERVER_MSG_COMPRESSION_TAG_NONE: u8 = 0;
 
-/// The tag recognized by the host and SDKs to mean brotli compression  of a [`ServerMessage`].
+/// The tag recognized by the host and SDKs to mean brotli compression of a [`ServerMessage`].
 pub const SERVER_MSG_COMPRESSION_TAG_BROTLI: u8 = 1;
 
-/// The tag recognized by the host and SDKs to mean brotli compression  of a [`ServerMessage`].
+/// The tag recognized by the host and SDKs to mean gzip compression of a [`ServerMessage`].
 pub const SERVER_MSG_COMPRESSION_TAG_GZIP: u8 = 2;
 
-/// The tag recognized by the host and SDKs to mean brotli compression  of a [`ServerMessage`].
+/// The tag recognized by the host and SDKs to mean zstd compression of a [`ServerMessage`].
 pub const SERVER_MSG_COMPRESSION_TAG_ZSTD: u8 = 3;
 
 /// Messages sent from the server to the client.

--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -4,10 +4,7 @@ use crate::host::module_host::{EventStatus, ModuleEvent};
 use crate::host::ArgsTuple;
 use crate::messages::websocket as ws;
 use derive_more::From;
-use spacetimedb_client_api_messages::websocket::{
-    BsatnFormat, Compression, FormatSwitch, JsonFormat, OneOffTable, RowListLen, WebsocketFormat,
-    SERVER_MSG_COMPRESSION_TAG_BROTLI, SERVER_MSG_COMPRESSION_TAG_GZIP, SERVER_MSG_COMPRESSION_TAG_NONE,
-};
+use spacetimedb_client_api_messages::websocket::{BsatnFormat, Compression, FormatSwitch, JsonFormat, OneOffTable, RowListLen, WebsocketFormat, SERVER_MSG_COMPRESSION_TAG_BROTLI, SERVER_MSG_COMPRESSION_TAG_GZIP, SERVER_MSG_COMPRESSION_TAG_NONE, SERVER_MSG_COMPRESSION_TAG_ZSTD};
 use spacetimedb_lib::identity::RequestId;
 use spacetimedb_lib::ser::serde::SerializeWrapper;
 use spacetimedb_lib::{ConnectionId, TimeDuration};
@@ -53,6 +50,11 @@ pub fn serialize(msg: impl ToProtocol<Encoded = SwitchedServerMessage>, config: 
                 Compression::Gzip => {
                     let mut out = vec![SERVER_MSG_COMPRESSION_TAG_GZIP];
                     ws::gzip_compress(srv_msg, &mut out);
+                    out
+                }
+                Compression::Zstd => {
+                    let mut out = vec![SERVER_MSG_COMPRESSION_TAG_ZSTD];
+                    ws::zstd_compress(srv_msg, &mut out);
                     out
                 }
             };


### PR DESCRIPTION
# Description of Changes

This add the option to the websocket/subscribe endpoint so you can use Zstd as the compression in addition to None/Brotli/Gzip. 

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] I have tested it with the simple chat example where I have enabled the zstd compression and added some logging to see if it was used
- [ ] Testing for the compression speed to find the best level


# Additional

What we could look into is to use zstd dictionary features to improve the performance even more as it could possible help with the base structure of each message. The only thing that would then needed to be done is have an extra option in the enum as an ZstdDict as the client and server would need to know about the dictionary.
