### PR TITLE
Implemented array literal in SQL

### DIFF
--- a/crates/core/src/subscription/metrics.rs
+++ b/crates/core/src/subscription/metrics.rs
@@ -64,7 +64,7 @@ fn extract_columns(
                 extract_columns(expr, schema, columns);
             }
         }
-        PhysicalExpr::Value(_) => {}
+        PhysicalExpr::Value(_) | PhysicalExpr::Tuple(_) => {}
     }
 }
 

--- a/crates/expr/src/errors.rs
+++ b/crates/expr/src/errors.rs
@@ -117,6 +117,21 @@ impl UnexpectedType {
 }
 
 #[derive(Debug, Error)]
+#[error("Unexpected array type: expected {expected}")]
+pub struct UnexpectedArrayType {
+    expected: String,
+    // TODO: inferred
+}
+
+impl UnexpectedArrayType {
+    pub fn new(expected: &AlgebraicType) -> Self {
+        Self {
+            expected: fmt_algebraic_type(expected).to_string(),
+        }
+    }
+}
+
+#[derive(Debug, Error)]
 #[error("Duplicate name `{0}`")]
 pub struct DuplicateName(pub RawIdentifier);
 
@@ -153,6 +168,8 @@ pub enum TypingError {
     Literal(#[from] InvalidLiteral),
     #[error(transparent)]
     Unexpected(#[from] UnexpectedType),
+    #[error(transparent)]
+    UnexpectedArray(#[from] UnexpectedArrayType),
     #[error(transparent)]
     Wildcard(#[from] InvalidWildcard),
     #[error(transparent)]

--- a/crates/expr/src/expr.rs
+++ b/crates/expr/src/expr.rs
@@ -383,6 +383,8 @@ pub enum Expr {
     LogOp(LogOp, Box<Expr>, Box<Expr>),
     /// A typed literal expression
     Value(AlgebraicValue, AlgebraicType),
+    /// A typed literal tuple expression
+    Tuple(Box<[AlgebraicValue]>, AlgebraicType),
     /// A field projection
     Field(FieldProject),
 }
@@ -396,7 +398,7 @@ impl Expr {
                 a.visit(f);
                 b.visit(f);
             }
-            Self::Value(..) | Self::Field(..) => {}
+            Self::Value(..) | Self::Tuple(..) | Self::Field(..) => {}
         }
     }
 
@@ -408,7 +410,7 @@ impl Expr {
                 a.visit_mut(f);
                 b.visit_mut(f);
             }
-            Self::Value(..) | Self::Field(..) => {}
+            Self::Value(..) | Self::Tuple(..) | Self::Field(..) => {}
         }
     }
 
@@ -426,7 +428,7 @@ impl Expr {
     pub fn ty(&self) -> &AlgebraicType {
         match self {
             Self::BinOp(..) | Self::LogOp(..) => &AlgebraicType::Bool,
-            Self::Value(_, ty) | Self::Field(FieldProject { ty, .. }) => ty,
+            Self::Value(_, ty) | Self::Tuple(_, ty) | Self::Field(FieldProject { ty, .. }) => ty,
         }
     }
 }

--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -5,7 +5,7 @@ use anyhow::Context;
 use bigdecimal::BigDecimal;
 use bigdecimal::ToPrimitive;
 use check::{Relvars, TypingResult};
-use errors::{DuplicateName, InvalidLiteral, InvalidOp, InvalidWildcard, UnexpectedType, Unresolved};
+use errors::{DuplicateName, InvalidLiteral, InvalidOp, InvalidWildcard, UnexpectedArrayType, UnexpectedType, Unresolved};
 use ethnum::i256;
 use ethnum::u256;
 use expr::AggType;
@@ -15,6 +15,7 @@ use spacetimedb_data_structures::map::HashSet;
 use spacetimedb_lib::ser::Serialize;
 use spacetimedb_lib::Timestamp;
 use spacetimedb_lib::{from_hex_pad, AlgebraicType, AlgebraicValue, ConnectionId, Identity, ProductType, ProductTypeElement};
+use spacetimedb_sats::{ArrayType, ArrayValue, F32, F64};
 use spacetimedb_sats::algebraic_type::fmt::fmt_algebraic_type;
 use spacetimedb_sats::algebraic_value::ser::ValueSerializer;
 use spacetimedb_sats::uuid::Uuid;
@@ -99,6 +100,12 @@ fn _type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&AlgebraicType>, d
             parse(&v, ty).map_err(|_| InvalidLiteral::new(v.into_string(), ty))?,
             ty.clone(),
         )),
+        (SqlExpr::Lit(SqlLiteral::Arr(_)), None) => {
+            Err(Unresolved::Literal.into())
+        }
+        (SqlExpr::Lit(SqlLiteral::Arr(_)), Some(ty)) => {
+            Err(UnexpectedArrayType::new(ty).into())
+        }
         (SqlExpr::Tup(_), None) => {
             Err(Unresolved::Literal.into())
         }
@@ -113,6 +120,12 @@ fn _type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&AlgebraicType>, d
                     }
                     (SqlLiteral::Str(v) | SqlLiteral::Num(v) | SqlLiteral::Hex(v), ProductTypeElement { algebraic_type: ty, .. }) => {
                         Ok(parse(&v, ty).map_err(|_| InvalidLiteral::new(v.clone().into_string(), ty))?)
+                    }
+                    (SqlLiteral::Arr(v), ProductTypeElement { algebraic_type: AlgebraicType::Array(a), .. }) => {
+                        Ok(parse_array_value(v, a).map_err(|_| UnexpectedArrayType::new(&a.elem_ty))?)
+                    }
+                    (SqlLiteral::Arr(_), ProductTypeElement { algebraic_type: ty, .. }) => {
+                        Err(UnexpectedArrayType::new(ty).into())
                     }
                 }
             }).collect::<TypingResult<Box<[AlgebraicValue]>>>()?,
@@ -384,6 +397,50 @@ pub(crate) fn parse(value: &str, ty: &AlgebraicType) -> anyhow::Result<Algebraic
         t if t.is_uuid() => to_uuid(),
         t => bail!("Literal values for type {} are not supported", fmt_algebraic_type(t)),
     }
+}
+
+macro_rules! parse_array_number {
+    ($arr:expr, $elem_ty:expr, $($t:ident, $ty:ty),*) => {
+        match $elem_ty {
+            AlgebraicType::Bool => ArrayValue::Bool($arr.iter().map(|x| match x {
+                SqlLiteral::Bool(b) => Ok(*b),
+                _ => Err(UnexpectedType::new(&$elem_ty, &AlgebraicType::Bool).into()),
+            }).collect::<TypingResult<Box<[bool]>>>()?),
+            AlgebraicType::String => ArrayValue::String($arr.iter().map(|x| match x {
+                SqlLiteral::Str(b) => Ok(b.clone()),
+                _ => Err(UnexpectedType::new(&$elem_ty, &AlgebraicType::String).into()),
+            }).collect::<TypingResult<Box<[Box<str>]>>>()?),
+            $(AlgebraicType::$t => ArrayValue::$t($arr.iter().map(|x| match x {
+                SqlLiteral::Num(v) | SqlLiteral::Hex(v) => Ok(match parse(v, &$elem_ty).map_err(|_| InvalidLiteral::new(v.clone().into_string(), &$elem_ty))? {
+                    AlgebraicValue::$t(r) => r,
+                    _ => unreachable!(),  // guaranteed by `parse()'
+                }.into()),
+                SqlLiteral::Str(_) => Err(UnexpectedType::new(&$elem_ty, &AlgebraicType::String).into()),
+                SqlLiteral::Bool(_) => Err(UnexpectedType::new(&$elem_ty, &AlgebraicType::Bool).into()),
+                SqlLiteral::Arr(_) => Err(UnexpectedArrayType::new(&$elem_ty).into()),
+            }).collect::<anyhow::Result<Box<[$ty]>>>()?),)*
+            _ => {
+                return Err(UnexpectedArrayType::new(&$elem_ty).into());
+            }
+        }
+    }
+}
+
+pub(crate) fn parse_array_value(arr: &Box<[SqlLiteral]>, a: &ArrayType) -> anyhow::Result<AlgebraicValue> {
+    Ok(AlgebraicValue::Array(parse_array_number!(arr, *a.elem_ty,
+        I8, i8,
+        U8, u8,
+        I16, i16,
+        U16, u16,
+        I32, i32,
+        U32, u32,
+        I128, i128,
+        U128, u128,
+        /*I256, i256,
+        U256, u256,*/ // TODO: Boxed
+        F32, F32,
+        F64, F64
+    )))
 }
 
 /// The source of a statement

--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -14,7 +14,7 @@ use spacetimedb_data_structures::map::HashCollectionExt as _;
 use spacetimedb_data_structures::map::HashSet;
 use spacetimedb_lib::ser::Serialize;
 use spacetimedb_lib::Timestamp;
-use spacetimedb_lib::{from_hex_pad, AlgebraicType, AlgebraicValue, ConnectionId, Identity};
+use spacetimedb_lib::{from_hex_pad, AlgebraicType, AlgebraicValue, ConnectionId, Identity, ProductType, ProductTypeElement};
 use spacetimedb_sats::algebraic_type::fmt::fmt_algebraic_type;
 use spacetimedb_sats::algebraic_value::ser::ValueSerializer;
 use spacetimedb_sats::uuid::Uuid;
@@ -99,6 +99,28 @@ fn _type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&AlgebraicType>, d
             parse(&v, ty).map_err(|_| InvalidLiteral::new(v.into_string(), ty))?,
             ty.clone(),
         )),
+        (SqlExpr::Tup(_), None) => {
+            Err(Unresolved::Literal.into())
+        }
+        (SqlExpr::Tup(t), Some(&AlgebraicType::Product(ref pty))) => Ok(Expr::Tuple(
+            t.iter().zip(pty.elements.iter()).map(|(lit, ty)| {
+                match (lit, ty) {
+                    (SqlLiteral::Bool(v), ProductTypeElement { algebraic_type: AlgebraicType::Bool, .. }) => {
+                        Ok(AlgebraicValue::Bool(*v))
+                    }
+                    (SqlLiteral::Bool(_), ProductTypeElement { algebraic_type: ty, .. }) => {
+                        Err(UnexpectedType::new(&AlgebraicType::Bool, ty).into())
+                    }
+                    (SqlLiteral::Str(v) | SqlLiteral::Num(v) | SqlLiteral::Hex(v), ProductTypeElement { algebraic_type: ty, .. }) => {
+                        Ok(parse(&v, ty).map_err(|_| InvalidLiteral::new(v.clone().into_string(), ty))?)
+                    }
+                }
+            }).collect::<TypingResult<Box<[AlgebraicValue]>>>()?,
+            AlgebraicType::Product(pty.clone()),
+        )),
+        (SqlExpr::Tup(_), Some(ty)) => {
+            Err(UnexpectedType::new(&AlgebraicType::Product(ProductType::unit()), ty).into())
+        }
         (SqlExpr::Field(SqlIdent(table), SqlIdent(field)), expected) => {
             let table_type = vars.deref().get(&*table).ok_or_else(|| Unresolved::var(&table))?;
             let ColumnSchema { col_pos, col_type, .. } = table_type
@@ -152,16 +174,20 @@ pub(crate) fn type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&Algebra
 }
 
 /// Is this type compatible with this binary operator?
-fn op_supports_type(_op: BinOp, t: &AlgebraicType) -> bool {
-    t.is_bool()
-        || t.is_integer()
-        || t.is_float()
-        || t.is_string()
-        || t.is_bytes()
-        || t.is_identity()
-        || t.is_connection_id()
-        || t.is_timestamp()
-        || t.is_uuid()
+fn op_supports_type(op: BinOp, ty: &AlgebraicType) -> bool {
+    match (ty, op) {
+        (AlgebraicType::Product(_), BinOp::Eq | BinOp::Ne) => true,
+        _ if ty.is_bool() => true,
+        _ if ty.is_integer() => true,
+        _ if ty.is_float() => true,
+        _ if ty.is_string() => true,
+        _ if ty.is_bytes() => true,
+        _ if ty.is_identity() => true,
+        _ if ty.is_connection_id() => true,
+        _ if ty.is_timestamp() => true,
+        _ if ty.is_uuid() => true,
+        _ => false,
+    }
 }
 
 /// Parse an integer literal into an [AlgebraicValue]

--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -93,16 +93,17 @@ fn _type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&AlgebraicType>, d
     match (expr, expected) {
         (SqlExpr::Lit(SqlLiteral::Bool(v)), None | Some(AlgebraicType::Bool)) => Ok(Expr::bool(v)),
         (SqlExpr::Lit(SqlLiteral::Bool(_)), Some(ty)) => Err(UnexpectedType::new(&AlgebraicType::Bool, ty).into()),
-        (SqlExpr::Lit(SqlLiteral::Str(_) | SqlLiteral::Num(_) | SqlLiteral::Hex(_)), None) => {
+        (SqlExpr::Lit(SqlLiteral::Str(_) | SqlLiteral::Num(_) | SqlLiteral::Hex(_) | SqlLiteral::Arr(_)), None) => {
             Err(Unresolved::Literal.into())
         }
         (SqlExpr::Lit(SqlLiteral::Str(v) | SqlLiteral::Num(v) | SqlLiteral::Hex(v)), Some(ty)) => Ok(Expr::Value(
             parse(&v, ty).map_err(|_| InvalidLiteral::new(v.into_string(), ty))?,
             ty.clone(),
         )),
-        (SqlExpr::Lit(SqlLiteral::Arr(_)), None) => {
-            Err(Unresolved::Literal.into())
-        }
+        (SqlExpr::Lit(SqlLiteral::Arr(v)), Some(AlgebraicType::Array(ty))) => Ok(Expr::Value(
+            parse_array_value(&v, &ty).map_err(|_| UnexpectedArrayType::new(&ty.elem_ty))?,
+            AlgebraicType::Array(ty.clone()),
+        )),
         (SqlExpr::Lit(SqlLiteral::Arr(_)), Some(ty)) => {
             Err(UnexpectedArrayType::new(ty).into())
         }
@@ -189,7 +190,7 @@ pub(crate) fn type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&Algebra
 /// Is this type compatible with this binary operator?
 fn op_supports_type(op: BinOp, ty: &AlgebraicType) -> bool {
     match (ty, op) {
-        (AlgebraicType::Product(_), BinOp::Eq | BinOp::Ne) => true,
+        (AlgebraicType::Product(_) | AlgebraicType::Array(_), BinOp::Eq | BinOp::Ne) => true,
         _ if ty.is_bool() => true,
         _ if ty.is_integer() => true,
         _ if ty.is_float() => true,

--- a/crates/expr/src/statement.rs
+++ b/crates/expr/src/statement.rs
@@ -23,9 +23,9 @@ use crate::{
 
 use super::{
     check::{SchemaView, TypeChecker, TypingResult},
-    errors::{InsertFieldsError, InsertValuesError, TypingError, UnexpectedType, Unresolved},
+    errors::{InsertFieldsError, InsertValuesError, TypingError, UnexpectedArrayType, UnexpectedType, Unresolved},
     expr::Expr,
-    parse, type_expr, type_proj, type_select, StatementCtx, StatementSource,
+    parse, parse_array_value, type_expr, type_proj, type_select, StatementCtx, StatementSource,
 };
 
 pub enum Statement {
@@ -149,6 +149,12 @@ pub fn type_insert(insert: SqlInsert, tx: &impl SchemaView) -> TypingResult<Tabl
                 (SqlLiteral::Hex(v), ty) | (SqlLiteral::Num(v), ty) => {
                     values.push(parse(&v, ty).map_err(|_| InvalidLiteral::new(v.into_string(), ty))?);
                 }
+                (SqlLiteral::Arr(v), AlgebraicType::Array(a)) => {
+                    values.push(parse_array_value(&v, a).map_err(|_| InvalidLiteral::new("[…]".into(), &a.elem_ty))?);
+                }
+                (SqlLiteral::Arr(_), _) => {
+                    return Err(UnexpectedArrayType::new(ty).into());
+                }
             }
         }
         rows.push(ProductValue::from(values));
@@ -237,6 +243,15 @@ pub fn type_update(update: SqlUpdate, tx: &impl SchemaView) -> TypingResult<Tabl
                     parse(&v, ty).map_err(|_| InvalidLiteral::new(v.into_string(), ty))?,
                 ));
             }
+            (SqlLiteral::Arr(v), AlgebraicType::Array(a)) => {
+                values.push((
+                    *col_id,
+                    parse_array_value(&v, a).map_err(|_| InvalidLiteral::new("[…]".into(), &a.elem_ty))?,
+                ));
+            }
+            (SqlLiteral::Arr(_), _) => {
+                return Err(UnexpectedArrayType::new(ty).into());
+            }
         }
     }
     let mut vars = Relvars::default();
@@ -294,6 +309,7 @@ pub fn type_and_rewrite_set(set: SqlSet, tx: &impl SchemaView) -> TypingResult<T
         SqlLiteral::Bool(_) => Err(UnexpectedType::new(&AlgebraicType::U64, &AlgebraicType::Bool).into()),
         SqlLiteral::Str(_) => Err(UnexpectedType::new(&AlgebraicType::U64, &AlgebraicType::String).into()),
         SqlLiteral::Hex(_) => Err(UnexpectedType::new(&AlgebraicType::U64, &AlgebraicType::bytes()).into()),
+        SqlLiteral::Arr(_) => Err(UnexpectedArrayType::new(&AlgebraicType::U64).into()),
         SqlLiteral::Num(n) => {
             let table = tx.schema(ST_VAR_NAME).ok_or_else(|| Unresolved::table(ST_VAR_NAME))?;
             let var_name = AlgebraicValue::String(var_name.as_ref().into());

--- a/crates/physical-plan/src/compile.rs
+++ b/crates/physical-plan/src/compile.rs
@@ -21,6 +21,7 @@ fn compile_expr(expr: Expr, var: &mut impl VarLabel) -> PhysicalExpr {
             PhysicalExpr::BinOp(op, a, b)
         }
         Expr::Value(v, _) => PhysicalExpr::Value(v),
+        Expr::Tuple(t, _) => PhysicalExpr::Tuple(t),
         Expr::Field(proj) => PhysicalExpr::Field(compile_field_project(var, proj)),
     }
 }

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -1286,6 +1286,8 @@ pub enum PhysicalExpr {
     BinOp(BinOp, Box<PhysicalExpr>, Box<PhysicalExpr>),
     /// A constant algebraic value
     Value(AlgebraicValue),
+    /// A tuple of constant algebraic values
+    Tuple(Box<[AlgebraicValue]>),
     /// A field projection expression
     Field(TupleField),
 }
@@ -1349,6 +1351,7 @@ impl PhysicalExpr {
     pub fn map(self, f: &impl Fn(Self) -> Self) -> Self {
         match f(self) {
             value @ Self::Value(..) => value,
+            values @ Self::Tuple(..) => values,
             field @ Self::Field(..) => field,
             Self::BinOp(op, a, b) => Self::BinOp(op, Box::new(a.map(f)), Box::new(b.map(f))),
             Self::LogOp(op, exprs) => Self::LogOp(op, exprs.into_iter().map(|expr| expr.map(f)).collect()),
@@ -1410,6 +1413,7 @@ impl PhysicalExpr {
                 Cow::Owned(value)
             }
             Self::Value(v) => Cow::Borrowed(v),
+            Self::Tuple(t) => Cow::Owned(AlgebraicValue::Product(ProductValue {elements: t.clone()})),
         }
     }
 
@@ -1428,7 +1432,7 @@ impl PhysicalExpr {
                     .collect(),
             ),
             Self::BinOp(op, a, b) => Self::BinOp(op, Box::new(a.flatten()), Box::new(b.flatten())),
-            Self::Field(..) | Self::Value(..) => self,
+            Self::Field(..) | Self::Value(..) | Self::Tuple(..) => self,
         }
     }
 }

--- a/crates/sats/src/algebraic_value.rs
+++ b/crates/sats/src/algebraic_value.rs
@@ -85,7 +85,7 @@ pub enum AlgebraicValue {
     I256(Box<i256>),
     /// A [`u256`] value of type [`AlgebraicType::U256`].
     ///
-    /// We pack these to shrink `AlgebraicValue`.
+    /// We box these up to shrink `AlgebraicValue`.
     U256(Box<u256>),
     /// A totally ordered [`F32`] value of type [`AlgebraicType::F32`].
     ///
@@ -124,6 +124,18 @@ impl<T> From<T> for Packed<T> {
         Self(value)
     }
 }
+
+macro_rules! impl_from_packed {
+    ($ty:ty) => {
+        impl From<Packed<$ty>> for $ty {
+            fn from(packed: Packed<$ty>) -> Self {
+                packed.0
+            }
+        }
+    };
+}
+impl_from_packed!(i128);
+impl_from_packed!(u128);
 
 #[allow(non_snake_case)]
 impl AlgebraicValue {

--- a/crates/sql-parser/src/ast/mod.rs
+++ b/crates/sql-parser/src/ast/mod.rs
@@ -209,6 +209,8 @@ pub enum SqlLiteral {
     Num(Box<str>),
     /// A string value
     Str(Box<str>),
+    /// A literal array
+    Arr(Box<[SqlLiteral]>),
 }
 
 /// Binary infix operators

--- a/crates/sql-parser/src/parser/mod.rs
+++ b/crates/sql-parser/src/parser/mod.rs
@@ -228,6 +228,7 @@ fn parse_expr(expr: Expr, depth: usize) -> SqlParseResult<SqlExpr> {
         Expr::Nested(expr) => parse_expr(*expr, depth + 1),
         Expr::Value(Value::Placeholder(param)) if &param == ":sender" => Ok(SqlExpr::Param(Parameter::Sender)),
         Expr::Value(v) => Ok(SqlExpr::Lit(parse_literal(v)?)),
+        Expr::Array(v) => Ok(SqlExpr::Lit(parse_literal_array(v)?)),
         Expr::Tuple(ref t) => Ok(SqlExpr::Tup(t.iter().map(|x| {
             match x {
                 Expr::Value(v) => parse_literal(v.clone()),

--- a/crates/sql-parser/src/parser/mod.rs
+++ b/crates/sql-parser/src/parser/mod.rs
@@ -1,8 +1,8 @@
 use errors::{SqlParseError, SqlRequired, SqlUnsupported};
 use sqlparser::ast::{
-    BinaryOperator, Expr, Function, FunctionArg, FunctionArgExpr, Ident, Join, JoinConstraint, JoinOperator,
-    ObjectName, Query, SelectItem, TableAlias, TableFactor, TableWithJoins, UnaryOperator, Value,
-    WildcardAdditionalOptions,
+    Array, BinaryOperator, Expr, Function, FunctionArg, FunctionArgExpr, Ident, Join, JoinConstraint,
+    JoinOperator, ObjectName, Query, SelectItem, TableAlias, TableFactor, TableWithJoins, UnaryOperator,
+    Value, WildcardAdditionalOptions,
 };
 
 use crate::ast::{
@@ -306,6 +306,16 @@ pub(crate) fn parse_literal(value: Value) -> SqlParseResult<SqlLiteral> {
         Value::HexStringLiteral(s) => Ok(SqlLiteral::Hex(s.into_boxed_str())),
         _ => Err(SqlUnsupported::Literal(value).into()),
     }
+}
+
+/// Parse a literal array expression
+pub(crate) fn parse_literal_array(array: Array) -> SqlParseResult<SqlLiteral> {
+    Ok(SqlLiteral::Arr(array.elem.into_iter().map(|expr| {
+        match expr {
+            Expr::Value(value) => Ok(parse_literal(value)?),
+            _ => Err(SqlUnsupported::Expr(expr).into()),
+        }
+    }).collect::<SqlParseResult<Box<[SqlLiteral]>>>()?))
 }
 
 /// Parse an identifier

--- a/crates/sql-parser/src/parser/mod.rs
+++ b/crates/sql-parser/src/parser/mod.rs
@@ -228,6 +228,12 @@ fn parse_expr(expr: Expr, depth: usize) -> SqlParseResult<SqlExpr> {
         Expr::Nested(expr) => parse_expr(*expr, depth + 1),
         Expr::Value(Value::Placeholder(param)) if &param == ":sender" => Ok(SqlExpr::Param(Parameter::Sender)),
         Expr::Value(v) => Ok(SqlExpr::Lit(parse_literal(v)?)),
+        Expr::Tuple(ref t) => Ok(SqlExpr::Tup(t.iter().map(|x| {
+            match x {
+                Expr::Value(v) => parse_literal(v.clone()),
+                _ => Err(SqlUnsupported::Expr(expr.clone()).into()),
+            }
+        }).collect::<SqlParseResult<Vec<_>>>()?)),
         Expr::UnaryOp {
             op: UnaryOperator::Plus,
             expr,


### PR DESCRIPTION
# Description of Changes

Ditto #2843 (and depends/bases on it).
```rust
#[table(name=test)]
struct Test {
	list: Vec<String>,
}
```
```sql
INSERT INTO test (list) VALUES ['test'];

UPDATE test SET list = ['test2', 'test3'] WHERE list != [];

DELETE FROM test WHERE list == [''];
```

# API and ABI breaking changes

None.

# Expected complexity level and risk

### 2.

# Testing

- [x] Manual testing for insertion.
- [ ] Needs unit tests. I leave this open for contributions or as an exercise to the employees.