### PR TITLE
Add an HTTP route to get the current `Timestamp`

### DIFF
--- a/crates/client-api/src/routes/mod.rs
+++ b/crates/client-api/src/routes/mod.rs
@@ -12,6 +12,7 @@ mod internal;
 pub mod metrics;
 pub mod prometheus;
 pub mod subscribe;
+pub mod unstable;
 
 /// This API call is just designed to allow clients to determine whether or not they can
 /// establish a connection to SpacetimeDB. This API call doesn't actually do anything.
@@ -40,4 +41,5 @@ where
     axum::Router::new()
         .nest("/v1", router.layer(cors))
         .nest("/internal", internal::router())
+        .nest("/unstable", unstable::router())
 }

--- a/crates/client-api/src/routes/unstable.rs
+++ b/crates/client-api/src/routes/unstable.rs
@@ -1,0 +1,21 @@
+use axum::response::IntoResponse;
+use spacetimedb_lib::{sats, Timestamp};
+
+use crate::NodeDelegate;
+
+/// Returns the database's view of the current time,
+/// as a SATS-JSON encoded [`Timestamp`].
+async fn get_timestamp() -> impl IntoResponse {
+    axum::Json(sats::serde::SerdeWrapper(Timestamp::now())).into_response()
+}
+
+/// The internal router is for routes which are early in design,
+/// and may incompatibly change or be removed without a major version bump.
+pub fn router<S>() -> axum::Router<S>
+where
+    S: NodeDelegate + Clone + 'static,
+{
+    use axum::routing::get;
+
+    axum::Router::new().route("/timestamp", get(get_timestamp))
+}

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -264,10 +264,11 @@ class Smoketest(unittest.TestCase):
             log_cmd([method, path])
             conn.request(method, path, body, headers)
             resp = conn.getresponse()
-            logging.debug(f"{resp.status} {resp.read()}")
+            body = resp.read()
+            logging.debug(f"{resp.status} {body}")
             if resp.status != 200:
                 raise resp
-            resp
+            return body
 
 
     @classmethod

--- a/smoketests/tests/timestamp_route.py
+++ b/smoketests/tests/timestamp_route.py
@@ -1,0 +1,19 @@
+from .. import Smoketest, random_string
+import unittest
+import json
+import io
+
+TIMESTAMP_TAG = "__timestamp_micros_since_unix_epoch__"
+
+class TimestampRoute(Smoketest):
+    AUTOPUBLISH = False
+
+    def test_timestamp_route(self):
+        resp = self.api_call(
+            "GET",
+            "/unstable/timestamp",
+        )
+        timestamp = json.load(io.BytesIO(resp))
+        self.assertIsInstance(timestamp, dict)
+        self.assertIn(TIMESTAMP_TAG, timestamp)
+        self.assertIsInstance(timestamp[TIMESTAMP_TAG], int)


### PR DESCRIPTION
# Description of Changes

Under a new router, `/unstable`, as `/unstable/timestamp`.

Also add a smoketest that this route is reachable and returns a JSON-encoded `Timestamp`.

# API and ABI breaking changes

Introduces a new HTTP route, but marks it unstable.

# Expected complexity level and risk

1.

# Testing

- [x] Manual call with cURL.
- [x] Added smoketest for reachability and well-typedness. No validation for the value.