### PR TITLE
Prune more queries when evaluating subscription updates

### DIFF
--- a/crates/core/src/subscription/mod.rs
+++ b/crates/core/src/subscription/mod.rs
@@ -179,7 +179,7 @@ where
         })
         .map(|(sql, plan)| (sql, plan, plan.subscribed_table_id(), plan.subscribed_table_name()))
         .map(|(sql, plan, table_id, table_name)| {
-            plan.physical_plan()
+            plan.optimized_physical_plan()
                 .clone()
                 .optimize()
                 .map(|plan| (sql, PipelinedProject::from(plan)))

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -201,7 +201,7 @@ impl ModuleSubscriptions {
             tx,
             |plan, tx| {
                 plan.plans_fragments()
-                    .map(|plan_fragment| estimate_rows_scanned(tx, plan_fragment.physical_plan()))
+                    .map(|plan_fragment| estimate_rows_scanned(tx, plan_fragment.optimized_physical_plan()))
                     .fold(0, |acc, rows_scanned| acc.saturating_add(rows_scanned))
             },
             auth,
@@ -212,7 +212,7 @@ impl ModuleSubscriptions {
 
         let plans = query
             .plans_fragments()
-            .map(|fragment| fragment.physical_plan())
+            .map(|fragment| fragment.optimized_physical_plan())
             .cloned()
             .map(|plan| plan.optimize())
             .collect::<Result<Vec<_>, _>>()?
@@ -244,7 +244,7 @@ impl ModuleSubscriptions {
             tx,
             |plan, tx| {
                 plan.plans_fragments()
-                    .map(|plan_fragment| estimate_rows_scanned(tx, plan_fragment.physical_plan()))
+                    .map(|plan_fragment| estimate_rows_scanned(tx, plan_fragment.optimized_physical_plan()))
                     .fold(0, |acc, rows_scanned| acc.saturating_add(rows_scanned))
             },
             auth,
@@ -686,7 +686,7 @@ impl ModuleSubscriptions {
             &tx,
             |plan, tx| {
                 plan.plans_fragments()
-                    .map(|plan_fragment| estimate_rows_scanned(tx, plan_fragment.physical_plan()))
+                    .map(|plan_fragment| estimate_rows_scanned(tx, plan_fragment.optimized_physical_plan()))
                     .fold(0, |acc, rows_scanned| acc.saturating_add(rows_scanned))
             },
             &auth,

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -1118,11 +1118,11 @@ impl SubscriptionManager {
                 &row.elements[edge.lhs_join_col.idx()],
             )
             // This read should always succeed, and it's a bug if it doesn't.
-            .unwrap()
+            .expect("This read should always succeed, and it's a bug if it doesn't")
             .next()
             .map(|row| {
                 // Similarly this read should always succeed
-                row.read_col(edge.rhs_col).unwrap()
+                row.read_col(edge.rhs_col).expect("This read should always succeed, and it's a bug if it doesn't")
             })
         }
 

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -1106,18 +1106,22 @@ impl SubscriptionManager {
 
         /// Returns the value pointed to by this join edge
         fn find_rhs_val(edge: &JoinEdge, row: &ProductValue, tx: &DeltaTx) -> Option<AlgebraicValue> {
+            // What if the joining row was deleted in this tx?
+            // Will we prune a query that we shouldn't have?
+            //
+            // Ultimately no we will not.
+            // We may prune it for this row specifically,
+            // but we will eventually include it for the joining row.
             tx.iter_by_col_eq(
                 edge.rhs_table,
                 edge.rhs_join_col,
                 &row.elements[edge.lhs_join_col.idx()],
             )
-            // Reading from this column should always succeed.
-            // It is a bug if it doesn't.
+            // This read should always succeed, and it's a bug if it doesn't.
             .unwrap()
             .next()
             .map(|row| {
-                // Reading from this column should always succeed.
-                // It is a bug if it doesn't.
+                // Similarly this read should always succeed
                 row.read_col(edge.rhs_col).unwrap()
             })
         }

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -1117,12 +1117,11 @@ impl SubscriptionManager {
                 edge.rhs_join_col,
                 &row.elements[edge.lhs_join_col.idx()],
             )
-            // This read should always succeed, and it's a bug if it doesn't.
             .expect("This read should always succeed, and it's a bug if it doesn't")
             .next()
             .map(|row| {
-                // Similarly this read should always succeed
-                row.read_col(edge.rhs_col).expect("This read should always succeed, and it's a bug if it doesn't")
+                row.read_col(edge.rhs_col)
+                    .expect("This read should always succeed, and it's a bug if it doesn't")
             })
         }
 

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -917,25 +917,31 @@ impl PhysicalPlan {
     /// If this plan has any simple equality filters such as `x = 0`,
     /// this method returns the values along with the appropriate table and column.
     /// Note, this excludes compound equality filters such as `x = 0 and y = 1`.
-    /// Also note that it is not valid to call this method on an optimized plan.
-    /// This is because we assume that index scans have not yet been generated.
+    /// Note, this must be called on an optimized plan.
+    /// Hence we must assume index scans have already been generated.
     pub fn search_args(&self) -> Vec<(TableId, ColId, AlgebraicValue)> {
         let mut args = vec![];
-        self.visit(&mut |op| {
-            if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, a, b)) = op {
-                match (&**a, &**b) {
-                    (PhysicalExpr::Field(field), PhysicalExpr::Value(value))
-                    | (PhysicalExpr::Value(value), PhysicalExpr::Field(field)) => {
-                        input.visit(&mut |op| match op {
-                            PhysicalPlan::TableScan(scan, name) if *name == field.label => {
-                                args.push((scan.schema.table_id, field.field_pos.into(), value.clone()));
-                            }
-                            _ => {}
-                        });
-                    }
-                    _ => {}
+        self.visit(&mut |op| match op {
+            PhysicalPlan::IxScan(
+                scan @ IxScan {
+                    arg: Sarg::Eq(col_id, value),
+                    ..
+                },
+                _,
+            ) if scan.prefix.is_empty() => {
+                args.push((scan.schema.table_id, *col_id, value.clone()));
+            }
+            PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, a, b)) => {
+                if let (PhysicalExpr::Field(field), PhysicalExpr::Value(value)) = (&**a, &**b) {
+                    input.visit(&mut |op| match op {
+                        PhysicalPlan::TableScan(scan, name) if *name == field.label => {
+                            args.push((scan.schema.table_id, field.field_pos.into(), value.clone()));
+                        }
+                        _ => {}
+                    });
                 }
             }
+            _ => {}
         });
         args
     }

--- a/crates/subscription/src/lib.rs
+++ b/crates/subscription/src/lib.rs
@@ -7,12 +7,12 @@ use spacetimedb_execution::{
     Datastore, DeltaStore, Row,
 };
 use spacetimedb_expr::check::SchemaView;
-use spacetimedb_lib::{identity::AuthCtx, metrics::ExecutionMetrics, query::Delta};
-use spacetimedb_physical_plan::plan::{HashJoin, IxJoin, Label, PhysicalPlan, ProjectPlan, TableScan};
-use spacetimedb_primitives::{IndexId, TableId};
+use spacetimedb_lib::{identity::AuthCtx, metrics::ExecutionMetrics, query::Delta, AlgebraicValue};
+use spacetimedb_physical_plan::plan::{IxJoin, IxScan, Label, PhysicalPlan, ProjectPlan, Sarg, TableScan, TupleField};
+use spacetimedb_primitives::{ColId, IndexId, TableId};
 use spacetimedb_query::compile_subscription;
-use std::collections::HashSet;
 use std::sync::Arc;
+use std::{collections::HashSet, ops::RangeBounds};
 
 /// A subscription is a view over a particular table.
 /// How do we incrementally maintain that view?
@@ -285,6 +285,60 @@ impl std::fmt::Display for TableName {
     }
 }
 
+/// A join edge is used for pruning queries when evaluating subscription updates.
+///
+/// If we have the following subscriptions:
+/// ```sql
+/// SELECT a.* FROM a JOIN b ON a.id = b.id WHERE b.x = 1
+/// SELECT a.* FROM a JOIN b ON a.id = b.id WHERE b.x = 2
+/// ...
+/// SELECT a.* FROM a JOIN b ON a.id = b.id WHERE b.x = n
+/// ```
+///
+/// Whenever `a` is updated, only the relevant queries are evaluated.
+#[derive(Debug, PartialEq, Eq, PartialOrd, Ord)]
+pub struct JoinEdge {
+    /// The [`TableId`] for `a`
+    pub lhs_table: TableId,
+    /// The [`TableId`] for `a`
+    pub rhs_table: TableId,
+    /// The [`ColId`] for `a.id`
+    pub lhs_join_col: ColId,
+    /// The [`ColId`] for `b.id`
+    pub rhs_join_col: ColId,
+    /// The [`ColId`] for `b.x`
+    pub rhs_col: ColId,
+}
+
+impl JoinEdge {
+    /// A helper method for finding a range of join edges for a particular table in a sorted set.
+    fn min_for_table(lhs_table: TableId) -> Self {
+        Self {
+            lhs_table,
+            rhs_table: TableId(u32::MIN),
+            lhs_join_col: ColId(u16::MIN),
+            rhs_join_col: ColId(u16::MIN),
+            rhs_col: ColId(u16::MIN),
+        }
+    }
+
+    /// A helper method for finding a range of join edges for a particular table in a sorted set.
+    fn max_for_table(lhs_table: TableId) -> Self {
+        Self {
+            lhs_table,
+            rhs_table: TableId(u32::MAX),
+            lhs_join_col: ColId(u16::MAX),
+            rhs_join_col: ColId(u16::MAX),
+            rhs_col: ColId(u16::MAX),
+        }
+    }
+
+    /// A helper method for finding a range of join edges for a particular table in a sorted set.
+    pub fn range_for_table(lhs_table: TableId) -> impl RangeBounds<Self> {
+        Self::min_for_table(lhs_table)..=Self::max_for_table(lhs_table)
+    }
+}
+
 /// A subscription defines a view over a table
 #[derive(Debug)]
 pub struct SubscriptionPlan {
@@ -297,12 +351,8 @@ pub struct SubscriptionPlan {
     table_ids: Vec<TableId>,
     /// The plan fragments for updating the view
     fragments: Fragments,
-    /// The original plan without any delta scans.
-    ///
-    /// TODO: Used for cardinality estimation,
-    /// but not for maintaining the view,
-    /// therefore it should ultimately be removed.
-    plan: ProjectPlan,
+    /// The optimized plan without any delta scans
+    plan_opt: ProjectPlan,
 }
 
 impl SubscriptionPlan {
@@ -326,13 +376,9 @@ impl SubscriptionPlan {
         self.table_ids.iter().copied()
     }
 
-    /// The original plan without any delta scans.
-    ///
-    /// TODO: Used for cardinality estimation,
-    /// but not for maintaining the view,
-    /// therefore it should ultimately be removed.
-    pub fn physical_plan(&self) -> &ProjectPlan {
-        &self.plan
+    /// The optimized plan without any delta scans
+    pub fn optimized_physical_plan(&self) -> &ProjectPlan {
+        &self.plan_opt
     }
 
     /// From which indexes does this plan read?
@@ -364,48 +410,97 @@ impl SubscriptionPlan {
         self.fragments.for_each_delete(tx, metrics, f)
     }
 
+    /// Returns a join edge for this query if it has one.
+    ///
+    /// Requirements include:
+    /// 1. The index for the join must be unique
+    /// 2. There must be a single column index lookup on the rhs table
+    pub fn join_edge(&self) -> Option<(JoinEdge, AlgebraicValue)> {
+        if !self.is_join() {
+            return None;
+        }
+        let mut join_edge = None;
+        self.plan_opt.visit(&mut |op| match op {
+            PhysicalPlan::IxJoin(
+                IxJoin {
+                    lhs,
+                    rhs,
+                    rhs_field: lhs_join_col,
+                    lhs_field:
+                        TupleField {
+                            field_pos: rhs_join_col,
+                            ..
+                        },
+                    unique: true,
+                    ..
+                },
+                _,
+            ) if rhs.table_id == self.return_id => match &**lhs {
+                PhysicalPlan::IxScan(
+                    IxScan {
+                        schema,
+                        prefix,
+                        arg: Sarg::Eq(rhs_col, rhs_val),
+                        ..
+                    },
+                    _,
+                ) if prefix.is_empty() => {
+                    let lhs_table = self.return_id;
+                    let rhs_table = schema.table_id;
+                    let rhs_col = *rhs_col;
+                    let rhs_val = rhs_val.clone();
+                    let lhs_join_col = *lhs_join_col;
+                    let rhs_join_col = (*rhs_join_col).into();
+                    let edge = JoinEdge {
+                        lhs_table,
+                        rhs_table,
+                        lhs_join_col,
+                        rhs_join_col,
+                        rhs_col,
+                    };
+                    join_edge = Some((edge, rhs_val));
+                }
+                _ => {}
+            },
+            _ => {}
+        });
+        join_edge
+    }
+
     /// Generate a plan for incrementally maintaining a subscription
     pub fn compile(sql: &str, tx: &impl SchemaView, auth: &AuthCtx) -> Result<(Vec<Self>, bool)> {
         let (plans, return_id, return_name, has_param) = compile_subscription(sql, tx, auth)?;
 
         /// Does this plan have any non-index joins?
         fn has_non_index_join(plan: &PhysicalPlan) -> bool {
-            let mut ix_joins = true;
-            plan.visit(&mut |plan| match plan {
-                PhysicalPlan::IxJoin(IxJoin { lhs_field, .. }, _) => {
-                    ix_joins = ix_joins && plan.index_on_field(&lhs_field.label, lhs_field.field_pos);
-                }
-                PhysicalPlan::HashJoin(
-                    HashJoin {
-                        lhs_field, rhs_field, ..
-                    },
-                    _,
-                ) => {
-                    ix_joins = ix_joins && plan.index_on_field(&lhs_field.label, lhs_field.field_pos);
-                    ix_joins = ix_joins && plan.index_on_field(&rhs_field.label, rhs_field.field_pos);
-                }
-                _ => {}
-            });
-            !ix_joins
+            plan.any(&|op| matches!(op, PhysicalPlan::HashJoin(..) | PhysicalPlan::NLJoin(..)))
         }
 
         /// What tables are involved in this plan?
         fn table_ids_for_plan(plan: &PhysicalPlan) -> (Vec<TableId>, Vec<Label>) {
             let mut table_aliases = vec![];
             let mut table_ids = vec![];
-            plan.visit(&mut |plan| {
-                if let PhysicalPlan::TableScan(
+            plan.visit(&mut |plan| match plan {
+                PhysicalPlan::TableScan(
                     TableScan {
+                        // What table are we reading?
                         schema,
-                        limit: None,
-                        delta: None,
+                        ..
                     },
                     alias,
-                ) = plan
-                {
+                )
+                | PhysicalPlan::IxScan(
+                    IxScan {
+                        // What table are we reading?
+                        schema,
+                        ..
+                    },
+                    alias,
+                ) => {
                     table_aliases.push(*alias);
                     table_ids.push(schema.table_id);
                 }
+                _ => {}
             });
             (table_ids, table_aliases)
         }
@@ -415,7 +510,9 @@ impl SubscriptionPlan {
         let return_name = TableName::from(return_name);
 
         for plan in plans {
-            if has_non_index_join(&plan) {
+            let plan_opt = plan.clone().optimize()?;
+
+            if has_non_index_join(&plan_opt) {
                 bail!("Subscriptions require indexes on join columns")
             }
 
@@ -427,7 +524,7 @@ impl SubscriptionPlan {
                 return_id,
                 return_name: return_name.clone(),
                 table_ids,
-                plan,
+                plan_opt,
                 fragments,
             });
         }

--- a/crates/subscription/src/lib.rs
+++ b/crates/subscription/src/lib.rs
@@ -413,8 +413,9 @@ impl SubscriptionPlan {
     /// Returns a join edge for this query if it has one.
     ///
     /// Requirements include:
-    /// 1. The index for the join must be unique
-    /// 2. There must be a single column index lookup on the rhs table
+    /// 1. Unique join index
+    /// 2. Single column index lookup on the rhs table
+    /// 3. No self joins
     pub fn join_edge(&self) -> Option<(JoinEdge, AlgebraicValue)> {
         if !self.is_join() {
             return None;
@@ -444,7 +445,7 @@ impl SubscriptionPlan {
                         ..
                     },
                     _,
-                ) if prefix.is_empty() => {
+                ) if schema.table_id != self.return_id && prefix.is_empty() => {
                     let lhs_table = self.return_id;
                     let rhs_table = schema.table_id;
                     let rhs_col = *rhs_col;

--- a/crates/subscription/src/lib.rs
+++ b/crates/subscription/src/lib.rs
@@ -300,7 +300,7 @@ impl std::fmt::Display for TableName {
 pub struct JoinEdge {
     /// The [`TableId`] for `a`
     pub lhs_table: TableId,
-    /// The [`TableId`] for `a`
+    /// The [`TableId`] for `b`
     pub rhs_table: TableId,
     /// The [`ColId`] for `a.id`
     pub lhs_join_col: ColId,


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

If a table is subscribed to, and it joins with many different tables, this optimization will attempt to prune joins that it knows are empty.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

3

A bug will most likely result in incorrect subscription results

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Internal tests
- [ ] Performance tests
