### PR TITLE
Always use identity when hashing queries from owners

### DIFF
--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -107,7 +107,11 @@ pub fn compile_query_with_hashes(
     let tx = SchemaViewer::new(tx, auth);
     let (plans, has_param) = SubscriptionPlan::compile(input, &tx, auth)?;
 
-    if has_param {
+    if auth.is_owner() || has_param {
+        // Note that when generating hashes for queries from owners,
+        // we always treat them as if they were parameterized by :sender.
+        // This is because RLS is not applicable to owners.
+        // Hence owner hashes must never overlap with client hashes.
         return Ok(Plan::new(plans, hash_with_param, input.to_owned()));
     }
     Ok(Plan::new(plans, hash, input.to_owned()))

--- a/crates/expr/src/rls.rs
+++ b/crates/expr/src/rls.rs
@@ -18,7 +18,7 @@ pub fn resolve_views_for_sub(
     has_param: &mut bool,
 ) -> anyhow::Result<Vec<ProjectName>> {
     // RLS does not apply to the database owner
-    if auth.caller == auth.owner {
+    if auth.is_owner() {
         return Ok(vec![expr]);
     }
 
@@ -56,7 +56,7 @@ pub fn resolve_views_for_sub(
 /// Mainly a wrapper around [resolve_views_for_expr].
 pub fn resolve_views_for_sql(tx: &impl SchemaView, expr: ProjectList, auth: &AuthCtx) -> anyhow::Result<ProjectList> {
     // RLS does not apply to the database owner
-    if auth.caller == auth.owner {
+    if auth.is_owner() {
         return Ok(expr);
     }
     // The subscription language is a subset of the sql language.

--- a/crates/lib/src/identity.rs
+++ b/crates/lib/src/identity.rs
@@ -22,6 +22,10 @@ impl AuthCtx {
     pub fn for_current(owner: Identity) -> Self {
         Self { owner, caller: owner }
     }
+    /// Does `owner == caller`
+    pub fn is_owner(&self) -> bool {
+        self.owner == self.caller
+    }
     /// WARNING: Use this only for simple test were the `auth` don't matter
     pub fn for_testing() -> Self {
         AuthCtx {


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Before this change, if the database owner and another client subscribed to the same query and that query had an RLS rule, both queries would get the same hash, despite not being semantically equivalent.

Now when hashing queries from the database owner, we always make sure to use their identity. This means the two queries in the above example will always hash to different values.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Automated functional test
