### PR TITLE
Remove incorrect `const` qualifiers on two imports in `bindings.c`

### DIFF
--- a/crates/bindings-csharp/Runtime/bindings.c
+++ b/crates/bindings-csharp/Runtime/bindings.c
@@ -61,9 +61,9 @@ IMPORT(int16_t, row_iter_bsatn_advance,
        (RowIter iter, uint8_t* buffer_ptr, size_t* buffer_len_ptr),
        (iter, buffer_ptr, buffer_len_ptr));
 IMPORT(uint16_t, row_iter_bsatn_close, (RowIter iter), (iter));
-IMPORT(Status, datastore_insert_bsatn, (TableId table_id, const uint8_t* row_ptr, size_t* row_len_ptr),
+IMPORT(Status, datastore_insert_bsatn, (TableId table_id, uint8_t* row_ptr, size_t* row_len_ptr),
        (table_id, row_ptr, row_len_ptr));
-IMPORT(Status, datastore_update_bsatn, (TableId table_id, IndexId index_id, const uint8_t* row_ptr, size_t* row_len_ptr),
+IMPORT(Status, datastore_update_bsatn, (TableId table_id, IndexId index_id, uint8_t* row_ptr, size_t* row_len_ptr),
        (table_id, index_id, row_ptr, row_len_ptr));
 IMPORT(Status, datastore_delete_by_index_scan_range_bsatn,
        (IndexId index_id, const uint8_t* prefix, uint32_t prefix_len, ColId prefix_elems,


### PR DESCRIPTION
# Description of Changes

`datastore_insert_bsatn` and `datastore_update_bsatn` will write back to the row buffer when passed a row with a 0 in an `auto_inc` column. The Rust imports correctly specify these row pointers as `*mut u8`, but the C# imports in `bindings.c` were declaring them as `const uint8_t*`. This commit removes the incorrect `const` qualifiers from the row pointer arguments in those declarations.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

N/a