### PR TITLE
Use a scope guard for decrementing queue length.

### DIFF
--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -583,7 +583,6 @@ impl ModuleHost {
             // This is done in a defer so that it happens even if the reducer call panics.
             queue_length_gauge.dec();
             queue_timer.stop_and_record();
-            
         });
 
         // Operations on module instances (e.g. calling reducers) is blocking,


### PR DESCRIPTION
# Description of Changes

If a client disconnected while waiting to send a message to the job queue, we would not decrement the queue counter. Adding a scope guard should handle all cases.

# Expected complexity level and risk

1
