### PR TITLE
Use database identity not owner identity for metrics

### DIFF
--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -476,7 +476,8 @@ impl ModuleSubscriptions {
             )
         };
 
-        let subscription_metrics = SubscriptionMetrics::new(&self.owner_identity, &WorkloadType::Unsubscribe);
+        let database_identity = self.relational_db.database_identity();
+        let subscription_metrics = SubscriptionMetrics::new(&database_identity, &WorkloadType::Unsubscribe);
 
         // Always lock the db before the subscription lock to avoid deadlocks.
         let tx = scopeguard::guard(self.relational_db.begin_tx(Workload::Unsubscribe), |tx| {
@@ -659,7 +660,8 @@ impl ModuleSubscriptions {
 
         let num_queries = request.query_strings.len();
 
-        let subscription_metrics = SubscriptionMetrics::new(&self.owner_identity, &WorkloadType::Subscribe);
+        let database_identity = self.relational_db.database_identity();
+        let subscription_metrics = SubscriptionMetrics::new(&database_identity, &WorkloadType::Subscribe);
 
         // How many queries make up this subscription?
         subscription_metrics.num_queries_subscribed.inc_by(num_queries as _);
@@ -756,7 +758,8 @@ impl ModuleSubscriptions {
         _assert: Option<AssertTxFn>,
     ) -> Result<ExecutionMetrics, DBError> {
         let num_queries = subscription.query_strings.len();
-        let subscription_metrics = SubscriptionMetrics::new(&self.owner_identity, &WorkloadType::Subscribe);
+        let database_identity = self.relational_db.database_identity();
+        let subscription_metrics = SubscriptionMetrics::new(&database_identity, &WorkloadType::Subscribe);
 
         // How many queries make up this subscription?
         subscription_metrics.num_queries_subscribed.inc_by(num_queries as _);
@@ -850,7 +853,8 @@ impl ModuleSubscriptions {
         mut event: ModuleEvent,
         tx: MutTx,
     ) -> Result<Result<(Arc<ModuleEvent>, ExecutionMetrics), WriteConflict>, DBError> {
-        let subscription_metrics = SubscriptionMetrics::new(&self.owner_identity, &WorkloadType::Update);
+        let database_identity = self.relational_db.database_identity();
+        let subscription_metrics = SubscriptionMetrics::new(&database_identity, &WorkloadType::Update);
 
         // Take a read lock on `subscriptions` before committing tx
         // else it can result in subscriber receiving duplicate updates.


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Uses the database identity, not the owner identity, for subscription metrics. They are different. I incorrectly tagged these metrics with the owner identity in https://github.com/clockworklabs/SpacetimeDB/pull/2861.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

0

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->
