### PR TITLE
Fix an outdated docstring on `identity` and `try_identity` in the Rust SDK

### DIFF
--- a/crates/sdk/src/db_context.rs
+++ b/crates/sdk/src/db_context.rs
@@ -51,8 +51,7 @@ pub trait DbContext {
 
     /// Get the [`Identity`] of this connection.
     ///
-    /// This method panics if the connection was constructed anonymously
-    /// and we have not yet received our newly-generated [`Identity`] from the host.
+    /// This method panics if we have not yet received our [`Identity`] from the host.
     /// For a non-panicking version, see [`Self::try_identity`].
     fn identity(&self) -> Identity {
         self.try_identity().unwrap()
@@ -60,8 +59,7 @@ pub trait DbContext {
 
     /// Get the [`Identity`] of this connection.
     ///
-    /// This method returns `None` if the connection was constructed anonymously
-    /// and we have not yet received our newly-generated [`Identity`] from the host.
+    /// This method returns `None` if we have not yet received our [`Identity`] from the host.
     /// For a panicking version, see [`Self::identity`].
     fn try_identity(&self) -> Option<Identity>;
 


### PR DESCRIPTION
# Description of Changes

Since we changed from `with_credentials` to `with_token`, the Rust client SDK no longer knows its `Identity` prior to `on_connect`, even when the connection is not anonymous.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

N/a