### PR TITLE
Lift restriction that multi-col indices only allow = constraints

### DIFF
--- a/crates/core/src/sql/compiler.rs
+++ b/crates/core/src/sql/compiler.rs
@@ -513,15 +513,14 @@ Seq Scan on test
         db.create_table_for_test("test", schema, indexes)?;
 
         let tx = begin_tx(&db);
-        // TODO: Need support for index range scans.
         expect_query(
             &tx,
             "select * from test where b > 2",
             expect![
                 r#"
-Seq Scan on test
-  Output: test.a, test.b
-  -> Filter: (test.b > U64(2))"#
+Index Scan using Index test_b_idx_btree (test.b) on test
+  Index Cond: (test.b > U64(2))
+  Output: test.a, test.b"#
             ],
         );
 
@@ -538,15 +537,15 @@ Seq Scan on test
         db.create_table_for_test("test", schema, indexes)?;
 
         let tx = begin_tx(&db);
-        //TODO(sql): Need support for index scans for ranges
         expect_query(
             &tx,
             "select * from test where b > 2 and b < 5",
             expect![
                 r#"
-Seq Scan on test
+Index Scan using Index test_b_idx_btree (test.b) on test
+  Index Cond: (test.b > U64(2))
   Output: test.a, test.b
-  -> Filter: (test.b > U64(2) AND test.b < U64(5))"#
+  -> Filter: (test.b < U64(5))"#
             ],
         );
 
@@ -717,9 +716,9 @@ Hash Join: Lhs
      Index Cond: (lhs.a = U64(3))
      Output: lhs.a, lhs.b
   -> Hash Build: rhs.b
-     -> Seq Scan on rhs
-        Output: rhs.b, rhs.c
-        -> Filter: (rhs.c < U64(4))"#
+     -> Index Scan using Index rhs_c_idx_btree (rhs.c) on rhs
+        Index Cond: (rhs.c < U64(4))
+        Output: rhs.b, rhs.c"#
             ],
         );
 
@@ -756,9 +755,10 @@ Index Join: Rhs on lhs
   Inner Unique: false
   Join Cond: (rhs.b = lhs.b)
   Output: lhs.a, lhs.b
-  -> Seq Scan on rhs
+  -> Index Scan using Index rhs_c_idx_btree (rhs.c) on rhs
+     Index Cond: (rhs.c > U64(2))
      Output: rhs.b, rhs.c, rhs.d
-     -> Filter: (rhs.c > U64(2) AND rhs.c < U64(4) AND rhs.d = U64(3))"#
+     -> Filter: (rhs.d = U64(3) AND rhs.c < U64(4))"#
             ],
         );
 

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -316,7 +316,7 @@ pub(crate) mod tests {
     use spacetimedb_lib::error::{ResultTest, TestError};
     use spacetimedb_lib::relation::Header;
     use spacetimedb_lib::{AlgebraicValue, Identity};
-    use spacetimedb_primitives::{col_list, ColId, TableId};
+    use spacetimedb_primitives::{col_list, ColId, ColList, TableId};
     use spacetimedb_sats::{product, AlgebraicType, ArrayValue, ProductType};
     use spacetimedb_vm::eval::test_helpers::create_game_data;
 
@@ -335,20 +335,49 @@ pub(crate) mod tests {
         run(db, sql_text, AuthCtx::for_testing(), Some(&subs), &mut vec![]).map(|x| x.rows)
     }
 
-    fn create_data(total_rows: u64) -> ResultTest<(TestDB, MemTable)> {
+    #[derive(Debug, Clone, Copy)]
+    pub(crate) enum TestData {
+        /// Data with no index
+        Scans,
+        /// Single column index on `inventory_id`
+        IndexId,
+        /// Index on all columns
+        IndexAll,
+        /// Index on [`x`, `y`]
+        IndexMultiColumn,
+        /// Index on [`x`, `y`] and `inventory_id`
+        IndexMixed,
+    }
+
+    fn create_data(total_rows: u64, using: TestData) -> ResultTest<(TestDB, MemTable)> {
         let stdb = TestDB::durable()?;
 
         let rows: Vec<_> = (1..=total_rows)
-            .map(|i| product!(i, format!("health{i}").into_boxed_str()))
+            .map(|i| product!(i, format!("health{i}").into_boxed_str(), i, i))
             .collect();
-        let head = ProductType::from([("inventory_id", AlgebraicType::U64), ("name", AlgebraicType::String)]);
-
+        let head = [
+            ("inventory_id", AlgebraicType::U64),
+            ("name", AlgebraicType::String),
+            ("x", AlgebraicType::U64),
+            ("y", AlgebraicType::U64),
+        ];
+        let (single, multi) = match using {
+            TestData::IndexId => (vec![0.into()], ColList::empty()),
+            TestData::IndexAll => (vec![0.into(), 1.into(), 2.into(), 3.into()], ColList::empty()),
+            TestData::IndexMultiColumn => (vec![], col_list![2, 3]),
+            TestData::IndexMixed => (vec![0.into()], col_list![2, 3]),
+            TestData::Scans => (vec![], ColList::empty()),
+        };
+        let table_id = stdb.create_table_for_test_mix_indexes("inventory", &head, &single, multi)?;
         let schema = with_auto_commit(&stdb, |tx| {
-            create_table_with_rows(&stdb, tx, "inventory", head.clone(), &rows, StAccess::Public)
+            for row in rows.iter() {
+                insert(&stdb, tx, table_id, row)?;
+            }
+            stdb.schema_for_table_mut(tx, table_id)
         })?;
         let header = Header::from(&*schema).into();
 
-        Ok((stdb, MemTable::new(header, schema.table_access, rows)))
+        Ok((stdb, MemTable::new(header, StAccess::Public, rows)))
     }
 
     fn create_identity_table(table_name: &str) -> ResultTest<(TestDB, MemTable)> {
@@ -366,7 +395,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_select_star() -> ResultTest<()> {
-        let (db, input) = create_data(1)?;
+        let (db, input) = create_data(1, TestData::Scans)?;
 
         let result = run_for_testing(&db, "SELECT * FROM inventory")?;
 
@@ -376,11 +405,11 @@ pub(crate) mod tests {
 
     #[test]
     fn test_limit() -> ResultTest<()> {
-        let (db, _) = create_data(5)?;
+        let (db, _) = create_data(5, TestData::Scans)?;
 
         let result = run_for_testing(&db, "SELECT * FROM inventory limit 2")?;
 
-        let (_, input) = create_data(2)?;
+        let (_, input) = create_data(2, TestData::Scans)?;
 
         assert_eq!(result, input.data, "Inventory");
         Ok(())
@@ -388,7 +417,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_count() -> ResultTest<()> {
-        let (db, _) = create_data(5)?;
+        let (db, _) = create_data(5, TestData::Scans)?;
 
         let sql = "SELECT count(*) as n FROM inventory";
         let result = run_for_testing(&db, sql)?;
@@ -491,39 +520,6 @@ pub(crate) mod tests {
                 .collect::<Vec<_>>(),
             expected.into_iter().sorted().dedup().collect::<Vec<_>>()
         );
-    }
-
-    /// Test a query that uses a multi-column index
-    #[test]
-    fn test_multi_column_index() -> anyhow::Result<()> {
-        let db = TestDB::in_memory()?;
-
-        let schema = [
-            ("a", AlgebraicType::U64),
-            ("b", AlgebraicType::U64),
-            ("c", AlgebraicType::U64),
-        ];
-
-        let table_id = db.create_table_for_test_multi_column("t", &schema, [1, 2].into())?;
-
-        insert_rows(
-            &db,
-            table_id,
-            vec![
-                product![0_u64, 1_u64, 2_u64],
-                product![1_u64, 2_u64, 1_u64],
-                product![2_u64, 2_u64, 2_u64],
-            ],
-        )?;
-
-        assert_query_results(
-            &db,
-            "select * from t where c = 1 and b = 2",
-            &AuthCtx::for_testing(),
-            [product![1_u64, 2_u64, 1_u64]],
-        );
-
-        Ok(())
     }
 
     /// Test querying a table with RLS rules
@@ -878,7 +874,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_select_star_table() -> ResultTest<()> {
-        let (db, input) = create_data(1)?;
+        let (db, input) = create_data(1, TestData::Scans)?;
 
         let result = run_for_testing(&db, "SELECT inventory.* FROM inventory")?;
 
@@ -896,7 +892,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_select_catalog() -> ResultTest<()> {
-        let (db, _) = create_data(1)?;
+        let (db, _) = create_data(1, TestData::Scans)?;
 
         let tx = begin_tx(&db);
         let _ = db.release_tx(tx);
@@ -921,7 +917,7 @@ pub(crate) mod tests {
 
     #[test]
     fn test_select_column() -> ResultTest<()> {
-        let (db, _) = create_data(1)?;
+        let (db, _) = create_data(1, TestData::Scans)?;
 
         let result = run_for_testing(&db, "SELECT inventory_id FROM inventory")?;
 
@@ -933,34 +929,73 @@ pub(crate) mod tests {
 
     #[test]
     fn test_where() -> ResultTest<()> {
-        let (db, _) = create_data(1)?;
+        for data in [
+            TestData::Scans,
+            TestData::IndexId,
+            TestData::IndexAll,
+            TestData::IndexMultiColumn,
+            TestData::IndexMixed,
+        ] {
+            let (db, _) = create_data(10, data)?;
 
-        let result = run_for_testing(&db, "SELECT inventory_id FROM inventory WHERE inventory_id = 1")?;
-
-        let row = product![1u64];
-
-        assert_eq!(result, vec![row], "Inventory");
+            for op in ["=", "<", ">", "<=", ">=", "!="] {
+                let sql = format!("SELECT inventory_id FROM inventory WHERE inventory_id {op} 5");
+                let result = run_for_testing(&db, &sql)?;
+                let expected: Vec<ProductValue> = (1u64..=10)
+                    .filter(|&i| match op {
+                        "=" => i == 5,
+                        "<" => i < 5,
+                        ">" => i > 5,
+                        "<=" => i <= 5,
+                        ">=" => i >= 5,
+                        "!=" => i != 5,
+                        _ => false,
+                    })
+                    .map(|i| product![i])
+                    .collect();
+                assert_eq!(result, expected, "Inventory with {:?}: {}", data, sql);
+            }
+        }
         Ok(())
     }
 
     #[test]
     fn test_or() -> ResultTest<()> {
-        let (db, _) = create_data(2)?;
+        for data in [
+            TestData::Scans,
+            TestData::IndexId,
+            TestData::IndexAll,
+            TestData::IndexMultiColumn,
+            TestData::IndexMixed,
+        ] {
+            let (db, _) = create_data(10, data)?;
 
-        let mut result = run_for_testing(
-            &db,
-            "SELECT inventory_id FROM inventory WHERE inventory_id = 1 OR inventory_id = 2",
-        )?;
+            for op in ["=", "<", ">", "<=", ">=", "!="] {
+                let sql =
+                    format!("SELECT inventory_id FROM inventory WHERE inventory_id {op} 5 OR inventory_id {op} 6");
+                let result = run_for_testing(&db, &sql)?;
+                let expected: Vec<ProductValue> = (1u64..=10)
+                    .filter(|&i| match op {
+                        "=" => i == 5 || i == 6,
+                        "<" => i < 5 || i < 6,
+                        ">" => i > 5 || i > 6,
+                        "<=" => i <= 5 || i <= 6,
+                        ">=" => i >= 5 || i >= 6,
+                        "!=" => i != 5 || i != 6,
+                        _ => false,
+                    })
+                    .map(|i| product![i])
+                    .collect();
+                assert_eq!(result, expected, "Inventory with {:?}: {}", data, sql);
+            }
+        }
 
-        result.sort();
-
-        assert_eq!(result, vec![product![1u64], product![2u64]], "Inventory");
         Ok(())
     }
 
     #[test]
     fn test_nested() -> ResultTest<()> {
-        let (db, _) = create_data(2)?;
+        let (db, _) = create_data(2, TestData::Scans)?;
 
         let mut result = run_for_testing(
             &db,
@@ -1029,15 +1064,18 @@ pub(crate) mod tests {
 
     #[test]
     fn test_insert() -> ResultTest<()> {
-        let (db, mut input) = create_data(1)?;
+        let (db, mut input) = create_data(1, TestData::Scans)?;
 
-        let result = run_for_testing(&db, "INSERT INTO inventory (inventory_id, name) VALUES (2, 'test')")?;
+        let result = run_for_testing(
+            &db,
+            "INSERT INTO inventory (inventory_id, name, x, y) VALUES (2, 'test', 0, 0)",
+        )?;
 
         assert_eq!(result.len(), 0, "Return results");
 
         let mut result = run_for_testing(&db, "SELECT * FROM inventory")?;
 
-        input.data.push(product![2u64, "test"]);
+        input.data.push(product![2u64, "test", 0u64, 0u64]);
         input.data.sort();
         result.sort();
 
@@ -1048,10 +1086,16 @@ pub(crate) mod tests {
 
     #[test]
     fn test_delete() -> ResultTest<()> {
-        let (db, _input) = create_data(1)?;
+        let (db, _input) = create_data(1, TestData::Scans)?;
 
-        run_for_testing(&db, "INSERT INTO inventory (inventory_id, name) VALUES (2, 't2')")?;
-        run_for_testing(&db, "INSERT INTO inventory (inventory_id, name) VALUES (3, 't3')")?;
+        run_for_testing(
+            &db,
+            "INSERT INTO inventory (inventory_id, name, x, y) VALUES (2, 't2', 0, 0)",
+        )?;
+        run_for_testing(
+            &db,
+            "INSERT INTO inventory (inventory_id, name, x, y) VALUES (3, 't3', 0, 0)",
+        )?;
 
         let result = run_for_testing(&db, "SELECT * FROM inventory")?;
         assert_eq!(result.len(), 3, "Not return results");
@@ -1071,10 +1115,16 @@ pub(crate) mod tests {
 
     #[test]
     fn test_update() -> ResultTest<()> {
-        let (db, input) = create_data(1)?;
+        let (db, input) = create_data(1, TestData::Scans)?;
 
-        run_for_testing(&db, "INSERT INTO inventory (inventory_id, name) VALUES (2, 't2')")?;
-        run_for_testing(&db, "INSERT INTO inventory (inventory_id, name) VALUES (3, 't3')")?;
+        run_for_testing(
+            &db,
+            "INSERT INTO inventory (inventory_id, name, x, y) VALUES (2, 't2', 0, 0)",
+        )?;
+        run_for_testing(
+            &db,
+            "INSERT INTO inventory (inventory_id, name, x, y) VALUES (3, 't3', 0, 0)",
+        )?;
 
         run_for_testing(&db, "UPDATE inventory SET name = 'c2' WHERE inventory_id = 2")?;
 
@@ -1082,7 +1132,7 @@ pub(crate) mod tests {
 
         let mut change = input;
         change.data.clear();
-        change.data.push(product![2u64, "c2"]);
+        change.data.push(product![2u64, "c2", 0u64, 0u64]);
 
         assert_eq!(result, change.data, "Update Inventory 2");
 
@@ -1095,27 +1145,6 @@ pub(crate) mod tests {
             .map(|x| x.field_as_str(1, None).unwrap().to_string())
             .collect();
         assert_eq!(vec!["c3"; 3], updated);
-
-        Ok(())
-    }
-
-    #[test]
-    fn test_multi_column() -> ResultTest<()> {
-        let (db, _input) = create_data(1)?;
-
-        // Create table [test] with index on [a, b]
-        let schema = &[
-            ("a", AlgebraicType::I32),
-            ("b", AlgebraicType::I32),
-            ("c", AlgebraicType::I32),
-            ("d", AlgebraicType::I32),
-        ];
-        let table_id = db.create_table_for_test_multi_column("test", schema, col_list![0, 1])?;
-        with_auto_commit(&db, |tx| insert(&db, tx, table_id, &product![1, 1, 1, 1]).map(drop))?;
-
-        let result = run_for_testing(&db, "select * from test where b = 1 and a = 1")?;
-
-        assert_eq!(result, vec![product![1, 1, 1, 1]]);
 
         Ok(())
     }
@@ -1142,6 +1171,60 @@ pub(crate) mod tests {
         query.push_str("((x = 1000) and (y = 1000))");
 
         assert!(run_for_testing(&db, &query).is_err());
+        Ok(())
+    }
+
+    #[test]
+    fn test_multi_column() -> ResultTest<()> {
+        let (db, _input) = create_data(1, TestData::Scans)?;
+
+        // Create table [test] with index on [a, b]
+        let schema = &[
+            ("a", AlgebraicType::I32),
+            ("b", AlgebraicType::I32),
+            ("c", AlgebraicType::I32),
+            ("d", AlgebraicType::I32),
+        ];
+        let table_id = db.create_table_for_test_multi_column("test", schema, col_list![0, 1])?;
+        with_auto_commit(&db, |tx| insert(&db, tx, table_id, &product![1, 1, 1, 1]).map(drop))?;
+
+        let result = run_for_testing(&db, "select * from test where b = 1 and a = 1")?;
+
+        assert_eq!(result, vec![product![1, 1, 1, 1]]);
+
+        Ok(())
+    }
+
+    /// Test a query that uses a multi-column index
+    #[test]
+    fn test_multi_column_index() -> anyhow::Result<()> {
+        let db = TestDB::in_memory()?;
+
+        let schema = [
+            ("a", AlgebraicType::U64),
+            ("b", AlgebraicType::U64),
+            ("c", AlgebraicType::U64),
+        ];
+
+        let table_id = db.create_table_for_test_multi_column("t", &schema, [1, 2].into())?;
+
+        insert_rows(
+            &db,
+            table_id,
+            vec![
+                product![0_u64, 1_u64, 2_u64],
+                product![1_u64, 2_u64, 1_u64],
+                product![2_u64, 2_u64, 2_u64],
+            ],
+        )?;
+
+        assert_query_results(
+            &db,
+            "select * from t where c = 1 and b = 2",
+            &AuthCtx::for_testing(),
+            [product![1_u64, 2_u64, 1_u64]],
+        );
+
         Ok(())
     }
 

--- a/crates/core/src/subscription/subscription.rs
+++ b/crates/core/src/subscription/subscription.rs
@@ -718,9 +718,10 @@ Index Join: Rhs on lhs
   Inner Unique: false
   Join Cond: (rhs.b = lhs.b)
   Output: lhs.a, lhs.b
-  -> Seq Scan on rhs
+  -> Index Scan using Index rhs_c_idx_btree (rhs.c) on rhs
+     Index Cond: (rhs.c > U64(2))
      Output: rhs.b, rhs.c, rhs.d
-     -> Filter: (rhs.c > U64(2) AND rhs.c < U64(4) AND rhs.d = U64(3))"#
+     -> Filter: (rhs.d = U64(3) AND rhs.c < U64(4))"#
             ],
         );
 
@@ -815,9 +816,10 @@ Index Join: Rhs on lhs
   Inner Unique: false
   Join Cond: (rhs.b = lhs.b)
   Output: lhs.a, lhs.b
-  -> Seq Scan on rhs
+  -> Index Scan using Index rhs_c_idx_btree (rhs.c) on rhs
+     Index Cond: (rhs.c > U64(2))
      Output: rhs.b, rhs.c, rhs.d
-     -> Filter: (rhs.c > U64(2) AND rhs.c < U64(4) AND rhs.d = U64(3))"#
+     -> Filter: (rhs.d = U64(3) AND rhs.c < U64(4))"#
             ],
         );
 
@@ -919,9 +921,10 @@ Index Join: Rhs on lhs
   Inner Unique: false
   Join Cond: (rhs.b = lhs.b)
   Output: lhs.a, lhs.b
-  -> Seq Scan on rhs
+  -> Index Scan using Index rhs_c_idx_btree (rhs.c) on rhs
+     Index Cond: (rhs.c > U64(2))
      Output: rhs.b, rhs.c, rhs.d
-     -> Filter: (rhs.c > U64(2) AND rhs.c < U64(4) AND rhs.d = U64(3))"#
+     -> Filter: (rhs.d = U64(3) AND rhs.c < U64(4))"#
             ],
         );
 

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -15,7 +15,7 @@ use spacetimedb_sql_parser::ast::{BinOp, LogOp};
 use spacetimedb_table::table::RowRef;
 
 use crate::rules::{
-    ComputePositions, HashToIxJoin, IxScanAnd, IxScanEq, IxScanEq2Col, IxScanEq3Col, PullFilterAboveHashJoin,
+    ComputePositions, HashToIxJoin, IxScanAnd, IxScanBinOp, IxScanOp2Col, IxScanOp3Col, PullFilterAboveHashJoin,
     PushConstAnd, PushConstEq, PushLimit, ReorderDeltaJoinRhs, ReorderHashJoin, RewriteRule, UniqueHashJoinRule,
     UniqueIxJoinRule,
 };
@@ -393,9 +393,9 @@ impl PhysicalPlan {
             .apply_rec::<PushConstEq>()?
             .apply_rec::<ReorderDeltaJoinRhs>()?
             .apply_rec::<PullFilterAboveHashJoin>()?
-            .apply_rec::<IxScanEq3Col>()?
-            .apply_rec::<IxScanEq2Col>()?
-            .apply_rec::<IxScanEq>()?
+            .apply_rec::<IxScanOp3Col>()?
+            .apply_rec::<IxScanOp2Col>()?
+            .apply_rec::<IxScanBinOp>()?
             .apply_rec::<IxScanAnd>()?
             .apply_rec::<ReorderHashJoin>()?
             .apply_rec::<HashToIxJoin>()?
@@ -983,6 +983,17 @@ pub enum Sarg {
 }
 
 impl Sarg {
+    pub fn from_op(op: BinOp, col: ColId, value: AlgebraicValue) -> Self {
+        match op {
+            BinOp::Eq => Sarg::Eq(col, value),
+            BinOp::Ne => unreachable!("Cannot create a search argument for inequality"),
+            BinOp::Lt => Sarg::Range(col, Bound::Unbounded, Bound::Excluded(value)),
+            BinOp::Gt => Sarg::Range(col, Bound::Excluded(value), Bound::Unbounded),
+            BinOp::Lte => Sarg::Range(col, Bound::Unbounded, Bound::Included(value)),
+            BinOp::Gte => Sarg::Range(col, Bound::Included(value), Bound::Unbounded),
+        }
+    }
+
     /// Decodes the sarg into a binary operator
     pub fn to_op(&self) -> BinOp {
         match self {
@@ -1239,20 +1250,47 @@ pub mod tests_utils {
             plan
         };
 
-        let explain = Explain::new(&plan).with_options(options);
+        let explain = Explain::new(&plan).with_options(options).build();
 
-        let explain = explain.build();
         expect.assert_eq(&explain.to_string());
+    }
+    #[cfg(test)]
+    fn check_assert(plan: PhysicalCtx, options: ExplainOptions, expect: String) {
+        let plan = if options.optimize {
+            plan.optimize().unwrap()
+        } else {
+            plan
+        };
+
+        let explain = Explain::new(&plan).with_options(options).build();
+
+        pretty_assertions::assert_eq!(explain.to_string(), expect, "{}", plan.sql)
     }
 
     pub fn check_sub(db: &impl SchemaView, options: ExplainOptions, auth: &AuthCtx, sql: &str, expect: Expect) {
         let plan = sub(db, auth, sql);
         check(plan, options, expect);
     }
+    #[cfg(test)]
+    pub fn check_sub_assert(db: &impl SchemaView, options: ExplainOptions, auth: &AuthCtx, sql: &str, expect: String) {
+        let plan = sub(db, auth, sql);
+        check_assert(plan, options, expect);
+    }
 
     pub fn check_query(db: &impl SchemaView, options: ExplainOptions, auth: &AuthCtx, sql: &str, expect: Expect) {
         let plan = query(db, auth, sql);
         check(plan, options, expect);
+    }
+    #[cfg(test)]
+    pub fn check_query_assert(
+        db: &impl SchemaView,
+        options: ExplainOptions,
+        auth: &AuthCtx,
+        sql: &str,
+        expect: String,
+    ) {
+        let plan = query(db, auth, sql);
+        check_assert(plan, options, expect);
     }
 }
 
@@ -1373,8 +1411,16 @@ mod tests {
         tests_utils::check_sub(db, db.options, &AuthCtx::for_testing(), sql, expect);
     }
 
+    fn check_sub_assert(db: &SchemaViewer, sql: &str, expect: String) {
+        tests_utils::check_sub_assert(db, db.options, &AuthCtx::for_testing(), sql, expect);
+    }
+
     fn check_query(db: &SchemaViewer, sql: &str, expect: Expect) {
         tests_utils::check_query(db, db.options, &AuthCtx::for_testing(), sql, expect);
+    }
+
+    fn check_query_assert(db: &SchemaViewer, sql: &str, expect: String) {
+        tests_utils::check_query_assert(db, db.options, &AuthCtx::for_testing(), sql, expect);
     }
 
     fn data() -> SchemaViewer {
@@ -1580,9 +1626,7 @@ Seq Scan on t
         );
     }
 
-    /// Test single and multi-column index selections
-    #[test]
-    fn index_scans() {
+    fn make_table_index() -> SchemaViewer {
         let t_id = TableId(1);
 
         let t = Arc::new(schema(
@@ -1594,12 +1638,158 @@ Seq Scan on t
                 ("y", AlgebraicType::U8),
                 ("z", AlgebraicType::U8),
             ],
-            &[&[1], &[2, 3], &[1, 2, 3]],
+            &[&[1], &[2, 3], &[1, 2, 3], &[0, 1, 2, 3]],
             &[],
             None,
         ));
 
-        let db = SchemaViewer::new(vec![t.clone()]).optimize(true);
+        SchemaViewer::new(vec![t.clone()]).optimize(true)
+    }
+
+    // We optimize up to 3 columns in an index, and:
+    // - When all the comparisons are`!=` is always a full table scan
+    // - Multi-column indexes are only used if the query has a prefix match (ie all operators are `=`)
+    // - Else are converted to a single column index scan on the leftmost column and a filter on the rest
+
+    /// Test index selections on 1 column
+    #[test]
+    fn index_scans_1_col() {
+        let db = make_table_index();
+
+        for op in ["=", ">", "<", ">=", "<="] {
+            check_sub_assert(
+                &db,
+                &format!("SELECT * FROM t WHERE x {op} 4"),
+                format!(
+                    "Index Scan using Index id 0 (t.x) on t
+  Index Cond: (t.x {op} U8(4))
+  Output: t.w, t.x, t.y, t.z",
+                ),
+            )
+        }
+        // `!=` is not supported in index scans
+        check_query(
+            &db,
+            "select * from t where  x != 4",
+            expect![
+                r#"
+Seq Scan on t
+  Output: t.w, t.x, t.y, t.z
+  -> Filter: (t.x <> U8(4))"#
+            ],
+        );
+
+        // Select index on x
+        check_query(
+            &db,
+            "select * from t where w = 5 and x = 4",
+            expect![
+                r#"
+Index Scan using Index id 0 (t.x) on t
+  Index Cond: (t.x = U8(4))
+  Output: t.w, t.x, t.y, t.z
+  -> Filter: (t.w = U8(5))"#
+            ],
+        );
+
+        // Do not select index on (y, z)
+        check_query(
+            &db,
+            "select * from t where y = 1",
+            expect![
+                r#"
+Seq Scan on t
+  Output: t.w, t.x, t.y, t.z
+  -> Filter: (t.y = U8(1))"#
+            ],
+        );
+    }
+
+    /// Test index selections on 2 columns
+    #[test]
+    fn index_scans_2_col() {
+        let db = make_table_index();
+
+        // TODO: The `Index Cond` should be `y, z` ie: match the index columns
+        // This is not to be fixed on the printer side, but on the planner side
+
+        // Select index on [y, z]
+        check_query(
+            &db,
+            "select * from t where y = 1 and z = 2",
+            expect![
+                r#"
+Index Scan using Index id 1 (t.z, t.y) on t
+  Index Cond: (t.z = U8(2), t.y = U8(1))
+  Output: t.w, t.x, t.y, t.z"#
+            ],
+        );
+        for op in [">", "<", ">=", "<="] {
+            check_query_assert(
+                &db,
+                &format!("select * from t where y {op} 1 and z {op} 2"),
+                format!(
+                    r#"Index Scan using Index id 1 (t.y) on t
+  Index Cond: (t.y {op} U8(1))
+  Output: t.w, t.x, t.y, t.z
+  -> Filter: (t.z {op} U8(2))"#
+                ),
+            );
+
+            // Check permutations of the same query
+            check_query_assert(
+                &db,
+                &format!("select * from t where z {op} 2 and y {op} 1"),
+                format!(
+                    r#"Index Scan using Index id 1 (t.y) on t
+  Index Cond: (t.y {op} U8(1))
+  Output: t.w, t.x, t.y, t.z
+  -> Filter: (t.z {op} U8(2))"#
+                ),
+            );
+
+            check_query_assert(
+                &db,
+                &format!("select * from t where z != 2 and y {op} 1"),
+                format!(
+                    r#"Index Scan using Index id 1 (t.y) on t
+  Index Cond: (t.y {op} U8(1))
+  Output: t.w, t.x, t.y, t.z
+  -> Filter: (t.z <> U8(2))"#
+                ),
+            );
+        }
+
+        // Select index on (y, z) and filter on (w)
+        check_query(
+            &db,
+            "select * from t where w = 1 and y = 2 and z = 3",
+            expect![
+                r#"
+Index Scan using Index id 1 (t.z, t.y) on t
+  Index Cond: (t.z = U8(3), t.y = U8(2))
+  Output: t.w, t.x, t.y, t.z
+  -> Filter: (t.w = U8(1))"#
+            ],
+        );
+
+        // `!=` is not supported in index scans
+        check_query(
+            &db,
+            "select * from t where y != 1 and z != 2",
+            expect![
+                r#"
+Seq Scan on t
+  Output: t.w, t.x, t.y, t.z
+  -> Filter: (t.y <> U8(1) AND t.z <> U8(2))"#
+            ],
+        );
+    }
+
+    /// Test index selections on 3 columns
+    #[test]
+    fn index_scans_3_col() {
+        let db = make_table_index();
         // Select index on (x, y, z)
         check_sub(
             &db,
@@ -1623,78 +1813,83 @@ Index Scan using Index id 2 (t.z, t.x, t.y) on t
   Output: t.w, t.x, t.y, t.z"#
             ],
         );
-        // Select index on x
-        check_sub(
-            &db,
-            "select * from t where x = 3 and y = 4",
-            expect![
-                r#"
-Index Scan using Index id 0 (t.x) on t
-  Index Cond: (t.x = U8(3))
+
+        for op in [">", "<", ">=", "<="] {
+            check_sub_assert(
+                &db,
+                &format!("select * from t where x {op} 3 and y {op} 4 and z {op} 5"),
+                format!(
+                    r#"Index Scan using Index id 2 (t.x) on t
+  Index Cond: (t.x {op} U8(3))
   Output: t.w, t.x, t.y, t.z
-  -> Filter: (t.y = U8(4))"#
-            ],
-        );
-        // Select index on x
+  -> Filter: (t.y {op} U8(4) AND t.z {op} U8(5))"#
+                ),
+            );
+
+            // Check permutations of the same query
+            check_sub_assert(
+                &db,
+                &format!("select * from t where z {op} 5 and y {op} 4 and x {op} 3"),
+                format!(
+                    r#"Index Scan using Index id 2 (t.x) on t
+  Index Cond: (t.x {op} U8(3))
+  Output: t.w, t.x, t.y, t.z
+  -> Filter: (t.z {op} U8(5) AND t.y {op} U8(4))"#
+                ),
+            );
+
+            check_sub_assert(
+                &db,
+                &format!("select * from t where x {op} 3 and y != 4 and z {op} 5"),
+                format!(
+                    r#"Index Scan using Index id 2 (t.x) on t
+  Index Cond: (t.x {op} U8(3))
+  Output: t.w, t.x, t.y, t.z
+  -> Filter: (t.y <> U8(4) AND t.z {op} U8(5))"#
+                ),
+            );
+        }
+
+        // `!=` is not supported in index scans
         check_query(
             &db,
-            "select * from t where w = 5 and x = 4",
-            expect![
-                r#"
-Index Scan using Index id 0 (t.x) on t
-  Index Cond: (t.x = U8(4))
-  Output: t.w, t.x, t.y, t.z
-  -> Filter: (t.w = U8(5))"#
-            ],
-        );
-        // Do not select index on (y, z)
-        check_query(
-            &db,
-            "select * from t where y = 1",
+            "select * from t where x != 3 and y != 4 and z != 5",
             expect![
                 r#"
 Seq Scan on t
   Output: t.w, t.x, t.y, t.z
-  -> Filter: (t.y = U8(1))"#
+  -> Filter: (t.x <> U8(3) AND t.y <> U8(4) AND t.z <> U8(5))"#
+            ],
+        );
+    }
+
+    /// Test index selections above 3 columns
+    #[test]
+    fn index_scans_after_3_col() {
+        let db = make_table_index();
+        // Select index on (x, y, z)
+        check_sub(
+            &db,
+            "select * from t as x where x = 3 and y = 4 and z = 5 and w = 6",
+            expect![
+                r#"
+Index Scan using Index id 2 (t.z, t.x, t.y) on t
+  Index Cond: (x.z = U8(5), x.x = U8(3), x.y = U8(4))
+  Output: x.w, x.x, x.y, x.z
+  -> Filter: (x.w = U8(6))"#
             ],
         );
 
-        // TODO: The `Index Cond` should be `y, z` ie: match the index columns
-        // This is not to be fixed on the printer side, but on the planner side
-
-        // Select index on [y, z]
-        check_query(
+        // Test permutations of the same query
+        check_sub(
             &db,
-            "select * from t where y = 1 and z = 2",
+            "select * from t where z = 5 and y = 4 and w = 6 and x = 3",
             expect![
                 r#"
-Index Scan using Index id 1 (t.z, t.y) on t
-  Index Cond: (t.z = U8(2), t.y = U8(1))
-  Output: t.w, t.x, t.y, t.z"#
-            ],
-        );
-
-        // Check permutations of the same query
-        check_query(
-            &db,
-            "select * from t where z = 2 and y = 1",
-            expect![
-                r#"
-Index Scan using Index id 1 (t.z, t.y) on t
-  Index Cond: (t.z = U8(2), t.y = U8(1))
-  Output: t.w, t.x, t.y, t.z"#
-            ],
-        );
-        // Select index on (y, z) and filter on (w)
-        check_query(
-            &db,
-            "select * from t where w = 1 and y = 2 and z = 3",
-            expect![
-                r#"
-Index Scan using Index id 1 (t.z, t.y) on t
-  Index Cond: (t.z = U8(3), t.y = U8(2))
+Index Scan using Index id 2 (t.z, t.x, t.y) on t
+  Index Cond: (t.z = U8(5), t.x = U8(3), t.y = U8(4))
   Output: t.w, t.x, t.y, t.z
-  -> Filter: (t.w = U8(1))"#
+  -> Filter: (t.w = U8(6))"#
             ],
         );
     }

--- a/crates/physical-plan/src/rules.rs
+++ b/crates/physical-plan/src/rules.rs
@@ -6,13 +6,13 @@
 //!     Push down predicates of the form `x=1`
 //! * [PushConstAnd]  
 //!     Push down predicates of the form `x=1 and y=2`
-//! * [IxScanEq]  
+//! * [IxScanBinOp]
 //!     Generate 1-column index scan for `x=1`
 //! * [IxScanAnd]  
 //!     Generate 1-column index scan for `x=1 and y=2`
-//! * [IxScanEq2Col]  
+//! * [IxScanOp2Col]
 //!     Generate 2-column index scan
-//! * [IxScanEq3Col]  
+//! * [IxScanOp3Col]
 //!     Generate 3-column index scan
 //! * [ReorderHashJoin]  
 //!     Reorder the sides of a hash join
@@ -26,6 +26,12 @@
 //!     Mark index join as unique
 //! * [UniqueHashJoinRule]  
 //!     Mark hash join as unique
+//!
+//! We optimize up to 3 columns in an index, and:
+//! - When all the comparisons are`!=` is always a full table scan
+//! - Multi-column indexes are only used if the query has a prefix match (ie all operators are `=`)
+//! - Else are converted to a single column index scan on the leftmost column and a filter on the rest
+
 use anyhow::{bail, Result};
 use spacetimedb_primitives::{ColId, ColSet, IndexId};
 use spacetimedb_schema::schema::IndexSchema;
@@ -400,7 +406,7 @@ impl RewriteRule for PushConstAnd {
     }
 }
 
-/// Match single field equality predicates such as:
+/// Match single field for [`BinOp`] predicates such as:
 ///
 /// ```sql
 /// select * from t where x = 1
@@ -408,20 +414,23 @@ impl RewriteRule for PushConstAnd {
 ///
 /// Rewrite as an index scan if applicable.
 ///
-/// NOTE: This rule does not consider multi-column indexes.
-pub(crate) struct IxScanEq;
+/// NOTE: This rule does not consider multi-column indexes, or [`BinOp::Ne`] predicates.
+pub(crate) struct IxScanBinOp;
 
 pub(crate) struct IxScanInfo {
     index_id: IndexId,
     cols: Vec<(usize, ColId)>,
 }
 
-impl RewriteRule for IxScanEq {
+impl RewriteRule for IxScanBinOp {
     type Plan = PhysicalPlan;
     type Info = (IndexId, ColId);
 
     fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, expr, value)) = plan {
+        if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(op, expr, value)) = plan {
+            if *op == BinOp::Ne {
+                return None;
+            }
             if let PhysicalPlan::TableScan(
                 TableScan {
                     schema,
@@ -455,7 +464,7 @@ impl RewriteRule for IxScanEq {
     }
 
     fn rewrite(plan: PhysicalPlan, (index_id, col_id): Self::Info) -> Result<PhysicalPlan> {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, _, value)) = plan {
+        if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(op, _, value)) = plan {
             if let PhysicalPlan::TableScan(TableScan { schema, limit, delta }, var) = *input {
                 if let PhysicalExpr::Value(v) = *value {
                     return Ok(PhysicalPlan::IxScan(
@@ -465,7 +474,7 @@ impl RewriteRule for IxScanEq {
                             delta,
                             index_id,
                             prefix: vec![],
-                            arg: Sarg::Eq(col_id, v),
+                            arg: Sarg::from_op(op, col_id, v),
                         },
                         var,
                     ));
@@ -476,15 +485,15 @@ impl RewriteRule for IxScanEq {
     }
 }
 
-/// Match multi-field equality predicates such as:
+/// Match multi-field [`BinOp`] predicates such as:
 ///
 /// ```sql
-/// select * from t where x = 1 and y = 1
+/// select * from t where x = 1 and y > 1
 /// ```
 ///
-/// Create an index scan for one of the equality conditions.
+/// Create an index scan for one of the [`BinOp`] conditions.
 ///
-/// NOTE: This rule does not consider multi-column indexes.
+/// NOTE: This rule does not consider multi-column indexes, or [`BinOp::Ne`] predicates.
 pub(crate) struct IxScanAnd;
 
 impl RewriteRule for IxScanAnd {
@@ -503,7 +512,10 @@ impl RewriteRule for IxScanAnd {
             ) = &**input
             {
                 return exprs.iter().enumerate().find_map(|(i, expr)| {
-                    if let PhysicalExpr::BinOp(BinOp::Eq, lhs, value) = expr {
+                    if let PhysicalExpr::BinOp(op, lhs, value) = expr {
+                        if *op == BinOp::Ne {
+                            return None;
+                        }
                         if let (PhysicalExpr::Field(TupleField { field_pos: pos, .. }), PhysicalExpr::Value(_)) =
                             (&**lhs, &**value)
                         {
@@ -533,7 +545,7 @@ impl RewriteRule for IxScanAnd {
     fn rewrite(plan: PhysicalPlan, (index_id, i, col_id): Self::Info) -> Result<PhysicalPlan> {
         if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, mut exprs)) = plan {
             if let PhysicalPlan::TableScan(TableScan { schema, limit, delta }, label) = *input {
-                if let PhysicalExpr::BinOp(BinOp::Eq, _, value) = exprs.swap_remove(i) {
+                if let PhysicalExpr::BinOp(op, _, value) = exprs.swap_remove(i) {
                     if let PhysicalExpr::Value(v) = *value {
                         return Ok(PhysicalPlan::Filter(
                             Box::new(PhysicalPlan::IxScan(
@@ -543,7 +555,7 @@ impl RewriteRule for IxScanAnd {
                                     delta,
                                     index_id,
                                     prefix: vec![],
-                                    arg: Sarg::Eq(col_id, v),
+                                    arg: Sarg::from_op(op, col_id, v),
                                 },
                                 label,
                             )),
@@ -560,18 +572,19 @@ impl RewriteRule for IxScanAnd {
     }
 }
 
-/// Match multi-field equality predicates such as:
+/// Match multi-field [`BinOp`] predicates such as:
 ///
 /// ```sql
-/// select * from t where x = 1 and y = 1
+/// select * from t where x = 1 and y = 1 // Full match
+/// select * from t where x = 1 and y > 1 // Partial match
 /// ```
 ///
 /// Rewrite as a multi-column index scan if applicable.
 ///
-/// NOTE: This rule does not consider indexes on 3 or more columns.
-pub(crate) struct IxScanEq2Col;
+/// NOTE: This rule does not consider indexes on 3 or more columns, or [`BinOp::Ne`] predicates.
+pub(crate) struct IxScanOp2Col;
 
-impl RewriteRule for IxScanEq2Col {
+impl RewriteRule for IxScanOp2Col {
     type Plan = PhysicalPlan;
     type Info = IxScanInfo;
 
@@ -594,9 +607,12 @@ impl RewriteRule for IxScanEq2Col {
 
         for (i, a) in exprs.iter().enumerate() {
             for (j, b) in exprs.iter().enumerate().filter(|(j, _)| i != *j) {
-                let (PhysicalExpr::BinOp(BinOp::Eq, a, u), PhysicalExpr::BinOp(BinOp::Eq, b, v)) = (a, b) else {
+                let (PhysicalExpr::BinOp(op1, a, u), PhysicalExpr::BinOp(op2, b, v)) = (a, b) else {
                     continue;
                 };
+                if (*op1, *op2) == (BinOp::Ne, BinOp::Ne) {
+                    continue;
+                }
 
                 let (PhysicalExpr::Field(u), PhysicalExpr::Value(_), PhysicalExpr::Field(v), PhysicalExpr::Value(_)) =
                     (&**a, &**u, &**b, &**v)
@@ -638,10 +654,8 @@ impl RewriteRule for IxScanEq2Col {
             [(i, a), (j, b)] => {
                 if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan {
                     if let PhysicalPlan::TableScan(TableScan { schema, limit, delta }, label) = *input {
-                        if let (
-                            Some(PhysicalExpr::BinOp(BinOp::Eq, _, u)),
-                            Some(PhysicalExpr::BinOp(BinOp::Eq, _, v)),
-                        ) = (exprs.get(*i), exprs.get(*j))
+                        if let (Some(PhysicalExpr::BinOp(lhs, _, u)), Some(PhysicalExpr::BinOp(rhs, _, v))) =
+                            (exprs.get(*i), exprs.get(*j))
                         {
                             if let (PhysicalExpr::Value(u), PhysicalExpr::Value(v)) = (&**u, &**v) {
                                 return Ok(match exprs.len() {
@@ -650,23 +664,23 @@ impl RewriteRule for IxScanEq2Col {
                                     }
                                     // If there are only 2 conditions in this filter,
                                     // we replace the filter with an index scan.
-                                    2 => PhysicalPlan::IxScan(
+                                    2 if (*lhs, *rhs) == (BinOp::Eq, BinOp::Eq) => PhysicalPlan::IxScan(
                                         IxScan {
                                             schema,
                                             limit,
                                             delta,
                                             index_id: info.index_id,
                                             prefix: vec![(*a, u.clone())],
-                                            arg: Sarg::Eq(*b, v.clone()),
+                                            arg: Sarg::from_op(*rhs, *b, v.clone()),
                                         },
                                         label,
                                     ),
                                     // If there are 3 conditions in this filter,
                                     // we create an index scan from 2 of them.
-                                    // The original conjunction is no longer well defined,
+                                    // The original conjunction is no longer well-defined,
                                     // because it only has a single operand now.
-                                    // Hence we must replace it with its operand.
-                                    3 => PhysicalPlan::Filter(
+                                    // Hence, we must replace it with its operand.
+                                    3 if (*lhs, *rhs) == (BinOp::Eq, BinOp::Eq) => PhysicalPlan::Filter(
                                         Box::new(PhysicalPlan::IxScan(
                                             IxScan {
                                                 schema,
@@ -674,7 +688,7 @@ impl RewriteRule for IxScanEq2Col {
                                                 delta,
                                                 index_id: info.index_id,
                                                 prefix: vec![(*a, u.clone())],
-                                                arg: Sarg::Eq(*b, v.clone()),
+                                                arg: Sarg::from_op(*rhs, *b, v.clone()),
                                             },
                                             label,
                                         )),
@@ -684,6 +698,30 @@ impl RewriteRule for IxScanEq2Col {
                                             .find(|(pos, _)| pos != i && pos != j)
                                             .map(|(_, expr)| expr)
                                             .unwrap(),
+                                    ),
+                                    // Or we create a filter with an index scan,
+                                    // removing the index condition from the conjunction.
+                                    _ if (*lhs, *rhs) != (BinOp::Eq, BinOp::Eq) => PhysicalPlan::Filter(
+                                        Box::new(PhysicalPlan::IxScan(
+                                            IxScan {
+                                                schema,
+                                                limit,
+                                                delta,
+                                                index_id: info.index_id,
+                                                prefix: vec![],
+                                                arg: Sarg::from_op(*lhs, *a, u.clone()),
+                                            },
+                                            label,
+                                        )),
+                                        PhysicalExpr::LogOp(
+                                            LogOp::And,
+                                            exprs
+                                                .into_iter()
+                                                .enumerate()
+                                                .filter(|(pos, _)| pos != i)
+                                                .map(|(_, expr)| expr)
+                                                .collect(),
+                                        ),
                                     ),
                                     // If there are more than 3 conditions in this filter,
                                     // we remove the 2 conditions used in the index scan.
@@ -696,7 +734,7 @@ impl RewriteRule for IxScanEq2Col {
                                                 delta,
                                                 index_id: info.index_id,
                                                 prefix: vec![(*a, u.clone())],
-                                                arg: Sarg::Eq(*b, v.clone()),
+                                                arg: Sarg::from_op(*rhs, *b, v.clone()),
                                             },
                                             label,
                                         )),
@@ -722,18 +760,19 @@ impl RewriteRule for IxScanEq2Col {
     }
 }
 
-/// Match multi-field equality predicates such as:
+/// Match multi-field [`BinOp`] predicates such as:
 ///
 /// ```sql
-/// select * from t where x = 1 and y = 1 and z = 1
+/// select * from t where x = 1 and y = 1 and z = 1 // Full match
+///  select * from t where x = 1 and y > 1 and z = 1 // Partial match
 /// ```
 ///
 /// Rewrite as a multi-column index scan if applicable.
 ///
-/// NOTE: This rule does not consider indexes on 4 or more columns.
-pub(crate) struct IxScanEq3Col;
+/// NOTE: This rule does not consider indexes on 4 or more columns, or [`BinOp::Ne`] predicates.
+pub(crate) struct IxScanOp3Col;
 
-impl RewriteRule for IxScanEq3Col {
+impl RewriteRule for IxScanOp3Col {
     type Plan = PhysicalPlan;
     type Info = IxScanInfo;
 
@@ -759,14 +798,16 @@ impl RewriteRule for IxScanEq3Col {
             for (j, b) in exprs.iter().enumerate().filter(|(j, _)| i != *j) {
                 for (k, c) in exprs.iter().enumerate().filter(|(k, _)| i != *k && j != *k) {
                     let (
-                        PhysicalExpr::BinOp(BinOp::Eq, a, u),
-                        PhysicalExpr::BinOp(BinOp::Eq, b, v),
-                        PhysicalExpr::BinOp(BinOp::Eq, c, w),
+                        PhysicalExpr::BinOp(op1, a, u),
+                        PhysicalExpr::BinOp(op2, b, v),
+                        PhysicalExpr::BinOp(op3, c, w),
                     ) = (a, b, c)
                     else {
                         continue;
                     };
-
+                    if (*op1, *op2, *op3) == (BinOp::Ne, BinOp::Ne, BinOp::Ne) {
+                        continue;
+                    }
                     let (
                         PhysicalExpr::Field(u),
                         PhysicalExpr::Value(_),
@@ -819,9 +860,9 @@ impl RewriteRule for IxScanEq3Col {
                 if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan {
                     if let PhysicalPlan::TableScan(TableScan { schema, limit, delta }, label) = *input {
                         if let (
-                            Some(PhysicalExpr::BinOp(BinOp::Eq, _, u)),
-                            Some(PhysicalExpr::BinOp(BinOp::Eq, _, v)),
-                            Some(PhysicalExpr::BinOp(BinOp::Eq, _, w)),
+                            Some(PhysicalExpr::BinOp(op1, _, u)),
+                            Some(PhysicalExpr::BinOp(op2, _, v)),
+                            Some(PhysicalExpr::BinOp(op3, _, w)),
                         ) = (exprs.get(*i), exprs.get(*j), exprs.get(*k))
                         {
                             if let (PhysicalExpr::Value(u), PhysicalExpr::Value(v), PhysicalExpr::Value(w)) =
@@ -833,41 +874,71 @@ impl RewriteRule for IxScanEq3Col {
                                     }
                                     // If there are only 3 conditions in this filter,
                                     // we replace the filter with an index scan.
-                                    3 => PhysicalPlan::IxScan(
-                                        IxScan {
-                                            schema,
-                                            limit,
-                                            delta,
-                                            index_id: info.index_id,
-                                            prefix: vec![(*a, u.clone()), (*b, v.clone())],
-                                            arg: Sarg::Eq(*c, w.clone()),
-                                        },
-                                        label,
-                                    ),
-                                    // If there are 4 conditions in this filter,
-                                    // we create an index scan from 3 of them.
-                                    // The original conjunction is no longer well defined,
-                                    // because it only has a single operand now.
-                                    // Hence we must replace it with its operand.
-                                    4 => PhysicalPlan::Filter(
-                                        Box::new(PhysicalPlan::IxScan(
+                                    3 if (*op1, *op2, *op3) == (BinOp::Eq, BinOp::Eq, BinOp::Eq) => {
+                                        PhysicalPlan::IxScan(
                                             IxScan {
                                                 schema,
                                                 limit,
                                                 delta,
                                                 index_id: info.index_id,
                                                 prefix: vec![(*a, u.clone()), (*b, v.clone())],
-                                                arg: Sarg::Eq(*c, w.clone()),
+                                                arg: Sarg::from_op(*op3, *c, w.clone()),
                                             },
                                             label,
-                                        )),
-                                        exprs
-                                            .into_iter()
-                                            .enumerate()
-                                            .find(|(pos, _)| pos != i && pos != j && pos != k)
-                                            .map(|(_, expr)| expr)
-                                            .unwrap(),
-                                    ),
+                                        )
+                                    }
+                                    // If there are 4 conditions in this filter,
+                                    // we create an index scan from 3 of them.
+                                    // The original conjunction is no longer well defined,
+                                    // because it only has a single operand now.
+                                    // Hence we must replace it with its operand.
+                                    4 if (*op1, *op2, *op3) == (BinOp::Eq, BinOp::Eq, BinOp::Eq) => {
+                                        PhysicalPlan::Filter(
+                                            Box::new(PhysicalPlan::IxScan(
+                                                IxScan {
+                                                    schema,
+                                                    limit,
+                                                    delta,
+                                                    index_id: info.index_id,
+                                                    prefix: vec![(*a, u.clone()), (*b, v.clone())],
+                                                    arg: Sarg::from_op(*op3, *c, w.clone()),
+                                                },
+                                                label,
+                                            )),
+                                            exprs
+                                                .into_iter()
+                                                .enumerate()
+                                                .find(|(pos, _)| pos != i && pos != j && pos != k)
+                                                .map(|(_, expr)| expr)
+                                                .unwrap(),
+                                        )
+                                    }
+                                    // Or we create a filter with an index scan,
+                                    // removing the index condition from the conjunction.
+                                    _ if (*op1, *op2, *op3) != (BinOp::Eq, BinOp::Eq, BinOp::Eq) => {
+                                        PhysicalPlan::Filter(
+                                            Box::new(PhysicalPlan::IxScan(
+                                                IxScan {
+                                                    schema,
+                                                    limit,
+                                                    delta,
+                                                    index_id: info.index_id,
+                                                    prefix: vec![],
+                                                    arg: Sarg::from_op(*op1, *a, u.clone()),
+                                                },
+                                                label,
+                                            )),
+                                            PhysicalExpr::LogOp(
+                                                LogOp::And,
+                                                exprs
+                                                    .into_iter()
+                                                    .enumerate()
+                                                    .filter(|(pos, _)| pos != i)
+                                                    .map(|(_, expr)| expr)
+                                                    .collect(),
+                                            ),
+                                        )
+                                    }
                                     // If there are more than 4 conditions in this filter,
                                     // we remove the 3 conditions used in the index scan.
                                     // The remaining conditions still form a conjunction.
@@ -879,7 +950,7 @@ impl RewriteRule for IxScanEq3Col {
                                                 delta,
                                                 index_id: info.index_id,
                                                 prefix: vec![(*a, u.clone()), (*b, v.clone())],
-                                                arg: Sarg::Eq(*c, w.clone()),
+                                                arg: Sarg::from_op(*op3, *c, w.clone()),
                                             },
                                             label,
                                         )),


### PR DESCRIPTION
# Description of Changes

Closes #1317

> We had to disable this in https://github.com/clockworklabs/SpacetimeDB/pull/1316 but we should lift the restriction eventually for better query performance.

# API and ABI breaking changes


# Expected complexity level and risk

2

We optimize up to 3 columns in an index, and:
- When all the comparisons are`!=` is always a full table scan
- Multi-column indexes are only used if the query has a prefix match (ie all operators are `=`)
- Else are converted to a single column index scan on the leftmost column and a filter on the rest

# Testing

- [*] Expand the testing to verify the plans to all the ops `"=", ">", "<", ">=", "<=", !=`
- [*] Expand the testing to verify we return the same rows when executing the query with the above ops
