### PR TITLE
Relax conditions for query pruning

### DIFF
--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -2189,7 +2189,9 @@ mod tests {
                 ("b", AlgebraicType::U64),
             ],
             &[0.into()],
-            &[0.into()],
+            // The join column for this table does not have to be unique,
+            // because pruning only requires us to probe the join index on `v`.
+            &[],
             StAccess::Public,
         )?;
         let v_id = db.create_table_for_test_with_the_works(

--- a/crates/subscription/src/lib.rs
+++ b/crates/subscription/src/lib.rs
@@ -9,7 +9,7 @@ use spacetimedb_execution::{
 use spacetimedb_expr::check::SchemaView;
 use spacetimedb_lib::{identity::AuthCtx, metrics::ExecutionMetrics, query::Delta, AlgebraicValue};
 use spacetimedb_physical_plan::plan::{IxJoin, IxScan, Label, PhysicalPlan, ProjectPlan, Sarg, TableScan, TupleField};
-use spacetimedb_primitives::{ColId, IndexId, TableId};
+use spacetimedb_primitives::{ColId, ColList, IndexId, TableId};
 use spacetimedb_query::compile_subscription;
 use std::sync::Arc;
 use std::{collections::HashSet, ops::RangeBounds};
@@ -432,7 +432,6 @@ impl SubscriptionPlan {
                             field_pos: rhs_join_col,
                             ..
                         },
-                    unique: true,
                     ..
                 },
                 _,
@@ -445,7 +444,10 @@ impl SubscriptionPlan {
                         ..
                     },
                     _,
-                ) if schema.table_id != self.return_id && prefix.is_empty() => {
+                ) if schema.table_id != self.return_id
+                    && prefix.is_empty()
+                    && schema.is_unique(&ColList::new((*rhs_join_col).into())) =>
+                {
                     let lhs_table = self.return_id;
                     let rhs_table = schema.table_id;
                     let rhs_col = *rhs_col;


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

When pruning joins, both join columns do not have to be unique. If we have a set of row updates from a table, we only care that the join column from the opposing table is unique.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Updated existing test
