### PR TITLE
Bump C# versions to 1.2.1

### DIFF
--- a/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
+++ b/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Codegen</AssemblyName>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Title>SpacetimeDB BSATN Codegen</Title>
     <Description>The SpacetimeDB BSATN Codegen implements the Roslyn incremental generators for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Runtime</AssemblyName>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Title>SpacetimeDB BSATN Runtime</Title>
     <Description>The SpacetimeDB BSATN Runtime implements APIs for BSATN serialization/deserialization in C#.</Description>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Codegen</AssemblyName>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Title>SpacetimeDB Module Codegen</Title>
     <Description>The SpacetimeDB Codegen implements the Roslyn incremental generators for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Runtime/Runtime.csproj
+++ b/crates/bindings-csharp/Runtime/Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Runtime</AssemblyName>
-    <Version>1.2.0</Version>
+    <Version>1.2.1</Version>
     <Title>SpacetimeDB Module Runtime</Title>
     <Description>The SpacetimeDB Runtime implements the database runtime bindings for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>


### PR DESCRIPTION
# Description of Changes

Bump C# versions to 1.2.1 in preparation for an upcoming release.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

CI only