### PR TITLE
`tools/upgrade-version` updates the Change Date in `LICENSE.txt`

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7107,6 +7107,7 @@ name = "upgrade-version"
 version = "0.1.0"
 dependencies = [
  "anyhow",
+ "chrono",
  "clap 4.5.37",
  "duct",
  "regex",

--- a/tools/upgrade-version/Cargo.toml
+++ b/tools/upgrade-version/Cargo.toml
@@ -9,6 +9,7 @@ license-file = "LICENSE"
 [dependencies]
 toml_edit = "0.22.4"
 anyhow.workspace = true
+chrono = { workspace = true, features=["clock"] }
 clap.workspace = true
 regex.workspace = true
 duct.workspace = true

--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -11,24 +11,23 @@ use std::path::PathBuf;
 
 fn process_license_file(upgrade_version: &str) {
     let path = "LICENSE.txt";
-    let contents = fs::read_to_string(path).unwrap();
+    let file = fs::read_to_string(path).unwrap();
 
     let version_re = Regex::new(r"(?m)^(Licensed Work:\s+SpacetimeDB )([\d\.]+)$").unwrap();
-    let date_re = Regex::new(r"(?m)^Change Date:\s+\d{4}-\d{2}-\d{2}$").unwrap();
-
-    let updated = version_re.replace_all(&contents, |caps: &regex::Captures| {
+    let file = version_re.replace_all(&file, |caps: &regex::Captures| {
         format!("{}{}", &caps[1], upgrade_version)
     });
 
+    let date_re = Regex::new(r"(?m)^Change Date:\s+\d{4}-\d{2}-\d{2}$").unwrap();
     let new_date = Local::now()
         .with_year(Local::now().year() + 5)
         .unwrap()
         .format("Change Date:          %Y-%m-%d")
         .to_string();
 
-    let final_text = date_re.replace_all(&updated, new_date.as_str());
+    let file = date_re.replace_all(&file, new_date.as_str());
 
-    fs::write(path, final_text.as_ref()).unwrap();
+    fs::write(path, &*file).unwrap();
 }
 
 fn edit_toml(path: impl AsRef<Path>, f: impl FnOnce(&mut toml_edit::DocumentMut)) -> anyhow::Result<()> {


### PR DESCRIPTION
# Description of Changes

We have sometimes missed this field when doing upgrades. This PR automates it as part of the rest of `tools/upgrade-version`.

Closes https://github.com/clockworklabs/SpacetimeDB/issues/2284.

# API and ABI breaking changes

No runtime changes

# Expected complexity level and risk

2

# Testing
```
$ ( cd tools/upgrade-version && cargo run -- 1.2.3 ) 2>/dev/null && git diff LICENSE.txt
diff --git a/LICENSE.txt b/LICENSE.txt
index ca1f88fef..adca0d5e3 100644
--- a/LICENSE.txt
+++ b/LICENSE.txt
@@ -5,7 +5,7 @@ Business Source License 1.1
 Parameters
 
 Licensor:             Clockwork Laboratories, Inc.
-Licensed Work:        SpacetimeDB 1.2.0
+Licensed Work:        SpacetimeDB 1.2.3
                       The Licensed Work is
                       (c) 2023 Clockwork Laboratories, Inc.
                       
@@ -21,7 +21,7 @@ Additional Use Grant: You may make use of the Licensed Work provided your
                       Licensed Work by creating tables whose schemas are
                       controlled by such third parties.
 
-Change Date:          2030-06-04
+Change Date:          2030-06-24
 
 Change License:       GNU Affero General Public License v3.0 with a linking
                       exception
```
