### PR TITLE
Remove unnecessary `.clone()` in `pipelined.rs`

### DIFF
--- a/crates/execution/src/pipelined.rs
+++ b/crates/execution/src/pipelined.rs
@@ -857,7 +857,7 @@ impl PipelinedIxJoin {
                         .map(Row::Ptr)
                         .map(Tuple::Row)
                     {
-                        f(u.clone().join(v.clone()))?;
+                        f(u.clone().join(v))?;
                     }
                     Ok(())
                 })?;


### PR DESCRIPTION
# Description of Changes

See diff.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

No semantic change.