### PR TITLE
Filter out dropped clients in the send worker

### DIFF
--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -1290,9 +1290,7 @@ struct SendWorkerClient {
 
 impl SendWorkerClient {
     fn is_dropped(&self) -> bool {
-        // We check this when processing subscription updates to exit early for dropped clients.
-        // We use `Acquire` here because we prioritize early exit over cheaper loads.
-        self.dropped.load(Ordering::Acquire)
+        self.dropped.load(Ordering::Relaxed)
     }
 
     fn is_cancelled(&self) -> bool {


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Moves the filtering out of dropped clients during subscription evaluation from inside of `eval_updates_sequential`, where we hold the transaction lock, to the send worker, where the lock has been released.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

0

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] cpu profile
