### PR TITLE
Fix equality comparison between Row::Ptr and Row::Ref

### DIFF
--- a/crates/execution/src/lib.rs
+++ b/crates/execution/src/lib.rs
@@ -115,11 +115,24 @@ pub trait DeltaStore {
     }
 }
 
-#[derive(Clone, PartialEq, Eq)]
+#[derive(Clone)]
 pub enum Row<'a> {
     Ptr(RowRef<'a>),
     Ref(&'a ProductValue),
 }
+
+impl PartialEq for Row<'_> {
+    fn eq(&self, other: &Self) -> bool {
+        match (self, other) {
+            (Self::Ptr(x), Self::Ptr(y)) => x == y,
+            (Self::Ref(x), Self::Ref(y)) => x == y,
+            (Self::Ptr(x), Self::Ref(y)) => x == *y,
+            (Self::Ref(x), Self::Ptr(y)) => y == *x,
+        }
+    }
+}
+
+impl Eq for Row<'_> {}
 
 impl Hash for Row<'_> {
     fn hash<H: Hasher>(&self, state: &mut H) {


### PR DESCRIPTION
# Description of Changes

The derived `PartialEq` always considers `Ptr` and `Ref` to be different, even if the values are the same.

This fixes the errors from [this repro](https://github.com/clockworklabs/SpacetimeDB/issues/2894).

# Expected complexity level and risk

1.

# Testing

Todo: this should have some test coverage, since this was causing a bug with joins.

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
