### PR TITLE
`update_database`: `is_unique` should only use the table's constraints

### DIFF
--- a/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/datastore.rs
@@ -1857,13 +1857,13 @@ mod tests {
         let mut tx = begin_mut_tx(&datastore);
         let schema = datastore.schema_for_table_mut_tx(&tx, table_id)?;
 
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         let mut dropped_indexes = 0;
         for (pos, index) in schema.indexes.iter().enumerate() {
             datastore.drop_index_mut_tx(&mut tx, index.index_id)?;
             dropped_indexes += 1;
 
-            let psc = &tx.tx_state.pending_schema_changes[pos];
+            let psc = &tx.pending_schema_changes()[pos];
             let PendingSchemaChange::IndexRemoved(tid, iid, _, schema) = psc else {
                 panic!("wrong pending schema change: {psc:?}");
             };
@@ -1878,7 +1878,7 @@ mod tests {
         datastore.commit_mut_tx(tx)?;
 
         let mut tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         assert!(
             datastore.schema_for_table_mut_tx(&tx, table_id)?.indexes.is_empty(),
             "no indexes should be left in the schema post-commit"
@@ -1897,7 +1897,7 @@ mod tests {
             true,
         )?;
         assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
+            tx.pending_schema_changes(),
             [PendingSchemaChange::IndexAdded(tid, _, Some(_))]
             if *tid == table_id
         );
@@ -1920,7 +1920,7 @@ mod tests {
         datastore.commit_mut_tx(tx)?;
 
         let tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         assert_eq!(
             datastore.schema_for_table_mut_tx(&tx, table_id)?.indexes,
             expected_indexes,
@@ -1935,10 +1935,10 @@ mod tests {
     #[test]
     fn test_schema_for_table_rollback() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
-        assert_eq!(tx.tx_state.pending_schema_changes.len(), 6);
+        assert_eq!(tx.pending_schema_changes().len(), 6);
         let _ = datastore.rollback_mut_tx(tx);
         let tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         let schema = datastore.schema_for_table_mut_tx(&tx, table_id);
         assert!(schema.is_err());
         Ok(())
@@ -2165,12 +2165,9 @@ mod tests {
         commit(&datastore, tx)?;
 
         let mut tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         create_foo_age_idx_btree(&datastore, &mut tx, table_id)?;
-        assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
-            [PendingSchemaChange::IndexAdded(.., None)]
-        );
+        assert_matches!(tx.pending_schema_changes(), [PendingSchemaChange::IndexAdded(.., None)]);
         assert_st_indices(&tx, true)?;
         let row = u32_str_u32(0, "Bar", 18); // 0 will be ignored.
         let result = insert(&datastore, &mut tx, table_id, &row);
@@ -2195,7 +2192,7 @@ mod tests {
         commit(&datastore, tx)?;
 
         let mut tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         assert_st_indices(&tx, true)?;
         let row = u32_str_u32(0, "Bar", 18); // 0 will be ignored.
         let result = insert(&datastore, &mut tx, table_id, &row);
@@ -2235,16 +2232,13 @@ mod tests {
         // Start a transaction. Schema changes empty so far.
         let datastore = get_datastore()?;
         let mut tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
 
         // Make the table and witness `TableAdded`. Commit.
         let column = ColumnSchema::for_test(0, "id", AlgebraicType::I32);
         let schema = user_public_table([column], [], [], [], None, None);
         let table_id = datastore.create_table_mut_tx(&mut tx, schema)?;
-        assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
-            [PendingSchemaChange::TableAdded(..)]
-        );
+        assert_matches!(tx.pending_schema_changes(), [PendingSchemaChange::TableAdded(..)]);
         commit(&datastore, tx)?;
 
         // Start a new tx. Insert a row and witness that a sequence isn't used.
@@ -2274,7 +2268,7 @@ mod tests {
         };
         let seq_id = datastore.create_sequence_mut_tx(&mut tx, sequence.clone())?;
         assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
+            tx.pending_schema_changes(),
             [PendingSchemaChange::SequenceAdded(_, added_seq_id)]
                 if *added_seq_id == seq_id
         );
@@ -2283,7 +2277,7 @@ mod tests {
         // Drop the uncommitted sequence.
         datastore.drop_sequence_mut_tx(&mut tx, seq_id)?;
         assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
+            tx.pending_schema_changes(),
             [
                 PendingSchemaChange::SequenceAdded(..),
                 PendingSchemaChange::SequenceRemoved(.., schema),
@@ -2295,7 +2289,7 @@ mod tests {
         // Add the sequence again and rollback, witnessing that this had no effect in the next tx.
         let seq_id = datastore.create_sequence_mut_tx(&mut tx, sequence.clone())?;
         assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
+            tx.pending_schema_changes(),
             [
                 PendingSchemaChange::SequenceAdded(..),
                 PendingSchemaChange::SequenceRemoved(..),
@@ -2305,45 +2299,39 @@ mod tests {
         );
         let _ = datastore.rollback_mut_tx(tx);
         let mut tx: MutTxId = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         insert_assert_and_remove(&mut tx, &zero, &zero)?;
 
         // Add the sequence and this time actually commit. Check that it exists in next tx.
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         let seq_id = datastore.create_sequence_mut_tx(&mut tx, sequence.clone())?;
         assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
+            tx.pending_schema_changes(),
             [PendingSchemaChange::SequenceAdded(_, added_seq_id)]
                 if *added_seq_id == seq_id
         );
         commit(&datastore, tx)?;
         let mut tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         insert_assert_and_remove(&mut tx, &zero, &one)?;
 
         // We have the sequence in committed state.
         // Drop it and then rollback, so in the next tx the seq is still there.
         datastore.drop_sequence_mut_tx(&mut tx, seq_id)?;
-        assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
-            [PendingSchemaChange::SequenceRemoved(..)]
-        );
+        assert_matches!(tx.pending_schema_changes(), [PendingSchemaChange::SequenceRemoved(..)]);
         insert_assert_and_remove(&mut tx, &zero, &zero)?;
         let _ = datastore.rollback_mut_tx(tx);
         let mut tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         insert_assert_and_remove(&mut tx, &zero, &product![2])?;
 
         // Drop the seq and commit this time around. In the next tx, we witness that there's no seq.
         datastore.drop_sequence_mut_tx(&mut tx, seq_id)?;
-        assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
-            [PendingSchemaChange::SequenceRemoved(..)]
-        );
+        assert_matches!(tx.pending_schema_changes(), [PendingSchemaChange::SequenceRemoved(..)]);
         insert_assert_and_remove(&mut tx, &zero, &zero)?;
         commit(&datastore, tx)?;
         let mut tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         insert_assert_and_remove(&mut tx, &zero, &zero)?;
 
         Ok(())
@@ -2570,16 +2558,16 @@ mod tests {
     fn test_update_no_such_index_because_deleted() -> ResultTest<()> {
         // Setup and immediately commit.
         let (datastore, tx, table_id) = setup_table()?;
-        assert_eq!(tx.tx_state.pending_schema_changes.len(), 6);
+        assert_eq!(tx.pending_schema_changes().len(), 6);
         commit(&datastore, tx)?;
 
         // Remove index in tx state.
         let mut tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         let index_id = extract_index_id(&datastore, &tx, &basic_indices()[0])?;
         tx.drop_index(index_id)?;
         assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
+            tx.pending_schema_changes(),
             [PendingSchemaChange::IndexRemoved(tid, iid, _, _)]
             if *tid == table_id && *iid == index_id
         );
@@ -2654,7 +2642,7 @@ mod tests {
     fn test_update_no_such_row_because_deleted_new_index_in_tx() -> ResultTest<()> {
         let (datastore, mut tx, table_id) = setup_table_with_indices([], [])?;
         assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
+            tx.pending_schema_changes(),
             [
                 PendingSchemaChange::TableAdded(_),
                 PendingSchemaChange::SequenceAdded(..),
@@ -2668,13 +2656,13 @@ mod tests {
 
         // Now add the indices and then delete the row.
         let mut tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         let mut indices = basic_indices();
         for (pos, index) in indices.iter_mut().enumerate() {
             index.table_id = table_id;
             index.index_id = datastore.create_index_mut_tx(&mut tx, index.clone(), true)?;
             assert_matches!(
-                &tx.tx_state.pending_schema_changes[pos],
+                &tx.pending_schema_changes()[pos],
                 PendingSchemaChange::IndexAdded(_, iid, _)
                 if *iid == index.index_id
             );
@@ -3087,10 +3075,10 @@ mod tests {
 
         // Create a transaction and drop the table and roll back.
         let mut tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         assert!(datastore.drop_table_mut_tx(&mut tx, table_id).is_ok());
         assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
+            tx.pending_schema_changes(),
             [
                 PendingSchemaChange::IndexRemoved(..),
                 PendingSchemaChange::IndexRemoved(..),
@@ -3105,7 +3093,7 @@ mod tests {
 
         // Ensure the table still exists in the next transaction.
         let tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         assert!(
             datastore.table_id_exists_mut_tx(&tx, &table_id),
             "Table should still exist",
@@ -3120,7 +3108,7 @@ mod tests {
         // Create a table in a failed transaction.
         let (datastore, tx, table_id) = setup_table()?;
         assert_matches!(
-            &*tx.tx_state.pending_schema_changes,
+            tx.pending_schema_changes(),
             [
                 PendingSchemaChange::TableAdded(added_table_id),
                 PendingSchemaChange::IndexAdded(.., Some(_)),
@@ -3135,7 +3123,7 @@ mod tests {
 
         // Nothing should have happened.
         let tx = begin_mut_tx(&datastore);
-        assert_eq!(&*tx.tx_state.pending_schema_changes, []);
+        assert_eq!(tx.pending_schema_changes(), []);
         assert!(
             !datastore.table_id_exists_mut_tx(&tx, &table_id),
             "Table should not exist"
@@ -3156,7 +3144,7 @@ mod tests {
         assert_access(&tx, StAccess::Public);
         tx.alter_table_access(table_id, StAccess::Private)?;
         assert_eq!(
-            &*tx.tx_state.pending_schema_changes,
+            tx.pending_schema_changes(),
             [PendingSchemaChange::TableAlterAccess(table_id, StAccess::Public)]
         );
         let _ = datastore.rollback_mut_tx(tx);
@@ -3260,7 +3248,7 @@ mod tests {
         let mut tx = begin_mut_tx(&datastore);
         datastore.alter_table_row_type_mut_tx(&mut tx, table_id, columns.clone())?;
         assert_eq!(
-            &*tx.tx_state.pending_schema_changes,
+            tx.pending_schema_changes(),
             [PendingSchemaChange::TableAlterRowType(
                 table_id,
                 columns_original.clone()

--- a/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mod.rs
@@ -10,6 +10,8 @@ pub use state_view::{IterByColEqTx, IterByColRangeTx};
 pub mod delete_table;
 pub(crate) mod tx;
 mod tx_state;
+#[cfg(test)]
+pub(crate) use tx_state::PendingSchemaChange;
 
 use parking_lot::{
     lock_api::{ArcMutexGuard, ArcRwLockReadGuard, ArcRwLockWriteGuard},

--- a/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/mut_tx.rs
@@ -150,6 +150,12 @@ impl MutTxId {
         self.tx_state.pending_schema_changes.push(change);
     }
 
+    /// Get the list of current pending schema changes, for testing.
+    #[cfg(test)]
+    pub(crate) fn pending_schema_changes(&self) -> &[PendingSchemaChange] {
+        &self.tx_state.pending_schema_changes
+    }
+
     /// Deletes all the rows in table with `table_id`
     /// where the column with `col_pos` equals `value`.
     fn delete_col_eq(&mut self, table_id: TableId, col_pos: ColId, value: &AlgebraicValue) -> Result<()> {

--- a/crates/core/src/db/datastore/locking_tx_datastore/sequence.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/sequence.rs
@@ -4,7 +4,7 @@ use spacetimedb_sats::memory_usage::MemoryUsage;
 use spacetimedb_schema::schema::SequenceSchema;
 
 #[derive(Debug, PartialEq)]
-pub(super) struct Sequence {
+pub(crate) struct Sequence {
     schema: SequenceSchema,
     pub(super) value: i128,
 }

--- a/crates/core/src/db/datastore/locking_tx_datastore/tx_state.rs
+++ b/crates/core/src/db/datastore/locking_tx_datastore/tx_state.rs
@@ -87,7 +87,7 @@ pub(super) struct TxState {
 /// Architecting this way should benefit performance both during transactions and merge.
 /// On rollback, it should be fairly cheap to e.g., just re-add an index or drop it on the floor.
 #[derive(Debug, PartialEq)]
-pub(super) enum PendingSchemaChange {
+pub(crate) enum PendingSchemaChange {
     /// The [`TableIndex`] / [`IndexSchema`] with `IndexId`
     /// was removed from the table with [`TableId`].
     IndexRemoved(TableId, IndexId, TableIndex, IndexSchema),

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -12,6 +12,17 @@ use spacetimedb_schema::def::TableDef;
 use spacetimedb_schema::schema::{column_schemas_from_defs, IndexSchema, Schema, SequenceSchema, TableSchema};
 use std::sync::Arc;
 
+/// The logger used for by [`update_database`] and friends.
+pub trait UpdateLogger {
+    fn info(&self, msg: &str);
+}
+
+impl UpdateLogger for SystemLogger {
+    fn info(&self, msg: &str) {
+        self.info(msg);
+    }
+}
+
 /// Update the database according to the migration plan.
 ///
 /// The update is performed within the transactional context `tx`.
@@ -27,7 +38,7 @@ pub fn update_database(
     tx: &mut MutTxId,
     auth_ctx: AuthCtx,
     plan: MigratePlan,
-    system_logger: &SystemLogger,
+    logger: &dyn UpdateLogger,
 ) -> anyhow::Result<()> {
     let existing_tables = stdb.get_all_tables_mut(tx)?;
 
@@ -45,8 +56,8 @@ pub fn update_database(
     }
 
     match plan {
-        MigratePlan::Manual(plan) => manual_migrate_database(stdb, tx, plan, system_logger, existing_tables),
-        MigratePlan::Auto(plan) => auto_migrate_database(stdb, tx, auth_ctx, plan, system_logger, existing_tables),
+        MigratePlan::Manual(plan) => manual_migrate_database(stdb, tx, plan, logger, existing_tables),
+        MigratePlan::Auto(plan) => auto_migrate_database(stdb, tx, auth_ctx, plan, logger, existing_tables),
     }
 }
 
@@ -55,16 +66,16 @@ fn manual_migrate_database(
     _stdb: &RelationalDB,
     _tx: &mut MutTxId,
     _plan: ManualMigratePlan,
-    _system_logger: &SystemLogger,
+    _logger: &dyn UpdateLogger,
     _existing_tables: Vec<Arc<TableSchema>>,
 ) -> anyhow::Result<()> {
     unimplemented!("Manual database migrations are not yet implemented")
 }
 
-/// Logs with `info` level to `$system_logger` as well as via the `log` crate.
-macro_rules! log_info {
-    ($system_logger:expr, $($tokens:tt)*) => {
-        $system_logger.info(&format!($($tokens)*));
+/// Logs with `info` level to `$logger` as well as via the `log` crate.
+macro_rules! log {
+    ($logger:expr, $($tokens:tt)*) => {
+        $logger.info(&format!($($tokens)*));
         log::info!($($tokens)*);
     };
 }
@@ -75,7 +86,7 @@ fn auto_migrate_database(
     tx: &mut MutTxId,
     auth_ctx: AuthCtx,
     plan: AutoMigratePlan,
-    system_logger: &SystemLogger,
+    logger: &dyn UpdateLogger,
     existing_tables: Vec<Arc<TableSchema>>,
 ) -> anyhow::Result<()> {
     // We have already checked in `migrate_database` that `existing_tables` are compatible with the `old` definition in `plan`.
@@ -126,7 +137,7 @@ fn auto_migrate_database(
                 // They will be initialized by the database when the table is created.
                 let table_schema = TableSchema::from_module_def(plan.new, table_def, (), TableId::SENTINEL);
 
-                log_info!(system_logger, "Creating table `{table_name}`");
+                log!(logger, "Creating table `{table_name}`");
 
                 stdb.create_table(tx, table_schema)?;
             }
@@ -143,12 +154,7 @@ fn auto_migrate_database(
                     .filter_map(|(_, c)| c.data.unique_columns())
                     .any(|unique_cols| unique_cols == &index_cols);
 
-                log_info!(
-                    system_logger,
-                    "Creating index `{}` on table `{}`",
-                    index_name,
-                    table_def.name
-                );
+                log!(logger, "Creating index `{}` on table `{}`", index_name, table_def.name);
 
                 let index_schema = IndexSchema::from_module_def(plan.new, index_def, table_id, 0.into());
 
@@ -164,12 +170,7 @@ fn auto_migrate_database(
                     .find(|index| index.index_name[..] == index_name[..])
                     .unwrap();
 
-                log_info!(
-                    system_logger,
-                    "Dropping index `{}` on table `{}`",
-                    index_name,
-                    table_def.name
-                );
+                log!(logger, "Dropping index `{}` on table `{}`", index_name, table_def.name);
                 stdb.drop_index(tx, index_schema.index_id)?;
             }
             spacetimedb_schema::auto_migrate::AutoMigrateStep::RemoveConstraint(constraint_name) => {
@@ -181,8 +182,8 @@ fn auto_migrate_database(
                     .find(|constraint| constraint.constraint_name[..] == constraint_name[..])
                     .unwrap();
 
-                log_info!(
-                    system_logger,
+                log!(
+                    logger,
                     "Dropping constraint `{}` on table `{}`",
                     constraint_name,
                     table_def.name
@@ -194,8 +195,8 @@ fn auto_migrate_database(
                 let sequence_def = table_def.sequences.get(sequence_name).unwrap();
                 let table_schema = &table_schemas_by_name[&table_def.name[..]];
 
-                log_info!(
-                    system_logger,
+                log!(
+                    logger,
                     "Adding sequence `{}` to table `{}`",
                     sequence_name,
                     table_def.name
@@ -213,8 +214,8 @@ fn auto_migrate_database(
                     .find(|sequence| sequence.sequence_name[..] == sequence_name[..])
                     .unwrap();
 
-                log_info!(
-                    system_logger,
+                log!(
+                    logger,
                     "Dropping sequence `{}` from table `{}`",
                     sequence_name,
                     table_def.name
@@ -226,7 +227,7 @@ fn auto_migrate_database(
                 let table_id = stdb.table_id_from_name_mut(tx, table_name).unwrap().unwrap();
                 let column_schemas = column_schemas_from_defs(plan.new, &table_def.columns, table_id);
 
-                log_info!(system_logger, "Changing columns of table `{}`", table_name);
+                log!(logger, "Changing columns of table `{}`", table_name);
 
                 stdb.alter_table_row_type(tx, table_id, column_schemas)?;
             }
@@ -241,14 +242,14 @@ fn auto_migrate_database(
                 anyhow::bail!("Removing schedules is not yet implemented");
             }
             spacetimedb_schema::auto_migrate::AutoMigrateStep::AddRowLevelSecurity(sql_rls) => {
-                log_info!(system_logger, "Adding row-level security `{sql_rls}`");
+                log!(logger, "Adding row-level security `{sql_rls}`");
                 let rls = plan.new.lookup_expect(sql_rls);
                 let rls = RowLevelExpr::build_row_level_expr(tx, &auth_ctx, rls)?;
 
                 stdb.create_row_level_security(tx, rls.def)?;
             }
             spacetimedb_schema::auto_migrate::AutoMigrateStep::RemoveRowLevelSecurity(sql_rls) => {
-                log_info!(system_logger, "Removing-row level security `{sql_rls}`");
+                log!(logger, "Removing-row level security `{sql_rls}`");
                 stdb.drop_row_level_security(tx, sql_rls.clone())?;
             }
         }
@@ -256,4 +257,98 @@ fn auto_migrate_database(
 
     log::info!("Database update complete");
     Ok(())
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::{
+        db::{
+            datastore::locking_tx_datastore::PendingSchemaChange,
+            relational_db::tests_utils::{begin_mut_tx, insert, TestDB},
+        },
+        host::module_host::create_table_from_def,
+    };
+    use spacetimedb_lib::db::raw_def::v9::{btree, RawModuleDefV9Builder, TableAccess};
+    use spacetimedb_sats::{product, AlgebraicType::U64};
+    use spacetimedb_schema::{auto_migrate::ponder_migrate, def::ModuleDef};
+
+    struct TestLogger;
+    impl UpdateLogger for TestLogger {
+        fn info(&self, _: &str) {}
+    }
+
+    #[test]
+    fn update_db_repro_2761() -> anyhow::Result<()> {
+        let auth_ctx = AuthCtx::for_testing();
+        let stdb = TestDB::durable()?;
+
+        // Define the old and new modules, the latter with the index on `b`.
+        let define_p = |builder: &mut RawModuleDefV9Builder| {
+            builder
+                .build_table_with_new_type("p", [("x", U64), ("y", U64)], true)
+                .with_unique_constraint(0)
+                .with_unique_constraint(1)
+                .with_index(btree(0), "idx_x")
+                .with_index(btree(1), "idx_y")
+                .with_access(TableAccess::Public)
+                .finish()
+        };
+        let define_t = |builder: &mut RawModuleDefV9Builder, with_index| {
+            let builder = builder
+                .build_table_with_new_type("t", [("a", U64), ("b", U64)], true)
+                .with_access(TableAccess::Public);
+
+            let builder = if with_index {
+                builder.with_index(btree(1), "idx_b")
+            } else {
+                builder
+            };
+
+            builder.finish()
+        };
+        let module_def = |with_index| -> ModuleDef {
+            let mut builder = RawModuleDefV9Builder::new();
+            define_p(&mut builder);
+            define_t(&mut builder, with_index);
+            builder
+                .finish()
+                .try_into()
+                .expect("builder should create a valid database definition")
+        };
+
+        let old = module_def(false);
+        let new = module_def(true);
+
+        // Create tables for `old`.
+        let mut tx = begin_mut_tx(&stdb);
+        for def in old.tables() {
+            create_table_from_def(&stdb, &mut tx, &old, def)?;
+        }
+
+        // Write two rows to `t`
+        // that would cause a unique constraint violation if `idx_b` was unique.
+        let t_id = stdb
+            .table_id_from_name_mut(&tx, "t")?
+            .expect("there should be a table with name `t`");
+        insert(&stdb, &mut tx, t_id, &product![0u64, 42u64])?;
+        insert(&stdb, &mut tx, t_id, &product![1u64, 42u64])?;
+        stdb.commit_tx(tx)?;
+
+        // Try to update the db.
+        let mut tx = begin_mut_tx(&stdb);
+        let plan = ponder_migrate(&old, &new)?;
+        update_database(&stdb, &mut tx, auth_ctx, plan, &TestLogger)?;
+
+        // Expect the schema change.
+        let idx_b_id = stdb
+            .index_id_from_name(&tx, "t_b_idx_btree")?
+            .expect("there should be an index named `idx_b`");
+        assert_eq!(
+            tx.pending_schema_changes(),
+            [PendingSchemaChange::IndexAdded(t_id, idx_b_id, None)]
+        );
+
+        Ok(())
+    }
 }

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -4,6 +4,7 @@ use crate::client::{ClientActorId, ClientConnectionSender};
 use crate::database_logger::{LogLevel, Record};
 use crate::db::datastore::locking_tx_datastore::MutTxId;
 use crate::db::datastore::traits::{IsolationLevel, Program, TxData};
+use crate::db::relational_db::RelationalDB;
 use crate::energy::EnergyQuanta;
 use crate::error::DBError;
 use crate::estimation::estimate_rows_scanned;
@@ -41,7 +42,7 @@ use spacetimedb_query::compile_subscription;
 use spacetimedb_sats::ProductValue;
 use spacetimedb_schema::auto_migrate::AutoMigrateError;
 use spacetimedb_schema::def::deserialize::ReducerArgsDeserializeSeed;
-use spacetimedb_schema::def::{ModuleDef, ReducerDef};
+use spacetimedb_schema::def::{ModuleDef, ReducerDef, TableDef};
 use spacetimedb_schema::schema::{Schema, TableSchema};
 use spacetimedb_vm::relation::RelValue;
 use std::fmt;
@@ -331,6 +332,19 @@ pub trait ModuleInstance: Send + 'static {
     fn call_reducer(&mut self, tx: Option<MutTxId>, params: CallReducerParams) -> ReducerCallResult;
 }
 
+/// Creates the table for `table_def` in `stdb`.
+pub fn create_table_from_def(
+    stdb: &RelationalDB,
+    tx: &mut MutTxId,
+    module_def: &ModuleDef,
+    table_def: &TableDef,
+) -> anyhow::Result<()> {
+    let schema = TableSchema::from_module_def(module_def, table_def, (), TableId::SENTINEL);
+    stdb.create_table(tx, schema)
+        .with_context(|| format!("failed to create table {}", &table_def.name))?;
+    Ok(())
+}
+
 /// If the module instance's replica_ctx is uninitialized, initialize it.
 fn init_database(
     replica_ctx: &ReplicaContext,
@@ -351,11 +365,8 @@ fn init_database(
             table_defs.sort_by(|a, b| a.name.cmp(&b.name));
 
             for def in table_defs {
-                let table_name = &def.name;
-                logger.info(&format!("Creating table `{table_name}`"));
-                let schema = TableSchema::from_module_def(module_def, def, (), TableId::SENTINEL);
-                stdb.create_table(tx, schema)
-                    .with_context(|| format!("failed to create table {table_name}"))?;
+                logger.info(&format!("Creating table `{}`", &def.name));
+                create_table_from_def(stdb, tx, module_def, def)?;
             }
             // Insert the late-bound row-level security expressions.
             for rls in module_def.row_level_security() {

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -493,12 +493,17 @@ impl RawModuleDefV9Builder {
     pub fn build_table_with_new_type(
         &mut self,
         table_name: impl Into<RawIdentifier>,
-        product_type: spacetimedb_sats::ProductType,
+        product_type: impl Into<spacetimedb_sats::ProductType>,
         custom_ordering: bool,
     ) -> RawTableDefBuilder {
         let table_name = table_name.into();
 
-        let product_type_ref = self.add_algebraic_type([], table_name.clone(), product_type.into(), custom_ordering);
+        let product_type_ref = self.add_algebraic_type(
+            [],
+            table_name.clone(),
+            AlgebraicType::from(product_type.into()),
+            custom_ordering,
+        );
 
         self.build_table(table_name, product_type_ref)
     }


### PR DESCRIPTION
# Description of Changes

Currently, before this PR, when checking if the index-to-add is unique, we consider all constraints in the module.
This caused a bug where we'd let the unique constraints of another table affect the table-to-alter.

Fixes https://github.com/clockworklabs/SpacetimeDB/issues/2761.

# API and ABI breaking changes

None

# Expected complexity level and risk

2?

# Testing

A regression test is added in the last commit.
Also verified that a module with the last repro in the reducer doesn't work on master and does with the PR.