### PR TITLE
SATS: Move some method bodies to be provided in 'Serializer' instead

### DIFF
--- a/crates/sats/src/ser/serde.rs
+++ b/crates/sats/src/ser/serde.rs
@@ -1,10 +1,8 @@
-use super::Serialize as _;
+use crate::{i256, u256};
 use crate::{
-    algebraic_value::ser::ValueSerializer,
     ser::{self, Serializer},
     serde::{SerdeError, SerdeWrapper},
 };
-use crate::{i256, u256};
 use core::fmt;
 use serde::ser as serde;
 
@@ -122,53 +120,6 @@ impl<S: serde::Serializer> Serializer for SerdeSerializer<S> {
             seq.serialize_element(value).map_err(SerdeError)?;
             seq.end().map_err(SerdeError)
         }
-    }
-
-    unsafe fn serialize_bsatn(self, ty: &crate::AlgebraicType, bsatn: &[u8]) -> Result<Self::Ok, Self::Error> {
-        // TODO(Centril): Consider instead deserializing the `bsatn` through a
-        // deserializer that serializes into `self` directly.
-
-        // First convert the BSATN to an `AlgebraicValue`.
-        // SAFETY: Forward caller requirements of this method to that we are calling.
-        let res = unsafe { ValueSerializer.serialize_bsatn(ty, bsatn) };
-        let value = res.unwrap_or_else(|x| match x {});
-
-        // Then serialize that.
-        value.serialize(self)
-    }
-
-    unsafe fn serialize_bsatn_in_chunks<'a, I: Clone + Iterator<Item = &'a [u8]>>(
-        self,
-        ty: &crate::AlgebraicType,
-        total_bsatn_len: usize,
-        bsatn: I,
-    ) -> Result<Self::Ok, Self::Error> {
-        // TODO(Centril): Unlike above, in this case we must at minimum concatenate `bsatn`
-        // before we can do the piping mentioned above, but that's better than
-        // serializing to `AlgebraicValue` first, so consider that.
-
-        // First convert the BSATN to an `AlgebraicValue`.
-        // SAFETY: Forward caller requirements of this method to that we are calling.
-        let res = unsafe { ValueSerializer.serialize_bsatn_in_chunks(ty, total_bsatn_len, bsatn) };
-        let value = res.unwrap_or_else(|x| match x {});
-
-        // Then serialize that.
-        value.serialize(self)
-    }
-
-    unsafe fn serialize_str_in_chunks<'a, I: Clone + Iterator<Item = &'a [u8]>>(
-        self,
-        total_len: usize,
-        string: I,
-    ) -> Result<Self::Ok, Self::Error> {
-        // First convert the `string` to an `AlgebraicValue`.
-        // SAFETY: Forward caller requirements of this method to that we are calling.
-        let res = unsafe { ValueSerializer.serialize_str_in_chunks(total_len, string) };
-        let value = res.unwrap_or_else(|x| match x {});
-
-        // Then serialize that.
-        // This incurs a very minor cost of branching on `AlgebraicValue::String`.
-        value.serialize(self)
     }
 }
 


### PR DESCRIPTION
# Description of Changes

The methods `serialize_bsatn`, `serialize_bsatn_in_chunks`, and `serialize_str_in_chunks` now have provided bodies, removing some duplicated code in some impls of `Serializer`.

This is extracted from https://github.com/clockworklabs/SpacetimeDB/pull/2839 which provides a new `Serializer` impl.

# API and ABI breaking changes

None

# Expected complexity level and risk

1 - just code motion.

# Testing

This makes the testing situation better thanks to code sharing.
Other than that, this is covered by existing tests.