### PR TITLE
core: Tone down `MessageExecutionError`

### DIFF
--- a/crates/core/src/client/message_handlers.rs
+++ b/crates/core/src/client/message_handlers.rs
@@ -141,7 +141,7 @@ pub async fn handle(client: &ClientConnection, message: DataMessage, timer: Inst
 }
 
 #[derive(thiserror::Error, Debug)]
-#[error("error executing message (reducer: {reducer:?}) (err: {err:?})")]
+#[error("error executing message (reducer: {reducer:?}) (err: {err:#})")]
 pub struct MessageExecutionError {
     pub reducer: Option<Box<str>>,
     pub reducer_id: Option<ReducerId>,


### PR DESCRIPTION
The display impl of the error prints a stack trace, which is not
particularly helpful given it is usually a user error.

Use the alternate format (`{:#}`) instead, which makes anyhow display a
single line and no backtrace.


# Expected complexity level and risk

1 -- Only changes how the error is rendered

# Testing

- [x] Run a smoketest that yields an execution error, e.g.
   `test_add_then_remove_index`, and convince yourself that one line is
   sufficient
