### PR TITLE
SATS: make `field_names`/`variant_names` return iterator + add `FieldNameVisitor::visit_seq`

### DIFF
--- a/crates/bindings-macro/src/sats.rs
+++ b/crates/bindings-macro/src/sats.rs
@@ -347,7 +347,7 @@ pub(crate) fn derive_deserialize(ty: &SatsType<'_>) -> TokenStream {
     de_generics.params.insert(0, de_lt_param.into());
     let (de_impl_generics, _, de_where_clause) = de_generics.split_for_impl();
 
-    let (iter_n, iter_n2, iter_n3) = (0usize.., 0usize.., 0usize..);
+    let (iter_n, iter_n2, iter_n3, iter_n4) = (0usize.., 0usize.., 0usize.., 0usize..);
 
     match &ty.data {
         SatsTypeData::Product(fields) => {
@@ -443,13 +443,20 @@ pub(crate) fn derive_deserialize(ty: &SatsType<'_>) -> TokenStream {
                     impl #de_impl_generics #spacetimedb_lib::de::FieldNameVisitor<'de> for __ProductVisitor #ty_generics #de_where_clause {
                         type Output = __ProductFieldIdent;
 
-                        fn field_names(&self, names: &mut dyn #spacetimedb_lib::de::ValidNames) {
-                            names.extend::<&[&str]>(&[#(#field_strings),*])
+                        fn field_names(&self) -> impl '_ + Iterator<Item = Option<&str>> {
+                            [#(#field_strings),*].into_iter().map(Some)
                         }
 
                         fn visit<__E: #spacetimedb_lib::de::Error>(self, name: &str) -> Result<Self::Output, __E> {
                             match name {
                                 #(#field_strings => Ok(__ProductFieldIdent::#field_names),)*
+                                _ => Err(#spacetimedb_lib::de::Error::unknown_field_name(name, &self)),
+                            }
+                        }
+
+                        fn visit_seq<__E: #spacetimedb_lib::de::Error>(self, index: usize, name: &str) -> Result<Self::Output, __E> {
+                            match index {
+                                #(#iter_n4 => Ok(__ProductFieldIdent::#field_names),)*
                                 _ => Err(#spacetimedb_lib::de::Error::unknown_field_name(name, &self)),
                             }
                         }
@@ -516,11 +523,11 @@ pub(crate) fn derive_deserialize(ty: &SatsType<'_>) -> TokenStream {
                         #(#variant_idents,)*
                     }
 
-                    impl #de_impl_generics #spacetimedb_lib::de::VariantVisitor for __SumVisitor #ty_generics #de_where_clause {
+                    impl #de_impl_generics #spacetimedb_lib::de::VariantVisitor<'de> for __SumVisitor #ty_generics #de_where_clause {
                         type Output = __Variant;
 
-                        fn variant_names(&self, names: &mut dyn #spacetimedb_lib::de::ValidNames) {
-                            names.extend::<&[&str]>(&[#(#variant_names,)*])
+                        fn variant_names(&self) -> impl '_ + Iterator<Item = &str> {
+                            [#(#variant_names,)*].into_iter()
                         }
 
                         fn visit_tag<E: #spacetimedb_lib::de::Error>(self, __tag: u8) -> Result<Self::Output, E> {

--- a/crates/sats/src/algebraic_value/de.rs
+++ b/crates/sats/src/algebraic_value/de.rs
@@ -173,12 +173,12 @@ impl SumAccess {
     }
 }
 
-impl de::SumAccess<'_> for SumAccess {
+impl<'de> de::SumAccess<'de> for SumAccess {
     type Error = ValueDeserializeError;
 
     type Variant = ValueDeserializer;
 
-    fn variant<V: de::VariantVisitor>(self, visitor: V) -> Result<(V::Output, Self::Variant), Self::Error> {
+    fn variant<V: de::VariantVisitor<'de>>(self, visitor: V) -> Result<(V::Output, Self::Variant), Self::Error> {
         let tag = visitor.visit_tag(self.sum.tag)?;
         let val = *self.sum.value;
         Ok((tag, ValueDeserializer { val }))
@@ -313,7 +313,7 @@ impl<'de> de::SumAccess<'de> for &'de SumAccess {
 
     type Variant = &'de ValueDeserializer;
 
-    fn variant<V: de::VariantVisitor>(self, visitor: V) -> Result<(V::Output, Self::Variant), Self::Error> {
+    fn variant<V: de::VariantVisitor<'de>>(self, visitor: V) -> Result<(V::Output, Self::Variant), Self::Error> {
         let tag = visitor.visit_tag(self.sum.tag)?;
         Ok((tag, ValueDeserializer::from_ref(&self.sum.value)))
     }

--- a/crates/sats/src/bsatn/de.rs
+++ b/crates/sats/src/bsatn/de.rs
@@ -146,7 +146,7 @@ impl<'de, R: BufReader<'de>> SumAccess<'de> for Deserializer<'_, R> {
     type Error = DecodeError;
     type Variant = Self;
 
-    fn variant<V: de::VariantVisitor>(self, visitor: V) -> Result<(V::Output, Self::Variant), Self::Error> {
+    fn variant<V: de::VariantVisitor<'de>>(self, visitor: V) -> Result<(V::Output, Self::Variant), Self::Error> {
         let tag = self.reader.get_u8()?;
         visitor.visit_tag(tag).map(|variant| (variant, self))
     }

--- a/crates/sats/src/de/impls.rs
+++ b/crates/sats/src/de/impls.rs
@@ -211,11 +211,11 @@ impl<'de, T: Deserialize<'de>> SumVisitor<'de> for OptionVisitor<T> {
     }
 }
 
-impl<'de, T: Deserialize<'de>> VariantVisitor for OptionVisitor<T> {
+impl<'de, T: Deserialize<'de>> VariantVisitor<'de> for OptionVisitor<T> {
     type Output = bool;
 
-    fn variant_names(&self, names: &mut dyn super::ValidNames) {
-        names.extend(["some", "none"])
+    fn variant_names(&self) -> impl '_ + Iterator<Item = &str> {
+        ["some", "none"].into_iter()
     }
 
     fn visit_tag<E: Error>(self, tag: u8) -> Result<Self::Output, E> {
@@ -268,11 +268,11 @@ impl<'de, T: Deserialize<'de>, E: Deserialize<'de>> SumVisitor<'de> for ResultVi
     }
 }
 
-impl<'de, T: Deserialize<'de>, U: Deserialize<'de>> VariantVisitor for ResultVisitor<T, U> {
+impl<'de, T: Deserialize<'de>, U: Deserialize<'de>> VariantVisitor<'de> for ResultVisitor<T, U> {
     type Output = ResultVariant;
 
-    fn variant_names(&self, names: &mut dyn super::ValidNames) {
-        names.extend(["ok", "err"])
+    fn variant_names(&self) -> impl '_ + Iterator<Item = &str> {
+        ["ok", "err"].into_iter()
     }
 
     fn visit_tag<E: Error>(self, tag: u8) -> Result<Self::Output, E> {
@@ -335,11 +335,11 @@ impl<'de, S: Copy + DeserializeSeed<'de>> SumVisitor<'de> for BoundVisitor<S> {
     }
 }
 
-impl<'de, T: Copy + DeserializeSeed<'de>> VariantVisitor for BoundVisitor<T> {
+impl<'de, T: Copy + DeserializeSeed<'de>> VariantVisitor<'de> for BoundVisitor<T> {
     type Output = BoundVariant;
 
-    fn variant_names(&self, names: &mut dyn super::ValidNames) {
-        names.extend(["included", "excluded", "unbounded"])
+    fn variant_names(&self) -> impl '_ + Iterator<Item = &str> {
+        ["included", "excluded", "unbounded"].into_iter()
     }
 
     fn visit_tag<E: Error>(self, tag: u8) -> Result<Self::Output, E> {
@@ -420,12 +420,12 @@ impl<'de> SumVisitor<'de> for WithTypespace<'_, SumType> {
     }
 }
 
-impl VariantVisitor for WithTypespace<'_, SumType> {
+impl VariantVisitor<'_> for WithTypespace<'_, SumType> {
     type Output = u8;
 
-    fn variant_names(&self, names: &mut dyn super::ValidNames) {
+    fn variant_names(&self) -> impl '_ + Iterator<Item = &str> {
         // Provide the names known from the `SumType`.
-        names.extend(self.ty().variants.iter().filter_map(|v| v.name()))
+        self.ty().variants.iter().filter_map(|v| v.name())
     }
 
     fn visit_tag<E: Error>(self, tag: u8) -> Result<Self::Output, E> {
@@ -643,8 +643,8 @@ impl FieldNameVisitor<'_> for TupleNameVisitor<'_> {
     // The index of the field name.
     type Output = usize;
 
-    fn field_names(&self, names: &mut dyn super::ValidNames) {
-        names.extend(self.elems.iter().filter_map(|f| f.name()))
+    fn field_names(&self) -> impl '_ + Iterator<Item = Option<&str>> {
+        self.elems.iter().map(|f| f.name())
     }
 
     fn kind(&self) -> ProductKind {
@@ -657,6 +657,14 @@ impl FieldNameVisitor<'_> for TupleNameVisitor<'_> {
             .iter()
             .position(|f| f.has_name(name))
             .ok_or_else(|| Error::unknown_field_name(name, &self))
+    }
+
+    fn visit_seq<E: Error>(self, index: usize, name: &str) -> Result<Self::Output, E> {
+        self.elems
+            .get(index)
+            .ok_or_else(|| Error::unknown_field_name(name, &self))?;
+
+        Ok(index)
     }
 }
 

--- a/crates/sats/src/layout.rs
+++ b/crates/sats/src/layout.rs
@@ -9,7 +9,7 @@
 use crate::{
     de::{
         Deserialize, DeserializeSeed, Deserializer, Error, NamedProductAccess, ProductVisitor, SeqProductAccess,
-        SumAccess, SumVisitor, ValidNames, VariantAccess as _, VariantVisitor,
+        SumAccess, SumVisitor, VariantAccess as _, VariantVisitor,
     },
     i256, impl_deserialize, impl_serialize,
     sum_type::{OPTION_NONE_TAG, OPTION_SOME_TAG},
@@ -906,12 +906,12 @@ impl<'de> SumVisitor<'de> for &SumTypeLayout {
     }
 }
 
-impl VariantVisitor for &SumTypeLayout {
+impl VariantVisitor<'_> for &SumTypeLayout {
     type Output = u8;
 
-    fn variant_names(&self, names: &mut dyn ValidNames) {
+    fn variant_names(&self) -> impl '_ + Iterator<Item = &str> {
         // Provide the names known from the `SumType`.
-        names.extend(self.variants.iter().filter_map(|v| v.name.as_deref()));
+        self.variants.iter().filter_map(|v| v.name.as_deref())
     }
 
     fn visit_tag<E: Error>(self, tag: u8) -> Result<Self::Output, E> {


### PR DESCRIPTION
# Description of Changes

- Nix `ValidNames` and return iterators instead. This makes the code simpler and the methods more reusable.
- Add `FieldNameVisitor::visit_seq`.

These changes are desired here:
https://github.com/clockworklabs/SpacetimeDB/pull/2839/files#diff-e2c58a18f948a7bbb84812f5b64edf9362bb7b4b9fcfb05c00931e08d366a4b5R249-R258

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Covered by existing tests.