### PR TITLE
commitlog: Set up options for toml configuration

### DIFF
--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -32,7 +32,12 @@ pub mod stream;
 pub mod tests;
 
 /// [`Commitlog`] options.
-#[derive(Clone, Copy, Debug)]
+#[derive(Clone, Copy, Debug, PartialEq)]
+#[cfg_attr(
+    feature = "serde",
+    derive(serde::Serialize, serde::Deserialize),
+    serde(rename_all = "kebab-case")
+)]
 pub struct Options {
     /// Set the log format version to write, and the maximum supported version.
     ///
@@ -42,11 +47,13 @@ pub struct Options {
     /// with new or very old versions.
     ///
     /// Default: [`DEFAULT_LOG_FORMAT_VERSION`]
+    #[cfg_attr(feature = "serde", serde(default = "Options::default_log_format_version"))]
     pub log_format_version: u8,
     /// The maximum size in bytes to which log segments should be allowed to
     /// grow.
     ///
     /// Default: 1GiB
+    #[cfg_attr(feature = "serde", serde(default = "Options::default_max_segment_size"))]
     pub max_segment_size: u64,
     /// The maximum number of records in a commit.
     ///
@@ -54,11 +61,13 @@ pub struct Options {
     /// explicitly calling [`Commitlog::flush`].
     ///
     /// Default: 65,535
+    #[cfg_attr(feature = "serde", serde(default = "Options::default_max_records_in_commit"))]
     pub max_records_in_commit: NonZeroU16,
     /// Whenever at least this many bytes have been written to the currently
     /// active segment, an entry is added to its offset index.
     ///
     /// Default: 4096
+    #[cfg_attr(feature = "serde", serde(default = "Options::default_offset_index_interval_bytes"))]
     pub offset_index_interval_bytes: NonZeroU64,
     /// If `true`, require that the segment must be synced to disk before an
     /// index entry is added.
@@ -74,22 +83,55 @@ pub struct Options {
     /// strictly every `offset_index_interval_bytes`.
     ///
     /// Default: false
+    #[cfg_attr(
+        feature = "serde",
+        serde(default = "Options::default_offset_index_require_segment_fsync")
+    )]
     pub offset_index_require_segment_fsync: bool,
 }
 
 impl Default for Options {
     fn default() -> Self {
-        Self {
-            log_format_version: DEFAULT_LOG_FORMAT_VERSION,
-            max_segment_size: 1024 * 1024 * 1024,
-            max_records_in_commit: NonZeroU16::MAX,
-            offset_index_interval_bytes: NonZeroU64::new(4096).unwrap(),
-            offset_index_require_segment_fsync: false,
-        }
+        Self::DEFAULT
     }
 }
 
 impl Options {
+    pub const DEFAULT_MAX_SEGMENT_SIZE: u64 = 1024 * 1024 * 1024;
+    pub const DEFAULT_MAX_RECORDS_IN_COMMIT: NonZeroU16 = NonZeroU16::MAX;
+    pub const DEFAULT_OFFSET_INDEX_INTERVAL_BYTES: NonZeroU64 =
+        // SAFETY: 4096 > 0, qed
+        unsafe { NonZeroU64::new_unchecked(4096) };
+    pub const DEFAULT_OFFSET_INDEX_REQUIRE_SEGMENT_FSYNC: bool = false;
+
+    pub const DEFAULT: Self = Self {
+        log_format_version: DEFAULT_LOG_FORMAT_VERSION,
+        max_segment_size: Self::default_max_segment_size(),
+        max_records_in_commit: Self::default_max_records_in_commit(),
+        offset_index_interval_bytes: Self::default_offset_index_interval_bytes(),
+        offset_index_require_segment_fsync: Self::default_offset_index_require_segment_fsync(),
+    };
+
+    pub const fn default_log_format_version() -> u8 {
+        DEFAULT_LOG_FORMAT_VERSION
+    }
+
+    pub const fn default_max_segment_size() -> u64 {
+        Self::DEFAULT_MAX_SEGMENT_SIZE
+    }
+
+    pub const fn default_max_records_in_commit() -> NonZeroU16 {
+        Self::DEFAULT_MAX_RECORDS_IN_COMMIT
+    }
+
+    pub const fn default_offset_index_interval_bytes() -> NonZeroU64 {
+        Self::DEFAULT_OFFSET_INDEX_INTERVAL_BYTES
+    }
+
+    pub const fn default_offset_index_require_segment_fsync() -> bool {
+        Self::DEFAULT_OFFSET_INDEX_REQUIRE_SEGMENT_FSYNC
+    }
+
     /// Compute the length in bytes of an offset index based on the settings in
     /// `self`.
     pub fn offset_index_len(&self) -> u64 {

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -99,9 +99,7 @@ impl Default for Options {
 impl Options {
     pub const DEFAULT_MAX_SEGMENT_SIZE: u64 = 1024 * 1024 * 1024;
     pub const DEFAULT_MAX_RECORDS_IN_COMMIT: NonZeroU16 = NonZeroU16::MAX;
-    pub const DEFAULT_OFFSET_INDEX_INTERVAL_BYTES: NonZeroU64 =
-        // SAFETY: 4096 > 0, qed
-        unsafe { NonZeroU64::new_unchecked(4096) };
+    pub const DEFAULT_OFFSET_INDEX_INTERVAL_BYTES: NonZeroU64 = NonZeroU64::new(4096).expect("4096 > 0, qed");
     pub const DEFAULT_OFFSET_INDEX_REQUIRE_SEGMENT_FSYNC: bool = false;
 
     pub const DEFAULT: Self = Self {


### PR DESCRIPTION
As per convention, field names are in kebab-case.
We set up defaults for each field individually, such that the external
configuration does not have to enumerate all of them, but only the ones
to override.

# API and ABI breaking changes

None

# Expected complexity level and risk

1.5

# Testing

- [x] Elsewhere
