### PR TITLE
Add React Native support to the Typescript SDK

### DIFF
--- a/sdks/typescript/packages/sdk/package.json
+++ b/sdks/typescript/packages/sdk/package.json
@@ -47,6 +47,7 @@
     "undici": "^6.19.2"
   },
   "dependencies": {
+    "@zxing/text-encoding": "^0.9.0",
     "base64-js": "^1.5.1"
   }
 }

--- a/sdks/typescript/packages/sdk/src/binary_reader.ts
+++ b/sdks/typescript/packages/sdk/src/binary_reader.ts
@@ -1,3 +1,5 @@
+import { TextDecoder } from '@zxing/text-encoding';
+
 export default class BinaryReader {
   #buffer: DataView;
   #offset: number = 0;

--- a/sdks/typescript/packages/sdk/src/binary_writer.ts
+++ b/sdks/typescript/packages/sdk/src/binary_writer.ts
@@ -1,4 +1,5 @@
 import { fromByteArray } from 'base64-js';
+import { TextEncoder } from '@zxing/text-encoding';
 
 export default class BinaryWriter {
   #buffer: Uint8Array;

--- a/sdks/typescript/packages/sdk/src/db_connection_impl.ts
+++ b/sdks/typescript/packages/sdk/src/db_connection_impl.ts
@@ -202,7 +202,10 @@ export class DbConnectionImpl<
   }: DbConnectionConfig) {
     stdbLogger('info', 'Connecting to SpacetimeDB WS...');
 
-    let url = new URL(uri);
+    // We use .toString() here because some versions of React Native contain a bug where the URL constructor
+    // incorrectly treats a URL instance as a plain string.
+    // This results in an attempt to call .endsWith() on it, leading to an error.
+    let url = new URL(uri.toString());
     if (!/^wss?:/.test(uri.protocol)) {
       url.protocol = url.protocol === 'https:' ? 'wss:' : 'ws:';
     }

--- a/sdks/typescript/pnpm-lock.yaml
+++ b/sdks/typescript/pnpm-lock.yaml
@@ -170,6 +170,9 @@ importers:
 
   packages/sdk:
     dependencies:
+      '@zxing/text-encoding':
+        specifier: ^0.9.0
+        version: 0.9.0
       base64-js:
         specifier: ^1.5.1
         version: 1.5.1
@@ -1315,6 +1318,9 @@ packages:
 
   '@vitest/utils@2.1.2':
     resolution: {integrity: sha512-zMO2KdYy6mx56btx9JvAqAZ6EyS3g49krMPPrgOp1yxGZiA93HumGk+bZ5jIZtOg5/VBYl5eBmGRQHqq4FG6uQ==}
+
+  '@zxing/text-encoding@0.9.0':
+    resolution: {integrity: sha512-U/4aVJ2mxI0aDNI8Uq0wEhMgY+u4CNtEb0om3+y3+niDAsoTCOB33UF0sxpzqzdqXLqmvc+vZyAt4O8pPdfkwA==}
 
   acorn-jsx@5.3.2:
     resolution: {integrity: sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ==}
@@ -3981,6 +3987,8 @@ snapshots:
       '@vitest/pretty-format': 2.1.2
       loupe: 3.1.2
       tinyrainbow: 1.2.0
+
+  '@zxing/text-encoding@0.9.0': {}
 
   acorn-jsx@5.3.2(acorn@8.14.0):
     dependencies:


### PR DESCRIPTION
This PR helps to support React Native in the Typescript SDK. We have identified two issues:

1. Certain versions of React Native exhibit a bug where the constructor mistakenly treats a URL object as a string. This causes an error when the constructor attempts to call `.endsWith()` on the URL object, leading to runtime errors. This PR adds a .toString() call when passing a URL instance to the URL constructor. 
2. React Native doesn't provide an implementation for TextEncoder and TextDecoder which are used to read/write strings in our binary reader and writer. This PR use introduce the usage of a library for these two types.

Note: this still requires the use of a Polyfill as React Native URL implementation is missing most methods in version older than 0.79 (>= 6 month old)
