### PR TITLE
Implemented newtype pattern support for tuples

### DIFF
--- a/crates/sats/src/de/impls.rs
+++ b/crates/sats/src/de/impls.rs
@@ -57,6 +57,7 @@ impl_deserialize!([] (), de => de.deserialize_product(UnitVisitor));
 /// The `UnitVisitor` looks for a unit product.
 /// That is, it consumes nothing from the input.
 struct UnitVisitor;
+
 impl<'de> ProductVisitor<'de> for UnitVisitor {
     type Output = ();
 
@@ -105,6 +106,36 @@ impl_deserialize!([] Box<str>, de => String::deserialize(de).map(|s| s.into_boxe
 impl_deserialize!([T: Deserialize<'de>] Box<[T]>, de => Vec::deserialize(de).map(|s| s.into_boxed_slice()));
 impl_deserialize!([T: Deserialize<'de>] Rc<[T]>, de => Vec::deserialize(de).map(|s| s.into()));
 impl_deserialize!([T: Deserialize<'de>] Arc<[T]>, de => Vec::deserialize(de).map(|s| s.into()));
+
+impl_deserialize!([U: Deserialize<'de>, V: Deserialize<'de>] (U, V), de => de.deserialize_product(TupleVisitor::<U, V> {u: PhantomData::<U>, v: PhantomData::<V>}));
+
+struct TupleVisitor<U, V> {
+    u: PhantomData<U>,
+    v: PhantomData<V>,
+}
+
+impl<'de, U: Deserialize<'de>, V: Deserialize<'de>> ProductVisitor<'de> for TupleVisitor<U, V> {
+    type Output = (U, V);
+
+    fn product_name(&self) -> Option<&str> {
+        None
+    }
+
+    fn product_len(&self) -> usize {
+        2
+    }
+
+    fn visit_seq_product<A: SeqProductAccess<'de>>(self, mut tup: A) -> Result<Self::Output, A::Error> {
+        Ok((
+            tup.next_element().transpose().unwrap_or(Err(Error::missing_field(0, None, &self)))?,
+            tup.next_element().transpose().unwrap_or(Err(Error::missing_field(1, None, &self)))?,
+        ))
+    }
+
+    fn visit_named_product<A: super::NamedProductAccess<'de>>(self, _tup: A) -> Result<Self::Output, A::Error> {
+        Err(Error::custom("Unnamed tuple"))
+    }
+}
 
 /// The visitor converts the slice to its owned version.
 struct OwnedSliceVisitor;

--- a/crates/sats/src/ser/impls.rs
+++ b/crates/sats/src/ser/impls.rs
@@ -73,8 +73,8 @@ impl Serialize for u8 {
 
 impl_serialize!([] F32, (self, ser) => f32::from(*self).serialize(ser));
 impl_serialize!([] F64, (self, ser) => f64::from(*self).serialize(ser));
-impl_serialize!([T: Serialize] Vec<T>, (self, ser)  => (**self).serialize(ser));
-impl_serialize!([T: Serialize, const N: usize] SmallVec<[T; N]>, (self, ser)  => (**self).serialize(ser));
+impl_serialize!([T: Serialize] Vec<T>, (self, ser) => (**self).serialize(ser));
+impl_serialize!([T: Serialize, const N: usize] SmallVec<[T; N]>, (self, ser) => (**self).serialize(ser));
 impl_serialize!([T: Serialize] [T], (self, ser) => T::__serialize_array(self, ser));
 impl_serialize!([T: Serialize, const N: usize] [T; N], (self, ser) => T::__serialize_array(self, ser));
 impl_serialize!([T: Serialize + ?Sized] Box<T>, (self, ser) => (**self).serialize(ser));
@@ -123,6 +123,12 @@ impl_serialize!([] ProductValue, (self, ser) => {
     for elem in &*self.elements {
         tup.serialize_element(elem)?;
     }
+    tup.end()
+});
+impl_serialize!([U: Serialize, V: Serialize] (U, V), (self, ser) => {
+    let mut tup = ser.serialize_seq_product(2)?;
+    tup.serialize_element(&self.0)?;
+    tup.serialize_element(&self.1)?;
     tup.end()
 });
 impl_serialize!([] SumValue, (self, ser) => ser.serialize_variant(self.tag, None, &*self.value));

--- a/crates/sats/src/typespace.rs
+++ b/crates/sats/src/typespace.rs
@@ -399,9 +399,10 @@ impl_primitives! {
     String => String,
 }
 
-impl_st!([](), AlgebraicType::unit());
+impl_st!([] (), AlgebraicType::unit());
 impl_st!([] str, AlgebraicType::String);
 impl_st!([T] [T], ts => AlgebraicType::array(T::make_type(ts)));
+impl_st!([T, const N: usize] [T; N], ts => AlgebraicType::array(T::make_type(ts)));
 impl_st!([T: ?Sized] &T, ts => T::make_type(ts));
 impl_st!([T: ?Sized] Box<T>, ts => T::make_type(ts));
 impl_st!([T: ?Sized] Rc<T>, ts => T::make_type(ts));
@@ -409,6 +410,8 @@ impl_st!([T: ?Sized] Arc<T>, ts => T::make_type(ts));
 impl_st!([T] Vec<T>, ts => <[T]>::make_type(ts));
 impl_st!([T, const N: usize] SmallVec<[T; N]>, ts => <[T]>::make_type(ts));
 impl_st!([T] Option<T>, ts => AlgebraicType::option(T::make_type(ts)));
+
+impl_st!([U, V: SpacetimeType] (U, V), ts => AlgebraicType::product([U::make_type(ts), V::make_type(ts)]));
 
 impl_st!([] spacetimedb_primitives::ColId, AlgebraicType::U16);
 impl_st!([] spacetimedb_primitives::TableId, AlgebraicType::U32);


### PR DESCRIPTION
# Description of Changes

To be able to do this:
```rust
#[derive(SpacetimeType)]
pub struct Position(vecmath::Vector3<f64>);
```
(previously, the derive macro would panic.)

**This is an early attempt!** I need help in figuring out all details on how to properly implement deserialization.

Also, currently this fails with errors like these:
```rust
error at typespace ref `&1`: internal codegen error: all type elements require names: (0: Array<F64>)

error at typespace ref `&2`: internal codegen error: non-special product or sum type (0: F64, 1: Array<F64>) cannot be used to generate a client type use
```

# API and ABI breaking changes

**Unknown.**

# Expected complexity level and risk

### ?…

# Testing

- [x] SpacetimeDB compiles
- [x] The module builds
- [ ] ~Publishing works~