### PR TITLE
Disable musl builds

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,7 +16,7 @@ jobs:
         include:
           - { name: x86_64 Linux, target: x86_64-unknown-linux-gnu, runner: bare-metal, container: 'debian:bookworm' }
           - { name: aarch64 Linux, target: aarch64-unknown-linux-gnu, runner: arm-runner }
-          - { name: x86_64 Linux musl, target: x86_64-unknown-linux-musl, runner: bare-metal, container: alpine }
+          # - { name: x86_64 Linux musl, target: x86_64-unknown-linux-musl, runner: bare-metal, container: alpine }
           # FIXME: arm musl build. "JavaScript Actions in Alpine containers are only supported on x64 Linux runners"
           # - { name: aarch64 Linux musl, target: aarch64-unknown-linux-musl, runner: arm-runner }
           - { name: aarch64 macOS, target: aarch64-apple-darwin, runner: macos-latest }

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -16,6 +16,7 @@ jobs:
         include:
           - { name: x86_64 Linux, target: x86_64-unknown-linux-gnu, runner: bare-metal, container: 'debian:bookworm' }
           - { name: aarch64 Linux, target: aarch64-unknown-linux-gnu, runner: arm-runner }
+          # Disabled because musl builds weren't working and we didn't want to investigate. See https://github.com/clockworklabs/SpacetimeDB/pull/2964.
           # - { name: x86_64 Linux musl, target: x86_64-unknown-linux-musl, runner: bare-metal, container: alpine }
           # FIXME: arm musl build. "JavaScript Actions in Alpine containers are only supported on x64 Linux runners"
           # - { name: aarch64 Linux musl, target: aarch64-unknown-linux-musl, runner: arm-runner }


### PR DESCRIPTION
# Description of Changes

Disable musl builds because our new v8 dependency (https://github.com/clockworklabs/SpacetimeDB/pull/2939) is not building successfully, and we currently don't want to investigate it.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None