### PR TITLE
smoketests: Adjust for node table rename

### DIFF
--- a/smoketests/tests/replication.py
+++ b/smoketests/tests/replication.py
@@ -75,7 +75,7 @@ class Cluster:
         leader_node_id = get_int(leader_node_tb)
 
         # Query leader hostname
-        sql = f"select network_addr from node where id={leader_node_id}"
+        sql = f"select network_addr from node_v2 where id={leader_node_id}"
         leader_host_tb = str(self.read_controldb(sql))
         lines = leader_host_tb.splitlines()
 


### PR DESCRIPTION
Forgot to do this for clockworklabs/SpacetimeDBPrivate#1881

# Expected complexity level and risk

1

# Testing

- [x] yes
