### PR TITLE
ci: Skip the Unity tests if the PR is an external contribution

### DIFF
--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -142,4 +142,4 @@ jobs:
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
         # Skip if this is an external contribution.
         # The license secrets will be empty, so the step would fail anyway.
-        if: !github.event.pull_request.head.repo.fork
+        if: ${{ !github.event.pull_request.head.repo.fork }}


### PR DESCRIPTION
We don't want to leak the license information.
Alternatively, we could just make the check non-required.

# Testing

Should test by submitting a PR from a fork.
I'll do that if / when we agree that this is the right approach.