### PR TITLE
Upgrade `jemalloc_pprof` and `tempfile` crates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -935,7 +935,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "117725a109d387c937a1533ce01b450cbde6b88abceea8473c4d7a85853cda3c"
 dependencies = [
  "lazy_static",
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]
@@ -2894,15 +2894,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "itertools"
-version = "0.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
-dependencies = [
- "either",
-]
-
-[[package]]
 name = "itoa"
 version = "1.0.15"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2910,9 +2901,9 @@ checksum = "4a5f13b858c8d314ee3e8f639011f7ccefe71f97f96e50151fb991f267928e2c"
 
 [[package]]
 name = "jemalloc_pprof"
-version = "0.7.0"
+version = "0.8.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5622af6d21ff86ed7797ef98e11b8f302da25ec69a7db9f6cde8e2e1c8df9992"
+checksum = "74ff642505c7ce8d31c0d43ec0e235c6fd4585d9b8172d8f9dd04d36590200b5"
 dependencies = [
  "anyhow",
  "libc",
@@ -3156,9 +3147,9 @@ dependencies = [
 
 [[package]]
 name = "mappings"
-version = "0.7.0"
+version = "0.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e434981a332777c2b3062652d16a55f8e74fa78e6b1882633f0d77399c84fc2a"
+checksum = "db4d277bb50d4508057e7bddd7fcd19ef4a4cc38051b6a5a36868d75ae2cbeb9"
 dependencies = [
  "anyhow",
  "libc",
@@ -3954,9 +3945,9 @@ checksum = "439ee305def115ba05938db6eb1644ff94165c5ab5e9420d1c1bcedbba909391"
 
 [[package]]
 name = "pprof_util"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9fa015c78eed2130951e22c58d2095849391e73817ab2e74f71b0b9f63dd8416"
+checksum = "f9aba4251d95ac86f14c33e688d57a9344bfcff29e9b0c5a063fc66b5facc8a1"
 dependencies = [
  "anyhow",
  "backtrace",
@@ -4101,7 +4092,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools 0.11.0",
  "proc-macro2",
  "quote",
  "syn 2.0.101",
@@ -6579,9 +6570,9 @@ dependencies = [
 
 [[package]]
 name = "tempfile"
-version = "3.19.1"
+version = "3.20.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7437ac7763b9b123ccf33c338a5cc1bac6f69b45a136c19bdd8a65e3916435bf"
+checksum = "e8a64e3985349f2441a1a9ef0b853f869006c3855f2cda6862a94d26ebb9d6a1"
 dependencies = [
  "fastrand",
  "getrandom 0.3.2",
@@ -7864,7 +7855,7 @@ version = "0.1.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cf221c93e13a30d793f7645a0e7762c55d169dbb0a49671918a2319d289b10bb"
 dependencies = [
- "windows-sys 0.59.0",
+ "windows-sys 0.48.0",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -257,7 +257,7 @@ syntect = { version = "5.0.0", default-features = false, features = ["default-fa
 tabled = "0.14.0"
 tar = "0.4"
 tempdir = "0.3.7"
-tempfile = "3.8"
+tempfile = "3.20"
 termcolor = "1.2.0"
 thin-vec = "0.2.13"
 thiserror = "1.0.37"
@@ -293,7 +293,7 @@ windows-sys = "0.59"
 xdg = "2.5"
 tikv-jemallocator = { version = "0.6.0", features = ["profiling", "stats"] }
 tikv-jemalloc-ctl = { version = "0.6.0", features = ["stats"] }
-jemalloc_pprof = { version = "0.7", features = ["symbolize", "flamegraph"] }
+jemalloc_pprof = { version = "0.8", features = ["symbolize", "flamegraph"] }
 zstd-framed = { version = "0.1.1", features = ["tokio"] }
 
 # Vendor the openssl we rely on, rather than depend on a

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1708,7 +1708,7 @@ pub mod tests_utils {
     impl TempReplicaDir {
         pub fn new() -> io::Result<Self> {
             let dir = TempDir::with_prefix("stdb_test")?;
-            Ok(Self(ReplicaDir::from_path_unchecked(dir.into_path())))
+            Ok(Self(ReplicaDir::from_path_unchecked(dir.keep())))
         }
     }
     impl Deref for TempReplicaDir {

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -527,7 +527,7 @@ mod test {
     /// An `InstanceEnv` requires a `DatabaseLogger`
     fn temp_logger() -> Result<DatabaseLogger> {
         let temp = TempDir::new()?;
-        let path = ModuleLogsDir::from_path_unchecked(temp.into_path());
+        let path = ModuleLogsDir::from_path_unchecked(temp.keep());
         let path = path.today();
         Ok(DatabaseLogger::open(path))
     }

--- a/crates/testing/src/sdk.rs
+++ b/crates/testing/src/sdk.rs
@@ -22,7 +22,7 @@ pub fn ensure_standalone_process() -> &'static SpacetimePaths {
             // TODO: This leaks the tempdir.
             //       We need the tempdir to live for the duration of the process,
             //       and all the options for post-`main` cleanup seem sketchy.
-            .into_path();
+            .keep();
         SpacetimePaths::from_root_dir(&RootDir(dir))
     });
 


### PR DESCRIPTION
We run `cargo update` in CI before testing the bindings, in order to
catch dependency issues for library users (which don't get dependency
pinning via our `Cargo.lock` file).

This turned up two issues, resolved here:

- `jemalloc_pprof` depends on `pprof_util` both directly and indirectly
  via `mappings`. Using the `^0.7` version constraint causes conflicting
  versions of `pprof_util` to be resolved.

  Upgrade to `^0.8` to resolve the issue.

- `tempfile` started to mark `TempDir::into_path` as deprecated in favor
  of the newly exported `TempDir::keep`, so bump to the latest version
  (recall that `3.20` is semver-compatible with `3.8`).


# Expected complexity level and risk

1

# Testing

- [x] "Build and test wasm bindings" CI check should pass
