### PR TITLE
smoketests: Make gathering container ports None-safe

### DIFF
--- a/smoketests/docker.py
+++ b/smoketests/docker.py
@@ -57,11 +57,12 @@ class DockerContainer:
         """
         host_ports = set()
         info = docker.inspect_container(self)
-        for ports in info['NetworkSettings']['Ports'].values():
-            for ip_and_port in ports:
-                host_port = ip_and_port.get("HostPort")
-                if host_port:
-                    host_ports.add(host_port)
+        for ports in info.get('NetworkSettings', {}).get('Ports', {}).values():
+            if ports:
+                for ip_and_port in ports:
+                    host_port = ip_and_port.get("HostPort")
+                    if host_port:
+                        host_ports.add(host_port)
         return host_ports
 
     def is_running(self, docker, ping_url: Callable[[int], str]) -> bool:


### PR DESCRIPTION
Python has a funny way of dealing with absent values.

Fixes (again) restart tests to handle slowly restarting containers.

# Expected complexity level and risk

1

# Testing

n/a