### PR TITLE
Bump C#/Unity Client SDK versions to 1.2.2

### DIFF
--- a/sdks/csharp/SpacetimeDB.ClientSDK.csproj
+++ b/sdks/csharp/SpacetimeDB.ClientSDK.csproj
@@ -16,8 +16,8 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk</RepositoryUrl>
-    <AssemblyVersion>1.2.1</AssemblyVersion>
-    <Version>1.2.1</Version>
+    <AssemblyVersion>1.2.2</AssemblyVersion>
+    <Version>1.2.2</Version>
     <DefaultItemExcludes>$(DefaultItemExcludes);*~/**</DefaultItemExcludes>
     <!-- We want to save DLLs for Unity which doesn't support NuGet. -->
     <RestorePackagesPath>packages</RestorePackagesPath>

--- a/sdks/csharp/package.json
+++ b/sdks/csharp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.clockworklabs.spacetimedbsdk",
   "displayName": "SpacetimeDB SDK",
-  "version": "1.2.1",
+  "version": "1.2.2",
   "description": "The SpacetimeDB Client SDK is a software development kit (SDK) designed to interact with and manipulate SpacetimeDB modules..",
   "keywords": [],
   "author": {


### PR DESCRIPTION
# Description of Changes

I ran `python3 tools~/upgrade-version.py 1.2.2` in preparation for an upcoming release.

# API and ABI breaking changes

None

# Expected complexity level and risk

1
# Testing

None, just a version bump.