### PR TITLE
Add additional logging to subscribe route and simplify calling `client_connected`

### DIFF
--- a/crates/client-api/src/routes/subscribe.rs
+++ b/crates/client-api/src/routes/subscribe.rs
@@ -145,7 +145,7 @@ where
 
     let identity_token = auth.creds.token().into();
 
-    let module_rx = leader.module_watcher().await.map_err(log_and_500)?;
+    let mut module_rx = leader.module_watcher().await.map_err(log_and_500)?;
 
     let client_id = ClientActorId {
         identity: auth.identity,
@@ -168,26 +168,36 @@ where
             }
         };
 
-        match forwarded_for {
+        let identity = client_id.identity;
+        let client_log_string = match forwarded_for {
             Some(TypedHeader(XForwardedFor(ip))) => {
-                log::debug!("New client connected from ip {ip}")
+                format!("ip {ip} with Identity {identity} and ConnectionId {connection_id}")
             }
-            None => log::debug!("New client connected from unknown ip"),
-        }
+            None => format!("unknown ip with Identity {identity} and ConnectionId {connection_id}"),
+        };
 
-        let actor = |client, sendrx| ws_client_actor(ws_opts, client, ws, sendrx);
-        let client = match ClientConnection::spawn(client_id, client_config, leader.replica_id, module_rx, actor).await
-        {
-            Ok(s) => s,
+        log::debug!("New client connected from {client_log_string}");
+
+        match ClientConnection::call_client_connected_maybe_reject(&mut module_rx, client_id).await {
+            Ok(()) => log::info!("client_connected returned Ok for {client_log_string}"),
             Err(e @ (ClientConnectedError::Rejected(_) | ClientConnectedError::OutOfEnergy)) => {
-                log::info!("{e}");
+                log::info!(
+                    "Rejecting connection for {client_log_string} due to error from client_connected reducer: {e}"
+                );
                 return;
             }
             Err(e @ (ClientConnectedError::DBError(_) | ClientConnectedError::ReducerCall(_))) => {
-                log::warn!("ModuleHost died while we were connecting: {e:#}");
+                log::warn!("ModuleHost died while {client_log_string} was connecting: {e:#}");
                 return;
             }
-        };
+        }
+
+        log::debug!(
+            "Database accepted connection from {client_log_string}; spawning ws_client_actor and ClientConnection"
+        );
+
+        let actor = |client, sendrx| ws_client_actor(ws_opts, client, ws, sendrx);
+        let client = ClientConnection::spawn(client_id, client_config, leader.replica_id, module_rx, actor).await;
 
         // Send the client their identity token message as the first message
         // NOTE: We're adding this to the protocol because some client libraries are
@@ -200,7 +210,7 @@ where
             connection_id,
         };
         if let Err(e) = client.send_message(message) {
-            log::warn!("{e}, before identity token was sent")
+            log::warn!("Error sending IdentityToken message to {client_log_string}: {e}");
         }
     });
 


### PR DESCRIPTION
# Description of Changes

Out-of-band discussions with the BitCraft team brought up questions about whether it was possible for a rejected client connection to start an expensive computation like a subscription before their connection was killed, e.g. by sending a `Subscribe` message along the WebSocket before `client_connected` had finished returning `Err`.

I don't believe this was actually possible, as `ClientConnection::spawn` called and awaited `call_identity_connected` before invoking its `actor` closure, and it was that `actor` which processed `Subscribe` messages. But it was somewhat difficult to verify that behavior, and so I re-organized the code so that the outer layer of the `subscribe` handler obviously had that property without having to step into `ClientConnection::spawn`.

I also added some additional logging to the subscribe route, including the `X-Forwarded-For` header in more messages, as the BitCraft team complained about having difficulty correlating IP addresses with connections. The log levels remain the same as before, just with additional information added:

- Successful connections are at `debug` level,
- Rejected connections are at `info` level (these are the ones BitCraft cares about in this case).
- Failed connections are at `warn`.

As the levels are unchanged, this should not add undesirable log noise.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

3? The `subscribe` route was complex and remains so. I believe this change simplifies the code and makes the logic more obvious, but reviewers should take care to verify that the behavior actually is equivalent as I believe.

# Testing

- [ ] I would like a test deployment of BitCraft to staging or something, or to include this patch in the next bot test that we do anyways, just for sanity's sake.