### PR TITLE
CI - C#/Unity test suite concurrency improvements

### DIFF
--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -7,8 +7,40 @@ on:
   pull_request:
 
 jobs:
-  unity-testsuite:
+  # The unity testsuite will fail if we try to run too many at once, due to the limited number of license seats.
+  # This job "gates" our testsuite runs by waiting until there's room to run.
+  gate:
+    # This prevents more than one gate check from running at once, to prevent potential race conditions.
+    concurrency:
+      group: unity-test-workflow-gate
+      cancel-in-progress: false
     runs-on: ubuntu-latest
+    steps:
+      - name: Wait until <2 workflows running
+        run: |
+          while true; do
+            running=$(gh run list \
+              --workflow "${GITHUB_WORKFLOW}" \
+              --status in_progress \
+              --json status \
+              | jq 'length')
+            if [ "$running" -lt 2 ]; then
+              echo "Allowed to run"
+              break
+            fi
+            echo "2 workflows running. Waiting..."
+            sleep 30
+          done
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+
+  unity-testsuite:
+    needs: gate
+    runs-on: ubuntu-latest
+    # Cancel any previous testsuites running on the same PR and/or ref.
+    concurrency:
+      group: ci-${{ github.event.pull_request.number || github.ref }}
+      cancel-in-progress: true
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description of Changes

Two main changes:
1. Prevent more than 2 unity testsuites from running at once
2. New test suite runs will cancel existing in-progress runs on the same PR or github ref

# API and ABI breaking changes

None. CI-only change.

# Expected complexity level and risk

1

# Testing
- [ ] Test suite still runs and succeeds
- [ ] If I push several commits in a row, previous runs get cancelled
- [ ] If I remove the "cancel previous" behavior and then push several commits, only 2 will run at once