### PR TITLE
CI - Set Unity testsuite timeout to 30m

### DIFF
--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -13,6 +13,7 @@ jobs:
     concurrency:
       group: unity-test-${{ github.event.pull_request.number || github.ref }}
       cancel-in-progress: true
+    timeout-minutes: 30
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4


### PR DESCRIPTION
# Description of Changes

Just what it says on the can. This test suite can sometimes mysteriously hang for a long time, so a timeout will help kill this (and free up resources) earlier.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None really. I guess I could test this by adding a step that just sleeps forever, but this is basically just setting some data.