### PR TITLE
Blackholio - Hide generated files from diffs

### DIFF
--- a/demo/Blackholio/client-unity/.gitattributes
+++ b/demo/Blackholio/client-unity/.gitattributes
@@ -1,0 +1,1 @@
+/Assets/Scripts/autogen/** linguist-generated=true

--- a/demo/Blackholio/client-unity/Assets/Scripts/autogen/SpacetimeDBClient.g.cs
+++ b/demo/Blackholio/client-unity/Assets/Scripts/autogen/SpacetimeDBClient.g.cs
@@ -6,10 +6,6 @@
 #nullable enable
 
 using System;
-using SpacetimeDB.ClientApi;
-using System.Collections.Generic;
-using System.Runtime.Serialization;
-
 namespace SpacetimeDB.Types
 {
     public sealed partial class RemoteReducers : RemoteBase

--- a/demo/Blackholio/client-unity/Assets/Scripts/autogen/SpacetimeDBClient.g.cs
+++ b/demo/Blackholio/client-unity/Assets/Scripts/autogen/SpacetimeDBClient.g.cs
@@ -6,6 +6,10 @@
 #nullable enable
 
 using System;
+using SpacetimeDB.ClientApi;
+using System.Collections.Generic;
+using System.Runtime.Serialization;
+
 namespace SpacetimeDB.Types
 {
     public sealed partial class RemoteReducers : RemoteBase


### PR DESCRIPTION
# Description of Changes

Just add a `.gitattributes` file that hide Blackholio autogenerated files from GitHub diffs

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] If I change one of the autogenerated files, it's hidden: https://github.com/clockworklabs/SpacetimeDB/pull/3119/files/8601b4d5316c66f91a2555e720fcfeb01b3241db