### PR TITLE
TypeScript - Bump version to 1.3.1 for release

### DIFF
--- a/sdks/typescript/packages/sdk/package.json
+++ b/sdks/typescript/packages/sdk/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@clockworklabs/spacetimedb-sdk",
-  "version": "1.3.0",
+  "version": "1.3.1",
   "description": "SDK for SpacetimeDB",
   "author": {
     "name": "Clockwork Labs",


### PR DESCRIPTION
# Description of Changes

We want to release #2980 for the TS SDK, so I'm bumping our version number.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None, just a version bump.