### PR TITLE
Add repo migration notice workflows

### DIFF
--- a/demo/Blackholio/.github/workflows/repo-migration-notice.yml
+++ b/demo/Blackholio/.github/workflows/repo-migration-notice.yml
@@ -16,6 +16,7 @@ jobs:
         env:
           migrated_repo: https://github.com/ClockworkLabs/SpacetimeDB
           migrated_path: demo/Blackholio
+          default_branch: master
         with:
           script: |
             const isPR = context.eventName === 'pull_request';
@@ -26,7 +27,7 @@ jobs:
               message = `
               Thank you for submitting this!
 
-              We are in the process of migrating this repository (see [DEVELOP.md](../blob/master/DEVELOP.md)).
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/${process.env.default_branch}/DEVELOP.md)).
 
               To make sure we see your PR, please open it in the [SpacetimeDB](${process.env.migrated_repo}) repo, under [${process.env.migrated_path}](${process.env.migrated_repo}/tree/master/${process.env.migrated_path}).
 
@@ -36,7 +37,7 @@ jobs:
               message = `
               Thank you for submitting this!
 
-              We are in the process of migrating this repository (see [DEVELOP.md](../blob/master/DEVELOP.md)).
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/${process.env.default_branch}/DEVELOP.md)).
 
               To make sure we actually see your issue, please open it here: [SpacetimeDB/issues/new](${process.env.migrated_repo}/issues/new).
 

--- a/demo/Blackholio/.github/workflows/repo-migration-notice.yml
+++ b/demo/Blackholio/.github/workflows/repo-migration-notice.yml
@@ -1,0 +1,59 @@
+name: Repo migration notice
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add comment
+        uses: actions/github-script@v7
+        env:
+          migrated_repo: https://github.com/ClockworkLabs/SpacetimeDB
+          migrated_path: demo/Blackholio
+        with:
+          script: |
+            const isPR = context.eventName === 'pull_request';
+            const number = isPR ? context.payload.pull_request.number : context.payload.issue.number;
+
+            let message;
+            if (isPR) {
+              message = `
+              Thank you for submitting this!
+
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/master/DEVELOP.md)).
+
+              To make sure we see your PR, please open it in the [SpacetimeDB](${process.env.migrated_repo}) repo, under [${process.env.migrated_path}](${process.env.migrated_repo}/tree/master/${process.env.migrated_path}).
+
+              Apologies for the inconvenience, and thank you again!
+              `;
+            } else {
+              message = `
+              Thank you for submitting this!
+
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/master/DEVELOP.md)).
+
+              To make sure we actually see your issue, please open it here: [SpacetimeDB/issues/new](${process.env.migrated_repo}/issues/new).
+
+              Apologies for the inconvenience, and thank you again!
+              `;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: message
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              state: 'closed'
+            });

--- a/docs/.github/workflows/repo-migration-notice.yml
+++ b/docs/.github/workflows/repo-migration-notice.yml
@@ -16,6 +16,7 @@ jobs:
         env:
           migrated_repo: https://github.com/ClockworkLabs/SpacetimeDB
           migrated_path: docs
+          default_branch: master
         with:
           script: |
             const isPR = context.eventName === 'pull_request';
@@ -26,7 +27,7 @@ jobs:
               message = `
               Thank you for submitting this!
 
-              We are in the process of migrating this repository (see [README.md](../blob/master/README.md)).
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/${process.env.default_branch}/DEVELOP.md)).
 
               To make sure we see your PR, please open it in the [SpacetimeDB](${process.env.migrated_repo}) repo, under [${process.env.migrated_path}](${process.env.migrated_repo}/tree/master/${process.env.migrated_path}).
 
@@ -36,7 +37,7 @@ jobs:
               message = `
               Thank you for submitting this!
 
-              We are in the process of migrating this repository (see [README.md](../blob/master/README.md)).
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/${process.env.default_branch}/DEVELOP.md)).
 
               To make sure we actually see your issue, please open it here: [SpacetimeDB/issues/new](${process.env.migrated_repo}/issues/new).
 

--- a/docs/.github/workflows/repo-migration-notice.yml
+++ b/docs/.github/workflows/repo-migration-notice.yml
@@ -1,0 +1,59 @@
+name: Repo migration notice
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add comment
+        uses: actions/github-script@v7
+        env:
+          migrated_repo: https://github.com/ClockworkLabs/SpacetimeDB
+          migrated_path: docs
+        with:
+          script: |
+            const isPR = context.eventName === 'pull_request';
+            const number = isPR ? context.payload.pull_request.number : context.payload.issue.number;
+
+            let message;
+            if (isPR) {
+              message = `
+              Thank you for submitting this!
+
+              We are in the process of migrating this repository (see [README.md](../blob/master/README.md)).
+
+              To make sure we see your PR, please open it in the [SpacetimeDB](${process.env.migrated_repo}) repo, under [${process.env.migrated_path}](${process.env.migrated_repo}/tree/master/${process.env.migrated_path}).
+
+              Apologies for the inconvenience, and thank you again!
+              `;
+            } else {
+              message = `
+              Thank you for submitting this!
+
+              We are in the process of migrating this repository (see [README.md](../blob/master/README.md)).
+
+              To make sure we actually see your issue, please open it here: [SpacetimeDB/issues/new](${process.env.migrated_repo}/issues/new).
+
+              Apologies for the inconvenience, and thank you again!
+              `;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: message
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              state: 'closed'
+            });

--- a/sdks/csharp/.github/workflows/repo-migration-notice.yml
+++ b/sdks/csharp/.github/workflows/repo-migration-notice.yml
@@ -16,6 +16,7 @@ jobs:
         env:
           migrated_repo: https://github.com/ClockworkLabs/SpacetimeDB
           migrated_path: sdks/csharp
+          default_branch: release/latest
         with:
           script: |
             const isPR = context.eventName === 'pull_request';
@@ -26,7 +27,7 @@ jobs:
               message = `
               Thank you for submitting this!
 
-              We are in the process of migrating this repository (see [DEVELOP.md](../blob/release/latest/DEVELOP.md)).
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/${process.env.default_branch}/DEVELOP.md)).
 
               To make sure we see your PR, please open it in the [SpacetimeDB](${process.env.migrated_repo}) repo, under [${process.env.migrated_path}](${process.env.migrated_repo}/tree/master/${process.env.migrated_path}).
 
@@ -36,7 +37,7 @@ jobs:
               message = `
               Thank you for submitting this!
 
-              We are in the process of migrating this repository (see [DEVELOP.md](../blob/release/latest/DEVELOP.md)).
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/${process.env.default_branch}/DEVELOP.md)).
 
               To make sure we actually see your issue, please open it here: [SpacetimeDB/issues/new](${process.env.migrated_repo}/issues/new).
 

--- a/sdks/csharp/.github/workflows/repo-migration-notice.yml
+++ b/sdks/csharp/.github/workflows/repo-migration-notice.yml
@@ -1,0 +1,59 @@
+name: Repo migration notice
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add comment
+        uses: actions/github-script@v7
+        env:
+          migrated_repo: https://github.com/ClockworkLabs/SpacetimeDB
+          migrated_path: sdks/csharp
+        with:
+          script: |
+            const isPR = context.eventName === 'pull_request';
+            const number = isPR ? context.payload.pull_request.number : context.payload.issue.number;
+
+            let message;
+            if (isPR) {
+              message = `
+              Thank you for submitting this!
+
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/release/latest/DEVELOP.md)).
+
+              To make sure we see your PR, please open it in the [SpacetimeDB](${process.env.migrated_repo}) repo, under [${process.env.migrated_path}](${process.env.migrated_repo}/tree/master/${process.env.migrated_path}).
+
+              Apologies for the inconvenience, and thank you again!
+              `;
+            } else {
+              message = `
+              Thank you for submitting this!
+
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/release/latest/DEVELOP.md)).
+
+              To make sure we actually see your issue, please open it here: [SpacetimeDB/issues/new](${process.env.migrated_repo}/issues/new).
+
+              Apologies for the inconvenience, and thank you again!
+              `;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: message
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              state: 'closed'
+            });

--- a/sdks/typescript/.github/workflows/repo-migration-notice.yml
+++ b/sdks/typescript/.github/workflows/repo-migration-notice.yml
@@ -1,0 +1,59 @@
+name: Repo migration notice
+
+on:
+  issues:
+    types: [opened]
+  pull_request:
+    types: [opened]
+
+jobs:
+  comment:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Add comment
+        uses: actions/github-script@v7
+        env:
+          migrated_repo: https://github.com/ClockworkLabs/SpacetimeDB
+          migrated_path: sdks/typescript
+        with:
+          script: |
+            const isPR = context.eventName === 'pull_request';
+            const number = isPR ? context.payload.pull_request.number : context.payload.issue.number;
+
+            let message;
+            if (isPR) {
+              message = `
+              Thank you for submitting this!
+
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/main/DEVELOP.md)).
+
+              To make sure we see your PR, please open it in the [SpacetimeDB](${process.env.migrated_repo}) repo, under [${process.env.migrated_path}](${process.env.migrated_repo}/tree/master/${process.env.migrated_path}).
+
+              Apologies for the inconvenience, and thank you again!
+              `;
+            } else {
+              message = `
+              Thank you for submitting this!
+
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/main/DEVELOP.md)).
+
+              To make sure we actually see your issue, please open it here: [SpacetimeDB/issues/new](${process.env.migrated_repo}/issues/new).
+
+              Apologies for the inconvenience, and thank you again!
+              `;
+            }
+
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              body: message
+            });
+
+            await github.rest.issues.update({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: number,
+              state: 'closed'
+            });

--- a/sdks/typescript/.github/workflows/repo-migration-notice.yml
+++ b/sdks/typescript/.github/workflows/repo-migration-notice.yml
@@ -16,6 +16,7 @@ jobs:
         env:
           migrated_repo: https://github.com/ClockworkLabs/SpacetimeDB
           migrated_path: sdks/typescript
+          default_branch: main
         with:
           script: |
             const isPR = context.eventName === 'pull_request';
@@ -26,7 +27,7 @@ jobs:
               message = `
               Thank you for submitting this!
 
-              We are in the process of migrating this repository (see [DEVELOP.md](../blob/main/DEVELOP.md)).
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/${process.env.default_branch}/DEVELOP.md)).
 
               To make sure we see your PR, please open it in the [SpacetimeDB](${process.env.migrated_repo}) repo, under [${process.env.migrated_path}](${process.env.migrated_repo}/tree/master/${process.env.migrated_path}).
 
@@ -36,7 +37,7 @@ jobs:
               message = `
               Thank you for submitting this!
 
-              We are in the process of migrating this repository (see [DEVELOP.md](../blob/main/DEVELOP.md)).
+              We are in the process of migrating this repository (see [DEVELOP.md](../blob/${process.env.default_branch}/DEVELOP.md)).
 
               To make sure we actually see your issue, please open it here: [SpacetimeDB/issues/new](${process.env.migrated_repo}/issues/new).
 


### PR DESCRIPTION
# Description of Changes

Added a repo migration notice to each repository that we've merged into SpacetimeDB.

These need to be mirrored back to the actual repos with a process like:
```bash
git subtree split --prefix=sdks/typescript -b release/typescript
git push -f git@github.com:clockworklabs/spacetimedb-typescript-sdk.git release/typescript:main
git branch -D release/typescript
```

# API and ABI breaking changes

None. CI-only changes.

# Expected complexity level and risk

2

# Testing

- [x] In a demo repo, it properly commented and closed a PR: https://github.com/clockworklabs/github-tooling-test/pull/42
- [x] In a demo repo, it properly commented and closed an issue: https://github.com/clockworklabs/github-tooling-test/issues/43