### PR TITLE
commitlog: Provide folding over a range of tx offsets

### DIFF
--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -1,6 +1,7 @@
 use std::{
     io,
     num::{NonZeroU16, NonZeroU64},
+    ops::RangeBounds,
     sync::RwLock,
 };
 
@@ -608,4 +609,12 @@ where
     D::Error: From<error::Traversal> + From<io::Error>,
 {
     commitlog::fold_transactions_from(repo::Fs::new(root)?, DEFAULT_LOG_FORMAT_VERSION, offset, de)
+}
+
+pub fn fold_transaction_range<D>(root: CommitLogDir, range: impl RangeBounds<u64>, de: D) -> Result<(), D::Error>
+where
+    D: Decoder,
+    D::Error: From<error::Traversal> + From<io::Error>,
+{
+    commitlog::fold_transaction_range(repo::Fs::new(root)?, DEFAULT_LOG_FORMAT_VERSION, range, de)
 }


### PR DESCRIPTION
Adds methods and free-standing functions to allow folds to stop at an upper
bound, by passing a range instead of only a start offset.

# Expected complexity level and risk

1

# Testing

