### PR TITLE
Drop log for already-compressed snapshot to debug

### DIFF
--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -940,7 +940,7 @@ impl SnapshotRepository {
         let (snapshot, compress_type) = Snapshot::read_from_file(&snapshot_file)?;
 
         if compress_type != CompressType::None {
-            log::info!(
+            log::debug!(
                 "Snapshot {snapshot_dir:?} of replica {} is already compressed: {compress_type:?}",
                 snapshot.replica_id
             );


### PR DESCRIPTION
# Description of Changes

On databases with many already-compressed snapshots, this was leading to log spam without providing any useful information.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

N/a