### PR TITLE
Add "How to compile" section to Rust quickstart

### DIFF
--- a/docs/docs/modules/rust/quickstart.md
+++ b/docs/docs/modules/rust/quickstart.md
@@ -44,6 +44,17 @@ Now create `server`, our module, which runs in the database:
 spacetime init --lang rust server
 ```
 
+## How to Compile
+
+> [!IMPORTANT]
+> You cannot use the traditional `cargo build` to build SpacetimeDB server modules. Keep this in mind when using an IDE that assumes using *cargo* for building. 
+Above, we just initialized a SpacetimeDB server module at `./server`:
+
+```bash
+cd server
+spacetime build
+```
+
 ## Declare imports
 
 `spacetime init` should have pre-populated `server/src/lib.rs` with a trivial module. Clear it out so we can write a new, simple module: a bare-bones chat server.


### PR DESCRIPTION
# Description of Changes

Migrate https://github.com/clockworklabs/spacetime-docs/pull/45.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None