### PR TITLE
C#/Unity SDK - Added Unit Test that checks the BTreeIndexBase Column implements IComparable

### DIFF
--- a/sdks/csharp/tests~/Tests.cs
+++ b/sdks/csharp/tests~/Tests.cs
@@ -81,7 +81,7 @@ public class Tests
         Assert.False(GenericEqualityComparer.Instance.Equals(statusFailed, statusFailedUnequalValue));
         Assert.False(GenericEqualityComparer.Instance.Equals(statusCommitted, statusOutOfEnergy));
     }
-    
+
     public class BTreeIndexBaseColumnImplementsIComparableTest
     {
 
@@ -103,7 +103,7 @@ public class Tests
                 Identity = new(this);
             }
         }
-        
+
         [Fact]
         public void Identity_ShouldImplementIComparable()
         {


### PR DESCRIPTION
# Description of Changes

Migrating "https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/277" since we are merging that repo into this one.

> Adds a test to [com.clockworklabs.spacetimedbsdk](https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/tree/master) that checks if the BTreeIndexBase class Column implements the IComparable interface. This is the implementation side of issue https://github.com/clockworklabs/SpacetimeDB/issues/2362.

# API and ABI breaking changes

>  - [x] This is an API breaking change to the SDK

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

> - [X] Ran `dotnet test`, all checks pass.
