### PR TITLE
C#/Unity SDK - Add expiration for stored request durations

### DIFF
--- a/sdks/csharp/tests~/VerifyInit.cs
+++ b/sdks/csharp/tests~/VerifyInit.cs
@@ -56,7 +56,7 @@ static class VerifyInit
             }
 
             if (
-                value.GetMinMaxTimes(int.MaxValue) is
+                value.GetMinMaxTimes(60) is
                 { Min.Metadata: var Min, Max.Metadata: var Max }
             )
             {


### PR DESCRIPTION
# Description of Changes

Migrating https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk/pull/193 since we are merging that repo into this one.

> This adds configurable expiration time for request durations. This is to prevent memory leak in long-running applications where otherwise the queue would only keep growing indefinitely.

# API and ABI breaking changes

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
