### PR TITLE
Typescript SDK: Fix to actually use the passed onclose function

### DIFF
--- a/sdks/typescript/packages/sdk/src/websocket_decompress_adapter.ts
+++ b/sdks/typescript/packages/sdk/src/websocket_decompress_adapter.ts
@@ -37,6 +37,10 @@ export class WebsocketDecompressAdapter {
     this.onerror?.(msg);
   }
 
+  #handleOnClose(msg: any) {
+    this.onclose?.(msg);
+  }
+
   send(msg: any): void {
     this.#ws.send(msg);
   }
@@ -53,7 +57,7 @@ export class WebsocketDecompressAdapter {
 
     ws.onmessage = this.#handleOnMessage.bind(this);
     ws.onerror = this.#handleOnError.bind(this);
-    ws.onclose = this.#handleOnError.bind(this);
+    ws.onclose = this.#handleOnClose.bind(this);
     ws.onopen = this.#handleOnOpen.bind(this);
 
     ws.binaryType = 'arraybuffer';


### PR DESCRIPTION
# Description of Changes

Fixes a Typescript SDK bug where onclose of WebsocketDecompressAdapter is never called

# API and ABI breaking changes
None
<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

Potential risk as Typescript SDK consumers might be currently relying only on onConnectError to report disconnection. Users should instead use onDisconnect, or can simply subscribe to both callbacks with the same function again to get the same functionality. 

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->
This is a trivial change, but could have minor repercussions on current code. I'd still say it's a level 1 change, with consumers able to easily change to the correct callback.
# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->


