### PR TITLE
Uncommented out 'delete by index' test code

### DIFF
--- a/modules/module-test-cs/Lib.cs
+++ b/modules/module-test-cs/Lib.cs
@@ -294,12 +294,11 @@ static partial class Module
         var rowCountBeforeDelete = ctx.Db.test_a.Count;
         Log.Info($"Row count before delete: {rowCountBeforeDelete}");
 
-        uint numDeleted = 0;
+        ulong numDeleted = 0;
         // Delete rows using the "foo" index (from 5 up to, but not including, 10).
         for (uint row = 5; row < 10; row++)
         {
-            // FIXME: Apparently in Rust you can delete by index, but in C# you can't.
-            // numDeleted += ctx.Db.test_a.foo.Delete(row);
+            numDeleted += ctx.Db.test_a.foo.Delete(row);
         }
 
         var rowCountAfterDelete = ctx.Db.test_a.Count;


### PR DESCRIPTION
# Description of Changes

Uncommented out code from test, in order to have "delete row by index" test of C# module code ran.
This is the implementation of a fix for issue https://github.com/clockworklabs/SpacetimeDB/issues/2233

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [X] Ran `dotnet run` and `dotnet test`, both returned no errors.
