### PR TITLE
Add a RemoteQuery regression test to C# SDK

### DIFF
--- a/sdks/csharp/examples~/regression-tests/client/Program.cs
+++ b/sdks/csharp/examples~/regression-tests/client/Program.cs
@@ -118,6 +118,11 @@ void OnSubscriptionApplied(SubscriptionEventContext context)
     Log.Debug("Calling ThrowError");
     waiting++;
     context.Reducers.ThrowError("this is an error");
+    
+    // RemoteQuery test
+    Log.Debug("Calling RemoteQuery");
+    var remoteRows = context.Db.ExampleData.RemoteQuery("WHERE Id = 1").Result;
+    Debug.Assert(remoteRows != null && remoteRows.Length > 0);
 
     // Now unsubscribe and check that the unsubscribe is actually applied.
     Log.Debug("Calling Unsubscribe");


### PR DESCRIPTION
# Description of Changes

Add a RemoteQuery regression test to C# SDK to address issue: https://github.com/clockworklabs/SpacetimeDB/issues/3064
This adds on to existing regression tests, creating a rather small change.

# API and ABI breaking changes

Not breaking change

# Expected complexity level and risk

1

# Testing

- [X] Ran `dotnet test`, all tests pass
