### PR TITLE
Increase default `incoming_queue_length` limit, log warning when a client violates it

### DIFF
--- a/crates/client-api/src/routes/subscribe.rs
+++ b/crates/client-api/src/routes/subscribe.rs
@@ -296,7 +296,7 @@ pub struct WebSocketOptions {
     ///
     /// If this number is exceeded, the client is disconnected.
     ///
-    /// Default: 2048
+    /// Default: 16384
     #[serde(default = "WebSocketOptions::default_incoming_queue_length")]
     pub incoming_queue_length: NonZeroUsize,
 }
@@ -311,7 +311,7 @@ impl WebSocketOptions {
     const DEFAULT_PING_INTERVAL: Duration = Duration::from_secs(15);
     const DEFAULT_IDLE_TIMEOUT: Duration = Duration::from_secs(30);
     const DEFAULT_CLOSE_HANDSHAKE_TIMEOUT: Duration = Duration::from_millis(250);
-    const DEFAULT_INCOMING_QUEUE_LENGTH: NonZeroUsize = NonZeroUsize::new(2048).expect("2048 > 0, qed");
+    const DEFAULT_INCOMING_QUEUE_LENGTH: NonZeroUsize = NonZeroUsize::new(16384).expect("16384 > 0, qed");
 
     const DEFAULT: Self = Self {
         ping_interval: Self::DEFAULT_PING_INTERVAL,


### PR DESCRIPTION
# Description of Changes

Closes #3170 .

Commit messages:

### Increase the default incoming-queue-length limit

2048 turned out to be too low a value for BitCraft, as their world upload process requests on the order of 6000 reducers very rapidly. We still feel that having a limit is valuable to prevent malicious or misguided clients from taking an arbitrarily large amount of host memory, so we bump the value to give us a wide safety error for BitCraft's needs but don't remove the limit entirely.

### Add log at `warn` when the host disconnects a client due to too many requests

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

- [x] @mamcx to run a BitCraft bot test.