### PR TITLE
Updated C# quickstart-chat to pattern match variable assignment

### DIFF
--- a/docs/docs/modules/c-sharp/quickstart.md
+++ b/docs/docs/modules/c-sharp/quickstart.md
@@ -120,8 +120,7 @@ public static void SetName(ReducerContext ctx, string name)
 {
     name = ValidateName(name);
 
-    var user = ctx.Db.user.Identity.Find(ctx.Sender);
-    if (user is not null)
+    if (ctx.Db.user.Identity.Find(ctx.Sender) is User user)
     {
         user.Name = name;
         ctx.Db.user.Identity.Update(user);
@@ -208,9 +207,8 @@ In `server/Lib.cs`, add the definition of the connect reducer to the `Module` cl
 public static void ClientConnected(ReducerContext ctx)
 {
     Log.Info($"Connect {ctx.Sender}");
-    var user = ctx.Db.user.Identity.Find(ctx.Sender);
-
-    if (user is not null)
+    
+    if (ctx.Db.user.Identity.Find(ctx.Sender) is User user)
     {
         // If this is a returning user, i.e., we already have a `User` with this `Identity`,
         // set `Online: true`, but leave `Name` and `Identity` unchanged.
@@ -241,9 +239,7 @@ Add the following code after the `OnConnect` handler:
 [Reducer(ReducerKind.ClientDisconnected)]
 public static void ClientDisconnected(ReducerContext ctx)
 {
-    var user = ctx.Db.user.Identity.Find(ctx.Sender);
-
-    if (user is not null)
+    if (ctx.Db.user.Identity.Find(ctx.Sender) is User user)
     {
         // This user should exist, so set `Online: false`.
         user.Online = false;

--- a/sdks/csharp/examples~/quickstart-chat/server/Lib.cs
+++ b/sdks/csharp/examples~/quickstart-chat/server/Lib.cs
@@ -10,7 +10,7 @@ public static partial class Module
         public string? Name;
         public bool Online;
     }
-    
+
     [Table(Name = "message", Public = true)]
     public partial class Message
     {
@@ -18,20 +18,19 @@ public static partial class Module
         public Timestamp Sent;
         public string Text = "";
     }
-    
+
     [Reducer]
     public static void SetName(ReducerContext ctx, string name)
     {
         name = ValidateName(name);
 
-        var user = ctx.Db.user.Identity.Find(ctx.Sender);
-        if (user is not null)
+        if (ctx.Db.user.Identity.Find(ctx.Sender) is User user)
         {
             user.Name = name;
             ctx.Db.user.Identity.Update(user);
         }
     }
-    
+
     /// Takes a name and checks if it's acceptable as a user's name.
     private static string ValidateName(string name)
     {
@@ -41,7 +40,7 @@ public static partial class Module
         }
         return name;
     }
-    
+
     [Reducer]
     public static void SendMessage(ReducerContext ctx, string text)
     {
@@ -56,7 +55,7 @@ public static partial class Module
             }
         );
     }
-    
+
     /// Takes a message's text and checks if it's acceptable to send.
     private static string ValidateMessage(string text)
     {
@@ -66,14 +65,13 @@ public static partial class Module
         }
         return text;
     }
-    
+
     [Reducer(ReducerKind.ClientConnected)]
     public static void ClientConnected(ReducerContext ctx)
     {
         Log.Info($"Connect {ctx.Sender}");
-        var user = ctx.Db.user.Identity.Find(ctx.Sender);
 
-        if (user is not null)
+        if (ctx.Db.user.Identity.Find(ctx.Sender) is User user)
         {
             // If this is a returning user, i.e., we already have a `User` with this `Identity`,
             // set `Online: true`, but leave `Name` and `Identity` unchanged.
@@ -94,13 +92,11 @@ public static partial class Module
             );
         }
     }
-    
+
     [Reducer(ReducerKind.ClientDisconnected)]
     public static void ClientDisconnected(ReducerContext ctx)
     {
-        var user = ctx.Db.user.Identity.Find(ctx.Sender);
-
-        if (user is not null)
+        if (ctx.Db.user.Identity.Find(ctx.Sender) is User user)
         {
             // This user should exist, so set `Online: false`.
             user.Online = false;


### PR DESCRIPTION
# Description of Changes

To address user issue https://github.com/clockworklabs/SpacetimeDB/issues/2647 , the C# implementation of quickstart-chat files and documentation have been updated to pattern match the variable assignment of User.

This has the benefit of the variables never being perceived by the analyzers as a nullable types.

# API and ABI breaking changes

Not API breaking

# Expected complexity level and risk

1

# Testing

- [X] Tested updated module code locally, following instructions from the documentation.