### PR TITLE
Reduce `tools/publish-crates.sh` to only publish `bindings` and `sdk`

### DIFF
--- a/tools/publish-crates.sh
+++ b/tools/publish-crates.sh
@@ -39,7 +39,6 @@ if [ $DRY_RUN -ne 1 ]; then
 fi
 
 BASEDIR=$(pwd)
-# TODO: Do we really need to publish the `cli` and `standalone` crates?
 declare -a ROOTS=(bindings sdk)
 declare -a CRATES=($(python3 tools/find-publish-list.py --recursive --quiet "${ROOTS[@]}"))
 


### PR DESCRIPTION
# Description of Changes

Fixes https://github.com/clockworklabs/SpacetimeDB/issues/3017. See that issue for more context.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

We should do a little extra verification on the next release.