### PR TITLE
CI - Fix caching in C#/Unity testsuite

### DIFF
--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -71,6 +71,8 @@ jobs:
           cache-all-crates: true
 
       - name: Install SpacetimeDB CLI from the local checkout
+        # Rebuild only if we didn't get a precise cache hit.
+        if: steps.cache-rust-deps.outputs.cache-hit == 'false'
         run: |
           cargo install --force --path crates/cli --locked --message-format=short
           cargo install --force --path crates/standalone --locked --message-format=short


### PR DESCRIPTION
# Description of Changes

We had weird caching issues in the C#/Unity testsuite. Somehow, they got triggered only as of https://github.com/clockworklabs/SpacetimeDB/pull/3181 merging, and I have no idea why/how.

I've restored the `id` field of the checkout step (which is used by the cache step), and this _seems_ to have fixed it.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1

# Testing

- [x] It passes on this PR
- [x] It passes in a test PR that combines this change with https://github.com/clockworklabs/SpacetimeDB/pull/3182