### PR TITLE
`alter_table_row_type`: write changes to `st_column`

### DIFF
--- a/crates/datastore/src/locking_tx_datastore/datastore.rs
+++ b/crates/datastore/src/locking_tx_datastore/datastore.rs
@@ -3284,7 +3284,13 @@ mod tests {
                 AlgebraicType::sum([("ba", AlgebraicType::U16), ("bb", AlgebraicType::U8)])
             ]
         );
-        commit(&datastore, tx)?;
+        let tx_data = commit(&datastore, tx)?;
+        // Ensure the change has been persisted in the commitlog.
+        let to_product = |col: &ColumnSchema| value_serialize(&StColumnRow::from(col.clone())).into_product().unwrap();
+        let (_, inserts) = tx_data.inserts().find(|(id, _)| **id == ST_COLUMN_ID).unwrap();
+        assert_eq!(&**inserts, [to_product(&columns[1])].as_slice());
+        let (_, deletes) = tx_data.deletes().find(|(id, _)| **id == ST_COLUMN_ID).unwrap();
+        assert_eq!(&**deletes, [to_product(&columns_original[1])].as_slice());
 
         // Check that we can successfully scan using the new schema type post commit.
         let tx = begin_tx(&datastore);

--- a/crates/datastore/src/system_tables.rs
+++ b/crates/datastore/src/system_tables.rs
@@ -568,6 +568,17 @@ impl From<StColumnRow> for ColumnSchema {
     }
 }
 
+impl From<ColumnSchema> for StColumnRow {
+    fn from(column: ColumnSchema) -> Self {
+        Self {
+            table_id: column.table_id,
+            col_pos: column.col_pos,
+            col_name: column.col_name,
+            col_type: column.col_type.into(),
+        }
+    }
+}
+
 /// System Table [ST_INDEX_NAME]
 ///
 /// | index_id | table_id | index_name  | index_algorithm            |


### PR DESCRIPTION
# Description of Changes

`fn alter_table_row_type` now writes the new row type to `st_column`.
This is not a fix for the adding-variants problem, but it does get us closer.

# API and ABI breaking changes

None

# Expected complexity level and risk

2, system tables stuff is always risky.

# Testing

`test_alter_table_row_type_is_transactional` is amended with assertions.