### PR TITLE
Sort columns in `st_column_changed` before automigrating.

### DIFF
--- a/crates/datastore/src/locking_tx_datastore/committed_state.rs
+++ b/crates/datastore/src/locking_tx_datastore/committed_state.rs
@@ -400,7 +400,7 @@ impl CommittedState {
         // Columns in `st_column` are not in general sorted by their `col_pos`,
         // though they will happen to be for tables which have never undergone migrations
         // because their initial insertion order matches their `col_pos` order.
-        columns.sort_by_key(|col: &ColumnSchema| col.col_pos.idx());
+        columns.sort_by_key(|col: &ColumnSchema| col.col_pos);
 
         // Update the columns and layout of the the in-memory table.
         if let Some(table) = self.tables.get_mut(&target_table_id) {


### PR DESCRIPTION
# Description of Changes

In `st_column_changed`, `iter_st_column_for_table` returns rows in physical storage order. In simple cases (without unrelated deletes) this will be the same as insertion order, and therefore also the same as sorted order, but in cases with multiple column-changing automigrations the physical storage order of the rows diverges from the correct sorted order. Because this isn't a hot path, we can just call `.sort()` and not worry about it.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

None yet. Needs manual testing with BitCraft update.
