### PR TITLE
fix: Drop table

### DIFF
--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -352,15 +352,14 @@ impl MutTxId {
             )?;
         }
 
+        // Delete all rows in the table.
+        let ptrs: Vec<_> = self.iter(table_id)?.map(|row| row.pointer()).collect();
+        for ptr in ptrs {
+            self.delete(table_id, ptr)?;
+        }
+
         // Delete the table and its rows and indexes from memory.
         self.tx_state.insert_tables.remove(&table_id);
-        self.tx_state.delete_tables.remove(&table_id);
-        let commit_table = self
-            .committed_state_write_lock
-            .tables
-            .remove(&table_id)
-            .expect("there should be a schema in the committed state if we reach here");
-        self.push_schema_change(PendingSchemaChange::TableRemoved(table_id, commit_table));
 
         Ok(())
     }

--- a/crates/datastore/src/locking_tx_datastore/tx_state.rs
+++ b/crates/datastore/src/locking_tx_datastore/tx_state.rs
@@ -95,8 +95,6 @@ pub enum PendingSchemaChange {
     /// If adding this index caused the pointer map to be removed,
     /// it will be present here.
     IndexAdded(TableId, IndexId, Option<PointerMap>),
-    /// The [`Table`] with [`TableId`] was removed.
-    TableRemoved(TableId, Table),
     /// The table with [`TableId`] was added.
     TableAdded(TableId),
     /// The access of the table with [`TableId`] was changed.


### PR DESCRIPTION
# Description of Changes
Current implementation of `drop_table` have few problems :
1. Table rows are not deleted, which means `blob_store` bytes are never reclaimed.
2. As a result, the generated `TxData` does not include deleted rows, so the commit log replay logic never drops the in-memory commit table.

Changes:
Make `MutTx::drop_table` to not drop commit table but only delete rows (using `delete_tables`) inside it. Later, let `CommitState::merge` to detect dropped tables by anaylyzing `st_table` rows deletions and remove commit tables accordingly.

This change fixes above two problems. However, we still need an additional change to drop empty tables during replay (WIP).

# Expected complexity level and risk
3, small change but it is in hotpath. 

# Testing

- [x ] Modified current unit test to cover table drop case.
- [ ] Planning to write smoketest for testing replay.
