### PR TITLE
utilities for archiving snapshots

### DIFF
--- a/crates/paths/src/server.rs
+++ b/crates/paths/src/server.rs
@@ -206,6 +206,11 @@ path_type! {
     SnapshotDirPath: dir
 }
 
+path_type! {
+    /// An archived snapshot directory. `{data-dir}/replica/$replica_id/snapshots/$tx_offset.archived_snapshot`
+    ArchivedSnapshotDirPath: dir
+}
+
 impl SnapshotDirPath {
     pub fn snapshot_file(&self, tx_offset: u64) -> SnapshotFilePath {
         let file_name = format!("{tx_offset:0>20}.snapshot_bsatn");
@@ -219,6 +224,12 @@ impl SnapshotDirPath {
     pub fn rename_invalid(&self) -> io::Result<()> {
         let invalid_path = self.0.with_extension("invalid_snapshot");
         fs::rename(self, invalid_path)
+    }
+
+    pub fn rename_as_archived(&self) -> io::Result<ArchivedSnapshotDirPath> {
+        let path = self.0.with_extension("archived_snapshot");
+        fs::rename(self, &path)?;
+        Ok(ArchivedSnapshotDirPath(path))
     }
 
     pub fn tx_offset(&self) -> Option<u64> {


### PR DESCRIPTION
# Description of Changes

Adds utilities for marking and deleting snapshot directories that have been archived 

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

Testing will be handled by the patch that adds archival
