### PR TITLE
`tools/upgrade-version` works properly on Windows

### DIFF
--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -12,10 +12,10 @@ use std::path::PathBuf;
 fn process_license_file(path: &str, version: &str) {
     let file = fs::read_to_string(path).unwrap();
 
-    let version_re = Regex::new(r"(?m)^(Licensed Work:\s+SpacetimeDB )([\d\.]+)$").unwrap();
+    let version_re = Regex::new(r"(?m)^(Licensed Work:\s+SpacetimeDB )([\d\.]+)\r?$").unwrap();
     let file = version_re.replace_all(&file, |caps: &regex::Captures| format!("{}{}", &caps[1], version));
 
-    let date_re = Regex::new(r"(?m)^Change Date:\s+\d{4}-\d{2}-\d{2}$").unwrap();
+    let date_re = Regex::new(r"(?m)^Change Date:\s+\d{4}-\d{2}-\d{2}\r?$").unwrap();
     let new_date = Local::now()
         .with_year(Local::now().year() + 5)
         .unwrap()


### PR DESCRIPTION
# Description of Changes

Fixed how the multi-line regexps worked on Windows (with `\r\n` line endings).

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing
- [x] `cargo run -- 1.4.1` works properly on Linux still
- [x] Applying the same diff and running on Windows, now updates the license files properly.