### PR TITLE
sdk/rust: escape hatch for cacheless mode

### DIFF
--- a/crates/codegen/src/rust.rs
+++ b/crates/codegen/src/rust.rs
@@ -979,7 +979,7 @@ fn print_db_update_defn(module: &ModuleDef, out: &mut Indenter) {
             for table in iter_tables(module) {
                 writeln!(
                     out,
-                    "{}: __sdk::TableUpdate<{}>,",
+                    "pub {}: __sdk::TableUpdate<{}>,",
                     table_method_name(&table.name),
                     type_ref_name(module, table.product_type_ref),
                 );

--- a/sdks/rust/src/spacetime_module.rs
+++ b/sdks/rust/src/spacetime_module.rs
@@ -54,10 +54,10 @@ pub trait SpacetimeModule: Send + Sync + 'static {
     type SetReducerFlags: InModule<Module = Self> + Send + 'static;
 
     /// Parsed and typed analogue of [`crate::ws::DatabaseUpdate`].
-    type DbUpdate: DbUpdate<Module = Self>;
+    type DbUpdate: DbUpdate<Module = Self> + Send + 'static;
 
     /// The result of applying `Self::DbUpdate` to the client cache.
-    type AppliedDiff<'r>: AppliedDiff<'r, Module = Self>;
+    type AppliedDiff<'r>: AppliedDiff<'r, Module = Self> + Default;
 
     /// Module-specific `SubscriptionHandle` type, representing an ongoing incremental subscription to a query.
     type SubscriptionHandle: SubscriptionHandle<Module = Self>;


### PR DESCRIPTION
# Description of Changes

These changes allow SDK consumers to register a `tokio::sync::mpsc::UnboundedSender<DbUpdate>` for a `DbConnection` that directly receives all database updates instead of the `ClientCache`.

# Rationale

For writing tooling the current client cache feels very inefficient - these changes allowed us to reduce memory consumption by around a factor of 8, from being able to run the tooling for one region of BitCraft Online to all of them. Batch processing all rows in a database update as well as processing them in a different thread also lead to increased performance.

# Expected complexity level and risk

1 - for complexity i believe this is a fairly minor change, although not completely aware of your scale.
? - for risk.

Behavioral changes only exist if the channel is registered via `DbConnectionBuilder::with_update_channel`, currently hidden from the docs. Risk may increase significantly if `DbUpdate`/`TableUpdate` channels are not meant to be public API and are in flux.

# Testing

I do not have any tests for these changes, but have run a patched SDK with these changes for a while in bitcraft tooling such as https://github.com/vis-eyth/bitcraft-nodeindex.