### PR TITLE
Implements React Hooks for the TypeScript SDK

### DIFF
--- a/crates/bindings-typescript/package.json
+++ b/crates/bindings-typescript/package.json
@@ -54,6 +54,12 @@
       "require": "./dist/sdk/index.cjs",
       "default": "./dist/sdk/index.mjs"
     },
+    "./react": {
+      "types": "./src/react/index.ts",
+      "import": "./dist/react/index.mjs",
+      "require": "./dist/react/index.cjs",
+      "default": "./dist/react/index.mjs"
+    },
     "./server": {
       "types": "./src/server/index.ts",
       "import": "./dist/server/index.mjs",
@@ -105,6 +111,23 @@
       "limit": "60 kB"
     },
     {
+      "name": "react esm min (brotli)",
+      "path": "dist/min/react/index.mjs",
+      "brotli": true,
+      "limit": "10 kB"
+    },
+    {
+      "name": "react esm min (uncompressed)",
+      "path": "dist/min/react/index.mjs",
+      "limit": "10 kB"
+    },
+    {
+      "name": "react esm min (gzip)",
+      "path": "dist/min/react/index.mjs",
+      "gzip": true,
+      "limit": "15 kB"
+    },
+    {
       "name": "sdk esm min (brotli)",
       "path": "dist/min/sdk/index.browser.mjs",
       "brotli": true,
@@ -127,9 +150,13 @@
     "prettier": "^3.3.3"
   },
   "peerDependencies": {
+    "react": "^18.0.0 || ^19.0.0-0 || ^19.0.0",
     "undici": "^6.19.2"
   },
   "peerDependenciesMeta": {
+    "react": {
+      "optional": true
+    },
     "undici": {
       "optional": true
     }
@@ -137,6 +164,7 @@
   "devDependencies": {
     "@eslint/js": "^9.17.0",
     "@size-limit/file": "^11.2.0",
+    "@types/react": "^19.1.13",
     "@typescript-eslint/eslint-plugin": "^8.18.2",
     "@typescript-eslint/parser": "^8.18.2",
     "@vitest/coverage-v8": "^3.2.4",

--- a/crates/bindings-typescript/src/lib/identity.ts
+++ b/crates/bindings-typescript/src/lib/identity.ts
@@ -55,4 +55,11 @@ export class Identity {
   static fromString(str: string): Identity {
     return new Identity(str);
   }
+
+  /**
+   * Zero identity (0x0000000000000000000000000000000000000000000000000000000000000000)
+   */
+  static zero(): Identity {
+    return new Identity(0n);
+  }
 }

--- a/crates/bindings-typescript/src/react/SpacetimeDBProvider.ts
+++ b/crates/bindings-typescript/src/react/SpacetimeDBProvider.ts
@@ -1,0 +1,35 @@
+import { DbConnectionBuilder, type DbConnectionImpl } from '../index';
+import * as React from 'react';
+import { SpacetimeDBContext } from './useSpacetimeDB';
+
+export interface SpacetimeDBProviderProps<
+  DbConnection extends DbConnectionImpl,
+  ErrorContext,
+  SubscriptionEventContext,
+> {
+  connectionBuilder: DbConnectionBuilder<
+    DbConnection,
+    ErrorContext,
+    SubscriptionEventContext
+  >;
+  children?: React.ReactNode;
+}
+
+export function SpacetimeDBProvider<
+  DbConnection extends DbConnectionImpl,
+  ErrorContext,
+  SubscriptionEventContext,
+>({
+  connectionBuilder,
+  children,
+}: SpacetimeDBProviderProps<
+  DbConnection,
+  ErrorContext,
+  SubscriptionEventContext
+>): React.JSX.Element {
+  return React.createElement(
+    SpacetimeDBContext.Provider,
+    { value: connectionBuilder.build() }, // May need to modify this to do it lazily in server-side rendering
+    children
+  );
+}

--- a/crates/bindings-typescript/src/react/index.ts
+++ b/crates/bindings-typescript/src/react/index.ts
@@ -1,0 +1,3 @@
+export * from './SpacetimeDBProvider.ts';
+export { useSpacetimeDB } from './useSpacetimeDB.ts';
+export { useTable } from './useTable.ts';

--- a/crates/bindings-typescript/src/react/index.ts
+++ b/crates/bindings-typescript/src/react/index.ts
@@ -1,3 +1,3 @@
 export * from './SpacetimeDBProvider.ts';
 export { useSpacetimeDB } from './useSpacetimeDB.ts';
-export { useTable } from './useTable.ts';
+export { useTable, where, eq } from './useTable.ts';

--- a/crates/bindings-typescript/src/react/useSpacetimeDB.ts
+++ b/crates/bindings-typescript/src/react/useSpacetimeDB.ts
@@ -1,0 +1,19 @@
+import { createContext, useContext, type Context } from 'react';
+import type { DbConnectionImpl } from '../index';
+
+export const SpacetimeDBContext: Context<DbConnectionImpl | undefined> =
+  createContext<DbConnectionImpl | undefined>(undefined);
+
+// Throws an error if used outside of a SpacetimeDBProvider
+// Error is caught by other hooks like useTable so they can provide better error messages
+export function useSpacetimeDB<
+  DbConnection extends DbConnectionImpl,
+>(): DbConnection {
+  const context = useContext(SpacetimeDBContext) as DbConnection | undefined;
+  if (!context) {
+    throw new Error(
+      'useSpacetimeDB must be used within a SpacetimeDBProvider component. Did you forget to add a `SpacetimeDBProvider` to your component tree?'
+    );
+  }
+  return context;
+}

--- a/crates/bindings-typescript/src/react/useTable.ts
+++ b/crates/bindings-typescript/src/react/useTable.ts
@@ -1,0 +1,237 @@
+import {
+  useCallback,
+  useEffect,
+  useRef,
+  useState,
+  useSyncExternalStore,
+} from 'react';
+import { useSpacetimeDB } from './useSpacetimeDB';
+import { DbConnectionImpl, TableCache } from '../sdk';
+
+export interface UseQueryCallbacks<RowType> {
+  onInsert?: (row: RowType) => void;
+  onDelete?: (row: RowType) => void;
+  onUpdate?: (oldRow: RowType, newRow: RowType) => void;
+}
+
+type WhereClause = {
+  key: string;
+  operator: '=';
+  value: string | number | boolean;
+};
+
+export function eq<ColumnType extends string>(
+  key: ColumnType,
+  value: string | number | boolean
+): WhereClause {
+  return { key, operator: '=', value };
+}
+
+export function where(condition: WhereClause) {
+  return `${condition.key} ${condition.operator} ${JSON.stringify(condition.value)}`;
+}
+
+function matchesWhereClause(
+  row: Record<string, any>,
+  whereClause: WhereClause
+): boolean {
+  const { key, operator, value } = whereClause;
+  if (!(key in row)) {
+    return false;
+  }
+  switch (operator) {
+    case '=':
+      return row[key] === value;
+    default:
+      return false;
+  }
+}
+
+type Snapshot<RowType> = {
+  readonly rows: readonly RowType[];
+  readonly state: 'loading' | 'ready';
+};
+
+export function useTable<
+  DbConnection extends DbConnectionImpl,
+  RowType extends Record<string, any>,
+  TableName extends keyof DbConnection['db'] &
+    string = keyof DbConnection['db'] & string,
+>(
+  tableName: TableName,
+  whereClauseOrCallbacks?: WhereClause | UseQueryCallbacks<RowType>,
+  callbacks?: UseQueryCallbacks<RowType>
+): Snapshot<RowType> {
+  let whereClause: WhereClause | undefined;
+  if (whereClauseOrCallbacks && 'key' in whereClauseOrCallbacks) {
+    whereClause = whereClauseOrCallbacks;
+  } else {
+    callbacks = whereClauseOrCallbacks as
+      | UseQueryCallbacks<RowType>
+      | undefined;
+  }
+  const [subscribeApplied, setSubscribeApplied] = useState(false);
+  const [isActive, setIsActive] = useState(false);
+  let spacetime: DbConnection | undefined;
+  try {
+    spacetime = useSpacetimeDB<DbConnection>();
+  } catch {
+    throw new Error(
+      'Could not find SpacetimeDB client! Did you forget to add a' +
+        '`SpacetimeDBProvider`? `useTable` must be used in the React component tree' +
+        'under a `SpacetimeDBProvider` component.'
+    );
+  }
+  const client = spacetime;
+
+  const query =
+    `SELECT * FROM ${tableName}` +
+    (whereClause ? ` WHERE ${where(whereClause)}` : '');
+
+  const latestTransactionEvent = useRef<any>(null);
+  const lastSnapshotRef = useRef<Snapshot<RowType> | null>(null);
+
+  const whereKey = whereClause
+    ? `${whereClause.key}|${whereClause.operator}|${JSON.stringify(whereClause.value)}`
+    : '';
+
+  const computeSnapshot = useCallback((): Snapshot<RowType> => {
+    const table = client.db[
+      tableName as keyof typeof client.db
+    ] as unknown as TableCache<RowType>;
+    const result: readonly RowType[] = whereClause
+      ? table.iter().filter(row => matchesWhereClause(row, whereClause))
+      : table.iter();
+    return {
+      rows: result,
+      state: subscribeApplied ? 'ready' : 'loading',
+    };
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, [client, tableName, whereKey, subscribeApplied]);
+
+  useEffect(() => {
+    const onConnect = () => {
+      setIsActive(client.isActive);
+    };
+    const onDisconnect = () => {
+      setIsActive(client.isActive);
+    };
+    const onConnectError = () => {
+      setIsActive(client.isActive);
+    };
+    client['on']('connect', onConnect);
+    client['on']('disconnect', onDisconnect);
+    client['on']('connectError', onConnectError);
+    return () => {
+      client['off']('connect', onConnect);
+      client['off']('disconnect', onDisconnect);
+      client['off']('connectError', onConnectError);
+    };
+  }, [client]);
+
+  useEffect(() => {
+    if (isActive) {
+      const cancel = client
+        .subscriptionBuilder()
+        .onApplied(() => {
+          setSubscribeApplied(true);
+        })
+        .subscribe(query);
+      return () => {
+        cancel.unsubscribe();
+      };
+    }
+  }, [query, isActive, client]);
+
+  const subscribe = useCallback(
+    (onStoreChange: () => void) => {
+      const onInsert = (ctx: any, row: RowType) => {
+        if (whereClause && !matchesWhereClause(row, whereClause)) {
+          return;
+        }
+        if (tableName === 'message') {
+          console.log('onInsert for messages table:', row);
+        }
+        callbacks?.onInsert?.(row);
+        if (
+          ctx.event !== latestTransactionEvent.current ||
+          !latestTransactionEvent.current
+        ) {
+          latestTransactionEvent.current = ctx.event;
+          lastSnapshotRef.current = computeSnapshot();
+          onStoreChange();
+        }
+      };
+
+      const onDelete = (ctx: any, row: RowType) => {
+        if (whereClause && !matchesWhereClause(row, whereClause)) {
+          return;
+        }
+        if (tableName === 'message') {
+          console.log('onDelete for messages table:', row);
+        }
+        callbacks?.onDelete?.(row);
+        if (
+          ctx.event !== latestTransactionEvent.current ||
+          !latestTransactionEvent.current
+        ) {
+          latestTransactionEvent.current = ctx.event;
+          lastSnapshotRef.current = computeSnapshot();
+          onStoreChange();
+        }
+      };
+
+      const onUpdate = (ctx: any, oldRow: RowType, newRow: RowType) => {
+        // If your filtering is based on newRow membership; adjust if you also care when it LEAVES the filter
+        const affected =
+          !whereClause ||
+          matchesWhereClause(oldRow, whereClause) ||
+          matchesWhereClause(newRow, whereClause);
+        if (!affected) {
+          return;
+        }
+        callbacks?.onUpdate?.(oldRow, newRow);
+        if (
+          ctx.event !== latestTransactionEvent.current ||
+          !latestTransactionEvent.current
+        ) {
+          latestTransactionEvent.current = ctx.event;
+          lastSnapshotRef.current = computeSnapshot();
+          onStoreChange();
+        }
+      };
+
+      const table = client.db[
+        tableName as keyof typeof client.db
+      ] as unknown as TableCache<RowType>;
+      table.onInsert(onInsert);
+      table.onDelete(onDelete);
+      table.onUpdate?.(onUpdate);
+
+      return () => {
+        table.removeOnInsert(onInsert);
+        table.removeOnDelete(onDelete);
+        table.removeOnUpdate?.(onUpdate);
+      };
+    },
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    [
+      client,
+      tableName,
+      whereKey,
+      callbacks?.onDelete,
+      callbacks?.onInsert,
+      callbacks?.onUpdate,
+    ]
+  );
+
+  const getSnapshot = useCallback((): Snapshot<RowType> => {
+    if (!lastSnapshotRef.current) {
+      lastSnapshotRef.current = computeSnapshot();
+    }
+    return lastSnapshotRef.current;
+  }, [computeSnapshot]);
+
+  // SSR fallback can be the same getter
+  return useSyncExternalStore(subscribe, getSnapshot, getSnapshot);
+}

--- a/crates/bindings-typescript/src/react/useTable.ts
+++ b/crates/bindings-typescript/src/react/useTable.ts
@@ -77,7 +77,7 @@ export function useTable<
     spacetime = useSpacetimeDB<DbConnection>();
   } catch {
     throw new Error(
-      'Could not find SpacetimeDB client! Did you forget to add a' +
+      'Could not find SpacetimeDB client! Did you forget to add a ' +
         '`SpacetimeDBProvider`? `useTable` must be used in the React component tree' +
         'under a `SpacetimeDBProvider` component.'
     );

--- a/crates/bindings-typescript/test-app/src/App.tsx
+++ b/crates/bindings-typescript/test-app/src/App.tsx
@@ -1,42 +1,21 @@
-import { DbConnection } from './module_bindings';
-import { useEffect, useState } from 'react';
+import { DbConnection, Player } from './module_bindings';
+import { useEffect } from 'react';
 import './App.css';
+import { useSpacetimeDB, useTable } from '../../src/react';
 
 function App() {
-  const [connection] = useState(() =>
-    DbConnection.builder()
-      .withUri('ws://localhost:3000')
-      .withModuleName('game')
-      .withLightMode(true)
-      .onDisconnect(() => {
-        console.log('disconnected');
-      })
-      .onConnectError(() => {
-        console.log('client_error');
-      })
-      .onConnect((conn, identity, _token) => {
-        console.log(
-          'Connected to SpacetimeDB with identity:',
-          identity.toHexString()
-        );
-
-        conn.subscriptionBuilder().subscribe('SELECT * FROM player');
-      })
-      .withToken(
-        'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIwMUpCQTBYRzRESFpIWUdQQk5GRFk5RDQ2SiIsImlzcyI6Imh0dHBzOi8vYXV0aC5zdGFnaW5nLnNwYWNldGltZWRiLmNvbSIsImlhdCI6MTczMDgwODUwNSwiZXhwIjoxNzkzODgwNTA1fQ.kGM4HGX0c0twL8NJoSQowzSZa8dc2Ogc-fsvaDK7otUrcdGFsZ3KsNON2eNkFh73FER0hl55_eJStr2tgoPwfTyl_v_TqkY45iUOUlLmHfB-X42cMzpE7PXbR_PKYcp-P-Wa4jGtVl4oF7CvdGKxlhIYEk3e0ElQlA9ThnZN4IEciYV0vwAXGqbaO9SOG8jbrmlmfN7oKgl02EgpodEAHTrnB2mD1qf1YyOw7_9n_EkxJxWLkJf9-nFCVRrbfSLqSJBeE6OKNAu2VLLYrSFE7GkVXNCFVugoCDM2oVJogX75AgzWimrp75QRmLsXbvB-YvvRkQ8Gfb2RZnqCj9kiYg'
-      )
-      .build()
-  );
+  const connection = useSpacetimeDB<DbConnection>();
+  const players = useTable<DbConnection, Player>('player', {
+    onInsert: player => {
+      console.log(player);
+    },
+  });
 
   useEffect(() => {
-    connection.db.player.onInsert(player => {
-      console.log(player);
-    });
-
     setTimeout(() => {
-      console.log(Array.from(connection.db.player.iter()));
+      console.log(Array.from(players.rows));
     }, 5000);
-  }, [connection]);
+  }, [connection, players.rows]);
 
   return (
     <div className="App">

--- a/crates/bindings-typescript/test-app/src/main.tsx
+++ b/crates/bindings-typescript/test-app/src/main.tsx
@@ -2,9 +2,35 @@ import React from 'react';
 import ReactDOM from 'react-dom/client';
 import App from './App.tsx';
 import './index.css';
+import { SpacetimeDBProvider } from '../../src/react';
+import { DbConnection } from './module_bindings/index.ts';
+
+const connectionBuilder = DbConnection.builder()
+  .withUri('ws://localhost:3000')
+  .withModuleName('game')
+  .withLightMode(true)
+  .onDisconnect(() => {
+    console.log('disconnected');
+  })
+  .onConnectError(() => {
+    console.log('client_error');
+  })
+  .onConnect((conn, identity, _token) => {
+    console.log(
+      'Connected to SpacetimeDB with identity:',
+      identity.toHexString()
+    );
+
+    conn.subscriptionBuilder().subscribe('SELECT * FROM player');
+  })
+  .withToken(
+    'eyJhbGciOiJSUzI1NiJ9.eyJzdWIiOiIwMUpCQTBYRzRESFpIWUdQQk5GRFk5RDQ2SiIsImlzcyI6Imh0dHBzOi8vYXV0aC5zdGFnaW5nLnNwYWNldGltZWRiLmNvbSIsImlhdCI6MTczMDgwODUwNSwiZXhwIjoxNzkzODgwNTA1fQ.kGM4HGX0c0twL8NJoSQowzSZa8dc2Ogc-fsvaDK7otUrcdGFsZ3KsNON2eNkFh73FER0hl55_eJStr2tgoPwfTyl_v_TqkY45iUOUlLmHfB-X42cMzpE7PXbR_PKYcp-P-Wa4jGtVl4oF7CvdGKxlhIYEk3e0ElQlA9ThnZN4IEciYV0vwAXGqbaO9SOG8jbrmlmfN7oKgl02EgpodEAHTrnB2mD1qf1YyOw7_9n_EkxJxWLkJf9-nFCVRrbfSLqSJBeE6OKNAu2VLLYrSFE7GkVXNCFVugoCDM2oVJogX75AgzWimrp75QRmLsXbvB-YvvRkQ8Gfb2RZnqCj9kiYg'
+  );
 
 ReactDOM.createRoot(document.getElementById('root')!).render(
   <React.StrictMode>
-    <App />
+    <SpacetimeDBProvider connectionBuilder={connectionBuilder}>
+      <App />
+    </SpacetimeDBProvider>
   </React.StrictMode>
 );

--- a/crates/bindings-typescript/tsup.config.ts
+++ b/crates/bindings-typescript/tsup.config.ts
@@ -54,6 +54,36 @@ export default defineConfig([
     esbuildOptions: commonEsbuildTweaks(),
   },
 
+  // React subpath (SSR-friendly): dist/react/index.{mjs,cjs}
+  {
+    entry: { index: 'src/react/index.ts' },
+    format: ['esm', 'cjs'],
+    target: 'es2022',
+    outDir: 'dist/react',
+    dts: false,
+    sourcemap: true,
+    clean: true,
+    platform: 'neutral',
+    treeshake: 'smallest',
+    outExtension,
+    esbuildOptions: commonEsbuildTweaks(),
+  },
+
+  // React subpath (browser ESM): dist/browser/react/index.mjs
+  {
+    entry: { index: 'src/react/index.ts' },
+    format: ['esm'],
+    target: 'es2022',
+    outDir: 'dist/browser/react',
+    dts: false,
+    sourcemap: true,
+    clean: true,
+    platform: 'browser',
+    treeshake: 'smallest',
+    outExtension,
+    esbuildOptions: commonEsbuildTweaks(),
+  },
+
   // SDK subpath (SSR-friendly): dist/sdk/index.{mjs,cjs}
   {
     entry: { index: 'src/sdk/index.ts' },
@@ -132,6 +162,21 @@ export default defineConfig([
       BROWSER: 'true',
     },
     outExtension,
+    esbuildOptions: commonEsbuildTweaks(),
+  },
+
+  // Minified browser React build: dist/min/react/index.mjs
+  {
+    entry: { index: 'src/react/index.ts' },
+    format: ['esm'],
+    target: 'es2022',
+    outDir: 'dist/min/react',
+    dts: false,
+    sourcemap: true,
+    minify: 'terser',
+    platform: 'browser',
+    treeshake: 'smallest',
+    outExtension: ({ format }) => ({ js: format === 'cjs' ? '.cjs' : '.mjs' }),
     esbuildOptions: commonEsbuildTweaks(),
   },
 

--- a/docs/docs/sdks/typescript/quickstart.md
+++ b/docs/docs/sdks/typescript/quickstart.md
@@ -48,20 +48,25 @@ Replace the entire contents of `client/src/App.tsx` with the following:
 
 ```tsx
 import React, { useEffect, useState } from 'react';
+import { DbConnection, Message, User } from './module_bindings';
 import './App.css';
 
 export type PrettyMessage = {
   senderName: string;
   text: string;
+  sent: Timestamp;
+  kind: 'system' | 'user';
 };
 
 function App() {
   const [newName, setNewName] = useState('');
   const [settingName, setSettingName] = useState(false);
-  const [systemMessage, setSystemMessage] = useState('');
+  const [systemMessages, setSystemMessages] = useState([] as Message[]);
   const [newMessage, setNewMessage] = useState('');
 
   const prettyMessages: PrettyMessage[] = [];
+  const onlineUsers: User[] = [];
+  const offlineUsers: User[] = [];
 
   const name = '';
 
@@ -77,7 +82,7 @@ function App() {
     // TODO: Call `sendMessage` reducer
   };
 
-  return (
+return (
     <div className="App">
       <div className="profile">
         <h1>Profile</h1>
@@ -97,6 +102,7 @@ function App() {
           <form onSubmit={onSubmitNewName}>
             <input
               type="text"
+              aria-label="username input"
               value={newName}
               onChange={e => setNewName(e.target.value)}
             />
@@ -104,25 +110,80 @@ function App() {
           </form>
         )}
       </div>
-      <div className="message">
+      <div className="message-panel">
         <h1>Messages</h1>
         {prettyMessages.length < 1 && <p>No messages</p>}
+        <div className="messages">
+          {prettyMessages.map((message, key) => {
+            const sentDate = message.sent.toDate();
+            const now = new Date();
+            const isOlderThanDay =
+              now.getFullYear() !== sentDate.getFullYear() ||
+              now.getMonth() !== sentDate.getMonth() ||
+              now.getDate() !== sentDate.getDate();
+
+            const timeString = sentDate.toLocaleTimeString([], {
+              hour: '2-digit',
+              minute: '2-digit',
+            });
+            const dateString = isOlderThanDay
+              ? sentDate.toLocaleDateString([], {
+                year: 'numeric',
+                month: 'short',
+                day: 'numeric',
+              }) + ' '
+              : '';
+
+            return (
+              <div
+                key={key}
+                className={
+                  message.kind === 'system' ? 'system-message' : 'user-message'
+                }
+              >
+                <p>
+                  <b>
+                    {message.kind === 'system' ? 'System' : message.senderName}
+                  </b>
+                  <span
+                    style={{
+                      fontSize: '0.8rem',
+                      marginLeft: '0.5rem',
+                      color: '#666',
+                    }}
+                  >
+                    {dateString}
+                    {timeString}
+                  </span>
+                </p>
+                <p>{message.text}</p>
+              </div>
+            );
+          })}
+        </div>
+      </div>
+      <div className="online" style={{ whiteSpace: 'pre-wrap' }}>
+        <h1>Online</h1>
         <div>
-          {prettyMessages.map((message, key) => (
+          {onlineUsers.map((user, key) => (
             <div key={key}>
-              <p>
-                <b>{message.senderName}</b>
-              </p>
-              <p>{message.text}</p>
+              <p>{user.name || user.identity.toHexString().substring(0, 8)}</p>
             </div>
           ))}
         </div>
-      </div>
-      <div className="system" style={{ whiteSpace: 'pre-wrap' }}>
-        <h1>System</h1>
-        <div>
-          <p>{systemMessage}</p>
-        </div>
+        {offlineUsers.length > 0 && (
+          <div>
+            <h1>Offline</h1>
+            {offlineUsers
+              .map((user, key) => (
+                <div key={key}>
+                  <p>
+                    {user.name || user.identity.toHexString().substring(0, 8)}
+                  </p>
+                </div>
+              ))}
+          </div>
+        )}
       </div>
       <div className="new-message">
         <form
@@ -136,6 +197,7 @@ function App() {
         >
           <h3>New Message</h3>
           <textarea
+            aria-label="message input"
             value={newMessage}
             onChange={e => setNewMessage(e.target.value)}
           ></textarea>
@@ -159,11 +221,11 @@ Let's also make it pretty. Replace the contents of `client/src/App.css` with the
   /* 
     3 rows: 
       1) Profile
-      2) Main content (left = message, right = system)
+      2) Main content (left = message, right = online)
       3) New message
   */
   grid-template-rows: auto 1fr auto;
-  /* 2 columns: left for chat, right for system */
+  /* 2 columns: left for chat, right for online */
   grid-template-columns: 2fr 1fr;
 
   height: 100vh; /* fill viewport height */
@@ -198,10 +260,10 @@ Let's also make it pretty. Replace the contents of `client/src/App.css` with the
 }
 
 /* ----- Chat Messages (Row 2, Col 1) ----- */
-.message {
+.message-panel {
   grid-row: 2 / 3;
   grid-column: 1 / 2;
-  
+
   /* Ensure this section scrolls if content is long */
   overflow-y: auto;
   padding: 1rem;
@@ -210,12 +272,32 @@ Let's also make it pretty. Replace the contents of `client/src/App.css` with the
   gap: 1rem;
 }
 
+.messages {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.system-message {
+  background-color: var(--theme-color);
+  color: var(--theme-color-contrast);
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-style: italic;
+}
+
+.user-message {
+  background-color: var(--textbox-color);
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+}
+
 .message h1 {
   margin-right: 0.5rem;
 }
 
-/* ----- System Panel (Row 2, Col 2) ----- */
-.system {
+/* ----- Online Panel (Row 2, Col 2) ----- */
+.online {
   grid-row: 2 / 3;
   grid-column: 2 / 3;
 
@@ -384,73 +466,66 @@ module_bindings
 └── user_type.ts
 ```
 
-With `spacetime generate` we have generated TypeScript types derived from the types you specified in your module, which we can conveniently use in our client. We've placed these in the `module_bindings` folder. The main entry to the SpacetimeDB API is the `DbConnection`, a type which manages a connection to a remote database. Let's import it and a few other types into our `client/src/App.tsx`.
+With `spacetime generate` we have generated TypeScript types derived from the types you specified in your module, which we can conveniently use in our client. We've placed these in the `module_bindings` folder.
+Now that we've set up our UI and generated our types, let's connect to SpacetimeDB.
+
+The main entry to the SpacetimeDB API is the `DbConnection`, a type which manages a connection to a remote database. Let's import it and a few other types into our `client/src/main.tsx` below our other imports:
 
 ```tsx
-import { DbConnection, type ErrorContext, type EventContext, Message, User } from './module_bindings';
+import { StrictMode } from 'react';
+import { createRoot } from 'react-dom/client';
+import './index.css';
+import App from './App.tsx';
 import { Identity } from '@clockworklabs/spacetimedb-sdk';
+import { SpacetimeDBProvider } from '@clockworklabs/spacetimedb-sdk/react';
+import { DbConnection, ErrorContext } from './module_bindings/index.ts';
 ```
+
+Note that we are importing `DbConnection` from our `module_bindings` so that it has all the type information about our tables and types.
+
+We've also imported the `SpacetimeDBProvider` React component which will allow us to seemlessly connect our SpacetimeDB state directly to our React state.
 
 ## Create your SpacetimeDB client
 
 Now that we've imported the `DbConnection` type, we can use it to connect our app to our database.
 
-Add the following to your `App` function, just below `const [newMessage, setNewMessage] = useState('');`:
+Replace the body of the `main.tsx` file with the following, just below your imports:
 
 ```tsx
-  const [connected, setConnected] = useState<boolean>(false);
-  const [identity, setIdentity] = useState<Identity | null>(null);
-  const [conn, setConn] = useState<DbConnection | null>(null);
+const onConnect = (conn: DbConnection, identity: Identity, token: string) => {
+  localStorage.setItem('auth_token', token);
+  console.log(
+    'Connected to SpacetimeDB with identity:',
+    identity.toHexString()
+  );
+  conn.reducers.onSendMessage(() => {
+    console.log('Message sent.');
+  });
+};
 
-  useEffect(() => {
-    const subscribeToQueries = (conn: DbConnection, queries: string[]) => {
-      conn
-        ?.subscriptionBuilder()
-        .onApplied(() => {
-          console.log('SDK client cache initialized.');
-        })
-        .subscribe(queries);
-    };
+const onDisconnect = () => {
+  console.log('Disconnected from SpacetimeDB');
+};
 
-    const onConnect = (
-      conn: DbConnection,
-      identity: Identity,
-      token: string
-    ) => {
-      setIdentity(identity);
-      setConnected(true);
-      localStorage.setItem('auth_token', token);
-      console.log(
-        'Connected to SpacetimeDB with identity:',
-        identity.toHexString()
-      );
-      conn.reducers.onSendMessage(() => {
-        console.log('Message sent.');
-      });
+const onConnectError = (_ctx: ErrorContext, err: Error) => {
+  console.log('Error connecting to SpacetimeDB:', err);
+};
 
-      subscribeToQueries(conn, ['SELECT * FROM message', 'SELECT * FROM user']);
-    };
+const connectionBuilder = DbConnection.builder()
+  .withUri('ws://localhost:3000')
+  .withModuleName('quickstart-chat')
+  .withToken(localStorage.getItem('auth_token') || '')
+  .onConnect(onConnect)
+  .onDisconnect(onDisconnect)
+  .onConnectError(onConnectError);
 
-    const onDisconnect = () => {
-      console.log('Disconnected from SpacetimeDB');
-      setConnected(false);
-    };
-
-    const onConnectError = (_ctx: ErrorContext, err: Error) => {
-      console.log('Error connecting to SpacetimeDB:', err);
-    };
-
-    setConn(
-      DbConnection.builder()
-        .withUri('ws://localhost:3000')
-        .withModuleName('quickstart-chat')
-        .withToken(localStorage.getItem('auth_token') || '')
-        .onConnect(onConnect)
-        .onDisconnect(onDisconnect)
-        .onConnectError(onConnectError)
-        .build()
-    );
-  }, []);
+createRoot(document.getElementById('root')!).render(
+  <StrictMode>
+    <SpacetimeDBProvider connectionBuilder={connectionBuilder}>
+      <App />
+    </SpacetimeDBProvider>
+  </StrictMode>
+);
 ```
 
 Here we are configuring our SpacetimeDB connection by specifying the server URI, database name, and a few callbacks including the `onConnect` callback. When `onConnect` is called after connecting, we store the connection state, our `Identity`, and our SpacetimeDB credentials in our React state. If there is an error connecting, we print that error to the console as well.
@@ -459,105 +534,58 @@ We are also using `localStorage` to store our SpacetimeDB credentials. This way,
 
 If you chose a different name for your database, replace `quickstart-chat` with that name, or republish your module as `quickstart-chat`.
 
-In the `onConnect` function we are also subscribing to the `message` and `user` tables. When we subscribe, SpacetimeDB will run our subscription queries and store the result in a local "client cache". This cache will be updated in real-time as the data in the table changes on the server. The `onApplied` callback is called after SpacetimeDB has synchronized our subscribed data with the client cache.
+In the `onConnect` function we are also subscribing to the `message` and `user` tables. When we subscribe, SpacetimeDB will run our subscription queries and store the result in a local "client cache". This cache will be updated in real-time as the data in the table changes on the server.
+
+We pass our connection configuration directly to the `SpacetimeDBProvider` which will manage our connection to SpacetimeDB.
 
 ### Accessing the Data
 
-Once SpacetimeDB is connected, we can easily access the data in the client cache using our `DbConnection`. The `conn.db` field allows you to access all of the tables of your database. Those tables will contain all data requested by your subscription configuration.
+Once SpacetimeDB is connected, we can easily access the data in the client cache using SpacetimeDB's provided React hooks, `useTable` and `useSpacetimeDB`.
 
-Let's create custom React hooks for the `message` and `user` tables. Add the following code above your `App` component:
+`useTable` is the simplest way to access your database data. `useTable` subscribes your React app to data in a SpacetimeDB table so that it updates as the data changes. It essentially acts just like `useState` in React except the data is being updated in real-time from SpacetimeDB tables.
 
-```tsx
-function useMessages(conn: DbConnection | null): Message[] {
-  const [messages, setMessages] = useState<Message[]>([]);
+`useSpacetimeDB` gives you direct access to the connection in case you want to check the state of the connection or access database table state. Note that `useSpacetimeDB` does not automatically subscribe your app to data in the database.
 
-  useEffect(() => {
-    if (!conn) return;
-    const onInsert = (_ctx: EventContext, message: Message) => {
-      setMessages(prev => [...prev, message]);
-    };
-    conn.db.message.onInsert(onInsert);
-
-    const onDelete = (_ctx: EventContext, message: Message) => {
-      setMessages(prev =>
-        prev.filter(
-          m =>
-            m.text !== message.text &&
-            m.sent !== message.sent &&
-            m.sender !== message.sender
-        )
-      );
-    };
-    conn.db.message.onDelete(onDelete);
-
-    return () => {
-      conn.db.message.removeOnInsert(onInsert);
-      conn.db.message.removeOnDelete(onDelete);
-    };
-  }, [conn]);
-
-  return messages;
-}
-
-function useUsers(conn: DbConnection | null): Map<string, User> {
-  const [users, setUsers] = useState<Map<string, User>>(new Map());
-
-  useEffect(() => {
-    if (!conn) return;
-    const onInsert = (_ctx: EventContext, user: User) => {
-      setUsers(prev => new Map(prev.set(user.identity.toHexString(), user)));
-    };
-    conn.db.user.onInsert(onInsert);
-
-    const onUpdate = (_ctx: EventContext, oldUser: User, newUser: User) => {
-      setUsers(prev => {
-        prev.delete(oldUser.identity.toHexString());
-        return new Map(prev.set(newUser.identity.toHexString(), newUser));
-      });
-    };
-    conn.db.user.onUpdate(onUpdate);
-
-    const onDelete = (_ctx: EventContext, user: User) => {
-      setUsers(prev => {
-        prev.delete(user.identity.toHexString());
-        return new Map(prev);
-      });
-    };
-    conn.db.user.onDelete(onDelete);
-
-    return () => {
-      conn.db.user.removeOnInsert(onInsert);
-      conn.db.user.removeOnUpdate(onUpdate);
-      conn.db.user.removeOnDelete(onDelete);
-    };
-  }, [conn]);
-
-  return users;
-}
-```
-
-These custom React hooks update the React state anytime a row in our tables change, causing React to rerender.
-
-> In principle, it should be possible to automatically generate these hooks based on your module's schema, or use [`useSyncExternalStore`](https://react.dev/reference/react/useSyncExternalStore). For simplicity, rather than creating them mechanically, we're just going to do it manually.
-
-Let's add these hooks to our `App` component just below our connection setup:
+Add the following `useSpacetimeDB` hook to the top of your render function, just below your `useState` declarations.
 
 ```tsx
-  const messages = useMessages(conn);
-  const users = useUsers(conn);
+  const conn = useSpacetimeDB<DbConnection>();
+  const { identity, isActive: connected } = conn;
+
+  // Subscribe to all messages in the chat
+  const { rows: messages } = useTable<DbConnection, Message>('message');
 ```
+
+Next replace `const onlineUsers: User[] = [];` with the following:
+
+```tsx
+  // Subscribe to all online users in the chat
+  // so we can show who's online and demonstrate
+  // the `where` and `eq` query expressions
+  const { rows: onlineUsers } = useTable<DbConnection, User>(
+    'user',
+    where(eq('online', true))
+  );
+```
+
+Notice that we can filter users in the `user` table based on their online status by passing a query expression into the `useTable` hook as the second argument.
 
 Let's now prettify our messages in our render function by sorting them by their `sent` timestamp, and joining the username of the sender to the message by looking up the user by their `Identity` in the `user` table. Replace `const prettyMessages: PrettyMessage[] = [];` with the following:
 
 ```tsx
-  const prettyMessages: PrettyMessage[] = messages
-    .sort((a, b) => (a.sent > b.sent ? 1 : -1))
-    .map(message => ({
-      senderName:
-        users.get(message.sender.toHexString())?.name ||
-        message.sender.toHexString().substring(0, 8),
-      text: message.text,
-    }));
+  const prettyMessages: PrettyMessage[] = Array.from(messages)
+    .sort((a, b) => (a.sent.toDate() > b.sent.toDate() ? 1 : -1))
+    .map(message => {
+      const user = users.find(
+        u => u.identity.toHexString() === message.sender.toHexString()
+      );
+      return {
+        senderName: user?.name || message.sender.toHexString().substring(0, 8),
+        text: message.text,
+        sent: message.sent,
+        kind: Identity.zero().isEqual(message.sender) ? 'system' : 'user',
+      };
+    });
 ```
 
 That's all we have to do to hook up our SpacetimeDB state to our React state. SpacetimeDB will make sure that any change on the server gets pushed down to our application and rerendered on screen in real-time.
@@ -565,7 +593,7 @@ That's all we have to do to hook up our SpacetimeDB state to our React state. Sp
 Let's also update our render function to show a loading message while we're connecting to SpacetimeDB. Add this just below our `prettyMessages` declaration:
 
 ```tsx
-  if (!conn || !connected || !identity) {
+  if (!connected || !identity) {
     return (
       <div className="App">
         <h1>Connecting...</h1>
@@ -577,10 +605,10 @@ Let's also update our render function to show a loading message while we're conn
 Finally, let's also compute the name of the user from the `Identity` in our `name` variable. Replace `const name = '';` with the following:
 
 ```tsx
-  const name =
-    users.get(identity?.toHexString())?.name ||
-    identity?.toHexString().substring(0, 8) ||
-    'unknown';
+  const name = (() => {
+    const user = users.find(u => u.identity.isEqual(identity));
+    return user?.name || identity?.toHexString().substring(0, 8) || '';
+  })();
 ```
 
 ### Calling Reducers
@@ -624,39 +652,56 @@ Try opening a few incognito windows to see what it's like with multiple users!
 
 ### Notify about new users
 
-We can also register `onInsert` and `onDelete` callbacks for the purpose of handling events, not just state. For example, we might want to show a notification any time a new user connects to the database.
+We can also register `onInsert`, `onUpdate`, and `onDelete` callbacks for the purpose of handling events, not just state. For example, we might want to show a notification any time a new user connects to the database.
 
 Note that these callbacks can fire in two contexts:
 
 - After a reducer runs, when the client's cache is updated about changes to subscribed rows.
 - After calling `subscribe`, when the client's cache is initialized with all existing matching rows.
 
-Our `user` table includes all users not just online users, so we want to take care to only show a notification when new users join. Let's add a `useEffect` which subscribes a callback when a `user` is inserted into the table and a callback when a `user` is updated. Add the following to your `App` component just below the other `useEffect`.
+Our current `useTable` filters just online users, but we can print a system message any time a user enters or leaves the room by subscribing to callbacks on the `onlineUsers` React hook.
+
+Update your `onlineUsers` React hook to add the following callbacks:
 
 ```tsx
-  useEffect(() => {
-    if (!conn) return;
-    conn.db.user.onInsert((_ctx, user) => {
-      if (user.online) {
+  // Subscribe to all online users in the chat
+  // so we can show who's online and demonstrate
+  // the `where` and `eq` query expressions
+  const { rows: onlineUsers } = useTable<DbConnection, User>(
+    'user',
+    where(eq('online', true)),
+    {
+      onInsert: user => {
+        // All users being inserted here are online
         const name = user.name || user.identity.toHexString().substring(0, 8);
-        setSystemMessage(prev => prev + `\n${name} has connected.`);
+        setSystemMessages(prev => [
+          ...prev,
+          {
+            sender: Identity.zero(),
+            text: `${name} has connected.`,
+            sent: Timestamp.now(),
+          },
+        ]);
+      },
+      onDelete: user => {
+        // All users being deleted here are offline
+        const name = user.name || user.identity.toHexString().substring(0, 8);
+        setSystemMessages(prev => [
+          ...prev,
+          {
+            sender: Identity.zero(),
+            text: `${name} has disconnected.`,
+            sent: Timestamp.now(),
+          },
+        ]);
       }
-    });
-    conn.db.user.onUpdate((_ctx, oldUser, newUser) => {
-      const name =
-        newUser.name || newUser.identity.toHexString().substring(0, 8);
-      if (oldUser.online === false && newUser.online === true) {
-        setSystemMessage(prev => prev + `\n${name} has connected.`);
-      } else if (oldUser.online === true && newUser.online === false) {
-        setSystemMessage(prev => prev + `\n${name} has disconnected.`);
-      }
-    });
-  }, [conn]);
+    }
+  );
 ```
 
-Here we post a message saying a new user has connected if the user is being added to the `user` table and they're online, or if an existing user's online status is being set to "online".
+These callbacks will be called any time the state of the `useTable` result changes to add or remove a row, while respecting your `where` filter.
 
-Note that `onInsert` and `onDelete` callbacks takes two arguments: an `EventContext` and the row. The `EventContext` can be used just like the `DbConnection` and has all the same access functions, in addition to containing information about the event that triggered this callback. For now, we can ignore this argument though, since we have all the info we need in the user rows.
+Here we post a system message saying a new user has connected if the user is being added to the `user` table and they're online, or if an existing user's online status is being set to "online".
 
 ## Conclusion
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -53,6 +53,9 @@ importers:
       prettier:
         specifier: ^3.3.3
         version: 3.6.2
+      react:
+        specifier: ^18.0.0 || ^19.0.0-0 || ^19.0.0
+        version: 18.3.1
       undici:
         specifier: ^6.19.2
         version: 6.21.3
@@ -63,6 +66,9 @@ importers:
       '@size-limit/file':
         specifier: ^11.2.0
         version: 11.2.0(size-limit@11.2.0)
+      '@types/react':
+        specifier: ^19.1.13
+        version: 19.1.13
       '@typescript-eslint/eslint-plugin':
         specifier: ^8.18.2
         version: 8.40.0(@typescript-eslint/parser@8.40.0(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2))(eslint@9.33.0(jiti@2.5.1))(typescript@5.9.2)

--- a/sdks/typescript/examples/quickstart-chat/src/App.css
+++ b/sdks/typescript/examples/quickstart-chat/src/App.css
@@ -3,11 +3,11 @@
   /* 
     3 rows: 
       1) Profile
-      2) Main content (left = message, right = system)
+      2) Main content (left = message, right = online)
       3) New message
   */
   grid-template-rows: auto 1fr auto;
-  /* 2 columns: left for chat, right for system */
+  /* 2 columns: left for chat, right for online */
   grid-template-columns: 2fr 1fr;
 
   height: 100vh; /* fill viewport height */
@@ -42,7 +42,7 @@
 }
 
 /* ----- Chat Messages (Row 2, Col 1) ----- */
-.message {
+.message-panel {
   grid-row: 2 / 3;
   grid-column: 1 / 2;
 
@@ -54,12 +54,32 @@
   gap: 1rem;
 }
 
+.messages {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.system-message {
+  background-color: var(--theme-color);
+  color: var(--theme-color-contrast);
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+  font-style: italic;
+}
+
+.user-message {
+  background-color: var(--textbox-color);
+  padding: 0.5rem 1rem;
+  border-radius: 0.375rem;
+}
+
 .message h1 {
   margin-right: 0.5rem;
 }
 
-/* ----- System Panel (Row 2, Col 2) ----- */
-.system {
+/* ----- Online Panel (Row 2, Col 2) ----- */
+.online {
   grid-row: 2 / 3;
   grid-column: 2 / 3;
 

--- a/sdks/typescript/examples/quickstart-chat/src/App.integration.test.tsx
+++ b/sdks/typescript/examples/quickstart-chat/src/App.integration.test.tsx
@@ -2,10 +2,20 @@ import { render, screen, waitFor } from '@testing-library/react';
 import userEvent from '@testing-library/user-event';
 import { describe, it, expect } from 'vitest';
 import App from './App';
+import { SpacetimeDBProvider } from '@clockworklabs/spacetimedb-sdk/react';
+import { DbConnection } from './module_bindings';
 
 describe('App Integration Test', () => {
   it('connects to the DB, allows name change and message sending', async () => {
-    render(<App />);
+    const connectionBuilder = DbConnection.builder()
+      .withUri('ws://localhost:3000')
+      .withModuleName('quickstart-chat')
+      .withToken(localStorage.getItem('auth_token') || '');
+    render(
+      <SpacetimeDBProvider connectionBuilder={connectionBuilder}>
+        <App />
+      </SpacetimeDBProvider>
+    );
 
     // Initially, we should see "Connecting..."
     expect(screen.getByText(/Connecting.../i)).toBeInTheDocument();

--- a/sdks/typescript/examples/quickstart-chat/src/App.tsx
+++ b/sdks/typescript/examples/quickstart-chat/src/App.tsx
@@ -104,7 +104,7 @@ function App() {
     conn.reducers.setName(newName);
   };
 
-  const onMessageSubmit = (e: React.FormEvent<HTMLFormElement>) => {
+  const onSubmitMessage = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();
     setNewMessage('');
     conn.reducers.sendMessage(newMessage);
@@ -214,7 +214,7 @@ function App() {
       </div>
       <div className="new-message">
         <form
-          onSubmit={onMessageSubmit}
+          onSubmit={onSubmitMessage}
           style={{
             display: 'flex',
             flexDirection: 'column',

--- a/sdks/typescript/examples/quickstart-chat/src/App.tsx
+++ b/sdks/typescript/examples/quickstart-chat/src/App.tsx
@@ -1,154 +1,30 @@
-import React, { useEffect, useState } from 'react';
+import React, { useState } from 'react';
 import './App.css';
-import {
-  DbConnection,
-  ErrorContext,
-  EventContext,
-  Message,
-  User,
-} from './module_bindings';
-import { Identity } from '@clockworklabs/spacetimedb-sdk';
+import { DbConnection, Message, User } from './module_bindings';
+import { useSpacetimeDB, useTable } from '@clockworklabs/spacetimedb-sdk/react';
 
 export type PrettyMessage = {
   senderName: string;
   text: string;
 };
 
-function useMessages(conn: DbConnection | null): Message[] {
-  const [messages, setMessages] = useState<Message[]>([]);
-
-  useEffect(() => {
-    if (!conn) return;
-    const onInsert = (_ctx: EventContext, message: Message) => {
-      setMessages(prev => [...prev, message]);
-    };
-    conn.db.message.onInsert(onInsert);
-
-    const onDelete = (_ctx: EventContext, message: Message) => {
-      setMessages(prev =>
-        prev.filter(
-          m =>
-            m.text !== message.text &&
-            m.sent !== message.sent &&
-            m.sender !== message.sender
-        )
-      );
-    };
-    conn.db.message.onDelete(onDelete);
-
-    return () => {
-      conn.db.message.removeOnInsert(onInsert);
-      conn.db.message.removeOnDelete(onDelete);
-    };
-  }, [conn]);
-
-  return messages;
-}
-
-function useUsers(conn: DbConnection | null): Map<string, User> {
-  const [users, setUsers] = useState<Map<string, User>>(new Map());
-
-  useEffect(() => {
-    if (!conn) return;
-    const onInsert = (_ctx: EventContext, user: User) => {
-      setUsers(prev => new Map(prev.set(user.identity.toHexString(), user)));
-    };
-    conn.db.user.onInsert(onInsert);
-
-    const onUpdate = (_ctx: EventContext, oldUser: User, newUser: User) => {
-      setUsers(prev => {
-        prev.delete(oldUser.identity.toHexString());
-        return new Map(prev.set(newUser.identity.toHexString(), newUser));
-      });
-    };
-    conn.db.user.onUpdate(onUpdate);
-
-    const onDelete = (_ctx: EventContext, user: User) => {
-      setUsers(prev => {
-        prev.delete(user.identity.toHexString());
-        return new Map(prev);
-      });
-    };
-    conn.db.user.onDelete(onDelete);
-
-    return () => {
-      conn.db.user.removeOnInsert(onInsert);
-      conn.db.user.removeOnUpdate(onUpdate);
-      conn.db.user.removeOnDelete(onDelete);
-    };
-  }, [conn]);
-
-  return users;
-}
-
 function App() {
+  const conn = useSpacetimeDB<DbConnection>();
+  const { identity, isActive: connected } = conn;
   const [newName, setNewName] = useState('');
   const [settingName, setSettingName] = useState(false);
   const [systemMessage, setSystemMessage] = useState('');
   const [newMessage, setNewMessage] = useState('');
-  const [connected, setConnected] = useState<boolean>(false);
-  const [identity, setIdentity] = useState<Identity | null>(null);
-  const [conn, setConn] = useState<DbConnection | null>(null);
 
-  useEffect(() => {
-    const subscribeToQueries = (conn: DbConnection, queries: string[]) => {
-      conn
-        ?.subscriptionBuilder()
-        .onApplied(() => {
-          console.log('SDK client cache initialized.');
-        })
-        .subscribe(queries);
-    };
-
-    const onConnect = (
-      conn: DbConnection,
-      identity: Identity,
-      token: string
-    ) => {
-      setIdentity(identity);
-      setConnected(true);
-      localStorage.setItem('auth_token', token);
-      console.log(
-        'Connected to SpacetimeDB with identity:',
-        identity.toHexString()
-      );
-      conn.reducers.onSendMessage(() => {
-        console.log('Message sent.');
-      });
-
-      subscribeToQueries(conn, ['SELECT * FROM message', 'SELECT * FROM user']);
-    };
-
-    const onDisconnect = () => {
-      console.log('Disconnected from SpacetimeDB');
-      setConnected(false);
-    };
-
-    const onConnectError = (_ctx: ErrorContext, err: Error) => {
-      console.log('Error connecting to SpacetimeDB:', err);
-    };
-
-    setConn(
-      DbConnection.builder()
-        .withUri('ws://localhost:3000')
-        .withModuleName('quickstart-chat')
-        .withToken(localStorage.getItem('auth_token') || '')
-        .onConnect(onConnect)
-        .onDisconnect(onDisconnect)
-        .onConnectError(onConnectError)
-        .build()
-    );
-  }, []);
-
-  useEffect(() => {
-    if (!conn) return;
-    conn.db.user.onInsert((_ctx, user) => {
+  const { rows: messages } = useTable<DbConnection, Message>('message');
+  const { rows: users } = useTable<DbConnection, User>('user', {
+    onInsert: user => {
       if (user.online) {
         const name = user.name || user.identity.toHexString().substring(0, 8);
         setSystemMessage(prev => prev + `\n${name} has connected.`);
       }
-    });
-    conn.db.user.onUpdate((_ctx, oldUser, newUser) => {
+    },
+    onUpdate: (oldUser, newUser) => {
       const name =
         newUser.name || newUser.identity.toHexString().substring(0, 8);
       if (oldUser.online === false && newUser.online === true) {
@@ -156,33 +32,38 @@ function App() {
       } else if (oldUser.online === true && newUser.online === false) {
         setSystemMessage(prev => prev + `\n${name} has disconnected.`);
       }
-    });
-  }, [conn]);
+    },
+    onDelete: user => {
+      const name = user.name || user.identity.toHexString().substring(0, 8);
+      setSystemMessage(prev => prev + `\n${name} has disconnected.`);
+    },
+  });
 
-  const messages = useMessages(conn);
-  const users = useUsers(conn);
-
-  const prettyMessages: PrettyMessage[] = messages
+  const prettyMessages: PrettyMessage[] = Array.from(messages)
     .sort((a, b) => (a.sent > b.sent ? 1 : -1))
-    .map(message => ({
-      senderName:
-        users.get(message.sender.toHexString())?.name ||
-        message.sender.toHexString().substring(0, 8),
-      text: message.text,
-    }));
+    .map(message => {
+      const user = users.find(
+        u => u.identity.toHexString() === message.sender.toHexString()
+      );
+      return {
+        senderName: user?.name || message.sender.toHexString().substring(0, 8),
+        text: message.text,
+      };
+    });
 
-  if (!conn || !connected || !identity) {
+  console.log('connected:', connected, 'identity:', identity?.toHexString());
+
+  if (!connected || !identity) {
     return (
       <div className="App">
         <h1>Connecting...</h1>
       </div>
     );
   }
-
-  const name =
-    users.get(identity?.toHexString())?.name ||
-    identity?.toHexString().substring(0, 8) ||
-    '';
+  const name = (() => {
+    const user = users.find(u => u.identity.isEqual(identity));
+    return user?.name || identity?.toHexString().substring(0, 8) || '';
+  })();
 
   const onSubmitNewName = (e: React.FormEvent<HTMLFormElement>) => {
     e.preventDefault();

--- a/sdks/typescript/examples/quickstart-chat/src/main.tsx
+++ b/sdks/typescript/examples/quickstart-chat/src/main.tsx
@@ -28,7 +28,7 @@ const onConnectError = (_ctx: ErrorContext, err: Error) => {
 const connectionBuilder = DbConnection.builder()
   .withUri('ws://localhost:3000')
   .withModuleName('quickstart-chat')
-  .withToken(localStorage.getItem('auth_token') || '')
+  .withToken(localStorage.getItem('auth_token') || undefined)
   .onConnect(onConnect)
   .onDisconnect(onDisconnect)
   .onConnectError(onConnectError);

--- a/sdks/typescript/examples/quickstart-chat/src/main.tsx
+++ b/sdks/typescript/examples/quickstart-chat/src/main.tsx
@@ -2,9 +2,41 @@ import { StrictMode } from 'react';
 import { createRoot } from 'react-dom/client';
 import './index.css';
 import App from './App.tsx';
+import { Identity } from '@clockworklabs/spacetimedb-sdk';
+import { SpacetimeDBProvider } from '@clockworklabs/spacetimedb-sdk/react';
+import { DbConnection, ErrorContext } from './module_bindings/index.ts';
+
+const onConnect = (conn: DbConnection, identity: Identity, token: string) => {
+  localStorage.setItem('auth_token', token);
+  console.log(
+    'Connected to SpacetimeDB with identity:',
+    identity.toHexString()
+  );
+  conn.reducers.onSendMessage(() => {
+    console.log('Message sent.');
+  });
+};
+
+const onDisconnect = () => {
+  console.log('Disconnected from SpacetimeDB');
+};
+
+const onConnectError = (_ctx: ErrorContext, err: Error) => {
+  console.log('Error connecting to SpacetimeDB:', err);
+};
+
+const connectionBuilder = DbConnection.builder()
+  .withUri('ws://localhost:3000')
+  .withModuleName('quickstart-chat')
+  .withToken(localStorage.getItem('auth_token') || '')
+  .onConnect(onConnect)
+  .onDisconnect(onDisconnect)
+  .onConnectError(onConnectError);
 
 createRoot(document.getElementById('root')!).render(
   <StrictMode>
-    <App />
+    <SpacetimeDBProvider connectionBuilder={connectionBuilder}>
+      <App />
+    </SpacetimeDBProvider>
   </StrictMode>
 );

--- a/sdks/typescript/package.json
+++ b/sdks/typescript/package.json
@@ -31,6 +31,12 @@
       "import": "./dist/index.js",
       "default": "./dist/index.js"
     },
+    "./react": {
+      "types": "./src/react/index.ts",
+      "browser": "./dist/browser/react/index.js",
+      "import": "./dist/react/index.js",
+      "default": "./dist/react/index.js"
+    },
     "./package.json": "./package.json"
   },
   "sideEffects": false,

--- a/sdks/typescript/src/react/index.ts
+++ b/sdks/typescript/src/react/index.ts
@@ -1,0 +1,2 @@
+export * from 'spacetimedb/react';
+export type * from 'spacetimedb/react';

--- a/sdks/typescript/tsup.config.ts
+++ b/sdks/typescript/tsup.config.ts
@@ -61,6 +61,36 @@ export default defineConfig([
     external: ['undici'],
     esbuildOptions: commonEsbuildTweaks(),
   },
+
+  // React subpath (SSR-friendly) -> dist/react/index.js
+  {
+    entry: { index: 'src/react/index.ts' },
+    format: ['esm'],
+    target: 'es2022',
+    outDir: 'dist/react',
+    dts: false, // wrapper doesn't own .d.ts; package.json points to src
+    sourcemap: true,
+    clean: true,
+    platform: 'neutral',
+    noExternal: ['spacetimedb'],
+    treeshake: 'smallest',
+    esbuildOptions: commonEsbuildTweaks(),
+  },
+
+  // React subpath (browser) -> dist/browser/react/index.js
+  {
+    entry: { index: 'src/react/index.ts' },
+    format: ['esm'],
+    target: 'es2022',
+    outDir: 'dist/browser/react',
+    dts: false,
+    sourcemap: true,
+    clean: true,
+    platform: 'browser',
+    noExternal: ['spacetimedb'],
+    treeshake: 'smallest',
+    esbuildOptions: commonEsbuildTweaks(),
+  },
 ]) satisfies
   | Options
   | Options[]


### PR DESCRIPTION
# Description of Changes

This adds `react` as an optional peer dependency. If the TypeScript SDK is imported into a library that uses React (of the appropriate version) then they will have access to two new React hooks:

```ts
useSpacetimeDB<DbConnection>();
useTable<DbConnection, MyTable>('my_table');
```

This PR also updates the TypeScript `quickstart-chat` tutorial in the docs to use the new React hooks. I will split that tutorial into separate `React` and `TypeScript` tutorials in a future PR.

# API and ABI breaking changes

This is a purely additive change to the SDK

# Expected complexity level and risk

2 because it changes how the SDK is built a bit. Namely it makes the `spacetimedb` library an external dependency.

# Testing

- [x] Tested the quickstart-chat tutorial app and confirmed features to be working.