### PR TITLE
Fix `tools/publish-crates.sh`

### DIFF
--- a/tools/find-publish-list.py
+++ b/tools/find-publish-list.py
@@ -86,6 +86,6 @@ if __name__ == "__main__":
         print("\nAll crates to publish, in order:")
     for crate in publish_order:
         if args.directories:
-            print(crate_metadata[crate]['manifest_path'])
+            print(Path(crate_metadata[crate]['manifest_path']).parent)
         else:
             print(crate)

--- a/tools/publish-crates.sh
+++ b/tools/publish-crates.sh
@@ -72,8 +72,9 @@ for path in "${CRATES[@]}"; do
         fi
     fi
 
+    crate="$(basename "$path")"
     # Add owners
-    echo "INFO: Adding owners for $crate..."
+    echo "Adding owners for $crate..."
     for owner in "${NEW_CRATE_OWNERS[@]}"; do
         if ! OUTPUT=$(cargo owner --add "$owner" 2>&1); then
           if echo "$OUTPUT" | grep -q "already" ; then
@@ -84,7 +85,7 @@ for path in "${CRATES[@]}"; do
             exit 1
           fi
         else
-          echo "INFO: Added $owner as an owner of $crate."
+          echo "Added $owner as an owner of $crate."
         fi
     done
     echo


### PR DESCRIPTION
# Description of Changes

Fixes two problems introduced in #3185:
1. The `--directories` option on `find-publish-list.py` was not printing directories
2. The `publish-crates.sh` script was using an undefined variable.

# API and ABI breaking changes

No breaking changes

# Expected complexity level and risk

1

# Testing

This was used to publish crates in the release yesterday.