### PR TITLE
Expand scope of `DurabilityProvider` to include snapshotting

### DIFF
--- a/crates/core/src/db/mod.rs
+++ b/crates/core/src/db/mod.rs
@@ -7,7 +7,9 @@ use crate::subscription::ExecutionCounters;
 use spacetimedb_datastore::execution_context::WorkloadType;
 use spacetimedb_datastore::{locking_tx_datastore::datastore::TxMetrics, traits::TxData};
 
+pub mod persistence;
 pub mod relational_db;
+pub mod snapshot;
 pub mod update;
 
 /// Whether SpacetimeDB is run in memory, or persists objects and

--- a/crates/core/src/db/persistence.rs
+++ b/crates/core/src/db/persistence.rs
@@ -1,0 +1,155 @@
+use std::{io, sync::Arc};
+
+use async_trait::async_trait;
+use spacetimedb_durability::{DurabilityExited, TxOffset};
+use spacetimedb_paths::server::ServerDataDir;
+use spacetimedb_snapshot::SnapshotRepository;
+
+use crate::{messages::control_db::Database, util::asyncify};
+
+use super::{
+    relational_db::{self, Txdata},
+    snapshot::{SnapshotDatabaseState, SnapshotWorker},
+};
+
+/// [spacetimedb_durability::Durability] impls with a [`Txdata`] transaction
+/// payload, suitable for use in the [`relational_db::RelationalDB`].
+pub type Durability = dyn spacetimedb_durability::Durability<TxData = Txdata>;
+
+/// A function to determine the size on disk of the durable state of the
+/// local database instance. This is used for metrics and energy accounting
+/// purposes.
+///
+/// It is not part of the [`Durability`] trait because it must report disk
+/// usage of the local instance only, even if exclusively remote durability is
+/// configured or the database is in follower state.
+pub type DiskSizeFn = Arc<dyn Fn() -> io::Result<u64> + Send + Sync>;
+
+/// Persistence services for a database.
+pub struct Persistence {
+    /// The [Durability] to use, for persisting transactions.
+    pub durability: Arc<Durability>,
+    /// The [DiskSizeFn].
+    ///
+    /// Currently the expectation is that the reported size is the commitlog
+    /// size only.
+    pub disk_size: DiskSizeFn,
+    /// An optional [SnapshotWorker].
+    ///
+    /// The current expectation is that snapshots are only enabled for
+    /// persistent (as opposed to in-memory) databases. This is enforced by
+    /// this type.
+    pub snapshots: Option<SnapshotWorker>,
+}
+
+impl Persistence {
+    /// Convenience constructor of a [Persistence] that handles boxing.
+    pub fn new(
+        durability: impl spacetimedb_durability::Durability<TxData = Txdata> + 'static,
+        disk_size: impl Fn() -> io::Result<u64> + Send + Sync + 'static,
+        snapshots: Option<SnapshotWorker>,
+    ) -> Self {
+        Self {
+            durability: Arc::new(durability),
+            disk_size: Arc::new(disk_size),
+            snapshots,
+        }
+    }
+
+    /// If snapshots are enabled, get the [SnapshotRepository] they are stored in.
+    pub fn snapshot_repo(&self) -> Option<&SnapshotRepository> {
+        self.snapshots.as_ref().map(|worker| worker.repo())
+    }
+
+    /// Get the [TxOffset] reported as durable by the [Durability] impl.
+    ///
+    /// Returns `Ok(None)` if no offset is durable yet, and `Err(DurabilityExited)`
+    /// if the [Durability] has shut down already.
+    pub fn durable_tx_offset(&self) -> Result<Option<TxOffset>, DurabilityExited> {
+        self.durability.durable_tx_offset().get()
+    }
+
+    /// Initialize the [SnapshotWorker], no-op if snapshots are not enabled.
+    pub(super) fn set_snapshot_state(&self, state: SnapshotDatabaseState) {
+        if let Some(worker) = &self.snapshots {
+            worker.start(state)
+        }
+    }
+
+    /// Convenience to deconstruct an [Option<Self>] into parts.
+    ///
+    /// Returns `(Some(durability), Some(disk_size), Option<SnapshotWorker>)`
+    /// if `this` is `Some`, and `(None, None, None)` if `this` is `None`.
+    pub(super) fn unzip(this: Option<Self>) -> (Option<Arc<Durability>>, Option<DiskSizeFn>, Option<SnapshotWorker>) {
+        this.map(
+            |Self {
+                 durability,
+                 disk_size,
+                 snapshots,
+             }| (Some(durability), Some(disk_size), snapshots),
+        )
+        .unwrap_or_default()
+    }
+}
+
+/// A persistence provider is a "factory" of sorts that can produce [Persistence]
+/// services for a given replica.
+///
+/// The [crate::host::HostController] uses this to obtain [Persistence]s from
+/// an external source, and construct [relational_db::RelationalDB]s with it.
+///
+/// This is an `async_trait` to allow it to be used as a trait object.
+#[async_trait]
+pub trait PersistenceProvider: Send + Sync {
+    async fn persistence(&self, database: &Database, replica_id: u64) -> anyhow::Result<Persistence>;
+}
+
+/// The standard [PersistenceProvider] for non-replicated databases.
+///
+/// [Persistence] services are provided for the local [ServerDataDir].
+///
+/// Note that its [PersistenceProvider::persistence] impl will spawn a
+/// background task that [compresses] older commitlog segments whenever a
+/// snapshot is taken.
+///
+/// [compresses]: relational_db::snapshot_watching_commitlog_compressor
+pub struct LocalPersistenceProvider {
+    data_dir: Arc<ServerDataDir>,
+}
+
+impl LocalPersistenceProvider {
+    pub fn new(data_dir: impl Into<Arc<ServerDataDir>>) -> Self {
+        Self {
+            data_dir: data_dir.into(),
+        }
+    }
+}
+
+#[async_trait]
+impl PersistenceProvider for LocalPersistenceProvider {
+    async fn persistence(&self, database: &Database, replica_id: u64) -> anyhow::Result<Persistence> {
+        let replica_dir = self.data_dir.replica(replica_id);
+        let commitlog_dir = replica_dir.commit_log();
+        let snapshot_dir = replica_dir.snapshots();
+
+        let (durability, disk_size) = relational_db::local_durability(commitlog_dir).await?;
+        let database_identity = database.database_identity;
+        let snapshot_worker =
+            asyncify(move || relational_db::open_snapshot_repo(snapshot_dir, database_identity, replica_id))
+                .await
+                .map(SnapshotWorker::new)?;
+
+        tokio::spawn(relational_db::snapshot_watching_commitlog_compressor(
+            snapshot_worker.subscribe(),
+            None,
+            None,
+            durability.clone(),
+        ));
+
+        Ok(Persistence {
+            durability,
+            disk_size,
+            snapshots: Some(snapshot_worker),
+        })
+    }
+}

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -7,15 +7,11 @@ use crate::worker_metrics::WORKER_METRICS;
 use anyhow::{anyhow, Context};
 use enum_map::EnumMap;
 use fs2::FileExt;
-use futures::channel::mpsc;
-use futures::StreamExt;
-use parking_lot::RwLock;
 use spacetimedb_commitlog as commitlog;
 use spacetimedb_data_structures::map::IntSet;
 use spacetimedb_datastore::db_metrics::DB_METRICS;
 use spacetimedb_datastore::error::{DatastoreError, TableError};
 use spacetimedb_datastore::execution_context::{ReducerContext, Workload, WorkloadType};
-use spacetimedb_datastore::locking_tx_datastore::committed_state::CommittedState;
 use spacetimedb_datastore::locking_tx_datastore::datastore::TxMetrics;
 use spacetimedb_datastore::locking_tx_datastore::state_view::{
     IterByColEqMutTx, IterByColRangeMutTx, IterMutTx, IterTx, StateView,
@@ -65,6 +61,8 @@ use std::path::Path;
 use std::sync::Arc;
 use tokio::sync::watch;
 
+pub use super::persistence::{DiskSizeFn, Durability, Persistence};
+pub use super::snapshot::SnapshotWorker;
 pub use durability::{DurableOffset, TxOffset};
 
 // NOTE(cloutiertyler): We should be using the associated types, but there is
@@ -74,15 +72,7 @@ pub type Tx = TxId; //<Locking as spacetimedb_datastore::traits::Tx>::Tx;
 
 type RowCountFn = Arc<dyn Fn(TableId, &str) -> i64 + Send + Sync>;
 
-/// A function to determine the size on disk of the durable state of the
-/// local database instance. This is used for metrics and energy accounting
-/// purposes.
-///
-/// It is not part of the [`Durability`] trait because it must report disk
-/// usage of the local instance only, even if exclusively remote durability is
-/// configured or the database is in follower state.
-pub type DiskSizeFn = Arc<dyn Fn() -> io::Result<u64> + Send + Sync>;
-
+/// The type of transactions committed by [RelationalDB].
 pub type Txdata = commitlog::payload::Txdata<ProductValue>;
 
 /// We've added a module version field to the system tables, but we don't yet
@@ -101,8 +91,6 @@ pub const ONLY_MODULE_VERSION: &str = "0.0.1";
 /// calling [`crate::host::ModuleHost::call_identity_connected_disconnected`]
 /// for each entry in [`ConnectedClients`].
 pub type ConnectedClients = HashSet<(Identity, ConnectionId)>;
-
-pub type Durability = dyn durability::Durability<TxData = Txdata>;
 
 #[derive(Clone)]
 pub struct RelationalDB {
@@ -131,92 +119,6 @@ pub struct RelationalDB {
     _lock: LockFile,
 }
 
-#[derive(Clone)]
-struct SnapshotWorker {
-    /// Send end of the [`Self::snapshot_loop`]'s `trigger` receiver.
-    ///
-    /// Send a message along this queue to request that the `snapshot_loop` asynchronously capture a snapshot.
-    request_snapshot: mpsc::UnboundedSender<()>,
-    /// An rx we keep around so that users can subscribe to snapshot updates.
-    notify_rx: watch::Receiver<TxOffset>,
-}
-
-impl SnapshotWorker {
-    fn new(committed_state: Arc<RwLock<CommittedState>>, repo: Arc<SnapshotRepository>) -> Self {
-        let (request_snapshot, trigger) = mpsc::unbounded();
-        let latest_snapshot = repo.latest_snapshot().ok().flatten().unwrap_or(0);
-        let (notify_tx, notify_rx) = watch::channel(latest_snapshot);
-        tokio::spawn(
-            SnapshotWorkerActor {
-                trigger,
-                committed_state,
-                repo,
-                notify_tx,
-            }
-            .run(),
-        );
-        SnapshotWorker {
-            request_snapshot,
-            notify_rx,
-        }
-    }
-}
-
-struct SnapshotWorkerActor {
-    trigger: mpsc::UnboundedReceiver<()>,
-    committed_state: Arc<RwLock<CommittedState>>,
-    repo: Arc<SnapshotRepository>,
-    notify_tx: watch::Sender<TxOffset>,
-}
-
-impl SnapshotWorkerActor {
-    /// The snapshot loop takes a snapshot after each `trigger` message received.
-    async fn run(mut self) {
-        while let Some(()) = self.trigger.next().await {
-            self.take_snapshot().await
-        }
-    }
-
-    async fn take_snapshot(&self) {
-        let start_time = std::time::Instant::now();
-        let committed_state = self.committed_state.clone();
-        let snapshot_repo = self.repo.clone();
-        let res = asyncify(move || {
-            Locking::take_snapshot_internal(&committed_state, &snapshot_repo).inspect(|opts| {
-                if let Some(opts) = opts {
-                    Locking::compress_older_snapshot_internal(&snapshot_repo, opts.0);
-                }
-            })
-        })
-        .await;
-        match res {
-            Err(e) => {
-                log::error!(
-                    "Error capturing snapshot of database {:?}: {e:?}",
-                    self.repo.database_identity()
-                );
-            }
-
-            Ok(None) => {
-                log::warn!(
-                    "SnapshotWorker::take_snapshot: refusing to take snapshot of database {} at TX offset -1",
-                    self.repo.database_identity()
-                );
-            }
-
-            Ok(Some((tx_offset, _path))) => {
-                log::info!(
-                    "Captured snapshot of database {:?} at TX offset {} in {:?}",
-                    self.repo.database_identity(),
-                    tx_offset,
-                    start_time.elapsed()
-                );
-                self.notify_tx.send_replace(tx_offset);
-            }
-        }
-    }
-}
-
 /// Perform a snapshot every `SNAPSHOT_FREQUENCY` transactions.
 // TODO(config): Allow DBs to specify how frequently to snapshot.
 // TODO(bikeshedding): Snapshot based on number of bytes written to commitlog, not tx offsets.
@@ -240,15 +142,13 @@ impl RelationalDB {
         database_identity: Identity,
         owner_identity: Identity,
         inner: Locking,
-        durability: Option<(Arc<Durability>, DiskSizeFn)>,
-        snapshot_repo: Option<Arc<SnapshotRepository>>,
+        persistence: Option<Persistence>,
         metrics_recorder_queue: Option<MetricsRecorderQueue>,
     ) -> Self {
-        let (durability, disk_size_fn) = durability.unzip();
-        let snapshot_worker =
-            snapshot_repo.map(|repo| SnapshotWorker::new(inner.committed_state.clone(), repo.clone()));
         let workload_type_to_exec_counters =
             Arc::new(EnumMap::from_fn(|ty| ExecutionCounters::new(&ty, &database_identity)));
+
+        let (durability, disk_size_fn, snapshot_worker) = Persistence::unzip(persistence);
 
         Self {
             inner,
@@ -357,8 +257,7 @@ impl RelationalDB {
         database_identity: Identity,
         owner_identity: Identity,
         history: impl durability::History<TxData = Txdata>,
-        durability: Option<(Arc<Durability>, DiskSizeFn)>,
-        snapshot_repo: Option<Arc<SnapshotRepository>>,
+        mut persistence: Option<Persistence>,
         metrics_recorder_queue: Option<MetricsRecorderQueue>,
         page_pool: PagePool,
     ) -> Result<(Self, ConnectedClients), DBError> {
@@ -369,11 +268,9 @@ impl RelationalDB {
         // Check the latest durable TX and restore from a snapshot no newer than it,
         // so that you drop TXes which were committed but not durable before the restart.
         // TODO: delete or mark as invalid snapshots newer than this.
-        let durable_tx_offset = durability
+        let durable_tx_offset = persistence
             .as_ref()
-            .map(|pair| pair.0.clone())
-            .as_deref()
-            .map(|durability| durability.durable_tx_offset().get())
+            .map(|p| p.durable_tx_offset())
             .transpose()?
             .flatten();
         let (min_commitlog_offset, _) = history.tx_range_hint();
@@ -384,11 +281,14 @@ impl RelationalDB {
 
         let inner = Self::restore_from_snapshot_or_bootstrap(
             database_identity,
-            snapshot_repo.as_deref(),
+            persistence.as_ref().and_then(|p| p.snapshot_repo()),
             durable_tx_offset,
             min_commitlog_offset,
             page_pool,
         )?;
+        if let Some(persistence) = &mut persistence {
+            persistence.set_snapshot_state(inner.committed_state.clone());
+        }
 
         apply_history(&inner, database_identity, history)?;
 
@@ -403,8 +303,7 @@ impl RelationalDB {
             database_identity,
             owner_identity,
             inner,
-            durability,
-            snapshot_repo,
+            persistence,
             metrics_recorder_queue,
         );
         db.migrate_system_tables()?;
@@ -974,7 +873,7 @@ impl RelationalDB {
         if let Some(snapshot_worker) = &self.snapshot_worker {
             if let Some(tx_offset) = tx_data.tx_offset() {
                 if tx_offset % SNAPSHOT_FREQUENCY == 0 {
-                    snapshot_worker.request_snapshot.unbounded_send(()).unwrap();
+                    snapshot_worker.request_snapshot();
                 }
             }
         }
@@ -986,7 +885,7 @@ impl RelationalDB {
     /// returns a `watch::Receiver` that updates with the latest [`TxOffset`] a snapshot
     /// was taken at.
     pub fn subscribe_to_snapshots(&self) -> Option<watch::Receiver<TxOffset>> {
-        self.snapshot_worker.as_ref().map(|snap| snap.notify_rx.clone())
+        self.snapshot_worker.as_ref().map(|snap| snap.subscribe())
     }
 
     /// Run a fallible function in a transaction.
@@ -1685,11 +1584,7 @@ pub async fn local_durability(commitlog_dir: CommitLogDir) -> io::Result<(LocalD
 /// Watches snapshot creation events and compresses all commitlog segments older
 /// than the snapshot.
 ///
-/// Intended to be spawned as a [StartSnapshotWatcher], provided by a
-/// [DurabilityProvider]. Suitable **only** for non-replicated databases.
-///
-/// [StartSnapshotWatcher]: crate::host::host_controller::StartSnapshotWatcher
-/// [DurabilityProvider]: crate::host::host_controller::DurabilityProvider
+/// Suitable **only** for non-replicated databases.
 pub async fn snapshot_watching_commitlog_compressor(
     mut snapshot_rx: watch::Receiver<u64>,
     mut clog_tx: Option<tokio::sync::mpsc::Sender<u64>>,
@@ -1769,6 +1664,8 @@ fn default_row_count_fn(db: Identity) -> RowCountFn {
 
 #[cfg(any(test, feature = "test"))]
 pub mod tests_utils {
+    use crate::db::snapshot::SnapshotWorker;
+
     use super::*;
     use core::ops::Deref;
     use durability::EmptyHistory;
@@ -1915,18 +1812,22 @@ pub mod tests_utils {
         ) -> Result<(RelationalDB, Arc<durability::Local<ProductValue>>), DBError> {
             let (local, disk_size_fn) = rt.block_on(local_durability(root.commit_log()))?;
             let history = local.clone();
-            let durability = local.clone() as Arc<Durability>;
-            let snapshot_repo = want_snapshot_repo
-                .then(|| open_snapshot_repo(root.snapshots(), db_identity, replica_id))
+            let snapshots = want_snapshot_repo
+                .then(|| open_snapshot_repo(root.snapshots(), db_identity, replica_id).map(SnapshotWorker::new))
                 .transpose()?;
+
+            let persistence = Persistence {
+                durability: local.clone(),
+                disk_size: disk_size_fn,
+                snapshots,
+            };
 
             let (db, _) = RelationalDB::open(
                 root,
                 db_identity,
                 owner_identity,
                 history,
-                Some((durability, disk_size_fn)),
-                snapshot_repo,
+                Some(persistence),
                 None,
                 PagePool::new_for_test(),
             )?;
@@ -1947,7 +1848,7 @@ pub mod tests_utils {
             expected_num_clients: usize,
         ) -> Result<Self, DBError> {
             let dir = TempReplicaDir::new()?;
-            let db = Self::open_db(&dir, history, None, None, None, expected_num_clients)?;
+            let db = Self::open_db(&dir, history, None, None, expected_num_clients)?;
             Ok(Self {
                 db,
                 durable: None,
@@ -2036,7 +1937,7 @@ pub mod tests_utils {
         }
 
         fn in_memory_internal(root: &ReplicaDir) -> Result<RelationalDB, DBError> {
-            Self::open_db(root, EmptyHistory::new(), None, None, None, 0)
+            Self::open_db(root, EmptyHistory::new(), None, None, 0)
         }
 
         fn durable_internal(
@@ -2046,11 +1947,14 @@ pub mod tests_utils {
         ) -> Result<(RelationalDB, Arc<durability::Local<ProductValue>>), DBError> {
             let (local, disk_size_fn) = rt.block_on(local_durability(root.commit_log()))?;
             let history = local.clone();
-            let durability = local.clone() as Arc<Durability>;
-            let snapshot_repo = want_snapshot_repo
-                .then(|| open_snapshot_repo(root.snapshots(), Identity::ZERO, 0))
-                .transpose()?;
-            let db = Self::open_db(root, history, Some((durability, disk_size_fn)), snapshot_repo, None, 0)?;
+            let persistence = Persistence {
+                durability: local.clone(),
+                disk_size: disk_size_fn,
+                snapshots: want_snapshot_repo
+                    .then(|| open_snapshot_repo(root.snapshots(), Identity::ZERO, 0).map(SnapshotWorker::new))
+                    .transpose()?,
+            };
+            let db = Self::open_db(root, history, Some(persistence), None, 0)?;
 
             Ok((db, local))
         }
@@ -2058,8 +1962,7 @@ pub mod tests_utils {
         pub fn open_db(
             root: &ReplicaDir,
             history: impl durability::History<TxData = Txdata>,
-            durability: Option<(Arc<Durability>, DiskSizeFn)>,
-            snapshot_repo: Option<Arc<SnapshotRepository>>,
+            persistence: Option<Persistence>,
             metrics_recorder_queue: Option<MetricsRecorderQueue>,
             expected_num_clients: usize,
         ) -> Result<RelationalDB, DBError> {
@@ -2068,8 +1971,7 @@ pub mod tests_utils {
                 Self::DATABASE_IDENTITY,
                 Self::OWNER,
                 history,
-                durability,
-                snapshot_repo,
+                persistence,
                 metrics_recorder_queue,
                 PagePool::new_for_test(),
             )?;
@@ -2317,7 +2219,6 @@ mod tests {
             Identity::ZERO,
             Identity::ZERO,
             EmptyHistory::new(),
-            None,
             None,
             None,
             PagePool::new_for_test(),

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -2120,7 +2120,7 @@ mod tests {
         system_tables, StConstraintRow, StIndexRow, StSequenceRow, StTableRow, ST_CONSTRAINT_ID, ST_INDEX_ID,
         ST_SEQUENCE_ID, ST_TABLE_ID,
     };
-    use spacetimedb_fs_utils::compression::{CompressCount, CompressType};
+    use spacetimedb_fs_utils::compression::CompressType;
     use spacetimedb_lib::db::raw_def::v9::{btree, RawTableDefBuilder};
     use spacetimedb_lib::error::ResultTest;
     use spacetimedb_lib::Identity;
@@ -2129,6 +2129,7 @@ mod tests {
     use spacetimedb_sats::buffer::BufReader;
     use spacetimedb_sats::product;
     use spacetimedb_schema::schema::RowLevelSecuritySchema;
+    use spacetimedb_snapshot::CompressionStats;
     #[cfg(unix)]
     use spacetimedb_snapshot::Snapshot;
     use spacetimedb_table::read_column::ReadColumn;
@@ -3142,7 +3143,9 @@ mod tests {
         assert_eq!(&offsets, &[1, 2, 3]);
         // Simulate we take except the last snapshot
         let last_compress = 2;
-        assert_eq!(repo.compress_older_snapshots(3)?, CompressCount { none: 0, zstd: 2 });
+        let mut stats = CompressionStats::default();
+        repo.compress_snapshots(&mut stats, ..3)?;
+        assert_eq!(stats.compression_timings.len(), 2);
         let size_compress_on = repo.size_on_disk()?;
         assert!(size_compress_on.total_size < size_compress_off.total_size);
         // Verify we hard-linked the second snapshot
@@ -3154,7 +3157,7 @@ mod tests {
             let mut hard_linked_off = 0;
 
             let (snapshot, compress) = Snapshot::read_from_file(&snapshot_dir.snapshot_file(last_compress))?;
-            assert_eq!(compress, CompressType::Zstd);
+            assert!(compress.is_compressed());
             let repo = SnapshotRepository::object_repo(&snapshot_dir)?;
             for (_, path) in snapshot.files(&repo) {
                 match path.metadata()?.nlink() {
@@ -3204,7 +3207,7 @@ mod tests {
         let out = TempDir::with_prefix("snapshot_test")?;
         let dir = SnapshotsPath::from_path_unchecked(out.path());
 
-        let (_, repo) = make_snapshot(dir.clone(), Identity::ZERO, 0, CompressType::Zstd, false);
+        let (_, repo) = make_snapshot(dir.clone(), Identity::ZERO, 0, CompressType::zstd(), false);
 
         stdb.take_snapshot(&repo)?;
         let size = repo.size_on_disk()?;

--- a/crates/core/src/db/snapshot.rs
+++ b/crates/core/src/db/snapshot.rs
@@ -4,12 +4,13 @@ use std::{
 };
 
 use futures::{channel::mpsc, StreamExt as _};
+use log::{error, info, warn};
 use parking_lot::RwLock;
-use prometheus::Histogram;
+use prometheus::{Histogram, IntGauge};
 use spacetimedb_datastore::locking_tx_datastore::{committed_state::CommittedState, datastore::Locking};
 use spacetimedb_durability::TxOffset;
 use spacetimedb_lib::Identity;
-use spacetimedb_snapshot::SnapshotRepository;
+use spacetimedb_snapshot::{CompressionStats, SnapshotRepository};
 use tokio::sync::watch;
 
 use crate::{util::asyncify, worker_metrics::WORKER_METRICS};
@@ -61,11 +62,12 @@ impl SnapshotWorker {
         let (request_tx, request_rx) = mpsc::unbounded();
         let metrics = ActorMetrics::new(self.snapshot_repository.database_identity());
         let actor = SnapshotWorkerActor {
-            trigger: request_rx,
-            committed_state: state,
-            repo: self.snapshot_repository.clone(),
-            notify_tx: self.snapshot_created.clone(),
+            snapshot_requests: request_rx,
+            database_state: state,
+            snapshot_repo: self.snapshot_repository.clone(),
+            snapshot_created: self.snapshot_created.clone(),
             metrics,
+            compression_stats: <_>::default(),
         };
         tokio::spawn(actor.run());
         self.request_snapshot
@@ -103,6 +105,11 @@ struct ActorMetrics {
     snapshot_timing_inner: Histogram,
     compression_timing_total: Histogram,
     compression_timing_inner: Histogram,
+    compression_timing_single: Histogram,
+    compression_skipped: IntGauge,
+    compression_compressed: IntGauge,
+    compression_objects_compressed: IntGauge,
+    compression_objects_hardlinked: IntGauge,
 }
 
 impl ActorMetrics {
@@ -112,81 +119,124 @@ impl ActorMetrics {
             snapshot_timing_inner: WORKER_METRICS.snapshot_creation_time_inner.with_label_values(&db),
             compression_timing_total: WORKER_METRICS.snapshot_compression_time_total.with_label_values(&db),
             compression_timing_inner: WORKER_METRICS.snapshot_compression_time_inner.with_label_values(&db),
+            compression_timing_single: WORKER_METRICS.snapshot_compression_time_single.with_label_values(&db),
+            compression_skipped: WORKER_METRICS.snapshot_compression_skipped.with_label_values(&db),
+            compression_compressed: WORKER_METRICS.snapshot_compression_compressed.with_label_values(&db),
+            compression_objects_compressed: WORKER_METRICS
+                .snapshot_compression_objects_compressed
+                .with_label_values(&db),
+            compression_objects_hardlinked: WORKER_METRICS
+                .snapshot_compression_objects_hardlinked
+                .with_label_values(&db),
         }
+    }
+
+    fn report_and_reset(
+        &self,
+        CompressionStats {
+            skipped,
+            compression_timings: compress_time,
+            objects,
+            // Don't reset `last_compressed`, we need it for the next run.
+            last_compressed: _,
+        }: &mut CompressionStats,
+    ) {
+        self.compression_skipped.set(*skipped as _);
+        *skipped = 0;
+
+        self.compression_compressed.set(compress_time.len() as _);
+        for duration in compress_time.drain(..) {
+            self.compression_timing_single.observe(duration.as_secs_f64());
+        }
+
+        self.compression_objects_compressed.set(objects.compressed as _);
+        self.compression_objects_hardlinked.set(objects.hardlinked as _);
+        objects.reset();
     }
 }
 
 struct SnapshotWorkerActor {
-    trigger: mpsc::UnboundedReceiver<()>,
-    committed_state: Arc<RwLock<CommittedState>>,
-    repo: Arc<SnapshotRepository>,
-    notify_tx: watch::Sender<TxOffset>,
+    snapshot_requests: mpsc::UnboundedReceiver<()>,
+    database_state: SnapshotDatabaseState,
+    snapshot_repo: Arc<SnapshotRepository>,
+    snapshot_created: watch::Sender<TxOffset>,
     metrics: ActorMetrics,
+    compression_stats: Option<CompressionStats>,
 }
 
 impl SnapshotWorkerActor {
     /// The snapshot loop takes a snapshot after each `trigger` message received.
     async fn run(mut self) {
-        while let Some(()) = self.trigger.next().await {
+        while let Some(()) = self.snapshot_requests.next().await {
             self.take_snapshot().await
         }
     }
 
-    async fn take_snapshot(&self) {
+    async fn take_snapshot(&mut self) {
         let timer = self.metrics.snapshot_timing_total.start_timer();
-        let committed_state = self.committed_state.clone();
-        let snapshot_repo = self.repo.clone();
-        let res = asyncify({
-            let inner_timer = self.metrics.snapshot_timing_inner.clone();
+        let inner_timer = self.metrics.snapshot_timing_inner.clone();
+
+        let committed_state = self.database_state.clone();
+        let snapshot_repo = self.snapshot_repo.clone();
+
+        let database_identity = self.snapshot_repo.database_identity();
+
+        let res = asyncify(move || {
+            let _timer = inner_timer.start_timer();
+            Locking::take_snapshot_internal(&committed_state, &snapshot_repo)
+        })
+        .await;
+
+        match res {
+            Err(e) => error!("Error capturing snapshot of database {database_identity}: {e:#}"),
+            Ok(None) => warn!("SnapshotWorker::take_snapshot: refusing to take snapshot of database {database_identity} at TX offset -1"),
+
+            Ok(Some((tx_offset, _path))) => {
+                let elapsed = Duration::from_secs_f64(timer.stop_and_record());
+                info!("Captured snapshot of database {database_identity} at TX offset {tx_offset} in {elapsed:?}");
+                self.snapshot_created.send_replace(tx_offset);
+                self.compress_snapshot_repo(tx_offset).await
+            }
+        }
+    }
+
+    async fn compress_snapshot_repo(&mut self, latest_snapshot: TxOffset) {
+        let timer = self.metrics.compression_timing_total.start_timer();
+        let inner_timer = self.metrics.compression_timing_inner.clone();
+
+        let database_identity = self.snapshot_repo.database_identity();
+
+        let snapshot_repo = self.snapshot_repo.clone();
+        // If we ran before, start at the last compressed snapshot,
+        // otherwise inspect all snapshots.
+        let last_compressed = self
+            .compression_stats
+            .as_ref()
+            .and_then(|stats| stats.last_compressed)
+            .unwrap_or_default();
+        let range = (last_compressed + 1)..latest_snapshot;
+        let mut stats = self.compression_stats.take().unwrap_or_default();
+
+        let (mut stats, res) = asyncify({
+            let range = range.clone();
             move || {
                 let _timer = inner_timer.start_timer();
-                Locking::take_snapshot_internal(&committed_state, &snapshot_repo)
+                let res = snapshot_repo.compress_snapshots(&mut stats, range);
+                (stats, res)
             }
         })
         .await;
-        match res {
-            Err(e) => {
-                log::error!(
-                    "Error capturing snapshot of database {:?}: {e:?}",
-                    self.repo.database_identity()
-                );
-            }
+        let elapsed = Duration::from_secs_f64(timer.stop_and_record());
+        self.metrics.report_and_reset(&mut stats);
+        // Store stats for reuse.
+        // `stats.last_compressed` is unchanged,
+        // we'll use it as the range start in the next invocation.
+        self.compression_stats = Some(stats);
 
-            Ok(None) => {
-                log::warn!(
-                    "SnapshotWorker::take_snapshot: refusing to take snapshot of database {} at TX offset -1",
-                    self.repo.database_identity()
-                );
-            }
-
-            Ok(Some((tx_offset, _path))) => {
-                let elapsed_secs = timer.stop_and_record();
-                log::info!(
-                    "Captured snapshot of database {:?} at TX offset {} in {:?}",
-                    self.repo.database_identity(),
-                    tx_offset,
-                    Duration::from_secs_f64(elapsed_secs),
-                );
-                self.notify_tx.send_replace(tx_offset);
-
-                let timer = self.metrics.compression_timing_total.start_timer();
-                let snapshot_repo = self.repo.clone();
-                asyncify({
-                    let inner_timer = self.metrics.compression_timing_inner.clone();
-                    move || {
-                        let _timer = inner_timer.start_timer();
-                        Locking::compress_older_snapshot_internal(&snapshot_repo, tx_offset)
-                    }
-                })
-                .await;
-                let elapsed_secs = timer.stop_and_record();
-                log::info!(
-                    "Compressed snapshots of database {} before offset {} in {:?}",
-                    self.repo.database_identity(),
-                    tx_offset,
-                    Duration::from_secs_f64(elapsed_secs),
-                );
-            }
+        if let Err(e) = res {
+            warn!("Error compressing snapshot range {range:?} of database {database_identity}: {e:#}");
+        } else {
+            info!("Compressed snapshot range {range:?} of database {database_identity} in {elapsed:?}");
         }
     }
 }

--- a/crates/core/src/db/snapshot.rs
+++ b/crates/core/src/db/snapshot.rs
@@ -1,0 +1,192 @@
+use std::{
+    sync::{Arc, OnceLock},
+    time::Duration,
+};
+
+use futures::{channel::mpsc, StreamExt as _};
+use parking_lot::RwLock;
+use prometheus::Histogram;
+use spacetimedb_datastore::locking_tx_datastore::{committed_state::CommittedState, datastore::Locking};
+use spacetimedb_durability::TxOffset;
+use spacetimedb_lib::Identity;
+use spacetimedb_snapshot::SnapshotRepository;
+use tokio::sync::watch;
+
+use crate::{util::asyncify, worker_metrics::WORKER_METRICS};
+
+pub type SnapshotDatabaseState = Arc<RwLock<CommittedState>>;
+
+/// Represents a handle to a background task that takes snapshots of a
+/// [SnapshotDatabaseState] and stores them on disk.
+///
+/// A snapshot can be [requested][Self::request_snapshot] and will be taken when
+/// the background task gets scheduled and can acquire a read lock on the
+/// database state, i.e. it happens at some point in the future.
+///
+/// Whenever a snapshot is complete, its [TxOffset] is published to a channel,
+/// to which one can [subscribe][Self::subscribe].
+///
+/// The [SnapshotWorker] handle is freely cloneable, so ownership can be shared
+/// between the database and control code.
+#[derive(Clone)]
+pub struct SnapshotWorker {
+    snapshot_created: watch::Sender<TxOffset>,
+    request_snapshot: OnceLock<mpsc::UnboundedSender<()>>,
+    snapshot_repository: Arc<SnapshotRepository>,
+}
+
+impl SnapshotWorker {
+    /// Create a new [SnapshotWorker].
+    ///
+    /// The handle is only partially initialized, as it is lacking the
+    /// [SnapshotDatabaseState]. This allows control code to [Self::subscribe]
+    /// to future snapshots before handing off the worker to the database.
+    pub fn new(snapshot_repository: Arc<SnapshotRepository>) -> Self {
+        let latest_snapshot = snapshot_repository.latest_snapshot().ok().flatten().unwrap_or(0);
+        Self {
+            snapshot_created: watch::channel(latest_snapshot).0,
+            request_snapshot: OnceLock::new(),
+            snapshot_repository,
+        }
+    }
+
+    /// Finish the initialization of [Self] by passing a [SnapshotDatabaseState].
+    ///
+    /// This is called during construction of a [super::relational_db::RelationalDB].
+    ///
+    /// # Panics
+    ///
+    /// Panics if called after the worker was already initialized.
+    pub(crate) fn start(&self, state: SnapshotDatabaseState) {
+        let (request_tx, request_rx) = mpsc::unbounded();
+        let metrics = ActorMetrics::new(self.snapshot_repository.database_identity());
+        let actor = SnapshotWorkerActor {
+            trigger: request_rx,
+            committed_state: state,
+            repo: self.snapshot_repository.clone(),
+            notify_tx: self.snapshot_created.clone(),
+            metrics,
+        };
+        tokio::spawn(actor.run());
+        self.request_snapshot
+            .set(request_tx)
+            .expect("snapshot worker already initialized");
+    }
+
+    /// Get the [SnapshotRepository] this worker is operating on.
+    pub fn repo(&self) -> &SnapshotRepository {
+        &self.snapshot_repository
+    }
+
+    /// Request a snapshot to be taken.
+    ///
+    /// The snapshot will be taken at some point in the future.
+    /// The request is dropped if the handle is not yet fully initialized.
+    pub fn request_snapshot(&self) {
+        if let Some(tx) = self.request_snapshot.get() {
+            tx.unbounded_send(()).unwrap()
+        }
+    }
+
+    /// Subscribe to the [TxOffset]s of snapshots created by this worker.
+    ///
+    /// Note that the returned [`watch::Receiver`] only stores the most recent
+    /// snapshot offset, but can be turned into a [`futures::Stream`] using the
+    /// `WatchStream` from the `tokio-stream` crate.
+    pub fn subscribe(&self) -> watch::Receiver<TxOffset> {
+        self.snapshot_created.subscribe()
+    }
+}
+
+struct ActorMetrics {
+    snapshot_timing_total: Histogram,
+    snapshot_timing_inner: Histogram,
+    compression_timing_total: Histogram,
+    compression_timing_inner: Histogram,
+}
+
+impl ActorMetrics {
+    fn new(db: Identity) -> Self {
+        Self {
+            snapshot_timing_total: WORKER_METRICS.snapshot_creation_time_total.with_label_values(&db),
+            snapshot_timing_inner: WORKER_METRICS.snapshot_creation_time_inner.with_label_values(&db),
+            compression_timing_total: WORKER_METRICS.snapshot_compression_time_total.with_label_values(&db),
+            compression_timing_inner: WORKER_METRICS.snapshot_compression_time_inner.with_label_values(&db),
+        }
+    }
+}
+
+struct SnapshotWorkerActor {
+    trigger: mpsc::UnboundedReceiver<()>,
+    committed_state: Arc<RwLock<CommittedState>>,
+    repo: Arc<SnapshotRepository>,
+    notify_tx: watch::Sender<TxOffset>,
+    metrics: ActorMetrics,
+}
+
+impl SnapshotWorkerActor {
+    /// The snapshot loop takes a snapshot after each `trigger` message received.
+    async fn run(mut self) {
+        while let Some(()) = self.trigger.next().await {
+            self.take_snapshot().await
+        }
+    }
+
+    async fn take_snapshot(&self) {
+        let timer = self.metrics.snapshot_timing_total.start_timer();
+        let committed_state = self.committed_state.clone();
+        let snapshot_repo = self.repo.clone();
+        let res = asyncify({
+            let inner_timer = self.metrics.snapshot_timing_inner.clone();
+            move || {
+                let _timer = inner_timer.start_timer();
+                Locking::take_snapshot_internal(&committed_state, &snapshot_repo)
+            }
+        })
+        .await;
+        match res {
+            Err(e) => {
+                log::error!(
+                    "Error capturing snapshot of database {:?}: {e:?}",
+                    self.repo.database_identity()
+                );
+            }
+
+            Ok(None) => {
+                log::warn!(
+                    "SnapshotWorker::take_snapshot: refusing to take snapshot of database {} at TX offset -1",
+                    self.repo.database_identity()
+                );
+            }
+
+            Ok(Some((tx_offset, _path))) => {
+                let elapsed_secs = timer.stop_and_record();
+                log::info!(
+                    "Captured snapshot of database {:?} at TX offset {} in {:?}",
+                    self.repo.database_identity(),
+                    tx_offset,
+                    Duration::from_secs_f64(elapsed_secs),
+                );
+                self.notify_tx.send_replace(tx_offset);
+
+                let timer = self.metrics.compression_timing_total.start_timer();
+                let snapshot_repo = self.repo.clone();
+                asyncify({
+                    let inner_timer = self.metrics.compression_timing_inner.clone();
+                    move || {
+                        let _timer = inner_timer.start_timer();
+                        Locking::compress_older_snapshot_internal(&snapshot_repo, tx_offset)
+                    }
+                })
+                .await;
+                let elapsed_secs = timer.stop_and_record();
+                log::info!(
+                    "Compressed snapshots of database {} before offset {} in {:?}",
+                    self.repo.database_identity(),
+                    tx_offset,
+                    Duration::from_secs_f64(elapsed_secs),
+                );
+            }
+        }
+    }
+}

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -3,6 +3,7 @@ use super::scheduler::SchedulerStarter;
 use super::wasmtime::WasmtimeRuntime;
 use super::{Scheduler, UpdateDatabaseResult};
 use crate::database_logger::DatabaseLogger;
+use crate::db::persistence::PersistenceProvider;
 use crate::db::relational_db::{self, DiskSizeFn, RelationalDB, Txdata};
 use crate::db::{self, spawn_tx_metrics_recorder};
 use crate::energy::{EnergyMonitor, EnergyQuanta, NullEnergyMonitor};
@@ -26,7 +27,7 @@ use spacetimedb_data_structures::map::IntMap;
 use spacetimedb_datastore::db_metrics::data_size::DATA_SIZE_METRICS;
 use spacetimedb_datastore::db_metrics::DB_METRICS;
 use spacetimedb_datastore::traits::Program;
-use spacetimedb_durability::{self as durability, TxOffset};
+use spacetimedb_durability::{self as durability};
 use spacetimedb_lib::{hash_bytes, Identity};
 use spacetimedb_paths::server::{ReplicaDir, ServerDataDir};
 use spacetimedb_paths::FromPathUnchecked;
@@ -53,13 +54,6 @@ type HostCell = Arc<AsyncRwLock<Option<Host>>>;
 type Hosts = Arc<Mutex<IntMap<u64, HostCell>>>;
 
 pub type ExternalDurability = (Arc<dyn Durability<TxData = Txdata>>, DiskSizeFn);
-
-pub type StartSnapshotWatcher = Box<dyn FnOnce(watch::Receiver<TxOffset>)>;
-
-#[async_trait]
-pub trait DurabilityProvider: Send + Sync + 'static {
-    async fn durability(&self, replica_id: u64) -> anyhow::Result<(ExternalDurability, Option<StartSnapshotWatcher>)>;
-}
 
 #[async_trait]
 pub trait ExternalStorage: Send + Sync + 'static {
@@ -98,8 +92,8 @@ pub struct HostController {
     program_storage: ProgramStorage,
     /// The [`EnergyMonitor`] used by this controller.
     energy_monitor: Arc<dyn EnergyMonitor>,
-    /// Provides implementations of [`Durability`] for each replica.
-    durability: Arc<dyn DurabilityProvider>,
+    /// Provides persistence services for each replica.
+    persistence: Arc<dyn PersistenceProvider>,
     /// The page pool all databases will use by cloning the ref counted pool.
     pub page_pool: PagePool,
     /// The runtimes for running our modules.
@@ -181,7 +175,7 @@ impl HostController {
         default_config: db::Config,
         program_storage: ProgramStorage,
         energy_monitor: Arc<impl EnergyMonitor>,
-        durability: Arc<dyn DurabilityProvider>,
+        persistence: Arc<dyn PersistenceProvider>,
         db_cores: JobCores,
     ) -> Self {
         Self {
@@ -189,7 +183,7 @@ impl HostController {
             default_config,
             program_storage,
             energy_monitor,
-            durability,
+            persistence,
             runtimes: HostRuntimes::new(Some(&data_dir)),
             data_dir,
             page_pool: PagePool::new(default_config.page_pool_max_size),
@@ -751,7 +745,7 @@ impl Host {
             program_storage,
             energy_monitor,
             runtimes,
-            durability,
+            persistence,
             page_pool,
             ..
         } = host_controller;
@@ -766,23 +760,18 @@ impl Host {
                 database.owner_identity,
                 EmptyHistory::new(),
                 None,
-                None,
                 Some(tx_metrics_queue),
                 page_pool.clone(),
             )?,
             db::Storage::Disk => {
-                let snapshot_repo =
-                    relational_db::open_snapshot_repo(replica_dir.snapshots(), database.database_identity, replica_id)?;
                 let (history, _) = relational_db::local_durability(replica_dir.commit_log()).await?;
-                let (durability, start_snapshot_watcher) = durability.durability(replica_id).await?;
-
+                let persistence = persistence.persistence(&database, replica_id).await?;
                 let (db, clients) = RelationalDB::open(
                     &replica_dir,
                     database.database_identity,
                     database.owner_identity,
                     history,
-                    Some(durability),
-                    Some(snapshot_repo),
+                    Some(persistence),
                     Some(tx_metrics_queue),
                     page_pool.clone(),
                 )
@@ -796,10 +785,7 @@ impl Host {
                         "Failed to open database: {e:#}"
                     );
                 })?;
-                if let Some(start_snapshot_watcher) = start_snapshot_watcher {
-                    let watcher = db.subscribe_to_snapshots().expect("we passed snapshot_repo");
-                    start_snapshot_watcher(watcher)
-                }
+
                 (db, clients)
             }
         };
@@ -901,7 +887,6 @@ impl Host {
             database.database_identity,
             database.owner_identity,
             EmptyHistory::new(),
-            None,
             None,
             None,
             page_pool,

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -25,8 +25,8 @@ mod wasm_common;
 
 pub use disk_storage::DiskStorage;
 pub use host_controller::{
-    extract_schema, DurabilityProvider, ExternalDurability, ExternalStorage, HostController, MigratePlanResult,
-    ProgramStorage, ReducerCallResult, ReducerOutcome, StartSnapshotWatcher,
+    extract_schema, ExternalDurability, ExternalStorage, HostController, MigratePlanResult, ProgramStorage,
+    ReducerCallResult, ReducerOutcome,
 };
 pub use module_host::{ModuleHost, NoSuchModule, ReducerCallError, UpdateDatabaseResult};
 pub use scheduler::Scheduler;

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -1018,7 +1018,7 @@ mod tests {
     use crate::db::relational_db::tests_utils::{
         begin_mut_tx, begin_tx, insert, with_auto_commit, with_read_only, TempReplicaDir, TestDB,
     };
-    use crate::db::relational_db::{RelationalDB, Txdata};
+    use crate::db::relational_db::{Persistence, RelationalDB, Txdata};
     use crate::error::DBError;
     use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent, ModuleFunctionCall};
     use crate::messages::websocket as ws;
@@ -1153,8 +1153,11 @@ mod tests {
         let db = TestDB::open_db(
             &dir,
             EmptyHistory::new(),
-            Some((durability.clone(), Arc::new(|| Ok(0)))),
-            None,
+            Some(Persistence {
+                durability: durability.clone(),
+                disk_size: Arc::new(|| Ok(0)),
+                snapshots: None,
+            }),
             None,
             0,
         )?;

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -312,6 +312,43 @@ metrics_group!(
         #[help = "Number of commits replayed after restoring from a snapshot upon restart"]
         #[labels(db: Identity)]
         pub replay_commitlog_num_commits: IntGaugeVec,
+
+        #[name = spacetime_snapshot_creation_time_total_sec]
+        #[help = "The time (in seconds) it took to take and store a database snapshot, including scheduling overhead"]
+        #[labels(db: Identity)]
+        // Snapshot creation should take in the order of milliseconds,
+        // but log data suggests that there are outliers.
+        // So let's track a wide range of buckets to get a better picture.
+        //
+        // We also track the timing without `asyncify` scheduling overhead
+        // (`snapshot_creation_time_inner`), and the snapshot compression
+        // timing with / without scheduling overhead (`snapshot_compression_time_total`
+        // and `snapshot_compression_time_inner`, respectively).
+        //
+        // Compression may have contributed to observed outliers, but is no
+        // longer included in the snapshot creation timing.
+        #[buckets(0.0005, 0.001, 0.005, 0.01, 0.1, 1.0, 5.0, 10.0)]
+        pub snapshot_creation_time_total: HistogramVec,
+
+        #[name = spacetime_snapshot_creation_time_inner_sec]
+        #[help = "The time (in seconds) it took to take and store a database snapshot, excluding scheduling overhead"]
+        #[labels(db: Identity)]
+        #[buckets(0.0005, 0.001, 0.005, 0.01, 0.1, 1.0, 5.0, 10.0)]
+        pub snapshot_creation_time_inner: HistogramVec,
+
+        #[name = spacetime_snapshot_compression_time_total_sec]
+        #[help = "The time (in seconds) it took to do a compression pass on the snapshot repository, including scheduling overhead"]
+        #[labels(db: Identity)]
+        // Not sure what range to expect, but certainly slower than snapshot
+        // creation.
+        #[buckets(0.001, 0.01, 0.1, 1.0, 5.0, 10.0)]
+        pub snapshot_compression_time_total: HistogramVec,
+
+        #[name = spacetime_snapshot_compression_time_inner_sec]
+        #[help = "The time (in seconds) it took to do a compression pass on the snapshot repository, excluding scheduling overhead"]
+        #[labels(db: Identity)]
+        #[buckets(0.001, 0.01, 0.1, 1.0, 5.0, 10.0)]
+        pub snapshot_compression_time_inner: HistogramVec,
     }
 );
 

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -349,6 +349,32 @@ metrics_group!(
         #[labels(db: Identity)]
         #[buckets(0.001, 0.01, 0.1, 1.0, 5.0, 10.0)]
         pub snapshot_compression_time_inner: HistogramVec,
+
+        #[name = spacetime_snapshot_compression_time_per_snapshot_sec]
+        #[help = "The time (in seconds) it took to compress a single snapshot"]
+        #[labels(db: Identity)]
+        #[buckets(0.001, 0.01, 0.1, 1.0, 5.0, 10.0)]
+        pub snapshot_compression_time_single: HistogramVec,
+
+        #[name = spacetime_snapshot_compression_skipped]
+        #[help = "The number of snapshots skipped in a single compression pass because they were already compressed"]
+        #[labels(db: Identity)]
+        pub snapshot_compression_skipped: IntGaugeVec,
+
+        #[name = spacetime_snapshot_compression_compressed]
+        #[help = "The number of snapshots compressed in a single compression pass"]
+        #[labels(db: Identity)]
+        pub snapshot_compression_compressed: IntGaugeVec,
+
+        #[name = spacetime_snapshot_compression_objects_compressed]
+        #[help = "The number of snapshot objects compressed in a single compression pass"]
+        #[labels(db: Identity)]
+        pub snapshot_compression_objects_compressed: IntGaugeVec,
+
+        #[name = spacetime_snapshot_compression_objects_hardlinked]
+        #[help = "The number of snapshot objects hardlinked in a single compression pass"]
+        #[labels(db: Identity)]
+        pub snapshot_compression_objects_hardlinked: IntGaugeVec,
     }
 );
 

--- a/crates/datastore/src/locking_tx_datastore/datastore.rs
+++ b/crates/datastore/src/locking_tx_datastore/datastore.rs
@@ -290,21 +290,6 @@ impl Locking {
         Ok(Some((tx_offset, snapshot_dir)))
     }
 
-    pub fn compress_older_snapshot_internal(repo: &SnapshotRepository, upper_bound: TxOffset) {
-        log::info!(
-            "Compressing snapshots of database {:?} older than TX offset {}",
-            repo.database_identity(),
-            upper_bound,
-        );
-        if let Err(err) = repo.compress_older_snapshots(upper_bound) {
-            log::error!(
-                "Failed to compress snapshot of database {:?} older than  {:?}: {err}",
-                repo.database_identity(),
-                upper_bound
-            );
-        };
-    }
-
     /// Returns a list over all the currently connected clients,
     /// reading from the `st_clients` system table.
     pub fn connected_clients<'a>(

--- a/crates/durability/Cargo.toml
+++ b/crates/durability/Cargo.toml
@@ -7,6 +7,9 @@ license-file = "LICENSE"
 
 description = "Traits and single-node implementation of durability for SpacetimeDB."
 
+[features]
+test = []
+
 [dependencies]
 anyhow.workspace = true
 itertools.workspace = true

--- a/crates/durability/src/imp/mod.rs
+++ b/crates/durability/src/imp/mod.rs
@@ -1,2 +1,42 @@
 pub mod local;
 pub use local::Local;
+
+#[cfg(any(test, feature = "test"))]
+pub use testing::NoDurability;
+
+#[cfg(any(test, feature = "test"))]
+mod testing {
+    use std::marker::PhantomData;
+
+    use tokio::sync::watch;
+
+    use crate::{Durability, DurableOffset, TxOffset};
+
+    /// A [`Durability`] impl that sends all transactions into the void.
+    ///
+    /// This should only be used for testing, and is thus only available when
+    /// the `test` feature is enabled.
+    pub struct NoDurability<T> {
+        durable_offset: watch::Sender<Option<TxOffset>>,
+        _txdata: PhantomData<T>,
+    }
+
+    impl<T> Default for NoDurability<T> {
+        fn default() -> Self {
+            let (durable_offset, _) = watch::channel(None);
+            Self {
+                durable_offset,
+                _txdata: PhantomData,
+            }
+        }
+    }
+
+    impl<T: Send + Sync> Durability for NoDurability<T> {
+        type TxData = T;
+
+        fn append_tx(&self, _: Self::TxData) {}
+        fn durable_tx_offset(&self) -> DurableOffset {
+            self.durable_offset.subscribe().into()
+        }
+    }
+}

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -6,7 +6,7 @@ use tokio::sync::watch;
 pub use spacetimedb_commitlog::{error, payload::Txdata, Decoder, Transaction};
 
 mod imp;
-pub use imp::{local, Local};
+pub use imp::*;
 
 /// Transaction offset.
 ///

--- a/crates/fs-utils/src/compression.rs
+++ b/crates/fs-utils/src/compression.rs
@@ -14,13 +14,36 @@ pub struct CompressCount {
     pub zstd: usize,
 }
 
+/// Supported compression algorithms.
+#[derive(Clone, Copy, Debug, PartialEq)]
+pub enum CompressionAlgorithm {
+    Zstd,
+}
+
 /// Compression type
 ///
 /// if `None`, the file is not compressed, otherwise it will be compressed using the specified algorithm.
 #[derive(Debug, Copy, Clone, PartialEq)]
 pub enum CompressType {
     None,
-    Zstd,
+    Algorithm(CompressionAlgorithm),
+}
+
+impl CompressType {
+    pub fn algorithm(&self) -> Option<CompressionAlgorithm> {
+        match self {
+            Self::None => None,
+            Self::Algorithm(algo) => Some(*algo),
+        }
+    }
+
+    pub fn zstd() -> Self {
+        Self::Algorithm(CompressionAlgorithm::Zstd)
+    }
+
+    pub fn is_compressed(&self) -> bool {
+        matches!(self, Self::Algorithm(_))
+    }
 }
 
 /// A reader that can read compressed files
@@ -73,7 +96,7 @@ impl CompressReader {
     pub fn compress_type(&self) -> CompressType {
         match self {
             CompressReader::None(_) => CompressType::None,
-            CompressReader::Zstd(_) => CompressType::Zstd,
+            CompressReader::Zstd(_) => CompressType::Algorithm(CompressionAlgorithm::Zstd),
         }
     }
 }
@@ -194,7 +217,7 @@ mod async_impls {
         pub fn compress_type(&self) -> CompressType {
             match self {
                 AsyncCompressReader::None(_) => CompressType::None,
-                AsyncCompressReader::Zstd(_) => CompressType::Zstd,
+                AsyncCompressReader::Zstd(_) => CompressType::Algorithm(CompressionAlgorithm::Zstd),
             }
         }
     }

--- a/crates/snapshot/Cargo.toml
+++ b/crates/snapshot/Cargo.toml
@@ -33,6 +33,7 @@ zstd-framed.workspace = true
 spacetimedb-core = { path = "../core", features = ["test"] }
 spacetimedb-schema = { path = "../schema" }
 spacetimedb-datastore = { path = "../datastore", features = ["test"] }
+spacetimedb-durability = { workspace = true, features = ["test"] }
 
 anyhow.workspace = true
 env_logger.workspace = true

--- a/crates/snapshot/src/lib.rs
+++ b/crates/snapshot/src/lib.rs
@@ -24,7 +24,9 @@
 #![allow(clippy::result_large_err)]
 
 use spacetimedb_durability::TxOffset;
-use spacetimedb_fs_utils::compression::{compress_with_zstd, CompressCount, CompressReader, CompressType};
+use spacetimedb_fs_utils::compression::{
+    compress_with_zstd, CompressCount, CompressReader, CompressType, CompressionAlgorithm,
+};
 use spacetimedb_fs_utils::{
     dir_trie::{o_excl, o_rdonly, CountCreated, DirTrie},
     lockfile::{Lockfile, LockfileError},
@@ -41,6 +43,8 @@ use spacetimedb_table::{
     table::Table,
 };
 use std::fs;
+use std::ops::RangeBounds;
+use std::time::{Duration, Instant};
 use std::{
     collections::BTreeMap,
     collections::HashMap,
@@ -490,7 +494,7 @@ impl Snapshot {
             .chain(self.tables.iter().flat_map(|t| t.pages.iter().copied()))
     }
 
-    /// Obtain an iterator over the [`Path`]s of all objects
+    /// Obtain an iterator over the [`PathBuf`]s of all objects
     pub fn files<'a>(&'a self, src_repo: &'a DirTrie) -> impl Iterator<Item = (blake3::Hash, PathBuf)> + 'a {
         self.objects().map(move |hash| {
             let path = src_repo.file_path(hash.as_bytes());
@@ -547,6 +551,70 @@ impl fmt::Debug for SnapshotSize {
             .field("total_size     ", &format_args!("{:>8} bytes", self.total_size))
             .finish()
     }
+}
+
+/// Number of objects compressed or hardlinked.
+#[derive(Clone, Copy, Debug, Default)]
+pub struct ObjectCompressionStats {
+    /// Number of objects freshly compressed.
+    pub compressed: usize,
+    /// Number of objects hardlinked from a parent repository.
+    pub hardlinked: usize,
+}
+
+impl ObjectCompressionStats {
+    fn is_zero(&self) -> bool {
+        self.compressed == 0 && self.hardlinked == 0
+    }
+
+    pub fn reset(&mut self) {
+        *self = Self::default();
+    }
+}
+
+impl AddAssign for ObjectCompressionStats {
+    fn add_assign(
+        &mut self,
+        Self {
+            compressed: objects_compressed,
+            hardlinked: objects_hardlinked,
+        }: Self,
+    ) {
+        self.compressed += objects_compressed;
+        self.hardlinked += objects_hardlinked;
+    }
+}
+
+/// Information about the progress of [compress_snapshots].
+///
+/// [compress_snapshots]: SnapshotRepository::compress_snapshots
+#[derive(Default)]
+pub struct CompressionStats {
+    /// Incremented for each snapshot in the supplied range that
+    /// is found to be already compressed.
+    pub skipped: usize,
+    /// Times to compress individual snapshots.
+    ///
+    /// Timings are only recorded for snapshots that were actually compressed
+    /// during the [compress_snapshots] pass, not the `skipped` ones.
+    ///
+    /// That is, `compressed.len() + skipped` is the total number of visited
+    /// snapshots during the pass.
+    ///
+    /// [compress_snapshots]: SnapshotRepository::compress_snapshots
+    pub compression_timings: Vec<Duration>,
+    /// The cumulative [ObjectCompressionStats] for all snapshots visited.
+    pub objects: ObjectCompressionStats,
+    /// The offset of the latest snapshot in the supplied range found to be
+    /// compressed.
+    ///
+    /// Note that the snapshot may have been compressed already, or was
+    /// compressed during the current [compress_snapshots] pass.
+    ///
+    /// If no snapshot was visited during the run, the value is left unchanged.
+    ///
+    /// [compress_snapshots]: SnapshotRepository::compress_snapshots
+    pub last_compressed: Option<TxOffset>,
 }
 
 /// A repository of snapshots of a particular database instance.
@@ -693,9 +761,9 @@ impl SnapshotRepository {
         self.root.snapshot_dir(tx_offset)
     }
 
-    /// Given `snapshot_dir` as the result of [`Self::snapshot_dir_path`],
+    /// Given `snapshot_dir` as the result of [`SnapshotRepository::snapshot_dir_path`],
     /// get the [`DirTrie`] which contains serialized objects (pages and large blobs)
-    /// referenced by the [`Snapshot`] contained in the [`Self::snapshot_file_path`].
+    /// referenced by the [`Snapshot`] contained in the [`SnapshotDirPath`].
     ///
     /// Consequences are unspecified if this method is called from outside this crate
     /// on a non-existent, locked or incomplete `snapshot_dir`.
@@ -834,7 +902,7 @@ impl SnapshotRepository {
 
     /// Open a repository at `root`, failing if the `root` doesn't exist or isn't a directory.
     ///
-    /// Calls [`Path::is_dir`] and requires that the result is `true`.
+    /// Calls [`SnapshotsPath::is_dir`] and requires that the result is `true`.
     /// See that method for more detailed preconditions on this function.
     pub fn open(root: SnapshotsPath, database_identity: Identity, replica_id: u64) -> Result<Self, SnapshotError> {
         if !root.is_dir() {
@@ -953,26 +1021,38 @@ impl SnapshotRepository {
         Ok(())
     }
 
-    /// Compress the snapshot (if not already compressed)
-    /// of the replica with the given `tx_offset`, and return the [`CompressType`] type..
-    pub fn compress_snapshot(
-        previous: Option<&(TxOffset, SnapshotDirPath)>,
+    /// Compress the `current` snapshot, unless it is already compressed.
+    ///
+    /// If a `parent` snapshot is given, its object repo will be used to
+    /// hardlink common objects and avoid re-compressing them:
+    ///
+    /// If an object in `current` is uncompressed, but exists in `parent` and
+    /// is compressed, a hardlink is created in `current`. Otherwise, the object
+    /// in `current` is compressed in place.
+    ///
+    /// The `parent`'s object repo is never modified.
+    ///
+    /// Returns [ObjectCompressionStats] with information about how many objects
+    /// were compressed and hardlinked, respectively.
+    fn compress_snapshot(
+        parent: Option<&(TxOffset, SnapshotDirPath)>,
         current: &(TxOffset, SnapshotDirPath),
-    ) -> Result<CompressType, SnapshotError> {
+    ) -> Result<ObjectCompressionStats, SnapshotError> {
         let (tx_offset, snapshot_dir) = current;
         let tx_offset = *tx_offset;
         let snapshot_file = snapshot_dir.snapshot_file(tx_offset);
         let (snapshot, compress_type) = Snapshot::read_from_file(&snapshot_file)?;
 
-        if compress_type != CompressType::None {
+        let mut stats = ObjectCompressionStats::default();
+        if let Some(algo) = compress_type.algorithm() {
             log::debug!(
-                "Snapshot {snapshot_dir:?} of replica {} is already compressed: {compress_type:?}",
+                "Snapshot {snapshot_dir:?} of replica {} is already compressed: {algo:?}",
                 snapshot.replica_id
             );
-            return Ok(compress_type);
+            return Ok(stats);
         }
 
-        let old = if let Some((tx_offset, snapshot_dir)) = previous {
+        let old = if let Some((tx_offset, snapshot_dir)) = parent {
             let snapshot_file = snapshot_dir.snapshot_file(*tx_offset);
             let (snapshot, _) = Snapshot::read_from_file(&snapshot_file)?;
             let dir = SnapshotRepository::object_repo(snapshot_dir)?;
@@ -986,6 +1066,7 @@ impl SnapshotRepository {
             old: &HashMap<blake3::Hash, PathBuf>,
             src: &PathBuf,
             hash: Option<blake3::Hash>,
+            stats: Option<&mut ObjectCompressionStats>,
         ) -> Result<(), SnapshotError> {
             let read = CompressReader::new(o_rdonly().open(src)?)?;
             if read.compress_type() != CompressType::None {
@@ -997,6 +1078,9 @@ impl SnapshotRepository {
                     if old_file.compress_type() != CompressType::None {
                         std::fs::hard_link(old_path, src.with_extension("_tmp"))?;
                         std::fs::rename(src.with_extension("_tmp"), src)?;
+                        if let Some(stats) = stats {
+                            stats.hardlinked += 1;
+                        }
                         return Ok(());
                     }
                 }
@@ -1007,6 +1091,10 @@ impl SnapshotRepository {
             // The default frame size compress better.
             compress_with_zstd(read, &mut write, None)?;
             std::fs::rename(dst, src)?;
+            if let Some(stats) = stats {
+                stats.compressed += 1;
+            }
+
             Ok(())
         }
 
@@ -1019,13 +1107,16 @@ impl SnapshotRepository {
 
         let dir = SnapshotRepository::object_repo(snapshot_dir)?;
         for (hash, path) in snapshot.files(&dir) {
-            compress(&old, &path, Some(hash)).inspect_err(|err| {
+            compress(&old, &path, Some(hash), Some(&mut stats)).inspect_err(|err| {
                 log::error!("Failed to compress object file {path:?}: {err}");
             })?;
         }
 
-        // Compress the snapshot file last, so it marks it compressed.
-        compress(&old, &snapshot_file.0, None).inspect_err(|err| {
+        // Compress the snapshot file last,
+        // which marks the whole snapshot as compressed.
+        //
+        // Don't update the stats for the snapshot file.
+        compress(&old, &snapshot_file.0, None, None).inspect_err(|err| {
             log::error!("Failed to compress snapshot file {snapshot_file:?}: {err}");
         })?;
 
@@ -1033,43 +1124,43 @@ impl SnapshotRepository {
             "Compressed snapshot {snapshot_dir:?} of replica {}: {compress_type:?}",
             snapshot.replica_id
         );
-        Ok(CompressType::Zstd)
+        Ok(stats)
     }
 
-    /// Compress the snapshots older than the given [`TxOffset`].
+    /// Attempt to compress all snapshots that fall into `range`, and record
+    /// the outcome in `stats`.
     ///
-    /// *NOTE*: Compression errors are logged but not returned.
-    pub fn compress_older_snapshots(&self, upper_bound: TxOffset) -> Result<CompressCount, SnapshotError> {
-        // TODO: The more snapshots we have, the more time it takes to compress, we need a way to limit this.
-        let mut snapshots: Vec<_> = self
+    /// The snapshots in `range` are traversed in ascending order.
+    /// If an error occurs, processing stops and the error is returned.
+    ///
+    /// See [CompressionStats] for how to interpret the results.
+    pub fn compress_snapshots(
+        &self,
+        stats: &mut CompressionStats,
+        range: impl RangeBounds<TxOffset>,
+    ) -> Result<(), SnapshotError> {
+        let mut snapshots = self
             .all_snapshots()?
-            // Ignore `tx_offset`s greater than the current upper bound.
-            .filter_map(|tx_offset| {
-                if tx_offset < upper_bound {
-                    let path = self.snapshot_dir_path(tx_offset);
-                    Some((tx_offset, path))
-                } else {
-                    None
-                }
-            })
-            .collect();
-        snapshots.sort_by(|(a_offset, _), (b_offset, _)| a_offset.cmp(b_offset));
-        let mut count = CompressCount::default();
+            .filter(|offset| range.contains(offset))
+            .map(|offset| (offset, self.snapshot_dir_path(offset)))
+            .collect::<Vec<_>>();
+        snapshots.sort_by_key(|&(offset, _)| offset);
+
         let mut previous = None;
-        for current in snapshots.iter() {
-            match Self::compress_snapshot(previous, current)
-                .inspect_err(|err| {
-                    log::error!("Failed to compress snapshot {:?}: {err}", current.1);
-                })
-                .unwrap_or(CompressType::None)
-            {
-                CompressType::None => count.none += 1,
-                CompressType::Zstd => count.zstd += 1,
+        for current in &snapshots {
+            let start = Instant::now();
+            let object_stats = Self::compress_snapshot(previous, current)?;
+            if object_stats.is_zero() {
+                stats.skipped += 1;
+            } else {
+                stats.compression_timings.push(start.elapsed());
             }
+            stats.objects += object_stats;
+            stats.last_compressed = Some(current.0);
             previous = Some(current);
         }
 
-        Ok(count)
+        Ok(())
     }
 
     /// Calculate the size of the snapshot repository in bytes.
@@ -1093,7 +1184,7 @@ impl SnapshotRepository {
 
         size.snapshot = match compress_type {
             CompressType::None => CompressCount { none: 1, zstd: 0 },
-            CompressType::Zstd => CompressCount { none: 0, zstd: 1 },
+            CompressType::Algorithm(CompressionAlgorithm::Zstd) => CompressCount { none: 0, zstd: 1 },
         };
 
         size.file_size += snapshot_file_size;

--- a/crates/snapshot/tests/remote.rs
+++ b/crates/snapshot/tests/remote.rs
@@ -5,16 +5,19 @@ use log::info;
 use pretty_assertions::assert_matches;
 use rand::seq::IndexedRandom as _;
 use spacetimedb::{
-    db::relational_db::{
-        tests_utils::{TempReplicaDir, TestDB},
-        SNAPSHOT_FREQUENCY,
+    db::{
+        relational_db::{
+            tests_utils::{TempReplicaDir, TestDB},
+            Persistence, SNAPSHOT_FREQUENCY,
+        },
+        snapshot::SnapshotWorker,
     },
     error::DBError,
     Identity,
 };
 use spacetimedb_datastore::execution_context::Workload;
 use spacetimedb_datastore::locking_tx_datastore::datastore::Locking;
-use spacetimedb_durability::{EmptyHistory, TxOffset};
+use spacetimedb_durability::{EmptyHistory, NoDurability, TxOffset};
 use spacetimedb_fs_utils::dir_trie::DirTrie;
 use spacetimedb_lib::{
     bsatn,
@@ -229,7 +232,13 @@ async fn create_snapshot(repo: Arc<SnapshotRepository>) -> anyhow::Result<TxOffs
     let start = Instant::now();
     let mut watch = spawn_blocking(|| {
         let tmp = TempReplicaDir::new()?;
-        let db = TestDB::open_db(&tmp, EmptyHistory::new(), None, Some(repo), None, 0)?;
+
+        let persistence = Persistence {
+            durability: Arc::new(NoDurability::default()),
+            disk_size: Arc::new(|| Ok(0)),
+            snapshots: Some(SnapshotWorker::new(repo)),
+        };
+        let db = TestDB::open_db(&tmp, EmptyHistory::new(), Some(persistence), None, 0)?;
         let watch = db.subscribe_to_snapshots().unwrap();
 
         let table_id = db.with_auto_commit(Workload::Internal, |tx| {
@@ -263,7 +272,11 @@ async fn create_snapshot(repo: Arc<SnapshotRepository>) -> anyhow::Result<TxOffs
     Ok(snapshot_offset)
 }
 
-fn table(name: &str, columns: ProductType, f: impl FnOnce(RawTableDefBuilder) -> RawTableDefBuilder) -> TableSchema {
+fn table(
+    name: &str,
+    columns: ProductType,
+    f: impl FnOnce(RawTableDefBuilder<'_>) -> RawTableDefBuilder,
+) -> TableSchema {
     let mut builder = RawModuleDefV9Builder::new();
     f(builder.build_table_with_new_type(name, columns, true));
     let raw = builder.finish();

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -10,12 +10,10 @@ use async_trait::async_trait;
 use clap::{ArgMatches, Command};
 use spacetimedb::client::ClientActorIndex;
 use spacetimedb::config::{CertificateAuthority, MetadataFile};
-use spacetimedb::db::{self, relational_db};
+use spacetimedb::db;
+use spacetimedb::db::persistence::LocalPersistenceProvider;
 use spacetimedb::energy::{EnergyBalance, EnergyQuanta, NullEnergyMonitor};
-use spacetimedb::host::{
-    DiskStorage, DurabilityProvider, ExternalDurability, HostController, MigratePlanResult, StartSnapshotWatcher,
-    UpdateDatabaseResult,
-};
+use spacetimedb::host::{DiskStorage, HostController, MigratePlanResult, UpdateDatabaseResult};
 use spacetimedb::identity::Identity;
 use spacetimedb::messages::control_db::{Database, Node, Replica};
 use spacetimedb::util::jobs::JobCores;
@@ -71,15 +69,13 @@ impl StandaloneEnv {
         let energy_monitor = Arc::new(NullEnergyMonitor);
         let program_store = Arc::new(DiskStorage::new(data_dir.program_bytes().0).await?);
 
-        let durability_provider = Arc::new(StandaloneDurabilityProvider {
-            data_dir: data_dir.clone(),
-        });
+        let persistence_provider = Arc::new(LocalPersistenceProvider::new(data_dir.clone()));
         let host_controller = HostController::new(
             data_dir,
             config.db_config,
             program_store.clone(),
             energy_monitor,
-            durability_provider,
+            persistence_provider,
             db_cores,
         );
         let client_actor_index = ClientActorIndex::new();
@@ -110,30 +106,6 @@ impl StandaloneEnv {
 
     pub fn page_pool(&self) -> &PagePool {
         &self.host_controller.page_pool
-    }
-}
-
-struct StandaloneDurabilityProvider {
-    data_dir: Arc<ServerDataDir>,
-}
-
-#[async_trait]
-impl DurabilityProvider for StandaloneDurabilityProvider {
-    async fn durability(&self, replica_id: u64) -> anyhow::Result<(ExternalDurability, Option<StartSnapshotWatcher>)> {
-        let commitlog_dir = self.data_dir.replica(replica_id).commit_log();
-        let (durability, disk_size) = relational_db::local_durability(commitlog_dir).await?;
-        let start_snapshot_watcher = {
-            let durability = durability.clone();
-            |snapshot_rx| {
-                tokio::spawn(relational_db::snapshot_watching_commitlog_compressor(
-                    snapshot_rx,
-                    None,
-                    None,
-                    durability,
-                ));
-            }
-        };
-        Ok(((durability, disk_size), Some(Box::new(start_snapshot_watcher))))
     }
 }
 


### PR DESCRIPTION
The `DurabilityProvider` trait was introduced to enable the `HostController` to procure an alternative `Durability` impl from an external source.

It is also useful to be able to instantiate a `SnapshotWorker` externally, in order to subscribe to snapshot creation events without access to the `RelationalDB` instance it is operating on.

At a later stage, we may also use it to control the snapshot frequency externally.

This patch thus reframes the trait as `PersistenceProvider`, whose job is to provide persistence-related services.

Also separates snapshot creation and compression of older snapshots, and adds instrumentation to gather timing information for both.

# Expected complexity level and risk

1.5

# Testing

Not a functional change, existing tests should cover that.
