### PR TITLE
Rust SDK: Make confirmed parameter optional

### DIFF
--- a/sdks/rust/src/db_connection.rs
+++ b/sdks/rust/src/db_connection.rs
@@ -975,8 +975,10 @@ but you must call one of them, or else the connection will never progress.
     /// Note that enabling confirmed reads will increase the latency between a
     /// reducer call and the corresponding subscription update arriving at the
     /// client.
+    ///
+    /// If this method is not called, the server chooses the default.
     pub fn with_confirmed_reads(mut self, confirmed: bool) -> Self {
-        self.params.confirmed = confirmed;
+        self.params.confirmed = Some(confirmed);
         self
     }
 

--- a/sdks/rust/src/websocket.rs
+++ b/sdks/rust/src/websocket.rs
@@ -107,8 +107,10 @@ fn parse_scheme(scheme: Option<Scheme>) -> Result<Scheme, UriError> {
 pub(crate) struct WsParams {
     pub compression: Compression,
     pub light: bool,
-    /// `true` to enable confirmed reads for the connection.
-    pub confirmed: bool,
+    /// `Some(true)` to enable confirmed reads for the connection,
+    /// `Some(false)` to disable them.
+    /// `None` to not set the parameter and let the server choose.
+    pub confirmed: Option<bool>,
 }
 
 fn make_uri(host: Uri, db_name: &str, connection_id: Option<ConnectionId>, params: WsParams) -> Result<Uri, UriError> {
@@ -155,8 +157,9 @@ fn make_uri(host: Uri, db_name: &str, connection_id: Option<ConnectionId>, param
     }
 
     // Enable confirmed reads if requested.
-    if params.confirmed {
-        path.push_str("&confirmed=true");
+    if let Some(confirmed) = params.confirmed {
+        path.push_str("&confirmed=");
+        path.push_str(if confirmed { "true" } else { "false" });
     }
 
     parts.path_and_query = Some(path.parse().map_err(|source: InvalidUri| UriError::InvalidUri {


### PR DESCRIPTION
For consistency with [TypeScript] and [C#].

If `DbConnectionBuilder::with_confirmed_reads` is not called, don't set the parameter on the connection URL, so that the server can choose the default.

[TypeScript]: https://github.com/clockworklabs/SpacetimeDB/pull/3247
[C#]: https://github.com/clockworklabs/SpacetimeDB/pull/3282

# Expected complexity level and risk

1