### PR TITLE
Wrap some tests in a `mod` so that I can `--skip` them

### DIFF
--- a/crates/schema/tests/ensure_same_schema.rs
+++ b/crates/schema/tests/ensure_same_schema.rs
@@ -1,61 +1,65 @@
-use serial_test::serial;
-use spacetimedb_schema::auto_migrate::{ponder_auto_migrate, AutoMigrateStep};
-use spacetimedb_schema::def::ModuleDef;
-use spacetimedb_testing::modules::{CompilationMode, CompiledModule};
+// Wrap these tests in a `mod` whose name contains `csharp`
+// so that we can run tests with `--skip csharp` in environments without dotnet installed.
+mod ensure_same_schema_rust_csharp {
+    use serial_test::serial;
+    use spacetimedb_schema::auto_migrate::{ponder_auto_migrate, AutoMigrateStep};
+    use spacetimedb_schema::def::ModuleDef;
+    use spacetimedb_testing::modules::{CompilationMode, CompiledModule};
 
-fn get_normalized_schema(module_name: &str) -> ModuleDef {
-    let module = CompiledModule::compile(module_name, CompilationMode::Debug);
-    module.extract_schema_blocking()
-}
-
-fn assert_identical_modules(module_name_prefix: &str) {
-    let rs = get_normalized_schema(module_name_prefix);
-    let cs = get_normalized_schema(&format!("{module_name_prefix}-cs"));
-    let mut diff = ponder_auto_migrate(&cs, &rs)
-        .expect("could not compute a diff between Rust and C#")
-        .steps;
-
-    // In any migration plan, all `RowLevelSecurityDef`s are ALWAYS removed and
-    // re-added to ensure the core engine reinintializes the policies.
-    // This is slightly silly (and arguably should be hidden inside `core`),
-    // but for now, we just ignore these steps and manually compare the `RowLevelSecurityDef`s.
-    diff.retain(|step| {
-        !matches!(
-            step,
-            AutoMigrateStep::AddRowLevelSecurity(_) | AutoMigrateStep::RemoveRowLevelSecurity(_)
-        )
-    });
-
-    assert!(
-        diff.is_empty(),
-        "Rust and C# modules are not identical. Here are the steps to migrate from C# to Rust: {diff:#?}"
-    );
-
-    let mut rls_rs = rs.row_level_security().collect::<Vec<_>>();
-    rls_rs.sort();
-    let mut rls_cs = cs.row_level_security().collect::<Vec<_>>();
-    rls_cs.sort();
-    assert_eq!(
-        rls_rs, rls_cs,
-        "Rust and C# modules are not identical: different row level security policies"
-    )
-}
-
-macro_rules! declare_tests {
-    ($($name:ident => $path:literal,)*) => {
-        $(
-            #[test]
-            #[serial]
-            fn $name() {
-                assert_identical_modules($path);
-            }
-        )*
+    fn get_normalized_schema(module_name: &str) -> ModuleDef {
+        let module = CompiledModule::compile(module_name, CompilationMode::Debug);
+        module.extract_schema_blocking()
     }
-}
 
-declare_tests! {
-    module_test => "module-test",
-    sdk_test_connect_disconnect => "sdk-test-connect-disconnect",
-    sdk_test => "sdk-test",
-    benchmarks => "benchmarks",
+    fn assert_identical_modules(module_name_prefix: &str) {
+        let rs = get_normalized_schema(module_name_prefix);
+        let cs = get_normalized_schema(&format!("{module_name_prefix}-cs"));
+        let mut diff = ponder_auto_migrate(&cs, &rs)
+            .expect("could not compute a diff between Rust and C#")
+            .steps;
+
+        // In any migration plan, all `RowLevelSecurityDef`s are ALWAYS removed and
+        // re-added to ensure the core engine reinintializes the policies.
+        // This is slightly silly (and arguably should be hidden inside `core`),
+        // but for now, we just ignore these steps and manually compare the `RowLevelSecurityDef`s.
+        diff.retain(|step| {
+            !matches!(
+                step,
+                AutoMigrateStep::AddRowLevelSecurity(_) | AutoMigrateStep::RemoveRowLevelSecurity(_)
+            )
+        });
+
+        assert!(
+            diff.is_empty(),
+            "Rust and C# modules are not identical. Here are the steps to migrate from C# to Rust: {diff:#?}"
+        );
+
+        let mut rls_rs = rs.row_level_security().collect::<Vec<_>>();
+        rls_rs.sort();
+        let mut rls_cs = cs.row_level_security().collect::<Vec<_>>();
+        rls_cs.sort();
+        assert_eq!(
+            rls_rs, rls_cs,
+            "Rust and C# modules are not identical: different row level security policies"
+        )
+    }
+
+    macro_rules! declare_tests {
+        ($($name:ident => $path:literal,)*) => {
+            $(
+                #[test]
+                #[serial]
+                fn $name() {
+                    assert_identical_modules($path);
+                }
+            )*
+        }
+    }
+
+    declare_tests! {
+        module_test => "module-test",
+        sdk_test_connect_disconnect => "sdk-test-connect-disconnect",
+        sdk_test => "sdk-test",
+        benchmarks => "benchmarks",
+    }
 }


### PR DESCRIPTION
# Description of Changes

In environments without dotnet installed, these tests were the only thing preventing `cargo test --all -- --skip csharp` from completing successfully.

I also included `rust` in the name, though running tests in an environment without cargo/rustc installed seems less likely to work.

Extracted from #3263 at request of @Centril .

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

N/a