### PR TITLE
Loosen `spacetimedb` dep on `spacetime init --lang rust`

### DIFF
--- a/crates/cli/src/subcommands/project/rust/Cargo._toml
+++ b/crates/cli/src/subcommands/project/rust/Cargo._toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "1.4.0"
+spacetimedb = "1.4"
 log = "0.4"


### PR DESCRIPTION
# Description of Changes

Addresses https://github.com/clockworklabs/SpacetimeDB/issues/2724. See that issue for background context.

# API and ABI breaking changes

No breaking changes

# Expected complexity level and risk

1

# Testing

Honestly none :sweat_smile: 