### PR TITLE
Smoketest : Hotswap should not disconnect subscribers.

### DIFF
--- a/smoketests/tests/auto_migration.py
+++ b/smoketests/tests/auto_migration.py
@@ -128,7 +128,7 @@ const BOOK_VISIBLE: spacetimedb::Filter = spacetimedb::Filter::Sql("SELECT * FRO
 
         logging.info("Initial publish complete")
 
-        // Start a subscription before publishing the module, to test that the subscription remains intact after re-publishing.
+        # Start a subscription before publishing the module, to test that the subscription remains intact after re-publishing.
         sub = self.subscribe("select * from person", n=4)
 
         # initial module code is already published by test framework

--- a/smoketests/tests/auto_migration.py
+++ b/smoketests/tests/auto_migration.py
@@ -128,6 +128,7 @@ const BOOK_VISIBLE: spacetimedb::Filter = spacetimedb::Filter::Sql("SELECT * FRO
 
         logging.info("Initial publish complete")
 
+        // Start a subscription before publishing the module, to test that the subscription remains intact after re-publishing.
         sub = self.subscribe("select * from person", n=4)
 
         # initial module code is already published by test framework


### PR DESCRIPTION
# Description of Changes

Updates smoketests to check for  following.
- Normal auto migration subscription should not disconnect subcriber.
- Add table columns migration should disconnect subscribers.

Solves #1957 .