### PR TITLE
Add a global.json for C# SDK to force running under .Net 8

### DIFF
--- a/sdks/csharp/global.json
+++ b/sdks/csharp/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "8.0.0",
+    "rollForward": "latestPatch"
+  }
+}


### PR DESCRIPTION
# Description of Changes

Adds a global.json file to enforce .NET 8  as the version to be used for the C# SDK, in order to prevent the `wasi-experimental` workload error that occurs when running under .NET 9 due to `wasi-experimental` only supported under .NET 8

# API and ABI breaking changes

No

# Expected complexity level and risk

1

# Testing

- [ ] Tested locally without errors, and passes GitHub tests
