### PR TITLE
Make optional to listen to pg wire protocol and param for the port

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -55,7 +55,7 @@ jobs:
         if: runner.os == 'Windows'
         run: |
           cargo build -p spacetimedb-cli -p spacetimedb-standalone -p spacetimedb-update
-          Start-Process target/debug/spacetimedb-cli.exe start
+          Start-Process target/debug/spacetimedb-cli.exe start --pg-port 5432
           cd modules
           # the sdk-manifests on windows-latest are messed up, so we need to update them
           dotnet workload config --update-mode manifests

--- a/crates/standalone/src/subcommands/start.rs
+++ b/crates/standalone/src/subcommands/start.rs
@@ -75,6 +75,12 @@ pub fn cli() -> clap::Command {
                 "The maximum size of the page pool in bytes. Should be a multiple of 64KiB. The default is 8GiB.",
             ),
         )
+        .arg(
+            Arg::new("pg_port")
+                .long("pg-port")
+                .help("If specified, enables the built-in PostgreSQL wire protocol server on the given port.")
+                .value_parser(clap::value_parser!(u16).range(1024..65535)),
+        )
     // .after_help("Run `spacetime help start` for more detailed information.")
 }
 
@@ -94,6 +100,7 @@ impl ConfigFile {
 
 pub async fn exec(args: &ArgMatches, db_cores: JobCores) -> anyhow::Result<()> {
     let listen_addr = args.get_one::<String>("listen_addr").unwrap();
+    let pg_port = args.get_one::<u16>("pg_port");
     let cert_dir = args.get_one::<spacetimedb_paths::cli::ConfigDir>("jwt_key_dir");
     let certs = Option::zip(
         args.get_one::<PubKeyPath>("jwt_pub_key_path").cloned(),
@@ -181,21 +188,32 @@ pub async fn exec(args: &ArgMatches, db_cores: JobCores) -> anyhow::Result<()> {
 
     let tcp = TcpListener::bind(listen_addr).await?;
     socket2::SockRef::from(&tcp).set_nodelay(true)?;
-    log::debug!("Starting SpacetimeDB listening on {}", tcp.local_addr()?);
-    let pg_server_addr = format!("{}:5432", listen_addr.split(':').next().unwrap());
-    let tcp_pg = TcpListener::bind(pg_server_addr).await?;
+    log::info!("Starting SpacetimeDB listening on {}", tcp.local_addr()?);
 
-    let notify = Arc::new(tokio::sync::Notify::new());
-    let shutdown_notify = notify.clone();
-    tokio::select! {
-        _ = pg_server::start_pg(notify.clone(), ctx, tcp_pg) => {},
-        _ = axum::serve(tcp, service).with_graceful_shutdown(async move  {
-            shutdown_notify.notified().await;
-        }) => {},
-        _ = tokio::signal::ctrl_c() => {
-            println!("Shutting down servers...");
-            notify.notify_waiters(); // Notify all tasks
+    if let Some(pg_port) = pg_port {
+        let server_addr = listen_addr.split(':').next().unwrap();
+        let tcp_pg = TcpListener::bind(format!("{server_addr}:{pg_port}")).await?;
+
+        let notify = Arc::new(tokio::sync::Notify::new());
+        let shutdown_notify = notify.clone();
+        tokio::select! {
+            _ = pg_server::start_pg(notify.clone(), ctx, tcp_pg) => {},
+            _ = axum::serve(tcp, service).with_graceful_shutdown(async move  {
+                shutdown_notify.notified().await;
+            }) => {},
+            _ = tokio::signal::ctrl_c() => {
+                println!("Shutting down servers...");
+                notify.notify_waiters(); // Notify all tasks
+            }
         }
+    } else {
+        log::warn!("PostgreSQL wire protocol server disabled");
+        axum::serve(tcp, service)
+            .with_graceful_shutdown(async {
+                tokio::signal::ctrl_c().await.expect("failed to install Ctrl+C handler");
+                log::info!("Shutting down server...");
+            })
+            .await?;
     }
 
     Ok(())

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -29,7 +29,7 @@ services:
       - "5432:5432"
       # Tracy
       - "8086:8086"
-    entrypoint: cargo watch -i flamegraphs -i log.conf --why -C crates/standalone -x 'run start --data-dir=/stdb/data --jwt-pub-key-path=/etc/spacetimedb/id_ecdsa.pub --jwt-priv-key-path=/etc/spacetimedb/id_ecdsa'
+    entrypoint: cargo watch -i flamegraphs -i log.conf --why -C crates/standalone -x 'run start --data-dir=/stdb/data --jwt-pub-key-path=/etc/spacetimedb/id_ecdsa.pub --jwt-priv-key-path=/etc/spacetimedb/id_ecdsa --pg-port 5432'
     privileged: true
     environment:
       SPACETIMEDB_FLAMEGRAPH_PATH: ../../../../flamegraphs/flamegraph.folded

--- a/run_standalone_temp.sh
+++ b/run_standalone_temp.sh
@@ -21,4 +21,5 @@ cargo run -p spacetimedb-standalone -- start \
             --data-dir ${STDB_PATH} \
             --jwt-pub-key-path "${STDB_PATH}/id_ecdsa.pub" \
             --jwt-priv-key-path "${STDB_PATH}/id_ecdsa" \
+            --pg-port 5432 \
             -l 127.0.0.1:3000 --enable-tracy


### PR DESCRIPTION
# Description of Changes

As the title says.

Add `--pg-port NUM` to the `start` command

# API and ABI breaking changes

Before this, it was set to `5432` unconditionally.

Docs updated at https://github.com/clockworklabs/SpacetimeDB/pull/3302.

# Expected complexity level and risk
1

# Testing

- [x] Run smoke tests