### PR TITLE
CI - Move Unity testsuite to a different runner

### DIFF
--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -8,7 +8,7 @@ on:
 
 jobs:
   unity-testsuite:
-    runs-on: ubuntu-latest
+    runs-on: spacetimedb-runner
     # Cancel any previous testsuites running on the same PR and/or ref.
     concurrency:
       group: unity-test-${{ github.event.pull_request.number || github.ref }}


### PR DESCRIPTION
# Description of Changes

Move the unity testsuite to `spacetimedb-runner` since it otherwise runs out of disk space.

# API and ABI breaking changes

None. CI only.

# Expected complexity level and risk

1

# Testing
- [x] Unity CI passes now.