### PR TITLE
CI - `apt install` invocations correctly pass `-y`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -231,7 +231,7 @@ jobs:
       - name: Install packages
         if: ${{ matrix.runner == 'arm-runner' }}
         shell: bash
-        run: sudo apt install libssl-dev
+        run: sudo apt install -y libssl-dev
 
       - name: Build spacetimedb-update
         run: cargo build --features github-token-auth --target ${{ matrix.target }} -p spacetimedb-update

--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -19,7 +19,7 @@ jobs:
           sudo apt-get install -y apt-transport-https
           echo "deb [arch=amd64 signed-by=/usr/share/keyrings/githubcli-archive-keyring.gpg] https://cli.github.com/packages stable main" | sudo tee /etc/apt/sources.list.d/github-cli.list
           sudo apt-get update
-          sudo apt-get install gh
+          sudo apt-get install -y gh
 
       - name: Fetch Check Run Results
         run: |


### PR DESCRIPTION
# Description of Changes

We had places that weren't passing `-y`. I assume these were only working because they were in environments where the things were already installed, so there wasn't any confirmation dialog. For some reason, the arm runner now newly needs to install packages, so CI invocations began failing.

# API and ABI breaking changes

None. CI only.

# Expected complexity level and risk

1

# Testing

- [x] CI passes
  - [ ] the "Test spacetimedb-update" flow passes on arm, which is not currently true elsewhere.