### PR TITLE
Adding wss:// support for the Unreal SDK

### DIFF
--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/DbConnectionBuilder.cpp
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/DbConnectionBuilder.cpp
@@ -108,10 +108,25 @@ UDbConnectionBase* UDbConnectionBuilderBase::BuildConnection(UDbConnectionBase* 
 	const FString CompressionName = CompressionEnum->GetNameStringByValue(static_cast<int64>(Compression));
 
 	// Construct the WebSocket URL using the provided URI, module name, and compression type
-	FString WebSocketUrl = FString::Printf(TEXT("ws://%s/v1/database/%s/subscribe?compression=%s"),
-		*Uri,
-		*ModuleName,
-		*CompressionName);
+	// If URI already contains a protocol (ws:// or wss://), use it as-is
+	// Otherwise, default to ws:// for backward compatibility
+	FString WebSocketUrl;
+	if (Uri.StartsWith(TEXT("ws://")) || Uri.StartsWith(TEXT("wss://")))
+	{
+		// URI already has protocol, just append the path
+		WebSocketUrl = FString::Printf(TEXT("%s/v1/database/%s/subscribe?compression=%s"),
+			*Uri,
+			*ModuleName,
+			*CompressionName);
+	}
+	else
+	{
+		// No protocol specified, default to ws:// for backward compatibility
+		WebSocketUrl = FString::Printf(TEXT("ws://%s/v1/database/%s/subscribe?compression=%s"),
+			*Uri,
+			*ModuleName,
+			*CompressionName);
+	}
 
 	Connection->WebSocket->OnConnectionError.AddDynamic(Connection, &UDbConnectionBase::HandleWSError);
 	Connection->WebSocket->OnClosed.AddDynamic(Connection, &UDbConnectionBase::HandleWSClosed);


### PR DESCRIPTION
# Description of Changes

Added support for wss:// protocol in Unreal SDK. The SDK previously forced all connections to use ws://, preventing connections to servers behind SSL/TLS proxies. The fix detects if the URI already includes a protocol (ws:// or wss://) and preserves it; otherwise defaults to ws:// for backward compatibility. This enables connections to SpacetimeDB servers hosted with Cloudflare Tunnels or other secure proxies.

# API and ABI breaking changes

This change is fully backwards compatible. URIs without a protocol prefix will continue to work as before, with ws:// being automatically prepended. No API signatures or existing behavior has changed.

# Expected complexity level and risk

Simple string prefix check before URL construction. The core WebSocket connection logic remains unchanged, and the default behavior is preserved when no protocol is specified.

# Testing

Successfully tested with a wss:// connection to my self-hosted SpacetimeDB server behind Cloudflare Tunnel. Verified backward compatibility with protocol-less URIs when directly connecting to the server. Currently running without issues.
