### PR TITLE
core: Allow snapshot worker to be reused

### DIFF
--- a/crates/core/src/db/persistence.rs
+++ b/crates/core/src/db/persistence.rs
@@ -72,7 +72,7 @@ impl Persistence {
     /// Initialize the [SnapshotWorker], no-op if snapshots are not enabled.
     pub(super) fn set_snapshot_state(&self, state: SnapshotDatabaseState) {
         if let Some(worker) = &self.snapshots {
-            worker.start(state)
+            worker.set_state(state)
         }
     }
 

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -287,6 +287,14 @@ impl RelationalDB {
             page_pool,
         )?;
         if let Some(persistence) = &mut persistence {
+            // Sanity check because the snapshot worker could've been used before.
+            debug_assert!(
+                persistence
+                    .snapshot_repo()
+                    .map(|repo| repo.database_identity() == database_identity)
+                    .unwrap_or(true),
+                "snapshot repository does not match database identity",
+            );
             persistence.set_snapshot_state(inner.committed_state.clone());
         }
 

--- a/crates/core/src/db/snapshot.rs
+++ b/crates/core/src/db/snapshot.rs
@@ -54,6 +54,8 @@ impl Compression {
 /// It is possible to re-use a [SnapshotWorker] to create a new database
 /// instance: when passed to [super::relational_db::RelationalDB::open], the
 /// worker's [SnapshotDatabaseState] will be replaced with the database's.
+/// We use this for replicated databases when transitioning between the leader and follower states,
+/// to preserve event subscriptions on the `SnapshotWorker`'s `snapshot_created` channel.
 #[derive(Clone)]
 pub struct SnapshotWorker {
     snapshot_created: watch::Sender<TxOffset>,


### PR DESCRIPTION
Make it so the `SnapshotWorker` can be re-configured with a new
committed state. This allows event subscriptions to remain valid while a
replica transitions from leader to follower and vice versa.

This is considerably simpler than keeping the lifetimes of database and
persistence services strictly in-sync, at the expense of an idle task
per replica.


# Expected complexity level and risk

1.5
