### PR TITLE
CI - Multi-line runs fail properly on Windows

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,12 +14,6 @@ on:
 name: CI
 
 jobs:
-  failure_test:
-    runs-on: windows-latest
-    steps:
-      - run: |
-          false
-
   docker_smoketests:
     name: Smoketests
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,6 +21,7 @@ jobs:
         include:
           - { runner: spacetimedb-runner, smoketest_args: --docker }
           - { runner: windows-latest, smoketest_args: --no-build-cli }
+        runner: [ spacetimedb-runner, windows-latest ]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Find Git ref

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,6 +14,12 @@ on:
 name: CI
 
 jobs:
+  failure_test:
+    runs-on: windows-latest
+    steps:
+      - run: |
+          false
+
   docker_smoketests:
     name: Smoketests
     strategy:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,7 +21,6 @@ jobs:
         include:
           - { runner: spacetimedb-runner, smoketest_args: --docker }
           - { runner: windows-latest, smoketest_args: --no-build-cli }
-        runner: [ spacetimedb-runner, windows-latest ]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Find Git ref
@@ -54,6 +53,10 @@ jobs:
       - name: Build and start database (Windows)
         if: runner.os == 'Windows'
         run: |
+          # Fail properly if any individual command fails
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
+
           cargo build -p spacetimedb-cli -p spacetimedb-standalone -p spacetimedb-update
           Start-Process target/debug/spacetimedb-cli.exe -ArgumentList 'start --pg-port 5432'
           cd modules

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -67,6 +67,7 @@ jobs:
 
       - name: Package (windows)
         if: ${{ runner.os == 'Windows' }}
+        shell: bash
         run: |
           mkdir build
           cd target/${{matrix.target}}/release

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,6 +7,7 @@ on:
     branches:
       - master
       - release/*
+      - bfops/ci-windows-fail
 
 jobs:
   build-cli:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,7 +7,6 @@ on:
     branches:
       - master
       - release/*
-      - bfops/ci-windows-fail
 
 jobs:
   build-cli:


### PR DESCRIPTION
# Description of Changes

It turns out that multi-line `run` statements don't fail properly on Windows. If one of the lines fails, the run won't exit early, and in fact the step will return successful.

# API and ABI breaking changes

CI-only changes.

# Expected complexity level and risk

1

# Testing
- [x] Confirmed that a one-line command will fail properly on Windows: https://github.com/clockworklabs/SpacetimeDB/actions/runs/18204663513/job/51831974918?pr=3337
- [x] Confirmed that a multi-line command properly exits early with these changes: https://github.com/clockworklabs/SpacetimeDB/actions/runs/18203897520/job/51829384741?pr=3335
- [x] Confirmed that a windows package build still works even though the shell is `bash` for part of it now (https://github.com/clockworklabs/SpacetimeDB/actions/runs/18205281236/job/51834045429)