### PR TITLE
Extract from wasm_instance_env + console_timer_end: use Noop backtrace

### DIFF
--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -1,5 +1,5 @@
 use super::scheduler::{get_schedule_from_row, ScheduleError, Scheduler};
-use crate::database_logger::{BacktraceProvider, LogLevel, Record};
+use crate::database_logger::{BacktraceFrame, BacktraceProvider, LogLevel, ModuleBacktrace, Record};
 use crate::db::relational_db::{MutTx, RelationalDB};
 use crate::error::{DBError, DatastoreError, IndexError, NodesError};
 use crate::host::wasm_common::TimingSpan;
@@ -191,9 +191,22 @@ impl InstanceEnv {
     }
 
     /// End a console timer by logging the span at INFO level.
-    pub(crate) fn console_timer_end(&self, span: &TimingSpan, function: Option<&str>, bt: &dyn BacktraceProvider) {
+    pub(crate) fn console_timer_end(&self, span: &TimingSpan, function: Option<&str>) {
         let elapsed = span.start.elapsed();
         let message = format!("Timing span {:?}: {:?}", &span.name, elapsed);
+
+        /// A backtrace provider that provides nothing.
+        struct Noop;
+        impl BacktraceProvider for Noop {
+            fn capture(&self) -> Box<dyn ModuleBacktrace> {
+                Box::new(Noop)
+            }
+        }
+        impl ModuleBacktrace for Noop {
+            fn frames(&self) -> Vec<BacktraceFrame<'_>> {
+                Vec::new()
+            }
+        }
 
         let record = Record {
             ts: chrono::Utc::now(),
@@ -203,7 +216,7 @@ impl InstanceEnv {
             function,
             message: &message,
         };
-        self.console_log(LogLevel::Info, &record, bt);
+        self.console_log(LogLevel::Info, &record, &Noop);
     }
 
     /// Project `cols` in `row_ref` encoded in BSATN to `buffer`

--- a/crates/core/src/host/wasm_common.rs
+++ b/crates/core/src/host/wasm_common.rs
@@ -337,6 +337,7 @@ impl TimingSpan {
 decl_index!(TimingSpanIdx => TimingSpan);
 pub(super) type TimingSpanSet = ResourceSlab<TimingSpanIdx>;
 
+/// Converts a [`NodesError`] to an error code, if possible.
 pub fn err_to_errno(err: &NodesError) -> Option<NonZeroU16> {
     match err {
         NodesError::NotInTransaction => Some(errno::NOT_IN_TRANSACTION),
@@ -360,6 +361,18 @@ pub fn err_to_errno(err: &NodesError) -> Option<NonZeroU16> {
         },
         _ => None,
     }
+}
+
+/// Converts a [`NodesError`] to an error code and logs, if possible.
+pub fn err_to_errno_and_log<C: From<u16>>(func: AbiCall, err: NodesError) -> anyhow::Result<C> {
+    let Some(errno) = err_to_errno(&err) else {
+        return Err(AbiRuntimeError { func, err }.into());
+    };
+    log::debug!(
+        "abi call to {func} returned an errno: {errno} ({})",
+        errno::strerror(errno).unwrap_or("<unknown>")
+    );
+    Ok(errno.get().into())
 }
 
 #[derive(Debug, thiserror::Error)]

--- a/crates/core/src/host/wasm_common/instrumentation.rs
+++ b/crates/core/src/host/wasm_common/instrumentation.rs
@@ -118,3 +118,8 @@ impl CallTimes {
         std::mem::replace(self, Self::new())
     }
 }
+
+#[cfg(not(feature = "spacetimedb-wasm-instance-env-times"))]
+pub use noop as span;
+#[cfg(feature = "spacetimedb-wasm-instance-env-times")]
+pub use op as span;

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -1,29 +1,19 @@
 #![allow(clippy::too_many_arguments)]
 
-use std::num::NonZeroU32;
-use std::time::Instant;
-
+use super::{Mem, MemView, NullableMemOp, WasmError, WasmPointee, WasmPtr};
 use crate::database_logger::{BacktraceFrame, BacktraceProvider, ModuleBacktrace, Record};
 use crate::host::instance_env::{ChunkPool, InstanceEnv};
-use crate::host::wasm_common::instrumentation;
+use crate::host::wasm_common::instrumentation::{span, CallTimes};
 use crate::host::wasm_common::module_host_actor::ExecutionTimings;
-use crate::host::wasm_common::{
-    err_to_errno, instrumentation::CallTimes, AbiRuntimeError, RowIterIdx, RowIters, TimingSpan, TimingSpanIdx,
-    TimingSpanSet,
-};
+use crate::host::wasm_common::{err_to_errno_and_log, RowIterIdx, RowIters, TimingSpan, TimingSpanIdx, TimingSpanSet};
 use crate::host::AbiCall;
 use anyhow::Context as _;
 use spacetimedb_data_structures::map::IntMap;
 use spacetimedb_lib::Timestamp;
 use spacetimedb_primitives::{errno, ColId};
+use std::num::NonZeroU32;
+use std::time::Instant;
 use wasmtime::{AsContext, Caller, StoreContextMut};
-
-use super::{Mem, MemView, NullableMemOp, WasmError, WasmPointee, WasmPtr};
-
-#[cfg(not(feature = "spacetimedb-wasm-instance-env-times"))]
-use instrumentation::noop as span;
-#[cfg(feature = "spacetimedb-wasm-instance-env-times")]
-use instrumentation::op as span;
 
 /// A stream of bytes which the WASM module can read from
 /// using [`WasmInstanceEnv::bytes_source_read`].
@@ -301,20 +291,11 @@ impl WasmInstanceEnv {
     }
 
     fn convert_wasm_result<T: From<u16>>(func: AbiCall, err: WasmError) -> RtResult<T> {
-        Err(match err {
-            WasmError::Db(err) => match err_to_errno(&err) {
-                Some(errno) => {
-                    log::debug!(
-                        "abi call to {func} returned an errno: {errno} ({})",
-                        errno::strerror(errno).unwrap_or("<unknown>")
-                    );
-                    return Ok(errno.get().into());
-                }
-                None => anyhow::Error::from(AbiRuntimeError { func, err }),
-            },
-            WasmError::BufferTooSmall => return Ok(errno::BUFFER_TOO_SMALL.get().into()),
-            WasmError::Wasm(err) => err,
-        })
+        match err {
+            WasmError::Db(err) => err_to_errno_and_log(func, err),
+            WasmError::BufferTooSmall => Ok(errno::BUFFER_TOO_SMALL.get().into()),
+            WasmError::Wasm(err) => Err(err),
+        }
     }
 
     /// Call the function `run` with the name `func`.
@@ -1332,12 +1313,8 @@ impl WasmInstanceEnv {
             let Some(span) = caller.data_mut().timing_spans.take(TimingSpanIdx(span_id)) else {
                 return Ok(errno::NO_SUCH_CONSOLE_TIMER.get().into());
             };
-
             let function = caller.data().log_record_function();
-            caller
-                .data()
-                .instance_env
-                .console_timer_end(&span, function, &caller.as_context());
+            caller.data().instance_env.console_timer_end(&span, function);
             Ok(0)
         })
     }


### PR DESCRIPTION
# Description of Changes

- Extract from `wasm_instance_env.rs`
- `console_timer_end`: use Noop backtrace.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

No semantic changes.