### PR TITLE
Generate read-only table handles for `#[table]`

### DIFF
--- a/crates/bindings-macro/src/table.rs
+++ b/crates/bindings-macro/src/table.rs
@@ -275,6 +275,41 @@ impl IndexArg {
     }
 }
 
+enum AccessorType {
+    Read,
+    ReadWrite,
+}
+
+impl AccessorType {
+    fn unique(&self) -> proc_macro2::TokenStream {
+        match self {
+            AccessorType::Read => quote!(spacetimedb::UniqueColumnReadOnly),
+            AccessorType::ReadWrite => quote!(spacetimedb::UniqueColumn),
+        }
+    }
+
+    fn range(&self) -> proc_macro2::TokenStream {
+        match self {
+            AccessorType::Read => quote!(spacetimedb::RangedIndexReadOnly),
+            AccessorType::ReadWrite => quote!(spacetimedb::RangedIndex),
+        }
+    }
+
+    fn unique_doc_typename(&self) -> &'static str {
+        match self {
+            AccessorType::Read => "UniqueColumnReadOnly",
+            AccessorType::ReadWrite => "UniqueColumn",
+        }
+    }
+
+    fn range_doc_typename(&self) -> &'static str {
+        match self {
+            AccessorType::Read => "RangedIndexReadOnly",
+            AccessorType::ReadWrite => "RangedIndex",
+        }
+    }
+}
+
 struct ValidatedIndex<'a> {
     index_name: String,
     accessor_name: &'a Ident,
@@ -312,46 +347,71 @@ impl ValidatedIndex<'_> {
         })
     }
 
-    fn accessor(&self, vis: &syn::Visibility, row_type_ident: &Ident) -> TokenStream {
+    fn accessor(
+        &self,
+        vis: &syn::Visibility,
+        row_type_ident: &Ident,
+        tbl_type_ident: &Ident,
+        flavor: AccessorType,
+    ) -> TokenStream {
         let cols = match &self.kind {
             ValidatedIndexType::BTree { cols } => &**cols,
             ValidatedIndexType::Direct { col } => slice::from_ref(col),
         };
         if self.is_unique {
             assert_eq!(cols.len(), 1);
-            let col = cols[0];
-            self.accessor_unique(col, row_type_ident)
+            self.unique_accessor(cols[0], row_type_ident, tbl_type_ident, flavor)
         } else {
-            self.accessor_general(vis, row_type_ident, cols)
+            self.range_accessor(vis, row_type_ident, tbl_type_ident, cols, flavor)
         }
     }
 
-    fn accessor_unique(&self, col: &Column<'_>, row_type_ident: &Ident) -> TokenStream {
+    fn unique_accessor(
+        &self,
+        col: &Column<'_>,
+        row_type_ident: &Ident,
+        tbl_type_ident: &Ident,
+        flavor: AccessorType,
+    ) -> TokenStream {
         let index_ident = self.accessor_name;
         let vis = col.vis;
         let col_ty = col.ty;
         let column_ident = col.ident;
 
+        let unique_ty = flavor.unique();
+        let tbl_token = quote!(#tbl_type_ident);
+        let doc_type = flavor.unique_doc_typename();
+
         let doc = format!(
-            "Gets the [`UniqueColumn`][spacetimedb::UniqueColumn] for the \
+            "Gets the [`{doc_type}`][spacetimedb::{doc_type}] for the \
              [`{column_ident}`][{row_type_ident}::{column_ident}] column."
         );
         quote! {
             #[doc = #doc]
-            #vis fn #column_ident(&self) -> spacetimedb::UniqueColumn<Self, #col_ty, __indices::#index_ident> {
-                spacetimedb::UniqueColumn::__NEW
+            #vis fn #column_ident(&self) -> #unique_ty<#tbl_token, #col_ty, __indices::#index_ident> {
+                #unique_ty::__NEW
             }
         }
     }
 
-    fn accessor_general(&self, vis: &syn::Visibility, row_type_ident: &Ident, cols: &[&Column<'_>]) -> TokenStream {
+    fn range_accessor(
+        &self,
+        vis: &syn::Visibility,
+        row_type_ident: &Ident,
+        tbl_type_ident: &Ident,
+        cols: &[&Column<'_>],
+        flavor: AccessorType,
+    ) -> TokenStream {
         let index_ident = self.accessor_name;
-        let col_tys = cols.iter().map(|col| col.ty);
+        let col_tys = cols.iter().map(|c| c.ty);
+
+        let range_ty = flavor.range();
+        let tbl_token = quote!(#tbl_type_ident);
+        let doc_type = flavor.range_doc_typename();
+
         let mut doc = format!(
-            "Gets the `{index_ident}` [`RangedIndex`][spacetimedb::RangedIndex] as defined \
-             on this table. \n\
-             \n\
-             This B-tree index is defined on the following columns, in order:\n"
+            "Gets the `{index_ident}` [`{doc_type}`][spacetimedb::{doc_type}] as defined \
+             on this table.\n\nThis B-tree index is defined on the following columns, in order:\n"
         );
         for col in cols {
             use std::fmt::Write;
@@ -363,10 +423,11 @@ impl ValidatedIndex<'_> {
             )
             .unwrap();
         }
+
         quote! {
             #[doc = #doc]
-            #vis fn #index_ident(&self) -> spacetimedb::RangedIndex<Self, (#(#col_tys,)*), __indices::#index_ident> {
-                spacetimedb::RangedIndex::__NEW
+            #vis fn #index_ident(&self) -> #range_ty<#tbl_token, (#(#col_tys,)*), __indices::#index_ident> {
+                #range_ty::__NEW
             }
         }
     }
@@ -521,6 +582,7 @@ pub(crate) fn table_impl(mut args: TableArgs, item: &syn::DeriveInput) -> syn::R
 
     let original_struct_ident = sats_ty.ident;
     let table_ident = &args.name;
+    let view_trait_ident = format_ident!("{}__view", table_ident);
     let table_name = table_ident.unraw().to_string();
     let sats::SatsTypeData::Product(fields) = &sats_ty.data else {
         return Err(syn::Error::new(Span::call_site(), "spacetimedb table must be a struct"));
@@ -656,9 +718,15 @@ pub(crate) fn table_impl(mut args: TableArgs, item: &syn::DeriveInput) -> syn::R
     indices.sort_by_key(|index| !index.is_unique);
 
     let tablehandle_ident = format_ident!("{}__TableHandle", table_ident);
+    let viewhandle_ident = format_ident!("{}__ViewHandle", table_ident);
 
     let index_descs = indices.iter().map(|index| index.desc());
-    let index_accessors = indices.iter().map(|index| index.accessor(vis, original_struct_ident));
+    let index_accessors_rw = indices
+        .iter()
+        .map(|index| index.accessor(vis, original_struct_ident, &tablehandle_ident, AccessorType::ReadWrite));
+    let index_accessors_ro = indices
+        .iter()
+        .map(|index| index.accessor(vis, original_struct_ident, &tablehandle_ident, AccessorType::Read));
     let index_marker_types = indices.iter().map(|index| index.marker_type(vis, &tablehandle_ident));
 
     // Generate `integrate_generated_columns`
@@ -831,10 +899,29 @@ pub(crate) fn table_impl(mut args: TableArgs, item: &syn::DeriveInput) -> syn::R
         }
     };
 
+    let trait_def_view = quote_spanned! {table_ident.span()=>
+        #[allow(non_camel_case_types, dead_code)]
+        #vis trait #view_trait_ident {
+            fn #table_ident(&self) -> &#viewhandle_ident;
+        }
+        impl #view_trait_ident for spacetimedb::LocalReadOnly {
+            #[inline]
+            fn #table_ident(&self) -> &#viewhandle_ident {
+                &#viewhandle_ident {}
+            }
+        }
+    };
+
     let tablehandle_def = quote! {
         #[allow(non_camel_case_types)]
         #[non_exhaustive]
         #vis struct #tablehandle_ident {}
+    };
+
+    let viewhandle_def = quote! {
+        #[allow(non_camel_case_types)]
+        #[non_exhaustive]
+        #vis struct #viewhandle_ident {}
     };
 
     let emission = quote! {
@@ -845,12 +932,18 @@ pub(crate) fn table_impl(mut args: TableArgs, item: &syn::DeriveInput) -> syn::R
         };
 
         #trait_def
+        #trait_def_view
 
         #tablehandle_def
+        #viewhandle_def
 
         const _: () = {
             impl #tablehandle_ident {
-                #(#index_accessors)*
+                #(#index_accessors_rw)*
+            }
+
+            impl #viewhandle_ident {
+                #(#index_accessors_ro)*
             }
 
             #tabletype_impl

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -667,16 +667,16 @@ pub use spacetimedb_bindings_macro::table;
 pub use spacetimedb_bindings_macro::reducer;
 
 /// One of two possible types that can be passed as the first argument to a `#[view]`.
-/// The other is [`SenderViewContext`].
+/// The other is [`ViewContext`].
 /// Use this type if the view does not depend on the caller's identity.
-pub struct ViewContext {
+pub struct AnonymousViewContext {
     pub db: LocalReadOnly,
 }
 
 /// One of two possible types that can be passed as the first argument to a `#[view]`.
-/// The other is [`ViewContext`].
+/// The other is [`AnonymousViewContext`].
 /// Use this type if the view depends on the caller's identity.
-pub struct SenderViewContext {
+pub struct ViewContext {
     pub sender: Identity,
     pub connection_id: Option<ConnectionId>,
     pub db: LocalReadOnly,
@@ -780,14 +780,14 @@ impl ReducerContext {
         Identity::from_byte_array(spacetimedb_bindings_sys::identity())
     }
 
-    /// Create a pure read-only view context (no sender).
-    pub fn as_view(&self) -> ViewContext {
-        ViewContext { db: LocalReadOnly {} }
+    /// Create an anonymous (no sender) read-only view context
+    pub fn as_anonymous_read_only(&self) -> AnonymousViewContext {
+        AnonymousViewContext { db: LocalReadOnly {} }
     }
 
     /// Create a sender-bound read-only view context using this reducer's caller.
-    pub fn as_sender_view(&self) -> SenderViewContext {
-        SenderViewContext {
+    pub fn as_read_only(&self) -> ViewContext {
+        ViewContext {
             sender: self.sender,
             connection_id: self.connection_id,
             db: LocalReadOnly {},

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -41,7 +41,10 @@ pub use spacetimedb_lib::TimeDuration;
 pub use spacetimedb_lib::Timestamp;
 pub use spacetimedb_primitives::TableId;
 pub use sys::Errno;
-pub use table::{AutoIncOverflow, RangedIndex, Table, TryInsertError, UniqueColumn, UniqueConstraintViolation};
+pub use table::{
+    AutoIncOverflow, RangedIndex, RangedIndexReadOnly, Table, TryInsertError, UniqueColumn, UniqueColumnReadOnly,
+    UniqueConstraintViolation,
+};
 
 pub type ReducerResult = core::result::Result<(), Box<str>>;
 
@@ -663,6 +666,22 @@ pub use spacetimedb_bindings_macro::table;
 #[doc(inline)]
 pub use spacetimedb_bindings_macro::reducer;
 
+/// One of two possible types that can be passed as the first argument to a `#[view]`.
+/// The other is [`SenderViewContext`].
+/// Use this type if the view does not depend on the caller's identity.
+pub struct ViewContext {
+    pub db: LocalReadOnly,
+}
+
+/// One of two possible types that can be passed as the first argument to a `#[view]`.
+/// The other is [`ViewContext`].
+/// Use this type if the view depends on the caller's identity.
+pub struct SenderViewContext {
+    pub sender: Identity,
+    pub connection_id: Option<ConnectionId>,
+    pub db: LocalReadOnly,
+}
+
 /// The context that any reducer is provided with.
 ///
 /// This must be the first argument of the reducer. Clients of the module will
@@ -760,6 +779,20 @@ impl ReducerContext {
         // which reads the module identity out of the `InstanceEnv`.
         Identity::from_byte_array(spacetimedb_bindings_sys::identity())
     }
+
+    /// Create a pure read-only view context (no sender).
+    pub fn as_view(&self) -> ViewContext {
+        ViewContext { db: LocalReadOnly {} }
+    }
+
+    /// Create a sender-bound read-only view context using this reducer's caller.
+    pub fn as_sender_view(&self) -> SenderViewContext {
+        SenderViewContext {
+            sender: self.sender,
+            connection_id: self.connection_id,
+            db: LocalReadOnly {},
+        }
+    }
 }
 
 /// A handle on a database with a particular table schema.
@@ -795,6 +828,10 @@ impl DbContext for ReducerContext {
 /// These are generated methods that allow you to access specific tables.
 #[non_exhaustive]
 pub struct Local {}
+
+/// The read-only version of [`Local`]
+#[non_exhaustive]
+pub struct LocalReadOnly {}
 
 // #[cfg(target_arch = "wasm32")]
 // #[global_allocator]

--- a/crates/bindings/src/table.rs
+++ b/crates/bindings/src/table.rs
@@ -318,16 +318,6 @@ impl<Tbl: Table, Col: Index + Column<Table = Tbl>> UniqueColumn<Tbl, Col::ColTyp
     #[doc(hidden)]
     pub const __NEW: Self = Self { _marker: PhantomData };
 
-    #[inline]
-    fn get_args(&self, col_val: &Col::ColType) -> IndexScanRangeArgs {
-        IndexScanRangeArgs {
-            data: IterBuf::serialize(&std::ops::Bound::Included(col_val)).unwrap(),
-            prefix_elems: 0,
-            rstart_idx: 0,
-            rend_idx: None,
-        }
-    }
-
     /// Finds and returns the row where the value in the unique column matches the supplied `col_val`,
     /// or `None` if no such row is present in the database state.
     //
@@ -341,26 +331,7 @@ impl<Tbl: Table, Col: Index + Column<Table = Tbl>> UniqueColumn<Tbl, Col::ColTyp
     where
         for<'a> &'a Col::ColType: FilterableValue,
     {
-        self._find(col_val.borrow())
-    }
-
-    fn _find(&self, col_val: &Col::ColType) -> Option<Tbl::Row> {
-        // Find the row with a match.
-        let index_id = Col::index_id();
-        let args = self.get_args(col_val);
-        let (prefix, prefix_elems, rstart, rend) = args.args_for_syscall();
-
-        let iter = sys::datastore_index_scan_range_bsatn(index_id, prefix, prefix_elems, rstart, rend)
-            .unwrap_or_else(|e| panic!("unique: unexpected error from `datastore_index_scan_range_bsatn`: {e}"));
-        let mut iter = TableIter::new_with_buf(iter, args.data);
-
-        // We will always find either 0 or 1 rows here due to the unique constraint.
-        let row = iter.next();
-        assert!(
-            iter.is_exhausted(),
-            "`datastore_index_scan_range_bsatn` on unique field cannot return >1 rows"
-        );
-        row
+        find::<Tbl, Col>(col_val.borrow())
     }
 
     /// Deletes the row where the value in the unique column matches the supplied `col_val`,
@@ -375,7 +346,7 @@ impl<Tbl: Table, Col: Index + Column<Table = Tbl>> UniqueColumn<Tbl, Col::ColTyp
 
     fn _delete(&self, col_val: &Col::ColType) -> (bool, IterBuf) {
         let index_id = Col::index_id();
-        let args = self.get_args(col_val);
+        let args = get_args::<Tbl, Col>(col_val);
         let (prefix, prefix_elems, rstart, rend) = args.args_for_syscall();
 
         let n_del = sys::datastore_delete_by_index_scan_range_bsatn(index_id, prefix, prefix_elems, rstart, rend)
@@ -430,6 +401,63 @@ impl<Tbl: Table, Col: Index + Column<Table = Tbl>> UniqueColumn<Tbl, Col::ColTyp
     #[cfg(feature = "unstable")]
     pub fn insert_or_update(&self, new_row: Tbl::Row) -> Tbl::Row {
         self.try_insert_or_update(new_row).unwrap_or_else(|e| panic!("{e}"))
+    }
+}
+
+#[inline]
+fn get_args<Tbl: Table, Col: Index + Column<Table = Tbl>>(col_val: &Col::ColType) -> IndexScanRangeArgs {
+    IndexScanRangeArgs {
+        data: IterBuf::serialize(&std::ops::Bound::Included(col_val)).unwrap(),
+        prefix_elems: 0,
+        rstart_idx: 0,
+        rend_idx: None,
+    }
+}
+
+#[inline]
+fn find<Tbl: Table, Col: Index + Column<Table = Tbl>>(col_val: &Col::ColType) -> Option<Tbl::Row> {
+    // Find the row with a match.
+    let index_id = Col::index_id();
+    let args = get_args::<Tbl, Col>(col_val);
+    let (prefix, prefix_elems, rstart, rend) = args.args_for_syscall();
+
+    let iter = sys::datastore_index_scan_range_bsatn(index_id, prefix, prefix_elems, rstart, rend)
+        .unwrap_or_else(|e| panic!("unique: unexpected error from `datastore_index_scan_range_bsatn`: {e}"));
+    let mut iter = TableIter::new_with_buf(iter, args.data);
+
+    // We will always find either 0 or 1 rows here due to the unique constraint.
+    let row = iter.next();
+    assert!(
+        iter.is_exhausted(),
+        "`datastore_index_scan_range_bsatn` on unique field cannot return >1 rows"
+    );
+    row
+}
+
+/// A read-only handle to a unique (single-column) index.
+///
+/// This is the read-only version of [`UniqueColumn`].
+/// It mirrors [`UniqueColumn`] but only exposes read APIs.
+/// It cannot insert or delete rows.
+/// It is used by `{table}__ViewHandle` to keep view code read-only at compile time.
+///
+/// Note, the `Tbl` generic is the read-write table handle `{table}__TableHandle`.
+/// This is because read-only indexes still need [`Table`] metadata.
+/// The view handle itself deliberately does not implement `Table`.
+pub struct UniqueColumnReadOnly<Tbl, ColType, Col> {
+    _marker: PhantomData<(Tbl, ColType, Col)>,
+}
+
+impl<Tbl: Table, Col: Index + Column<Table = Tbl>> UniqueColumnReadOnly<Tbl, Col::ColType, Col> {
+    #[doc(hidden)]
+    pub const __NEW: Self = Self { _marker: PhantomData };
+
+    #[inline]
+    pub fn find(&self, col_val: impl Borrow<Col::ColType>) -> Option<Tbl::Row>
+    where
+        for<'a> &'a Col::ColType: FilterableValue,
+    {
+        find::<Tbl, Col>(col_val.borrow())
     }
 }
 
@@ -573,12 +601,7 @@ impl<Tbl: Table, IndexType, Idx: Index> RangedIndex<Tbl, IndexType, Idx> {
     where
         B: IndexScanRangeBounds<IndexType, K>,
     {
-        let index_id = Idx::index_id();
-        let args = b.get_args();
-        let (prefix, prefix_elems, rstart, rend) = args.args_for_syscall();
-        let iter = sys::datastore_index_scan_range_bsatn(index_id, prefix, prefix_elems, rstart, rend)
-            .unwrap_or_else(|e| panic!("unexpected error from `datastore_index_scan_range_bsatn`: {e}"));
-        TableIter::new(iter)
+        filter::<Tbl, Idx, IndexType, B, K>(b)
     }
 
     /// Deletes all rows in the database state where the indexed column(s) match the bounds `b`.
@@ -658,6 +681,45 @@ impl<Tbl: Table, IndexType, Idx: Index> RangedIndex<Tbl, IndexType, Idx> {
         sys::datastore_delete_by_index_scan_range_bsatn(index_id, prefix, prefix_elems, rstart, rend)
             .unwrap_or_else(|e| panic!("unexpected error from `datastore_delete_by_index_scan_range_bsatn`: {e}"))
             .into()
+    }
+}
+
+fn filter<Tbl, Idx, IndexType, B, K>(b: B) -> impl Iterator<Item = Tbl::Row>
+where
+    Tbl: Table,
+    Idx: Index,
+    B: IndexScanRangeBounds<IndexType, K>,
+{
+    let index_id = Idx::index_id();
+    let args = b.get_args();
+    let (prefix, prefix_elems, rstart, rend) = args.args_for_syscall();
+    let iter = sys::datastore_index_scan_range_bsatn(index_id, prefix, prefix_elems, rstart, rend)
+        .unwrap_or_else(|e| panic!("unexpected error from `datastore_index_scan_range_bsatn`: {e}"));
+    TableIter::new(iter)
+}
+
+/// A read-only handle to a B-tree index.
+///
+/// This is the read-only version of [`RangedIndex`].
+/// It mirrors [`RangedIndex`] but exposes only `.filter(..)`, not `.delete(..)`.
+/// It is used by `{table}__ViewHandle` to keep view code read-only at compile time.
+///
+/// Note, the `Tbl` generic is the read-write table handle `{table}__TableHandle`.
+/// This is because read-only indexes still need [`Table`] metadata.
+/// The view handle itself deliberately does not implement `Table`.
+pub struct RangedIndexReadOnly<Tbl: Table, IndexType, Idx: Index> {
+    _marker: PhantomData<(Tbl, IndexType, Idx)>,
+}
+
+impl<Tbl: Table, IndexType, Idx: Index> RangedIndexReadOnly<Tbl, IndexType, Idx> {
+    #[doc(hidden)]
+    pub const __NEW: Self = Self { _marker: PhantomData };
+
+    pub fn filter<B, K>(&self, b: B) -> impl Iterator<Item = Tbl::Row>
+    where
+        B: IndexScanRangeBounds<IndexType, K>,
+    {
+        filter::<Tbl, Idx, IndexType, B, K>(b)
     }
 }
 

--- a/crates/bindings/tests/ui/views.rs
+++ b/crates/bindings/tests/ui/views.rs
@@ -1,0 +1,67 @@
+use spacetimedb::{reducer, table, ReducerContext};
+
+#[table(name = test)]
+struct Test {
+    #[unique]
+    id: u32,
+    #[index(btree)]
+    x: u32,
+}
+
+#[reducer]
+fn view_handle_no_iter(ctx: &ReducerContext) {
+    let read_only = ctx.as_view();
+    // Should not compile: ViewHandle does not expose `iter()`
+    for _ in read_only.db.test().iter() {}
+}
+
+#[reducer]
+fn view_handle_no_count(ctx: &ReducerContext) {
+    let read_only = ctx.as_view();
+    // Should not compile: ViewHandle does not expose `count()`
+    let _ = read_only.db.test().count();
+}
+
+#[reducer]
+fn view_handle_no_insert(ctx: &ReducerContext) {
+    let read_only = ctx.as_view();
+    // Should not compile: ViewHandle does not expose `insert()`
+    read_only.db.test().insert(Test { id: 0, x: 0 });
+}
+
+#[reducer]
+fn view_handle_no_try_insert(ctx: &ReducerContext) {
+    let read_only = ctx.as_view();
+    // Should not compile: ViewHandle does not expose `try_insert()`
+    read_only.db.test().try_insert(Test { id: 0, x: 0 });
+}
+
+#[reducer]
+fn view_handle_no_delete(ctx: &ReducerContext) {
+    let read_only = ctx.as_view();
+    // Should not compile: ViewHandle does not expose `delete()`
+    read_only.db.test().delete(Test { id: 0, x: 0 });
+}
+
+#[reducer]
+fn read_only_unqiue_index_no_delete(ctx: &ReducerContext) {
+    let read_only = ctx.as_view();
+    // Should not compile: unique read-only index does not expose `delete()`
+    read_only.db.test().id().delete(&0);
+}
+
+#[reducer]
+fn read_only_unqiue_index_no_update(ctx: &ReducerContext) {
+    let read_only = ctx.as_view();
+    // Should not compile: unique read-only index does not expose `update()`
+    read_only.db.test().id().update(Test { id: 0, x: 0 });
+}
+
+#[reducer]
+fn read_only_btree_index_no_delete(ctx: &ReducerContext) {
+    let read_only = ctx.as_view();
+    // Should not compile: read-only btree index does not expose `delete()`
+    read_only.db.test().x().delete(0u32..);
+}
+
+fn main() {}

--- a/crates/bindings/tests/ui/views.rs
+++ b/crates/bindings/tests/ui/views.rs
@@ -10,56 +10,56 @@ struct Test {
 
 #[reducer]
 fn view_handle_no_iter(ctx: &ReducerContext) {
-    let read_only = ctx.as_view();
+    let read_only = ctx.as_read_only();
     // Should not compile: ViewHandle does not expose `iter()`
     for _ in read_only.db.test().iter() {}
 }
 
 #[reducer]
 fn view_handle_no_count(ctx: &ReducerContext) {
-    let read_only = ctx.as_view();
+    let read_only = ctx.as_read_only();
     // Should not compile: ViewHandle does not expose `count()`
     let _ = read_only.db.test().count();
 }
 
 #[reducer]
 fn view_handle_no_insert(ctx: &ReducerContext) {
-    let read_only = ctx.as_view();
+    let read_only = ctx.as_read_only();
     // Should not compile: ViewHandle does not expose `insert()`
     read_only.db.test().insert(Test { id: 0, x: 0 });
 }
 
 #[reducer]
 fn view_handle_no_try_insert(ctx: &ReducerContext) {
-    let read_only = ctx.as_view();
+    let read_only = ctx.as_read_only();
     // Should not compile: ViewHandle does not expose `try_insert()`
     read_only.db.test().try_insert(Test { id: 0, x: 0 });
 }
 
 #[reducer]
 fn view_handle_no_delete(ctx: &ReducerContext) {
-    let read_only = ctx.as_view();
+    let read_only = ctx.as_read_only();
     // Should not compile: ViewHandle does not expose `delete()`
     read_only.db.test().delete(Test { id: 0, x: 0 });
 }
 
 #[reducer]
 fn read_only_unqiue_index_no_delete(ctx: &ReducerContext) {
-    let read_only = ctx.as_view();
+    let read_only = ctx.as_read_only();
     // Should not compile: unique read-only index does not expose `delete()`
     read_only.db.test().id().delete(&0);
 }
 
 #[reducer]
 fn read_only_unqiue_index_no_update(ctx: &ReducerContext) {
-    let read_only = ctx.as_view();
+    let read_only = ctx.as_read_only();
     // Should not compile: unique read-only index does not expose `update()`
     read_only.db.test().id().update(Test { id: 0, x: 0 });
 }
 
 #[reducer]
 fn read_only_btree_index_no_delete(ctx: &ReducerContext) {
-    let read_only = ctx.as_view();
+    let read_only = ctx.as_read_only();
     // Should not compile: read-only btree index does not expose `delete()`
     read_only.db.test().x().delete(0u32..);
 }

--- a/crates/bindings/tests/ui/views.stderr
+++ b/crates/bindings/tests/ui/views.stderr
@@ -1,0 +1,90 @@
+error[E0599]: no method named `iter` found for reference `&test__ViewHandle` in the current scope
+  --> tests/ui/views.rs:15:34
+   |
+15 |     for _ in read_only.db.test().iter() {}
+   |                                  ^^^^ method not found in `&test__ViewHandle`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following traits define an item `iter`, perhaps you need to implement one of them:
+           candidate #1: `Table`
+           candidate #2: `bitflags::traits::Flags`
+
+error[E0599]: `&test__ViewHandle` is not an iterator
+  --> tests/ui/views.rs:22:33
+   |
+3  | #[table(name = test)]
+   | ------------------- doesn't satisfy `test__ViewHandle: Iterator`
+...
+22 |     let _ = read_only.db.test().count();
+   |                                 ^^^^^ `&test__ViewHandle` is not an iterator
+   |
+   = note: the following trait bounds were not satisfied:
+           `&test__ViewHandle: Iterator`
+           which is required by `&mut &test__ViewHandle: Iterator`
+           `test__ViewHandle: Iterator`
+           which is required by `&mut test__ViewHandle: Iterator`
+note: the trait `Iterator` must be implemented
+  --> $RUST/core/src/iter/traits/iterator.rs
+   |
+   | pub trait Iterator {
+   | ^^^^^^^^^^^^^^^^^^
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following traits define an item `count`, perhaps you need to implement one of them:
+           candidate #1: `Table`
+   = note: the trait `Iterator` defines an item `count`, but is explicitly unimplemented
+
+error[E0599]: no method named `insert` found for reference `&test__ViewHandle` in the current scope
+  --> tests/ui/views.rs:29:25
+   |
+29 |     read_only.db.test().insert(Test { id: 0, x: 0 });
+   |                         ^^^^^^ method not found in `&test__ViewHandle`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following traits define an item `insert`, perhaps you need to implement one of them:
+           candidate #1: `Table`
+           candidate #2: `bitflags::traits::Flags`
+           candidate #3: `ppv_lite86::types::Vec2`
+           candidate #4: `ppv_lite86::types::Vec4`
+
+error[E0599]: no method named `try_insert` found for reference `&test__ViewHandle` in the current scope
+  --> tests/ui/views.rs:36:25
+   |
+36 |     read_only.db.test().try_insert(Test { id: 0, x: 0 });
+   |                         ^^^^^^^^^^
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `try_insert`, perhaps you need to implement it:
+           candidate #1: `Table`
+help: there is a method `try_into` with a similar name, but with different arguments
+  --> $RUST/core/src/convert/mod.rs
+   |
+   |     fn try_into(self) -> Result<T, Self::Error>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+error[E0599]: no method named `delete` found for reference `&test__ViewHandle` in the current scope
+  --> tests/ui/views.rs:43:25
+   |
+43 |     read_only.db.test().delete(Test { id: 0, x: 0 });
+   |                         ^^^^^^ method not found in `&test__ViewHandle`
+   |
+   = help: items from traits can only be used if the trait is implemented and in scope
+   = note: the following trait defines an item `delete`, perhaps you need to implement it:
+           candidate #1: `Table`
+
+error[E0599]: no method named `delete` found for struct `UniqueColumnReadOnly` in the current scope
+  --> tests/ui/views.rs:50:30
+   |
+50 |     read_only.db.test().id().delete(&0);
+   |                              ^^^^^^ method not found in `UniqueColumnReadOnly<test__TableHandle, u32, id>`
+
+error[E0599]: no method named `update` found for struct `UniqueColumnReadOnly` in the current scope
+  --> tests/ui/views.rs:57:30
+   |
+57 |     read_only.db.test().id().update(Test { id: 0, x: 0 });
+   |                              ^^^^^^ method not found in `UniqueColumnReadOnly<test__TableHandle, u32, id>`
+
+error[E0599]: no method named `delete` found for struct `RangedIndexReadOnly` in the current scope
+  --> tests/ui/views.rs:64:29
+   |
+64 |     read_only.db.test().x().delete(0u32..);
+   |                             ^^^^^^ method not found in `RangedIndexReadOnly<test__TableHandle, (u32,), x>`

--- a/crates/bindings/tests/ui/views.stderr
+++ b/crates/bindings/tests/ui/views.stderr
@@ -25,9 +25,6 @@ error[E0599]: `&test__ViewHandle` is not an iterator
            which is required by `&mut test__ViewHandle: Iterator`
 note: the trait `Iterator` must be implemented
   --> $RUST/core/src/iter/traits/iterator.rs
-   |
-   | pub trait Iterator {
-   | ^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `count`, perhaps you need to implement one of them:
            candidate #1: `Table`
@@ -57,9 +54,6 @@ error[E0599]: no method named `try_insert` found for reference `&test__ViewHandl
            candidate #1: `Table`
 help: there is a method `try_into` with a similar name, but with different arguments
   --> $RUST/core/src/convert/mod.rs
-   |
-   |     fn try_into(self) -> Result<T, Self::Error>;
-   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0599]: no method named `delete` found for reference `&test__ViewHandle` in the current scope
   --> tests/ui/views.rs:43:25

--- a/smoketests/tests/filtering.py
+++ b/smoketests/tests/filtering.py
@@ -48,7 +48,7 @@ pub fn find_person(ctx: &ReducerContext, id: i32) {
 
 #[spacetimedb::reducer]
 pub fn find_person_read_only(ctx: &ReducerContext, id: i32) {
-    let ctx = ctx.as_view();
+    let ctx = ctx.as_read_only();
     match ctx.db.person().id().find(&id) {
         Some(person) => log::info!("UNIQUE FOUND: id {}: {}", id, person.name),
         None => log::info!("UNIQUE NOT FOUND: id {}", id),
@@ -72,7 +72,7 @@ pub fn find_person_by_nick(ctx: &ReducerContext, nick: String) {
 
 #[spacetimedb::reducer]
 pub fn find_person_by_nick_read_only(ctx: &ReducerContext, nick: String) {
-    let ctx = ctx.as_view();
+    let ctx = ctx.as_read_only();
     match ctx.db.person().nick().find(&nick) {
         Some(person) => log::info!("UNIQUE FOUND: id {}: {}", person.id, person.nick),
         None => log::info!("UNIQUE NOT FOUND: nick {}", nick),
@@ -101,7 +101,7 @@ pub fn find_nonunique_person(ctx: &ReducerContext, id: i32) {
 
 #[spacetimedb::reducer]
 pub fn find_nonunique_person_read_only(ctx: &ReducerContext, id: i32) {
-    let ctx = ctx.as_view();
+    let ctx = ctx.as_read_only();
     for person in ctx.db.nonunique_person().id().filter(&id) {
         log::info!("NONUNIQUE FOUND: id {}: {}", id, person.name)
     }
@@ -179,7 +179,7 @@ fn find_indexed_people(ctx: &ReducerContext, surname: String) {
 
 #[spacetimedb::reducer]
 fn find_indexed_people_read_only(ctx: &ReducerContext, surname: String) {
-    let ctx = ctx.as_view();
+    let ctx = ctx.as_read_only();
     for person in ctx.db.indexed_person().surname().filter(&surname) {
         log::info!("INDEXED FOUND: id {}: {}, {}", person.id, person.surname, person.given_name);
     }

--- a/smoketests/tests/filtering.py
+++ b/smoketests/tests/filtering.py
@@ -47,6 +47,15 @@ pub fn find_person(ctx: &ReducerContext, id: i32) {
 }
 
 #[spacetimedb::reducer]
+pub fn find_person_read_only(ctx: &ReducerContext, id: i32) {
+    let ctx = ctx.as_view();
+    match ctx.db.person().id().find(&id) {
+        Some(person) => log::info!("UNIQUE FOUND: id {}: {}", id, person.name),
+        None => log::info!("UNIQUE NOT FOUND: id {}", id),
+    }
+}
+
+#[spacetimedb::reducer]
 pub fn find_person_by_name(ctx: &ReducerContext, name: String) {
     for person in ctx.db.person().iter().filter(|p| p.name == name) {
         log::info!("UNIQUE FOUND: id {}: {} aka {}", person.id, person.name, person.nick);
@@ -55,6 +64,15 @@ pub fn find_person_by_name(ctx: &ReducerContext, name: String) {
 
 #[spacetimedb::reducer]
 pub fn find_person_by_nick(ctx: &ReducerContext, nick: String) {
+    match ctx.db.person().nick().find(&nick) {
+        Some(person) => log::info!("UNIQUE FOUND: id {}: {}", person.id, person.nick),
+        None => log::info!("UNIQUE NOT FOUND: nick {}", nick),
+    }
+}
+
+#[spacetimedb::reducer]
+pub fn find_person_by_nick_read_only(ctx: &ReducerContext, nick: String) {
+    let ctx = ctx.as_view();
     match ctx.db.person().nick().find(&nick) {
         Some(person) => log::info!("UNIQUE FOUND: id {}: {}", person.id, person.nick),
         None => log::info!("UNIQUE NOT FOUND: nick {}", nick),
@@ -76,6 +94,14 @@ pub fn insert_nonunique_person(ctx: &ReducerContext, id: i32, name: String, is_h
 
 #[spacetimedb::reducer]
 pub fn find_nonunique_person(ctx: &ReducerContext, id: i32) {
+    for person in ctx.db.nonunique_person().id().filter(&id) {
+        log::info!("NONUNIQUE FOUND: id {}: {}", id, person.name)
+    }
+}
+
+#[spacetimedb::reducer]
+pub fn find_nonunique_person_read_only(ctx: &ReducerContext, id: i32) {
+    let ctx = ctx.as_view();
     for person in ctx.db.nonunique_person().id().filter(&id) {
         log::info!("NONUNIQUE FOUND: id {}: {}", id, person.name)
     }
@@ -150,6 +176,14 @@ fn find_indexed_people(ctx: &ReducerContext, surname: String) {
         log::info!("INDEXED FOUND: id {}: {}, {}", person.id, person.surname, person.given_name);
     }
 }
+
+#[spacetimedb::reducer]
+fn find_indexed_people_read_only(ctx: &ReducerContext, surname: String) {
+    let ctx = ctx.as_view();
+    for person in ctx.db.indexed_person().surname().filter(&surname) {
+        log::info!("INDEXED FOUND: id {}: {}, {}", person.id, person.surname, person.given_name);
+    }
+}
 """
 
     # TODO: split this into multiple test functions
@@ -173,17 +207,25 @@ fn find_indexed_people(ctx: &ReducerContext, surname: String) {
         # Fail to find a person who is not there.
         self.call("find_person", 43)
         self.assertIn("UNIQUE NOT FOUND: id 43", self.logs(2))
+        self.call("find_person_read_only", 43)
+        self.assertIn("UNIQUE NOT FOUND: id 43", self.logs(2))
 
         # Find a person by nickname.
         self.call("find_person_by_nick", "al")
+        self.assertIn("UNIQUE FOUND: id 23: al", self.logs(2))
+        self.call("find_person_by_nick_read_only", "al")
         self.assertIn("UNIQUE FOUND: id 23: al", self.logs(2))
 
         # Remove a person, and then fail to find them.
         self.call("delete_person", 23)
         self.call("find_person", 23)
         self.assertIn("UNIQUE NOT FOUND: id 23", self.logs(2))
+        self.call("find_person_read_only", 23)
+        self.assertIn("UNIQUE NOT FOUND: id 23", self.logs(2))
         # Also fail by nickname
         self.call("find_person_by_nick", "al")
+        self.assertIn("UNIQUE NOT FOUND: nick al", self.logs(2))
+        self.call("find_person_by_nick_read_only", "al")
         self.assertIn("UNIQUE NOT FOUND: nick al", self.logs(2))
 
         # Add some nonunique people.
@@ -192,11 +234,14 @@ fn find_indexed_people(ctx: &ReducerContext, surname: String) {
 
         # Find a nonunique person who is there.
         self.call("find_nonunique_person", 23)
-        # run_test cargo run logs "$IDENT" 100
+        self.assertIn('NONUNIQUE FOUND: id 23: Alice', self.logs(2))
+        self.call("find_nonunique_person_read_only", 23)
         self.assertIn('NONUNIQUE FOUND: id 23: Alice', self.logs(2))
 
         # Fail to find a nonunique person who is not there.
         self.call("find_nonunique_person", 43)
+        self.assertNotIn("NONUNIQUE NOT FOUND: id 43", self.logs(2))
+        self.call("find_nonunique_person_read_only", 43)
         self.assertNotIn("NONUNIQUE NOT FOUND: id 43", self.logs(2))
 
         # Insert a non-human, then find humans, then find non-humans
@@ -212,6 +257,9 @@ fn find_indexed_people(ctx: &ReducerContext, surname: String) {
         self.call("find_nonunique_person", 23)
         self.assertIn('NONUNIQUE FOUND: id 23: Alice', self.logs(2))
         self.assertIn('NONUNIQUE FOUND: id 23: Claire', self.logs(2))
+        self.call("find_nonunique_person_read_only", 23)
+        self.assertIn('NONUNIQUE FOUND: id 23: Alice', self.logs(2))
+        self.assertIn('NONUNIQUE FOUND: id 23: Claire', self.logs(2))
 
         # Check for issues with things present in index but not DB
         self.call("insert_person", 101, "Fee", "fee")
@@ -221,6 +269,8 @@ fn find_indexed_people(ctx: &ReducerContext, surname: String) {
         self.call("delete_person", 103)
         self.call("find_person", 104)
         self.assertIn('UNIQUE FOUND: id 104: Fum', self.logs(2))
+        self.call("find_person_read_only", 104)
+        self.assertIn('UNIQUE FOUND: id 104: Fum', self.logs(2))
 
         # As above, but for non-unique indices: check for consistency between index and DB
         self.call("insert_indexed_person", 7, "James", "Bond")
@@ -229,6 +279,12 @@ fn find_indexed_people(ctx: &ReducerContext, surname: String) {
         self.call("insert_indexed_person", 100, "Whiskey", "Bond")
         self.call("delete_indexed_person", 100)
         self.call("find_indexed_people", "Bond")
+        logs = self.logs(10)
+        self.assertIn('INDEXED FOUND: id 7: Bond, James', logs)
+        self.assertIn('INDEXED FOUND: id 79: Bond, Gold', logs)
+        self.assertIn('INDEXED FOUND: id 1: Bond, Hydrogen', logs)
+        self.assertNotIn('INDEXED FOUND: id 100: Bond, Whiskey', logs)
+        self.call("find_indexed_people_read_only", "Bond")
         logs = self.logs(10)
         self.assertIn('INDEXED FOUND: id 7: Bond, James', logs)
         self.assertIn('INDEXED FOUND: id 79: Bond, Gold', logs)


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

The `#[table]` macro now generates read-only table and index handles.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] positive and negative test cases using `ReducerContext::as_read_only()`
