### PR TITLE
consult, prioritize event.request_id over database_update.request_id (#2729)

### DIFF
--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -419,8 +419,9 @@ impl ToProtocol for TransactionUpdateMessage {
         let TransactionUpdateMessage { event, database_update } = self;
         let update = database_update.database_update;
         protocol.assert_matches_format_switch(&update);
-        let mut request_id = database_update.request_id.unwrap_or(0);
-        request_id = event.clone().map_or(request_id, |e| e.request_id.unwrap_or(request_id));
+        let request_id = database_update.request_id
+          .or_else(|| event.as_ref().map(|event| event.request_id)
+          .unwrap_or(0);
         match update {
             ws_v1::FormatSwitch::Bsatn(update) => {
                 ws_v1::FormatSwitch::Bsatn(convert(event, request_id, update, |args| {

--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -421,7 +421,7 @@ impl ToProtocol for TransactionUpdateMessage {
         protocol.assert_matches_format_switch(&update);
         let request_id = database_update
             .request_id
-            .or_else(|| event.as_ref().map(|event| event.request_id))
+            .or_else(|| event.as_ref().and_then(|event| event.request_id))
             .unwrap_or(0);
         match update {
             ws_v1::FormatSwitch::Bsatn(update) => {

--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -419,9 +419,10 @@ impl ToProtocol for TransactionUpdateMessage {
         let TransactionUpdateMessage { event, database_update } = self;
         let update = database_update.database_update;
         protocol.assert_matches_format_switch(&update);
-        let request_id = database_update.request_id
-          .or_else(|| event.as_ref().map(|event| event.request_id))
-          .unwrap_or(0);
+        let request_id = database_update
+            .request_id
+            .or_else(|| event.as_ref().map(|event| event.request_id))
+            .unwrap_or(0);
         match update {
             ws_v1::FormatSwitch::Bsatn(update) => {
                 ws_v1::FormatSwitch::Bsatn(convert(event, request_id, update, |args| {

--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -420,7 +420,7 @@ impl ToProtocol for TransactionUpdateMessage {
         let update = database_update.database_update;
         protocol.assert_matches_format_switch(&update);
         let request_id = database_update.request_id
-          .or_else(|| event.as_ref().map(|event| event.request_id)
+          .or_else(|| event.as_ref().map(|event| event.request_id))
           .unwrap_or(0);
         match update {
             ws_v1::FormatSwitch::Bsatn(update) => {

--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -419,7 +419,8 @@ impl ToProtocol for TransactionUpdateMessage {
         let TransactionUpdateMessage { event, database_update } = self;
         let update = database_update.database_update;
         protocol.assert_matches_format_switch(&update);
-        let request_id = database_update.request_id.unwrap_or(0);
+        let mut request_id = database_update.request_id.unwrap_or(0);
+        request_id = event.clone().map_or(request_id, |e| e.request_id.unwrap_or(request_id));
         match update {
             ws_v1::FormatSwitch::Bsatn(update) => {
                 ws_v1::FormatSwitch::Bsatn(convert(event, request_id, update, |args| {


### PR DESCRIPTION
Directly addresses issue #2729.

On error, the `database_update` is created by a default pattern which always produces a `request_id` of `None`.
However the event struct holds the true `request_id`, hence it should prioritize that request_id value.
