### PR TITLE
Fix Rust dep versions

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,38 +98,38 @@ edition = "2021"
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-spacetimedb = { path = "crates/bindings", version = "1.5.0" }
-spacetimedb-auth = { path = "crates/auth", version = "1.5.0" }
-spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.5.0" }
-spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.5.0" }
-spacetimedb-cli = { path = "crates/cli", version = "1.5.0" }
-spacetimedb-client-api = { path = "crates/client-api", version = "1.5.0" }
-spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.5.0" }
-spacetimedb-codegen = { path = "crates/codegen", version = "1.5.0" }
-spacetimedb-commitlog = { path = "crates/commitlog", version = "1.5.0" }
-spacetimedb-core = { path = "crates/core", version = "1.5.0" }
-spacetimedb-data-structures = { path = "crates/data-structures", version = "1.5.0" }
-spacetimedb-datastore = { path = "crates/datastore", version = "1.5.0" }
-spacetimedb-durability = { path = "crates/durability", version = "1.5.0" }
-spacetimedb-execution = { path = "crates/execution", version = "1.5.0" }
-spacetimedb-expr = { path = "crates/expr", version = "1.5.0" }
-spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.5.0" }
-spacetimedb-memory-usage = { path = "crates/memory-usage", version = "1.5.0", default-features = false }
-spacetimedb-metrics = { path = "crates/metrics", version = "1.5.0" }
-spacetimedb-paths = { path = "crates/paths", version = "1.5.0" }
-spacetimedb-pg = { path = "crates/pg", version = "1.5.0" }
-spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.5.0" }
-spacetimedb-primitives = { path = "crates/primitives", version = "1.5.0" }
-spacetimedb-query = { path = "crates/query", version = "1.5.0" }
-spacetimedb-sats = { path = "crates/sats", version = "1.5.0" }
-spacetimedb-schema = { path = "crates/schema", version = "1.5.0" }
-spacetimedb-standalone = { path = "crates/standalone", version = "1.5.0" }
-spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.5.0" }
-spacetimedb-table = { path = "crates/table", version = "1.5.0" }
-spacetimedb-vm = { path = "crates/vm", version = "1.5.0" }
-spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.5.0" }
-spacetimedb-snapshot = { path = "crates/snapshot", version = "1.5.0" }
-spacetimedb-subscription = { path = "crates/subscription", version = "1.5.0" }
+spacetimedb = { path = "crates/bindings", version = "1.5.*" }
+spacetimedb-auth = { path = "crates/auth", version = "1.5.*" }
+spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.5.*" }
+spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.5.*" }
+spacetimedb-cli = { path = "crates/cli", version = "1.5.*" }
+spacetimedb-client-api = { path = "crates/client-api", version = "1.5.*" }
+spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.5.*" }
+spacetimedb-codegen = { path = "crates/codegen", version = "1.5.*" }
+spacetimedb-commitlog = { path = "crates/commitlog", version = "1.5.*" }
+spacetimedb-core = { path = "crates/core", version = "1.5.*" }
+spacetimedb-data-structures = { path = "crates/data-structures", version = "1.5.*" }
+spacetimedb-datastore = { path = "crates/datastore", version = "1.5.*" }
+spacetimedb-durability = { path = "crates/durability", version = "1.5.*" }
+spacetimedb-execution = { path = "crates/execution", version = "1.5.*" }
+spacetimedb-expr = { path = "crates/expr", version = "1.5.*" }
+spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.5.*" }
+spacetimedb-memory-usage = { path = "crates/memory-usage", version = "1.5.*", default-features = false }
+spacetimedb-metrics = { path = "crates/metrics", version = "1.5.*" }
+spacetimedb-paths = { path = "crates/paths", version = "1.5.*" }
+spacetimedb-pg = { path = "crates/pg", version = "1.5.*" }
+spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.5.*" }
+spacetimedb-primitives = { path = "crates/primitives", version = "1.5.*" }
+spacetimedb-query = { path = "crates/query", version = "1.5.*" }
+spacetimedb-sats = { path = "crates/sats", version = "1.5.*" }
+spacetimedb-schema = { path = "crates/schema", version = "1.5.*" }
+spacetimedb-standalone = { path = "crates/standalone", version = "1.5.*" }
+spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.5.*" }
+spacetimedb-table = { path = "crates/table", version = "1.5.*" }
+spacetimedb-vm = { path = "crates/vm", version = "1.5.*" }
+spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.5.*" }
+spacetimedb-snapshot = { path = "crates/snapshot", version = "1.5.*" }
+spacetimedb-subscription = { path = "crates/subscription", version = "1.5.*" }
 
 # Prevent `ahash` from pulling in `getrandom` by disabling default features.
 # Modules use `getrandom02` and we need to prevent an incompatible version

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -98,38 +98,38 @@ edition = "2021"
 rust-version = "1.88.0"
 
 [workspace.dependencies]
-spacetimedb = { path = "crates/bindings", version = "1.5.*" }
-spacetimedb-auth = { path = "crates/auth", version = "1.5.*" }
-spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "1.5.*" }
-spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "1.5.*" }
-spacetimedb-cli = { path = "crates/cli", version = "1.5.*" }
-spacetimedb-client-api = { path = "crates/client-api", version = "1.5.*" }
-spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "1.5.*" }
-spacetimedb-codegen = { path = "crates/codegen", version = "1.5.*" }
-spacetimedb-commitlog = { path = "crates/commitlog", version = "1.5.*" }
-spacetimedb-core = { path = "crates/core", version = "1.5.*" }
-spacetimedb-data-structures = { path = "crates/data-structures", version = "1.5.*" }
-spacetimedb-datastore = { path = "crates/datastore", version = "1.5.*" }
-spacetimedb-durability = { path = "crates/durability", version = "1.5.*" }
-spacetimedb-execution = { path = "crates/execution", version = "1.5.*" }
-spacetimedb-expr = { path = "crates/expr", version = "1.5.*" }
-spacetimedb-lib = { path = "crates/lib", default-features = false, version = "1.5.*" }
-spacetimedb-memory-usage = { path = "crates/memory-usage", version = "1.5.*", default-features = false }
-spacetimedb-metrics = { path = "crates/metrics", version = "1.5.*" }
-spacetimedb-paths = { path = "crates/paths", version = "1.5.*" }
-spacetimedb-pg = { path = "crates/pg", version = "1.5.*" }
-spacetimedb-physical-plan = { path = "crates/physical-plan", version = "1.5.*" }
-spacetimedb-primitives = { path = "crates/primitives", version = "1.5.*" }
-spacetimedb-query = { path = "crates/query", version = "1.5.*" }
-spacetimedb-sats = { path = "crates/sats", version = "1.5.*" }
-spacetimedb-schema = { path = "crates/schema", version = "1.5.*" }
-spacetimedb-standalone = { path = "crates/standalone", version = "1.5.*" }
-spacetimedb-sql-parser = { path = "crates/sql-parser", version = "1.5.*" }
-spacetimedb-table = { path = "crates/table", version = "1.5.*" }
-spacetimedb-vm = { path = "crates/vm", version = "1.5.*" }
-spacetimedb-fs-utils = { path = "crates/fs-utils", version = "1.5.*" }
-spacetimedb-snapshot = { path = "crates/snapshot", version = "1.5.*" }
-spacetimedb-subscription = { path = "crates/subscription", version = "1.5.*" }
+spacetimedb = { path = "crates/bindings", version = "=1.5.0" }
+spacetimedb-auth = { path = "crates/auth", version = "=1.5.0" }
+spacetimedb-bindings-macro = { path = "crates/bindings-macro", version = "=1.5.0" }
+spacetimedb-bindings-sys = { path = "crates/bindings-sys", version = "=1.5.0" }
+spacetimedb-cli = { path = "crates/cli", version = "=1.5.0" }
+spacetimedb-client-api = { path = "crates/client-api", version = "=1.5.0" }
+spacetimedb-client-api-messages = { path = "crates/client-api-messages", version = "=1.5.0" }
+spacetimedb-codegen = { path = "crates/codegen", version = "=1.5.0" }
+spacetimedb-commitlog = { path = "crates/commitlog", version = "=1.5.0" }
+spacetimedb-core = { path = "crates/core", version = "=1.5.0" }
+spacetimedb-data-structures = { path = "crates/data-structures", version = "=1.5.0" }
+spacetimedb-datastore = { path = "crates/datastore", version = "=1.5.0" }
+spacetimedb-durability = { path = "crates/durability", version = "=1.5.0" }
+spacetimedb-execution = { path = "crates/execution", version = "=1.5.0" }
+spacetimedb-expr = { path = "crates/expr", version = "=1.5.0" }
+spacetimedb-lib = { path = "crates/lib", default-features = false, version = "=1.5.0" }
+spacetimedb-memory-usage = { path = "crates/memory-usage", version = "=1.5.0", default-features = false }
+spacetimedb-metrics = { path = "crates/metrics", version = "=1.5.0" }
+spacetimedb-paths = { path = "crates/paths", version = "=1.5.0" }
+spacetimedb-pg = { path = "crates/pg", version = "=1.5.0" }
+spacetimedb-physical-plan = { path = "crates/physical-plan", version = "=1.5.0" }
+spacetimedb-primitives = { path = "crates/primitives", version = "=1.5.0" }
+spacetimedb-query = { path = "crates/query", version = "=1.5.0" }
+spacetimedb-sats = { path = "crates/sats", version = "=1.5.0" }
+spacetimedb-schema = { path = "crates/schema", version = "=1.5.0" }
+spacetimedb-standalone = { path = "crates/standalone", version = "=1.5.0" }
+spacetimedb-sql-parser = { path = "crates/sql-parser", version = "=1.5.0" }
+spacetimedb-table = { path = "crates/table", version = "=1.5.0" }
+spacetimedb-vm = { path = "crates/vm", version = "=1.5.0" }
+spacetimedb-fs-utils = { path = "crates/fs-utils", version = "=1.5.0" }
+spacetimedb-snapshot = { path = "crates/snapshot", version = "=1.5.0" }
+spacetimedb-subscription = { path = "crates/subscription", version = "=1.5.0" }
 
 # Prevent `ahash` from pulling in `getrandom` by disabling default features.
 # Modules use `getrandom02` and we need to prevent an incompatible version

--- a/crates/cli/src/subcommands/project/rust/Cargo._toml
+++ b/crates/cli/src/subcommands/project/rust/Cargo._toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "1.5"
+spacetimedb = "1.5.*"
 log = "0.4"

--- a/crates/cli/src/subcommands/project/rust/Cargo._toml
+++ b/crates/cli/src/subcommands/project/rust/Cargo._toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "1.5.*"
+spacetimedb = "=1.5.0"
 log = "0.4"

--- a/crates/cli/src/subcommands/project/rust/Cargo._toml
+++ b/crates/cli/src/subcommands/project/rust/Cargo._toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "=1.5.0"
+spacetimedb = "1.5.*"
 log = "0.4"

--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -103,14 +103,10 @@ fn main() -> anyhow::Result<()> {
         anyhow::bail!("You must execute this binary from inside of the SpacetimeDB directory, or use --spacetime-path");
     }
 
-    let semver = Version::parse(version).expect("Invalid semver provided to upgrade-version");
-    let major_minor = format!("{}.{}.*", semver.major, semver.minor);
-    let full_version = format!("{}.{}.{}", semver.major, semver.minor, semver.patch);
-
     if matches.get_flag("rust-and-cli") {
         // Use `=` for dependency versions, to avoid issues where Cargo automatically rolls forward to later minor versions.
         // See https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#default-requirements.
-        let dep_version = format!("={}", full_version);
+        let dep_version = format!("={}", version);
 
         // root Cargo.toml
         edit_toml("Cargo.toml", |doc| {
@@ -132,7 +128,9 @@ fn main() -> anyhow::Result<()> {
             //
             // Note: This is meaningfully different than setting just major.minor.
             // See https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#default-requirements.
-            doc["dependencies"]["spacetimedb"] = toml_edit::value(major_minor.clone());
+            let v = Version::parse(version).expect("Invalid semver provided to upgrade-version");
+            let major_minor = format!("{}.{}.*", v.major, v.minor);
+            doc["dependencies"]["spacetimedb"] = toml_edit::value(major_minor);
         })?;
 
         process_license_file("LICENSE.txt", version);

--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -1,7 +1,7 @@
 #![allow(clippy::disallowed_macros)]
 
 use chrono::{Datelike, Local};
-use clap::{Arg, ArgGroup, Command};
+use clap::{Arg, Command};
 use duct::cmd;
 use regex::Regex;
 use semver::Version;
@@ -89,12 +89,6 @@ fn main() -> anyhow::Result<()> {
                 .long("csharp")
                 .action(clap::ArgAction::SetTrue)
                 .help("Also bump versions in C# SDK and templates"),
-        )
-        .group(
-            ArgGroup::new("update-targets")
-                .args(["typescript", "rust-and-cli", "csharp"])
-                .required(true)
-                .multiple(true),
         )
         .get_matches();
 

--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -120,7 +120,7 @@ fn main() -> anyhow::Result<()> {
 
         // root Cargo.toml
         edit_toml("Cargo.toml", |doc| {
-            doc["workspace"]["package"]["version"] = toml_edit::value(full_version.clone());
+            doc["workspace"]["package"]["version"] = toml_edit::value(version);
             for (key, dep) in doc["workspace"]["dependencies"]
                 .as_table_like_mut()
                 .expect("workspace.dependencies is not a table")
@@ -133,8 +133,11 @@ fn main() -> anyhow::Result<()> {
         })?;
 
         edit_toml("crates/cli/src/subcommands/project/rust/Cargo._toml", |doc| {
-            // Only use major.minor for the spacetimedb dependency.
+            // Only set major.minor.* for the spacetimedb dependency.
             // See https://github.com/clockworklabs/SpacetimeDB/issues/2724.
+            //
+            // Note: This is meaningfully different than setting just major.minor.
+            // See https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#default-requirements.
             doc["dependencies"]["spacetimedb"] = toml_edit::value(major_minor.clone());
         })?;
 

--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -93,7 +93,8 @@ fn main() -> anyhow::Result<()> {
         .group(
             ArgGroup::new("update-targets")
                 .args(["typescript", "rust-and-cli", "csharp"])
-                .required(true),
+                .required(true)
+                .multiple(true),
         )
         .get_matches();
 

--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -98,6 +98,7 @@ fn main() -> anyhow::Result<()> {
         )
         .get_matches();
 
+    let version = matches.get_one::<String>("upgrade_version").unwrap();
     if let Some(path) = matches.get_one::<PathBuf>("spacetime-path") {
         env::set_current_dir(path).ok();
     }

--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -106,7 +106,7 @@ fn main() -> anyhow::Result<()> {
     if matches.get_flag("rust-and-cli") {
         // Use `=` for dependency versions, to avoid issues where Cargo automatically rolls forward to later minor versions.
         // See https://doc.rust-lang.org/cargo/reference/specifying-dependencies.html#default-requirements.
-        let dep_version = format!("={}", version);
+        let dep_version = format!("={version}");
 
         // root Cargo.toml
         edit_toml("Cargo.toml", |doc| {


### PR DESCRIPTION
# Description of Changes

It turns out that cargo automatically uses the latest semver-compatible versions of dependencies, which is not what we expected. tl;dr specifying `1.5.0` actually means `>=1.5.0 <2.0.0`, but we actually intend `1.5.*`.

This PR updates our `upgrade-version` tool, and re-runs it to fix the dep versions.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1

# Testing

- [x] I ran `cargo bump-versions 1.5.0 --rust-and-cli` to regenerate the other committed files.