### PR TITLE
Pin `temporal_rs` version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7102,8 +7102,7 @@ dependencies = [
 [[package]]
 name = "temporal_rs"
 version = "0.0.11"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7807e330b12e288b847a3e2a2b0dcd41ca764d0f90f9e8940f02c6ddd68cd2d7"
+source = "git+https://github.com/boa-dev/temporal?tag=v0.0.11#1980ece2d4ebf796d0fe62645392599f64d7b130"
 dependencies = [
  "combine",
  "core_maths",
@@ -7294,9 +7293,8 @@ dependencies = [
 
 [[package]]
 name = "timezone_provider"
-version = "0.0.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f357f8e2cddee6a7b56b69fbb4cab30a7e82914c80ee7f9a5eb799ee3de3f24d"
+version = "0.0.11"
+source = "git+https://github.com/boa-dev/temporal?tag=v0.0.11#1980ece2d4ebf796d0fe62645392599f64d7b130"
 dependencies = [
  "tinystr 0.8.1",
  "zerotrie",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -341,3 +341,11 @@ unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }
 [workspace.lints.clippy]
 # FIXME: we should work on this lint incrementally
 result_large_err = "allow"
+
+[patch.crates-io]
+# Note(bfops): We require this override because temporal_rs (pulled via core->v8->ry_temporal_capi)
+# depends on timezone_provider using a `~` which allows a roll-forward to an incompatible version.
+# Maybe this will no longer be an issue if we bump v8 to a version that depends on a post-0.1
+# version of temporal_rs, but I'm not holding my breath.
+timezone_provider = { git = "https://github.com/boa-dev/temporal", tag = "v0.0.11" }
+temporal_rs = { git = "https://github.com/boa-dev/temporal", tag = "v0.0.11" }


### PR DESCRIPTION
# Description of Changes

Pin the `temporal_rs` and `timezone_provider` versions to `0.0.11`, because future versions such as `0.0.16` are incompatible, but their version constraints are not correct so we keep getting auto-rolled-forward to build-breaking versions.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1

# Testing

- [x] CI passes
- [x] If I `rm Cargo.lock && cargo clippy`, the build still passes