### PR TITLE
Fix python example to not advise to use ~/token.py

### DIFF
--- a/docs/docs/sql/pg-wire.md
+++ b/docs/docs/sql/pg-wire.md
@@ -70,20 +70,16 @@ spacetime login show --token
 
 To export the token to `PGPASSWORD`:
 
-```python
-# token.py
-import sys, re
-
-text = sys.stdin.read()
-match = re.search(r"Your auth token \(don't share this!\) is\s+(\S+)", text)
-if not match:
-    sys.exit("No token found")
-
-print(f"export PGPASSWORD={match.group(1)}")
-```
+*For Bash*:
 
 ```bash
-eval "$(spacetime login show --token | python3 ~/token.py)"
+export PGPASSWORD="$(spacetime login show --token | sed -n 's/^Your auth token.*is //p')"
+```
+
+*For PowerShell*:
+
+```powershell
+$env:PGPASSWORD = (spacetime login show --token | Select-String 'Your auth token.*is (.*)' | % { $_.Matches[0].Groups[1].Value })
 ```
 
 ## Examples


### PR DESCRIPTION
# Description of Changes

Python is funny, if a file `token.py` is created and another script run on the same dir, it will cause python to block:

```python
python3-3.13.7/lib/python3.13/tokenize.py", line 35, in <module>
    from token import *
  File "/Users/mamcx/token.py", line 3, in <module>
    text = sys.stdin.read()
```

By coincidence the docs on `pg wire` use this name. Changed to one that don't cause the trouble.

# Expected complexity level and risk
1

# Testing

- [x] Created another script and run it, see it blocks because this...