### PR TITLE
CI - Tweak caching in `typescript/build-and-test`

### DIFF
--- a/.github/workflows/typescript-test.yml
+++ b/.github/workflows/typescript-test.yml
@@ -77,6 +77,9 @@ jobs:
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
+          workspaces: |
+            .
+            modules/quickstart-chat
           shared-key: quickstart-chat-test
 
       - name: Install SpacetimeDB CLI from the local checkout


### PR DESCRIPTION
# Description of Changes

I changed some variables related to caching in the TypeScript test CI, since it was failing on master due to suspected cache issues.

# API and ABI breaking changes

None

# Expected complexity level and risk
1

# Testing

- [x] CI passes on this PR when it didn't on master