### PR TITLE
Fix windows linker errors

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -10,4 +10,6 @@ bump-versions = "run -p upgrade-version --"
 # I (@bfops) tried a variety of other link options besides switching linkers, but this
 # seems to be the only thing that worked.
 linker = "lld-link"
+# Without this, the linker complains that libc functions are undefined -
+# it probably signals to rustc and lld-link that libucrt should be included.
 rustflags = ["-Ctarget-feature=+crt-static"]


### PR DESCRIPTION
# Description of Changes

My guess as to the problem was that there were static libs in the dependency graph that were wanting to statically link to libc functions, but rustc didn't know we wanted to link libc statically - so adding `+crt-static` fixes it.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

1
<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Builds successfully on windows now.
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
