### PR TITLE
Weaken minimum dotnet version

### DIFF
--- a/global.json
+++ b/global.json
@@ -1,6 +1,6 @@
 {
   "sdk": {
-    "version": "8.0.0",
+    "version": "8.0.100",
     "rollForward": "latestMinor"
   }
 }


### PR DESCRIPTION
# Description of Changes

Relax the patch version requirement in `global.json`, because `8.0.400` isn't available on Linux.

# API and ABI breaking changes

No.

# Expected complexity level and risk

1

# Testing

I've been using this modification for a long time and we've never had people complain about bad C# DLLs or anything.