### PR TITLE
Fixed a circular import that was not detected in the TypeScript SDK

### DIFF
--- a/crates/bindings-typescript/src/sdk/db_connection_impl.ts
+++ b/crates/bindings-typescript/src/sdk/db_connection_impl.ts
@@ -52,14 +52,7 @@ import { stdbLogger } from './logger.ts';
 import { type ReducerRuntimeTypeInfo } from './spacetime_module.ts';
 import { fromByteArray } from 'base64-js';
 
-export {
-  BinaryReader,
-  BinaryWriter,
-  DbConnectionBuilder,
-  SubscriptionBuilderImpl,
-  TableCache,
-  type Event,
-};
+export { DbConnectionBuilder, SubscriptionBuilderImpl, TableCache, type Event };
 
 export type {
   DbContext,

--- a/crates/bindings-typescript/src/server/runtime.ts
+++ b/crates/bindings-typescript/src/server/runtime.ts
@@ -6,7 +6,8 @@ import type Typespace from '../lib/autogen/typespace_type';
 import { ConnectionId } from '../lib/connection_id';
 import { Identity } from '../lib/identity';
 import { Timestamp } from '../lib/timestamp';
-import { BinaryReader, BinaryWriter } from '../sdk';
+import BinaryReader from '../lib/binary_reader';
+import BinaryWriter from '../lib/binary_writer';
 import { SenderError, SpacetimeHostError } from './errors';
 import { Range, type Bound } from './range';
 import {


### PR DESCRIPTION
# Description of Changes

Alessandro ran into a stack overflow trying to use the TypeScript SDK from Remix (Node.js). We debugged it to be a circular import of `BinaryWriter` due to a barrel import. This fixes that issue.

# API and ABI breaking changes

This is technically an API breaking change because anyone who was importing `BinaryWriter` or `BinaryReader` from `spacetimedb/sdk` will now have to import it from `spacetimedb` or `spacetimedb/lib`.

# Expected complexity level and risk

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Alessandro and I have tested this change.
