### PR TITLE
Fix CLI package._json version

### DIFF
--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -212,13 +212,6 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
     // Set the host type.
     builder = builder.query(&[("host_type", host_type)]);
 
-    // JS/TS is beta quality atm.
-    if host_type == "Js" {
-        println!("JavaScript / TypeScript support is currently in BETA.");
-        println!("There may be bugs. Please file issues if you encounter any.");
-        println!("<https://github.com/clockworklabs/SpacetimeDB/issues/new>");
-    }
-
     let res = builder.body(program_bytes).send().await?;
     if res.status() == StatusCode::UNAUTHORIZED && !anon_identity {
         // If we're not in the `anon_identity` case, then we have already forced the user to log in above (using `get_auth_header`), so this should be safe to unwrap.


### PR DESCRIPTION
# Description of Changes

We didn't fix this after merging the 1.6.0 version bump into the TypeScript PR.

I had originally fixed this in the release branch, but that patch got lost once I recreated the branch, so we should release an updated CLI (probably just update the existing GH release).

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Existing CI only