### PR TITLE
Bump TypeScript versions to 1.6.2

### DIFF
--- a/crates/bindings-typescript/package.json
+++ b/crates/bindings-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spacetimedb",
-  "version": "1.6.1",
+  "version": "1.6.2",
   "description": "API and ABI bindings for the SpacetimeDB TypeScript module library",
   "homepage": "https://github.com/clockworklabs/SpacetimeDB#readme",
   "bugs": {

--- a/crates/cli/src/subcommands/project/typescript/package._json
+++ b/crates/cli/src/subcommands/project/typescript/package._json
@@ -10,6 +10,6 @@
   "author": "",
   "license": "ISC",
   "dependencies": {
-    "spacetimedb": "1.5.*"
+    "spacetimedb": "1.6.*"
   }
 }


### PR DESCRIPTION
# Description of Changes

Bump the TypeScript package version to 1.6.2 in preparation for a release.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Existing CI only