### PR TITLE
add rust-src to the toolchain and update trybuild test output

### DIFF
--- a/crates/bindings/tests/ui/views.stderr
+++ b/crates/bindings/tests/ui/views.stderr
@@ -25,6 +25,9 @@ error[E0599]: `&test__ViewHandle` is not an iterator
            which is required by `&mut test__ViewHandle: Iterator`
 note: the trait `Iterator` must be implemented
   --> $RUST/core/src/iter/traits/iterator.rs
+   |
+   | pub trait Iterator {
+   | ^^^^^^^^^^^^^^^^^^
    = help: items from traits can only be used if the trait is implemented and in scope
    = note: the following traits define an item `count`, perhaps you need to implement one of them:
            candidate #1: `Table`
@@ -54,6 +57,9 @@ error[E0599]: no method named `try_insert` found for reference `&test__ViewHandl
            candidate #1: `Table`
 help: there is a method `try_into` with a similar name, but with different arguments
   --> $RUST/core/src/convert/mod.rs
+   |
+   |     fn try_into(self) -> Result<T, Self::Error>;
+   |     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0599]: no method named `delete` found for reference `&test__ViewHandle` in the current scope
   --> tests/ui/views.rs:43:25

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -5,3 +5,4 @@
 channel = "1.90.0"
 profile = "default"
 targets = ["wasm32-unknown-unknown"]
+components = ["rust-src"]


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Adds `rust-src` to the toolchain and updates the expected output of the `trybuild` tests.

`rust-src` places the entire source code of the rust stdlib under the local toolchain directory. `rust-analyzer` uses it for "go to definition" (among other things) in the stdlib. When included in the toolchain, rustc can provide code frames that it can't otherwise.

The reason for its addition is that if anyone includes it in their local toolchain, the error messages produced by rustc when running the `ui` tests will be slightly different (have some more information) than when run in CI. Hence those tests will fail locally but not in CI. Rather than removing `rust-src` locally so that the tests will pass, I've opted to just add it to the toolchain so that everyone runs with it by default, including in CI.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

0

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Updated rustc tests
