### PR TITLE
CI - Remove previews on discord posts for merged PRs

### DIFF
--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -41,7 +41,7 @@ jobs:
           CHECK_RESULT: ${{ env.CHECK_RESULT }}
           MENTION_ON_FAILURE: ${{ secrets.DEV_OPS_ROLE_ID }}
         run: |
-          message="PR merged: [(#${PR_NUMBER}) ${PR_TITLE}](${PR_URL})"
+          message="PR merged: [(#${PR_NUMBER}) ${PR_TITLE}](<${PR_URL}>)"
           message+=$'\n'
           message+="${CHECK_NAME} result: ${CHECK_RESULT}"
           # Note that anything besides success is treated as a failure (e.g. if the check did not run at all, or if it is still pending).


### PR DESCRIPTION
# Description of Changes

The previews only work for public repos, meaning that the posts end up looking inconsistent. I don't believe the previews add much information anyway. _If_ there's information in there that we want, we should add it to the post itself.

# API and ABI breaking changes

No.

# Expected complexity level and risk

1

# Testing

None. We'll see when it merges!