### PR TITLE
gitignore `node_modules` even when it's a symlink

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -51,10 +51,10 @@ build/Release
 
 # Dependency directories
 node_modules
-jspm_packages/
+jspm_packages
 
 # Snowpack dependency directory (https://snowpack.dev/)
-web_modules/
+web_modules
 
 # TypeScript cache
 *.tsbuildinfo


### PR DESCRIPTION
# Description of Changes

Just a gitignore tweak.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] `git` is no longer trying to commit my `node_modules` symlink