### PR TITLE
CI - move as much as possible off of spacetimedb-runner

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -19,9 +19,9 @@ jobs:
     strategy:
       matrix:
         include:
-          - { runner: spacetimedb-runner, smoketest_args: --docker }
+          - { runner: ubuntu-latest, smoketest_args: --docker }
           - { runner: windows-latest, smoketest_args: --no-build-cli }
-        runner: [ spacetimedb-runner, windows-latest ]
+        runner: [ ubuntu-latest, windows-latest ]
     runs-on: ${{ matrix.runner }}
     steps:
       - name: Find Git ref
@@ -78,7 +78,7 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: spacetimedb-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Find Git ref
         env:
@@ -139,7 +139,7 @@ jobs:
 
   lints:
     name: Lints
-    runs-on: spacetimedb-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -178,7 +178,7 @@ jobs:
 
   wasm_bindings:
     name: Build and test wasm bindings
-    runs-on: spacetimedb-runner
+    runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v3
 
@@ -231,7 +231,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { target: x86_64-unknown-linux-gnu, runner: spacetimedb-runner }
+          - { target: x86_64-unknown-linux-gnu, runner: ubuntu-latest }
           - { target: aarch64-unknown-linux-gnu, runner: arm-runner }
           - { target: aarch64-apple-darwin, runner: macos-latest }
           - { target: x86_64-pc-windows-msvc, runner: windows-latest }

--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -8,6 +8,7 @@ on:
 
 jobs:
   unity-testsuite:
+    # This can't go on ubuntu-latest (at least as-is) because it relies on pre-installed Unity.
     runs-on: spacetimedb-runner
     # Cancel any previous testsuites running on the same PR and/or ref.
     concurrency:

--- a/.github/workflows/upgrade-version-check.yml
+++ b/.github/workflows/upgrade-version-check.yml
@@ -8,7 +8,7 @@ permissions: read-all
 
 jobs:
   version_upgrade_check:
-    runs-on: spacetimedb-runner
+    runs-on: ubuntu-latest
     steps:
       - name: Checkout
         uses: actions/checkout@v3


### PR DESCRIPTION
# Description of Changes

We have persistent issues around CI jobs getting cancelled mysteriously and unceremoniously. It has been hard to figure out why this happens, so this workaround just moves as many things as possible off of the custom runner.

This slowed down the smoketests from 17m -> 22m.

# API and ABI breaking changes

CI-only change.

# Expected complexity level and risk

1

# Testing

- [x] CI still passes