### PR TITLE
Revert "feat: update pgwire to 0.34 and improve how we disable ssl (#3432)"

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -317,6 +317,30 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c08606f8c3cbf4ce6ec8e28fb0014a2c086708fe954eaa885384a6165172e7e8"
 
 [[package]]
+name = "aws-lc-rs"
+version = "1.14.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "879b6c89592deb404ba4dc0ae6b58ffd1795c78991cbb5b8bc441c48a070440d"
+dependencies = [
+ "aws-lc-sys",
+ "untrusted 0.7.1",
+ "zeroize",
+]
+
+[[package]]
+name = "aws-lc-sys"
+version = "0.32.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "107a4e9d9cab9963e04e84bb8dee0e25f2a987f9a8bad5ed054abd439caa8f8c"
+dependencies = [
+ "bindgen",
+ "cc",
+ "cmake",
+ "dunce",
+ "fs_extra",
+]
+
+[[package]]
 name = "axum"
 version = "0.7.9"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1000,6 +1024,15 @@ dependencies = [
  "error-code",
  "str-buf",
  "winapi",
+]
+
+[[package]]
+name = "cmake"
+version = "0.1.54"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7caa3f9de89ddbe2c607f4101924c5abec803763ae9534e4f4d7d8f84aa81f0"
+dependencies = [
+ "cc",
 ]
 
 [[package]]
@@ -4817,11 +4850,12 @@ dependencies = [
 
 [[package]]
 name = "pgwire"
-version = "0.34.1"
+version = "0.32.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c748793f2a9267fa2aa409d9375a5e26e4f1504ea96e34f8cab3e2fc32042d69"
+checksum = "ddf403a6ee31cf7f2217b2bd8447cb13dbb6c268d7e81501bc78a4d3daafd294"
 dependencies = [
  "async-trait",
+ "aws-lc-rs",
  "bytes",
  "chrono",
  "derive-new",
@@ -4832,10 +4866,10 @@ dependencies = [
  "postgres-types",
  "rand 0.9.2",
  "rust_decimal",
- "serde",
- "serde_json",
+ "rustls-pki-types",
  "thiserror 2.0.17",
  "tokio",
+ "tokio-rustls",
  "tokio-util",
 ]
 
@@ -5040,8 +5074,6 @@ dependencies = [
  "fallible-iterator 0.2.0",
  "postgres-derive",
  "postgres-protocol",
- "serde_core",
- "serde_json",
 ]
 
 [[package]]
@@ -5743,7 +5775,7 @@ dependencies = [
  "cfg-if",
  "getrandom 0.2.16",
  "libc",
- "untrusted",
+ "untrusted 0.9.0",
  "windows-sys 0.52.0",
 ]
 
@@ -6252,6 +6284,8 @@ version = "0.23.33"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "751e04a496ca00bb97a5e043158d23d66b5aabf2e1d5aa2a0aaebb1aafe6f82c"
 dependencies = [
+ "aws-lc-rs",
+ "log",
  "once_cell",
  "rustls-pki-types",
  "rustls-webpki",
@@ -6283,9 +6317,10 @@ version = "0.103.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e10b3f4191e8a80e6b43eebabfac91e5dcecebb27a71f04e820c47ec41d314bf"
 dependencies = [
+ "aws-lc-rs",
  "ring",
  "rustls-pki-types",
- "untrusted",
+ "untrusted 0.9.0",
 ]
 
 [[package]]
@@ -9213,6 +9248,12 @@ name = "unicode-xid"
 version = "0.2.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "ebc1c04c71510c7f702b52b7c350734c9ff1295c464a03335b00bb84fc54f853"
+
+[[package]]
+name = "untrusted"
+version = "0.7.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a156c684c91ea7d62626509bce3cb4e1d9ed5c4d978f7b4352658f96a4c26b4a"
 
 [[package]]
 name = "untrusted"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -219,7 +219,7 @@ paste = "1.0"
 percent-encoding = "2.3"
 petgraph = { version = "0.6.5", default-features = false }
 pin-project-lite = "0.2.9"
-pgwire = { version = "0.34.1", default-features = false, features = ["server-api", "pg-ext-types"] }
+pgwire = { version = "0.32", features = ["server-api"] }
 postgres-types = "0.2.5"
 pretty_assertions = { version = "1.4", features = ["unstable"] }
 proc-macro2 = "1.0"

--- a/crates/pg/src/pg_server.rs
+++ b/crates/pg/src/pg_server.rs
@@ -46,6 +46,8 @@ pub(crate) enum PgError {
     DatabaseNameRequired,
     #[error(transparent)]
     Pg(#[from] PgWireError),
+    #[error("SSL is not supported by SpacetimeDB")]
+    SSLNotSupported,
     #[error(transparent)]
     Other(#[from] anyhow::Error),
 }
@@ -148,7 +150,7 @@ struct PgSpacetimeDB<T> {
 }
 
 impl<T: ControlStateReadAccess + ControlStateWriteAccess + NodeDelegate + Clone> PgSpacetimeDB<T> {
-    async fn exe_sql(&self, query: String) -> PgWireResult<Vec<Response>> {
+    async fn exe_sql<'a>(&self, query: String) -> PgWireResult<Vec<Response<'a>>> {
         let params = self.cached.lock().await.clone().unwrap();
         let db = SqlParams {
             name_or_identity: database::NameOrIdentity::Name(DatabaseName(params.database.clone())),
@@ -280,6 +282,12 @@ impl<T: Sync + Send + ControlStateReadAccess + ControlStateWriteAccess + NodeDel
                 self.cached.lock().await.clone_from(&Some(metadata));
                 finish_authentication(client, &self.parameter_provider).await?;
             }
+            PgWireFrontendMessage::SslRequest(_) => {
+                let err = PgError::SSLNotSupported;
+                log::error!("{err}");
+                let err = ErrorInfo::new("FATAL".to_owned(), "28P01".to_owned(), err.to_string());
+                return close_client(client, err).await;
+            }
             // The other messages are for features not supported by SpacetimeDB, that are rejected by the parser.
             _ => {
                 unreachable!("Unsupported startup message: {message:?}");
@@ -293,7 +301,7 @@ impl<T: Sync + Send + ControlStateReadAccess + ControlStateWriteAccess + NodeDel
 impl<T: Sync + Send + ControlStateReadAccess + ControlStateWriteAccess + NodeDelegate + Clone> SimpleQueryHandler
     for PgSpacetimeDB<T>
 {
-    async fn do_query<C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response>>
+    async fn do_query<'a, C>(&self, _client: &mut C, query: &str) -> PgWireResult<Vec<Response<'a>>>
     where
         C: ClientInfo + Unpin + Send + Sync,
     {


### PR DESCRIPTION
# Description of Changes

This reverts commit d20579555351f9e88f3d92eff35a8b7f50ce6be7, because it was causing some nontrivial downstream breakages. We will re-apply these changes when we're ready with downstream changes.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Existing CI only