### PR TITLE
[TS] Fix ctx.timestamp serialization

### DIFF
--- a/crates/core/src/host/v8/syscall.rs
+++ b/crates/core/src/host/v8/syscall.rs
@@ -342,7 +342,7 @@ pub(super) fn call_call_reducer<'scope>(
     let reducer_id = serialize_to_js(scope, &reducer_id)?;
     let sender = serialize_to_js(scope, &sender.to_u256())?;
     let conn_id: v8::Local<'_, v8::Value> = serialize_to_js(scope, &conn_id.to_u128())?;
-    let timestamp = serialize_to_js(scope, &timestamp)?;
+    let timestamp = serialize_to_js(scope, &timestamp.to_micros_since_unix_epoch())?;
     let reducer_args = serialize_to_js(scope, reducer_args.get_bsatn())?;
     let args = &[reducer_id, sender, conn_id, timestamp, reducer_args];
 


### PR DESCRIPTION
# Description of Changes

Resolves #3433. The issue was caused by the fact we were calling `serialize_to_js` with a full `Timestamp` struct, not just an `i64`. In the future I'd like to move away from the use of `serialize_to_js` to avoid problems like this.

# API and ABI breaking changes

Technically a breaking change, but fixes a bug.

# Expected complexity level and risk

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Checked to ensure `ctx.timestamp` is correct.
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
