### PR TITLE
Remove `connection_id` from ViewContext

### DIFF
--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -806,7 +806,6 @@ pub struct AnonymousViewContext {
 /// Use this type if the view depends on the caller's identity.
 pub struct ViewContext {
     pub sender: Identity,
-    pub connection_id: Option<ConnectionId>,
     pub db: LocalReadOnly,
 }
 
@@ -943,7 +942,6 @@ impl ReducerContext {
     pub fn as_read_only(&self) -> ViewContext {
         ViewContext {
             sender: self.sender,
-            connection_id: self.connection_id,
             db: LocalReadOnly {},
         }
     }


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Removing `connection_id` from `ViewContext` for performance reasons. We intend to wait to hear from clients before assuming that it's necessary to include.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None (unreleased feature)

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

0

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

n/a
