### PR TITLE
Make `release-fast`use fat lto

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -68,7 +68,7 @@ rpath = false
 
 [profile.release-fast]
 inherits = "release"
-lto = "thin"
+lto = "fat"
 
 [profile.dev]
 opt-level = 0


### PR DESCRIPTION
# Description of Changes

Randomly spotted that the `release-fast` profile in the Cargo.toml is not actually different from `release`.
I assume yall wanted to mark the lto as fat for it.

Alternatively one could remove the release-fast profile.

# API and ABI breaking changes

0

# Expected complexity level and risk

0

# Testing

0