### PR TITLE
Clarified TableCache onUpdate as optional

### DIFF
--- a/crates/bindings-typescript/src/sdk/table_cache.ts
+++ b/crates/bindings-typescript/src/sdk/table_cache.ts
@@ -293,7 +293,7 @@ export class TableCache<
    *
    * @param cb Callback to be called when a new row is inserted
    */
-  onUpdate = <EventContext>(
+  onUpdate? = <EventContext>(
     cb: (ctx: EventContext, oldRow: RowType, row: RowType) => void
   ): void => {
     this.emitter.on('update', cb);


### PR DESCRIPTION
The onUpdate method only exists on tables with a primary key; auto-generated types specify the existance of this method, but the class itself does not, a tripping hazard for generic implementations.

# Description of Changes

Mark a method as optional.

# API and ABI breaking changes

None. 

# Expected complexity level and risk

Complexity 1. 

# Testing

This makes no changes to the compiled JS code, and every instance of this method already treats it as optional. No testing should be needed.
