### PR TITLE
Remove unused `release-fast` profile

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,10 +66,6 @@ incremental = false
 codegen-units = 16
 rpath = false
 
-[profile.release-fast]
-inherits = "release"
-lto = "thin"
-
 [profile.dev]
 opt-level = 0
 debug = true


### PR DESCRIPTION
# Description of Changes

Remove this custom build profile that was the same as `release`.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None