### PR TITLE
Make `name` a required parameter of `view` macro

### DIFF
--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -125,7 +125,7 @@ pub fn reducer(args: StdTokenStream, item: StdTokenStream) -> StdTokenStream {
 #[proc_macro_attribute]
 pub fn view(args: StdTokenStream, item: StdTokenStream) -> StdTokenStream {
     cvt_attr::<ItemFn>(args, item, quote!(), |args, original_function| {
-        let args = view::ViewArgs::parse(args)?;
+        let args = view::ViewArgs::parse(args, &original_function.sig.ident)?;
         view::view_impl(args, original_function)
     })
 }

--- a/crates/bindings-macro/src/view.rs
+++ b/crates/bindings-macro/src/view.rs
@@ -1,55 +1,56 @@
-use proc_macro2::{Span, TokenStream};
+use heck::ToSnakeCase;
+use proc_macro2::{Ident, Span, TokenStream};
 use quote::quote;
+use syn::ext::IdentExt;
 use syn::parse::Parser;
 use syn::{FnArg, ItemFn};
 
 use crate::sym;
-use crate::util::{ident_to_litstr, match_meta};
+use crate::util::{check_duplicate_msg, match_meta};
 
 pub(crate) struct ViewArgs {
+    name: Ident,
     #[allow(unused)]
     public: bool,
 }
 
 impl ViewArgs {
-    /// Parse `#[view(public)]` where `public` is required.
-    pub(crate) fn parse(input: TokenStream) -> syn::Result<Self> {
-        if input.is_empty() {
-            return Err(syn::Error::new(
-                Span::call_site(),
-                "views must be declared as `#[view(public)]`; `public` is required",
-            ));
-        }
-        let mut public = false;
+    /// Parse `#[view(name = ..., public)]` where both `name` and `public` are required.
+    pub(crate) fn parse(input: TokenStream, func_ident: &Ident) -> syn::Result<Self> {
+        let mut name = None;
+        let mut public = None;
         syn::meta::parser(|meta| {
             match_meta!(match meta {
+                sym::name => {
+                    check_duplicate_msg(&name, &meta, "`name` already specified")?;
+                    name = Some(meta.value()?.parse()?);
+                }
                 sym::public => {
-                    if public {
-                        return Err(syn::Error::new(
-                            Span::call_site(),
-                            "duplicate attribute argument: `public`",
-                        ));
-                    }
-                    public = true;
+                    check_duplicate_msg(&public, &meta, "`public` already specified")?;
+                    public = Some(());
                 }
             });
             Ok(())
         })
         .parse2(input)?;
-        if !public {
-            return Err(syn::Error::new(
+        let name = name.ok_or_else(|| {
+            let view = func_ident.to_string().to_snake_case();
+            syn::Error::new(
                 Span::call_site(),
-                "views must be declared as `#[view(public)]`; `public` is required",
-            ));
-        }
-        Ok(Self { public })
+                format_args!("must specify view name, e.g. `#[spacetimedb::view(name = {view})]"),
+            )
+        })?;
+        let () = public
+            .ok_or_else(|| syn::Error::new(Span::call_site(), "views must be `public`, e.g. `#[view(public)]`"))?;
+        Ok(Self { name, public: true })
     }
 }
 
-pub(crate) fn view_impl(_args: ViewArgs, original_function: &ItemFn) -> syn::Result<TokenStream> {
-    let func_name = &original_function.sig.ident;
-    let view_name = ident_to_litstr(func_name);
+pub(crate) fn view_impl(args: ViewArgs, original_function: &ItemFn) -> syn::Result<TokenStream> {
     let vis = &original_function.vis;
+    let func_name = &original_function.sig.ident;
+    let view_ident = args.name;
+    let view_name = view_ident.unraw().to_string();
 
     for param in &original_function.sig.generics.params {
         let err = |msg| syn::Error::new_spanned(param, msg);
@@ -116,7 +117,7 @@ pub(crate) fn view_impl(_args: ViewArgs, original_function: &ItemFn) -> syn::Res
         }
     };
 
-    let register_describer_symbol = format!("__preinit__20_register_describer_{}", view_name.value());
+    let register_describer_symbol = format!("__preinit__20_register_describer_{}", view_name);
 
     let lt_params = &original_function.sig.generics;
     let lt_where_clause = &lt_params.where_clause;

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -820,25 +820,25 @@ pub use spacetimedb_bindings_macro::procedure;
 /// }
 ///
 /// // A view that selects at most one row from a table
-/// #[view(public)]
+/// #[view(name = my_player, public)]
 /// fn my_player(ctx: &ViewContext) -> Option<Player> {
 ///     ctx.db.player().identity().find(ctx.sender)
 /// }
 ///
 /// // An example of column projection
-/// #[view(public)]
+/// #[view(name = my_player_id, public)]
 /// fn my_player_id(ctx: &ViewContext) -> Option<PlayerId> {
 ///     ctx.db.player().identity().find(ctx.sender).map(|Player { id, .. }| PlayerId { id })
 /// }
 ///
 /// // An example of a parameterized view
-/// #[view(public)]
+/// #[view(name = players_at_level, public)]
 /// fn players_at_level(ctx: &AnonymousViewContext, level: u32) -> Vec<Player> {
 ///     ctx.db.player().level().filter(level).collect()
 /// }
 ///
 /// // An example that is analogous to a semijoin in sql
-/// #[view(public)]
+/// #[view(name = players_at_coordinates, public)]
 /// fn players_at_coordinates(ctx: &AnonymousViewContext, x: u64, y: u64) -> Vec<Player> {
 ///     ctx
 ///         .db
@@ -850,7 +850,7 @@ pub use spacetimedb_bindings_macro::procedure;
 /// }
 ///
 /// // An example of a join that combines fields from two different tables
-/// #[view(public)]
+/// #[view(name = players_with_coordinates, public)]
 /// fn players_with_coordinates(ctx: &AnonymousViewContext, x: u64, y: u64) -> Vec<PlayerAndLocation> {
 ///     ctx
 ///         .db

--- a/crates/bindings/tests/ui/views.rs
+++ b/crates/bindings/tests/ui/views.rs
@@ -72,54 +72,60 @@ struct Player {
 
 struct NotSpacetimeType {}
 
-/// Private views not allowed; must be `#[view(public)]`
-#[view]
+/// Private views not allowed; must be `#[view(public, ...)]`
+#[view(name = view_def_no_public)]
 fn view_def_no_public(_: &ViewContext) -> Vec<Player> {
     vec![]
 }
 
 /// Duplicate `public`
-#[view(public, public)]
-fn view_def_duplicate_attribute_arg() -> Vec<Player> {
+#[view(name = view_def_dup_public, public, public)]
+fn view_def_dup_public() -> Vec<Player> {
+    vec![]
+}
+
+/// Duplicate `name`
+#[view(name = view_def_dup_name, name = view_def_dup_name, public)]
+fn view_def_dup_name() -> Vec<Player> {
     vec![]
 }
 
 /// Unsupported attribute arg
-#[view(public, anonymous)]
-fn view_def_unsupported_attribute_arg() -> Vec<Player> {
+#[view(name = view_def_unsupported_arg, public, anonymous)]
+fn view_def_unsupported_arg() -> Vec<Player> {
     vec![]
 }
 
 /// A `ViewContext` is required
-#[view(public)]
+#[view(name = view_def_no_context, public)]
 fn view_def_no_context() -> Vec<Player> {
     vec![]
 }
 
 /// A `ViewContext` is required
-#[view(public)]
+#[view(name = view_def_wrong_context, public)]
 fn view_def_wrong_context(_: &ReducerContext) -> Vec<Player> {
     vec![]
 }
 
 /// Must pass the `ViewContext` by ref
-#[view(public)]
+#[view(name = view_def_pass_context_by_value, public)]
 fn view_def_pass_context_by_value(_: ViewContext) -> Vec<Player> {
     vec![]
 }
 
 /// The view context must be the first parameter
-#[view(public)]
+#[view(name = view_def_wrong_context_position, public)]
 fn view_def_wrong_context_position(_: &u32, _: &ViewContext) -> Vec<Player> {
     vec![]
 }
 
 /// Must return `Vec<T>` or `Option<T>` where `T` is a SpacetimeType
-#[view(public)]
+#[view(name = view_def_no_return, public)]
 fn view_def_no_return(_: &ViewContext) {}
 
 /// Must return `Vec<T>` or `Option<T>` where `T` is a SpacetimeType
-#[view(public)]
+#[view(name = view_def_wrong_return, public)]
 fn view_def_wrong_return(_: &ViewContext) -> Player {
     Player {
         identity: Identity::ZERO,
@@ -127,7 +133,7 @@ fn view_def_wrong_return(_: &ViewContext) -> Player {
 }
 
 /// Must return `Vec<T>` or `Option<T>` where `T` is a SpacetimeType
-#[view(public)]
+#[view(name = view_def_returns_not_a_spacetime_type, public)]
 fn view_def_returns_not_a_spacetime_type(_: &AnonymousViewContext) -> Option<NotSpacetimeType> {
     None
 }
@@ -144,7 +150,7 @@ struct ScheduledTable {
 }
 
 /// Cannot use a view as a scheduled function
-#[view(public)]
+#[view(name = scheduled_table_view, public)]
 fn scheduled_table_view(_: &ViewContext, _args: ScheduledTable) -> Vec<Player> {
     vec![]
 }

--- a/crates/bindings/tests/ui/views.stderr
+++ b/crates/bindings/tests/ui/views.stderr
@@ -1,48 +1,52 @@
-error: views must be declared as `#[view(public)]`; `public` is required
+error: views must be `public`, e.g. `#[view(public)]`
   --> tests/ui/views.rs:76:1
    |
-76 | #[view]
-   | ^^^^^^^
+76 | #[view(name = view_def_no_public)]
+   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
    |
    = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
-error: duplicate attribute argument: `public`
-  --> tests/ui/views.rs:82:1
+error: `public` already specified
+  --> tests/ui/views.rs:82:44
    |
-82 | #[view(public, public)]
-   | ^^^^^^^^^^^^^^^^^^^^^^^
-   |
-   = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
+82 | #[view(name = view_def_dup_public, public, public)]
+   |                                            ^^^^^^
 
-error: expected `public`
-  --> tests/ui/views.rs:88:16
+error: `name` already specified
+  --> tests/ui/views.rs:88:34
    |
-88 | #[view(public, anonymous)]
-   |                ^^^^^^^^^
+88 | #[view(name = view_def_dup_name, name = view_def_dup_name, public)]
+   |                                  ^^^^
+
+error: expected `name` or `public`
+  --> tests/ui/views.rs:94:49
+   |
+94 | #[view(name = view_def_unsupported_arg, public, anonymous)]
+   |                                                 ^^^^^^^^^
 
 error: Views must always have a context parameter: `&ViewContext` or `&AnonymousViewContext`
-  --> tests/ui/views.rs:95:1
-   |
-95 | fn view_def_no_context() -> Vec<Player> {
-   | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
+   --> tests/ui/views.rs:101:1
+    |
+101 | fn view_def_no_context() -> Vec<Player> {
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error: The first parameter of a view must be a context parameter: `&ViewContext` or `&AnonymousViewContext`; passed by reference
-   --> tests/ui/views.rs:107:38
+   --> tests/ui/views.rs:113:38
     |
-107 | fn view_def_pass_context_by_value(_: ViewContext) -> Vec<Player> {
+113 | fn view_def_pass_context_by_value(_: ViewContext) -> Vec<Player> {
     |                                      ^^^^^^^^^^^
 
 error: views must return `Vec<T>` or `Option<T>` where `T` is a `SpacetimeType`
-   --> tests/ui/views.rs:119:1
+   --> tests/ui/views.rs:125:1
     |
-119 | fn view_def_no_return(_: &ViewContext) {}
+125 | fn view_def_no_return(_: &ViewContext) {}
     | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^
 
 error[E0277]: the trait bound `ViewKind<ReducerContext>: ViewKindTrait` is not satisfied
-   --> tests/ui/views.rs:100:1
+   --> tests/ui/views.rs:106:1
     |
-100 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ the trait `ViewKindTrait` is not implemented for `ViewKind<ReducerContext>`
+106 | #[view(name = view_def_wrong_context, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ViewKindTrait` is not implemented for `ViewKind<ReducerContext>`
     |
     = help: the following other types implement trait `ViewKindTrait`:
               ViewKind<AnonymousViewContext>
@@ -50,18 +54,18 @@ error[E0277]: the trait bound `ViewKind<ReducerContext>: ViewKindTrait` is not s
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0276]: impl has stricter requirements than trait
-   --> tests/ui/views.rs:100:1
+   --> tests/ui/views.rs:106:1
     |
-100 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ impl has extra requirement `ViewKind<ReducerContext>: ViewKindTrait`
+106 | #[view(name = view_def_wrong_context, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl has extra requirement `ViewKind<ReducerContext>: ViewKindTrait`
     |
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `ViewKind<u32>: ViewKindTrait` is not satisfied
-   --> tests/ui/views.rs:112:1
+   --> tests/ui/views.rs:118:1
     |
-112 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ the trait `ViewKindTrait` is not implemented for `ViewKind<u32>`
+118 | #[view(name = view_def_wrong_context_position, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `ViewKindTrait` is not implemented for `ViewKind<u32>`
     |
     = help: the following other types implement trait `ViewKindTrait`:
               ViewKind<AnonymousViewContext>
@@ -69,10 +73,10 @@ error[E0277]: the trait bound `ViewKind<u32>: ViewKindTrait` is not satisfied
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0276]: impl has stricter requirements than trait
-   --> tests/ui/views.rs:112:1
+   --> tests/ui/views.rs:118:1
     |
-112 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ impl has extra requirement `ViewKind<u32>: ViewKindTrait`
+118 | #[view(name = view_def_wrong_context_position, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ impl has extra requirement `ViewKind<u32>: ViewKindTrait`
     |
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
@@ -168,10 +172,10 @@ error[E0599]: no method named `delete` found for struct `RangedIndexReadOnly` in
    |                             ^^^^^^ method not found in `RangedIndexReadOnly<test__TableHandle, (u32,), x>`
 
 error[E0599]: no function or associated item named `register` found for struct `ViewRegistrar<ReducerContext>` in the current scope
-   --> tests/ui/views.rs:100:1
+   --> tests/ui/views.rs:106:1
     |
-100 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ function or associated item not found in `ViewRegistrar<ReducerContext>`
+106 | #[view(name = view_def_wrong_context, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `ViewRegistrar<ReducerContext>`
     |
     = note: the function or associated item was found for
             - `ViewRegistrar<AnonymousViewContext>`
@@ -179,9 +183,9 @@ error[E0599]: no function or associated item named `register` found for struct `
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: The first parameter of a `#[view]` must be `&ViewContext` or `&AnonymousViewContext`
-   --> tests/ui/views.rs:101:31
+   --> tests/ui/views.rs:107:31
     |
-101 | fn view_def_wrong_context(_: &ReducerContext) -> Vec<Player> {
+107 | fn view_def_wrong_context(_: &ReducerContext) -> Vec<Player> {
     |                               ^^^^^^^^^^^^^^ the trait `ViewContextArg` is not implemented for `ReducerContext`
     |
     = help: the following other types implement trait `ViewContextArg`:
@@ -189,10 +193,10 @@ error[E0277]: The first parameter of a `#[view]` must be `&ViewContext` or `&Ano
               ViewContext
 
 error[E0599]: no function or associated item named `invoke` found for struct `ViewDispatcher<ReducerContext>` in the current scope
-   --> tests/ui/views.rs:100:1
+   --> tests/ui/views.rs:106:1
     |
-100 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ function or associated item not found in `ViewDispatcher<ReducerContext>`
+106 | #[view(name = view_def_wrong_context, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `ViewDispatcher<ReducerContext>`
     |
     = note: the function or associated item was found for
             - `ViewDispatcher<AnonymousViewContext>`
@@ -200,10 +204,10 @@ error[E0599]: no function or associated item named `invoke` found for struct `Vi
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0599]: no function or associated item named `register` found for struct `ViewRegistrar<u32>` in the current scope
-   --> tests/ui/views.rs:112:1
+   --> tests/ui/views.rs:118:1
     |
-112 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ function or associated item not found in `ViewRegistrar<u32>`
+118 | #[view(name = view_def_wrong_context_position, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `ViewRegistrar<u32>`
     |
     = note: the function or associated item was found for
             - `ViewRegistrar<AnonymousViewContext>`
@@ -211,9 +215,9 @@ error[E0599]: no function or associated item named `register` found for struct `
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: The first parameter of a `#[view]` must be `&ViewContext` or `&AnonymousViewContext`
-   --> tests/ui/views.rs:113:40
+   --> tests/ui/views.rs:119:40
     |
-113 | fn view_def_wrong_context_position(_: &u32, _: &ViewContext) -> Vec<Player> {
+119 | fn view_def_wrong_context_position(_: &u32, _: &ViewContext) -> Vec<Player> {
     |                                        ^^^ the trait `ViewContextArg` is not implemented for `u32`
     |
     = help: the following other types implement trait `ViewContextArg`:
@@ -221,9 +225,9 @@ error[E0277]: The first parameter of a `#[view]` must be `&ViewContext` or `&Ano
               ViewContext
 
 error[E0277]: the view argument `&ViewContext` does not implement `SpacetimeType`
-   --> tests/ui/views.rs:113:48
+   --> tests/ui/views.rs:119:48
     |
-113 | fn view_def_wrong_context_position(_: &u32, _: &ViewContext) -> Vec<Player> {
+119 | fn view_def_wrong_context_position(_: &u32, _: &ViewContext) -> Vec<Player> {
     |                                                ^^^^^^^^^^^^ the trait `SpacetimeType` is not implemented for `ViewContext`
     |
     = note: if you own the type, try adding `#[derive(SpacetimeType)]` to its definition
@@ -241,10 +245,10 @@ error[E0277]: the view argument `&ViewContext` does not implement `SpacetimeType
     = note: required for `&ViewContext` to implement `ViewArg`
 
 error[E0599]: no function or associated item named `invoke` found for struct `ViewDispatcher<u32>` in the current scope
-   --> tests/ui/views.rs:112:1
+   --> tests/ui/views.rs:118:1
     |
-112 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ function or associated item not found in `ViewDispatcher<u32>`
+118 | #[view(name = view_def_wrong_context_position, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ function or associated item not found in `ViewDispatcher<u32>`
     |
     = note: the function or associated item was found for
             - `ViewDispatcher<AnonymousViewContext>`
@@ -252,10 +256,10 @@ error[E0599]: no function or associated item named `invoke` found for struct `Vi
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: invalid view signature
-   --> tests/ui/views.rs:122:1
+   --> tests/ui/views.rs:128:1
     |
-122 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ this view signature is not valid
+128 | #[view(name = view_def_wrong_return, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this view signature is not valid
     |
     = help: the trait `spacetimedb::rt::View<'_, _, _>` is not implemented for fn item `for<'a> fn(&'a ViewContext) -> Player {view_def_wrong_return}`
     = note:
@@ -274,9 +278,9 @@ note: required by a bound in `ViewRegistrar::<ViewContext>::register`
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: Views must return `Vec<T>` or `Option<T>` where `T` is a `SpacetimeType`
-   --> tests/ui/views.rs:123:46
+   --> tests/ui/views.rs:129:46
     |
-123 | fn view_def_wrong_return(_: &ViewContext) -> Player {
+129 | fn view_def_wrong_return(_: &ViewContext) -> Player {
     |                                              ^^^^^^ the trait `ViewReturn` is not implemented for `Player`
     |
     = help: the following other types implement trait `ViewReturn`:
@@ -284,10 +288,10 @@ error[E0277]: Views must return `Vec<T>` or `Option<T>` where `T` is a `Spacetim
               Vec<T>
 
 error[E0277]: invalid view signature
-   --> tests/ui/views.rs:122:1
+   --> tests/ui/views.rs:128:1
     |
-122 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ this view signature is not valid
+128 | #[view(name = view_def_wrong_return, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ this view signature is not valid
     |
     = help: the trait `spacetimedb::rt::View<'_, _, _>` is not implemented for fn item `for<'a> fn(&'a ViewContext) -> Player {view_def_wrong_return}`
     = note:
@@ -306,10 +310,10 @@ note: required by a bound in `ViewDispatcher::<ViewContext>::invoke`
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotSpacetimeType: SpacetimeType` is not satisfied
-   --> tests/ui/views.rs:130:1
+   --> tests/ui/views.rs:136:1
     |
-130 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ the trait `SpacetimeType` is not implemented for `NotSpacetimeType`
+136 | #[view(name = view_def_returns_not_a_spacetime_type, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SpacetimeType` is not implemented for `NotSpacetimeType`
     |
     = note: if you own the type, try adding `#[derive(SpacetimeType)]` to its definition
     = help: the following other types implement trait `SpacetimeType`:
@@ -334,10 +338,10 @@ note: required by a bound in `ViewRegistrar::<AnonymousViewContext>::register`
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotSpacetimeType: Serialize` is not satisfied
-   --> tests/ui/views.rs:130:1
+   --> tests/ui/views.rs:136:1
     |
-130 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `NotSpacetimeType`
+136 | #[view(name = view_def_returns_not_a_spacetime_type, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `NotSpacetimeType`
     |
     = help: the following other types implement trait `Serialize`:
               &T
@@ -361,9 +365,9 @@ note: required by a bound in `ViewRegistrar::<AnonymousViewContext>::register`
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotSpacetimeType: SpacetimeType` is not satisfied
-   --> tests/ui/views.rs:131:71
+   --> tests/ui/views.rs:137:71
     |
-131 | fn view_def_returns_not_a_spacetime_type(_: &AnonymousViewContext) -> Option<NotSpacetimeType> {
+137 | fn view_def_returns_not_a_spacetime_type(_: &AnonymousViewContext) -> Option<NotSpacetimeType> {
     |                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SpacetimeType` is not implemented for `NotSpacetimeType`
     |
     = note: if you own the type, try adding `#[derive(SpacetimeType)]` to its definition
@@ -380,10 +384,10 @@ error[E0277]: the trait bound `NotSpacetimeType: SpacetimeType` is not satisfied
     = note: required for `Option<NotSpacetimeType>` to implement `ViewReturn`
 
 error[E0277]: the trait bound `NotSpacetimeType: SpacetimeType` is not satisfied
-   --> tests/ui/views.rs:130:1
+   --> tests/ui/views.rs:136:1
     |
-130 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ the trait `SpacetimeType` is not implemented for `NotSpacetimeType`
+136 | #[view(name = view_def_returns_not_a_spacetime_type, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SpacetimeType` is not implemented for `NotSpacetimeType`
     |
     = note: if you own the type, try adding `#[derive(SpacetimeType)]` to its definition
     = help: the following other types implement trait `SpacetimeType`:
@@ -408,10 +412,10 @@ note: required by a bound in `ViewDispatcher::<AnonymousViewContext>::invoke`
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotSpacetimeType: Serialize` is not satisfied
-   --> tests/ui/views.rs:130:1
+   --> tests/ui/views.rs:136:1
     |
-130 | #[view(public)]
-    | ^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `NotSpacetimeType`
+136 | #[view(name = view_def_returns_not_a_spacetime_type, public)]
+    | ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^ the trait `Serialize` is not implemented for `NotSpacetimeType`
     |
     = help: the following other types implement trait `Serialize`:
               &T
@@ -435,9 +439,9 @@ note: required by a bound in `ViewDispatcher::<AnonymousViewContext>::invoke`
     = note: this error originates in the attribute macro `view` (in Nightly builds, run with -Z macro-backtrace for more info)
 
 error[E0277]: the trait bound `NotSpacetimeType: SpacetimeType` is not satisfied
-   --> tests/ui/views.rs:131:71
+   --> tests/ui/views.rs:137:71
     |
-131 | fn view_def_returns_not_a_spacetime_type(_: &AnonymousViewContext) -> Option<NotSpacetimeType> {
+137 | fn view_def_returns_not_a_spacetime_type(_: &AnonymousViewContext) -> Option<NotSpacetimeType> {
     |                                                                       ^^^^^^^^^^^^^^^^^^^^^^^^ the trait `SpacetimeType` is not implemented for `NotSpacetimeType`
     |
     = note: if you own the type, try adding `#[derive(SpacetimeType)]` to its definition
@@ -454,9 +458,9 @@ error[E0277]: the trait bound `NotSpacetimeType: SpacetimeType` is not satisfied
     = note: required for `Option<NotSpacetimeType>` to implement `SpacetimeType`
 
 error[E0277]: invalid signature for scheduled table reducer or procedure
-   --> tests/ui/views.rs:136:56
+   --> tests/ui/views.rs:142:56
     |
-136 | #[spacetimedb::table(name = scheduled_table, scheduled(scheduled_table_view))]
+142 | #[spacetimedb::table(name = scheduled_table, scheduled(scheduled_table_view))]
     | -------------------------------------------------------^^^^^^^^^^^^^^^^^^^^---
     | |                                                      |
     | |                                                      unsatisfied trait bound

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -596,10 +596,10 @@ impl TableSchema {
     ///     b: u32,
     /// }
     ///
-    /// #[view(public)]
+    /// #[view(name = my_view, public)]
     /// fn my_view(ctx: &ViewContext, x: u32, y: u32) -> Vec<MyTable> { ... }
     ///
-    /// #[view(public)]
+    /// #[view(name = my_anonymous_view, public)]
     /// fn my_anonymous_view(ctx: &AnonymousViewContext, x: u32, y: u32) -> Vec<MyTable> { ... }
     /// ```
     ///

--- a/smoketests/tests/views.py
+++ b/smoketests/tests/views.py
@@ -14,7 +14,7 @@ pub struct PlayerState {
     level: u64,
 }
 
-#[spacetimedb::view(public)]
+#[spacetimedb::view(name = player, public)]
 pub fn player(ctx: &ViewContext, id: u64) -> Option<PlayerState> {
     ctx.db.player_state().id().find(id)
 }
@@ -60,7 +60,7 @@ pub struct Person {
     name: String,
 }
 
-#[spacetimedb::view(public)]
+#[spacetimedb::view(name = person, public)]
 pub fn person(ctx: &ViewContext) -> Option<Person> {
     None
 }
@@ -76,7 +76,7 @@ pub enum ABC {
     C,
 }
 
-#[spacetimedb::view(public)]
+#[spacetimedb::view(name = person, public)]
 pub fn person(ctx: &ViewContext) -> Option<ABC> {
     None
 }


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Makes `name` a required parameter of the `#[view]` macro. This is to be consistent with the `#[table]` macro since views should expose the same interface as tables.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Added new compile tests
- [x] Updated existing compile tests
