### PR TITLE
Included `dropped_table_id` into the error message in replay

### DIFF
--- a/crates/datastore/src/locking_tx_datastore/committed_state.rs
+++ b/crates/datastore/src/locking_tx_datastore/committed_state.rs
@@ -359,7 +359,7 @@ impl CommittedState {
             let dropped_table_id = Self::read_table_id(row);
             self.tables
                 .remove(&dropped_table_id)
-                .expect("table to remove should exist");
+                .unwrap_or_else(|| panic!("table {} to remove should exist", dropped_table_id));
             // Mark the table as dropped so that when
             // processing row deletions for that table later,
             // they are simply ignored in (1).


### PR DESCRIPTION
# Description of Changes

Extra debug info for #3465.

# API and ABI breaking changes

None.

# Expected complexity level and risk

### 1.

# Testing

- [x] Manual testing on a borked database.