### PR TITLE
Auto-migration rules for views

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1055,13 +1055,30 @@ impl RelationalDB {
         Ok(self.inner.create_table_mut_tx(tx, schema)?)
     }
 
-    pub fn create_view_table(
+    pub fn drop_table(&self, tx: &mut MutTx, table_id: TableId) -> Result<(), DBError> {
+        let table_name = self
+            .table_name_from_id_mut(tx, table_id)?
+            .map(|name| name.to_string())
+            .unwrap_or_default();
+        Ok(self.inner.drop_table_mut_tx(tx, table_id).map(|_| {
+            DB_METRICS
+                .rdb_num_table_rows
+                .with_label_values(&self.database_identity, &table_id.into(), &table_name)
+                .set(0)
+        })?)
+    }
+
+    pub fn create_view(
         &self,
         tx: &mut MutTx,
         module_def: &ModuleDef,
         view_def: &ViewDef,
     ) -> Result<(ViewId, TableId), DBError> {
-        Ok(tx.create_view_with_backing_table(module_def, view_def)?)
+        Ok(tx.create_view(module_def, view_def)?)
+    }
+
+    pub fn drop_view(&self, tx: &mut MutTx, view_id: ViewId) -> Result<(), DBError> {
+        Ok(tx.drop_view(view_id)?)
     }
 
     pub fn create_table_for_test_with_the_works(
@@ -1141,19 +1158,6 @@ impl RelationalDB {
         self.create_table_for_test_with_the_works(name, schema, &indexes[..], &[], StAccess::Public)
     }
 
-    pub fn drop_table(&self, tx: &mut MutTx, table_id: TableId) -> Result<(), DBError> {
-        let table_name = self
-            .table_name_from_id_mut(tx, table_id)?
-            .map(|name| name.to_string())
-            .unwrap_or_default();
-        Ok(self.inner.drop_table_mut_tx(tx, table_id).map(|_| {
-            DB_METRICS
-                .rdb_num_table_rows
-                .with_label_values(&self.database_identity, &table_id.into(), &table_name)
-                .set(0)
-        })?)
-    }
-
     /// Rename a table.
     ///
     /// Sets the name of the table to `new_name` regardless of the previous value. This is a
@@ -1162,6 +1166,10 @@ impl RelationalDB {
     /// If the table is not found or is a system table, an error is returned.
     pub fn rename_table(&self, tx: &mut MutTx, table_id: TableId, new_name: &str) -> Result<(), DBError> {
         Ok(self.inner.rename_table_mut_tx(tx, table_id, new_name)?)
+    }
+
+    pub fn view_id_from_name_mut(&self, tx: &MutTx, view_name: &str) -> Result<Option<ViewId>, DBError> {
+        Ok(self.inner.view_id_from_name_mut_tx(tx, view_name)?)
     }
 
     pub fn table_id_from_name_mut(&self, tx: &MutTx, table_name: &str) -> Result<Option<TableId>, DBError> {

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -7,7 +7,7 @@ use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::AlgebraicValue;
 use spacetimedb_primitives::{ColSet, TableId};
 use spacetimedb_schema::auto_migrate::{AutoMigratePlan, ManualMigratePlan, MigratePlan};
-use spacetimedb_schema::def::TableDef;
+use spacetimedb_schema::def::{TableDef, ViewDef};
 use spacetimedb_schema::schema::{column_schemas_from_defs, IndexSchema, Schema, SequenceSchema, TableSchema};
 
 /// The logger used for by [`update_database`] and friends.
@@ -136,6 +136,17 @@ fn auto_migrate_database(
                 log!(logger, "Creating table `{table_name}`");
 
                 stdb.create_table(tx, table_schema)?;
+            }
+            spacetimedb_schema::auto_migrate::AutoMigrateStep::AddView(view_name) => {
+                let view_def: &ViewDef = plan.new.expect_lookup(view_name);
+                stdb.create_view(tx, plan.new, view_def)?;
+            }
+            spacetimedb_schema::auto_migrate::AutoMigrateStep::RemoveView(view_name) => {
+                let view_id = stdb.view_id_from_name_mut(tx, view_name)?.unwrap();
+                stdb.drop_view(tx, view_id)?;
+            }
+            spacetimedb_schema::auto_migrate::AutoMigrateStep::UpdateView(_) => {
+                unimplemented!("Recompute view and update its backing table")
             }
             spacetimedb_schema::auto_migrate::AutoMigrateStep::AddIndex(index_name) => {
                 let table_def = plan.new.stored_in_table_def(index_name).unwrap();

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -422,7 +422,7 @@ pub fn create_table_from_view_def(
     module_def: &ModuleDef,
     view_def: &ViewDef,
 ) -> anyhow::Result<()> {
-    stdb.create_view_table(tx, module_def, view_def)
+    stdb.create_view(tx, module_def, view_def)
         .with_context(|| format!("failed to create table for view {}", &view_def.name))?;
     Ok(())
 }

--- a/crates/datastore/src/locking_tx_datastore/datastore.rs
+++ b/crates/datastore/src/locking_tx_datastore/datastore.rs
@@ -35,7 +35,7 @@ use spacetimedb_durability::TxOffset;
 use spacetimedb_lib::{db::auth::StAccess, metrics::ExecutionMetrics};
 use spacetimedb_lib::{ConnectionId, Identity};
 use spacetimedb_paths::server::SnapshotDirPath;
-use spacetimedb_primitives::{ColList, ConstraintId, IndexId, SequenceId, TableId};
+use spacetimedb_primitives::{ColList, ConstraintId, IndexId, SequenceId, TableId, ViewId};
 use spacetimedb_sats::{
     algebraic_value::de::ValueDeserializer, bsatn, buffer::BufReader, AlgebraicValue, ProductValue,
 };
@@ -510,6 +510,10 @@ impl MutTxDatastore for Locking {
 
     fn rename_table_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, new_name: &str) -> Result<()> {
         tx.rename_table(table_id, new_name)
+    }
+
+    fn view_id_from_name_mut_tx(&self, tx: &Self::MutTx, view_name: &str) -> Result<Option<ViewId>> {
+        tx.view_id_from_name(view_name)
     }
 
     fn table_id_from_name_mut_tx(&self, tx: &Self::MutTx, table_name: &str) -> Result<Option<TableId>> {

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -9,8 +9,9 @@ use super::{
     SharedMutexGuard, SharedWriteGuard,
 };
 use crate::system_tables::{
-    system_tables, ConnectionIdViaU128, StConnectionCredentialsFields, StConnectionCredentialsRow, StViewFields,
-    StViewParamRow, ST_CONNECTION_CREDENTIALS_ID, ST_VIEW_COLUMN_ID, ST_VIEW_ID, ST_VIEW_PARAM_ID,
+    system_tables, ConnectionIdViaU128, StConnectionCredentialsFields, StConnectionCredentialsRow, StViewColumnFields,
+    StViewFields, StViewParamFields, StViewParamRow, ST_CONNECTION_CREDENTIALS_ID, ST_VIEW_COLUMN_ID, ST_VIEW_ID,
+    ST_VIEW_PARAM_ID,
 };
 use crate::traits::{InsertFlags, RowTypeForTable, TxData, UpdateFlags};
 use crate::{
@@ -46,7 +47,7 @@ use spacetimedb_sats::{
     AlgebraicType, AlgebraicValue, ProductType, ProductValue, WithTypespace,
 };
 use spacetimedb_schema::{
-    def::{ColumnDef, ModuleDef, ViewDef},
+    def::{ModuleDef, ViewColumnDef, ViewDef},
     schema::{ColumnSchema, ConstraintSchema, IndexSchema, RowLevelSecuritySchema, SequenceSchema, TableSchema},
 };
 use spacetimedb_table::{
@@ -184,7 +185,7 @@ impl MutTxId {
         Ok(())
     }
 
-    /// Create a backing table for a view.
+    /// Create a backing table for a view and update the system tables.
     ///
     /// Requires:
     /// - Everything [`Self::create_table`] requires.
@@ -193,11 +194,7 @@ impl MutTxId {
     /// - Everything [`Self::create_table`] ensures.
     /// - The returned [`ViewId`] is unique and not [`ViewId::SENTINEL`].
     /// - All view metadata maintained by the datastore is created atomically
-    pub fn create_view_with_backing_table(
-        &mut self,
-        module_def: &ModuleDef,
-        view_def: &ViewDef,
-    ) -> Result<(ViewId, TableId)> {
+    pub fn create_view(&mut self, module_def: &ModuleDef, view_def: &ViewDef) -> Result<(ViewId, TableId)> {
         let table_schema = TableSchema::from_view_def(module_def, view_def);
         let table_id = self.create_table(table_schema)?;
 
@@ -206,14 +203,33 @@ impl MutTxId {
             is_anonymous,
             is_public,
             params,
-            columns,
+            return_columns,
             ..
         } = view_def;
 
         let view_id = self.insert_into_st_view(name.clone().into(), table_id, *is_public, *is_anonymous)?;
         self.insert_into_st_view_param(view_id, params)?;
-        self.insert_into_st_view_column(view_id, columns)?;
+        self.insert_into_st_view_column(view_id, return_columns)?;
         Ok((view_id, table_id))
+    }
+
+    /// Drop the backing table of a view and update the system tables.
+    pub fn drop_view(&mut self, view_id: ViewId) -> Result<()> {
+        // Drop the view's metadata
+        self.drop_st_view(view_id)?;
+        self.drop_st_view_param(view_id)?;
+        self.drop_st_view_column(view_id)?;
+
+        // Drop the view's backing table if materialized
+        if let StViewRow {
+            table_id: Some(table_id),
+            ..
+        } = self.lookup_st_view(view_id)?
+        {
+            return self.drop_table(table_id);
+        };
+
+        Ok(())
     }
 
     /// Create a table.
@@ -320,6 +336,15 @@ impl MutTxId {
         })
     }
 
+    fn lookup_st_view(&self, view_id: ViewId) -> Result<StViewRow> {
+        let row = self
+            .iter_by_col_eq(ST_VIEW_ID, StViewFields::ViewId, &view_id.into())?
+            .next()
+            .ok_or_else(|| TableError::IdNotFound(SystemTable::st_view, view_id.into()))?;
+
+        StViewRow::try_from(row)
+    }
+
     /// Insert a row into `st_view`, auto-increments and returns the [`ViewId`].
     fn insert_into_st_view(
         &mut self,
@@ -365,7 +390,7 @@ impl MutTxId {
     }
 
     /// For each column or field returned in a view, insert a row into `st_view_column`.
-    fn insert_into_st_view_column(&mut self, view_id: ViewId, columns: &[ColumnDef]) -> Result<()> {
+    fn insert_into_st_view_column(&mut self, view_id: ViewId, columns: &[ViewColumnDef]) -> Result<()> {
         for def in columns {
             self.insert_via_serialize_bsatn(
                 ST_VIEW_COLUMN_ID,
@@ -425,6 +450,26 @@ impl MutTxId {
         self.delete_col_eq(ST_COLUMN_ID, StColumnFields::TableId.col_id(), &table_id.into())
     }
 
+    /// Drops the row in `st_table` for this `table_id`
+    fn drop_st_table(&mut self, table_id: TableId) -> Result<()> {
+        self.delete_col_eq(ST_TABLE_ID, StTableFields::TableId.col_id(), &table_id.into())
+    }
+
+    /// Drops the row in `st_view` for this `view_id`
+    fn drop_st_view(&mut self, view_id: ViewId) -> Result<()> {
+        self.delete_col_eq(ST_VIEW_ID, StViewFields::ViewId.col_id(), &view_id.into())
+    }
+
+    /// Drops the rows in `st_view_param` for this `view_id`
+    fn drop_st_view_param(&mut self, view_id: ViewId) -> Result<()> {
+        self.delete_col_eq(ST_VIEW_PARAM_ID, StViewParamFields::ViewId.col_id(), &view_id.into())
+    }
+
+    /// Drops the rows in `st_view_column` for this `view_id`
+    fn drop_st_view_column(&mut self, view_id: ViewId) -> Result<()> {
+        self.delete_col_eq(ST_VIEW_COLUMN_ID, StViewColumnFields::ViewId.col_id(), &view_id.into())
+    }
+
     pub fn drop_table(&mut self, table_id: TableId) -> Result<()> {
         self.clear_table(table_id)?;
 
@@ -443,7 +488,7 @@ impl MutTxId {
         }
 
         // Drop the table and their columns
-        self.delete_col_eq(ST_TABLE_ID, StTableFields::TableId.col_id(), &table_id.into())?;
+        self.drop_st_table(table_id)?;
         self.drop_st_column(table_id)?;
 
         if let Some(schedule) = &schema.schedule {
@@ -490,6 +535,14 @@ impl MutTxId {
         self.insert_via_serialize_bsatn(ST_TABLE_ID, &row)?;
 
         Ok(ret)
+    }
+
+    pub fn view_id_from_name(&self, view_name: &str) -> Result<Option<ViewId>> {
+        let view_name = &view_name.into();
+        let row = self
+            .iter_by_col_eq(ST_VIEW_ID, StViewFields::ViewName, view_name)?
+            .next();
+        Ok(row.map(|row| row.read_col(StViewFields::ViewId).unwrap()))
     }
 
     pub fn table_id_from_name(&self, table_name: &str) -> Result<Option<TableId>> {

--- a/crates/datastore/src/system_tables.rs
+++ b/crates/datastore/src/system_tables.rs
@@ -107,6 +107,7 @@ pub const ST_RESERVED_SEQUENCE_RANGE: u32 = 4096;
 #[derive(Debug, Display)]
 pub enum SystemTable {
     st_table,
+    st_view,
     st_column,
     st_sequence,
     st_index,
@@ -747,6 +748,13 @@ pub struct StViewRow {
     /// Specifically, it is a view that has an `AnonymousViewContext` as its first argument.
     /// This type does not have access to the [`Identity`] of the caller.
     pub is_anonymous: bool,
+}
+
+impl TryFrom<RowRef<'_>> for StViewRow {
+    type Error = DatastoreError;
+    fn try_from(row: RowRef<'_>) -> Result<Self, DatastoreError> {
+        read_via_bsatn(row)
+    }
 }
 
 /// A wrapper around `AlgebraicType` that acts like `AlgegbraicType::bytes()` for serialization purposes.

--- a/crates/datastore/src/traits.rs
+++ b/crates/datastore/src/traits.rs
@@ -509,6 +509,7 @@ pub trait MutTxDatastore: TxDatastore + MutTx {
     fn schema_for_table_mut_tx(&self, tx: &Self::MutTx, table_id: TableId) -> Result<Arc<TableSchema>>;
     fn drop_table_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId) -> Result<()>;
     fn rename_table_mut_tx(&self, tx: &mut Self::MutTx, table_id: TableId, new_name: &str) -> Result<()>;
+    fn view_id_from_name_mut_tx(&self, tx: &Self::MutTx, view_name: &str) -> Result<Option<ViewId>>;
     fn table_id_from_name_mut_tx(&self, tx: &Self::MutTx, table_name: &str) -> Result<Option<TableId>>;
     fn table_id_exists_mut_tx(&self, tx: &Self::MutTx, table_id: &TableId) -> bool;
     fn table_name_from_id_mut_tx<'a>(&'a self, tx: &'a Self::MutTx, table_id: TableId) -> Result<Option<Cow<'a, str>>>;

--- a/crates/sats/src/convert.rs
+++ b/crates/sats/src/convert.rs
@@ -1,7 +1,7 @@
 use crate::sum_value::SumTag;
 use crate::{i256, u256};
 use crate::{AlgebraicType, AlgebraicValue, ProductType, ProductValue};
-use spacetimedb_primitives::{ColId, ConstraintId, IndexId, ScheduleId, SequenceId, TableId};
+use spacetimedb_primitives::{ColId, ConstraintId, IndexId, ScheduleId, SequenceId, TableId, ViewId};
 
 impl crate::Value for AlgebraicValue {
     type Type = AlgebraicType;
@@ -64,6 +64,7 @@ macro_rules! system_id {
     };
 }
 system_id!(TableId);
+system_id!(ViewId);
 system_id!(ColId);
 system_id!(SequenceId);
 system_id!(IndexId);

--- a/crates/schema/src/auto_migrate/formatter.rs
+++ b/crates/schema/src/auto_migrate/formatter.rs
@@ -5,7 +5,7 @@ use std::io;
 use super::{AutoMigratePlan, IndexAlgorithm, ModuleDefLookup, TableDef};
 use crate::{
     auto_migrate::AutoMigrateStep,
-    def::{ConstraintData, FunctionKind, ModuleDef, ScheduleDef},
+    def::{ConstraintData, FunctionKind, ModuleDef, ScheduleDef, ViewDef},
     identifier::Identifier,
 };
 use itertools::Itertools;
@@ -32,6 +32,18 @@ fn format_step<F: MigrationFormatter>(
     plan: &super::AutoMigratePlan,
 ) -> Result<(), FormattingErrors> {
     match step {
+        AutoMigrateStep::AddView(view) => {
+            let view_info = extract_view_info(*view, plan.new)?;
+            f.format_view(&view_info, Action::Created)
+        }
+        AutoMigrateStep::RemoveView(view) => {
+            let view_info = extract_view_info(*view, plan.old)?;
+            f.format_view(&view_info, Action::Removed)
+        }
+        // This means the body of the view may have been updated.
+        // So we must recompute it and send any updates to clients.
+        // No need to include this step in the formatted plan.
+        AutoMigrateStep::UpdateView(_) => Ok(()),
         AutoMigrateStep::AddTable(t) => {
             let table_info = extract_table_info(*t, plan)?;
             f.format_add_table(&table_info)
@@ -98,6 +110,8 @@ fn format_step<F: MigrationFormatter>(
 pub enum FormattingErrors {
     #[error("Table not found: {table}")]
     TableNotFound { table: Box<str> },
+    #[error("View not found: {view}")]
+    ViewNotFound { view: Box<str> },
     #[error("Index not found")]
     IndexNotFound,
     #[error("Constraint not found")]
@@ -128,6 +142,7 @@ pub enum Action {
 pub trait MigrationFormatter {
     fn format_header(&mut self) -> io::Result<()>;
     fn format_add_table(&mut self, table_info: &TableInfo) -> io::Result<()>;
+    fn format_view(&mut self, view_info: &ViewInfo, action: Action) -> io::Result<()>;
     fn format_index(&mut self, index_info: &IndexInfo, action: Action) -> io::Result<()>;
     fn format_constraint(&mut self, constraint_info: &ConstraintInfo, action: Action) -> io::Result<()>;
     fn format_sequence(&mut self, sequence_info: &SequenceInfo, action: Action) -> io::Result<()>;
@@ -149,6 +164,26 @@ pub struct TableInfo {
     pub indexes: Vec<IndexInfo>,
     pub sequences: Vec<SequenceInfo>,
     pub schedule: Option<ScheduleInfo>,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ViewInfo {
+    pub name: String,
+    pub params: Vec<ViewParamInfo>,
+    pub columns: Vec<ViewColumnInfo>,
+    pub is_anonymous: bool,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ViewColumnInfo {
+    pub name: Identifier,
+    pub type_name: AlgebraicType,
+}
+
+#[derive(Debug, Clone, PartialEq)]
+pub struct ViewParamInfo {
+    pub name: Identifier,
+    pub type_name: AlgebraicType,
 }
 
 #[derive(Debug, Clone, PartialEq)]
@@ -328,6 +363,53 @@ fn extract_table_info(
         indexes,
         sequences,
         schedule,
+    })
+}
+
+fn extract_view_info(
+    view: <ViewDef as crate::def::ModuleDefLookup>::Key<'_>,
+    module_def: &ModuleDef,
+) -> Result<ViewInfo, FormattingErrors> {
+    let view_def = module_def.view(view).ok_or_else(|| FormattingErrors::ViewNotFound {
+        view: view.to_string().into(),
+    })?;
+
+    let name = view_def.name.to_string();
+    let is_anonymous = view_def.is_anonymous;
+
+    let params = view_def
+        .param_columns
+        .iter()
+        .map(|column| {
+            let type_name = WithTypespace::new(module_def.typespace(), &column.ty)
+                .resolve_refs()
+                .map_err(|_| FormattingErrors::TypeResolution)?;
+            Ok(ViewParamInfo {
+                name: column.name.clone(),
+                type_name,
+            })
+        })
+        .collect::<Result<Vec<_>, FormattingErrors>>()?;
+
+    let columns = view_def
+        .return_columns
+        .iter()
+        .map(|column| {
+            let type_name = WithTypespace::new(module_def.typespace(), &column.ty)
+                .resolve_refs()
+                .map_err(|_| FormattingErrors::TypeResolution)?;
+            Ok(ViewColumnInfo {
+                name: column.name.clone(),
+                type_name,
+            })
+        })
+        .collect::<Result<Vec<_>, FormattingErrors>>()?;
+
+    Ok(ViewInfo {
+        name,
+        params,
+        columns,
+        is_anonymous,
     })
 }
 

--- a/crates/schema/src/auto_migrate/termcolor_formatter.rs
+++ b/crates/schema/src/auto_migrate/termcolor_formatter.rs
@@ -5,6 +5,8 @@ use spacetimedb_lib::{db::raw_def::v9::TableAccess, AlgebraicType};
 use spacetimedb_sats::algebraic_type::fmt::fmt_algebraic_type;
 use termcolor::{Buffer, Color, ColorChoice, ColorSpec, WriteColor};
 
+use crate::auto_migrate::formatter::ViewInfo;
+
 use super::formatter::{
     AccessChangeInfo, Action, ColumnChange, ColumnChanges, ConstraintInfo, IndexInfo, MigrationFormatter, NewColumns,
     RlsInfo, ScheduleInfo, SequenceInfo, TableInfo,
@@ -220,6 +222,48 @@ impl MigrationFormatter for TermColorFormatter {
             self.write_colored_line("Schedule:", Some(self.colors.section_header), true)?;
             self.indent();
             self.write_bullet(&format!("Calls {}: {}", s.function_kind, s.function_name))?;
+            self.dedent();
+        }
+
+        self.dedent();
+        self.write_line("")
+    }
+
+    fn format_view(&mut self, view: &ViewInfo, action: Action) -> io::Result<()> {
+        self.write_indent()?;
+        self.buffer.write_all("▸ ".to_string().as_bytes())?;
+        self.write_action_prefix(&action)?;
+        self.buffer.write_all(if view.is_anonymous {
+            b" anonymous view: "
+        } else {
+            b" view: "
+        })?;
+        self.write_colored(&view.name, Some(self.colors.table_name), true)?;
+        self.buffer.write_all(b"\n")?;
+
+        self.indent();
+
+        if !view.params.is_empty() {
+            self.write_colored_line("Parameters:", Some(self.colors.section_header), true)?;
+            self.indent();
+            for col in &view.params {
+                self.write_indent()?;
+                self.buffer.write_all(format!("• {}: ", col.name).as_bytes())?;
+                self.write_type_name(&col.type_name)?;
+                self.buffer.write_all(b"\n")?;
+            }
+            self.dedent();
+        }
+
+        if !view.columns.is_empty() {
+            self.write_colored_line("Columns:", Some(self.colors.section_header), true)?;
+            self.indent();
+            for col in &view.columns {
+                self.write_indent()?;
+                self.buffer.write_all(format!("• {}: ", col.name).as_bytes())?;
+                self.write_type_name(&col.type_name)?;
+                self.buffer.write_all(b"\n")?;
+            }
             self.dedent();
         }
 

--- a/crates/schema/src/def.rs
+++ b/crates/schema/src/def.rs
@@ -240,6 +240,12 @@ impl ModuleDef {
         self.tables.get(name)
     }
 
+    /// Convenience method to look up a view, possibly by a string.
+    pub fn view<K: ?Sized + Hash + Equivalent<Identifier>>(&self, name: &K) -> Option<&ViewDef> {
+        // If the string IS a valid identifier, we can just look it up.
+        self.views.get(name)
+    }
+
     /// Convenience method to look up a reducer, possibly by a string.
     pub fn reducer<K: ?Sized + Hash + Equivalent<Identifier>>(&self, name: &K) -> Option<&ReducerDef> {
         // If the string IS a valid identifier, we can just look it up.
@@ -713,6 +719,67 @@ pub struct ColumnDef {
     pub default_value: Option<AlgebraicValue>,
 }
 
+/// A struct representing a validated view column
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct ViewColumnDef {
+    /// The name of the column.
+    pub name: Identifier,
+
+    /// The position of this column in the view's return type.
+    pub col_id: ColId,
+
+    /// The type of this column.
+    pub ty: AlgebraicType,
+
+    /// The type of the column, formatted for client code generation.
+    pub ty_for_generate: AlgebraicTypeUse,
+
+    /// The view this def is stored in.
+    pub view_name: Identifier,
+}
+
+impl From<ColumnDef> for ViewColumnDef {
+    fn from(
+        ColumnDef {
+            name,
+            col_id,
+            ty,
+            ty_for_generate,
+            table_name: view_name,
+            ..
+        }: ColumnDef,
+    ) -> Self {
+        Self {
+            name,
+            col_id,
+            ty,
+            ty_for_generate,
+            view_name,
+        }
+    }
+}
+
+/// A struct representing a validated view parameter
+#[derive(Debug, Clone, Eq, PartialEq)]
+#[non_exhaustive]
+pub struct ViewParamDef {
+    /// The name of the parameter.
+    pub name: Identifier,
+
+    /// The position of this parameter in the view's parameter list.
+    pub col_id: ColId,
+
+    /// The type of this parameter.
+    pub ty: AlgebraicType,
+
+    /// The type of the parameter, formatted for client code generation.
+    pub ty_for_generate: AlgebraicTypeUse,
+
+    /// The view this def is stored in.
+    pub view_name: Identifier,
+}
+
 /// A constraint definition attached to a table.
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub struct ConstraintDef {
@@ -1011,10 +1078,27 @@ pub struct ViewDef {
     /// The return type of the view, formatted for client codegen.
     pub return_type_for_generate: AlgebraicTypeUse,
 
-    /// The columns of this view.
+    /// The return columns of this view.
     /// The same information is stored in `return_type`.
     /// This is just a more convenient-to-access format.
-    pub columns: Vec<ColumnDef>,
+    pub return_columns: Vec<ViewColumnDef>,
+
+    /// The columns that track the arguments of this view.
+    /// The same information is stored in `params`.
+    /// This is just a more convenient-to-access format.
+    pub param_columns: Vec<ViewParamDef>,
+}
+
+impl ViewDef {
+    /// Get a column by the column's name.
+    pub fn get_column_by_name(&self, name: &Identifier) -> Option<&ViewColumnDef> {
+        self.return_columns.iter().find(|c| &c.name == name)
+    }
+
+    /// Get a parameter by the parameter's name.
+    pub fn get_param_by_name(&self, name: &Identifier) -> Option<&ViewParamDef> {
+        self.param_columns.iter().find(|c| &c.name == name)
+    }
 }
 
 impl From<ViewDef> for RawViewDefV9 {
@@ -1027,7 +1111,8 @@ impl From<ViewDef> for RawViewDefV9 {
             params_for_generate: _,
             return_type,
             return_type_for_generate: _,
-            columns: _,
+            return_columns: _,
+            param_columns: _,
         } = val;
         RawViewDefV9 {
             name: name.into(),
@@ -1174,6 +1259,40 @@ impl ModuleDefLookup for ColumnDef {
             .tables
             .get(table_name)
             .and_then(|table| table.get_column_by_name(name))
+    }
+}
+
+impl ModuleDefLookup for ViewColumnDef {
+    // We don't use `ColId` here because we want this to be portable
+    // across migrations.
+    type Key<'a> = (&'a Identifier, &'a Identifier);
+
+    fn key(&self) -> Self::Key<'_> {
+        (&self.view_name, &self.name)
+    }
+
+    fn lookup<'a>(module_def: &'a ModuleDef, (view_name, name): Self::Key<'_>) -> Option<&'a Self> {
+        module_def
+            .views
+            .get(view_name)
+            .and_then(|view| view.get_column_by_name(name))
+    }
+}
+
+impl ModuleDefLookup for ViewParamDef {
+    // We don't use `ColId` here because we want this to be portable
+    // across migrations.
+    type Key<'a> = (&'a Identifier, &'a Identifier);
+
+    fn key(&self) -> Self::Key<'_> {
+        (&self.view_name, &self.name)
+    }
+
+    fn lookup<'a>(module_def: &'a ModuleDef, (view_name, name): Self::Key<'_>) -> Option<&'a Self> {
+        module_def
+            .views
+            .get(view_name)
+            .and_then(|view| view.get_param_by_name(name))
     }
 }
 

--- a/crates/schema/src/def/validate/v9.rs
+++ b/crates/schema/src/def/validate/v9.rs
@@ -496,7 +496,7 @@ impl ModuleValidator<'_> {
             view_name: Cow::Borrowed(&name),
             position,
             arg_name,
-        });
+        })?;
 
         let return_type_for_generate = self.validate_for_type_use(
             &TypeLocation::ViewReturn {
@@ -505,7 +505,14 @@ impl ModuleValidator<'_> {
             &return_type,
         );
 
-        let mut view_in_progress = ViewValidator::new(name.clone(), product_type_ref, product_type, self);
+        let mut view_in_progress = ViewValidator::new(
+            name.clone(),
+            product_type_ref,
+            product_type,
+            &params,
+            &params_for_generate,
+            self,
+        );
 
         // Views have the same interface as tables and therefore must be registered in the global namespace.
         //
@@ -516,12 +523,18 @@ impl ModuleValidator<'_> {
         // See `check_function_names_are_unique`.
         let name = view_in_progress.add_to_global_namespace(name).and_then(identifier);
 
-        let columns = (0..product_type.elements.len())
-            .map(|id| view_in_progress.validate_column_def(id.into()))
+        let n = product_type.elements.len();
+        let return_columns = (0..n)
+            .map(|id| view_in_progress.validate_view_column_def(id.into()))
             .collect_all_errors();
 
-        let (name, params_for_generate, return_type_for_generate, columns) =
-            (name, params_for_generate, return_type_for_generate, columns).combine_errors()?;
+        let n = params.elements.len();
+        let param_columns = (0..n)
+            .map(|id| view_in_progress.validate_param_column_def(id.into()))
+            .collect_all_errors();
+
+        let (name, return_type_for_generate, return_columns, param_columns) =
+            (name, return_type_for_generate, return_columns, param_columns).combine_errors()?;
 
         Ok(ViewDef {
             name,
@@ -534,7 +547,8 @@ impl ModuleValidator<'_> {
             },
             return_type,
             return_type_for_generate,
-            columns,
+            return_columns,
+            param_columns,
         })
     }
 
@@ -682,6 +696,8 @@ impl ModuleValidator<'_> {
 /// 2. Insert view names into the global namespace.
 struct ViewValidator<'a, 'b> {
     inner: TableValidator<'a, 'b>,
+    params: &'a ProductType,
+    params_for_generate: &'a [(Identifier, AlgebraicTypeUse)],
 }
 
 impl<'a, 'b> ViewValidator<'a, 'b> {
@@ -689,6 +705,8 @@ impl<'a, 'b> ViewValidator<'a, 'b> {
         raw_name: Box<str>,
         product_type_ref: AlgebraicTypeRef,
         product_type: &'a ProductType,
+        params: &'a ProductType,
+        params_for_generate: &'a [(Identifier, AlgebraicTypeUse)],
         module_validator: &'a mut ModuleValidator<'b>,
     ) -> Self {
         Self {
@@ -699,11 +717,51 @@ impl<'a, 'b> ViewValidator<'a, 'b> {
                 module_validator,
                 has_sequence: Default::default(),
             },
+            params,
+            params_for_generate,
         }
     }
 
-    fn validate_column_def(&mut self, col_id: ColId) -> Result<ColumnDef> {
-        self.inner.validate_column_def(col_id)
+    fn validate_param_column_def(&mut self, col_id: ColId) -> Result<ViewParamDef> {
+        let column = &self
+            .params
+            .elements
+            .get(col_id.idx())
+            .expect("enumerate is generating an out-of-range index...");
+
+        let (_, ty_for_generate) = self
+            .params_for_generate
+            .get(col_id.idx())
+            .expect("enumerate is generating an out-of-range index...");
+
+        let name: Result<Identifier> = identifier(
+            column
+                .name()
+                .map(|name| name.into())
+                .unwrap_or_else(|| format!("param_{}", col_id).into_boxed_str()),
+        );
+
+        // This error will be created multiple times if the view name is invalid,
+        // but we sort and deduplicate the error stream afterwards,
+        // so it isn't a huge deal.
+        //
+        // This is necessary because we require `ErrorStream` to be nonempty.
+        // We need to put something in there if the view name is invalid.
+        let view_name = identifier(self.inner.raw_name.clone());
+
+        let (name, view_name) = (name, view_name).combine_errors()?;
+
+        Ok(ViewParamDef {
+            name,
+            ty: column.algebraic_type.clone(),
+            ty_for_generate: ty_for_generate.clone(),
+            col_id,
+            view_name,
+        })
+    }
+
+    fn validate_view_column_def(&mut self, col_id: ColId) -> Result<ViewColumnDef> {
+        self.inner.validate_column_def(col_id).map(ViewColumnDef::from)
     }
 
     fn add_to_global_namespace(&mut self, name: Box<str>) -> Result<Box<str>> {

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -21,7 +21,7 @@ use std::sync::Arc;
 
 use crate::def::{
     ColumnDef, ConstraintData, ConstraintDef, IndexAlgorithm, IndexDef, ModuleDef, ModuleDefLookup, ScheduleDef,
-    SequenceDef, TableDef, UniqueConstraintData, ViewDef,
+    SequenceDef, TableDef, UniqueConstraintData, ViewColumnDef, ViewDef, ViewParamDef,
 };
 use crate::identifier::Identifier;
 
@@ -623,15 +623,16 @@ impl TableSchema {
             name,
             is_anonymous,
             is_public,
-            params,
+            params: _,
             params_for_generate: _,
             return_type: _,
             return_type_for_generate: _,
-            columns: cols,
+            return_columns,
+            param_columns,
         } = view_def;
 
-        let num_args = params.elements.len();
-        let num_cols = cols.len();
+        let num_args = param_columns.len();
+        let num_cols = return_columns.len();
         let n = num_args + num_cols + if *is_anonymous { 0 } else { 1 };
 
         let mut columns = Vec::with_capacity(n);
@@ -647,20 +648,17 @@ impl TableSchema {
 
         let n = columns.len();
 
-        for (i, elem) in params.elements.iter().cloned().enumerate() {
-            columns.push(ColumnSchema {
-                table_id: TableId::SENTINEL,
-                col_pos: (n + i).into(),
-                col_name: elem.name.unwrap_or_else(|| format!("param_{i}").into_boxed_str()),
-                col_type: elem.algebraic_type,
-            });
-        }
+        let param_iter = param_columns
+            .iter()
+            .map(|def| ColumnSchema::from_view_param_def(module_def, def));
 
-        let n = columns.len();
+        let column_iter = return_columns
+            .iter()
+            .map(|def| ColumnSchema::from_view_column_def(module_def, def));
 
         columns.extend(
-            column_schemas_from_defs(module_def, cols, TableId::SENTINEL)
-                .into_iter()
+            param_iter
+                .chain(column_iter)
                 .enumerate()
                 .map(|(i, schema)| ColumnSchema {
                     col_pos: (n + i).into(),
@@ -879,6 +877,30 @@ impl ColumnSchema {
             col_pos: pos.into(),
             col_name: name.into(),
             col_type: ty,
+        }
+    }
+
+    fn from_view_column_def(module_def: &ModuleDef, def: &ViewColumnDef) -> Self {
+        let col_type = WithTypespace::new(module_def.typespace(), &def.ty)
+            .resolve_refs()
+            .expect("validated module should have all types resolve");
+        ColumnSchema {
+            table_id: TableId::SENTINEL,
+            col_pos: def.col_id,
+            col_name: (*def.name).into(),
+            col_type,
+        }
+    }
+
+    fn from_view_param_def(module_def: &ModuleDef, def: &ViewParamDef) -> Self {
+        let col_type = WithTypespace::new(module_def.typespace(), &def.ty)
+            .resolve_refs()
+            .expect("validated module should have all types resolve");
+        ColumnSchema {
+            table_id: TableId::SENTINEL,
+            col_pos: def.col_id,
+            col_name: (*def.name).into(),
+            col_type,
         }
     }
 }

--- a/crates/schema/src/snapshots/spacetimedb_schema__auto_migrate__tests__empty_to_populated_migration.snap
+++ b/crates/schema/src/snapshots/spacetimedb_schema__auto_migrate__tests__empty_to_populated_migration.snap
@@ -51,5 +51,13 @@ expression: "plan.pretty_print(PrettyPrintStyle::AnsiColor).expect(\"should pret
     [0m[1m[34mAuto-increment constraints:[0m
         • Inspections_scheduled_id_seq on scheduled_id
 
+▸ ▸ [0m[1m[32mCreated[0m anonymous view: [0m[1m[36mmy_view[0m
+    [0m[1m[34mParameters:[0m
+        • x: [0m[35mU32[0m
+        • y: [0m[35mU32[0m
+    [0m[1m[34mColumns:[0m
+        • a: [0m[35mU64[0m
+        • b: [0m[35mU64[0m
+
 ▸ [0m[1m[32mCreated[0m row level security policy:
     `[0m[34mSELECT * FROM Apples[0m`

--- a/crates/schema/src/snapshots/spacetimedb_schema__auto_migrate__tests__updated pretty print no color.snap
+++ b/crates/schema/src/snapshots/spacetimedb_schema__auto_migrate__tests__updated pretty print no color.snap
@@ -1,6 +1,6 @@
 ---
 source: crates/schema/src/auto_migrate.rs
-expression: "plan.pretty_print(true).expect(\"should pretty print\")"
+expression: "plan.pretty_print(PrettyPrintStyle::NoColor).expect(\"should pretty print\")"
 ---
 ━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━━
 Database Migration Plan
@@ -10,6 +10,14 @@ Database Migration Plan
 ▸ Removed unique constraint Apples_id_key on [id] of table Apples
 ▸ Removed auto-increment constraint Apples_id_seq on column id of table Apples
 ▸ Removed schedule for table Deliveries_sched calling reducer check_deliveries
+▸ ▸ Removed anonymous view: my_view
+    Parameters:
+        • x: U32
+        • y: U32
+    Columns:
+        • a: U64
+        • b: U64
+
 ▸ Removed row level security policy:
     `SELECT * FROM Apples`
 ▸ Changed columns for table Apples
@@ -31,6 +39,12 @@ Database Migration Plan
 ▸ Created index Apples_id_count_idx_btree on [id, count] of table Apples
 ▸ Created auto-increment constraint Bananas_id_seq on column id of table Bananas
 ▸ Created schedule for table Inspections_sched calling reducer perform_inspection
+▸ ▸ Created anonymous view: my_view
+    Parameters:
+        • x: U32
+    Columns:
+        • a: U64
+
 ▸ Created row level security policy:
     `SELECT * FROM Bananas`
 ▸ Changed access for table Bananas (public → private)

--- a/crates/schema/src/snapshots/spacetimedb_schema__auto_migrate__tests__updated pretty print.snap
+++ b/crates/schema/src/snapshots/spacetimedb_schema__auto_migrate__tests__updated pretty print.snap
@@ -10,6 +10,14 @@ expression: "plan.pretty_print(PrettyPrintStyle::AnsiColor).expect(\"should pret
 ▸ [0m[1m[31mRemoved[0m unique constraint Apples_id_key on [id] of table [0m[1m[36mApples[0m
 ▸ [0m[1m[31mRemoved[0m auto-increment constraint Apples_id_seq on column id of table [0m[1m[36mApples[0m
 ▸ [0m[1m[31mRemoved[0m schedule for table [0m[1m[36mDeliveries_sched[0m calling reducer check_deliveries
+▸ ▸ [0m[1m[31mRemoved[0m anonymous view: [0m[1m[36mmy_view[0m
+    [0m[1m[34mParameters:[0m
+        • x: [0m[35mU32[0m
+        • y: [0m[35mU32[0m
+    [0m[1m[34mColumns:[0m
+        • a: [0m[35mU64[0m
+        • b: [0m[35mU64[0m
+
 ▸ [0m[1m[31mRemoved[0m row level security policy:
     `[0m[34mSELECT * FROM Apples[0m`
 ▸ [0m[1m[33mChanged[0m columns for table [0m[1m[36mApples[0m
@@ -31,6 +39,12 @@ expression: "plan.pretty_print(PrettyPrintStyle::AnsiColor).expect(\"should pret
 ▸ [0m[1m[32mCreated[0m index Apples_id_count_idx_btree on [id, count] of table [0m[1m[36mApples[0m
 ▸ [0m[1m[32mCreated[0m auto-increment constraint Bananas_id_seq on column id of table [0m[1m[36mBananas[0m
 ▸ [0m[1m[32mCreated[0m schedule for table [0m[1m[36mInspections_sched[0m calling reducer perform_inspection
+▸ ▸ [0m[1m[32mCreated[0m anonymous view: [0m[1m[36mmy_view[0m
+    [0m[1m[34mParameters:[0m
+        • x: [0m[35mU32[0m
+    [0m[1m[34mColumns:[0m
+        • a: [0m[35mU64[0m
+
 ▸ [0m[1m[32mCreated[0m row level security policy:
     `[0m[34mSELECT * FROM Bananas[0m`
 ▸ [0m[1m[33mChanged[0m access for table [0m[1m[36mBananas[0m ([0m[32mpublic → private[0m)


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Defines auto-migration rules for views.

> What are they?

Answer: You can always auto-migrate a view. It's just a matter of whether you have to disconnect clients. Removal of a view or changing the return type in a breaking way requires that we disconnect clients.

TODO: Even if a view is updated in a completely compatible way, we still have to wipe or dirty the read set in order to force a re-computation because the behavior could have changed.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

2.5

Not just a mechanical change.

Most of the time you can think of views as though they were tables. However for auto-migration there is a key distinction. Views don't have observably persistent state. While we can persist state internally, we can always derive a view's result set from the database state. Hence auto-migration rules are not as strict.

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Auto-migration planner tests
