### PR TITLE
Don't depend on `[!Default; 0]: Default` impl

### DIFF
--- a/crates/sats/src/array_value.rs
+++ b/crates/sats/src/array_value.rs
@@ -141,7 +141,7 @@ impl ArrayValue {
 impl Default for ArrayValue {
     /// The default `ArrayValue` is an empty array of sum values.
     fn default() -> Self {
-        Self::from(<[crate::SumValue; 0]>::default())
+        Self::from([] as [crate::SumValue; 0])
     }
 }
 


### PR DESCRIPTION
# Description of Changes

There are plans to remove the unconditional `[T; 0]: Default` impl (where `T` doesn't necessarily implement `Default`) from the standard library (see https://github.com/rust-lang/rust/pull/145457). That is a breaking change that would affect this crate.

This PR fixes this by removing a dependency on that impl.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1, there is no risk, the change is trivial.

# Testing

No testing is required, `<[T; 0]>::default()` is always equivalent to `[]`.