### PR TITLE
CI - Cancel runs on new pushes

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,9 +14,8 @@ on:
 name: CI
 
 concurrency:
-  # Use the PR number when available; otherwise a unique run_id so non-PR
-  # events never share a group.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  # When a PR number isn't available, the event won't be a `pull_request` event so it won't matter.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   # Only cancel when the event is a pull_request
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -7,9 +7,8 @@ on:
   pull_request:
 
 concurrency:
-  # Use the PR number when available; otherwise a unique run_id so non-PR
-  # events never share a group.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  # When a PR number isn't available, the event won't be a `pull_request` event so it won't matter.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   # Only cancel when the event is a pull_request
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/internal-tests.yml
+++ b/.github/workflows/internal-tests.yml
@@ -10,9 +10,8 @@ permissions:
   contents: read
 
 concurrency:
-  # Use the PR number when available; otherwise a unique run_id so non-PR
-  # events never share a group.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  # When a PR number isn't available, the event won't be a `pull_request` event so it won't matter.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   # Only cancel when the event is a pull_request
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 

--- a/.github/workflows/typescript-test.yml
+++ b/.github/workflows/typescript-test.yml
@@ -8,9 +8,8 @@ on:
   merge_group:
 
 concurrency:
-  # Use the PR number when available; otherwise a unique run_id so non-PR
-  # events never share a group.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number || github.run_id }}
+  # When a PR number isn't available, the event won't be a `pull_request` event so it won't matter.
+  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
   # Only cancel when the event is a pull_request
   cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 


### PR DESCRIPTION
# Description of Changes

Add `cancel-in-progress` to our GitHub workflows.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] Pushing new commits to this PR causes cancels of previous CI runs