### PR TITLE
Fix to Unreal tests to stop requesting infinite resources

### DIFF
--- a/sdks/unreal/tests/test.rs
+++ b/sdks/unreal/tests/test.rs
@@ -86,7 +86,7 @@ fn make_test(test_name: &str) -> Test {
 		// Updated to -NoZen and -dcc=InstalledNoZenLocalFallback to stop Unreal from trying to install Zen Server in CI
 		// This is failing during tests as each test tries to install Zen and create a race condition where two tests try to handle this at the same time
 		// Zen Server and the Derived Cache seem like a good idea during tests but they were not designed with mutli-threaded tests in mind, it is suggested to allow each test to run in isolation
-        "\"{editor_exe}\" \"{uproject_path}\" -NullRHI -Unattended -NoSound -nop4 -NoSplash -NoZen -ddc=InstalledNoZenLocalFallback -ExecCmds=\"Automation RunTests SpacetimeDB.TestClient.{test_name}; Quit\""
+        "\"{editor_exe}\" \"{uproject_path}\" -NullRHI -Unattended -NoSound -nop4 -NoSplash -NoZen -ddc=InstalledNoZenLocalFallback -nocore -ExecCmds=\"Automation RunTests SpacetimeDB.TestClient.{test_name}; Quit\""
     );
 
     Test::builder()


### PR DESCRIPTION
# Description of Changes

For core dumps Unreal tries to use setrlimit() for infinity when setting resource limits, it seems this becomes an issue intermittently when running tests in parallel. There is an option when running Unreal to disable this and we can rely on error longs only which makes sense for CI imo.

# API and ABI breaking changes

None

# Expected complexity level and risk

1 - small flag change

# Testing

- [x] Re-ran all tests locally