### PR TITLE
Improve spacetime-install.ps1

### DIFF
--- a/crates/update/spacetime-install.ps1
+++ b/crates/update/spacetime-install.ps1
@@ -28,7 +28,6 @@ function Install {
         $Installer = Join-Path ([System.IO.Path]::GetTempPath()) "vc_redist.x64.exe"
         Invoke-WebRequest $DownloadUrl -OutFile $Installer -UseBasicParsing
         Start-Process -Wait -FilePath $Installer -ArgumentList "/quiet", "/install"
-        return
     }
 
     $DownloadUrl = "https://github.com/clockworklabs/SpacetimeDB/releases/latest/download/spacetimedb-update-x86_64-pc-windows-msvc.exe"


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

This is a follow-up to https://github.com/clockworklabs/SpacetimeDB/pull/2356 . Essentially we want to remove this `return` statement so that you can both install the vcruntime and also continue installing SpacetimeDB without having to run the installer twice on Windows.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

1 - this affects windows installation.

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

I tested this on a new Windows 11 install. You can test the script by downloading it from this PR and then running the following:
```
iex (Get-Content .\spacetime-install.ps1 -Raw -Encoding UTF8)
```

- [x] I have tested this

This is from a brand-new Windows11 install with all updates installed:
<img width="971" height="328" alt="image" src="https://github.com/user-attachments/assets/76e9b813-64f9-4a92-b961-c2136fa1372e" />

Then I opened a new terminal window:
<img width="815" height="162" alt="image" src="https://github.com/user-attachments/assets/49e7cf95-fa37-4a5b-9fdd-7722e2055495" />
