### PR TITLE
commitlog: Improve error context

### DIFF
--- a/crates/commitlog/src/repo/mem.rs
+++ b/crates/commitlog/src/repo/mem.rs
@@ -1,6 +1,6 @@
 use std::{
     collections::{btree_map, BTreeMap},
-    io,
+    fmt, io,
     sync::{Arc, RwLock, RwLockWriteGuard},
 };
 
@@ -210,6 +210,12 @@ pub struct Memory(SharedLock<BTreeMap<u64, SharedBytes>>);
 impl Memory {
     pub fn new() -> Self {
         Self::default()
+    }
+}
+
+impl fmt::Display for Memory {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        f.write_str("<memory>")
     }
 }
 

--- a/crates/commitlog/src/repo/mod.rs
+++ b/crates/commitlog/src/repo/mod.rs
@@ -1,4 +1,4 @@
-use std::io;
+use std::{fmt, io};
 
 use log::{debug, warn};
 
@@ -59,7 +59,10 @@ impl<T: FileLike + io::Read + io::Write + SegmentLen + Send + Sync> SegmentWrite
 ///
 /// This is mainly an internal trait to allow testing against an in-memory
 /// representation.
-pub trait Repo: Clone {
+///
+/// The [fmt::Display] should provide context about the location of the repo,
+/// e.g. the root directory for a filesystem-based implementation.
+pub trait Repo: Clone + fmt::Display {
     /// The type of log segments managed by this repo, which must behave like a file.
     type SegmentWriter: SegmentWriter + 'static;
     type SegmentReader: SegmentReader + 'static;


### PR DESCRIPTION
The commitlog creates new segments atomically, returning EEXIST if the segment already exists. This is to break a retry loop in case the filesystem becomes unwritable.

This error did not contain any context about what does not exist, so this patch adds some.

Also, an unhandled edge case has been discovered:

When opening an existing log, the commitlog will try to resume the last segment for writing. If it finds a corrupt commit in that segment, it won't resume, but instead create a new segment at the corrupt commit's offset + 1.

However, if the first commit in the last segment is corrupted, the offset will be that of the last segment -- trying to start a new segment will thus fail with EEXIST.

Without additional recovery mechanisms, it is not obvious what to do in this case: the segment could contain valid data after the initial commit, so we certainly don't want to throw it away.

Instead, we now detect this case and return `InvalidData` with some context.

# Expected complexity level and risk

1

# Testing

- [ ] A (regression) test is included
