### PR TITLE
Update the docs for postgres wire format changes in 1.6.0

### DIFF
--- a/docs/docs/08-SQL/02-pg-wire.md
+++ b/docs/docs/08-SQL/02-pg-wire.md
@@ -91,9 +91,9 @@ _For PowerShell_:
 $env:PGPASSWORD = (spacetime login show --token | Select-String 'Your auth token.*is (.*)' | % { $_.Matches[0].Groups[1].Value })
 ```
 
-### Enabling the _PGWire_ in SpacetimeDB Standalone
+### Enabling _PGWire_ in SpacetimeDB Standalone
 
-By default, the _PGWire_ is disabled when starting the `SpacetimeDB Standalone` server.
+_PGWire_ is disabled by default when starting a `SpacetimeDB Standalone` server.
 
 To enable it, start the server with the `--pg-port` flag:
 

--- a/docs/docs/08-SQL/02-pg-wire.md
+++ b/docs/docs/08-SQL/02-pg-wire.md
@@ -95,7 +95,7 @@ $env:PGPASSWORD = (spacetime login show --token | Select-String 'Your auth token
 
 _PGWire_ is disabled by default when starting a `SpacetimeDB Standalone` server.
 
-To enable it, start the server with the `--pg-port` flag:
+To enable it, start the server with the `--pg-port` option:
 
 ```bash
 spacetime start --pg-port 5432 [ARGS]

--- a/docs/docs/08-SQL/02-pg-wire.md
+++ b/docs/docs/08-SQL/02-pg-wire.md
@@ -91,6 +91,16 @@ _For PowerShell_:
 $env:PGPASSWORD = (spacetime login show --token | Select-String 'Your auth token.*is (.*)' | % { $_.Matches[0].Groups[1].Value })
 ```
 
+### Enabling the _PGWire_ in SpacetimeDB Standalone
+
+By default, the _PGWire_ is disabled when starting the `SpacetimeDB Standalone` server.
+
+To enable it, start the server with the `--pg-port` flag:
+
+```bash
+spacetime start --pg-port 5432 [ARGS]
+```
+
 ## Examples
 
 In the following example, we assume you are using the `quickstart-chat` database created in


### PR DESCRIPTION
# Description of Changes

Closes #3502. 

Adding section for more clarification (the remark in `Connection Parameters` could be easy to miss)

# Expected complexity level and risk
1

# Testing

- [x] See the changes with the `pnpm dev`
