### PR TITLE
[teams 2/5] client-api: Add `parent` parameter to publish endpoint

### DIFF
--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -163,6 +163,7 @@ pub struct DatabaseDef {
     pub num_replicas: Option<NonZeroU8>,
     /// The host type of the supplied program.
     pub host_type: HostType,
+    pub parent: Option<Identity>,
 }
 
 /// Parameters for resetting a database via [`ControlStateDelegate::reset_database`].

--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -681,6 +681,8 @@ pub struct PublishDatabaseQueryParams {
     policy: MigrationPolicy,
     #[serde(default)]
     host_type: HostType,
+    #[allow(unused)] // ignore for now
+    parent: Option<NameOrIdentity>,
 }
 
 pub async fn publish<S: NodeDelegate + ControlStateDelegate>(
@@ -692,6 +694,7 @@ pub async fn publish<S: NodeDelegate + ControlStateDelegate>(
         token,
         policy,
         host_type,
+        parent: _, // ignore for now
     }): Query<PublishDatabaseQueryParams>,
     Extension(auth): Extension<SpacetimeAuth>,
     program_bytes: Bytes,
@@ -762,6 +765,7 @@ pub async fn publish<S: NodeDelegate + ControlStateDelegate>(
                 program_bytes,
                 num_replicas,
                 host_type,
+                parent: None,
             },
             schema_migration_policy,
         )
@@ -914,6 +918,7 @@ pub async fn pre_publish<S: NodeDelegate + ControlStateDelegate>(
                 program_bytes,
                 num_replicas: None,
                 host_type,
+                parent: None,
             },
             style,
         )

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -210,6 +210,7 @@ impl CompiledModule {
                 program_bytes: self.program_bytes(),
                 num_replicas: None,
                 host_type: self.host_type,
+                parent: None,
             },
             MigrationPolicy::Compatible,
         )


### PR DESCRIPTION
This is the minimal patch to implement the private controldb side of the
teams feature.

The parameter is ignored for now.

Depends-on: https://github.com/clockworklabs/SpacetimeDB/pull/3496