### PR TITLE
Switch subscriptions to use mutable transactions in preparation for views

### DIFF
--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -21,7 +21,7 @@ use crate::subscription::module_subscription_actor::ModuleSubscriptions;
 use crate::subscription::tx::DeltaTx;
 use crate::subscription::websocket_building::BuildableWebsocketFormat;
 use crate::util::jobs::{SingleCoreExecutor, WeakSingleCoreExecutor};
-use crate::vm::check_row_limit;
+use crate::vm::{check_row_limit, TxMode};
 use crate::worker_metrics::WORKER_METRICS;
 use anyhow::Context;
 use bytes::Bytes;
@@ -1375,7 +1375,7 @@ impl ModuleHost {
                     check_row_limit(
                         &optimized,
                         &db,
-                        &tx,
+                        &TxMode::from(&*tx),
                         // Estimate the number of rows this query will scan
                         |plan, tx| estimate_rows_scanned(tx, plan),
                         &auth,

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -231,7 +231,7 @@ pub fn run(
                 check_row_limit(
                     &[&plan],
                     db,
-                    &tx,
+                    &TxMode::from(&*tx),
                     |plan, tx| plan.plan_iter().map(|plan| estimate_rows_scanned(tx, plan)).sum(),
                     &auth,
                 )?;

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -330,7 +330,7 @@ impl ExecutionUnit {
 
     /// The estimated number of rows returned by this execution unit.
     pub fn row_estimate(&self, tx: &TxId) -> u64 {
-        estimation::num_rows(tx, &self.eval_plan)
+        estimation::num_rows(&TxMode::from(tx), &self.eval_plan)
     }
 }
 

--- a/crates/core/src/subscription/mod.rs
+++ b/crates/core/src/subscription/mod.rs
@@ -3,7 +3,6 @@ use crate::{error::DBError, worker_metrics::WORKER_METRICS};
 use anyhow::Result;
 use module_subscription_manager::Plan;
 use prometheus::IntCounter;
-use rayon::iter::{IntoParallelRefIterator, ParallelIterator};
 use spacetimedb_client_api_messages::websocket::{
     ByteListLen, Compression, DatabaseUpdate, QueryUpdate, SingleQueryUpdate, TableUpdate,
 };
@@ -169,8 +168,8 @@ where
     F: BuildableWebsocketFormat,
 {
     plans
-        .par_iter()
-        .flat_map_iter(|plan| plan.plans_fragments().map(|fragment| (plan.sql(), fragment)))
+        .iter()
+        .flat_map(|plan| plan.plans_fragments().map(|fragment| (plan.sql(), fragment)))
         .filter(|(_, plan)| {
             // Since subscriptions only support selects and inner joins,
             // we filter out any plans that read from an empty table.

--- a/crates/core/src/subscription/query.rs
+++ b/crates/core/src/subscription/query.rs
@@ -5,6 +5,8 @@ use crate::sql::compiler::compile_sql;
 use crate::subscription::subscription::SupportedQuery;
 use once_cell::sync::Lazy;
 use regex::Regex;
+use spacetimedb_datastore::locking_tx_datastore::state_view::StateView;
+use spacetimedb_execution::Datastore;
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_subscription::SubscriptionPlan;
 use spacetimedb_vm::expr::{self, Crud, CrudExpr, QueryExpr};
@@ -93,7 +95,7 @@ pub fn compile_read_only_query(auth: &AuthCtx, tx: &Tx, input: &str) -> Result<P
 
 /// Compile a string into a single read-only query.
 /// This returns an error if the string has multiple queries or mutations.
-pub fn compile_query_with_hashes(
+pub fn compile_query_with_hashes<Tx: Datastore + StateView>(
     auth: &AuthCtx,
     tx: &Tx,
     input: &str,

--- a/crates/datastore/src/locking_tx_datastore/tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/tx.rs
@@ -43,9 +43,7 @@ impl Datastore for TxId {
         Self: 'a;
 
     fn row_count(&self, table_id: TableId) -> u64 {
-        self.committed_state_shared_lock
-            .table_row_count(table_id)
-            .unwrap_or_default()
+        self.table_row_count(table_id).unwrap_or_default()
     }
 
     fn table_scan<'a>(&'a self, table_id: TableId) -> anyhow::Result<Self::TableIter<'a>> {


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Switch subscriptions to use mutable transactions in preparation for views.

The main implication of this patch is that we no longer use rayon to parallelize subscriptions. Past performance tests have shown that we don't get much parallelism out of rayon, however we should still test the performance of this patch extensively.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

3

This is mainly due to an ugly diff which is the result of making things suitably generic so as to allow for both mutable and read only subscriptions.

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

This is a refactor with the result being that subscriptions now run in mutable transactions. Most of the subscription tests will now use a `MutTxId` instead of a `TxId`, so the current tests should give us sufficient coverage.

TODO: Performance test
