### PR TITLE
Fix TypeScript module quickstart

### DIFF
--- a/docs/docs/06-Server Module Languages/05-typescript-quickstart.md
+++ b/docs/docs/06-Server Module Languages/05-typescript-quickstart.md
@@ -35,20 +35,6 @@ spacetime init --lang typescript quickstart-chat
 
 Inside the `spacetimedb/` directory will be a `src/index.ts` entrypoint (required for publishing).
 
-## How to Build & Publish
-
-> [!IMPORTANT]
-> TypeScript modules are built and published with the `spacetime` CLI. `spacetime publish` will transpile and bundle your server module for you starting with the `src/index.ts` entrypoint. If you bundle your js yourself, you can specify `spacetime publish --js-path <path-to-your-bundle-file>` when publishing.
-
-From the `spacetimedb/` directory you can lint/typecheck locally if you like, but to make the module live you’ll publish it to a database:
-
-```bash
-cd quickstart-chat
-spacetime publish --project-path spacetimedb quickstart-chat
-```
-
-Publishing bundles your TypeScript into a single artifact and installs it into the `quickstart-chat` database.
-
 ## Declare imports
 
 Open `spacetimedb/src/index.ts`. Replace its contents with the following imports to start building a bare-bones real-time chat server:
@@ -199,6 +185,11 @@ spacetime start
 (If it’s already running, you can skip this step.)
 
 ## Publish the module
+
+From the `spacetimedb/` directory you can lint/typecheck locally if you like, but to make the module live you’ll need to publish it to a database. Publishing bundles your TypeScript into a single artifact and installs it into the `quickstart-chat` database.
+
+> [!IMPORTANT]
+> TypeScript modules are built and published with the `spacetime` CLI. `spacetime publish` will transpile and bundle your server module for you starting with the `src/index.ts` entrypoint. If you bundle your js yourself, you can specify `spacetime publish --js-path <path-to-your-bundle-file>` when publishing.
 
 From the `quickstart-chat` directory (the parent of `spacetimedb/`):
 


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

- Fixes an issue in the new TypeScript module quickstart which would cause users to encounter an error.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

1

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] I did the quickstart from start to finish and it works now without hitting any errors

Manual test output:
```
boppy@geralt MINGW64 ~/clockwork/SpacetimeDB/quickstart-chat (jdetter/fix-typescript-quickstart)
$ spacetime publish --project-path spacetimedb quickstart-chat
Build finished successfully.
Uploading to local => http://127.0.0.1:3000
Checking for breaking changes...
Publishing module...
JavaScript / TypeScript support is currently in BETA.
There may be bugs. Please file issues if you encounter any.
<https://github.com/clockworklabs/SpacetimeDB/issues/new>
Created new database with name: quickstart-chat, identity: c200a4abaa304575600961ee0a39210a536bcd9d52d14580ce56dd51627013f5

boppy@geralt MINGW64 ~/clockwork/SpacetimeDB/quickstart-chat (jdetter/fix-typescript-quickstart)
$ spacetime call quickstart-chat send_message "Hello, World!"
WARNING: This command is UNSTABLE and subject to breaking changes.


boppy@geralt MINGW64 ~/clockwork/SpacetimeDB/quickstart-chat (jdetter/fix-typescript-quickstart)
$ spacetime logs quickstart-chat
2025-10-30T15:50:23.882048Z  INFO: Creating table `message`
2025-10-30T15:50:23.882191Z  INFO: Creating table `user`
2025-10-30T15:50:23.882713Z  INFO: Invoking `init` reducer
2025-10-30T15:50:23.883599Z  INFO: Database initialized
2025-10-30T15:50:31.461395Z  INFO: send_message spacetimedb_module:3640: User c20093cd8df79879ae6d2b058650ca5112d6bb11334b5003f443cc0776da3d15: Hello, World!

boppy@geralt MINGW64 ~/clockwork/SpacetimeDB/quickstart-chat (jdetter/fix-typescript-quickstart)
$ spacetime sql quickstart-chat "SELECT * FROM message"
WARNING: This command is UNSTABLE and subject to breaking changes.

 sender                                                             | sent                             | text           
--------------------------------------------------------------------+----------------------------------+-----------------
 0xc20093cd8df79879ae6d2b058650ca5112d6bb11334b5003f443cc0776da3d15 | 2025-10-30T15:50:31.460991+00:00 | "Hello, World!"
```
