### PR TITLE
Don't cancel SpacetimeDB Internal Tests job

### DIFF
--- a/.github/workflows/internal-tests.yml
+++ b/.github/workflows/internal-tests.yml
@@ -9,12 +9,6 @@ name: Internal Tests
 permissions:
   contents: read
 
-concurrency:
-  # When a PR number isn't available, the event won't be a `pull_request` event so it won't matter.
-  group: ${{ github.workflow }}-${{ github.event.pull_request.number }}
-  # Only cancel when the event is a pull_request
-  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
-
 jobs:
   run-tests:
     # Skip if this is an external contribution. GitHub secrets will be empty, so the step would fail anyway.


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

I am proposing this change based off of [this test run](https://github.com/clockworklabs/SpacetimeDB/actions/runs/18953573342/job/54124423324) where the internal test run in our other repository continued to run but the CI job within SpacetimeDB was cancelled. Since the job in the other repo continued to run we might as well report the result here.

I'm proposing this change just so that at least the internal tests results from our other repository will be properly displayed on the target PR but I am also fine with updating the internal tests in our other repository to cancel in progress. Let me know what you want to do @bfops .

# API and ABI breaking changes

No

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

1

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

- Will test by pushing an empty commit

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->
