### PR TITLE
CI - Move the Package job to ubuntu-latest

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: x86_64 Linux, target: x86_64-unknown-linux-gnu, runner: bare-metal, container: 'debian:bookworm' }
+          - { name: x86_64 Linux, target: x86_64-unknown-linux-gnu, runner: ubuntu-latest }
           - { name: aarch64 Linux, target: aarch64-unknown-linux-gnu, runner: arm-runner }
           # Disabled because musl builds weren't working and we didn't want to investigate. See https://github.com/clockworklabs/SpacetimeDB/pull/2964.
           # - { name: x86_64 Linux musl, target: x86_64-unknown-linux-musl, runner: bare-metal, container: alpine }


### PR DESCRIPTION
# Description of Changes

The job is now failing on `bare-metal`, so trying this.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] Package job passes on https://github.com/clockworklabs/SpacetimeDB/pull/3543 with this merged in.