### PR TITLE
Use production API key

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -32,7 +32,7 @@ shikiTheme.colors!['editor.background'] =
 
 const inkeepConfig: Partial<InkeepConfig> = {
   baseSettings: {
-    apiKey: 'fe642f176d62fd867d93c0934f3a7c2336097bcef5f43e92',
+    apiKey: '13504c49fb56b7c09a5ea0bcd68c2b55857661be4d6d311b',
     organizationDisplayName: 'SpacetimeDB',
     primaryBrandColor: '#4cf490',
     colorMode: {


### PR DESCRIPTION
# Description of Changes

Inkeep's API key for the search bar is the staging one instead of production, therefore requests made are failing due to an incorrect referrer.
I've fixed this on `docs/release` quickly after we migrated the new docs but haven't made a PR to add it to master, due to this the change was lost on `docs/release` in the last docs release.
I just cherry-picked the commit that I had on my local branch

# API and ABI breaking changes

None.

# Expected complexity level and risk

1

# Testing

Cherry-pick of a commit that was already deployed
