### PR TITLE
Add comment about public API key use on Docusaurus

### DIFF
--- a/docs/docs/00-Ask AI/01-ask-ai.mdx
+++ b/docs/docs/00-Ask AI/01-ask-ai.mdx
@@ -7,6 +7,8 @@ hide_title: true
 
 import { InkeepEmbeddedChat } from '@inkeep/cxkit-react';
 
+<!-- This API key is public, it's okay to have it in client code, https://docs.inkeep.com/cloud/ui-components/public-api-keys#public-clients -->
+
 <InkeepEmbeddedChat
   shouldAutoFocusInput={true}
   baseSettings={{

--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -32,6 +32,7 @@ shikiTheme.colors!['editor.background'] =
 
 const inkeepConfig: Partial<InkeepConfig> = {
   baseSettings: {
+    // This API key is public, it's okay to have it in client code, https://docs.inkeep.com/cloud/ui-components/public-api-keys#public-clients
     apiKey: '13504c49fb56b7c09a5ea0bcd68c2b55857661be4d6d311b',
     organizationDisplayName: 'SpacetimeDB',
     primaryBrandColor: '#4cf490',
@@ -93,7 +94,8 @@ const config: Config = {
       'classic',
       {
         docs: {
-          editUrl: "https://github.com/clockworklabs/SpacetimeDB/edit/master/docs/",
+          editUrl:
+            'https://github.com/clockworklabs/SpacetimeDB/edit/master/docs/',
           routeBasePath: '/',
           sidebarPath: './sidebars.ts',
           sidebarCollapsed: false,


### PR DESCRIPTION
# Description of Changes

Following discussions about having our Inkeep's API key being public, I added a comment to all the places where we use it saying that this is OK and a link to the documentation.

As per Inkeep's documentation:
> When you embed your AI assistant in websites where the user is not authenticated, like in your public docs, help center, or marketing site, the web browser is considered a "public client". Since many of these clients often don't have a backend, the most practical way to use the AI assistant is for UI components to talk directly to the Inkeep service.
While it is up to your company's own policies and best practices, in these scenarios, the Inkeep API key is generally ok to be included in the source code of your web page that is exposed in the browser. This is similar to how [Algolia's search service](https://support.algolia.com/hc/en-us/articles/18966776061329-Can-the-search-API-key-be-public) or [Sentry's error logging](https://forum.sentry.io/t/how-does-sentry-prevent-spammers/8188) works.

https://docs.inkeep.com/cloud/ui-components/public-api-keys#public-clients

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Ran the docs locally to ensure that the comment isn't visible on the markdown pages