### PR TITLE
View resolution in sql

### DIFF
--- a/crates/core/src/vm.rs
+++ b/crates/core/src/vm.rs
@@ -686,6 +686,7 @@ pub(crate) mod tests {
             TableSchema::new(
                 TableId::SENTINEL,
                 table_name.into(),
+                None,
                 columns,
                 vec![],
                 vec![],

--- a/crates/datastore/src/locking_tx_datastore/datastore.rs
+++ b/crates/datastore/src/locking_tx_datastore/datastore.rs
@@ -1576,6 +1576,7 @@ mod tests {
         TableSchema::new(
             TableId::SENTINEL,
             "Foo".into(),
+            None,
             cols.into(),
             indices.into(),
             constraints.into(),

--- a/crates/datastore/src/locking_tx_datastore/state_view.rs
+++ b/crates/datastore/src/locking_tx_datastore/state_view.rs
@@ -123,6 +123,7 @@ pub trait StateView {
         Ok(TableSchema::new(
             table_id,
             table_name,
+            None,
             columns,
             indexes,
             constraints,

--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -7,7 +7,7 @@ use crate::expr::{Expr, ProjectList, ProjectName, Relvar};
 use spacetimedb_lib::identity::AuthCtx;
 use spacetimedb_lib::AlgebraicType;
 use spacetimedb_primitives::TableId;
-use spacetimedb_schema::schema::TableSchema;
+use spacetimedb_schema::schema::TableOrViewSchema;
 use spacetimedb_sql_parser::ast::BinOp;
 use spacetimedb_sql_parser::{
     ast::{sub::SqlSelect, SqlFrom, SqlIdent, SqlJoin},
@@ -26,19 +26,19 @@ pub type TypingResult<T> = core::result::Result<T, TypingError>;
 /// A view of the database schema
 pub trait SchemaView {
     fn table_id(&self, name: &str) -> Option<TableId>;
-    fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableSchema>>;
+    fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableOrViewSchema>>;
     fn rls_rules_for_table(&self, table_id: TableId) -> anyhow::Result<Vec<Box<str>>>;
 
-    fn schema(&self, name: &str) -> Option<Arc<TableSchema>> {
+    fn schema(&self, name: &str) -> Option<Arc<TableOrViewSchema>> {
         self.table_id(name).and_then(|table_id| self.schema_for_table(table_id))
     }
 }
 
 #[derive(Default)]
-pub struct Relvars(HashMap<Box<str>, Arc<TableSchema>>);
+pub struct Relvars(HashMap<Box<str>, Arc<TableOrViewSchema>>);
 
 impl Deref for Relvars {
-    type Target = HashMap<Box<str>, Arc<TableSchema>>;
+    type Target = HashMap<Box<str>, Arc<TableOrViewSchema>>;
     fn deref(&self) -> &Self::Target {
         &self.0
     }
@@ -116,7 +116,7 @@ pub trait TypeChecker {
         }
     }
 
-    fn type_relvar(tx: &impl SchemaView, name: &str) -> TypingResult<Arc<TableSchema>> {
+    fn type_relvar(tx: &impl SchemaView, name: &str) -> TypingResult<Arc<TableOrViewSchema>> {
         tx.schema(name)
             .ok_or_else(|| Unresolved::table(name))
             .map_err(TypingError::from)
@@ -180,7 +180,7 @@ pub mod test_utils {
     use spacetimedb_primitives::TableId;
     use spacetimedb_schema::{
         def::ModuleDef,
-        schema::{Schema, TableSchema},
+        schema::{Schema, TableOrViewSchema, TableSchema},
     };
     use std::sync::Arc;
 
@@ -205,7 +205,7 @@ pub mod test_utils {
             }
         }
 
-        fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableSchema>> {
+        fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableOrViewSchema>> {
             match table_id.idx() {
                 0 => Some((TableId(0), "t")),
                 1 => Some((TableId(1), "s")),
@@ -215,6 +215,8 @@ pub mod test_utils {
                 self.0
                     .table(name)
                     .map(|def| Arc::new(TableSchema::from_module_def(&self.0, def, (), table_id)))
+                    .map(TableOrViewSchema::from)
+                    .map(Arc::new)
             })
         }
 

--- a/crates/expr/src/errors.rs
+++ b/crates/expr/src/errors.rs
@@ -122,6 +122,12 @@ pub struct DuplicateName(pub String);
 #[error("`filter!` does not support column projections; Must return table rows")]
 pub struct FilterReturnType;
 
+#[derive(Debug, Error)]
+#[error("`{view_name}` is a view; DML on views is not supported")]
+pub struct DmlOnView {
+    pub view_name: Box<str>,
+}
+
 #[derive(Error, Debug)]
 pub enum TypingError {
     #[error(transparent)]
@@ -137,6 +143,8 @@ pub enum TypingError {
     #[error(transparent)]
     ParseError(#[from] SqlParseError),
 
+    #[error(transparent)]
+    DmlOnView(#[from] DmlOnView),
     #[error(transparent)]
     InvalidOp(#[from] InvalidOp),
     #[error(transparent)]

--- a/crates/expr/src/rls.rs
+++ b/crates/expr/src/rls.rs
@@ -476,7 +476,7 @@ mod tests {
     use spacetimedb_primitives::TableId;
     use spacetimedb_schema::{
         def::ModuleDef,
-        schema::{Schema, TableSchema},
+        schema::{Schema, TableOrViewSchema, TableSchema},
     };
     use spacetimedb_sql_parser::ast::BinOp;
 
@@ -499,7 +499,7 @@ mod tests {
             }
         }
 
-        fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableSchema>> {
+        fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableOrViewSchema>> {
             match table_id.idx() {
                 0 => Some((TableId(0), "users")),
                 1 => Some((TableId(1), "admins")),
@@ -510,6 +510,8 @@ mod tests {
                 self.0
                     .table(name)
                     .map(|def| Arc::new(TableSchema::from_module_def(&self.0, def, (), table_id)))
+                    .map(TableOrViewSchema::from)
+                    .map(Arc::new)
             })
         }
 

--- a/crates/expr/src/statement.rs
+++ b/crates/expr/src/statement.rs
@@ -2,7 +2,7 @@ use std::sync::Arc;
 
 use spacetimedb_lib::{identity::AuthCtx, st_var::StVarValue, AlgebraicType, AlgebraicValue, ProductValue};
 use spacetimedb_primitives::{ColId, TableId};
-use spacetimedb_schema::schema::{ColumnSchema, TableSchema};
+use spacetimedb_schema::schema::{ColumnSchema, TableOrViewSchema};
 use spacetimedb_sql_parser::{
     ast::{
         sql::{SqlAst, SqlDelete, SqlInsert, SqlSelect, SqlSet, SqlShow, SqlUpdate},
@@ -14,7 +14,7 @@ use thiserror::Error;
 
 use crate::{
     check::Relvars,
-    errors::InvalidLiteral,
+    errors::{DmlOnView, InvalidLiteral},
     expr::{FieldProject, ProjectList, RelExpr, Relvar},
     type_limit,
 };
@@ -39,7 +39,7 @@ pub enum DML {
 
 impl DML {
     /// Returns the schema of the table on which this mutation applies
-    pub fn table_schema(&self) -> &TableSchema {
+    pub fn table_schema(&self) -> &TableOrViewSchema {
         match self {
             Self::Insert(insert) => &insert.table,
             Self::Delete(delete) => &delete.table,
@@ -59,17 +59,17 @@ impl DML {
 }
 
 pub struct TableInsert {
-    pub table: Arc<TableSchema>,
+    pub table: Arc<TableOrViewSchema>,
     pub rows: Box<[ProductValue]>,
 }
 
 pub struct TableDelete {
-    pub table: Arc<TableSchema>,
+    pub table: Arc<TableOrViewSchema>,
     pub filter: Option<Expr>,
 }
 
 pub struct TableUpdate {
-    pub table: Arc<TableSchema>,
+    pub table: Arc<TableOrViewSchema>,
     pub columns: Box<[(ColId, AlgebraicValue)]>,
     pub filter: Option<Expr>,
 }
@@ -96,13 +96,17 @@ pub fn type_insert(insert: SqlInsert, tx: &impl SchemaView) -> TypingResult<Tabl
         .ok_or_else(|| Unresolved::table(&table_name))
         .map_err(TypingError::from)?;
 
+    if schema.is_view() {
+        return Err(TypingError::DmlOnView(DmlOnView { view_name: table_name }));
+    }
+
     // Expect n fields
-    let n = schema.columns().len();
-    if fields.len() != schema.columns().len() {
+    let n = schema.public_columns().len();
+    if fields.len() != schema.public_columns().len() {
         return Err(TypingError::from(InsertFieldsError {
             table: table_name.into_string(),
             nfields: fields.len(),
-            ncols: schema.columns().len(),
+            ncols: schema.public_columns().len(),
         }));
     }
 
@@ -120,7 +124,7 @@ pub fn type_insert(insert: SqlInsert, tx: &impl SchemaView) -> TypingResult<Tabl
         for (value, ty) in row.into_iter().zip(
             schema
                 .as_ref()
-                .columns()
+                .public_columns()
                 .iter()
                 .map(|ColumnSchema { col_type, .. }| col_type),
         ) {
@@ -159,6 +163,10 @@ pub fn type_delete(delete: SqlDelete, tx: &impl SchemaView) -> TypingResult<Tabl
         .schema(&table_name)
         .ok_or_else(|| Unresolved::table(&table_name))
         .map_err(TypingError::from)?;
+
+    if from.is_view() {
+        return Err(TypingError::DmlOnView(DmlOnView { view_name: table_name }));
+    }
     let mut vars = Relvars::default();
     vars.insert(table_name.clone(), from.clone());
     let expr = filter
@@ -181,6 +189,10 @@ pub fn type_update(update: SqlUpdate, tx: &impl SchemaView) -> TypingResult<Tabl
         .schema(&table_name)
         .ok_or_else(|| Unresolved::table(&table_name))
         .map_err(TypingError::from)?;
+
+    if schema.is_view() {
+        return Err(TypingError::DmlOnView(DmlOnView { view_name: table_name }));
+    }
     let mut values = Vec::new();
     for SqlSet(SqlIdent(field), lit) in assignments {
         let ColumnSchema {
@@ -312,7 +324,7 @@ pub fn type_and_rewrite_show(show: SqlShow, tx: &impl SchemaView) -> TypingResul
 
     let value_col_ty = table_schema
         .as_ref()
-        .get_column(1)
+        .get_column_by_name(VALUE_COLUMN)
         .map(|ColumnSchema { col_type, .. }| col_type)
         .ok_or_else(|| Unresolved::field(ST_VAR_NAME, VALUE_COLUMN))?;
 
@@ -450,6 +462,8 @@ pub fn compile_sql_stmt<'a>(sql: &'a str, tx: &impl SchemaView, auth: &AuthCtx) 
 
 #[cfg(test)]
 mod tests {
+    use std::sync::Arc;
+
     use super::Statement;
     use crate::ast::LogOp;
     use crate::check::{
@@ -457,8 +471,11 @@ mod tests {
         Relvars, SchemaView, TypingResult,
     };
     use crate::type_expr;
+    use spacetimedb::TableId;
+    use spacetimedb_lib::db::raw_def::v9::RawModuleDefV9Builder;
     use spacetimedb_lib::{identity::AuthCtx, AlgebraicType, ProductType};
     use spacetimedb_schema::def::ModuleDef;
+    use spacetimedb_schema::schema::{TableOrViewSchema, TableSchema};
     use spacetimedb_sql_parser::ast::{SqlExpr, SqlLiteral};
 
     fn module_def() -> ModuleDef {
@@ -542,5 +559,96 @@ mod tests {
         assert_eq!(build_query(2_501, ','), Err("Recursion limit exceeded".to_string()));
 
         assert!(build_query(2_500, ',').is_ok());
+    }
+
+    #[test]
+    fn views() {
+        struct SchemaViewer {
+            module_def: ModuleDef,
+        }
+
+        impl SchemaViewer {
+            fn schema_for_view(&self, name: &str) -> Option<Arc<TableOrViewSchema>> {
+                self.module_def
+                    .view(name)
+                    .map(|def| TableSchema::from_view_def_for_datastore(&self.module_def, def))
+                    .map(Arc::new)
+                    .map(TableOrViewSchema::from)
+                    .map(Arc::new)
+            }
+        }
+
+        impl SchemaView for SchemaViewer {
+            fn table_id(&self, _: &str) -> Option<TableId> {
+                None
+            }
+
+            fn schema(&self, name: &str) -> Option<Arc<TableOrViewSchema>> {
+                self.schema_for_view(name)
+            }
+
+            fn schema_for_table(&self, _: TableId) -> Option<Arc<TableOrViewSchema>> {
+                self.schema_for_view("v")
+            }
+
+            fn rls_rules_for_table(&self, _: TableId) -> anyhow::Result<Vec<Box<str>>> {
+                Ok(vec![])
+            }
+        }
+
+        fn build_view_def(
+            builder: &mut RawModuleDefV9Builder,
+            name: &str,
+            columns: impl Into<ProductType>,
+            is_anonymous: bool,
+        ) {
+            let product_type = AlgebraicType::from(columns.into());
+            let type_ref = builder.add_algebraic_type([], name, product_type, true);
+            let return_type = AlgebraicType::array(AlgebraicType::Ref(type_ref));
+            builder.add_view(name, true, is_anonymous, ProductType::unit(), return_type);
+        }
+
+        let mut builder = RawModuleDefV9Builder::new();
+        build_view_def(&mut builder, "v", [("a", AlgebraicType::String)], true);
+        let module_def: ModuleDef = builder.finish().try_into().expect("failed to generate module def");
+
+        let tx = SchemaViewer { module_def };
+
+        struct TestCase {
+            sql: &'static str,
+            msg: &'static str,
+        }
+
+        for TestCase { sql, msg } in [
+            TestCase {
+                sql: "select a from v",
+                msg: "Column projection on view",
+            },
+            TestCase {
+                sql: "select * from v where a = 'hello'",
+                msg: "Column selection on view",
+            },
+        ] {
+            let result = parse_and_type_sql(sql, &tx);
+            assert!(result.is_ok(), "{msg}");
+        }
+
+        for TestCase { sql, msg } in [
+            TestCase {
+                sql: "select b from v",
+                msg: "`v` does not have a column named `b`",
+            },
+            TestCase {
+                sql: "select sender from v",
+                msg: "`v` does not have a column named `sender`",
+            },
+            TestCase {
+                sql: "select arg_id from v",
+                msg: "`v` does not have a column named `arg_id`",
+            },
+        ] {
+            let result = parse_and_type_sql(sql, &tx);
+            assert!(result.is_err(), "{msg}");
+        }
     }
 }

--- a/crates/physical-plan/src/compile.rs
+++ b/crates/physical-plan/src/compile.rs
@@ -65,6 +65,7 @@ fn compile_rel_expr(var: &mut impl VarLabel, ast: RelExpr) -> PhysicalPlan {
     match ast {
         RelExpr::RelVar(Relvar { schema, alias, delta }) => {
             let label = var.label(alias.as_ref());
+            let schema = schema.inner();
             PhysicalPlan::TableScan(
                 TableScan {
                     schema,
@@ -97,7 +98,7 @@ fn compile_rel_expr(var: &mut impl VarLabel, ast: RelExpr) -> PhysicalPlan {
                 lhs: Box::new(compile_rel_expr(var, *lhs)),
                 rhs: Box::new(PhysicalPlan::TableScan(
                     TableScan {
-                        schema: rhs_schema,
+                        schema: rhs_schema.inner(),
                         limit: None,
                         delta,
                     },
@@ -130,7 +131,7 @@ fn compile_rel_expr(var: &mut impl VarLabel, ast: RelExpr) -> PhysicalPlan {
             let lhs = compile_rel_expr(var, *lhs);
             let rhs = PhysicalPlan::TableScan(
                 TableScan {
-                    schema: rhs_schema,
+                    schema: rhs_schema.inner(),
                     limit: None,
                     delta,
                 },

--- a/crates/physical-plan/src/dml.rs
+++ b/crates/physical-plan/src/dml.rs
@@ -7,7 +7,7 @@ use spacetimedb_expr::{
 };
 use spacetimedb_lib::{AlgebraicValue, ProductValue};
 use spacetimedb_primitives::ColId;
-use spacetimedb_schema::schema::TableSchema;
+use spacetimedb_schema::schema::TableOrViewSchema;
 
 use crate::{compile::compile_select, plan::ProjectPlan};
 
@@ -31,7 +31,7 @@ impl MutationPlan {
 
 /// A plan for inserting rows into a table
 pub struct InsertPlan {
-    pub table: Arc<TableSchema>,
+    pub table: Arc<TableOrViewSchema>,
     pub rows: Vec<ProductValue>,
 }
 
@@ -45,7 +45,7 @@ impl From<TableInsert> for InsertPlan {
 
 /// A plan for deleting rows from a table
 pub struct DeletePlan {
-    pub table: Arc<TableSchema>,
+    pub table: Arc<TableOrViewSchema>,
     pub filter: ProjectPlan,
 }
 
@@ -78,7 +78,7 @@ impl DeletePlan {
 
 /// A plan for updating rows in a table
 pub struct UpdatePlan {
-    pub table: Arc<TableSchema>,
+    pub table: Arc<TableOrViewSchema>,
     pub columns: Vec<(ColId, AlgebraicValue)>,
     pub filter: ProjectPlan,
 }

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -1209,7 +1209,7 @@ mod tests {
     use spacetimedb_primitives::{ColId, ColList, ColSet, TableId};
     use spacetimedb_schema::{
         def::{BTreeAlgorithm, ConstraintData, IndexAlgorithm, UniqueConstraintData},
-        schema::{ColumnSchema, ConstraintSchema, IndexSchema, TableSchema},
+        schema::{ColumnSchema, ConstraintSchema, IndexSchema, TableOrViewSchema, TableSchema},
     };
     use spacetimedb_sql_parser::ast::BinOp;
 
@@ -1221,7 +1221,7 @@ mod tests {
     use super::{PhysicalExpr, ProjectPlan, TableScan};
 
     struct SchemaViewer {
-        schemas: Vec<Arc<TableSchema>>,
+        schemas: Vec<Arc<TableOrViewSchema>>,
     }
 
     impl SchemaView for SchemaViewer {
@@ -1232,7 +1232,7 @@ mod tests {
                 .map(|schema| schema.table_id)
         }
 
-        fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableSchema>> {
+        fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableOrViewSchema>> {
             self.schemas.iter().find(|schema| schema.table_id == table_id).cloned()
         }
 
@@ -1248,10 +1248,11 @@ mod tests {
         indexes: &[&[usize]],
         unique: &[&[usize]],
         primary_key: Option<usize>,
-    ) -> TableSchema {
-        TableSchema::new(
+    ) -> TableOrViewSchema {
+        TableOrViewSchema::from(Arc::new(TableSchema::new(
             table_id,
             table_name.to_owned().into_boxed_str(),
+            None,
             columns
                 .iter()
                 .enumerate()
@@ -1291,7 +1292,7 @@ mod tests {
             StAccess::Public,
             None,
             primary_key.map(ColId::from),
-        )
+        )))
     }
 
     /// A wrapper around [spacetimedb_expr::check::parse_and_type_sub] that takes a dummy [AuthCtx]

--- a/crates/sats/src/product_value.rs
+++ b/crates/sats/src/product_value.rs
@@ -85,6 +85,7 @@ impl ProductValue {
     ///
     /// The resulting [AlgebraicValue] will wrap into a [ProductValue] when projecting multiple
     /// (including zero) fields, otherwise it will consist of a single [AlgebraicValue].
+    /// If you want to wrap single elements in a [ProductValue] as well, see [Self::project_product].
     ///
     /// **Parameters:**
     /// - `cols`: A [ColList] containing the indexes of fields to be projected.
@@ -98,6 +99,23 @@ impl ProductValue {
             }
             Ok(AlgebraicValue::product(fields))
         }
+    }
+
+    /// This utility function is designed to project fields based on the supplied `indexes`.
+    ///
+    /// **Important:**
+    ///
+    /// Returns a [ProductValue] even when projecting a single element.
+    /// If you don't want to wrap a single element in a [ProductValue], see [Self::project].
+    ///
+    /// **Parameters:**
+    /// - `cols`: A [ColList] containing the indexes of fields to be projected.
+    pub fn project_product(&self, cols: &ColList) -> Result<ProductValue, InvalidFieldError> {
+        let mut fields = Vec::with_capacity(cols.len() as usize);
+        for col in cols.iter() {
+            fields.push(self.get_field(col.idx(), None)?.clone());
+        }
+        Ok(ProductValue::from(fields))
     }
 
     /// Extracts the `value` at field of `self` identified by `index`

--- a/crates/schema/src/schema.rs
+++ b/crates/schema/src/schema.rs
@@ -50,6 +50,97 @@ pub trait Schema: Sized {
     fn check_compatible(&self, module_def: &ModuleDef, def: &Self::Def) -> Result<(), anyhow::Error>;
 }
 
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+pub struct ViewInfo {
+    pub view_id: ViewId,
+    pub has_args: bool,
+    pub is_anonymous: bool,
+}
+
+impl ViewInfo {
+    pub fn num_private_cols(&self) -> usize {
+        (if self.is_anonymous { 0 } else { 1 }) + (if self.has_args { 1 } else { 0 })
+    }
+}
+
+/// A wrapper around a [`TableSchema`] for views.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct TableOrViewSchema {
+    pub table_id: TableId,
+    pub view_info: Option<ViewInfo>,
+    pub table_name: Box<str>,
+    pub table_access: StAccess,
+    inner: Arc<TableSchema>,
+}
+
+impl From<Arc<TableSchema>> for TableOrViewSchema {
+    fn from(inner: Arc<TableSchema>) -> Self {
+        Self {
+            table_id: inner.table_id,
+            view_info: inner.view_info,
+            table_name: inner.table_name.clone(),
+            table_access: inner.table_access,
+            inner,
+        }
+    }
+}
+
+impl TableOrViewSchema {
+    /// Is this schema that of a view?
+    pub fn is_view(&self) -> bool {
+        self.view_info.is_some()
+    }
+
+    /// Is this schema that of an anonymous view?
+    pub fn is_anonymous_view(&self) -> bool {
+        self.view_info.as_ref().is_some_and(|view_info| view_info.is_anonymous)
+    }
+
+    /// Returns the [`TableSchema`] of the underlying datastore table.
+    /// For views, this schema will include the internal `sender` and `arg_id` columns.
+    pub fn inner(&self) -> Arc<TableSchema> {
+        self.inner.clone()
+    }
+
+    /// Returns the public columns of this table.
+    ///
+    /// The [`ColId`]s in this list do not necessarily correspond to their position in this list.
+    /// Rather they correspond to the position of the column in the physical datastore table.
+    /// This is important since this method may not return all columns recorded in the datastore.
+    /// For views in particular it will not include the internal `sender` and `arg_id` columns.
+    /// Hence columns in this list should be looked up by their [`ColId`] - not their position.
+    pub fn public_columns(&self) -> &[ColumnSchema] {
+        match self.view_info {
+            Some(ViewInfo {
+                has_args: true,
+                is_anonymous: false,
+                ..
+            }) => &self.inner.columns[2..],
+            Some(ViewInfo {
+                has_args: true,
+                is_anonymous: true,
+                ..
+            }) => &self.inner.columns[1..],
+            Some(ViewInfo {
+                has_args: false,
+                is_anonymous: false,
+                ..
+            }) => &self.inner.columns[1..],
+            Some(ViewInfo {
+                has_args: false,
+                is_anonymous: true,
+                ..
+            })
+            | None => &self.inner.columns,
+        }
+    }
+
+    /// Check if the `col_name` exist on this [`TableOrViewSchema`]
+    pub fn get_column_by_name(&self, col_name: &str) -> Option<&ColumnSchema> {
+        self.public_columns().iter().find(|x| &*x.col_name == col_name)
+    }
+}
+
 /// A data structure representing the schema of a database table.
 ///
 /// This struct holds information about the table, including its identifier,
@@ -62,6 +153,9 @@ pub struct TableSchema {
     /// The name of the table.
     // TODO(perf): This should likely be an `Arc<str>`, not a `Box<str>`, as we `Clone` it somewhat frequently.
     pub table_name: Box<str>,
+
+    /// Is this the backing table of a view?
+    pub view_info: Option<ViewInfo>,
 
     /// The columns of the table.
     /// The ordering of the columns is significant. Columns are frequently identified by `ColId`, that is, position in this list.
@@ -108,6 +202,7 @@ impl TableSchema {
     pub fn new(
         table_id: TableId,
         table_name: Box<str>,
+        view_info: Option<ViewInfo>,
         columns: Vec<ColumnSchema>,
         indexes: Vec<IndexSchema>,
         constraints: Vec<ConstraintSchema>,
@@ -121,6 +216,7 @@ impl TableSchema {
             row_type: columns_to_row_type(&columns),
             table_id,
             table_name,
+            view_info,
             columns,
             indexes,
             constraints,
@@ -151,6 +247,7 @@ impl TableSchema {
         TableSchema::new(
             TableId::SENTINEL,
             "TestTable".into(),
+            None,
             columns,
             vec![],
             vec![],
@@ -160,6 +257,24 @@ impl TableSchema {
             None,
             None,
         )
+    }
+
+    /// Is this the backing table for a view?
+    pub fn is_view(&self) -> bool {
+        self.view_info.is_some()
+    }
+
+    /// Is this the backing table for an anonymous view?
+    pub fn is_anonymous_view(&self) -> bool {
+        self.view_info.as_ref().is_some_and(|view_info| view_info.is_anonymous)
+    }
+
+    /// How many private columns does this table have?
+    /// Will only be non-zero in the case of views.
+    pub fn num_private_cols(&self) -> usize {
+        self.view_info
+            .map(|view_info| view_info.num_private_cols())
+            .unwrap_or_default()
     }
 
     /// Update the table id of this schema.
@@ -198,6 +313,11 @@ impl TableSchema {
     /// The ordering of the columns is significant. Columns are frequently identified by `ColId`, that is, position in this list.
     pub fn columns(&self) -> &[ColumnSchema] {
         &self.columns
+    }
+
+    /// How many columns does this table have?
+    pub fn num_cols(&self) -> usize {
+        self.columns.len()
     }
 
     /// Extracts all the [Self::indexes], [Self::sequences], and [Self::constraints].
@@ -599,6 +719,8 @@ impl TableSchema {
         let ViewDef {
             name,
             is_public,
+            is_anonymous,
+            param_columns,
             return_columns,
             ..
         } = view_def;
@@ -617,9 +739,16 @@ impl TableSchema {
             StAccess::Private
         };
 
+        let view_info = ViewInfo {
+            view_id: ViewId::SENTINEL,
+            has_args: !param_columns.is_empty(),
+            is_anonymous: *is_anonymous,
+        };
+
         TableSchema::new(
             TableId::SENTINEL,
             (*name).clone().into(),
+            Some(view_info),
             columns,
             vec![],
             vec![],
@@ -670,47 +799,61 @@ impl TableSchema {
         let ViewDef {
             name,
             is_public,
+            is_anonymous,
+            param_columns,
             return_columns,
             ..
         } = view_def;
 
         let n = return_columns.len() + 2;
         let mut columns = Vec::with_capacity(n);
+        let mut meta_cols = 0;
+        let mut index_name = format!("{name}");
 
-        let sender_col_name = "sender";
-        let arg_id_col_name = "arg_id";
+        let mut push_column = |name, col_type| {
+            meta_cols += 1;
+            index_name += "_";
+            index_name += name;
+            columns.push(ColumnSchema {
+                table_id: TableId::SENTINEL,
+                col_pos: columns.len().into(),
+                col_name: name.into(),
+                col_type,
+            });
+        };
 
-        columns.push(ColumnSchema {
-            table_id: TableId::SENTINEL,
-            col_pos: ColId(0),
-            col_name: sender_col_name.into(),
-            col_type: AlgebraicType::option(AlgebraicType::identity()),
-        });
+        if !is_anonymous {
+            push_column("sender", AlgebraicType::identity());
+        }
 
-        columns.push(ColumnSchema {
-            table_id: TableId::SENTINEL,
-            col_pos: ColId(1),
-            col_name: arg_id_col_name.into(),
-            col_type: AlgebraicType::U64,
-        });
+        if !param_columns.is_empty() {
+            push_column("arg_id", AlgebraicType::U64);
+        }
 
         columns.extend(
             return_columns
                 .iter()
                 .map(|def| ColumnSchema::from_view_column_def(module_def, def))
                 .enumerate()
-                .map(|(i, schema)| (ColId::from(i + 2), schema))
+                .map(|(i, schema)| (ColId::from(meta_cols + i), schema))
                 .map(|(col_pos, schema)| ColumnSchema { col_pos, ..schema }),
         );
 
-        let index_name = format!("{}_{}_{}_idx_btree", name, sender_col_name, arg_id_col_name);
+        let index_schema = |col_list: ColList| {
+            index_name += "idx_btree";
+            IndexSchema {
+                index_id: IndexId::SENTINEL,
+                table_id: TableId::SENTINEL,
+                index_name: index_name.into_boxed_str(),
+                index_algorithm: IndexAlgorithm::BTree(col_list.into()),
+            }
+        };
 
-        let indexes = vec![IndexSchema {
-            index_id: IndexId::SENTINEL,
-            table_id: TableId::SENTINEL,
-            index_name: index_name.into_boxed_str(),
-            index_algorithm: IndexAlgorithm::BTree(col_list![0, 1].into()),
-        }];
+        let indexes = match meta_cols {
+            1 => vec![index_schema(col_list![0])],
+            2 => vec![index_schema(col_list![0, 1])],
+            _ => vec![],
+        };
 
         let table_access = if *is_public {
             StAccess::Public
@@ -718,9 +861,16 @@ impl TableSchema {
             StAccess::Private
         };
 
+        let view_info = ViewInfo {
+            view_id: ViewId::SENTINEL,
+            has_args: !param_columns.is_empty(),
+            is_anonymous: *is_anonymous,
+        };
+
         TableSchema::new(
             TableId::SENTINEL,
             (*name).clone().into(),
+            Some(view_info),
             columns,
             indexes,
             vec![],
@@ -786,6 +936,7 @@ impl Schema for TableSchema {
         TableSchema::new(
             table_id,
             (*name).clone().into(),
+            None,
             columns,
             indexes,
             constraints,


### PR DESCRIPTION
# Description of Changes

Not many changes were required for the query compiler to be able to resolve views. This is because the query engine can always assume a view is materialized and therefore has a backing table. So from the perspective of the query engine, a view is just another table with one small caveat: The physical table in the datastore has two internal metadata columns - `sender` and `arg_id`. These columns are not user facing and so should be hidden from name resolution/type checking.

# API and ABI breaking changes

None

# Expected complexity level and risk

1.5

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] SQL type checking tests
