### PR TITLE
Add view handling to query engine and planner

### DIFF
--- a/crates/bench/benches/subscription.rs
+++ b/crates/bench/benches/subscription.rs
@@ -128,7 +128,7 @@ fn eval(c: &mut Criterion) {
             let (plans, table_id, table_name, _) = compile_subscription(sql, schema_viewer, &auth).unwrap();
             let plans = plans
                 .into_iter()
-                .map(|plan| plan.optimize().unwrap())
+                .map(|plan| plan.optimize(&auth).unwrap())
                 .map(PipelinedProject::from)
                 .collect::<Vec<_>>();
             let tx = DeltaTx::from(&tx);

--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -2088,6 +2088,57 @@ pub mod tests_utils {
         Ok((gen_cols, row_ref))
     }
 
+    /// Allocate a backing table in the datastore for a view
+    pub fn create_view_for_test(
+        db: &RelationalDB,
+        name: &str,
+        schema: &[(&str, AlgebraicType)],
+        is_anonymous: bool,
+    ) -> Result<TableId, DBError> {
+        let mut builder = RawModuleDefV9Builder::new();
+
+        // Add the view's product type to the typespace
+        let type_ref = builder.add_algebraic_type(
+            [],
+            name,
+            AlgebraicType::Product(ProductType::from_iter(schema.iter().cloned())),
+            true,
+        );
+
+        builder.add_view(
+            name,
+            true,
+            is_anonymous,
+            ProductType::unit(),
+            AlgebraicType::array(AlgebraicType::Ref(type_ref)),
+        );
+
+        let module_def: ModuleDef = builder.finish().try_into()?;
+        let view_def: &ViewDef = module_def.view(name).expect("view not found");
+
+        // Allocate a backing table and return its table id
+        db.with_auto_commit(Workload::Internal, |tx| db.create_view(tx, &module_def, view_def))
+            .map(|(_, table_id)| table_id)
+    }
+
+    /// Insert a row into a view's backing table
+    pub fn insert_into_view<'a>(
+        db: &'a RelationalDB,
+        tx: &'a mut MutTx,
+        table_id: TableId,
+        sender: Option<Identity>,
+        row: ProductValue,
+    ) -> Result<RowRef<'a>, DBError> {
+        let meta_cols = match sender {
+            Some(identity) => vec![identity.into()],
+            None => vec![],
+        };
+        let cols = meta_cols.into_iter().chain(row.elements);
+        let row = ProductValue::from_iter(cols);
+        db.insert(tx, table_id, &to_vec(&row).unwrap())
+            .map(|(_, row_ref, _)| row_ref)
+    }
+
     /// An in-memory commitlog used for tests that want to replay a known history.
     pub struct TestHistory(commitlog::commitlog::Generic<commitlog::repo::Memory, Txdata>);
 

--- a/crates/core/src/estimation.rs
+++ b/crates/core/src/estimation.rs
@@ -198,7 +198,7 @@ mod tests {
             .map(|(plans, ..)| plans)
             .expect("failed to compile sql query")
             .into_iter()
-            .map(|plan| plan.optimize().expect("failed to optimize sql query"))
+            .map(|plan| plan.optimize(&auth).expect("failed to optimize sql query"))
             .map(|plan| row_estimate(&tx, &plan))
             .sum()
     }

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -17,10 +17,10 @@ use crate::module_host_context::ModuleCreationContext;
 use crate::replica_context::ReplicaContext;
 use crate::sql::ast::SchemaViewer;
 use crate::sql::parser::RowLevelExpr;
-use crate::subscription::execute_plan;
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
 use crate::subscription::tx::DeltaTx;
 use crate::subscription::websocket_building::BuildableWebsocketFormat;
+use crate::subscription::{execute_plan, execute_plan_for_view};
 use crate::util::jobs::{SingleCoreExecutor, WeakSingleCoreExecutor};
 use crate::vm::check_row_limit;
 use crate::worker_metrics::WORKER_METRICS;
@@ -41,7 +41,7 @@ use spacetimedb_datastore::locking_tx_datastore::MutTxId;
 use spacetimedb_datastore::system_tables::{ST_CLIENT_ID, ST_CONNECTION_CREDENTIALS_ID};
 use spacetimedb_datastore::traits::{IsolationLevel, Program, TxData};
 use spacetimedb_durability::DurableOffset;
-use spacetimedb_execution::pipelined::PipelinedProject;
+use spacetimedb_execution::pipelined::{PipelinedProject, ViewProject};
 use spacetimedb_lib::db::raw_def::v9::Lifecycle;
 use spacetimedb_lib::identity::{AuthCtx, RequestId};
 use spacetimedb_lib::metrics::ExecutionMetrics;
@@ -1495,7 +1495,7 @@ impl ModuleHost {
                     // Optimize each fragment
                     let optimized = plans
                         .into_iter()
-                        .map(|plan| plan.optimize())
+                        .map(|plan| plan.optimize(&auth))
                         .collect::<Result<Vec<_>, _>>()?;
 
                     check_row_limit(
@@ -1507,11 +1507,30 @@ impl ModuleHost {
                         &auth,
                     )?;
 
+                    let return_table = || optimized.first().and_then(|plan| plan.return_table());
+
+                    let returns_view_table = optimized.first().is_some_and(|plan| plan.returns_view_table());
+                    let num_cols = return_table().map(|schema| schema.num_cols()).unwrap_or_default();
+                    let num_private_cols = return_table()
+                        .map(|schema| schema.num_private_cols())
+                        .unwrap_or_default();
+
                     let optimized = optimized
                         .into_iter()
                         // Convert into something we can execute
                         .map(PipelinedProject::from)
                         .collect::<Vec<_>>();
+
+                    if returns_view_table && num_private_cols > 0 {
+                        let optimized = optimized
+                            .into_iter()
+                            .map(|plan| ViewProject::new(plan, num_cols, num_private_cols))
+                            .collect::<Vec<_>>();
+                        // Execute the union and return the results
+                        return execute_plan_for_view::<_, F>(&optimized, &DeltaTx::from(&*tx))
+                            .map(|(rows, _, metrics)| (OneOffTable { table_name, rows }, metrics))
+                            .context("One-off queries are not allowed to modify the database");
+                    }
 
                     // Execute the union and return the results
                     execute_plan::<_, F>(&optimized, &DeltaTx::from(&*tx))

--- a/crates/physical-plan/src/dml.rs
+++ b/crates/physical-plan/src/dml.rs
@@ -5,7 +5,7 @@ use spacetimedb_expr::{
     expr::{ProjectName, RelExpr, Relvar},
     statement::{TableDelete, TableInsert, TableUpdate},
 };
-use spacetimedb_lib::{AlgebraicValue, ProductValue};
+use spacetimedb_lib::{identity::AuthCtx, AlgebraicValue, ProductValue};
 use spacetimedb_primitives::ColId;
 use spacetimedb_schema::schema::TableOrViewSchema;
 
@@ -20,11 +20,11 @@ pub enum MutationPlan {
 
 impl MutationPlan {
     /// Optimizes the filters in updates and deletes
-    pub fn optimize(self) -> Result<Self> {
+    pub fn optimize(self, auth: &AuthCtx) -> Result<Self> {
         match self {
             Self::Insert(..) => Ok(self),
-            Self::Delete(plan) => Ok(Self::Delete(plan.optimize()?)),
-            Self::Update(plan) => Ok(Self::Update(plan.optimize()?)),
+            Self::Delete(plan) => Ok(Self::Delete(plan.optimize(auth)?)),
+            Self::Update(plan) => Ok(Self::Update(plan.optimize(auth)?)),
         }
     }
 }
@@ -51,9 +51,9 @@ pub struct DeletePlan {
 
 impl DeletePlan {
     /// Optimize the filter part of the delete
-    fn optimize(self) -> Result<Self> {
+    fn optimize(self, auth: &AuthCtx) -> Result<Self> {
         let Self { table, filter } = self;
-        let filter = filter.optimize()?;
+        let filter = filter.optimize(auth)?;
         Ok(Self { table, filter })
     }
 
@@ -85,9 +85,9 @@ pub struct UpdatePlan {
 
 impl UpdatePlan {
     /// Optimize the filter part of the update
-    fn optimize(self) -> Result<Self> {
+    fn optimize(self, auth: &AuthCtx) -> Result<Self> {
         let Self { table, columns, filter } = self;
-        let filter = filter.optimize()?;
+        let filter = filter.optimize(auth)?;
         Ok(Self { columns, table, filter })
     }
 

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -64,12 +64,13 @@ pub fn compile_sql_stmt(sql: &str, tx: &impl SchemaView, auth: &AuthCtx) -> Resu
 
 /// A utility for executing a sql select statement
 pub fn execute_select_stmt<Tx: Datastore + DeltaStore>(
+    auth: &AuthCtx,
     stmt: ProjectList,
     tx: &Tx,
     metrics: &mut ExecutionMetrics,
     check_row_limit: impl Fn(ProjectListPlan) -> Result<ProjectListPlan>,
 ) -> Result<Vec<ProductValue>> {
-    let plan = compile_select_list(stmt).optimize()?;
+    let plan = compile_select_list(stmt).optimize(auth)?;
     let plan = check_row_limit(plan)?;
     let plan = ProjectListExecutor::from(plan);
     let mut rows = vec![];
@@ -81,8 +82,13 @@ pub fn execute_select_stmt<Tx: Datastore + DeltaStore>(
 }
 
 /// A utility for executing a sql dml statement
-pub fn execute_dml_stmt<Tx: MutDatastore>(stmt: DML, tx: &mut Tx, metrics: &mut ExecutionMetrics) -> Result<()> {
-    let plan = compile_dml_plan(stmt).optimize()?;
+pub fn execute_dml_stmt<Tx: MutDatastore>(
+    auth: &AuthCtx,
+    stmt: DML,
+    tx: &mut Tx,
+    metrics: &mut ExecutionMetrics,
+) -> Result<()> {
+    let plan = compile_dml_plan(stmt).optimize(auth)?;
     let plan = MutExecutor::from(plan);
     plan.execute(tx, metrics)
 }

--- a/crates/subscription/src/lib.rs
+++ b/crates/subscription/src/lib.rs
@@ -159,7 +159,7 @@ impl Fragments {
     /// dv(+) = R'ds(+) U dr(+)S' U dr(+)ds(-) U dr(-)ds(+)
     /// dv(-) = R'ds(-) U dr(-)S' U dr(+)ds(+) U dr(-)ds(-)
     /// ```
-    fn compile_from_plan(plan: &ProjectPlan, tables: &[Label]) -> Result<Self> {
+    fn compile_from_plan(plan: &ProjectPlan, tables: &[Label], auth: &AuthCtx) -> Result<Self> {
         /// Mutate a query plan by turning a table scan into a delta scan
         fn mut_plan(plan: &mut ProjectPlan, relvar: Label, delta: Delta) {
             plan.visit_mut(&mut |plan| match plan {
@@ -178,18 +178,18 @@ impl Fragments {
         }
 
         /// Return a new plan with delta scans for the given tables
-        fn new_plan(plan: &ProjectPlan, tables: &[(Label, Delta)]) -> Result<PipelinedProject> {
+        fn new_plan(plan: &ProjectPlan, tables: &[(Label, Delta)], auth: &AuthCtx) -> Result<PipelinedProject> {
             let mut plan = plan.clone();
             for (alias, delta) in tables {
                 mut_plan(&mut plan, *alias, *delta);
             }
-            plan.optimize().map(PipelinedProject::from)
+            plan.optimize(auth).map(PipelinedProject::from)
         }
 
         match tables {
             [dr] => Ok(Fragments {
-                insert_plans: vec![new_plan(plan, &[(*dr, Delta::Inserts)])?],
-                delete_plans: vec![new_plan(plan, &[(*dr, Delta::Deletes)])?],
+                insert_plans: vec![new_plan(plan, &[(*dr, Delta::Inserts)], auth)?],
+                delete_plans: vec![new_plan(plan, &[(*dr, Delta::Deletes)], auth)?],
             }),
             [dr, ds] => Ok(Fragments {
                 insert_plans: vec![
@@ -197,21 +197,25 @@ impl Fragments {
                         // dr(+)S'
                         plan,
                         &[(*dr, Delta::Inserts)],
+                        auth,
                     )?,
                     new_plan(
                         // R'ds(+)
                         plan,
                         &[(*ds, Delta::Inserts)],
+                        auth,
                     )?,
                     new_plan(
                         // dr(+)ds(-)
                         plan,
                         &[(*dr, Delta::Inserts), (*ds, Delta::Deletes)],
+                        auth,
                     )?,
                     new_plan(
                         // dr(-)ds(+)
                         plan,
                         &[(*dr, Delta::Deletes), (*ds, Delta::Inserts)],
+                        auth,
                     )?,
                 ],
                 delete_plans: vec![
@@ -219,21 +223,25 @@ impl Fragments {
                         // dr(-)S'
                         plan,
                         &[(*dr, Delta::Deletes)],
+                        auth,
                     )?,
                     new_plan(
                         // R'ds(-)
                         plan,
                         &[(*ds, Delta::Deletes)],
+                        auth,
                     )?,
                     new_plan(
                         // dr(+)ds(+)
                         plan,
                         &[(*dr, Delta::Inserts), (*ds, Delta::Inserts)],
+                        auth,
                     )?,
                     new_plan(
                         // dr(-)ds(-)
                         plan,
                         &[(*dr, Delta::Deletes), (*ds, Delta::Deletes)],
+                        auth,
                     )?,
                 ],
             }),
@@ -513,7 +521,7 @@ impl SubscriptionPlan {
         let return_name = TableName::from(return_name);
 
         for plan in plans {
-            let plan_opt = plan.clone().optimize()?;
+            let plan_opt = plan.clone().optimize(auth)?;
 
             if has_non_index_join(&plan_opt) {
                 bail!("Subscriptions require indexes on join columns")
@@ -521,7 +529,7 @@ impl SubscriptionPlan {
 
             let (table_ids, table_aliases) = table_ids_for_plan(&plan);
 
-            let fragments = Fragments::compile_from_plan(&plan, &table_aliases)?;
+            let fragments = Fragments::compile_from_plan(&plan, &table_aliases, auth)?;
 
             subscriptions.push(Self {
                 return_id,


### PR DESCRIPTION
# Description of Changes

This patch does the following:

1. Expands views as part of query planning. Views are always assumed to be materialized by the query planner, however a view's backing table may have private columns such as the `sender` column. The query planner needs to filter by this column in order to select the rows pertaining to a particular caller.
2. Plumbs `AuthCtx` through the query optimizer. This is needed in order to implement (1).
3. Adds a new operator for views to the query engine that drops a view's private columns

# API and ABI breaking changes

None

# Expected complexity level and risk

2.5

# Testing

- [x] SQL http tests
- [ ] Subscription tests
- [ ] One off query tests
