### PR TITLE
[teams 1/5] Reset database

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7227,6 +7227,7 @@ dependencies = [
  "spacetimedb-paths",
  "spacetimedb-schema",
  "tempfile",
+ "thiserror 1.0.69",
  "tokio",
  "tokio-stream",
  "tokio-tungstenite",
@@ -7979,6 +7980,7 @@ name = "spacetimedb-testing"
 version = "1.6.0"
 dependencies = [
  "anyhow",
+ "bytes",
  "clap 4.5.50",
  "duct",
  "env_logger 0.10.2",

--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -8,8 +8,8 @@ use std::path::PathBuf;
 use std::{env, fs};
 
 use crate::config::Config;
-use crate::util::{add_auth_header_opt, get_auth_header, AuthHeader, ResponseExt};
-use crate::util::{decode_identity, unauth_error_context, y_or_n};
+use crate::util::{add_auth_header_opt, get_auth_header, unauth_error_context, AuthHeader, ResponseExt};
+use crate::util::{decode_identity, y_or_n};
 use crate::{build, common_args};
 
 pub fn cli() -> clap::Command {

--- a/crates/client-api/Cargo.toml
+++ b/crates/client-api/Cargo.toml
@@ -53,6 +53,7 @@ scopeguard.workspace = true
 serde_with.workspace = true
 async-stream.workspace = true
 humantime.workspace = true
+thiserror.workspace = true
 
 [target.'cfg(not(target_env = "msvc"))'.dependencies]
 jemalloc_pprof.workspace = true

--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -3,6 +3,7 @@ use std::sync::Arc;
 
 use async_trait::async_trait;
 use axum::response::ErrorResponse;
+use bytes::Bytes;
 use http::StatusCode;
 
 use spacetimedb::client::ClientActorIndex;
@@ -162,13 +163,21 @@ pub struct DatabaseDef {
     /// The [`Identity`] the database shall have.
     pub database_identity: Identity,
     /// The compiled program of the database module.
-    pub program_bytes: Vec<u8>,
+    pub program_bytes: Bytes,
     /// The desired number of replicas the database shall have.
     ///
     /// If `None`, the edition default is used.
     pub num_replicas: Option<NonZeroU8>,
     /// The host type of the supplied program.
     pub host_type: HostType,
+}
+
+/// Parameters for resetting a database via [`ControlStateDelegate::reset_database`].
+pub struct DatabaseResetDef {
+    pub database_identity: Identity,
+    pub program_bytes: Option<Bytes>,
+    pub num_replicas: Option<NonZeroU8>,
+    pub host_type: Option<HostType>,
 }
 
 /// API of the SpacetimeDB control plane.
@@ -239,6 +248,10 @@ pub trait ControlStateWriteAccess: Send + Sync {
     async fn migrate_plan(&self, spec: DatabaseDef, style: PrettyPrintStyle) -> anyhow::Result<MigratePlanResult>;
 
     async fn delete_database(&self, caller_identity: &Identity, database_identity: &Identity) -> anyhow::Result<()>;
+
+    /// Remove all data from a database, and reset it according to the
+    /// given [DatabaseResetDef].
+    async fn reset_database(&self, caller_identity: &Identity, spec: DatabaseResetDef) -> anyhow::Result<()>;
 
     // Energy
     async fn add_energy(&self, identity: &Identity, amount: EnergyQuanta) -> anyhow::Result<()>;
@@ -337,6 +350,10 @@ impl<T: ControlStateWriteAccess + ?Sized> ControlStateWriteAccess for Arc<T> {
 
     async fn delete_database(&self, caller_identity: &Identity, database_identity: &Identity) -> anyhow::Result<()> {
         (**self).delete_database(caller_identity, database_identity).await
+    }
+
+    async fn reset_database(&self, caller_identity: &Identity, spec: DatabaseResetDef) -> anyhow::Result<()> {
+        (**self).reset_database(caller_identity, spec).await
     }
 
     async fn add_energy(&self, identity: &Identity, amount: EnergyQuanta) -> anyhow::Result<()> {

--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -1,3 +1,5 @@
+use std::borrow::Cow;
+use std::env;
 use std::num::NonZeroU8;
 use std::str::FromStr;
 use std::time::Duration;
@@ -8,7 +10,7 @@ use crate::auth::{
 };
 use crate::routes::subscribe::generate_random_connection_id;
 pub use crate::util::{ByteStringBody, NameOrIdentity};
-use crate::{log_and_500, ControlStateDelegate, DatabaseDef, Host, NodeDelegate};
+use crate::{log_and_500, ControlStateDelegate, DatabaseDef, DatabaseResetDef, Host, NodeDelegate};
 use axum::body::{Body, Bytes};
 use axum::extract::{Path, Query, State};
 use axum::response::{ErrorResponse, IntoResponse};
@@ -24,20 +26,43 @@ use spacetimedb::host::UpdateDatabaseResult;
 use spacetimedb::host::{FunctionArgs, MigratePlanResult};
 use spacetimedb::host::{ModuleHost, ReducerOutcome};
 use spacetimedb::host::{ProcedureCallError, ReducerCallError};
-use spacetimedb::identity::Identity;
 use spacetimedb::messages::control_db::{Database, HostType};
+use spacetimedb_client_api_messages::http::SqlStmtResult;
 use spacetimedb_client_api_messages::name::{
     self, DatabaseName, DomainName, MigrationPolicy, PrePublishResult, PrettyPrintStyle, PublishOp, PublishResult,
 };
 use spacetimedb_lib::db::raw_def::v9::RawModuleDefV9;
-use spacetimedb_lib::identity::AuthCtx;
-use spacetimedb_lib::{sats, AlgebraicValue, ProductValue, Timestamp};
+use spacetimedb_lib::identity::{AuthCtx, Identity};
+use spacetimedb_lib::{sats, AlgebraicValue, Hash, ProductValue, Timestamp};
 use spacetimedb_schema::auto_migrate::{
     MigrationPolicy as SchemaMigrationPolicy, MigrationToken, PrettyPrintStyle as AutoMigratePrettyPrintStyle,
 };
 
 use super::subscribe::{handle_websocket, HasWebSocketOptions};
 
+fn require_spacetime_auth_for_creation() -> bool {
+    env::var("TEMP_REQUIRE_SPACETIME_AUTH").is_ok_and(|v| !v.is_empty())
+}
+
+// A hacky function to let us restrict database creation on maincloud.
+fn allow_creation(auth: &SpacetimeAuth) -> Result<(), ErrorResponse> {
+    if !require_spacetime_auth_for_creation() {
+        return Ok(());
+    }
+    if auth.claims.issuer.trim_end_matches('/') == "https://auth.spacetimedb.com" {
+        Ok(())
+    } else {
+        log::trace!(
+            "Rejecting creation request because auth issuer is {}",
+            auth.claims.issuer
+        );
+        Err((
+            StatusCode::UNAUTHORIZED,
+            "To create a database, you must be logged in with a SpacetimeDB account.",
+        )
+            .into())
+    }
+}
 #[derive(Deserialize)]
 pub struct CallParams {
     name_or_identity: NameOrIdentity,
@@ -581,6 +606,61 @@ pub async fn get_names<S: ControlStateDelegate>(
 }
 
 #[derive(Deserialize)]
+pub struct ResetDatabaseParams {
+    name_or_identity: NameOrIdentity,
+}
+
+#[derive(Deserialize)]
+pub struct ResetDatabaseQueryParams {
+    num_replicas: Option<usize>,
+    #[serde(default)]
+    host_type: HostType,
+}
+
+pub async fn reset<S: NodeDelegate + ControlStateDelegate>(
+    State(ctx): State<S>,
+    Path(ResetDatabaseParams { name_or_identity }): Path<ResetDatabaseParams>,
+    Query(ResetDatabaseQueryParams {
+        num_replicas,
+        host_type,
+    }): Query<ResetDatabaseQueryParams>,
+    Extension(auth): Extension<SpacetimeAuth>,
+    program_bytes: Option<Bytes>,
+) -> axum::response::Result<axum::Json<PublishResult>> {
+    let database_identity = name_or_identity.resolve(&ctx).await?;
+    let database = worker_ctx_find_database(&ctx, &database_identity)
+        .await?
+        .ok_or(NO_SUCH_DATABASE)?;
+
+    if database.database_identity != auth.claims.identity {
+        return Err((
+            StatusCode::UNAUTHORIZED,
+            "only the database owner can reset / clear a database",
+        )
+            .into());
+    }
+
+    let num_replicas = num_replicas.map(validate_replication_factor).transpose()?.flatten();
+    ctx.reset_database(
+        &auth.claims.identity,
+        DatabaseResetDef {
+            database_identity,
+            program_bytes,
+            num_replicas,
+            host_type: Some(host_type),
+        },
+    )
+    .await
+    .map_err(log_and_500)?;
+
+    Ok(axum::Json(PublishResult::Success {
+        domain: name_or_identity.name().cloned(),
+        database_identity,
+        op: PublishOp::Updated,
+    }))
+}
+
+#[derive(Deserialize)]
 pub struct PublishDatabaseParams {
     name_or_identity: Option<NameOrIdentity>,
 }
@@ -594,38 +674,11 @@ pub struct PublishDatabaseQueryParams {
     ///
     /// Users obtain such a hash via the `/database/:name_or_identity/pre-publish POST` route.
     /// This is a safeguard to require explicit approval for updates which will break clients.
-    token: Option<spacetimedb_lib::Hash>,
+    token: Option<Hash>,
     #[serde(default)]
     policy: MigrationPolicy,
     #[serde(default)]
     host_type: HostType,
-}
-
-use spacetimedb_client_api_messages::http::SqlStmtResult;
-use std::env;
-
-fn require_spacetime_auth_for_creation() -> bool {
-    env::var("TEMP_REQUIRE_SPACETIME_AUTH").is_ok_and(|v| !v.is_empty())
-}
-
-// A hacky function to let us restrict database creation on maincloud.
-fn allow_creation(auth: &SpacetimeAuth) -> Result<(), ErrorResponse> {
-    if !require_spacetime_auth_for_creation() {
-        return Ok(());
-    }
-    if auth.claims.issuer.trim_end_matches('/') == "https://auth.spacetimedb.com" {
-        Ok(())
-    } else {
-        log::trace!(
-            "Rejecting creation request because auth issuer is {}",
-            auth.claims.issuer
-        );
-        Err((
-            StatusCode::UNAUTHORIZED,
-            "To create a database, you must be logged in with a SpacetimeDB account.",
-        )
-            .into())
-    }
 }
 
 pub async fn publish<S: NodeDelegate + ControlStateDelegate>(
@@ -639,142 +692,190 @@ pub async fn publish<S: NodeDelegate + ControlStateDelegate>(
         host_type,
     }): Query<PublishDatabaseQueryParams>,
     Extension(auth): Extension<SpacetimeAuth>,
-    body: Bytes,
+    program_bytes: Bytes,
 ) -> axum::response::Result<axum::Json<PublishResult>> {
-    // You should not be able to publish to a database that you do not own
-    // so, unless you are the owner, this will fail.
-
-    let (database_identity, db_name) = match &name_or_identity {
-        Some(noa) => match noa.try_resolve(&ctx).await.map_err(log_and_500)? {
-            Ok(resolved) => (resolved, noa.name()),
-            Err(name) => {
-                // `name_or_identity` was a `NameOrIdentity::Name`, but no record
-                // exists yet. Create it now with a fresh identity.
-                allow_creation(&auth)?;
-                let database_auth = SpacetimeAuth::alloc(&ctx).await?;
-                let database_identity = database_auth.claims.identity;
-                let tld: name::Tld = name.clone().into();
-                let tld = match ctx
-                    .register_tld(&auth.claims.identity, tld)
-                    .await
-                    .map_err(log_and_500)?
-                {
-                    name::RegisterTldResult::Success { domain }
-                    | name::RegisterTldResult::AlreadyRegistered { domain } => domain,
-                    name::RegisterTldResult::Unauthorized { .. } => {
-                        return Err((
-                            StatusCode::UNAUTHORIZED,
-                            axum::Json(PublishResult::PermissionDenied { name: name.clone() }),
-                        )
-                            .into())
-                    }
-                };
-                let res = ctx
-                    .create_dns_record(&auth.claims.identity, &tld.into(), &database_identity)
-                    .await
-                    .map_err(log_and_500)?;
-                match res {
-                    name::InsertDomainResult::Success { .. } => {}
-                    name::InsertDomainResult::TldNotRegistered { .. }
-                    | name::InsertDomainResult::PermissionDenied { .. } => {
-                        return Err(log_and_500("impossible: we just registered the tld"))
-                    }
-                    name::InsertDomainResult::OtherError(e) => return Err(log_and_500(e)),
-                }
-                (database_identity, Some(name))
-            }
-        },
-        None => {
-            let database_auth = SpacetimeAuth::alloc(&ctx).await?;
-            let database_identity = database_auth.claims.identity;
-            (database_identity, None)
-        }
-    };
-
-    let policy: SchemaMigrationPolicy = match policy {
-        MigrationPolicy::BreakClients => {
-            if let Some(token) = token {
-                Ok(SchemaMigrationPolicy::BreakClients(token))
-            } else {
-                Err((
-                    StatusCode::BAD_REQUEST,
-                    "Migration policy is set to `BreakClients`, but no migration token was provided.",
-                ))
+    // If `clear`, check that the database exists and delegate to `reset`.
+    // If it doesn't exist, ignore the `clear` parameter.
+    // TODO: Replace with actual redirect at the next possible version bump.
+    if clear {
+        let name_or_identity = name_or_identity
+            .as_ref()
+            .ok_or_else(|| bad_request("Clear database requires database name or identity".into()))?;
+        if let Ok(identity) = name_or_identity.try_resolve(&ctx).await.map_err(log_and_500)? {
+            if ctx.get_database_by_identity(&identity).map_err(log_and_500)?.is_some() {
+                return reset(
+                    State(ctx),
+                    Path(ResetDatabaseParams {
+                        name_or_identity: name_or_identity.clone(),
+                    }),
+                    Query(ResetDatabaseQueryParams {
+                        num_replicas,
+                        host_type,
+                    }),
+                    Extension(auth),
+                    Some(program_bytes),
+                )
+                .await;
             }
         }
+    }
 
-        MigrationPolicy::Compatible => Ok(SchemaMigrationPolicy::Compatible),
-    }?;
+    let (database_identity, db_name) = get_or_create_identity_and_name(&ctx, &auth, name_or_identity.as_ref()).await?;
+
+    // Check that the replication factor looks somewhat sane.
+    let num_replicas = num_replicas.map(validate_replication_factor).transpose()?.flatten();
 
     log::trace!("Publishing to the identity: {}", database_identity.to_hex());
 
-    let op = {
-        let exists = ctx
-            .get_database_by_identity(&database_identity)
-            .map_err(log_and_500)?
-            .is_some();
-        if !exists {
+    // Check if the database already exists.
+    let existing = ctx.get_database_by_identity(&database_identity).map_err(log_and_500)?;
+    match existing.as_ref() {
+        // If not, check that the we caller is sufficiently authenticated.
+        None => {
             allow_creation(&auth)?;
         }
-
-        if clear && exists {
-            ctx.delete_database(&auth.claims.identity, &database_identity)
-                .await
-                .map_err(log_and_500)?;
+        // If yes, authorize via ctx.
+        Some(database) => {
+            // NOTE: This is redundant at the moment, but will be replaced by
+            // a more interesting authorization check with the "teams" feature.
+            if database.owner_identity != auth.claims.identity {
+                return Err((StatusCode::UNAUTHORIZED, "a database can only be updated by its owner").into());
+            }
         }
+    }
 
-        if exists {
-            PublishOp::Updated
-        } else {
-            PublishOp::Created
-        }
+    // Indicate in the response whether we created or updated the database.
+    let publish_op = if existing.is_some() {
+        PublishOp::Updated
+    } else {
+        PublishOp::Created
     };
 
-    let num_replicas = num_replicas
-        .map(|n| {
-            let n = u8::try_from(n).map_err(|_| (StatusCode::BAD_REQUEST, "Replication factor {n} out of bounds"))?;
-            Ok::<_, ErrorResponse>(NonZeroU8::new(n))
-        })
-        .transpose()?
-        .flatten();
-
+    let schema_migration_policy = schema_migration_policy(policy, token)?;
     let maybe_updated = ctx
         .publish_database(
             &auth.claims.identity,
             DatabaseDef {
                 database_identity,
-                program_bytes: body.into(),
+                program_bytes,
                 num_replicas,
                 host_type,
             },
-            policy,
+            schema_migration_policy,
         )
         .await
         .map_err(log_and_500)?;
 
-    if let Some(updated) = maybe_updated {
-        match updated {
-            UpdateDatabaseResult::AutoMigrateError(errs) => {
-                return Err((StatusCode::BAD_REQUEST, format!("Database update rejected: {errs}")).into());
-            }
-            UpdateDatabaseResult::ErrorExecutingMigration(err) => {
-                return Err((
-                    StatusCode::BAD_REQUEST,
-                    format!("Failed to create or update the database: {err}"),
-                )
-                    .into());
-            }
+    match maybe_updated {
+        Some(UpdateDatabaseResult::AutoMigrateError(errs)) => {
+            Err(bad_request(format!("Database update rejected: {errs}").into()))
+        }
+        Some(UpdateDatabaseResult::ErrorExecutingMigration(err)) => Err(bad_request(
+            format!("Failed to create or update the database: {err}").into(),
+        )),
+        None
+        | Some(
             UpdateDatabaseResult::NoUpdateNeeded
             | UpdateDatabaseResult::UpdatePerformed
-            | UpdateDatabaseResult::UpdatePerformedWithClientDisconnect => {}
+            | UpdateDatabaseResult::UpdatePerformedWithClientDisconnect,
+        ) => Ok(axum::Json(PublishResult::Success {
+            domain: db_name.cloned(),
+            database_identity,
+            op: publish_op,
+        })),
+    }
+}
+
+/// Try to resolve `name_or_identity` to an [Identity] and [DatabaseName].
+///
+/// - If the database exists and has a name registered for it, return that.
+/// - If the database does not exist, but `name_or_identity` is a name,
+///   try to register the name and return alongside a newly allocated [Identity]
+/// - Otherwise, if the database does not exist and `name_or_identity` is `None`,
+///   allocate a fresh [Identity] and no name.
+///
+async fn get_or_create_identity_and_name<'a>(
+    ctx: &(impl ControlStateDelegate + NodeDelegate),
+    auth: &SpacetimeAuth,
+    name_or_identity: Option<&'a NameOrIdentity>,
+) -> axum::response::Result<(Identity, Option<&'a DatabaseName>)> {
+    match name_or_identity {
+        Some(noi) => match noi.try_resolve(ctx).await.map_err(log_and_500)? {
+            Ok(resolved) => Ok((resolved, noi.name())),
+            Err(name) => {
+                // `name_or_identity` was a `NameOrIdentity::Name`, but no record
+                // exists yet. Create it now with a fresh identity.
+                allow_creation(auth)?;
+                let database_auth = SpacetimeAuth::alloc(ctx).await?;
+                let database_identity = database_auth.claims.identity;
+                create_name(ctx, auth, &database_identity, name).await?;
+                Ok((database_identity, Some(name)))
+            }
+        },
+        None => {
+            let database_auth = SpacetimeAuth::alloc(ctx).await?;
+            let database_identity = database_auth.claims.identity;
+            Ok((database_identity, None))
         }
     }
+}
 
-    Ok(axum::Json(PublishResult::Success {
-        domain: db_name.cloned(),
-        database_identity,
-        op,
-    }))
+/// Try to register `name` for database `database_identity`.
+async fn create_name(
+    ctx: &(impl NodeDelegate + ControlStateDelegate),
+    auth: &SpacetimeAuth,
+    database_identity: &Identity,
+    name: &DatabaseName,
+) -> axum::response::Result<()> {
+    let tld: name::Tld = name.clone().into();
+    let tld = match ctx
+        .register_tld(&auth.claims.identity, tld)
+        .await
+        .map_err(log_and_500)?
+    {
+        name::RegisterTldResult::Success { domain } | name::RegisterTldResult::AlreadyRegistered { domain } => domain,
+        name::RegisterTldResult::Unauthorized { .. } => {
+            return Err((
+                StatusCode::UNAUTHORIZED,
+                axum::Json(PublishResult::PermissionDenied { name: name.clone() }),
+            )
+                .into())
+        }
+    };
+    let res = ctx
+        .create_dns_record(&auth.claims.identity, &tld.into(), database_identity)
+        .await
+        .map_err(log_and_500)?;
+    match res {
+        name::InsertDomainResult::Success { .. } => Ok(()),
+        name::InsertDomainResult::TldNotRegistered { .. } | name::InsertDomainResult::PermissionDenied { .. } => {
+            Err(log_and_500("impossible: we just registered the tld"))
+        }
+        name::InsertDomainResult::OtherError(e) => Err(log_and_500(e)),
+    }
+}
+
+fn schema_migration_policy(
+    policy: MigrationPolicy,
+    token: Option<Hash>,
+) -> axum::response::Result<SchemaMigrationPolicy> {
+    const MISSING_TOKEN: &str = "Migration policy is set to `BreakClients`, but no migration token was provided.";
+
+    match policy {
+        MigrationPolicy::BreakClients => token
+            .map(SchemaMigrationPolicy::BreakClients)
+            .ok_or_else(|| bad_request(MISSING_TOKEN.into())),
+        MigrationPolicy::Compatible => Ok(SchemaMigrationPolicy::Compatible),
+    }
+}
+
+fn validate_replication_factor(n: usize) -> Result<Option<NonZeroU8>, ErrorResponse> {
+    let n = u8::try_from(n).map_err(|_| bad_request(format!("Replication factor {n} out of bounds").into()))?;
+    Ok(NonZeroU8::new(n))
+}
+
+fn bad_request(message: Cow<'static, str>) -> ErrorResponse {
+    (StatusCode::BAD_REQUEST, message).into()
 }
 
 #[derive(serde::Deserialize)]
@@ -795,7 +896,7 @@ pub async fn pre_publish<S: NodeDelegate + ControlStateDelegate>(
     Path(PrePublishParams { name_or_identity }): Path<PrePublishParams>,
     Query(PrePublishQueryParams { style, host_type }): Query<PrePublishQueryParams>,
     Extension(auth): Extension<SpacetimeAuth>,
-    body: Bytes,
+    program_bytes: Bytes,
 ) -> axum::response::Result<axum::Json<PrePublishResult>> {
     // User should not be able to print migration plans for a database that they do not own
     let database_identity = resolve_and_authenticate(&ctx, &name_or_identity, &auth).await?;
@@ -808,7 +909,7 @@ pub async fn pre_publish<S: NodeDelegate + ControlStateDelegate>(
         .migrate_plan(
             DatabaseDef {
                 database_identity,
-                program_bytes: body.into(),
+                program_bytes,
                 num_replicas: None,
                 host_type,
             },
@@ -1047,6 +1148,8 @@ pub struct DatabaseRoutes<S> {
     pub sql_post: MethodRouter<S>,
     /// POST: /database/:name_or_identity/pre-publish
     pub pre_publish: MethodRouter<S>,
+    /// PUT: /database/:name_or_identity/reset
+    pub db_reset: MethodRouter<S>,
     /// GET: /database/: name_or_identity/unstable/timestamp
     pub timestamp_get: MethodRouter<S>,
 }
@@ -1073,6 +1176,7 @@ where
             logs_get: get(logs::<S>),
             sql_post: post(sql::<S>),
             pre_publish: post(pre_publish::<S>),
+            db_reset: put(reset::<S>),
             timestamp_get: get(get_timestamp::<S>),
         }
     }
@@ -1098,7 +1202,8 @@ where
             .route("/logs", self.logs_get)
             .route("/sql", self.sql_post)
             .route("/unstable/timestamp", self.timestamp_get)
-            .route("/pre_publish", self.pre_publish);
+            .route("/pre_publish", self.pre_publish)
+            .route("/reset", self.db_reset);
 
         axum::Router::new()
             .route("/", self.root_post)

--- a/crates/client-api/src/util.rs
+++ b/crates/client-api/src/util.rs
@@ -89,7 +89,7 @@ impl NameOrIdentity {
     /// Otherwise, if `self` is a [`NameOrIdentity::Name`], the [`Identity`] is
     /// looked up by that name in the SpacetimeDB DNS and returned.
     ///
-    /// Errors are returned if [`NameOrIdentity::Name`] the DNS lookup fails.
+    /// Errors are returned if the DNS lookup fails.
     ///
     /// An `Ok` result is itself a [`Result`], which is `Err(DatabaseName)` if the
     /// given [`NameOrIdentity::Name`] is not registered in the SpacetimeDB DNS,
@@ -111,7 +111,7 @@ impl NameOrIdentity {
         self.try_resolve(ctx)
             .await
             .map_err(log_and_500)?
-            .map_err(|_| StatusCode::NOT_FOUND.into())
+            .map_err(|name| (StatusCode::NOT_FOUND, format!("Could not resolve database `{name}`")).into())
     }
 }
 

--- a/crates/standalone/src/control_db.rs
+++ b/crates/standalone/src/control_db.rs
@@ -38,6 +38,8 @@ pub enum Error {
     RecordAlreadyExists(DomainName),
     #[error("database with identity {0} already exists")]
     DatabaseAlreadyExists(Identity),
+    #[error("database with identity {0} does not exist")]
+    DatabaseNotFound(Identity),
     #[error("failed to register {0} domain")]
     DomainRegistrationFailure(DomainName),
     #[error("failed to decode data")]
@@ -375,6 +377,21 @@ impl ControlDb {
         tree.insert(id.to_be_bytes(), buf)?;
 
         Ok(id)
+    }
+
+    pub(crate) fn update_database(&self, database: Database) -> Result<()> {
+        let Some(stored_database) = self.get_database_by_identity(&database.database_identity)? else {
+            return Err(Error::DatabaseNotFound(database.database_identity));
+        };
+
+        let tree = self.db.open_tree("database_by_identity")?;
+        let buf = sled::IVec::from(compat::Database::from(database).to_vec()?);
+        tree.insert(stored_database.database_identity.to_be_byte_array(), buf.clone())?;
+
+        let tree = self.db.open_tree("database")?;
+        tree.insert(stored_database.id.to_be_bytes(), buf)?;
+
+        Ok(())
     }
 
     pub fn delete_database(&self, id: u64) -> Result<Option<u64>> {

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -5,7 +5,7 @@ pub mod version;
 
 use crate::control_db::ControlDb;
 use crate::subcommands::{extract_schema, start};
-use anyhow::{ensure, Context as _, Ok};
+use anyhow::{ensure, Context as _};
 use async_trait::async_trait;
 use clap::{ArgMatches, Command};
 use spacetimedb::client::ClientActorIndex;
@@ -20,7 +20,7 @@ use spacetimedb::util::jobs::JobCores;
 use spacetimedb::worker_metrics::WORKER_METRICS;
 use spacetimedb_client_api::auth::{self, LOCALHOST};
 use spacetimedb_client_api::routes::subscribe::{HasWebSocketOptions, WebSocketOptions};
-use spacetimedb_client_api::{Host, NodeDelegate};
+use spacetimedb_client_api::{DatabaseResetDef, Host, NodeDelegate};
 use spacetimedb_client_api_messages::name::{DomainName, InsertDomainResult, RegisterTldResult, SetDomainsResult, Tld};
 use spacetimedb_datastore::db_metrics::data_size::DATA_SIZE_METRICS;
 use spacetimedb_datastore::db_metrics::DB_METRICS;
@@ -273,7 +273,7 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
                     .await?
                     .ok_or_else(|| anyhow::anyhow!("No leader for database"))?;
                 let update_result = leader
-                    .update(database, spec.host_type, spec.program_bytes.into(), policy)
+                    .update(database, spec.host_type, spec.program_bytes.to_vec().into(), policy)
                     .await?;
                 if update_result.was_successful() {
                     let replicas = self.control_db.get_replicas_by_database(database_id)?;
@@ -337,7 +337,13 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
                     .await?
                     .ok_or_else(|| anyhow::anyhow!("No leader for database"))?;
                 self.host_controller
-                    .migrate_plan(db, spec.host_type, host.replica_id, spec.program_bytes.into(), style)
+                    .migrate_plan(
+                        db,
+                        spec.host_type,
+                        host.replica_id,
+                        spec.program_bytes.to_vec().into(),
+                        style,
+                    )
                     .await
             }
             None => anyhow::bail!(
@@ -365,6 +371,42 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
         for instance in self.control_db.get_replicas_by_database(database.id)? {
             self.delete_replica(instance.id).await?;
         }
+
+        Ok(())
+    }
+
+    async fn reset_database(&self, _caller_identity: &Identity, spec: DatabaseResetDef) -> anyhow::Result<()> {
+        let mut database = self
+            .control_db
+            .get_database_by_identity(&spec.database_identity)?
+            .with_context(|| format!("Database `{}` does not exist", spec.database_identity))?;
+        let database_id = database.id;
+
+        if let Some(program) = spec.program_bytes {
+            let program_bytes = &program[..];
+            let program = Program::from_bytes(program_bytes);
+            let _hash_for_assert = program.hash;
+
+            database.initial_program = program.hash;
+            if let Some(host_type) = spec.host_type {
+                database.host_type = host_type;
+            }
+
+            self.host_controller
+                .check_module_validity(database.clone(), program)
+                .await?;
+            let _stored_hash_for_assert = self.program_store.put(program_bytes).await?;
+            debug_assert_eq!(_hash_for_assert, _stored_hash_for_assert);
+
+            self.control_db.update_database(database)?;
+        }
+
+        for instance in self.control_db.get_replicas_by_database(database_id)? {
+            self.delete_replica(instance.id).await?;
+        }
+        // Standalone only support a single replica.
+        let num_replicas = 1;
+        self.schedule_replicas(database_id, num_replicas).await?;
 
         Ok(())
     }

--- a/crates/testing/Cargo.toml
+++ b/crates/testing/Cargo.toml
@@ -16,6 +16,7 @@ spacetimedb-paths.workspace = true
 spacetimedb-schema.workspace = true
 
 anyhow.workspace = true
+bytes.workspace = true
 env_logger.workspace = true
 log.workspace = true
 clap.workspace = true

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -5,6 +5,7 @@ use std::sync::Arc;
 use std::sync::OnceLock;
 use std::time::Instant;
 
+use bytes::Bytes;
 use spacetimedb::config::CertificateAuthority;
 use spacetimedb::messages::control_db::HostType;
 use spacetimedb::util::jobs::JobCores;
@@ -95,7 +96,7 @@ pub struct CompiledModule {
     name: String,
     path: PathBuf,
     pub(super) host_type: HostType,
-    program_bytes: OnceLock<Vec<u8>>,
+    program_bytes: OnceLock<Bytes>,
 }
 
 #[derive(Debug, PartialEq, Eq)]
@@ -124,12 +125,16 @@ impl CompiledModule {
         &self.path
     }
 
-    pub fn program_bytes(&self) -> &[u8] {
-        self.program_bytes.get_or_init(|| std::fs::read(&self.path).unwrap())
+    pub fn program_bytes(&self) -> Bytes {
+        self.program_bytes
+            .get_or_init(|| std::fs::read(&self.path).unwrap().into())
+            .clone()
     }
 
     pub async fn extract_schema(&self) -> ModuleDef {
-        spacetimedb::host::extract_schema(self.program_bytes().into(), self.host_type)
+        // TODO: extract_schema should accept &[u8]
+        let boxed_bytes: Box<[u8]> = self.program_bytes()[..].into();
+        spacetimedb::host::extract_schema(boxed_bytes, self.host_type)
             .await
             .unwrap()
     }
@@ -198,13 +203,11 @@ impl CompiledModule {
         let db_identity = SpacetimeAuth::alloc(&env).await.unwrap().claims.identity;
         let connection_id = generate_random_connection_id();
 
-        let program_bytes = self.program_bytes().to_owned();
-
         env.publish_database(
             &identity,
             DatabaseDef {
                 database_identity: db_identity,
-                program_bytes,
+                program_bytes: self.program_bytes(),
                 num_replicas: None,
                 host_type: self.host_type,
             },


### PR DESCRIPTION
So far, the `--clear-database` option to `publish` has simply dropped
and then re-created the database (if it did exist).

This will no longer work when databases can have "children": because
dropping and re-creating is not atomic, children would either become
orphans, or be dropped as well.

To solve this, `reset_database` is introduced as a separate action that:

- shuts down all replicas
- if a `program_bytes` is supplied, replaces the database's initial
  program
- if a `host_type` is supplied, replaces the database's host type
- starts `num_replicas` or the previous number of replicas, which
  initialize themselves as normal

As this could be its own CLI command, the action is provided as its own
API endpoint (undocumented).

However, since `publish` has no way of knowing whether the database it
operates on actually exists, the `publish_database` handler will just
invoke the `reset_database` handler if `clear=true` and the database
exists, and return its result. This is to avoid starting the transfer of
the program in the request body, only to receive a redirect.

Some refactoring was necessary to dissect and understand the flow.


# API and ABI breaking changes

Introduces a new, undocumented API endpoint.
We may want to nest it under `/unstable`.

# Expected complexity level and risk

2

# Testing

From the outside, the observed behavior should be as before,
so smoketests should cover it.
