### PR TITLE
PR merge discord post includes all non-successful checks

### DIFF
--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -36,8 +36,10 @@ jobs:
               jq '.[] | select(.state != "SUCCESS")' |
               jq -r '"\(.workflow) / \(.name): \(.state)"'
           )"
-          if [[ -n "${FAILED_CHECKS}" ]]; then
-            message+=$'\n'
+          message+=$'\n'
+          if [[ -z "${FAILED_CHECKS}" ]]; then
+            message+='All checks passed.'
+          else
             message+="${FAILED_CHECKS}"
             message+=$'\n'
             # This uses special Discord syntax for pinging a particular role.


### PR DESCRIPTION
# Description of Changes

Now, the "PR merged" discord post will include all non-successful CI.

# API and ABI breaking changes

CI-only.

# Expected complexity level and risk

2

# Testing

Note: I tested this by commenting out / hardcoding some pieces, rather than by actually merging PRs in some other repo.

Some test posts it generated:
<img width="528" height="266" alt="image" src="https://github.com/user-attachments/assets/27151c5f-216a-47aa-9f3b-74d991bcbbe7" />
<img width="493" height="146" alt="image" src="https://github.com/user-attachments/assets/677de1d5-8268-400c-be16-b3806382bb51" />
