### PR TITLE
Procedures: add WASM ABI for anonymous mutable transactions

### DIFF
--- a/crates/core/src/error.rs
+++ b/crates/core/src/error.rs
@@ -263,6 +263,8 @@ pub enum NodesError {
     BadColumn,
     #[error("can't perform operation; not inside transaction")]
     NotInTransaction,
+    #[error("can't perform operation; a transaction already exists")]
+    WouldBlockTransaction,
     #[error("table with name {0:?} already exists")]
     AlreadyExists(String),
     #[error("table with name `{0}` start with 'st_' and that is reserved for internal system tables.")]

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -4,12 +4,15 @@ use crate::db::relational_db::{MutTx, RelationalDB};
 use crate::error::{DBError, DatastoreError, IndexError, NodesError};
 use crate::host::wasm_common::TimingSpan;
 use crate::replica_context::ReplicaContext;
+use crate::util::asyncify;
 use chrono::{DateTime, Utc};
 use core::mem;
 use parking_lot::{Mutex, MutexGuard};
 use smallvec::SmallVec;
+use spacetimedb_datastore::execution_context::Workload;
 use spacetimedb_datastore::locking_tx_datastore::state_view::StateView;
 use spacetimedb_datastore::locking_tx_datastore::{MutTxId, ViewCall};
+use spacetimedb_datastore::traits::IsolationLevel;
 use spacetimedb_lib::{ConnectionId, Identity, Timestamp};
 use spacetimedb_primitives::{ColId, ColList, IndexId, TableId};
 use spacetimedb_sats::{
@@ -198,6 +201,14 @@ impl InstanceEnv {
         self.tx.get()
     }
 
+    pub(crate) fn take_tx(&self) -> Result<MutTxId, GetTxError> {
+        self.tx.take()
+    }
+
+    pub(crate) fn relational_db(&self) -> &Arc<RelationalDB> {
+        &self.replica_ctx.relational_db
+    }
+
     pub(crate) fn get_jwt_payload(&self, connection_id: ConnectionId) -> Result<Option<String>, NodesError> {
         let tx = &mut *self.get_tx()?;
         Ok(tx.get_jwt_payload(connection_id).map_err(DBError::from)?)
@@ -268,7 +279,7 @@ impl InstanceEnv {
     }
 
     pub fn insert(&self, table_id: TableId, buffer: &mut [u8]) -> Result<usize, NodesError> {
-        let stdb = &*self.replica_ctx.relational_db;
+        let stdb = self.relational_db();
         let tx = &mut *self.get_tx()?;
 
         let (row_len, row_ptr, insert_flags) = stdb
@@ -337,7 +348,7 @@ impl InstanceEnv {
     }
 
     pub fn update(&self, table_id: TableId, index_id: IndexId, buffer: &mut [u8]) -> Result<usize, NodesError> {
-        let stdb = &*self.replica_ctx.relational_db;
+        let stdb = self.relational_db();
         let tx = &mut *self.get_tx()?;
 
         let (row_len, row_ptr, update_flags) = stdb
@@ -380,8 +391,8 @@ impl InstanceEnv {
         rstart: &[u8],
         rend: &[u8],
     ) -> Result<u32, NodesError> {
-        let stdb = &*self.replica_ctx.relational_db;
-        let tx = &mut *self.tx.get()?;
+        let stdb = self.relational_db();
+        let tx = &mut *self.get_tx()?;
 
         // Find all rows in the table to delete.
         let (table_id, _, _, iter) = stdb.index_scan_range(tx, index_id, prefix, prefix_elems, rstart, rend)?;
@@ -410,7 +421,7 @@ impl InstanceEnv {
     /// - a row couldn't be decoded to the table schema type.
     #[tracing::instrument(level = "trace", skip(self, relation))]
     pub fn datastore_delete_all_by_eq_bsatn(&self, table_id: TableId, relation: &[u8]) -> Result<u32, NodesError> {
-        let stdb = &*self.replica_ctx.relational_db;
+        let stdb = self.relational_db();
         let tx = &mut *self.get_tx()?;
 
         // Track the number of bytes coming from the caller
@@ -437,7 +448,7 @@ impl InstanceEnv {
     /// and `TableNotFound` if the table does not exist.
     #[tracing::instrument(level = "trace", skip_all)]
     pub fn table_id_from_name(&self, table_name: &str) -> Result<TableId, NodesError> {
-        let stdb = &*self.replica_ctx.relational_db;
+        let stdb = self.relational_db();
         let tx = &mut *self.get_tx()?;
 
         // Query the table id from the name.
@@ -451,7 +462,7 @@ impl InstanceEnv {
     /// and `IndexNotFound` if the index does not exist.
     #[tracing::instrument(level = "trace", skip_all)]
     pub fn index_id_from_name(&self, index_name: &str) -> Result<IndexId, NodesError> {
-        let stdb = &*self.replica_ctx.relational_db;
+        let stdb = self.relational_db();
         let tx = &mut *self.get_tx()?;
 
         // Query the index id from the name.
@@ -465,7 +476,7 @@ impl InstanceEnv {
     /// and `TableNotFound` if the table does not exist.
     #[tracing::instrument(level = "trace", skip_all)]
     pub fn datastore_table_row_count(&self, table_id: TableId) -> Result<u64, NodesError> {
-        let stdb = &*self.replica_ctx.relational_db;
+        let stdb = self.relational_db();
         let tx = &mut *self.get_tx()?;
 
         // Query the row count for id.
@@ -482,8 +493,8 @@ impl InstanceEnv {
         pool: &mut ChunkPool,
         table_id: TableId,
     ) -> Result<Vec<Vec<u8>>, NodesError> {
-        let stdb = &*self.replica_ctx.relational_db;
-        let tx = &mut *self.tx.get()?;
+        let stdb = self.relational_db();
+        let tx = &mut *self.get_tx()?;
 
         // Track the number of rows and the number of bytes scanned by the iterator
         let mut rows_scanned = 0;
@@ -515,8 +526,8 @@ impl InstanceEnv {
         rstart: &[u8],
         rend: &[u8],
     ) -> Result<Vec<Vec<u8>>, NodesError> {
-        let stdb = &*self.replica_ctx.relational_db;
-        let tx = &mut *self.tx.get()?;
+        let stdb = self.relational_db();
+        let tx = &mut *self.get_tx()?;
 
         // Track rows and bytes scanned by the iterator
         let mut rows_scanned = 0;
@@ -563,25 +574,51 @@ impl InstanceEnv {
 
         written
     }
+
+    pub async fn start_mutable_tx(&mut self) -> Result<(), NodesError> {
+        if self.get_tx().is_ok() {
+            return Err(NodesError::WouldBlockTransaction);
+        }
+
+        let stdb = self.replica_ctx.relational_db.clone();
+        // TODO(procedure-tx): should we add a new workload, e.g., `AnonTx`?
+        let tx = asyncify(move || stdb.begin_mut_tx(IsolationLevel::Serializable, Workload::Internal)).await;
+        self.tx.set_raw(tx);
+
+        Ok(())
+    }
 }
 
 impl TxSlot {
-    pub fn set<T>(&mut self, tx: MutTxId, f: impl FnOnce() -> T) -> (MutTxId, T) {
+    /// Sets the slot to `tx`, ensuring that there was no tx before.
+    pub fn set_raw(&mut self, tx: MutTxId) {
         let prev = self.inner.lock().replace(tx);
         assert!(prev.is_none(), "reentrant TxSlot::set");
-        let remove_tx = || self.inner.lock().take();
+    }
+
+    /// Sets the slot to `tx` runs `work`, and returns back `tx`.
+    pub fn set<T>(&mut self, tx: MutTxId, work: impl FnOnce() -> T) -> (MutTxId, T) {
+        self.set_raw(tx);
+
+        let remove_tx = || self.take().expect("tx was removed during transaction");
 
         let res = {
             scopeguard::defer_on_unwind! { remove_tx(); }
-            f()
+            work()
         };
 
-        let tx = remove_tx().expect("tx was removed during transaction");
+        let tx = remove_tx();
         (tx, res)
     }
 
+    /// Returns the tx in the slot.
     pub fn get(&self) -> Result<impl DerefMut<Target = MutTxId> + '_, GetTxError> {
         MutexGuard::try_map(self.inner.lock(), |map| map.as_mut()).map_err(|_| GetTxError)
+    }
+
+    /// Steals th tx from the slot.
+    pub fn take(&self) -> Result<MutTxId, GetTxError> {
+        self.inner.lock().take().ok_or(GetTxError)
     }
 }
 

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -178,4 +178,7 @@ pub enum AbiCall {
     VolatileNonatomicScheduleImmediate,
 
     ProcedureSleepUntil,
+    ProcedureStartMutTransaction,
+    ProcedureCommitMutTransaction,
+    ProcedureAbortMutTransaction,
 }

--- a/crates/core/src/host/wasm_common.rs
+++ b/crates/core/src/host/wasm_common.rs
@@ -347,6 +347,7 @@ pub(super) type TimingSpanSet = ResourceSlab<TimingSpanIdx>;
 pub fn err_to_errno(err: &NodesError) -> Option<NonZeroU16> {
     match err {
         NodesError::NotInTransaction => Some(errno::NOT_IN_TRANSACTION),
+        NodesError::WouldBlockTransaction => Some(errno::WOULD_BLOCK_TRANSACTION),
         NodesError::DecodeRow(_) => Some(errno::BSATN_DECODE_ERROR),
         NodesError::TableNotFound => Some(errno::NO_SUCH_TABLE),
         NodesError::IndexNotFound => Some(errno::NO_SUCH_INDEX),
@@ -422,6 +423,9 @@ macro_rules! abi_funcs {
 
         $link_async! {
             "spacetime_10.3"::procedure_sleep_until,
+            "spacetime_10.3"::procedure_start_mut_transaction,
+            "spacetime_10.3"::procedure_commit_mut_transaction,
+            "spacetime_10.3"::procedure_abort_mut_transaction,
         }
     };
 }

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -2,12 +2,19 @@
 
 use super::{Mem, MemView, NullableMemOp, WasmError, WasmPointee, WasmPtr};
 use crate::database_logger::{BacktraceFrame, BacktraceProvider, ModuleBacktrace, Record};
+use crate::error::NodesError;
 use crate::host::instance_env::{ChunkPool, InstanceEnv};
+use crate::host::module_host::{DatabaseUpdate, EventStatus, ModuleEvent, ModuleFunctionCall};
+use crate::host::wasm_common::instrumentation::noop::CallSpanStart;
 use crate::host::wasm_common::instrumentation::{span, CallTimes};
 use crate::host::wasm_common::module_host_actor::ExecutionTimings;
 use crate::host::wasm_common::{err_to_errno_and_log, RowIterIdx, RowIters, TimingSpan, TimingSpanIdx, TimingSpanSet};
 use crate::host::AbiCall;
+use crate::subscription::module_subscription_actor::{commit_and_broadcast_event, ModuleSubscriptions};
+use crate::util::asyncify;
 use anyhow::Context as _;
+use core::time::Duration;
+use spacetimedb_client_api_messages::energy::EnergyQuanta;
 use spacetimedb_data_structures::map::IntMap;
 use spacetimedb_datastore::locking_tx_datastore::ViewCall;
 use spacetimedb_lib::{ConnectionId, Timestamp};
@@ -119,6 +126,9 @@ pub(super) struct WasmInstanceEnv {
     /// A pool of unused allocated chunks that can be reused.
     // TODO(Centril): consider using this pool for `console_timer_start` and `bytes_sink_write`.
     chunk_pool: ChunkPool,
+
+    /// Are we in an anonymous tx context?
+    in_anon_tx: bool,
 }
 
 const STANDARD_BYTES_SINK: u32 = 1;
@@ -151,6 +161,7 @@ impl WasmInstanceEnv {
             call_times: CallTimes::new(),
             funcall_name: String::from("<initializing>"),
             chunk_pool: <_>::default(),
+            in_anon_tx: false,
         }
     }
 
@@ -258,6 +269,8 @@ impl WasmInstanceEnv {
             }
         }
 
+        self.in_anon_tx = false;
+
         (args, errors)
     }
 
@@ -307,17 +320,37 @@ impl WasmInstanceEnv {
         (timings, self.take_standard_bytes_sink())
     }
 
+    /// Record a span with `start`.
+    fn end_span(mut caller: Caller<'_, Self>, start: CallSpanStart) {
+        let span = start.end();
+        span::record_span(&mut caller.data_mut().call_times, span);
+    }
+
     fn with_span<R>(mut caller: Caller<'_, Self>, func: AbiCall, run: impl FnOnce(&mut Caller<'_, Self>) -> R) -> R {
         let span_start = span::CallSpanStart::new(func);
 
         // Call `run` with the caller and a handle to the memory.
         let result = run(&mut caller);
 
-        // Track the span of this call.
-        let span = span_start.end();
-        span::record_span(&mut caller.data_mut().call_times, span);
+        Self::end_span(caller, span_start);
 
         result
+    }
+
+    fn async_with_span<'caller, R, F: Send + 'caller + Future<Output = (Caller<'caller, Self>, R)>>(
+        caller: Caller<'caller, Self>,
+        func: AbiCall,
+        run: impl Send + 'caller + FnOnce(Caller<'caller, Self>) -> F,
+    ) -> Fut<'caller, R> {
+        Box::new(async move {
+            let span_start = span::CallSpanStart::new(func);
+
+            // Call `run` with the caller and a handle to the memory.
+            let (caller, result) = run(caller).await;
+
+            Self::end_span(caller, span_start);
+            result
+        })
     }
 
     fn convert_wasm_result<T: From<u16>>(func: AbiCall, err: WasmError) -> RtResult<T> {
@@ -1415,14 +1448,12 @@ impl WasmInstanceEnv {
     /// - The calling WASM instance is not executing a procedure.
     // TODO(procedure-sleep-until): remove this
     pub fn procedure_sleep_until<'caller>(
-        mut caller: Caller<'caller, Self>,
+        caller: Caller<'caller, Self>,
         (wake_at_micros_since_unix_epoch,): (i64,),
-    ) -> Box<dyn Future<Output = i64> + Send + 'caller> {
-        Box::new(async move {
+    ) -> Fut<'caller, i64> {
+        Self::async_with_span(caller, AbiCall::ProcedureSleepUntil, move |caller| async move {
             use std::time::SystemTime;
-            let span_start = span::CallSpanStart::new(AbiCall::ProcedureSleepUntil);
-
-            let get_current_time = || Timestamp::now().to_micros_since_unix_epoch();
+            let get_current_time = || (caller, Timestamp::now().to_micros_since_unix_epoch());
 
             if wake_at_micros_since_unix_epoch < 0 {
                 return get_current_time();
@@ -1435,15 +1466,178 @@ impl WasmInstanceEnv {
 
             tokio::time::sleep(duration).await;
 
-            let res = get_current_time();
+            get_current_time()
+        })
+    }
 
-            let span = span_start.end();
-            span::record_span(&mut caller.data_mut().call_times, span);
+    /// Starts a mutable transaction,
+    /// suspending execution of this WASM instance until
+    /// a mutable transaction lock is aquired.
+    ///
+    /// Upon resuming, returns `0` on success,
+    /// enabling further calls that require a pending transaction,
+    /// or an error code otherwise.
+    ///
+    /// # Traps
+    ///
+    /// This function does not trap.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error:
+    ///
+    /// - `WOULD_BLOCK_TRANSACTION`, if there's already an ongoing transaction.
+    pub fn procedure_start_mut_transaction<'caller>(
+        caller: Caller<'caller, Self>,
+        (): (),
+    ) -> Fut<'caller, RtResult<u32>> {
+        Self::async_with_span(caller, AbiCall::ProcedureStartMutTransaction, |mut caller| async {
+            let (_, env) = Self::mem_env(&mut caller);
+            let res = env.instance_env.start_mutable_tx().await;
 
-            res
+            let result = res
+                .map(|()| {
+                    env.in_anon_tx = true;
+                    0u16.into()
+                })
+                .or_else(|err| Self::convert_wasm_result(AbiCall::ProcedureStartMutTransaction, err.into()));
+
+            (caller, result)
+        })
+    }
+
+    /// Commits a mutable transaction,
+    /// suspending execution of this WASM instance until
+    /// the transaction has been committed
+    /// and subscription queries have been run and broadcast.
+    ///
+    /// Upon resuming, returns `0` on success, or an error code otherwise.
+    ///
+    /// # Traps
+    ///
+    /// This function does not trap.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error:
+    ///
+    /// - `TRANSACTION_NOT_ANONYMOUS`,
+    ///   if the transaction was not started in [`procedure_start_mut_transaction`].
+    ///   This can happen if this syscall is erroneously called by a reducer.
+    ///   The code `NOT_IN_TRANSACTION` does not happen,
+    ///   as it is subsumed by `TRANSACTION_NOT_ANONYMOUS`.
+    /// - `TRANSACTION_IS_READ_ONLY`, if the pending transaction is read-only.
+    ///   This currently does not happen as anonymous read transactions
+    ///   are not exposed to modules.
+    pub fn procedure_commit_mut_transaction<'caller>(
+        caller: Caller<'caller, Self>,
+        (): (),
+    ) -> Fut<'caller, RtResult<u32>> {
+        Self::async_with_span(
+            caller,
+            AbiCall::ProcedureCommitMutTransaction,
+            |mut caller| async move {
+                let (_, env) = Self::mem_env(&mut caller);
+
+                if !env.in_anon_tx {
+                    // Not in an anon tx context.
+                    // This can happen if a reducer calls this ABI
+                    // and tries to commit its own transaction early.
+                    // We refuse to do this, as it would cause a later panic in the host.
+                    return (caller, Ok(errno::TRANSACTION_NOT_ANONYMOUS.get().into()));
+                }
+
+                let inst = env.instance_env();
+                let stdb = inst.relational_db().clone();
+                let tx = inst.take_tx();
+                let subs = inst.replica_ctx.subscriptions.clone();
+
+                let res = async move {
+                    let tx = tx?;
+                    let event = ModuleEvent {
+                        timestamp: Timestamp::now(),
+                        caller_identity: stdb.database_identity(),
+                        caller_connection_id: None,
+                        function_call: ModuleFunctionCall::default(),
+                        status: EventStatus::Committed(DatabaseUpdate::default()),
+                        request_id: None,
+                        timer: None,
+                        // The procedure will pick up the tab for the energy.
+                        energy_quanta_used: EnergyQuanta { quanta: 0 },
+                        host_execution_duration: Duration::from_millis(0),
+                    };
+                    // Commit the tx and broadcast it.
+                    // This is somewhat expensive,
+                    // and can block for a while,
+                    // so we need to asyncify it.
+                    asyncify(move || commit_and_broadcast_event(&subs, None, event, tx)).await;
+
+                    Ok::<_, NodesError>(0u16.into())
+                }
+                .await
+                .or_else(|err| Self::convert_wasm_result(AbiCall::ProcedureCommitMutTransaction, err.into()));
+
+                (caller, res)
+            },
+        )
+    }
+
+    /// Aborts a mutable transaction,
+    /// suspending execution of this WASM instance until
+    /// the transaction has been rolled back.
+    ///
+    /// Upon resuming, returns `0` on success, or an error code otherwise.
+    ///
+    /// # Traps
+    ///
+    /// This function does not trap.
+    ///
+    /// # Errors
+    ///
+    /// Returns an error:
+    ///
+    /// - `TRANSACTION_NOT_ANONYMOUS`,
+    ///   if the transaction was not started in [`procedure_start_mut_transaction`].
+    ///   This can happen if this syscall is erroneously called by a reducer.
+    ///   The code `NOT_IN_TRANSACTION` does not happen,
+    ///   as it is subsumed by `TRANSACTION_NOT_ANONYMOUS`.
+    /// - `TRANSACTION_IS_READ_ONLY`, if the pending transaction is read-only.
+    ///   This currently does not happen as anonymous read transactions
+    ///   are not exposed to modules.
+    pub fn procedure_abort_mut_transaction<'caller>(
+        caller: Caller<'caller, Self>,
+        (): (),
+    ) -> Fut<'caller, RtResult<u32>> {
+        Self::async_with_span(caller, AbiCall::ProcedureAbortMutTransaction, |mut caller| async move {
+            let (_, env) = Self::mem_env(&mut caller);
+
+            if !env.in_anon_tx {
+                // Not in an anon tx context.
+                // This can happen if a reducer calls this ABI
+                // and tries to commit its own transaction early.
+                // We refuse to do this, as it would cause a later panic in the host.
+                return (caller, Ok(errno::TRANSACTION_NOT_ANONYMOUS.get().into()));
+            }
+
+            let inst = env.instance_env();
+            let stdb = inst.relational_db().clone();
+            let tx = inst.take_tx();
+
+            let res = async move {
+                let tx = tx?;
+                // Roll back the tx.
+                ModuleSubscriptions::rollback_mut_tx(&stdb, tx);
+                Ok::<_, NodesError>(0u16.into())
+            }
+            .await
+            .or_else(|err| Self::convert_wasm_result(AbiCall::ProcedureAbortMutTransaction, err.into()));
+
+            (caller, res)
         })
     }
 }
+
+type Fut<'caller, T> = Box<dyn Send + 'caller + Future<Output = T>>;
 
 impl<T> BacktraceProvider for wasmtime::StoreContext<'_, T> {
     fn capture(&self) -> Box<dyn ModuleBacktrace> {

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -8,7 +8,7 @@ use crate::error::DBError;
 use crate::estimation::estimate_rows_scanned;
 use crate::host::module_host::{DatabaseTableUpdate, DatabaseUpdate, EventStatus, ModuleEvent, ModuleFunctionCall};
 use crate::host::{ArgsTuple, ModuleHost};
-use crate::subscription::module_subscription_actor::{ModuleSubscriptions, WriteConflict};
+use crate::subscription::module_subscription_actor::{commit_and_broadcast_event, ModuleSubscriptions};
 use crate::subscription::module_subscription_manager::TransactionOffset;
 use crate::subscription::tx::DeltaTx;
 use crate::util::slow::SlowQueryLogger;
@@ -143,10 +143,8 @@ pub fn execute_sql(
                 request_id: None,
                 timer: None,
             };
-            match subs.unwrap().commit_and_broadcast_event(None, event, tx).unwrap() {
-                Ok(_) => res,
-                Err(WriteConflict) => todo!("See module_host_actor::call_reducer_with_tx"),
-            }
+            commit_and_broadcast_event(subs.unwrap(), None, event, tx);
+            res
         } else {
             db.finish_tx(tx, res)
         }
@@ -311,38 +309,27 @@ pub async fn run(
             // Note, we get the delta by downgrading the tx.
             // Hence we just pass a default `DatabaseUpdate` here.
             // It will ultimately be replaced with the correct one.
-            match subs
-                .unwrap()
-                .commit_and_broadcast_event(
-                    None,
-                    ModuleEvent {
-                        timestamp: Timestamp::now(),
-                        caller_identity: auth.caller,
-                        caller_connection_id: None,
-                        function_call: ModuleFunctionCall {
-                            reducer: String::new(),
-                            reducer_id: u32::MAX.into(),
-                            args: ArgsTuple::default(),
-                        },
-                        status: EventStatus::Committed(DatabaseUpdate::default()),
-                        energy_quanta_used: EnergyQuanta::ZERO,
-                        host_execution_duration: Duration::ZERO,
-                        request_id: None,
-                        timer: None,
-                    },
-                    tx,
-                )
-                .unwrap()
-            {
-                Err(WriteConflict) => {
-                    todo!("See module_host_actor::call_reducer_with_tx")
-                }
-                Ok(res) => Ok(SqlResult {
-                    tx_offset: res.tx_offset,
-                    rows: vec![],
-                    metrics,
-                }),
-            }
+            let event = ModuleEvent {
+                timestamp: Timestamp::now(),
+                caller_identity: auth.caller,
+                caller_connection_id: None,
+                function_call: ModuleFunctionCall {
+                    reducer: String::new(),
+                    reducer_id: u32::MAX.into(),
+                    args: ArgsTuple::default(),
+                },
+                status: EventStatus::Committed(DatabaseUpdate::default()),
+                energy_quanta_used: EnergyQuanta::ZERO,
+                host_execution_duration: Duration::ZERO,
+                request_id: None,
+                timer: None,
+            };
+            let res = commit_and_broadcast_event(subs.unwrap(), None, event, tx);
+            Ok(SqlResult {
+                tx_offset: res.tx_offset,
+                rows: vec![],
+                metrics,
+            })
         }
     }
 }

--- a/crates/primitives/src/errno.rs
+++ b/crates/primitives/src/errno.rs
@@ -23,6 +23,16 @@ macro_rules! errnos {
             INDEX_NOT_UNIQUE(14, "The index was not unique"),
             NO_SUCH_ROW(15, "The row was not found, e.g., in an update call"),
             AUTO_INC_OVERFLOW(16, "The auto-increment sequence overflowed"),
+            WOULD_BLOCK_TRANSACTION(
+                17,
+                "Attempted async or blocking op while holding open a transaction"
+            ),
+            TRANSACTION_NOT_ANONYMOUS(18, "Not in an anonymous transaction. Called by a reducer?"),
+            TRANSACTION_IS_READ_ONLY(19, "ABI call can only be made while within a mutable transaction"),
+            TRANSACTION_IS_MUT(
+                20,
+                "ABI call can only be made while within a read-only transaction"
+            ),
         );
     };
 }


### PR DESCRIPTION
# Description of Changes

Unstably adds the ABIs:
```
pub fn procedure_start_mut_transaction() -> u16;
pub fn procedure_commit_mut_transaction() -> u16;
pub fn procedure_abort_mut_transaction() -> u16;
```

# API and ABI breaking changes

None

# Expected complexity level and risk

2 -- pretty localized stuff.

# Testing

This is just the wasm syscall ABI. Once bindings is added atop of this, tests will be included too.