### PR TITLE
remove module watcher from subscription

### DIFF
--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -886,7 +886,11 @@ impl Host {
         let disk_metrics_recorder_task = tokio::spawn(metric_reporter(replica_ctx.clone())).abort_handle();
 
         let module = watch::Sender::new(module_host);
-        replica_ctx.subscriptions.init(module.subscribe());
+        //TODO(shub): Below code interfere with `exit_module` code,
+        // I suspect channel internally holds a reference to the module,
+        // even after we drop the sender.
+        //
+        // replica_ctx.subscriptions.init(module.subscribe());
         Ok(Host {
             module,
             replica_ctx,


### PR DESCRIPTION
# Description of Changes

Problem is visible in replication smoketests, which exit and re-lauch modules, erorring out with:
```
ERROR /app/public/crates/core/src/host/host_controller.rs:818: Failed to open database: DatabaseError: Database is already opened. Path:`/stdb/data/replicas/4`. Error:Resource temporarily unavailable (os error 11).: Database is already opened. Path:`/stdb/data/replicas/4`. Error:Resource temporarily unavailable (os error 11)
```

Commented code will be a blocker for releasing Views but we want CIs to pass.