### PR TITLE
Implemented `NULL` literal in SQL for `Unit`s and `Option`s

### DIFF
--- a/crates/expr/src/expr.rs
+++ b/crates/expr/src/expr.rs
@@ -351,6 +351,23 @@ impl Expr {
         }
     }
 
+    /// A literal unit value
+    pub fn unit() -> Self {
+        Self::Value(AlgebraicValue::unit(), AlgebraicType::unit())
+    }
+
+    /// A literal option none value
+    #[allow(non_snake_case)]
+    pub fn OptionNone(ty: AlgebraicType) -> Self {
+        Self::Value(AlgebraicValue::OptionNone(), AlgebraicType::option(ty))
+    }
+
+    /// A literal option none value
+    #[allow(non_snake_case)]
+    pub fn OptionSome(ty: AlgebraicType, v: AlgebraicValue) -> Self {
+        Self::Value(AlgebraicValue::OptionSome(v), AlgebraicType::option(ty))
+    }
+
     /// A literal boolean value
     pub const fn bool(v: bool) -> Self {
         Self::Value(AlgebraicValue::Bool(v), AlgebraicType::Bool)

--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -88,6 +88,10 @@ fn _type_expr(vars: &Relvars, expr: SqlExpr, expected: Option<&AlgebraicType>, d
     recursion::guard(depth, recursion::MAX_RECURSION_TYP_EXPR, "expr::type_expr")?;
 
     match (expr, expected) {
+        (SqlExpr::Lit(SqlLiteral::Null), None) => Ok(Expr::unit()),
+        (SqlExpr::Lit(SqlLiteral::Null), Some(ty)) if ty.is_unit() => Ok(Expr::unit()),
+        (SqlExpr::Lit(SqlLiteral::Null), Some(ty)) if ty.is_option() => Ok(Expr::OptionNone(ty.clone())),
+        (SqlExpr::Lit(SqlLiteral::Null), Some(ty)) => Err(UnexpectedType::new(&AlgebraicType::unit(), ty).into()),
         (SqlExpr::Lit(SqlLiteral::Bool(v)), None | Some(AlgebraicType::Bool)) => Ok(Expr::bool(v)),
         (SqlExpr::Lit(SqlLiteral::Bool(_)), Some(ty)) => Err(UnexpectedType::new(&AlgebraicType::Bool, ty).into()),
         (SqlExpr::Lit(SqlLiteral::Str(_) | SqlLiteral::Num(_) | SqlLiteral::Hex(_)), None) => {

--- a/crates/sql-parser/src/ast/mod.rs
+++ b/crates/sql-parser/src/ast/mod.rs
@@ -199,6 +199,8 @@ impl From<Ident> for SqlIdent {
 /// A SQL constant expression
 #[derive(Debug)]
 pub enum SqlLiteral {
+    /// Null literal
+    Null,
     /// A boolean constant
     Bool(bool),
     /// A hex value like 0xFF or x'FF'

--- a/crates/sql-parser/src/parser/mod.rs
+++ b/crates/sql-parser/src/parser/mod.rs
@@ -291,6 +291,7 @@ pub(crate) fn parse_binop(op: BinaryOperator) -> SqlParseResult<BinOp> {
 /// Parse a literal expression
 pub(crate) fn parse_literal(value: Value) -> SqlParseResult<SqlLiteral> {
     match value {
+        Value::Null => Ok(SqlLiteral::Null),
         Value::Boolean(v) => Ok(SqlLiteral::Bool(v)),
         Value::Number(v, _) => Ok(SqlLiteral::Num(v.into_boxed_str())),
         Value::SingleQuotedString(s) => Ok(SqlLiteral::Str(s.into_boxed_str())),


### PR DESCRIPTION
# Description of Changes

Ability to, given a table:
```rust
#[table(name=table)]
struct Table {
	option: Option<i32>,
}
```
do:
```sql
INSERT INTO table (option) VALUES (Null);
```
instead of getting:
```log
Error: Unsupported literal expression: NULL
```

# API and ABI breaking changes

None.

# Expected complexity level and risk

### 2:
Existing code, just extended it to support another `SqlLiteral` variant.

# Testing

- [x] Manual testing
- [ ] Unit tests