### PR TITLE
CI - TypeScript quickstart works properly in the face of version bumps

### DIFF
--- a/smoketests/tests/quickstart.py
+++ b/smoketests/tests/quickstart.py
@@ -361,8 +361,9 @@ class TypeScript(Rust):
 
     def server_postprocess(self, server_path: Path):
         build_typescript_sdk()
-        # We already have spacetimedb installed somehow, but it's not the right version.
-        # If we don't uninstall before installing, pnpm can panic because it can't find the specified version on npm.
+        # We already have spacetimedb as a depencency, but it's expecting to fetch from npm.
+        # If we don't uninstall before installing, pnpm can panic because it can't find
+        # the specified version on npm (even though we're about to override it anyway).
         pnpm("uninstall", 'spacetimedb', cwd=server_path)
         pnpm("install", TYPESCRIPT_BINDINGS_PATH, cwd=server_path)
 


### PR DESCRIPTION
# Description of Changes

Fixes the issue described in https://github.com/clockworklabs/SpacetimeDB/issues/3558.

# API and ABI breaking changes

None. CI only.

# Expected complexity level and risk

1

# Testing

- [x] Smoketests are now successful after running `cargo bump-versions 1.8.0 --typescript`.