### PR TITLE
Fix the basic-rust client template for CLI's init command

### DIFF
--- a/crates/cli/templates/basic-rust/client/src/main.rs
+++ b/crates/cli/templates/basic-rust/client/src/main.rs
@@ -1,8 +1,9 @@
 mod module_bindings;
 use module_bindings::*;
 use std::env;
+use std::io::{self, Read};
 
-use spacetimedb_sdk::{DbConnection, Table};
+use spacetimedb_sdk::{DbContext, Table};
 
 fn main() {
     // The URI of the SpacetimeDB instance hosting our chat module.
@@ -14,28 +15,31 @@ fn main() {
     // Connect to the database
     let conn = DbConnection::builder()
         .with_module_name(db_name)
-        .with_host(host)
+        .with_uri(host)
         .on_connect(|_, _, _| {
             println!("Connected to SpacetimeDB");
         })
-        .on_connect_error(|e| {
+        .on_connect_error(|_ctx, e| {
             eprintln!("Connection error: {:?}", e);
             std::process::exit(1);
         })
         .build()
         .expect("Failed to connect");
 
+    conn.run_threaded();
+
     // Subscribe to the person table
-    conn.subscribe(&[
-        "SELECT * FROM person"
-    ]);
+    conn.subscription_builder()
+        .on_applied(|_ctx| println!("Subscripted to the person table"))
+        .on_error(|_ctx, e| eprintln!("There was an error when subscring to the person table: {e}"))
+        .subscribe(["SELECT * FROM person"]);
 
     // Register a callback for when rows are inserted into the person table
-    Person::on_insert(|_ctx, person| {
+    conn.db().person().on_insert(|_ctx, person| {
         println!("New person: {}", person.name);
     });
 
-    // Run the connection on the current thread
-    // This will block and handle all database events
-    conn.run();
+    println!("Press any key to exit...");
+
+    let _ = io::stdin().read(&mut [0u8]).unwrap();
 }

--- a/crates/cli/templates/basic-rust/server/src/lib.rs
+++ b/crates/cli/templates/basic-rust/server/src/lib.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{ReducerContext, Table};
 
-#[spacetimedb::table(name = person)]
+#[spacetimedb::table(name = person, public)]
 pub struct Person {
     name: String,
 }


### PR DESCRIPTION
# Description of Changes

This template was never properly tested, and it contains wrong API usage that can't even compile.

The only problem is that in order to make it work the person table has to be public, and I'm not sure if we want to make that change. Alternatively we could make basic-rust code not subscribe to anything and just connect to the database.

# Expected complexity level and risk

2

# Testing

- [x] I compiled the template and checked that it works against 