### PR TITLE
Fix noisy Discord notifications on PR merge

### DIFF
--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -33,7 +33,10 @@ jobs:
           FAILED_CHECKS="$(
             gh pr checks "${{github.event.pull_request.html_url}}" \
               --json 'workflow,state,name' |
-              jq '.[] | select(.state != "SUCCESS")' |
+              jq '.[]
+                | select(.workflow != "Discord notifications")
+                | select(.state != "SUCCESS" and .state != "NEUTRAL")
+              ' |
               jq -r '"\(.workflow) / \(.name): \(.state)"'
           )"
           message+=$'\n'


### PR DESCRIPTION
# Description of Changes

Filter out the discord notification job itself, as well as any neutral results.

# API and ABI breaking changes

CI only.

# Expected complexity level and risk

1

# Testing

Unsure how to test this without merging the PR