### PR TITLE
Use new runner for testsuite

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -157,7 +157,7 @@ jobs:
 
         # The fallocate tests have been flakely when running in parallel
       - name: Run fallocate tests
-        run: cargo test -p spacetimedb-durability --features fallocate --test-threads=1
+        run: cargo test -p spacetimedb-durability --features fallocate -- --test-threads=1
 
       - name: Check that the test outputs are up-to-date
         run: bash tools/check-diff.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -94,6 +94,16 @@ jobs:
   test:
     name: Test Suite
     runs-on: spacetimedb-new-runner
+
+    # Add this for isolation:
+    container:
+      image: spacetimedb-ci:latest
+      options: >-
+        --user runner
+        -v /var/run/docker.sock:/var/run/docker.sock
+        -v /opt/github-runner/cargo-cache:/home/runner/.cargo/registry
+        -v /opt/github-runner/cargo-git:/home/runner/.cargo/git
+
     steps:
       - name: Find Git ref
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,7 +97,7 @@ jobs:
 
     # Add this for isolation:
     container:
-      image: spacetimedb-ci:latest
+      image: localhost/spacetimedb-ci:latest
       options: >-
         --user runner
         -v /var/run/docker.sock:/var/run/docker.sock

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -121,11 +121,10 @@ jobs:
         with:
           ref: ${{ env.GIT_REF }}
 
-      - uses: dsherret/rust-toolchain-file@v1
+      - name: Verify .NET
+        run: dotnet --version
 
-      - uses: actions/setup-dotnet@v3
-        with:
-          global-json-file: global.json
+      - uses: dsherret/rust-toolchain-file@v1
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -135,11 +134,6 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           run_install: true
-
-      - name: Create /stdb dir
-        run: |
-          sudo mkdir /stdb
-          sudo chmod 777 /stdb
 
       - name: Build typescript module sdk
         working-directory: crates/bindings-typescript

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -155,8 +155,9 @@ jobs:
         #Note: Unreal tests will be run separately
         run: cargo test --all -- --skip unreal
 
+        # The fallocate tests have been flakely when running in parallel
       - name: Run fallocate tests
-        run: cargo test -p spacetimedb-durability --features fallocate
+        run: cargo test -p spacetimedb-durability --features fallocate --test-threads=1
 
       - name: Check that the test outputs are up-to-date
         run: bash tools/check-diff.sh

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -75,6 +75,11 @@ jobs:
       - name: Start Docker daemon
         if: runner.os == 'Linux'
         run: /usr/local/bin/start-docker.sh
+
+      - name: Debug - Check files exist
+        run: |
+          ls -la /__w/SpacetimeDB/SpacetimeDB/Cargo.toml
+          pwd
       - name: Build and start database (Linux)
         if: runner.os == 'Linux'
         run: docker compose up -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -74,6 +74,9 @@ jobs:
         shell: powershell
       - name: Build and start database (Linux)
         if: runner.os == 'Linux'
+      - name: Start Docker daemon
+        if: runner.os == 'Linux'
+        run: /usr/local/bin/start-docker.sh
         run: docker compose up -d
       - name: Build and start database (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -72,11 +72,11 @@ jobs:
         if: runner.os == 'Windows'
         run: choco install psql -y --no-progress
         shell: powershell
-      - name: Build and start database (Linux)
-        if: runner.os == 'Linux'
       - name: Start Docker daemon
         if: runner.os == 'Linux'
         run: /usr/local/bin/start-docker.sh
+      - name: Build and start database (Linux)
+        if: runner.os == 'Linux'
         run: docker compose up -d
       - name: Build and start database (Windows)
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,10 +23,14 @@ jobs:
     strategy:
       matrix:
         include:
-          - { runner: spacetimedb-runner, smoketest_args: --docker }
+          - { runner: spacetimedb-new-runner, smoketest_args: --docker }
           - { runner: windows-latest, smoketest_args: --no-build-cli }
-        runner: [ spacetimedb-runner, windows-latest ]
     runs-on: ${{ matrix.runner }}
+    
+    # Add container only for Linux runner
+    container: ${{ matrix.runner == 'spacetimedb-new-runner' && 'localhost:5000/spacetimedb-ci:latest' || '' }}
+    runs-on: ${{ matrix.runner }}
+
     steps:
       - name: Find Git ref
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -397,7 +397,7 @@ jobs:
 
               cd "$GITHUB_WORKSPACE/sdks/unreal"
               cargo --version
-              cargo test -p sdk-unreal-test-harness --test test -- --test-threads=1 --nocapture
+              cargo test -- --test-threads=1
             '
 
   cli_docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -111,7 +111,6 @@ jobs:
       image: localhost:5000/spacetimedb-ci:latest
       options: >-
         --privileged
-        -v /var/run/docker.sock:/var/run/docker.sock
     steps:
       - name: Find Git ref
         env:
@@ -180,7 +179,6 @@ jobs:
       image: localhost:5000/spacetimedb-ci:latest
       options: >-
         --privileged
-        -v /var/run/docker.sock:/var/run/docker.sock
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -224,7 +222,6 @@ jobs:
       image: localhost:5000/spacetimedb-ci:latest
       options: >-
         --privileged
-        -v /var/run/docker.sock:/var/run/docker.sock
     steps:
       - uses: actions/checkout@v3
 
@@ -254,7 +251,6 @@ jobs:
       image: localhost:5000/spacetimedb-ci:latest
       options: >-
         --privileged
-        -v /var/run/docker.sock:/var/run/docker.sock
     permissions: read-all
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -31,9 +31,7 @@ jobs:
           - runner: windows-latest
             smoketest_args: --no-build-cli
             container: null
-
     runs-on: ${{ matrix.runner }}
-
     container: ${{ matrix.container }}
     
     steps:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -100,6 +100,7 @@ jobs:
       image: localhost:5000/spacetimedb-ci:latest
       options: >-
         --user runner
+        --privileged
         -v /var/run/docker.sock:/var/run/docker.sock
         -v /opt/github-runner/cargo-cache:/home/runner/.cargo/registry
         -v /opt/github-runner/cargo-git:/home/runner/.cargo/git

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,7 +28,10 @@ jobs:
     runs-on: ${{ matrix.runner }}
     
     # Add container only for Linux runner
-    container: ${{ matrix.use_container && fromJSON('{"image":"localhost:5000/spacetimedb-ci:latest","options":"--privileged -v /opt/github-runner/cargo-cache:/home/runner/.cargo/registry -v /opt/github-runner/cargo-git:/home/runner/.cargo/git"}') || null }}
+    container: ${{ matrix.use_container && fromJSON('{
+      "image": "localhost:5000/spacetimedb-ci:latest",
+      "options": "--privileged"
+    }') || null }}
     
     steps:
       - name: Find Git ref
@@ -48,9 +51,7 @@ jobs:
         with:
           ref: ${{ env.GIT_REF }}
       - uses: dsherret/rust-toolchain-file@v1
-      # Only install .NET on Windows (not in container where it's pre-installed)
       - uses: actions/setup-dotnet@v4
-        if: ${{ !matrix.use_container }}
         with:
           global-json-file: global.json
 
@@ -99,15 +100,11 @@ jobs:
   test:
     name: Test Suite
     runs-on: spacetimedb-new-runner
-
-    # Add this for isolation:
     container:
       image: localhost:5000/spacetimedb-ci:latest
       options: >-
         --privileged
         -v /var/run/docker.sock:/var/run/docker.sock
-        -v /opt/github-runner/cargo-cache:/home/runner/.cargo/registry
-        -v /opt/github-runner/cargo-git:/home/runner/.cargo/git
     steps:
       - name: Find Git ref
         env:
@@ -126,10 +123,11 @@ jobs:
         with:
           ref: ${{ env.GIT_REF }}
 
-      - name: Verify .NET
-        run: dotnet --version
-
       - uses: dsherret/rust-toolchain-file@v1
+
+      - uses: actions/setup-dotnet@v3
+        with:
+          global-json-file: global.json
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -139,6 +137,11 @@ jobs:
       - uses: pnpm/action-setup@v4
         with:
           run_install: true
+
+      - name: Create /stdb dir
+        run: |
+          sudo mkdir /stdb
+          sudo chmod 777 /stdb
 
       - name: Build typescript module sdk
         working-directory: crates/bindings-typescript
@@ -165,7 +168,12 @@ jobs:
 
   lints:
     name: Lints
-    runs-on: spacetimedb-runner
+    runs-on: spacetimedb-new-runner
+    container:
+      image: localhost:5000/spacetimedb-ci:latest
+      options: >-
+        --privileged
+        -v /var/run/docker.sock:/var/run/docker.sock
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -204,7 +212,12 @@ jobs:
 
   wasm_bindings:
     name: Build and test wasm bindings
-    runs-on: spacetimedb-runner
+    runs-on: spacetimedb-new-runner
+    container:
+      image: localhost:5000/spacetimedb-ci:latest
+      options: >-
+        --privileged
+        -v /var/run/docker.sock:/var/run/docker.sock
     steps:
       - uses: actions/checkout@v3
 
@@ -229,7 +242,12 @@ jobs:
 
   publish_checks:
     name: Check that packages are publishable
-    runs-on: ubuntu-latest
+    runs-on: spacetimedb-new-runner
+    container:
+      image: localhost:5000/spacetimedb-ci:latest
+      options: >-
+        --privileged
+        -v /var/run/docker.sock:/var/run/docker.sock
     permissions: read-all
     steps:
       - uses: actions/checkout@v3

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,14 +23,13 @@ jobs:
     strategy:
       matrix:
         include:
-          - { runner: spacetimedb-new-runner, smoketest_args: --docker }
-          - { runner: windows-latest, smoketest_args: --no-build-cli }
+          - { runner: spacetimedb-new-runner, smoketest_args: --docker, use_container: true }
+          - { runner: windows-latest, smoketest_args: --no-build-cli, use_container: false }
     runs-on: ${{ matrix.runner }}
     
     # Add container only for Linux runner
-    container: ${{ matrix.runner == 'spacetimedb-new-runner' && 'localhost:5000/spacetimedb-ci:latest' || '' }}
-    runs-on: ${{ matrix.runner }}
-
+    container: ${{ matrix.use_container && fromJSON('{"image":"localhost:5000/spacetimedb-ci:latest","options":"--privileged -v /opt/github-runner/cargo-cache:/home/runner/.cargo/registry -v /opt/github-runner/cargo-git:/home/runner/.cargo/git"}') || null }}
+    
     steps:
       - name: Find Git ref
         env:
@@ -49,7 +48,9 @@ jobs:
         with:
           ref: ${{ env.GIT_REF }}
       - uses: dsherret/rust-toolchain-file@v1
+      # Only install .NET on Windows (not in container where it's pre-installed)
       - uses: actions/setup-dotnet@v4
+        if: ${{ !matrix.use_container }}
         with:
           global-json-file: global.json
 
@@ -103,7 +104,6 @@ jobs:
     container:
       image: localhost:5000/spacetimedb-ci:latest
       options: >-
-        --user runner
         --privileged
         -v /var/run/docker.sock:/var/run/docker.sock
         -v /opt/github-runner/cargo-cache:/home/runner/.cargo/registry

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -394,7 +394,7 @@ jobs:
 
               cd "$GITHUB_WORKSPACE/sdks/unreal"
               cargo --version
-              cargo test
+              cargo test --test-threads=1
             '
 
   cli_docs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -403,6 +403,10 @@ jobs:
     name: Check CLI docs
     permissions: read-all
     runs-on: spacetimedb-new-runner
+    container:
+      image: localhost:5000/spacetimedb-ci:latest
+      options: >-
+        --privileged
     steps:
       - name: Find Git ref
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -23,13 +23,18 @@ jobs:
     strategy:
       matrix:
         include:
-          - { runner: spacetimedb-new-runner, smoketest_args: --docker, use_container: true }
-          - { runner: windows-latest, smoketest_args: --no-build-cli, use_container: false }
-    runs-on: ${{ matrix.runner }}
-    
-    # Add container only for Linux runner
-    container: ${{ matrix.use_container && fromJSON('{"image":"localhost:5000/spacetimedb-ci:latest","options":"--privileged"}') || null }}
+          - runner: spacetimedb-new-runner
+            smoketest_args: --docker
+            container:
+              image: localhost:5000/spacetimedb-ci:latest
+              options: --privileged
+          - runner: windows-latest
+            smoketest_args: --no-build-cli
+            container: null
 
+    runs-on: ${{ matrix.runner }}
+
+    container: ${{ matrix.container }}
     
     steps:
       - name: Find Git ref

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -317,7 +317,7 @@ jobs:
     name: Unreal Engine Tests
     # This can't go on e.g. ubuntu-latest because that runner runs out of disk space. ChatGPT suggested that the general solution tends to be to use
     # a custom runner.
-    runs-on: spacetimedb-runner
+    runs-on: spacetimedb-new-runner
     # Skip if this is an external contribution. GitHub secrets will be empty, so the step would fail anyway.
     if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     container:
@@ -402,7 +402,7 @@ jobs:
   cli_docs:
     name: Check CLI docs
     permissions: read-all
-    runs-on: ubuntu-latest
+    runs-on: spacetimedb-new-runner
     steps:
       - name: Find Git ref
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -76,10 +76,6 @@ jobs:
         if: runner.os == 'Linux'
         run: /usr/local/bin/start-docker.sh
 
-      - name: Debug - Check files exist
-        run: |
-          ls -la /__w/SpacetimeDB/SpacetimeDB/Cargo.toml
-          pwd
       - name: Build and start database (Linux)
         if: runner.os == 'Linux'
         run: docker compose up -d

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -97,13 +97,12 @@ jobs:
 
     # Add this for isolation:
     container:
-      image: localhost/spacetimedb-ci:latest
+      image: localhost:5000/spacetimedb-ci:latest
       options: >-
         --user runner
         -v /var/run/docker.sock:/var/run/docker.sock
         -v /opt/github-runner/cargo-cache:/home/runner/.cargo/registry
         -v /opt/github-runner/cargo-git:/home/runner/.cargo/git
-
     steps:
       - name: Find Git ref
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -93,7 +93,7 @@ jobs:
 
   test:
     name: Test Suite
-    runs-on: spacetimedb-runner
+    runs-on: spacetimedb-new-runner
     steps:
       - name: Find Git ref
         env:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,6 +22,7 @@ jobs:
     name: Smoketests
     strategy:
       matrix:
+        runner: [spacetimedb-new-runner, windows-latest]
         include:
           - runner: spacetimedb-new-runner
             smoketest_args: --docker

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,10 +28,8 @@ jobs:
     runs-on: ${{ matrix.runner }}
     
     # Add container only for Linux runner
-    container: ${{ matrix.use_container && fromJSON('{
-      "image": "localhost:5000/spacetimedb-ci:latest",
-      "options": "--privileged"
-    }') || null }}
+    container: ${{ matrix.use_container && fromJSON('{"image":"localhost:5000/spacetimedb-ci:latest","options":"--privileged"}') || null }}
+
     
     steps:
       - name: Find Git ref

--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -12,7 +12,11 @@ concurrency:
 
 jobs:
   unity-testsuite:
-    runs-on: spacetimedb-runner
+    runs-on: spacetimedb-new-runner
+    container:
+      image: localhost:5000/spacetimedb-ci:latest
+      options: >-
+        --privileged
     # Cancel any previous testsuites running on the same PR and/or ref.
     concurrency:
       group: unity-test-${{ github.event.pull_request.number || github.ref }}

--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -85,7 +85,7 @@ jobs:
           cargo install --force --path crates/cli --locked --message-format=short
           cargo install --force --path crates/standalone --locked --message-format=short
           # Add a handy alias using the old binary name, so that we don't have to rewrite all scripts (incl. in submodules).
-          ln -sf $HOME/.cargo/bin/spacetimedb-cli $HOME/.cargo/bin/spacetime
+          ln -sf $CARGO_HOME/bin/spacetimedb-cli $CARGO_HOME/bin/spacetime
         env:
           # Share the target directory with our local project to avoid rebuilding same SpacetimeDB crates twice.
           CARGO_TARGET_DIR: demo/Blackholio/server-rust/target

--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -162,6 +162,7 @@ jobs:
           key: Unity-${{ github.head_ref }}
           restore-keys: Unity-
 
+        # We need this to support "Docker in Docker"
       - name: Start Docker daemon
         run: /usr/local/bin/start-docker.sh
       - name: Run Unity tests

--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -164,9 +164,6 @@ jobs:
 
       - name: Start Docker daemon
         run: /usr/local/bin/start-docker.sh
-      - name: Debug Docker info
-        run: |
-          docker info
       - name: Run Unity tests
         uses: game-ci/unity-test-runner@v4
         with:

--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -17,6 +17,7 @@ jobs:
       image: localhost:5000/spacetimedb-ci:latest
       options: >-
         --privileged
+        --cgroupns=host
     # Cancel any previous testsuites running on the same PR and/or ref.
     concurrency:
       group: unity-test-${{ github.event.pull_request.number || github.ref }}
@@ -163,6 +164,9 @@ jobs:
 
       - name: Start Docker daemon
         run: /usr/local/bin/start-docker.sh
+      - name: Debug Docker info
+        run: |
+          docker info
       - name: Run Unity tests
         uses: game-ci/unity-test-runner@v4
         with:

--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -161,6 +161,8 @@ jobs:
           key: Unity-${{ github.head_ref }}
           restore-keys: Unity-
 
+      - name: Start Docker daemon
+        run: /usr/local/bin/start-docker.sh
       - name: Run Unity tests
         uses: game-ci/unity-test-runner@v4
         with:


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Speed improvements:

|CI Job|Before|After|Change|
|---|---|---|---|
|CI/Unreal Engine|29m|19m|34% faster|
|CI/Testsuite|21m|11m|47% faster|
|C#/Unity|20m|16m|20% faster|
|CI/Build and test wasm bindings|10m|3m|70% faster|
|CI/Smoketests (linux)|17m|12m|29% faster|

CI/Unreal Engine - switch to serial test execution
CI/Testsuite - partially switch to serial test execution

I also haven't seen an unexpected `Operation cancelled`, so I think that problem might be behind us.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

No user facing changes

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

2 - this touches a lot of our CI. It has been solid so far but if we start getting random CI failures this could be the cause.

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] All CI passes

(ok as of this update the internal tests are failing but that isn't related to this PR 😅 )

# Future Work

There are 2 remaining tests that could be optimized by moving them to faster runners:
1. (~45m) The windows smoketests (difficult because it requires Windows). @bfops has brought up the idea of only running this test on PRs that are in the merge queue and I think that would be the best 80/20 here. There really is not a great reason to be running this on every commit anyway.
2. (36m) The internal tests (easier because it's on Linux)

I would also consider moving from instantiating container images to instantiating VM snapshots. This would allow us a lot more flexibility and we wouldn't have to have as much container config in our workflow files. Based on guides I've seen online this is also somewhat common. Also managing docker within docker has been kind of a nightmare so it would be easier to run containers inside of VMs to remove a layer of containerization there.

## Testsuite inconsistencies

We have at least 2 different jobs that are inconsistent/flaky: the "testsuite" and the "unreal engine tests".

I'd like @JasonAtClockwork to make the unreal engine tests run sequentially so that we have less random failures. I know this will increase the testing time but due to this PR we should have extra headroom there.

I've also pinged Joshua about one of the tests that I've seen sometimes fails randomly. This is either an issue in the test or an issue in SpacetimeDB itself, I'm not sure yet.

These inconsistencies are present both in our custom runner and in the Github runners, so merging this PR will not make this situation any worse than it already is.
