### PR TITLE
CI - Fix "Check that packages are publishable" check

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -233,10 +233,10 @@ jobs:
         run: |
           set -ueo pipefail
           FAILED=0
-          ROOTS=(spacetimedb spacetimedb-sdk spacetimedb-cli spacetimedb-standalone)
-          CRATES=$(venv/bin/python3 tools/find-publish-list.py --recursive --quiet "${ROOTS[@]}")
-          for crate in $CRATES; do
-            if ! venv/bin/python3 tools/crate-publish-checks.py "crates/$crate"; then
+          ROOTS=(spacetimedb spacetimedb-sdk)
+          CRATES=$(venv/bin/python3 tools/find-publish-list.py --recursive --directories --quiet "${ROOTS[@]}")
+          for crate_dir in $CRATES; do
+            if ! venv/bin/python3 tools/crate-publish-checks.py "${crate_dir}"; then
               FAILED=$(( $FAILED + 1 ))
             fi
           done


### PR DESCRIPTION
# Description of Changes

Our `Check that packages are publishable` CI check was silently failing due to a subshell error not getting propagated upward.

This PR both fixes that error-swallowing behavior, and fixes the errors that were present.

# API and ABI breaking changes

No. CI only.

# Expected complexity level and risk

1

# Testing

- [x] Check fails if the script to find crates fails (https://github.com/clockworklabs/SpacetimeDB/actions/runs/19349995837/job/55359458732?pr=3660)
- [x] Check is now passing
