### PR TITLE
Improve tracking of module errors or panics for prometheus

### DIFF
--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -242,8 +242,9 @@ metrics_group!(
         pub reducer_wait_time: HistogramVec,
 
         #[name = spacetime_worker_wasm_instance_errors_total]
-        #[help = "The number of fatal WASM instance errors, such as reducer panics."]
-        #[labels(caller_identity: Identity, module_hash: Hash, caller_connection_id: ConnectionId, reducer_symbol: str)]
+        #[help = "The number of WASM instance errors, such as reducer panics."]
+        #[labels(database_identity: Identity, caller_identity: Identity, module_hash: Hash, caller_connection_id: ConnectionId, trapped:
+            bool, reducer_symbol: str)]
         pub wasm_instance_errors: IntCounterVec,
 
         #[name = spacetime_worker_wasm_memory_bytes]


### PR DESCRIPTION
# Description of Changes

Closes [#3507](https://github.com/clockworklabs/SpacetimeDB/issues/3507).

Add the database `identity` and if the error is `trap`.

# Expected complexity level and risk
1
# Testing
- [x] Manual inspection of metric, displays now:

```js
# TYPE spacetime_worker_wasm_instance_errors_total counter
spacetime_worker_wasm_instance_errors_total{caller_connection_id="bd7cc4bd2a2ed433524394207d55f948",caller_identity="c200da2d6ddb6c0beef0bbaafacffe5f0649c86b8d19411e3219066a6d0e5123",database_identity="c20076c95fc2e78175d8d8eec4aeb7f181f812279e03abadd21c878988478dc8",module_hash="50e173de3e047eaa422f3bbac12019e085472ec8c324dbe9d30f4a068f3be0db",reducer_symbol="panic_err",trapped="true"} 1
```