### PR TITLE
commitlog: Change default max-records-in-commit to 1

### DIFF
--- a/crates/commitlog/src/commitlog.rs
+++ b/crates/commitlog/src/commitlog.rs
@@ -920,7 +920,7 @@ fn range_is_empty(range: &impl RangeBounds<u64>) -> bool {
 
 #[cfg(test)]
 mod tests {
-    use std::{cell::Cell, iter::repeat};
+    use std::{cell::Cell, iter::repeat, num::NonZeroU16};
 
     use pretty_assertions::assert_matches;
 
@@ -1231,6 +1231,7 @@ mod tests {
             log.repo.clone(),
             Options {
                 max_segment_size: 1024,
+                max_records_in_commit: NonZeroU16::new(10).unwrap(),
                 ..Options::default()
             },
         )

--- a/crates/commitlog/src/lib.rs
+++ b/crates/commitlog/src/lib.rs
@@ -62,7 +62,7 @@ pub struct Options {
     /// If this number is exceeded, the commit is flushed to disk even without
     /// explicitly calling [`Commitlog::flush`].
     ///
-    /// Default: 65,535
+    /// Default: 1
     #[cfg_attr(feature = "serde", serde(default = "Options::default_max_records_in_commit"))]
     pub max_records_in_commit: NonZeroU16,
     /// Whenever at least this many bytes have been written to the currently
@@ -106,7 +106,7 @@ impl Default for Options {
 
 impl Options {
     pub const DEFAULT_MAX_SEGMENT_SIZE: u64 = 1024 * 1024 * 1024;
-    pub const DEFAULT_MAX_RECORDS_IN_COMMIT: NonZeroU16 = NonZeroU16::MAX;
+    pub const DEFAULT_MAX_RECORDS_IN_COMMIT: NonZeroU16 = NonZeroU16::new(1).expect("1 > 0, qed");
     pub const DEFAULT_OFFSET_INDEX_INTERVAL_BYTES: NonZeroU64 = NonZeroU64::new(4096).expect("4096 > 0, qed");
     pub const DEFAULT_OFFSET_INDEX_REQUIRE_SEGMENT_FSYNC: bool = false;
     pub const DEFAULT_PREALLOCATE_SEGMENTS: bool = false;

--- a/crates/commitlog/src/segment.rs
+++ b/crates/commitlog/src/segment.rs
@@ -772,7 +772,16 @@ mod tests {
     fn write_read_roundtrip() {
         let repo = repo::Memory::unlimited();
 
-        let mut writer = repo::create_segment_writer(&repo, Options::default(), Commit::DEFAULT_EPOCH, 0).unwrap();
+        let mut writer = repo::create_segment_writer(
+            &repo,
+            Options {
+                max_records_in_commit: NonZeroU16::new(4).unwrap(),
+                ..<_>::default()
+            },
+            Commit::DEFAULT_EPOCH,
+            0,
+        )
+        .unwrap();
         writer.append([0; 32]).unwrap();
         writer.append([1; 32]).unwrap();
         writer.append([2; 32]).unwrap();
@@ -801,7 +810,16 @@ mod tests {
     fn metadata() {
         let repo = repo::Memory::unlimited();
 
-        let mut writer = repo::create_segment_writer(&repo, Options::default(), Commit::DEFAULT_EPOCH, 0).unwrap();
+        let mut writer = repo::create_segment_writer(
+            &repo,
+            Options {
+                max_records_in_commit: NonZeroU16::new(3).unwrap(),
+                ..<_>::default()
+            },
+            Commit::DEFAULT_EPOCH,
+            0,
+        )
+        .unwrap();
         // Commit 0..2
         writer.append([0; 32]).unwrap();
         writer.append([0; 32]).unwrap();
@@ -835,7 +853,17 @@ mod tests {
         let repo = repo::Memory::unlimited();
         let commits = vec![vec![[1; 32], [2; 32]], vec![[3; 32]], vec![[4; 32], [5; 32]]];
 
-        let mut writer = repo::create_segment_writer(&repo, Options::default(), Commit::DEFAULT_EPOCH, 0).unwrap();
+        let mut writer = repo::create_segment_writer(
+            &repo,
+            Options {
+                max_records_in_commit: NonZeroU16::new(3).unwrap(),
+                ..<_>::default()
+            },
+            Commit::DEFAULT_EPOCH,
+            0,
+        )
+        .unwrap();
+
         for commit in &commits {
             for tx in commit {
                 writer.append(*tx).unwrap();
@@ -868,7 +896,16 @@ mod tests {
         let repo = repo::Memory::unlimited();
         let commits = vec![vec![[1; 32], [2; 32]], vec![[3; 32]], vec![[4; 32], [5; 32]]];
 
-        let mut writer = repo::create_segment_writer(&repo, Options::default(), Commit::DEFAULT_EPOCH, 0).unwrap();
+        let mut writer = repo::create_segment_writer(
+            &repo,
+            Options {
+                max_records_in_commit: NonZeroU16::new(3).unwrap(),
+                ..<_>::default()
+            },
+            Commit::DEFAULT_EPOCH,
+            0,
+        )
+        .unwrap();
         for commit in &commits {
             for tx in commit {
                 writer.append(*tx).unwrap();

--- a/crates/commitlog/src/tests/helpers.rs
+++ b/crates/commitlog/src/tests/helpers.rs
@@ -1,4 +1,4 @@
-use std::fmt::Debug;
+use std::{fmt::Debug, num::NonZeroU16};
 
 use env_logger::Env;
 
@@ -13,6 +13,7 @@ pub fn mem_log<T: Encode>(max_segment_size: u64) -> commitlog::Generic<repo::Mem
         repo::Memory::unlimited(),
         Options {
             max_segment_size,
+            max_records_in_commit: NonZeroU16::new(10).unwrap(),
             ..Options::default()
         },
     )

--- a/crates/commitlog/src/tests/partial.rs
+++ b/crates/commitlog/src/tests/partial.rs
@@ -180,6 +180,7 @@ fn open_log<T>(repo: ShortMem) -> commitlog::Generic<ShortMem, T> {
         repo,
         Options {
             max_segment_size: 1024,
+            max_records_in_commit: NonZeroU16::new(10).unwrap(),
             ..Options::default()
         },
     )


### PR DESCRIPTION
It is almost always wrong / undesirable to pack more than one
transaction in a commit, so adjust the default accordingly.

This also avoids surprises when using `#[serde(default)]` with nested
structs -- serde evaluates the default depth-first, so overriding a
single field in a nested struct will not consider any
`#[serde(default = "custom_default")]` annotations on the parent.
