### PR TITLE
CI - Fix empty lookup

### DIFF
--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -45,7 +45,7 @@ jobs:
           author_discord_id="$(
             jq -r \
               --arg u "${{ github.event.pull_request.user.login }}" \
-              'try .[$u] catch empty' \
+              '.[$u] // empty' \
               <<<"${DISCORD_USER_MAP}"
           )"
           if [ -z "${author_discord_id}" ]; then


### PR DESCRIPTION
# Description of Changes

When the author isn't in the lookup table, we were getting `null` instead of the empty string. This fixes that.

# API and ABI breaking changes

None. CI only.

# Expected complexity level and risk

1

# Testing

None