### PR TITLE
Add extra claims to v1/identity/websocket-token

### DIFF
--- a/crates/auth/src/identity.rs
+++ b/crates/auth/src/identity.rs
@@ -4,6 +4,7 @@ pub use jsonwebtoken::{DecodingKey, EncodingKey};
 use serde::Deserializer;
 use serde::{Deserialize, Serialize};
 use spacetimedb_lib::Identity;
+use std::collections::HashMap;
 use std::time::SystemTime;
 
 #[derive(Debug, Clone)]
@@ -41,6 +42,9 @@ pub struct SpacetimeIdentityClaims {
     pub iat: SystemTime,
     #[serde_as(as = "Option<serde_with::TimestampSeconds>")]
     pub exp: Option<SystemTime>,
+
+    #[serde(flatten)]
+    pub extra: Option<HashMap<String, serde_json::Value>>,
 }
 
 fn deserialize_audience<'de, D>(deserializer: D) -> Result<Vec<String>, D::Error>
@@ -84,6 +88,10 @@ pub struct IncomingClaims {
     pub iat: SystemTime,
     #[serde_as(as = "Option<serde_with::TimestampSeconds>")]
     pub exp: Option<SystemTime>,
+
+    /// All remaining claims from the JWT payload
+    #[serde(flatten)]
+    pub extra: Option<HashMap<String, serde_json::Value>>,
 }
 
 impl TryInto<SpacetimeIdentityClaims> for IncomingClaims {
@@ -122,6 +130,7 @@ impl TryInto<SpacetimeIdentityClaims> for IncomingClaims {
             audience: self.audience,
             iat: self.iat,
             exp: self.exp,
+            extra: self.extra,
         })
     }
 }

--- a/crates/client-api/src/auth.rs
+++ b/crates/client-api/src/auth.rs
@@ -14,6 +14,7 @@ use spacetimedb::auth::token_validation::{
 use spacetimedb::auth::JwtKeys;
 use spacetimedb::energy::EnergyQuanta;
 use spacetimedb::identity::Identity;
+use std::collections::HashMap;
 use std::time::{Duration, SystemTime};
 use uuid::Uuid;
 
@@ -117,6 +118,7 @@ pub struct TokenClaims {
     pub issuer: String,
     pub subject: String,
     pub audience: Vec<String>,
+    pub extra: Option<HashMap<String, serde_json::Value>>,
 }
 
 impl From<SpacetimeAuth> for TokenClaims {
@@ -126,6 +128,7 @@ impl From<SpacetimeAuth> for TokenClaims {
             subject: auth.claims.subject,
             // This will need to be changed when we care about audiencies.
             audience: Vec::new(),
+            extra: auth.claims.extra,
         }
     }
 }
@@ -136,6 +139,7 @@ impl TokenClaims {
             issuer,
             subject,
             audience: Vec::new(),
+            extra: None,
         }
     }
 
@@ -159,6 +163,7 @@ impl TokenClaims {
             subject: self.subject.clone(),
             issuer: self.issuer.clone(),
             audience: self.audience.clone(),
+            extra: self.extra.clone(),
             iat,
             exp,
         };
@@ -184,6 +189,7 @@ impl SpacetimeAuth {
             subject: subject.clone(),
             // Placeholder audience.
             audience: vec!["spacetimedb".to_string()],
+            extra: None,
         };
 
         let (claims, token) = claims.encode_and_sign(ctx.jwt_auth_provider()).map_err(log_and_500)?;
@@ -291,6 +297,7 @@ mod tests {
             issuer: "localhost".to_string(),
             subject: "test-subject".to_string(),
             audience: vec!["spacetimedb".to_string()],
+            extra: None,
         };
         let id = claims.id();
         let (_, token) = claims.encode_and_sign(&kp.private)?;
@@ -310,6 +317,7 @@ mod tests {
             issuer: "localhost".to_string(),
             subject: "test-subject".to_string(),
             audience: vec![dummy_audience.clone()],
+            extra: None,
         };
         let (_, token) = claims.encode_and_sign(&kp.private)?;
         let st_creds = SpacetimeCreds::from_signed_token(token);

--- a/crates/core/src/auth/token_validation.rs
+++ b/crates/core/src/auth/token_validation.rs
@@ -349,6 +349,7 @@ mod tests {
             audience: vec![],
             iat: std::time::SystemTime::now(),
             exp: None,
+            extra: None,
         };
         let token = kp.private.sign(&orig_claims)?;
 
@@ -391,6 +392,7 @@ mod tests {
             audience: vec![],
             iat: std::time::SystemTime::now(),
             exp: None,
+            extra: None,
         };
         let token = kp.private.sign(&orig_claims)?;
 
@@ -444,6 +446,7 @@ mod tests {
             audience: vec![],
             iat: std::time::SystemTime::now(),
             exp: None,
+            extra: None,
         };
         let token = kp.private.sign(&orig_claims)?;
 
@@ -609,6 +612,7 @@ mod tests {
             audience: vec![],
             iat: std::time::SystemTime::now(),
             exp: None,
+            extra: None,
         };
         for kp in [kp1, kp2] {
             log::debug!("Testing with key {:?}", kp.kid);

--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -335,6 +335,7 @@ impl ClientConnectionSender {
             audience: vec![],
             iat: SystemTime::now(),
             exp: None,
+            extra: None,
         };
         let sender = Self {
             id,


### PR DESCRIPTION
# Description of Changes

Due to a limitation around passing headers to a WebSocket connection, The typescript SDK rely on the endpoint `/v1/identity/websocket-token` to get a new, short-lived token.
Currently, this endpoint strips all the other claims from the token and only returns the following claims:

- `hex_identity`
- `sub`
- `iss`
- `aud`
- `iat`
- `exp`

This PR aims to fix this issue by introducing a new member field `extra` to `SpacetimeIdentityClaims` and `TokenClaims` and letting serde do its job.

# API and ABI breaking changes

None

# Expected complexity level and risk

2 - The change is trivial (1) but I'm not 100% familiar with all the places where we would be signing a token (1).

# Testing

1. `curl` the endpoint and checking that the token returned contains all the expected claims
2. Check that that the endpoint `v1/identity` still correctly issues and identity and token
