### PR TITLE
Added staging to allowable issuers

### DIFF
--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -45,8 +45,7 @@ use spacetimedb_schema::auto_migrate::{
 use super::subscribe::{handle_websocket, HasWebSocketOptions};
 
 fn require_spacetime_auth_for_creation() -> Option<String> {
-    // If the string is a non-empty value, require SpacetimeAuth for database creation
-    // and return the value for logging purposes.
+    // If the string is a non-empty value, return the string to be used as the required issuer
     // TODO(cloutiertyler): This env var replaces TEMP_REQUIRE_SPACETIME_AUTH,
     // we should remove that one in the future. We may eventually remove
     // the below restriction entirely as well in Maincloud.


### PR DESCRIPTION
# Description of Changes

This modifies the environment variable that we pass in for requiring SpacetimeAuth to publish so that we can put different issuer values for live and staging.

# API and ABI breaking changes

This requires a new environment variable or it skips this requirement.

# Expected complexity level and risk

1

# Testing

I have not tested this change locally.
