### PR TITLE
Use custom runner for building CLI

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -19,7 +19,7 @@ jobs:
             runner: spacetimedb-new-runner
             container:
               image: localhost:5000/spacetimedb-ci:latest
-              options: >
+              options: >-
                 --privileged
 
           - name: aarch64 Linux

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,7 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: x86_64 Linux, target: x86_64-unknown-linux-gnu, runner: ubuntu-latest }
+          - { name: x86_64 Linux, target: x86_64-unknown-linux-gnu, runner: spacetimedb-new-runner }
           - { name: aarch64 Linux, target: aarch64-unknown-linux-gnu, runner: arm-runner }
           # Disabled because musl builds weren't working and we didn't want to investigate. See https://github.com/clockworklabs/SpacetimeDB/pull/2964.
           # - { name: x86_64 Linux musl, target: x86_64-unknown-linux-musl, runner: bare-metal, container: alpine }

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -21,35 +21,14 @@ jobs:
               image: localhost:5000/spacetimedb-ci:latest
               options: >-
                 --privileged
-
-          - name: aarch64 Linux
-            target: aarch64-unknown-linux-gnu
-            runner: arm-runner
-
-          # Disabled because musl builds weren't working and we didn't want to investigate.
-          # See https://github.com/clockworklabs/SpacetimeDB/pull/2964.
-          # - name: x86_64 Linux musl
-          #   target: x86_64-unknown-linux-musl
-          #   runner: bare-metal
-          #   container: alpine
-
-          # FIXME: arm musl build.
-          # "JavaScript Actions in Alpine containers are only supported on x64 Linux runners"
-          # - name: aarch64 Linux musl
-          #   target: aarch64-unknown-linux-musl
-          #   runner: arm-runner
-
-          - name: aarch64 macOS
-            target: aarch64-apple-darwin
-            runner: macos-latest
-
-          - name: x86_64 macOS
-            target: x86_64-apple-darwin
-            runner: macos-latest
-
-          - name: x86_64 Windows
-            target: x86_64-pc-windows-msvc
-            runner: windows-latest
+          - { name: aarch64 Linux, target: aarch64-unknown-linux-gnu, runner: arm-runner }
+          # Disabled because musl builds weren't working and we didn't want to investigate. See https://github.com/clockworklabs/SpacetimeDB/pull/2964.
+          # - { name: x86_64 Linux musl, target: x86_64-unknown-linux-musl, runner: bare-metal, container: alpine }
+          # FIXME: arm musl build. "JavaScript Actions in Alpine containers are only supported on x64 Linux runners"
+          # - { name: aarch64 Linux musl, target: aarch64-unknown-linux-musl, runner: arm-runner }
+          - { name: aarch64 macOS, target: aarch64-apple-darwin, runner: macos-latest }
+          - { name: x86_64 macOS, target: x86_64-apple-darwin, runner: macos-latest }
+          - { name: x86_64 Windows, target: x86_64-pc-windows-msvc, runner: windows-latest }
 
     name: Build CLI for ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,15 +14,42 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: x86_64 Linux, target: x86_64-unknown-linux-gnu, runner: spacetimedb-new-runner }
-          - { name: aarch64 Linux, target: aarch64-unknown-linux-gnu, runner: arm-runner }
-          # Disabled because musl builds weren't working and we didn't want to investigate. See https://github.com/clockworklabs/SpacetimeDB/pull/2964.
-          # - { name: x86_64 Linux musl, target: x86_64-unknown-linux-musl, runner: bare-metal, container: alpine }
-          # FIXME: arm musl build. "JavaScript Actions in Alpine containers are only supported on x64 Linux runners"
-          # - { name: aarch64 Linux musl, target: aarch64-unknown-linux-musl, runner: arm-runner }
-          - { name: aarch64 macOS, target: aarch64-apple-darwin, runner: macos-latest }
-          - { name: x86_64 macOS, target: x86_64-apple-darwin, runner: macos-latest }
-          - { name: x86_64 Windows, target: x86_64-pc-windows-msvc, runner: windows-latest }
+          - name: x86_64 Linux
+            target: x86_64-unknown-linux-gnu
+            runner: spacetimedb-new-runner
+            container:
+              image: localhost:5000/spacetimedb-ci:latest
+              options: >
+                --privileged
+
+          - name: aarch64 Linux
+            target: aarch64-unknown-linux-gnu
+            runner: arm-runner
+
+          # Disabled because musl builds weren't working and we didn't want to investigate.
+          # See https://github.com/clockworklabs/SpacetimeDB/pull/2964.
+          # - name: x86_64 Linux musl
+          #   target: x86_64-unknown-linux-musl
+          #   runner: bare-metal
+          #   container: alpine
+
+          # FIXME: arm musl build.
+          # "JavaScript Actions in Alpine containers are only supported on x64 Linux runners"
+          # - name: aarch64 Linux musl
+          #   target: aarch64-unknown-linux-musl
+          #   runner: arm-runner
+
+          - name: aarch64 macOS
+            target: aarch64-apple-darwin
+            runner: macos-latest
+
+          - name: x86_64 macOS
+            target: x86_64-apple-darwin
+            runner: macos-latest
+
+          - name: x86_64 Windows
+            target: x86_64-pc-windows-msvc
+            runner: windows-latest
 
     name: Build CLI for ${{ matrix.name }}
     runs-on: ${{ matrix.runner }}


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

- This has 2 benefits:
1. `ubuntu-latest` recently changed to 24.04 instead of 22.04 so that broke the last CLI on some systems. This will fix that issue.
2. Performance - this should build much much faster.

# API and ABI breaking changes

None

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

2 - if the CLI fails to build this might be why.

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

- [x] Tested via today's release: https://github.com/clockworklabs/SpacetimeDB/actions/runs/19550648024/job/55980960439
