### PR TITLE
CI - No discord ping for skipped checks

### DIFF
--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -36,7 +36,7 @@ jobs:
               --json 'workflow,state,name' |
               jq '.[]
                 | select(.workflow != "Discord notifications")
-                | select(.state != "SUCCESS" and .state != "NEUTRAL")
+                | select(.state != "SUCCESS" and .state != "NEUTRAL" and .state != "SKIPPED")
               ' |
               jq -r '"\(.workflow) / \(.name): \(.state)"'
           )"


### PR DESCRIPTION
# Description of Changes

I thought this was covered by the `NEUTRAL` case, but apparently `SKIPPED` is separate.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

We'll see when it merges :shrug: 