### PR TITLE
Allowed specifying hex strings in the Postgres escape format

### DIFF
--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -305,7 +305,7 @@ pub fn from_hex_pad<R: hex::FromHex<Error = hex::FromHexError>, T: AsRef<[u8]>>(
     hex: T,
 ) -> Result<R, hex::FromHexError> {
     let hex = hex.as_ref();
-    let hex = if hex.starts_with(b"0x") {
+    let hex = if hex.starts_with(b"0x") || hex.starts_with(b"\\x") {
         &hex[2..]
     } else if hex.starts_with(b"X'") {
         &hex[2..hex.len()]

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -305,14 +305,32 @@ pub fn from_hex_pad<R: hex::FromHex<Error = hex::FromHexError>, T: AsRef<[u8]>>(
     hex: T,
 ) -> Result<R, hex::FromHexError> {
     let hex = hex.as_ref();
-    let hex = if hex.starts_with(b"0x") || hex.starts_with(b"\\x") {
+    let hex = if hex.starts_with(b"0x") {
         &hex[2..]
-    } else if hex.starts_with(b"X'") {
-        &hex[2..hex.len()]
+    } else if hex.starts_with(b"\\x") {
+        &hex[2..]
+    } else if hex.starts_with(b"X'") && hex.ends_with(b"'") {
+        &hex[2..hex.len() - 1]
     } else {
         hex
     };
     hex::FromHex::from_hex(hex)
+}
+
+#[cfg(test)]
+mod tests {
+    use super::from_hex_pad;
+
+    #[test]
+    fn from_hex_pad_accepts_pg_escape_hex() {
+        assert_eq!(from_hex_pad::<Vec<u8>, _>(r"\xAABBCCDD").unwrap(), [0xAA, 0xBB, 0xCC, 0xDD]);
+    }
+
+    #[test]
+    fn from_hex_pad_accepts_prefixed_and_delimited_hex() {
+        assert_eq!(from_hex_pad::<Vec<u8>, _>("0xAABBCCDD").unwrap(), [0xAA, 0xBB, 0xCC, 0xDD]);
+        assert_eq!(from_hex_pad::<Vec<u8>, _>("X'AABBCCDD'").unwrap(), [0xAA, 0xBB, 0xCC, 0xDD]);
+    }
 }
 
 /// Returns a resolved `AlgebraicType` (containing no `AlgebraicTypeRefs`) for a given `SpacetimeType`,


### PR DESCRIPTION
# Description of Changes

For consistency with the PG Wire output format for `BYTEA`.

Before,
```sql
SELECT * FROM user WHERE id = '\xc200a1589a788b44c6269819cba4b3493db01ade34652acf33476662fdfc0cfb';
```
gave:
```error
The literal expression `\xc200a1589a788b44c6269819cba4b3493db01ade34652acf33476662fdfc0cfb` cannot be parsed as type `(__identity__: U256)`
```

# API and ABI breaking changes

None.

# Expected complexity level and risk

### 1:
Trivial change.

# Testing

- [x] Manual testing