### PR TITLE
Refactor typescript table iterators

### DIFF
--- a/crates/bindings-typescript/src/lib/indexes.ts
+++ b/crates/bindings-typescript/src/lib/indexes.ts
@@ -108,7 +108,7 @@ export interface ReadonlyRangedIndex<
 > {
   filter(
     range: IndexScanRangeBounds<TableDef, I>
-  ): IteratorObject<Prettify<RowType<TableDef>>>;
+  ): IteratorObject<Prettify<RowType<TableDef>>, undefined>;
 }
 
 /**

--- a/crates/bindings-typescript/src/lib/table.ts
+++ b/crates/bindings-typescript/src/lib/table.ts
@@ -166,8 +166,8 @@ export interface ReadonlyTableMethods<TableDef extends UntypedTableDef> {
   count(): bigint;
 
   /** Iterate over all rows in the TX state. Rust Iterator<Item=Row> → TS IterableIterator<Row>. */
-  iter(): IteratorObject<Prettify<RowType<TableDef>>>;
-  [Symbol.iterator](): IteratorObject<Prettify<RowType<TableDef>>>;
+  iter(): IteratorObject<Prettify<RowType<TableDef>>, undefined>;
+  [Symbol.iterator](): IteratorObject<Prettify<RowType<TableDef>>, undefined>;
 }
 
 /**

--- a/crates/bindings-typescript/src/sdk/table_cache.ts
+++ b/crates/bindings-typescript/src/sdk/table_cache.ts
@@ -201,7 +201,7 @@ export class TableCacheImpl<
       return impl as ReadonlyIndex<TableDef, I>;
     } else {
       const impl: ReadonlyRangedIndex<TableDef, I> = {
-        *filter(range: any): IteratorObject<Row, void> {
+        *filter(range: any): IteratorObject<Row, undefined> {
           for (const row of self.iter()) {
             if (matchRange(row, range)) yield row;
           }
@@ -223,7 +223,7 @@ export class TableCacheImpl<
    */
   iter(): IteratorObject<
     Prettify<RowType<TableDefForTableName<RemoteModule, TableName>>>,
-    void
+    undefined
   > {
     function* generator(
       rows: Map<
@@ -232,7 +232,7 @@ export class TableCacheImpl<
       >
     ): IteratorObject<
       Prettify<RowType<TableDefForTableName<RemoteModule, TableName>>>,
-      void
+      undefined
     > {
       for (const [row] of rows.values()) {
         yield row as Prettify<
@@ -249,7 +249,7 @@ export class TableCacheImpl<
    */
   [Symbol.iterator](): IteratorObject<
     Prettify<RowType<TableDefForTableName<RemoteModule, TableName>>>,
-    void
+    undefined
   > {
     return this.iter();
   }

--- a/crates/bindings-typescript/src/server/runtime.ts
+++ b/crates/bindings-typescript/src/server/runtime.ts
@@ -649,7 +649,7 @@ function hasOwn<K extends PropertyKey>(
   return Object.hasOwn(o, k);
 }
 
-function* tableIterator(id: u32, ty: AlgebraicType): Generator<any, void> {
+function* tableIterator(id: u32, ty: AlgebraicType): Generator<any, undefined> {
   using iter = new IteratorHandle(id);
   const { typespace } = MODULE_DEF;
 

--- a/crates/bindings-typescript/src/server/view.test-d.ts
+++ b/crates/bindings-typescript/src/server/view.test-d.ts
@@ -87,6 +87,7 @@ spacetime.anonymousView(
 spacetime.anonymousView(
   { name: 'optionalPersonWrong', public: true },
   optionalPerson,
+  // @ts-expect-error returns a value of the wrong type.
   ctx => {
     return ctx.db.order.iter().next().value;
   }


### PR DESCRIPTION
# Description of Changes

A few main goals here:
* have our iterator functions return an [`Iterator` object](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Iterator) so that users can use its combinators like `filter()` and `find()` and `reduce()`. It's a very new JS api but we happen to know that the module code will always be run in an environment that has it* :)

* improve lifecycle handling for iterator handles - mainly, if an iterator is not run to completion, it will now eventually get garbage collected, whereas before we would have a resource leak.

It turns out that the easiest way to do both of those things was to turn TableIterator into a generator function, which also happens to make the code much easier to read. Hooray :)

\* I did mention it in `table_cache` (which isn't run in our module host) but it's fine, since that's only in the type system and `IteratorObject` is defined in typescript's `lib.es2015.iterable.d.ts` but is only given fancy methods in `lib.esnext.iterator.d.ts` - so if the user uses esnext, they'll have access to them, but otherwise not.

# Expected complexity level and risk

1: this better separates concerns and makes the code clearer in its purpose.

# Testing

- [x] Refactor, so automated testing is sufficient.