### PR TITLE
CI - Run C# test suite on `merge_group`

### DIFF
--- a/.github/workflows/csharp-test.yml
+++ b/.github/workflows/csharp-test.yml
@@ -5,6 +5,7 @@ on:
     branches:
       - master
   pull_request:
+  merge_group:
 
 concurrency:
   group: ${{ github.workflow }}-${{ github.event.pull_request.number || format('sha-{0}', github.sha) }}


### PR DESCRIPTION
# Description of Changes

The merge queue was getting stuck since this is now a required check.

# API and ABI breaking changes

None. CI only.

# Expected complexity level and risk

1

# Testing

We'll see if this merges!