### PR TITLE
Update typescript package size limits

### DIFF
--- a/crates/bindings-typescript/package.json
+++ b/crates/bindings-typescript/package.json
@@ -82,13 +82,13 @@
       "name": "cjs (brotli)",
       "path": "dist/index.cjs",
       "brotli": true,
-      "limit": "27 kB"
+      "limit": "54 kB"
     },
     {
       "name": "esm (brotli)",
       "path": "dist/index.mjs",
       "brotli": true,
-      "limit": "26 kB"
+      "limit": "62 kB"
     },
     {
       "name": "esm (gzip)",
@@ -100,25 +100,25 @@
       "name": "esm (uncompressed)",
       "path": "dist/index.mjs",
       "brotli": false,
-      "limit": "164 kB"
+      "limit": "328 kB"
     },
     {
       "name": "esm min (brotli)",
       "path": "dist/min/index.browser.mjs",
       "brotli": true,
-      "limit": "15 kB"
+      "limit": "30 kB"
     },
     {
       "name": "esm min (gzip)",
       "path": "dist/min/index.browser.mjs",
       "gzip": true,
-      "limit": "17 kB"
+      "limit": "34 kB"
     },
     {
       "name": "esm min (uncompressed)",
       "path": "dist/min/index.browser.mjs",
       "brotli": false,
-      "limit": "67 kB"
+      "limit": "134 kB"
     },
     {
       "name": "react esm min (brotli)",

--- a/crates/bindings-typescript/package.json
+++ b/crates/bindings-typescript/package.json
@@ -82,7 +82,7 @@
       "name": "cjs (brotli)",
       "path": "dist/index.cjs",
       "brotli": true,
-      "limit": "26 kB"
+      "limit": "27 kB"
     },
     {
       "name": "esm (brotli)",
@@ -94,31 +94,31 @@
       "name": "esm (gzip)",
       "path": "dist/index.mjs",
       "gzip": true,
-      "limit": "30 kB"
+      "limit": "31 kB"
     },
     {
       "name": "esm (uncompressed)",
       "path": "dist/index.mjs",
       "brotli": false,
-      "limit": "160 kB"
+      "limit": "164 kB"
     },
     {
       "name": "esm min (brotli)",
       "path": "dist/min/index.browser.mjs",
       "brotli": true,
-      "limit": "14 kB"
+      "limit": "15 kB"
     },
     {
       "name": "esm min (gzip)",
       "path": "dist/min/index.browser.mjs",
       "gzip": true,
-      "limit": "16 kB"
+      "limit": "17 kB"
     },
     {
       "name": "esm min (uncompressed)",
       "path": "dist/min/index.browser.mjs",
       "brotli": false,
-      "limit": "65 kB"
+      "limit": "67 kB"
     },
     {
       "name": "react esm min (brotli)",


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

I got these errors when I tried sending out the typescript NPM package:

```
  cjs (brotli)
  Package size limit has exceeded by 165 B
  Size limit: 26 kB
  Size:       26.16 kB brotlied
  
  esm (brotli)
  Size limit: 26 kB
  Size:       25.87 kB brotlied
  
  esm (gzip)
  Package size limit has exceeded by 536 B
  Size limit: 30 kB
  Size:       30.54 kB gzipped
  
  esm (uncompressed)
  Package size limit has exceeded by 3.77 kB
  Size limit: 160 kB
  Size:       163.77 kB
  
  esm min (brotli)
  Package size limit has exceeded by 194 B
  Size limit: 14 kB
  Size:       14.19 kB brotlied
  
  esm min (gzip)
  Package size limit has exceeded by 144 B
  Size limit: 16 kB
  Size:       16.14 kB gzipped
  
  esm min (uncompressed)
  Package size limit has exceeded by 1.29 kB
  Size limit: 65 kB
  Size:       66.29 kB
```

# API and ABI breaking changes

None

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

1

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] After this change I was able to publish the typescript NPM package.
