### PR TITLE
[TS] fix `connectionBuilder` wrong codegen type.

### DIFF
--- a/crates/codegen/src/typescript.rs
+++ b/crates/codegen/src/typescript.rs
@@ -408,7 +408,7 @@ impl Lang for TypeScript {
         );
         writeln!(
             out,
-            "export class DbConnectionBuilder extends __DbConnectionBuilder<DbConnection> {{}}"
+            "export class DbConnectionBuilder extends __DbConnectionBuilder<__DbConnectionImpl<typeof REMOTE_MODULE>> {{}}"
         );
 
         writeln!(out);


### PR DESCRIPTION
# Description of Changes

When trying to use the react hook and you supply a DbConnectionBuilder to `connectionBuilder={builder}` from your module bindings typescript throws a type error since the codegeneration type for the generic field is wrong.

With `bun dev` this error lets you still build the application and view it but with a production build it hard errors.

Fix it by changing the codegen to use the right interface instead of a hardcoded `DbConnection` type that isn't even present in the file and should come from the module_bindings.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] Tried production build with the fix and it succeeded since no more type errors are present.

