### PR TITLE
Actually report reducer fuel used

### DIFF
--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -738,6 +738,11 @@ impl InstanceCommon {
             self.call_function(caller_identity, reducer_name, |budget| inst.call_reducer(op, budget))
         });
 
+        // Report the reducer execution metrics
+        vm_metrics.report_energy_used(result.stats.energy_used());
+        vm_metrics.report_total_duration(result.stats.total_duration());
+        vm_metrics.report_abi_duration(result.stats.abi_duration());
+
         // An outer error occurred.
         // This signifies a logic error in the module rather than a properly
         // handled bad argument from the caller of a reducer.


### PR DESCRIPTION
# Description of Changes

In the `call_reducer_with_tx` function we only reported the WASM fuel used by view evaulation, but not the stats from the actual reducer call. This PR fixes it and we now properly record it.

# Expected complexity level and risk

1

# Testing

I've tested the change locally. Before the change the reported metrics were always zero after running any reducer. Now the usage is reported properly.