### PR TITLE
CI - Skip the Unity testsuite on external PRs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -526,6 +526,9 @@ jobs:
           fi
 
   unity-testsuite:
+    # Skip if this is an external contribution.
+    # The license secrets will be empty, so the step would fail anyway.
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
     permissions:
       contents: read
       checks: write
@@ -650,9 +653,6 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
-        # Skip if this is an external contribution.
-        # The license secrets will be empty, so the step would fail anyway.
-        if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
 
   csharp-testsuite:
     runs-on: spacetimedb-new-runner


### PR DESCRIPTION
# Description of Changes

Bubbling up an `if` since we split out the unity testsuite into its own job.

The GitHub docs say (https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/collaborating-on-repositories-with-code-quality-features/about-status-checks):
> A job that is skipped will report its status as "Success". It will not prevent a pull request from merging, even if it is a required check.

# API and ABI breaking changes

None. CI-only change.

# Expected complexity level and risk

1

# Testing

Unsure how to test this honestly :shrug: 