### PR TITLE
[Rust] update module bindings to use new view abi

### DIFF
--- a/crates/bindings/tests/ui/views.stderr
+++ b/crates/bindings/tests/ui/views.stderr
@@ -237,6 +237,7 @@ error[E0277]: Views must return `Vec<T>` or `Option<T>` where `T` is a `Spacetim
     |
     = help: the following other types implement trait `ViewReturn`:
               Option<T>
+              Query<T>
               Vec<T>
 
 error[E0277]: invalid view signature


### PR DESCRIPTION
# Description of Changes

Updates the rust module bindings to use new view abi (`ViewResultHeader`) and updates the return codes for the `__call_view__` and `__call_view_anon__` module exports. This is in preparation for `Query` builder support.

# API and ABI breaking changes

Not breaking. Existing modules will continue to use the old abi. New modules will use the new abi. However previous host versions will not support modules built using this version of the bindings.

# Expected complexity level and risk

2

# Testing

This is an internal refactor. All existing tests should continue to pass. The only tests that needed updating were the negative module compilation tests because the error messages produced by rustc changed.
