### PR TITLE
client-api: Deny changing the parent of an existing database

### DIFF
--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -710,14 +710,21 @@ pub async fn publish<S: NodeDelegate + ControlStateDelegate + Authorization>(
         let name_or_identity = name_or_identity
             .as_ref()
             .ok_or_else(|| bad_request("Clear database requires database name or identity".into()))?;
-        if let Ok(identity) = name_or_identity.try_resolve(&ctx).await.map_err(log_and_500)? {
-            if ctx
+        let database_identity = name_or_identity.try_resolve(&ctx).await.map_err(log_and_500)?;
+        if let Ok(identity) = database_identity {
+            let exists = ctx
                 .get_database_by_identity(&identity)
                 .await
                 .map_err(log_and_500)?
-                .is_some()
-            {
-                return reset(
+                .is_some();
+            if exists {
+                if parent.is_some() {
+                    return Err(bad_request(
+                        "Setting the parent of an existing database is not supported".into(),
+                    ));
+                }
+
+                return self::reset(
                     State(ctx),
                     Path(ResetDatabaseParams {
                         name_or_identity: name_or_identity.clone(),

--- a/smoketests/tests/teams.py
+++ b/smoketests/tests/teams.py
@@ -36,6 +36,37 @@ class CreateChildDatabase(Smoketest):
         )
         return parse_sql_result(str(res))
 
+
+class ChangeDatabaseHierarchy(Smoketest):
+    AUTOPUBLISH = False
+
+    def test_change_database_hierarchy(self):
+        """
+        Test that changing the hierarchy of an existing database is not
+        supported.
+        """
+
+        parent_name = f"parent-{random_string()}"
+        sibling_name = f"sibling-{random_string()}"
+        child_name = f"child-{random_string()}"
+
+        self.publish_module(parent_name)
+        self.publish_module(sibling_name)
+
+        # Publish as a child of 'parent_name'.
+        self.publish_module(f"{parent_name}/{child_name}")
+
+        # Publishing again with a different parent is rejected...
+        with self.assertRaises(Exception):
+            self.publish_module(f"{sibling_name}/{child_name}", clear = False)
+        # ..even if `clear = True`
+        with self.assertRaises(Exception):
+            self.publish_module(f"{sibling_name}/{child_name}", clear = True)
+
+        # Publishing again with the same parent is ok.
+        self.publish_module(f"{parent_name}/{child_name}", clear = False)
+
+
 class PermissionsTest(Smoketest):
     AUTOPUBLISH = False
 


### PR DESCRIPTION
Mainly a smoketest to exercise the intended behaviour. Also return an error if we end up delegating to the reset database endpoint, which itself doesn't accept a `parent` parameter.