### PR TITLE
Make /v1/database/:name/call/:func call procedures too, remove procedure route

### DIFF
--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -9,23 +9,25 @@ use convert_case::{Case, Casing};
 use itertools::Itertools;
 use spacetimedb_lib::sats::{self, AlgebraicType, Typespace};
 use spacetimedb_lib::{Identity, ProductTypeElement};
-use spacetimedb_schema::def::{ModuleDef, ReducerDef};
+use spacetimedb_schema::def::{ModuleDef, ProcedureDef, ReducerDef};
 use std::fmt::Write;
 
 use super::sql::parse_req;
 
 pub fn cli() -> clap::Command {
     clap::Command::new("call")
-        .about(format!("Invokes a reducer function in a database. {UNSTABLE_WARNING}"))
+        .about(format!(
+            "Invokes a reducer function OR procedure in a database. {UNSTABLE_WARNING}"
+        ))
         .arg(
             Arg::new("database")
                 .required(true)
                 .help("The database name or identity to use to invoke the call"),
         )
         .arg(
-            Arg::new("reducer_name")
+            Arg::new("reducer_procedure_name")
                 .required(true)
-                .help("The name of the reducer to call"),
+                .help("The name of the reducer OR procedure to call"),
         )
         .arg(Arg::new("arguments").help("arguments formatted as JSON").num_args(1..))
         .arg(common_args::server().help("The nickname, host name or URL of the server hosting the database"))
@@ -34,9 +36,35 @@ pub fn cli() -> clap::Command {
         .after_help("Run `spacetime help call` for more detailed information.\n")
 }
 
+enum CallDef<'a> {
+    Reducer(&'a ReducerDef),
+    Procedure(&'a ProcedureDef),
+}
+
+impl<'a> CallDef<'a> {
+    fn params(&self) -> &'a sats::ProductType {
+        match self {
+            CallDef::Reducer(reducer_def) => &reducer_def.params,
+            CallDef::Procedure(procedure_def) => &procedure_def.params,
+        }
+    }
+    fn name(&self) -> &str {
+        match self {
+            CallDef::Reducer(reducer_def) => &reducer_def.name,
+            CallDef::Procedure(procedure_def) => &procedure_def.name,
+        }
+    }
+    fn kind(&self) -> &str {
+        match self {
+            CallDef::Reducer(_) => "reducer",
+            CallDef::Procedure(_) => "procedure",
+        }
+    }
+}
+
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), Error> {
     eprintln!("{UNSTABLE_WARNING}\n");
-    let reducer_name = args.get_one::<String>("reducer_name").unwrap();
+    let reducer_procedure_name = args.get_one::<String>("reducer_procedure_name").unwrap();
     let arguments = args.get_many::<String>("arguments");
 
     let conn = parse_req(config, args).await?;
@@ -47,14 +75,25 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), Error> {
 
     let module_def: ModuleDef = api.module_def().await?.try_into()?;
 
-    let reducer_def = module_def
-        .reducer(&**reducer_name)
-        .ok_or_else(|| anyhow::Error::msg(no_such_reducer(&database_identity, database, reducer_name, &module_def)))?;
+    let call_def = match module_def.reducer(&**reducer_procedure_name) {
+        Some(reducer_def) => CallDef::Reducer(reducer_def),
+        None => match module_def.procedure(&**reducer_procedure_name) {
+            Some(procedure_def) => CallDef::Procedure(procedure_def),
+            None => {
+                return Err(anyhow::Error::msg(no_such_reducer_or_procedure(
+                    &database_identity,
+                    database,
+                    reducer_procedure_name,
+                    &module_def,
+                )));
+            }
+        },
+    };
 
     // String quote any arguments that should be quoted
     let arguments = arguments
         .unwrap_or_default()
-        .zip(&*reducer_def.params.elements)
+        .zip(&call_def.params().elements)
         .map(|(argument, element)| match &element.algebraic_type {
             AlgebraicType::String if !argument.starts_with('\"') || !argument.ends_with('\"') => {
                 format!("\"{argument}\"")
@@ -63,7 +102,7 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), Error> {
         });
 
     let arg_json = format!("[{}]", arguments.format(", "));
-    let res = api.call(reducer_name, arg_json).await?;
+    let res = api.call(reducer_procedure_name, arg_json).await?;
 
     if let Err(e) = res.error_for_status_ref() {
         let Ok(response_text) = res.text().await else {
@@ -73,31 +112,34 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), Error> {
 
         let error = Err(e).context(format!("Response text: {response_text}"));
 
-        let error_msg = if response_text.starts_with("no such reducer") {
-            no_such_reducer(&database_identity, database, reducer_name, &module_def)
-        } else if response_text.starts_with("invalid arguments") {
-            invalid_arguments(&database_identity, database, &response_text, &module_def, reducer_def)
-        } else {
-            return error;
-        };
+        let error_msg =
+            if response_text.starts_with("no such reducer") || response_text.starts_with("no such procedure") {
+                no_such_reducer_or_procedure(&database_identity, database, reducer_procedure_name, &module_def)
+            } else if response_text.starts_with("invalid arguments") {
+                invalid_arguments(&database_identity, database, &response_text, &module_def, call_def)
+            } else {
+                return error;
+            };
 
         return error.context(error_msg);
+    }
+
+    if let CallDef::Procedure(_) = call_def {
+        let body = res.text().await?;
+        println!("{body}");
     }
 
     Ok(())
 }
 
 /// Returns an error message for when `reducer` is called with wrong arguments.
-fn invalid_arguments(
-    identity: &Identity,
-    db: &str,
-    text: &str,
-    module_def: &ModuleDef,
-    reducer_def: &ReducerDef,
-) -> String {
+fn invalid_arguments(identity: &Identity, db: &str, text: &str, module_def: &ModuleDef, call_def: CallDef) -> String {
     let mut error = format!(
-        "Invalid arguments provided for reducer `{}` for database `{}` resolving to identity `{}`.",
-        reducer_def.name, db, identity
+        "Invalid arguments provided for {} `{}` for database `{}` resolving to identity `{}`.",
+        call_def.kind(),
+        call_def.name(),
+        db,
+        identity
     );
 
     if let Some((actual, expected)) = find_actual_expected(text).filter(|(a, e)| a != e) {
@@ -110,8 +152,9 @@ fn invalid_arguments(
 
     write!(
         error,
-        "\n\nThe reducer has the following signature:\n\t{}",
-        ReducerSignature(module_def.typespace().with_type(reducer_def))
+        "\n\nThe {} has the following signature:\n\t{}",
+        call_def.kind(),
+        CallSignature(module_def.typespace().with_type(&call_def))
     )
     .unwrap();
 
@@ -138,18 +181,18 @@ fn split_at_first_substring<'t>(text: &'t str, substring: &str) -> Option<(&'t s
 }
 
 /// Provided the `schema_json` for the database,
-/// returns the signature for a reducer with `reducer_name`.
-struct ReducerSignature<'a>(sats::WithTypespace<'a, ReducerDef>);
-impl std::fmt::Display for ReducerSignature<'_> {
+/// returns the signature for a reducer OR procedure with `name`.
+struct CallSignature<'a>(sats::WithTypespace<'a, CallDef<'a>>);
+impl std::fmt::Display for CallSignature<'_> {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        let reducer_def = self.0.ty();
+        let call_def = self.0.ty();
         let typespace = self.0.typespace();
 
-        write!(f, "{}(", reducer_def.name)?;
+        write!(f, "{}(", call_def.name())?;
 
         // Print the arguments to `args`.
         let mut comma = false;
-        for arg in &*reducer_def.params.elements {
+        for arg in &*call_def.params().elements {
             if comma {
                 write!(f, ", ")?;
             }
@@ -164,51 +207,65 @@ impl std::fmt::Display for ReducerSignature<'_> {
     }
 }
 
-/// Returns an error message for when `reducer` does not exist in `db`.
-fn no_such_reducer(database_identity: &Identity, db: &str, reducer: &str, module_def: &ModuleDef) -> String {
-    let mut error =
-        format!("No such reducer `{reducer}` for database `{db}` resolving to identity `{database_identity}`.");
+/// Returns an error message for when `reducer` or `procedure` does not exist in `db`.
+fn no_such_reducer_or_procedure(database_identity: &Identity, db: &str, name: &str, module_def: &ModuleDef) -> String {
+    let mut error = format!(
+        "No such reducer OR procedure `{name}` for database `{db}` resolving to identity `{database_identity}`."
+    );
 
-    add_reducer_ctx_to_err(&mut error, module_def, reducer);
+    add_reducer_procedure_ctx_to_err(&mut error, module_def, name);
 
     error
 }
 
-const REDUCER_PRINT_LIMIT: usize = 10;
+const CALL_PRINT_LIMIT: usize = 10;
 
 /// Provided the schema for the database,
-/// decorate `error` with more helpful info about reducers.
-fn add_reducer_ctx_to_err(error: &mut String, module_def: &ModuleDef, reducer_name: &str) {
-    let mut reducers = module_def
+/// decorate `error` with more helpful info about reducers and procedures.
+fn add_reducer_procedure_ctx_to_err(error: &mut String, module_def: &ModuleDef, reducer_name: &str) {
+    let reducers = module_def
         .reducers()
         .filter(|reducer| reducer.lifecycle.is_none())
         .map(|reducer| &*reducer.name)
         .collect::<Vec<_>>();
 
+    let procedures = module_def
+        .procedures()
+        .map(|reducer| &*reducer.name)
+        .collect::<Vec<_>>();
+
     if let Some(best) = find_best_match_for_name(&reducers, reducer_name, None) {
         write!(error, "\n\nA reducer with a similar name exists: `{best}`").unwrap();
-    } else if reducers.is_empty() {
-        write!(error, "\n\nThe database has no reducers.").unwrap();
+    } else if let Some(best) = find_best_match_for_name(&procedures, reducer_name, None) {
+        write!(error, "\n\nA procedure with a similar name exists: `{best}`").unwrap();
     } else {
-        // Sort reducers by relevance.
-        reducers.sort_by_key(|candidate| edit_distance(reducer_name, candidate, usize::MAX));
+        let mut list_similar = |mut list: Vec<&str>, name: &str, kind: &str| {
+            if list.is_empty() {
+                write!(error, "\n\nThe database has no {kind}s.").unwrap();
+                return;
+            }
+            list.sort_by_key(|candidate| edit_distance(name, candidate, usize::MAX));
 
-        // Don't spam the user with too many entries.
-        let too_many_to_show = reducers.len() > REDUCER_PRINT_LIMIT;
-        let diff = reducers.len().abs_diff(REDUCER_PRINT_LIMIT);
-        reducers.truncate(REDUCER_PRINT_LIMIT);
+            // Don't spam the user with too many entries.
+            let too_many_to_show = list.len() > CALL_PRINT_LIMIT;
+            let diff = list.len().abs_diff(CALL_PRINT_LIMIT);
+            list.truncate(CALL_PRINT_LIMIT);
 
-        // List them.
-        write!(error, "\n\nHere are some existing reducers:").unwrap();
-        for candidate in reducers {
-            write!(error, "\n- {candidate}").unwrap();
-        }
+            // List them.
+            write!(error, "\n\nHere are some existing {kind}s:").unwrap();
+            for candidate in list {
+                write!(error, "\n- {candidate}").unwrap();
+            }
 
-        // When some where not listed, note that are more.
-        if too_many_to_show {
-            let plural = if diff == 1 { "" } else { "s" };
-            write!(error, "\n... ({diff} reducer{plural} not shown)").unwrap();
-        }
+            // When somewhere not listed, note that are more.
+            if too_many_to_show {
+                let plural = if diff == 1 { "" } else { "s" };
+                write!(error, "\n... ({diff} {kind}{plural} not shown)").unwrap();
+            }
+        };
+
+        list_similar(reducers, reducer_name, "reducer");
+        list_similar(procedures, reducer_name, "procedure");
     }
 }
 

--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -17,7 +17,7 @@ use super::sql::parse_req;
 pub fn cli() -> clap::Command {
     clap::Command::new("call")
         .about(format!(
-            "Invokes a reducer function OR procedure in a database. {UNSTABLE_WARNING}"
+            "Invokes a function (reducer or procedure) in a database. {UNSTABLE_WARNING}"
         ))
         .arg(
             Arg::new("database")
@@ -25,9 +25,9 @@ pub fn cli() -> clap::Command {
                 .help("The database name or identity to use to invoke the call"),
         )
         .arg(
-            Arg::new("reducer_procedure_name")
+            Arg::new("function_name")
                 .required(true)
-                .help("The name of the reducer OR procedure to call"),
+                .help("The name of the function to call"),
         )
         .arg(Arg::new("arguments").help("arguments formatted as JSON").num_args(1..))
         .arg(common_args::server().help("The nickname, host name or URL of the server hosting the database"))
@@ -64,7 +64,7 @@ impl<'a> CallDef<'a> {
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), Error> {
     eprintln!("{UNSTABLE_WARNING}\n");
-    let reducer_procedure_name = args.get_one::<String>("reducer_procedure_name").unwrap();
+    let reducer_procedure_name = args.get_one::<String>("function_name").unwrap();
     let arguments = args.get_many::<String>("arguments");
 
     let conn = parse_req(config, args).await?;

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -185,6 +185,12 @@ pub struct ProcedureCallResult {
 }
 
 #[derive(Debug)]
+pub enum CallResult {
+    Reducer(ReducerCallResult),
+    Procedure(ProcedureCallResult),
+}
+
+#[derive(Debug)]
 pub struct CallProcedureReturn {
     pub result: Result<ProcedureCallResult, ProcedureCallError>,
     pub tx_offset: Option<TransactionOffset>,

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -25,8 +25,8 @@ mod wasm_common;
 
 pub use disk_storage::DiskStorage;
 pub use host_controller::{
-    extract_schema, CallProcedureReturn, ExternalDurability, ExternalStorage, HostController, MigratePlanResult,
-    ProcedureCallResult, ProgramStorage, ReducerCallResult, ReducerOutcome,
+    extract_schema, CallProcedureReturn, CallResult, ExternalDurability, ExternalStorage, HostController,
+    MigratePlanResult, ProcedureCallResult, ProgramStorage, ReducerCallResult, ReducerOutcome,
 };
 pub use module_host::{ModuleHost, NoSuchModule, ProcedureCallError, ReducerCallError, UpdateDatabaseResult};
 pub use scheduler::Scheduler;
@@ -34,7 +34,7 @@ pub use scheduler::Scheduler;
 /// Encoded arguments to a database function.
 ///
 /// A database function is either a reducer or a procedure.
-#[derive(Debug)]
+#[derive(Debug, Clone)]
 pub enum FunctionArgs {
     Json(ByteString),
     Bsatn(Bytes),

--- a/crates/schema/src/def.rs
+++ b/crates/schema/src/def.rs
@@ -284,6 +284,12 @@ impl ModuleDef {
             .map(|(_, def)| def)
     }
 
+    /// Convenience method to look up a procedure, possibly by a string.
+    pub fn procedure<K: ?Sized + Hash + Equivalent<Identifier>>(&self, name: &K) -> Option<&ProcedureDef> {
+        // If the string IS a valid identifier, we can just look it up.
+        self.procedures.get(name)
+    }
+
     /// Convenience method to look up a procedure, possibly by a string, returning its id as well.
     pub fn procedure_full<K: ?Sized + Hash + Equivalent<Identifier>>(
         &self,

--- a/docs/docs/00300-resources/01000-reference/00100-cli-reference/00100-cli-reference.md
+++ b/docs/docs/00300-resources/01000-reference/00100-cli-reference/00100-cli-reference.md
@@ -49,7 +49,7 @@ This document contains the help content for the `spacetime` command-line program
 * `publish` — Create and update a SpacetimeDB database
 * `delete` — Deletes a SpacetimeDB database
 * `logs` — Prints logs from a SpacetimeDB database
-* `call` — Invokes a reducer function in a database. WARNING: This command is UNSTABLE and subject to breaking changes.
+* `call` — Invokes a reducer function OR procedure in a database. WARNING: This command is UNSTABLE and subject to breaking changes.
 * `describe` — Describe the structure of a database or entities within it. WARNING: This command is UNSTABLE and subject to breaking changes.
 * `dev` — Start development mode with auto-regenerate client module bindings, auto-rebuild, and auto-publish on file changes.
 * `energy` — Invokes commands related to database budgets. WARNING: This command is UNSTABLE and subject to breaking changes.
@@ -163,9 +163,9 @@ Run `spacetime help logs` for more detailed information.
 
 ## `spacetime call`
 
-Invokes a reducer function in a database. WARNING: This command is UNSTABLE and subject to breaking changes.
+Invokes a reducer function OR procedure in a database. WARNING: This command is UNSTABLE and subject to breaking changes.
 
-**Usage:** `spacetime call [OPTIONS] <database> <reducer_name> [arguments]...`
+**Usage:** `spacetime call [OPTIONS] <database> <reducer_procedure_name> [arguments]...`
 
 Run `spacetime help call` for more detailed information.
 
@@ -173,7 +173,7 @@ Run `spacetime help call` for more detailed information.
 ###### **Arguments:**
 
 * `<DATABASE>` — The database name or identity to use to invoke the call
-* `<REDUCER_NAME>` — The name of the reducer to call
+* `<REDUCER_PROCEDURE_NAME>` — The name of the reducer OR procedure to call
 * `<ARGUMENTS>` — arguments formatted as JSON
 
 ###### **Options:**

--- a/docs/docs/00300-resources/01000-reference/00100-cli-reference/00100-cli-reference.md
+++ b/docs/docs/00300-resources/01000-reference/00100-cli-reference/00100-cli-reference.md
@@ -49,7 +49,7 @@ This document contains the help content for the `spacetime` command-line program
 * `publish` — Create and update a SpacetimeDB database
 * `delete` — Deletes a SpacetimeDB database
 * `logs` — Prints logs from a SpacetimeDB database
-* `call` — Invokes a reducer function OR procedure in a database. WARNING: This command is UNSTABLE and subject to breaking changes.
+* `call` — Invokes a function (reducer or procedure) in a database. WARNING: This command is UNSTABLE and subject to breaking changes.
 * `describe` — Describe the structure of a database or entities within it. WARNING: This command is UNSTABLE and subject to breaking changes.
 * `dev` — Start development mode with auto-regenerate client module bindings, auto-rebuild, and auto-publish on file changes.
 * `energy` — Invokes commands related to database budgets. WARNING: This command is UNSTABLE and subject to breaking changes.
@@ -163,9 +163,9 @@ Run `spacetime help logs` for more detailed information.
 
 ## `spacetime call`
 
-Invokes a reducer function OR procedure in a database. WARNING: This command is UNSTABLE and subject to breaking changes.
+Invokes a function (reducer or procedure) in a database. WARNING: This command is UNSTABLE and subject to breaking changes.
 
-**Usage:** `spacetime call [OPTIONS] <database> <reducer_procedure_name> [arguments]...`
+**Usage:** `spacetime call [OPTIONS] <database> <function_name> [arguments]...`
 
 Run `spacetime help call` for more detailed information.
 
@@ -173,7 +173,7 @@ Run `spacetime help call` for more detailed information.
 ###### **Arguments:**
 
 * `<DATABASE>` — The database name or identity to use to invoke the call
-* `<REDUCER_PROCEDURE_NAME>` — The name of the reducer OR procedure to call
+* `<FUNCTION_NAME>` — The name of the function to call
 * `<ARGUMENTS>` — arguments formatted as JSON
 
 ###### **Options:**

--- a/docs/docs/00300-resources/01000-reference/00200-http-api/00300-database.md
+++ b/docs/docs/00300-resources/01000-reference/00200-http-api/00300-database.md
@@ -19,7 +19,7 @@ The HTTP endpoints in `/v1/database` allow clients to interact with Spacetime da
 | [`PUT /v1/database/:name_or_identity/names`](#put-v1databasename_or_identitynames)                 | Set the list of names for this database.          |
 | [`GET /v1/database/:name_or_identity/identity`](#get-v1databasename_or_identityidentity)           | Get the identity of a database.                   |
 | [`GET /v1/database/:name_or_identity/subscribe`](#get-v1databasename_or_identitysubscribe)         | Begin a WebSocket connection.                     |
-| [`POST /v1/database/:name_or_identity/call/:reducer`](#post-v1databasename_or_identitycallreducer) | Invoke a reducer in a database.                   |
+| [`POST /v1/database/:name_or_identity/call/:reducer`](#post-v1databasename_or_identitycallreducer) | Invoke a reducer OR procedure in a database.      |
 | [`GET /v1/database/:name_or_identity/schema`](#get-v1databasename_or_identityschema)               | Get the schema for a database.                    |
 | [`GET /v1/database/:name_or_identity/logs`](#get-v1databasename_or_identitylogs)                   | Retrieve logs from a database.                    |
 | [`POST /v1/database/:name_or_identity/sql`](#post-v1databasename_or_identitysql)                   | Run a SQL query against a database.               |
@@ -245,9 +245,9 @@ Invoke a reducer in a database.
 
 #### Path parameters
 
-| Name       | Value                    |
-| ---------- | ------------------------ |
-| `:reducer` | The name of the reducer. |
+| Name       | Value                                 |
+| ---------- | ------------------------------------- |
+| `:reducer` | The name of the reducer OR procedure. |
 
 #### Required Headers
 

--- a/smoketests/__init__.py
+++ b/smoketests/__init__.py
@@ -217,11 +217,10 @@ class Smoketest(unittest.TestCase):
         if not hasattr(self, "database_identity"):
             raise Exception("Cannot use this function without publishing a module")
 
-    def call(self, reducer, *args, anon=False):
+    def call(self, reducer, *args, anon=False, check=True, full_output = False):
         self._check_published()
         anon = ["--anonymous"] if anon else []
-        self.spacetime("call", *anon, "--", self.database_identity, reducer, *map(json.dumps, args))
-
+        return self.spacetime("call", *anon, "--", self.database_identity, reducer, *map(json.dumps, args), check = check, full_output=full_output)
 
     def sql(self, sql):
         self._check_published()

--- a/smoketests/tests/call.py
+++ b/smoketests/tests/call.py
@@ -1,0 +1,151 @@
+import string
+
+from .. import Smoketest
+
+class CallReducerProcedure(Smoketest):
+    MODULE_CODE = """
+use spacetimedb::{log, ProcedureContext, ReducerContext, Table};
+
+#[spacetimedb::table(name = person)]
+pub struct Person {
+    name: String,
+}
+
+#[spacetimedb::reducer]
+pub fn say_hello(_ctx: &ReducerContext) {
+    log::info!("Hello, World!");
+}
+
+#[spacetimedb::procedure]
+pub fn return_person(_ctx: &mut ProcedureContext) -> Person {
+   return Person { name: "World".to_owned() };
+}
+"""
+
+    def test_call_reducer_procedure(self):
+        """Check calling a reducer (not return) and procedure (return)"""
+        msg = self.call("say_hello")
+        self.assertEqual(msg, "")
+        
+        msg = self.call("return_person")
+        self.assertEqual(msg.strip(), '["World"]')
+    
+    def test_call_errors(self):
+        """Check calling a non-existent reducer/procedure raises error"""
+        out = self.call("non_existent_reducer", check= False, full_output=True).stderr
+        identity = self.database_identity
+        self.assertIn(out.strip(), f"""
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+Error: No such reducer OR procedure `non_existent_reducer` for database `{identity}` resolving to identity `{identity}`.
+
+Here are some existing reducers:
+- say_hello
+
+Here are some existing procedures:
+- return_person""".strip())
+        
+        out = self.call("non_existent_procedure", check= False, full_output=True).stderr
+        self.assertIn(out.strip(), f"""
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+Error: No such reducer OR procedure `non_existent_procedure` for database `{identity}` resolving to identity `{identity}`.
+
+Here are some existing reducers:
+- say_hello
+
+Here are some existing procedures:
+- return_person""".strip())
+        
+        out = self.call("say_hell", check= False, full_output=True).stderr
+
+        self.assertIn(out.strip(), f"""
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+Error: No such reducer OR procedure `say_hell` for database `{identity}` resolving to identity `{identity}`.
+
+A reducer with a similar name exists: `say_hello`""".strip())
+        
+        out = self.call("return_perso", check= False, full_output=True).stderr
+        
+        self.assertIn(out.strip(), f"""
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+Error: No such reducer OR procedure `return_perso` for database `{identity}` resolving to identity `{identity}`.
+
+A procedure with a similar name exists: `return_person`""".strip())
+
+class CallEmptyReducerProcedure(Smoketest):
+    MODULE_CODE = """
+use spacetimedb::{log, ReducerContext, Table};
+
+#[spacetimedb::table(name = person)]
+pub struct Person {
+    name: String,
+}
+"""
+    def test_call_empty_errors(self):
+        """Check calling into a database with no reducers/procedures raises error"""
+        out = self.call("non_existent", check= False, full_output=True).stderr
+        identity = self.database_identity
+        self.assertIn(out.strip(), f"""
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+Error: No such reducer OR procedure `non_existent` for database `{identity}` resolving to identity `{identity}`.
+
+The database has no reducers.
+
+The database has no procedures.""".strip())
+
+module_template = string.Template("""
+#[spacetimedb::reducer]
+pub fn say_reducer_$NUM(_ctx: &ReducerContext) {
+    log::info!("Hello from reducer $NUM!");
+}
+#[spacetimedb::procedure]
+pub fn say_procedure_$NUM(_ctx: &mut ProcedureContext) {
+    log::info!("Hello from procedure $NUM!");
+}
+""")
+
+class CallManyReducerProcedure(Smoketest):
+    MODULE_CODE = f"""
+use spacetimedb::{{log, ProcedureContext, ReducerContext}};
+{"".join(module_template.substitute(NUM=i) for i in range(11))}
+"""
+
+    def test_call_many_errors(self):
+        """Check calling into a database with many reducers/procedures raises error with listing"""
+        out = self.call("non_existent", check= False, full_output=True).stderr
+        identity = self.database_identity
+        self.assertIn(out.strip(), f"""
+WARNING: This command is UNSTABLE and subject to breaking changes.
+
+Error: No such reducer OR procedure `non_existent` for database `{identity}` resolving to identity `{identity}`.
+
+Here are some existing reducers:
+- say_reducer_0
+- say_reducer_1
+- say_reducer_2
+- say_reducer_3
+- say_reducer_4
+- say_reducer_5
+- say_reducer_6
+- say_reducer_7
+- say_reducer_8
+- say_reducer_9
+... (1 reducer not shown)
+
+Here are some existing procedures:
+- say_procedure_0
+- say_procedure_1
+- say_procedure_2
+- say_procedure_3
+- say_procedure_4
+- say_procedure_5
+- say_procedure_6
+- say_procedure_7
+- say_procedure_8
+- say_procedure_9
+... (1 procedure not shown)
+""".strip())


### PR DESCRIPTION
# Description of Changes

Closes #3659 

# API and ABI breaking changes

Remove route and alter the semantics of the `call` route on both server and `cli`

# Expected complexity level and risk

1

# Testing

- [x] Publish module with `procedures` and observe calling the `cli` the result is print.