### PR TITLE
Fix broken SpacetimeDB logo in docs

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -49,7 +49,7 @@ const config: Config = {
 
   url: 'https://spacetimedb.com',
   // this means the site is served at https://spacetimedb.com/docs/
-  baseUrl: '/docs/', 
+  baseUrl: '/docs/',
 
   onBrokenLinks: 'throw',
   onBrokenAnchors: 'throw',
@@ -140,7 +140,7 @@ const config: Config = {
     navbar: {
       logo: {
         alt: 'SpacetimeDB Logo',
-        src: 'https://spacetimedb.com/images/brand.png',
+        src: 'https://spacetimedb.com/images/brand.svg',
         href: 'https://spacetimedb.com',
         target: '_self',
       },
@@ -201,7 +201,6 @@ const config: Config = {
       },
     ],
   ],
-
 };
 
 export default config;


### PR DESCRIPTION
# Description of Changes

The `.png` logo image has been replaced by a `.svg` and needed to be updated.

# API and ABI breaking changes

Not applicable

# Expected complexity level and risk

0.000001

# Testing

Run `pnpm dev` and check that the logo is correctly displayed in the top left corner
