### PR TITLE
cli: Flush stdout after printing the database tree

### DIFF
--- a/crates/cli/src/subcommands/delete.rs
+++ b/crates/cli/src/subcommands/delete.rs
@@ -73,9 +73,12 @@ async fn send_request(
 }
 
 async fn print_database_tree_info(tree: &DatabaseTree) -> io::Result<()> {
-    tokio::io::stdout()
-        .write_all(as_termtree(tree).to_string().as_bytes())
-        .await
+    let mut stdout = tokio::io::stdout();
+    stdout.write_all(as_termtree(tree).to_string().as_bytes()).await?;
+    stdout.write_u8(b'\n').await?;
+    stdout.flush().await?;
+
+    Ok(())
 }
 
 fn as_termtree(tree: &DatabaseTree) -> termtree::Tree<String> {


### PR DESCRIPTION
`spacetime delete` may print the database tree and ask for confirmation. We did not flush stdout, causing the tree to be interleaved with the yes/no prompt.


# Expected complexity level and risk

1