### PR TITLE
Don't error during replay when deleting a table with no in-memory instance

### DIFF
--- a/crates/datastore/src/locking_tx_datastore/datastore.rs
+++ b/crates/datastore/src/locking_tx_datastore/datastore.rs
@@ -1284,9 +1284,7 @@ impl<F: FnMut(u64)> spacetimedb_commitlog::payload::txdata::Visitor for ReplayVi
     }
 
     fn visit_tx_end(&mut self) -> std::result::Result<(), Self::Error> {
-        self.committed_state.next_tx_offset += 1;
-
-        Ok(())
+        self.committed_state.replay_end_tx().map_err(Into::into)
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Based on #3891 . Begin reviewing from commit 4370b69cb.

Prior to this commit, we treated it as an error (in fact a panic, prior to an earlier commit of mine today) when deleting a table during replay which didn't have an in-memory instace. This should not have been an error, as it's not problematic, and it can occur in valid commitlogs when a table is initially empty and is never used prior to its deletion.

With this commit, don't error.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

- [x] Manually replayed a database with such a deleted table. Got an error prior to this commit, succeeded replay with this commit.