### PR TITLE
Bump typescript package sizes again

### DIFF
--- a/crates/bindings-typescript/package.json
+++ b/crates/bindings-typescript/package.json
@@ -143,7 +143,7 @@
       "name": "sdk esm min (gzip)",
       "path": "dist/min/sdk/index.browser.mjs",
       "gzip": true,
-      "limit": "16 kB"
+      "limit": "32 kB"
     },
     {
       "name": "sdk esm min (uncompressed)",


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

- Just bumping typescript size limits again

# API and ABI breaking changes

No

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

0 - this is just a release change.

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

I have not tested this but I've verified the new limit is greater than the package size.

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->
