### PR TITLE
CI - Hackily fix V8 linker errors

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -703,7 +703,8 @@ jobs:
           find "${CARGO_TARGET_DIR}"/ -type f | grep '[/_]v8' || true
           if ! [ -f "${CARGO_TARGET_DIR}"/debug/gn_out/obj/librusty_v8.a ]; then
             echo "Could not find v8 output file librusty_v8.a; rebuilding manually."
-            cargo build v8
+            cargo clean -p v8 || true
+            cargo build -p v8
           fi
 
       - name: Check quickstart-chat bindings are up to date


### PR DESCRIPTION
# Description of Changes

Introduce a hacky workaround to our `csharp-testsuite` to address missing `librusty_v8.a`: manually check for that file and manually build the package if it's missing.

# API and ABI breaking changes

CI-only change

# Expected complexity level and risk

1

# Testing

- [x] Locally tested removing the `librusty_v8.a` and then running `cargo clean -p v8 && cargo build -p v8`, and this does seem to repair it.
- [x] The CI has run with a cache that is "broken", but successfully passes `csharp-testsuite`