### PR TITLE
Bump TS package size limits

### DIFF
--- a/crates/bindings-typescript/package.json
+++ b/crates/bindings-typescript/package.json
@@ -78,77 +78,77 @@
       "name": "cjs (brotli)",
       "path": "dist/index.cjs",
       "brotli": true,
-      "limit": "54 kB"
+      "limit": "500 kB"
     },
     {
       "name": "esm (brotli)",
       "path": "dist/index.mjs",
       "brotli": true,
-      "limit": "62 kB"
+      "limit": "500 kB"
     },
     {
       "name": "esm (gzip)",
       "path": "dist/index.mjs",
       "gzip": true,
-      "limit": "31 kB"
+      "limit": "500 kB"
     },
     {
       "name": "esm (uncompressed)",
       "path": "dist/index.mjs",
       "brotli": false,
-      "limit": "328 kB"
+      "limit": "500 kB"
     },
     {
       "name": "esm min (brotli)",
       "path": "dist/min/index.browser.mjs",
       "brotli": true,
-      "limit": "30 kB"
+      "limit": "500 kB"
     },
     {
       "name": "esm min (gzip)",
       "path": "dist/min/index.browser.mjs",
       "gzip": true,
-      "limit": "34 kB"
+      "limit": "500 kB"
     },
     {
       "name": "esm min (uncompressed)",
       "path": "dist/min/index.browser.mjs",
       "brotli": false,
-      "limit": "134 kB"
+      "limit": "500 kB"
     },
     {
       "name": "react esm min (brotli)",
       "path": "dist/min/react/index.mjs",
       "brotli": true,
-      "limit": "10 kB"
+      "limit": "500 kB"
     },
     {
       "name": "react esm min (uncompressed)",
       "path": "dist/min/react/index.mjs",
-      "limit": "10 kB"
+      "limit": "500 kB"
     },
     {
       "name": "react esm min (gzip)",
       "path": "dist/min/react/index.mjs",
       "gzip": true,
-      "limit": "15 kB"
+      "limit": "500 kB"
     },
     {
       "name": "sdk esm min (brotli)",
       "path": "dist/min/sdk/index.browser.mjs",
       "brotli": true,
-      "limit": "30 kB"
+      "limit": "500 kB"
     },
     {
       "name": "sdk esm min (gzip)",
       "path": "dist/min/sdk/index.browser.mjs",
       "gzip": true,
-      "limit": "32 kB"
+      "limit": "500 kB"
     },
     {
       "name": "sdk esm min (uncompressed)",
       "path": "dist/min/sdk/index.browser.mjs",
-      "limit": "30 kB"
+      "limit": "500 kB"
     }
   ],
   "dependencies": {


### PR DESCRIPTION
# Description of Changes

Bump all package size limits to 500 kB after a discussion about repeatedly triggering them.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1

# Testing

None