### PR TITLE
Fixed inverted `wasm-opt` condition

### DIFF
--- a/crates/cli/src/tasks/mod.rs
+++ b/crates/cli/src/tasks/mod.rs
@@ -27,7 +27,7 @@ pub fn build(
 
     if lang == ModuleLanguage::Javascript {
         Ok((output_path, "Js"))
-    } else if !build_debug {
+    } else if build_debug {
         Ok((output_path, "Wasm"))
     } else {
         // for release builds, optimize wasm modules with wasm-opt


### PR DESCRIPTION
# Description of Changes

Reverted the incorrect inversion of `build_debug` condition introduced by https://github.com/clockworklabs/SpacetimeDB/commit/bb432132457b023d98a379beea2a52d76d3bd8d6 that resulted in only debug builds being optimized instead of only release ones, as the comment just below says.

# API and ABI breaking changes

None.

# Expected complexity level and risk

### 1.

# Testing

- [x] Manual testing
- [x] Personal experience (saw `.opt.wasm` files disappear at some point)