### PR TITLE
Use table def accessorName instead of server table name to access table db view

### DIFF
--- a/crates/bindings-typescript/src/react/useTable.ts
+++ b/crates/bindings-typescript/src/react/useTable.ts
@@ -268,6 +268,7 @@ export function useTable<TableDef extends UntypedTableDef>(
 ): [readonly Prettify<RowType<TableDef>>[], boolean] {
   type UseTableRowType = RowType<TableDef>;
   const tableName = tableDef.name;
+  const accessorName = tableDef.accessorName;
   let whereClause: Expr<ColumnsFromRow<UseTableRowType>> | undefined;
   if (
     whereClauseOrCallbacks &&
@@ -313,7 +314,7 @@ export function useTable<TableDef extends UntypedTableDef>(
     if (!connection) {
       return [[], false];
     }
-    const table = connection.db[tableName];
+    const table = connection.db[accessorName];
     const result: readonly Prettify<UseTableRowType>[] = whereClause
       ? (Array.from(table.iter()).filter(row =>
           evaluate(whereClause, row as UseTableRowType)
@@ -321,7 +322,7 @@ export function useTable<TableDef extends UntypedTableDef>(
       : (Array.from(table.iter()) as Prettify<UseTableRowType>[]);
     return [result, subscribeApplied];
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [connectionState, tableName, whereKey, subscribeApplied]);
+  }, [connectionState, accessorName, whereKey, subscribeApplied]);
 
   useEffect(() => {
     const connection = connectionState.getConnection()!;
@@ -412,7 +413,7 @@ export function useTable<TableDef extends UntypedTableDef>(
         return () => {};
       }
 
-      const table = connection.db[tableName];
+      const table = connection.db[accessorName];
       table.onInsert(onInsert);
       table.onDelete(onDelete);
       table.onUpdate?.(onUpdate);
@@ -426,7 +427,7 @@ export function useTable<TableDef extends UntypedTableDef>(
     // eslint-disable-next-line react-hooks/exhaustive-deps
     [
       connectionState,
-      tableName,
+      accessorName,
       whereKey,
       callbacks?.onDelete,
       callbacks?.onInsert,


### PR DESCRIPTION
# Description of Changes

Update the `useTable` hook in the `spacetimedb/react` package to use the client language convention aware table accessor key to lookup the correct table

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

I built and ran a client using this code change before and after. Previously with multi-word table names in rust module (i.e. `crew_assignments` table), the useTable hook would fail to lookup the table information and hookup the onInsert/onDelete/onUpdate callbacks. With this change, they successfully connect and data returned by the useTable hook now flows.

All of my testing was with module_bindings generated with the 1.11.0 rust module crate. Additional testing for backwards compatibility might be useful. I'm not sure what the clockwork labs target is for that sort of thing.
