### PR TITLE
Return Options as nullable values over PG Wire

### DIFF
--- a/crates/pg/src/encoder.rs
+++ b/crates/pg/src/encoder.rs
@@ -136,8 +136,15 @@ impl TypedWriter for PsqlFormatter<'_> {
         name: Option<&str>,
         value: ValueWithType<AlgebraicValue>,
     ) -> Result<(), Self::Error> {
-        // Is a simple enum?
         if let AlgebraicType::Sum(sum) = &ty.field.algebraic_type {
+            if sum.is_option() {
+                if *value.value() == AlgebraicValue::unit() {
+                    self.write("")?;
+                } else {
+                    self.write(satn::PsqlWrapper { ty, value })?;
+                }
+                return Ok(());
+            }
             if sum.is_simple_enum() {
                 if let Some(variant_name) = name {
                     self.encoder.encode_field(&variant_name)?;


### PR DESCRIPTION
# Description of Changes

Improves usability compared to regular DBs.

* #### Before:
  ```sql
   id | test         
  ----+--------------
    1 | {"some":"x"} 
    2 | {"none":{}}  
  ```
* #### After:
  ```sql
   id | test 
  ----+------
    1 | "x"  
    2 |      
  ```

## Note:
The current implementation returns an empty string (2 bytes: `""`) on the wire. A correct one would return actual 0-byte `NULL`s, but this seemingly requires an elaborate refactoring of the current conversion implementation to support passing `Option<AlgebraicValue>` straight to the encoder, without converting it to a string first.

# API and ABI breaking changes

Breaks the PG Wire protocol to move it closer to standard.

# Expected complexity level and risk

### 3:
Will probably have to hear from `pgwire`'s author if that's correct.

# Testing

- [x] Manual testing
- [ ] Unit tests