### PR TITLE
Cargo.toml whitespace ONLY fix

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,63 +1,63 @@
 [workspace]
 members = [
-	"crates/auth",
-	"crates/bench",
-	"crates/bindings-sys",
-	"crates/bindings",
-	"crates/bindings-macro",
-	"crates/cli",
-	"crates/client-api",
-	"crates/client-api-messages",
-	"crates/commitlog",
-	"crates/core",
-	"crates/data-structures",
-	"crates/datastore",
-	"crates/durability",
-	"crates/execution",
-	"crates/expr",
-	"crates/fs-utils",
-	"crates/lib",
-	"crates/metrics",
-	"crates/paths",
-	"crates/pg",
-	"crates/physical-plan",
-	"crates/primitives",
-	"crates/query",
-	"crates/sats",
-	"crates/schema",
-	"sdks/rust",
-	"sdks/unreal",
-	"crates/snapshot",
-	"crates/sqltest",
-	"crates/sql-parser",
-	"crates/standalone",
-	"crates/subscription",
-	"crates/table",
-	"crates/testing",
-	"crates/update",
-	"crates/vm",
-	"modules/benchmarks",
-	"modules/keynote-benchmarks",
-	"modules/perf-test",
-	"modules/module-test",
-	"modules/quickstart-chat",
-	"modules/sdk-test",
-	"modules/sdk-test-connect-disconnect",
-	"modules/sdk-test-procedure",
-	"modules/sdk-test-view",
-	"sdks/rust/tests/test-client",
-	"sdks/rust/tests/test-counter",
-	"sdks/rust/tests/connect_disconnect_client",
-	"sdks/rust/tests/procedure-client",
-	"sdks/rust/tests/view-client",
-	"tools/ci",
-	"tools/upgrade-version",
-	"tools/license-check",
-	"tools/replace-spacetimedb",
-	"tools/generate-client-api",
-	"tools/gen-bindings",
-	"crates/bindings-typescript/test-app/server",
-	"crates/bindings-typescript/test-react-router-app/server",
+  "crates/auth",
+  "crates/bench",
+  "crates/bindings-sys",
+  "crates/bindings",
+  "crates/bindings-macro",
+  "crates/cli",
+  "crates/client-api",
+  "crates/client-api-messages",
+  "crates/commitlog",
+  "crates/core",
+  "crates/data-structures",
+  "crates/datastore",
+  "crates/durability",
+  "crates/execution",
+  "crates/expr",
+  "crates/fs-utils",
+  "crates/lib",
+  "crates/metrics",
+  "crates/paths",
+  "crates/pg",
+  "crates/physical-plan",
+  "crates/primitives",
+  "crates/query",
+  "crates/sats",
+  "crates/schema",
+  "sdks/rust",
+  "sdks/unreal",
+  "crates/snapshot",
+  "crates/sqltest",
+  "crates/sql-parser",
+  "crates/standalone",
+  "crates/subscription",
+  "crates/table",
+  "crates/testing",
+  "crates/update",
+  "crates/vm",
+  "modules/benchmarks",
+  "modules/keynote-benchmarks",
+  "modules/perf-test",
+  "modules/module-test",
+  "modules/quickstart-chat",
+  "modules/sdk-test",
+  "modules/sdk-test-connect-disconnect",
+  "modules/sdk-test-procedure",
+  "modules/sdk-test-view",
+  "sdks/rust/tests/test-client",
+  "sdks/rust/tests/test-counter",
+  "sdks/rust/tests/connect_disconnect_client",
+  "sdks/rust/tests/procedure-client",
+  "sdks/rust/tests/view-client",
+  "tools/ci",
+  "tools/upgrade-version",
+  "tools/license-check",
+  "tools/replace-spacetimedb",
+  "tools/generate-client-api",
+  "tools/gen-bindings",
+  "crates/bindings-typescript/test-app/server",
+  "crates/bindings-typescript/test-react-router-app/server",
 ]
 default-members = ["crates/cli", "crates/standalone", "crates/update"]
 # cargo feature graph resolver. v3 is default in edition2024 but workspace
@@ -165,16 +165,10 @@ colored = "2.0.0"
 console = { version = "0.15.6" }
 convert_case = "0.6.0"
 crc32c = "0.6.4"
-criterion = { version = "0.5.1", features = [
-	"async",
-	"async_tokio",
-	"html_reports",
-] }
+criterion = { version = "0.5.1", features = ["async", "async_tokio", "html_reports"] }
 crossbeam-channel = "0.5"
 crossbeam-queue = "0.3.12"
-cursive = { version = "0.20", default-features = false, features = [
-	"crossterm-backend",
-] }
+cursive = { version = "0.20", default-features = false, features = ["crossterm-backend"] }
 decorum = { version = "0.3.1", default-features = false, features = ["std"] }
 derive_more = "0.99"
 dialoguer = { version = "0.11", default-features = false }
@@ -198,19 +192,14 @@ futures-util = "0.3"
 getrandom02 = { package = "getrandom", version = "0.2" }
 git2 = "0.19"
 glob = "0.3.1"
-hashbrown = { version = "0.16.1", default-features = false, features = [
-	"equivalent",
-	"inline-more",
-	"rayon",
-	"serde",
-] }
+hashbrown = { version = "0.16.1", default-features = false, features = ["equivalent", "inline-more", "rayon", "serde"] }
 headers = "0.4"
 heck = "0.4"
 hex = "0.4.3"
 home = "0.5"
 hostname = "^0.3"
 http = "1.0"
-http-body-util = "0.1.3"
+http-body-util= "0.1.3"
 humantime = "2.1.0"
 hyper = "1.0"
 hyper-util = { version = "0.1", features = ["tokio"] }
@@ -239,10 +228,7 @@ paste = "1.0"
 percent-encoding = "2.3"
 petgraph = { version = "0.6.5", default-features = false }
 pin-project-lite = "0.2.9"
-pgwire = { version = "0.34.2", default-features = false, features = [
-	"server-api",
-	"pg-ext-types",
-] }
+pgwire = { version = "0.34.2", default-features = false, features = ["server-api", "pg-ext-types"] }
 postgres-types = "0.2.5"
 pretty_assertions = { version = "1.4", features = ["unstable"] }
 proc-macro2 = "1.0"
@@ -272,10 +258,7 @@ second-stack = "0.3"
 self-replace = "1.5"
 semver = "1"
 serde = { version = "1.0.136", features = ["derive"] }
-serde_json = { version = "1.0.128", features = [
-	"raw_value",
-	"arbitrary_precision",
-] }
+serde_json = { version = "1.0.128", features = ["raw_value", "arbitrary_precision"] }
 serde_path_to_error = "0.1.9"
 serde_with = { version = "3.3.0", features = ["base64", "hex"] }
 serial_test = "2.0.0"
@@ -292,9 +275,7 @@ sqllogictest-engines = "0.17"
 sqlparser = "0.38.0"
 strum = { version = "0.25.0", features = ["derive"] }
 syn = { version = "2", features = ["full", "extra-traits"] }
-syntect = { version = "5.0.0", default-features = false, features = [
-	"default-fancy",
-] }
+syntect = { version = "5.0.0", default-features = false, features = ["default-fancy"] }
 tabled = "0.14.0"
 tar = "0.4"
 tempdir = "0.3.7"
@@ -347,14 +328,14 @@ openssl = { version = "0.10", features = ["vendored"] }
 version = "39"
 default-features = false
 features = [
-	"addr2line",
-	"async",
-	"cache",
-	"cranelift",
-	"demangle",
-	"parallel-compilation",
-	"runtime",
-	"std",
+  "addr2line",
+  "async",
+  "cache",
+  "cranelift",
+  "demangle",
+  "parallel-compilation",
+  "runtime",
+  "std",
 ]
 
 [workspace.dependencies.wasmtime-internal-fiber]
@@ -368,13 +349,13 @@ version = "0.10.4"
 # and reconnecting, from the tracy client to the database.
 # TODO(George): Need to be able to remove "broadcast" in some build configurations.
 features = [
-	"enable",
-	"system-tracing",
-	"context-switch-tracing",
-	"sampling",
-	"code-transfer",
-	"broadcast",
-	"ondemand",
+  "enable",
+  "system-tracing",
+  "context-switch-tracing",
+  "sampling",
+  "code-transfer",
+  "broadcast",
+  "ondemand",
 ]
 
 [workspace.lints.rust]


### PR DESCRIPTION
# Description of Changes

This reverts unnecessary changes to whitespace to prevent conflicts in old PRs.

If you hide whitespace, you can confirm that this commit is a no-op.

# API and ABI breaking changes

None

# Expected complexity level and risk

0
