### PR TITLE
Fix rollback metrics

### DIFF
--- a/crates/datastore/src/locking_tx_datastore/datastore.rs
+++ b/crates/datastore/src/locking_tx_datastore/datastore.rs
@@ -3717,4 +3717,18 @@ mod tests {
 
         Ok(())
     }
+
+    #[test]
+    fn test_committed_and_rollback_metrics() -> ResultTest<()> {
+        let datastore = get_datastore()?;
+
+        let tx = begin_mut_tx(&datastore);
+        let (_, _, metrics, _) = tx.commit();
+        assert!(metrics.committed);
+
+        let tx = begin_mut_tx(&datastore);
+        let (_, metrics, _) = tx.rollback();
+        assert!(!metrics.committed);
+        Ok(())
+    }
 }

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -2011,7 +2011,7 @@ impl MutTxId {
             self.timer,
             self.lock_wait_time,
             self.metrics,
-            true,
+            false,
             None,
             &self.committed_state_write_lock,
         );
@@ -2039,7 +2039,7 @@ impl MutTxId {
             self.timer,
             self.lock_wait_time,
             self.metrics,
-            true,
+            false,
             None,
             &self.committed_state_write_lock,
         );


### PR DESCRIPTION
# Description of Changes

Sets the `committed` label to `false` when we rollback a txn. It was always set to `true` before this change.

# API and ABI breaking changes

None

# Expected complexity level and risk

0

# Testing

- [x] Unit test
