### PR TITLE
Use a class for ReducerCtx

### DIFF
--- a/crates/bindings-typescript/src/lib/reducers.ts
+++ b/crates/bindings-typescript/src/lib/reducers.ts
@@ -119,8 +119,6 @@ export type ReducerCtx<SchemaDef extends UntypedSchemaDef> = Readonly<{
   identity: Identity;
   timestamp: Timestamp;
   connectionId: ConnectionId | null;
-  // **Note:** must be 0..=u32::MAX
-  counter_uuid: { value: number };
   db: DbView<SchemaDef>;
   senderAuth: AuthCtx;
   newUuidV4(): Uuid;

--- a/crates/bindings-typescript/src/server/procedures.ts
+++ b/crates/bindings-typescript/src/server/procedures.ts
@@ -12,7 +12,7 @@ import { MODULE_DEF, type UntypedSchemaDef } from '../lib/schema';
 import { Timestamp } from '../lib/timestamp';
 import { Uuid } from '../lib/uuid';
 import { httpClient } from './http_internal';
-import { callUserFunction, makeReducerCtx, sys } from './runtime';
+import { callUserFunction, ReducerCtxImpl, sys } from './runtime';
 
 const { freeze } = Object;
 
@@ -45,8 +45,10 @@ export function callProcedure(
         const timestamp = sys.procedure_start_mut_tx();
 
         try {
-          const ctx: TransactionCtx<UntypedSchemaDef> = freeze(
-            makeReducerCtx(sender, new Timestamp(timestamp), connectionId)
+          const ctx: TransactionCtx<UntypedSchemaDef> = new ReducerCtxImpl(
+            sender,
+            new Timestamp(timestamp),
+            connectionId
           );
           return body(ctx);
         } catch (e) {


### PR DESCRIPTION
# Description of Changes

#3538 added a `uuid_counter` field to ReducerCtx, which has no need to be public. Implementing ReducerCtx as a class allows us to encapsulate better, and lets us enumerate exactly the data that it needs to hold so that the runtime could possibly optimize it.

# Expected complexity level and risk

1: straightforward switch

# Testing

- [x] Automated testing is sufficient.