### PR TITLE
Fix CI hash save in llm quick fix summary file

### DIFF
--- a/tools/xtask-llm-benchmark/src/bench/results_merge.rs
+++ b/tools/xtask-llm-benchmark/src/bench/results_merge.rs
@@ -44,6 +44,9 @@ pub fn ensure_lang<'a>(root: &'a mut Results, lang: &str) -> &'a mut LangEntry {
 
 fn ensure_mode<'a>(lang_v: &'a mut LangEntry, mode: &str, hash: Option<String>) -> &'a mut ModeEntry {
     if let Some(i) = lang_v.modes.iter().position(|m| m.mode == mode) {
+        if let Some(h) = hash {
+            lang_v.modes[i].hash = Some(h);
+        }
         return &mut lang_v.modes[i];
     }
     lang_v.modes.push(ModeEntry {


### PR DESCRIPTION
# Description of Changes

Previously the run file was used with ci-check, and whatever summary hash was not used. I have updated the `ensure_mode` to always update the hash in the summary file.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
