### PR TITLE
Fix reducer errors to return message not stack trace

### DIFF
--- a/crates/bindings-csharp/Runtime/Internal/Module.cs
+++ b/crates/bindings-csharp/Runtime/Internal/Module.cs
@@ -312,7 +312,7 @@ public static class Module
         }
         catch (Exception e)
         {
-            var error_str = e.ToString();
+            var error_str = e.Message ?? e.GetType().FullName;
             var error_bytes = System.Text.Encoding.UTF8.GetBytes(error_str);
             error.Write(error_bytes);
             return Errno.HOST_CALL_FAILURE;


### PR DESCRIPTION
# Description of Changes
This PR fixes a C# reducer error-reporting issue where exceptions thrown in reducers were returned to clients with full stack traces, as reported in [#3959](https://github.com/clockworklabs/SpacetimeDB/issues/3959).

- Updated the C# reducer host-call error serialization to return only `Exception.Message` (instead of `Exception.ToString()`), preventing server-side stack traces from being leaked to clients.
- Added a C# regression-test client assertion to validate reducer failures do not contain stack traces:
  - `exception.Message` matches the thrown message exactly
  - the message does not contain newlines or `" at "` stack-trace markers

# API and ABI breaking changes
None.
- No schema or wire-format changes.
- Behavior change is limited to the *contents* of reducer error strings returned to clients (stack traces removed).

# Expected complexity level and risk
2 - Low
- Change is isolated to C# reducer error formatting plus a regression assertion.
- Removes unintended information exposure without affecting reducer success paths.

# Testing
- [X] Ran C# regression-tests client; verified reducer error message is preserved and stack trace is not present.