### PR TITLE
`--feature no-core-pinning` disables core pinning

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -143,6 +143,8 @@ spacetimedb-wasm-instance-env-times = []
 test = ["spacetimedb-commitlog/test", "spacetimedb-datastore/test"]
 # Perfmaps for profiling modules
 perfmap = []
+# Disables core pinning
+no-core-pinning = []
 
 [dev-dependencies]
 spacetimedb-lib = { path = "../lib", features = ["proptest", "test"] }

--- a/crates/core/src/startup.rs
+++ b/crates/core/src/startup.rs
@@ -317,9 +317,14 @@ impl Cores {
 
     /// Get the cores of the local host, as reported by the operating system.
     ///
-    /// Returns `None` if `num_cpus` is less than 8.
+    /// Returns `None` if `num_cpus` is less than 8
+    /// or if core pinning is disabled.
     /// If `Some` is returned, the `Vec` is non-empty.
     pub fn get_core_ids() -> Option<Vec<CoreId>> {
+        if cfg!(feature = "no-core-pinning") {
+            return None;
+        }
+
         let cores = core_affinity::get_core_ids()
             .filter(|cores| cores.len() >= 10)?
             .into_iter()

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -17,9 +17,11 @@ harness = true         # Use libtest harness.
 required-features = [] # Features required to build this target (N/A for lib)
 
 [features]
+unstable = ["spacetimedb-client-api/unstable"]
 # Perfmaps for profiling modules
 perfmap = ["spacetimedb-core/perfmap"]
-unstable = ["spacetimedb-client-api/unstable"]
+# Disables core pinning
+no-core-pinning = ["spacetimedb-core/no-core-pinning"]
 
 [dependencies]
 spacetimedb-client-api-messages.workspace = true


### PR DESCRIPTION
# Description of Changes

Adds a feature `no-core-pinning` that disables core pinning.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Covered by existing tests.