### PR TITLE
Handle database states better when serving module logs

### DIFF
--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -34,6 +34,17 @@ pub mod util;
 /// surfaced to the API.
 #[async_trait]
 pub trait NodeDelegate: Send + Sync {
+    /// Error returned by [Self::leader].
+    ///
+    /// Must satisfy [MaybeMisdirected] to indicate whether the method would
+    /// never succeed on this node due to the database not being scheduled on it.
+    ///
+    /// The [Into<axum::response::ErrorResponse] shall convert the error into an
+    /// HTTP response, providing an error message suitable for API clients.
+    /// The [fmt::Display] impl is used for logging the error, and may provide
+    /// additional context useful for debugging purposes.
+    type GetLeaderHostError: MaybeMisdirected + Into<axum::response::ErrorResponse> + fmt::Display + Send + Sync;
+
     fn gather_metrics(&self) -> Vec<prometheus::proto::MetricFamily>;
     fn client_actor_index(&self) -> &ClientActorIndex;
 
@@ -41,10 +52,36 @@ pub trait NodeDelegate: Send + Sync {
     fn jwt_auth_provider(&self) -> &Self::JwtAuthProviderT;
     /// Return the leader [`Host`] of `database_id`.
     ///
-    /// Returns `None` if the current leader is not hosted by this node.
     /// The [`Host`] is spawned implicitly if not already running.
-    async fn leader(&self, database_id: u64) -> anyhow::Result<Option<Host>>;
+    async fn leader(&self, database_id: u64) -> Result<Host, Self::GetLeaderHostError>;
     fn module_logs_dir(&self, replica_id: u64) -> ModuleLogsDir;
+}
+
+/// Predicate on the [NodeDelegate::GetLeaderHostError].
+///
+/// Normally, the routing layer determines the cluster node hosting the current
+/// leader. In between the routing decision and actually executing the API
+/// handler on the node, the database's state can, however, change, so that the
+/// [NodeDelegate::leader] method is unable to provide the current leader [Host].
+///
+/// This trait allows to detect this case.
+//
+// Used in the logs endpoint to allow serving module logs even if
+// the database is not currently running.
+pub trait MaybeMisdirected {
+    /// Return `true` if the current node is not responsible for the leader
+    /// replica of the requested database.
+    ///
+    /// This could be the case if:
+    ///
+    /// - the current or most-recently-known leader is not assigned to the node
+    /// - no leader is currently known
+    /// - the database does not exist
+    ///
+    /// Note that a database may not be running (e.g. due to being in a
+    /// suspended state). If its last leader is known and assigned to the
+    /// current node, this method shall return `true`.
+    fn is_misdirected(&self) -> bool;
 }
 
 /// Client view of a running module.
@@ -391,6 +428,8 @@ impl<T: ControlStateWriteAccess + ?Sized> ControlStateWriteAccess for Arc<T> {
 #[async_trait]
 impl<T: NodeDelegate + ?Sized> NodeDelegate for Arc<T> {
     type JwtAuthProviderT = T::JwtAuthProviderT;
+    type GetLeaderHostError = T::GetLeaderHostError;
+
     fn gather_metrics(&self) -> Vec<prometheus::proto::MetricFamily> {
         (**self).gather_metrics()
     }
@@ -403,7 +442,7 @@ impl<T: NodeDelegate + ?Sized> NodeDelegate for Arc<T> {
         (**self).jwt_auth_provider()
     }
 
-    async fn leader(&self, database_id: u64) -> anyhow::Result<Option<Host>> {
+    async fn leader(&self, database_id: u64) -> Result<Host, Self::GetLeaderHostError> {
         (**self).leader(database_id).await
     }
 

--- a/crates/client-api/src/routes/subscribe.rs
+++ b/crates/client-api/src/routes/subscribe.rs
@@ -151,11 +151,7 @@ where
         .unwrap()
         .ok_or(StatusCode::NOT_FOUND)?;
 
-    let leader = ctx
-        .leader(database.id)
-        .await
-        .map_err(log_and_500)?
-        .ok_or(StatusCode::NOT_FOUND)?;
+    let leader = ctx.leader(database.id).await.map_err(log_and_500)?;
 
     let identity_token = auth.creds.token().into();
 

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -8,6 +8,7 @@ use crate::subcommands::{extract_schema, start};
 use anyhow::Context as _;
 use async_trait::async_trait;
 use clap::{ArgMatches, Command};
+use http::StatusCode;
 use spacetimedb::client::ClientActorIndex;
 use spacetimedb::config::{CertificateAuthority, MetadataFile};
 use spacetimedb::db;
@@ -114,8 +115,42 @@ impl StandaloneEnv {
     }
 }
 
+#[derive(Debug, thiserror::Error)]
+pub enum GetLeaderHostError {
+    #[error("database does not exist")]
+    NoSuchDatabase,
+    #[error("replica does not exist")]
+    NoSuchReplica,
+    #[error("error starting database")]
+    LaunchError { source: anyhow::Error },
+    #[error("error accessing controldb")]
+    Control(#[from] control_db::Error),
+}
+
+impl spacetimedb_client_api::MaybeMisdirected for GetLeaderHostError {
+    fn is_misdirected(&self) -> bool {
+        matches!(self, Self::NoSuchDatabase | Self::NoSuchReplica)
+    }
+}
+
+impl From<GetLeaderHostError> for axum::response::ErrorResponse {
+    fn from(e: GetLeaderHostError) -> Self {
+        let status = match e {
+            GetLeaderHostError::NoSuchDatabase | GetLeaderHostError::NoSuchReplica => StatusCode::NOT_FOUND,
+            GetLeaderHostError::LaunchError { .. } | GetLeaderHostError::Control { .. } => {
+                StatusCode::INTERNAL_SERVER_ERROR
+            }
+        };
+
+        Self::from((status, e.to_string()))
+    }
+}
+
 #[async_trait]
 impl NodeDelegate for StandaloneEnv {
+    type JwtAuthProviderT = auth::DefaultJwtAuthProvider;
+    type GetLeaderHostError = GetLeaderHostError;
+
     fn gather_metrics(&self) -> Vec<prometheus::proto::MetricFamily> {
         self.metrics_registry.gather()
     }
@@ -124,30 +159,27 @@ impl NodeDelegate for StandaloneEnv {
         &self.client_actor_index
     }
 
-    type JwtAuthProviderT = auth::DefaultJwtAuthProvider;
-
     fn jwt_auth_provider(&self) -> &Self::JwtAuthProviderT {
         &self.auth_provider
     }
 
-    async fn leader(&self, database_id: u64) -> anyhow::Result<Option<Host>> {
-        let leader = match self.control_db.get_leader_replica_by_database(database_id) {
-            Some(leader) => leader,
-            None => return Ok(None),
+    async fn leader(&self, database_id: u64) -> Result<Host, Self::GetLeaderHostError> {
+        let Some(leader) = self.control_db.get_leader_replica_by_database(database_id) else {
+            return Err(GetLeaderHostError::NoSuchReplica);
         };
 
-        let database = self
-            .control_db
-            .get_database_by_id(database_id)?
-            .with_context(|| format!("Database {database_id} not found"))?;
+        let Some(database) = self.control_db.get_database_by_id(database_id)? else {
+            return Err(GetLeaderHostError::NoSuchDatabase);
+        };
 
         self.host_controller
             .get_or_launch_module_host(database, leader.id)
             .await
-            .context("failed to get or launch module host")?;
+            .map_err(|source| GetLeaderHostError::LaunchError { source })?;
 
-        Ok(Some(Host::new(leader.id, self.host_controller.clone())))
+        Ok(Host::new(leader.id, self.host_controller.clone()))
     }
+
     fn module_logs_dir(&self, replica_id: u64) -> ModuleLogsDir {
         self.data_dir().replica(replica_id).module_logs()
     }
@@ -267,10 +299,7 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
                 let database_id = database.id;
                 let database_identity = database.database_identity;
 
-                let leader = self
-                    .leader(database_id)
-                    .await?
-                    .ok_or_else(|| anyhow::anyhow!("No leader for database"))?;
+                let leader = self.leader(database_id).await?;
                 let update_result = leader
                     .update(database, spec.host_type, spec.program_bytes.to_vec().into(), policy)
                     .await?;
@@ -331,10 +360,7 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
 
         match existing_db {
             Some(db) => {
-                let host = self
-                    .leader(db.id)
-                    .await?
-                    .ok_or_else(|| anyhow::anyhow!("No leader for database"))?;
+                let host = self.leader(db.id).await?;
                 self.host_controller
                     .migrate_plan(
                         db,

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -236,11 +236,7 @@ impl CompiledModule {
             name: env.client_actor_index().next_client_name(),
         };
 
-        let host = env
-            .leader(database.id)
-            .await
-            .expect("host should be running")
-            .expect("host should be running");
+        let host = env.leader(database.id).await.expect("host should be running");
         let module_rx = host.module_watcher().await.unwrap();
 
         // TODO: it might be neat to add some functionality to module handle to make


### PR DESCRIPTION
If a database is not currently running / runnable, we can still serve module logs if, and only if, the routing layer has correctly picked the last known leader.

To determine that this is the case, we make it so a predicate can be evaluated against the error return of `NodeDelegate::leader`.

In the future, we may be able to fetch from the last known leader transparently, or store module logs in distributed storage altogether, at which point the predicate trait can be retired.

In order to not leak information about the server's directory structure, `DatabaseLogger::read_latest_on_disk` will return an empty stream in case no log directory or recent log file exist on disk.


# Expected complexity level and risk

1.5

# Testing

n/a
