### PR TITLE
Make new `Uuid` type Filterable

### DIFF
--- a/crates/bindings/tests/ui/tables.stderr
+++ b/crates/bindings/tests/ui/tables.stderr
@@ -121,10 +121,10 @@ error[E0277]: `&'a Alpha` cannot appear as an argument to an index filtering ope
   --> tests/ui/tables.rs:32:33
    |
 32 |     ctx.db.delta().compound_a().find(Alpha { beta: 0 });
-   |                                 ^^^^ should be an integer type, `bool`, `String`, `&str`, `Identity`, `ConnectionId`, `Hash` or a no-payload enum which derives `SpacetimeType`, not `&'a Alpha`
+   |                                 ^^^^ should be an integer type, `bool`, `String`, `&str`, `Identity`, `Uuid`, `ConnectionId`, `Hash` or a no-payload enum which derives `SpacetimeType`, not `&'a Alpha`
    |
    = help: the trait `for<'a> FilterableValue` is not implemented for `&'a Alpha`
-   = note: The allowed set of types are limited to integers, bool, strings, `Identity`, `ConnectionId`, `Hash` and no-payload enums which derive `SpacetimeType`,
+   = note: The allowed set of types are limited to integers, bool, strings, `Identity`, `Uuid`, `ConnectionId`, `Hash` and no-payload enums which derive `SpacetimeType`,
    = help: the following other types implement trait `FilterableValue`:
              &ConnectionId
              &Identity

--- a/crates/lib/src/filterable_value.rs
+++ b/crates/lib/src/filterable_value.rs
@@ -38,7 +38,7 @@ use spacetimedb_sats::{hash::Hash, i256, u256, Serialize};
 //   E.g. `&str: FilterableValue<Column = String>` is desirable.
 #[diagnostic::on_unimplemented(
     message = "`{Self}` cannot appear as an argument to an index filtering operation",
-    label = "should be an integer type, `bool`, `String`, `&str`, `Identity` , `Uuid`, `ConnectionId`, `Hash` or a no-payload enum which derives `SpacetimeType`, not `{Self}`",
+    label = "should be an integer type, `bool`, `String`, `&str`, `Identity`, `Uuid`, `ConnectionId`, `Hash` or a no-payload enum which derives `SpacetimeType`, not `{Self}`",
     note = "The allowed set of types are limited to integers, bool, strings, `Identity`, `Uuid`, `ConnectionId`, `Hash` and no-payload enums which derive `SpacetimeType`,"
 )]
 pub trait FilterableValue: Serialize + Private {


### PR DESCRIPTION
# Description of Changes

`Uuid` addad in the last update is not filterable even though it is `Copy` and (imo) obviously _very_ suited to filter.
Promote it to a special `FilterableValue` in the same way as `Identity`  and adjust the docs.

# API and ABI breaking changes

None

# Expected complexity level and risk

1. Only copies the same strategy as `Identity` which is also a newtype wrapper around a integer like `Uuid`

# Testing

Tested on my project.

After the change:
<img width="586" height="298" alt="image" src="https://github.com/user-attachments/assets/98e97c16-906b-4e66-b132-676ece40462e" />

Before the change:
<img width="1495" height="547" alt="image" src="https://github.com/user-attachments/assets/da74e49a-1dbd-43ae-9b13-39dcc39c81dc" />


You can also test this yourself when adding:
`spacetimedb = { version = "1.11.2", git = "https://github.com/kistz/SpacetimeDB.git", branch = "uuid-as-filter" }` to your cargo.toml project

- [x] Tested before and after. Before it was a compiler error afterwards not.
