### PR TITLE
CI - LLM benchmark update uses `clockworklabs-bot`

### DIFF
--- a/.github/workflows/llm-benchmark-update.yml
+++ b/.github/workflows/llm-benchmark-update.yml
@@ -300,11 +300,11 @@ jobs:
       # Commit the changes.
       - name: Commit changes
         run: |
-          git config user.name "spacetimedb-bot"
-          git config user.email "spacetimedb-bot@users.noreply.github.com"
+          git config user.name "clockworklabs-bot"
+          git config user.email "clockworklabs-bot@users.noreply.github.com"
 
           # Prefer staging only the benchmark output area (adjust as needed)
-          git add docs/llms 
+          git add docs/llms
 
           git diff --cached --quiet && exit 0
           git commit -m "Update LLM benchmark results"


### PR DESCRIPTION
# Description of Changes

Make the GH username for this job correspond to an actual GH user, so we can have it sign our CLA.

# API and ABI breaking changes

CI only

# Expected complexity level and risk

1

# Testing

I think we could test this by having clockworklabs-bot create an external PR, if we think that's worth it. Alternatively we could merge and test in prod.