### PR TITLE
CI - Decrease number of iterations for long-running UUID test

### DIFF
--- a/crates/bindings-typescript/tests/uuid.test.ts
+++ b/crates/bindings-typescript/tests/uuid.test.ts
@@ -82,7 +82,7 @@ describe('Uuid', () => {
     expect(uStart.getCounter()).toBe(0);
 
     // Check ordering over many UUIDs up to the max counter value
-    const total = 100_000;
+    const total = 10_000;
     const counter = { value: 0x7fffffff - total };
     const ts = Timestamp.now();
 


### PR DESCRIPTION
# Description of Changes

One of the TypeScript UUID tests took several seconds to run, and would sometimes time out in CI. This PR decreases the number of iterations so that it runs comfortably.

We do not think that this will materially impact the correctness of the test.

# API and ABI breaking changes

None. Test only.

# Expected complexity level and risk

1

# Testing

- [x] The test now runs in ~500ms on my machine, instead of ~4s