### PR TITLE
Fixed `SERVER_MSG_COMPRESSION_TAG_*` descriptions

### DIFF
--- a/crates/client-api-messages/src/websocket.rs
+++ b/crates/client-api-messages/src/websocket.rs
@@ -342,10 +342,10 @@ impl_deserialize!([] CallProcedureFlags, de => match de.deserialize_u8()? {
 /// The tag recognized by the host and SDKs to mean no compression of a [`ServerMessage`].
 pub const SERVER_MSG_COMPRESSION_TAG_NONE: u8 = 0;
 
-/// The tag recognized by the host and SDKs to mean brotli compression  of a [`ServerMessage`].
+/// The tag recognized by the host and SDKs to mean brotli compression of a [`ServerMessage`].
 pub const SERVER_MSG_COMPRESSION_TAG_BROTLI: u8 = 1;
 
-/// The tag recognized by the host and SDKs to mean brotli compression  of a [`ServerMessage`].
+/// The tag recognized by the host and SDKs to mean gzip compression of a [`ServerMessage`].
 pub const SERVER_MSG_COMPRESSION_TAG_GZIP: u8 = 2;
 
 /// Messages sent from the server to the client.


### PR DESCRIPTION
# Description of Changes

Typo fix.

# API and ABI breaking changes

None.

# Expected complexity level and risk

### 0:
Comment changes only.

# Testing

- [x] Eyeballing it