### PR TITLE
Time out database shutdown

### DIFF
--- a/crates/core/src/db/snapshot.rs
+++ b/crates/core/src/db/snapshot.rs
@@ -186,6 +186,7 @@ impl SnapshotWorkerActor {
     /// message is received, unless a new snapshot request is already being
     /// processed.
     async fn run(mut self) {
+        let database_identity = self.snapshot_repo.database_identity();
         let mut database_state: Option<WeakDatabaseState> = None;
         while let Some(req) = self.snapshot_requests.next().await {
             match req {
@@ -193,7 +194,7 @@ impl SnapshotWorkerActor {
                     let res = self
                         .maybe_take_snapshot(database_state.as_ref())
                         .await
-                        .inspect_err(|e| warn!("SnapshotWorker: {e:#}"));
+                        .inspect_err(|e| warn!("database={database_identity} SnapshotWorker: {e:#}"));
                     if let Ok(snapshot_offset) = res {
                         self.maybe_compress_snapshots(snapshot_offset).await;
                         self.snapshot_created.send_replace(snapshot_offset);

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -25,6 +25,7 @@ use async_trait::async_trait;
 use durability::{Durability, EmptyHistory};
 use log::{info, trace, warn};
 use parking_lot::Mutex;
+use scopeguard::defer;
 use spacetimedb_commitlog::SizeOnDisk;
 use spacetimedb_data_structures::error_stream::ErrorStream;
 use spacetimedb_data_structures::map::IntMap;
@@ -496,7 +497,7 @@ impl HostController {
     /// Release all resources of the [`ModuleHost`] identified by `replica_id`,
     /// and deregister it from the controller.
     #[tracing::instrument(level = "trace", skip_all)]
-    pub async fn exit_module_host(&self, replica_id: u64) -> Result<(), anyhow::Error> {
+    pub async fn exit_module_host(&self, replica_id: u64, timeout: Duration) -> Result<(), anyhow::Error> {
         let Some(lock) = self.hosts.lock().remove(&replica_id) else {
             return Ok(());
         };
@@ -505,38 +506,46 @@ impl HostController {
         // we'll log a warning every 5s if we can't acquire an exclusive lock.
         let start = Instant::now();
         let mut t = interval_at(start + Duration::from_secs(5), Duration::from_secs(5));
-        // Spawn so we don't lose our place in the queue.
-        let mut excl = tokio::spawn(lock.write_owned());
-        loop {
-            tokio::select! {
-                guard = &mut excl => {
-                    let Ok(mut guard) = guard else {
-                        warn!("cancelled shutdown of module of replica {replica_id}");
-                        break;
-                    };
-                    let Some(host) = guard.take() else {
-                        break;
-                    };
-                    let module = host.module.borrow().clone();
-                    let info = module.info();
-                    info!("exiting replica {} of database {}", replica_id, info.database_identity);
-                    module.exit().await;
-                    let db = &module.replica_ctx().relational_db;
-                    db.shutdown().await;
-                    let table_names = info.module_def.tables().map(|t| t.name.deref());
-                    remove_database_gauges(&info.database_identity, table_names);
-                    info!("replica {} of database {} exited", replica_id, info.database_identity);
-
-                    break;
-                },
-                _ = t.tick() => {
-                    warn!(
-                        "blocked waiting to exit module for replica {} since {}s",
-                        replica_id,
-                        start.elapsed().as_secs_f32()
-                    );
-                }
+        let warn_blocked = tokio::spawn(async move {
+            loop {
+                t.tick().await;
+                warn!(
+                    "blocked waiting to exit module for replica {} since {}s",
+                    replica_id,
+                    start.elapsed().as_secs_f32()
+                );
             }
+        });
+        defer!(warn_blocked.abort());
+
+        let shutdown = tokio::time::timeout(timeout, async {
+            let mut guard = lock.write_owned().await;
+            let Some(host) = guard.take() else {
+                return;
+            };
+            let module = host.module.borrow().clone();
+            let info = module.info();
+
+            let database_identity = info.database_identity;
+            let table_names = info.module_def.tables().map(|t| t.name.deref());
+
+            // Ensure we clear the metrics even if the future is cancelled.
+            defer!(remove_database_gauges(&database_identity, table_names));
+
+            info!("replica={replica_id} database={database_identity} exiting module");
+            module.exit().await;
+            let db = &module.replica_ctx().relational_db;
+            info!("replica={replica_id} database={database_identity} exiting database");
+            db.shutdown().await;
+            info!("replica={replica_id} database={database_identity} module host exited");
+        })
+        .await;
+
+        if shutdown.is_err() {
+            warn!(
+                "replica={replica_id} shutdown timed out after {}s",
+                start.elapsed().as_secs_f32()
+            );
         }
 
         Ok(())

--- a/crates/durability/src/lib.rs
+++ b/crates/durability/src/lib.rs
@@ -135,6 +135,11 @@ pub trait Durability: Send + Sync {
     ///
     /// Note that errors are not propagated, as the [Durability] may already be
     /// closed.
+    ///
+    /// # Cancellation
+    ///
+    /// Dropping the [Close] future shall abort the shutdown process,
+    /// and leave the [Durability] in a closed state.
     fn close(&self) -> Close;
 }
 

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -31,6 +31,7 @@ use spacetimedb_paths::standalone::StandaloneDataDirExt;
 use spacetimedb_schema::auto_migrate::{MigrationPolicy, PrettyPrintStyle};
 use spacetimedb_table::page_pool::PagePool;
 use std::sync::Arc;
+use std::time::Duration;
 
 pub use spacetimedb_client_api::routes::subscribe::{BIN_PROTOCOL, TEXT_PROTOCOL};
 
@@ -538,7 +539,9 @@ impl StandaloneEnv {
         // replicas which have been deleted. This will just drop
         // them from memory, but will not remove them from disk.  We need
         // some kind of database lifecycle manager long term.
-        self.host_controller.exit_module_host(replica_id).await?;
+        self.host_controller
+            .exit_module_host(replica_id, Duration::from_secs(30))
+            .await?;
 
         Ok(())
     }


### PR DESCRIPTION
It is possible that, under pathological conditions, a database has a
huge transaction backlog, or that there is some bug that prevents
progress on draining this backlog upon shutdown.

In order to avoid piling up `exit_module_host` tasks (which we would not
notice), impose a timeout to be specified after which `exit_module_host`
will drop resources without waiting for the shutdown to complete
gracefully.
