### PR TITLE
CI - "Fix" v8 error in TypeScript CI

### DIFF
--- a/.github/workflows/typescript-test.yml
+++ b/.github/workflows/typescript-test.yml
@@ -102,13 +102,6 @@ jobs:
           # Clear any existing information
           spacetime server clear -y
 
-      - name: Generate client bindings
-        working-directory: templates/quickstart-chat-typescript/spacetimedb
-        run: |
-          spacetime generate --lang typescript --out-dir ../src/module_bindings
-          cd ../../../crates/bindings-typescript
-          pnpm format
-
       # This step shouldn't be needed, but somehow we end up with caches that are missing librusty_v8.a.
       # This may be due to reusing CARGO_TARGET_DIR while mixing different build strategies (`cargo install` and `cargo build -p`).
       # However, this fix seems to work.
@@ -120,6 +113,13 @@ jobs:
             cargo clean -p v8 || true
             cargo build -p v8
           fi
+
+      - name: Generate client bindings
+        working-directory: templates/quickstart-chat-typescript/spacetimedb
+        run: |
+          spacetime generate --lang typescript --out-dir ../src/module_bindings
+          cd ../../../crates/bindings-typescript
+          pnpm format
 
       - name: Check for changes
         working-directory: templates/quickstart-chat-typescript


### PR DESCRIPTION
# Description of Changes

See https://github.com/clockworklabs/SpacetimeDB/pull/3921 for a previous version of this PR. Just expanding that hacky fix.

# API and ABI breaking changes

CI-only change.

# Expected complexity level and risk

1

# Testing

- [x] Build fixed in https://github.com/clockworklabs/SpacetimeDB/pull/3980