### PR TITLE
Support `Uuid` in React Hook `where` clause

### DIFF
--- a/crates/bindings-typescript/src/react/useTable.ts
+++ b/crates/bindings-typescript/src/react/useTable.ts
@@ -87,11 +87,11 @@ export function evaluate<Column extends string>(
         return v === expr.value;
       }
       if (typeof v === 'object') {
-        // Value of the Column and passed Value are both a Uuid so do an integer comparison. 
+        // Value of the Column and passed Value are both a Uuid so do an integer comparison.
         if (v instanceof Uuid && expr.value instanceof Uuid) {
           return v.asBigInt() === expr.value.asBigInt();
         }
-        // Value of the Column is a Uuid but passed Value is a String so compare them via string. 
+        // Value of the Column is a Uuid but passed Value is a String so compare them via string.
         if (v instanceof Uuid && typeof expr.value === 'string') {
           return v.toString() === expr.value;
         }
@@ -309,8 +309,8 @@ export function useTable<TableDef extends UntypedTableDef>(
   } catch {
     throw new Error(
       'Could not find SpacetimeDB client! Did you forget to add a ' +
-      '`SpacetimeDBProvider`? `useTable` must be used in the React component tree ' +
-      'under a `SpacetimeDBProvider` component.'
+        '`SpacetimeDBProvider`? `useTable` must be used in the React component tree ' +
+        'under a `SpacetimeDBProvider` component.'
     );
   }
 
@@ -336,8 +336,8 @@ export function useTable<TableDef extends UntypedTableDef>(
     const table = connection.db[accessorName];
     const result: readonly Prettify<UseTableRowType>[] = whereClause
       ? (Array.from(table.iter()).filter(row =>
-        evaluate(whereClause, row as UseTableRowType)
-      ) as Prettify<UseTableRowType>[])
+          evaluate(whereClause, row as UseTableRowType)
+        ) as Prettify<UseTableRowType>[])
       : (Array.from(table.iter()) as Prettify<UseTableRowType>[]);
     return [result, subscribeApplied];
     // eslint-disable-next-line react-hooks/exhaustive-deps
@@ -429,7 +429,7 @@ export function useTable<TableDef extends UntypedTableDef>(
 
       const connection = connectionState.getConnection();
       if (!connection) {
-        return () => { };
+        return () => {};
       }
 
       const table = connection.db[accessorName];


### PR DESCRIPTION
# Description of Changes

Dpends on and includes: #4011 
Will remove commits whenever that merges 👍 

This impacts the `useTable()` functions `where`clause.
We add a new possibility for the `Value` type which is the new `Uuid` type.


Also my formatter is bugging again :( whenever i `pnpm format` it does things differently than the guidelines? Would be cool for that reason if someone can run format for me maybe bfops like the last time :>

# API and ABI breaking changes

None

# Expected complexity level and risk

1. Only lifts the filter for the where clause a bit to further support `Uuid` alongside bool, string, and number.

# Testing
- [x] Getting syntax highlithing for the new availbale row
- [x] Getting row back from subscription when supplying a uuid
- [x] Fix edge case with string
