### PR TITLE
Add a feature flag `no-job-core-pinning`

### DIFF
--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -145,6 +145,7 @@ test = ["spacetimedb-commitlog/test", "spacetimedb-datastore/test"]
 perfmap = []
 # Disables core pinning
 no-core-pinning = []
+no-job-core-pinning = []
 
 [dev-dependencies]
 spacetimedb-lib = { path = "../lib", features = ["proptest", "test"] }

--- a/crates/core/src/util/jobs.rs
+++ b/crates/core/src/util/jobs.rs
@@ -125,7 +125,7 @@ impl JobCores {
     /// and runs all databases in the `global_runtime`.
     pub fn from_pinned_cores(cores: impl IntoIterator<Item = CoreId>, global_runtime: runtime::Handle) -> Self {
         let cores: IndexMap<_, _> = cores.into_iter().map(|id| (id, CoreInfo::spawn_executor(id))).collect();
-        let inner = if cores.is_empty() {
+        let inner = if cfg!(feature = "no-job-core-pinning") || cores.is_empty() {
             JobCoresInner::NoPinning(global_runtime)
         } else {
             JobCoresInner::PinnedCores(Arc::new(Mutex::new(PinnedCoresExecutorManager {

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -22,6 +22,7 @@ unstable = ["spacetimedb-client-api/unstable"]
 perfmap = ["spacetimedb-core/perfmap"]
 # Disables core pinning
 no-core-pinning = ["spacetimedb-core/no-core-pinning"]
+no-job-core-pinning = ["spacetimedb-core/no-job-core-pinning"]
 
 [dependencies]
 spacetimedb-client-api-messages.workspace = true


### PR DESCRIPTION
# Description of Changes

Anther knob for benchmarking only without job core pinning but keeping other core pinning (tokio background, rayon, etc.).

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

No semantic changes.