### PR TITLE
Fix `Hash` indices not working

### DIFF
--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -51,8 +51,8 @@ pub use spacetimedb_lib::Uuid;
 pub use spacetimedb_primitives::TableId;
 pub use sys::Errno;
 pub use table::{
-    AutoIncOverflow, RangedIndex, RangedIndexReadOnly, Table, TryInsertError, UniqueColumn, UniqueColumnReadOnly,
-    UniqueConstraintViolation,
+    AutoIncOverflow, PointIndex, PointIndexReadOnly, RangedIndex, RangedIndexReadOnly, Table, TryInsertError,
+    UniqueColumn, UniqueColumnReadOnly, UniqueConstraintViolation,
 };
 
 pub type ReducerResult = core::result::Result<(), Box<str>>;


### PR DESCRIPTION
# Description of Changes

This pr reexports `PointIndex` and `PointIndexReadOnly` because currently the new `Hash` indices dont compile when used in projects. This is because the table macro cant find those two exports.

Maybe @Centril could take a look? :>

# API and ABI breaking changes

None

# Expected complexity level and risk

1. Only fixes a compiler error.

# Testing

- [x] Project compiles now.

Before:
<img width="1454" height="337" alt="image" src="https://github.com/user-attachments/assets/42df164c-dd09-42b9-97df-a1df719dc3b4" />

After:
<img width="1404" height="172" alt="image" src="https://github.com/user-attachments/assets/0d11158c-daae-44b6-b001-ccccfe0940fd" />

