### PR TITLE
Add ~/.local/bin to GITHUB_PATH for llm benchmark workflow

### DIFF
--- a/.github/workflows/llm-benchmark-update.yml
+++ b/.github/workflows/llm-benchmark-update.yml
@@ -39,7 +39,9 @@ jobs:
       # If we want to change that it is possible to have the benchmark compile
       # SpacetimeDB from source.
       - name: Install spacetime CLI
-        run: curl -sSf https://install.spacetimedb.com | sh -s -- -y
+        run: |
+          curl -sSf https://install.spacetimedb.com | sh -s -- -y
+          echo "$HOME/.local/bin" >> $GITHUB_PATH
 
       - name: Load PR info
         id: pr


### PR DESCRIPTION
# Description of Changes

This is a try to fix the Update LLM benchmarks workflow

# Expected complexity level and risk
1
