### PR TITLE
Pass --yes flag from dev command to generate command

### DIFF
--- a/crates/cli/src/subcommands/dev.rs
+++ b/crates/cli/src/subcommands/dev.rs
@@ -109,7 +109,6 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
         .copied()
         .unwrap_or(ClearMode::OnConflict);
     let force = args.get_flag("force");
-    let yes = args.get_flag("yes");
 
     // If you don't specify a server, we default to your default server
     // If you don't have one of those, we default to "maincloud"
@@ -278,7 +277,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
         client_language,
         resolved_server,
         clear_database,
-        yes,
+        force,
     )
     .await?;
 
@@ -328,7 +327,7 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
                 client_language,
                 resolved_server,
                 clear_database,
-                yes,
+                force,
             )
             .await
             {


### PR DESCRIPTION
# Description of Changes

  When `--yes` is passed to `spacetime dev`, the flag is now also passed through to the internal `spacetime generate` call. This ensures that generate skips its interactive prompts when running in non-interactive mode.

  # API and ABI breaking changes

  None.

  # Expected complexity level and risk

  1 - Trivial change. Adds a conditional argument to an internal command invocation.

  # Testing

  - [x] Run `spacetime dev --yes` and verify generate does not prompt for confirmation
  - [x] Run `spacetime dev` (without --yes) and verify generate still prompts as expected