### PR TITLE
`copy_filter` & co: make blob handling more flexible

### DIFF
--- a/crates/table/benches/page.rs
+++ b/crates/table/benches/page.rs
@@ -461,7 +461,7 @@ fn copy_filter_into_fixed_len_keep_ratio<Row: FixedLenRow>(b: &mut Bencher, keep
                 target_page,
                 row_size_for_type::<Row>(),
                 &visitor,
-                &mut NullBlobStore,
+                None::<&mut Box<dyn FnMut(_)>>,
                 |_page, _row| rng.random_bool(*keep_ratio),
             )
         };

--- a/crates/table/benches/page_manager.rs
+++ b/crates/table/benches/page_manager.rs
@@ -460,7 +460,7 @@ fn copy_filter_fixed_len(c: &mut Criterion) {
             group.bench_function(keep_ratio.to_string(), |b| {
                 b.iter_with_large_drop(|| unsafe {
                     let mut keep_iter = keep_seq.iter().copied();
-                    black_box(&pages).copy_filter(visitor, row_size, &mut NullBlobStore, |_, _| {
+                    black_box(&pages).copy_filter(visitor, row_size, None::<&mut Box<dyn FnMut(_)>>, |_, _| {
                         black_box(keep_iter.next().unwrap_or_default())
                     })
                 });

--- a/crates/table/src/page.rs
+++ b/crates/table/src/page.rs
@@ -33,12 +33,14 @@
 //!   for a discussion on safety and validity invariants.
 
 use super::{
-    blob_store::BlobStore,
+    blob_store::{BlobHash, BlobStore},
     fixed_bit_set::FixedBitSet,
-    indexes::{Byte, Bytes, PageOffset, PAGE_HEADER_SIZE, PAGE_SIZE},
+    fixed_bit_set::IterSet,
+    indexes::{max_rows_in_page, Byte, Bytes, PageOffset, PAGE_HEADER_SIZE, PAGE_SIZE},
+    static_assert_size,
+    table::BlobNumBytes,
     var_len::{is_granule_offset_aligned, VarLenGranule, VarLenGranuleHeader, VarLenMembers, VarLenRef},
 };
-use crate::{fixed_bit_set::IterSet, indexes::max_rows_in_page, static_assert_size, table::BlobNumBytes};
 use core::{mem, ops::ControlFlow};
 use spacetimedb_sats::layout::{Size, MIN_ROW_SIZE};
 use spacetimedb_sats::memory_usage::MemoryUsage;
@@ -1640,7 +1642,7 @@ impl Page {
         dst: &mut Page,
         fixed_row_size: Size,
         var_len_visitor: &impl VarLenMembers,
-        blob_store: &mut dyn BlobStore,
+        mut blob_policy: Option<&mut impl FnMut(BlobHash)>,
         mut filter: impl FnMut(&Page, PageOffset) -> bool,
     ) -> ControlFlow<(), PageOffset> {
         for row_offset in self
@@ -1648,11 +1650,12 @@ impl Page {
             // Only copy rows satisfying the predicate `filter`.
             .filter(|o| filter(self, *o))
         {
+            let blob_policy = blob_policy.as_mut();
             // SAFETY:
             // - `starting_from` points to a valid row and thus `row_offset` also does.
             // - `var_len_visitor` will visit the right `VarLenRef`s and is consistent with other calls.
             // - `fixed_row_size` is consistent with `var_len_visitor` and `self`.
-            if !unsafe { self.copy_row_into(row_offset, dst, fixed_row_size, var_len_visitor, blob_store) } {
+            if !unsafe { self.copy_row_into(row_offset, dst, fixed_row_size, var_len_visitor, blob_policy) } {
                 // Target doesn't have enough space for row;
                 // stop here and return the offset of the uncopied row
                 // so a later call to `copy_filter_into` can start there.
@@ -1684,7 +1687,7 @@ impl Page {
         dst: &mut Page,
         fixed_row_size: Size,
         var_len_visitor: &impl VarLenMembers,
-        blob_store: &mut dyn BlobStore,
+        mut blob_policy: Option<&mut impl FnMut(BlobHash)>,
     ) -> bool {
         // SAFETY: Caller promised that `starting_from` points to a valid row
         // consistent with `fixed_row_size` which was also
@@ -1717,6 +1720,7 @@ impl Page {
         // SAFETY: forward our requirement on `var_len_visitor` to `visit_var_len_mut`.
         let target_vlr_iter = unsafe { var_len_visitor.visit_var_len_mut(dst_row) };
         for (src_vlr, target_vlr_slot) in src_vlr_iter.zip(target_vlr_iter) {
+            let blob_policy = blob_policy.as_mut();
             // SAFETY:
             //
             // - requirements of `visit_var_len_assume_init` were met,
@@ -1724,7 +1728,7 @@ impl Page {
             //
             // - the call to `dst.has_space_for_row` above ensures
             //   that the allocation will not fail part-way through.
-            let target_vlr_fixup = unsafe { self.copy_var_len_into(*src_vlr, &mut dst_var, blob_store) }
+            let target_vlr_fixup = unsafe { self.copy_var_len_into(*src_vlr, &mut dst_var, blob_policy) }
                 .expect("Failed to allocate var-len object in dst page after checking for available space");
 
             *target_vlr_slot = target_vlr_fixup;
@@ -1751,7 +1755,7 @@ impl Page {
         &self,
         src_vlr: VarLenRef,
         dst_var: &mut VarView<'_>,
-        blob_store: &mut dyn BlobStore,
+        blob_policy: Option<&mut impl FnMut(BlobHash)>,
     ) -> Result<VarLenRef, Error> {
         // SAFETY: Caller promised that `src_vlr.first_granule` points to a valid granule is be NULL.
         let mut iter = unsafe { self.iter_var_len_object(src_vlr.first_granule) };
@@ -1803,12 +1807,12 @@ impl Page {
         //    or was `next_dst_chunk` in the previous iteration and hasn't been written to yet.
         unsafe { dst_var.write_chunk_to_granule(data, data.len(), dst_chunk, PageOffset::VAR_LEN_NULL) };
 
-        // For a large blob object,
-        // notify the `blob_store` that we've taken a reference to the blob hash.
-        if src_vlr.is_large_blob() {
-            blob_store
-                .clone_blob(&src_chunk.blob_hash())
-                .expect("blob_store could not mark hash as used");
+        // For a large blob object, run the blob policy, if we have one.
+        // This could, for example:
+        // - increment the refcount in the blob store
+        // - clone the blob object and the bytes to a new blob store.
+        if let Some(blob_policy) = blob_policy.filter(|_| src_vlr.is_large_blob()) {
+            blob_policy(src_chunk.blob_hash());
         }
 
         Ok(VarLenRef {

--- a/crates/table/src/pages.rs
+++ b/crates/table/src/pages.rs
@@ -1,6 +1,6 @@
 //! Provides [`Pages`], a page manager dealing with [`Page`]s as a collection.
 
-use super::blob_store::BlobStore;
+use super::blob_store::{BlobHash, BlobStore};
 use super::indexes::{Bytes, PageIndex, PageOffset, RowPointer};
 use super::page::Page;
 use super::page_pool::PagePool;
@@ -264,7 +264,7 @@ impl Pages {
         &self,
         var_len_visitor: &impl VarLenMembers,
         fixed_row_size: Size,
-        blob_store: &mut dyn BlobStore,
+        mut blob_policy: Option<&mut impl FnMut(BlobHash)>,
         mut filter: impl FnMut(&Page, PageOffset) -> bool,
     ) -> Self {
         // Build a new container to hold the materialized view.
@@ -311,7 +311,7 @@ impl Pages {
                         &mut to_page,
                         fixed_row_size,
                         var_len_visitor,
-                        blob_store,
+                        blob_policy.as_mut(),
                         &mut filter,
                     )
                 };


### PR DESCRIPTION
# Description of Changes

Makes `Pages::copy_filter` more flexible by allowing passing in no blob store (policy) so that the in a follow PR, blob stores can be merged wholesale instead, so that transaction merging can be optimized.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

`copy_filter` and friends are currently unused but will be used in follow ups.