### PR TITLE
CI: pack C# NuGet overrides in Release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -559,8 +559,8 @@ jobs:
 
       - name: Override NuGet packages
         run: |
-          dotnet pack crates/bindings-csharp/BSATN.Runtime
-          dotnet pack crates/bindings-csharp/Runtime
+          dotnet pack -c Release crates/bindings-csharp/BSATN.Runtime
+          dotnet pack -c Release crates/bindings-csharp/Runtime
 
           # Write out the nuget config file to `nuget.config`. This causes the spacetimedb-csharp-sdk repository
           # to be aware of the local versions of the `bindings-csharp` packages in SpacetimeDB, and use them if
@@ -681,8 +681,8 @@ jobs:
 
       - name: Override NuGet packages
         run: |
-          dotnet pack crates/bindings-csharp/BSATN.Runtime
-          dotnet pack crates/bindings-csharp/Runtime
+          dotnet pack -c Release crates/bindings-csharp/BSATN.Runtime
+          dotnet pack -c Release crates/bindings-csharp/Runtime
 
           # Write out the nuget config file to `nuget.config`. This causes the spacetimedb-csharp-sdk repository
           # to be aware of the local versions of the `bindings-csharp` packages in SpacetimeDB, and use them if


### PR DESCRIPTION
# Description of Changes
CI now packs the local `SpacetimeDB.BSATN.Runtime` and `SpacetimeDB.Runtime` NuGet packages using the `Release` configuration in both the `unity-testsuite` and `csharp-testsuite` jobs.

This makes the NuGet override deterministic because `sdks/csharp/tools~/write-nuget-config.sh` points to `crates/bindings-csharp/*/bin/Release`, and `dotnet pack` otherwise defaults to Debug.

This is needed due to a CI failure occurring in #3982 in which the one of our smoketests fails because the resolved version of the package lacks `RefOption<...>.GetListSerializer`, resulting in a `CS0117` error. Because this failure is not actually related of the changes in 3982, it is being pulled out into a separate PR.

# API and ABI breaking changes
None.

# Expected complexity level and risk
1 - Trivial

# Testing
- [ ] Confirm CI pass
