### PR TITLE
[2.0 Breaking] `sender` changes for TypeScript modules

### DIFF
--- a/crates/bindings-typescript/src/lib/procedures.ts
+++ b/crates/bindings-typescript/src/lib/procedures.ts
@@ -30,7 +30,7 @@ export type ProcedureFn<
 > = (ctx: ProcedureCtx<S>, args: InferTypeOfRow<Params>) => Infer<Ret>;
 
 export interface ProcedureCtx<S extends UntypedSchemaDef> {
-  readonly sender: Identity;
+  readonly sender: () => Identity;
   readonly identity: Identity;
   readonly timestamp: Timestamp;
   readonly connectionId: ConnectionId | null;

--- a/crates/bindings-typescript/src/lib/reducers.ts
+++ b/crates/bindings-typescript/src/lib/reducers.ts
@@ -60,7 +60,7 @@ type ParamsAsObject<ParamDef extends ParamsObj> = InferTypeOfRow<ParamDef>;
  *   (ctx, { username, email }) => {
  *     // Access the 'user' table from the database view in the context
  *     ctx.db.user.insert({ username, email, created_at: ctx.timestamp });
- *     console.log(`User ${username} created by ${ctx.sender.identityId}`);
+ *     console.log(`User ${username} created by ${ctx.sender().identityId}`);
  *   }
  * );
  * ```
@@ -116,7 +116,7 @@ export interface JwtClaims {
  * Reducer context parametrized by the inferred Schema
  */
 export type ReducerCtx<SchemaDef extends UntypedSchemaDef> = Readonly<{
-  sender: Identity;
+  sender: () => Identity;
   identity: Identity;
   timestamp: Timestamp;
   connectionId: ConnectionId | null;
@@ -205,7 +205,7 @@ export const REDUCERS: Reducer<any, any>[] = [];
  *   (ctx, { username, email }) => {
  *     // Access the 'user' table from the database view in the context
  *     ctx.db.user.insert({ username, email, created_at: ctx.timestamp });
- *     console.log(`User ${username} created by ${ctx.sender.identityId}`);
+ *     console.log(`User ${username} created by ${ctx.sender().identityId}`);
  *   }
  * );
  * ```

--- a/crates/bindings-typescript/src/lib/schema.ts
+++ b/crates/bindings-typescript/src/lib/schema.ts
@@ -310,7 +310,7 @@ export function splitName(name: string): Infer<typeof RawScopedTypeNameV9> {
  *   {  username: t.string(), email: t.string() },
  *   (ctx, { username, email }) => {
  *     ctx.db.user.insert({ username, email, created_at: ctx.timestamp });
- *     console.log(`User ${username} created by ${ctx.sender.identityId}`);
+ *     console.log(`User ${username} created by ${ctx.sender().identityId}`);
  *   }
  * );
  * ```
@@ -364,7 +364,7 @@ class Schema<S extends UntypedSchemaDef> {
    *   (ctx, { username, email }) => {
    *     // Access the 'user' table from the database view in the context
    *     ctx.db.user.insert({ username, email, created_at: ctx.timestamp });
-   *     console.log(`User ${username} created by ${ctx.sender.identityId}`);
+   *     console.log(`User ${username} created by ${ctx.sender().identityId}`);
    *   }
    * );
    * ```

--- a/crates/bindings-typescript/src/lib/views.ts
+++ b/crates/bindings-typescript/src/lib/views.ts
@@ -24,7 +24,7 @@ import { bsatnBaseSize, toPascalCase } from './util';
 import { type QueryBuilder, type RowTypedQuery } from './query';
 
 export type ViewCtx<S extends UntypedSchemaDef> = Readonly<{
-  sender: Identity;
+  sender: () => Identity;
   db: ReadonlyDbView<S>;
   from: QueryBuilder<S>;
 }>;

--- a/crates/bindings-typescript/src/server/procedures.ts
+++ b/crates/bindings-typescript/src/server/procedures.ts
@@ -31,7 +31,7 @@ export function callProcedure(
   );
 
   const ctx: ProcedureCtx<UntypedSchemaDef> = {
-    sender,
+    sender: () => sender,
     timestamp,
     connectionId,
     http: httpClient,

--- a/crates/bindings-typescript/src/server/runtime.ts
+++ b/crates/bindings-typescript/src/server/runtime.ts
@@ -196,6 +196,7 @@ export const ReducerCtxImpl = class ReducerCtx<
   #identity: Identity | undefined;
   #senderAuth: AuthCtx | undefined;
   #uuidCounter: { value: number } | undefined;
+  #random: Random | undefined;
   sender: () => Identity;
   timestamp: Timestamp;
   connectionId: ConnectionId | null;

--- a/docs/docs/00100-intro/00100-getting-started/00400-key-architecture.md
+++ b/docs/docs/00100-intro/00100-getting-started/00400-key-architecture.md
@@ -424,7 +424,7 @@ spacetimedb.view(
   { name: 'my_player', public: true },
   t.option(players.row()),
   (ctx) => {
-    const row = ctx.db.players.identity.find(ctx.sender);
+    const row = ctx.db.players.identity.find(ctx.sender());
     return row ?? null;
   }
 );

--- a/docs/docs/00100-intro/00300-tutorials/00100-chat-app.md
+++ b/docs/docs/00100-intro/00300-tutorials/00100-chat-app.md
@@ -303,7 +303,7 @@ function validateName(name: string) {
 
 spacetimedb.reducer('set_name', { name: t.string() }, (ctx, { name }) => {
   validateName(name);
-  const user = ctx.db.user.identity.find(ctx.sender);
+  const user = ctx.db.user.identity.find(ctx.sender());
   if (!user) {
     throw new SenderError('Cannot set name for unknown user');
   }
@@ -388,9 +388,9 @@ function validateMessage(text: string) {
 
 spacetimedb.reducer('send_message', { text: t.string() }, (ctx, { text }) => {
   validateMessage(text);
-  console.info(`User ${ctx.sender}: ${text}`);
+  console.info(`User ${ctx.sender()}: ${text}`);
   ctx.db.message.insert({
-    sender: ctx.sender,
+    sender: ctx.sender(),
     text,
     sent: ctx.timestamp,
   });
@@ -471,12 +471,12 @@ Add:
 spacetimedb.init(_ctx => {});
 
 spacetimedb.clientConnected(ctx => {
-  const user = ctx.db.user.identity.find(ctx.sender);
+  const user = ctx.db.user.identity.find(ctx.sender());
   if (user) {
     ctx.db.user.identity.update({ ...user, online: true });
   } else {
     ctx.db.user.insert({
-      identity: ctx.sender,
+      identity: ctx.sender(),
       name: undefined,
       online: true,
     });
@@ -484,12 +484,12 @@ spacetimedb.clientConnected(ctx => {
 });
 
 spacetimedb.clientDisconnected(ctx => {
-  const user = ctx.db.user.identity.find(ctx.sender);
+  const user = ctx.db.user.identity.find(ctx.sender());
   if (user) {
     ctx.db.user.identity.update({ ...user, online: false });
   } else {
     console.warn(
-      `Disconnect event for unknown user with identity ${ctx.sender}`
+      `Disconnect event for unknown user with identity ${ctx.sender()}`
     );
   }
 });

--- a/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00400-part-3.md
+++ b/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00400-part-3.md
@@ -511,7 +511,7 @@ const START_PLAYER_MASS: i32 = 15;
 #[spacetimedb::reducer]
 pub fn enter_game(ctx: &ReducerContext, name: String) -> Result<(), String> {
     log::info!("Creating player with name {}", name);
-    let mut player: Player = ctx.db.player().identity().find(ctx.sender).ok_or("")?;
+    let mut player: Player = ctx.db.player().identity().find(ctx.sender()).ok_or("")?;
     let player_id = player.player_id;
     player.name = name;
     ctx.db.player().identity().update(player);
@@ -602,11 +602,11 @@ pub fn disconnect(ctx: &ReducerContext) -> Result<(), String> {
         .db
         .player()
         .identity()
-        .find(&ctx.sender)
+        .find(&ctx.sender())
         .ok_or("Player not found")?;
     let player_id = player.player_id;
     ctx.db.logged_out_player().insert(player);
-    ctx.db.player().identity().delete(&ctx.sender);
+    ctx.db.player().identity().delete(&ctx.sender());
 
     // Remove any circles from the arena
     for circle in ctx.db.circle().player_id().filter(&player_id) {

--- a/docs/docs/00200-core-concepts/00100-databases/00500-cheat-sheet.md
+++ b/docs/docs/00200-core-concepts/00100-databases/00500-cheat-sheet.md
@@ -438,7 +438,7 @@ fn fetch_data(ctx: &mut ProcedureContext, url: String) -> String {
 ```typescript
 // Return single row
 spacetimedb.view('my_player', {}, t.option(player.rowType), ctx => {
-  return ctx.db.player.identity.find(ctx.sender);
+  return ctx.db.player.identity.find(ctx.sender());
 });
 
 // Return multiple rows
@@ -499,7 +499,7 @@ fn top_players(ctx: &ViewContext) -> Vec<Player> {
 
 ```typescript
 ctx.db                  // Database access
-ctx.sender              // Identity of caller
+ctx.sender()            // Identity of caller
 ctx.connectionId        // ConnectionId | undefined
 ctx.timestamp           // Timestamp
 ctx.identity            // Module's identity

--- a/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00400-reducer-context.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00400-reducer-context.md
@@ -111,7 +111,7 @@ const spacetimedb = schema(player);
 
 spacetimedb.reducer('update_score', { newScore: t.u32() }, (ctx, { newScore }) => {
   // Get the caller's identity
-  const caller = ctx.sender;
+  const caller = ctx.sender();
   
   // Find and update their player record
   const existingPlayer = ctx.db.player.identity.find(caller);
@@ -232,7 +232,7 @@ const spacetimedb = schema(scheduledTask);
 
 spacetimedb.reducer('send_reminder', { arg: scheduledTask.rowType }, (ctx, { arg }) => {
   // Only allow the scheduler (module identity) to call this
-  if (ctx.sender != ctx.identity) {
+  if (ctx.sender() != ctx.identity) {
     throw new SenderError('This reducer can only be called by the scheduler');
   }
   
@@ -309,7 +309,6 @@ fn send_reminder(ctx: &ReducerContext, task: ScheduledTask) {
 | Property       | Type                       | Description                                     |
 | -------------- | -------------------------- | ----------------------------------------------- |
 | `db`           | `DbView`                   | Access to the module's database tables          |
-| `sender`       | `Identity`                 | Identity of the caller                          |
 | `senderAuth`   | `AuthCtx`                  | Authorization context for the caller (includes JWT claims and internal call detection) |
 | `connectionId` | `ConnectionId \| undefined`| Connection ID of the caller, if available       |
 | `timestamp`    | `Timestamp`                | Time when the reducer was invoked               |
@@ -323,7 +322,6 @@ TypeScript uses `Math.random()` for random number generation, which is automatic
 | Property       | Type                  | Description                                     |
 | -------------- | --------------------- | ----------------------------------------------- |
 | `Db`           | `DbView`              | Access to the module's database tables          |
-| `Sender`       | `Identity`            | Identity of the caller                          |
 | `SenderAuth`   | `AuthCtx`             | Authorization context for the caller (includes JWT claims and internal call detection) |
 | `ConnectionId` | `ConnectionId?`       | Connection ID of the caller, if available       |
 | `Timestamp`    | `Timestamp`           | Time when the reducer was invoked               |
@@ -335,13 +333,13 @@ TypeScript uses `Math.random()` for random number generation, which is automatic
 | Property        | Type                  | Description                                     |
 | --------------- | --------------------- | ----------------------------------------------- |
 | `db`            | `Local`               | Access to the module's database tables          |
-| `sender`        | `Identity`            | Identity of the caller                          |
 | `connection_id` | `Option<ConnectionId>`| Connection ID of the caller, if available       |
 | `timestamp`     | `Timestamp`           | Time when the reducer was invoked               |
 
 **Methods:**
 
 - `identity() -> Identity` - Get the module's identity
+- `sender() -> Identity` - Get the identity of the caller
 - `rng() -> &StdbRng` - Get the random number generator
 - `random<T>() -> T` - Generate a single random value
 - `sender_auth() -> &AuthCtx` - Get authorization context for the caller (includes JWT claims and internal call detection)

--- a/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00500-lifecycle.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00500-lifecycle.md
@@ -89,7 +89,7 @@ Runs when a client establishes a connection.
 
 ```typescript
 spacetimedb.clientConnected((ctx) => {
-  console.log(`Client connected: ${ctx.sender}`);
+  console.log(`Client connected: ${ctx.sender()}`);
   
   // ctx.connectionId is guaranteed to be defined
   const connId = ctx.connectionId!;
@@ -97,7 +97,7 @@ spacetimedb.clientConnected((ctx) => {
   // Initialize client session
   ctx.db.sessions.insert({
     connection_id: connId,
-    identity: ctx.sender,
+    identity: ctx.sender(),
     connected_at: ctx.timestamp
   });
 });
@@ -165,7 +165,7 @@ Runs when a client connection terminates.
 
 ```typescript
 spacetimedb.clientDisconnected((ctx) => {
-  console.log(`Client disconnected: ${ctx.sender}`);
+  console.log(`Client disconnected: ${ctx.sender()}`);
   
   // ctx.connectionId is guaranteed to be defined
   const connId = ctx.connectionId!;

--- a/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00600-error-handling.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00600-error-handling.md
@@ -26,7 +26,7 @@ import { SenderError } from 'spacetimedb/server';
 spacetimedb.reducer('transfer_credits', 
   { to_user: t.u64(), amount: t.u32() },
   (ctx, { to_user, amount }) => {
-    const fromUser = ctx.db.users.id.find(ctx.sender);
+    const fromUser = ctx.db.users.id.find(ctx.sender());
     if (!fromUser) {
       throw new SenderError('User not found');
     }
@@ -88,7 +88,7 @@ pub fn transfer_credits(
     to_user: u64,
     amount: u32
 ) -> Result<(), String> {
-    let from_balance = ctx.db.users().id().find(ctx.sender.identity)
+    let from_balance = ctx.db.users().id().find(ctx.sender())
         .ok_or("User not found");
     
     if from_balance.credits < amount {

--- a/docs/docs/00200-core-concepts/00200-functions/00400-procedures.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00400-procedures.md
@@ -943,7 +943,7 @@ spacetimedb.procedure(
     // Store the conversation in the database
     ctx.withTx(txCtx => {
       txCtx.db.aiMessage.insert({
-        user: txCtx.sender,
+        user: txCtx.sender(),
         prompt,
         response: aiResponse,
         createdAt: txCtx.timestamp,
@@ -1088,7 +1088,7 @@ pub fn ask_ai(ctx: &mut ProcedureContext, prompt: String, api_key: String) -> Re
     // Store the conversation in the database
     ctx.with_tx(|tx_ctx| {
         tx_ctx.db.ai_message().insert(AiMessage {
-            user: tx_ctx.sender,
+            user: tx_ctx.sender(),
             prompt: prompt.clone(),
             response: ai_response.clone(),
             created_at: tx_ctx.timestamp,

--- a/docs/docs/00200-core-concepts/00300-tables/00210-file-storage.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00210-file-storage.md
@@ -176,7 +176,7 @@ spacetimedb.reducer('register_document', {
 }, (ctx, { filename, mimeType, sizeBytes, storageUrl }) => {
   ctx.db.document.insert({
     id: 0,  // auto-increment
-    ownerId: ctx.sender,
+    ownerId: ctx.sender(),
     filename,
     mimeType,
     sizeBytes,

--- a/docs/docs/00200-core-concepts/00300-tables/00400-access-permissions.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00400-access-permissions.md
@@ -358,8 +358,8 @@ spacetimedb.view(
   t.array(message.rowType),
   (ctx) => {
     // Look up messages by index where caller is sender or recipient
-    const sent = Array.from(ctx.db.message.sender.filter(ctx.sender));
-    const received = Array.from(ctx.db.message.recipient.filter(ctx.sender));
+    const sent = Array.from(ctx.db.message.sender.filter(ctx.sender()));
+    const received = Array.from(ctx.db.message.recipient.filter(ctx.sender()));
     return [...sent, ...received];
   }
 );
@@ -476,7 +476,7 @@ spacetimedb.view(
   t.option(publicUserProfile),
   (ctx) => {
     // Look up the caller's account by their identity (unique index)
-    const user = ctx.db.userAccount.identity.find(ctx.sender);
+    const user = ctx.db.userAccount.identity.find(ctx.sender());
     if (!user) return null;
     return {
       id: user.id,
@@ -626,7 +626,7 @@ spacetimedb.view(
   t.array(colleague),
   (ctx) => {
     // Find the caller's employee record by identity (unique index)
-    const me = ctx.db.employee.identity.find(ctx.sender);
+    const me = ctx.db.employee.identity.find(ctx.sender());
     if (!me) return [];
 
     // Look up employees in the same department

--- a/docs/docs/00300-resources/00100-how-to/00300-logging.md
+++ b/docs/docs/00300-resources/00100-how-to/00300-logging.md
@@ -31,7 +31,7 @@ spacetimedb.reducer('process_data', { value: t.u32() }, (ctx, { value }) => {
     throw new Error('Value cannot be zero');
   }
   
-  console.debug(`Debug information: ctx.sender = ${ctx.sender}`);
+  console.debug(`Debug information: ctx.sender() = ${ctx.sender()}`);
 });
 ```
 
@@ -102,7 +102,7 @@ pub fn process_data(ctx: &ReducerContext, value: u32) -> Result<(), String> {
         return Err("Value cannot be zero".to_string());
     }
     
-    log::debug!("Debug information: ctx.sender = {:?}", ctx.sender());
+    log::debug!("Debug information: ctx.sender() = {:?}", ctx.sender());
     
     Ok(())
 }
@@ -186,7 +186,7 @@ Include relevant context in your log messages:
 spacetimedb.reducer('transfer_credits', 
   { to_user: t.u64(), amount: t.u32() },
   (ctx, { to_user, amount }) => {
-    console.log(`Credit transfer: from=${ctx.sender}, to=${to_user}, amount=${amount}`);
+    console.log(`Credit transfer: from=${ctx.sender()}, to=${to_user}, amount=${amount}`);
     
     // ... transfer logic
   }

--- a/modules/module-test-ts/src/index.ts
+++ b/modules/module-test-ts/src/index.ts
@@ -224,7 +224,7 @@ spacetimedb.view(
   { name: 'my_player', public: true },
   playerLikeRow.optional(),
   // FIXME: this should not be necessary; change `OptionBuilder` to accept `null|undefined` for `none`
-  ctx => ctx.db.player.identity.find(ctx.sender) ?? undefined
+  ctx => ctx.db.player.identity.find(ctx.sender()) ?? undefined
 );
 
 // ─────────────────────────────────────────────────────────────────────────────
@@ -288,7 +288,7 @@ spacetimedb.reducer(
   { arg: testA, arg2: testB, arg3: testC, arg4: testF },
   (ctx, { arg, arg2, arg3, arg4 }) => {
     console.info('BEGIN');
-    console.info(`sender: ${ctx.sender}`);
+    console.info(`sender: ${ctx.sender()}`);
     console.info(`timestamp: ${ctx.timestamp}`);
     console.info(`bar: ${arg2.foo}`);
 
@@ -433,7 +433,7 @@ spacetimedb.reducer('test_btree_index_args', {}, ctx => {
 
 // assert_caller_identity_is_module_identity
 spacetimedb.reducer('assert_caller_identity_is_module_identity', {}, ctx => {
-  const caller = ctx.sender;
+  const caller = ctx.sender();
   const owner = ctx.identity;
   if (String(caller) !== String(owner)) {
     throw new Error(`Caller ${caller} is not the owner ${owner}`);

--- a/modules/sdk-test-connect-disconnect-ts/src/index.ts
+++ b/modules/sdk-test-connect-disconnect-ts/src/index.ts
@@ -16,9 +16,9 @@ const Disconnected = table(
 const spacetimedb = schema(Connected, Disconnected);
 
 spacetimedb.clientConnected('identity_connected', ctx => {
-  ctx.db.connected.insert({ identity: ctx.sender });
+  ctx.db.connected.insert({ identity: ctx.sender() });
 });
 
 spacetimedb.clientDisconnected('identity_disconnected', ctx => {
-  ctx.db.disconnected.insert({ identity: ctx.sender });
+  ctx.db.disconnected.insert({ identity: ctx.sender() });
 });

--- a/modules/sdk-test-ts/src/index.ts
+++ b/modules/sdk-test-ts/src/index.ts
@@ -949,18 +949,18 @@ spacetimedb.reducer(
 );
 
 spacetimedb.reducer('insert_caller_one_identity', ctx => {
-  ctx.db.oneIdentity.insert({ i: ctx.sender });
+  ctx.db.oneIdentity.insert({ i: ctx.sender() });
 });
 
 spacetimedb.reducer('insert_caller_vec_identity', ctx => {
-  ctx.db.vecIdentity.insert({ i: [ctx.sender] });
+  ctx.db.vecIdentity.insert({ i: [ctx.sender()] });
 });
 
 spacetimedb.reducer(
   'insert_caller_unique_identity',
   { data: t.i32() },
   (ctx, { data }) => {
-    ctx.db.uniqueIdentity.insert({ i: ctx.sender, data });
+    ctx.db.uniqueIdentity.insert({ i: ctx.sender(), data });
   }
 );
 
@@ -968,7 +968,7 @@ spacetimedb.reducer(
   'insert_caller_pk_identity',
   { data: t.i32() },
   (ctx, { data }) => {
-    ctx.db.pkIdentity.insert({ i: ctx.sender, data });
+    ctx.db.pkIdentity.insert({ i: ctx.sender(), data });
   }
 );
 


### PR DESCRIPTION
# Description of Changes

Change `sender` to be callable on [Reducer|View|Procedure|Tx]Ctx in TypeScript. Equivalent changes to https://github.com/clockworklabs/SpacetimeDB/pull/4101.

# API and ABI breaking changes

Breaks the module api

# Expected complexity level and risk

1

# Testing

Pure refactor, no additional testing.
