### PR TITLE
Fix for `cargo ci dlls` missing some `.meta` files

### DIFF
--- a/sdks/csharp/unity-meta-skeleton~/spacetimedb.bsatn.runtime/version.meta
+++ b/sdks/csharp/unity-meta-skeleton~/spacetimedb.bsatn.runtime/version.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ae5666f23a6d73c43b030a1b9ba5916b
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/sdks/csharp/unity-meta-skeleton~/spacetimedb.runtime/version.meta
+++ b/sdks/csharp/unity-meta-skeleton~/spacetimedb.runtime/version.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 414c282c02d41b7468a56cbff39145f4
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -118,9 +118,7 @@ fn overlay_unity_meta_skeleton(pkg_id: &str) -> Result<()> {
     let versioned_dir = match find_only_subdir(&pkg_root) {
         Ok(dir) => dir,
         Err(err) => {
-            log::info!(
-                "Skipping Unity meta overlay for {pkg_id}: could not locate restored version dir: {err}"
-            );
+            log::info!("Skipping Unity meta overlay for {pkg_id}: could not locate restored version dir: {err}");
             return Ok(());
         }
     };

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -95,7 +95,8 @@ fn check_global_json_policy() -> Result<()> {
 }
 
 fn overlay_unity_meta_skeleton(pkg_id: &str) -> Result<()> {
-    let skeleton_root = Path::new("sdks/csharp/unity-meta-skeleton~").join(pkg_id);
+    let skeleton_base = Path::new("sdks/csharp/unity-meta-skeleton~");
+    let skeleton_root = skeleton_base.join(pkg_id);
     if !skeleton_root.exists() {
         return Ok(());
     }
@@ -105,13 +106,36 @@ fn overlay_unity_meta_skeleton(pkg_id: &str) -> Result<()> {
         return Ok(());
     }
 
+    // Copy spacetimedb.<pkg>.meta
+    let pkg_root_meta = skeleton_base.join(format!("{pkg_id}.meta"));
+    if pkg_root_meta.exists() {
+        if let Some(parent) = pkg_root.parent() {
+            let pkg_meta_dst = parent.join(format!("{pkg_id}.meta"));
+            fs::copy(&pkg_root_meta, &pkg_meta_dst)?;
+        }
+    }
+
     let versioned_dir = match find_only_subdir(&pkg_root) {
         Ok(dir) => dir,
         Err(err) => {
-            log::info!("Skipping Unity meta overlay for {pkg_id}: could not locate restored version dir: {err}");
+            log::info!(
+                "Skipping Unity meta overlay for {pkg_id}: could not locate restored version dir: {err}"
+            );
             return Ok(());
         }
     };
+
+    // If version.meta exists under the skeleton package, rename it to match the restored version dir.
+    let version_meta_template = skeleton_root.join("version.meta");
+    if version_meta_template.exists() {
+        if let Some(parent) = versioned_dir.parent() {
+            let version_name = versioned_dir
+                .file_name()
+                .expect("versioned directory should have a file name");
+            let version_meta_dst = parent.join(format!("{}.meta", version_name.to_string_lossy()));
+            fs::copy(&version_meta_template, &version_meta_dst)?;
+        }
+    }
 
     copy_overlay_dir(&skeleton_root, &versioned_dir)
 }


### PR DESCRIPTION
# Description of Changes
This patches a regression introduced in [#4033](https://github.com/clockworklabs/SpacetimeDB/pull/4033) where cargo ci dlls stopped copying the Unity .meta files that live outside the package skeleton tree:
1. `overlay_unity_meta_skeleton` now copies any `sdks/csharp/unity-meta-skeleton~/spacetimedb.<pkg>.meta` file into `sdks/csharp/packages/` before overlaying nested content.
2. Added support for a `version.meta` template inside each skeleton package; it’s renamed to match the single restored version directory (e.g. `1.11.2.meta`).
3. Added the missing `version.meta` templates for both `spacetimedb.bsatn.runtime` and `spacetimedb.runtime`, based on the historical GUIDs Unity already knows about.

Together this restores the `spacetimedb.bsatn.runtime.meta` and `<version>.meta` files that Unity requires to keep those folders visible when developers run `cargo ci dlls` on a clean checkout.

# API and ABI breaking changes
None. This only affects the CI helper responsible for syncing Unity metadata.

# Expected complexity level and risk
2 — localized changes to the CI helper and skeleton assets. Primary risk is forgetting a template or mis-copying a GUID; the code paths themselves are straightforward.

# Testing
- [X] Ran `cargo check -p ci`
- [X] Ran `cargo ci dlls` on a clean tree, verifying that:
  * `sdks/csharp/packages/spacetimedb.bsatn.runtime.meta` exists
  * The restored version directory (e.g. `sdks/csharp/packages/spacetimedb.bsatn.runtime/1.11.2.meta`) exists
- [X] Locally launched Unity with a SpacetimeDB project and had no errors/issues.