### PR TITLE
websocket format: use `RawIdentifier`

### DIFF
--- a/crates/client-api-messages/src/websocket.rs
+++ b/crates/client-api-messages/src/websocket.rs
@@ -28,6 +28,7 @@ use spacetimedb_primitives::TableId;
 use spacetimedb_sats::{
     de::{Deserialize, Error},
     impl_deserialize, impl_serialize, impl_st,
+    raw_identifier::RawIdentifier,
     ser::Serialize,
     AlgebraicType, SpacetimeType,
 };
@@ -151,7 +152,7 @@ impl<Args> ClientMessage<Args> {
 #[sats(crate = spacetimedb_lib)]
 pub struct CallReducer<Args> {
     /// The name of the reducer to call.
-    pub reducer: Box<str>,
+    pub reducer: RawIdentifier,
     /// The arguments to the reducer.
     ///
     /// In the wire format, this will be a [`Bytes`], BSATN or JSON encoded according to the reducer's argument schema
@@ -312,7 +313,7 @@ pub struct OneOffQuery {
 /// Parametric over the argument type to enable [`ClientMessage::map_args`].
 pub struct CallProcedure<Args> {
     /// The name of the procedure to call.
-    pub procedure: Box<str>,
+    pub procedure: RawIdentifier,
     /// The arguments to the procedure.
     ///
     /// In the wire format, this will be a [`Bytes`], BSATN or JSON encoded according to the reducer's argument schema
@@ -384,7 +385,7 @@ pub struct SubscribeRows<F: WebsocketFormat> {
     /// The table ID of the query.
     pub table_id: TableId,
     /// The table name of the query.
-    pub table_name: Box<str>,
+    pub table_name: RawIdentifier,
     /// The BSATN row values.
     pub table_rows: TableUpdate<F>,
 }
@@ -588,7 +589,7 @@ pub struct ReducerCallInfo<F: WebsocketFormat> {
     /// We should consider not sending this at all and instead
     /// having a startup message where the name <-> id bindings
     /// are established between the host and the client.
-    pub reducer_name: Box<str>,
+    pub reducer_name: RawIdentifier,
     /// The numerical id of the reducer that was called.
     pub reducer_id: u32,
     /// The arguments to the reducer, encoded as BSATN or JSON according to the reducer's argument schema
@@ -653,7 +654,7 @@ pub struct TableUpdate<F: WebsocketFormat> {
     ///
     /// NOTE(centril, 1.0): we might want to remove this and instead
     /// tell clients about changes to table_name <-> table_id mappings.
-    pub table_name: Box<str>,
+    pub table_name: RawIdentifier,
     /// The sum total of rows in `self.updates`,
     pub num_rows: u64,
     /// The actual insert and delete updates for this table.
@@ -668,7 +669,7 @@ pub struct SingleQueryUpdate<F: WebsocketFormat> {
 }
 
 impl<F: WebsocketFormat> TableUpdate<F> {
-    pub fn new(table_id: TableId, table_name: Box<str>, update: SingleQueryUpdate<F>) -> Self {
+    pub fn new(table_id: TableId, table_name: RawIdentifier, update: SingleQueryUpdate<F>) -> Self {
         Self {
             table_id,
             table_name,
@@ -677,7 +678,7 @@ impl<F: WebsocketFormat> TableUpdate<F> {
         }
     }
 
-    pub fn empty(table_id: TableId, table_name: Box<str>) -> Self {
+    pub fn empty(table_id: TableId, table_name: RawIdentifier) -> Self {
         Self {
             table_id,
             table_name,
@@ -746,7 +747,7 @@ pub struct OneOffQueryResponse<F: WebsocketFormat> {
 #[sats(crate = spacetimedb_lib)]
 pub struct OneOffTable<F: WebsocketFormat> {
     /// The name of the table.
-    pub table_name: Box<str>,
+    pub table_name: RawIdentifier,
     /// The set of rows which matched the query, encoded as BSATN or JSON according to the table's schema
     /// and the client's requested protocol.
     ///

--- a/crates/core/src/client/message_handlers.rs
+++ b/crates/core/src/client/message_handlers.rs
@@ -166,7 +166,7 @@ pub async fn handle(client: &ClientConnection, message: DataMessage, timer: Inst
 #[derive(thiserror::Error, Debug)]
 #[error("error executing message (reducer: {reducer:?}) (err: {err:#})")]
 pub struct MessageExecutionError {
-    pub reducer: Option<Box<str>>,
+    pub reducer: Option<RawIdentifier>,
     pub reducer_id: Option<ReducerId>,
     pub caller_identity: Identity,
     pub caller_connection_id: Option<ConnectionId>,

--- a/crates/core/src/client/messages.rs
+++ b/crates/core/src/client/messages.rs
@@ -285,9 +285,9 @@ impl ToProtocol for TransactionUpdateMessage {
                     reducer_name: event
                         .function_call
                         .reducer
-                        .as_ref()
-                        .map(|r| (&**r).into())
-                        .unwrap_or_default(),
+                        .clone()
+                        .map(Into::into)
+                        .unwrap_or_else(|| "".into()),
                     reducer_id: event.function_call.reducer_id.into(),
                     args,
                     request_id,
@@ -455,7 +455,7 @@ impl ToProtocol for SubscriptionMessage {
                             query_id,
                             rows: ws::SubscribeRows {
                                 table_id: result.table_id,
-                                table_name: result.table_name.to_boxed_str(),
+                                table_name: result.table_name.into(),
                                 table_rows,
                             },
                         }
@@ -468,7 +468,7 @@ impl ToProtocol for SubscriptionMessage {
                             query_id,
                             rows: ws::SubscribeRows {
                                 table_id: result.table_id,
-                                table_name: result.table_name.to_boxed_str(),
+                                table_name: result.table_name.into(),
                                 table_rows,
                             },
                         }
@@ -486,7 +486,7 @@ impl ToProtocol for SubscriptionMessage {
                             query_id,
                             rows: ws::SubscribeRows {
                                 table_id: result.table_id,
-                                table_name: result.table_name.to_boxed_str(),
+                                table_name: result.table_name.into(),
                                 table_rows,
                             },
                         }
@@ -499,7 +499,7 @@ impl ToProtocol for SubscriptionMessage {
                             query_id,
                             rows: ws::SubscribeRows {
                                 table_id: result.table_id,
-                                table_name: result.table_name.to_boxed_str(),
+                                table_name: result.table_name.into(),
                                 table_rows,
                             },
                         }

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -2072,7 +2072,7 @@ impl ModuleHost {
                         .map(PipelinedProject::from)
                         .collect::<Vec<_>>();
 
-                    let table_name = table_name.to_boxed_str();
+                    let table_name = table_name.into();
 
                     if returns_view_table && num_private_cols > 0 {
                         let optimized = optimized

--- a/crates/core/src/subscription/execution_unit.rs
+++ b/crates/core/src/subscription/execution_unit.rs
@@ -261,7 +261,7 @@ impl ExecutionUnit {
             let update = F::into_query_update(qu, compression);
             TableUpdate::new(
                 self.return_table(),
-                self.return_name().to_boxed_str(),
+                self.return_name().clone().into(),
                 SingleQueryUpdate { update, num_rows },
             )
         })

--- a/crates/core/src/subscription/mod.rs
+++ b/crates/core/src/subscription/mod.rs
@@ -203,7 +203,7 @@ where
         (
             TableUpdate::new(
                 table_id,
-                table_name.to_boxed_str(),
+                table_name.clone().into(),
                 SingleQueryUpdate { update, num_rows },
             ),
             metrics,
@@ -239,7 +239,7 @@ pub fn collect_table_update<F: BuildableWebsocketFormat>(
         (
             TableUpdate::new(
                 table_id,
-                table_name.to_boxed_str(),
+                table_name.clone().into(),
                 SingleQueryUpdate { update, num_rows },
             ),
             metrics,

--- a/crates/core/src/subscription/module_subscription_manager.rs
+++ b/crates/core/src/subscription/module_subscription_manager.rs
@@ -1554,7 +1554,7 @@ impl SendWorker {
             .filter(|upd| !clients_with_errors.contains(&upd.id))
             // Do the aggregation.
             .fold(client_table_id_updates, |mut tables, upd| {
-                let table_name = upd.table_name.to_boxed_str();
+                let table_name = upd.table_name.into();
                 match tables.entry((upd.id, upd.table_id)) {
                     Entry::Occupied(mut entry) => match entry.get_mut().zip_mut(upd.update) {
                         Bsatn((tbl_upd, update)) => tbl_upd.push(update),

--- a/crates/schema/src/table_name.rs
+++ b/crates/schema/src/table_name.rs
@@ -20,10 +20,6 @@ impl TableName {
     pub fn for_test(name: &str) -> Self {
         Self(Identifier::for_test(name))
     }
-
-    pub fn to_boxed_str(&self) -> Box<str> {
-        self.as_ref().into()
-    }
 }
 
 impl Deref for TableName {


### PR DESCRIPTION
# Description of Changes

Adjusts the websocket format to use `RawIdentifier` instead of `Box<str>`, avoiding some allocations in the process.
This seems to be a net gain of 1.5k TPS on phoenix nap.

Based on https://github.com/clockworklabs/SpacetimeDB/pull/4177.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Covered by existing tests.