### PR TITLE
`write-nuget-config.sh` resolves paths properly

### DIFF
--- a/sdks/csharp/tools~/write-nuget-config.sh
+++ b/sdks/csharp/tools~/write-nuget-config.sh
@@ -1,6 +1,6 @@
 set -ueo pipefail
 
-SPACETIMEDB_REPO_PATH="$1"
+SPACETIMEDB_REPO_PATH="$(readlink -f "$1")"
 
 cd "$(dirname "$(readlink -f "$0")")"
 cd ..


### PR DESCRIPTION
# Description of Changes

The script was running `cd` but using the STDB path as passed, so if it was run from e.g. the root directory, it would generate incorrect paths.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] Running `sdks/csharp/tools~/write-nuget-config.sh .` from the root directory generates a `NuGet.Config` that uses correct paths