### PR TITLE
[2.0 Breaking] Make `connection_id` a method on `ReducerContext`

### DIFF
--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -938,7 +938,7 @@ pub struct ReducerContext {
     ///
     /// Will be `None` for certain reducers invoked automatically by the host,
     /// including `init` and scheduled reducers.
-    pub connection_id: Option<ConnectionId>,
+    connection_id: Option<ConnectionId>,
 
     sender_auth: AuthCtx,
 
@@ -1022,6 +1022,14 @@ impl ReducerContext {
     /// The `Identity` of the client that invoked the reducer.
     pub fn sender(&self) -> Identity {
         self.sender
+    }
+
+    /// The `ConnectionId` of the client that invoked the reducer.
+    ///
+    /// Will be `None` for certain reducers invoked automatically by the host,
+    /// including `init` and scheduled reducers.
+    pub fn connection_id(&self) -> Option<ConnectionId> {
+        self.connection_id
     }
 
     /// Returns the authorization information for the caller of this reducer.
@@ -1142,7 +1150,7 @@ pub struct ProcedureContext {
     /// The `ConnectionId` of the client that invoked the procedure.
     ///
     /// Will be `None` for certain scheduled procedures.
-    pub connection_id: Option<ConnectionId>,
+    connection_id: Option<ConnectionId>,
 
     /// Methods for performing HTTP requests.
     pub http: crate::http::HttpClient,
@@ -1176,6 +1184,13 @@ impl ProcedureContext {
     /// The `Identity` of the client that invoked the procedure.
     pub fn sender(&self) -> Identity {
         self.sender
+    }
+
+    /// The `ConnectionId` of the client that invoked the procedure.
+    ///
+    /// Will be `None` for certain scheduled procedures.
+    pub fn connection_id(&self) -> Option<ConnectionId> {
+        self.connection_id
     }
 
     /// Read the current module's [`Identity`].

--- a/docs/docs/00200-core-concepts/00100-databases/00500-cheat-sheet.md
+++ b/docs/docs/00200-core-concepts/00100-databases/00500-cheat-sheet.md
@@ -523,7 +523,7 @@ ctx.Rng                 // Random number generator
 ```rust
 ctx.db                  // Database access
 ctx.sender()            // Identity of caller
-ctx.connection_id       // Option<ConnectionId>
+ctx.connection_id()     // Option<ConnectionId>
 ctx.timestamp           // Timestamp
 ctx.identity()          // Module's identity
 ctx.rng()               // Random number generator

--- a/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00500-lifecycle.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00500-lifecycle.md
@@ -133,8 +133,8 @@ public static void OnConnect(ReducerContext ctx)
 pub fn on_connect(ctx: &ReducerContext) -> Result<(), String> {
     log::info!("Client connected: {}", ctx.sender());
     
-    // ctx.connection_id is guaranteed to be Some(...)
-    let conn_id = ctx.connection_id.unwrap();
+    // ctx.connection_id() is guaranteed to be Some(...)
+    let conn_id = ctx.connection_id().unwrap();
     
     // Initialize client session
     ctx.db.sessions().try_insert(Session {
@@ -152,7 +152,7 @@ pub fn on_connect(ctx: &ReducerContext) -> Result<(), String> {
 
 The `client_connected` reducer:
 - Cannot take arguments beyond `ReducerContext`
-- `ctx.connection_id` is guaranteed to be present
+- `ctx.connection_id()` is guaranteed to be present
 - Failure disconnects the client
 - Runs for each distinct connection (WebSocket, HTTP call)
 
@@ -200,8 +200,8 @@ public static void OnDisconnect(ReducerContext ctx)
 pub fn on_disconnect(ctx: &ReducerContext) -> Result<(), String> {
     log::info!("Client disconnected: {}", ctx.sender());
     
-    // ctx.connection_id is guaranteed to be Some(...)
-    let conn_id = ctx.connection_id.unwrap();
+    // ctx.connection_id() is guaranteed to be Some(...)
+    let conn_id = ctx.connection_id().unwrap();
     
     // Clean up client session
     ctx.db.sessions().connection_id().delete(&conn_id);
@@ -215,7 +215,7 @@ pub fn on_disconnect(ctx: &ReducerContext) -> Result<(), String> {
 
 The `client_disconnected` reducer:
 - Cannot take arguments beyond `ReducerContext`
-- `ctx.connection_id` is guaranteed to be present
+- `ctx.connection_id()` is guaranteed to be present
 - Failure is logged but doesn't prevent disconnection
 - Runs when connection ends (close, timeout, error)
 
@@ -231,5 +231,5 @@ Reducers can be triggered at specific times using schedule tables. See [Schedule
 :::info Scheduled Reducer Context
 Scheduled reducer calls originate from SpacetimeDB itself, not from a client. Therefore:
 - `ctx.sender()` will be the module's own identity
-- `ctx.connection_id` will be `None`/`null`/`undefined`
+- `ctx.connection_id()` will be `None`/`null`/`undefined`
 :::

--- a/modules/sdk-test/src/lib.rs
+++ b/modules/sdk-test/src/lib.rs
@@ -664,7 +664,7 @@ fn insert_caller_pk_identity(ctx: &ReducerContext, data: i32) -> anyhow::Result<
 #[spacetimedb::reducer]
 fn insert_caller_one_connection_id(ctx: &ReducerContext) -> anyhow::Result<()> {
     ctx.db.one_connection_id().insert(OneConnectionId {
-        a: ctx.connection_id.context("No connection id in reducer context")?,
+        a: ctx.connection_id().context("No connection id in reducer context")?,
     });
     Ok(())
 }
@@ -672,7 +672,7 @@ fn insert_caller_one_connection_id(ctx: &ReducerContext) -> anyhow::Result<()> {
 #[spacetimedb::reducer]
 fn insert_caller_vec_connection_id(ctx: &ReducerContext) -> anyhow::Result<()> {
     ctx.db.vec_connection_id().insert(VecConnectionId {
-        a: vec![ctx.connection_id.context("No connection id in reducer context")?],
+        a: vec![ctx.connection_id().context("No connection id in reducer context")?],
     });
     Ok(())
 }
@@ -680,7 +680,7 @@ fn insert_caller_vec_connection_id(ctx: &ReducerContext) -> anyhow::Result<()> {
 #[spacetimedb::reducer]
 fn insert_caller_unique_connection_id(ctx: &ReducerContext, data: i32) -> anyhow::Result<()> {
     ctx.db.unique_connection_id().insert(UniqueConnectionId {
-        a: ctx.connection_id.context("No connection id in reducer context")?,
+        a: ctx.connection_id().context("No connection id in reducer context")?,
         data,
     });
     Ok(())
@@ -689,7 +689,7 @@ fn insert_caller_unique_connection_id(ctx: &ReducerContext, data: i32) -> anyhow
 #[spacetimedb::reducer]
 fn insert_caller_pk_connection_id(ctx: &ReducerContext, data: i32) -> anyhow::Result<()> {
     ctx.db.pk_connection_id().insert(PkConnectionId {
-        a: ctx.connection_id.context("No connection id in reducer context")?,
+        a: ctx.connection_id().context("No connection id in reducer context")?,
         data,
     });
     Ok(())

--- a/smoketests/tests/zz_docker.py
+++ b/smoketests/tests/zz_docker.py
@@ -113,14 +113,15 @@ pub struct ConnectedClient {
 fn on_connect(ctx: &ReducerContext) {
     ctx.db.connected_client().insert(ConnectedClient {
         identity: ctx.sender(),
-        connection_id: ctx.connection_id.expect("sender connection id unset"),
+        connection_id: ctx.connection_id().expect("sender connection id unset"),
     });
 }
 
 #[spacetimedb::reducer(client_disconnected)]
 fn on_disconnect(ctx: &ReducerContext) {
     let sender_identity = &ctx.sender();
-    let sender_connection_id = ctx.connection_id.as_ref().expect("sender connection id unset");
+    let connection_id = ctx.connection_id();
+    let sender_connection_id = connection_id.as_ref().expect("sender connection id unset");
     let match_client = |row: &ConnectedClient| {
         &row.identity == sender_identity && &row.connection_id == sender_connection_id
     };


### PR DESCRIPTION
# Description of Changes

Same changes as https://github.com/clockworklabs/SpacetimeDB/pull/4101 but for `connection_id`.

# API and ABI breaking changes

API Breaking

# Expected complexity level and risk

1

# Testing

Pure refactor. Tests and docs have been updated, but no new tests added.
