### PR TITLE
Update `librusty_v8.nix` for our new V8 dependency version.

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -315,7 +315,14 @@ unicode-normalization = "0.1.23"
 url = "2.3.1"
 urlencoding = "2.1.2"
 uuid = { version = "1.18.1", default-features = false }
-v8 = "145"
+
+# Pinned to a specific version rather than allowing SemVer fuzzy resolution
+# because our flake references the specific version of this library.
+# See librusty_v8.nix for more details.
+# When updating the V8 crate, either update the version and hashes in that file,
+# or ping phoebe @gefjon to do so.
+v8 = "=145.0.0"
+
 walkdir = "2.2.5"
 wasmbin = "0.6"
 webbrowser = "1.0.2"

--- a/librusty_v8.nix
+++ b/librusty_v8.nix
@@ -22,14 +22,14 @@
     };
 in
   fetch_librusty_v8 {
-    version = "140.2.0";
+    version = "145.0.0";
     shas = {
-      x86_64-linux = "sha256-r3qrYDVaT4Z6udC6YuQG1BKqrsQc7IhuACDCTbr083U=";
+      x86_64-linux = "sha256-chV1PAx40UH3Ute5k3lLrgfhih39Rm3KqE+mTna6ysE=";
       # I (pgoldman 2025-10-17) only use x86_64-linux, so I haven't filled in these hashes.
       # If you use one of these platforms, run the build and wait for it to fail,
       # copy the detected sha256 from the error message in here, then re-run.
       aarch64-linux = "0000000000000000000000000000000000000000000000000000";
       x86_64-darwin = "0000000000000000000000000000000000000000000000000000";
-      aarch64-darwin = "sha256-eZ2l9ovI2divQake+Z4/Ofcl5QwJ+Y/ql2Dymisx1oA=";
+      aarch64-darwin = "0000000000000000000000000000000000000000000000000000";
     };
   }


### PR DESCRIPTION
# Description of Changes

And more precisely pin the Cargo dep, along with a comment.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

- [x] `nix build` now exits 0 and produces runnable binaries locally. (`nix flake check` is still broken.)
