### PR TITLE
Moved C# SDK's `packages` ignore from SDK's `.gitignore` to project root

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -245,3 +245,7 @@ nul
 
 [Nn][Uu][Gg][Ee][Tt].[Cc][Oo][Nn][Ff][Ii][Gg]
 [Nn][Uu][Gg][Ee][Tt].[Cc][Oo][Nn][Ff][Ii][Gg].meta
+ 
+# csharp SDK packages
+/sdks/csharp/packages/
+/sdks/csharp/packages.meta

--- a/sdks/csharp/.gitignore
+++ b/sdks/csharp/.gitignore
@@ -76,8 +76,3 @@ obj~
 [Nn][Uu][Gg][Ee][Tt].config
 [Nn][Uu][Gg][Ee][Tt].config.meta
 .idea/
-
-# Hydrated SDK DLLs (produced by `cargo ci dlls`)
-/packages/
-/packages.meta
-!/packages/.gitignore


### PR DESCRIPTION
# Description of Changes

Moves the `root/sdks/csharp/packages/` directory from the `root/sdks/csharp/.gitignore` to `root/.gitignore`.
This is to resolve Issue #4207 , which was introduced during the DLLs generation rework.

`/sdks/csharp/packages/` should be ignored by git, to prevent locally generated DLLs from accidentally getting added to the repo.

**Root cause:**
 When Unity imports a package by URL, it looks at the `.gitignore` list and filters by it, causing the entire `packages` directory to not be imported. In earlier versions of Unity (like `2022.3` where this was initially tested), this was not a problem because Unity would allow us to do a `dotnet restore`. In modern version of Unity, this is no longer allowed as all imported packages are considered immutable.

Because the `/sdks/csharp/` is cloned into `com.clockworklabs.spacetimedbsdk`, if we move at what level the `root/sdks/csharp/packages/` is ignored at, we can prevent the accidental inclusion of the DLLs from developers in the SpacetimeDB repo, while ensuring `com.clockworklabs.spacetimedbsdk` does not contain a reference to ignore the `packages` directory.

# API and ABI breaking changes

No API or ABI changes

# Expected complexity level and risk

1

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

- [X] Tested removing the `packages` directory from the `.gitignore` list on a custom branch of `com.clockworklabs.spacetimedbsdk` to observe the behavior in both Unity `6000.3.2f1` and `2002.3.62f2`.