### PR TITLE
Fail conflicting `describe_module` exports for wasm and v8

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7781,6 +7781,7 @@ dependencies = [
  "urlencoding",
  "uuid",
  "v8",
+ "wasmbin",
  "wasmtime",
  "wasmtime-internal-fiber",
 ]

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -164,6 +164,7 @@ pretty_assertions.workspace = true
 jsonwebtoken.workspace = true
 axum.workspace = true
 fs_extra.workspace = true
+wasmbin.workspace = true
 
 [lints]
 workspace = true

--- a/crates/core/src/host/mod.rs
+++ b/crates/core/src/host/mod.rs
@@ -16,6 +16,8 @@ mod module_common;
 #[allow(clippy::too_many_arguments)]
 pub mod module_host;
 pub mod scheduler;
+#[cfg(test)]
+pub(crate) mod test_utils;
 pub mod wasmtime;
 
 // Visible for integration testing.

--- a/crates/core/src/host/test_utils.rs
+++ b/crates/core/src/host/test_utils.rs
@@ -1,0 +1,45 @@
+use crate::database_logger::DatabaseLogger;
+use crate::db::relational_db::tests_utils::TestDB;
+use crate::energy::NullEnergyMonitor;
+use crate::host::Scheduler;
+use crate::messages::control_db::{Database, HostType};
+use crate::module_host_context::ModuleCreationContext;
+use crate::replica_context::ReplicaContext;
+use crate::subscription::module_subscription_actor::ModuleSubscriptions;
+use spacetimedb_lib::{Hash, Identity};
+use std::sync::Arc;
+
+pub(crate) fn module_creation_context_for_test(
+    host_type: HostType,
+) -> (ModuleCreationContext, tokio::runtime::Runtime) {
+    let TestDB { db, .. } = TestDB::in_memory().expect("failed to make test db");
+    let (subscriptions, runtime) = ModuleSubscriptions::for_test_new_runtime(db.clone());
+    let logger = {
+        let _rt = runtime.enter();
+        Arc::new(DatabaseLogger::in_memory(64 * 1024))
+    };
+    let replica_ctx = Arc::new(ReplicaContext {
+        database: Database {
+            id: 0,
+            database_identity: Identity::ZERO,
+            owner_identity: Identity::ZERO,
+            host_type,
+            initial_program: Hash::ZERO,
+        },
+        replica_id: 0,
+        logger,
+        subscriptions,
+        relational_db: db,
+    });
+    let (scheduler, _starter) = Scheduler::open(replica_ctx.relational_db.clone());
+
+    (
+        ModuleCreationContext {
+            replica_ctx,
+            scheduler,
+            program_hash: Hash::ZERO,
+            energy_monitor: Arc::new(NullEnergyMonitor),
+        },
+        runtime,
+    )
+}

--- a/crates/core/src/host/v8/syscall/v1.rs
+++ b/crates/core/src/host/v8/syscall/v1.rs
@@ -14,7 +14,7 @@ use super::common::{
     procedure_start_mut_tx, row_iter_bsatn_close, table_id_from_name, volatile_nonatomic_schedule_immediate,
 };
 use super::hooks::HookFunctions;
-use super::hooks::{get_hook_function, set_hook_slots};
+use super::hooks::{get_hook_function, set_hook_slots, validate_describe_hooks};
 use super::{AbiVersion, FnRet, ModuleHookKey};
 use crate::host::instance_env::InstanceEnv;
 use crate::host::wasm_common::instrumentation::span;
@@ -311,9 +311,11 @@ fn with_span<'scope, T, E: From<ExceptionThrown>>(
 ///
 /// Throws a `TypeError` if:
 /// - `hooks` is not an object that has functions `__describe_module__` and `__call_reducer__`.
+/// - `hooks` contains both `__describe_module__` and `__describe_module_v10__`.
 fn register_hooks_v1_0<'scope>(scope: &mut PinScope<'scope, '_>, args: FunctionCallbackArguments<'_>) -> FnRet<'scope> {
     // Convert `hooks` to an object.
     let hooks = cast!(scope, args.get(0), Object, "hooks object").map_err(|e| e.throw(scope))?;
+    validate_describe_hooks(scope, hooks)?;
 
     let describe_module = get_hook_function(scope, hooks, str_from_ident!(__describe_module__))?;
     let call_reducer = get_hook_function(scope, hooks, str_from_ident!(__call_reducer__))?;


### PR DESCRIPTION
# Description of Changes

Host will fail to load a module that exports both `__describe_module__` and `__describe_module_v10__`.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Added tests for wasm and v8
