### PR TITLE
Sort version output of `spacetime version list`

### DIFF
--- a/crates/update/src/cli/list.rs
+++ b/crates/update/src/cli/list.rs
@@ -61,7 +61,7 @@ impl List {
             let is_current = Some(ver) == current.as_ref();
 
             if is_current {
-                println!("{} {}", ver, "(current)");
+                println!("{} (current)", ver);
             } else {
                 println!("{ver}");
             }


### PR DESCRIPTION
# Description of Changes

The output of `spacetime version list` is sorted in alphabetical order, which is not the correct semver order.
This fixes the order printed, by sorting correctly.

Example before:
```
1.11.0
1.9.0
1.3.0
1.3.1
1.1.2
1.12.0 (current)
1.0.0
```

After:
```
1.12.0 (current)
1.11.0
1.9.0
1.3.1
1.3.0
1.1.2
1.0.0
```

# API and ABI breaking changes

Not an API or ABI breaking change

# Expected complexity level and risk

1

# Testing

Ran `spacetime version list` and `spacetime version list --all` with the new code and confirmed that the result was correctly sorted.
I additionally tested that if the latest available version was not installed that it would show with the upgrade hint command.
