### PR TITLE
Download from Digital Ocean if Github download fails

### DIFF
--- a/crates/update/src/cli/install.rs
+++ b/crates/update/src/cli/install.rs
@@ -86,8 +86,8 @@ async fn mirror_release(
         }
     };
     let ver_str = tag.strip_prefix('v').unwrap_or(&tag);
-    let release_version = semver::Version::parse(ver_str)
-        .with_context(|| format!("Could not parse version from mirror: {tag}"))?;
+    let release_version =
+        semver::Version::parse(ver_str).with_context(|| format!("Could not parse version from mirror: {tag}"))?;
     let release = Release {
         tag_name: tag.clone(),
         assets: vec![ReleaseAsset {
@@ -149,9 +149,7 @@ pub(super) async fn download_and_install(
             mirror_release(client, version.as_ref(), download_name)
                 .await
                 .map_err(|mirror_err| {
-                    anyhow::anyhow!(
-                        "GitHub failed: {github_err:#}\nMirror also failed: {mirror_err:#}"
-                    )
+                    anyhow::anyhow!("GitHub failed: {github_err:#}\nMirror also failed: {mirror_err:#}")
                 })?
         }
     };
@@ -182,9 +180,7 @@ pub(super) async fn download_and_install(
             download_with_progress(&pb, client, &mirror_url)
                 .await
                 .map_err(|mirror_err| {
-                    anyhow::anyhow!(
-                        "Primary download failed: {primary_err:#}\nMirror also failed: {mirror_err:#}"
-                    )
+                    anyhow::anyhow!("Primary download failed: {primary_err:#}\nMirror also failed: {mirror_err:#}")
                 })?
         }
     };
@@ -229,7 +225,19 @@ impl ArtifactType {
 
 pub(super) async fn available_releases(client: &reqwest::Client) -> anyhow::Result<Vec<String>> {
     let url = releases_url();
-    match async { anyhow::Ok(client.get(url).send().await?.error_for_status()?.json::<Vec<Release>>().await?) }.await {
+    match async {
+        anyhow::Ok(
+            client
+                .get(url)
+                .send()
+                .await?
+                .error_for_status()?
+                .json::<Vec<Release>>()
+                .await?,
+        )
+    }
+    .await
+    {
         Ok(releases) => releases
             .into_iter()
             .map(|release| Ok(release.version()?.to_string()))

--- a/crates/update/src/cli/upgrade.rs
+++ b/crates/update/src/cli/upgrade.rs
@@ -47,8 +47,7 @@ impl Upgrade {
                         cli_bin_file.0.parent().unwrap(),
                     )?;
                     file.write_all(&bin.to_bytes())?;
-                    self_replace::self_replace(file.path())
-                        .context("failed to overwrite the original spacetime binary")
+                    self_replace::self_replace(file.path()).context("failed to overwrite the original spacetime binary")
                 })
                 .await??;
 


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Since Github has been going down *a lot* recently, we would like to add support for downloading from our mirror instead. This PR updates:
- The install script for both windows and linux to try the mirror if Github is down
- The `spacetime version install ...` to install a specific version
- The `spacetime upgrade` which grabs the latest version from Github.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

3 - This is touching both the windows and linux/macos install scripts which are quite sensitive. Proper manual testing is needed on this (see Testing below)

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

For these tests I executed the respective install script locally. To simulate github being down I set the github download to http instead of https and then I spun up a local server which returns 500. I also added a `127.0.0.1 github.com` entry to my hosts file (this works on both Windows, linux and macOS).

Linux
- [x] Tested that the Github download works normally
- [x] Tested that if Github returns a 500 the digital ocean download works normally

The download failed here and then it correctly retried with the mirror - I wasn't able to capture the retry part because it's part of the progress spinner so it just updates dynamically but this was the final output:
```
boppy@geralt:~/clockwork/SpacetimeDB$ spacetime-install
The SpacetimeDB command line tool will now be installed:
        CLI configuration directory: /home/boppy/.config/spacetime/
        `spacetime` binary: /home/boppy/.local/bin/spacetime
        directory for installed SpacetimeDB versions: /home/boppy/.local/share/spacetime/bin
        database directory: /home/boppy/.local/share/spacetime/data
Would you like to continue? yes
Downloading latest version...
  Installing v1.12.0: done!                                                                                                                                                                                                                                 The `spacetime` command has been installed as /home/boppy/.local/bin/spacetime

The install process is complete; check out our quickstart guide to get started!
        <https://spacetimedb.com/docs/getting-started>
```

Windows
- [x] Tested that the Github download works normally
- [x] Tested that if Github returns a 500 the digital ocean download works normally

This worked as well:
```
PS C:\Users\boppy\clockwork\SpacetimeDB\crates\update> .\spacetime-install.ps1
vcruntime140.dll is already installed at C:\WINDOWS\System32\vcruntime140.dll
Downloading installer...
Download failed, trying mirror...
We have added spacetimedb to your Path. You may have to logout and log back in to reload your environment.
```

macOS
- [x] Tested that the Github download works normally
- [x] Tested that if Github returns a 500 the digital ocean download works normally

```
boppy@Johns-Laptop update % bash ./spacetime-install.sh
Downloading installer...
curl: (22) The requested URL returned error: 500
Download failed, trying mirror...
The SpacetimeDB command line tool will now be installed:
        CLI configuration directory: /Users/boppy/.config/spacetime/
        `spacetime` binary: /Users/boppy/.local/bin/spacetime
        directory for installed SpacetimeDB versions: /Users/boppy/.local/share/spacetime/bin
        database directory: /Users/boppy/.local/share/spacetime/data
Would you like to continue? yes
Downloading latest version...
  Installing v1.12.0: done!
The `spacetime` command has been installed as /Users/boppy/.local/bin/spacetime

The install process is complete; check out our quickstart guide to get started!
        <https://spacetimedb.com/docs/getting-started>
```