### PR TITLE
Fix release for GLIBC_2.38 issue

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -14,7 +14,9 @@ jobs:
       fail-fast: false
       matrix:
         include:
-          - { name: x86_64 Linux, target: x86_64-unknown-linux-gnu, runner: spacetimedb-new-runner-2 }
+          # WARNING - do not upgrade this runner to 24.04 or the self hosted runners because it will break downloads for
+          #   anyone who uses a linux distro that doesn't have glibc >= GLIBC_2.38
+          - { name: x86_64 Linux, target: x86_64-unknown-linux-gnu, runner: ubuntu-22.04 }
           - { name: aarch64 Linux, target: aarch64-unknown-linux-gnu, runner: arm-runner }
           # Disabled because musl builds weren't working and we didn't want to investigate. See https://github.com/clockworklabs/SpacetimeDB/pull/2964.
           # - { name: x86_64 Linux musl, target: x86_64-unknown-linux-musl, runner: bare-metal, container: alpine }


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Our releases are currently broken because the machine that built the release is based off of ubuntu 24.04. I've now changed it back to `ubuntu-22.04` so that we don't have this issue.

```
boppy@geralt:~/clockwork/SpacetimeDB/crates/update$ curl -sSf https://install.spacetimedb.com | sh
Downloading installer...
/tmp/tmp.6i9sLQU0ff/spacetime-install: /lib/x86_64-linux-gnu/libc.so.6: version `GLIBC_2.38' not found (required by /tmp/tmp.6i9sLQU0ff/spacetime-install)
boppy@geralt:~/clockwork/SpacetimeDB/crates/update$ lsb_release -a
No LSB modules are available.
Distributor ID: Ubuntu
Description:    Ubuntu 22.04.5 LTS
Release:        22.04
Codename:       jammy
```

# API and ABI breaking changes

None

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

1 - we had fixed this before but we (meaning me) broket this again recently.

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

I have not tested this myself but I know this fixes the issue because I was the one who broke it.
