### PR TITLE
Fix docker unauthenticated pull rate limit issue in CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -841,6 +841,12 @@ jobs:
           key: Unity-${{ github.head_ref }}
           restore-keys: Unity-
 
+      - name: Login to DockerHub
+        uses: docker/login-action@v2
+        with:
+          username: ${{ vars.DOCKERHUB_USERNAME }}
+          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+
       - name: Run Unity tests
         uses: game-ci/unity-test-runner@v4
         with:


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Apparently we ran too many unity testsuite jobs today and we got this:
```
Unable to find image 'unityci/editor:ubuntu-2022.3.32f1-linux-il2cpp-3' locally
ubuntu-2022.3.32f1-linux-il2cpp-3: Pulling from unityci/editor
docker: error from registry: You have reached your unauthenticated pull rate limit. https://www.docker.com/increase-rate-limit
```

So now we login before pulling to increase our limit.

# API and ABI breaking changes

None

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

1 - this just logs us into docker before running the test

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] CI still passes
