### PR TITLE
CI - Fix smoketests using wrong binary path

### DIFF
--- a/crates/guard/src/lib.rs
+++ b/crates/guard/src/lib.rs
@@ -42,7 +42,7 @@ fn target_dir() -> PathBuf {
 
 /// Returns the expected CLI binary path.
 fn cli_binary_path() -> PathBuf {
-    let profile = if cfg!(debug_assertions) { "debug" } else { "release" };
+    let profile = "release";
     let cli_name = if cfg!(windows) {
         "spacetimedb-cli.exe"
     } else {


### PR DESCRIPTION
# Description of Changes

The smoketests try to infer whether to use the built `debug` or `release` binaries.. but the common invocation via `cargo ci smoketests` always pre-builds the release binaries. This was causing people to test the wrong binary locally.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1.

# Testing

- [x] CI passes