### PR TITLE
Add `on_abort` handler support for procedures

### DIFF
--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -52,6 +52,7 @@ mod sym {
     symbol!(index);
     symbol!(init);
     symbol!(name);
+    symbol!(on_abort);
     symbol!(primary_key);
     symbol!(private);
     symbol!(public);

--- a/crates/bindings/src/rt.rs
+++ b/crates/bindings/src/rt.rs
@@ -158,6 +158,9 @@ pub trait FnInfo {
     /// The name of the function.
     const NAME: &'static str;
 
+    /// The name of the on-abort handler, if any.
+    const ON_ABORT: Option<&'static str> = None;
+
     /// The lifecycle of the function, if there is one.
     const LIFECYCLE: Option<LifecycleReducer> = None;
 
@@ -799,7 +802,9 @@ where
     register_describer(|module| {
         let params = A::schema::<I>(&mut module.inner);
         let ret_ty = <Ret as SpacetimeType>::make_type(&mut module.inner);
-        module.inner.add_procedure(I::NAME, params, ret_ty);
+        module
+            .inner
+            .add_procedure(I::NAME, params, ret_ty, I::ON_ABORT.map(Into::into));
         module.procedures.push(I::INVOKE);
     })
 }

--- a/crates/lib/src/db/raw_def/v10.rs
+++ b/crates/lib/src/db/raw_def/v10.rs
@@ -342,6 +342,9 @@ pub struct RawProcedureDefV10 {
     /// it should be registered in the typespace and indirected through an [`AlgebraicType::Ref`].
     pub return_type: AlgebraicType,
 
+    /// The name of the procedure to invoke if this procedure aborts.
+    pub on_abort: Option<RawIdentifier>,
+
     /// Whether this procedure is callable from clients or is internal-only.
     pub visibility: FunctionVisibility,
 }
@@ -927,11 +930,13 @@ impl RawModuleDefV10Builder {
         source_name: impl Into<RawIdentifier>,
         params: ProductType,
         return_type: AlgebraicType,
+        on_abort: Option<RawIdentifier>,
     ) {
         self.procedures_mut().push(RawProcedureDefV10 {
             source_name: source_name.into(),
             params,
             return_type,
+            on_abort,
             visibility: FunctionVisibility::ClientCallable,
         })
     }

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -592,6 +592,9 @@ pub struct RawProcedureDefV9 {
     /// This `ProductType` need not be registered in the typespace.
     pub params: ProductType,
 
+    /// The name of the procedure to invoke if this procedure aborts.
+    pub on_abort: Option<RawIdentifier>,
+
     /// The type of the return value.
     ///
     /// If this is a user-defined product or sum type,
@@ -784,8 +787,9 @@ impl RawModuleDefV9Builder {
     pub fn add_procedure(
         &mut self,
         name: impl Into<RawIdentifier>,
-        params: spacetimedb_sats::ProductType,
-        return_type: spacetimedb_sats::AlgebraicType,
+        params: ProductType,
+        return_type: AlgebraicType,
+        on_abort: Option<RawIdentifier>,
     ) {
         self.module
             .misc_exports
@@ -793,6 +797,7 @@ impl RawModuleDefV9Builder {
                 name: name.into(),
                 params,
                 return_type,
+                on_abort,
             }))
     }
 

--- a/crates/schema/src/def.rs
+++ b/crates/schema/src/def.rs
@@ -1645,6 +1645,9 @@ pub struct ProcedureDef {
     /// and indirected through an [`AlgebraicTypeUse::Ref`].
     pub return_type_for_generate: AlgebraicTypeUse,
 
+    /// The name of the procedure to invoke if this procedure aborts.
+    pub on_abort: Option<Identifier>,
+
     /// The visibility of this procedure.
     pub visibility: FunctionVisibility,
 }
@@ -1655,6 +1658,7 @@ impl From<ProcedureDef> for RawProcedureDefV9 {
             name: val.name.into(),
             params: val.params,
             return_type: val.return_type,
+            on_abort: val.on_abort.map(Into::into),
         }
     }
 }
@@ -1665,6 +1669,7 @@ impl From<ProcedureDef> for RawProcedureDefV10 {
             source_name: val.name.into(),
             params: val.params,
             return_type: val.return_type,
+            on_abort: val.on_abort.map(Into::into),
             visibility: val.visibility.into(),
         }
     }

--- a/crates/schema/src/error.rs
+++ b/crates/schema/src/error.rs
@@ -119,6 +119,15 @@ pub enum ValidationError {
         expected: PrettyAlgebraicType,
         actual: PrettyAlgebraicType,
     },
+    #[error("Procedure {procedure} specifies on_abort handler {handler} that does not exist")]
+    MissingProcedureOnAbortHandler { procedure: Identifier, handler: Identifier },
+    #[error("Procedure {procedure} on_abort handler {handler} expected params {expected}, but has params {actual}")]
+    ProcedureOnAbortParamsMismatch {
+        procedure: Identifier,
+        handler: Identifier,
+        expected: PrettyAlgebraicType,
+        actual: PrettyAlgebraicType,
+    },
     #[error("Table name is reserved for system use: {table}")]
     TableNameReserved { table: Identifier },
     #[error("Row-level security invalid: `{error}`, query: `{sql}")]


### PR DESCRIPTION
# Description of Changes

Adds support for procedure `on_abort` handlers, including macro parsing, bindings propagation, schema validation, and runtime scheduling of the handler when a procedure traps. Also updates V9 validation tests to use the new `add_procedure(..., on_abort)` signature.

Helps #3789, this allows us to reschedule the procedure when aborted

# API and ABI breaking changes

No breaking changes expected. (Adds optional `on_abort` metadata and preserves existing behavior when omitted.)

# Expected complexity level and risk

Touches multiple layers (macro → bindings → schema → runtime), but the change is additive and limited in scope. Primary risk is mismatched server/client versions or handler scheduling edge cases, mitigated by validation and async scheduling.

# Testing

- [x] Run `cargo test`
- [x] (Optional) Integration check: publish a module with `#[procedure(on_abort = "...")]`, trigger a trap, and verify handler is scheduled