### PR TITLE
Use direct I/O for commitlog compression

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3633,9 +3633,9 @@ checksum = "09edd9e8b54e49e587e4f6295a7d29c3ea94d469cb40ab8ca70b288248a81db2"
 
 [[package]]
 name = "libc"
-version = "0.2.177"
+version = "0.2.182"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2874a2af47a2325c2001a6e6fad9b16a53b802102b528163885171cf92b15976"
+checksum = "6800badb6cb2082ffd7b6a67e6125bb39f18782f793520caee8cb8846be06112"
 
 [[package]]
 name = "libgit2-sys"
@@ -8024,10 +8024,12 @@ dependencies = [
  "anyhow",
  "fs2",
  "hex",
+ "libc",
  "rand 0.9.2",
  "tempdir",
  "thiserror 1.0.69",
  "tokio",
+ "windows-sys 0.59.0",
  "zstd-framed",
 ]
 

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -227,6 +227,7 @@ jwks = { package = "spacetimedb-jwks", version = "0.1.3" }
 lazy_static = "1.4.0"
 lean_string = "0.5.1"
 log = "0.4.17"
+libc = "0.2.182"
 memchr = "2"
 mimalloc = "0.1.39"
 names = "0.14"
@@ -381,6 +382,7 @@ features = [
   "broadcast",
   "ondemand",
 ]
+
 
 [workspace.lints.rust]
 unexpected_cfgs = { level = "warn", check-cfg = ['cfg(tokio_unstable)'] }

--- a/crates/commitlog/tests/random_payload/mod.rs
+++ b/crates/commitlog/tests/random_payload/mod.rs
@@ -87,7 +87,7 @@ fn compression() {
     let clog = Commitlog::open(
         CommitLogDir::from_path_unchecked(root.path()),
         Options {
-            max_segment_size: 8 * 1024,
+            max_segment_size: 16 * 1024,
             max_records_in_commit: NonZeroU16::MIN,
             ..Options::default()
         },
@@ -111,7 +111,12 @@ fn compression() {
     clog.compress_segments(segments_to_compress).unwrap();
 
     let compressed_size = clog.size_on_disk().unwrap();
-    assert!(compressed_size.total_bytes < uncompressed_size.total_bytes);
+    assert!(
+        compressed_size.total_bytes < uncompressed_size.total_bytes,
+        "expected total size to be smaller after compression: uncompressed={:?} compressed={:?}",
+        uncompressed_size,
+        compressed_size
+    );
 
     assert!(clog
         .transactions(&payload::ArrayDecoder)

--- a/crates/commitlog/tests/random_payload/mod.rs
+++ b/crates/commitlog/tests/random_payload/mod.rs
@@ -97,7 +97,7 @@ fn compression() {
 
     // try to generate commitlogs that will be amenable to compression -
     // random data doesn't compress well, so try and have there be repetition
-    let payloads = (0..4).map(|_| gen_payload()).cycle().take(1024).collect::<Vec<_>>();
+    let payloads = (0..4).map(|_| gen_payload()).cycle().take(1500).collect::<Vec<_>>();
     for payload in &payloads {
         clog.append_maybe_flush(*payload).unwrap();
     }

--- a/crates/fs-utils/Cargo.toml
+++ b/crates/fs-utils/Cargo.toml
@@ -15,6 +15,12 @@ thiserror.workspace = true
 tokio.workspace = true
 zstd-framed.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+libc.workspace = true
+
+[target.'cfg(windows)'.dependencies]
+windows-sys.workspace = true
+
 [dev-dependencies]
 tempdir.workspace = true
 

--- a/crates/fs-utils/src/dir_trie.rs
+++ b/crates/fs-utils/src/dir_trie.rs
@@ -187,7 +187,7 @@ impl DirTrie {
     /// It will be decompressed based on the file's magic bytes.
     ///
     /// It will be opened with [`o_rdonly`].
-    pub fn open_entry_reader(&self, file_id: &FileId) -> Result<CompressReader, io::Error> {
+    pub fn open_entry_reader(&self, file_id: &FileId) -> Result<CompressReader<File>, io::Error> {
         let path = self.file_path(file_id);
         Self::create_parent(&path)?;
         CompressReader::new(o_rdonly().open(path)?)

--- a/crates/fs-utils/src/direct_io.rs
+++ b/crates/fs-utils/src/direct_io.rs
@@ -1,0 +1,86 @@
+mod page;
+mod reader;
+mod writer;
+
+use std::{
+    fs::{File, OpenOptions},
+    io,
+    path::Path,
+};
+
+pub use self::{page::Page, reader::AlignedBufReader, writer::AlignedBufWriter};
+
+/// Open a [File] according to [OpenOptions], enabling `O_DIRECT` or a platform
+/// equivalent.
+///
+/// On all supported platforms, direct I/O requires alignment of memory buffers
+/// and file offsets to the logical block size of the filesystem. Wrap the
+/// returned [File] in [AlignedBufReader] or [AlignedBufWriter] respectively to
+/// have this being taken care of for you.
+///
+/// # Platform differences
+///
+/// * Unix (except macOS):
+///
+///   The file will be opened with the `O_DIRECT` flag.
+///
+/// * macOS:
+///
+///   The `F_NOCACHE` fcntl will be set on the opened file.
+///   It may be necessary to set `F_PREALLOCATE` as well[1].
+///
+/// * Windows:
+///
+///   The file will be opened with [FILE_FLAG_NO_BUFFERING].
+///
+/// [1]: https://forums.developer.apple.com/forums/thread/25464
+/// [FILE_FLAG_NO_BUFFERING]: https://docs.microsoft.com/en-us/windows/win32/fileio/file-buffering
+pub fn open_file(path: impl AsRef<Path>, opts: &mut OpenOptions) -> io::Result<File> {
+    open_file_impl(path.as_ref(), opts)
+}
+
+/// Open the file at `path` for reading in `O_DIRECT` mode and wrap it in an
+/// [AlignedBufReader].
+pub fn file_reader(path: impl AsRef<Path>) -> io::Result<AlignedBufReader<File>> {
+    open_file(path, OpenOptions::new().read(true)).map(AlignedBufReader::new)
+}
+
+/// Open the file at `path` for writing in `O_DIRECT` mode and wrap it in an
+/// [AlignedBufWriter].
+///
+/// The file will be created if it does not exist, and truncated if it does.
+pub fn file_writer(path: impl AsRef<Path>) -> io::Result<AlignedBufWriter<File>> {
+    open_file(path, OpenOptions::new().create(true).write(true).truncate(true)).map(AlignedBufWriter::new)
+}
+
+#[cfg(all(unix, not(target_os = "macos")))]
+fn open_file_impl(path: &Path, opts: &mut OpenOptions) -> io::Result<File> {
+    use std::os::unix::fs::OpenOptionsExt as _;
+
+    opts.custom_flags(libc::O_DIRECT);
+    opts.open(path)
+}
+
+#[cfg(target_os = "macos")]
+fn open_file_impl(path: &Path, opts: &mut OpenOptions) -> io::Result<File> {
+    use libc::{fcntl, F_NOCACHE};
+    use std::os::fd::AsRawFd;
+
+    let file = opts.open(path)?;
+    let fd = file.as_raw_fd();
+    let ret = unsafe { fcntl(fd, F_NOCACHE, 1) };
+    if ret != 0 {
+        return Err(io::Error::from_raw_os_error(ret));
+    }
+
+    Ok(file)
+}
+
+#[cfg(target_os = "windows")]
+fn open_file_impl(path: &Path, opts: &mut OpenOptions) -> io::Result<File> {
+    use std::os::windows::fs::OpenOptionsExt;
+    use windows_sys::Win32::Storage::FileSystem::FILE_FLAG_NO_BUFFERING;
+
+    opts.custom_flags(FILE_FLAG_NO_BUFFERING);
+    opts.open(path)
+}

--- a/crates/fs-utils/src/direct_io/page.rs
+++ b/crates/fs-utils/src/direct_io/page.rs
@@ -1,0 +1,136 @@
+use std::ops::{Deref, DerefMut};
+
+/// The (assumed) size of an OS memory page: 4096 bytes.
+pub const PAGE_SIZE: usize = 4096;
+
+/// The (assumed) size of a logical device block.
+///
+/// Under Linux, this is the value returned by `blockdev --getss`.
+///
+/// Although the value may differ across machines, filesystems or OSs, we
+/// currently assume that it is a safe value to align I/O buffers to.
+pub const BLOCK_SIZE: usize = 512;
+
+#[derive(Debug)]
+#[repr(C, align(512))]
+struct Aligned([u8; PAGE_SIZE]);
+
+impl Deref for Aligned {
+    type Target = [u8];
+
+    fn deref(&self) -> &Self::Target {
+        &self.0
+    }
+}
+
+impl DerefMut for Aligned {
+    fn deref_mut(&mut self) -> &mut Self::Target {
+        &mut self.0
+    }
+}
+
+/// A buffer of size [`PAGE_SIZE`], aligned to [`BLOCK_SIZE`].
+///
+/// The memory of the buffer is intended to be reused by manipulating its
+/// (write) position (similar to a cursor).
+#[derive(Debug)]
+pub struct Page {
+    buf: Aligned,
+    pos: usize,
+}
+
+impl Page {
+    /// Create a new page.
+    pub fn new() -> Self {
+        Self {
+            buf: Aligned([0; PAGE_SIZE]),
+            pos: 0,
+        }
+    }
+
+    /// The current position, i.e. up to which offset the buffer is considered
+    /// filled.
+    #[inline]
+    pub fn pos(&self) -> usize {
+        self.pos
+    }
+
+    /// Reset the current position to zero.
+    #[inline]
+    pub fn reset(&mut self) {
+        self.pos = 0;
+    }
+
+    /// Set the current position to `pos`.
+    ///
+    /// The caller must ensure that `pos <= self.buf.len()`.
+    #[inline]
+    pub(super) fn set_pos(&mut self, pos: usize) {
+        debug_assert!(pos <= self.buf.len(), "pos > buf.len()");
+        self.pos = pos;
+    }
+
+    /// Return the entire underlying buffer as a slice, regardless of position.
+    #[inline]
+    pub fn buf(&self) -> &[u8] {
+        &self.buf
+    }
+
+    /// Return the entire underlying buffer as a mutable slice, regardless of
+    /// position.
+    ///
+    /// The caller must ensure to update the position as necessary.
+    #[inline]
+    pub fn buf_mut(&mut self) -> &mut [u8] {
+        &mut self.buf
+    }
+
+    /// Return the current position, rounded up to the next multiple of
+    /// [`BLOCK_SIZE`].
+    ///
+    /// Never exceeds the length of the buffer.
+    #[inline]
+    pub fn next_block_offset(&self) -> usize {
+        self.pos.next_multiple_of(BLOCK_SIZE).min(self.buf.len())
+    }
+
+    /// Copy the given slice to the internal buffer, starting from `self.pos()`.
+    ///
+    /// The position is updated with the length of the source slice.
+    ///
+    /// # Panics
+    ///
+    /// Panics if there is not enough space to copy `src`, i.e.
+    /// `src.len() > self.spare_capacity()`.
+    #[inline]
+    pub fn copy_from_slice(&mut self, src: &[u8]) {
+        self.buf[self.pos..self.pos + src.len()].copy_from_slice(src);
+        self.pos += src.len();
+    }
+
+    /// `true` if the current position is zero.
+    #[inline]
+    pub const fn is_empty(&self) -> bool {
+        self.pos == 0
+    }
+
+    /// `true` if the buffer is full, shorthand for `self.spare_capacity() == 0`.
+    pub const fn is_full(&self) -> bool {
+        self.spare_capacity() == 0
+    }
+
+    /// Returns the number of bytes remaining in the buffer after `self.pos()`.
+    pub const fn spare_capacity(&self) -> usize {
+        self.buf.0.len() - self.pos
+    }
+
+    pub const fn capacity(&self) -> usize {
+        PAGE_SIZE
+    }
+}
+
+impl Default for Page {
+    fn default() -> Self {
+        Self::new()
+    }
+}

--- a/crates/fs-utils/src/direct_io/reader.rs
+++ b/crates/fs-utils/src/direct_io/reader.rs
@@ -1,0 +1,117 @@
+use std::{
+    cmp,
+    io::{self, BufRead, Read, Seek},
+};
+
+use super::page::Page;
+
+/// A buffered reader using an aligned buffer internally.
+///
+/// The alignment makes the reader suitable for files opened using `O_DIRECT`
+/// or a platform equivalent.
+///
+/// Other than the alignment of the buffer, this is basically a stripped down
+/// version of [`io::BufReader`], borrowing much of its code.
+pub struct AlignedBufReader<R> {
+    inner: R,
+
+    page: Page,
+    /// The number of bytes read during the last `fill_buf`.
+    ///
+    /// That is, `page.buf()[page.pos()..filled]` is the currently buffered,
+    /// unconsumed data.
+    filled: usize,
+}
+
+impl<R> AlignedBufReader<R> {
+    /// Create a new [AlignedBufReader] wrapping the `inner` reader.
+    pub fn new(inner: R) -> Self {
+        Self {
+            inner,
+            page: Page::new(),
+            filled: 0,
+        }
+    }
+
+    pub const fn from_raw_parts(inner: R, page: Page, filled: usize) -> Self {
+        Self { inner, page, filled }
+    }
+
+    pub fn into_raw_parts(self) -> (R, Page, usize) {
+        (self.inner, self.page, self.filled)
+    }
+}
+
+impl<R: Read> AlignedBufReader<R> {
+    #[inline]
+    fn consume_with(&mut self, amt: usize, mut visitor: impl FnMut(&[u8])) -> bool {
+        if let Some(claimed) = self.page.buf()[self.page.pos()..self.filled].get(..amt) {
+            visitor(claimed);
+            self.consume(amt);
+            true
+        } else {
+            false
+        }
+    }
+}
+
+impl<R: Read> Read for AlignedBufReader<R> {
+    fn read(&mut self, buf: &mut [u8]) -> std::io::Result<usize> {
+        let mut rem = self.fill_buf()?;
+        let n = rem.read(buf)?;
+        self.consume(n);
+
+        Ok(n)
+    }
+
+    fn read_exact(&mut self, buf: &mut [u8]) -> io::Result<()> {
+        if self.consume_with(buf.len(), |claimed| buf.copy_from_slice(claimed)) {
+            return Ok(());
+        }
+
+        let mut buf = buf;
+        while !buf.is_empty() {
+            match self.read(buf) {
+                Ok(0) => break,
+                Ok(n) => {
+                    buf = &mut buf[n..];
+                }
+                Err(e) if e.kind() == io::ErrorKind::Interrupted => {}
+                Err(e) => return Err(e),
+            }
+        }
+
+        if !buf.is_empty() {
+            return Err(io::Error::new(
+                io::ErrorKind::UnexpectedEof,
+                "failed to fill whole page",
+            ));
+        }
+
+        Ok(())
+    }
+}
+
+impl<R: Read> BufRead for AlignedBufReader<R> {
+    fn fill_buf(&mut self) -> io::Result<&[u8]> {
+        if self.page.pos() >= self.filled {
+            let n = self.inner.read(self.page.buf_mut())?;
+            self.page.reset();
+            self.filled = n;
+        }
+
+        Ok(&self.page.buf()[self.page.pos()..self.filled])
+    }
+
+    fn consume(&mut self, amt: usize) {
+        self.page.set_pos(cmp::min(self.page.pos() + amt, self.filled));
+    }
+}
+
+impl<R: Seek> Seek for AlignedBufReader<R> {
+    fn seek(&mut self, pos: io::SeekFrom) -> io::Result<u64> {
+        self.page.reset();
+        self.filled = 0;
+        self.inner.seek(pos)
+    }
+}

--- a/crates/fs-utils/src/direct_io/writer.rs
+++ b/crates/fs-utils/src/direct_io/writer.rs
@@ -1,0 +1,123 @@
+use std::io;
+
+use super::page::Page;
+
+/// A buffered writer using an aligned buffer internally.
+///
+/// Similar to [`io::BufWriter`], but suitable for files opened using `O_DIRECT`
+/// or a platform equivalent, due to the alignment.
+///
+/// # Flushing behaviour
+///
+/// [`io::Write::write`] calls will only flush the buffer when it is full.
+/// [`io::Write::flush`] calls, however, will flush the buffer up to the next
+/// [`BLOCK_SIZE`] boundary, padding the data with zeroes if necessary.
+///
+/// This is done so that partial writes to the underlying storage can be
+/// detected on the application layer, and retried if appropriate. It is also
+/// necessary to preserve `fsync` semantics: a [`PagedWriter`] replaces the OS
+/// page cache, where the latter is flushed to the device when `fsync` is called.
+///
+/// After a flush of an underfull buffer, the file and page positions are
+/// rewound to the _previous_ [`BLOCK_SIZE`] boundary, such that the subsequent
+/// write will overwrite the padding if more data has been added to the writer.
+///
+/// Dropping a [`PagedWriter`] will attempt to flush all data, but will not sync
+/// it.
+#[derive(Debug)]
+pub struct AlignedBufWriter<W: io::Write> {
+    inner: W,
+    page: Page,
+}
+
+impl<W: io::Write> AlignedBufWriter<W> {
+    /// Create a new `AlignedBufWriter` wrapping the `inner` writer.
+    pub fn new(inner: W) -> Self {
+        Self::from_raw_parts(inner, Page::new())
+    }
+
+    /// Create a new `AlignedBufWriter` from its constituent parts.
+    ///
+    /// This allows to reuse [`Page`]s.
+    pub const fn from_raw_parts(inner: W, page: Page) -> Self {
+        Self { inner, page }
+    }
+
+    /// Get a reference to the underlying writer.
+    pub fn get_ref(&self) -> &W {
+        &self.inner
+    }
+}
+
+impl<F: io::Write> io::Write for AlignedBufWriter<F> {
+    fn write(&mut self, buf: &[u8]) -> io::Result<usize> {
+        let mut wrote = 0;
+        let mut buf = buf;
+
+        while !buf.is_empty() {
+            let (chunk, rest) = buf.split_at(self.page.spare_capacity().min(buf.len()));
+            self.page.copy_from_slice(chunk);
+            if self.page.is_full() {
+                self.flush()?;
+            }
+            wrote += chunk.len();
+            buf = rest;
+        }
+
+        Ok(wrote)
+    }
+
+    #[inline]
+    fn flush(&mut self) -> io::Result<()> {
+        let pos = self.page.pos();
+        let next_block = self.page.next_block_offset();
+
+        // Pad with zeroes.
+        self.page.buf_mut()[pos..next_block].fill(0);
+        let buf = &self.page.buf()[..next_block];
+        let len = buf.len();
+
+        self.inner.write_all(buf)?;
+        if pos + len > self.page.capacity() {
+            self.page.reset();
+        } else {
+            self.page.set_pos(pos + len);
+        }
+        self.inner.flush()?;
+
+        Ok(())
+    }
+}
+
+impl<F: io::Write> Drop for AlignedBufWriter<F> {
+    fn drop(&mut self) {
+        let _ = io::Write::flush(self);
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use std::io::Write as _;
+
+    #[test]
+    fn write_flushes_aligned() {
+        let mut writer = AlignedBufWriter::new(Vec::new());
+        writer.write_all(&[42; 4096]).unwrap();
+        writer.write_all(&[1; 512]).unwrap();
+
+        assert_eq!(&writer.inner, &[42; 4096])
+    }
+
+    #[test]
+    fn flush_flushes_all_with_padding() {
+        let mut writer = AlignedBufWriter::new(Vec::new());
+        writer.write_all(&[42; 5000]).unwrap();
+        writer.flush().unwrap();
+
+        assert_eq!(
+            &writer.inner,
+            [[42; 5000].as_slice(), [0; 120].as_slice()].concat().as_slice()
+        );
+    }
+}

--- a/crates/fs-utils/src/lib.rs
+++ b/crates/fs-utils/src/lib.rs
@@ -3,6 +3,7 @@ use std::path::Path;
 
 pub mod compression;
 pub mod dir_trie;
+pub mod direct_io;
 pub mod lockfile;
 
 pub fn create_parent_dir(file: &Path) -> Result<(), std::io::Error> {


### PR DESCRIPTION
The page cache is of little value when compressing commitlog segments, as a segment will 
usually be read at most once (for archival). Churning GBs through the page cache starves
other critical I/O, namely commitlog `fsync`s.

Thus, use `O_DIRECT` for compression.

# Expected complexity level and risk

2

# Testing

Existing tests.