### PR TITLE
Minor fixes to examples in event tables document

### DIFF
--- a/docs/docs/00200-core-concepts/00300-tables/00550-event-tables.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00550-event-tables.md
@@ -28,6 +28,11 @@ const damageEvent = table({
   damage: t.u32(),
   source: t.string(),
 });
+
+const spacetimedb = schema({
+  damageEvent,
+});
+export default spacetimedb;
 ```
 
 </TabItem>
@@ -47,7 +52,7 @@ public partial struct DamageEvent
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = damage_event, public, event)]
+#[spacetimedb::table(accessor = damage_event, public, event)]
 pub struct DamageEvent {
     pub entity_id: Identity,
     pub damage: u32,


### PR DESCRIPTION
# Description of Changes

Use `accessor =` rather than `name =` in Rust code snippet which defines event table.

Add `schema` call and `export default` to TypeScript code snippet which defines event table. I'm not sure this is better, and it's certainly more cluttered, but the example as written you can't just copy/paste into your module code.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

Docs only

# Testing

Described elsewhere.
