### PR TITLE
Pinning C++ and Unreal to 1.12.0

### DIFF
--- a/crates/bindings-cpp/CMakeLists.txt
+++ b/crates/bindings-cpp/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 project(SpacetimeDBCppModuleLibrary 
-    VERSION 2.0.0
+    VERSION 1.12.0
     LANGUAGES CXX)
 
 # Generate version header from template

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00200-part-1.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00200-part-1.md
@@ -11,7 +11,7 @@ Need help with the tutorial? [Join our Discord server](https://discord.gg/spacet
 
 > A completed version of the game we'll create in this tutorial is available at:
 >
-> [https://github.com/clockworklabs/SpacetimeDB/tree/master/demo/Blackholio](https://github.com/clockworklabs/SpacetimeDB/tree/master/demo/Blackholio)
+> [https://github.com/clockworklabs/SpacetimeDB/tree/v1.12.0/demo/Blackholio](https://github.com/clockworklabs/SpacetimeDB/tree/v1.12.0/demo/Blackholio)
 
 ## Setting up the Tutorial Unreal Project
 
@@ -36,7 +36,7 @@ Click **Create** to generate the blank project.
 
 While the SpacetimeDB Unreal client SDK is in preview releases, it can only be installed from GitHub:
 
-> [https://github.com/clockworklabs/SpacetimeDB/tree/master/sdks/unreal/src](https://github.com/clockworklabs/SpacetimeDB/tree/master/sdks/unreal/src)
+> [https://github.com/clockworklabs/SpacetimeDB/tree/v1.12.0/sdks/unreal/src](https://github.com/clockworklabs/SpacetimeDB/tree/v1.12.0/sdks/unreal/src)
 
 Once the SDK is stabilized, we'll find a more ergonomic way to distribute it.
 

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00500-part-4.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00500-part-4.md
@@ -957,6 +957,6 @@ There's still plenty more we can do to build this into a proper game though. For
 
 Fortunately, we've done that for you! If you'd like to check out the completed tutorial game, with these additional features, you can download it on GitHub:
 
-[https://github.com/clockworklabs/SpacetimeDB/tree/master/demo/Blackholio](https://github.com/clockworklabs/SpacetimeDB/tree/master/demo/Blackholio)
+[https://github.com/clockworklabs/SpacetimeDB/tree/v1.12.0/demo/Blackholio](https://github.com/clockworklabs/SpacetimeDB/tree/v1.12.0/demo/Blackholio)
 
 If you have any suggestions or comments on the tutorial, either [open an issue](https://github.com/clockworklabs/SpacetimeDB/issues/new), or join our Discord ([https://discord.gg/SpacetimeDB](https://discord.gg/SpacetimeDB)) and chat with us!

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/index.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/index.md
@@ -6,13 +6,17 @@ slug: /tutorials/unreal
 
 Need help with the tutorial or CLI commands? [Join our Discord server](https://discord.gg/spacetimedb)!
 
-In this tutorial you'll learn how to build a small-scoped massive multiplayer online action game in Unreal, from scratch, using SpacetimeDB. Although, the game we're going to build is small in scope, it'll scale to hundreds of players and will help you get acquainted with all the features and best practices of SpacetimeDB, while building [a fun little game](https://github.com/clockworklabs/SpacetimeDB/tree/master/demo/Blackholio).
+:::important SpacetimeDB 2.0 Coming Soon
+SpacetimeDB `2.0` is coming soon. Until the Unreal SDK is updated for `2.0`, this tutorial is pinned to the `v1.12.0` release track.
+:::
+
+In this tutorial you'll learn how to build a small-scoped massive multiplayer online action game in Unreal, from scratch, using SpacetimeDB. Although, the game we're going to build is small in scope, it'll scale to hundreds of players and will help you get acquainted with all the features and best practices of SpacetimeDB, while building [a fun little game](https://github.com/clockworklabs/SpacetimeDB/tree/v1.12.0/demo/Blackholio).
 
 By the end, you should have a basic understanding of what SpacetimeDB offers for developers making multiplayer games.
 
 The game is inspired by [agar.io](https://agar.io), but SpacetimeDB themed with some fun twists. If you're not familiar [agar.io](https://agar.io), it's a web game in which you and hundreds of other players compete to cultivate mass to become the largest cell in the Petri dish.
 
-Our game, called [Blackhol.io](https://github.com/clockworklabs/SpacetimeDB/tree/master/demo/Blackholio), will be similar but space themed. It should give you a great idea of the types of games you can develop easily with SpacetimeDB.
+Our game, called [Blackhol.io](https://github.com/clockworklabs/SpacetimeDB/tree/v1.12.0/demo/Blackholio), will be similar but space themed. It should give you a great idea of the types of games you can develop easily with SpacetimeDB.
 
 This tutorial assumes that you have a basic understanding of the Unreal Engine, using a command line terminal and programming in C++. We'll give you some CLI commands to execute. If you are using Windows, we recommend using Git Bash or PowerShell. For Mac, we recommend Terminal.
 
@@ -37,4 +41,4 @@ First you'll get started with the core client/server setup. For part 2, you'll b
 
 If you already have a good understanding of the SpacetimeDB client and server, check out our completed tutorial project!
 
-[https://github.com/clockworklabs/SpacetimeDB/tree/master/demo/Blackholio](https://github.com/clockworklabs/SpacetimeDB/tree/master/demo/Blackholio)
+[https://github.com/clockworklabs/SpacetimeDB/tree/v1.12.0/demo/Blackholio](https://github.com/clockworklabs/SpacetimeDB/tree/v1.12.0/demo/Blackholio)

--- a/templates/basic-cpp/spacetimedb/CMakeLists.txt
+++ b/templates/basic-cpp/spacetimedb/CMakeLists.txt
@@ -18,7 +18,7 @@ project(spacetime_cpp_module LANGUAGES C CXX)
 #     The directory should contain the bindings' CMakeLists.txt at its root.
 # ------------------------------------------------------------------------------
 
-set(SPACETIMEDB_CPP_VERSION "2.0.0" CACHE STRING "Version selector: MAJOR.MINOR (uses release/MAJOR.MINOR) or MAJOR.MINOR.PATCH (uses tag vMAJOR.MINOR.PATCH)")
+set(SPACETIMEDB_CPP_VERSION "1.12.0" CACHE STRING "Version selector: MAJOR.MINOR (uses release/MAJOR.MINOR) or MAJOR.MINOR.PATCH (uses tag vMAJOR.MINOR.PATCH)")
 set(SPACETIMEDB_CPP_REF "" CACHE STRING "Override Git ref directly (e.g. release/1.0, release/latest, v1.0.0)")  
 set(SPACETIMEDB_CPP_DIR "" CACHE PATH "Path to a local clone of SpacetimeDB C++ bindings (overrides FetchContent)")
 

--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -367,8 +367,16 @@ fn main() -> anyhow::Result<()> {
         )?;
     }
     if matches.get_flag("cpp") || matches.get_flag("all") {
-        rewrite_cmake_version_inplace("crates/bindings-cpp/CMakeLists.txt", &full_version)?;
-        rewrite_cmake_version_inplace("templates/basic-cpp/spacetimedb/CMakeLists.txt", &full_version)?;
+        // TODO(26-02-17 jlarabie): Keep C++ pinned to 1.12.x for the 2.0 release train.
+        // Re-enable this codepath when C++ 2.0 is ready and we're intentionally
+        // moving the C++ SDK/template versions forward.
+        return Ok(());
+
+        #[allow(unreachable_code)]
+        {
+            rewrite_cmake_version_inplace("crates/bindings-cpp/CMakeLists.txt", &full_version)?;
+            rewrite_cmake_version_inplace("templates/basic-cpp/spacetimedb/CMakeLists.txt", &full_version)?;
+        }
     }
     Ok(())
 }

--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -370,6 +370,7 @@ fn main() -> anyhow::Result<()> {
         // TODO(26-02-17 jlarabie): Keep C++ pinned to 1.12.x for the 2.0 release train.
         // Re-enable this codepath when C++ 2.0 is ready and we're intentionally
         // moving the C++ SDK/template versions forward.
+        eprintln!("Warning: Not bumping C++ version. See inline comment for details.");
         return Ok(());
 
         #[allow(unreachable_code)]


### PR DESCRIPTION
# Description of Changes
A few small changes to pin the version:
- Updated the CMakeLists back from 2.0.0 to 1.12.0
- Updated the Unreal Blackholio tutorial documentation to target the 1.12.0 branch and not master
- Updated the Unreal Blackholio tutorial to call out 2.0 is coming soon
- Disabled the upgrade-version tool code path for C++ upgrades, but left logic in place for the near future

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1 - Docs change, config change, and blocking update path for C++

# Testing

- [x] Reviewed the docs
- [x] Tested update command locally
- [x] Tested `spacetime init` for `basic-cpp` and successfully built
