### PR TITLE
Small fixes for the Blackholio tutorial

### DIFF
--- a/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00300-part-2.md
+++ b/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00300-part-2.md
@@ -166,7 +166,7 @@ Let's start by defining the `Config` table. This is a simple table which will st
 ```rust
 // We're using this table as a singleton, so in this table
 // there only be one element where the `id` is 0.
-#[spacetimedb::table(name = config, public)]
+#[spacetimedb::table(accessor = config, public)]
 pub struct Config {
     #[primary_key]
     pub id: i32,
@@ -176,7 +176,7 @@ pub struct Config {
 
 Let's break down this code. This defines a normal Rust `struct` with two fields: `id` and `world_size`. We have decorated the struct with the `spacetimedb::table` macro. This procedural Rust macro signals to SpacetimeDB that it should create a new SpacetimeDB table with the row type defined by the `Config` type's fields.
 
-The `spacetimedb::table` macro takes two parameters, a `name` which is the name of the table and what you will use to query the table in SQL, and a `public` visibility modifier which ensures that the rows of this table are visible to everyone.
+The `spacetimedb::table` macro takes two parameters, an `accessor` which is the name of the table and what you will use to query the table in SQL, and a `public` visibility modifier which ensures that the rows of this table are visible to everyone.
 
 The `#[primary_key]` attribute, specifies that the `id` field should be used as the primary key of the table.
 
@@ -284,7 +284,7 @@ pub struct DbVector2 {
 Let's create a few tables to represent entities in our game.
 
 ```rust
-#[spacetimedb::table(name = entity, public)]
+#[spacetimedb::table(accessor = entity, public)]
 #[derive(Debug, Clone)]
 pub struct Entity {
     // The `auto_inc` attribute indicates to SpacetimeDB that
@@ -296,7 +296,7 @@ pub struct Entity {
     pub mass: i32,
 }
 
-#[spacetimedb::table(name = circle, public)]
+#[spacetimedb::table(accessor = circle, public)]
 pub struct Circle {
     #[primary_key]
     pub entity_id: i32,
@@ -307,7 +307,7 @@ pub struct Circle {
     pub last_split_time: Timestamp,
 }
 
-#[spacetimedb::table(name = food, public)]
+#[spacetimedb::table(accessor = food, public)]
 pub struct Food {
     #[primary_key]
     pub entity_id: i32,
@@ -399,7 +399,7 @@ There are a few new concepts we should touch on. First of all, we are using the 
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = player, public)]
+#[spacetimedb::table(accessor = player, public)]
 #[derive(Debug, Clone)]
 pub struct Player {
     #[primary_key]
@@ -659,7 +659,6 @@ This will generate a set of files in the `Assets/autogen` directory which contai
 
 ```
 ├── Reducers
-│   └── Connect.g.cs
 ├── Tables
 │   ├── Circle.g.cs
 │   ├── Config.g.cs

--- a/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00400-part-3.md
+++ b/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00400-part-3.md
@@ -259,7 +259,7 @@ Note the `Scheduled = nameof(SpawnFood)` parameter in the table macro. This tell
 In order to schedule a reducer to be called we have to create a new table which specifies when and how a reducer should be called. Add this new table to the top of the file, below your imports.
 
 ```rust
-#[spacetimedb::table(name = spawn_food_timer, scheduled(spawn_food))]
+#[spacetimedb::table(accessor = spawn_food_timer, scheduled(spawn_food))]
 pub struct SpawnFoodTimer {
     #[primary_key]
     #[auto_inc]
@@ -420,7 +420,7 @@ Let's add a second table to our `Player` struct. Modify the `Player` struct by a
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = logged_out_player)]
+#[spacetimedb::table(accessor = logged_out_player)]
 ```
 
 </TabItem>
@@ -455,8 +455,8 @@ public partial struct Player
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = player, public)]
-#[spacetimedb::table(name = logged_out_player)]
+#[spacetimedb::table(accessor = player, public)]
+#[spacetimedb::table(accessor = logged_out_player)]
 #[derive(Debug, Clone)]
 pub struct Player {
     #[primary_key]

--- a/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00500-part-4.md
+++ b/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00500-part-4.md
@@ -374,7 +374,7 @@ public static void MoveAllPlayers(ReducerContext ctx, MoveAllPlayersTimer timer)
 <TabItem value="rust" label="Rust" >
 
 ```rust
-#[spacetimedb::table(name = move_all_players_timer, scheduled(move_all_players))]
+#[spacetimedb::table(accessor = move_all_players_timer, scheduled(move_all_players))]
 pub struct MoveAllPlayersTimer {
     #[primary_key]
     #[auto_inc]

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00300-part-2.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00300-part-2.md
@@ -165,7 +165,7 @@ Let's start by defining the `Config` table. This is a simple table which will st
 ```rust
 // We're using this table as a singleton, so in this table
 // there will only be one element where the `id` is 0.
-#[spacetimedb::table(name = config, public)]
+#[spacetimedb::table(accessor = config, public)]
 pub struct Config {
     #[primary_key]
     pub id: i32,
@@ -175,7 +175,7 @@ pub struct Config {
 
 Let's break down this code. This defines a normal Rust `struct` with two fields: `id` and `world_size`. We have decorated the struct with the `spacetimedb::table` macro. This procedural Rust macro signals to SpacetimeDB that it should create a new SpacetimeDB table with the row type defined by the `Config` type's fields.
 
-The `spacetimedb::table` macro takes two parameters, a `name` which is the name of the table and what you will use to query the table in SQL, and a `public` visibility modifier which ensures that the rows of this table are visible to everyone.
+The `spacetimedb::table` macro takes two parameters, an `accessor` which is the name of the table and what you will use to query the table in SQL, and a `public` visibility modifier which ensures that the rows of this table are visible to everyone.
 
 The `#[primary_key]` attribute, specifies that the `id` field should be used as the primary key of the table.
 </TabItem>
@@ -284,7 +284,7 @@ pub struct DbVector2 {
 Let's create a few tables to represent entities in our game.
 
 ```rust
-#[spacetimedb::table(name = entity, public)]
+#[spacetimedb::table(accessor = entity, public)]
 #[derive(Debug, Clone)]
 pub struct Entity {
     // The `auto_inc` attribute indicates to SpacetimeDB that
@@ -296,7 +296,7 @@ pub struct Entity {
     pub mass: i32,
 }
 
-#[spacetimedb::table(name = circle, public)]
+#[spacetimedb::table(accessor = circle, public)]
 pub struct Circle {
     #[primary_key]
     pub entity_id: i32,
@@ -307,7 +307,7 @@ pub struct Circle {
     pub last_split_time: Timestamp,
 }
 
-#[spacetimedb::table(name = food, public)]
+#[spacetimedb::table(accessor = food, public)]
 pub struct Food {
     #[primary_key]
     pub entity_id: i32,
@@ -398,7 +398,7 @@ There are a few new concepts we should touch on. First of all, we are using the 
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = player, public)]
+#[spacetimedb::table(accessor = player, public)]
 #[derive(Debug, Clone)]
 pub struct Player {
     #[primary_key]
@@ -657,7 +657,6 @@ This will generate a set of files in the `blackholio/Source/blackholio/Private/M
 
 ```
 ├── Reducers
-│   └── Connect.g.h
 ├── Tables
 │   ├── CircleTable.g.h
 │   ├── ConfigTable.g.h
@@ -796,7 +795,7 @@ void AGameManager::BeginPlay()
     FOnDisconnectDelegate DisconnectDelegate;
     BIND_DELEGATE_SAFE(DisconnectDelegate, this, AGameManager, HandleDisconnect);
     FOnConnectErrorDelegate ConnectErrorDelegate;
-    BIND_DELEGATE_SAFE(ConnectErrorDelegate, this, AGameManager, HandleConnect);
+    BIND_DELEGATE_SAFE(ConnectErrorDelegate, this, AGameManager, HandleConnectError);
 
     UCredentials::Init(*TokenFilePath);
     FString Token = UCredentials::LoadToken();

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00400-part-3.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00400-part-3.md
@@ -258,7 +258,7 @@ Note the `Scheduled = nameof(SpawnFood)` parameter in the table macro. This tell
 In order to schedule a reducer to be called we have to create a new table which specifies when and how a reducer should be called. Add this new table to the top of the file, below your imports.
 
 ```rust
-#[spacetimedb::table(name = spawn_food_timer, scheduled(spawn_food))]
+#[spacetimedb::table(accessor = spawn_food_timer, scheduled(spawn_food))]
 pub struct SpawnFoodTimer {
     #[primary_key]
     #[auto_inc]
@@ -414,7 +414,7 @@ Let's add a second table to our `Player` struct. Modify the `Player` struct by a
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = logged_out_player)]
+#[spacetimedb::table(accessor = logged_out_player)]
 ```
 
 </TabItem>
@@ -449,8 +449,8 @@ public partial struct Player
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = player, public)]
-#[spacetimedb::table(name = logged_out_player)]
+#[spacetimedb::table(accessor = player, public)]
+#[spacetimedb::table(accessor = logged_out_player)]
 #[derive(Debug, Clone)]
 pub struct Player {
     #[primary_key]

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00500-part-4.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00500-part-4.md
@@ -373,7 +373,7 @@ public static void MoveAllPlayers(ReducerContext ctx, MoveAllPlayersTimer timer)
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = move_all_players_timer, scheduled(move_all_players))]
+#[spacetimedb::table(accessor = move_all_players_timer, scheduled(move_all_players))]
 pub struct MoveAllPlayersTimer {
     #[primary_key]
     #[auto_inc]


### PR DESCRIPTION
# Description of Changes
- Updated the tutorials to use `accessor` in place of `name` for Rust table definitions
- Removed incorrect file listings for Connect reducer as it's now private
- Fixed a bug in the Unreal tutorial to bind to correct method for error handling

# API and ABI breaking changes

N/A

# Expected complexity level and risk
1- Documentation update only

# Testing
- [x] Tested the connect error build for Unreal
- [x] Discovered these issues through manual test of the tutorials
