### PR TITLE
Rust docs updated for `name` to `accessor`

### DIFF
--- a/crates/bindings/README.md
+++ b/crates/bindings/README.md
@@ -115,7 +115,7 @@ The project's `lib.rs` will contain the following skeleton:
 # #[cfg(target_arch = "wasm32")] mod demo {
 use spacetimedb::{ReducerContext, Table};
 
-#[spacetimedb::table(name = person)]
+#[spacetimedb::table(accessor = person)]
 pub struct Person {
     name: String
 }

--- a/crates/bindings/README.md
+++ b/crates/bindings/README.md
@@ -456,7 +456,7 @@ SpacetimeDB supports both single- and multi-column [B-Tree](https://en.wikipedia
 
 Indexes are declared using the syntax:
 
-[`#[table(..., index(name = my_index, btree(columns = [a, b, c]))]`](macro@crate::table#index).
+[`#[table(..., index(accessor = my_index, btree(columns = [a, b, c]))]`](macro@crate::table#index).
 
 For example:
 
@@ -464,7 +464,7 @@ For example:
 # #[cfg(target_arch = "wasm32")] mod demo {
 use spacetimedb::table;
 
-#[table(accessor = paper, index(name = url_and_country, btree(columns = [url, country])))]
+#[table(accessor = paper, index(accessor = url_and_country, btree(columns = [url, country])))]
 struct Paper {
     url: String,
     country: String,

--- a/crates/smoketests/DEVELOP.md
+++ b/crates/smoketests/DEVELOP.md
@@ -77,7 +77,7 @@ use spacetimedb_smoketests::Smoketest;
 const MODULE_CODE: &str = r#"
 use spacetimedb::{ReducerContext, Table};
 
-#[spacetimedb::table(name = example, public)]
+#[spacetimedb::table(accessor = example, public)]
 pub struct Example { value: u64 }
 
 #[spacetimedb::reducer]

--- a/docs/docs/00100-intro/00100-getting-started/00400-key-architecture.md
+++ b/docs/docs/00100-intro/00100-getting-started/00400-key-architecture.md
@@ -61,7 +61,7 @@ public partial struct Player
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = players, public)]
+#[spacetimedb::table(accessor = players, public)]
 pub struct Player {
    #[primary_key]
    id: u64,

--- a/docs/docs/00100-intro/00200-quickstarts/00500-rust.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00500-rust.md
@@ -67,7 +67,7 @@ my-spacetime-app/
 ```rust
 use spacetimedb::{ReducerContext, Table};
 
-#[spacetimedb::table(name = person, public)]
+#[spacetimedb::table(accessor = person, public)]
 pub struct Person {
     name: String,
 }

--- a/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00300-part-2.md
+++ b/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00300-part-2.md
@@ -166,7 +166,7 @@ Let's start by defining the `Config` table. This is a simple table which will st
 ```rust
 // We're using this table as a singleton, so in this table
 // there only be one element where the `id` is 0.
-#[spacetimedb::table(name = config, public)]
+#[spacetimedb::table(accessor = config, public)]
 pub struct Config {
     #[primary_key]
     pub id: i32,
@@ -284,7 +284,7 @@ pub struct DbVector2 {
 Let's create a few tables to represent entities in our game.
 
 ```rust
-#[spacetimedb::table(name = entity, public)]
+#[spacetimedb::table(accessor = entity, public)]
 #[derive(Debug, Clone)]
 pub struct Entity {
     // The `auto_inc` attribute indicates to SpacetimeDB that
@@ -296,7 +296,7 @@ pub struct Entity {
     pub mass: i32,
 }
 
-#[spacetimedb::table(name = circle, public)]
+#[spacetimedb::table(accessor = circle, public)]
 pub struct Circle {
     #[primary_key]
     pub entity_id: i32,
@@ -307,7 +307,7 @@ pub struct Circle {
     pub last_split_time: Timestamp,
 }
 
-#[spacetimedb::table(name = food, public)]
+#[spacetimedb::table(accessor = food, public)]
 pub struct Food {
     #[primary_key]
     pub entity_id: i32,
@@ -399,7 +399,7 @@ There are a few new concepts we should touch on. First of all, we are using the 
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = player, public)]
+#[spacetimedb::table(accessor = player, public)]
 #[derive(Debug, Clone)]
 pub struct Player {
     #[primary_key]

--- a/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00400-part-3.md
+++ b/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00400-part-3.md
@@ -259,7 +259,7 @@ Note the `Scheduled = nameof(SpawnFood)` parameter in the table macro. This tell
 In order to schedule a reducer to be called we have to create a new table which specifies when and how a reducer should be called. Add this new table to the top of the file, below your imports.
 
 ```rust
-#[spacetimedb::table(name = spawn_food_timer, scheduled(spawn_food))]
+#[spacetimedb::table(accessor = spawn_food_timer, scheduled(spawn_food))]
 pub struct SpawnFoodTimer {
     #[primary_key]
     #[auto_inc]
@@ -420,7 +420,7 @@ Let's add a second table to our `Player` struct. Modify the `Player` struct by a
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = logged_out_player)]
+#[spacetimedb::table(accessor = logged_out_player)]
 ```
 
 </TabItem>
@@ -455,8 +455,8 @@ public partial struct Player
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = player, public)]
-#[spacetimedb::table(name = logged_out_player)]
+#[spacetimedb::table(accessor = player, public)]
+#[spacetimedb::table(accessor = logged_out_player)]
 #[derive(Debug, Clone)]
 pub struct Player {
     #[primary_key]

--- a/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00500-part-4.md
+++ b/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00500-part-4.md
@@ -374,7 +374,7 @@ public static void MoveAllPlayers(ReducerContext ctx, MoveAllPlayersTimer timer)
 <TabItem value="rust" label="Rust" >
 
 ```rust
-#[spacetimedb::table(name = move_all_players_timer, scheduled(move_all_players))]
+#[spacetimedb::table(accessor = move_all_players_timer, scheduled(move_all_players))]
 pub struct MoveAllPlayersTimer {
     #[primary_key]
     #[auto_inc]

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00300-part-2.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00300-part-2.md
@@ -165,7 +165,7 @@ Let's start by defining the `Config` table. This is a simple table which will st
 ```rust
 // We're using this table as a singleton, so in this table
 // there will only be one element where the `id` is 0.
-#[spacetimedb::table(name = config, public)]
+#[spacetimedb::table(accessor = config, public)]
 pub struct Config {
     #[primary_key]
     pub id: i32,
@@ -284,7 +284,7 @@ pub struct DbVector2 {
 Let's create a few tables to represent entities in our game.
 
 ```rust
-#[spacetimedb::table(name = entity, public)]
+#[spacetimedb::table(accessor = entity, public)]
 #[derive(Debug, Clone)]
 pub struct Entity {
     // The `auto_inc` attribute indicates to SpacetimeDB that
@@ -296,7 +296,7 @@ pub struct Entity {
     pub mass: i32,
 }
 
-#[spacetimedb::table(name = circle, public)]
+#[spacetimedb::table(accessor = circle, public)]
 pub struct Circle {
     #[primary_key]
     pub entity_id: i32,
@@ -307,7 +307,7 @@ pub struct Circle {
     pub last_split_time: Timestamp,
 }
 
-#[spacetimedb::table(name = food, public)]
+#[spacetimedb::table(accessor = food, public)]
 pub struct Food {
     #[primary_key]
     pub entity_id: i32,
@@ -398,7 +398,7 @@ There are a few new concepts we should touch on. First of all, we are using the 
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = player, public)]
+#[spacetimedb::table(accessor = player, public)]
 #[derive(Debug, Clone)]
 pub struct Player {
     #[primary_key]

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00400-part-3.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00400-part-3.md
@@ -258,7 +258,7 @@ Note the `Scheduled = nameof(SpawnFood)` parameter in the table macro. This tell
 In order to schedule a reducer to be called we have to create a new table which specifies when and how a reducer should be called. Add this new table to the top of the file, below your imports.
 
 ```rust
-#[spacetimedb::table(name = spawn_food_timer, scheduled(spawn_food))]
+#[spacetimedb::table(accessor = spawn_food_timer, scheduled(spawn_food))]
 pub struct SpawnFoodTimer {
     #[primary_key]
     #[auto_inc]
@@ -414,7 +414,7 @@ Let's add a second table to our `Player` struct. Modify the `Player` struct by a
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = logged_out_player)]
+#[spacetimedb::table(accessor = logged_out_player)]
 ```
 
 </TabItem>
@@ -449,8 +449,8 @@ public partial struct Player
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = player, public)]
-#[spacetimedb::table(name = logged_out_player)]
+#[spacetimedb::table(accessor = player, public)]
+#[spacetimedb::table(accessor = logged_out_player)]
 #[derive(Debug, Clone)]
 pub struct Player {
     #[primary_key]

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00500-part-4.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00500-part-4.md
@@ -373,7 +373,7 @@ public static void MoveAllPlayers(ReducerContext ctx, MoveAllPlayersTimer timer)
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = move_all_players_timer, scheduled(move_all_players))]
+#[spacetimedb::table(accessor = move_all_players_timer, scheduled(move_all_players))]
 pub struct MoveAllPlayersTimer {
     #[primary_key]
     #[auto_inc]

--- a/docs/docs/00200-core-concepts/00100-databases/00500-cheat-sheet.md
+++ b/docs/docs/00200-core-concepts/00100-databases/00500-cheat-sheet.md
@@ -150,7 +150,7 @@ pub struct Player {
 }
 
 // Multi-column index
-#[table(accessor = score, index(name = idx, btree(columns = [player_id, level])))]
+#[table(accessor = score, index(accessor = idx, btree(columns = [player_id, level])))]
 pub struct Score {
     player_id: u64,
     level: u32,

--- a/docs/docs/00200-core-concepts/00100-databases/00500-migrations/00300-incremental-migrations.md
+++ b/docs/docs/00200-core-concepts/00100-databases/00500-migrations/00300-incremental-migrations.md
@@ -19,7 +19,7 @@ For example, imagine we have a table `player` which stores information about our
 <!-- TODO: switchable language widget with C# version of below code. -->
 
 ```rust
-#[spacetimedb::table(name = character, public)]
+#[spacetimedb::table(accessor = character, public)]
 pub struct Character {
     #[primary_key]
     player_id: Identity,
@@ -130,7 +130,7 @@ See [the SATS JSON reference](/sats-json) for more on the encoding of arguments 
 Now we want to add a new feature: each player should be able to align themselves with the forces of good or evil, so we can get some healthy competition going between our players. We'll start each character off with `Alliance::Neutral`, and then offer them a reducer `choose_alliance` to set it to either `Alliance::Good` or `Alliance::Evil`. Our first attempt will be to add a new column to the type `Character`:
 
 ```rust
-#[spacetimedb::table(name = character, public)]
+#[spacetimedb::table(accessor = character, public)]
 struct Character {
     #[primary_key]
     player_id: Identity,
@@ -176,7 +176,7 @@ Adding a column alliance to table character requires a manual migration
 Instead, we'll add a new table, `character_v2`, which will coexist with our original `character` table:
 
 ```rust
-#[spacetimedb::table(name = character_v2, public)]
+#[spacetimedb::table(accessor = character_v2, public)]
 struct CharacterV2 {
     #[primary_key]
     player_id: Identity,

--- a/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00300-reducers.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00300-reducers.md
@@ -522,7 +522,7 @@ Reducers are designed to be free of side effects. They should only modify tables
 static mut COUNTER: u64 = 0;
 
 // ✅ Store state in a table instead
-#[spacetimedb::table(name = counter)]
+#[spacetimedb::table(accessor = counter)]
 pub struct Counter {
     #[primary_key]
     id: u32,
@@ -626,7 +626,7 @@ public partial class Module
 use spacetimedb::{ScheduleAt, ReducerContext, ProcedureContext, Table};
 use std::time::Duration;
 
-#[spacetimedb::table(name = fetch_schedule, scheduled(fetch_external_data))]
+#[spacetimedb::table(accessor = fetch_schedule, scheduled(fetch_external_data))]
 pub struct FetchSchedule {
     #[primary_key]
     #[auto_inc]

--- a/docs/docs/00200-core-concepts/00200-functions/00400-procedures.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00400-procedures.md
@@ -228,7 +228,7 @@ This means there's no `ctx.db` field to access the database.
 Instead, procedure code must manage transactions explicitly with `ProcedureContext::with_tx`.
 
 ```rust
-#[spacetimedb::table(name = my_table)]
+#[spacetimedb::table(accessor = my_table)]
 struct MyTable {
     a: u32,
     b: String,
@@ -516,7 +516,7 @@ may return a value, and that value will be returned to the calling procedure.
 Transaction return values are never saved or broadcast to clients, and are used only by the calling procedure.
 
 ```rust
-#[spacetimedb::table(name = player)]
+#[spacetimedb::table(accessor = player)]
 struct Player {
     id: spacetimedb::Identity,
     level: u32,

--- a/docs/docs/00200-core-concepts/00200-functions/00500-views.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00500-views.md
@@ -169,7 +169,7 @@ Use the `#[spacetimedb::view]` macro on a function:
 use spacetimedb::{view, ViewContext, AnonymousViewContext, table, SpacetimeType};
 use spacetimedb_lib::Identity;
 
-#[spacetimedb::table(name = player)]
+#[spacetimedb::table(accessor = player)]
 pub struct Player {
     #[primary_key]
     #[auto_inc]
@@ -179,7 +179,7 @@ pub struct Player {
     name: String,
 }
 
-#[spacetimedb::table(name = player_level)]
+#[spacetimedb::table(accessor = player_level)]
 pub struct PlayerLevel {
     #[unique]
     player_id: u64,
@@ -429,7 +429,7 @@ public static List<Player> HighScorers(AnonymousViewContext ctx)
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = player, public)]
+#[spacetimedb::table(accessor = player, public)]
 pub struct Player {
     #[primary_key]
     #[auto_inc]
@@ -598,7 +598,7 @@ public partial class Module
 ```rust
 use spacetimedb::{view, AnonymousViewContext, ViewContext};
 
-#[spacetimedb::table(name = entity, public)]
+#[spacetimedb::table(accessor = entity, public)]
 pub struct Entity {
     #[primary_key]
     #[auto_inc]
@@ -612,7 +612,7 @@ pub struct Entity {
     entity_type: String,
 }
 
-#[spacetimedb::table(name = player_chunk, public)]
+#[spacetimedb::table(accessor = player_chunk, public)]
 pub struct PlayerChunk {
     #[primary_key]
     player_id: u64,

--- a/docs/docs/00200-core-concepts/00300-tables.md
+++ b/docs/docs/00200-core-concepts/00300-tables.md
@@ -148,7 +148,7 @@ The `partial` modifier is required to allow code generation.
 Use the `#[spacetimedb::table]` macro on a struct:
 
 ```rust
-#[spacetimedb::table(name = person, public)]
+#[spacetimedb::table(accessor = person, public)]
 pub struct Person {
     #[primary_key]
     #[auto_inc]
@@ -244,7 +244,7 @@ The accessor name **exactly matches** the `name` attribute value:
 
 ```rust
 // Table definition
-#[spacetimedb::table(name = player, public)]
+#[spacetimedb::table(accessor = player, public)]
 pub struct Player { /* columns */ }
 
 // Accessor matches name exactly
@@ -326,10 +326,10 @@ public partial struct Secret { /* ... */ }
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = user, public)]
+#[spacetimedb::table(accessor = user, public)]
 pub struct User { /* ... */ }
 
-#[spacetimedb::table(name = secret)]
+#[spacetimedb::table(accessor = secret)]
 pub struct Secret { /* ... */ }
 ```
 
@@ -423,8 +423,8 @@ if (player != null)
 Apply multiple `#[spacetimedb::table]` attributes to the same struct:
 
 ```rust
-#[spacetimedb::table(name = player, public)]
-#[spacetimedb::table(name = logged_out_player)]
+#[spacetimedb::table(accessor = player, public)]
+#[spacetimedb::table(accessor = logged_out_player)]
 pub struct Player {
     #[primary_key]
     identity: Identity,

--- a/docs/docs/00200-core-concepts/00300-tables/00200-column-types.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00200-column-types.md
@@ -285,7 +285,7 @@ pub enum Status {
     Suspended { reason: String },
 }
 
-#[spacetimedb::table(name = player, public)]
+#[spacetimedb::table(accessor = player, public)]
 pub struct Player {
     // Primitive types
     #[primary_key]

--- a/docs/docs/00200-core-concepts/00300-tables/00210-file-storage.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00210-file-storage.md
@@ -92,7 +92,7 @@ public static partial class Module
 ```rust
 use spacetimedb::{ReducerContext, Timestamp, Table};
 
-#[spacetimedb::table(name = user_avatar, public)]
+#[spacetimedb::table(accessor = user_avatar, public)]
 pub struct UserAvatar {
     #[primary_key]
     user_id: u64,
@@ -271,7 +271,7 @@ public static partial class Module
 ```rust
 use spacetimedb::{Identity, ReducerContext, Timestamp, Table};
 
-#[spacetimedb::table(name = document, public)]
+#[spacetimedb::table(accessor = document, public)]
 pub struct Document {
     #[primary_key]
     #[auto_inc]
@@ -519,7 +519,7 @@ public static partial class Module
 ```rust
 use spacetimedb::{Identity, ProcedureContext, Timestamp, Table};
 
-#[spacetimedb::table(name = document, public)]
+#[spacetimedb::table(accessor = document, public)]
 pub struct Document {
     #[primary_key]
     #[auto_inc]
@@ -787,7 +787,7 @@ public partial class Module
 ```rust
 use spacetimedb::{Identity, Timestamp};
 
-#[spacetimedb::table(name = image, public)]
+#[spacetimedb::table(accessor = image, public)]
 pub struct Image {
     #[primary_key]
     #[auto_inc]

--- a/docs/docs/00200-core-concepts/00300-tables/00230-auto-increment.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00230-auto-increment.md
@@ -71,7 +71,7 @@ Auto-increment columns must be integer types: `sbyte`, `byte`, `short`, `ushort`
 ```rust
 use spacetimedb::{ReducerContext, Table};
 
-#[spacetimedb::table(name = post, public)]
+#[spacetimedb::table(accessor = post, public)]
 pub struct Post {
     #[primary_key]
     #[auto_inc]
@@ -214,7 +214,7 @@ public partial class Module
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = user, public)]
+#[spacetimedb::table(accessor = user, public)]
 pub struct User {
     #[auto_inc]
     user_id: u64,
@@ -287,14 +287,14 @@ If your application requires strictly sequential numbering without gaps, maintai
 use spacetimedb::{ReducerContext, Table};
 
 #[derive(Clone)]
-#[spacetimedb::table(name = counter, public)]
+#[spacetimedb::table(accessor = counter, public)]
 pub struct Counter {
     #[primary_key]
     name: String,
     value: u64,
 }
 
-#[spacetimedb::table(name = invoice, public)]
+#[spacetimedb::table(accessor = invoice, public)]
 pub struct Invoice {
     #[primary_key]
     invoice_number: u64,
@@ -328,7 +328,7 @@ This pattern guarantees sequential values because the counter update and row ins
 Auto-increment columns are commonly combined with primary keys:
 
 ```rust
-#[spacetimedb::table(name = post, public)]
+#[spacetimedb::table(accessor = post, public)]
 pub struct Post {
     #[primary_key]
     #[auto_inc]
@@ -340,7 +340,7 @@ pub struct Post {
 Auto-increment columns can also be combined with unique constraints:
 
 ```rust
-#[spacetimedb::table(name = item, public)]
+#[spacetimedb::table(accessor = item, public)]
 pub struct Item {
     #[primary_key]
     name: String,

--- a/docs/docs/00200-core-concepts/00300-tables/00240-constraints.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00240-constraints.md
@@ -51,7 +51,7 @@ Use the `[SpacetimeDB.PrimaryKey]` attribute to mark a field as the primary key.
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = user, public)]
+#[spacetimedb::table(accessor = user, public)]
 pub struct User {
     #[primary_key]
     id: u64,
@@ -136,7 +136,7 @@ public partial struct Inventory
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = inventory, public, index(name = inventory_index, btree(columns = [user_id, item_id])))]
+#[spacetimedb::table(accessor = inventory, public, index(name = inventory_index, btree(columns = [user_id, item_id])))]
 pub struct Inventory {
     #[primary_key]
     #[auto_inc]
@@ -256,7 +256,7 @@ Primary keys add indexing overhead. If your table is only accessed by iterating 
 **Auto-incrementing IDs**: Combine `primaryKey()` with `autoInc()` for automatically assigned unique identifiers:
 
 ```rust
-#[spacetimedb::table(name = post, public)]
+#[spacetimedb::table(accessor = post, public)]
 pub struct Post {
     #[primary_key]
     #[auto_inc]
@@ -269,7 +269,7 @@ pub struct Post {
 **Identity as primary key**: Use the caller's identity as the primary key for user-specific data:
 
 ```rust
-#[spacetimedb::table(name = user_profile, public)]
+#[spacetimedb::table(accessor = user_profile, public)]
 pub struct UserProfile {
     #[primary_key]
     identity: Identity,
@@ -324,7 +324,7 @@ Use the `[SpacetimeDB.Unique]` attribute.
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = user, public)]
+#[spacetimedb::table(accessor = user, public)]
 pub struct User {
     #[primary_key]
     id: u32,

--- a/docs/docs/00200-core-concepts/00300-tables/00240-constraints.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00240-constraints.md
@@ -136,7 +136,7 @@ public partial struct Inventory
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(accessor = inventory, public, index(name = inventory_index, btree(columns = [user_id, item_id])))]
+#[spacetimedb::table(accessor = inventory, public, index(accessor = inventory_index, btree(columns = [user_id, item_id])))]
 pub struct Inventory {
     #[primary_key]
     #[auto_inc]

--- a/docs/docs/00200-core-concepts/00300-tables/00250-default-values.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00250-default-values.md
@@ -65,7 +65,7 @@ The `[SpacetimeDB.Default(value)]` attribute specifies the default value. The va
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = player, public)]
+#[spacetimedb::table(accessor = player, public)]
 pub struct Player {
     #[primary_key]
     #[auto_inc]

--- a/docs/docs/00200-core-concepts/00300-tables/00300-indexes.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00300-indexes.md
@@ -73,7 +73,7 @@ const position = table(
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = position, public)]
+#[spacetimedb::table(accessor = position, public)]
 pub struct Position {
     #[primary_key]
     #[index(direct)]
@@ -135,7 +135,7 @@ public partial struct User
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = user, public)]
+#[spacetimedb::table(accessor = user, public)]
 pub struct User {
     #[primary_key]
     id: u32,
@@ -212,7 +212,7 @@ public partial struct User
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = user, public, index(name = idx_age, btree(columns = [age])))]
+#[spacetimedb::table(accessor = user, public, index(name = idx_age, btree(columns = [age])))]
 pub struct User {
     #[primary_key]
     id: u32,
@@ -278,7 +278,7 @@ public partial struct Score
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = score, public, index(name = by_player_and_level, btree(columns = [player_id, level])))]
+#[spacetimedb::table(accessor = score, public, index(name = by_player_and_level, btree(columns = [player_id, level])))]
 pub struct Score {
     player_id: u32,
     level: u32,

--- a/docs/docs/00200-core-concepts/00300-tables/00300-indexes.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00300-indexes.md
@@ -212,7 +212,7 @@ public partial struct User
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(accessor = user, public, index(name = idx_age, btree(columns = [age])))]
+#[spacetimedb::table(accessor = user, public, index(accessor = idx_age, btree(columns = [age])))]
 pub struct User {
     #[primary_key]
     id: u32,
@@ -278,7 +278,7 @@ public partial struct Score
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(accessor = score, public, index(name = by_player_and_level, btree(columns = [player_id, level])))]
+#[spacetimedb::table(accessor = score, public, index(accessor = by_player_and_level, btree(columns = [player_id, level])))]
 pub struct Score {
     player_id: u32,
     level: u32,

--- a/docs/docs/00200-core-concepts/00300-tables/00400-access-permissions.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00400-access-permissions.md
@@ -69,7 +69,7 @@ public partial struct Player
 
 ```rust
 // Private table (default) - only accessible from server-side code
-#[spacetimedb::table(name = internal_config)]
+#[spacetimedb::table(accessor = internal_config)]
 pub struct InternalConfig {
     #[primary_key]
     key: String,
@@ -77,7 +77,7 @@ pub struct InternalConfig {
 }
 
 // Public table - clients can subscribe and query
-#[spacetimedb::table(name = player, public)]
+#[spacetimedb::table(accessor = player, public)]
 pub struct Player {
     #[primary_key]
     #[auto_inc]
@@ -496,7 +496,7 @@ public partial class Module
 use spacetimedb::{Identity, Timestamp, ViewContext};
 
 // Private table containing all messages
-#[spacetimedb::table(name = message)]  // Private by default
+#[spacetimedb::table(accessor = message)]  // Private by default
 pub struct Message {
     #[primary_key]
     #[auto_inc]
@@ -664,7 +664,7 @@ public partial class Module
 use spacetimedb::{SpacetimeType, ViewContext, Timestamp, Identity};
 
 // Private table with sensitive data
-#[spacetimedb::table(name = user_account)]  // Private by default
+#[spacetimedb::table(accessor = user_account)]  // Private by default
 pub struct UserAccount {
     #[primary_key]
     #[auto_inc]
@@ -863,7 +863,7 @@ public partial class Module
 use spacetimedb::{SpacetimeType, Identity, ViewContext};
 
 // Private table with all employee data
-#[spacetimedb::table(name = employee)]
+#[spacetimedb::table(accessor = employee)]
 pub struct Employee {
     #[primary_key]
     id: u64,

--- a/docs/docs/00200-core-concepts/00300-tables/00500-schedule-tables.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00500-schedule-tables.md
@@ -69,7 +69,7 @@ public static partial class Module
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = reminder_schedule, scheduled(send_reminder))]
+#[spacetimedb::table(accessor = reminder_schedule, scheduled(send_reminder))]
 pub struct Reminder {
     #[primary_key]
     #[auto_inc]

--- a/docs/docs/00200-core-concepts/00300-tables/00600-performance.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00600-performance.md
@@ -155,7 +155,7 @@ public partial struct Player
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = player)]
+#[spacetimedb::table(accessor = player)]
 pub struct Player {
     id: u32,
     name: String,
@@ -289,7 +289,7 @@ public partial struct PlayerSettings
 <TabItem value="rust" label="Rust">
 
 ```rust
-#[spacetimedb::table(name = player)]
+#[spacetimedb::table(accessor = player)]
 pub struct Player {
     #[primary_key]
     id: u32,
@@ -297,7 +297,7 @@ pub struct Player {
     name: String,
 }
 
-#[spacetimedb::table(name = player_state)]
+#[spacetimedb::table(accessor = player_state)]
 pub struct PlayerState {
     #[unique]
     player_id: u32,
@@ -306,7 +306,7 @@ pub struct PlayerState {
     health: u32,
 }
 
-#[spacetimedb::table(name = player_stats)]
+#[spacetimedb::table(accessor = player_stats)]
 pub struct PlayerStats {
     #[unique]
     player_id: u32,
@@ -315,7 +315,7 @@ pub struct PlayerStats {
     play_time_seconds: u64,
 }
 
-#[spacetimedb::table(name = player_settings)]
+#[spacetimedb::table(accessor = player_settings)]
 pub struct PlayerSettings {
     #[unique]
     player_id: u32,
@@ -469,12 +469,12 @@ public partial struct InternalState { /* ... */ }
 
 ```rust
 // Public table - clients can subscribe and receive updates
-#[spacetimedb::table(name = player, public)]
+#[spacetimedb::table(accessor = player, public)]
 pub struct Player { /* ... */ }
 
 // Private table - only visible to module and owner
 // Better for internal state, caches, or sensitive data
-#[spacetimedb::table(name = internal_state)]
+#[spacetimedb::table(accessor = internal_state)]
 pub struct InternalState { /* ... */ }
 ```
 

--- a/docs/docs/00300-resources/00100-how-to/00600-migrating-to-2.0.md
+++ b/docs/docs/00300-resources/00100-how-to/00600-migrating-to-2.0.md
@@ -69,7 +69,7 @@ fn deal_damage(ctx: &ReducerContext, target: Identity, amount: u32) {
 **Server (module) -- after:**
 ```rust
 // 2.0 server -- explicitly publish events via an event table
-#[spacetimedb::table(name = damage_event, public, event)]
+#[spacetimedb::table(accessor = damage_event, public, event)]
 pub struct DamageEvent {
     pub target: Identity,
     pub amount: u32,

--- a/docs/docs/00300-resources/00200-reference/00400-sql-reference.md
+++ b/docs/docs/00300-resources/00200-reference/00400-sql-reference.md
@@ -583,8 +583,8 @@ public partial struct Orders
 
 ```rust
 #[table(
-    name = Inventory,
-    index(name = product_name, btree = [name]),
+    accessor = Inventory,
+    index(accessor = product_name, btree = [name]),
     public
 )]
 struct Inventory {
@@ -595,7 +595,7 @@ struct Inventory {
 }
 
 #[table(
-    name = Customers,
+    accessor = Customers,
     public
 )]
 struct Customers {
@@ -607,7 +607,7 @@ struct Customers {
 }
 
 #[table(
-    name = Orders,
+    accessor = Orders,
     public
 )]
 struct Orders {

--- a/docs/static/ai-rules/spacetimedb-rust.mdc
+++ b/docs/static/ai-rules/spacetimedb-rust.mdc
@@ -30,11 +30,11 @@ pub struct User { ... }
 
 // ❌ WRONG — SpacetimeType on tables (causes conflicts!)
 #[derive(SpacetimeType)]
-#[table(name = my_table)]
+#[table(accessor = my_table)]
 pub struct MyTable { ... }
 
 // ✅ CORRECT — use #[table(...)] macro with options, NO SpacetimeType
-#[table(name = user, public)]
+#[table(accessor = user, public)]
 pub struct User {
     #[primary_key]
     identity: Identity,
@@ -194,7 +194,7 @@ The SpacetimeDB Rust client SDK uses blocking I/O. If mixing with async runtimes
 | `ctx.db.player().find(id)` | `ctx.db.player().id().find(&id)` | Must access via index |
 | `&mut ReducerContext` | `&ReducerContext` | Wrong context type |
 | Missing `use spacetimedb::Table;` | Add import | "no method named `insert`" |
-| `#[table(name = "my_table")]` | `#[table(name = my_table)]` | String literals not allowed |
+| `#[table(accessor = "my_table")]` | `#[table(accessor = my_table)]` | String literals not allowed |
 | Missing `public` on table | Add `public` flag | Clients can't subscribe |
 | `#[spacetimedb::reducer]` | `#[reducer]` after import | Wrong attribute path |
 | Network/filesystem in reducer | Use procedures instead | Sandbox violation |
@@ -213,11 +213,11 @@ use spacetimedb::{table, reducer, Table, ReducerContext, Identity, Timestamp};
 
 // ❌ WRONG — DO NOT derive SpacetimeType on tables!
 #[derive(SpacetimeType)]  // REMOVE THIS!
-#[table(name = task)]
+#[table(accessor = task)]
 pub struct Task { ... }
 
 // ✅ CORRECT — just the #[table] attribute
-#[table(name = user, public)]
+#[table(accessor = user, public)]
 pub struct User {
     #[primary_key]
     identity: Identity,
@@ -228,7 +228,7 @@ pub struct User {
     online: bool,
 }
 
-#[table(name = message, public)]
+#[table(accessor = message, public)]
 pub struct Message {
     #[primary_key]
     #[auto_inc]
@@ -240,7 +240,7 @@ pub struct Message {
 }
 
 // With multi-column index
-#[table(name = task, public, index(name = by_owner, btree(columns = [owner_id])))]
+#[table(accessor = task, public, index(name = by_owner, btree(columns = [owner_id])))]
 pub struct Task {
     #[primary_key]
     #[auto_inc]
@@ -253,8 +253,8 @@ pub struct Task {
 ### Table Options
 
 ```rust
-#[table(name = my_table)]           // Private table (default)
-#[table(name = my_table, public)]   // Public table - clients can subscribe
+#[table(accessor = my_table)]           // Private table (default)
+#[table(accessor = my_table, public)]   // Public table - clients can subscribe
 ```
 
 ### Column Attributes
@@ -399,7 +399,7 @@ if let Some(user) = user {
 ### BTree Index — `.filter()` returns iterator
 
 ```rust
-#[table(name = message, public)]
+#[table(accessor = message, public)]
 pub struct Message {
     #[primary_key]
     #[auto_inc]
@@ -453,7 +453,7 @@ pub enum PlayerStatus {
 }
 
 // Use in table (DO NOT derive SpacetimeType on the table!)
-#[table(name = player, public)]
+#[table(accessor = player, public)]
 pub struct Player {
     #[primary_key]
     pub id: Identity,
@@ -469,7 +469,7 @@ pub struct Player {
 ```rust
 use spacetimedb::{table, reducer, ReducerContext, ScheduleAt, Timestamp};
 
-#[table(name = cleanup_job, scheduled(cleanup_expired))]
+#[table(accessor = cleanup_job, scheduled(cleanup_expired))]
 pub struct CleanupJob {
     #[primary_key]
     #[auto_inc]

--- a/docs/static/llms.md
+++ b/docs/static/llms.md
@@ -353,7 +353,7 @@ Database tables store the application's persistent state. They are defined using
   - Avoid manually inserting values into `#[auto_inc]` fields that are also `#[unique]`, especially values larger than the current sequence counter, as this can lead to future unique constraint violations when the counter catches up.
   - Ensure `public` is set if clients need access.
   - Do not manually derive `SpacetimeType`.
-  - Define indexes _within_ the main `#[table(name=..., index=...)]` attribute. Each `#[table]` macro invocation defines a _distinct_ table and requires a `name`; separate `#[table]` attributes cannot be used solely to add indexes to a previously named table.
+  - Define indexes _within_ the main `#[table(accessor=..., index=...)]` attribute. Each `#[table]` macro invocation defines a _distinct_ table and requires an `accessor`; separate `#[table]` attributes cannot be used solely to add indexes to a previously named table.
 
 ```rust
 use spacetimedb::{table, Identity, Timestamp, SpacetimeType, Table}; // Added Table import
@@ -891,7 +891,7 @@ Views are defined using the `#[view]` macro and must specify a `name` and `publi
 use spacetimedb::{view, ViewContext, AnonymousViewContext, table, SpacetimeType};
 use spacetimedb_lib::Identity;
 
-#[spacetimedb::table(name = player, public)]
+#[spacetimedb::table(accessor = player, public)]
 pub struct Player {
     #[primary_key]
     #[auto_inc]
@@ -901,7 +901,7 @@ pub struct Player {
     name: String,
 }
 
-#[spacetimedb::table(name = player_level, public)]
+#[spacetimedb::table(accessor = player_level, public)]
 pub struct PlayerLevel {
     #[unique]
     player_id: u64,
@@ -1335,7 +1335,7 @@ Database tables store the application's persistent state. They are defined using
   - Avoid manually inserting values into `[AutoInc]` fields that are also `[Unique]`, especially values larger than the current sequence counter, as this can lead to future unique constraint violations when the counter catches up.
   - Ensure `Public = true` is set if clients need access.
   - Always use the `partial` keyword on table definitions.
-  - Define indexes _within_ the main `#[table(name=..., index=...)]` attribute. Each `#[table]` macro invocation defines a _distinct_ table and requires a `name`; separate `#[table]` attributes cannot be used solely to add indexes to a previously named table.
+  - Define indexes _within_ the main `#[table(accessor=..., index=...)]` attribute. Each `#[table]` macro invocation defines a _distinct_ table and requires an `accessor`; separate `#[table]` attributes cannot be used solely to add indexes to a previously named table.
 
 ```csharp
 using SpacetimeDB;

--- a/docs/static/llms.md
+++ b/docs/static/llms.md
@@ -345,7 +345,7 @@ Database tables store the application's persistent state. They are defined using
 - **Primary Keys:** Designate a single field as the primary key using `#[primary_key]`. This ensures uniqueness, creates an efficient index, and allows clients to track row updates.
 - **Auto-Increment:** Mark an integer-typed primary key field with `#[auto_inc]` to have SpacetimeDB automatically assign unique, sequentially increasing values upon insertion. Provide `0` as the value for this field when inserting a new row to trigger the auto-increment mechanism.
 - **Unique Constraints:** Enforce uniqueness on non-primary key fields using `#[unique]`. Attempts to insert or update rows violating this constraint will fail.
-- **Indexes:** Create B-tree indexes for faster lookups on specific fields or combinations of fields. Use `#[index(btree)]` on a single field for a simple index, or `#[table(index(name = my_index_name, btree(columns = [col_a, col_b])))])` within the `#[table(...)]` attribute for named, multi-column indexes.
+- **Indexes:** Create B-tree indexes for faster lookups on specific fields or combinations of fields. Use `#[index(btree)]` on a single field for a simple index, or `#[table(index(accessor = my_index_name, btree(columns = [col_a, col_b])))])` within the `#[table(...)]` attribute for named, multi-column indexes.
 - **Nullable Fields:** Use standard Rust `Option<T>` for fields that can hold null values.
 - **Instances vs. Database:** Remember that table struct instances (e.g., `let player = PlayerState { ... };`) are just data. Modifying an instance does **not** automatically update the database. Interaction happens through generated handles accessed via the `ReducerContext` (e.g., `ctx.db.player_state().insert(...)`).
 - **Case Sensitivity:** Table names specified via `name = ...` are case-sensitive and must be matched exactly in SQL queries.
@@ -362,10 +362,10 @@ use spacetimedb::{table, Identity, Timestamp, SpacetimeType, Table}; // Added Ta
 
 // Example Table Definition
 #[table(
-    name = player_state,
+    accessor = player_state,
     public,
     // Index definition is included here
-    index(name = idx_level_btree, btree(columns = [level]))
+    index(accessor = idx_level_btree, btree(columns = [level]))
 )]
 #[derive(Clone, Debug)] // No SpacetimeType needed here
 pub struct PlayerState {
@@ -640,7 +640,7 @@ SpacetimeDB provides powerful ways to filter and delete table rows using B-tree 
 ```rust
 use spacetimedb::{table, reducer, ReducerContext, Table, log};
 
-#[table(accessor = points, index(name = idx_xy, btree(columns = [x, y])))]
+#[table(accessor = points, index(accessor = idx_xy, btree(columns = [x, y])))]
 #[derive(Clone, Debug)]
 pub struct Point { #[primary_key] id: u64, x: i64, y: i64 }
 #[table(accessor = items, index(btree(columns = [name])))]

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_001_basic_tables/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_001_basic_tables/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::table;
 
-#[table(name = user)]
+#[table(accessor = user)]
 pub struct User {
     #[primary_key]
     pub id: i32,
@@ -9,7 +9,7 @@ pub struct User {
     pub active: bool,
 }
 
-#[table(name = product)]
+#[table(accessor = product)]
 pub struct Product {
     #[primary_key]
     pub id: i32,
@@ -18,7 +18,7 @@ pub struct Product {
     pub in_stock: bool,
 }
 
-#[table(name = note)]
+#[table(accessor = note)]
 pub struct Note {
     #[primary_key]
     pub id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_002_scheduled_table/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_002_scheduled_table/answers/rust.rs
@@ -1,7 +1,7 @@
 use spacetimedb::{reducer, table, ReducerContext, ScheduleAt, Table};
 use std::time::Duration;
 
-#[table(name = tick_timer, scheduled(tick))]
+#[table(accessor = tick_timer, scheduled(tick))]
 pub struct TickTimer {
     #[primary_key]
     #[auto_inc]

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_003_struct_in_table/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_003_struct_in_table/answers/rust.rs
@@ -6,10 +6,9 @@ pub struct Position {
     pub y: i32,
 }
 
-#[table(name = entity)]
+#[table(accessor = entity)]
 pub struct Entity {
     #[primary_key]
     pub id: i32,
     pub pos: Position,
 }
-

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(name = user)]
+#[table(accessor = user)]
 pub struct User {
     #[primary_key]
     pub id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext};
 
-#[table(name = user)]
+#[table(accessor = user)]
 pub struct User {
     #[primary_key]
     pub id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext};
 
-#[table(name = user)]
+#[table(accessor = user)]
 pub struct User {
     #[primary_key]
     pub id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(name = user)]
+#[table(accessor = user)]
 pub struct User {
     #[primary_key]
     pub id: i32,
@@ -11,8 +11,23 @@ pub struct User {
 
 #[reducer]
 pub fn crud(ctx: &ReducerContext) {
-    ctx.db.user().insert(User { id: 1, name: "Alice".into(), age: 30, active: true });
-    ctx.db.user().insert(User { id: 2, name: "Bob".into(),   age: 22, active: false });
-    ctx.db.user().id().update(User { id: 1, name: "Alice2".into(), age: 31, active: false });
+    ctx.db.user().insert(User {
+        id: 1,
+        name: "Alice".into(),
+        age: 30,
+        active: true,
+    });
+    ctx.db.user().insert(User {
+        id: 2,
+        name: "Bob".into(),
+        age: 22,
+        active: false,
+    });
+    ctx.db.user().id().update(User {
+        id: 1,
+        name: "Alice2".into(),
+        age: 31,
+        active: false,
+    });
     ctx.db.user().id().delete(2);
 }

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(name = user)]
+#[table(accessor = user)]
 pub struct User {
     #[primary_key]
     pub id: i32,
@@ -9,7 +9,7 @@ pub struct User {
     pub active: bool,
 }
 
-#[table(name = result)]
+#[table(accessor = result)]
 pub struct ResultRow {
     #[primary_key]
     pub id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(name = user)]
+#[table(accessor = user)]
 pub struct User {
     #[primary_key]
     pub id: i32,
@@ -11,6 +11,16 @@ pub struct User {
 
 #[reducer(init)]
 pub fn init(ctx: &ReducerContext) {
-    ctx.db.user().insert(User { id: 1, name: "Alice".into(), age: 30, active: true });
-    ctx.db.user().insert(User { id: 2, name: "Bob".into(),   age: 22, active: false });
+    ctx.db.user().insert(User {
+        id: 1,
+        name: "Alice".into(),
+        age: 30,
+        active: true,
+    });
+    ctx.db.user().insert(User {
+        id: 2,
+        name: "Bob".into(),
+        age: 22,
+        active: false,
+    });
 }

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_010_connect/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_010_connect/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(name = event)]
+#[table(accessor = event)]
 pub struct Event {
     #[primary_key]
     #[auto_inc]
@@ -10,10 +10,16 @@ pub struct Event {
 
 #[reducer(client_connected)]
 pub fn client_connected(ctx: &ReducerContext) {
-    ctx.db.event().insert(Event { id: 0, kind: "connected".into() });
+    ctx.db.event().insert(Event {
+        id: 0,
+        kind: "connected".into(),
+    });
 }
 
 #[reducer(client_disconnected)]
 pub fn client_disconnected(ctx: &ReducerContext) {
-    ctx.db.event().insert(Event { id: 0, kind: "disconnected".into() });
+    ctx.db.event().insert(Event {
+        id: 0,
+        kind: "disconnected".into(),
+    });
 }

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/answers/rust.rs
@@ -1,13 +1,15 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(name = result)]
+#[table(accessor = result)]
 pub struct ResultRow {
     #[primary_key]
     pub id: i32,
     pub sum: i32,
 }
 
-fn add(a: i32, b: i32) -> i32 { a + b }
+fn add(a: i32, b: i32) -> i32 {
+    a + b
+}
 
 #[reducer]
 pub fn compute_sum(ctx: &ReducerContext, id: i32, a: i32, b: i32) {

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/answers/rust.rs
@@ -6,7 +6,7 @@ pub struct Score {
     pub right: i32,
 }
 
-#[table(name = result)]
+#[table(accessor = result)]
 pub struct ResultRow {
     #[primary_key]
     pub id: i32,
@@ -15,5 +15,8 @@ pub struct ResultRow {
 
 #[reducer]
 pub fn set_score(ctx: &ReducerContext, id: i32, left: i32, right: i32) {
-    ctx.db.result().insert(ResultRow { id, value: Score { left, right } });
+    ctx.db.result().insert(ResultRow {
+        id,
+        value: Score { left, right },
+    });
 }

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/answers/rust.rs
@@ -12,7 +12,7 @@ pub enum Shape {
     Rectangle(Rect),
 }
 
-#[table(name = result)]
+#[table(accessor = result)]
 pub struct ResultRow {
     #[primary_key]
     pub id: i32,
@@ -21,5 +21,8 @@ pub struct ResultRow {
 
 #[reducer]
 pub fn set_circle(ctx: &ReducerContext, id: i32, radius: i32) {
-    ctx.db.result().insert(ResultRow { id, value: Shape::Circle(radius) });
+    ctx.db.result().insert(ResultRow {
+        id,
+        value: Shape::Circle(radius),
+    });
 }

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(name = primitive)]
+#[table(accessor = primitive)]
 pub struct Primitive {
     #[primary_key]
     pub id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/answers/rust.rs
@@ -12,7 +12,7 @@ pub struct Position {
     pub y: i32,
 }
 
-#[table(name = profile)]
+#[table(accessor = profile)]
 pub struct Profile {
     #[primary_key]
     pub id: i32,
@@ -25,8 +25,14 @@ pub struct Profile {
 pub fn seed(ctx: &ReducerContext) {
     ctx.db.profile().insert(Profile {
         id: 1,
-        home: Address { street: "1 Main".into(),  zip: 11111 },
-        work: Address { street: "2 Broad".into(), zip: 22222 },
-        pos:  Position { x: 7, y: 9 },
+        home: Address {
+            street: "1 Main".into(),
+            zip: 11111,
+        },
+        work: Address {
+            street: "2 Broad".into(),
+            zip: 22222,
+        },
+        pos: Position { x: 7, y: 9 },
     });
 }

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/answers/rust.rs
@@ -12,7 +12,7 @@ pub enum Shape {
     Rectangle(Rect),
 }
 
-#[table(name = drawing)]
+#[table(accessor = drawing)]
 pub struct Drawing {
     #[primary_key]
     pub id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/answers/rust.rs
@@ -1,7 +1,7 @@
 use spacetimedb::{reducer, table, ReducerContext, ScheduleAt, Table};
 use std::time::Duration;
 
-#[table(name = tick_timer, scheduled(tick))]
+#[table(accessor = tick_timer, scheduled(tick))]
 pub struct TickTimer {
     #[primary_key]
     #[auto_inc]
@@ -10,8 +10,7 @@ pub struct TickTimer {
 }
 
 #[reducer]
-pub fn tick(_ctx: &ReducerContext, _schedule: TickTimer) {
-}
+pub fn tick(_ctx: &ReducerContext, _schedule: TickTimer) {}
 
 #[reducer(init)]
 pub fn init(ctx: &ReducerContext) {

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/answers/rust.rs
@@ -1,8 +1,8 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
 #[table(
-    name = account,
-    index(name = by_name, btree(columns = [name]))
+    accessor = account,
+    index(accessor = by_name, btree(columns = [name]))
 )]
 pub struct Account {
     #[primary_key]
@@ -14,6 +14,14 @@ pub struct Account {
 
 #[reducer]
 pub fn seed(ctx: &ReducerContext) {
-    ctx.db.account().insert(Account { id: 1, email: "a@example.com".into(), name: "Alice".into() });
-    ctx.db.account().insert(Account { id: 2, email: "b@example.com".into(), name: "Bob".into() });
+    ctx.db.account().insert(Account {
+        id: 1,
+        email: "a@example.com".into(),
+        name: "Alice".into(),
+    });
+    ctx.db.account().insert(Account {
+        id: 2,
+        email: "b@example.com".into(),
+        name: "Bob".into(),
+    });
 }

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/answers/rust.rs
@@ -1,13 +1,13 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(name = user)]
+#[table(accessor = user)]
 pub struct User {
     #[primary_key]
     pub user_id: i32,
     pub name: String,
 }
 
-#[table(name = group)]
+#[table(accessor = group)]
 pub struct Group {
     #[primary_key]
     pub group_id: i32,
@@ -28,13 +28,37 @@ pub struct Membership {
 
 #[reducer]
 pub fn seed(ctx: &ReducerContext) {
-    ctx.db.user().insert(User  { user_id: 1, name: "Alice".into() });
-    ctx.db.user().insert(User  { user_id: 2, name: "Bob".into()   });
+    ctx.db.user().insert(User {
+        user_id: 1,
+        name: "Alice".into(),
+    });
+    ctx.db.user().insert(User {
+        user_id: 2,
+        name: "Bob".into(),
+    });
 
-    ctx.db.group().insert(Group { group_id: 10, title: "Admin".into() });
-    ctx.db.group().insert(Group { group_id: 20, title: "Dev".into()   });
+    ctx.db.group().insert(Group {
+        group_id: 10,
+        title: "Admin".into(),
+    });
+    ctx.db.group().insert(Group {
+        group_id: 20,
+        title: "Dev".into(),
+    });
 
-    ctx.db.membership().insert(Membership { id: 1, user_id: 1, group_id: 10 });
-    ctx.db.membership().insert(Membership { id: 2, user_id: 1, group_id: 20 });
-    ctx.db.membership().insert(Membership { id: 3, user_id: 2, group_id: 20 });
+    ctx.db.membership().insert(Membership {
+        id: 1,
+        user_id: 1,
+        group_id: 10,
+    });
+    ctx.db.membership().insert(Membership {
+        id: 2,
+        user_id: 1,
+        group_id: 20,
+    });
+    ctx.db.membership().insert(Membership {
+        id: 3,
+        user_id: 2,
+        group_id: 20,
+    });
 }

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/answers/rust.rs
@@ -15,9 +15,9 @@ pub struct Group {
 }
 
 #[table(
-    name = membership,
-    index(name = by_user,  btree(columns = [user_id])),
-    index(name = by_group, btree(columns = [group_id]))
+    accessor = membership,
+    index(accessor = by_user,  btree(columns = [user_id])),
+    index(accessor = by_group, btree(columns = [group_id]))
 )]
 pub struct Membership {
     #[primary_key]

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/answers/rust.rs
@@ -1,12 +1,12 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(name = entity)]
+#[table(accessor = entity)]
 pub struct Entity {
     #[primary_key]
     pub id: i32,
 }
 
-#[table(name = position)]
+#[table(accessor = position)]
 pub struct Position {
     #[primary_key]
     pub entity_id: i32,
@@ -14,7 +14,7 @@ pub struct Position {
     pub y: i32,
 }
 
-#[table(name = velocity)]
+#[table(accessor = velocity)]
 pub struct Velocity {
     #[primary_key]
     pub entity_id: i32,
@@ -22,7 +22,7 @@ pub struct Velocity {
     pub vy: i32,
 }
 
-#[table(name = next_position)]
+#[table(accessor = next_position)]
 pub struct NextPosition {
     #[primary_key]
     pub entity_id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/answers/rust.rs
@@ -1,8 +1,8 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
 #[table(
-    name = log,
-    index(name = by_user_day, btree(columns = [user_id, day]))
+    accessor = log,
+    index(accessor = by_user_day, btree(columns = [user_id, day]))
 )]
 pub struct Log {
     #[primary_key]
@@ -14,7 +14,22 @@ pub struct Log {
 
 #[reducer]
 pub fn seed(ctx: &ReducerContext) {
-    ctx.db.log().insert(Log { id: 1, user_id: 7, day: 1, message: "a".into() });
-    ctx.db.log().insert(Log { id: 2, user_id: 7, day: 2, message: "b".into() });
-    ctx.db.log().insert(Log { id: 3, user_id: 9, day: 1, message: "c".into() });
+    ctx.db.log().insert(Log {
+        id: 1,
+        user_id: 7,
+        day: 1,
+        message: "a".into(),
+    });
+    ctx.db.log().insert(Log {
+        id: 2,
+        user_id: 7,
+        day: 2,
+        message: "b".into(),
+    });
+    ctx.db.log().insert(Log {
+        id: 3,
+        user_id: 9,
+        day: 1,
+        message: "c".into(),
+    });
 }


### PR DESCRIPTION
# Description of Changes

- Updated all markdown files that call out `#[spacetimedb::table(name` to `#[spacetimedb::table(accessor`
- Updated the LLM details on the same change

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1 - Small rework in documentation to use the new 

# Testing

- [x] Did a small double check on name vs accessor locally
- [x] Codex tested all the LLM answers
