### PR TITLE
Docs - add shared C++ version notice inside first C++ tab across docs

### DIFF
--- a/docs/docs/00100-intro/00100-getting-started/00400-key-architecture.md
+++ b/docs/docs/00100-intro/00100-getting-started/00400-key-architecture.md
@@ -5,6 +5,7 @@ slug: /intro/key-architecture
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 ## Host
 
@@ -73,6 +74,8 @@ pub struct Player {
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 struct Player {

--- a/docs/docs/00100-intro/00300-tutorials/00100-chat-app.md
+++ b/docs/docs/00100-intro/00300-tutorials/00100-chat-app.md
@@ -8,6 +8,7 @@ toc_max_heading_level: 2
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
 import { InstallCardLink } from "@site/src/components/InstallCardLink";
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 In this tutorial, we'll implement a simple chat server as a SpacetimeDB module. You can write your module in TypeScript, C#, or Rust - use the tabs throughout this guide to see code examples in your preferred language.
@@ -43,6 +44,8 @@ SpacetimeDB runs your module inside the database host (not Node.js). There's no 
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 - Each table is defined as a C++ struct with the `SPACETIMEDB_STRUCT` macro to register its fields, and the `SPACETIMEDB_TABLE` macro to create the table. An instance of the struct represents a row, and each field represents a column.
 - By default, tables are **private**. Use `SPACETIMEDB_TABLE(StructName, table_name, Public)` to make a table public. **Public** tables are readable by all users but can still only be modified by your server module code.

--- a/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00300-part-2.md
+++ b/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00300-part-2.md
@@ -5,6 +5,7 @@ slug: /tutorials/unity/part-2
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Need help with the tutorial? [Join our Discord server](https://discord.gg/spacetimedb)!
@@ -60,6 +61,8 @@ This command creates a new folder named `spacetimedb` inside of your Unity proje
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 Run the following command to initialize the SpacetimeDB server module project with C++ as the language:
 
 ```bash

--- a/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00400-part-3.md
+++ b/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00400-part-3.md
@@ -5,6 +5,7 @@ slug: /tutorials/unity/part-3
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Need help with the tutorial? [Join our Discord server](https://discord.gg/spacetimedb)!
@@ -158,6 +159,8 @@ In this reducer, we are using the `world_size` we configured along with the `Red
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 Let's start by spawning food into the map. The first thing we need to do is create a new, special reducer called the `SPACETIMEDB_INIT` reducer. SpacetimeDB calls the `SPACETIMEDB_INIT` reducer automatically when you first publish your module, and also after any time you run with `publish --delete-data`. It gives you an opportunity to initialize the state of your database before any clients connect.
 
 Add this new reducer above our `connect` reducer.

--- a/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00500-part-4.md
+++ b/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00500-part-4.md
@@ -5,6 +5,7 @@ slug: /tutorials/unity/part-4
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Need help with the tutorial? [Join our Discord server](https://discord.gg/spacetimedb)!
@@ -222,6 +223,8 @@ This is a simple reducer that takes the movement input from the client and appli
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 Let's start by building out a simple math library to help us do collision calculations. Create a new `math.h` file in the `blackholio/spacetimedb/src` directory and add the following contents. We'll also move the `DbVector2` type from `lib.cpp` into this file.
 

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00200-part-1.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00200-part-1.md
@@ -5,6 +5,7 @@ slug: /tutorials/unreal/part-1
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Need help with the tutorial? [Join our Discord server](https://discord.gg/spacetimedb)!
@@ -64,6 +65,8 @@ Before beginning make sure to close the Unreal project and IDE.
 
 <Tabs groupId="client-language" defaultValue="cpp">
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 1. Open the `blackholio` project in your IDE (Visual Studio or JetBrains Rider) and run the project to launch the Unreal Editor.
    - This will enable **Live Coding**, making the workflow a bit smoother.
    - Unreal will prompt you to build the `SpacetimeDbSdk` plugin. Do so.

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00300-part-2.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00300-part-2.md
@@ -5,6 +5,7 @@ slug: /tutorials/unreal/part-2
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Need help with the tutorial? [Join our Discord server](https://discord.gg/spacetimedb)!
@@ -62,6 +63,8 @@ spacetime init --lang rust --server-only blackholio
 This command creates a new folder named `blackholio` inside of your Unreal project `blackholio` directory and sets up the SpacetimeDB server project with Rust as the programming language.
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 Run the following command to initialize the SpacetimeDB server module project with C++ as the language:
 
 ```bash

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00400-part-3.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00400-part-3.md
@@ -5,6 +5,7 @@ slug: /tutorials/unreal/part-3
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Need help with the tutorial? [Join our Discord server](https://discord.gg/spacetimedb)!
@@ -158,6 +159,8 @@ In this reducer, we are using the `world_size` we configured along with the `Red
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 Let's start by spawning food into the map. The first thing we need to do is create a new, special reducer called the `SPACETIMEDB_INIT` reducer. SpacetimeDB calls the `SPACETIMEDB_INIT` reducer automatically when you first publish your module, and also after any time you run with `publish --delete-data`. It gives you an opportunity to initialize the state of your database before any clients connect.
 
 Add this new reducer above our `connect` reducer.

--- a/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00500-part-4.md
+++ b/docs/docs/00100-intro/00300-tutorials/00400-unreal-tutorial/00500-part-4.md
@@ -5,6 +5,7 @@ slug: /tutorials/unreal/part-4
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Need help with the tutorial? [Join our Discord server](https://discord.gg/spacetimedb)!
@@ -221,6 +222,8 @@ pub fn update_player_input(ctx: &ReducerContext, direction: DbVector2) -> Result
 This is a simple reducer that takes the movement input from the client and applies them to all circles that that player controls. Note that it is not possible for a player to move another player's circles using this reducer, because the `ctx.sender()` value is not set by the client. Instead `ctx.sender()` is set by SpacetimeDB after it has authenticated that sender. You can rest assured that the caller has been authenticated as that player by the time this reducer is called.
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 Let's start by building out a simple math library to help us do collision calculations. Create a new `math.h` file in the `blackholio/spacetimedb/src` directory and add the following contents. We'll also move the `DbVector2` type from `lib.cpp` into this file.
 

--- a/docs/docs/00200-core-concepts/00100-databases.md
+++ b/docs/docs/00200-core-concepts/00100-databases.md
@@ -3,6 +3,7 @@ title: The Database Module
 slug: /databases
 ---
 
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -59,6 +60,8 @@ Rust is fully supported for server modules. Rust is a great choice for performan
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 C++ is fully supported for server modules. C++ is an excellent choice for developers working with Unreal Engine or those who prefer to stay in the C++ ecosystem.
 

--- a/docs/docs/00200-core-concepts/00100-databases/00100-transactions-atomicity.md
+++ b/docs/docs/00200-core-concepts/00100-databases/00100-transactions-atomicity.md
@@ -5,6 +5,7 @@ slug: /databases/transactions-atomicity
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 SpacetimeDB provides strong transactional guarantees for all database operations. Every [reducer](/functions/reducers) runs inside a database transaction, ensuring your data remains consistent and reliable even under concurrent load.
@@ -154,6 +155,8 @@ pub fn child_reducer(ctx: &ReducerContext) -> Result<(), String> {
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 using namespace SpacetimeDB;

--- a/docs/docs/00200-core-concepts/00100-databases/00200-spacetime-dev.md
+++ b/docs/docs/00200-core-concepts/00100-databases/00200-spacetime-dev.md
@@ -5,6 +5,7 @@ slug: /databases/developing
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 # `spacetime dev`
 
@@ -175,6 +176,8 @@ my-project/
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```text
 my-project/

--- a/docs/docs/00200-core-concepts/00100-databases/00500-cheat-sheet.md
+++ b/docs/docs/00200-core-concepts/00100-databases/00500-cheat-sheet.md
@@ -3,6 +3,7 @@ title: Cheat Sheet
 slug: /databases/cheat-sheet
 ---
 
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
@@ -43,6 +44,8 @@ spacetime publish <DATABASE_NAME>
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```bash
 spacetime init --lang cpp --project-path my-project my-project

--- a/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00300-reducers.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00300-reducers.md
@@ -5,6 +5,7 @@ slug: /functions/reducers
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Reducers are functions that modify database state in response to client requests or system events. They are the **only** way to mutate tables in SpacetimeDB - all database changes must go through reducers.
@@ -110,6 +111,8 @@ If you see errors like "no method named `try_insert` found", add this import.
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 Use the `SPACETIMEDB_REDUCER` macro on a function:
 

--- a/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00400-reducer-context.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00400-reducer-context.md
@@ -5,6 +5,7 @@ slug: /functions/reducers/reducer-context
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Every reducer receives a special context parameter as its first argument. This context provides read-write access to the database, information about the caller, and additional utilities like random number generation.
@@ -84,6 +85,8 @@ fn create_user(ctx: &ReducerContext, name: String) {
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 #include <spacetimedb.h>

--- a/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00500-lifecycle.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00500-lifecycle.md
@@ -5,6 +5,7 @@ slug: /functions/reducers/lifecycle
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Special reducers handle system events during the database lifecycle.
@@ -73,6 +74,8 @@ pub fn init(ctx: &ReducerContext) -> Result<(), String> {
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 #include <spacetimedb.h>

--- a/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00600-error-handling.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00300-reducers/00600-error-handling.md
@@ -5,6 +5,7 @@ slug: /functions/reducers/error-handling
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 ## Error Handling
@@ -102,6 +103,8 @@ pub fn transfer_credits(
 
 </TabItem>
   <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
   ```cpp
   #include <spacetimedb.h>

--- a/docs/docs/00200-core-concepts/00200-functions/00400-procedures.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00400-procedures.md
@@ -5,6 +5,7 @@ slug: /functions/procedures
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 A **procedure** is a function exported by a [database](/databases), similar to a [reducer](/functions/reducers).
@@ -97,6 +98,8 @@ fn add_two_numbers(ctx: &mut spacetimedb::ProcedureContext, lhs: u32, rhs: u32) 
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 :::warning Unstable Feature
 Procedures in C++ are currently unstable. To use them, add `#define SPACETIMEDB_UNSTABLE_FEATURES` before including the SpacetimeDB header.

--- a/docs/docs/00200-core-concepts/00200-functions/00500-views.md
+++ b/docs/docs/00200-core-concepts/00200-functions/00500-views.md
@@ -5,6 +5,7 @@ slug: /functions/views
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Views are read-only functions that compute and return results from your tables. Unlike [reducers](/functions/reducers), views do not modify database state - they only query and return data. Views are useful for computing derived data, aggregations, or joining multiple tables before sending results to clients.
@@ -228,6 +229,8 @@ Views can return either `Option<T>` for at-most-one row or `Vec<T>` for multiple
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 Use the `SPACETIMEDB_VIEW` macro:
 

--- a/docs/docs/00200-core-concepts/00300-tables.md
+++ b/docs/docs/00200-core-concepts/00300-tables.md
@@ -5,6 +5,7 @@ slug: /tables
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Tables are the way to store data in SpacetimeDB. All data in SpacetimeDB is stored in memory for extremely low latency and high throughput access. SpacetimeDB also automatically persists all data to disk.
@@ -166,6 +167,8 @@ The `pub` modifier on the struct follows normal Rust visibility rules and has no
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 Register the struct with `SPACETIMEDB_STRUCT`, the table with `SPACETIMEDB_TABLE`, then add field constraints:
 

--- a/docs/docs/00200-core-concepts/00300-tables/00200-column-types.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00200-column-types.md
@@ -5,6 +5,7 @@ slug: /tables/column-types
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Columns define the structure of your tables. SpacetimeDB supports primitive types, composite types for complex data, and special types for database-specific functionality.
@@ -134,6 +135,8 @@ These optimizations apply across all supported languages.
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 | Category | Type | Description |
 |----------|------|-------------|

--- a/docs/docs/00200-core-concepts/00300-tables/00210-file-storage.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00210-file-storage.md
@@ -5,6 +5,7 @@ slug: /tables/file-storage
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 SpacetimeDB can store binary data directly in table columns, making it suitable for files, images, and other blobs that need to participate in transactions and subscriptions.
@@ -123,6 +124,8 @@ pub fn upload_avatar(
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 struct UserAvatar {

--- a/docs/docs/00200-core-concepts/00300-tables/00230-auto-increment.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00230-auto-increment.md
@@ -5,6 +5,7 @@ slug: /tables/auto-increment
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Auto-increment columns automatically generate unique integer values for new rows. When you insert a row with a zero value in an auto-increment column, SpacetimeDB assigns the next value from an internal sequence.
@@ -95,6 +96,8 @@ Auto-increment columns must be integer types: `i8`, `i16`, `i32`, `i64`, `i128`,
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 struct Post {

--- a/docs/docs/00200-core-concepts/00300-tables/00240-constraints.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00240-constraints.md
@@ -5,6 +5,7 @@ slug: /tables/constraints
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Constraints enforce data integrity rules on your tables. SpacetimeDB supports primary key and unique constraints.
@@ -64,6 +65,8 @@ Use the `#[primary_key]` attribute to mark a field as the primary key.
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 struct User {

--- a/docs/docs/00200-core-concepts/00300-tables/00250-default-values.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00250-default-values.md
@@ -5,6 +5,7 @@ slug: /tables/default-values
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Default values allow you to add new columns to existing tables during [automatic migrations](/databases/automatic-migrations). When you republish a module with a new column that has a default value, existing rows are automatically populated with that default.
@@ -87,6 +88,8 @@ Default values in Rust must be const-evaluable. This means you **cannot** use `S
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 struct Player {

--- a/docs/docs/00200-core-concepts/00300-tables/00300-indexes.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00300-indexes.md
@@ -5,6 +5,7 @@ slug: /tables/indexes
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Indexes accelerate queries by maintaining sorted data structures alongside your tables. Without an index, finding rows that match a condition requires scanning every row. With an index, the database locates matching rows directly.
@@ -148,6 +149,8 @@ pub struct User {
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 struct User {

--- a/docs/docs/00200-core-concepts/00300-tables/00400-access-permissions.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00400-access-permissions.md
@@ -5,6 +5,7 @@ slug: /tables/access-permissions
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 SpacetimeDB controls data access through table visibility and context-based permissions. Tables can be public or private, and different execution contexts (reducers, views, clients) have different levels of access.
@@ -89,6 +90,8 @@ pub struct Player {
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 // Private table (default) - only accessible from server-side code

--- a/docs/docs/00200-core-concepts/00300-tables/00500-schedule-tables.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00500-schedule-tables.md
@@ -5,6 +5,7 @@ slug: /tables/schedule-tables
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Tables can trigger [reducers](/functions/reducers) or [procedures](/functions/procedures) at specific times by including a special scheduling column. This allows you to schedule future actions like sending reminders, expiring items, or running periodic maintenance tasks.
@@ -88,6 +89,8 @@ fn send_reminder(ctx: &ReducerContext, reminder: Reminder) -> Result<(), String>
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 struct Reminder {

--- a/docs/docs/00200-core-concepts/00300-tables/00600-performance.md
+++ b/docs/docs/00200-core-concepts/00300-tables/00600-performance.md
@@ -5,6 +5,7 @@ slug: /tables/performance
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 Follow these guidelines to optimize table performance in your SpacetimeDB modules.
@@ -41,6 +42,8 @@ ctx.db.player().name().filter("Alice")
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 // Fast: Uses index on name

--- a/docs/docs/00200-core-concepts/00500-authentication/00500-usage.md
+++ b/docs/docs/00200-core-concepts/00500-authentication/00500-usage.md
@@ -2,6 +2,7 @@
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 SpacetimeDB allows you to easily access authentication (auth) claims embedded in
 OIDC-compliant JWT tokens. Auth claims are key-value pairs that provide
@@ -73,6 +74,8 @@ INFO: src\lib.rs:64: sub: 321321321321321, iss: https://accounts.google.com
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 SPACETIMEDB_CLIENT_CONNECTED(auth_claims_connect, ReducerContext ctx) {

--- a/docs/docs/00300-resources/00100-how-to/00100-deploy/00100-maincloud.md
+++ b/docs/docs/00300-resources/00100-how-to/00100-deploy/00100-maincloud.md
@@ -5,6 +5,7 @@ slug: /how-to/deploy/maincloud
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 Maincloud is SpacetimeDB's fully managed serverless platform. It handles infrastructure, scaling, replication, and backups so you can focus on building your application. Maincloud scales to zero when your database is idle, so you only pay for what you use.
 
@@ -80,6 +81,8 @@ DbConnection::builder()
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 ```cpp
 auto conn = DbConnection::builder()

--- a/docs/docs/00300-resources/00100-how-to/00300-logging.md
+++ b/docs/docs/00300-resources/00100-how-to/00300-logging.md
@@ -5,6 +5,7 @@ slug: /how-to/logging
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 
 SpacetimeDB provides logging capabilities for debugging and monitoring your modules. Log messages are private to the database owner and are not visible to clients.
@@ -117,6 +118,8 @@ Available log levels:
 
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 
 Use the `LOG_*` macros to write logs from your reducers:
 

--- a/docs/docs/00300-resources/00100-how-to/00500-reject-client-connections.md
+++ b/docs/docs/00300-resources/00100-how-to/00500-reject-client-connections.md
@@ -4,6 +4,7 @@ slug: /how-to/reject-client-connections
 
 import Tabs from '@theme/Tabs';
 import TabItem from '@theme/TabItem';
+import { CppModuleVersionNotice } from "@site/src/components/CppModuleVersionNotice";
 
 # Reject Client Connections
 
@@ -67,6 +68,8 @@ Regardless of the client type, from the rust server's perspective, the client wi
 `ERROR: : The client connection was rejected. With our current code logic, all clients will be rejected.`
 </TabItem>
 <TabItem value="cpp" label="C++">
+
+<CppModuleVersionNotice />
 In C++, if we return an error during the `client_connected` reducer, the client will be disconnected.
 
 Here is a simple example where the server module returns an error for all incoming client connections.

--- a/docs/src/components/CppModuleVersionNotice.tsx
+++ b/docs/src/components/CppModuleVersionNotice.tsx
@@ -5,9 +5,9 @@ export function CppModuleVersionNotice(): JSX.Element {
   return (
     <Admonition type="important" title="C++ Modules and SpacetimeDB 2.0">
       <p>
-        SpacetimeDB <code>2.0</code> is available for other module languages, but C++ server modules
-        are currently pinned to <code>v1.12.0</code>. If you are following the C++ tab in this guide,
-        use the <code>v1.12.0</code> release track for now.
+        C++ support is currently in beta and subject to change. SpacetimeDB C++ <code>2.0</code> is
+        coming soon, but C++ server modules are currently pinned to <code>v1.12.0</code>. If you are
+        following the C++ tab in this guide, use the <code>v1.12.0</code> release track for now.
       </p>
     </Admonition>
   );

--- a/docs/src/components/CppModuleVersionNotice.tsx
+++ b/docs/src/components/CppModuleVersionNotice.tsx
@@ -1,0 +1,14 @@
+import React from "react";
+import Admonition from "@theme/Admonition";
+
+export function CppModuleVersionNotice(): JSX.Element {
+  return (
+    <Admonition type="important" title="C++ Modules and SpacetimeDB 2.0">
+      <p>
+        SpacetimeDB <code>2.0</code> is available for other module languages, but C++ server modules
+        are currently pinned to <code>v1.12.0</code>. If you are following the C++ tab in this guide,
+        use the <code>v1.12.0</code> release track for now.
+      </p>
+    </Admonition>
+  );
+}


### PR DESCRIPTION
# Description of Changes
- Added a shared component with a message for C++ on the version pinning
- Updated every doc that has a C++ tab to include the new message

# API and ABI breaking changes

N/A

# Expected complexity level and risk

2 - Small document change but used a shared component

# Testing
- [x] Tested locally with pnpm dev
- [x] Hosted on my personal site to double check the shared component
