### PR TITLE
Fix publishing and generating from subdirs if config is present

### DIFF
--- a/crates/cli/src/spacetime_config.rs
+++ b/crates/cli/src/spacetime_config.rs
@@ -730,6 +730,11 @@ impl<'a> CommandConfig<'a> {
         self.config_values.get(key)
     }
 
+    /// Returns true when this key was explicitly provided via CLI.
+    pub fn is_from_cli(&self, key: &str) -> bool {
+        self.schema.is_from_cli(self.matches, key)
+    }
+
     /// Validate that all required keys are present in either config or CLI.
     pub fn validate(&self) -> Result<(), CommandConfigError> {
         for key in &self.schema.keys {


### PR DESCRIPTION
# Description of Changes

When config is present and no explicit `module-path` has been passed, we should be resolving paths from the config and defaults relative to the config file

# Expected complexity level and risk

2

# Testing

- [x] Tested locally
