### PR TITLE
Remove database names in quickstarts

### DIFF
--- a/docs/docs/00100-intro/00200-quickstarts/00100-react.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00100-react.md
@@ -30,7 +30,7 @@ Get a SpacetimeDB React app running in under 5 minutes.
     </StepText>
     <StepCode>
 ```bash
-spacetime dev --template react-ts my-spacetime-app
+spacetime dev --template react-ts
 ```
     </StepCode>
   </Step>

--- a/docs/docs/00100-intro/00200-quickstarts/00100-react.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00100-react.md
@@ -105,19 +105,19 @@ export const say_hello = spacetimedb.reducer((ctx) => {
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call <database-name> add Alice
+spacetime call add Alice
 
 # Query the person table
-spacetime sql <database-name> "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
  name
 ---------
  "Alice"
 
 # Call say_hello to greet everyone
-spacetime call <database-name> say_hello
+spacetime call say_hello
 
 # View the module logs
-spacetime logs <database-name>
+spacetime logs
 2025-01-13T12:00:00.000000Z  INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z  INFO: Hello, World!
 ```

--- a/docs/docs/00100-intro/00200-quickstarts/00150-nextjs.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00150-nextjs.md
@@ -29,7 +29,7 @@ Get a SpacetimeDB Next.js app running in under 5 minutes.
     </StepText>
     <StepCode>
 ```bash
-spacetime dev --template nextjs-ts my-nextjs-app
+spacetime dev --template nextjs-ts
 ```
     </StepCode>
   </Step>

--- a/docs/docs/00100-intro/00200-quickstarts/00150-nextjs.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00150-nextjs.md
@@ -108,19 +108,19 @@ spacetimedb.reducer('say_hello', (ctx) => {
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call my-nextjs-app add Alice
+spacetime call add Alice
 
 # Query the person table
-spacetime sql my-nextjs-app "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
  name
 ---------
  "Alice"
 
 # Call say_hello to greet everyone
-spacetime call my-nextjs-app say_hello
+spacetime call say_hello
 
 # View the module logs
-spacetime logs my-nextjs-app
+spacetime logs
 2025-01-13T12:00:00.000000Z  INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z  INFO: Hello, World!
 ```

--- a/docs/docs/00100-intro/00200-quickstarts/00150-vue.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00150-vue.md
@@ -103,19 +103,19 @@ export const say_hello = spacetimedb.reducer((ctx) => {
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call <database-name> add Alice
+spacetime call add Alice
 
 # Query the person table
-spacetime sql <database-name> "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
  name
 ---------
  "Alice"
 
 # Call say_hello to greet everyone
-spacetime call <database-name> say_hello
+spacetime call say_hello
 
 # View the module logs
-spacetime logs <database-name>
+spacetime logs
 2025-01-13T12:00:00.000000Z  INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z  INFO: Hello, World!
 ```

--- a/docs/docs/00100-intro/00200-quickstarts/00155-nuxt.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00155-nuxt.md
@@ -107,19 +107,19 @@ spacetimedb.reducer('say_hello', (ctx) => {
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call <database-name> add Alice
+spacetime call add Alice
 
 # Query the person table
-spacetime sql <database-name> "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
  name
 ---------
  "Alice"
 
 # Call say_hello to greet everyone
-spacetime call <database-name> say_hello
+spacetime call say_hello
 
 # View the module logs
-spacetime logs <database-name>
+spacetime logs
 2025-01-13T12:00:00.000000Z  INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z  INFO: Hello, World!
 ```

--- a/docs/docs/00100-intro/00200-quickstarts/00160-svelte.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00160-svelte.md
@@ -103,19 +103,19 @@ export const say_hello = spacetimedb.reducer((ctx) => {
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call <database-name> add Alice
+spacetime call add Alice
 
 # Query the person table
-spacetime sql <database-name> "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
  name
 ---------
  "Alice"
 
 # Call say_hello to greet everyone
-spacetime call <database-name> say_hello
+spacetime call say_hello
 
 # View the module logs
-spacetime logs <database-name>
+spacetime logs
 2025-01-13T12:00:00.000000Z  INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z  INFO: Hello, World!
 ```

--- a/docs/docs/00100-intro/00200-quickstarts/00165-angular.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00165-angular.md
@@ -105,19 +105,19 @@ spacetimedb.reducer('say_hello', (ctx) => {
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call <database-name> add Alice
+spacetime call add Alice
 
 # Query the person table
-spacetime sql <database-name> "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
  name
 ---------
  "Alice"
 
 # Call say_hello to greet everyone
-spacetime call <database-name> say_hello
+spacetime call say_hello
 
 # View the module logs
-spacetime logs <database-name>
+spacetime logs
 2025-01-13T12:00:00.000000Z  INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z  INFO: Hello, World!
 ```

--- a/docs/docs/00100-intro/00200-quickstarts/00170-tanstack.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00170-tanstack.md
@@ -29,7 +29,7 @@ Get a SpacetimeDB app with TanStack Start running in under 5 minutes.
     <StepCode>
 
 ```bash
-spacetime dev --template tanstack-ts my-spacetime-app
+spacetime dev --template tanstack-ts
 ```
 
     </StepCode>

--- a/docs/docs/00100-intro/00200-quickstarts/00170-tanstack.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00170-tanstack.md
@@ -111,19 +111,19 @@ spacetimedb.reducer('say_hello', (ctx) => {
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call <database-name> add Alice
+spacetime call add Alice
 
 # Query the person table
-spacetime sql <database-name> "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
  name
 ---------
  "Alice"
 
 # Call say_hello to greet everyone
-spacetime call <database-name> say_hello
+spacetime call say_hello
 
 # View the module logs
-spacetime logs <database-name>
+spacetime logs
 2025-01-13T12:00:00.000000Z  INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z  INFO: Hello, World!
 ```

--- a/docs/docs/00100-intro/00200-quickstarts/00175-remix.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00175-remix.md
@@ -29,7 +29,7 @@ Get a SpacetimeDB Remix app running in under 5 minutes.
     </StepText>
     <StepCode>
 ```bash
-spacetime dev --template remix-ts my-remix-app
+spacetime dev --template remix-ts
 ```
     </StepCode>
   </Step>

--- a/docs/docs/00100-intro/00200-quickstarts/00175-remix.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00175-remix.md
@@ -107,19 +107,19 @@ spacetimedb.reducer('say_hello', (ctx) => {
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call my-remix-app add Alice
+spacetime call add Alice
 
 # Query the person table
-spacetime sql my-remix-app "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
  name
 ---------
  "Alice"
 
 # Call say_hello to greet everyone
-spacetime call my-remix-app say_hello
+spacetime call say_hello
 
 # View the module logs
-spacetime logs my-remix-app
+spacetime logs
 2025-01-13T12:00:00.000000Z  INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z  INFO: Hello, World!
 ```

--- a/docs/docs/00100-intro/00200-quickstarts/00180-browser.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00180-browser.md
@@ -29,7 +29,7 @@ Get a SpacetimeDB app running in the browser with inline JavaScript.
     </StepText>
     <StepCode>
 ```bash
-spacetime dev --template browser-ts my-spacetime-app
+spacetime dev --template browser-ts
 ```
     </StepCode>
   </Step>

--- a/docs/docs/00100-intro/00200-quickstarts/00250-bun.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00250-bun.md
@@ -200,11 +200,11 @@ DbConnection.builder()
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call <database-name> add Charlie
+spacetime call add Charlie
 
 # Query the person table
 
-spacetime sql <database-name> "SELECT \* FROM person"
+spacetime sql "SELECT \* FROM person"
 name
 
 ---
@@ -215,11 +215,11 @@ name
 
 # Call say_hello to greet everyone
 
-spacetime call <database-name> say_hello
+spacetime call say_hello
 
 # View the module logs
 
-spacetime logs <database-name>
+spacetime logs
 2025-01-13T12:00:00.000000Z INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z INFO: Hello, Bob!
 2025-01-13T12:00:00.000000Z INFO: Hello, Charlie!

--- a/docs/docs/00100-intro/00200-quickstarts/00275-deno.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00275-deno.md
@@ -200,11 +200,11 @@ DbConnection.builder()
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call <database-name> add Charlie
+spacetime call add Charlie
 
 # Query the person table
 
-spacetime sql <database-name> "SELECT \* FROM person"
+spacetime sql "SELECT \* FROM person"
 name
 
 ---
@@ -215,11 +215,11 @@ name
 
 # Call say_hello to greet everyone
 
-spacetime call <database-name> say_hello
+spacetime call say_hello
 
 # View the module logs
 
-spacetime logs <database-name>
+spacetime logs
 2025-01-13T12:00:00.000000Z INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z INFO: Hello, Bob!
 2025-01-13T12:00:00.000000Z INFO: Hello, Charlie!

--- a/docs/docs/00100-intro/00200-quickstarts/00300-nodejs.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00300-nodejs.md
@@ -200,11 +200,11 @@ DbConnection.builder()
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call <database-name> add Charlie
+spacetime call add Charlie
 
 # Query the person table
 
-spacetime sql <database-name> "SELECT \* FROM person"
+spacetime sql "SELECT \* FROM person"
 name
 
 ---
@@ -215,11 +215,11 @@ name
 
 # Call say_hello to greet everyone
 
-spacetime call <database-name> say_hello
+spacetime call say_hello
 
 # View the module logs
 
-spacetime logs <database-name>
+spacetime logs
 2025-01-13T12:00:00.000000Z INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z INFO: Hello, Bob!
 2025-01-13T12:00:00.000000Z INFO: Hello, Charlie!

--- a/docs/docs/00100-intro/00200-quickstarts/00400-typescript.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00400-typescript.md
@@ -29,7 +29,7 @@ Get a SpacetimeDB TypeScript app running in under 5 minutes.
     </StepText>
     <StepCode>
 ```bash
-spacetime dev --template basic-ts my-spacetime-app
+spacetime dev --template basic-ts
 ```
     </StepCode>
   </Step>

--- a/docs/docs/00100-intro/00200-quickstarts/00400-typescript.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00400-typescript.md
@@ -96,19 +96,19 @@ export const say_hello = spacetimedb.reducer((ctx) => {
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call <database-name> add Alice
+spacetime call add Alice
 
 # Query the person table
-spacetime sql <database-name> "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
  name
 ---------
  "Alice"
 
 # Call say_hello to greet everyone
-spacetime call <database-name> say_hello
+spacetime call say_hello
 
 # View the module logs
-spacetime logs <database-name>
+spacetime logs
 2025-01-13T12:00:00.000000Z  INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z  INFO: Hello, World!
 ```

--- a/docs/docs/00100-intro/00200-quickstarts/00500-rust.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00500-rust.md
@@ -95,19 +95,19 @@ pub fn say_hello(ctx: &ReducerContext) {
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call my-spacetime-app add Alice
+spacetime call add Alice
 
 # Query the person table
-spacetime sql my-spacetime-app "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
  name
 ---------
  "Alice"
 
 # Call say_hello to greet everyone
-spacetime call my-spacetime-app say_hello
+spacetime call say_hello
 
 # View the module logs
-spacetime logs my-spacetime-app
+spacetime logs
 2025-01-13T12:00:00.000000Z  INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z  INFO: Hello, World!
 ```

--- a/docs/docs/00100-intro/00200-quickstarts/00500-rust.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00500-rust.md
@@ -29,7 +29,7 @@ Get a SpacetimeDB Rust app running in under 5 minutes.
     </StepText>
     <StepCode>
 ```bash
-spacetime dev --template basic-rs my-spacetime-app
+spacetime dev --template basic-rs
 ```
     </StepCode>
   </Step>

--- a/docs/docs/00100-intro/00200-quickstarts/00600-c-sharp.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00600-c-sharp.md
@@ -40,7 +40,7 @@ dotnet workload install wasi-experimental
     </StepText>
     <StepCode>
 ```bash
-spacetime dev --template basic-cs my-spacetime-app
+spacetime dev --template basic-cs
 ```
     </StepCode>
   </Step>

--- a/docs/docs/00100-intro/00200-quickstarts/00600-c-sharp.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00600-c-sharp.md
@@ -111,19 +111,19 @@ public static partial class Module
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call <database-name> Add Alice
+spacetime call Add Alice
 
 # Query the person table
-spacetime sql <database-name> "SELECT * FROM Person"
+spacetime sql "SELECT * FROM Person"
  name
 ---------
  "Alice"
 
 # Call say_hello to greet everyone
-spacetime call <database-name> SayHello
+spacetime call SayHello
 
 # View the module logs
-spacetime logs <database-name>
+spacetime logs
 2025-01-13T12:00:00.000000Z  INFO: Hello, Alice!
 2025-01-13T12:00:00.000000Z  INFO: Hello, World!
 ```

--- a/docs/docs/00100-intro/00200-quickstarts/00700-cpp.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00700-cpp.md
@@ -110,16 +110,16 @@ SPACETIMEDB_REDUCER(say_hello, ReducerContext ctx) {
     <StepCode>
 ```bash
 # Insert a person
-spacetime call <database-name> add Alice
+spacetime call add Alice
 
 # Query the person table
-spacetime sql <database-name> "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
 
 # Call say_hello to greet everyone
-spacetime call <database-name> say_hello
+spacetime call say_hello
 
 # View the module logs
-spacetime logs <database-name>
+spacetime logs
 ```
     </StepCode>
   </Step>

--- a/docs/docs/00100-intro/00200-quickstarts/00700-cpp.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00700-cpp.md
@@ -50,7 +50,7 @@ source ./emsdk_env.sh
     </StepText>
     <StepCode>
 ```bash
-spacetime dev --template basic-cpp my-spacetime-app
+spacetime dev --template basic-cpp
 ```
     </StepCode>
     <StepText>


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

- For the quickstarts we don't want to pass a database name during `spacetime dev --template ...`

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None - this is just docs

# Expected complexity level and risk

None - this is just docs

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] All quickstarts no longer pass a database name during `spacetime dev --template ...`
