### PR TITLE
Fix warnings in regen-cpp-moduledef

### DIFF
--- a/crates/codegen/examples/regen-cpp-moduledef.rs
+++ b/crates/codegen/examples/regen-cpp-moduledef.rs
@@ -1,5 +1,6 @@
 //! This script is used to generate the C++ bindings for the `RawModuleDef` type.
 //! Run `cargo run --example regen-cpp-moduledef` to update C++ bindings whenever the module definition changes.
+#![allow(clippy::disallowed_macros)]
 
 use fs_err as fs;
 use spacetimedb_codegen::{cpp, generate, CodegenOptions, OutputFile};


### PR DESCRIPTION
# Description of Changes

This has been annoying me for a bit. We don't care if we use println in a dev tool.

# Expected complexity level and risk

1

# Testing

- [x] The warnings are gone.