### PR TITLE
Allow skipping DB if the config file is available

### DIFF
--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -2,7 +2,9 @@ use crate::api::ClientApi;
 use crate::common_args;
 use crate::config::Config;
 use crate::edit_distance::{edit_distance, find_best_match_for_name};
+use crate::subcommands::db_arg_resolution::{load_config_db_targets, resolve_optional_database_parts};
 use crate::util::UNSTABLE_WARNING;
+use crate::util::{database_identity, get_auth_header};
 use anyhow::{bail, Context, Error};
 use clap::{Arg, ArgMatches};
 use convert_case::{Case, Casing};
@@ -13,27 +15,25 @@ use spacetimedb_lib::{Identity, ProductTypeElement};
 use spacetimedb_schema::def::{ModuleDef, ProcedureDef, ReducerDef};
 use std::fmt::Write;
 
-use super::sql::parse_req;
-
 pub fn cli() -> clap::Command {
     clap::Command::new("call")
         .about(format!(
             "Invokes a function (reducer or procedure) in a database. {UNSTABLE_WARNING}"
         ))
         .arg(
-            Arg::new("database")
-                .required(true)
-                .help("The database name or identity to use to invoke the call"),
+            Arg::new("call_parts")
+                .help("Call arguments: [DATABASE] <FUNCTION_NAME> [ARGUMENTS...]")
+                .num_args(1..),
         )
-        .arg(
-            Arg::new("function_name")
-                .required(true)
-                .help("The name of the function to call"),
-        )
-        .arg(Arg::new("arguments").help("arguments formatted as JSON").num_args(1..))
         .arg(common_args::server().help("The nickname, host name or URL of the server hosting the database"))
         .arg(common_args::anonymous())
         .arg(common_args::yes())
+        .arg(
+            Arg::new("no_config")
+                .long("no-config")
+                .action(clap::ArgAction::SetTrue)
+                .help("Ignore spacetime.json configuration"),
+        )
         .after_help("Run `spacetime help call` for more detailed information.\n")
 }
 
@@ -65,10 +65,37 @@ impl<'a> CallDef<'a> {
 
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), Error> {
     eprintln!("{UNSTABLE_WARNING}\n");
-    let reducer_procedure_name = args.get_one::<String>("function_name").unwrap();
-    let arguments = args.get_many::<String>("arguments");
+    let server = args.get_one::<String>("server").map(|s| s.as_ref());
+    let force = args.get_flag("force");
+    let anon_identity = args.get_flag("anon_identity");
+    let no_config = args.get_flag("no_config");
 
-    let conn = parse_req(config, args).await?;
+    let raw_parts: Vec<String> = args
+        .get_many::<String>("call_parts")
+        .map(|vals| vals.cloned().collect())
+        .unwrap_or_default();
+
+    let config_targets = load_config_db_targets(no_config)?;
+    let resolved = resolve_optional_database_parts(
+        &raw_parts,
+        config_targets.as_deref(),
+        "function_name",
+        "spacetime call [database] <function_name> <arguments>... (or --no-config for legacy behavior)",
+    )?;
+    let reducer_procedure_name = resolved
+        .remaining_args
+        .first()
+        .ok_or_else(|| anyhow::anyhow!("internal error: function_name should be present after argument resolution"))?;
+    let call_arguments = resolved.remaining_args.iter().skip(1);
+    let resolved_server = server.or(resolved.server.as_deref());
+
+    let mut config = config;
+    let conn = crate::api::Connection {
+        host: config.get_host_url(resolved_server)?,
+        auth_header: get_auth_header(&mut config, anon_identity, resolved_server, !force).await?,
+        database_identity: database_identity(&config, &resolved.database, resolved_server).await?,
+        database: resolved.database.clone(),
+    };
     let api = ClientApi::new(conn);
 
     let database_identity = api.con.database_identity;
@@ -92,8 +119,7 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), Error> {
     };
 
     // String quote any arguments that should be quoted
-    let arguments = arguments
-        .unwrap_or_default()
+    let arguments = call_arguments
         .zip(&call_def.params().elements)
         .map(|(argument, element)| match &element.algebraic_type {
             AlgebraicType::String if !argument.starts_with('\"') || !argument.ends_with('\"') => {
@@ -363,4 +389,9 @@ mod write_type {
 
         Ok(())
     }
+}
+
+#[cfg(test)]
+mod tests {
+    // Resolution tests live in db_arg_resolution.rs
 }

--- a/crates/cli/src/subcommands/db_arg_resolution.rs
+++ b/crates/cli/src/subcommands/db_arg_resolution.rs
@@ -90,13 +90,6 @@ pub(crate) fn resolve_optional_database_parts(
         });
     }
 
-    if raw_parts.len() < 2 {
-        return if raw_parts.is_empty() {
-            Err(require_arg("database"))
-        } else {
-            Err(require_arg(required_arg_name))
-        };
-    }
     let db = &raw_parts[0];
     let Some(target) = config_targets.iter().find(|t| t.database == *db) else {
         return Err(anyhow::anyhow!(
@@ -104,6 +97,9 @@ pub(crate) fn resolve_optional_database_parts(
             db
         ));
     };
+    if raw_parts.len() < 2 {
+        return Err(require_arg(required_arg_name));
+    }
 
     Ok(ResolvedDbArgs {
         database: db.clone(),

--- a/crates/cli/src/subcommands/db_arg_resolution.rs
+++ b/crates/cli/src/subcommands/db_arg_resolution.rs
@@ -1,0 +1,315 @@
+use crate::spacetime_config::find_and_load_with_env;
+use itertools::Itertools;
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ConfigDbTarget {
+    pub database: String,
+    pub server: Option<String>,
+}
+
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub(crate) struct ResolvedDbArgs {
+    pub database: String,
+    pub server: Option<String>,
+    pub remaining_args: Vec<String>,
+}
+
+pub(crate) fn load_config_db_targets(no_config: bool) -> anyhow::Result<Option<Vec<ConfigDbTarget>>> {
+    if no_config {
+        return Ok(None);
+    }
+
+    Ok(find_and_load_with_env(None)?
+        .map(|loaded| {
+            loaded
+                .config
+                .collect_all_targets_with_inheritance()
+                .iter()
+                .filter_map(|t| {
+                    let database = t.fields.get("database").and_then(|v| v.as_str())?;
+                    let server = t.fields.get("server").and_then(|v| v.as_str()).map(|s| s.to_string());
+                    Some(ConfigDbTarget {
+                        database: database.to_string(),
+                        server,
+                    })
+                })
+                .unique_by(|t| t.database.clone())
+                .collect::<Vec<_>>()
+        })
+        .filter(|targets| !targets.is_empty()))
+}
+
+pub(crate) fn resolve_optional_database_parts(
+    raw_parts: &[String],
+    config_targets: Option<&[ConfigDbTarget]>,
+    required_arg_name: &str,
+    usage: &str,
+) -> anyhow::Result<ResolvedDbArgs> {
+    let require_arg = |name: &str| {
+        anyhow::anyhow!(
+            "the following required arguments were not provided:\n  <{}>\n\nUsage: {}",
+            name,
+            usage
+        )
+    };
+
+    let Some(config_targets) = config_targets else {
+        if raw_parts.len() < 2 {
+            return if raw_parts.is_empty() {
+                Err(require_arg("database"))
+            } else {
+                Err(require_arg(required_arg_name))
+            };
+        }
+        return Ok(ResolvedDbArgs {
+            database: raw_parts[0].clone(),
+            server: None,
+            remaining_args: raw_parts[1..].to_vec(),
+        });
+    };
+
+    if config_targets.len() == 1 {
+        let target = &config_targets[0];
+        if raw_parts.is_empty() {
+            return Err(require_arg(required_arg_name));
+        }
+        if raw_parts[0] == target.database {
+            if raw_parts.len() < 2 {
+                return Err(require_arg(required_arg_name));
+            }
+            return Ok(ResolvedDbArgs {
+                database: target.database.clone(),
+                server: target.server.clone(),
+                remaining_args: raw_parts[1..].to_vec(),
+            });
+        }
+        return Ok(ResolvedDbArgs {
+            database: target.database.clone(),
+            server: target.server.clone(),
+            remaining_args: raw_parts.to_vec(),
+        });
+    }
+
+    if raw_parts.len() < 2 {
+        return if raw_parts.is_empty() {
+            Err(require_arg("database"))
+        } else {
+            Err(require_arg(required_arg_name))
+        };
+    }
+    let db = &raw_parts[0];
+    let Some(target) = config_targets.iter().find(|t| t.database == *db) else {
+        return Err(anyhow::anyhow!(
+            "Database '{}' is not in the config file. If you want to run against a database outside of the current project, pass --no-config.",
+            db
+        ));
+    };
+
+    Ok(ResolvedDbArgs {
+        database: db.clone(),
+        server: target.server.clone(),
+        remaining_args: raw_parts[1..].to_vec(),
+    })
+}
+
+pub(crate) fn resolve_database_arg(
+    raw_database: Option<&str>,
+    config_targets: Option<&[ConfigDbTarget]>,
+    usage: &str,
+) -> anyhow::Result<ResolvedDbArgs> {
+    let require_database = || {
+        anyhow::anyhow!(
+            "the following required arguments were not provided:\n  <database>\n\nUsage: {}",
+            usage
+        )
+    };
+
+    let Some(config_targets) = config_targets else {
+        let database = raw_database.ok_or_else(require_database)?;
+        return Ok(ResolvedDbArgs {
+            database: database.to_string(),
+            server: None,
+            remaining_args: vec![],
+        });
+    };
+
+    if config_targets.len() == 1 {
+        let target = &config_targets[0];
+        if let Some(db) = raw_database {
+            if db != target.database {
+                return Err(anyhow::anyhow!(
+                    "Database '{}' is not in the config file. If you want to run against a database outside of the current project, pass --no-config.",
+                    db
+                ));
+            }
+        }
+        return Ok(ResolvedDbArgs {
+            database: target.database.clone(),
+            server: target.server.clone(),
+            remaining_args: vec![],
+        });
+    }
+
+    let db = raw_database.ok_or_else(require_database)?;
+    let Some(target) = config_targets.iter().find(|t| t.database == db) else {
+        return Err(anyhow::anyhow!(
+            "Database '{}' is not in the config file. If you want to run against a database outside of the current project, pass --no-config.",
+            db
+        ));
+    };
+
+    Ok(ResolvedDbArgs {
+        database: target.database.clone(),
+        server: target.server.clone(),
+        remaining_args: vec![],
+    })
+}
+
+pub(crate) fn resolve_database_with_optional_parts(
+    raw_parts: &[String],
+    config_targets: Option<&[ConfigDbTarget]>,
+    usage: &str,
+) -> anyhow::Result<ResolvedDbArgs> {
+    let require_database = || {
+        anyhow::anyhow!(
+            "the following required arguments were not provided:\n  <database>\n\nUsage: {}",
+            usage
+        )
+    };
+
+    let Some(config_targets) = config_targets else {
+        let Some(database) = raw_parts.first() else {
+            return Err(require_database());
+        };
+        return Ok(ResolvedDbArgs {
+            database: database.clone(),
+            server: None,
+            remaining_args: raw_parts[1..].to_vec(),
+        });
+    };
+
+    if config_targets.len() == 1 {
+        let target = &config_targets[0];
+        if raw_parts.first().is_some_and(|db| db == &target.database) {
+            return Ok(ResolvedDbArgs {
+                database: target.database.clone(),
+                server: target.server.clone(),
+                remaining_args: raw_parts[1..].to_vec(),
+            });
+        }
+        return Ok(ResolvedDbArgs {
+            database: target.database.clone(),
+            server: target.server.clone(),
+            remaining_args: raw_parts.to_vec(),
+        });
+    }
+
+    let Some(db) = raw_parts.first() else {
+        return Err(require_database());
+    };
+    let Some(target) = config_targets.iter().find(|t| t.database == *db) else {
+        return Err(anyhow::anyhow!(
+            "Database '{}' is not in the config file. If you want to run against a database outside of the current project, pass --no-config.",
+            db
+        ));
+    };
+
+    Ok(ResolvedDbArgs {
+        database: db.clone(),
+        server: target.server.clone(),
+        remaining_args: raw_parts[1..].to_vec(),
+    })
+}
+
+#[cfg(test)]
+mod tests {
+    use super::{
+        resolve_database_arg, resolve_database_with_optional_parts, resolve_optional_database_parts, ConfigDbTarget,
+    };
+
+    #[test]
+    fn single_db_infers_database() {
+        let parts = vec!["reducer".to_string(), "arg1".to_string()];
+        let targets = vec![ConfigDbTarget {
+            database: "foo".to_string(),
+            server: Some("maincloud".to_string()),
+        }];
+        let parsed = resolve_optional_database_parts(
+            &parts,
+            Some(&targets),
+            "function_name",
+            "spacetime call [database] <function_name> <arguments>...",
+        )
+        .unwrap();
+        assert_eq!(parsed.database, "foo");
+        assert_eq!(parsed.server.as_deref(), Some("maincloud"));
+        assert_eq!(parsed.remaining_args, parts);
+    }
+
+    #[test]
+    fn single_db_accepts_explicit_db_prefix() {
+        let parts = vec!["foo".to_string(), "SELECT 1".to_string()];
+        let targets = vec![ConfigDbTarget {
+            database: "foo".to_string(),
+            server: Some("local".to_string()),
+        }];
+        let parsed = resolve_optional_database_parts(
+            &parts,
+            Some(&targets),
+            "query",
+            "spacetime subscribe [database] <query> [query...]",
+        )
+        .unwrap();
+        assert_eq!(parsed.database, "foo");
+        assert_eq!(parsed.server.as_deref(), Some("local"));
+        assert_eq!(parsed.remaining_args, vec!["SELECT 1".to_string()]);
+    }
+
+    #[test]
+    fn multi_db_rejects_unknown_database() {
+        let parts = vec!["baz".to_string(), "SELECT 1".to_string()];
+        let targets = vec![
+            ConfigDbTarget {
+                database: "foo".to_string(),
+                server: Some("maincloud".to_string()),
+            },
+            ConfigDbTarget {
+                database: "bar".to_string(),
+                server: Some("local".to_string()),
+            },
+        ];
+        let err = resolve_optional_database_parts(
+            &parts,
+            Some(&targets),
+            "query",
+            "spacetime subscribe [database] <query> [query...]",
+        )
+        .unwrap_err();
+        assert!(err.to_string().contains("Database 'baz' is not in the config file"));
+        assert!(err.to_string().contains("--no-config"));
+    }
+
+    #[test]
+    fn resolve_database_arg_single_target_uses_config_database() {
+        let targets = vec![ConfigDbTarget {
+            database: "foo".to_string(),
+            server: Some("maincloud".to_string()),
+        }];
+        let resolved = resolve_database_arg(None, Some(&targets), "spacetime logs [database]").unwrap();
+        assert_eq!(resolved.database, "foo");
+        assert_eq!(resolved.server.as_deref(), Some("maincloud"));
+    }
+
+    #[test]
+    fn resolve_database_with_optional_parts_single_target_allows_no_parts() {
+        let targets = vec![ConfigDbTarget {
+            database: "foo".to_string(),
+            server: Some("maincloud".to_string()),
+        }];
+        let resolved =
+            resolve_database_with_optional_parts(&[], Some(&targets), "spacetime describe [database] [entity]")
+                .unwrap();
+        assert_eq!(resolved.database, "foo");
+        assert!(resolved.remaining_args.is_empty());
+    }
+}

--- a/crates/cli/src/subcommands/mod.rs
+++ b/crates/cli/src/subcommands/mod.rs
@@ -1,5 +1,6 @@
 pub mod build;
 pub mod call;
+pub mod db_arg_resolution;
 pub mod delete;
 pub mod describe;
 pub mod dev;

--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -5,6 +5,9 @@ use std::time::{Duration, Instant};
 use crate::api::{from_json_seed, ClientApi, Connection, SqlStmtResult, StmtStats};
 use crate::common_args;
 use crate::config::Config;
+use crate::subcommands::db_arg_resolution::{
+    load_config_db_targets, resolve_database_arg, resolve_optional_database_parts,
+};
 use crate::util::{database_identity, get_auth_header, ResponseExt, UNSTABLE_WARNING};
 use anyhow::Context;
 use clap::{Arg, ArgAction, ArgMatches};
@@ -17,35 +20,40 @@ pub fn cli() -> clap::Command {
     clap::Command::new("sql")
         .about(format!("Runs a SQL query on the database. {UNSTABLE_WARNING}"))
         .arg(
-            Arg::new("database")
-                .required(true)
-                .help("The name or identity of the database you would like to query"),
-        )
-        .arg(
-            Arg::new("query")
-                .action(ArgAction::Set)
-                .required(true)
+            Arg::new("sql_parts")
+                .num_args(0..)
                 .conflicts_with("interactive")
-                .help("The SQL query to execute"),
+                .help("SQL arguments: [DATABASE] <QUERY>"),
         )
         .arg(
             Arg::new("interactive")
                 .long("interactive")
                 .action(ArgAction::SetTrue)
-                .conflicts_with("query")
+                .conflicts_with("sql_parts")
                 .help("Instead of using a query, run an interactive command prompt for `SQL` expressions"),
         )
         .arg(common_args::confirmed())
         .arg(common_args::anonymous())
         .arg(common_args::server().help("The nickname, host name or URL of the server hosting the database"))
         .arg(common_args::yes())
+        .arg(
+            Arg::new("no_config")
+                .long("no-config")
+                .action(ArgAction::SetTrue)
+                .help("Ignore spacetime.json configuration"),
+        )
 }
 
-pub(crate) async fn parse_req(mut config: Config, args: &ArgMatches) -> Result<Connection, anyhow::Error> {
-    let server = args.get_one::<String>("server").map(|s| s.as_ref());
+pub(crate) async fn parse_req(
+    mut config: Config,
+    args: &ArgMatches,
+    database_name_or_identity: &str,
+    server_from_config: Option<&str>,
+) -> Result<Connection, anyhow::Error> {
+    let server_from_cli = args.get_one::<String>("server").map(|s| s.as_ref());
     let force = args.get_flag("force");
-    let database_name_or_identity = args.get_one::<String>("database").unwrap();
     let anon_identity = args.get_flag("anon_identity");
+    let server = server_from_cli.or(server_from_config);
 
     Ok(Connection {
         host: config.get_host_url(server)?,
@@ -175,21 +183,44 @@ fn stmt_result_to_table(client: PsqlClient, stmt_result: &SqlStmtResult) -> anyh
 pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error> {
     eprintln!("{UNSTABLE_WARNING}\n");
     let interactive = args.get_one::<bool>("interactive").unwrap_or(&false);
+    let no_config = args.get_flag("no_config");
+    let raw_parts: Vec<String> = args
+        .get_many::<String>("sql_parts")
+        .map(|vals| vals.cloned().collect())
+        .unwrap_or_default();
+    let config_targets = load_config_db_targets(no_config)?;
+
     if *interactive {
-        let con = parse_req(config, args).await?;
+        if raw_parts.len() > 1 {
+            anyhow::bail!(
+                "Too many positional arguments for interactive mode.\nUsage: spacetime sql [database] --interactive [--no-config]"
+            );
+        }
+        let resolved = resolve_database_arg(
+            raw_parts.first().map(|s| s.as_str()),
+            config_targets.as_deref(),
+            "spacetime sql [database] --interactive [--no-config]",
+        )?;
+        let con = parse_req(config, args, &resolved.database, resolved.server.as_deref()).await?;
 
         crate::repl::exec(con).await?;
     } else {
-        let query = args.get_one::<String>("query").unwrap();
+        let resolved = resolve_optional_database_parts(
+            &raw_parts,
+            config_targets.as_deref(),
+            "query",
+            "spacetime sql [database] <query> [--no-config]",
+        )?;
+        let query = resolved.remaining_args.join(" ");
         let confirmed = args.get_flag("confirmed");
 
-        let con = parse_req(config, args).await?;
+        let con = parse_req(config, args, &resolved.database, resolved.server.as_deref()).await?;
         let mut api = ClientApi::new(con).sql();
         if confirmed {
             api = api.query(&[("confirmed", "true")]);
         }
 
-        run_sql(api, query, false).await?;
+        run_sql(api, &query, false).await?;
     }
     Ok(())
 }

--- a/docs/docs/00300-resources/00200-reference/00100-cli-reference/00100-cli-reference.md
+++ b/docs/docs/00300-resources/00200-reference/00100-cli-reference/00100-cli-reference.md
@@ -178,7 +178,7 @@ Run `spacetime help call` for more detailed information.
 
 ###### **Arguments:**
 
-* `<CALL_PARTS>` — Call arguments: [DATABASE] <FUNCTION_NAME> [ARGUMENTS...]
+* `<CALL_PARTS>` — Call arguments: [DATABASE] \<FUNCTION_NAME\> [ARGUMENTS...]
 
 ###### **Options:**
 
@@ -256,7 +256,7 @@ Start development mode with auto-regenerate client module bindings, auto-rebuild
 Invokes commands related to database budgets. WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime energy
-       energy <COMMAND>`
+       energy \<COMMAND\>`
 
 ###### **Subcommands:**
 
@@ -286,7 +286,7 @@ Runs a SQL query on the database. WARNING: This command is UNSTABLE and subject 
 
 ###### **Arguments:**
 
-* `<SQL_PARTS>` — SQL arguments: [DATABASE] <QUERY>
+* `<SQL_PARTS>` — SQL arguments: [DATABASE] \<QUERY\>
 
 ###### **Options:**
 
@@ -377,7 +377,7 @@ Lists the databases attached to an identity. WARNING: This command is UNSTABLE a
 Manage your login to the SpacetimeDB CLI
 
 **Usage:** `spacetime login [OPTIONS]
-       login <COMMAND>`
+       login \<COMMAND\>`
 
 ###### **Subcommands:**
 
@@ -460,7 +460,7 @@ Builds a spacetime module.
 Manage the connection to the SpacetimeDB server. WARNING: This command is UNSTABLE and subject to breaking changes.
 
 **Usage:** `spacetime server
-       server <COMMAND>`
+       server \<COMMAND\>`
 
 ###### **Subcommands:**
 
@@ -597,7 +597,7 @@ Subscribe to SQL queries on the database. WARNING: This command is UNSTABLE and 
 
 ###### **Arguments:**
 
-* `<SUBSCRIBE_PARTS>` — Subscribe arguments: [DATABASE] <QUERY> [QUERY...]
+* `<SUBSCRIBE_PARTS>` — Subscribe arguments: [DATABASE] \<QUERY\> [QUERY...]
 
 ###### **Options:**
 

--- a/docs/docs/00300-resources/00200-reference/00100-cli-reference/00100-cli-reference.md
+++ b/docs/docs/00300-resources/00200-reference/00100-cli-reference/00100-cli-reference.md
@@ -121,7 +121,7 @@ Run `spacetime help publish` for more detailed information.
 
 Deletes a SpacetimeDB database
 
-**Usage:** `spacetime delete [OPTIONS] <database>`
+**Usage:** `spacetime delete [OPTIONS] [database]`
 
 Run `spacetime help delete` for more detailed information.
 
@@ -134,6 +134,7 @@ Run `spacetime help delete` for more detailed information.
 
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+* `--no-config` — Ignore spacetime.json configuration
 
 
 
@@ -141,7 +142,7 @@ Run `spacetime help delete` for more detailed information.
 
 Prints logs from a SpacetimeDB database
 
-**Usage:** `spacetime logs [OPTIONS] <database>`
+**Usage:** `spacetime logs [OPTIONS] [database]`
 
 Run `spacetime help logs` for more detailed information.
 
@@ -162,6 +163,7 @@ Run `spacetime help logs` for more detailed information.
   Possible values: `text`, `json`
 
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+* `--no-config` — Ignore spacetime.json configuration
 
 
 
@@ -169,22 +171,21 @@ Run `spacetime help logs` for more detailed information.
 
 Invokes a function (reducer or procedure) in a database. WARNING: This command is UNSTABLE and subject to breaking changes.
 
-**Usage:** `spacetime call [OPTIONS] <database> <function_name> [arguments]...`
+**Usage:** `spacetime call [OPTIONS] [call_parts]...`
 
 Run `spacetime help call` for more detailed information.
 
 
 ###### **Arguments:**
 
-* `<DATABASE>` — The database name or identity to use to invoke the call
-* `<FUNCTION_NAME>` — The name of the function to call
-* `<ARGUMENTS>` — arguments formatted as JSON
+* `<CALL_PARTS>` — Call arguments: [DATABASE] <FUNCTION_NAME> [ARGUMENTS...]
 
 ###### **Options:**
 
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
 * `--anonymous` — Perform this action with an anonymous identity
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+* `--no-config` — Ignore spacetime.json configuration
 
 
 
@@ -192,19 +193,14 @@ Run `spacetime help call` for more detailed information.
 
 Describe the structure of a database or entities within it. WARNING: This command is UNSTABLE and subject to breaking changes.
 
-**Usage:** `spacetime describe [OPTIONS] --json <database> [entity_type] [entity_name]`
+**Usage:** `spacetime describe [OPTIONS] --json [describe_parts]...`
 
 Run `spacetime help describe` for more detailed information.
 
 
 ###### **Arguments:**
 
-* `<DATABASE>` — The name or identity of the database to describe
-* `<ENTITY_TYPE>` — Whether to describe a reducer or table
-
-  Possible values: `reducer`, `table`
-
-* `<ENTITY_NAME>` — The name of the entity to describe
+* `<DESCRIBE_PARTS>` — Describe arguments: [DATABASE] [ENTITY_TYPE ENTITY_NAME]
 
 ###### **Options:**
 
@@ -212,6 +208,7 @@ Run `spacetime help describe` for more detailed information.
 * `--anonymous` — Perform this action with an anonymous identity
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+* `--no-config` — Ignore spacetime.json configuration
 
 
 
@@ -285,12 +282,11 @@ Show current energy balance for an identity
 
 Runs a SQL query on the database. WARNING: This command is UNSTABLE and subject to breaking changes.
 
-**Usage:** `spacetime sql [OPTIONS] <database> <query>`
+**Usage:** `spacetime sql [OPTIONS] [sql_parts]...`
 
 ###### **Arguments:**
 
-* `<DATABASE>` — The name or identity of the database you would like to query
-* `<QUERY>` — The SQL query to execute
+* `<SQL_PARTS>` — SQL arguments: [DATABASE] <QUERY>
 
 ###### **Options:**
 
@@ -299,6 +295,7 @@ Runs a SQL query on the database. WARNING: This command is UNSTABLE and subject 
 * `--anonymous` — Perform this action with an anonymous identity
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+* `--no-config` — Ignore spacetime.json configuration
 
 
 
@@ -596,12 +593,11 @@ Deletes all data from all local databases
 
 Subscribe to SQL queries on the database. WARNING: This command is UNSTABLE and subject to breaking changes.
 
-**Usage:** `spacetime subscribe [OPTIONS] <database> <query>...`
+**Usage:** `spacetime subscribe [OPTIONS] [subscribe_parts]...`
 
 ###### **Arguments:**
 
-* `<DATABASE>` — The name or identity of the database you would like to query
-* `<QUERY>` — The SQL query to execute
+* `<SUBSCRIBE_PARTS>` — Subscribe arguments: [DATABASE] <QUERY> [QUERY...]
 
 ###### **Options:**
 
@@ -612,6 +608,7 @@ Subscribe to SQL queries on the database. WARNING: This command is UNSTABLE and 
 * `--confirmed` — Instruct the server to deliver only updates of confirmed transactions
 * `--anonymous` — Perform this action with an anonymous identity
 * `-y`, `--yes` — Run non-interactively wherever possible. This will answer "yes" to almost all prompts, but will sometimes answer "no" to preserve non-interactivity (e.g. when prompting whether to log in with spacetimedb.com).
+* `--no-config` — Ignore spacetime.json configuration
 * `-s`, `--server <SERVER>` — The nickname, host name or URL of the server hosting the database
 
 

--- a/docs/scripts/generate-cli-docs.mjs
+++ b/docs/scripts/generate-cli-docs.mjs
@@ -38,6 +38,29 @@ function runCargoAndAppend({ cwd, outFilePath }) {
   });
 }
 
+/**
+ * Escape `<PLACEHOLDER>` patterns that appear outside backtick code spans
+ * so MDX doesn't treat them as JSX tags.
+ *
+ * Splits each line on backtick boundaries, and only escapes in the non-code
+ * segments. E.g. `<FOO>` (inside backticks) is left alone, but bare <FOO>
+ * becomes \<FOO\>.
+ */
+function escapeAngleBracketsOutsideBackticks(content) {
+  return content
+    .split('\n')
+    .map(line => {
+      // Split on backtick-delimited code spans, alternating: text, code, text, code, ...
+      const parts = line.split('`');
+      for (let i = 0; i < parts.length; i += 2) {
+        // Even indices are outside backticks
+        parts[i] = parts[i].replace(/<([A-Z][A-Z0-9_-]*(?:\s+[A-Z][A-Z0-9_-]*)*)>/g, '\\<$1\\>');
+      }
+      return parts.join('`');
+    })
+    .join('\n');
+}
+
 async function main() {
   const repoRoot = getRepoRoot();
 
@@ -55,6 +78,10 @@ async function main() {
 
   await fs.writeFile(outFile, header, 'utf8');
   await runCargoAndAppend({ cwd: repoRoot, outFilePath: outFile });
+
+  // Post-process: escape angle-bracket placeholders outside backtick spans for MDX
+  const raw = await fs.readFile(outFile, 'utf8');
+  await fs.writeFile(outFile, escapeAngleBracketsOutsideBackticks(raw), 'utf8');
 }
 
 main().catch(err => {


### PR DESCRIPTION
# Description of Changes

This PR introduces a possibility to skip passing a DB name to various commands if there is a config file with one database defined

# API and ABI breaking changes

This changes the behaviour of several CLI commands:

  1. call
  2. subscribe
  3. sql
  4. describe
  5. logs
  6. delete

# Expected complexity level and risk

4 - it's tricky to get all of the combinations of CLI arguments right

# Testing

I've tested the simplest cases manually.