### PR TITLE
Make Rust test clients listen for reducer errors

### DIFF
--- a/sdks/rust/tests/procedure-client/src/main.rs
+++ b/sdks/rust/tests/procedure-client/src/main.rs
@@ -352,7 +352,13 @@ fn exec_schedule_procedure() {
 
             subscribe_all_then(ctx, move |ctx| {
                 sub_applied_nothing_result(assert_all_tables_empty(ctx));
-                ctx.reducers.schedule_proc().unwrap();
+                ctx.reducers
+                    .schedule_proc_then(|_ctx, outcome| match outcome {
+                        Ok(Ok(())) => (),
+                        Ok(Err(msg)) => panic!("`schedule_proc` reducer returned error: {msg}"),
+                        Err(internal_error) => panic!("`schedule_proc` reducer panicked: {internal_error:?}"),
+                    })
+                    .unwrap();
             });
         }
     });

--- a/sdks/rust/tests/test-client/src/pk_test_table.rs
+++ b/sdks/rust/tests/test-client/src/pk_test_table.rs
@@ -125,11 +125,11 @@ macro_rules! impl_pk_test_table {
     (__impl $table:ident {
         Key = $key:ty;
         key_field_name = $field_name:ident;
-        insert_reducer = $insert_reducer:ident;
+        insert_then = $insert_reducer_then:ident;
         insert_reducer_event = $insert_reducer_event:ident;
-        delete_reducer = $delete_reducer:ident;
+        delete_then = $delete_reducer_then:ident;
         delete_reducer_event = $delete_reducer_event:ident;
-        update_reducer = $update_reducer:ident;
+        update_then= $update_reducer_then:ident;
         update_reducer_event = $update_reducer_event:ident;
         accessor_method = $accessor_method:ident;
     }) => {
@@ -155,13 +155,31 @@ macro_rules! impl_pk_test_table {
             }
 
             fn insert(ctx: &impl RemoteDbContext, key: Self::PrimaryKey, value: i32) {
-                ctx.reducers().$insert_reducer(key, value).unwrap();
+                ctx.reducers().$insert_reducer_then(key, value, |ctx, outcome| {
+                    match outcome {
+                        Ok(Ok(())) => assert!(Self::is_insert_reducer_event(&ctx.event.reducer)),
+                        Ok(Err(msg)) => panic!("Insert reducer returned error: {msg}"),
+                        Err(internal_error) => panic!("Insert reducer panicked: {internal_error:?}"),
+                    }
+                }).unwrap();
             }
             fn delete(ctx: &impl RemoteDbContext, key: Self::PrimaryKey) {
-                ctx.reducers().$delete_reducer(key).unwrap();
+                ctx.reducers().$delete_reducer_then(key, |ctx, outcome| {
+                    match outcome {
+                        Ok(Ok(())) => assert!(Self::is_delete_reducer_event(&ctx.event.reducer)),
+                        Ok(Err(msg)) => panic!("Delete reducer returned error: {msg}"),
+                        Err(internal_error) => panic!("Delete reducer panicked: {internal_error:?}"),
+                    }
+                }).unwrap();
             }
             fn update(ctx: &impl RemoteDbContext, key: Self::PrimaryKey, new_value: i32) {
-                ctx.reducers().$update_reducer(key, new_value).unwrap();
+                ctx.reducers().$update_reducer_then(key, new_value, |ctx, outcome| {
+                    match outcome {
+                        Ok(Ok(())) => assert!(Self::is_update_reducer_event(&ctx.event.reducer)),
+                        Ok(Err(msg)) => panic!("Update reducer returned error: {msg}"),
+                        Err(internal_error) => panic!("Update reducer panicked: {internal_error:?}"),
+                    }
+                }).unwrap();
             }
 
             fn on_insert(ctx: &impl RemoteDbContext, callback: impl FnMut(&EventContext, &Self) + Send + 'static) {
@@ -185,77 +203,77 @@ impl_pk_test_table! {
     PkU8 {
         Key = u8;
         key_field_name = n;
-        insert_reducer = insert_pk_u_8;
+        insert_then = insert_pk_u_8_then;
         insert_reducer_event = InsertPkU8;
-        delete_reducer = delete_pk_u_8;
+        delete_then = delete_pk_u_8_then;
         delete_reducer_event = DeletePkU8;
-        update_reducer = update_pk_u_8;
+        update_then = update_pk_u_8_then;
         update_reducer_event = UpdatePkU8;
         accessor_method = pk_u_8;
     }
     PkU16 {
         Key = u16;
         key_field_name = n;
-        insert_reducer = insert_pk_u_16;
+        insert_then = insert_pk_u_16_then;
         insert_reducer_event = InsertPkU16;
-        delete_reducer = delete_pk_u_16;
+        delete_then = delete_pk_u_16_then;
         delete_reducer_event = DeletePkU16;
-        update_reducer = update_pk_u_16;
+        update_then = update_pk_u_16_then;
         update_reducer_event = UpdatePkU16;
         accessor_method = pk_u_16;
     }
     PkU32 {
         Key = u32;
         key_field_name = n;
-        insert_reducer = insert_pk_u_32;
+        insert_then = insert_pk_u_32_then;
         insert_reducer_event = InsertPkU32;
-        delete_reducer = delete_pk_u_32;
+        delete_then = delete_pk_u_32_then;
         delete_reducer_event = DeletePkU32;
-        update_reducer = update_pk_u_32;
+        update_then = update_pk_u_32_then;
         update_reducer_event = UpdatePkU32;
         accessor_method = pk_u_32;
     }
     PkU32Two {
         Key = u32;
         key_field_name = n;
-        insert_reducer = insert_pk_u_32_two;
+        insert_then = insert_pk_u_32_two_then;
         insert_reducer_event = InsertPkU32Two;
-        delete_reducer = delete_pk_u_32_two;
+        delete_then = delete_pk_u_32_two_then;
         delete_reducer_event = DeletePkU32Two;
-        update_reducer = update_pk_u_32_two;
+        update_then = update_pk_u_32_two_then;
         update_reducer_event = UpdatePkU32Two;
         accessor_method = pk_u_32_two;
     }
     PkU64 {
         Key = u64;
         key_field_name = n;
-        insert_reducer = insert_pk_u_64;
+        insert_then = insert_pk_u_64_then;
         insert_reducer_event = InsertPkU64;
-        delete_reducer = delete_pk_u_64;
+        delete_then = delete_pk_u_64_then;
         delete_reducer_event = DeletePkU64;
-        update_reducer = update_pk_u_64;
+        update_then = update_pk_u_64_then;
         update_reducer_event = UpdatePkU64;
         accessor_method = pk_u_64;
     }
     PkU128 {
         Key = u128;
         key_field_name = n;
-        insert_reducer = insert_pk_u_128;
+        insert_then = insert_pk_u_128_then;
         insert_reducer_event = InsertPkU128;
-        delete_reducer = delete_pk_u_128;
+        delete_then = delete_pk_u_128_then;
         delete_reducer_event = DeletePkU128;
-        update_reducer = update_pk_u_128;
+        update_then = update_pk_u_128_then;
         update_reducer_event = UpdatePkU128;
         accessor_method = pk_u_128;
     }
     PkU256 {
         Key = u256;
         key_field_name = n;
-        insert_reducer = insert_pk_u_256;
+        insert_then = insert_pk_u_256_then;
         insert_reducer_event = InsertPkU256;
-        delete_reducer = delete_pk_u_256;
+        delete_then = delete_pk_u_256_then;
         delete_reducer_event = DeletePkU256;
-        update_reducer = update_pk_u_256;
+        update_then = update_pk_u_256_then;
         update_reducer_event = UpdatePkU256;
         accessor_method = pk_u_256;
     }
@@ -263,66 +281,66 @@ impl_pk_test_table! {
     PkI8 {
         Key = i8;
         key_field_name = n;
-        insert_reducer = insert_pk_i_8;
+        insert_then = insert_pk_i_8_then;
         insert_reducer_event = InsertPkI8;
-        delete_reducer = delete_pk_i_8;
+        delete_then = delete_pk_i_8_then;
         delete_reducer_event = DeletePkI8;
-        update_reducer = update_pk_i_8;
+        update_then = update_pk_i_8_then;
         update_reducer_event = UpdatePkI8;
         accessor_method = pk_i_8;
     }
     PkI16 {
         Key = i16;
         key_field_name = n;
-        insert_reducer = insert_pk_i_16;
+        insert_then = insert_pk_i_16_then;
         insert_reducer_event = InsertPkI16;
-        delete_reducer = delete_pk_i_16;
+        delete_then = delete_pk_i_16_then;
         delete_reducer_event = DeletePkI16;
-        update_reducer = update_pk_i_16;
+        update_then = update_pk_i_16_then;
         update_reducer_event = UpdatePkI16;
         accessor_method = pk_i_16;
     }
     PkI32 {
         Key = i32;
         key_field_name = n;
-        insert_reducer = insert_pk_i_32;
+        insert_then = insert_pk_i_32_then;
         insert_reducer_event = InsertPkI32;
-        delete_reducer = delete_pk_i_32;
+        delete_then = delete_pk_i_32_then;
         delete_reducer_event = DeletePkI32;
-        update_reducer = update_pk_i_32;
+        update_then = update_pk_i_32_then;
         update_reducer_event = UpdatePkI32;
         accessor_method = pk_i_32;
     }
     PkI64 {
         Key = i64;
         key_field_name = n;
-        insert_reducer = insert_pk_i_64;
+        insert_then = insert_pk_i_64_then;
         insert_reducer_event = InsertPkI64;
-        delete_reducer = delete_pk_i_64;
+        delete_then = delete_pk_i_64_then;
         delete_reducer_event = DeletePkI64;
-        update_reducer = update_pk_i_64;
+        update_then = update_pk_i_64_then;
         update_reducer_event = UpdatePkI64;
         accessor_method = pk_i_64;
     }
     PkI128 {
         Key = i128;
         key_field_name = n;
-        insert_reducer = insert_pk_i_128;
+        insert_then = insert_pk_i_128_then;
         insert_reducer_event = InsertPkI128;
-        delete_reducer = delete_pk_i_128;
+        delete_then = delete_pk_i_128_then;
         delete_reducer_event = DeletePkI128;
-        update_reducer = update_pk_i_128;
+        update_then = update_pk_i_128_then;
         update_reducer_event = UpdatePkI128;
         accessor_method = pk_i_128;
     }
     PkI256 {
         Key = i256;
         key_field_name = n;
-        insert_reducer = insert_pk_i_256;
+        insert_then = insert_pk_i_256_then;
         insert_reducer_event = InsertPkI256;
-        delete_reducer = delete_pk_i_256;
+        delete_then = delete_pk_i_256_then;
         delete_reducer_event = DeletePkI256;
-        update_reducer = update_pk_i_256;
+        update_then = update_pk_i_256_then;
         update_reducer_event = UpdatePkI256;
         accessor_method = pk_i_256;
     }
@@ -330,11 +348,11 @@ impl_pk_test_table! {
     PkBool {
         Key = bool;
         key_field_name = b;
-        insert_reducer = insert_pk_bool;
+        insert_then = insert_pk_bool_then;
         insert_reducer_event = InsertPkBool;
-        delete_reducer = delete_pk_bool;
+        delete_then = delete_pk_bool_then;
         delete_reducer_event = DeletePkBool;
-        update_reducer = update_pk_bool;
+        update_then = update_pk_bool_then;
         update_reducer_event = UpdatePkBool;
         accessor_method = pk_bool;
     }
@@ -342,11 +360,11 @@ impl_pk_test_table! {
     PkString {
         Key = String;
         key_field_name = s;
-        insert_reducer = insert_pk_string;
+        insert_then = insert_pk_string_then;
         insert_reducer_event = InsertPkString;
-        delete_reducer = delete_pk_string;
+        delete_then = delete_pk_string_then;
         delete_reducer_event = DeletePkString;
-        update_reducer = update_pk_string;
+        update_then = update_pk_string_then;
         update_reducer_event = UpdatePkString;
         accessor_method = pk_string;
     }
@@ -354,11 +372,11 @@ impl_pk_test_table! {
     PkIdentity {
         Key = Identity;
         key_field_name = i;
-        insert_reducer = insert_pk_identity;
+        insert_then = insert_pk_identity_then;
         insert_reducer_event = InsertPkIdentity;
-        delete_reducer = delete_pk_identity;
+        delete_then = delete_pk_identity_then;
         delete_reducer_event = DeletePkIdentity;
-        update_reducer = update_pk_identity;
+        update_then = update_pk_identity_then;
         update_reducer_event = UpdatePkIdentity;
         accessor_method = pk_identity;
     }
@@ -366,11 +384,11 @@ impl_pk_test_table! {
     PkConnectionId {
         Key = ConnectionId;
         key_field_name = a;
-        insert_reducer = insert_pk_connection_id;
+        insert_then = insert_pk_connection_id_then;
         insert_reducer_event = InsertPkConnectionId;
-        delete_reducer = delete_pk_connection_id;
+        delete_then = delete_pk_connection_id_then;
         delete_reducer_event = DeletePkConnectionId;
-        update_reducer = update_pk_connection_id;
+        update_then = update_pk_connection_id_then;
         update_reducer_event = UpdatePkConnectionId;
         accessor_method = pk_connection_id;
     }
@@ -378,11 +396,11 @@ impl_pk_test_table! {
      PkUuid {
         Key = Uuid;
         key_field_name = u;
-        insert_reducer = insert_pk_uuid;
+        insert_then = insert_pk_uuid_then;
         insert_reducer_event = InsertPkUuid;
-        delete_reducer = delete_pk_uuid;
+        delete_then = delete_pk_uuid_then;
         delete_reducer_event = DeletePkUuid;
-        update_reducer = update_pk_uuid;
+        update_then = update_pk_uuid_then;
         update_reducer_event = UpdatePkUuid;
         accessor_method = pk_uuid;
     }

--- a/sdks/rust/tests/test-client/src/simple_test_table.rs
+++ b/sdks/rust/tests/test-client/src/simple_test_table.rs
@@ -22,7 +22,7 @@ macro_rules! impl_simple_test_table {
     (__impl $table:ident {
         Contents = $contents:ty;
         field_name = $field_name:ident;
-        insert_reducer = $insert_reducer:ident;
+        insert_then = $insert_reducer_then:ident;
         insert_reducer_event = $insert_reducer_event:ident;
         accessor_method = $accessor_method:ident;
     }) => {
@@ -38,7 +38,13 @@ macro_rules! impl_simple_test_table {
             }
 
             fn insert(ctx: &impl RemoteDbContext, contents: Self::Contents) {
-                ctx.reducers().$insert_reducer(contents).unwrap();
+                ctx.reducers().$insert_reducer_then(contents, |ctx, outcome| {
+                    match outcome {
+                        Ok(Ok(())) => assert!(Self::is_insert_reducer_event(&ctx.event.reducer)),
+                        Ok(Err(msg)) => panic!("Insert reducer returned error: {msg}"),
+                        Err(internal_error) => panic!("Insert reducer panicked: {internal_error:?}"),
+                    }
+                }).unwrap();
             }
 
             fn on_insert(ctx: &impl RemoteDbContext, callback: impl FnMut(&EventContext, &Self) + Send + 'static) {
@@ -55,42 +61,42 @@ impl_simple_test_table! {
     OneU8 {
         Contents = u8;
         field_name = n;
-        insert_reducer = insert_one_u_8;
+        insert_then = insert_one_u_8_then;
         insert_reducer_event = InsertOneU8;
         accessor_method = one_u_8;
     }
     OneU16 {
         Contents = u16;
         field_name = n;
-        insert_reducer = insert_one_u_16;
+        insert_then = insert_one_u_16_then;
         insert_reducer_event = InsertOneU16;
         accessor_method = one_u_16;
     }
     OneU32 {
         Contents = u32;
         field_name = n;
-        insert_reducer = insert_one_u_32;
+        insert_then = insert_one_u_32_then;
         insert_reducer_event = InsertOneU32;
         accessor_method = one_u_32;
     }
     OneU64 {
         Contents = u64;
         field_name = n;
-        insert_reducer = insert_one_u_64;
+        insert_then = insert_one_u_64_then;
         insert_reducer_event = InsertOneU64;
         accessor_method = one_u_64;
     }
     OneU128 {
         Contents = u128;
         field_name = n;
-        insert_reducer = insert_one_u_128;
+        insert_then = insert_one_u_128_then;
         insert_reducer_event = InsertOneU128;
         accessor_method = one_u_128;
     }
     OneU256 {
         Contents = u256;
         field_name = n;
-        insert_reducer = insert_one_u_256;
+        insert_then = insert_one_u_256_then;
         insert_reducer_event = InsertOneU256;
         accessor_method = one_u_256;
     }
@@ -98,42 +104,42 @@ impl_simple_test_table! {
     OneI8 {
         Contents = i8;
         field_name = n;
-        insert_reducer = insert_one_i_8;
+        insert_then = insert_one_i_8_then;
         insert_reducer_event = InsertOneI8;
         accessor_method = one_i_8;
     }
     OneI16 {
         Contents = i16;
         field_name = n;
-        insert_reducer = insert_one_i_16;
+        insert_then = insert_one_i_16_then;
         insert_reducer_event = InsertOneI16;
         accessor_method = one_i_16;
     }
     OneI32 {
         Contents = i32;
         field_name = n;
-        insert_reducer = insert_one_i_32;
+        insert_then = insert_one_i_32_then;
         insert_reducer_event = InsertOneI32;
         accessor_method = one_i_32;
     }
     OneI64 {
         Contents = i64;
         field_name = n;
-        insert_reducer = insert_one_i_64;
+        insert_then = insert_one_i_64_then;
         insert_reducer_event = InsertOneI64;
         accessor_method = one_i_64;
     }
     OneI128 {
         Contents = i128;
         field_name = n;
-        insert_reducer = insert_one_i_128;
+        insert_then = insert_one_i_128_then;
         insert_reducer_event = InsertOneI128;
         accessor_method = one_i_128;
     }
     OneI256 {
         Contents = i256;
         field_name = n;
-        insert_reducer = insert_one_i_256;
+        insert_then = insert_one_i_256_then;
         insert_reducer_event = InsertOneI256;
         accessor_method = one_i_256;
     }
@@ -141,14 +147,14 @@ impl_simple_test_table! {
     OneF32 {
         Contents = f32;
         field_name = f;
-        insert_reducer = insert_one_f_32;
+        insert_then = insert_one_f_32_then;
         insert_reducer_event = InsertOneF32;
         accessor_method = one_f_32;
     }
     OneF64 {
         Contents = f64;
         field_name = f;
-        insert_reducer = insert_one_f_64;
+        insert_then = insert_one_f_64_then;
         insert_reducer_event = InsertOneF64;
         accessor_method = one_f_64;
     }
@@ -156,7 +162,7 @@ impl_simple_test_table! {
     OneBool {
         Contents = bool;
         field_name = b;
-        insert_reducer = insert_one_bool;
+        insert_then = insert_one_bool_then;
         insert_reducer_event = InsertOneBool;
         accessor_method = one_bool;
     }
@@ -164,7 +170,7 @@ impl_simple_test_table! {
     OneString {
         Contents = String;
         field_name = s;
-        insert_reducer = insert_one_string;
+        insert_then = insert_one_string_then;
         insert_reducer_event = InsertOneString;
         accessor_method = one_string;
     }
@@ -172,7 +178,7 @@ impl_simple_test_table! {
     OneIdentity {
         Contents = Identity;
         field_name = i;
-        insert_reducer = insert_one_identity;
+        insert_then = insert_one_identity_then;
         insert_reducer_event = InsertOneIdentity;
         accessor_method = one_identity;
     }
@@ -180,7 +186,7 @@ impl_simple_test_table! {
     OneConnectionId {
         Contents = ConnectionId;
         field_name = a;
-        insert_reducer = insert_one_connection_id;
+        insert_then = insert_one_connection_id_then;
         insert_reducer_event = InsertOneConnectionId;
         accessor_method = one_connection_id;
     }
@@ -188,7 +194,7 @@ impl_simple_test_table! {
     OneTimestamp {
         Contents = Timestamp;
         field_name = t;
-        insert_reducer = insert_one_timestamp;
+        insert_then = insert_one_timestamp_then;
         insert_reducer_event = InsertOneTimestamp;
         accessor_method = one_timestamp;
     }
@@ -196,7 +202,7 @@ impl_simple_test_table! {
     OneUuid {
         Contents = Uuid;
         field_name = u;
-        insert_reducer = insert_one_uuid;
+        insert_then = insert_one_uuid_then;
         insert_reducer_event = InsertOneUuid;
         accessor_method = one_uuid;
     }
@@ -204,14 +210,14 @@ impl_simple_test_table! {
     OneSimpleEnum {
         Contents = SimpleEnum;
         field_name = e;
-        insert_reducer = insert_one_simple_enum;
+        insert_then = insert_one_simple_enum_then;
         insert_reducer_event = InsertOneSimpleEnum;
         accessor_method = one_simple_enum;
     }
     OneEnumWithPayload {
         Contents = EnumWithPayload;
         field_name = e;
-        insert_reducer = insert_one_enum_with_payload;
+        insert_then = insert_one_enum_with_payload_then;
         insert_reducer_event = InsertOneEnumWithPayload;
         accessor_method = one_enum_with_payload;
     }
@@ -219,28 +225,28 @@ impl_simple_test_table! {
     OneUnitStruct {
         Contents = UnitStruct;
         field_name = s;
-        insert_reducer = insert_one_unit_struct;
+        insert_then = insert_one_unit_struct_then;
         insert_reducer_event = InsertOneUnitStruct;
         accessor_method = one_unit_struct;
     }
     OneByteStruct {
         Contents = ByteStruct;
         field_name = s;
-        insert_reducer = insert_one_byte_struct;
+        insert_then = insert_one_byte_struct_then;
         insert_reducer_event = InsertOneByteStruct;
         accessor_method = one_byte_struct;
     }
     OneEveryPrimitiveStruct {
         Contents = EveryPrimitiveStruct;
         field_name = s;
-        insert_reducer = insert_one_every_primitive_struct;
+        insert_then = insert_one_every_primitive_struct_then;
         insert_reducer_event = InsertOneEveryPrimitiveStruct;
         accessor_method = one_every_primitive_struct;
     }
     OneEveryVecStruct {
         Contents = EveryVecStruct;
         field_name = s;
-        insert_reducer = insert_one_every_vec_struct;
+        insert_then = insert_one_every_vec_struct_then;
         insert_reducer_event = InsertOneEveryVecStruct;
         accessor_method = one_every_vec_struct;
     }
@@ -248,42 +254,42 @@ impl_simple_test_table! {
     VecU8 {
         Contents = Vec<u8>;
         field_name = n;
-        insert_reducer = insert_vec_u_8;
+        insert_then = insert_vec_u_8_then;
         insert_reducer_event = InsertVecU8;
         accessor_method = vec_u_8;
     }
     VecU16 {
         Contents = Vec<u16>;
         field_name = n;
-        insert_reducer = insert_vec_u_16;
+        insert_then = insert_vec_u_16_then;
         insert_reducer_event = InsertVecU16;
         accessor_method = vec_u_16;
     }
     VecU32 {
         Contents = Vec<u32>;
         field_name = n;
-        insert_reducer = insert_vec_u_32;
+        insert_then = insert_vec_u_32_then;
         insert_reducer_event = InsertVecU32;
         accessor_method = vec_u_32;
     }
     VecU64 {
         Contents = Vec<u64>;
         field_name = n;
-        insert_reducer = insert_vec_u_64;
+        insert_then = insert_vec_u_64_then;
         insert_reducer_event = InsertVecU64;
         accessor_method = vec_u_64;
     }
     VecU128 {
         Contents = Vec<u128>;
         field_name = n;
-        insert_reducer = insert_vec_u_128;
+        insert_then = insert_vec_u_128_then;
         insert_reducer_event = InsertVecU128;
         accessor_method = vec_u_128;
     }
     VecU256 {
         Contents = Vec<u256>;
         field_name = n;
-        insert_reducer = insert_vec_u_256;
+        insert_then = insert_vec_u_256_then;
         insert_reducer_event = InsertVecU256;
         accessor_method = vec_u_256;
     }
@@ -291,42 +297,42 @@ impl_simple_test_table! {
     VecI8 {
         Contents = Vec<i8>;
         field_name = n;
-        insert_reducer = insert_vec_i_8;
+        insert_then = insert_vec_i_8_then;
         insert_reducer_event = InsertVecI8;
         accessor_method = vec_i_8;
     }
     VecI16 {
         Contents = Vec<i16>;
         field_name = n;
-        insert_reducer = insert_vec_i_16;
+        insert_then = insert_vec_i_16_then;
         insert_reducer_event = InsertVecI16;
         accessor_method = vec_i_16;
     }
     VecI32 {
         Contents = Vec<i32>;
         field_name = n;
-        insert_reducer = insert_vec_i_32;
+        insert_then = insert_vec_i_32_then;
         insert_reducer_event = InsertVecI32;
         accessor_method = vec_i_32;
     }
     VecI64 {
         Contents = Vec<i64>;
         field_name = n;
-        insert_reducer = insert_vec_i_64;
+        insert_then = insert_vec_i_64_then;
         insert_reducer_event = InsertVecI64;
         accessor_method = vec_i_64;
     }
     VecI128 {
         Contents = Vec<i128>;
         field_name = n;
-        insert_reducer = insert_vec_i_128;
+        insert_then = insert_vec_i_128_then;
         insert_reducer_event = InsertVecI128;
         accessor_method = vec_i_128;
     }
     VecI256 {
         Contents = Vec<i256>;
         field_name = n;
-        insert_reducer = insert_vec_i_256;
+        insert_then = insert_vec_i_256_then;
         insert_reducer_event = InsertVecI256;
         accessor_method = vec_i_256;
     }
@@ -334,14 +340,14 @@ impl_simple_test_table! {
     VecF32 {
         Contents = Vec<f32>;
         field_name = f;
-        insert_reducer = insert_vec_f_32;
+        insert_then = insert_vec_f_32_then;
         insert_reducer_event = InsertVecF32;
         accessor_method = vec_f_32;
     }
     VecF64 {
         Contents = Vec<f64>;
         field_name = f;
-        insert_reducer = insert_vec_f_64;
+        insert_then = insert_vec_f_64_then;
         insert_reducer_event = InsertVecF64;
         accessor_method = vec_f_64;
     }
@@ -349,7 +355,7 @@ impl_simple_test_table! {
     VecBool {
         Contents = Vec<bool>;
         field_name = b;
-        insert_reducer = insert_vec_bool;
+        insert_then = insert_vec_bool_then;
         insert_reducer_event = InsertVecBool;
         accessor_method = vec_bool;
     }
@@ -357,7 +363,7 @@ impl_simple_test_table! {
     VecString {
         Contents = Vec<String>;
         field_name = s;
-        insert_reducer = insert_vec_string;
+        insert_then = insert_vec_string_then;
         insert_reducer_event = InsertVecString;
         accessor_method = vec_string;
     }
@@ -365,7 +371,7 @@ impl_simple_test_table! {
     VecIdentity {
         Contents = Vec<Identity>;
         field_name = i;
-        insert_reducer = insert_vec_identity;
+        insert_then = insert_vec_identity_then;
         insert_reducer_event = InsertVecIdentity;
         accessor_method = vec_identity;
     }
@@ -373,7 +379,7 @@ impl_simple_test_table! {
     VecConnectionId {
         Contents = Vec<ConnectionId>;
         field_name = a;
-        insert_reducer = insert_vec_connection_id;
+        insert_then = insert_vec_connection_id_then;
         insert_reducer_event = InsertVecConnectionId;
         accessor_method = vec_connection_id;
     }
@@ -381,7 +387,7 @@ impl_simple_test_table! {
     VecTimestamp {
         Contents = Vec<Timestamp>;
         field_name = t;
-        insert_reducer = insert_vec_timestamp;
+        insert_then = insert_vec_timestamp_then;
         insert_reducer_event = InsertVecTimestamp;
         accessor_method = vec_timestamp;
     }
@@ -389,7 +395,7 @@ impl_simple_test_table! {
     VecUuid {
         Contents = Vec<Uuid>;
         field_name = u;
-        insert_reducer = insert_vec_uuid;
+        insert_then = insert_vec_uuid_then;
         insert_reducer_event = InsertVecUuid;
         accessor_method = vec_uuid;
     }
@@ -397,14 +403,14 @@ impl_simple_test_table! {
     VecSimpleEnum {
         Contents = Vec<SimpleEnum>;
         field_name = e;
-        insert_reducer = insert_vec_simple_enum;
+        insert_then = insert_vec_simple_enum_then;
         insert_reducer_event = InsertVecSimpleEnum;
         accessor_method = vec_simple_enum;
     }
     VecEnumWithPayload {
         Contents = Vec<EnumWithPayload>;
         field_name = e;
-        insert_reducer = insert_vec_enum_with_payload;
+        insert_then = insert_vec_enum_with_payload_then;
         insert_reducer_event = InsertVecEnumWithPayload;
         accessor_method = vec_enum_with_payload;
     }
@@ -412,77 +418,77 @@ impl_simple_test_table! {
     VecUnitStruct {
         Contents = Vec<UnitStruct>;
         field_name = s;
-        insert_reducer = insert_vec_unit_struct;
+        insert_then = insert_vec_unit_struct_then;
         insert_reducer_event = InsertVecUnitStruct;
         accessor_method = vec_unit_struct;
     }
     VecByteStruct {
         Contents = Vec<ByteStruct>;
         field_name = s;
-        insert_reducer = insert_vec_byte_struct;
+        insert_then = insert_vec_byte_struct_then;
         insert_reducer_event = InsertVecByteStruct;
         accessor_method = vec_byte_struct;
     }
     VecEveryPrimitiveStruct {
         Contents = Vec<EveryPrimitiveStruct>;
         field_name = s;
-        insert_reducer = insert_vec_every_primitive_struct;
+        insert_then = insert_vec_every_primitive_struct_then;
         insert_reducer_event = InsertVecEveryPrimitiveStruct;
         accessor_method = vec_every_primitive_struct;
     }
     VecEveryVecStruct {
         Contents = Vec<EveryVecStruct>;
         field_name = s;
-        insert_reducer = insert_vec_every_vec_struct;
+        insert_then = insert_vec_every_vec_struct_then;
         insert_reducer_event = InsertVecEveryVecStruct;
         accessor_method = vec_every_vec_struct;
     }
     OptionI32 {
         Contents = Option<i32>;
         field_name = n;
-        insert_reducer = insert_option_i_32;
+        insert_then = insert_option_i_32_then;
         insert_reducer_event = InsertOptionI32;
         accessor_method = option_i_32;
     }
     OptionString {
         Contents = Option<String>;
         field_name = s;
-        insert_reducer = insert_option_string;
+        insert_then = insert_option_string_then;
         insert_reducer_event = InsertOptionString;
         accessor_method = option_string;
     }
     OptionIdentity {
         Contents = Option<Identity>;
         field_name = i;
-        insert_reducer = insert_option_identity;
+        insert_then = insert_option_identity_then;
         insert_reducer_event = InsertOptionIdentity;
         accessor_method = option_identity;
     }
     OptionUuid {
         Contents = Option<Uuid>;
         field_name = u;
-        insert_reducer = insert_option_uuid;
+        insert_then = insert_option_uuid_then;
         insert_reducer_event = InsertOptionUuid;
         accessor_method = option_uuid;
     }
     OptionSimpleEnum {
         Contents = Option<SimpleEnum>;
         field_name = e;
-        insert_reducer = insert_option_simple_enum;
+        insert_then = insert_option_simple_enum_then;
         insert_reducer_event = InsertOptionSimpleEnum;
         accessor_method = option_simple_enum;
     }
     OptionEveryPrimitiveStruct {
         Contents = Option<EveryPrimitiveStruct>;
         field_name = s;
-        insert_reducer = insert_option_every_primitive_struct;
+        insert_then = insert_option_every_primitive_struct_then;
         insert_reducer_event = InsertOptionEveryPrimitiveStruct;
         accessor_method = option_every_primitive_struct;
     }
     OptionVecOptionI32 {
         Contents = Option<Vec<Option<i32>>>;
         field_name = v;
-        insert_reducer = insert_option_vec_option_i_32;
+        insert_then = insert_option_vec_option_i_32_then;
         insert_reducer_event = InsertOptionVecOptionI32;
         accessor_method = option_vec_option_i_32;
     }

--- a/sdks/rust/tests/test-client/src/unique_test_table.rs
+++ b/sdks/rust/tests/test-client/src/unique_test_table.rs
@@ -86,9 +86,9 @@ macro_rules! impl_unique_test_table {
     (__impl $table:ident {
         Key = $key:ty;
         key_field_name = $field_name:ident;
-        insert_reducer = $insert_reducer:ident;
+        insert_then = $insert_reducer_then:ident;
         insert_reducer_event = $insert_reducer_event:ident;
-        delete_reducer = $delete_reducer:ident;
+        delete_then = $delete_reducer_then:ident;
         delete_reducer_event = $delete_reducer_event:ident;
         accessor_method = $accessor_method:ident;
     }) => {
@@ -110,10 +110,22 @@ macro_rules! impl_unique_test_table {
             }
 
             fn insert(ctx: &impl RemoteDbContext, key: Self::Key, value: i32) {
-                ctx.reducers().$insert_reducer(key, value).unwrap();
+                ctx.reducers().$insert_reducer_then(key, value, |ctx, outcome| {
+                    match outcome {
+                        Ok(Ok(())) => assert!(Self::is_insert_reducer_event(&ctx.event.reducer)),
+                        Ok(Err(msg)) => panic!("Insert reducer returned error: {msg}"),
+                        Err(internal_error) => panic!("Insert reducer panicked: {internal_error:?}"),
+                    }
+                }).unwrap();
             }
             fn delete(ctx: &impl RemoteDbContext, key: Self::Key) {
-                ctx.reducers().$delete_reducer(key).unwrap();
+                ctx.reducers().$delete_reducer_then(key, |ctx, outcome| {
+                    match outcome {
+                        Ok(Ok(())) => assert!(Self::is_delete_reducer_event(&ctx.event.reducer)),
+                        Ok(Err(msg)) => panic!("Delete reducer returned error: {msg}"),
+                        Err(internal_error) => panic!("Delete reducer panicked: {internal_error:?}"),
+                    }
+                }).unwrap();
             }
 
             fn on_insert(ctx: &impl RemoteDbContext, callback: impl FnMut(&EventContext, &$table) + Send + 'static) {
@@ -133,54 +145,54 @@ impl_unique_test_table! {
     UniqueU8 {
         Key = u8;
         key_field_name = n;
-        insert_reducer = insert_unique_u_8;
+        insert_then = insert_unique_u_8_then;
         insert_reducer_event = InsertUniqueU8;
-        delete_reducer = delete_unique_u_8;
+        delete_then = delete_unique_u_8_then;
         delete_reducer_event = DeleteUniqueU8;
         accessor_method = unique_u_8;
     }
     UniqueU16 {
         Key = u16;
         key_field_name = n;
-        insert_reducer = insert_unique_u_16;
+        insert_then = insert_unique_u_16_then;
         insert_reducer_event = InsertUniqueU16;
-        delete_reducer = delete_unique_u_16;
+        delete_then = delete_unique_u_16_then;
         delete_reducer_event = DeleteUniqueU16;
         accessor_method = unique_u_16;
     }
     UniqueU32 {
         Key = u32;
         key_field_name = n;
-        insert_reducer = insert_unique_u_32;
+        insert_then = insert_unique_u_32_then;
         insert_reducer_event = InsertUniqueU32;
-        delete_reducer = delete_unique_u_32;
+        delete_then = delete_unique_u_32_then;
         delete_reducer_event = DeleteUniqueU32;
         accessor_method = unique_u_32;
     }
     UniqueU64 {
         Key = u64;
         key_field_name = n;
-        insert_reducer = insert_unique_u_64;
+        insert_then = insert_unique_u_64_then;
         insert_reducer_event = InsertUniqueU64;
-        delete_reducer = delete_unique_u_64;
+        delete_then = delete_unique_u_64_then;
         delete_reducer_event = DeleteUniqueU64;
         accessor_method = unique_u_64;
     }
     UniqueU128 {
         Key = u128;
         key_field_name = n;
-        insert_reducer = insert_unique_u_128;
+        insert_then = insert_unique_u_128_then;
         insert_reducer_event = InsertUniqueU128;
-        delete_reducer = delete_unique_u_128;
+        delete_then = delete_unique_u_128_then;
         delete_reducer_event = DeleteUniqueU128;
         accessor_method = unique_u_128;
     }
     UniqueU256 {
         Key = u256;
         key_field_name = n;
-        insert_reducer = insert_unique_u_256;
+        insert_then = insert_unique_u_256_then;
         insert_reducer_event = InsertUniqueU256;
-        delete_reducer = delete_unique_u_256;
+        delete_then = delete_unique_u_256_then;
         delete_reducer_event = DeleteUniqueU256;
         accessor_method = unique_u_256;
     }
@@ -188,54 +200,54 @@ impl_unique_test_table! {
     UniqueI8 {
         Key = i8;
         key_field_name = n;
-        insert_reducer = insert_unique_i_8;
+        insert_then = insert_unique_i_8_then;
         insert_reducer_event = InsertUniqueI8;
-        delete_reducer = delete_unique_i_8;
+        delete_then = delete_unique_i_8_then;
         delete_reducer_event = DeleteUniqueI8;
         accessor_method = unique_i_8;
     }
     UniqueI16 {
         Key = i16;
         key_field_name = n;
-        insert_reducer = insert_unique_i_16;
+        insert_then = insert_unique_i_16_then;
         insert_reducer_event = InsertUniqueI16;
-        delete_reducer = delete_unique_i_16;
+        delete_then = delete_unique_i_16_then;
         delete_reducer_event = DeleteUniqueI16;
         accessor_method = unique_i_16;
     }
     UniqueI32 {
         Key = i32;
         key_field_name = n;
-        insert_reducer = insert_unique_i_32;
+        insert_then = insert_unique_i_32_then;
         insert_reducer_event = InsertUniqueI32;
-        delete_reducer = delete_unique_i_32;
+        delete_then = delete_unique_i_32_then;
         delete_reducer_event = DeleteUniqueI32;
         accessor_method = unique_i_32;
     }
     UniqueI64 {
         Key = i64;
         key_field_name = n;
-        insert_reducer = insert_unique_i_64;
+        insert_then = insert_unique_i_64_then;
         insert_reducer_event = InsertUniqueI64;
-        delete_reducer = delete_unique_i_64;
+        delete_then = delete_unique_i_64_then;
         delete_reducer_event = DeleteUniqueI64;
         accessor_method = unique_i_64;
     }
     UniqueI128 {
         Key = i128;
         key_field_name = n;
-        insert_reducer = insert_unique_i_128;
+        insert_then = insert_unique_i_128_then;
         insert_reducer_event = InsertUniqueI128;
-        delete_reducer = delete_unique_i_128;
+        delete_then = delete_unique_i_128_then;
         delete_reducer_event = DeleteUniqueI128;
         accessor_method = unique_i_128;
     }
     UniqueI256 {
         Key = i256;
         key_field_name = n;
-        insert_reducer = insert_unique_i_256;
+        insert_then = insert_unique_i_256_then;
         insert_reducer_event = InsertUniqueI256;
-        delete_reducer = delete_unique_i_256;
+        delete_then = delete_unique_i_256_then;
         delete_reducer_event = DeleteUniqueI256;
         accessor_method = unique_i_256;
     }
@@ -243,9 +255,9 @@ impl_unique_test_table! {
     UniqueBool {
         Key = bool;
         key_field_name = b;
-        insert_reducer = insert_unique_bool;
+        insert_then = insert_unique_bool_then;
         insert_reducer_event = InsertUniqueBool;
-        delete_reducer = delete_unique_bool;
+        delete_then = delete_unique_bool_then;
         delete_reducer_event = DeleteUniqueBool;
         accessor_method = unique_bool;
     }
@@ -253,9 +265,9 @@ impl_unique_test_table! {
     UniqueString {
         Key = String;
         key_field_name = s;
-        insert_reducer = insert_unique_string;
+        insert_then = insert_unique_string_then;
         insert_reducer_event = InsertUniqueString;
-        delete_reducer = delete_unique_string;
+        delete_then = delete_unique_string_then;
         delete_reducer_event = DeleteUniqueString;
         accessor_method = unique_string;
     }
@@ -263,9 +275,9 @@ impl_unique_test_table! {
     UniqueIdentity {
         Key = Identity;
         key_field_name = i;
-        insert_reducer = insert_unique_identity;
+        insert_then = insert_unique_identity_then;
         insert_reducer_event = InsertUniqueIdentity;
-        delete_reducer = delete_unique_identity;
+        delete_then = delete_unique_identity_then;
         delete_reducer_event = DeleteUniqueIdentity;
         accessor_method = unique_identity;
     }
@@ -273,9 +285,9 @@ impl_unique_test_table! {
     UniqueConnectionId {
         Key = ConnectionId;
         key_field_name = a;
-        insert_reducer = insert_unique_connection_id;
+        insert_then = insert_unique_connection_id_then;
         insert_reducer_event = InsertUniqueConnectionId;
-        delete_reducer = delete_unique_connection_id;
+        delete_then = delete_unique_connection_id_then;
         delete_reducer_event = DeleteUniqueConnectionId;
         accessor_method = unique_connection_id;
     }
@@ -283,9 +295,9 @@ impl_unique_test_table! {
     UniqueUuid {
         Key = Uuid;
         key_field_name = u;
-        insert_reducer = insert_unique_uuid;
+        insert_then = insert_unique_uuid_then;
         insert_reducer_event = InsertUniqueUuid;
-        delete_reducer = delete_unique_uuid;
+        delete_then = delete_unique_uuid_then;
         delete_reducer_event = DeleteUniqueUuid;
         accessor_method = unique_uuid;
     }

--- a/sdks/rust/tests/view-client/src/main.rs
+++ b/sdks/rust/tests/view-client/src/main.rs
@@ -2,7 +2,7 @@ mod module_bindings;
 
 use module_bindings::*;
 use spacetimedb_lib::Identity;
-use spacetimedb_sdk::{DbConnectionBuilder, DbContext, Table};
+use spacetimedb_sdk::{error::InternalError, DbConnectionBuilder, DbContext, Table};
 use test_counter::TestCounter;
 
 const LOCALHOST: &str = "http://localhost:3000";
@@ -92,6 +92,16 @@ fn put_result(result: &mut Option<ResultRecorder>, res: Result<(), anyhow::Error
     (result.take().unwrap())(res);
 }
 
+fn reducer_callback_assert_committed(
+    reducer_name: &'static str,
+) -> impl FnOnce(&ReducerEventContext, Result<Result<(), String>, InternalError>) + Send + 'static {
+    move |_ctx, outcome| match outcome {
+        Ok(Ok(())) => (),
+        Ok(Err(msg)) => panic!("`{reducer_name}` reducer returned error: {msg}"),
+        Err(internal_error) => panic!("`{reducer_name}` reducer panicked: {internal_error:?}"),
+    }
+}
+
 fn exec_anonymous_subscribe() {
     let test_counter = TestCounter::new();
     let mut insert_0 = Some(test_counter.add_test("insert_0"));
@@ -115,19 +125,38 @@ fn exec_anonymous_subscribe() {
                 unreachable!("Unexpected identity on delete: `{}`", player.identity)
             });
             ctx.reducers()
-                .insert_player(Identity::from_byte_array([1; 32]), 1)
+                .insert_player_then(
+                    Identity::from_byte_array([1; 32]),
+                    1,
+                    reducer_callback_assert_committed("insert_player"),
+                )
                 .unwrap();
             ctx.reducers()
-                .insert_player(Identity::from_byte_array([2; 32]), 0)
+                .insert_player_then(
+                    Identity::from_byte_array([2; 32]),
+                    0,
+                    reducer_callback_assert_committed("insert_player"),
+                )
                 .unwrap();
             ctx.reducers()
-                .insert_player(Identity::from_byte_array([3; 32]), 1)
+                .insert_player_then(
+                    Identity::from_byte_array([3; 32]),
+                    1,
+                    reducer_callback_assert_committed("insert_player"),
+                )
                 .unwrap();
             ctx.reducers()
-                .insert_player(Identity::from_byte_array([4; 32]), 0)
+                .insert_player_then(
+                    Identity::from_byte_array([4; 32]),
+                    0,
+                    reducer_callback_assert_committed("insert_player"),
+                )
                 .unwrap();
             ctx.reducers()
-                .delete_player(Identity::from_byte_array([4; 32]))
+                .delete_player_then(
+                    Identity::from_byte_array([4; 32]),
+                    reducer_callback_assert_committed("insert_player"),
+                )
                 .unwrap();
         });
     });
@@ -159,19 +188,38 @@ fn exec_anonymous_subscribe_with_query_builder() {
                     unreachable!("Unexpected identity on delete: `{}`", player.identity)
                 });
                 ctx.reducers()
-                    .insert_player(Identity::from_byte_array([1; 32]), 1)
+                    .insert_player_then(
+                        Identity::from_byte_array([1; 32]),
+                        1,
+                        reducer_callback_assert_committed("insert_player"),
+                    )
                     .unwrap();
                 ctx.reducers()
-                    .insert_player(Identity::from_byte_array([2; 32]), 0)
+                    .insert_player_then(
+                        Identity::from_byte_array([2; 32]),
+                        0,
+                        reducer_callback_assert_committed("insert_player"),
+                    )
                     .unwrap();
                 ctx.reducers()
-                    .insert_player(Identity::from_byte_array([3; 32]), 1)
+                    .insert_player_then(
+                        Identity::from_byte_array([3; 32]),
+                        1,
+                        reducer_callback_assert_committed("insert_player"),
+                    )
                     .unwrap();
                 ctx.reducers()
-                    .insert_player(Identity::from_byte_array([4; 32]), 0)
+                    .insert_player_then(
+                        Identity::from_byte_array([4; 32]),
+                        0,
+                        reducer_callback_assert_committed("insert_player"),
+                    )
                     .unwrap();
                 ctx.reducers()
-                    .delete_player(Identity::from_byte_array([4; 32]))
+                    .delete_player_then(
+                        Identity::from_byte_array([4; 32]),
+                        reducer_callback_assert_committed("delete_player"),
+                    )
                     .unwrap();
             })
             .add_query(|ctx| {
@@ -202,13 +250,24 @@ fn exec_non_anonymous_subscribe() {
                 put_result(&mut delete, Ok(()));
             });
             ctx.reducers()
-                .insert_player(Identity::from_byte_array([1; 32]), 0)
+                .insert_player_then(
+                    Identity::from_byte_array([1; 32]),
+                    0,
+                    reducer_callback_assert_committed("insert_player"),
+                )
                 .unwrap();
-            ctx.reducers().insert_player(my_identity, 0).unwrap();
             ctx.reducers()
-                .delete_player(Identity::from_byte_array([1; 32]))
+                .insert_player_then(my_identity, 0, reducer_callback_assert_committed("insert_player"))
                 .unwrap();
-            ctx.reducers().delete_player(my_identity).unwrap();
+            ctx.reducers()
+                .delete_player_then(
+                    Identity::from_byte_array([1; 32]),
+                    reducer_callback_assert_committed("insert_player"),
+                )
+                .unwrap();
+            ctx.reducers()
+                .delete_player_then(my_identity, reducer_callback_assert_committed("delete_player"))
+                .unwrap();
         });
     });
     test_counter.wait_for_all();
@@ -232,13 +291,24 @@ fn exec_non_table_return() {
                 put_result(&mut delete, Ok(()));
             });
             ctx.reducers()
-                .insert_player(Identity::from_byte_array([1; 32]), 0)
+                .insert_player_then(
+                    Identity::from_byte_array([1; 32]),
+                    0,
+                    reducer_callback_assert_committed("insert_player"),
+                )
                 .unwrap();
-            ctx.reducers().insert_player(my_identity, 1).unwrap();
             ctx.reducers()
-                .delete_player(Identity::from_byte_array([1; 32]))
+                .insert_player_then(my_identity, 1, reducer_callback_assert_committed("insert_player"))
                 .unwrap();
-            ctx.reducers().delete_player(my_identity).unwrap();
+            ctx.reducers()
+                .delete_player_then(
+                    Identity::from_byte_array([1; 32]),
+                    reducer_callback_assert_committed("delete_player"),
+                )
+                .unwrap();
+            ctx.reducers()
+                .delete_player_then(my_identity, reducer_callback_assert_committed("delete_player"))
+                .unwrap();
         });
     });
     test_counter.wait_for_all();
@@ -264,14 +334,25 @@ fn exec_non_table_query_builder_return() {
                     put_result(&mut delete, Ok(()));
                 });
                 ctx.reducers()
-                    .insert_player(Identity::from_byte_array([1; 32]), 0)
+                    .insert_player_then(
+                        Identity::from_byte_array([1; 32]),
+                        0,
+                        reducer_callback_assert_committed("insert_player"),
+                    )
                     .unwrap();
-                ctx.reducers().insert_player(my_identity, 1).unwrap();
+                ctx.reducers()
+                    .insert_player_then(my_identity, 1, reducer_callback_assert_committed("insert_player"))
+                    .unwrap();
 
                 ctx.reducers()
-                    .delete_player(Identity::from_byte_array([1; 32]))
+                    .delete_player_then(
+                        Identity::from_byte_array([1; 32]),
+                        reducer_callback_assert_committed("delete_player"),
+                    )
                     .unwrap();
-                ctx.reducers().delete_player(my_identity).unwrap();
+                ctx.reducers()
+                    .delete_player_then(my_identity, reducer_callback_assert_committed("delete_player"))
+                    .unwrap();
             })
             .add_query(|q_ctx| q_ctx.from.my_player_and_level().filter(|p| p.level.eq(1)).build())
             .subscribe();
@@ -302,7 +383,9 @@ fn exec_subscription_update() {
                     put_result(&mut delete_0, Ok(()));
                 });
                 // Insert player 0 at coords (0, 0)
-                ctx.reducers().move_player(0, 0).unwrap();
+                ctx.reducers()
+                    .move_player_then(0, 0, reducer_callback_assert_committed("move_player"))
+                    .unwrap();
             });
         },
     );
@@ -321,7 +404,9 @@ fn exec_subscription_update() {
                     assert_eq!(loc.y, 0);
                     put_result(&mut insert_1, Ok(()));
                     // Move player 1 outside of visible region
-                    ctx.reducers().move_player(3, 3).unwrap();
+                    ctx.reducers()
+                        .move_player_then(3, 3, reducer_callback_assert_committed("move_player"))
+                        .unwrap();
                 });
                 ctx.db.nearby_players().on_delete(move |_, loc| {
                     assert_eq!(loc.x, 0);
@@ -329,7 +414,9 @@ fn exec_subscription_update() {
                     put_result(&mut delete_1, Ok(()));
                 });
                 // Insert player 1 at coords (2, 2)
-                ctx.reducers().move_player(2, 2).unwrap();
+                ctx.reducers()
+                    .move_player_then(2, 2, reducer_callback_assert_committed("move_player"))
+                    .unwrap();
             });
         },
     );


### PR DESCRIPTION
# Description of Changes

Prior to this commit, if a reducer call failed during a test in the Rust SDK test suite, the client would hang, as it generally didn't register callbacks when invoking reducers. This could mask some bugs, causing the tests to fail with TIMEOUT rather than a useful message. For example, we relied on consistency between all of the test modules, which was broken by our not having updated the C++ bindings library to use the new case-conversion scheme. This meant that the client was sending reducer calls with incorrect reducer names to at least one database per test run, which would result in a `Panic` status or an `Err(Err(_))` outcome.

With this commit, the SDK test clients are updated to inspect the exit status of reducers they invoke, and (except for intentional reducer failures) to panic the test client when encountering a reducer error or panic.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

- [x] Automated tests passed locally.
- [x] Intentionally broke reducer calls via the 2.0 WS API, causing them to skip the call and unconditionally respond with `Status::Panic`. Observed "loud" failures in the test suite with non-`TIMEOUT` output that looked more debuggable to me.