### PR TITLE
rust sdk: ConnectionId override via builder

### DIFF
--- a/sdks/rust/src/lib.rs
+++ b/sdks/rust/src/lib.rs
@@ -71,6 +71,5 @@ pub mod unstable {
     //! Unstable interfaces not ready for the prime time.
     //!
     //! These may change incompatibly without a major version bump.
-    pub use crate::db_connection::set_connection_id;
     pub use crate::metrics::{ClientMetrics, CLIENT_METRICS};
 }


### PR DESCRIPTION
Instead of a global, provide a builder method to override the connection ID.

This should allow using multiple connections per process.

# Expected complexity level and risk

1

# Testing

Trivial change.
