### PR TITLE
Change deno quickstart to use package.json instead of deno.json

### DIFF
--- a/docs/docs/00100-intro/00200-quickstarts/00275-deno.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00275-deno.md
@@ -52,7 +52,7 @@ my-spacetime-app/
 ├── src/
 │   ├── main.ts           # Deno client script
 │   └── module_bindings/  # Auto-generated types
-└── deno.json             # Deno config and tasks
+└── package.json          # Scripts and dependencies (dev, start, spacetime:generate)
 ```
 
     </StepCode>
@@ -102,12 +102,12 @@ spacetimedb.reducer('say_hello', ctx => {
     <StepCode>
 ```bash
 # Run with auto-reload during development
-deno task dev
+pnpm run dev
+# or: npm run dev
 
 # Or run once
-
-deno task start
-
+pnpm run start
+# or: npm run start
 ```
     </StepCode>
   </Step>
@@ -237,29 +237,30 @@ spacetime logs
 
       **Built-in TypeScript:** Deno runs TypeScript directly without transpilation, making startup faster and eliminating the need for build tools.
 
-      **Import maps:** The `deno.json` file defines import maps, allowing you to import `spacetimedb` directly without `npm:` prefix in your code.
+      **Dependencies:** The `package.json` file declares the `spacetimedb` dependency; Deno resolves it from there (and from `node_modules` after `pnpm install` when developing in the SpacetimeDB repo).
 
-      **No node_modules:** Deno caches dependencies globally, so there's no `node_modules` folder to manage.
+      **node_modules:** When using the template from the repo workspace, run `pnpm install` so `spacetimedb` is linked. For a project created with `spacetime init`, Deno resolves the versioned dependency from package.json.
     </StepText>
     <StepCode>
 ```bash
 # Configure via environment variables
 SPACETIMEDB_HOST=ws://localhost:3000 \
 SPACETIMEDB_DB_NAME=my-app \
-deno task start
+pnpm run start
 
 # Or run with explicit permissions
 deno run --allow-net --allow-read --allow-write --allow-env --unstable-sloppy-imports src/main.ts
 
-# The deno.json configures tasks and imports
-cat deno.json
+# package.json defines scripts and the spacetimedb dependency
+cat package.json
 {
-  "tasks": {
+  "scripts": {
     "dev": "deno run --watch --allow-net --allow-read --allow-write --allow-env --unstable-sloppy-imports src/main.ts",
-    "start": "deno run --allow-net --allow-read --allow-write --allow-env --unstable-sloppy-imports src/main.ts"
+    "start": "deno run --allow-net --allow-read --allow-write --allow-env --unstable-sloppy-imports src/main.ts",
+    "spacetime:generate": "spacetime generate --lang typescript --out-dir src/module_bindings --module-path spacetimedb"
   },
-  "imports": {
-    "spacetimedb": "npm:spacetimedb@1.*"
+  "dependencies": {
+    "spacetimedb": "workspace:*"
   }
 }
 ````

--- a/templates/deno-ts/package.json
+++ b/templates/deno-ts/package.json
@@ -1,10 +1,14 @@
 {
-  "tasks": {
+  "name": "@clockworklabs/deno-ts",
+  "private": true,
+  "version": "0.0.1",
+  "type": "module",
+  "scripts": {
     "dev": "deno run --watch --allow-net --allow-read --allow-write --allow-env --unstable-sloppy-imports src/main.ts",
     "start": "deno run --allow-net --allow-read --allow-write --allow-env --unstable-sloppy-imports src/main.ts",
     "spacetime:generate": "spacetime generate --lang typescript --out-dir src/module_bindings --module-path spacetimedb"
   },
-  "imports": {
-    "spacetimedb": "npm:spacetimedb@1.*"
+  "dependencies": {
+    "spacetimedb": "workspace:*"
   }
 }


### PR DESCRIPTION
# Description of Changes

Deno quickstart template now uses `package.json` instead of `deno.json` so `spacetime dev` can run it. Added `templates/deno-ts/package.json`, removed `deno.json`, and updated the Deno quickstart doc.

# API and ABI breaking changes

None.

# Expected complexity level and risk

**1** — Template and docs only.

# Testing

- [ ] `spacetime dev --template deno-ts` and confirm client runs.
- [ ] Spot-check updated Deno quickstart doc.