### PR TITLE
Don't shadow Math.random() in typescript

### DIFF
--- a/crates/bindings-typescript/src/server/rng.ts
+++ b/crates/bindings-typescript/src/server/rng.ts
@@ -4,12 +4,6 @@ import { unsafeUniformIntDistribution } from 'pure-rand/distribution/UnsafeUnifo
 import { xoroshiro128plus } from 'pure-rand/generator/XoroShiro';
 import type { Timestamp } from '../lib/timestamp';
 
-declare global {
-  interface Math {
-    random(): never;
-  }
-}
-
 type IntArray =
   | Int8Array
   | Uint8Array


### PR DESCRIPTION
# Description of Changes

This also affects typescript clients, which wasn't the intention.

# Expected complexity level and risk

1

# Testing

- [x] Typescript client code that uses Math.random is no longer broken.
