### PR TITLE
Rename UnknownTransaction event to Transaction

### DIFF
--- a/crates/bindings-typescript/src/sdk/db_connection_impl.ts
+++ b/crates/bindings-typescript/src/sdk/db_connection_impl.ts
@@ -740,7 +740,7 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
       case 'TransactionUpdate': {
         const event: Event<never> = {
           id: this.#nextEventId(),
-          tag: 'UnknownTransaction',
+          tag: 'Transaction',
         };
         const eventContext = this.#makeEventContext(event);
         const callbacks = this.#applyTransactionUpdates(
@@ -777,7 +777,7 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
               }
             : {
                 id: eventId,
-                tag: 'UnknownTransaction',
+                tag: 'Transaction',
               };
           const eventContext = this.#makeEventContext(event as any);
 

--- a/crates/bindings-typescript/src/sdk/event.ts
+++ b/crates/bindings-typescript/src/sdk/event.ts
@@ -14,5 +14,5 @@ export type Event<Reducer extends ReducerEventInfo> = WithId &
     | { tag: 'SubscribeApplied' }
     | { tag: 'UnsubscribeApplied' }
     | { tag: 'Error'; value: Error }
-    | { tag: 'UnknownTransaction' }
+    | { tag: 'Transaction' }
   );


### PR DESCRIPTION
# Description of Changes

This changes the event tag from `UnknownTransaction` to `Transaction` to be more in line with the rust sdk.

# API and ABI breaking changes

This changes the event tags for row updates that happen for transactions triggered by SQL transactions or reducers called by other connections.

# Expected complexity level and risk

1.

# Testing

Seems trivial.
