### PR TITLE
Update `bump-versions` to support prereleases

### DIFF
--- a/tools/upgrade-version/src/main.rs
+++ b/tools/upgrade-version/src/main.rs
@@ -321,6 +321,7 @@ fn main() -> anyhow::Result<()> {
         // 1) Client SDK csproj
         let client_sdk = "sdks/csharp/SpacetimeDB.ClientSDK.csproj";
         rewrite_xml_tag_value(client_sdk, "Version", &full_version)?;
+        // <AssemblyVersion> doesn't support prerelease or metadata version suffixes like <Version> does.
         rewrite_xml_tag_value(client_sdk, "AssemblyVersion", &numeric_version)?;
         // Update SpacetimeDB.BSATN.Runtime dependency to major.minor.*
         rewrite_csproj_package_ref_version(client_sdk, "SpacetimeDB.BSATN.Runtime", &wildcard_patch)?;


### PR DESCRIPTION
# Description of Changes

`cargo bump-versions` works properly with prerelease versions. Before it would quietly drop the `-foo` or `+foo` suffix.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] Ran the script and bumped the versions for the 2.0.0 prerelease