### PR TITLE
Fix view macro to keep original visibility

### DIFF
--- a/crates/bindings-macro/src/view.rs
+++ b/crates/bindings-macro/src/view.rs
@@ -194,6 +194,7 @@ pub(crate) fn view_impl(args: ViewArgs, original_function: &ItemFn) -> syn::Resu
         (
             quote! {
                 #(#original_attrs)*
+                #vis
                 #new_sig {
                     spacetimedb::RawQuery::new(
                         Query::into_sql(#original_body)
@@ -214,6 +215,7 @@ pub(crate) fn view_impl(args: ViewArgs, original_function: &ItemFn) -> syn::Resu
         (
             quote! {
                 #(#original_attrs)*
+                #vis
                 #original_sig
                     #emitted_body
             },

--- a/crates/smoketests/modules/Cargo.lock
+++ b/crates/smoketests/modules/Cargo.lock
@@ -880,6 +880,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoketest-module-views-callable"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "spacetimedb",
+]
+
+[[package]]
 name = "smoketest-module-views-drop-view"
 version = "0.1.0"
 dependencies = [

--- a/crates/smoketests/modules/Cargo.toml
+++ b/crates/smoketests/modules/Cargo.toml
@@ -24,6 +24,7 @@ members = [
     "views-recovered",
     "views-subscribe",
     "views-query",
+    "views-callable",
 
     # Security and permissions
     "rls",

--- a/crates/smoketests/modules/views-callable/Cargo.toml
+++ b/crates/smoketests/modules/views-callable/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "smoketest-module-views-callable"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+spacetimedb.workspace = true
+log.workspace = true

--- a/crates/smoketests/modules/views-callable/src/lib.rs
+++ b/crates/smoketests/modules/views-callable/src/lib.rs
@@ -1,0 +1,22 @@
+use spacetimedb::{ReducerContext, Table, ViewContext};
+
+#[spacetimedb::table(accessor = items, public)]
+pub struct Item {
+    value: u8,
+}
+
+mod foo {
+    use super::*;
+
+    #[spacetimedb::view(accessor = bar, public)]
+    pub(crate) fn bar(_ctx: &ViewContext) -> Option<Item> {
+        Some(Item { value: 7 })
+    }
+}
+
+#[spacetimedb::reducer]
+pub fn baz(ctx: &ReducerContext) {
+    if let Some(item) = foo::bar(&ctx.as_read_only()) {
+        ctx.db.items().insert(item);
+    }
+}

--- a/crates/smoketests/tests/views.rs
+++ b/crates/smoketests/tests/views.rs
@@ -306,6 +306,21 @@ fn test_auto_migration_add_view() {
 }
 
 #[test]
+fn test_view_accessibility() {
+    let test = Smoketest::builder().precompiled_module("views-callable").build();
+
+    test.new_identity().unwrap();
+    test.call("baz", &[]).unwrap();
+
+    test.assert_sql(
+        "SELECT * FROM items",
+        r#" value
+-------
+ 7"#,
+    );
+}
+
+#[test]
 fn test_recovery_from_trapped_views_auto_migration() {
     let mut test = Smoketest::builder().precompiled_module("views-auto-migrate").build();
 


### PR DESCRIPTION
# Description of Changes

Fixes a bug that dropped a view function's original visibility.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] Smoketest as regression test
