### PR TITLE
Remove `.Build()` from C# query builder

### DIFF
--- a/crates/bindings-csharp/BSATN.Runtime/QueryBuilder.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/QueryBuilder.cs
@@ -65,20 +65,6 @@ public interface IQuery<TRow>
     string ToSql();
 }
 
-public readonly struct Query<TRow> : IQuery<TRow>
-{
-    public string Sql { get; }
-
-    public Query(string sql)
-    {
-        Sql = sql;
-    }
-
-    public string ToSql() => Sql;
-
-    public override string ToString() => Sql;
-}
-
 public readonly struct BoolExpr<TRow>
 {
     public string Sql { get; }
@@ -275,8 +261,6 @@ public sealed class Table<TRow, TCols, TIxCols> : IQuery<TRow>
 
     public string ToSql() => $"SELECT * FROM {SqlFormat.QuoteIdent(tableName)}";
 
-    public Query<TRow> Build() => new(ToSql());
-
     public FromWhere<TRow, TCols, TIxCols> Where(Func<TCols, BoolExpr<TRow>> predicate) =>
         new(this, predicate(cols));
 
@@ -332,8 +316,6 @@ public sealed class FromWhere<TRow, TCols, TIxCols> : IQuery<TRow>
         Where(predicate);
 
     public string ToSql() => $"{table.ToSql()} WHERE {expr.Sql}";
-
-    public Query<TRow> Build() => new(ToSql());
 
     public LeftSemiJoin<TRow, TCols, TIxCols, TRightRow, TRightCols, TRightIxCols> LeftSemijoin<
         TRightRow,
@@ -444,8 +426,6 @@ public sealed class LeftSemiJoin<
         var whereClause = whereExpr.HasValue ? $" WHERE {whereExpr.Value.Sql}" : string.Empty;
         return $"SELECT {left.TableRefSql}.* FROM {left.TableRefSql} JOIN {right.TableRefSql} ON {leftJoinRefSql} = {rightJoinRefSql}{whereClause}";
     }
-
-    public Query<TLeftRow> Build() => new(ToSql());
 }
 
 public sealed class RightSemiJoin<
@@ -569,8 +549,6 @@ public sealed class RightSemiJoin<
 
         return $"SELECT {right.TableRefSql}.* FROM {left.TableRefSql} JOIN {right.TableRefSql} ON {leftJoinRefSql} = {rightJoinRefSql}{whereClause}";
     }
-
-    public Query<TRightRow> Build() => new(ToSql());
 }
 
 public static class QueryBuilderExtensions

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/client/Lib.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/client/Lib.cs
@@ -121,18 +121,18 @@ internal static class PublicTableViewRegressions
     }
 
     private static string BuildPublicTableQuerySql() =>
-        MakeTable().Where(cols => cols.Id.Eq(0)).Build().Sql;
+        MakeTable().Where(cols => cols.Id.Eq(0)).ToSql();
 
     private static string BuildPublicTableViewSql()
     {
         var cols = new PublicTableCols("PublicTable");
-        return MakeTable().Where(_ => cols.Id.Eq(0)).Build().Sql;
+        return MakeTable().Where(_ => cols.Id.Eq(0)).ToSql();
     }
 
     private static string BuildFindPublicTableByIdentitySql()
     {
         var table = MakeTable();
-        return table.Where(cols => cols.Id.Eq(0)).Build().Sql;
+        return table.Where(cols => cols.Id.Eq(0)).ToSql();
     }
 
     /// <summary>

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/Lib.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/Lib.cs
@@ -579,6 +579,12 @@ public partial class Module
         return ctx.From.Player();
     }
 
+    // Invalid: Query builder no longer supports `.Build()`
+    public static string NoBuildForQueryBuilder(ViewContext ctx)
+    {
+        return ctx.From.Player().Build().ToSql();
+    }
+
     // Invalid: Returns type that is not a SpacetimeType
     [SpacetimeDB.View(Accessor = "view_def_returns_not_a_spacetime_type", Public = true)]
     public static NotSpacetimeType? ViewDefReturnsNotASpacetimeType(AnonymousViewContext ctx)

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/ExtraCompilationErrors.verified.txt
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/diag/snapshots/ExtraCompilationErrors.verified.txt
@@ -161,6 +161,29 @@ SpacetimeDB.Internal.Module.RegisterClientVisibilityFilter(global::Module.MY_FOU
     }
   },
   {/*
+    {
+        return ctx.From.Player().Build().ToSql();
+                                 ^^^^^
+    }
+*/
+    Message: 'Table<Player, PlayerCols, PlayerIxCols>' does not contain a definition for 'Build' and no accessible extension method 'Build' accepting a first argument of type 'Table<Player, PlayerCols, PlayerIxCols>' could be found (are you missing a using directive or an assembly reference?),
+    Severity: Error,
+    Descriptor: {
+      Id: CS1061,
+      Title: ,
+      HelpLink: https://msdn.microsoft.com/query/roslyn.query?appId=roslyn&k=k(CS1061),
+      MessageFormat: '{0}' does not contain a definition for '{1}' and no accessible extension method '{1}' accepting a first argument of type '{0}' could be found (are you missing a using directive or an assembly reference?),
+      Category: Compiler,
+      DefaultSeverity: Error,
+      IsEnabledByDefault: true,
+      CustomTags: [
+        Compiler,
+        Telemetry,
+        NotConfigurable
+      ]
+    }
+  },
+  {/*
 
 partial struct TestTypeParams<T>  : System.IEquatable<TestTypeParams>, SpacetimeDB.BSATN.IStructuralReadWrite {
                                     ^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^^

--- a/crates/bindings-csharp/Codegen.Tests/fixtures/server/Lib.cs
+++ b/crates/bindings-csharp/Codegen.Tests/fixtures/server/Lib.cs
@@ -281,9 +281,9 @@ public class Module
     }
 
     [SpacetimeDB.View(Accessor = "public_table_query", Public = true)]
-    public static Query<PublicTable> PublicTableQuery(ViewContext ctx)
+    public static IQuery<PublicTable> PublicTableQuery(ViewContext ctx)
     {
-        return ctx.From.PublicTable().Where(cols => cols.Id.Eq(0)).Build();
+        return ctx.From.PublicTable().Where(cols => cols.Id.Eq(0));
     }
 
     [SpacetimeDB.View(Accessor = "find_public_table__by_identity", Public = true)]

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -1158,14 +1158,14 @@ record ViewDeclaration
         ITypeSymbol? queryRowType = null;
         if (method.ReturnType is INamedTypeSymbol namedReturnType)
         {
-            static bool IsSpacetimeQueryReturnType(INamedTypeSymbol type) =>
-                (type.Name == "Query" || type.Name == "IQuery")
+            static bool IsSpacetimeIQueryReturnType(INamedTypeSymbol type) =>
+                type.Name == "IQuery"
                 && type.TypeArguments.Length == 1
                 && type.ContainingNamespace.ToDisplayString() == "SpacetimeDB";
 
-            // Accept only explicit Query<T> or IQuery<T> view return types.
+            // Accept only explicit IQuery<T> view return types.
             if (
-                IsSpacetimeQueryReturnType(namedReturnType)
+                IsSpacetimeIQueryReturnType(namedReturnType)
                 && namedReturnType.TypeArguments is [var rowType]
             )
             {
@@ -1181,7 +1181,7 @@ record ViewDeclaration
                 ? "SpacetimeDB.BSATN.ValueOption"
                 : "SpacetimeDB.BSATN.RefOption";
             var opt = $"{optType}<{rowType.Name}, {rowType.BSATNName}>";
-            // Match Rust semantics: Query<T> is described as Option<T>.
+            // Match Rust semantics: IQuery<T> is described as Option<T>.
             ReturnType = new ReferenceUse(opt, opt);
         }
         else

--- a/docs/static/llms.md
+++ b/docs/static/llms.md
@@ -1870,25 +1870,23 @@ Both contexts provide read-only access to tables and indexes through `ctx.Db`.
 Views can return:
 - `T?` (nullable) - For at-most-one row (e.g., looking up a specific player)
 - `List<T>` or `T[]` - For multiple rows (e.g., listing all players at a level)
-- `Query<T>` - A typed SQL query that behaves like the deprecated RLS (Row-Level Security) feature
+- `IQuery<T>` - A typed SQL query that behaves like the deprecated RLS (Row-Level Security) feature
 
 Where `T` can be a table type or any custom type marked with `[SpacetimeDB.Type]`.
 
-**Query<T> Return Type**
+**IQuery<T> Return Type**
 
-When a view returns `Query<T>`, SpacetimeDB computes results incrementally as the underlying data changes. This enables efficient table scanning because query results are maintained incrementally rather than recomputed from scratch. Without `Query<T>`, you must use indexed column lookups to access tables inside view functions.
+When a view returns `IQuery<T>`, SpacetimeDB computes results incrementally as the underlying data changes. This enables efficient table scanning because query results are maintained incrementally rather than recomputed from scratch. Without `IQuery<T>`, you must use indexed column lookups to access tables inside view functions.
 
 The query builder provides a fluent API for constructing type-safe SQL queries:
 
 ```csharp
 // This view can scan the whole table efficiently because
-// Query<T> results are computed incrementally
+// IQuery<T> results are computed incrementally
 [SpacetimeDB.View(Accessor = "MyMessages", Public = true)]
-public static Query<Message> MyMessages(ViewContext ctx)
+public static IQuery<Message> MyMessages(ViewContext ctx)
 {
-    return ctx.Db.Message
-        .Filter(msg => msg.Sender == ctx.Sender)
-        .Build();
+    return ctx.From.Message().Where(msg => msg.Sender.Eq(ctx.Sender));
 }
 
 // Query builder supports various operations:


### PR DESCRIPTION
# Description of Changes

Removes `.build()` entirely from all query builders. Before this change, it was discouraged but still allowed.

# API and ABI breaking changes

Breaking API change to all module languages

# Expected complexity level and risk

1

# Testing

Negative compilation tests have been added asserting `.build()`'s removal
