### PR TITLE
CI - Fail properly if `psql` failed to install

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -108,6 +108,7 @@ jobs:
           $PSNativeCommandUseErrorActionPreference = $true
           choco install psql -y --no-progress
           # Check for existence, since `choco` doesn't seem to fail the step if it fails to install..
+          # See https://github.com/clockworklabs/SpacetimeDB/pull/4399 for more background.
           Get-Command psql
 
       - name: Update dotnet workloads

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -101,8 +101,10 @@ jobs:
 
       - name: Install psql (Windows)
         if: runner.os == 'Windows'
-        run: choco install psql -y --no-progress
-        shell: powershell
+        shell: pwsh
+        run: |
+          choco install psql -y --no-progress
+          echo "C:\ProgramData\chocolatey\lib\psql\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
 
       - name: Update dotnet workloads
         if: runner.os == 'Windows'

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -103,8 +103,12 @@ jobs:
         if: runner.os == 'Windows'
         shell: pwsh
         run: |
+          # Fail properly if any individual command fails
+          $ErrorActionPreference = 'Stop'
+          $PSNativeCommandUseErrorActionPreference = $true
           choco install psql -y --no-progress
-          echo "C:\ProgramData\chocolatey\lib\psql\tools" | Out-File -FilePath $env:GITHUB_PATH -Encoding utf8 -Append
+          # Check for existence, since `choco` doesn't seem to fail the step if it fails to install..
+          Get-Command psql
 
       - name: Update dotnet workloads
         if: runner.os == 'Windows'


### PR DESCRIPTION
# Description of Changes

We had an issue where the install failed but did not fail the step:
```
Run choco install psql -y --no-progress
Chocolatey v2.6.0
Installing the following packages:
psql
By installing, you accept licenses for the packages.
Failed to fetch results from V2 feed at 'https://community.chocolatey.org/api/v2/Packages(Id='psql',Version='16.2.0')' with following message : Response status code does not indicate success: 504 (Gateway Time-out).
Need to add specific handling for exception type NuGetResolverInputException
Unable to find package 'psql'. Existing packages must be restored before performing an install or update.
```

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None - this is just CI

# Expected complexity level and risk

None - this is just CI

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Windows smoketests are able to use `psql` properly
