### PR TITLE
Use the query type in the useTable of vue and svelte

### DIFF
--- a/crates/bindings-typescript/src/svelte/useTable.ts
+++ b/crates/bindings-typescript/src/svelte/useTable.ts
@@ -10,6 +10,8 @@ import {
   evaluateBooleanExpr,
   getQueryAccessorName,
   getQueryWhereClause,
+  type Query,
+  toSql,
 } from '../lib/query';
 
 export interface UseTableCallbacks<RowType> {
@@ -46,13 +48,13 @@ function classifyMembership(
  * @returns A tuple of [rows, isReady].
  */
 export function useTable<TableDef extends UntypedTableDef>(
-  query: { toSql(): string } & Record<string, any>,
+  query: Query<TableDef>,
   callbacks?: UseTableCallbacks<Prettify<RowType<TableDef>>>
 ): [Readable<readonly Prettify<RowType<TableDef>>[]>, Readable<boolean>] {
   type Row = RowType<TableDef>;
   const accessorName = getQueryAccessorName(query);
   const whereExpr = getQueryWhereClause(query);
-  const querySql = query.toSql();
+  const querySql = toSql(query);
 
   let connectionStore;
   try {

--- a/crates/bindings-typescript/src/vue/useTable.ts
+++ b/crates/bindings-typescript/src/vue/useTable.ts
@@ -14,7 +14,9 @@ import type { UntypedRemoteModule } from '../sdk/spacetime_module';
 import type { RowType, UntypedTableDef } from '../lib/table';
 import type { Prettify } from '../lib/type_util';
 import {
+  type Query,
   type BooleanExpr,
+  toSql,
   evaluateBooleanExpr,
   getQueryAccessorName,
   getQueryWhereClause,
@@ -54,7 +56,7 @@ function classifyMembership(
  * @returns A tuple of [rows, isReady].
  */
 export function useTable<TableDef extends UntypedTableDef>(
-  query: { toSql(): string } & Record<string, any>,
+  query: Query<TableDef>,
   callbacks?: UseTableCallbacks<Prettify<RowType<TableDef>>>
 ): [
   DeepReadonly<Ref<readonly Prettify<RowType<TableDef>>[]>>,
@@ -63,7 +65,7 @@ export function useTable<TableDef extends UntypedTableDef>(
   type Row = RowType<TableDef>;
   const accessorName = getQueryAccessorName(query);
   const whereExpr = getQueryWhereClause(query);
-  const querySql = query.toSql();
+  const querySql = toSql(query);
 
   let conn;
   try {


### PR DESCRIPTION
# Description of Changes

Use the `Query` type for the vue and svelte `useTable` functions.

# API and ABI breaking changes

This shouldn't break any code that is using query builders.

# Expected complexity level and risk

1.

