### PR TITLE
fix(vue/svelte): fix useTable type interence

### DIFF
--- a/crates/bindings-typescript/src/svelte/useTable.ts
+++ b/crates/bindings-typescript/src/svelte/useTable.ts
@@ -6,6 +6,8 @@ import type { UntypedRemoteModule } from '../sdk/spacetime_module';
 import type { RowType, UntypedTableDef } from '../lib/table';
 import type { Prettify } from '../lib/type_util';
 import {
+  type Query,
+  toSql,
   type BooleanExpr,
   evaluateBooleanExpr,
   getQueryAccessorName,
@@ -46,13 +48,13 @@ function classifyMembership(
  * @returns A tuple of [rows, isReady].
  */
 export function useTable<TableDef extends UntypedTableDef>(
-  query: { toSql(): string } & Record<string, any>,
+  query: Query<TableDef>,
   callbacks?: UseTableCallbacks<Prettify<RowType<TableDef>>>
 ): [Readable<readonly Prettify<RowType<TableDef>>[]>, Readable<boolean>] {
   type Row = RowType<TableDef>;
   const accessorName = getQueryAccessorName(query);
   const whereExpr = getQueryWhereClause(query);
-  const querySql = query.toSql();
+  const querySql = toSql(query);
 
   let connectionStore;
   try {

--- a/crates/bindings-typescript/src/vue/useTable.ts
+++ b/crates/bindings-typescript/src/vue/useTable.ts
@@ -14,6 +14,8 @@ import type { UntypedRemoteModule } from '../sdk/spacetime_module';
 import type { RowType, UntypedTableDef } from '../lib/table';
 import type { Prettify } from '../lib/type_util';
 import {
+  type Query,
+  toSql,
   type BooleanExpr,
   evaluateBooleanExpr,
   getQueryAccessorName,
@@ -54,7 +56,7 @@ function classifyMembership(
  * @returns A tuple of [rows, isReady].
  */
 export function useTable<TableDef extends UntypedTableDef>(
-  query: { toSql(): string } & Record<string, any>,
+  query: Query<TableDef>,
   callbacks?: UseTableCallbacks<Prettify<RowType<TableDef>>>
 ): [
   DeepReadonly<Ref<readonly Prettify<RowType<TableDef>>[]>>,
@@ -63,7 +65,7 @@ export function useTable<TableDef extends UntypedTableDef>(
   type Row = RowType<TableDef>;
   const accessorName = getQueryAccessorName(query);
   const whereExpr = getQueryWhereClause(query);
-  const querySql = query.toSql();
+  const querySql = toSql(query);
 
   let conn;
   try {


### PR DESCRIPTION
# Description of Changes
- Fix types (no runtime behavior changes) for `useTable` type interence for Vue and Svelte which resulting in `{ [x: string]: any }` instead of properly typed rows
    - Changed to match the pattern React already uses of `Query<TableDef>`

<!-- Please describe your change, mention any related tickets, and so on here. -->

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk
1

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
