### PR TITLE
`sql_parts` does not conflict with `interactive` in CLI `sql` subcommand

### DIFF
--- a/crates/cli/src/subcommands/sql.rs
+++ b/crates/cli/src/subcommands/sql.rs
@@ -22,14 +22,12 @@ pub fn cli() -> clap::Command {
         .arg(
             Arg::new("sql_parts")
                 .num_args(0..)
-                .conflicts_with("interactive")
                 .help("SQL arguments: [DATABASE] <QUERY>"),
         )
         .arg(
             Arg::new("interactive")
                 .long("interactive")
                 .action(ArgAction::SetTrue)
-                .conflicts_with("sql_parts")
                 .help("Instead of using a query, run an interactive command prompt for `SQL` expressions"),
         )
         .arg(common_args::confirmed())


### PR DESCRIPTION
# Description of Changes

With the introduction of `spacetime.json`, our arg parsing has gotten more complex, and in particular, we now use the `sql_parts` argument to pass the database name rather than a separate positional arg, to support eliding the database name. This means that there is a case where both `sql_parts` and `interactive` will be supplied, so they cannot be marked as conflicting.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

- [x] Manually ran `spacetime sql --interactive my-database`, which worked locally with this patch.