### PR TITLE
Remove database names from node-js quickstart

### DIFF
--- a/docs/docs/00100-intro/00200-quickstarts/00300-nodejs.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00300-nodejs.md
@@ -113,16 +113,16 @@ spacetime dev --template nodejs-ts
     <StepCode>
 ```bash
 # Add a person
-spacetime call nodejs-ts add Alice
-spacetime call nodejs-ts add Bob
+spacetime call add Alice
+spacetime call add Bob
 
 # Greet everyone (check server logs)
 
-spacetime call nodejs-ts say_hello
+spacetime call say_hello
 
 # Query the database
 
-spacetime sql nodejs-ts "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
 
 ````
     </StepCode>
@@ -172,11 +172,11 @@ DbConnection.builder()
     <StepCode>
 ```bash
 # Call the add reducer to insert a person
-spacetime call nodejs-ts add Charlie
+spacetime call add Charlie
 
 # Query the person table
 
-spacetime sql nodejs-ts "SELECT * FROM person"
+spacetime sql "SELECT * FROM person"
 name
 
 ---
@@ -187,7 +187,7 @@ name
 
 # Call say_hello to greet everyone
 
-spacetime call nodejs-ts say_hello
+spacetime call say_hello
 
 # View the module logs
 


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

- We forgot to remove the database name from the example commands so I've fixed that here.

# API and ABI breaking changes

- None, just a docs change

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

- None, this is just a docs change

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

- [x] The nodejs quickstart works as written

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->
