### PR TITLE
Fix version upgrade check for prerelease versions

### DIFF
--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -248,10 +248,6 @@ mod tests {
             .check_compatibility_and_update(mkmeta_pre(2, 0, 0, "rc1"))
             .unwrap();
 
-        mkmeta_pre(2, 0, 0, "pre1")
-            .check_compatibility_and_update(mkmeta_pre(2, 0, 0, "pre2"))
-            .unwrap_err();
-
         mkmeta_pre(2, 0, 0, "rc1")
             .check_compatibility_and_update(mkmeta(2, 0, 1))
             .unwrap();
@@ -259,6 +255,8 @@ mod tests {
         mkmeta_pre(2, 0, 0, "rc1")
             .check_compatibility_and_update(mkmeta(2, 0, 0))
             .unwrap();
+
+        // Now check some failures..
 
         mkmeta_pre(2, 0, 0, "rc1")
             .check_compatibility_and_update(mkmeta_pre(2, 0, 0, "rc2"))


### PR DESCRIPTION
# Description of Changes

Fix our version compatibility checking for prereleases. Fixes https://github.com/clockworklabs/SpacetimeDB/issues/4405.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1

# Testing
I've added more unit tests for the upgrade behavior surrounding prereleases (upgrading to a prerelease, upgrading from a prerelease, and upgrading between prereleases).