### PR TITLE
LLM benchmark tool updates

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1850,6 +1850,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "dotenvy"
+version = "0.15.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1aaf95b3e5c8f23aa320147307562d361db0ae0d51242340f558153b4eb2439b"
+
+[[package]]
 name = "dragonbox_ecma"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11212,6 +11218,7 @@ dependencies = [
  "blake3",
  "chrono",
  "clap 4.5.50",
+ "dotenvy",
  "fs2",
  "futures",
  "heck 0.5.0",

--- a/docs/DEVELOP.md
+++ b/docs/DEVELOP.md
@@ -1,4 +1,4 @@
-﻿# DEVELOP.md
+# DEVELOP.md
 
 This document explains how to configure the environment, run the LLM benchmark tool, and work with the benchmark suite.
 
@@ -6,11 +6,20 @@ This document explains how to configure the environment, run the LLM benchmark t
 
 ## Table of Contents
 
-1. [Quick Checks & Fixes](#quick-checks-fixes)
-2. [Environment Variables](#environment-variables)
-3. [Benchmark Suite](#benchmark-suite)
-4. [Context Construction](#context-construction)
-5. [Troubleshooting](#troubleshooting)
+1. [Prerequisites](#prerequisites)
+2. [Quick Checks & Fixes](#quick-checks-fixes)
+3. [Environment Variables](#environment-variables)
+4. [Benchmark Suite](#benchmark-suite)
+5. [Context Construction](#context-construction)
+6. [Troubleshooting](#troubleshooting)
+---
+
+## Prerequisites
+
+- **Run from repo root** — `cargo llm` and related commands must be run from the workspace root (this repo).
+- **TypeScript benchmarks** — Run `pnpm build` in `crates/bindings-typescript` first. Rust and C# use local crates that are built as part of the workspace.
+- **Windows (nvm4w)** — If `pnpm` is not found when running TypeScript benchmarks, set `NODEJS_DIR` to your Node.js bin directory (e.g. `C:\nvm\v20.10.0`).
+
 ---
 
 ## Quick Checks & Fixes

--- a/docs/llms/llm-comparison-summary.json
+++ b/docs/llms/llm-comparison-summary.json
@@ -1,1240 +1,105 @@
 {
   "version": 1,
-  "generated_at": "2026-01-04T18:07:19.608Z",
+  "generated_at": "2026-02-21T19:00:17.834Z",
   "by_language": {
-    "rust": {
+    "csharp": {
       "modes": {
-        "rustdoc_json": {
-          "models": {
-            "Grok 4": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 13,
-                  "pass_pct": 48.148148,
-                  "task_pass_equiv": 6.0,
-                  "task_pass_pct": 50.0
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 31,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 58,
-                "passed_tests": 13,
-                "pass_pct": 22.413794,
-                "task_pass_equiv": 6.0,
-                "task_pass_pct": 27.272728
-              }
-            },
-            "Grok 3 Mini (Beta)": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 8,
-                  "pass_pct": 29.62963,
-                  "task_pass_equiv": 4.0,
-                  "task_pass_pct": 33.333336
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 8,
-                "pass_pct": 13.114754,
-                "task_pass_equiv": 4.0,
-                "task_pass_pct": 18.181818
-              }
-            },
-            "Gemini 2.5 Pro": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 15,
-                  "pass_pct": 55.555557,
-                  "task_pass_equiv": 6.0,
-                  "task_pass_pct": 50.0
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 13,
-                  "pass_pct": 38.235294,
-                  "task_pass_equiv": 3.0,
-                  "task_pass_pct": 30.000002
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 28,
-                "pass_pct": 45.901638,
-                "task_pass_equiv": 9.0,
-                "task_pass_pct": 40.909092
-              }
-            },
-            "Gemini 2.5 Flash": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 30,
-                  "passed_tests": 7,
-                  "pass_pct": 23.333334,
-                  "task_pass_equiv": 2.0,
-                  "task_pass_pct": 20.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 14,
-                  "pass_pct": 51.851852,
-                  "task_pass_equiv": 6.0,
-                  "task_pass_pct": 50.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 57,
-                "passed_tests": 21,
-                "pass_pct": 36.842106,
-                "task_pass_equiv": 8.0,
-                "task_pass_pct": 36.363636
-              }
-            },
-            "DeepSeek V3": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 15,
-                  "pass_pct": 44.117645,
-                  "task_pass_equiv": 4.0,
-                  "task_pass_pct": 40.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 12,
-                  "pass_pct": 44.444443,
-                  "task_pass_equiv": 5.0,
-                  "task_pass_pct": 41.666664
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 27,
-                "pass_pct": 44.262295,
-                "task_pass_equiv": 9.0,
-                "task_pass_pct": 40.909092
-              }
-            },
-            "Claude 4.5 Sonnet": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 23,
-                  "pass_pct": 67.64706,
-                  "task_pass_equiv": 6.0,
-                  "task_pass_pct": 60.000004
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 18,
-                  "pass_pct": 66.666664,
-                  "task_pass_equiv": 7.0,
-                  "task_pass_pct": 58.333332
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 41,
-                "pass_pct": 67.21311,
-                "task_pass_equiv": 13.0,
-                "task_pass_pct": 59.090908
-              }
-            },
-            "Meta Llama 3.1 405B": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 4,
-                  "pass_pct": 14.814815,
-                  "task_pass_equiv": 2.0,
-                  "task_pass_pct": 16.666668
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 4,
-                "pass_pct": 6.557377,
-                "task_pass_equiv": 2.0,
-                "task_pass_pct": 9.090909
-              }
-            },
-            "DeepSeek R1": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 7,
-                  "pass_pct": 20.588236,
-                  "task_pass_equiv": 2.0,
-                  "task_pass_pct": 20.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 14,
-                  "pass_pct": 51.851852,
-                  "task_pass_equiv": 6.0,
-                  "task_pass_pct": 50.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 21,
-                "pass_pct": 34.42623,
-                "task_pass_equiv": 8.0,
-                "task_pass_pct": 36.363636
-              }
-            },
-            "o4-mini": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 21,
-                  "pass_pct": 61.764706,
-                  "task_pass_equiv": 6.0,
-                  "task_pass_pct": 60.000004
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 16,
-                  "pass_pct": 59.25926,
-                  "task_pass_equiv": 8.0,
-                  "task_pass_pct": 66.66667
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 37,
-                "pass_pct": 60.65574,
-                "task_pass_equiv": 14.0,
-                "task_pass_pct": 63.636364
-              }
-            },
-            "Claude 4 Sonnet": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 20,
-                  "pass_pct": 74.07407,
-                  "task_pass_equiv": 9.0,
-                  "task_pass_pct": 75.0
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 18,
-                  "pass_pct": 52.941177,
-                  "task_pass_equiv": 5.0,
-                  "task_pass_pct": 50.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 38,
-                "pass_pct": 62.295082,
-                "task_pass_equiv": 14.0,
-                "task_pass_pct": 63.636364
-              }
-            },
-            "Claude 4.5 Haiku": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 19,
-                  "pass_pct": 55.882355,
-                  "task_pass_equiv": 4.8,
-                  "task_pass_pct": 48.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 19,
-                  "pass_pct": 70.37037,
-                  "task_pass_equiv": 8.0,
-                  "task_pass_pct": 66.66667
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 38,
-                "pass_pct": 62.295082,
-                "task_pass_equiv": 12.8,
-                "task_pass_pct": 58.181816
-              }
-            },
-            "GPT-5": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 11,
-                  "pass_pct": 32.35294,
-                  "task_pass_equiv": 2.35,
-                  "task_pass_pct": 23.499998
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 5,
-                  "pass_pct": 18.518518,
-                  "task_pass_equiv": 1.3333334,
-                  "task_pass_pct": 11.111112
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 16,
-                "pass_pct": 26.229507,
-                "task_pass_equiv": 3.6833334,
-                "task_pass_pct": 16.742424
-              }
-            },
-            "GPT-4o": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 19,
-                  "pass_pct": 70.37037,
-                  "task_pass_equiv": 8.0,
-                  "task_pass_pct": 66.66667
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 15,
-                  "pass_pct": 44.117645,
-                  "task_pass_equiv": 4.0,
-                  "task_pass_pct": 40.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 34,
-                "pass_pct": 55.737705,
-                "task_pass_equiv": 12.0,
-                "task_pass_pct": 54.545456
-              }
-            },
-            "GPT-4.1": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 17,
-                  "pass_pct": 62.962963,
-                  "task_pass_equiv": 7.0,
-                  "task_pass_pct": 58.333332
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 5,
-                  "pass_pct": 14.705882,
-                  "task_pass_equiv": 1.4,
-                  "task_pass_pct": 14.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 22,
-                "pass_pct": 36.065575,
-                "task_pass_equiv": 8.4,
-                "task_pass_pct": 38.181816
-              }
-            }
-          }
-        },
         "docs": {
+          "hash": "a4ddc223e2035781ae7e86c8c38c0d78212e9a0c4149c6535625b4033878e3a4",
           "models": {
-            "GPT-4.1": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 4,
-                  "pass_pct": 14.814815,
-                  "task_pass_equiv": 4.0,
-                  "task_pass_pct": 33.333336
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 4,
-                "pass_pct": 6.557377,
-                "task_pass_equiv": 4.0,
-                "task_pass_pct": 18.181818
-              }
-            },
-            "Grok 3 Mini (Beta)": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 17,
-                  "pass_pct": 62.962963,
-                  "task_pass_equiv": 7.0,
-                  "task_pass_pct": 58.333332
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 17,
-                  "pass_pct": 50.0,
-                  "task_pass_equiv": 5.0,
-                  "task_pass_pct": 50.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 34,
-                "pass_pct": 55.737705,
-                "task_pass_equiv": 12.0,
-                "task_pass_pct": 54.545456
-              }
-            },
-            "Claude 3.5 Sonnet": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 10,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 12,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 22,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            },
-            "Claude 3.5 Haiku": {
-              "categories": {
-                "basics": {
-                  "tasks": 11,
-                  "total_tests": 18,
-                  "passed_tests": 1,
-                  "pass_pct": 5.5555553,
-                  "task_pass_equiv": 1.0,
-                  "task_pass_pct": 9.090909
-                }
-              },
-              "totals": {
-                "tasks": 11,
-                "total_tests": 18,
-                "passed_tests": 1,
-                "pass_pct": 5.5555553,
-                "task_pass_equiv": 1.0,
-                "task_pass_pct": 9.090909
-              }
-            },
-            "GPT-5": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 3,
-                  "pass_pct": 8.823529,
-                  "task_pass_equiv": 1.0,
-                  "task_pass_pct": 10.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 13,
-                  "pass_pct": 48.148148,
-                  "task_pass_equiv": 6.0,
-                  "task_pass_pct": 50.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 16,
-                "pass_pct": 26.229507,
-                "task_pass_equiv": 7.0,
-                "task_pass_pct": 31.818182
-              }
-            },
-            "Claude 3.7 Sonnet": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 10,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 16,
-                  "passed_tests": 6,
-                  "pass_pct": 37.5,
-                  "task_pass_equiv": 2.0,
-                  "task_pass_pct": 16.666668
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 26,
-                "passed_tests": 6,
-                "pass_pct": 23.076923,
-                "task_pass_equiv": 2.0,
-                "task_pass_pct": 9.090909
-              }
-            },
-            "DeepSeek R1": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 14,
-                  "pass_pct": 51.851852,
-                  "task_pass_equiv": 6.0,
-                  "task_pass_pct": 50.0
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 14,
-                "pass_pct": 22.950819,
-                "task_pass_equiv": 6.0,
-                "task_pass_pct": 27.272728
-              }
-            },
-            "Claude 4.5 Sonnet": {
+            "Claude Opus 4.6": {
               "categories": {
                 "basics": {
                   "tasks": 12,
                   "total_tests": 27,
                   "passed_tests": 25,
                   "pass_pct": 92.59259,
-                  "task_pass_equiv": 10.0,
-                  "task_pass_pct": 83.33333
+                  "task_pass_equiv": 11.333334,
+                  "task_pass_pct": 94.44445
                 },
                 "schema": {
                   "tasks": 10,
                   "total_tests": 34,
-                  "passed_tests": 30,
-                  "pass_pct": 88.23529,
-                  "task_pass_equiv": 9.0,
-                  "task_pass_pct": 90.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 55,
-                "pass_pct": 90.16393,
-                "task_pass_equiv": 19.0,
-                "task_pass_pct": 86.36364
-              }
-            },
-            "Grok 4": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 25,
-                  "pass_pct": 92.59259,
-                  "task_pass_equiv": 10.0,
-                  "task_pass_pct": 83.33333
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 14,
-                  "pass_pct": 41.17647,
-                  "task_pass_equiv": 4.0,
-                  "task_pass_pct": 40.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 39,
-                "pass_pct": 63.934425,
-                "task_pass_equiv": 14.0,
-                "task_pass_pct": 63.636364
-              }
-            },
-            "DeepSeek V3": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 12,
-                  "pass_pct": 35.294117,
-                  "task_pass_equiv": 3.0,
-                  "task_pass_pct": 30.000002
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 19,
-                  "pass_pct": 70.37037,
+                  "passed_tests": 28,
+                  "pass_pct": 82.35294,
                   "task_pass_equiv": 8.0,
-                  "task_pass_pct": 66.66667
+                  "task_pass_pct": 80.0
                 }
               },
               "totals": {
                 "tasks": 22,
                 "total_tests": 61,
-                "passed_tests": 31,
-                "pass_pct": 50.81967,
-                "task_pass_equiv": 11.0,
-                "task_pass_pct": 50.0
+                "passed_tests": 53,
+                "pass_pct": 86.88525,
+                "task_pass_equiv": 19.333334,
+                "task_pass_pct": 87.87879
               }
             },
-            "Gemini 2.5 Flash": {
+            "Claude Sonnet 4.6": {
               "categories": {
                 "basics": {
                   "tasks": 12,
                   "total_tests": 27,
-                  "passed_tests": 13,
-                  "pass_pct": 48.148148,
-                  "task_pass_equiv": 5.0,
-                  "task_pass_pct": 41.666664
+                  "passed_tests": 25,
+                  "pass_pct": 92.59259,
+                  "task_pass_equiv": 11.5,
+                  "task_pass_pct": 95.83333
                 },
                 "schema": {
                   "tasks": 10,
                   "total_tests": 34,
-                  "passed_tests": 10,
-                  "pass_pct": 29.411764,
-                  "task_pass_equiv": 2.6666667,
-                  "task_pass_pct": 26.666668
+                  "passed_tests": 33,
+                  "pass_pct": 97.05882,
+                  "task_pass_equiv": 9.666666,
+                  "task_pass_pct": 96.66666
                 }
               },
               "totals": {
                 "tasks": 22,
                 "total_tests": 61,
-                "passed_tests": 23,
-                "pass_pct": 37.704918,
-                "task_pass_equiv": 7.666667,
-                "task_pass_pct": 34.848488
+                "passed_tests": 58,
+                "pass_pct": 95.08197,
+                "task_pass_equiv": 21.166666,
+                "task_pass_pct": 96.21212
               }
             },
-            "Claude 4 Sonnet": {
+            "DeepSeek Chat": {
               "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 23,
+                  "pass_pct": 85.18519,
+                  "task_pass_equiv": 10.833334,
+                  "task_pass_pct": 90.27779
+                },
                 "schema": {
                   "tasks": 10,
                   "total_tests": 34,
-                  "passed_tests": 23,
-                  "pass_pct": 67.64706,
-                  "task_pass_equiv": 7.0,
-                  "task_pass_pct": 70.0
-                },
+                  "passed_tests": 29,
+                  "pass_pct": 85.29412,
+                  "task_pass_equiv": 8.733334,
+                  "task_pass_pct": 87.333336
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 52,
+                "pass_pct": 85.2459,
+                "task_pass_equiv": 19.566668,
+                "task_pass_pct": 88.9394
+              }
+            },
+            "DeepSeek Reasoner": {
+              "categories": {
                 "basics": {
                   "tasks": 12,
                   "total_tests": 27,
                   "passed_tests": 22,
                   "pass_pct": 81.48148,
-                  "task_pass_equiv": 10.0,
-                  "task_pass_pct": 83.33333
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 45,
-                "pass_pct": 73.77049,
-                "task_pass_equiv": 17.0,
-                "task_pass_pct": 77.27273
-              }
-            },
-            "o4-mini": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            },
-            "Gemini 2.5 Pro": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 17,
-                  "pass_pct": 62.962963,
-                  "task_pass_equiv": 8.0,
-                  "task_pass_pct": 66.66667
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 17,
-                "pass_pct": 27.868853,
-                "task_pass_equiv": 8.0,
-                "task_pass_pct": 36.363636
-              }
-            },
-            "GPT-4o": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            }
-          }
-        },
-        "llms.md": {
-          "models": {
-            "Gemini 2.5 Pro": {
-              "categories": {
-                "schema": {
-                  "tasks": 1,
-                  "total_tests": 4,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 1,
-                "total_tests": 4,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            },
-            "GPT-5": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 34,
-                  "pass_pct": 100.0,
-                  "task_pass_equiv": 10.0,
-                  "task_pass_pct": 100.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 27,
-                  "pass_pct": 100.0,
-                  "task_pass_equiv": 12.0,
-                  "task_pass_pct": 100.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 61,
-                "pass_pct": 100.0,
-                "task_pass_equiv": 22.0,
-                "task_pass_pct": 100.0
-              }
-            },
-            "Gemini 2.5 Flash": {
-              "categories": {
-                "schema": {
-                  "tasks": 1,
-                  "total_tests": 4,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 1,
-                "total_tests": 4,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            },
-            "Grok 3 Mini (Beta)": {
-              "categories": {
-                "schema": {
-                  "tasks": 1,
-                  "total_tests": 1,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 1,
-                "total_tests": 1,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            },
-            "Claude 3.7 Sonnet": {
-              "categories": {
-                "schema": {
-                  "tasks": 1,
-                  "total_tests": 4,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 1,
-                "total_tests": 4,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            },
-            "Claude 4.5 Sonnet": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 15,
-                  "passed_tests": 3,
-                  "pass_pct": 20.0,
-                  "task_pass_equiv": 1.0,
-                  "task_pass_pct": 10.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 12,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 27,
-                "passed_tests": 3,
-                "pass_pct": 11.111111,
-                "task_pass_equiv": 1.0,
-                "task_pass_pct": 4.5454545
-              }
-            },
-            "Claude 4 Sonnet": {
-              "categories": {
-                "schema": {
-                  "tasks": 1,
-                  "total_tests": 1,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 1,
-                "total_tests": 1,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            },
-            "DeepSeek V3": {
-              "categories": {
-                "schema": {
-                  "tasks": 1,
-                  "total_tests": 4,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 1,
-                "total_tests": 4,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            },
-            "Meta Llama 3.1 405B": {
-              "categories": {
-                "schema": {
-                  "tasks": 1,
-                  "total_tests": 1,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 1,
-                "total_tests": 1,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            },
-            "Grok 4": {
-              "categories": {
-                "schema": {
-                  "tasks": 1,
-                  "total_tests": 1,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 1,
-                "total_tests": 1,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            },
-            "Claude 3.5 Haiku": {
-              "categories": {
-                "schema": {
-                  "tasks": 1,
-                  "total_tests": 4,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 1,
-                "total_tests": 4,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            },
-            "Claude 3.5 Sonnet": {
-              "categories": {
-                "schema": {
-                  "tasks": 1,
-                  "total_tests": 1,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 1,
-                "total_tests": 1,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            }
-          }
-        }
-      }
-    },
-    "csharp": {
-      "modes": {
-        "llms.md": {
-          "models": {
-            "GPT-4.1": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 12,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 10,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 22,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            },
-            "GPT-4o": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 12,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 10,
-                  "passed_tests": 0,
-                  "pass_pct": 0.0,
-                  "task_pass_equiv": 0.0,
-                  "task_pass_pct": 0.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 22,
-                "passed_tests": 0,
-                "pass_pct": 0.0,
-                "task_pass_equiv": 0.0,
-                "task_pass_pct": 0.0
-              }
-            }
-          }
-        },
-        "docs": {
-          "models": {
-            "o4-mini": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 18,
-                  "pass_pct": 52.941177,
-                  "task_pass_equiv": 6.0,
-                  "task_pass_pct": 60.000004
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 17,
-                  "pass_pct": 62.962963,
-                  "task_pass_equiv": 7.8333335,
-                  "task_pass_pct": 65.27778
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 35,
-                "pass_pct": 57.37705,
-                "task_pass_equiv": 13.833333,
-                "task_pass_pct": 62.878788
-              }
-            },
-            "Claude 4 Sonnet": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 22,
-                  "pass_pct": 64.70588,
-                  "task_pass_equiv": 7.0,
-                  "task_pass_pct": 70.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 27,
-                  "pass_pct": 100.0,
-                  "task_pass_equiv": 12.0,
-                  "task_pass_pct": 100.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 49,
-                "pass_pct": 80.327866,
-                "task_pass_equiv": 19.0,
-                "task_pass_pct": 86.36364
-              }
-            },
-            "Grok 4": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 20,
-                  "pass_pct": 74.07407,
-                  "task_pass_equiv": 10.0,
-                  "task_pass_pct": 83.33333
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 31,
-                  "pass_pct": 91.17647,
-                  "task_pass_equiv": 9.0,
-                  "task_pass_pct": 90.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 51,
-                "pass_pct": 83.60656,
-                "task_pass_equiv": 19.0,
-                "task_pass_pct": 86.36364
-              }
-            },
-            "DeepSeek R1": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 24,
-                  "pass_pct": 88.888885,
-                  "task_pass_equiv": 11.0,
-                  "task_pass_pct": 91.66667
+                  "task_pass_equiv": 10.583334,
+                  "task_pass_pct": 88.19445
                 },
                 "schema": {
                   "tasks": 10,
@@ -1248,42 +113,134 @@
               "totals": {
                 "tasks": 22,
                 "total_tests": 61,
-                "passed_tests": 40,
-                "pass_pct": 65.57377,
-                "task_pass_equiv": 16.4,
-                "task_pass_pct": 74.545456
+                "passed_tests": 38,
+                "pass_pct": 62.295082,
+                "task_pass_equiv": 15.983334,
+                "task_pass_pct": 72.65152
               }
             },
-            "Claude 4.5 Sonnet": {
+            "GPT-5-mini": {
               "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 26,
-                  "pass_pct": 76.47059,
-                  "task_pass_equiv": 7.6666665,
-                  "task_pass_pct": 76.666664
-                },
                 "basics": {
                   "tasks": 12,
                   "total_tests": 27,
-                  "passed_tests": 27,
-                  "pass_pct": 100.0,
-                  "task_pass_equiv": 12.0,
-                  "task_pass_pct": 100.0
+                  "passed_tests": 23,
+                  "pass_pct": 85.18519,
+                  "task_pass_equiv": 10.833334,
+                  "task_pass_pct": 90.27779
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 25,
+                  "pass_pct": 73.52941,
+                  "task_pass_equiv": 7.0,
+                  "task_pass_pct": 70.0
                 }
               },
               "totals": {
                 "tasks": 22,
                 "total_tests": 61,
-                "passed_tests": 53,
-                "pass_pct": 86.88525,
-                "task_pass_equiv": 19.666668,
-                "task_pass_pct": 89.39394
+                "passed_tests": 48,
+                "pass_pct": 78.68852,
+                "task_pass_equiv": 17.833334,
+                "task_pass_pct": 81.06061
               }
             },
-            "Gemini 2.5 Pro": {
+            "GPT-5.2-Codex": {
               "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 16,
+                  "pass_pct": 59.25926,
+                  "task_pass_equiv": 6.416667,
+                  "task_pass_pct": 53.472225
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 29,
+                  "pass_pct": 85.29412,
+                  "task_pass_equiv": 8.55,
+                  "task_pass_pct": 85.5
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 45,
+                "pass_pct": 73.77049,
+                "task_pass_equiv": 14.966668,
+                "task_pass_pct": 68.03031
+              }
+            },
+            "Gemini 3 Flash": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 23,
+                  "pass_pct": 85.18519,
+                  "task_pass_equiv": 10.833334,
+                  "task_pass_pct": 90.27779
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 22,
+                  "pass_pct": 64.70588,
+                  "task_pass_equiv": 6.666667,
+                  "task_pass_pct": 66.66667
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 45,
+                "pass_pct": 73.77049,
+                "task_pass_equiv": 17.5,
+                "task_pass_pct": 79.545456
+              }
+            },
+            "Gemini 3.1 Pro": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 23,
+                  "pass_pct": 85.18519,
+                  "task_pass_equiv": 10.833334,
+                  "task_pass_pct": 90.27779
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 28,
+                  "pass_pct": 82.35294,
+                  "task_pass_equiv": 8.0,
+                  "task_pass_pct": 80.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 51,
+                "pass_pct": 83.60656,
+                "task_pass_equiv": 18.833334,
+                "task_pass_pct": 85.606064
+              }
+            },
+            "Grok 4": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 23,
+                  "pass_pct": 85.18519,
+                  "task_pass_equiv": 10.833334,
+                  "task_pass_pct": 90.27779
+                },
                 "schema": {
                   "tasks": 10,
                   "total_tests": 34,
@@ -1291,13 +248,107 @@
                   "pass_pct": 100.0,
                   "task_pass_equiv": 10.0,
                   "task_pass_pct": 100.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 57,
+                "pass_pct": 93.44262,
+                "task_pass_equiv": 20.833334,
+                "task_pass_pct": 94.696976
+              }
+            },
+            "Grok Code": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 22,
+                  "pass_pct": 81.48148,
+                  "task_pass_equiv": 10.5,
+                  "task_pass_pct": 87.5
                 },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 28,
+                  "pass_pct": 82.35294,
+                  "task_pass_equiv": 8.8,
+                  "task_pass_pct": 88.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 50,
+                "pass_pct": 81.96722,
+                "task_pass_equiv": 19.3,
+                "task_pass_pct": 87.727264
+              }
+            }
+          }
+        },
+        "llms.md": {
+          "hash": "171b01e97d14a2c03356933e7c86331362cc53b87e82cd534cd74273e7bc8ea4",
+          "models": {}
+        }
+      }
+    },
+    "rust": {
+      "modes": {
+        "cursor_rules": {
+          "hash": "edbeadd577ce7acdedf6ce10e46c0aaee75d0cd6c30c8faef266a23ad86d12cf",
+          "models": {
+            "Grok 4": {
+              "categories": {
+                "basics": {
+                  "tasks": 3,
+                  "total_tests": 7,
+                  "passed_tests": 7,
+                  "pass_pct": 100.0,
+                  "task_pass_equiv": 3.0,
+                  "task_pass_pct": 100.0
+                },
+                "schema": {
+                  "tasks": 5,
+                  "total_tests": 17,
+                  "passed_tests": 13,
+                  "pass_pct": 76.47059,
+                  "task_pass_equiv": 4.0,
+                  "task_pass_pct": 80.0
+                }
+              },
+              "totals": {
+                "tasks": 8,
+                "total_tests": 24,
+                "passed_tests": 20,
+                "pass_pct": 83.333336,
+                "task_pass_equiv": 7.0,
+                "task_pass_pct": 87.5
+              }
+            }
+          }
+        },
+        "docs": {
+          "hash": "cb5bf60a6d17e761b5fcec5d8e69bafbaf56602e570522e688d4da57973c7ea8",
+          "models": {
+            "Claude Opus 4.6": {
+              "categories": {
                 "basics": {
                   "tasks": 12,
                   "total_tests": 27,
                   "passed_tests": 27,
                   "pass_pct": 100.0,
                   "task_pass_equiv": 12.0,
+                  "task_pass_pct": 100.0
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 34,
+                  "pass_pct": 100.0,
+                  "task_pass_equiv": 10.0,
                   "task_pass_pct": 100.0
                 }
               },
@@ -1310,175 +361,7 @@
                 "task_pass_pct": 100.0
               }
             },
-            "Gemini 2.5 Flash": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 19,
-                  "pass_pct": 55.882355,
-                  "task_pass_equiv": 6.0666666,
-                  "task_pass_pct": 60.666668
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 24,
-                  "passed_tests": 18,
-                  "pass_pct": 75.0,
-                  "task_pass_equiv": 9.0,
-                  "task_pass_pct": 75.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 58,
-                "passed_tests": 37,
-                "pass_pct": 63.793102,
-                "task_pass_equiv": 15.066667,
-                "task_pass_pct": 68.48485
-              }
-            },
-            "GPT-4o": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 19,
-                  "pass_pct": 70.37037,
-                  "task_pass_equiv": 8.833334,
-                  "task_pass_pct": 73.611115
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 26,
-                  "pass_pct": 76.47059,
-                  "task_pass_equiv": 8.0,
-                  "task_pass_pct": 80.0
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 45,
-                "pass_pct": 73.77049,
-                "task_pass_equiv": 16.833334,
-                "task_pass_pct": 76.51516
-              }
-            },
-            "DeepSeek V3": {
-              "categories": {
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 24,
-                  "pass_pct": 88.888885,
-                  "task_pass_equiv": 11.0,
-                  "task_pass_pct": 91.66667
-                },
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 27,
-                  "pass_pct": 79.411766,
-                  "task_pass_equiv": 8.466667,
-                  "task_pass_pct": 84.66667
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 51,
-                "pass_pct": 83.60656,
-                "task_pass_equiv": 19.466667,
-                "task_pass_pct": 88.484856
-              }
-            },
-            "Meta Llama 3.1 405B": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 26,
-                  "pass_pct": 76.47059,
-                  "task_pass_equiv": 8.25,
-                  "task_pass_pct": 82.5
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 24,
-                  "pass_pct": 88.888885,
-                  "task_pass_equiv": 11.0,
-                  "task_pass_pct": 91.66667
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 50,
-                "pass_pct": 81.96722,
-                "task_pass_equiv": 19.25,
-                "task_pass_pct": 87.5
-              }
-            },
-            "Grok 3 Mini (Beta)": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 17,
-                  "pass_pct": 50.0,
-                  "task_pass_equiv": 5.0,
-                  "task_pass_pct": 50.0
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 9,
-                  "pass_pct": 33.333332,
-                  "task_pass_equiv": 5.0,
-                  "task_pass_pct": 41.666664
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 26,
-                "pass_pct": 42.62295,
-                "task_pass_equiv": 10.0,
-                "task_pass_pct": 45.454548
-              }
-            },
-            "GPT-5": {
-              "categories": {
-                "schema": {
-                  "tasks": 10,
-                  "total_tests": 34,
-                  "passed_tests": 4,
-                  "pass_pct": 11.764706,
-                  "task_pass_equiv": 1.25,
-                  "task_pass_pct": 12.5
-                },
-                "basics": {
-                  "tasks": 12,
-                  "total_tests": 27,
-                  "passed_tests": 5,
-                  "pass_pct": 18.518518,
-                  "task_pass_equiv": 1.3333334,
-                  "task_pass_pct": 11.111112
-                }
-              },
-              "totals": {
-                "tasks": 22,
-                "total_tests": 61,
-                "passed_tests": 9,
-                "pass_pct": 14.754098,
-                "task_pass_equiv": 2.5833335,
-                "task_pass_pct": 11.742425
-              }
-            },
-            "Claude 4.5 Haiku": {
+            "Claude Sonnet 4.6": {
               "categories": {
                 "basics": {
                   "tasks": 12,
@@ -1491,30 +374,114 @@
                 "schema": {
                   "tasks": 10,
                   "total_tests": 34,
-                  "passed_tests": 21,
-                  "pass_pct": 61.764706,
-                  "task_pass_equiv": 5.8,
-                  "task_pass_pct": 58.000004
+                  "passed_tests": 34,
+                  "pass_pct": 100.0,
+                  "task_pass_equiv": 10.0,
+                  "task_pass_pct": 100.0
                 }
               },
               "totals": {
                 "tasks": 22,
                 "total_tests": 61,
-                "passed_tests": 48,
-                "pass_pct": 78.68852,
-                "task_pass_equiv": 17.8,
-                "task_pass_pct": 80.90909
+                "passed_tests": 61,
+                "pass_pct": 100.0,
+                "task_pass_equiv": 22.0,
+                "task_pass_pct": 100.0
               }
             },
-            "GPT-4.1": {
+            "DeepSeek Chat": {
               "categories": {
                 "basics": {
                   "tasks": 12,
                   "total_tests": 27,
                   "passed_tests": 23,
                   "pass_pct": 85.18519,
+                  "task_pass_equiv": 11.0,
+                  "task_pass_pct": 91.66667
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 26,
+                  "pass_pct": 76.47059,
+                  "task_pass_equiv": 7.4,
+                  "task_pass_pct": 74.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 49,
+                "pass_pct": 80.327866,
+                "task_pass_equiv": 18.4,
+                "task_pass_pct": 83.63636
+              }
+            },
+            "DeepSeek Reasoner": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 22,
+                  "pass_pct": 81.48148,
+                  "task_pass_equiv": 8.333333,
+                  "task_pass_pct": 69.44444
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 12,
+                  "pass_pct": 35.294117,
+                  "task_pass_equiv": 3.4,
+                  "task_pass_pct": 34.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 34,
+                "pass_pct": 55.737705,
+                "task_pass_equiv": 11.733333,
+                "task_pass_pct": 53.33333
+              }
+            },
+            "GPT-5-mini": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 23,
+                  "pass_pct": 85.18519,
+                  "task_pass_equiv": 10.833334,
+                  "task_pass_pct": 90.27779
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 34,
+                  "pass_pct": 100.0,
                   "task_pass_equiv": 10.0,
-                  "task_pass_pct": 83.33333
+                  "task_pass_pct": 100.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 57,
+                "pass_pct": 93.44262,
+                "task_pass_equiv": 20.833334,
+                "task_pass_pct": 94.696976
+              }
+            },
+            "GPT-5.2-Codex": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 26,
+                  "pass_pct": 96.296295,
+                  "task_pass_equiv": 11.0,
+                  "task_pass_pct": 91.66667
                 },
                 "schema": {
                   "tasks": 10,
@@ -1528,10 +495,543 @@
               "totals": {
                 "tasks": 22,
                 "total_tests": 61,
+                "passed_tests": 55,
+                "pass_pct": 90.16393,
+                "task_pass_equiv": 20.0,
+                "task_pass_pct": 90.909096
+              }
+            },
+            "Gemini 3 Flash": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 25,
+                  "pass_pct": 92.59259,
+                  "task_pass_equiv": 11.5,
+                  "task_pass_pct": 95.83333
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 34,
+                  "pass_pct": 100.0,
+                  "task_pass_equiv": 10.0,
+                  "task_pass_pct": 100.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 59,
+                "pass_pct": 96.72131,
+                "task_pass_equiv": 21.5,
+                "task_pass_pct": 97.72727
+              }
+            },
+            "Gemini 3.1 Pro": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 22,
+                  "pass_pct": 81.48148,
+                  "task_pass_equiv": 9.0,
+                  "task_pass_pct": 75.0
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 28,
+                  "pass_pct": 82.35294,
+                  "task_pass_equiv": 8.0,
+                  "task_pass_pct": 80.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 50,
+                "pass_pct": 81.96722,
+                "task_pass_equiv": 17.0,
+                "task_pass_pct": 77.27273
+              }
+            },
+            "Grok 4": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 24,
+                  "pass_pct": 88.888885,
+                  "task_pass_equiv": 11.0,
+                  "task_pass_pct": 91.66667
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 31,
+                  "pass_pct": 91.17647,
+                  "task_pass_equiv": 9.0,
+                  "task_pass_pct": 90.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 55,
+                "pass_pct": 90.16393,
+                "task_pass_equiv": 20.0,
+                "task_pass_pct": 90.909096
+              }
+            },
+            "Grok Code": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 22,
+                  "pass_pct": 81.48148,
+                  "task_pass_equiv": 9.833334,
+                  "task_pass_pct": 81.94445
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 33,
+                  "pass_pct": 97.05882,
+                  "task_pass_equiv": 9.8,
+                  "task_pass_pct": 98.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 55,
+                "pass_pct": 90.16393,
+                "task_pass_equiv": 19.633333,
+                "task_pass_pct": 89.242424
+              }
+            }
+          }
+        },
+        "llms.md": {
+          "hash": "7bd4918052e02c4b09d50e7037cd2e81add76a4b42468acac54ee8f4073e37cf",
+          "models": {
+            "Grok 4": {
+              "categories": {
+                "basics": {
+                  "tasks": 1,
+                  "total_tests": 1,
+                  "passed_tests": 0,
+                  "pass_pct": 0.0,
+                  "task_pass_equiv": 0.0,
+                  "task_pass_pct": 0.0
+                },
+                "schema": {
+                  "tasks": 3,
+                  "total_tests": 9,
+                  "passed_tests": 5,
+                  "pass_pct": 55.555557,
+                  "task_pass_equiv": 2.0,
+                  "task_pass_pct": 66.66667
+                }
+              },
+              "totals": {
+                "tasks": 4,
+                "total_tests": 10,
+                "passed_tests": 5,
+                "pass_pct": 50.0,
+                "task_pass_equiv": 2.0,
+                "task_pass_pct": 50.0
+              }
+            }
+          }
+        },
+        "none": {
+          "hash": "af1349b9f5f9a1a6a0404dea36dcc9499bcb25c9adc112b7cc9a93cae41f3262",
+          "models": {
+            "Grok 4": {
+              "categories": {
+                "basics": {
+                  "tasks": 1,
+                  "total_tests": 1,
+                  "passed_tests": 0,
+                  "pass_pct": 0.0,
+                  "task_pass_equiv": 0.0,
+                  "task_pass_pct": 0.0
+                },
+                "schema": {
+                  "tasks": 3,
+                  "total_tests": 3,
+                  "passed_tests": 0,
+                  "pass_pct": 0.0,
+                  "task_pass_equiv": 0.0,
+                  "task_pass_pct": 0.0
+                }
+              },
+              "totals": {
+                "tasks": 4,
+                "total_tests": 4,
+                "passed_tests": 0,
+                "pass_pct": 0.0,
+                "task_pass_equiv": 0.0,
+                "task_pass_pct": 0.0
+              }
+            }
+          }
+        },
+        "rustdoc_json": {
+          "hash": "b0d5bbe755291d8ec65de0a74b4eecfa344670639ca5f1a365ced3ab9717e97c",
+          "models": {
+            "Grok 4": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 13,
+                  "pass_pct": 48.148148,
+                  "task_pass_equiv": 6.0,
+                  "task_pass_pct": 50.0
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 28,
+                  "passed_tests": 0,
+                  "pass_pct": 0.0,
+                  "task_pass_equiv": 0.0,
+                  "task_pass_pct": 0.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 55,
+                "passed_tests": 13,
+                "pass_pct": 23.636364,
+                "task_pass_equiv": 6.0,
+                "task_pass_pct": 27.272728
+              }
+            }
+          }
+        }
+      }
+    },
+    "typescript": {
+      "modes": {
+        "cursor_rules": {
+          "hash": "f3691654a6b470fedbee3a465fd09fbf63705ffddbd0454b775385d72e02e2b3",
+          "models": {
+            "GPT-5.2-Codex": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 0,
+                  "pass_pct": 0.0,
+                  "task_pass_equiv": 0.0,
+                  "task_pass_pct": 0.0
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 0,
+                  "pass_pct": 0.0,
+                  "task_pass_equiv": 0.0,
+                  "task_pass_pct": 0.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 0,
+                "pass_pct": 0.0,
+                "task_pass_equiv": 0.0,
+                "task_pass_pct": 0.0
+              }
+            }
+          }
+        },
+        "docs": {
+          "hash": "3924da8acd3f980dd3c715b8feeec704c6d1a33c376ebb95ece2d4e0eef81093",
+          "models": {
+            "Claude Opus 4.6": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 26,
+                  "pass_pct": 96.296295,
+                  "task_pass_equiv": 11.0,
+                  "task_pass_pct": 91.66667
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 30,
+                  "pass_pct": 88.23529,
+                  "task_pass_equiv": 8.666667,
+                  "task_pass_pct": 86.666664
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 56,
+                "pass_pct": 91.803276,
+                "task_pass_equiv": 19.666666,
+                "task_pass_pct": 89.393936
+              }
+            },
+            "Claude Sonnet 4.6": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 26,
+                  "pass_pct": 96.296295,
+                  "task_pass_equiv": 11.0,
+                  "task_pass_pct": 91.66667
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 30,
+                  "pass_pct": 88.23529,
+                  "task_pass_equiv": 8.666667,
+                  "task_pass_pct": 86.666664
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 56,
+                "pass_pct": 91.803276,
+                "task_pass_equiv": 19.666666,
+                "task_pass_pct": 89.393936
+              }
+            },
+            "DeepSeek Chat": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 25,
+                  "pass_pct": 92.59259,
+                  "task_pass_equiv": 10.0,
+                  "task_pass_pct": 83.33333
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 25,
+                  "pass_pct": 73.52941,
+                  "task_pass_equiv": 7.066667,
+                  "task_pass_pct": 70.66667
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 50,
+                "pass_pct": 81.96722,
+                "task_pass_equiv": 17.066666,
+                "task_pass_pct": 77.57575
+              }
+            },
+            "DeepSeek Reasoner": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 17,
+                  "pass_pct": 62.962963,
+                  "task_pass_equiv": 6.833333,
+                  "task_pass_pct": 56.944443
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 15,
+                  "pass_pct": 44.117645,
+                  "task_pass_equiv": 4.3333335,
+                  "task_pass_pct": 43.333332
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 32,
+                "pass_pct": 52.459015,
+                "task_pass_equiv": 11.166666,
+                "task_pass_pct": 50.757576
+              }
+            },
+            "GPT-5-mini": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 25,
+                  "pass_pct": 92.59259,
+                  "task_pass_equiv": 10.0,
+                  "task_pass_pct": 83.33333
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 15,
+                  "pass_pct": 44.117645,
+                  "task_pass_equiv": 4.533334,
+                  "task_pass_pct": 45.333336
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 40,
+                "pass_pct": 65.57377,
+                "task_pass_equiv": 14.533333,
+                "task_pass_pct": 66.0606
+              }
+            },
+            "GPT-5.2-Codex": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 15,
+                  "pass_pct": 55.555557,
+                  "task_pass_equiv": 6.0,
+                  "task_pass_pct": 50.0
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 28,
+                  "pass_pct": 82.35294,
+                  "task_pass_equiv": 7.666667,
+                  "task_pass_pct": 76.66667
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 43,
+                "pass_pct": 70.491806,
+                "task_pass_equiv": 13.666667,
+                "task_pass_pct": 62.121212
+              }
+            },
+            "Gemini 3 Flash": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 25,
+                  "pass_pct": 92.59259,
+                  "task_pass_equiv": 10.0,
+                  "task_pass_pct": 83.33333
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 28,
+                  "pass_pct": 82.35294,
+                  "task_pass_equiv": 8.0,
+                  "task_pass_pct": 80.0
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 53,
+                "pass_pct": 86.88525,
+                "task_pass_equiv": 18.0,
+                "task_pass_pct": 81.818184
+              }
+            },
+            "Gemini 3.1 Pro": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 22,
+                  "pass_pct": 81.48148,
+                  "task_pass_equiv": 9.833334,
+                  "task_pass_pct": 81.94445
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 30,
+                  "pass_pct": 88.23529,
+                  "task_pass_equiv": 8.666667,
+                  "task_pass_pct": 86.666664
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
                 "passed_tests": 52,
                 "pass_pct": 85.2459,
-                "task_pass_equiv": 19.0,
-                "task_pass_pct": 86.36364
+                "task_pass_equiv": 18.5,
+                "task_pass_pct": 84.090904
+              }
+            },
+            "Grok 4": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 20,
+                  "pass_pct": 74.07407,
+                  "task_pass_equiv": 8.5,
+                  "task_pass_pct": 70.83333
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 21,
+                  "pass_pct": 61.764706,
+                  "task_pass_equiv": 6.0,
+                  "task_pass_pct": 60.000004
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 41,
+                "pass_pct": 67.21311,
+                "task_pass_equiv": 14.499999,
+                "task_pass_pct": 65.90909
+              }
+            },
+            "Grok Code": {
+              "categories": {
+                "basics": {
+                  "tasks": 12,
+                  "total_tests": 27,
+                  "passed_tests": 24,
+                  "pass_pct": 88.888885,
+                  "task_pass_equiv": 10.333334,
+                  "task_pass_pct": 86.111115
+                },
+                "schema": {
+                  "tasks": 10,
+                  "total_tests": 34,
+                  "passed_tests": 28,
+                  "pass_pct": 82.35294,
+                  "task_pass_equiv": 7.666667,
+                  "task_pass_pct": 76.66667
+                }
+              },
+              "totals": {
+                "tasks": 22,
+                "total_tests": 61,
+                "passed_tests": 52,
+                "pass_pct": 85.2459,
+                "task_pass_equiv": 18.0,
+                "task_pass_pct": 81.818184
               }
             }
           }

--- a/tools/xtask-llm-benchmark/Cargo.toml
+++ b/tools/xtask-llm-benchmark/Cargo.toml
@@ -19,6 +19,7 @@ serde_json.workspace = true
 blake3.workspace = true
 clap.workspace = true
 chrono = { version = "0.4", features = ["clock", "serde"] }
+dotenvy = "0.15"
 async-trait = "0.1.89"
 tokio = { version = "1", features = ["rt-multi-thread", "macros"] }
 urlencoding = "2.1.3"

--- a/tools/xtask-llm-benchmark/src/bench/publishers.rs
+++ b/tools/xtask-llm-benchmark/src/bench/publishers.rs
@@ -2,8 +2,9 @@ use crate::bench::utils::sanitize_db_name;
 use anyhow::{bail, Result};
 use regex::Regex;
 use std::borrow::Cow;
+use std::env;
 use std::fs;
-use std::path::Path;
+use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::LazyLock;
 
@@ -248,14 +249,60 @@ impl Publisher for TypeScriptPublisher {
         Self::ensure_package_json(source)?;
         let db = sanitize_db_name(module_name);
 
-        // Install dependencies (--ignore-workspace to avoid parent workspace interference)
-        run(
-            Command::new("pnpm")
-                .arg("install")
-                .arg("--ignore-workspace")
-                .current_dir(source),
-            "pnpm install (typescript)",
-        )?;
+        // Install dependencies (--ignore-workspace to avoid parent workspace interference).
+        // If NODEJS_DIR is set (e.g. nvm4w on Windows), use full path to pnpm so spawn finds it.
+        let pnpm_exe = env::var("NODEJS_DIR")
+            .ok()
+            .map(|s| s.trim().trim_matches('"').trim().to_string())
+            .filter(|s| !s.is_empty())
+            .map(PathBuf::from)
+            .and_then(|dir| {
+                #[cfg(windows)]
+                {
+                    let pnpm_cmd = dir.join("pnpm.cmd");
+                    let pnpm_exe_path = dir.join("pnpm.exe");
+                    if pnpm_cmd.is_file() {
+                        eprintln!("[pnpm] using NODEJS_DIR: {} (pnpm.cmd)", dir.display());
+                        Some(pnpm_cmd)
+                    } else if pnpm_exe_path.is_file() {
+                        eprintln!("[pnpm] using NODEJS_DIR: {} (pnpm.exe)", dir.display());
+                        Some(pnpm_exe_path)
+                    } else {
+                        eprintln!(
+                            "[pnpm] NODEJS_DIR set to {} but pnpm.cmd/pnpm.exe not found there, using PATH",
+                            dir.display()
+                        );
+                        None
+                    }
+                }
+                #[cfg(not(windows))]
+                {
+                    let pnpm = dir.join("pnpm");
+                    if pnpm.is_file() {
+                        eprintln!("[pnpm] using NODEJS_DIR: {} (pnpm)", dir.display());
+                        Some(pnpm)
+                    } else {
+                        eprintln!("[pnpm] NODEJS_DIR set to {} but pnpm not found there, using PATH", dir.display());
+                        None
+                    }
+                }
+            });
+        let mut pnpm_cmd = match &pnpm_exe {
+            Some(p) => Command::new(p),
+            None => Command::new("pnpm"),
+        };
+        pnpm_cmd.arg("install").arg("--ignore-workspace").current_dir(source);
+        // When using NODEJS_DIR, prepend it to PATH so pnpm.cmd can find node.
+        if let Some(ref dir) = pnpm_exe {
+            if let Some(parent) = dir.parent() {
+                let mut paths: Vec<PathBuf> = env::split_paths(&env::var("PATH").unwrap_or_default()).collect();
+                paths.insert(0, parent.to_path_buf());
+                if let Ok(new_path) = env::join_paths(paths) {
+                    pnpm_cmd.env("PATH", new_path);
+                }
+            }
+        }
+        run(&mut pnpm_cmd, "pnpm install (typescript)")?;
 
         // Publish (spacetime CLI handles TypeScript compilation internally)
         run(

--- a/tools/xtask-llm-benchmark/src/bench/publishers.rs
+++ b/tools/xtask-llm-benchmark/src/bench/publishers.rs
@@ -282,7 +282,10 @@ impl Publisher for TypeScriptPublisher {
                         eprintln!("[pnpm] using NODEJS_DIR: {} (pnpm)", dir.display());
                         Some(pnpm)
                     } else {
-                        eprintln!("[pnpm] NODEJS_DIR set to {} but pnpm not found there, using PATH", dir.display());
+                        eprintln!(
+                            "[pnpm] NODEJS_DIR set to {} but pnpm not found there, using PATH",
+                            dir.display()
+                        );
                         None
                     }
                 }

--- a/tools/xtask-llm-benchmark/src/bench/runner.rs
+++ b/tools/xtask-llm-benchmark/src/bench/runner.rs
@@ -690,6 +690,7 @@ fn load_golden_source(task: &TaskPaths, lang: Lang) -> Result<String> {
 }
 
 // "1" | "01" | "001" | "t_001" -> "t_001"
+// "t_000_empty_reducers" | "t_001_basic_tables" -> accepted as-is (full task dir name)
 fn normalize_task_selector(raw: &str) -> Result<String> {
     let s = raw.trim().to_ascii_lowercase();
     if s.is_empty() {
@@ -699,6 +700,12 @@ fn normalize_task_selector(raw: &str) -> Result<String> {
         if rest.chars().all(|c| c.is_ascii_digit()) {
             let n: u32 = rest.parse()?;
             return Ok(format!("t_{:03}", n));
+        }
+        // Full task dir name: t_000_empty_reducers, t_001_basic_tables, etc.
+        if rest.chars().next().map_or(false, |c| c.is_ascii_digit())
+            && rest.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
+        {
+            return Ok(s);
         }
         bail!("invalid task selector: {raw}");
     }

--- a/tools/xtask-llm-benchmark/src/bench/runner.rs
+++ b/tools/xtask-llm-benchmark/src/bench/runner.rs
@@ -702,7 +702,7 @@ fn normalize_task_selector(raw: &str) -> Result<String> {
             return Ok(format!("t_{:03}", n));
         }
         // Full task dir name: t_000_empty_reducers, t_001_basic_tables, etc.
-        if rest.chars().next().map_or(false, |c| c.is_ascii_digit())
+        if rest.chars().next().is_some_and(|c| c.is_ascii_digit())
             && rest.chars().all(|c| c.is_ascii_alphanumeric() || c == '_')
         {
             return Ok(s);

--- a/tools/xtask-llm-benchmark/src/bench/templates.rs
+++ b/tools/xtask-llm-benchmark/src/bench/templates.rs
@@ -55,8 +55,12 @@ fn workspace_root() -> PathBuf {
 /// Relative path from materialized root to a workspace subpath (e.g. "crates/bindings").
 /// Avoids Windows canonical paths (//?/D:/...) which can break Cargo/MSBuild/pnpm.
 fn relative_to_workspace(root: &Path, ws_subpath: &str) -> Result<String> {
-    let ws = workspace_root().canonicalize().with_context(|| "workspace root not found")?;
-    let root_canon = root.canonicalize().with_context(|| format!("materialized root not found: {}", root.display()))?;
+    let ws = workspace_root()
+        .canonicalize()
+        .with_context(|| "workspace root not found")?;
+    let root_canon = root
+        .canonicalize()
+        .with_context(|| format!("materialized root not found: {}", root.display()))?;
     let root_rel = root_canon
         .strip_prefix(&ws)
         .with_context(|| format!("materialized dir {:?} not under workspace {:?}", root_canon, ws))?;

--- a/tools/xtask-llm-benchmark/src/bench/templates.rs
+++ b/tools/xtask-llm-benchmark/src/bench/templates.rs
@@ -65,7 +65,7 @@ fn relative_to_workspace(root: &Path, ws_subpath: &str) -> Result<String> {
         .strip_prefix(&ws)
         .with_context(|| format!("materialized dir {:?} not under workspace {:?}", root_canon, ws))?;
     let ups = root_rel.components().count();
-    Ok(std::iter::repeat("..").take(ups).collect::<Vec<_>>().join("/") + "/" + ws_subpath)
+    Ok(std::iter::repeat_n("..", ups).collect::<Vec<_>>().join("/") + "/" + ws_subpath)
 }
 
 fn copy_tree_with_templates(src: &Path, dst: &Path) -> Result<()> {

--- a/tools/xtask-llm-benchmark/src/bench/templates.rs
+++ b/tools/xtask-llm-benchmark/src/bench/templates.rs
@@ -43,6 +43,27 @@ fn tmpl_root() -> PathBuf {
     PathBuf::from(env!("CARGO_MANIFEST_DIR")).join("src").join("templates")
 }
 
+/// Workspace root (public/) for local SDK paths.
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("xtask-llm-benchmark is under public/tools/xtask-llm-benchmark")
+        .to_path_buf()
+}
+
+/// Relative path from materialized root to a workspace subpath (e.g. "crates/bindings").
+/// Avoids Windows canonical paths (//?/D:/...) which can break Cargo/MSBuild/pnpm.
+fn relative_to_workspace(root: &Path, ws_subpath: &str) -> Result<String> {
+    let ws = workspace_root().canonicalize().with_context(|| "workspace root not found")?;
+    let root_canon = root.canonicalize().with_context(|| format!("materialized root not found: {}", root.display()))?;
+    let root_rel = root_canon
+        .strip_prefix(&ws)
+        .with_context(|| format!("materialized dir {:?} not under workspace {:?}", root_canon, ws))?;
+    let ups = root_rel.components().count();
+    Ok(std::iter::repeat("..").take(ups).collect::<Vec<_>>().join("/") + "/" + ws_subpath)
+}
+
 fn copy_tree_with_templates(src: &Path, dst: &Path) -> Result<()> {
     fn recurse(from: &Path, to: &Path) -> Result<()> {
         fs::create_dir_all(to)?;
@@ -98,7 +119,19 @@ fn inject_rust(root: &Path, llm_code: &str) -> anyhow::Result<()> {
         }
         contents.push_str(&cleaned);
     }
-    fs::write(&lib, contents).with_context(|| format!("write {}", lib.display()))
+    fs::write(&lib, contents).with_context(|| format!("write {}", lib.display()))?;
+
+    let relative = relative_to_workspace(root, "crates/bindings")?;
+    let sdk_path = workspace_root().join("crates/bindings");
+    if !sdk_path.is_dir() {
+        bail!("local Rust SDK not found at {}", sdk_path.display());
+    }
+    let replacement = format!(r#"{{ path = "{}" }}"#, relative);
+    let cargo_toml = root.join("Cargo.toml");
+    let mut toml = fs::read_to_string(&cargo_toml).with_context(|| format!("read {}", cargo_toml.display()))?;
+    toml = toml.replace("{SPACETIME_RUST_SDK_PATH}", &replacement);
+    fs::write(&cargo_toml, toml).with_context(|| format!("write {}", cargo_toml.display()))?;
+    Ok(())
 }
 
 fn inject_csharp(root: &Path, llm_code: &str) -> anyhow::Result<()> {
@@ -116,7 +149,23 @@ fn inject_csharp(root: &Path, llm_code: &str) -> anyhow::Result<()> {
         }
         contents.push_str(&cleaned);
     }
-    fs::write(&prog, contents).with_context(|| format!("write {}", prog.display()))
+    fs::write(&prog, contents).with_context(|| format!("write {}", prog.display()))?;
+
+    let base_rel = relative_to_workspace(root, "crates/bindings-csharp")?;
+    let runtime_csproj = workspace_root().join("crates/bindings-csharp/Runtime/Runtime.csproj");
+    if !runtime_csproj.is_file() {
+        bail!("local C# Runtime not found at {}", runtime_csproj.display());
+    }
+    let runtime_ref = format!("{}/Runtime/Runtime.csproj", base_rel);
+    let runtime_dir = format!("{}/Runtime", base_rel);
+    let codegen_ref = format!("{}/Codegen/Codegen.csproj", base_rel);
+    let csproj_path = root.join("StdbModule.csproj");
+    let mut csproj = fs::read_to_string(&csproj_path).with_context(|| format!("read {}", csproj_path.display()))?;
+    csproj = csproj.replace("{SPACETIME_CSHARP_RUNTIME_DIR}", &runtime_dir);
+    csproj = csproj.replace("{SPACETIME_CSHARP_RUNTIME_REF}", &runtime_ref);
+    csproj = csproj.replace("{SPACETIME_CSHARP_CODEGEN_REF}", &codegen_ref);
+    fs::write(&csproj_path, csproj).with_context(|| format!("write {}", csproj_path.display()))?;
+    Ok(())
 }
 
 fn inject_typescript(root: &Path, llm_code: &str) -> anyhow::Result<()> {
@@ -134,7 +183,26 @@ fn inject_typescript(root: &Path, llm_code: &str) -> anyhow::Result<()> {
         }
         contents.push_str(&cleaned);
     }
-    fs::write(&lib, contents).with_context(|| format!("write {}", lib.display()))
+    fs::write(&lib, contents).with_context(|| format!("write {}", lib.display()))?;
+
+    let relative = relative_to_workspace(root, "crates/bindings-typescript")?;
+    let sdk_path = workspace_root().join("crates/bindings-typescript");
+    if !sdk_path.is_dir() {
+        bail!("local TypeScript SDK not found at {}", sdk_path.display());
+    }
+    let dist_server = sdk_path.join("dist/server/index.mjs");
+    if !dist_server.is_file() {
+        bail!(
+            "local TypeScript SDK at {} is not built (missing dist/server). Run: pnpm build (in crates/bindings-typescript)",
+            sdk_path.display()
+        );
+    }
+    let replacement = format!("file:{}", relative);
+    let package_json = root.join("package.json");
+    let mut pkg = fs::read_to_string(&package_json).with_context(|| format!("read {}", package_json.display()))?;
+    pkg = pkg.replace("{SPACETIME_TS_SDK_REF}", &replacement);
+    fs::write(&package_json, pkg).with_context(|| format!("write {}", package_json.display()))?;
+    Ok(())
 }
 
 /// Remove leading/trailing Markdown fences like ```rust ... ``` or ~~~

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/answers/csharp.cs
@@ -2,6 +2,12 @@ using SpacetimeDB;
 
 public static partial class Module
 {
+    [Table(Accessor = "EmptyTable")]
+    public partial struct EmptyTable
+    {
+        [PrimaryKey] public int Id;
+    }
+
     [Reducer]
     public static void EmptyReducer_NoArgs(ReducerContext ctx) { }
 

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/answers/rust.rs
@@ -1,4 +1,10 @@
-use spacetimedb::{reducer, ReducerContext};
+use spacetimedb::{reducer, table, ReducerContext};
+
+#[table(accessor = empty_table)]
+pub struct EmptyTable {
+    #[primary_key]
+    pub id: i32,
+}
 
 #[reducer]
 pub fn empty_reducer_no_args(ctx: &ReducerContext) -> Result<(), String> {

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/answers/typescript.ts
@@ -1,6 +1,8 @@
-import { schema, t } from 'spacetimedb/server';
+import { schema, table, t } from 'spacetimedb/server';
 
-const spacetimedb = schema({});
+const emptyTable = table({ name: 'empty_table' }, { id: t.i32().primaryKey() });
+
+const spacetimedb = schema({ emptyTable });
 export default spacetimedb;
 
 export const emptyReducerNoArgs = spacetimedb.reducer({}, ctx => {

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/tasks/csharp.txt
@@ -1,4 +1,10 @@
-﻿Write a SpacetimeDB backend module in C# that defines only these five empty reducers.
+Write a SpacetimeDB backend module in C# that defines a table and these five empty reducers.
+
+TABLES
+- EmptyTable
+  - Struct: EmptyTable
+  - Fields:
+    - Id: int (primary key)
 
 REDUCERS
 - EmptyReducer_NoArgs: no arguments, returns void, empty body

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/tasks/rust.txt
@@ -1,4 +1,10 @@
-﻿Write a SpacetimeDB backend module in Rust that defines only these five empty reducers.
+Write a SpacetimeDB backend module in Rust that defines a table and these five empty reducers.
+
+TABLES
+- EmptyTable
+  - Struct: EmptyTable
+  - Fields:
+    - id: i32 (primary key)
 
 REDUCERS
 - empty_reducer_no_args: no arguments, returns (), empty body

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/tasks/typescript.txt
@@ -1,4 +1,9 @@
-Write a SpacetimeDB backend module in TypeScript that defines five empty reducers with different argument patterns.
+Write a SpacetimeDB backend module in TypeScript that defines a table and five empty reducers with different argument patterns.
+
+TABLES
+- emptyTable
+  - Fields:
+    - id: number (i32, primary key)
 
 REDUCERS
 - emptyReducerNoArgs: no arguments

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_001_basic_tables/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_001_basic_tables/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const user = table({
+const user = table({
   name: 'user',
 }, {
   id: t.i32().primaryKey(),
@@ -9,7 +9,7 @@ export const user = table({
   active: t.bool(),
 });
 
-export const product = table({
+const product = table({
   name: 'product',
 }, {
   id: t.i32().primaryKey(),
@@ -18,7 +18,7 @@ export const product = table({
   inStock: t.bool(),
 });
 
-export const note = table({
+const note = table({
   name: 'note',
 }, {
   id: t.i32().primaryKey(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_001_basic_tables/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_001_basic_tables/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines three tables with basic columns.
+Write a SpacetimeDB backend module in C# that defines three tables with basic columns.
 
 TABLES
 - User

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_002_scheduled_table/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_002_scheduled_table/answers/typescript.ts
@@ -1,7 +1,7 @@
 import { ScheduleAt } from 'spacetimedb';
 import { table, schema, t } from 'spacetimedb/server';
 
-export const tickTimer = table({
+const tickTimer = table({
   name: 'tickTimer',
   scheduled: (): any => tick,
 }, {

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_002_scheduled_table/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_002_scheduled_table/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines a scheduled table and a scheduled reducer.
+Write a SpacetimeDB backend module in C# that defines a scheduled table and a scheduled reducer.
 
 TABLE
 - TickTimer

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_003_struct_in_table/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_003_struct_in_table/answers/typescript.ts
@@ -1,11 +1,11 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const Position = t.object('Position', {
+const Position = t.object('Position', {
   x: t.i32(),
   y: t.i32(),
 });
 
-export const entity = table({
+const entity = table({
   name: 'entity',
 }, {
   id: t.i32().primaryKey(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_003_struct_in_table/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_003_struct_in_table/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines a struct type and uses it in a table.
+Write a SpacetimeDB backend module in C# that defines a struct type and uses it in a table.
 
 TYPES
 - Struct: Position

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const user = table(
+const user = table(
   {
     name: 'user',
   },

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/spec.rs
@@ -9,7 +9,7 @@ pub fn spec() -> BenchmarkSpec {
         let casing = casing_for_lang(lang);
         let sb = SqlBuilder::new(casing);
         let select = sb.select_by_id(&table_name("user", lang), &["id","name","age","active"], "id", 1);
-        let reducer_name = ident("InsertUser", casing);
+        let reducer_name = ident("InsertUser", crate::eval::Casing::Snake);
 
         v.push(make_reducer_data_parity_scorer(host_url, ReducerDataParityConfig {
             src_file: file!(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines one table and a reducer that inserts a row.
+Write a SpacetimeDB backend module in C# that defines one table and a reducer that inserts a row.
 
 TABLE
 - User

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const user = table(
+const user = table(
   {
     name: 'user',
   },

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/spec.rs
@@ -16,7 +16,7 @@ pub fn spec() -> BenchmarkSpec {
         let user_table = table_name("user", lang);
         let seed = sb.insert_values(&user_table, &["id","name","age","active"], &["1","'Alice'","30","true"]);
         let select = sb.select_by_id(&user_table, &["id","name","age","active"], "id", 1);
-        let reducer_name = ident("UpdateUser", casing);
+        let reducer_name = ident("UpdateUser", crate::eval::Casing::Snake);
 
         v.push(make_sql_exec_both_scorer(
             host_url,

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines one table and a reducer that updates a row.
+Write a SpacetimeDB backend module in C# that defines one table and a reducer that updates a row.
 
 TABLE
 - User

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const user = table(
+const user = table(
   {
     name: 'user',
   },

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/spec.rs
@@ -16,7 +16,7 @@ pub fn spec() -> BenchmarkSpec {
         let user_table = table_name("user", lang);
         let seed = sb.insert_values(&user_table, &["id","name","age","active"], &["1","'Alice'","30","true"]);
         let count = sb.count_by_id(&user_table, "id", 1);
-        let reducer_name = ident("DeleteUser", casing);
+        let reducer_name = ident("DeleteUser", crate::eval::Casing::Snake);
 
         v.push(make_sql_exec_both_scorer(
             host_url,

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines one table and a reducer that deletes a row.
+Write a SpacetimeDB backend module in C# that defines one table and a reducer that deletes a row.
 
 TABLE
 - User

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const user = table(
+const user = table(
   {
     name: 'user',
   },

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/spec.rs
@@ -8,7 +8,7 @@ pub fn spec() -> BenchmarkSpec {
 
         let casing = casing_for_lang(lang);
         let sb = SqlBuilder::new(casing);
-        let reducer = ident("Crud", casing);
+        let reducer = ident("Crud", crate::eval::Casing::Snake);
         let user_table = table_name("user", lang);
 
         let select_id1 = sb.select_by_id(&user_table, &["id","name","age","active"], "id", 1);

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines one table and a reducer that performs insert, update, and delete in one call.
+Write a SpacetimeDB backend module in C# that defines one table and a reducer that performs insert, update, and delete in one call.
 
 TABLE
 - User

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const user = table(
+const user = table(
   {
     name: 'user',
   },
@@ -12,7 +12,7 @@ export const user = table(
   }
 );
 
-export const result = table(
+const result = table(
   {
     name: 'result',
   },

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/spec.rs
@@ -13,7 +13,7 @@ pub fn spec() -> BenchmarkSpec {
 
         let casing = casing_for_lang(lang);
         let sb = SqlBuilder::new(casing);
-        let reducer_name = ident("LookupUserName", casing);
+        let reducer_name = ident("LookupUserName", crate::eval::Casing::Snake);
         let user_table = table_name("user", lang);
         let result_table = table_name("result", lang);
 

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines two tables and a reducer that looks up a row by primary-key index and writes a projection to another table.
+Write a SpacetimeDB backend module in C# that defines two tables and a reducer that looks up a row by primary-key index and writes a projection to another table.
 
 TABLES
 - User

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const user = table(
+const user = table(
   {
     name: 'user',
   },

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines one table and an Init reducer that seeds rows on database initialization.
+Write a SpacetimeDB backend module in C# that defines one table and an Init reducer that seeds rows on database initialization.
 
 TABLE
 - User

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_010_connect/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_010_connect/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const event = table(
+const event = table(
   {
     name: 'event',
   },

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_010_connect/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_010_connect/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines one table and two reducers for client lifecycle events.
+Write a SpacetimeDB backend module in C# that defines one table and two reducers for client lifecycle events.
 
 TABLE
 - Event

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const result = table({
+const result = table({
   name: 'result',
 }, {
   id: t.i32().primaryKey(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/spec.rs
@@ -10,7 +10,7 @@ pub fn spec() -> BenchmarkSpec {
 
         let casing = casing_for_lang(lang);
         let sb = SqlBuilder::new(casing);
-        let reducer = ident("ComputeSum", casing);
+        let reducer = ident("ComputeSum", crate::eval::Casing::Snake);
         let result_table = table_name("result", lang);
         let select = sb.select_by_id(&result_table, &["id","sum"], "id", 1);
 

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines a table, a non-reducer helper function, and a reducer that uses the helper.
+Write a SpacetimeDB backend module in C# that defines a table, a non-reducer helper function, and a reducer that uses the helper.
 
 TABLE
 - Result

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/answers/typescript.ts
@@ -1,11 +1,11 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const Score = t.object('Score', {
+const Score = t.object('Score', {
   left: t.i32(),
   right: t.i32(),
 });
 
-export const result = table({
+const result = table({
   name: 'result',
 }, {
   id: t.i32().primaryKey(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/spec.rs
@@ -6,11 +6,10 @@ use std::time::Duration;
 pub fn spec() -> BenchmarkSpec {
     BenchmarkSpec::from_tasks_auto(file!(), |lang, route_tag, host_url| {
         let mut v = default_schema_parity_scorers(host_url, file!(), route_tag);
-        let casing = casing_for_lang(lang);
         let sb = SqlBuilder::new(casing_for_lang(lang));
         let result_table = table_name("result", lang);
 
-        let reducer = ident("SetScore", casing);
+        let reducer = ident("SetScore", crate::eval::Casing::Snake);
 
         // Compare the full row (including the product-typed column) across golden/llm
         let select = sb.select_by_id(&result_table, &["id","value"], "id", 1);

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines a product type and uses it in a table.
+Write a SpacetimeDB backend module in C# that defines a product type and uses it in a table.
 
 TYPES
 - Struct: Score

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/answers/typescript.ts
@@ -1,16 +1,16 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const Rect = t.object('Rect', {
+const Rect = t.object('Rect', {
   width: t.i32(),
   height: t.i32(),
 });
 
-export const Shape = t.enum('Shape', {
+const Shape = t.enum('Shape', {
   circle: t.i32(),
   rectangle: Rect,
 });
 
-export const result = table(
+const result = table(
   {
     name: 'result',
   },

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/spec.rs
@@ -6,10 +6,9 @@ use std::time::Duration;
 pub fn spec() -> BenchmarkSpec {
     BenchmarkSpec::from_tasks_auto(file!(), |lang, route_tag, host_url| {
         let mut v = default_schema_parity_scorers(host_url, file!(), route_tag);
-        let casing = casing_for_lang(lang);
         let sb = SqlBuilder::new(casing_for_lang(lang));
         let result_table = table_name("result", lang);
-        let reducer = ident("SetCircle", casing);
+        let reducer = ident("SetCircle", crate::eval::Casing::Snake);
 
         let select = sb.select_by_id(&result_table, &["id","value"], "id", 1);
         v.push(make_reducer_data_parity_scorer(host_url, ReducerDataParityConfig {

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines a new sum type and uses it in a table.
+Write a SpacetimeDB backend module in C# that defines a new sum type and uses it in a table.
 
 TYPES
 - Struct: Circle

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const primitive = table(
+const primitive = table(
   {
     name: 'primitive',
   },

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/spec.rs
@@ -1,5 +1,5 @@
 use crate::eval::defaults::{default_schema_parity_scorers, make_reducer_data_parity_scorer, make_sql_count_only_scorer};
-use crate::eval::{casing_for_lang, ident, BenchmarkSpec, ReducerDataParityConfig, SqlBuilder};
+use crate::eval::{casing_for_lang, ident, table_name, BenchmarkSpec, ReducerDataParityConfig, SqlBuilder};
 use std::time::Duration;
 
 
@@ -8,10 +8,11 @@ pub fn spec() -> BenchmarkSpec {
         let mut v = default_schema_parity_scorers(host_url, file!(), route_tag);
         let casing = casing_for_lang(lang);
         let sb = SqlBuilder::new(casing);
-        let reducer = ident("Seed", casing);
+        let reducer = ident("Seed", crate::eval::Casing::Snake);
+        let primitive_table = table_name("primitive", lang);
 
         let select = sb.select_by_id(
-            "primitive",
+            &primitive_table,
             &["id","count","total","price","ratio","active","name"],
             "id",
             1
@@ -28,7 +29,7 @@ pub fn spec() -> BenchmarkSpec {
             timeout: Duration::from_secs(10),
         }));
 
-        let count = sb.count_by_id("primitive", "id", 1);
+        let count = sb.count_by_id(&primitive_table, "id", 1);
         v.push(make_sql_count_only_scorer(
             host_url,
             file!(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines one table and seeds one row.
+Write a SpacetimeDB backend module in C# that defines one table and seeds one row.
 
 TABLE
 - Primitive

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/answers/typescript.ts
@@ -1,16 +1,16 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const Address = t.object('Address', {
+const Address = t.object('Address', {
   street: t.string(),
   zip: t.i32(),
 });
 
-export const Position = t.object('Position', {
+const Position = t.object('Position', {
   x: t.i32(),
   y: t.i32(),
 });
 
-export const profile = table(
+const profile = table(
   {
     name: 'profile',
   },

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/spec.rs
@@ -12,7 +12,7 @@ pub fn spec() -> BenchmarkSpec {
 
         let casing = casing_for_lang(lang);
         let sb = SqlBuilder::new(casing);
-        let reducer = ident("Seed", casing);
+        let reducer = ident("Seed", crate::eval::Casing::Snake);
         let profile_table = table_name("profile", lang);
 
         let select = sb.select_by_id(

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines product types and uses them as columns in a table.
+Write a SpacetimeDB backend module in C# that defines product types and uses them as columns in a table.
 
 TYPES
 - Struct: Address

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/answers/typescript.ts
@@ -1,16 +1,16 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const Rect = t.object('Rect', {
+const Rect = t.object('Rect', {
   width: t.i32(),
   height: t.i32(),
 });
 
-export const Shape = t.enum('Shape', {
+const Shape = t.enum('Shape', {
   circle: t.i32(),
   rectangle: Rect,
 });
 
-export const drawing = table({
+const drawing = table({
   name: 'drawing',
 }, {
   id: t.i32().primaryKey(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/spec.rs
@@ -1,7 +1,7 @@
 use crate::eval::defaults::{
     default_schema_parity_scorers, make_reducer_data_parity_scorer, make_sql_count_only_scorer,
 };
-use crate::eval::{casing_for_lang, ident, BenchmarkSpec, ReducerDataParityConfig, SqlBuilder};
+use crate::eval::{casing_for_lang, ident, table_name, BenchmarkSpec, ReducerDataParityConfig, SqlBuilder};
 use std::time::Duration;
 
 pub fn spec() -> BenchmarkSpec {
@@ -9,9 +9,10 @@ pub fn spec() -> BenchmarkSpec {
         let mut v = default_schema_parity_scorers(host_url, file!(), route_tag);
         let casing = casing_for_lang(lang);
         let sb = SqlBuilder::new(casing);
-        let reducer = ident("Seed", casing);
+        let reducer = ident("Seed", crate::eval::Casing::Snake);
+        let drawing_table = table_name("drawing", lang);
 
-        let select = sb.select_by_id("drawing", &["id", "a", "b"], "id", 1);
+        let select = sb.select_by_id(&drawing_table, &["id", "a", "b"], "id", 1);
 
         v.push(make_reducer_data_parity_scorer(
             host_url,
@@ -27,7 +28,7 @@ pub fn spec() -> BenchmarkSpec {
             },
         ));
 
-        let count = sb.count_by_id("drawing", "id", 1);
+        let count = sb.count_by_id(&drawing_table, "id", 1);
         v.push(make_sql_count_only_scorer(
             host_url,
             file!(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines a sum type and uses it in multiple table columns.
+Write a SpacetimeDB backend module in C# that defines a sum type and uses it in multiple table columns.
 
 TYPES
 - Struct: Circle

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/answers/typescript.ts
@@ -1,7 +1,7 @@
 import { ScheduleAt } from 'spacetimedb';
 import { table, schema, t } from 'spacetimedb/server';
 
-export const tickTimer = table(
+const tickTimer = table(
   {
     name: 'tickTimer',
     scheduled: (): any => tick,
@@ -16,7 +16,7 @@ const spacetimedb = schema({ tickTimer });
 export default spacetimedb;
 
 export const tick = spacetimedb.reducer(
-  { schedule: TickTimer.rowType },
+  { schedule: tickTimer.rowType },
   (ctx, { schedule }) => {}
 );
 

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/spec.rs
@@ -2,7 +2,7 @@ use crate::eval::defaults::{
     default_schema_parity_scorers,
     make_sql_count_only_scorer,
 };
-use crate::eval::{casing_for_lang, ident, BenchmarkSpec, SqlBuilder};
+use crate::eval::{casing_for_lang, ident, table_name, BenchmarkSpec, SqlBuilder};
 use std::time::Duration;
 
 pub fn spec() -> BenchmarkSpec {
@@ -12,8 +12,9 @@ pub fn spec() -> BenchmarkSpec {
 
         // After publish (Init ran), exactly one scheduled row should exist.
         let sb = SqlBuilder::new(casing_for_lang(lang));
+        let tick_timer_table = table_name("tick_timer", lang);
         let idcol = ident("scheduled_id", sb.case);
-        let q = format!("SELECT COUNT(*) AS n FROM tick_timer WHERE {idcol}>=0");
+        let q = format!("SELECT COUNT(*) AS n FROM {tick_timer_table} WHERE {idcol}>=0");
 
         v.push(make_sql_count_only_scorer(
             host_url,

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines a scheduled table and seeds one schedule entry.
+Write a SpacetimeDB backend module in C# that defines a scheduled table and seeds one schedule entry.
 
 TABLE
 - TickTimer

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const account = table({
+const account = table({
   name: 'account',
   indexes: [{ name: 'byName', algorithm: 'btree', columns: ['name'] }],
 }, {

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/spec.rs
@@ -12,7 +12,7 @@ pub fn spec() -> BenchmarkSpec {
 
         let casing = casing_for_lang(lang);
         let sb = SqlBuilder::new(casing);
-        let reducer = ident("Seed", casing);
+        let reducer = ident("Seed", crate::eval::Casing::Snake);
         let account_table = table_name("account", lang);
 
         let select = sb.select_by_id(&account_table, &["id","email","name"], "id", 1);

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines one table and seeds two rows.
+Write a SpacetimeDB backend module in C# that defines one table and seeds two rows.
 
 TABLE
 - Account (public)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const user = table(
+const user = table(
   {
     name: 'user',
   },
@@ -10,7 +10,7 @@ export const user = table(
   }
 );
 
-export const group = table(
+const group = table(
   {
     name: 'group',
   },
@@ -20,7 +20,7 @@ export const group = table(
   }
 );
 
-export const membership = table(
+const membership = table(
   {
     name: 'membership',
     indexes: [

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/spec.rs
@@ -11,7 +11,7 @@ pub fn spec() -> BenchmarkSpec {
         let casing = casing_for_lang(lang);
 
         let sb = SqlBuilder::new(casing);
-        let reducer_name = ident("Seed", casing);
+        let reducer_name = ident("Seed", crate::eval::Casing::Snake);
         let membership_table = table_name("membership", lang);
 
         let user_id = ident("user_id", sb.case);

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines three tables modeling a many-to-many relationship and seeds rows.
+Write a SpacetimeDB backend module in C# that defines three tables modeling a many-to-many relationship and seeds rows.
 
 TABLES
 - User

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const entity = table(
+const entity = table(
   {
     name: 'entity',
   },
@@ -9,7 +9,7 @@ export const entity = table(
   }
 );
 
-export const position = table(
+const position = table(
   {
     name: 'position',
   },
@@ -20,7 +20,7 @@ export const position = table(
   }
 );
 
-export const velocity = table(
+const velocity = table(
   {
     name: 'velocity',
   },
@@ -31,7 +31,7 @@ export const velocity = table(
   }
 );
 
-export const nextPosition = table(
+const nextPosition = table(
   {
     name: 'nextPosition',
   },
@@ -49,7 +49,7 @@ export const seed = spacetimedb.reducer(ctx => {
   ctx.db.entity.insert({ id: 1 });
   ctx.db.entity.insert({ id: 2 });
 
-  ctx.db.position.insert({ entityId: 1, x: 1, y: 0 });
+  ctx.db.position.insert({ entityId: 1, x: 0, y: 0 });
   ctx.db.position.insert({ entityId: 2, x: 10, y: 0 });
 
   ctx.db.velocity.insert({ entityId: 1, vx: 1, vy: 0 });

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/spec.rs
@@ -2,7 +2,7 @@ use crate::eval::defaults::{
     default_schema_parity_scorers,
     make_reducer_sql_count_scorer,
 };
-use crate::eval::{casing_for_lang, ident, BenchmarkSpec, ReducerSqlCountConfig, SqlBuilder};
+use crate::eval::{casing_for_lang, ident, table_name, BenchmarkSpec, ReducerSqlCountConfig, SqlBuilder};
 use std::time::Duration;
 pub fn spec() -> BenchmarkSpec {
     BenchmarkSpec::from_tasks_auto(file!(), |lang, route_tag, host_url| {
@@ -11,12 +11,15 @@ pub fn spec() -> BenchmarkSpec {
         let case = casing_for_lang(lang);
         let sb   = SqlBuilder::new(case);
 
-        let seed = ident("Seed", case);
-        let step = ident("Step", case);
+        let seed = ident("Seed", crate::eval::Casing::Snake);
+        let step = ident("Step", crate::eval::Casing::Snake);
 
         let entity_id = ident("entity_id", sb.case);
         let x = ident("x", sb.case);
         let y = ident("y", sb.case);
+
+        let position_table = table_name("position", lang);
+        let next_position_table = table_name("next_position", lang);
 
         let base = |reducer: &str| ReducerSqlCountConfig {
             src_file: file!(),
@@ -30,23 +33,22 @@ pub fn spec() -> BenchmarkSpec {
         };
 
         v.push(make_reducer_sql_count_scorer(host_url, ReducerSqlCountConfig {
-            sql_count_query: "SELECT COUNT(*) AS n FROM positions".into(),
+            sql_count_query: format!("SELECT COUNT(*) AS n FROM {position_table}"),
             expected_count: 2,
-            id_str: "ecs_seed_positions_count",
+            id_str: "ecs_seed_position_count",
             ..base(&seed) // or base("seed") if it's a &str
         }));
 
         v.push(make_reducer_sql_count_scorer(host_url, ReducerSqlCountConfig {
-            sql_count_query: "SELECT COUNT(*) AS n FROM next_positions".into(),
+            sql_count_query: format!("SELECT COUNT(*) AS n FROM {next_position_table}"),
             expected_count: 2,
-            id_str: "ecs_step_next_positions_count",
+            id_str: "ecs_step_next_position_count",
             ..base(&step) // or base("step")
         }));
 
         v.push(make_reducer_sql_count_scorer(host_url, ReducerSqlCountConfig {
             sql_count_query: format!(
-                "SELECT COUNT(*) AS n FROM next_positions WHERE {eid}=1 AND {x}=1 AND {y}=0",
-                eid = entity_id, x = x, y = y
+                "SELECT COUNT(*) AS n FROM {next_position_table} WHERE {entity_id}=1 AND {x}=1 AND {y}=0",
             ),
             expected_count: 1,
             id_str: "ecs_next_pos_entity1",
@@ -55,8 +57,7 @@ pub fn spec() -> BenchmarkSpec {
 
         v.push(make_reducer_sql_count_scorer(host_url, ReducerSqlCountConfig {
             sql_count_query: format!(
-                "SELECT COUNT(*) AS n FROM next_positions WHERE {eid}=2 AND {x}=8 AND {y}=3",
-                eid = entity_id, x = x, y = y
+                "SELECT COUNT(*) AS n FROM {next_position_table} WHERE {entity_id}=2 AND {x}=8 AND {y}=3",
             ),
             expected_count: 1,
             id_str: "ecs_next_pos_entity2",

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that models a minimal ECS and computes next positions.
+Write a SpacetimeDB backend module in C# that models a minimal ECS and computes next positions.
 
 TABLES
 - Entity

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/tasks/typescript.txt
@@ -25,7 +25,7 @@ TABLES
 
 REDUCERS
 - seed: insert 2 entities with positions and velocities:
-  - Entity 1: position(1,0), velocity(1,0)
+  - Entity 1: position(0,0), velocity(1,0)
   - Entity 2: position(10,0), velocity(-2,3)
 
 - step: for each position, find velocity, compute next position (x+vx, y+vy), upsert to nextPosition

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { table, schema, t } from 'spacetimedb/server';
 
-export const log = table({
+const log = table({
   name: 'log',
   indexes: [{ name: 'byUserDay', algorithm: 'btree', columns: ['userId', 'day'] }],
 }, {

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/spec.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/spec.rs
@@ -12,7 +12,7 @@ pub fn spec() -> BenchmarkSpec {
         let case = casing_for_lang(lang);
         let sb   = SqlBuilder::new(case);
 
-        let seed = ident("Seed", case);
+        let seed = ident("Seed", crate::eval::Casing::Snake);
         let log_table = table_name("log", lang);
 
         let user_id = ident("user_id", sb.case);

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/tasks/csharp.txt
@@ -1,4 +1,4 @@
-﻿Write a SpacetimeDB backend module in C# that defines one table with a multi-column B-Tree index and seeds rows.
+Write a SpacetimeDB backend module in C# that defines one table with a multi-column B-Tree index and seeds rows.
 
 TABLE
 - Log

--- a/tools/xtask-llm-benchmark/src/bin/llm_benchmark.rs
+++ b/tools/xtask-llm-benchmark/src/bin/llm_benchmark.rs
@@ -337,9 +337,11 @@ fn run_benchmarks(args: RunArgs, details_path: &Path, summary_path: &Path) -> Re
         println!("  Summary: {}", summary_path.display());
 
         // Show HTTP/timeout failures for this run's scope (providers/models we ran)
-        if let Some((total, http_list)) =
-            load_details_and_http_failures(details_path, config.providers_filter.as_ref(), config.model_filter.as_ref())?
-        {
+        if let Some((total, http_list)) = load_details_and_http_failures(
+            details_path,
+            config.providers_filter.as_ref(),
+            config.model_filter.as_ref(),
+        )? {
             if !http_list.is_empty() {
                 print_http_failures_summary(total, &http_list);
             }
@@ -918,18 +920,16 @@ fn filter_routes(config: &RunConfig) -> Vec<ModelRoute> {
     default_model_routes()
         .iter()
         .filter(|r| config.providers_filter.as_ref().is_none_or(|f| f.contains(&r.vendor)))
-        .filter(|r| {
-            match &config.model_filter {
-                None => true,
-                Some(allowed_by_vendor) => match allowed_by_vendor.get(&r.vendor) {
-                    None => false,
-                    Some(allowed) => {
-                        let api = r.api_model.to_ascii_lowercase();
-                        let dn = r.display_name.to_ascii_lowercase();
-                        allowed.contains(&api) || allowed.contains(&dn)
-                    }
+        .filter(|r| match &config.model_filter {
+            None => true,
+            Some(allowed_by_vendor) => match allowed_by_vendor.get(&r.vendor) {
+                None => false,
+                Some(allowed) => {
+                    let api = r.api_model.to_ascii_lowercase();
+                    let dn = r.display_name.to_ascii_lowercase();
+                    allowed.contains(&api) || allowed.contains(&dn)
                 }
-            }
+            },
         })
         .cloned()
         .collect()
@@ -1284,7 +1284,9 @@ fn cmd_scan_rerun_commands(args: ScanRerunCommandsArgs) -> Result<()> {
     keys.sort();
 
     for (lang, mode, vendor, api_model) in keys {
-        let (model_name, tasks) = groups.get(&(lang.clone(), mode.clone(), vendor.clone(), api_model.clone())).unwrap();
+        let (model_name, tasks) = groups
+            .get(&(lang.clone(), mode.clone(), vendor.clone(), api_model.clone()))
+            .unwrap();
         let tasks_arg = tasks.join(",");
         println!("# {} + {} ({})", model_name, lang, mode);
         println!(
@@ -1302,9 +1304,9 @@ fn is_model_in_routes(vendor_str: &str, api_model: &str) -> bool {
         return false;
     };
     let api_lower = api_model.to_ascii_lowercase();
-    default_model_routes().iter().any(|r| {
-        r.vendor == vendor && r.api_model.to_ascii_lowercase() == api_lower
-    })
+    default_model_routes()
+        .iter()
+        .any(|r| r.vendor == vendor && r.api_model.to_ascii_lowercase() == api_lower)
 }
 
 /// Collect LLM API failures with full (lang, mode, vendor, api_model, model_name, task_id) for building rerun commands.
@@ -1347,9 +1349,7 @@ fn collect_http_failures_full(details_path: &Path) -> Result<Vec<(String, String
                                 .find(|r| r.display_name == model_entry.name)
                                 .map(|r| r.api_model.to_string())
                         })
-                        .unwrap_or_else(|| {
-                            model_entry.name.to_ascii_lowercase().replace(' ', "-")
-                        });
+                        .unwrap_or_else(|| model_entry.name.to_ascii_lowercase().replace(' ', "-"));
                     if !is_model_in_routes(&vendor, &api_model) {
                         continue;
                     }
@@ -1414,9 +1414,7 @@ fn load_details_and_http_failures(
                                     .find(|r| r.display_name == model_entry.name)
                                     .map(|r| r.api_model.to_string())
                             })
-                            .unwrap_or_else(|| {
-                                model_entry.name.to_ascii_lowercase().replace(' ', "-")
-                            });
+                            .unwrap_or_else(|| model_entry.name.to_ascii_lowercase().replace(' ', "-"));
                         // Only count/show failures for models in default_model_routes().
                         if !is_model_in_routes(&vendor, &api_model) {
                             continue;
@@ -1476,9 +1474,9 @@ fn outcome_matches_run_scope(
                 let a_norm = al.replace(' ', "-");
                 model_norm == a_norm
                     || model_lower == al
-                    || api_lower
-                        .as_ref()
-                        .map_or(false, |api| api == &al || api.contains(al.as_str()) || al.contains(api.as_str()))
+                    || api_lower.as_ref().map_or(false, |api| {
+                        api == &al || api.contains(al.as_str()) || al.contains(api.as_str())
+                    })
             });
             if !matches {
                 return false;
@@ -1518,7 +1516,9 @@ fn print_http_failures_summary(
     keys.sort();
 
     for (lang, mode, vendor, api_model) in keys {
-        let (model_name, tasks) = groups.get(&(lang.clone(), mode.clone(), vendor.clone(), api_model.clone())).unwrap();
+        let (model_name, tasks) = groups
+            .get(&(lang.clone(), mode.clone(), vendor.clone(), api_model.clone()))
+            .unwrap();
         let tasks_arg = tasks.join(",");
         println!("# {} + {} ({})", model_name, lang, mode);
         println!(

--- a/tools/xtask-llm-benchmark/src/bin/llm_benchmark.rs
+++ b/tools/xtask-llm-benchmark/src/bin/llm_benchmark.rs
@@ -14,7 +14,7 @@ use xtask_llm_benchmark::bench::bench_route_concurrency;
 use xtask_llm_benchmark::bench::runner::{
     build_goldens_only_for_lang, ensure_goldens_built_once, run_selected_or_all_for_model_async_for_lang,
 };
-use xtask_llm_benchmark::bench::types::{BenchRunContext, RouteRun, RunConfig};
+use xtask_llm_benchmark::bench::types::{BenchRunContext, RouteRun, RunConfig, RunOutcome};
 use xtask_llm_benchmark::context::constants::{
     docs_benchmark_comment, docs_benchmark_details, docs_benchmark_summary, llm_comparison_details,
     llm_comparison_summary, ALL_MODES,
@@ -94,6 +94,12 @@ enum Commands {
 
     /// Analyze benchmark failures and generate a human-readable markdown report.
     Analyze(AnalyzeArgs),
+
+    /// Count failures due to HTTP/API errors (429, 503, timeouts, etc.) and list task IDs to rerun.
+    CountHttpFailures(CountHttpFailuresArgs),
+
+    /// Scan details file for LLM API failures and print rerun commands per (lang, model). Does not run anything.
+    ScanRerunCommands(ScanRerunCommandsArgs),
 }
 
 #[derive(Args, Debug, Clone)]
@@ -158,6 +164,20 @@ struct SummaryArgs {
 }
 
 #[derive(Args, Debug, Clone)]
+struct CountHttpFailuresArgs {
+    /// Input details.json (default: same as run output, llm-comparison-details.json)
+    #[arg(long)]
+    details: Option<PathBuf>,
+}
+
+#[derive(Args, Debug, Clone)]
+struct ScanRerunCommandsArgs {
+    /// Input details.json (default: llm-comparison-details.json)
+    #[arg(long)]
+    details: Option<PathBuf>,
+}
+
+#[derive(Args, Debug, Clone)]
 struct AnalyzeArgs {
     /// Input details.json file (default: docs-benchmark-details.json)
     #[arg(long)]
@@ -197,7 +217,34 @@ impl FromStr for VendorArg {
     }
 }
 
+/// Load `.env` from workspace root (repo) first, then current directory.
+/// Uses from_path_override so .env always wins over existing env vars.
+/// Runs once at startup; each new process loads .env fresh (no in-process reload).
+fn load_dotenv() {
+    let workspace_env = PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .map(|p| p.join(".env"))
+        .filter(|p| p.is_file());
+    let cwd_env = std::env::current_dir()
+        .ok()
+        .map(|c| c.join(".env"))
+        .filter(|p| p.is_file());
+    let path = workspace_env.or(cwd_env);
+    if let Some(p) = path {
+        match dotenvy::from_path_override(&p) {
+            Ok(()) => eprintln!("[env] loaded .env from {}", p.display()),
+            Err(e) => eprintln!("[env] failed to load .env from {}: {}", p.display(), e),
+        }
+    } else {
+        eprintln!("[env] no .env found (tried workspace root and cwd)");
+    }
+}
+
 fn main() -> Result<()> {
+    // Load .env from current directory or workspace root so API keys and settings are available.
+    load_dotenv();
+
     let cli = Cli::parse();
 
     match cli.command {
@@ -207,6 +254,8 @@ fn main() -> Result<()> {
         Commands::CiComment(args) => cmd_ci_comment(args),
         Commands::Summary(args) => cmd_summary(args),
         Commands::Analyze(args) => cmd_analyze(args),
+        Commands::CountHttpFailures(args) => cmd_count_http_failures(args),
+        Commands::ScanRerunCommands(args) => cmd_scan_rerun_commands(args),
     }
 }
 
@@ -286,6 +335,15 @@ fn run_benchmarks(args: RunArgs, details_path: &Path, summary_path: &Path) -> Re
         println!("Results written to:");
         println!("  Details: {}", details_path.display());
         println!("  Summary: {}", summary_path.display());
+
+        // Show HTTP/timeout failures for this run's scope (providers/models we ran)
+        if let Some((total, http_list)) =
+            load_details_and_http_failures(details_path, config.providers_filter.as_ref(), config.model_filter.as_ref())?
+        {
+            if !http_list.is_empty() {
+                print_http_failures_summary(total, &http_list);
+            }
+        }
     }
 
     Ok(())
@@ -854,19 +912,24 @@ fn run_mode_benchmarks(
     Ok(())
 }
 
+/// Routes to run: when `model_filter` is set (from --models), only routes whose vendor and
+/// model are in that filter are included; vendors not in the filter are excluded.
 fn filter_routes(config: &RunConfig) -> Vec<ModelRoute> {
     default_model_routes()
         .iter()
         .filter(|r| config.providers_filter.as_ref().is_none_or(|f| f.contains(&r.vendor)))
         .filter(|r| {
-            if let Some(map) = &config.model_filter {
-                if let Some(allowed) = map.get(&r.vendor) {
-                    let api = r.api_model.to_ascii_lowercase();
-                    let dn = r.display_name.to_ascii_lowercase();
-                    return allowed.contains(&api) || allowed.contains(&dn);
+            match &config.model_filter {
+                None => true,
+                Some(allowed_by_vendor) => match allowed_by_vendor.get(&r.vendor) {
+                    None => false,
+                    Some(allowed) => {
+                        let api = r.api_model.to_ascii_lowercase();
+                        let dn = r.display_name.to_ascii_lowercase();
+                        allowed.contains(&api) || allowed.contains(&dn)
+                    }
                 }
             }
-            true
         })
         .cloned()
         .collect()
@@ -947,7 +1010,8 @@ fn initialize_runtime_and_provider(hash_only: bool, goldens_only: bool) -> Resul
         });
     }
 
-    let spacetime = SpacetimeDbGuard::spawn_in_temp_data_dir_use_cli();
+    // Use locally built SpacetimeDB so server supports spacetime:sys@2.0 (required by local TypeScript SDK).
+    let spacetime = SpacetimeDbGuard::spawn_in_temp_data_dir();
 
     let runtime = tokio::runtime::Builder::new_multi_thread().enable_all().build()?;
 
@@ -1176,6 +1240,325 @@ fn cmd_analyze(args: AnalyzeArgs) -> Result<()> {
     println!("Analysis written to: {}", output_path.display());
 
     Ok(())
+}
+
+fn cmd_count_http_failures(args: CountHttpFailuresArgs) -> Result<()> {
+    let details_path = args.details.unwrap_or_else(llm_comparison_details);
+    let Some((total, http_list)) = load_details_and_http_failures(&details_path, None, None)? else {
+        println!("No details file or no failures at {}", details_path.display());
+        return Ok(());
+    };
+    println!("Total failures: {}", total);
+    println!("HTTP/API failures (e.g. 429, 503, timeout): {}", http_list.len());
+    if !http_list.is_empty() {
+        print_http_failures_summary(total, &http_list);
+    }
+    Ok(())
+}
+
+fn cmd_scan_rerun_commands(args: ScanRerunCommandsArgs) -> Result<()> {
+    let details_path = args.details.unwrap_or_else(llm_comparison_details);
+    let failures = collect_http_failures_full(&details_path)?;
+    if failures.is_empty() {
+        println!("No LLM provider API failures found.");
+        return Ok(());
+    }
+
+    let count = failures.len();
+    println!("Scanning {} — {} LLM API failures\n", details_path.display(), count);
+
+    // Group by (lang, mode, vendor, api_model) -> sorted task IDs
+    let mut groups: HashMap<(String, String, String, String), (String, Vec<String>)> = HashMap::new();
+    for (lang, mode, vendor, api_model, model_name, task_id) in failures {
+        let key = (lang.clone(), mode.clone(), vendor.clone(), api_model.clone());
+        let entry = groups.entry(key).or_insert_with(|| (model_name, Vec::new()));
+        if !entry.1.contains(&task_id) {
+            entry.1.push(task_id);
+        }
+    }
+    for (_, (_, tasks)) in groups.iter_mut() {
+        tasks.sort();
+    }
+
+    let mut keys: Vec<_> = groups.keys().collect();
+    keys.sort();
+
+    for (lang, mode, vendor, api_model) in keys {
+        let (model_name, tasks) = groups.get(&(lang.clone(), mode.clone(), vendor.clone(), api_model.clone())).unwrap();
+        let tasks_arg = tasks.join(",");
+        println!("# {} + {} ({})", model_name, lang, mode);
+        println!(
+            "cargo run --package xtask-llm-benchmark -- run --lang {} --modes {} --models {}:{} --tasks {}",
+            lang, mode, vendor, api_model, tasks_arg
+        );
+        println!();
+    }
+    Ok(())
+}
+
+/// True if (vendor, api_model) matches a route in default_model_routes (model_routes.rs).
+fn is_model_in_routes(vendor_str: &str, api_model: &str) -> bool {
+    let Some(vendor) = Vendor::parse(vendor_str) else {
+        return false;
+    };
+    let api_lower = api_model.to_ascii_lowercase();
+    default_model_routes().iter().any(|r| {
+        r.vendor == vendor && r.api_model.to_ascii_lowercase() == api_lower
+    })
+}
+
+/// Collect LLM API failures with full (lang, mode, vendor, api_model, model_name, task_id) for building rerun commands.
+/// Only includes models that are in default_model_routes (model_routes.rs).
+fn collect_http_failures_full(details_path: &Path) -> Result<Vec<(String, String, String, String, String, String)>> {
+    use xtask_llm_benchmark::results::schema::Results;
+
+    let content = match fs::read_to_string(details_path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(Vec::new()),
+        Err(e) => return Err(e).with_context(|| format!("read {}", details_path.display())),
+    };
+    let results: Results = serde_json::from_str(&content).with_context(|| "parse details.json")?;
+
+    let mut out: Vec<(String, String, String, String, String, String)> = Vec::new();
+    for lang_entry in &results.languages {
+        for mode_entry in &lang_entry.modes {
+            for model_entry in &mode_entry.models {
+                for (task_id, outcome) in &model_entry.tasks {
+                    if outcome.passed_tests >= outcome.total_tests {
+                        continue;
+                    }
+                    if outcome.llm_output.is_some() {
+                        continue;
+                    }
+                    let Some(err) = get_publish_error_from_outcome(outcome) else {
+                        continue;
+                    };
+                    if !is_http_like_error(&err) {
+                        continue;
+                    }
+                    let vendor = outcome.vendor.clone();
+                    let api_model = outcome
+                        .route_api_model
+                        .clone()
+                        .or_else(|| model_entry.route_api_model.clone())
+                        .or_else(|| {
+                            default_model_routes()
+                                .iter()
+                                .find(|r| r.display_name == model_entry.name)
+                                .map(|r| r.api_model.to_string())
+                        })
+                        .unwrap_or_else(|| {
+                            model_entry.name.to_ascii_lowercase().replace(' ', "-")
+                        });
+                    if !is_model_in_routes(&vendor, &api_model) {
+                        continue;
+                    }
+                    out.push((
+                        lang_entry.lang.clone(),
+                        mode_entry.mode.clone(),
+                        vendor,
+                        api_model,
+                        model_entry.name.clone(),
+                        task_id.clone(),
+                    ));
+                }
+            }
+        }
+    }
+    Ok(out)
+}
+
+/// Load details JSON and return (total_failures, list of (lang, mode, model, task_id, vendor, api_model) for HTTP-like failures).
+/// When providers_filter/model_filter are set (from --providers/--models), only count outcomes
+/// from that run's scope so the summary reflects what we just ran, not the entire file.
+/// Returns Ok(None) if file missing or no failures.
+fn load_details_and_http_failures(
+    details_path: &Path,
+    providers_filter: Option<&HashSet<Vendor>>,
+    model_filter: Option<&HashMap<Vendor, HashSet<String>>>,
+) -> Result<Option<(u32, Vec<(String, String, String, String, String, String)>)>> {
+    use xtask_llm_benchmark::results::schema::Results;
+
+    let content = match fs::read_to_string(details_path) {
+        Ok(c) => c,
+        Err(e) if e.kind() == std::io::ErrorKind::NotFound => return Ok(None),
+        Err(e) => return Err(e).with_context(|| format!("read {}", details_path.display())),
+    };
+    let results: Results = serde_json::from_str(&content).with_context(|| "parse details.json")?;
+
+    let mut total_failures = 0u32;
+    let mut http_failures: Vec<(String, String, String, String, String, String)> = Vec::new();
+
+    for lang_entry in &results.languages {
+        for mode_entry in &lang_entry.modes {
+            for model_entry in &mode_entry.models {
+                for (task_id, outcome) in &model_entry.tasks {
+                    if outcome.passed_tests < outcome.total_tests {
+                        if !outcome_matches_run_scope(
+                            &outcome.vendor,
+                            &model_entry.name,
+                            outcome.route_api_model.as_deref(),
+                            providers_filter,
+                            model_filter,
+                        ) {
+                            continue;
+                        }
+                        let vendor = outcome.vendor.clone();
+                        let api_model = outcome
+                            .route_api_model
+                            .clone()
+                            .or_else(|| model_entry.route_api_model.clone())
+                            .or_else(|| {
+                                default_model_routes()
+                                    .iter()
+                                    .find(|r| r.display_name == model_entry.name)
+                                    .map(|r| r.api_model.to_string())
+                            })
+                            .unwrap_or_else(|| {
+                                model_entry.name.to_ascii_lowercase().replace(' ', "-")
+                            });
+                        // Only count/show failures for models in default_model_routes().
+                        if !is_model_in_routes(&vendor, &api_model) {
+                            continue;
+                        }
+                        total_failures += 1;
+                        // Only count LLM API failures (timeout, 429, etc.): we never got a response.
+                        // If llm_output is present, we got a response and the failure was publish/compile.
+                        if outcome.llm_output.is_some() {
+                            continue;
+                        }
+                        if let Some(err) = get_publish_error_from_outcome(outcome) {
+                            if is_http_like_error(&err) {
+                                http_failures.push((
+                                    lang_entry.lang.clone(),
+                                    mode_entry.mode.clone(),
+                                    model_entry.name.clone(),
+                                    task_id.clone(),
+                                    vendor,
+                                    api_model,
+                                ));
+                            }
+                        }
+                    }
+                }
+            }
+        }
+    }
+
+    if total_failures == 0 {
+        return Ok(None);
+    }
+    Ok(Some((total_failures, http_failures)))
+}
+
+fn outcome_matches_run_scope(
+    vendor_slug: &str,
+    model_name: &str,
+    route_api_model: Option<&str>,
+    providers_filter: Option<&HashSet<Vendor>>,
+    model_filter: Option<&HashMap<Vendor, HashSet<String>>>,
+) -> bool {
+    let Some(vendor) = Vendor::parse(vendor_slug) else {
+        return true; // unknown vendor, include
+    };
+    if let Some(pf) = providers_filter {
+        if !pf.contains(&vendor) {
+            return false;
+        }
+    }
+    if let Some(mf) = model_filter {
+        if let Some(allowed) = mf.get(&vendor) {
+            let model_lower = model_name.to_ascii_lowercase();
+            let api_lower = route_api_model.map(|s| s.to_ascii_lowercase());
+            let model_norm = model_lower.replace(' ', "-");
+            let matches = allowed.iter().any(|a| {
+                let al = a.to_ascii_lowercase();
+                let a_norm = al.replace(' ', "-");
+                model_norm == a_norm
+                    || model_lower == al
+                    || api_lower
+                        .as_ref()
+                        .map_or(false, |api| api == &al || api.contains(al.as_str()) || al.contains(api.as_str()))
+            });
+            if !matches {
+                return false;
+            }
+        }
+    }
+    true
+}
+
+/// Print a summary of HTTP/timeout failures: grouped by (lang, mode, vendor, api_model) with one rerun command per group.
+fn print_http_failures_summary(
+    total_failures: u32,
+    http_failures: &[(String, String, String, String, String, String)],
+) {
+    // (lang, mode, model, task_id, vendor, api_model)
+    println!();
+    println!("---");
+    println!(
+        "LLM provider API failures (timeout, 429, etc.): {} of {} total failures — rerun these",
+        http_failures.len(),
+        total_failures
+    );
+
+    let mut groups: HashMap<(String, String, String, String), (String, Vec<String>)> = HashMap::new();
+    for (lang, mode, model_name, task_id, vendor, api_model) in http_failures {
+        let key = (lang.clone(), mode.clone(), vendor.clone(), api_model.clone());
+        let entry = groups.entry(key).or_insert_with(|| (model_name.clone(), Vec::new()));
+        if !entry.1.contains(task_id) {
+            entry.1.push(task_id.clone());
+        }
+    }
+    for (_, (_, tasks)) in groups.iter_mut() {
+        tasks.sort();
+    }
+
+    let mut keys: Vec<_> = groups.keys().collect();
+    keys.sort();
+
+    for (lang, mode, vendor, api_model) in keys {
+        let (model_name, tasks) = groups.get(&(lang.clone(), mode.clone(), vendor.clone(), api_model.clone())).unwrap();
+        let tasks_arg = tasks.join(",");
+        println!("# {} + {} ({})", model_name, lang, mode);
+        println!(
+            "cargo run --package xtask-llm-benchmark -- run --lang {} --modes {} --models {}:{} --tasks {}",
+            lang, mode, vendor, api_model, tasks_arg
+        );
+        println!();
+    }
+    println!("---");
+}
+
+/// True if the error message looks like an HTTP/API failure (rate limit, server error, timeout, etc.).
+fn is_http_like_error(err: &str) -> bool {
+    let lower = err.to_ascii_lowercase();
+    lower.contains("status")
+        || lower.contains("429")
+        || lower.contains("503")
+        || lower.contains("502")
+        || lower.contains("504")
+        || lower.contains("500")
+        || lower.contains("post ")
+        || lower.contains(" get ")
+        || lower.contains("timed out")
+        || lower.contains("timeout")
+        || lower.contains("too many requests")
+        || lower.contains("service unavailable")
+        || lower.contains("bad gateway")
+        || lower.contains("gateway timeout")
+        || lower.contains("connection")
+        || lower.contains("request failed")
+        || lower.contains("reqwest")
+}
+
+/// Get the error from the publish_error scorer only. LLM API failures (429, timeout, etc.)
+/// are recorded there. Scorer-phase errors (schema_parity, call_reducer, sql) are from
+/// SpacetimeDB CLI and can also say "timeout" — we must not count those as HTTP failures.
+fn get_publish_error_from_outcome(outcome: &RunOutcome) -> Option<String> {
+    let details = outcome.scorer_details.as_ref()?;
+    let score = details.get("publish_error")?;
+    score.notes.get("error").and_then(|v| v.as_str()).map(String::from)
 }
 
 #[allow(dead_code)]

--- a/tools/xtask-llm-benchmark/src/bin/llm_benchmark.rs
+++ b/tools/xtask-llm-benchmark/src/bin/llm_benchmark.rs
@@ -1,4 +1,4 @@
-#![allow(clippy::disallowed_macros)]
+#![allow(clippy::disallowed_macros, clippy::type_complexity, clippy::enum_variant_names)]
 
 use anyhow::{bail, Context, Result};
 use clap::{Args, Parser, Subcommand};
@@ -1474,9 +1474,9 @@ fn outcome_matches_run_scope(
                 let a_norm = al.replace(' ', "-");
                 model_norm == a_norm
                     || model_lower == al
-                    || api_lower.as_ref().map_or(false, |api| {
-                        api == &al || api.contains(al.as_str()) || al.contains(api.as_str())
-                    })
+                    || api_lower
+                        .as_ref()
+                        .is_some_and(|api| api == &al || api.contains(al.as_str()) || al.contains(api.as_str()))
             });
             if !matches {
                 return false;

--- a/tools/xtask-llm-benchmark/src/context/constants.rs
+++ b/tools/xtask-llm-benchmark/src/context/constants.rs
@@ -12,7 +12,7 @@ pub const DOCS_BENCHMARK_COMMENT_DEFAULT: &str = "../../docs/llms/docs-benchmark
 pub const LLM_COMPARISON_DETAILS_DEFAULT: &str = "../../docs/llms/llm-comparison-details.json";
 pub const LLM_COMPARISON_SUMMARY_DEFAULT: &str = "../../docs/llms/llm-comparison-summary.json";
 
-pub const ALL_MODES: &[&str] = &["docs", "llms.md", "cursor_rules", "rustdoc_json"];
+pub const ALL_MODES: &[&str] = &["docs", "llms.md", "cursor_rules", "rustdoc_json", "none"];
 
 #[inline]
 pub fn docs_dir() -> PathBuf {

--- a/tools/xtask-llm-benchmark/src/context/hashing.rs
+++ b/tools/xtask-llm-benchmark/src/context/hashing.rs
@@ -97,7 +97,7 @@ pub fn gather_docs_files() -> Result<Vec<PathBuf>> {
     if let Some(pos) = out.iter().position(|p| {
         p.file_name()
             .and_then(|n| n.to_str())
-            .map_or(false, |n| n == "00600-migrating-to-2.0.md")
+            .is_some_and(|n| n == "00600-migrating-to-2.0.md")
     }) {
         let migration = out.remove(pos);
         out.insert(0, migration);

--- a/tools/xtask-llm-benchmark/src/context/paths.rs
+++ b/tools/xtask-llm-benchmark/src/context/paths.rs
@@ -1,6 +1,7 @@
 use crate::context::constants::docs_dir;
 use crate::context::hashing::gather_docs_files;
 use crate::context::{rustdoc_crate_root, rustdoc_readme_path};
+use crate::eval::lang::Lang;
 use anyhow::{anyhow, bail, Context, Result};
 use serde_json::Value;
 use std::path::PathBuf;
@@ -15,19 +16,56 @@ const PINNED_NIGHTLY: &str = "nightly-2026-01-15";
 pub fn resolve_mode_paths(mode: &str) -> Result<Vec<PathBuf>> {
     match mode {
         "docs" => gather_docs_files(),
-        "llms.md" => Ok(vec![docs_dir().join("llms.md")]),
-        "cursor_rules" => Ok(vec![docs_dir().join(".cursor/rules/spacetimedb.md")]),
+        "llms.md" => Ok(vec![docs_dir().join("static/llms.md")]),
+        "cursor_rules" => gather_cursor_rules_files(docs_dir().join("static/ai-rules"), None),
         "rustdoc_json" => resolve_rustdoc_json_paths_always(),
-        other => bail!("unknown mode `{other}` (expected: docs | llms.md | cursor_rules | rustdoc_json)"),
+        "none" => Ok(Vec::new()),
+        other => bail!("unknown mode `{other}` (expected: docs | llms.md | cursor_rules | rustdoc_json | none)"),
     }
+}
+
+/// Cursor rules under docs: include general rules + rules for the given language.
+/// General = filename (lowercase) does not contain "typescript", "rust", or "csharp".
+/// Lang-specific = filename contains lang (e.g. "typescript" for TypeScript).
+pub fn gather_cursor_rules_files(rules_dir: PathBuf, lang: Option<Lang>) -> Result<Vec<PathBuf>> {
+    if !rules_dir.is_dir() {
+        return Ok(Vec::new());
+    }
+    let mut out: Vec<PathBuf> = fs::read_dir(&rules_dir)
+        .with_context(|| format!("read cursor rules dir {}", rules_dir.display()))?
+        .filter_map(|e| e.ok())
+        .map(|e| e.path())
+        .filter(|p| {
+            p.extension()
+                .and_then(|e| e.to_str())
+                .map(|e| e == "md" || e == "mdc")
+                .unwrap_or(false)
+        })
+        .collect();
+    if let Some(l) = lang {
+        let tag = l.as_str();
+        out.retain(|p| {
+            let name = p
+                .file_stem()
+                .and_then(|s| s.to_str())
+                .unwrap_or("")
+                .to_lowercase();
+            let is_general = !name.contains("typescript") && !name.contains("rust") && !name.contains("csharp");
+            let is_lang = name.contains(tag);
+            is_general || is_lang
+        });
+    }
+    out.sort();
+    Ok(out)
 }
 
 // --- hashing resolver stays as you wrote it ---
 pub fn resolve_mode_paths_hashing(mode: &str) -> Result<Vec<PathBuf>> {
     match mode {
         "docs" => gather_docs_files(),
-        "llms.md" => Ok(vec![docs_dir().join("llms.md")]),
-        "cursor_rules" => Ok(vec![docs_dir().join(".cursor/rules/spacetimedb.md")]),
+        "llms.md" => Ok(vec![docs_dir().join("static/llms.md")]),
+        "cursor_rules" => gather_cursor_rules_files(docs_dir().join("static/ai-rules"), None),
+        "none" => Ok(Vec::new()),
         "rustdoc_json" => {
             if let Some(p) = rustdoc_readme_path() {
                 Ok(vec![p])
@@ -35,7 +73,7 @@ pub fn resolve_mode_paths_hashing(mode: &str) -> Result<Vec<PathBuf>> {
                 bail!("README not found under {}", rustdoc_crate_root().display())
             }
         }
-        other => bail!("unknown mode `{other}` (expected: docs | llms.md | cursor_rules | rustdoc_json)"),
+        other => bail!("unknown mode `{other}` (expected: docs | llms.md | cursor_rules | rustdoc_json | none)"),
     }
 }
 

--- a/tools/xtask-llm-benchmark/src/context/paths.rs
+++ b/tools/xtask-llm-benchmark/src/context/paths.rs
@@ -45,11 +45,7 @@ pub fn gather_cursor_rules_files(rules_dir: PathBuf, lang: Option<Lang>) -> Resu
     if let Some(l) = lang {
         let tag = l.as_str();
         out.retain(|p| {
-            let name = p
-                .file_stem()
-                .and_then(|s| s.to_str())
-                .unwrap_or("")
-                .to_lowercase();
+            let name = p.file_stem().and_then(|s| s.to_str()).unwrap_or("").to_lowercase();
             let is_general = !name.contains("typescript") && !name.contains("rust") && !name.contains("csharp");
             let is_lang = name.contains(tag);
             is_general || is_lang

--- a/tools/xtask-llm-benchmark/src/llm/clients/deepseek.rs
+++ b/tools/xtask-llm-benchmark/src/llm/clients/deepseek.rs
@@ -4,8 +4,7 @@ use serde::{Deserialize, Serialize};
 use super::http::HttpClient;
 use crate::llm::prompt::BuiltPrompt;
 use crate::llm::segmentation::{
-    deepseek_ctx_limit_tokens, deterministic_trim_prefix, estimate_tokens,
-    non_context_reserve_tokens_env, Segment,
+    deepseek_ctx_limit_tokens, deterministic_trim_prefix, estimate_tokens, non_context_reserve_tokens_env, Segment,
 };
 use crate::llm::types::Vendor;
 

--- a/tools/xtask-llm-benchmark/src/llm/clients/deepseek.rs
+++ b/tools/xtask-llm-benchmark/src/llm/clients/deepseek.rs
@@ -4,7 +4,8 @@ use serde::{Deserialize, Serialize};
 use super::http::HttpClient;
 use crate::llm::prompt::BuiltPrompt;
 use crate::llm::segmentation::{
-    deepseek_ctx_limit_tokens, deterministic_trim_prefix, non_context_reserve_tokens_env, Segment,
+    deepseek_ctx_limit_tokens, deterministic_trim_prefix, estimate_tokens,
+    non_context_reserve_tokens_env, Segment,
 };
 use crate::llm::types::Vendor;
 
@@ -30,7 +31,15 @@ impl DeepSeekClient {
 
         let ctx_limit = deepseek_ctx_limit_tokens(model);
         let reserve = non_context_reserve_tokens_env(Vendor::DeepSeek);
-        let allowance = ctx_limit.saturating_sub(reserve);
+        let system_tok = system.as_deref().map(estimate_tokens).unwrap_or(0);
+        let segments_tok: usize = segs.iter().map(|s| estimate_tokens(&s.text)).sum();
+        // API counts tokens differently; reserve extra headroom so we stay under limit
+        const DEEPSEEK_HEADROOM_EXTRA: usize = 25_000;
+        let allowance = ctx_limit
+            .saturating_sub(reserve)
+            .saturating_sub(system_tok)
+            .saturating_sub(segments_tok)
+            .saturating_sub(DEEPSEEK_HEADROOM_EXTRA);
         static_prefix = deterministic_trim_prefix(&static_prefix, allowance);
 
         #[derive(Serialize)]

--- a/tools/xtask-llm-benchmark/src/llm/clients/meta.rs
+++ b/tools/xtask-llm-benchmark/src/llm/clients/meta.rs
@@ -42,6 +42,8 @@ impl MetaLlamaClient {
             messages: Vec<Msg<'a>>,
             temperature: f32,
             #[serde(skip_serializing_if = "Option::is_none")]
+            top_p: Option<f32>,
+            #[serde(skip_serializing_if = "Option::is_none")]
             max_tokens: Option<u32>,
         }
 
@@ -81,6 +83,7 @@ impl MetaLlamaClient {
             model: wire_model,
             messages,
             temperature: 0.0,
+            top_p: Some(0.9), // avoid creative tangents; deterministic code
             max_tokens: None,
         };
 
@@ -101,12 +104,19 @@ impl MetaLlamaClient {
 // Map friendly names → OpenRouter slugs. Extend as needed.
 fn normalize_meta_model(id: &str) -> &str {
     match id {
-        // OpenRouter slugs
+        // OpenRouter slugs (Llama 4)
+        "meta-llama/llama-4-maverick" => "meta-llama/llama-4-maverick",
+        "meta-llama/llama-4-scout" => "meta-llama/llama-4-scout",
+        // Llama 3.x
+        "meta-llama/llama-3.3-70b-instruct" => "meta-llama/llama-3.3-70b-instruct",
         "meta-llama/llama-3.1-405b-instruct" => "meta-llama/llama-3.1-405b-instruct",
         "meta-llama/llama-3.1-70b-instruct" => "meta-llama/llama-3.1-70b-instruct",
         "meta-llama/llama-3.1-8b-instruct" => "meta-llama/llama-3.1-8b-instruct",
 
         // Friendly aliases -> slugs
+        "llama-4-maverick" | "llama4-maverick" => "meta-llama/llama-4-maverick",
+        "llama-4-scout" | "llama4-scout" => "meta-llama/llama-4-scout",
+        "llama-3.3-70b-instruct" | "llama3.3-70b-instruct" | "llama-3.3-70b" => "meta-llama/llama-3.3-70b-instruct",
         "llama-3.1-405b-instruct" | "llama3.1-405b-instruct" | "llama-3.1-405b" => "meta-llama/llama-3.1-405b-instruct",
         "llama-3.1-70b-instruct" | "llama3.1-70b-instruct" | "llama-3.1-70b" => "meta-llama/llama-3.1-70b-instruct",
         "llama-3.1-8b-instruct" | "llama3.1-8b-instruct" | "llama-3.1-8b" => "meta-llama/llama-3.1-8b-instruct",

--- a/tools/xtask-llm-benchmark/src/llm/model_routes.rs
+++ b/tools/xtask-llm-benchmark/src/llm/model_routes.rs
@@ -46,7 +46,7 @@ pub fn default_model_routes() -> &'static [ModelRoute] {
         },
         ModelRoute {
             display_name: "Gemini 3.1 Pro",
-            vendor: Meta,  // uses MetaLlamaClient = OpenRouter
+            vendor: Meta, // uses MetaLlamaClient = OpenRouter
             api_model: "google/gemini-3.1-pro-preview",
         },
         ModelRoute {

--- a/tools/xtask-llm-benchmark/src/llm/model_routes.rs
+++ b/tools/xtask-llm-benchmark/src/llm/model_routes.rs
@@ -11,81 +11,70 @@ pub struct ModelRoute {
 pub fn default_model_routes() -> &'static [ModelRoute] {
     use Vendor::*;
     &[
-        //GPT
+        // OpenAI: Best GPT-5.2-Codex, Cheaper GPT-5-mini
         ModelRoute {
-            display_name: "GPT-5",
+            display_name: "GPT-5.2-Codex",
             vendor: OpenAi,
-            api_model: "gpt-5",
+            api_model: "gpt-5.2-codex",
         },
         ModelRoute {
-            display_name: "GPT-4.1",
+            display_name: "GPT-5-mini",
             vendor: OpenAi,
-            api_model: "gpt-4.1",
+            api_model: "gpt-5-mini",
         },
+        // Claude: Best Opus 4.6, Cheaper Sonnet 4.6
         ModelRoute {
-            display_name: "o4-mini",
-            vendor: OpenAi,
-            api_model: "o4-mini",
-        },
-        ModelRoute {
-            display_name: "GPT-4o",
-            vendor: OpenAi,
-            api_model: "gpt-4o",
-        },
-        // CLAUDE (Anthropic)
-        ModelRoute {
-            display_name: "Claude 4.5 Sonnet",
+            display_name: "Claude Opus 4.6",
             vendor: Anthropic,
-            api_model: "claude-sonnet-4-5",
+            api_model: "claude-opus-4-6",
         },
         ModelRoute {
-            display_name: "Claude 4 Sonnet",
+            display_name: "Claude Sonnet 4.6",
             vendor: Anthropic,
-            api_model: "claude-sonnet-4",
+            api_model: "claude-sonnet-4-6",
         },
-        ModelRoute {
-            display_name: "Claude 4.5 Haiku",
-            vendor: Anthropic,
-            api_model: "claude-haiku-4-5",
-        },
-        //GROK
+        // Grok: Best Grok 4, Cheaper Grok Code
         ModelRoute {
             display_name: "Grok 4",
             vendor: Xai,
             api_model: "grok-4",
         },
         ModelRoute {
-            display_name: "Grok 3 Mini (Beta)",
+            display_name: "Grok Code",
             vendor: Xai,
-            api_model: "grok-3-mini",
-        },
-        //GEMINI
-        ModelRoute {
-            display_name: "Gemini 2.5 Pro",
-            vendor: Google,
-            api_model: "gemini-2.5-pro",
+            api_model: "grok-code-fast-1",
         },
         ModelRoute {
-            display_name: "Gemini 2.5 Flash",
-            vendor: Google,
-            api_model: "gemini-2.5-flash",
-        },
-        //DEEPSPEEK
-        ModelRoute {
-            display_name: "DeepSeek V3",
-            vendor: DeepSeek,
-            api_model: "deepseek-chat",
+            display_name: "Gemini 3.1 Pro",
+            vendor: Meta,  // uses MetaLlamaClient = OpenRouter
+            api_model: "google/gemini-3.1-pro-preview",
         },
         ModelRoute {
-            display_name: "DeepSeek R1",
+            display_name: "Gemini 3 Flash",
+            vendor: Meta,
+            api_model: "google/gemini-3-flash-preview",
+        },
+        // Gemini: Best 3.1 Pro, Cheaper 3 Flash
+        // ModelRoute {
+        //     display_name: "Gemini 3.1 Pro",
+        //     vendor: Google,
+        //     api_model: "gemini-3.1-pro-preview",
+        // },
+        // ModelRoute {
+        //     display_name: "Gemini 3 Flash",
+        //     vendor: Google,
+        //     api_model: "gemini-3-flash-preview",
+        // },
+        // DeepSeek: Reasoner (thinking), Chat (general)
+        ModelRoute {
+            display_name: "DeepSeek Reasoner",
             vendor: DeepSeek,
             api_model: "deepseek-reasoner",
         },
-        //META
         ModelRoute {
-            display_name: "Meta Llama 3.1 405B",
-            vendor: Meta,
-            api_model: "meta-llama/llama-3.1-405b-instruct",
+            display_name: "DeepSeek Chat",
+            vendor: DeepSeek,
+            api_model: "deepseek-chat",
         },
     ]
 }

--- a/tools/xtask-llm-benchmark/src/llm/prompt.rs
+++ b/tools/xtask-llm-benchmark/src/llm/prompt.rs
@@ -32,10 +32,14 @@ Rules:\n\
             lang = self.lang
         ));
 
-        let static_prefix = Some(format!(
-            "<<<DOCS START>>>Context:\n{context}\n<<<DOCS END>>>\n",
-            context = context,
-        ));
+        let static_prefix = Some(if context.trim().is_empty() {
+            "<<<DOCS START>>>\nNo documentation provided. You must rely on your knowledge of SpacetimeDB syntax and conventions.\n<<<DOCS END>>>\n".to_string()
+        } else {
+            format!(
+                "<<<DOCS START>>>Context:\n{context}\n<<<DOCS END>>>\n",
+                context = context,
+            )
+        });
 
         // TASK: identical in both modes; API details must come from DOCS in Knowledge mode.
         // In Conformance mode we keep it the same—to measure formatting discipline separately in scoring.

--- a/tools/xtask-llm-benchmark/src/llm/segmentation.rs
+++ b/tools/xtask-llm-benchmark/src/llm/segmentation.rs
@@ -89,13 +89,14 @@ pub fn build_anthropic_messages(
 
 // Provider-specific context limits
 pub fn anthropic_ctx_limit_tokens(_model: &str) -> usize {
-    200_000 - 2000 // extra space
+    // Anthropic hard limit is 200k; reserve ~15k for tokenizer variance + system/segments
+    185_000
 }
 
 pub fn openai_ctx_limit_tokens(model: &str) -> usize {
     let m = model.to_ascii_lowercase();
     if m.contains("gpt-5") || m.contains("gpt-4.1") {
-        300_000
+        400_000
     } else {
         128_000
     }
@@ -104,6 +105,7 @@ pub fn openai_ctx_limit_tokens(model: &str) -> usize {
 pub fn deepseek_ctx_limit_tokens(model: &str) -> usize {
     let m = model.to_ascii_lowercase();
 
+    // API limit 128K for deepseek-chat and deepseek-reasoner
     if m.starts_with("deepseek-reasoner") || m.starts_with("deepseek-r1") {
         return 128_000;
     }
@@ -142,14 +144,25 @@ pub fn gemini_ctx_limit_tokens(model: &str) -> usize {
 
 pub fn meta_ctx_limit_tokens(model: &str) -> usize {
     let m = model.to_ascii_lowercase();
-    if m.contains("405b") || m.contains("70b") || m.contains("chat") {
-        return 120_000; //8k headroom
+    // Llama 4: Maverick 1M, Scout 328K context
+    if m.contains("maverick") {
+        return 992_000; // 1M - 8k headroom
     }
-    120_000 //8k headroom
+    if m.contains("scout") {
+        return 320_000; // 328K - 8k headroom
+    }
+    // Llama 3.x
+    if m.contains("405b") || m.contains("70b") || m.contains("8b") || m.contains("chat") {
+        return 120_000; // 8k headroom
+    }
+    120_000 // 8k headroom
 }
 
 pub fn xai_ctx_limit_tokens(model: &str) -> usize {
     let m = model.to_ascii_lowercase();
+    if m.contains("grok-code-fast-1") {
+        return 256_000;
+    }
     if m.contains("grok-4") || m.contains("grok-3") {
         return 128_000;
     }

--- a/tools/xtask-llm-benchmark/src/templates/csharp/server/StdbModule.csproj
+++ b/tools/xtask-llm-benchmark/src/templates/csharp/server/StdbModule.csproj
@@ -1,4 +1,8 @@
-﻿<Project Sdk="Microsoft.NET.Sdk">
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <!-- Import Runtime build props/targets when using ProjectReference (NuGet auto-imports these; ProjectReference does not) -->
+  <Import Project="{SPACETIME_CSHARP_RUNTIME_DIR}/build/SpacetimeDB.Runtime.props" />
+  <Import Project="{SPACETIME_CSHARP_RUNTIME_DIR}/build/SpacetimeDB.Runtime.targets" />
 
   <PropertyGroup>
     <TargetFramework>net8.0</TargetFramework>
@@ -8,7 +12,9 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="SpacetimeDB.Runtime" Version="1.6" />
+    <ProjectReference Include="{SPACETIME_CSHARP_RUNTIME_REF}" />
+    <!-- Codegen is packed into the NuGet Runtime package; with ProjectReference we must add it explicitly -->
+    <ProjectReference Include="{SPACETIME_CSHARP_CODEGEN_REF}" OutputItemType="Analyzer" ReferenceOutputAssembly="false" />
   </ItemGroup>
 
 </Project>

--- a/tools/xtask-llm-benchmark/src/templates/rust/server/Cargo.toml
+++ b/tools/xtask-llm-benchmark/src/templates/rust/server/Cargo.toml
@@ -1,4 +1,4 @@
-﻿[workspace]
+[workspace]
 
 [package]
 name = "spacetime-module"
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = "=1.11.1"
+spacetimedb = {SPACETIME_RUST_SDK_PATH}
 log = "0.4"

--- a/tools/xtask-llm-benchmark/src/templates/typescript/server/package.json
+++ b/tools/xtask-llm-benchmark/src/templates/typescript/server/package.json
@@ -4,7 +4,7 @@
   "type": "module",
   "main": "src/lib.ts",
   "dependencies": {
-    "spacetimedb": "^1.11.0"
+    "spacetimedb": "{SPACETIME_TS_SDK_REF}"
   },
   "devDependencies": {
     "typescript": "^5.0.0"

--- a/tools/xtask-llm-benchmark/src/tools/llm_benchmark_stats_viewer.html
+++ b/tools/xtask-llm-benchmark/src/tools/llm_benchmark_stats_viewer.html
@@ -274,7 +274,6 @@ byId('loadPasteBtn').addEventListener('click',()=>{
   const txt=byId('jsonPaste').value.trim(); if(!txt){setStatus('Paste box is empty.',true);return}
   const obj=safeParse(txt); loadJsonObject(obj,'pasted JSON');
 });
-
 function getControls(){
   const lang=byId('langSel').value, mode=byId('modeSel').value;
   const colsSel=byId('colsSel').value||'2', failedOnly=byId('failedOnly').checked, hidePerfectCats=byId('hidePerfectCats').checked;
@@ -374,8 +373,8 @@ function buildView(data,lang,mode){
         work_dir_llm: outcome?.work_dir_llm ?? null,
         llm_output: outcome?.llm_output ?? null,
         scorer_details: outcome?.scorer_details ?? null,
-        golden_answer: goldenAnswers?.[tid]?.answer ?? null,
-        golden_syntax: goldenAnswers?.[tid]?.syntax ?? null
+        golden_answer: (goldenAnswers?.[`${outcome?.category||''}/${tid}`] ?? goldenAnswers?.[tid])?.answer ?? null,
+        golden_syntax: (goldenAnswers?.[`${outcome?.category||''}/${tid}`] ?? goldenAnswers?.[tid])?.syntax ?? null
       };
     }
     modelTaskMap[mname]=tmap; modelOutcomeMap[mname]=omap;
@@ -499,10 +498,9 @@ function matchesSearch(tid,view,q,cols){
   if(!q) return true;
   const needle=q.toLowerCase();
   if(tid.toLowerCase().includes(needle)) return true;
-  const ga=view.goldenAnswers?.[tid]?.answer;
-  if(ga && String(ga).toLowerCase().includes(needle)) return true;
   for(const m of cols){
     const oc=view.modelOutcomeMap[m]?.[tid];
+    if(oc?.golden_answer && String(oc.golden_answer).toLowerCase().includes(needle)) return true;
     if(oc?.llm_output && String(oc.llm_output).toLowerCase().includes(needle)) return true;
   }
   return false;
@@ -618,18 +616,36 @@ function renderMatrices(view){
     blocks.push(header+table);
   }
 
+  const chosenModels=selectedModels() ?? view.modelNames;
   const overall=`
     <h2>Overall totals (all categories)</h2>
     <div class="twrap">
       <table>
-        <thead><tr><th>Model</th><th>Passed / Total</th><th>Rate</th></tr></thead>
+        <thead><tr><th>Model</th><th>Task pass rate</th><th>Rate</th></tr></thead>
         <tbody>
-          ${(selectedModels() ?? view.modelNames).map(m=>{
+          ${chosenModels.map(m=>{
             let p=0,t=0; for(const tids of Object.values(view.categories)){t+=tids.length; for(const tid of tids){const rec=view.modelTaskMap[m]?.[tid]; if(rec?.pass) p++;}}
             const rate=t?Math.round(100*p/t):0; const cls=rate===100?'ok':(rate===0?'bad':'muted');
             return `<tr>
               <td>${esc(m)}</td>
-              <td class="cell-tight"><div><span class="mono ${cls}">${p}/${t}</span></div><div class="mini">${rate}%</div></td>
+              <td class="cell-tight"><div><span class="mono ${cls}">${p}/${t}</span> tasks</div><div class="mini">${rate}%</div></td>
+              <td class="${cls} cell-tight">${rate}%</td>
+            </tr>`;
+          }).join("")}
+        </tbody>
+      </table>
+    </div>
+    <h2 style="margin-top:24px;">Point pass rate (individual test assertions)</h2>
+    <div class="twrap">
+      <table>
+        <thead><tr><th>Model</th><th>Points passed / total</th><th>Rate</th></tr></thead>
+        <tbody>
+          ${chosenModels.map(m=>{
+            let pt=0,tt=0; for(const tids of Object.values(view.categories)){for(const tid of tids){const rec=view.modelTaskMap[m]?.[tid]; if(rec){pt+=rec.pt||0; tt+=rec.tt||0}}}
+            const rate=tt?Math.round(100*pt/tt):0; const cls=rate===100?'ok':(rate===0?'bad':'muted');
+            return `<tr>
+              <td>${esc(m)}</td>
+              <td class="cell-tight"><div><span class="mono ${cls}">${pt}/${tt}</span> points</div><div class="mini">${rate}%</div></td>
               <td class="${cls} cell-tight">${rate}%</td>
             </tr>`;
           }).join("")}
@@ -712,9 +728,12 @@ function buildCsv(view){
     const totals=["Category totals"]; for(const m of cols){const total=view.categories[cat].length; let p=0; for(const tid of view.categories[cat]){const rec=view.modelTaskMap[m]?.[tid]; if(rec?.pass) p++} totals.push(`${p}/${total}`)}
     lines.push(totals.map(qcsv).join(",")); lines.push("");
   }
-  lines.push("Overall totals"); lines.push(["Model","Passed/Total","Rate"].map(qcsv).join(","));
+  lines.push("Overall totals (task pass rate)"); lines.push(["Model","Tasks passed/Total","Rate"].map(qcsv).join(","));
   for(const m of cols){let p=0,t=0; for(const tids of Object.values(view.categories)){t+=tids.length; for(const tid of tids){const rec=view.modelTaskMap[m]?.[tid]; if(rec?.pass) p++}}
     const rate=t?Math.round(100*p/t):0; lines.push([m,`${p}/${t}`,`${rate}%`].map(qcsv).join(","))}
+  lines.push(""); lines.push("Point pass rate (individual test assertions)"); lines.push(["Model","Points passed/Total","Rate"].map(qcsv).join(","));
+  for(const m of cols){let pt=0,tt=0; for(const tids of Object.values(view.categories)){for(const tid of tids){const rec=view.modelTaskMap[m]?.[tid]; if(rec){pt+=rec.pt||0; tt+=rec.tt||0}}}
+    const rate=tt?Math.round(100*pt/tt):0; lines.push([m,`${pt}/${tt}`,`${rate}%`].map(qcsv).join(","))}
   return lines.join("\n")+"\n";
 }
 


### PR DESCRIPTION
# Description of Changes

LLM benchmark updates for local development:

- **Local SDK paths**: Templates use relative paths to workspace crates (`crates/bindings`, `crates/bindings-csharp`, `crates/bindings-typescript`) instead of published packages, so the bench runs against local SDK changes.
- **NODEJS_DIR support**: On Windows (e.g. nvm4w), if `pnpm` is not on PATH, the bench uses `NODEJS_DIR` to locate `pnpm` and prepends it to PATH for subprocesses.
- **Refactor**: Extracted `relative_to_workspace()` in `templates.rs` and removed noisy `NODEJS_DIR` logging in `publishers.rs`.
- **Benchmark results**: Updated `docs/llms/llm-comparison-details.json` and `docs/llms/llm-comparison-summary.json`.

# API and ABI breaking changes

None.

# Expected complexity level and risk

**2** — Local-only changes to the benchmark tool. Templates now require local SDKs to be built (especially TypeScript: `pnpm build` in `crates/bindings-typescript`). No impact on published SDKs or runtime.

# Testing

- [ ] Run `cargo llm run --lang rust --modes docs --providers openai` from repo root
- [ ] Run TypeScript benchmarks with `pnpm build` in `crates/bindings-typescript` first
- [ ] On Windows with nvm4w, set `NODEJS_DIR` if `pnpm` is not on PATH and run TypeScript benchmarks