### PR TITLE
[Docs] Updates to `00600-c-sharp.md` to work in 2.0

### DIFF
--- a/docs/docs/00100-intro/00200-quickstarts/00600-c-sharp.md
+++ b/docs/docs/00100-intro/00200-quickstarts/00600-c-sharp.md
@@ -57,10 +57,9 @@ my-spacetime-app/
 ├── spacetimedb/          # Your SpacetimeDB module
 │   ├── StdbModule.csproj
 │   └── Lib.cs            # Server-side logic
-├── client/               # Client application
-│   ├── Client.csproj
-│   └── Program.cs
-│       └── module_bindings/  # Auto-generated types
+├── client.csproj         # Client application
+├── Program.cs
+├── module_bindings/  # Auto-generated types
 └── README.md
 ```
     </StepCode>
@@ -113,7 +112,7 @@ public static partial class Module
 cd my-spacetime-app
 
 # Call the add reducer to insert a person
-spacetime call Add Alice
+spacetime call add Alice
 
 # Query the person table
 spacetime sql "SELECT * FROM Person"
@@ -122,7 +121,7 @@ spacetime sql "SELECT * FROM Person"
  "Alice"
 
 # Call say_hello to greet everyone
-spacetime call SayHello
+spacetime call say_hello
 
 # View the module logs
 spacetime logs


### PR DESCRIPTION
# Description of Changes

* Updates directory tree to reflect the actual results of running `spacetime dev --template basic-cs my-spacetime-app` with no additional arguments.
* Updates the `Add` -> `add` reducer call to use lower-case to match the default when no override is specified.
* Updates the `SayHello` -> `say_hello` reducer  call to use lower-case to match the default when no override is specified.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [X] Walked through every step with a local server to test behavior. This involved.
* Cleared all local cache and rebuilding the CLI.
* Rebuilding the DLLs
* From my test project directory, running: `D:\Projects\ClockworkLabs\SpacetimeDB\target\debug\spacetimedb-cli.exe dev --template basic-cs my-spacetime-app` and selecting the default values.
  * This threw an error because, I believe, it was not using the local DLLs.
* Going into each `.csproj` to ensure they are using the local versions of the files.
* Running the remaining commands, while targeting the local CLI executables:
  * Note: `local` server is mapped to `127.0.0.1:3000`
```
D:\Projects\ClockworkLabs\SpacetimeDB\target\debug\spacetimedb-cli.exe publish -s local my-spacetime-app
D:\Projects\ClockworkLabs\SpacetimeDB\target\debug\spacetimedb-cli.exe call -s local my-spacetime-app add Alice
D:\Projects\ClockworkLabs\SpacetimeDB\target\debug\spacetimedb-cli.exe sql -s local my-spacetime-app "SELECT * FROM Person"
D:\Projects\ClockworkLabs\SpacetimeDB\target\debug\spacetimedb-cli.exe call -s local my-spacetime-app say_hello
D:\Projects\ClockworkLabs\SpacetimeDB\target\debug\spacetimedb-cli.exe logs -s local my-spacetime-app
```
