### PR TITLE
durability: Default local durability sync interval to 50ms

### DIFF
--- a/crates/durability/src/imp/local.rs
+++ b/crates/durability/src/imp/local.rs
@@ -34,7 +34,7 @@ pub use spacetimedb_commitlog::repo::{OnNewSegmentFn, SizeOnDisk};
 pub struct Options {
     /// Periodically flush and sync the log this often.
     ///
-    /// Default: 500ms
+    /// Default: 50ms
     pub sync_interval: Duration,
     /// [`Commitlog`] configuration.
     pub commitlog: spacetimedb_commitlog::Options,
@@ -43,7 +43,7 @@ pub struct Options {
 impl Default for Options {
     fn default() -> Self {
         Self {
-            sync_interval: Duration::from_millis(500),
+            sync_interval: Duration::from_millis(50),
             commitlog: Default::default(),
         }
     }


### PR DESCRIPTION
Cherry-picked from #4404
Better default for confirmed reads (which are the default since #4390).