### PR TITLE
Don't save source_config to spacetime.json

### DIFF
--- a/crates/cli/src/spacetime_config.rs
+++ b/crates/cli/src/spacetime_config.rs
@@ -120,7 +120,7 @@ pub struct SpacetimeConfig {
     pub children: Option<Vec<SpacetimeConfig>>,
 
     /// Name of the config file from which this target's `database` value was merged.
-    #[serde(rename = "_source-config", skip_serializing_if = "Option::is_none")]
+    #[serde(rename = "_source-config", skip_serializing)]
     pub source_config: Option<String>,
 
     /// All other entity-level fields (database, module-path, server, etc.)


### PR DESCRIPTION
# Description of Changes

We mistakenly save a struct field that is only for internal usage into the spacetime.json config file. This PR fixes that.


# Expected complexity level and risk

1
