### PR TITLE
Fix AI assistant rules links in llms.txt

### DIFF
--- a/docs/static/llms.md
+++ b/docs/static/llms.md
@@ -111,11 +111,10 @@ Clockwork Labs, the developers of SpacetimeDB, offers three products:
 
 | Language | Rules |
 |----------|-------|
-| All Languages | [spacetimedb.mdc](https://spacetimedb.com/ai-rules/spacetimedb.mdc) |
-| TypeScript | [spacetimedb-typescript.mdc](https://spacetimedb.com/ai-rules/spacetimedb-typescript.mdc) |
-| Rust | [spacetimedb-rust.mdc](https://spacetimedb.com/ai-rules/spacetimedb-rust.mdc) |
-| C# | [spacetimedb-csharp.mdc](https://spacetimedb.com/ai-rules/spacetimedb-csharp.mdc) |
-
+| All Languages | [spacetimedb.mdc](https://spacetimedb.com/docs/ai-rules/spacetimedb.mdc) |
+| TypeScript | [spacetimedb-typescript.mdc](https://spacetimedb.com/docs/ai-rules/spacetimedb-typescript.mdc) |
+| Rust | [spacetimedb-rust.mdc](https://spacetimedb.com/docs/ai-rules/spacetimedb-rust.mdc) |
+| C# | [spacetimedb-csharp.mdc](https://spacetimedb.com/docs/ai-rules/spacetimedb-csharp.mdc) |
 ## Basic Project Workflow
 
 Getting started with SpacetimeDB involves a few key steps:


### PR DESCRIPTION
# Description of Changes

Fix AI assistant rules links in llms.txt, they were missing a `/docs`

# API and ABI breaking changes

None.

# Expected complexity level and risk

0.0001

# Testing

Clicked the link
