### PR TITLE
guard: Attempt to kill server gracefully

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8050,9 +8050,11 @@ dependencies = [
 name = "spacetimedb-guard"
 version = "2.0.1"
 dependencies = [
+ "nix 0.30.1",
  "portpicker",
  "reqwest 0.12.24",
  "tempfile",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]

--- a/crates/guard/Cargo.toml
+++ b/crates/guard/Cargo.toml
@@ -9,6 +9,12 @@ portpicker = "0.1"
 reqwest = { workspace = true, features = ["blocking", "json"] }
 tempfile.workspace = true
 
+[target.'cfg(unix)'.dependencies]
+nix = { workspace = true, features = ["process", "signal"] }
+
+[target.'cfg(windows)'.dependencies]
+windows-sys = { workspace = true, features = ["Win32_System_Console", "Win32_System_Threading"] }
+
 [lints]
 workspace = true
 


### PR DESCRIPTION
Send it SIGINT / CTRL_BREAK_EVENT, which standalone handles. Wait a bit. Send it SIGKILL.

This gives the server a chance to run finalizers. We aren't well equipped to deal with sudden death currently.

