### PR TITLE
Adds code signing to tagged windows builds

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -7,6 +7,8 @@ on:
     branches:
       - master
       - release/*
+permissions:
+  contents: read
 
 jobs:
   build-cli:


### PR DESCRIPTION
**Note**: This change requires the addition of new entries in the secrets to work properly. These should be added prior to this merging.

# Description of Changes

* Add a tag-only Windows signing job that runs on a self-hosted signing runner.
  * This is an alternative/separate code-path just for the signing job. See **Alternatives Considered** for details.
* Skip the unsigned Windows matrix build on tags so signed artifacts are the only Windows release outputs.
* Sign `spacetimedb-update.exe`, `spacetimedb-cli.exe`, and `spacetimedb-standalone.exe` before packaging, then upload the signed artifacts as usual.

# Alternatives Considered
**Inline signing in the existing Windows packaging step**. This was rejected because it would require all Windows builds (including non-tag builds) to run on the signing-capable runner or to install/signing tooling on GitHub-hosted runners. The chosen approach isolates signing to tag releases, avoids exposing credentials in standard builds, and keeps routine CI behavior unchanged.

# API and ABI breaking changes

None

# Expected complexity level and risk

2 – low risk. CI-only change that adds a new signing job and preserves existing artifact layout.

# Testing

- [X] None (Not running, workflow change only)