### PR TITLE
fix(docs): Rename spacerace to referrals for nav item

### DIFF
--- a/docs/docusaurus.config.ts
+++ b/docs/docusaurus.config.ts
@@ -186,7 +186,7 @@ const config: Config = {
         },
         {
           href: 'https://spacetimedb.com/space-race',
-          label: 'Spacerace',
+          label: 'Referrals',
           position: 'right',
         },
         {


### PR DESCRIPTION
# Description of Changes
- Rename `Spacerace` to `Referrals` for docs nav item to align with updated naming

<!-- Please describe your change, mention any related tickets, and so on here. -->

# Screenshots
- After:
<img width="1510" height="49" alt="image" src="https://github.com/user-attachments/assets/3bdbe6ec-8a51-4686-9292-28c38b6d14d9" />

- Before:
<img width="1460" height="47" alt="image" src="https://github.com/user-attachments/assets/5c70b0ef-d5fc-42fa-9dc9-5fd4f034d415" />


# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk
1

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Docs displays correctly
