### PR TITLE
keynote-2: alpha -> 1.5, withConfirmedReads(true), remove warmup

### DIFF
--- a/templates/keynote-2/DEVELOP.md
+++ b/templates/keynote-2/DEVELOP.md
@@ -193,7 +193,7 @@ From `src/cli.ts`:
 
 - **`--alpha A`**
   - Zipf α parameter for account selection (hot vs cold distribution)
-  - Default: `0.5`
+  - Default: `1.5`
 
 - **`--connectors list`**
   - Optional, comma-separated list of connector `system` names

--- a/templates/keynote-2/README.md
+++ b/templates/keynote-2/README.md
@@ -195,7 +195,7 @@ docker compose up -d pg crdb
 npm run prep
 
 # Run benchmark
-npm run bench -- --seconds 10 --concurrency 50 --alpha 0 --connectors spacetimedb,postgres_rpc,sqlite_rpc
+npm run bench -- --seconds 10 --concurrency 50 --alpha 1.5 --connectors spacetimedb,postgres_rpc,sqlite_rpc
 ```
 
 ## Output

--- a/templates/keynote-2/docker-compose-linux-raid-crdb.yml
+++ b/templates/keynote-2/docker-compose-linux-raid-crdb.yml
@@ -194,7 +194,7 @@
     volumes:
       - /mnt/local-ssd/sqlite_data:/data
       - ./runs:/app/runs
-    command: ["--seconds", "5", "--concurrency", "50", "--alpha", "1", "--connectors", "sqlite"]
+    command: ["--seconds", "5", "--concurrency", "50", "--alpha", "1.5", "--connectors", "sqlite"]
     network_mode: host
 
   sqlite-seed:

--- a/templates/keynote-2/docker-compose-linux-raid.yml
+++ b/templates/keynote-2/docker-compose-linux-raid.yml
@@ -315,7 +315,7 @@
     volumes:
       - /mnt/local-ssd/sqlite_data:/data
       - ./runs:/app/runs
-    command: ["--seconds", "5", "--concurrency", "50", "--alpha", "1", "--connectors", "sqlite"]
+    command: ["--seconds", "5", "--concurrency", "50", "--alpha", "1.5", "--connectors", "sqlite"]
     network_mode: host
 
   sqlite-seed:

--- a/templates/keynote-2/docker-compose.yml
+++ b/templates/keynote-2/docker-compose.yml
@@ -276,7 +276,7 @@
     volumes:
       - sqlite_data:/data
       - ./runs:/app/runs
-    command: ["--seconds", "5", "--concurrency", "50", "--alpha", "1", "--connectors", "sqlite"]
+    command: ["--seconds", "5", "--concurrency", "50", "--alpha", "1.5", "--connectors", "sqlite"]
     network_mode: host
 
   sqlite-seed:

--- a/templates/keynote-2/src/cli.ts
+++ b/templates/keynote-2/src/cli.ts
@@ -22,7 +22,7 @@ let seconds = 1,
   accounts = process.env.SEED_ACCOUNTS
     ? Number(process.env.SEED_ACCOUNTS)
     : 100_000,
-  alpha = 0.5,
+  alpha = 1.5,
   connectors: string[] | null = null,
   contentionTests: {
     startAlpha: number;
@@ -173,7 +173,7 @@ class BenchmarkTester {
     startConc: number = 1,
     endConc: number = 100,
     step: number = 1,
-    alpha: number = 1,
+    alpha: number = 1.5,
   ) {
     const results: { concurrency: number; avgResult: RunResult }[] = [];
     for (let conc = startConc; conc <= endConc; conc += step) {
@@ -189,7 +189,7 @@ class BenchmarkTester {
     startConc: number = 1,
     endConc: number = 100,
     factor: number = 2,
-    alpha: number = 1,
+    alpha: number = 1.5,
   ) {
     if (factor <= 1) {
       throw new Error('factor must be > 1 to avoid infinite loop');

--- a/templates/keynote-2/src/demo.ts
+++ b/templates/keynote-2/src/demo.ts
@@ -71,7 +71,7 @@ function hasFlag(name: string): boolean {
 
 const seconds = getArg('seconds', 10);
 const concurrency = getArg('concurrency', 10);
-const alpha = getArg('alpha', 0.5);
+const alpha = getArg('alpha', 1.5);
 const systems = getStringArg('systems', 'convex,spacetimedb')
   .split(',')
   .map((s) => s.trim());


### PR DESCRIPTION
# Description of Changes

This does 3 things to the keynote-2 benchmark:
- it changes the default alpha to 1.5, which we actually tested the other services with
- it turns on confirmed reads (not the default for < 2.0)
- it removes warmup

This was tested on https://github.com/clockworklabs/SpacetimeDB/pull/4404 to have no impact on the TPS throughput of spacetimedb.
**This PR shouldn't be merged before #4404 has.**

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

This tweaks a bench test.