### PR TITLE
Bring typescript benchmark client to parity with rust

### DIFF
--- a/crates/bindings-typescript/src/lib/binary_writer.ts
+++ b/crates/bindings-typescript/src/lib/binary_writer.ts
@@ -42,6 +42,10 @@ export default class BinaryWriter {
     this.buffer = typeof init === 'number' ? new ResizableBuffer(init) : init;
   }
 
+  clear() {
+    this.offset = 0;
+  }
+
   reset(buffer: ResizableBuffer) {
     this.buffer = buffer;
     this.offset = 0;

--- a/crates/bindings-typescript/src/sdk/websocket_decompress_adapter.ts
+++ b/crates/bindings-typescript/src/sdk/websocket_decompress_adapter.ts
@@ -1,48 +1,55 @@
 import { decompress } from './decompress';
 import { resolveWS } from './ws';
 
-export class WebsocketDecompressAdapter {
-  onclose?: (...ev: any[]) => void;
-  onopen?: (...ev: any[]) => void;
-  onmessage?: (msg: { data: Uint8Array }) => void;
-  onerror?: (msg: ErrorEvent) => void;
+export interface WebsocketAdapter {
+  send(msg: Uint8Array): void;
+  close(): void;
+
+  set onclose(handler: (ev: CloseEvent) => void);
+  set onopen(handler: () => void);
+  set onmessage(handler: (msg: { data: Uint8Array }) => void);
+  set onerror(handler: (msg: ErrorEvent) => void);
+}
+
+export class WebsocketDecompressAdapter implements WebsocketAdapter {
+  set onclose(handler: (ev: CloseEvent) => void) {
+    this.#ws.onclose = handler;
+  }
+  set onopen(handler: () => void) {
+    this.#ws.onopen = handler;
+  }
+  set onmessage(handler: (msg: { data: Uint8Array }) => void) {
+    this.#ws.onmessage = async (msg: MessageEvent<ArrayBuffer>) => {
+      const data = await this.#decompress(new Uint8Array(msg.data));
+      handler({ data });
+    };
+  }
+  set onerror(handler: (msg: ErrorEvent) => void) {
+    this.#ws.onerror = handler as (msg: Event) => void;
+  }
 
   #ws: WebSocket;
 
-  async #handleOnMessage(msg: MessageEvent) {
-    const buffer = new Uint8Array(msg.data);
-    let decompressed: Uint8Array;
-
-    if (buffer[0] === 0) {
-      decompressed = buffer.slice(1);
-    } else if (buffer[0] === 1) {
-      throw new Error(
-        'Brotli Compression not supported. Please use gzip or none compression in withCompression method on DbConnection.'
-      );
-    } else if (buffer[0] === 2) {
-      decompressed = await decompress(buffer.slice(1), 'gzip');
-    } else {
-      throw new Error(
-        'Unexpected Compression Algorithm. Please use `gzip` or `none`'
-      );
+  async #decompress(buffer: Uint8Array): Promise<Uint8Array> {
+    const tag = buffer[0];
+    const data = buffer.subarray(1);
+    switch (tag) {
+      case 0:
+        return data;
+      case 1:
+        throw new Error(
+          'Brotli Compression not supported. Please use gzip or none compression in withCompression method on DbConnection.'
+        );
+      case 2:
+        return await decompress(data, 'gzip');
+      default:
+        throw new Error(
+          'Unexpected Compression Algorithm. Please use `gzip` or `none`'
+        );
     }
-
-    this.onmessage?.({ data: decompressed });
   }
 
-  #handleOnOpen(msg: any) {
-    this.onopen?.(msg);
-  }
-
-  #handleOnError(msg: any) {
-    this.onerror?.(msg);
-  }
-
-  #handleOnClose(msg: any) {
-    this.onclose?.(msg);
-  }
-
-  send(msg: any): void {
+  send(msg: Uint8Array): void {
     this.#ws.send(msg);
   }
 
@@ -51,16 +58,6 @@ export class WebsocketDecompressAdapter {
   }
 
   constructor(ws: WebSocket) {
-    this.onmessage = undefined;
-    this.onopen = undefined;
-    this.onmessage = undefined;
-    this.onerror = undefined;
-
-    ws.onmessage = this.#handleOnMessage.bind(this);
-    ws.onerror = this.#handleOnError.bind(this);
-    ws.onclose = this.#handleOnClose.bind(this);
-    ws.onopen = this.#handleOnOpen.bind(this);
-
     ws.binaryType = 'arraybuffer';
 
     this.#ws = ws;

--- a/crates/bindings-typescript/src/sdk/websocket_test_adapter.ts
+++ b/crates/bindings-typescript/src/sdk/websocket_test_adapter.ts
@@ -1,10 +1,11 @@
 import { BinaryReader, BinaryWriter } from '../';
 import { ClientMessage, ServerMessage } from './client_api/types';
+import type { WebsocketAdapter } from './websocket_decompress_adapter';
 
-class WebsocketTestAdapter {
+class WebsocketTestAdapter implements WebsocketAdapter {
   onclose: any;
   // eslint-disable-next-line @typescript-eslint/no-unsafe-function-type
-  onopen!: Function;
+  onopen!: () => void;
   onmessage: any;
   onerror: any;
 

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -468,8 +468,8 @@ importers:
         specifier: ^3.0.1
         version: 3.0.1
       spacetimedb:
-        specifier: ^2.0
-        version: 2.0.1(@angular/core@21.1.4(@angular/compiler@21.1.4)(rxjs@7.8.2))(@tanstack/react-query@5.90.19(react@19.2.4))(react@19.2.4)(svelte@5.46.4)(undici@6.21.3)(vue@3.5.26(typescript@5.9.3))
+        specifier: workspace:^
+        version: link:../../crates/bindings-typescript
       sql.js:
         specifier: ^1.13.0
         version: 1.14.0
@@ -12871,29 +12871,6 @@ packages:
 
   space-separated-tokens@2.0.2:
     resolution: {integrity: sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q==}
-
-  spacetimedb@2.0.1:
-    resolution: {integrity: sha512-19YkLz1P+JQDlYvlegDsn3YF4OsE2Pih31e5Xx/kobTExKwx/AtFWRUSA/EiRWvMV9jaIWzMhnsVfG+1fJ39Aw==}
-    peerDependencies:
-      '@angular/core': '>=17.0.0'
-      '@tanstack/react-query': ^5.0.0
-      react: ^18.0.0 || ^19.0.0-0 || ^19.0.0
-      svelte: ^4.0.0 || ^5.0.0
-      undici: ^6.19.2
-      vue: ^3.3.0
-    peerDependenciesMeta:
-      '@angular/core':
-        optional: true
-      '@tanstack/react-query':
-        optional: true
-      react:
-        optional: true
-      svelte:
-        optional: true
-      undici:
-        optional: true
-      vue:
-        optional: true
 
   spdx-correct@3.2.0:
     resolution: {integrity: sha512-kN9dJbvnySHULIluDHy32WHRUu3Og7B9sbY7tsFLctQkIqnMh3hErYgdMjTYuqmcXX+lK5T1lnUt3G7zNswmZA==}
@@ -30810,24 +30787,6 @@ snapshots:
       whatwg-url: 7.1.0
 
   space-separated-tokens@2.0.2: {}
-
-  spacetimedb@2.0.1(@angular/core@21.1.4(@angular/compiler@21.1.4)(rxjs@7.8.2))(@tanstack/react-query@5.90.19(react@19.2.4))(react@19.2.4)(svelte@5.46.4)(undici@6.21.3)(vue@3.5.26(typescript@5.9.3)):
-    dependencies:
-      base64-js: 1.5.1
-      headers-polyfill: 4.0.3
-      object-inspect: 1.13.4
-      prettier: 3.6.2
-      pure-rand: 7.0.1
-      safe-stable-stringify: 2.5.0
-      statuses: 2.0.2
-      url-polyfill: 1.1.14
-    optionalDependencies:
-      '@angular/core': 21.1.4(@angular/compiler@21.1.4)(rxjs@7.8.2)
-      '@tanstack/react-query': 5.90.19(react@19.2.4)
-      react: 19.2.4
-      svelte: 5.46.4
-      undici: 6.21.3
-      vue: 3.5.26(typescript@5.9.3)
 
   spdx-correct@3.2.0:
     dependencies:

--- a/templates/keynote-2/package.json
+++ b/templates/keynote-2/package.json
@@ -36,7 +36,7 @@
     "drizzle-orm": "^0.44.7",
     "express": "^5.1.0",
     "hdr-histogram-js": "^3.0.1",
-    "spacetimedb": "^2.0",
+    "spacetimedb": "workspace:^",
     "sql.js": "^1.13.0",
     "undici": "^6.19.2"
   }

--- a/templates/keynote-2/src/connectors/convex.ts
+++ b/templates/keynote-2/src/connectors/convex.ts
@@ -84,6 +84,7 @@ export default function convex(
 
   const root: RpcConnector = {
     name: 'convex',
+    maxInflightPerWorker: 16,
 
     async open() {},
     async close() {},

--- a/templates/keynote-2/src/connectors/index.ts
+++ b/templates/keynote-2/src/connectors/index.ts
@@ -10,6 +10,7 @@ import planetscale_pg_rpc from './rpc/planetscale_pg_rpc.ts';
 export const CONNECTORS = {
   convex,
   spacetimedb,
+  spacetimedbRustClient: spacetimedb,
   bun,
   postgres_rpc,
   cockroach_rpc,

--- a/templates/keynote-2/src/connectors/spacetimedb.ts
+++ b/templates/keynote-2/src/connectors/spacetimedb.ts
@@ -134,6 +134,7 @@ export function spacetimedb(
 
   return {
     name: 'spacetimedb',
+    maxInflightPerWorker: 16384,
 
     async open() {
       try {
@@ -178,14 +179,14 @@ export function spacetimedb(
       return worker;
     },
 
-    async reducer(fn: string, args: Record<string, any>) {
+    async call(fn: string, args: Record<string, any>) {
       await ready;
 
       switch (fn) {
         case 'seed': {
           conn.reducers.seed({
-            n: args.n,
-            initialBalance: args.initial_balance,
+            n: args.accounts,
+            initialBalance: args.initialBalance,
           });
           return;
         }
@@ -261,7 +262,7 @@ export function spacetimedb(
         return;
       }
 
-      let initial = BigInt(rawInitial);
+      const initial = BigInt(rawInitial);
 
       const accounts = conn.db?.accounts;
       if (!accounts) {

--- a/templates/keynote-2/src/core/connectors.ts
+++ b/templates/keynote-2/src/core/connectors.ts
@@ -8,6 +8,8 @@
   } | null>;
   verify(): Promise<void>;
 
+  maxInflightPerWorker?: number;
+
   createWorker?(opts: { index: number; total: number }): Promise<BaseConnector>;
 }
 
@@ -19,7 +21,7 @@ export interface SqlConnector extends BaseConnector {
 }
 
 export interface ReducerConnector extends BaseConnector {
-  reducer(name: string, args?: Record<string, any>): Promise<unknown>;
+  call(name: string, args?: Record<string, any>): Promise<unknown>;
 }
 
 export interface RpcConnector extends BaseConnector {

--- a/templates/keynote-2/src/scenario_recipes/reducer_single.ts
+++ b/templates/keynote-2/src/scenario_recipes/reducer_single.ts
@@ -1,14 +1,14 @@
 ﻿import type { ReducerConnector } from '../core/connectors';
 
 export async function reducer_single(
-  conn: unknown,
+  conn: ReducerConnector,
   from: number,
   to: number,
   amount: number,
 ): Promise<void> {
   if (from === to || amount <= 0) return;
 
-  await (conn as ReducerConnector).reducer('transfer', {
+  await conn.call('transfer', {
     from,
     to,
     amount: BigInt(amount),

--- a/templates/keynote-2/src/scenario_recipes/rpc_single_call.ts
+++ b/templates/keynote-2/src/scenario_recipes/rpc_single_call.ts
@@ -1,7 +1,7 @@
 ﻿import type { RpcConnector } from '../core/connectors';
 
 export async function rpc_single_call(
-  conn: unknown,
+  conn: RpcConnector,
   from: number,
   to: number,
   amount: number,


### PR DESCRIPTION
# Description of Changes

* Enable pipelining by default
  * Set defaults for `MAX_INFLIGHT_PER_WORKER` for spacetime and convex
* Add a warmup period
* Reduce allocations in sdk (not that much of an effect but still improved things)

This gives improved parity with the rust client on my machine.

# Expected complexity level and risk

1

# Testing

- [x] Yup:
    ```    ══════════════════════════════════════════════════════════════════════
      RESULTS
    ══════════════════════════════════════════════════════════════════════

      spacetimedb    ████████████████████████████████████████     80,617 TPS
      convex         █░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░        235 TPS

      ╔════════════════════════════════════════════════════════════╗
      ║                                                            ║
      ║       🚀 spacetimedb is 343x FASTER than convex! 🚀        ║
      ║                                                            ║
      ╚════════════════════════════════════════════════════════════╝
    ```
