### PR TITLE
fix index truncate edge cases

### DIFF
--- a/crates/commitlog/src/index/indexfile.rs
+++ b/crates/commitlog/src/index/indexfile.rs
@@ -512,7 +512,6 @@ mod tests {
         Ok(())
     }
 
-
     #[test]
     fn test_truncate_eddge_cases() -> Result<(), IndexError> {
         // index file with no entries


### PR DESCRIPTION
# Description of Changes
Index offset `truncate` methods returns `IndexError::KeyNotFound` when asked to truncate on empty index offset file or the key in input is smaller than the first entry.

This was causing `commitlog::reset_to` method to return error, and stuck replicas in re-spawn loop.

# API and ABI breaking changes
NA

# Expected complexity level and risk
1

# Testing
Added new tests to cover edge scenerios.