### PR TITLE
Fix typo in self-hosting docs: incorrect endpoint reference

### DIFF
--- a/docs/docs/00300-resources/00100-how-to/00100-deploy/00200-self-hosting.md
+++ b/docs/docs/00300-resources/00100-how-to/00100-deploy/00200-self-hosting.md
@@ -213,7 +213,7 @@ On your local machine, add this new server to your CLI config. Make sure to repl
 spacetime server add self-hosted --url https://example.com
 ```
 
-If you have uncommented the `/v1/publish` restriction in Step 3 then you won't be able to publish to this instance unless you copy your module to the host first and then publish. We recommend something like this:
+If you have kept the `location /` restriction enabled in Step 3 then you won't be able to publish to this instance unless you copy your module to the host first and then publish. We recommend something like this:
 
 ```bash
 spacetime build


### PR DESCRIPTION
Fixes issue #4496. The documentation referred to a non-existent /v1/publish endpoint in Step 3. The actual blocking is done by the location / block that only allows localhost access.

Changed the text to correctly reference the location / restriction instead of the incorrect /v1/publish endpoint.