### PR TITLE
Upgrade prompt is skipped when `-y` is passed

### DIFF
--- a/crates/cli/src/subcommands/publish.rs
+++ b/crates/cli/src/subcommands/publish.rs
@@ -246,13 +246,17 @@ fn confirm_and_clear(
     Ok(builder)
 }
 
-fn confirm_major_version_upgrade() -> Result<(), anyhow::Error> {
+fn confirm_major_version_upgrade(force: bool) -> Result<(), anyhow::Error> {
     println!(
         "It looks like you're trying to do a major version upgrade from 1.0 to 2.0. We recommend first looking at the upgrade notes before committing to this upgrade: https://spacetimedb.com/docs/upgrade"
     );
     println!();
     println!("WARNING: Once you publish you cannot revert back to version 1.0.");
     println!();
+
+    if force {
+        return Ok(());
+    }
 
     let mut input = String::new();
     print!("Please type 'upgrade' to accept this change: ");
@@ -671,7 +675,7 @@ async fn apply_pre_publish_if_needed(
             PrePublishResult::ManualMigrate(manual) => manual.major_version_upgrade,
         };
         if major_version_upgrade {
-            confirm_major_version_upgrade()?;
+            confirm_major_version_upgrade(force)?;
         }
 
         match pre {

--- a/crates/smoketests/src/lib.rs
+++ b/crates/smoketests/src/lib.rs
@@ -1015,7 +1015,7 @@ log = "0.4"
     }
 
     /// Publishes the module without passing `--yes`, so interactive prompts are not suppressed.
-    pub fn publish_module_named_no_yes(&mut self, name: &str) -> Result<String> {
+    pub fn publish_module_named_no_force(&mut self, name: &str) -> Result<String> {
         self.publish_module_internal(Some(name), false, false, false, None)
     }
 

--- a/crates/smoketests/src/lib.rs
+++ b/crates/smoketests/src/lib.rs
@@ -1003,19 +1003,25 @@ log = "0.4"
 
     /// Publishes the module with name, clear, and break_clients options.
     pub fn publish_module_with_options(&mut self, name: &str, clear: bool, break_clients: bool) -> Result<String> {
-        self.publish_module_internal(Some(name), clear, break_clients, None)
+        self.publish_module_internal(Some(name), clear, break_clients, true, None)
     }
 
     /// Publishes the module and allows supplying stdin input to the CLI.
     ///
     /// Useful for interactive publish prompts which require typed acknowledgements.
+    /// Note: does NOT pass `--yes` so that interactive prompts are not suppressed.
     pub fn publish_module_with_stdin(&mut self, name: &str, stdin_input: &str) -> Result<String> {
-        self.publish_module_internal(Some(name), false, false, Some(stdin_input))
+        self.publish_module_internal(Some(name), false, false, false, Some(stdin_input))
+    }
+
+    /// Publishes the module without passing `--yes`, so interactive prompts are not suppressed.
+    pub fn publish_module_named_no_yes(&mut self, name: &str) -> Result<String> {
+        self.publish_module_internal(Some(name), false, false, false, None)
     }
 
     /// Internal helper for publishing with options.
     fn publish_module_opts(&mut self, name: Option<&str>, clear: bool) -> Result<String> {
-        self.publish_module_internal(name, clear, false, None)
+        self.publish_module_internal(name, clear, false, true, None)
     }
 
     /// Internal helper for publishing with all options.
@@ -1024,6 +1030,7 @@ log = "0.4"
         name: Option<&str>,
         clear: bool,
         break_clients: bool,
+        force: bool,
         stdin_input: Option<&str>,
     ) -> Result<String> {
         let start = Instant::now();
@@ -1072,8 +1079,11 @@ log = "0.4"
             &self.server_url,
             "--bin-path",
             &wasm_path_str,
-            "--yes",
         ];
+
+        if force {
+            args.push("--yes");
+        }
 
         if clear {
             args.push("--clear-database");

--- a/crates/smoketests/src/lib.rs
+++ b/crates/smoketests/src/lib.rs
@@ -1073,13 +1073,7 @@ log = "0.4"
 
         // Now publish with --bin-path to skip rebuild
         let publish_start = Instant::now();
-        let mut args = vec![
-            "publish",
-            "--server",
-            &self.server_url,
-            "--bin-path",
-            &wasm_path_str,
-        ];
+        let mut args = vec!["publish", "--server", &self.server_url, "--bin-path", &wasm_path_str];
 
         if force {
             args.push("--yes");

--- a/crates/smoketests/tests/smoketests/publish_upgrade_prompt.rs
+++ b/crates/smoketests/tests/smoketests/publish_upgrade_prompt.rs
@@ -33,10 +33,31 @@ fn upgrade_prompt_on_publish() {
     // Switch back to source-built module, which uses current bindings.
     test.write_module_code(MODULE_CODE).unwrap();
 
-    let deny_err = test.publish_module_named(&db_name, false).unwrap_err().to_string();
+    let deny_err = test.publish_module_named_no_yes(&db_name).unwrap_err().to_string();
     assert!(deny_err.contains("major version upgrade from 1.0 to 2.0"));
     assert!(deny_err.contains("Please type 'upgrade' to accept this change:"));
 
     let accepted_identity = test.publish_module_with_stdin(&db_name, "upgrade\n").unwrap();
+    assert_eq!(accepted_identity, initial_identity);
+}
+
+#[test]
+fn upgrade_prompt_suppressed_by_yes_flag() {
+    let mut test = Smoketest::builder().autopublish(false).build();
+
+    let old_wasm = old_fixture_wasm();
+    assert!(old_wasm.exists(), "expected old fixture wasm at {}", old_wasm.display());
+
+    let db_name = format!("upgrade-smoke-yes-{}", random_string());
+
+    test.use_precompiled_wasm_path(&old_wasm).unwrap();
+    let initial_identity = test.publish_module_named(&db_name, false).unwrap();
+    assert_eq!(test.database_identity.as_deref(), Some(initial_identity.as_str()));
+
+    // Switch back to source-built module, which uses current bindings.
+    test.write_module_code(MODULE_CODE).unwrap();
+
+    // With --yes, the upgrade prompt should be suppressed and publish should succeed.
+    let accepted_identity = test.publish_module_named(&db_name, false).unwrap();
     assert_eq!(accepted_identity, initial_identity);
 }

--- a/crates/smoketests/tests/smoketests/publish_upgrade_prompt.rs
+++ b/crates/smoketests/tests/smoketests/publish_upgrade_prompt.rs
@@ -33,7 +33,7 @@ fn upgrade_prompt_on_publish() {
     // Switch back to source-built module, which uses current bindings.
     test.write_module_code(MODULE_CODE).unwrap();
 
-    let deny_err = test.publish_module_named_no_yes(&db_name).unwrap_err().to_string();
+    let deny_err = test.publish_module_named_no_force(&db_name).unwrap_err().to_string();
     assert!(deny_err.contains("major version upgrade from 1.0 to 2.0"));
     assert!(deny_err.contains("Please type 'upgrade' to accept this change:"));
 


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

This prompt is now skipped when `-y` is passed:

<img width="1053" height="530" alt="image" src="https://github.com/user-attachments/assets/7237df85-4a12-4ab7-b377-95abbd0084c2" />

# API and ABI breaking changes

None

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

1 - this just skips a prompt in the CLI

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

- [x] publish a 1.0 database to maincloud, then upgrade it to 2.0 and pass `-y`. You should no longer get the upgrade prompt.
- [x] publish a 1.0 database to maincloud, then upgrade it to 2.0 without passing `-y`. You should still get the upgrade prompt.
