### PR TITLE
[docs] Corrected `call` case and updated `out-dir` to match part 3

### DIFF
--- a/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00300-part-2.md
+++ b/docs/docs/00100-intro/00300-tutorials/00300-unity-tutorial/00300-part-2.md
@@ -526,7 +526,7 @@ Created new database with name: blackholio, identity: c200d2c69b4524292b91822afa
 Next, use the `spacetime` command to call our newly defined `Debug` reducer:
 
 ```sh
-spacetime call --server local blackholio Debug
+spacetime call --server local blackholio debug
 ```
 
 </TabItem>
@@ -655,10 +655,10 @@ Let's generate our types for our module. In the `blackholio/spacetimedb` directo
 </Tabs>
 
 ```sh
-spacetime generate --lang csharp --out-dir ../Assets/autogen
+spacetime generate --lang csharp --out-dir ../Assets/module_bindings
 ```
 
-This will generate a set of files in the `Assets/autogen` directory which contain the code generated types and reducer functions that are defined in your module, but usable on the client.
+This will generate a set of files in the `Assets/module_bindings` directory which contain the code generated types and reducer functions that are defined in your module, but usable on the client.
 
 ```
 ├── Reducers


### PR DESCRIPTION
# Description of Changes

Contains 2 changes to documentation:
* Updates Unity Client Blackholio tutorial, part 2, with a corrected `call` command. `Debug` became `debug` to match the automatic case conversion that now occurs. Originally found and reported by discord user `chrispavs`
*  Updates Unity Client Blackholio tutorial, part 2, with the `out-dir` path to match the path given in the [Entering the Game](https://spacetimedb.com/docs/tutorials/unity/part-3#entering-the-game) of `step 3`.

# API and ABI breaking changes

None

# Expected complexity level and risk

1 - Docs correction

# Testing

- [X] Tested all `blackholio` tutorial steps using C# server and Unity client