### PR TITLE
Fix a misprint in the self-hosting docs

### DIFF
--- a/docs/docs/00300-resources/00100-how-to/00100-deploy/00200-self-hosting.md
+++ b/docs/docs/00300-resources/00100-how-to/00100-deploy/00200-self-hosting.md
@@ -213,7 +213,7 @@ On your local machine, add this new server to your CLI config. Make sure to repl
 spacetime server add self-hosted --url https://example.com
 ```
 
-If you have uncommented the `/v1/publish` restriction in Step 3 then you won't be able to publish to this instance unless you copy your module to the host first and then publish. We recommend something like this:
+If you have `/` restriction uncommented in Step 3 then you won't be able to publish to this instance unless you copy your module to the host first and then publish. We recommend something like this:
 
 ```bash
 spacetime build


### PR DESCRIPTION
# Description of Changes

Closes https://github.com/clockworklabs/SpacetimeDB/issues/4496.

The docs refer to a block mentioning `/v1/publish` but we don't have such a block in our example config. What we actually have is:
```
    # Block all other routes explicitly. Only localhost can use these routes. If you want to open your
    # server up so that anyone can publish to it you should comment this section out.
    location / {
        allow 127.0.0.1;
        deny all;
    }
```

# API and ABI breaking changes

None.

# Expected complexity level and risk

1.

# Testing

None