### PR TITLE
Make `accessor` required for table-level index defs in typescript

### DIFF
--- a/crates/bindings-typescript/src/lib/indexes.ts
+++ b/crates/bindings-typescript/src/lib/indexes.ts
@@ -9,7 +9,7 @@ import type { ColumnIsUnique } from './constraints';
  * existing column names are referenced.
  */
 export type IndexOpts<AllowedCol extends string> = {
-  accessor?: string;
+  accessor: string;
   name?: string;
 } & (
   | { algorithm: 'btree'; columns: readonly AllowedCol[] }

--- a/crates/bindings-typescript/src/lib/schema.ts
+++ b/crates/bindings-typescript/src/lib/schema.ts
@@ -74,14 +74,14 @@ export function tablesToSchema<
   // `TablesToSchema<T>['tables']` is intentionally readonly in the public type,
   // but we need a mutable builder while materializing it from entries.
   type MutableTableDefs = {
-    -readonly [AccName in keyof TablesToSchema<T>['tables']]: TablesToSchema<
-      T
-    >['tables'][AccName];
+    -readonly [AccName in keyof TablesToSchema<T>['tables']]:
+      TablesToSchema<T>['tables'][AccName];
   };
   const tableDefs = Object.create(null) as MutableTableDefs;
-  for (const [accName, schema] of Object.entries(tables) as Array<
-    [keyof T & string, T[keyof T & string]]
-  >) {
+  for (const [accName, schema] of Object.entries(tables) as [
+    keyof T & string,
+    T[keyof T & string],
+  ][]) {
     tableDefs[accName] = tableToSchema(
       accName,
       schema,

--- a/crates/bindings-typescript/src/lib/schema.ts
+++ b/crates/bindings-typescript/src/lib/schema.ts
@@ -119,7 +119,9 @@ export function tableToSchema<
       }
 
       const columnIds =
-        idx.algorithm.tag === 'Direct' ? [idx.algorithm.value] : idx.algorithm.value;
+        idx.algorithm.tag === 'Direct'
+          ? [idx.algorithm.value]
+          : idx.algorithm.value;
 
       const unique = tableDef.constraints.some(
         c =>

--- a/crates/bindings-typescript/src/lib/schema.ts
+++ b/crates/bindings-typescript/src/lib/schema.ts
@@ -61,20 +61,36 @@ export interface TableToSchema<
   accessorName: AccName;
   columns: T['rowType']['row'];
   rowType: T['rowSpacetimeType'];
+  // Declarative user-provided table-level indexes.
   indexes: T['idxs'];
+  // Resolved runtime index metadata used by runtime consumers (e.g. TableCache).
+  resolvedIndexes: readonly UntypedIndex<keyof T['rowType']['row'] & string>[];
   constraints: T['constraints'];
 }
 
 export function tablesToSchema<
   const T extends Record<string, UntypedTableSchema>,
 >(ctx: ModuleContext, tables: T): TablesToSchema<T> {
+  // `TablesToSchema<T>['tables']` is intentionally readonly in the public type,
+  // but we need a mutable builder while materializing it from entries.
+  type MutableTableDefs = {
+    -readonly [AccName in keyof TablesToSchema<T>['tables']]: TablesToSchema<
+      T
+    >['tables'][AccName];
+  };
+  const tableDefs = Object.create(null) as MutableTableDefs;
+  for (const [accName, schema] of Object.entries(tables) as Array<
+    [keyof T & string, T[keyof T & string]]
+  >) {
+    tableDefs[accName] = tableToSchema(
+      accName,
+      schema,
+      schema.tableDef(ctx, accName)
+    ) as TablesToSchema<T>['tables'][typeof accName];
+  }
+
   return {
-    tables: Object.fromEntries(
-      Object.entries(tables).map(([accName, schema]) => [
-        accName,
-        tableToSchema(accName, schema, schema.tableDef(ctx, accName)),
-      ])
-    ) as TablesToSchema<T>['tables'],
+    tables: tableDefs as TablesToSchema<T>['tables'],
   };
 }
 
@@ -90,6 +106,44 @@ export function tableToSchema<
     schema.rowType.algebraicType.value.elements[i].name;
 
   type AllowedCol = keyof T['rowType']['row'] & string;
+  // Build fully-resolved runtime index metadata from the host-facing RawTableDef.
+  // This is intentionally separate from `schema.idxs`, which keeps the original
+  // user-declared `IndexOpts` shape for type-level inference.
+  const resolvedIndexes: UntypedIndex<AllowedCol>[] = tableDef.indexes.map(
+    idx => {
+      const accessorName = idx.accessorName;
+      if (typeof accessorName !== 'string' || accessorName.length === 0) {
+        throw new TypeError(
+          `Index '${idx.sourceName ?? '<unknown>'}' on table '${tableDef.sourceName}' is missing accessor name`
+        );
+      }
+
+      const columnIds =
+        idx.algorithm.tag === 'Direct' ? [idx.algorithm.value] : idx.algorithm.value;
+
+      const unique = tableDef.constraints.some(
+        c =>
+          c.data.tag === 'Unique' &&
+          c.data.value.columns.every(col => columnIds.includes(col))
+      );
+
+      const algorithm = (
+        {
+          BTree: 'btree',
+          Hash: 'hash',
+          Direct: 'direct',
+        } as const
+      )[idx.algorithm.tag];
+
+      return {
+        name: accessorName,
+        unique,
+        algorithm,
+        columns: columnIds.map(getColName) as AllowedCol[],
+      };
+    }
+  );
+
   return {
     // For client,`schama.tableName` will always be there as canonical name.
     // For module, if explicit name is not provided via `name`, accessor name will
@@ -98,29 +152,16 @@ export function tableToSchema<
     accessorName: accName,
     columns: schema.rowType.row, // typed as T[i]['rowType']['row'] under TablesToSchema<T>
     rowType: schema.rowSpacetimeType,
+    // Keep declarative indexes in their original shape for type-level consumers.
+    indexes: schema.idxs,
     constraints: tableDef.constraints.map(c => ({
       name: c.sourceName,
       constraint: 'unique',
       columns: c.data.value.columns.map(getColName) as [string],
     })),
-    // TODO: horrible horrible horrible. we smuggle this `Array<UntypedIndex>`
-    // by casting it to an `Array<IndexOpts>` as `TableToSchema` expects.
-    // This is then used in `TableCacheImpl.constructor` and who knows where else.
-    // We should stop lying about our types.
-    indexes: tableDef.indexes.map((idx): UntypedIndex<AllowedCol> => {
-      const columnIds =
-        idx.algorithm.tag === 'Direct'
-          ? [idx.algorithm.value]
-          : idx.algorithm.value;
-      return {
-        name: idx.accessorName!,
-        unique: tableDef.constraints.some(c =>
-          c.data.value.columns.every(col => columnIds.includes(col))
-        ),
-        algorithm: idx.algorithm.tag.toLowerCase() as 'btree',
-        columns: columnIds.map(getColName),
-      };
-    }) as T['idxs'],
+    // Expose resolved runtime indexes separately so runtime users don't have to
+    // reinterpret `indexes` with unsafe casts.
+    resolvedIndexes,
     tableDef,
     ...(tableDef.isEvent ? { isEvent: true } : {}),
   };

--- a/crates/bindings-typescript/src/lib/schema.ts
+++ b/crates/bindings-typescript/src/lib/schema.ts
@@ -74,8 +74,7 @@ export function tablesToSchema<
   // `TablesToSchema<T>['tables']` is intentionally readonly in the public type,
   // but we need a mutable builder while materializing it from entries.
   type MutableTableDefs = {
-    -readonly [AccName in keyof TablesToSchema<T>['tables']]:
-      TablesToSchema<T>['tables'][AccName];
+    -readonly [AccName in keyof TablesToSchema<T>['tables']]: TablesToSchema<T>['tables'][AccName];
   };
   const tableDefs = Object.create(null) as MutableTableDefs;
   for (const [accName, schema] of Object.entries(tables) as [

--- a/crates/bindings-typescript/src/lib/table.ts
+++ b/crates/bindings-typescript/src/lib/table.ts
@@ -399,7 +399,28 @@ export function table<Row extends RowObj, const Opts extends TableOpts<Row>>(
   }
 
   // convert explicit multi‑column indexes coming from options.indexes
+  const takenIndexAccessors = new Set(
+    indexes
+      .map(index => index.accessorName)
+      .filter((accessor): accessor is string => accessor !== undefined)
+  );
   for (const indexOpts of userIndexes ?? []) {
+    const accessor = indexOpts.accessor;
+    if (typeof accessor !== 'string' || accessor.length === 0) {
+      const tableLabel = name ?? '<unnamed>';
+      const indexLabel = indexOpts.name ?? '<unnamed>';
+      throw new TypeError(
+        `Index '${indexLabel}' on table '${tableLabel}' must define a non-empty 'accessor'`
+      );
+    }
+    if (takenIndexAccessors.has(accessor)) {
+      const tableLabel = name ?? '<unnamed>';
+      throw new TypeError(
+        `Duplicate index accessor '${accessor}' on table '${tableLabel}'`
+      );
+    }
+    takenIndexAccessors.add(accessor);
+
     let algorithm: RawIndexAlgorithm;
     switch (indexOpts.algorithm) {
       case 'btree':
@@ -418,16 +439,12 @@ export function table<Row extends RowObj, const Opts extends TableOpts<Row>>(
         algorithm = { tag: 'Direct', value: colIds.get(indexOpts.column)! };
         break;
     }
-    // unnamed indexes will be assigned a globally unique name
-    // The name users supply is actually the accessor name which will be used
-    // in TypeScript to access the index. This will be used verbatim.
-    // This is confusing because it is not the index name and there is
-    // no actual way for the user to set the actual index name.
-    // I think we should standardize: name and accessorName as the way to set
-    // the name and accessor name of an index across all SDKs.
+    // Unnamed indexes are assigned a globally unique source name.
+    // `accessor` controls the TypeScript property used to access the index.
+    // `name` (if present) is preserved as the canonical schema name.
     indexes.push({
       sourceName: undefined,
-      accessorName: indexOpts.accessor,
+      accessorName: accessor,
       algorithm,
       canonicalName: indexOpts.name,
     });

--- a/crates/bindings-typescript/src/lib/table.ts
+++ b/crates/bindings-typescript/src/lib/table.ts
@@ -17,6 +17,7 @@ import type {
   Indexes,
   IndexOpts,
   ReadonlyIndexes,
+  UntypedIndex,
 } from './indexes';
 import ScheduleAt from './schedule_at';
 import type { TableSchema } from './table_schema';
@@ -116,7 +117,25 @@ export type UntypedTableDef = {
   columns: Record<string, ColumnBuilder<any, any, ColumnMetadata<any>>>;
   // This is really just a ProductType where all the elements have names.
   rowType: RowBuilder<RowObj>['algebraicType']['value'];
+  /**
+   * Declarative multi-column indexes supplied by user code in `table({ indexes: [...] }, ...)`.
+   *
+   * This is intentionally the *declarative* shape (`IndexOpts`) because a lot of
+   * type-level behavior is derived from these entries (for example query-builder
+   * inference over composite indexes).
+   */
   indexes: readonly IndexOpts<any>[];
+  /**
+   * Fully-resolved runtime indexes materialized from `RawTableDefV10`.
+   *
+   * This contains both:
+   * 1) field-level indexes inferred from column metadata, and
+   * 2) explicit table-level indexes.
+   *
+   * Runtime consumers like `TableCacheImpl` should use this field instead of
+   * reinterpreting `indexes` as runtime index metadata.
+   */
+  resolvedIndexes: readonly UntypedIndex<any>[];
   constraints: readonly ConstraintOpts<any>[];
   tableDef: RawTableDefV10;
   isEvent?: boolean;
@@ -513,7 +532,9 @@ export function table<Row extends RowObj, const Opts extends TableOpts<Row>>(
         isEvent,
       };
     },
-    idxs: {} as OptsIndices<Opts>,
+    // Preserve the declared index options as runtime data so `tableToSchema`
+    // can expose them without type-smuggling.
+    idxs: userIndexes as OptsIndices<Opts>,
     constraints: constraints as OptsConstraints<Opts>,
     schedule,
   };

--- a/crates/bindings-typescript/src/lib/table.ts
+++ b/crates/bindings-typescript/src/lib/table.ts
@@ -418,11 +418,6 @@ export function table<Row extends RowObj, const Opts extends TableOpts<Row>>(
   }
 
   // convert explicit multi‑column indexes coming from options.indexes
-  const takenIndexAccessors = new Set(
-    indexes
-      .map(index => index.accessorName)
-      .filter((accessor): accessor is string => accessor !== undefined)
-  );
   for (const indexOpts of userIndexes ?? []) {
     const accessor = indexOpts.accessor;
     if (typeof accessor !== 'string' || accessor.length === 0) {
@@ -432,14 +427,6 @@ export function table<Row extends RowObj, const Opts extends TableOpts<Row>>(
         `Index '${indexLabel}' on table '${tableLabel}' must define a non-empty 'accessor'`
       );
     }
-    if (takenIndexAccessors.has(accessor)) {
-      const tableLabel = name ?? '<unnamed>';
-      throw new TypeError(
-        `Duplicate index accessor '${accessor}' on table '${tableLabel}'`
-      );
-    }
-    takenIndexAccessors.add(accessor);
-
     let algorithm: RawIndexAlgorithm;
     switch (indexOpts.algorithm) {
       case 'btree':
@@ -458,9 +445,16 @@ export function table<Row extends RowObj, const Opts extends TableOpts<Row>>(
         algorithm = { tag: 'Direct', value: colIds.get(indexOpts.column)! };
         break;
     }
+
     // Unnamed indexes are assigned a globally unique source name.
     // `accessor` controls the TypeScript property used to access the index.
     // `name` (if present) is preserved as the canonical schema name.
+    //
+    // IMPORTANT: we intentionally do not reject duplicate accessor names here.
+    // This preserves existing behavior for raw table definitions. Downstream
+    // runtime consumers decide how duplicates are resolved:
+    // - server runtime merges duplicate accessors onto one accessor object
+    // - client cache assignment is last-write-wins for duplicate accessors
     indexes.push({
       sourceName: undefined,
       accessorName: accessor,

--- a/crates/bindings-typescript/src/sdk/table_cache.ts
+++ b/crates/bindings-typescript/src/sdk/table_cache.ts
@@ -91,6 +91,9 @@ export class TableCacheImpl<
     //   field-level and explicit table-level indexes.
     for (const idxDef of this.tableDef.resolvedIndexes) {
       const index = this.#makeReadonlyIndex(this.tableDef, idxDef);
+      // IMPORTANT: for duplicate accessor names, client cache uses assignment
+      // semantics and later entries overwrite earlier ones. This matches prior
+      // behavior and is intentionally different from server runtime merge logic.
       (this as any)[idxDef.name] = index;
     }
   }

--- a/crates/bindings-typescript/src/sdk/table_cache.ts
+++ b/crates/bindings-typescript/src/sdk/table_cache.ts
@@ -12,7 +12,6 @@ import type {
   ReadonlyIndexes,
   ReadonlyRangedIndex,
   ReadonlyUniqueIndex,
-  UntypedIndex,
 } from '../lib/indexes.ts';
 import type { Bound } from '../server/range.ts';
 import type { Prettify } from '../lib/type_util.ts';
@@ -84,13 +83,13 @@ export class TableCacheImpl<
     this.tableDef = tableDef;
     this.rows = new Map();
     this.emitter = new EventEmitter();
-    // Build indexes
-    const indexesDef = this.tableDef.indexes || [];
-    for (const idx of indexesDef) {
-      // TODO: don't do this. See comment in `tableToSchema` in `schema.ts`
-      const idxDef = idx as UntypedIndex<
-        keyof TableDefForTableName<RemoteModule, TableName>['columns'] & string
-      >;
+    // Build index views from the resolved runtime index metadata.
+    //
+    // We intentionally use `resolvedIndexes` rather than `indexes`:
+    // - `indexes` is declarative table-level config (`IndexOpts`) used mainly for typing.
+    // - `resolvedIndexes` is the runtime shape (`UntypedIndex`) that includes both
+    //   field-level and explicit table-level indexes.
+    for (const idxDef of this.tableDef.resolvedIndexes) {
       const index = this.#makeReadonlyIndex(this.tableDef, idxDef);
       (this as any)[idxDef.name] = index;
     }
@@ -98,9 +97,10 @@ export class TableCacheImpl<
 
   // TODO: this just scans the whole table; we should build proper index structures
   #makeReadonlyIndex<
-    I extends UntypedIndex<
-      keyof TableDefForTableName<RemoteModule, TableName>['columns'] & string
-    >,
+    I extends TableDefForTableName<
+      RemoteModule,
+      TableName
+    >['resolvedIndexes'][number],
   >(
     tableDef: TableDefForTableName<RemoteModule, TableName>,
     idx: I

--- a/crates/bindings-typescript/src/server/runtime.ts
+++ b/crates/bindings-typescript/src/server/runtime.ts
@@ -516,12 +516,7 @@ function makeTableView(
   ) as Table<any>;
 
   for (const indexDef of table.indexes) {
-    const accessorName = indexDef.accessorName;
-    if (typeof accessorName !== 'string' || accessorName.length === 0) {
-      throw new TypeError(
-        `Index '${indexDef.sourceName ?? '<unknown>'}' on table '${table.sourceName}' is missing accessor name`
-      );
-    }
+    const accessorName = indexDef.accessorName!;
     const index_id = sys.index_id_from_name(indexDef.sourceName!);
 
     let column_ids: number[];
@@ -801,12 +796,13 @@ function makeTableView(
       } as RangedIndex<any, any>;
     }
 
+    // IMPORTANT: duplicate accessor handling.
+    // When multiple raw indexes share the same accessor name, we merge index
+    // methods onto a single accessor object instead of throwing.
     if (Object.hasOwn(tableView, accessorName)) {
-      throw new TypeError(
-        `Duplicate index accessor '${accessorName}' on table '${table.sourceName}'`
-      );
+      freeze(Object.assign((tableView as any)[accessorName], index));
     } else {
-      tableView[accessorName] = freeze(index) as any;
+      (tableView as any)[accessorName] = freeze(index);
     }
   }
 

--- a/crates/bindings-typescript/src/server/runtime.ts
+++ b/crates/bindings-typescript/src/server/runtime.ts
@@ -519,7 +519,7 @@ function makeTableView(
     const accessorName = indexDef.accessorName;
     if (typeof accessorName !== 'string' || accessorName.length === 0) {
       throw new TypeError(
-        `Index '${indexDef.sourceName ?? '<unknown>'}' on table '${table.accessorName}' is missing accessor name`
+        `Index '${indexDef.sourceName ?? '<unknown>'}' on table '${table.sourceName}' is missing accessor name`
       );
     }
     const index_id = sys.index_id_from_name(indexDef.sourceName!);
@@ -803,7 +803,7 @@ function makeTableView(
 
     if (Object.hasOwn(tableView, accessorName)) {
       throw new TypeError(
-        `Duplicate index accessor '${accessorName}' on table '${table.accessorName}'`
+        `Duplicate index accessor '${accessorName}' on table '${table.sourceName}'`
       );
     } else {
       tableView[accessorName] = freeze(index) as any;

--- a/crates/bindings-typescript/src/server/runtime.ts
+++ b/crates/bindings-typescript/src/server/runtime.ts
@@ -516,6 +516,12 @@ function makeTableView(
   ) as Table<any>;
 
   for (const indexDef of table.indexes) {
+    const accessorName = indexDef.accessorName;
+    if (typeof accessorName !== 'string' || accessorName.length === 0) {
+      throw new TypeError(
+        `Index '${indexDef.sourceName ?? '<unknown>'}' on table '${table.accessorName}' is missing accessor name`
+      );
+    }
     const index_id = sys.index_id_from_name(indexDef.sourceName!);
 
     let column_ids: number[];
@@ -795,10 +801,12 @@ function makeTableView(
       } as RangedIndex<any, any>;
     }
 
-    if (Object.hasOwn(tableView, indexDef.accessorName!)) {
-      freeze(Object.assign(tableView[indexDef.accessorName!], index));
+    if (Object.hasOwn(tableView, accessorName)) {
+      throw new TypeError(
+        `Duplicate index accessor '${accessorName}' on table '${table.accessorName}'`
+      );
     } else {
-      tableView[indexDef.accessorName!] = freeze(index) as any;
+      tableView[accessorName] = freeze(index) as any;
     }
   }
 

--- a/crates/bindings-typescript/src/server/schema.test-d.ts
+++ b/crates/bindings-typescript/src/server/schema.test-d.ts
@@ -60,3 +60,40 @@ spacetimedb.init(ctx => {
   // @ts-expect-error update() is NOT allowed on non-PK unique indexes
   const _update = ctx.db.person.name2.update;
 });
+
+/**
+ * Regression coverage for the declared-vs-resolved index split:
+ * - declared table-level indexes must still produce typed accessors
+ * - field-level indexes must still produce typed accessors
+ * - non-indexed fields must not accidentally become index accessors
+ */
+const account = table(
+  {
+    indexes: [
+      {
+        accessor: 'byEmailAndOrg',
+        algorithm: 'btree',
+        columns: ['email', 'orgId'] as const,
+      },
+    ] as const,
+  },
+  {
+    accountId: t.u32(),
+    email: t.string().index('hash'),
+    orgId: t.u32(),
+    nickname: t.string(),
+  }
+);
+
+const spacetimedbIndexSplit = schema({ account });
+
+spacetimedbIndexSplit.init(ctx => {
+  // Explicit table-level index accessor from `table({ indexes: [...] })`.
+  ctx.db.account.byEmailAndOrg.filter(['a@example.com', 1]);
+
+  // Field-level index accessor derived from column metadata.
+  ctx.db.account.email.filter('a@example.com');
+
+  // @ts-expect-error `nickname` is not indexed, so no index accessor should exist.
+  const _nickname = ctx.db.account.nickname;
+});

--- a/crates/bindings-typescript/src/server/view.test-d.ts
+++ b/crates/bindings-typescript/src/server/view.test-d.ts
@@ -7,6 +7,7 @@ const person = table(
     name: 'person',
     indexes: [
       {
+        accessor: 'name_id_idx',
         name: 'name_id_idx',
         algorithm: 'btree',
         columns: ['name', 'id'] as const,
@@ -48,6 +49,7 @@ const order = table(
     name: 'order',
     indexes: [
       {
+        accessor: 'id_person_id',
         name: 'id_person_id', // We are adding this to make sure `person_id` still isn't considered indexed.
         algorithm: 'btree',
         columns: ['id', 'person_id'] as const,

--- a/crates/bindings-typescript/test-app/src/module_bindings/index.ts
+++ b/crates/bindings-typescript/test-app/src/module_bindings/index.ts
@@ -50,7 +50,14 @@ const tablesSchema = __schema({
   player: __table(
     {
       name: 'player',
-      indexes: [{ name: 'id', algorithm: 'btree', columns: ['id'] }],
+      indexes: [
+        {
+          accessor: 'id',
+          name: 'player_id_idx_btree',
+          algorithm: 'btree',
+          columns: ['id'],
+        },
+      ],
       constraints: [
         { name: 'player_id_key', constraint: 'unique', columns: ['id'] },
       ],
@@ -60,7 +67,14 @@ const tablesSchema = __schema({
   unindexed_player: __table(
     {
       name: 'unindexed_player',
-      indexes: [{ name: 'id', algorithm: 'btree', columns: ['id'] }],
+      indexes: [
+        {
+          accessor: 'id',
+          name: 'unindexed_player_id_idx_btree',
+          algorithm: 'btree',
+          columns: ['id'],
+        },
+      ],
       constraints: [
         {
           name: 'unindexed_player_id_key',
@@ -75,7 +89,12 @@ const tablesSchema = __schema({
     {
       name: 'user',
       indexes: [
-        { name: 'identity', algorithm: 'btree', columns: ['identity'] },
+        {
+          accessor: 'identity',
+          name: 'user_identity_idx_btree',
+          algorithm: 'btree',
+          columns: ['identity'],
+        },
       ],
       constraints: [
         {

--- a/crates/bindings-typescript/test-react-router-app/src/module_bindings/index.ts
+++ b/crates/bindings-typescript/test-react-router-app/src/module_bindings/index.ts
@@ -51,7 +51,14 @@ const tablesSchema = __schema({
   counter: __table(
     {
       name: 'counter',
-      indexes: [{ name: 'id', algorithm: 'btree', columns: ['id'] }],
+      indexes: [
+        {
+          accessor: 'id',
+          name: 'counter_id_idx_btree',
+          algorithm: 'btree',
+          columns: ['id'],
+        },
+      ],
       constraints: [
         { name: 'counter_id_key', constraint: 'unique', columns: ['id'] },
       ],
@@ -62,7 +69,12 @@ const tablesSchema = __schema({
     {
       name: 'offline_user',
       indexes: [
-        { name: 'identity', algorithm: 'btree', columns: ['identity'] },
+        {
+          accessor: 'identity',
+          name: 'offline_user_identity_idx_btree',
+          algorithm: 'btree',
+          columns: ['identity'],
+        },
       ],
       constraints: [
         {
@@ -78,7 +90,12 @@ const tablesSchema = __schema({
     {
       name: 'user',
       indexes: [
-        { name: 'identity', algorithm: 'btree', columns: ['identity'] },
+        {
+          accessor: 'identity',
+          name: 'user_identity_idx_btree',
+          algorithm: 'btree',
+          columns: ['identity'],
+        },
       ],
       constraints: [
         {

--- a/crates/bindings-typescript/tests/query.test.ts
+++ b/crates/bindings-typescript/tests/query.test.ts
@@ -19,6 +19,7 @@ const personTable = table(
 
     indexes: [
       {
+        accessor: 'id_name_idx',
         name: 'id_name_idx',
         algorithm: 'btree',
         columns: ['id', 'name'] as const,
@@ -37,6 +38,7 @@ const ordersTable = table(
     name: 'orders',
     indexes: [
       {
+        accessor: 'orders_person_id_idx',
         name: 'orders_person_id_idx',
         algorithm: 'btree',
         columns: ['person_id'],

--- a/crates/bindings-typescript/tests/schema_index_resolution.test.ts
+++ b/crates/bindings-typescript/tests/schema_index_resolution.test.ts
@@ -1,0 +1,78 @@
+import { describe, expect, it } from 'vitest';
+import { ModuleContext, tablesToSchema } from '../src/lib/schema';
+import { table } from '../src/lib/table';
+import { t } from '../src/lib/type_builders';
+
+describe('schema index resolution', () => {
+  it('keeps declarative index options separate from resolved runtime indexes', () => {
+    /**
+     * Why this test exists:
+     * We intentionally model two different index representations:
+     * 1) `indexes`: declarative table-level options as authored by the user
+     * 2) `resolvedIndexes`: runtime-ready index metadata derived from RawTableDef
+     *
+     * The rewrite is correct only if:
+     * - `indexes` still preserves the original declaration shape for type inference.
+     * - `resolvedIndexes` includes every runtime index (field-level + table-level).
+     */
+    const player = table(
+      {
+        name: 'player',
+        indexes: [
+          {
+            accessor: 'byTeamAndLevel',
+            algorithm: 'btree',
+            columns: ['team', 'level'] as const,
+          },
+        ] as const,
+      },
+      {
+        // Field-level index declared on metadata.
+        displayName: t.string().index('hash'),
+        team: t.string(),
+        level: t.u32(),
+      }
+    );
+
+    const schemaDef = tablesToSchema(new ModuleContext(), { player });
+    const playerDef = schemaDef.tables.player;
+
+    /**
+     * `indexes` should remain the declarative shape from `table({ indexes: ... })`.
+     * This drives type-level behavior, so it must not be replaced with resolved
+     * runtime metadata.
+     */
+    expect(playerDef.indexes).toEqual([
+      {
+        accessor: 'byTeamAndLevel',
+        algorithm: 'btree',
+        columns: ['team', 'level'],
+      },
+    ]);
+
+    /**
+     * `resolvedIndexes` should contain:
+     * - the field-level index derived from `displayName.index('hash')`, and
+     * - the explicit table-level index `byTeamAndLevel`.
+     *
+     * Runtime consumers (e.g. TableCache) use this field because it is the
+     * normalized shape with resolved algorithms, names, and column lists.
+     */
+    expect(playerDef.resolvedIndexes).toEqual(
+      expect.arrayContaining([
+        {
+          name: 'displayName',
+          unique: false,
+          algorithm: 'hash',
+          columns: ['displayName'],
+        },
+        {
+          name: 'byTeamAndLevel',
+          unique: false,
+          algorithm: 'btree',
+          columns: ['team', 'level'],
+        },
+      ])
+    );
+  });
+});

--- a/crates/bindings-typescript/tests/table_cache_resolved_indexes.test.ts
+++ b/crates/bindings-typescript/tests/table_cache_resolved_indexes.test.ts
@@ -1,0 +1,71 @@
+import { describe, expect, it } from 'vitest';
+import { ModuleContext, tablesToSchema } from '../src/lib/schema';
+import { table } from '../src/lib/table';
+import { TableCacheImpl } from '../src/sdk/table_cache';
+import { t } from '../src/lib/type_builders';
+
+describe('table cache resolved indexes', () => {
+  it('builds index accessors from resolvedIndexes (field-level + table-level)', () => {
+    /**
+     * Why this test exists:
+     * `TableCacheImpl` previously consumed `table.indexes` and re-cast it into a
+     * runtime shape. After the refactor, runtime index construction must come
+     * from `table.resolvedIndexes` instead.
+     *
+     * This test validates the observable contract:
+     * - field-level indexes still materialize as cache accessors
+     * - explicit table-level indexes still materialize as cache accessors
+     * - both accessors execute correctly against cached rows
+     */
+    const player = table(
+      {
+        name: 'player',
+        indexes: [
+          {
+            accessor: 'byTeamAndLevel',
+            algorithm: 'btree',
+            columns: ['team', 'level'] as const,
+          },
+        ] as const,
+      },
+      {
+        // Field-level index.
+        email: t.string().index('btree'),
+        team: t.string(),
+        level: t.u32(),
+      }
+    );
+
+    const schemaDef = tablesToSchema(new ModuleContext(), { player });
+    const playerDef = schemaDef.tables.player;
+    const tableCache = new TableCacheImpl<any, string>(playerDef as any);
+
+    const rows = [
+      { email: 'a@example.com', team: 'red', level: 1 },
+      { email: 'b@example.com', team: 'blue', level: 2 },
+      { email: 'c@example.com', team: 'red', level: 3 },
+    ];
+
+    const callbacks = tableCache.applyOperations(
+      rows.map(row => ({
+        type: 'insert' as const,
+        // This table has no primary key, so any stable row id is acceptable for this test.
+        rowId: row.email,
+        row,
+      })),
+      {}
+    );
+    callbacks.forEach(cb => cb.cb());
+
+    const emailIndex = (tableCache as any).email;
+    const byTeamAndLevel = (tableCache as any).byTeamAndLevel;
+
+    // The field-level accessor must exist and support point lookup semantics.
+    expect(typeof emailIndex?.filter).toBe('function');
+    expect(Array.from(emailIndex.filter('a@example.com'))).toEqual([rows[0]]);
+
+    // The explicit table-level accessor must exist and support tuple filtering.
+    expect(typeof byTeamAndLevel?.filter).toBe('function');
+    expect(Array.from(byTeamAndLevel.filter(['red', 1]))).toEqual([rows[0]]);
+  });
+});

--- a/crates/bindings-typescript/tests/table_index_accessor.test.ts
+++ b/crates/bindings-typescript/tests/table_index_accessor.test.ts
@@ -24,30 +24,40 @@ describe('table index accessors', () => {
     ).toThrowError("must define a non-empty 'accessor'");
   });
 
-  it('throws when explicit indexes reuse an accessor', () => {
-    expect(() =>
-      table(
-        {
-          name: 'person',
-          indexes: [
-            {
-              accessor: 'dup',
-              algorithm: 'btree',
-              columns: ['id'] as const,
-            },
-            {
-              accessor: 'dup',
-              algorithm: 'hash',
-              columns: ['email'] as const,
-            },
-          ] as const,
-        },
-        {
-          id: t.identity(),
-          email: t.string(),
-        }
-      )
-    ).toThrowError("Duplicate index accessor 'dup'");
+  it('allows duplicate explicit index accessors in raw table definitions', () => {
+    /**
+     * table() does not reject duplicate explicit accessor names at definition
+     * time. Runtime table view construction handles duplicate accessors by
+     * merging methods onto a single accessor object.
+     */
+    const tableSchema = table(
+      {
+        name: 'person',
+        indexes: [
+          {
+            accessor: 'dup',
+            algorithm: 'btree',
+            columns: ['id'] as const,
+          },
+          {
+            accessor: 'dup',
+            algorithm: 'hash',
+            columns: ['email'] as const,
+          },
+        ] as const,
+      },
+      {
+        id: t.identity(),
+        email: t.string(),
+      }
+    );
+
+    const rawTableDef = tableSchema.tableDef(new ModuleContext(), 'person');
+    expect(rawTableDef.indexes).toHaveLength(2);
+    expect(rawTableDef.indexes.map(index => index.accessorName)).toEqual([
+      'dup',
+      'dup',
+    ]);
   });
 
   it('accepts an explicit accessor for table-level indexes', () => {
@@ -85,5 +95,52 @@ describe('table index accessors', () => {
     const rawTableDef = tableSchema.tableDef(new ModuleContext(), 'person');
     expect(rawTableDef.indexes).toHaveLength(1);
     expect(rawTableDef.indexes[0].accessorName).toBe('displayName');
+  });
+
+  it('keeps both implicit and explicit index entries when accessors match', () => {
+    /**
+     * Generated client bindings can include an explicit table-level index entry
+     * for the same logical index that is already inferred from field metadata
+     * (e.g. primaryKey implies an implicit index). This should not fail as a
+     * duplicate accessor when the definitions are equivalent.
+     */
+    const tableSchema = table(
+      {
+        name: 'player',
+        indexes: [
+          {
+            accessor: 'id',
+            name: 'player_id_idx_btree',
+            algorithm: 'btree',
+            columns: ['id'] as const,
+          },
+        ] as const,
+      },
+      {
+        id: t.u32().primaryKey(),
+      }
+    );
+
+    const ctx = new ModuleContext();
+    const rawTableDef = tableSchema.tableDef(ctx, 'player');
+
+    // Raw schema keeps both entries; runtime accessor construction merges by
+    // accessor name.
+    expect(rawTableDef.indexes).toHaveLength(2);
+    expect(rawTableDef.indexes.map(index => index.accessorName)).toEqual([
+      'id',
+      'id',
+    ]);
+
+    // The explicit canonical name should still be preserved in explicit names.
+    expect(ctx.moduleDef.explicitNames.entries).toEqual([
+      {
+        tag: 'Index',
+        value: {
+          sourceName: 'player_id_idx_btree',
+          canonicalName: 'player_id_idx_btree',
+        },
+      },
+    ]);
   });
 });

--- a/crates/bindings-typescript/tests/table_index_accessor.test.ts
+++ b/crates/bindings-typescript/tests/table_index_accessor.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it } from 'vitest';
+import { ModuleContext } from '../src/lib/schema';
+import { table } from '../src/lib/table';
+import { t } from '../src/lib/type_builders';
+
+describe('table index accessors', () => {
+  it('throws when an explicit index is missing accessor', () => {
+    expect(() =>
+      table(
+        {
+          name: 'person',
+          indexes: [
+            {
+              name: 'id_idx',
+              algorithm: 'btree',
+              columns: ['id'] as const,
+            } as any,
+          ] as const,
+        },
+        {
+          id: t.identity(),
+        }
+      )
+    ).toThrowError("must define a non-empty 'accessor'");
+  });
+
+  it('throws when explicit indexes reuse an accessor', () => {
+    expect(() =>
+      table(
+        {
+          name: 'person',
+          indexes: [
+            {
+              accessor: 'dup',
+              algorithm: 'btree',
+              columns: ['id'] as const,
+            },
+            {
+              accessor: 'dup',
+              algorithm: 'hash',
+              columns: ['email'] as const,
+            },
+          ] as const,
+        },
+        {
+          id: t.identity(),
+          email: t.string(),
+        }
+      )
+    ).toThrowError("Duplicate index accessor 'dup'");
+  });
+
+  it('accepts an explicit accessor for table-level indexes', () => {
+    const tableSchema = table(
+      {
+        name: 'person',
+        indexes: [
+          {
+            accessor: 'byName',
+            algorithm: 'btree',
+            columns: ['name'] as const,
+          },
+        ] as const,
+      },
+      {
+        name: t.string(),
+      }
+    );
+
+    const rawTableDef = tableSchema.tableDef(new ModuleContext(), 'person');
+    expect(rawTableDef.indexes).toHaveLength(1);
+    expect(rawTableDef.indexes[0].accessorName).toBe('byName');
+  });
+
+  it('derives accessor from the field name for field-level indexes', () => {
+    const tableSchema = table(
+      {
+        name: 'person',
+      },
+      {
+        displayName: t.string().index('btree'),
+      }
+    );
+
+    const rawTableDef = tableSchema.tableDef(new ModuleContext(), 'person');
+    expect(rawTableDef.indexes).toHaveLength(1);
+    expect(rawTableDef.indexes[0].accessorName).toBe('displayName');
+  });
+});

--- a/crates/codegen/src/typescript.rs
+++ b/crates/codegen/src/typescript.rs
@@ -39,7 +39,12 @@ impl Lang for TypeScript {
     /// table({
     ///   name: 'player',
     ///   indexes: [
-    ///     { name: 'this_is_an_index', algorithm: "btree", columns: [ "ownerId" ] }
+    ///     {
+    ///       accessor: 'this_is_an_index',
+    ///       name: 'this_is_an_index',
+    ///       algorithm: "btree",
+    ///       columns: [ "ownerId" ],
+    ///     }
     ///   ],
     /// }, t.row({
     ///   id: t.u32().primaryKey(),
@@ -651,18 +656,12 @@ fn write_table_opts<'a>(
             let name_camel = field_name.deref().to_case(Case::Camel);
             (name_camel, field_type)
         };
-        // TODO(cloutiertyler):
-        // The name users supply is actually the accessor name which will be used
-        // in TypeScript to access the index. This will be used verbatim.
-        // This is confusing because it is not the index name and there is
-        // no actual way for the user to set the actual index name.
-        // I think we should standardize: name and accessorName as the way to set
-        // the name and accessor name of an index across all SDKs.
-        if let Some(accessor_name) = &index_def.accessor_name {
-            writeln!(out, "{{ name: '{}', algorithm: 'btree', columns: [", accessor_name);
-        } else {
-            writeln!(out, "{{ name: '{}', algorithm: 'btree', columns: [", index_def.name);
-        }
+        let accessor_name = index_def.accessor_name.as_deref().unwrap_or(&index_def.name);
+        writeln!(
+            out,
+            "{{ accessor: '{}', name: '{}', algorithm: 'btree', columns: [",
+            accessor_name, index_def.name
+        );
         out.indent(1);
         for col_id in columns.iter() {
             writeln!(out, "'{}',", get_name_and_type(col_id).0);

--- a/crates/codegen/tests/snapshots/codegen__codegen_typescript.snap
+++ b/crates/codegen/tests/snapshots/codegen__codegen_typescript.snap
@@ -1,5 +1,6 @@
 ---
 source: crates/codegen/tests/codegen.rs
+assertion_line: 37
 expression: outfiles
 ---
 "add_player_reducer.ts" = '''
@@ -190,13 +191,13 @@ const tablesSchema = __schema({
   logged_out_player: __table({
     name: 'logged_out_player',
     indexes: [
-      { name: 'identity', algorithm: 'btree', columns: [
+      { accessor: 'identity', name: 'logged_out_player_identity_idx_btree', algorithm: 'btree', columns: [
         'identity',
       ] },
-      { name: 'name', algorithm: 'btree', columns: [
+      { accessor: 'name', name: 'logged_out_player_name_idx_btree', algorithm: 'btree', columns: [
         'name',
       ] },
-      { name: 'player_id', algorithm: 'btree', columns: [
+      { accessor: 'player_id', name: 'logged_out_player_player_id_idx_btree', algorithm: 'btree', columns: [
         'playerId',
       ] },
     ],
@@ -209,10 +210,10 @@ const tablesSchema = __schema({
   person: __table({
     name: 'person',
     indexes: [
-      { name: 'age', algorithm: 'btree', columns: [
+      { accessor: 'age', name: 'person_age_idx_btree', algorithm: 'btree', columns: [
         'age',
       ] },
-      { name: 'id', algorithm: 'btree', columns: [
+      { accessor: 'id', name: 'person_id_idx_btree', algorithm: 'btree', columns: [
         'id',
       ] },
     ],
@@ -223,13 +224,13 @@ const tablesSchema = __schema({
   player: __table({
     name: 'player',
     indexes: [
-      { name: 'identity', algorithm: 'btree', columns: [
+      { accessor: 'identity', name: 'player_identity_idx_btree', algorithm: 'btree', columns: [
         'identity',
       ] },
-      { name: 'name', algorithm: 'btree', columns: [
+      { accessor: 'name', name: 'player_name_idx_btree', algorithm: 'btree', columns: [
         'name',
       ] },
-      { name: 'player_id', algorithm: 'btree', columns: [
+      { accessor: 'player_id', name: 'player_player_id_idx_btree', algorithm: 'btree', columns: [
         'playerId',
       ] },
     ],

--- a/templates/chat-react-ts/src/module_bindings/index.ts
+++ b/templates/chat-react-ts/src/module_bindings/index.ts
@@ -59,7 +59,12 @@ const tablesSchema = __schema({
     {
       name: 'user',
       indexes: [
-        { name: 'identity', algorithm: 'btree', columns: ['identity'] },
+        {
+          accessor: 'identity',
+          name: 'identity',
+          algorithm: 'btree',
+          columns: ['identity'],
+        },
       ],
       constraints: [
         {

--- a/templates/chat-react-ts/src/module_bindings/index.ts
+++ b/templates/chat-react-ts/src/module_bindings/index.ts
@@ -61,7 +61,7 @@ const tablesSchema = __schema({
       indexes: [
         {
           accessor: 'identity',
-          name: 'identity',
+          name: 'user_identity_idx_btree',
           algorithm: 'btree',
           columns: ['identity'],
         },


### PR DESCRIPTION
# Description of Changes

This patch contains two main changes:

1. It makes `accessor` a required argument for table-level index defs in typescript to align with rust.

2. It removes unsound index typing in the TypeScript bindings by splitting index data into two explicit representations:

    - `indexes`: declarative user config (`IndexOpts`) used for type inference
    - `resolvedIndexes`: normalized runtime metadata (`UntypedIndex`) derived from `RawTableDefV10`

    `TableCacheImpl` now builds index accessors from `resolvedIndexes` instead of re-casting `indexes` at runtime.

    This addressed the following comment:
    ```
    // TODO: horrible horrible horrible. we smuggle this `Array<UntypedIndex>`
    // by casting it to an `Array<IndexOpts>` as `TableToSchema` expects.
    // This is then used in `TableCacheImpl.constructor` and who knows where else.
    // We should stop lying about our types.
    ```

    > Why?

    We were conflating two different concepts under `tableDef.indexes`:

      1. declared table-level index options authored by users
      2. resolved runtime index definitions (including field-level inferred indexes)

    This required unsafe casts (`T['idxs']` / `UntypedIndex`) and made the type model unsound.

Note, (2) was largely ai assisted.

# API and ABI breaking changes

Technically breaks the module api, although I believe this is the behavior that is outlined in the spec, and so the current behavior should really be considered a bug.

# Expected complexity level and risk

2

# Testing

Added unit tests covering the following:
1. Table-level explicit index without accessor throws.
2. Table-level duplicate accessor throws.
3. Table-level explicit accessor is accepted and used.
4. Field-level `.index(...)` derives accessor from the field name (`displayName`).
