### PR TITLE
Fix 'unsafe attr without unsafe' error

### DIFF
--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -343,7 +343,7 @@ pub fn settings(args: StdTokenStream, item: StdTokenStream) -> StdTokenStream {
             #item
 
             const _: () = {
-                #[export_name = #register_symbol]
+                #[unsafe(export_name = #register_symbol)]
                 extern "C" fn __register_setting() {
                     #register_call
                 }

--- a/modules/module-test/src/lib.rs
+++ b/modules/module-test/src/lib.rs
@@ -4,7 +4,8 @@ use std::time::Duration;
 use spacetimedb::spacetimedb_lib::db::raw_def::v9::TableAccess;
 use spacetimedb::spacetimedb_lib::{self, bsatn};
 use spacetimedb::{
-    duration, table, ConnectionId, Deserialize, Identity, ReducerContext, SpacetimeType, Table, Timestamp, ViewContext,
+    duration, table, CaseConversionPolicy, ConnectionId, Deserialize, Identity, ReducerContext, SpacetimeType, Table,
+    Timestamp, ViewContext,
 };
 use spacetimedb::{log, ProcedureContext};
 
@@ -512,3 +513,6 @@ fn get_my_schema_via_http(ctx: &mut ProcedureContext) -> String {
         Err(e) => format!("{e}"),
     }
 }
+
+#[spacetimedb::settings]
+const CASE_CONVERSION_POLICY: CaseConversionPolicy = CaseConversionPolicy::SnakeCase;


### PR DESCRIPTION
# Description of Changes

Followup to #3802; was causing issues in modules in private. Rust 2024 now requires `unsafe()` around certain attributes, but the `settings` macro was added after I first opened that PR, so I didn't wrap it. Additionally, `settings` wasn't tested in this repo, so it wasn't caught.

# Expected complexity level and risk

1

# Testing

- [x] Added use of `#[spacetimedb::settings]` in `module-test`
