### PR TITLE
Don't put invalid `Cargo.toml` files in our repo

### DIFF
--- a/tools/xtask-llm-benchmark/src/bench/templates.rs
+++ b/tools/xtask-llm-benchmark/src/bench/templates.rs
@@ -133,7 +133,10 @@ fn inject_rust(root: &Path, llm_code: &str) -> anyhow::Result<()> {
     let replacement = format!(r#"{{ path = "{}" }}"#, relative);
     let cargo_toml = root.join("Cargo.toml");
     let mut toml = fs::read_to_string(&cargo_toml).with_context(|| format!("read {}", cargo_toml.display()))?;
-    toml = toml.replace("{SPACETIME_RUST_SDK_PATH}", &replacement);
+    toml = toml.replace(
+        "spacetimedb = { path = \"../../../../../../sdks/rust/\" }",
+        &replacement,
+    );
     fs::write(&cargo_toml, toml).with_context(|| format!("write {}", cargo_toml.display()))?;
     Ok(())
 }

--- a/tools/xtask-llm-benchmark/src/templates/rust/server/Cargo.toml
+++ b/tools/xtask-llm-benchmark/src/templates/rust/server/Cargo.toml
@@ -9,5 +9,5 @@ edition = "2021"
 crate-type = ["cdylib"]
 
 [dependencies]
-spacetimedb = {SPACETIME_RUST_SDK_PATH}
+spacetimedb = { path = "../../../../../../sdks/rust/" }
 log = "0.4"


### PR DESCRIPTION
# Description of Changes

Our flake.nix relies on Crane, which begins by scanning the repo for `Cargo.toml` files in order to pre-compute the full set of dependencies in order to record them in the Nix store. A previous PR, #4413, introduced a `Cargo.toml` which was intentionally invalid to our repository, with a script that modified it as part of a test. This `Cargo.toml` was excluded from our workspace, but unfortunately, Crane's `buildDepsOnly` doesn't respect the workspace, and just searches the whole repository. I consider this a bug in Crane, but in the interest of doing useful work on SpacetimeDB in the near future rather than spending hours hacking on my build script, this commit changes the `Cargo.toml` in question to be valid at rest, so that Crane doesn't get angry due to failing to parse it.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

- [x] `nix build` and `nix develop` work locally.
- [ ] @bradleyshep should please run `cargo llm run` to his satisfaction to verify that I haven't broken it.
