### PR TITLE
CI - Reduce when package job runs

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -4,8 +4,6 @@ on:
   push:
     tags:
       - '**'
-    branches:
-      - release/*
   workflow_dispatch:
 
 permissions:


### PR DESCRIPTION
# Description of Changes

We run the "package CLI" job for every `master` commit, but I think we basically never use those. Instead I added the work flow dispatch option which can run as a one off if needed. (I didn't test it, but now that it's added, we'll be able to fix it in a PR if needed).

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None