### PR TITLE
gitignore `*.local` files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -264,3 +264,6 @@ nul
 # AI agent config
 .codex
 .claude
+
+# Any local file
+*.local


### PR DESCRIPTION
# Description of Changes

Just ignoring `*.local` so that I can commit e.g. custom shell configs.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

1

# Testing

My `.fishrc.local` is no longer picked up :shrug: 