### PR TITLE
Fix typos in comments and doc comments across crates

### DIFF
--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -760,7 +760,7 @@ pub use spacetimedb_bindings_macro::reducer;
 // TODO(procedure-transaction): document obtaining and using a transaction within a procedure.
 ///
 /// # Scheduled procedures
-// TODO(docs): after moving scheduled reducer docs into table secion, link there.
+// TODO(docs): after moving scheduled reducer docs into table section, link there.
 ///
 /// Like [reducer]s, procedures can be made **scheduled**.
 /// This allows calling procedures at a particular time, or in a loop.

--- a/crates/lib/src/http.rs
+++ b/crates/lib/src/http.rs
@@ -128,7 +128,7 @@ impl Headers {
     /// The sum of the lengths of all the header names and header values.
     ///
     /// For headers with multiple values for the same header name,
-    /// the length of the header name is counted once for each occurence.
+    /// the length of the header name is counted once for each occurrence.
     fn size_in_bytes(&self) -> usize {
         self.entries
             .iter()

--- a/crates/sats/src/ser.rs
+++ b/crates/sats/src/ser.rs
@@ -277,7 +277,7 @@ pub trait Serializer: Sized {
 /// See the documentation of `serde::Serialize` for more information of the data model.
 ///
 /// Do not manually implement this trait unless you know what you are doing.
-/// Implementations must be consistent with `Deerialize<'de> for T`, `SpacetimeType for T` and `Serialize, Deserialize for AlgebraicValue`.
+/// Implementations must be consistent with `Deserialize<'de> for T`, `SpacetimeType for T` and `Serialize, Deserialize for AlgebraicValue`.
 /// Implementations that are inconsistent across these traits may result in data loss.
 ///
 /// [`serde`]: https://crates.io/crates/serde

--- a/crates/sats/src/typespace.rs
+++ b/crates/sats/src/typespace.rs
@@ -300,7 +300,7 @@ pub trait GroundSpacetimeType {
 /// (Storing collections in rows of a database table is a form of [denormalization](https://en.wikipedia.org/wiki/Denormalization).)
 ///
 /// Do not manually implement this trait unless you are VERY sure you know what you're doing.
-/// Implementations must be consistent with `Deerialize<'de> for T`, `Serialize for T` and `Serialize, Deserialize for AlgebraicValue`.
+/// Implementations must be consistent with `Deserialize<'de> for T`, `Serialize for T` and `Serialize, Deserialize for AlgebraicValue`.
 /// Implementations that are inconsistent across these traits may result in data loss.
 ///
 /// N.B.: It's `SpacetimeType`, not `SpaceTimeType`.

--- a/crates/schema/tests/ensure_same_schema.rs
+++ b/crates/schema/tests/ensure_same_schema.rs
@@ -18,7 +18,7 @@ fn assert_identical_modules(module_name_prefix: &str, lang_name: &str, suffix: &
         .steps;
 
     // In any migration plan, all `RowLevelSecurityDef`s are ALWAYS removed and
-    // re-added to ensure the core engine reinintializes the policies.
+    // re-added to ensure the core engine reinitializes the policies.
     // This is slightly silly (and arguably should be hidden inside `core`),
     // but for now, we just ignore these steps and manually compare the `RowLevelSecurityDef`s.
     diff.retain(|step| {

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -457,7 +457,7 @@ impl Table {
         self.validate_row_type_layout(&new_row_layout, new_columns)
             .map_err(|e| make_err(e.reason.into()))?;
 
-        // Validate that all new columns have default values and thier types match.
+        // Validate that all new columns have default values and their types match.
         for (idx, new_col) in new_columns.iter().skip(existing_columns.len()).enumerate() {
             let default_value = default_values
                 .get(idx)


### PR DESCRIPTION
## Summary
- Fix `Deerialize` → `Deserialize` in doc comments for `ser.rs` and `typespace.rs` (these are in developer-facing trait documentation)
- Fix `thier` → `their`, `reinintializes` → `reinitializes`, `occurence` → `occurrence`, `secion` → `section` across 4 other crates

## Details
Six typo fixes across 6 files, no logic changes:

| File | Typo | Fix |
|------|------|-----|
| `crates/sats/src/ser.rs:280` | `Deerialize` | `Deserialize` |
| `crates/sats/src/typespace.rs:303` | `Deerialize` | `Deserialize` |
| `crates/table/src/table.rs:460` | `thier` | `their` |
| `crates/schema/tests/ensure_same_schema.rs:21` | `reinintializes` | `reinitializes` |
| `crates/lib/src/http.rs:131` | `occurence` | `occurrence` |
| `crates/bindings/src/lib.rs:763` | `secion` | `section` |

## Test plan
- [ ] No logic changes — comments and doc comments only
- [ ] CI should pass without issues

