### PR TITLE
Remove broken `generate` command from templates

### DIFF
--- a/templates/angular-ts/package.json
+++ b/templates/angular-ts/package.json
@@ -6,7 +6,6 @@
   "scripts": {
     "dev": "node scripts/dev.mjs",
     "build": "ng build",
-    "generate": "cargo run -p gen-bindings -- --out-dir src/module_bindings --module-path spacetimedb && prettier --write src/module_bindings",
     "spacetime:generate": "spacetime generate --lang typescript --out-dir src/module_bindings --project-path spacetimedb",
     "spacetime:publish:local": "spacetime publish --project-path spacetimedb --server local",
     "spacetime:publish": "spacetime publish --project-path spacetimedb --server maincloud"

--- a/templates/chat-react-ts/package.json
+++ b/templates/chat-react-ts/package.json
@@ -10,7 +10,6 @@
     "lint": "eslint . && prettier . --check --ignore-path ../../.prettierignore",
     "preview": "vite preview",
     "test": "vitest run",
-    "generate": "cargo run -p gen-bindings -- --out-dir src/module_bindings --module-path spacetimedb && prettier --write src/module_bindings",
     "spacetime:generate": "spacetime generate --lang typescript --out-dir src/module_bindings --module-path spacetimedb",
     "spacetime:publish:local": "spacetime publish --module-path server --server local",
     "spacetime:publish": "spacetime publish --module-path server --server maincloud"

--- a/templates/nextjs-ts/package.json
+++ b/templates/nextjs-ts/package.json
@@ -8,7 +8,6 @@
     "build": "next build",
     "start": "next start",
     "lint": "next lint",
-    "generate": "pnpm --dir spacetimedb install && cargo run -p gen-bindings -- --out-dir src/module_bindings --module-path spacetimedb && prettier --write src/module_bindings",
     "spacetime:generate": "spacetime generate --lang typescript --out-dir src/module_bindings --module-path spacetimedb",
     "spacetime:publish:local": "spacetime publish --module-path spacetimedb --server local",
     "spacetime:publish": "spacetime publish --module-path spacetimedb --server maincloud"

--- a/templates/nuxt-ts/package.json
+++ b/templates/nuxt-ts/package.json
@@ -7,7 +7,6 @@
     "dev": "nuxt dev",
     "build": "nuxt build",
     "preview": "nuxt preview",
-    "generate": "pnpm --dir spacetimedb install && cargo run -p gen-bindings -- --out-dir module_bindings --module-path spacetimedb && prettier --write module_bindings",
     "spacetime:generate": "spacetime generate --lang typescript --out-dir module_bindings --module-path spacetimedb",
     "spacetime:publish:local": "spacetime publish --module-path spacetimedb --server local",
     "spacetime:publish": "spacetime publish --module-path spacetimedb --server maincloud"

--- a/templates/react-ts/package.json
+++ b/templates/react-ts/package.json
@@ -7,7 +7,6 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "preview": "vite preview",
-    "generate": "cargo run -p gen-bindings -- --out-dir src/module_bindings --module-path spacetimedb && prettier --write src/module_bindings",
     "spacetime:generate": "spacetime generate --lang typescript --out-dir src/module_bindings --project-path spacetimedb",
     "spacetime:publish:local": "spacetime publish --project-path server --server local",
     "spacetime:publish": "spacetime publish --project-path server --server maincloud"

--- a/templates/remix-ts/package.json
+++ b/templates/remix-ts/package.json
@@ -7,7 +7,6 @@
     "dev": "npx remix vite:dev",
     "build": "npx remix vite:build",
     "start": "npx remix-serve ./build/server/index.js",
-    "generate": "pnpm --dir spacetimedb install && cargo run -p gen-bindings -- --out-dir src/module_bindings --module-path spacetimedb && prettier --write src/module_bindings",
     "spacetime:generate": "spacetime generate --lang typescript --out-dir src/module_bindings --module-path spacetimedb",
     "spacetime:publish:local": "spacetime publish --module-path spacetimedb --server local",
     "spacetime:publish": "spacetime publish --module-path spacetimedb --server maincloud"

--- a/templates/svelte-ts/package.json
+++ b/templates/svelte-ts/package.json
@@ -7,7 +7,6 @@
     "dev": "vite",
     "build": "vite build",
     "preview": "vite preview",
-    "generate": "pnpm --dir spacetimedb install && cargo run -p gen-bindings -- --out-dir src/module_bindings --project-path spacetimedb && prettier --write src/module_bindings",
     "spacetime:generate": "spacetime generate --lang typescript --out-dir src/module_bindings --project-path spacetimedb",
     "spacetime:publish:local": "spacetime publish --project-path spacetimedb --server local",
     "spacetime:publish": "spacetime publish --project-path spacetimedb --server maincloud"

--- a/templates/vue-ts/package.json
+++ b/templates/vue-ts/package.json
@@ -7,7 +7,6 @@
     "dev": "vite",
     "build": "vue-tsc -b && vite build",
     "preview": "vite preview",
-    "generate": "pnpm --dir spacetimedb install && cargo run -p gen-bindings -- --out-dir src/module_bindings --project-path spacetimedb && prettier --write src/module_bindings",
     "spacetime:generate": "spacetime generate --lang typescript --out-dir src/module_bindings --project-path spacetimedb",
     "spacetime:publish:local": "spacetime publish --project-path spacetimedb --server local",
     "spacetime:publish": "spacetime publish --project-path spacetimedb --server maincloud"


### PR DESCRIPTION
# Description of Changes

We have this `generate` command in our templates that only makes sense in the context of our repo. However, we use these templates to initialize user projects, where the command is just broken.

This PR removes that command.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None