### PR TITLE
CI - `clockwork-labs-bot` needs 2 approvals

### DIFF
--- a/.github/workflows/pr_approval_check.yml
+++ b/.github/workflows/pr_approval_check.yml
@@ -3,6 +3,8 @@ name: PR Approval Check
 on:
   pull_request:
     types: [opened, synchronize, reopened, ready_for_review]
+  pull_request_review:
+    types: [submitted]
 
 permissions:
   contents: read


### PR DESCRIPTION
# Description of Changes

PRs created by `clockwork-labs-bot` require 2 approvals.

After merging, we would need to make this check required.

# API and ABI breaking changes

CI only.

# Expected complexity level and risk

1. This is copy-pasted and simplified from another repo that has the same workflow.

# Testing

None