### PR TITLE
CI - Simplify PR approval check

### DIFF
--- a/.github/workflows/pr_approval_check.yml
+++ b/.github/workflows/pr_approval_check.yml
@@ -1,4 +1,4 @@
-name: PR Approval Check
+name: Review Checks
 
 on:
   pull_request:
@@ -27,7 +27,7 @@ jobs:
         with:
           github-token: ${{ secrets.GITHUB_TOKEN }}
           script: |
-            const contextName = "bot-pr-approval-check";
+            const contextName = "PR approval check";
 
             let targetSha;
             let state;


### PR DESCRIPTION
# Description of Changes

The previous version ended up incurring two different entries on the PR (one for the `pull_request` event and one for the `pull_request_review` event). Both versions were marked "required", so PRs could end up in an unmergeable state if one check had succeeded but the other had failed (e.g. if you submitted a PR approval, the previous `pull_request` version of the check would still be failed since it didn't refresh).

See the entries at top and bottom here:
<img width="481" height="225" alt="image" src="https://github.com/user-attachments/assets/5b7a4302-6bc2-47e9-93c8-812cb9ece60b" />

This PR fixes it by only allowing the `pull_request_review` events. I _think_ this covers all the cases, but I'm not sure.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1

# Testing

I don't know how to test it really :shrug: 