### PR TITLE
CI - Label check always runs

### DIFF
--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -12,10 +12,11 @@ jobs:
     name: Check merge labels
     runs-on: ubuntu-latest
     steps:
-      - if: github.event_name == 'merge_group'
-        run: echo "Merge group run; skipping merge-label checks."
-
       - if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'do not merge')
         run: |
           echo "This is labeled \"Do not merge\"."
           exit 1
+
+      # If we're in a merge queue, the PR has already passed checks these checks before being added to the queue.
+      - if: github.event_name == 'merge_group'
+        run: echo "Merge group run; skipping merge-label checks."


### PR DESCRIPTION
# Description of Changes

The CI check for the Do Not Merge label was only running on label-change events, so if a PR never received a label (any label), the check would never run. This meant that the check couldn't be marked required because it was missing on PRs that were never labeled anything.

Additionally, the check was not configured to run properly in the merge queue, so it would have blocked the merge queue if it were a required check.

This PR fixes those issues by making the check run on more pull request events, and by trivially succeeding in the merge queue.

This enables the check to be made required.

# API and ABI breaking changes

None. CI only.

# Expected complexity level and risk

1

# Testing
- [x] The check is now showing as run on this PR
- [x] The check still fails if I add a "do not merge" label