### PR TITLE
CI - Label check runs on `synchronize` events

### DIFF
--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -2,7 +2,7 @@ name: Check merge labels
 
 on:
   pull_request:
-    types: [opened, reopened, labeled, unlabeled]
+    types: [opened, reopened, synchronize, labeled, unlabeled]
   merge_group:
 
 permissions: read-all


### PR DESCRIPTION
# Description of Changes

This shouldn't actually be required in the long-term, because it runs on new PRs and any label changes, but the case where it _is_ required? PRs that are currently already open and merge in `master`. That triggers a `synchronize` event but not any of the events that this check runs on. Sigh.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None