### PR TITLE
CI - Skip PR approval check on external PRs

### DIFF
--- a/.github/workflows/pr_approval_check.yml
+++ b/.github/workflows/pr_approval_check.yml
@@ -20,6 +20,7 @@ jobs:
   publish-approval-status:
     name: Set approval status
     runs-on: ubuntu-latest
+    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
 
     steps:
       - name: Evaluate and publish approval status


### PR DESCRIPTION
# Description of Changes

It doesn't have permission to run on external PRs, but that's kinda okay since external PRs are rarely authored by clockwork-labs-bot anyway.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1

# Testing

None