### PR TITLE
CI - PR approval check skips for external PRs (properly this time)

### DIFF
--- a/.github/workflows/pr_approval_check.yml
+++ b/.github/workflows/pr_approval_check.yml
@@ -20,7 +20,6 @@ jobs:
   publish-approval-status:
     name: Set approval status
     runs-on: ubuntu-latest
-    if: ${{ github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork }}
 
     steps:
       - name: Evaluate and publish approval status
@@ -42,7 +41,10 @@ jobs:
               const pr = context.payload.pull_request;
               targetSha = pr.head.sha;
 
-              if (pr.user.login !== "clockwork-labs-bot") {
+              if (pr.head.repo.fork) {
+                state = "success";
+                description = "Skipped for external PR";
+              } else if (pr.user.login !== "clockwork-labs-bot") {
                 state = "success";
                 description = "PR author is not clockwork-labs-bot";
               } else {


### PR DESCRIPTION
# Description of Changes

https://github.com/clockworklabs/SpacetimeDB/pull/4604 skipped the check run for external PRs, but because it needs to post a separate commit status (see https://github.com/clockworklabs/SpacetimeDB/pull/4578), this was not the right solution. We need to _run_ the check but trivially post a success on external PRs. Sigh.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1

# Testing

I don't know how to test github workflows.