### PR TITLE
Use column names instead of accessors for ts queries

### DIFF
--- a/crates/bindings-typescript/src/lib/query.ts
+++ b/crates/bindings-typescript/src/lib/query.ts
@@ -348,7 +348,8 @@ function createRowExpr<TableDef extends TypedTableDef>(
       columnBuilder.typeBuilder.algebraicType as InferSpacetimeTypeOfColumn<
         TableDef,
         typeof columnName
-      >
+      >,
+      columnBuilder.columnMetadata.name
     );
     row[columnName] = Object.freeze(column);
   }
@@ -438,7 +439,10 @@ export class ColumnExpression<
   ColumnName extends ColumnNames<TableDef>,
 > {
   readonly type = 'column' as const;
+  // This is the column accessor
   readonly column: ColumnName;
+  // The name of the column in the database.
+  readonly columnName: string;
   readonly table: TableDef['sourceName'];
   // phantom: actual runtime value is undefined
   readonly tsValueType?: RowType<TableDef>[ColumnName];
@@ -447,10 +451,12 @@ export class ColumnExpression<
   constructor(
     table: TableDef['sourceName'],
     column: ColumnName,
-    spacetimeType: InferSpacetimeTypeOfColumn<TableDef, ColumnName>
+    spacetimeType: InferSpacetimeTypeOfColumn<TableDef, ColumnName>,
+    columnName?: string
   ) {
     this.table = table;
     this.column = column;
+    this.columnName = columnName || column;
     this.spacetimeType = spacetimeType;
   }
 
@@ -838,7 +844,7 @@ function valueExprToSql<Table extends TypedTableDef>(
     return literalValueToSql(expr.value);
   }
   const table = tableAlias ?? expr.table;
-  return `${quoteIdentifier(table)}.${quoteIdentifier(expr.column)}`;
+  return `${quoteIdentifier(table)}.${quoteIdentifier(expr.columnName)}`;
 }
 
 function literalValueToSql(value: unknown): string {

--- a/crates/bindings-typescript/tests/query.test.ts
+++ b/crates/bindings-typescript/tests/query.test.ts
@@ -54,9 +54,20 @@ const ordersTable = table(
   }
 );
 
+const renamedColumnsTable = table(
+  {
+    name: 'renamed_columns',
+  },
+  {
+    displayName: t.string().name('display_name'),
+    ageYears: t.u32().name('age_years'),
+  }
+);
+
 const schemaDef = tablesToSchema(new ModuleContext(), {
   person: personTable,
   orders: ordersTable,
+  renamedColumns: renamedColumnsTable,
 });
 
 describe('Timestamp thing', () => {
@@ -346,5 +357,18 @@ describe('TableScan.toSql', () => {
     const qb = makeQueryBuilder(schemaDef);
     const sql = toSql(qb.person);
     expect(sql).toBe('SELECT * FROM "person"');
+  });
+
+  it('uses DB column names for accessors with explicit DB names', () => {
+    const qb = makeQueryBuilder(schemaDef);
+    const sql = toSql(
+      qb.renamedColumns
+        .where(row => row.displayName.eq('Alice').and(row.ageYears.gt(30)))
+        .build()
+    );
+
+    expect(sql).toBe(
+      `SELECT * FROM "renamed_columns" WHERE ("renamed_columns"."display_name" = 'Alice') AND ("renamed_columns"."age_years" > 30)`
+    );
   });
 });


### PR DESCRIPTION
# Description of Changes

When creating sql queries, we were using the column accessor name, rather than the name used in the database. This should fix that.


# Expected complexity level and risk

1.

# Testing

This has some unit tests.