### PR TITLE
feat(ts-sdk): add reconnect() method to DbConnectionImpl

### DIFF
--- a/crates/bindings-typescript/src/sdk/db_connection_impl.ts
+++ b/crates/bindings-typescript/src/sdk/db_connection_impl.ts
@@ -176,6 +176,15 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
   private ws?: WebsocketAdapter;
   private wsPromise: Promise<WebsocketAdapter | undefined>;
 
+  private wsConfig?: {
+    url: URL;
+    nameOrAddress: string;
+    createWSFn: typeof WebsocketDecompressAdapter.createWebSocketFn;
+    compression: 'gzip' | 'none';
+    lightMode: boolean;
+    confirmedReads?: boolean;
+  };
+
   constructor({
     uri,
     nameOrAddress,
@@ -242,6 +251,8 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
     this.db = this.#makeDbView();
     this.reducers = this.#makeReducers(remoteModule);
     this.procedures = this.#makeProcedures(remoteModule);
+
+    this.wsConfig = { url, nameOrAddress, createWSFn, compression, lightMode, confirmedReads };
 
     this.wsPromise = createWSFn({
       url,
@@ -978,6 +989,69 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
    */
   disconnect(): void {
     this.wsPromise.then(ws => ws?.close());
+  }
+
+  /**
+   * Reconnect to SpacetimeDB with an optional new authentication token.
+   *
+   * Preserves the client cache — existing table data stays intact while
+   * subscriptions are re-established on the new connection. This avoids
+   * the data gap that occurs when creating a new connection object.
+   *
+   * @param newToken - Optional new auth token. If not provided, reuses the existing token.
+   *
+   * @example
+   *
+   * ```ts
+   * connection.onDisconnect(() => {
+   *   const freshToken = await refreshAuthToken();
+   *   connection.reconnect(freshToken);
+   * });
+   * ```
+   */
+  reconnect(newToken?: string): void {
+    if (newToken !== undefined) {
+      this.token = newToken;
+    }
+    stdbLogger('info', 'Reconnecting to SpacetimeDB WS...');
+    if (this.ws) {
+      this.ws.onclose = null as any;
+      this.ws.onerror = null as any;
+      this.ws.onopen = null as any;
+      this.ws.onmessage = null as any;
+      this.ws.close();
+      this.ws = undefined;
+    }
+    this.isActive = false;
+    const cfg = this.wsConfig!;
+    this.wsPromise = cfg.createWSFn({
+      url: cfg.url,
+      nameOrAddress: cfg.nameOrAddress,
+      wsProtocol: 'v2.bsatn.spacetimedb',
+      authToken: this.token,
+      compression: cfg.compression,
+      lightMode: cfg.lightMode,
+      confirmedReads: cfg.confirmedReads,
+    })
+      .then(v => {
+        this.ws = v;
+        this.ws.onclose = () => {
+          this.#emitter.emit('disconnect', this);
+          this.isActive = false;
+        };
+        this.ws.onerror = (e: ErrorEvent) => {
+          this.#emitter.emit('connectError', this, e);
+          this.isActive = false;
+        };
+        this.ws.onopen = this.#handleOnOpen.bind(this);
+        this.ws.onmessage = this.#handleOnMessage.bind(this);
+        return v;
+      })
+      .catch(e => {
+        stdbLogger('error', 'Error reconnecting to SpacetimeDB WS');
+        this.#emitter.emit('connectError', this, e);
+        return undefined;
+      });
   }
 
   private on(


### PR DESCRIPTION
# Description of Changes

Adds a `reconnect(newToken?)` method to `DbConnectionImpl` that reopens the WebSocket on the **same connection object**, preserving the client cache.

**Problem:** Long-lived browser tabs (games, dashboards) lose their SpacetimeDB connection due to network changes, token expiration, or browser throttling. Currently the only recovery path is creating a new `DbConnection`, which destroys the client cache — all `useTable` hooks return `[]`, causing UI flashes and loading screens.

**Solution:** `reconnect()` stores WS creation config in a private `wsConfig` field, silently closes the old WS (nulling handlers to prevent spurious events), then creates a new one. `useTable` hooks keep returning cached data while subscriptions re-establish.

```ts
connection.onDisconnect(() => {
  const freshToken = await refreshAuthToken();
  connection.reconnect(freshToken);
});
```

# API and ABI breaking changes

None. This is a purely additive change — one new public method on `DbConnectionImpl`.

# Expected complexity level and risk

1 — The change is small (74 lines) and self-contained. It reuses the existing WS creation pattern from the constructor. No existing behavior is modified.

# Testing

- [ ] Call `connection.disconnect()` then `connection.reconnect()` — WS reconnects and `onConnect` fires
- [ ] `useTable` hooks retain cached data during reconnect
- [ ] Subscriptions re-establish after reconnect
- [ ] `reconnect(newToken)` uses the new token for authentication