### PR TITLE
fix: Replace unwrap with proper error handling in set_domains handler

### DIFF
--- a/crates/client-api/src/routes/database.rs
+++ b/crates/client-api/src/routes/database.rs
@@ -1107,7 +1107,12 @@ pub async fn set_names<S: ControlStateDelegate + Authorization>(
         })?;
 
     for name in &validated_names {
-        if ctx.lookup_database_identity(name.as_str()).await.map_err(log_and_500)?.is_some() {
+        if ctx
+            .lookup_database_identity(name.as_str())
+            .await
+            .map_err(log_and_500)?
+            .is_some()
+        {
             return Ok((
                 StatusCode::BAD_REQUEST,
                 axum::Json(name::SetDomainsResult::OtherError(format!(


### PR DESCRIPTION
 Closes #4635     
                                                                                                                                                                                                                                                                      In `crates/client-api/src/routes/database.rs` line 1111, `lookup_database_identity` returns a `Result` but the error was handled with `.unwrap()`, which panics instead of returning an HTTP 500. Replaced it with `.map_err(log_and_500)?` to match the rest of the file.     