### PR TITLE
cleanup `TypedIndexPointIter` & ditch `Direct` variant

### DIFF
--- a/crates/table/proptest-regressions/table_index/mod.txt
+++ b/crates/table/proptest-regressions/table_index/mod.txt
@@ -6,3 +6,4 @@
 # everyone who runs the test benefits from these saved cases.
 cc 3276d3db4a1a70d78db9a6a01eaa3bba810a2317e9c67e4d5d8d93cbba472c99 # shrinks to ((ty, cols, pv), is_unique) = ((ProductType {None: Bool}, [ColId(0)], ProductValue { elements: [Bool(false)] }), false)
 cc bc80b80ac2390452c0a152d2c6e2abc29ce146642f3cd0fe136ffe6173cf4c8c # shrinks to (ty, cols, pv) = (ProductType {None: I64}, [ColId(0)], ProductValue { elements: [I64(0)] }), kind = Direct
+cc c1e4c959a32f6ab8ef9c4e29d39a24ec47cb03524584606a7f1fa4563f0f8cca # shrinks to (ty, cols, pv) = (ProductType {None: Sum(SumType {"variant_0": Product(ProductType {})})}, [ColId(0)], ProductValue { elements: [Sum(SumValue { tag: 0, value: Product(ProductValue { elements: [] }) })] }), kind = Direct

--- a/crates/table/src/table_index/unique_direct_fixed_cap_index.rs
+++ b/crates/table/src/table_index/unique_direct_fixed_cap_index.rs
@@ -1,5 +1,6 @@
 use super::index::{Index, RangedIndex};
-use super::unique_direct_index::{expose, injest, ToFromUsize, UniqueDirectIndexPointIter, NONE_PTR};
+use super::unique_direct_index::{expose, injest, ToFromUsize, NONE_PTR};
+use super::uniquemap::UniquePointIter;
 use crate::indexes::RowPointer;
 use crate::table_index::KeySize;
 use core::marker::PhantomData;
@@ -79,13 +80,18 @@ impl<K: ToFromUsize + KeySize> Index for UniqueDirectFixedCapIndex<K> {
     }
 
     type PointIter<'a>
-        = UniqueDirectIndexPointIter
+        = UniquePointIter
     where
         Self: 'a;
 
     fn seek_point(&self, &key: &Self::Key) -> Self::PointIter<'_> {
-        let point = self.array.get(key.to_usize()).copied().filter(|slot| *slot != NONE_PTR);
-        UniqueDirectIndexPointIter::new(point)
+        let point = self
+            .array
+            .get(key.to_usize())
+            .copied()
+            .filter(|slot| *slot != NONE_PTR)
+            .map(expose);
+        UniquePointIter::new(point)
     }
 
     fn num_keys(&self) -> usize {

--- a/crates/table/src/table_index/unique_direct_index.rs
+++ b/crates/table/src/table_index/unique_direct_index.rs
@@ -1,10 +1,10 @@
 use super::index::{Despecialize, Index, RangedIndex};
+use super::uniquemap::UniquePointIter;
 use super::{BtreeUniqueIndex, KeySize};
 use crate::indexes::{PageIndex, PageOffset, RowPointer, SquashedOffset};
 use core::marker::PhantomData;
 use core::mem;
 use core::ops::{Bound, RangeBounds};
-use core::option::IntoIter;
 use spacetimedb_sats::memory_usage::MemoryUsage;
 use spacetimedb_sats::sum_value::SumTag;
 
@@ -226,7 +226,7 @@ impl<K: ToFromUsize + KeySize> Index for UniqueDirectIndex<K> {
     }
 
     type PointIter<'a>
-        = UniqueDirectIndexPointIter
+        = UniquePointIter
     where
         Self: 'a;
 
@@ -238,8 +238,9 @@ impl<K: ToFromUsize + KeySize> Index for UniqueDirectIndex<K> {
             .get(outer_key)
             .and_then(|x| x.as_ref())
             .map(|inner| inner.get(inner_key))
-            .filter(|slot| *slot != NONE_PTR);
-        UniqueDirectIndexPointIter::new(point)
+            .filter(|slot| *slot != NONE_PTR)
+            .map(expose);
+        UniquePointIter::new(point)
     }
 
     fn num_keys(&self) -> usize {
@@ -312,25 +313,6 @@ impl<K: ToFromUsize + KeySize> RangedIndex for UniqueDirectIndex<K> {
             start,
             end,
         }
-    }
-}
-
-/// An iterator over the potential value in a [`UniqueDirectMap`] for a given key.
-pub struct UniqueDirectIndexPointIter {
-    iter: IntoIter<RowPointer>,
-}
-
-impl UniqueDirectIndexPointIter {
-    pub(super) fn new(point: Option<RowPointer>) -> Self {
-        let iter = point.map(expose).into_iter();
-        Self { iter }
-    }
-}
-
-impl Iterator for UniqueDirectIndexPointIter {
-    type Item = RowPointer;
-    fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next()
     }
 }
 

--- a/crates/table/src/table_index/unique_hash_index.rs
+++ b/crates/table/src/table_index/unique_hash_index.rs
@@ -1,5 +1,5 @@
 use super::{Index, KeySize};
-use crate::table_index::uniquemap::UniqueMapPointIter;
+use crate::table_index::uniquemap::UniquePointIter;
 use crate::{indexes::RowPointer, table_index::key_size::KeyBytesStorage};
 use core::hash::Hash;
 use spacetimedb_data_structures::map::hash_map::Entry;
@@ -87,12 +87,11 @@ impl<K: KeySize + Eq + Hash> Index for UniqueHashIndex<K> {
     }
 
     type PointIter<'a>
-        = UniqueMapPointIter<'a>
+        = UniquePointIter
     where
         Self: 'a;
 
     fn seek_point(&self, point: &Self::Key) -> Self::PointIter<'_> {
-        let iter = self.map.get(point).into_iter();
-        UniqueMapPointIter { iter }
+        UniquePointIter::new(self.map.get(point).copied())
     }
 }

--- a/crates/table/src/table_index/uniquemap.rs
+++ b/crates/table/src/table_index/uniquemap.rs
@@ -66,13 +66,12 @@ impl<K: Ord + KeySize> Index for UniqueMap<K> {
     }
 
     type PointIter<'a>
-        = UniqueMapPointIter<'a>
+        = UniquePointIter
     where
         Self: 'a;
 
-    fn seek_point(&self, key: &Self::Key) -> Self::PointIter<'_> {
-        let iter = self.map.get(key).into_iter();
-        UniqueMapPointIter { iter }
+    fn seek_point(&self, point: &Self::Key) -> Self::PointIter<'_> {
+        UniquePointIter::new(self.map.get(point).copied())
     }
 
     /// Deletes all entries from the map, leaving it empty.
@@ -96,16 +95,24 @@ impl<K: Ord + KeySize> Index for UniqueMap<K> {
 }
 
 /// An iterator over the potential value in a [`UniqueMap`] for a given key.
-pub struct UniqueMapPointIter<'a> {
+pub struct UniquePointIter {
     /// The iterator seeking for matching keys in the range.
-    pub(super) iter: IntoIter<&'a RowPointer>,
+    pub(super) iter: IntoIter<RowPointer>,
 }
 
-impl<'a> Iterator for UniqueMapPointIter<'a> {
+impl UniquePointIter {
+    /// Returns a new iterator over the possibly found row pointer.
+    pub fn new(point: Option<RowPointer>) -> Self {
+        let iter = point.into_iter();
+        Self { iter }
+    }
+}
+
+impl Iterator for UniquePointIter {
     type Item = RowPointer;
 
     fn next(&mut self) -> Option<Self::Item> {
-        self.iter.next().copied()
+        self.iter.next()
     }
 }
 


### PR DESCRIPTION
# Description of Changes

Ditches `TypedIndexPointIter::Direct` and then does some renaming of variants in `TypedIndexPointIter` to reflect reality.

Extracted from https://github.com/clockworklabs/SpacetimeDB/pull/4311.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Covered by existing tests.