### PR TITLE
core, datastore: Work around race in request_durability

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -808,16 +808,16 @@ impl RelationalDB {
 
         let reducer_context = tx.ctx.reducer_context().cloned();
         // TODO: Never returns `None` -- should it?
-        let Some((tx_offset, tx_data, tx_metrics, reducer)) = self.inner.commit_mut_tx(tx)? else {
+        let Some((tx_offset, tx_data, tx_metrics, reducer)) = self.inner.commit_mut_tx(tx, |tx_data| {
+            if let Some(durability) = &self.durability {
+                durability.request_durability(reducer_context, tx_data);
+            }
+        })?
+        else {
             return Ok(None);
         };
 
         self.maybe_do_snapshot(&tx_data);
-
-        let tx_data = Arc::new(tx_data);
-        if let Some(durability) = &self.durability {
-            durability.request_durability(reducer_context, &tx_data);
-        }
 
         Ok(Some((tx_offset, tx_data, tx_metrics, reducer)))
     }
@@ -826,14 +826,14 @@ impl RelationalDB {
     pub fn commit_tx_downgrade(&self, tx: MutTx, workload: Workload) -> (Arc<TxData>, TxMetrics, Tx) {
         log::trace!("COMMIT MUT TX");
 
-        let (tx_data, tx_metrics, tx) = self.inner.commit_mut_tx_downgrade(tx, workload);
+        let reducer_context = tx.ctx.reducer_context().cloned();
+        let (tx_data, tx_metrics, tx) = self.inner.commit_mut_tx_downgrade(tx, workload, |tx_data| {
+            if let Some(durability) = &self.durability {
+                durability.request_durability(reducer_context, tx_data);
+            }
+        });
 
         self.maybe_do_snapshot(&tx_data);
-
-        let tx_data = Arc::new(tx_data);
-        if let Some(durability) = &self.durability {
-            durability.request_durability(tx.ctx.reducer_context().cloned(), &tx_data);
-        }
 
         (tx_data, tx_metrics, tx)
     }

--- a/crates/datastore/src/locking_tx_datastore/datastore.rs
+++ b/crates/datastore/src/locking_tx_datastore/datastore.rs
@@ -1580,8 +1580,12 @@ mod tests {
         datastore.begin_mut_tx(IsolationLevel::Serializable, Workload::ForTests)
     }
 
-    fn commit(datastore: &Locking, tx: MutTxId) -> ResultTest<TxData> {
-        let (_, tx_data, _, _) = datastore.commit_mut_tx(tx)?.expect("commit should produce `TxData`");
+    fn noop(_: &Arc<TxData>) {}
+
+    fn commit(datastore: &Locking, tx: MutTxId) -> ResultTest<Arc<TxData>> {
+        let (_, tx_data, _, _) = datastore
+            .commit_mut_tx(tx, noop)?
+            .expect("commit should produce `TxData`");
         Ok(tx_data)
     }
 
@@ -2042,7 +2046,7 @@ mod tests {
     #[test]
     fn test_create_table_post_commit() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
         let tx = begin_mut_tx(&datastore);
         let query = query_st_tables(&tx);
 
@@ -2098,7 +2102,7 @@ mod tests {
     #[test]
     fn test_schema_for_table_post_commit() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
         let mut tx = begin_mut_tx(&datastore);
         verify_schemas_consistent(&mut tx, table_id);
         let schema = &*datastore.schema_for_table_mut_tx(&tx, table_id)?;
@@ -2111,7 +2115,7 @@ mod tests {
     #[test]
     fn test_schema_for_table_alter_indexes() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
 
         let mut tx = begin_mut_tx(&datastore);
         let schema = datastore.schema_for_table_mut_tx(&tx, table_id)?;
@@ -2134,7 +2138,7 @@ mod tests {
             datastore.schema_for_table_mut_tx(&tx, table_id)?.indexes.is_empty(),
             "no indexes should be left in the schema pre-commit"
         );
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
 
         let mut tx = begin_mut_tx(&datastore);
         assert_eq!(tx.pending_schema_changes(), []);
@@ -2177,7 +2181,7 @@ mod tests {
             "created index should be present in schema pre-commit"
         );
 
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
 
         let tx = begin_mut_tx(&datastore);
         assert_eq!(tx.pending_schema_changes(), []);
@@ -2187,7 +2191,7 @@ mod tests {
             "created index should be present in schema post-commit"
         );
 
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
 
         Ok(())
     }
@@ -2229,7 +2233,7 @@ mod tests {
         let (datastore, mut tx, table_id) = setup_table()?;
         // 0 will be ignored.
         insert(&datastore, &mut tx, table_id, &u32_str_u32(0, "Foo", 18))?;
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
         let tx = begin_mut_tx(&datastore);
         #[rustfmt::skip]
         assert_eq!(all_rows(&datastore, &tx, table_id), vec![u32_str_u32(1, "Foo", 18)]);
@@ -2240,7 +2244,7 @@ mod tests {
     fn test_insert_post_rollback() -> ResultTest<()> {
         let (datastore, tx, table_id) = setup_table()?;
         let row = u32_str_u32(15, "Foo", 18); // 15 is ignored.
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
         let mut tx = begin_mut_tx(&datastore);
         insert(&datastore, &mut tx, table_id, &row)?;
         let _ = datastore.rollback_mut_tx(tx);
@@ -2255,7 +2259,7 @@ mod tests {
         let (datastore, mut tx, table_id) = setup_table()?;
         let row = u32_str_u32(0, "Foo", 18); // 0 will be ignored.
         insert(&datastore, &mut tx, table_id, &row)?;
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
         let mut tx = begin_mut_tx(&datastore);
         let created_row = u32_str_u32(1, "Foo", 18);
         let num_deleted = datastore.delete_by_rel_mut_tx(&mut tx, table_id, [created_row]);
@@ -2319,7 +2323,7 @@ mod tests {
         let (datastore, mut tx, table_id) = setup_table()?;
         let row = u32_str_u32(0, "Foo", 18); // 0 will be ignored.
         insert(&datastore, &mut tx, table_id, &row)?;
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
         let mut tx = begin_mut_tx(&datastore);
         let result = insert(&datastore, &mut tx, table_id, &row);
         match result {
@@ -2488,7 +2492,7 @@ mod tests {
         let (datastore, mut tx, table_id) = setup_table()?;
         let row = u32_str_u32(0, "Foo", 18); // 0 will be ignored.
         insert(&datastore, &mut tx, table_id, &row)?;
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
         let mut tx = begin_mut_tx(&datastore);
         create_foo_age_idx_btree(&datastore, &mut tx, table_id)?;
 
@@ -2623,7 +2627,7 @@ mod tests {
                                              // Because of auto_inc columns, we will get a slightly different
                                              // value than the one we inserted.
         let row = insert(&datastore, &mut tx, table_id, &row)?.1.to_product_value();
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
 
         let all_rows_col_0_eq_1 = |tx: &MutTxId| {
             datastore
@@ -2654,7 +2658,7 @@ mod tests {
         // second transaction, and see exactly one row.
         assert_eq!(all_rows_col_0_eq_1(&tx).len(), 1);
 
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
 
         Ok(())
     }
@@ -3111,7 +3115,7 @@ mod tests {
         insert(&datastore, &mut tx, table_id, &row1)?;
         let row2 = u32_str_u32(2, "Bar", 20);
         insert(&datastore, &mut tx, table_id, &row2)?;
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
 
         // create multiple read only tx, and use them together.
         let read_tx_1 = begin_tx(&datastore);
@@ -3192,7 +3196,7 @@ mod tests {
         let datastore = get_datastore()?;
         let mut tx = begin_mut_tx(&datastore);
         let table_id = datastore.create_table_mut_tx(&mut tx, schema)?;
-        datastore.commit_mut_tx(tx)?;
+        datastore.commit_mut_tx(tx, noop)?;
         Ok((datastore, table_id))
     }
 
@@ -3757,7 +3761,7 @@ mod tests {
         let datastore = get_datastore()?;
 
         let tx = begin_mut_tx(&datastore);
-        let (_, _, metrics, _) = tx.commit();
+        let (_, _, metrics, _) = tx.commit(noop);
         assert!(metrics.committed);
 
         let tx = begin_mut_tx(&datastore);

--- a/crates/datastore/src/locking_tx_datastore/datastore.rs
+++ b/crates/datastore/src/locking_tx_datastore/datastore.rs
@@ -953,8 +953,12 @@ impl MutTx for Locking {
 
     /// This method only updates the in-memory `committed_state`.
     /// For durability, see `RelationalDB::commit_tx`.
-    fn commit_mut_tx(&self, tx: Self::MutTx) -> Result<Option<(TxOffset, TxData, TxMetrics, Option<ReducerName>)>> {
-        Ok(Some(tx.commit()))
+    fn commit_mut_tx(
+        &self,
+        tx: Self::MutTx,
+        before_release: impl FnOnce(&Arc<TxData>),
+    ) -> Result<Option<(TxOffset, Arc<TxData>, TxMetrics, Option<ReducerName>)>> {
+        Ok(Some(tx.commit(before_release)))
     }
 }
 
@@ -965,8 +969,13 @@ impl Locking {
 
     /// This method only updates the in-memory `committed_state`.
     /// For durability, see `RelationalDB::commit_tx_downgrade`.
-    pub fn commit_mut_tx_downgrade(&self, tx: MutTxId, workload: Workload) -> (TxData, TxMetrics, TxId) {
-        tx.commit_downgrade(workload)
+    pub fn commit_mut_tx_downgrade(
+        &self,
+        tx: MutTxId,
+        workload: Workload,
+        before_downgrade: impl FnOnce(&Arc<TxData>),
+    ) -> (Arc<TxData>, TxMetrics, TxId) {
+        tx.commit_downgrade(workload, before_downgrade)
     }
 }
 

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -2032,7 +2032,10 @@ impl MutTxId {
     /// - [`TxData`], the set of inserts and deletes performed by this transaction.
     /// - [`TxMetrics`], various measurements of the work performed by this transaction.
     /// - `String`, the name of the reducer which ran during this transaction.
-    pub(super) fn commit(mut self) -> (TxOffset, TxData, TxMetrics, Option<ReducerName>) {
+    pub(super) fn commit(
+        mut self,
+        before_release: impl FnOnce(&Arc<TxData>),
+    ) -> (TxOffset, Arc<TxData>, TxMetrics, Option<ReducerName>) {
         let tx_offset = self.committed_state_write_lock.next_tx_offset;
         let tx_data = self
             .committed_state_write_lock
@@ -2066,6 +2069,9 @@ impl MutTxId {
             tx_offset
         };
 
+        let tx_data = Arc::new(tx_data);
+        before_release(&tx_data);
+
         (tx_offset, tx_data, tx_metrics, reducer)
     }
 
@@ -2082,7 +2088,11 @@ impl MutTxId {
     /// - [`TxData`], the set of inserts and deletes performed by this transaction.
     /// - [`TxMetrics`], various measurements of the work performed by this transaction.
     /// - [`TxId`], a read-only transaction with a shared lock on the committed state.
-    pub(super) fn commit_downgrade(mut self, workload: Workload) -> (TxData, TxMetrics, TxId) {
+    pub(super) fn commit_downgrade(
+        mut self,
+        workload: Workload,
+        before_downgrade: impl FnOnce(&Arc<TxData>),
+    ) -> (Arc<TxData>, TxMetrics, TxId) {
         let tx_data = self
             .committed_state_write_lock
             .merge(self.tx_state, self.read_sets, &self.ctx);
@@ -2100,6 +2110,9 @@ impl MutTxId {
             Some(&tx_data),
             &self.committed_state_write_lock,
         );
+
+        let tx_data = Arc::new(tx_data);
+        before_downgrade(&tx_data);
 
         // Update the workload type of the execution context
         self.ctx.workload = workload.workload_type();

--- a/crates/datastore/src/traits.rs
+++ b/crates/datastore/src/traits.rs
@@ -239,6 +239,8 @@ pub struct TxData {
 
 impl TxData {
     /// Set `tx_offset` as the expected on-disk transaction offset of this transaction.
+    ///
+    /// Panics if the offset has already been set for this transaction.
     pub fn set_tx_offset(&mut self, tx_offset: u64) {
         assert!(self.tx_offset.is_none());
         self.tx_offset = Some(tx_offset);

--- a/crates/datastore/src/traits.rs
+++ b/crates/datastore/src/traits.rs
@@ -240,6 +240,7 @@ pub struct TxData {
 impl TxData {
     /// Set `tx_offset` as the expected on-disk transaction offset of this transaction.
     pub fn set_tx_offset(&mut self, tx_offset: u64) {
+        assert!(self.tx_offset.is_none());
         self.tx_offset = Some(tx_offset);
     }
 
@@ -478,7 +479,11 @@ pub trait MutTx {
     /// - [`TxMetrics`], various measurements of the work performed by this transaction.
     /// - `ReducerName`, the name of the reducer which ran during this transaction.
     #[allow(clippy::type_complexity)]
-    fn commit_mut_tx(&self, tx: Self::MutTx) -> Result<Option<(TxOffset, TxData, TxMetrics, Option<ReducerName>)>>;
+    fn commit_mut_tx(
+        &self,
+        tx: Self::MutTx,
+        before_release: impl FnOnce(&Arc<TxData>),
+    ) -> Result<Option<(TxOffset, Arc<TxData>, TxMetrics, Option<ReducerName>)>>;
 
     /// Rolls back this transaction, discarding its changes.
     ///


### PR DESCRIPTION
Both `commit` and `commit_downgrade` release the exclusive lock on the committed state before returning control to `RelationalDB`. The latter is then responsible for submitting the `TxData` to the durability worker via `request_durability`.

Perhaps surprisingly -- datastore operations are supposedly running on a single thread -- it is possible that the `RelationalDB` gets preempted after committing the transaction, but before having called `request_durability`. This can result in out-of-order transactions being submitted to the durability layer.

The presented workaround prevents this by forcing the datastore to trigger durability submission before releasing the lock. This fixes the issue at hand, but the author suspects that the long term fix involves revising database scheduling, namely enforcing single-threaded execution.
