### PR TITLE
Add `ConsumeEntityEvent` to Blackholio C++ and C# modules

### DIFF
--- a/demo/Blackholio/server-cpp/spacetimedb/src/lib.cpp
+++ b/demo/Blackholio/server-cpp/spacetimedb/src/lib.cpp
@@ -177,6 +177,13 @@ SPACETIMEDB_TABLE(CircleRecombineTimer, circle_recombine_timer, Private)
 FIELD_PrimaryKeyAutoInc(circle_recombine_timer, scheduled_id)
 SPACETIMEDB_SCHEDULE(circle_recombine_timer, 1, circle_recombine)
 
+struct ConsumeEntityEvent {
+    int32_t consumed_entity_id;
+    int32_t consumer_entity_id;
+};
+SPACETIMEDB_STRUCT(ConsumeEntityEvent, consumed_entity_id, consumer_entity_id)
+SPACETIMEDB_TABLE(ConsumeEntityEvent, consume_entity_event, Public, true)
+
 struct ConsumeEntityTimer {
     uint64_t scheduled_id;
     ScheduleAt scheduled_at;
@@ -594,6 +601,12 @@ SPACETIMEDB_REDUCER(consume_entity, ReducerContext ctx, ConsumeEntityTimer reque
     Entity consumed_entity = consumed_opt.value();
     Entity consumer_entity = consumer_opt.value();
     consumer_entity.mass += consumed_entity.mass;
+	
+	ConsumeEntityEvent consume_event{
+		consumed_entity.entity_id,
+		consumer_entity.entity_id
+	};
+	ctx.db[consume_entity_event].insert(consume_event);
 
     auto destroy_result = destroy_entity(ctx, consumed_entity.entity_id);
     if (destroy_result.is_err()) {

--- a/demo/Blackholio/server-csharp/Lib.cs
+++ b/demo/Blackholio/server-csharp/Lib.cs
@@ -101,6 +101,13 @@ public static partial class Module
 		public ScheduleAt scheduled_at;
 		public int player_id;
 	}
+    
+    [Table(Accessor = "consume_entity_event", Public = true, Event = true)]
+    public partial struct ConsumeEntityEvent
+    {
+        public int consumed_entity_id;
+        public int consumer_entity_id;
+    }
 
 	[Table(Accessor = "consume_entity_timer", Scheduled = nameof(ConsumeEntity), ScheduledAt = nameof(scheduled_at))]
 	public partial struct ConsumeEntityTimer
@@ -433,6 +440,12 @@ public static partial class Module
 	{
 		var consumed_entity = ctx.Db.entity.entity_id.Find(request.consumed_entity_id) ?? throw new Exception("Consumed entity doesn't exist");
 		var consumer_entity = ctx.Db.entity.entity_id.Find(request.consumer_entity_id) ?? throw new Exception("Consumer entity doesn't exist");
+        
+        ctx.Db.consume_entity_event.Insert(new ConsumeEntityEvent
+        {
+            consumed_entity_id = consumed_entity.entity_id,
+            consumer_entity_id = consumer_entity.entity_id
+        });
 
 		consumer_entity.mass += consumed_entity.mass;
 		DestroyEntity(ctx, consumed_entity.entity_id);


### PR DESCRIPTION
This resolves an issue found while testing C# module behavior against the Blackholio demo in an unrelated PR.

# Description of Changes

Updates the C# and C++ server modules for the Blackholio demo, to reflect changes made to the Rust module in #4217
This is needed if testing against Blackholio using either the C# or C++, or else the `ConsumeEntityEvent` will be missing from the generated client bindings.

# API and ABI breaking changes

Not API or ABI breaking.

# Expected complexity level and risk

1

# Testing

- [X] Tested Unity Blackholio demo using the C# module
- [X] Tested Unity Blackholio demo using the C++ module