### PR TITLE
Keynote-2 sqlite fixes

### DIFF
--- a/templates/keynote-2/src/connectors/rpc/sqlite_rpc.ts
+++ b/templates/keynote-2/src/connectors/rpc/sqlite_rpc.ts
@@ -1,4 +1,4 @@
-﻿import type { RpcConnector } from '../../core/connectors.ts';
+import type { RpcConnector } from '../../core/connectors.ts';
 import { RpcRequest, RpcResponse } from './rpc_common.ts';
 
 export default function sqlite_rpc(
@@ -81,7 +81,14 @@ export default function sqlite_rpc(
     },
 
     async verify() {
-      await httpCall('verify');
+      const result = (await httpCall('verify')) as
+        | { skipped?: boolean }
+        | undefined;
+      if (result && typeof result === 'object' && result.skipped === true) {
+        throw new Error(
+          '[sqlite_rpc] verify was skipped on the server (set SEED_INITIAL_BALANCE in the sqlite-rpc-server process env, matching the bench)',
+        );
+      }
     },
 
     async call(name: string, args?: Record<string, unknown>) {

--- a/templates/keynote-2/src/core/runner.ts
+++ b/templates/keynote-2/src/core/runner.ts
@@ -401,8 +401,10 @@ export async function runOne({
     console.log(`[${connector.name}] Running verification pass...`);
     try {
       await withOpTimeout(connector.verify(), `${connector.name} verify()`);
+      console.log(`[${connector.name}] Verification passed`);
     } catch (err) {
-      console.error(`[${connector.name}] Verification failed:`, err);
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[${connector.name}] Verification failed: ${msg}`);
     }
   }
 

--- a/templates/keynote-2/src/core/runner_1.ts
+++ b/templates/keynote-2/src/core/runner_1.ts
@@ -1,4 +1,4 @@
-﻿import hdr from 'hdr-histogram-js';
+import hdr from 'hdr-histogram-js';
 import { performance } from 'node:perf_hooks';
 import { pickTwoDistinct, zipfSampler } from './zipf.ts';
 import { getSpacetimeCommittedTransfers } from './spacetimeMetrics.ts';
@@ -255,8 +255,10 @@ export async function runOne({
     console.log(`[${connector.name}] Running verification pass...`);
     try {
       await withOpTimeout(connector.verify(), `${connector.name} verify()`);
+      console.log(`[${connector.name}] Verification passed`);
     } catch (err) {
-      console.error(`[${connector.name}] Verification failed:`, err);
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[${connector.name}] Verification failed: ${msg}`);
     }
   }
 

--- a/templates/keynote-2/src/rpc-servers/sqlite-rpc-server.ts
+++ b/templates/keynote-2/src/rpc-servers/sqlite-rpc-server.ts
@@ -1,4 +1,4 @@
-﻿import 'dotenv/config';
+import 'dotenv/config';
 import http from 'node:http';
 import Database from 'better-sqlite3';
 import { drizzle } from 'drizzle-orm/better-sqlite3';
@@ -81,11 +81,13 @@ async function rpcTransfer(args: Record<string, unknown>) {
 
     tx.update(accounts)
       .set({ balance: Number(newFrom) })
-      .where(eq(accounts.id, fromId));
+      .where(eq(accounts.id, fromId))
+      .run();
 
     tx.update(accounts)
       .set({ balance: Number(newTo) })
-      .where(eq(accounts.id, toId));
+      .where(eq(accounts.id, toId))
+      .run();
   });
 }
 
@@ -204,6 +206,10 @@ async function rpcSeed(args: Record<string, unknown>) {
   );
 }
 
+function rpcErr(err: unknown): string {
+  return err instanceof Error ? err.message : String(err);
+}
+
 async function handleRpc(body: RpcRequest): Promise<RpcResponse> {
   const name = body?.name;
   const args = body?.args ?? {};
@@ -226,10 +232,9 @@ async function handleRpc(body: RpcRequest): Promise<RpcResponse> {
       default:
         return { ok: false, error: `unknown method: ${name}` };
     }
-  } catch (err: any) {
-    // Log full error details on the server, but return a generic message to the client.
+  } catch (err: unknown) {
     console.error('Unhandled error in handleRpc:', err);
-    return { ok: false, error: 'internal error' };
+    return { ok: false, error: rpcErr(err) };
   }
 }
 
@@ -244,20 +249,27 @@ const server = http.createServer((req, res) => {
       buf += chunk;
     });
     req.on('end', async () => {
-      let body: RpcRequest;
       try {
-        body = JSON.parse(buf) as RpcRequest;
-      } catch {
-        res.statusCode = 400;
-        res.setHeader('content-type', 'application/json');
-        res.end(JSON.stringify({ ok: false, error: 'invalid json' }));
-        return;
-      }
+        let body: RpcRequest;
+        try {
+          body = JSON.parse(buf) as RpcRequest;
+        } catch {
+          res.statusCode = 400;
+          res.setHeader('content-type', 'application/json');
+          res.end(JSON.stringify({ ok: false, error: 'invalid json' }));
+          return;
+        }
 
-      const rsp = await handleRpc(body);
-      res.statusCode = rsp.ok ? 200 : 500;
-      res.setHeader('content-type', 'application/json');
-      res.end(JSON.stringify(rsp));
+        const rsp = await handleRpc(body);
+        res.statusCode = rsp.ok ? 200 : 500;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify(rsp));
+      } catch (err: unknown) {
+        console.error('[sqlite-rpc] request handler error:', err);
+        res.statusCode = 500;
+        res.setHeader('content-type', 'application/json');
+        res.end(JSON.stringify({ ok: false, error: rpcErr(err) }));
+      }
     });
     return;
   }


### PR DESCRIPTION
# Description of Changes

Fix the SQLite RPC benchmark so transfers actually persist and verification produces useful output.

**`sqlite-rpc-server.ts`:**
- Add `.run()` to both Drizzle `tx.update()` chains in `rpcTransfer`. Without this, the UPDATE statements were never executed — the benchmark was only measuring SELECT + HTTP overhead, not real transactional writes. This inflated SQLite TPS numbers significantly.
- Replace the generic `"internal error"` catch-all in `handleRpc` with `rpcErr()`, which returns the actual error message to the client. Also wrap the outer HTTP handler in a try/catch so errors outside `handleRpc` are surfaced too.

**`sqlite_rpc.ts` (connector):**
- Detect `{ skipped: true }` from the server's verify endpoint and throw a clear error telling the user to set `SEED_INITIAL_BALANCE` on the RPC server process. Previously this was silently treated as success.

**`runner.ts` / `runner_1.ts`:**
- Log "Verification passed" on success and "Verification failed: \<reason\>" (as a string, not a raw Error object) on failure, so the outcome is always visible in bench output.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1 

# Testing

- [ ] Run `npx tsx src/rpc-servers/sqlite-rpc-server.ts` (with `SEED_INITIAL_BALANCE` set), then `npm run test-1 -- --connectors sqlite_rpc --seconds 5` with `VERIFY=1`. Confirm TPS drops significantly vs the old (broken) numbers and "Verification passed" appears.
- [ ] Run the same without `SEED_INITIAL_BALANCE` on the server process. Confirm "Verification failed" with a message about the missing env var (not "internal error").