### PR TITLE
CI - Disable PR approval check

### DIFF
--- a/.github/workflows/pr_approval_check.yml
+++ b/.github/workflows/pr_approval_check.yml
@@ -30,6 +30,9 @@ jobs:
   publish-approval-status:
     name: Set approval status
     runs-on: ubuntu-latest
+    # Disabled until we can spend some more focus on making this work consistently.
+    # See https://github.com/clockworklabs/SpacetimeDB/pull/4673.
+    if: false
 
     # SECURITY: Do not add a checkout step to this job. See comment at the top of this file.
     steps:


### PR DESCRIPTION
# Description of Changes

Disabling this for now since it's buggy and I'm about to be out for a while.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

This can't be tested since it runs using the version in the base branch.