### PR TITLE
Rotate V8 isolate on heap growth or fragmentation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -7991,6 +7991,7 @@ dependencies = [
  "hostname",
  "http 1.3.1",
  "http-body-util",
+ "humantime",
  "hyper 1.7.0",
  "imara-diff",
  "indexmap 2.12.0",

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -64,6 +64,7 @@ hex.workspace = true
 hostname.workspace = true
 http.workspace = true
 http-body-util.workspace = true
+humantime.workspace = true
 hyper.workspace = true
 imara-diff.workspace = true
 indexmap.workspace = true

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,6 +1,8 @@
 use std::path::Path;
+use std::time::Duration;
 use std::{fmt, io};
 
+use serde::Deserialize;
 use spacetimedb_lib::ConnectionId;
 use spacetimedb_paths::cli::{ConfigDir, PrivKeyPath, PubKeyPath};
 use spacetimedb_paths::server::{ConfigToml, MetadataTomlPath};
@@ -131,6 +133,8 @@ pub struct ConfigFile {
     pub certificate_authority: Option<CertificateAuthority>,
     #[serde(default)]
     pub logs: LogConfig,
+    #[serde(default)]
+    pub v8_heap_policy: V8HeapPolicyConfig,
 }
 
 impl ConfigFile {
@@ -167,6 +171,139 @@ pub struct LogConfig {
     pub level: Option<tracing_core::LevelFilter>,
     #[serde(default)]
     pub directives: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+pub struct V8HeapPolicyConfig {
+    #[serde(default = "def_req_interval", deserialize_with = "de_nz_u64")]
+    pub heap_check_request_interval: Option<u64>,
+    #[serde(default = "def_time_interval", deserialize_with = "de_nz_duration")]
+    pub heap_check_time_interval: Option<Duration>,
+    #[serde(default = "def_gc_trigger", deserialize_with = "de_fraction")]
+    pub heap_gc_trigger_fraction: f64,
+    #[serde(default = "def_retire", deserialize_with = "de_fraction")]
+    pub heap_retire_fraction: f64,
+    #[serde(default, rename = "heap-limit-mb", deserialize_with = "de_limit_mb")]
+    pub heap_limit_bytes: Option<usize>,
+}
+
+impl Default for V8HeapPolicyConfig {
+    fn default() -> Self {
+        Self {
+            heap_check_request_interval: def_req_interval(),
+            heap_check_time_interval: def_time_interval(),
+            heap_gc_trigger_fraction: def_gc_trigger(),
+            heap_retire_fraction: def_retire(),
+            heap_limit_bytes: None,
+        }
+    }
+}
+
+impl V8HeapPolicyConfig {
+    pub fn normalized(mut self) -> Self {
+        if self.heap_retire_fraction < self.heap_gc_trigger_fraction {
+            log::warn!(
+                "v8-heap-policy.heap-retire-fraction ({}) is below \
+                 v8-heap-policy.heap-gc-trigger-fraction ({}); using the GC trigger fraction for both",
+                self.heap_retire_fraction,
+                self.heap_gc_trigger_fraction,
+            );
+            self.heap_retire_fraction = self.heap_gc_trigger_fraction;
+        }
+
+        self
+    }
+}
+
+/// Default number of requests between V8 heap checks.
+fn def_req_interval() -> Option<u64> {
+    Some(65_536)
+}
+
+/// Default wall-clock interval between V8 heap checks.
+fn def_time_interval() -> Option<Duration> {
+    Some(Duration::from_secs(30))
+}
+
+/// Default heap fill fraction that triggers a GC.
+fn def_gc_trigger() -> f64 {
+    0.67
+}
+
+/// Default heap fill fraction that retires the worker after a GC.
+fn def_retire() -> f64 {
+    0.75
+}
+
+fn de_nz_u64<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = u64::deserialize(deserializer)?;
+    Ok((value != 0).then_some(value))
+}
+
+fn de_nz_duration<'de, D>(deserializer: D) -> Result<Option<Duration>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum DurationValue {
+        String(String),
+        Seconds(u64),
+    }
+
+    let duration = match DurationValue::deserialize(deserializer)? {
+        DurationValue::String(value) => humantime::parse_duration(&value).map_err(serde::de::Error::custom)?,
+        DurationValue::Seconds(value) => Duration::from_secs(value),
+    };
+
+    Ok((!duration.is_zero()).then_some(duration))
+}
+
+fn de_fraction<'de, D>(deserializer: D) -> Result<f64, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    #[derive(serde::Deserialize)]
+    #[serde(untagged)]
+    enum FractionValue {
+        Integer(u64),
+        Float(f64),
+    }
+
+    let value = match FractionValue::deserialize(deserializer)? {
+        FractionValue::Integer(value) => value as f64,
+        FractionValue::Float(value) => value,
+    };
+
+    if value.is_finite() && (0.0..=1.0).contains(&value) {
+        Ok(value)
+    } else {
+        Err(serde::de::Error::custom(format!(
+            "expected a fraction between 0.0 and 1.0, got {value}"
+        )))
+    }
+}
+
+fn de_limit_mb<'de, D>(deserializer: D) -> Result<Option<usize>, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = u64::deserialize(deserializer)?;
+    if value == 0 {
+        return Ok(None);
+    }
+
+    let bytes = value
+        .checked_mul(1024 * 1024)
+        .ok_or_else(|| serde::de::Error::custom("heap-limit-mb is too large"))?;
+
+    usize::try_from(bytes)
+        .map(Some)
+        .map_err(|_| serde::de::Error::custom("heap-limit-mb does not fit in usize"))
 }
 
 #[cfg(test)]
@@ -269,5 +406,42 @@ mod tests {
         mkmeta(2, 0, 0)
             .check_compatibility_and_update(mkmeta_pre(2, 1, 0, "rc1"))
             .unwrap_err();
+    }
+
+    #[test]
+    fn v8_heap_policy_defaults_when_omitted() {
+        let config: ConfigFile = toml::from_str("").unwrap();
+
+        assert_eq!(config.v8_heap_policy.heap_check_request_interval, Some(65_536));
+        assert_eq!(
+            config.v8_heap_policy.heap_check_time_interval,
+            Some(Duration::from_secs(30))
+        );
+        assert_eq!(config.v8_heap_policy.heap_gc_trigger_fraction, 0.67);
+        assert_eq!(config.v8_heap_policy.heap_retire_fraction, 0.75);
+        assert_eq!(config.v8_heap_policy.heap_limit_bytes, None);
+    }
+
+    #[test]
+    fn v8_heap_policy_parses_from_toml() {
+        let toml = r#"
+            [v8-heap-policy]
+            heap-check-request-interval = 0
+            heap-check-time-interval = "45s"
+            heap-gc-trigger-fraction = 0.6
+            heap-retire-fraction = 0.8
+            heap-limit-mb = 256
+        "#;
+
+        let config: ConfigFile = toml::from_str(toml).unwrap();
+
+        assert_eq!(config.v8_heap_policy.heap_check_request_interval, None);
+        assert_eq!(
+            config.v8_heap_policy.heap_check_time_interval,
+            Some(Duration::from_secs(45))
+        );
+        assert_eq!(config.v8_heap_policy.heap_gc_trigger_fraction, 0.6);
+        assert_eq!(config.v8_heap_policy.heap_retire_fraction, 0.8);
+        assert_eq!(config.v8_heap_policy.heap_limit_bytes, Some(256 * 1024 * 1024));
     }
 }

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -3,6 +3,7 @@ use super::scheduler::SchedulerStarter;
 use super::wasmtime::WasmtimeRuntime;
 use super::{Scheduler, UpdateDatabaseResult};
 use crate::client::{ClientActorId, ClientName};
+use crate::config::V8HeapPolicyConfig;
 use crate::database_logger::DatabaseLogger;
 use crate::db::persistence::PersistenceProvider;
 use crate::db::relational_db::{self, spawn_view_cleanup_loop, DiskSizeFn, RelationalDB, Txdata};
@@ -124,9 +125,9 @@ pub(crate) struct HostRuntimes {
 }
 
 impl HostRuntimes {
-    fn new(data_dir: Option<&ServerDataDir>) -> Arc<Self> {
+    fn new(data_dir: Option<&ServerDataDir>, v8_heap_policy: V8HeapPolicyConfig) -> Arc<Self> {
         let wasmtime = WasmtimeRuntime::new(data_dir);
-        let v8 = V8Runtime::default();
+        let v8 = V8Runtime::new(v8_heap_policy);
         Arc::new(Self { wasmtime, v8 })
     }
 }
@@ -210,6 +211,7 @@ impl HostController {
     pub fn new(
         data_dir: Arc<ServerDataDir>,
         default_config: db::Config,
+        v8_heap_policy: V8HeapPolicyConfig,
         program_storage: ProgramStorage,
         energy_monitor: Arc<impl EnergyMonitor>,
         persistence: Arc<dyn PersistenceProvider>,
@@ -221,7 +223,7 @@ impl HostController {
             program_storage,
             energy_monitor,
             persistence,
-            runtimes: HostRuntimes::new(Some(&data_dir)),
+            runtimes: HostRuntimes::new(Some(&data_dir), v8_heap_policy),
             data_dir,
             page_pool: PagePool::new(default_config.page_pool_max_size),
             bsatn_rlb_pool: BsatnRowListBuilderPool::new(),
@@ -1387,7 +1389,7 @@ pub async fn extract_schema(program_bytes: Box<[u8]>, host_type: HostType) -> an
     extract_schema_with_pools(
         PagePool::new(None),
         BsatnRowListBuilderPool::new(),
-        &HostRuntimes::new(None),
+        &HostRuntimes::new(None, V8HeapPolicyConfig::default()),
         program_bytes,
         host_type,
     )
@@ -1421,4 +1423,12 @@ where
         .data_size_blob_store_bytes_used_by_blobs
         .remove_label_values(db);
     let _ = WORKER_METRICS.wasm_memory_bytes.remove_label_values(db);
+    let _ = WORKER_METRICS.v8_total_heap_size_bytes.remove_label_values(db);
+    let _ = WORKER_METRICS.v8_total_physical_size_bytes.remove_label_values(db);
+    let _ = WORKER_METRICS.v8_used_global_handles_size_bytes.remove_label_values(db);
+    let _ = WORKER_METRICS.v8_used_heap_size_bytes.remove_label_values(db);
+    let _ = WORKER_METRICS.v8_heap_size_limit_bytes.remove_label_values(db);
+    let _ = WORKER_METRICS.v8_external_memory_bytes.remove_label_values(db);
+    let _ = WORKER_METRICS.v8_native_contexts.remove_label_values(db);
+    let _ = WORKER_METRICS.v8_detached_contexts.remove_label_values(db);
 }

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -347,8 +347,8 @@ pub enum ModuleWithInstance {
 }
 
 enum ModuleHostInner {
-    Wasm(WasmtimeModuleHost),
-    Js(V8ModuleHost),
+    Wasm(Box<WasmtimeModuleHost>),
+    Js(Box<V8ModuleHost>),
 }
 
 struct WasmtimeModuleHost {
@@ -1070,20 +1070,20 @@ impl ModuleHost {
             } => {
                 info = module.info();
                 let instance_manager = ModuleInstanceManager::new(module, Some(init_inst), database_identity);
-                Arc::new(ModuleHostInner::Wasm(WasmtimeModuleHost {
+                Arc::new(ModuleHostInner::Wasm(Box::new(WasmtimeModuleHost {
                     executor,
                     instance_manager,
-                }))
+                })))
             }
             ModuleWithInstance::Js { module, init_inst } => {
                 info = module.info();
                 let instance_lane = super::v8::JsInstanceLane::new(module.clone(), init_inst);
                 let procedure_instances = ModuleInstanceManager::new(module.clone(), None, database_identity);
-                Arc::new(ModuleHostInner::Js(V8ModuleHost {
+                Arc::new(ModuleHostInner::Js(Box::new(V8ModuleHost {
                     module,
                     instance_lane,
                     procedure_instances,
-                }))
+                })))
             }
         };
         let on_panic = Arc::new(on_panic);
@@ -1143,7 +1143,8 @@ impl ModuleHost {
         let timer_guard = self.start_call_timer(label);
 
         Ok(match &*self.inner {
-            ModuleHostInner::Wasm(WasmtimeModuleHost { executor, .. }) => {
+            ModuleHostInner::Wasm(wasm) => {
+                let executor = &wasm.executor;
                 executor
                     .run_job(async move || {
                         drop(timer_guard);
@@ -1151,7 +1152,8 @@ impl ModuleHost {
                     })
                     .await
             }
-            ModuleHostInner::Js(V8ModuleHost { instance_lane, .. }) => {
+            ModuleHostInner::Js(js) => {
+                let instance_lane = &js.instance_lane;
                 instance_lane
                     .run_on_thread(async move || {
                         drop(timer_guard);
@@ -1215,15 +1217,14 @@ impl ModuleHost {
         });
 
         Ok(match &*self.inner {
-            ModuleHostInner::Wasm(WasmtimeModuleHost {
-                executor,
-                instance_manager,
-            }) => {
+            ModuleHostInner::Wasm(wasm) => {
+                let executor = &wasm.executor;
+                let instance_manager = &wasm.instance_manager;
                 instance_manager
                     .with_instance(async |inst| work_wasm(timer_guard, executor, inst, arg).await)
                     .await
             }
-            ModuleHostInner::Js(V8ModuleHost { instance_lane, .. }) => work_js(timer_guard, instance_lane, arg).await,
+            ModuleHostInner::Js(js) => work_js(timer_guard, &js.instance_lane, arg).await,
         })
     }
 
@@ -1294,13 +1295,10 @@ impl ModuleHost {
         });
 
         Ok(match &*self.inner {
-            ModuleHostInner::Wasm(WasmtimeModuleHost {
-                executor,
-                instance_manager,
-            }) => {
-                instance_manager
+            ModuleHostInner::Wasm(host) => {
+                host.instance_manager
                     .with_instance(async |mut inst| {
-                        executor
+                        host.executor
                             .run_job(async move || {
                                 drop(timer_guard);
                                 (wasm(arg, &mut inst).await, inst)
@@ -1309,10 +1307,8 @@ impl ModuleHost {
                     })
                     .await
             }
-            ModuleHostInner::Js(V8ModuleHost {
-                procedure_instances, ..
-            }) => {
-                procedure_instances
+            ModuleHostInner::Js(host) => {
+                host.procedure_instances
                     .with_instance(async |inst| {
                         drop(timer_guard);
                         let res = js(arg, &inst).await;

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -13,6 +13,7 @@ use super::module_common::{build_common_module_from_raw, run_describer, ModuleCo
 use super::module_host::{CallProcedureParams, CallReducerParams, ModuleInfo, ModuleWithInstance};
 use super::UpdateDatabaseResult;
 use crate::client::ClientActorId;
+use crate::config::V8HeapPolicyConfig;
 use crate::host::host_controller::CallProcedureReturn;
 use crate::host::instance_env::{ChunkPool, InstanceEnv, TxSlot};
 use crate::host::module_host::{
@@ -31,12 +32,14 @@ use crate::module_host_context::ModuleCreationContext;
 use crate::replica_context::ReplicaContext;
 use crate::subscription::module_subscription_manager::TransactionOffset;
 use crate::util::jobs::{AllocatedJobCore, CorePinner, LoadBalanceOnDropGuard};
+use crate::worker_metrics::WORKER_METRICS;
 use core::any::type_name;
 use core::str;
 use futures::future::LocalBoxFuture;
 use futures::FutureExt;
 use itertools::Either;
 use parking_lot::RwLock;
+use prometheus::IntGauge;
 use spacetimedb_auth::identity::ConnectionAuthCtx;
 use spacetimedb_client_api_messages::energy::FunctionBudget;
 use spacetimedb_datastore::locking_tx_datastore::FuncCallType;
@@ -71,19 +74,32 @@ mod to_value;
 mod util;
 
 /// The V8 runtime, for modules written in e.g., JS or TypeScript.
-#[derive(Default)]
 pub struct V8Runtime {
-    _priv: (),
+    heap_policy: V8HeapPolicyConfig,
+}
+
+impl Default for V8Runtime {
+    fn default() -> Self {
+        Self::new(V8HeapPolicyConfig::default())
+    }
 }
 
 impl V8Runtime {
+    pub fn new(heap_policy: V8HeapPolicyConfig) -> Self {
+        Self {
+            heap_policy: heap_policy.normalized(),
+        }
+    }
+
     pub async fn make_actor(
         &self,
         mcc: ModuleCreationContext,
         program_bytes: &[u8],
         core: AllocatedJobCore,
     ) -> anyhow::Result<ModuleWithInstance> {
-        V8_RUNTIME_GLOBAL.make_actor(mcc, program_bytes, core).await
+        V8_RUNTIME_GLOBAL
+            .make_actor(mcc, program_bytes, core, self.heap_policy)
+            .await
     }
 }
 
@@ -182,6 +198,7 @@ impl V8RuntimeInner {
         mcc: ModuleCreationContext,
         program_bytes: &[u8],
         core: AllocatedJobCore,
+        heap_policy: V8HeapPolicyConfig,
     ) -> anyhow::Result<ModuleWithInstance> {
         #![allow(unreachable_code, unused_variables)]
 
@@ -198,13 +215,20 @@ impl V8RuntimeInner {
         let mcc = Either::Right(mcc);
         let load_balance_guard = Arc::new(core.guard);
         let core_pinner = core.pinner;
-        let (common, init_inst) =
-            spawn_instance_worker(program.clone(), mcc, load_balance_guard.clone(), core_pinner.clone()).await?;
+        let (common, init_inst) = spawn_instance_worker(
+            program.clone(),
+            mcc,
+            load_balance_guard.clone(),
+            core_pinner.clone(),
+            heap_policy,
+        )
+        .await?;
         let module = JsModule {
             common,
             program,
             load_balance_guard,
             core_pinner,
+            heap_policy,
         };
 
         Ok(ModuleWithInstance::Js { module, init_inst })
@@ -217,6 +241,7 @@ pub struct JsModule {
     program: Arc<str>,
     load_balance_guard: Arc<LoadBalanceOnDropGuard>,
     core_pinner: CorePinner,
+    heap_policy: V8HeapPolicyConfig,
 }
 
 impl JsModule {
@@ -237,11 +262,18 @@ impl JsModule {
         let common = self.common.clone();
         let load_balance_guard = self.load_balance_guard.clone();
         let core_pinner = self.core_pinner.clone();
+        let heap_policy = self.heap_policy;
 
         // This has to be done in a blocking context because of `blocking_recv`.
-        let (_, instance) = spawn_instance_worker(program, Either::Left(common), load_balance_guard, core_pinner)
-            .await
-            .expect("`spawn_instance_worker` should succeed when passed `ModuleCommon`");
+        let (_, instance) = spawn_instance_worker(
+            program,
+            Either::Left(common),
+            load_balance_guard,
+            core_pinner,
+            heap_policy,
+        )
+        .await
+        .expect("`spawn_instance_worker` should succeed when passed `ModuleCommon`");
         instance
     }
 }
@@ -589,6 +621,97 @@ fn send_worker_reply<T>(ctx: &str, reply_tx: JsReplyTx<T>, value: T, trapped: bo
     }
 }
 
+struct V8HeapMetrics {
+    total_heap_size_bytes: IntGauge,
+    total_physical_size_bytes: IntGauge,
+    used_global_handles_size_bytes: IntGauge,
+    used_heap_size_bytes: IntGauge,
+    heap_size_limit_bytes: IntGauge,
+    external_memory_bytes: IntGauge,
+    native_contexts: IntGauge,
+    detached_contexts: IntGauge,
+}
+
+impl V8HeapMetrics {
+    fn new(database_identity: &Identity) -> Self {
+        Self {
+            total_heap_size_bytes: WORKER_METRICS
+                .v8_total_heap_size_bytes
+                .with_label_values(database_identity),
+            total_physical_size_bytes: WORKER_METRICS
+                .v8_total_physical_size_bytes
+                .with_label_values(database_identity),
+            used_global_handles_size_bytes: WORKER_METRICS
+                .v8_used_global_handles_size_bytes
+                .with_label_values(database_identity),
+            used_heap_size_bytes: WORKER_METRICS
+                .v8_used_heap_size_bytes
+                .with_label_values(database_identity),
+            heap_size_limit_bytes: WORKER_METRICS
+                .v8_heap_size_limit_bytes
+                .with_label_values(database_identity),
+            external_memory_bytes: WORKER_METRICS
+                .v8_external_memory_bytes
+                .with_label_values(database_identity),
+            native_contexts: WORKER_METRICS.v8_native_contexts.with_label_values(database_identity),
+            detached_contexts: WORKER_METRICS.v8_detached_contexts.with_label_values(database_identity),
+        }
+    }
+
+    fn observe(&self, stats: &v8::HeapStatistics) {
+        self.total_heap_size_bytes.set(stats.total_heap_size() as i64);
+        self.total_physical_size_bytes.set(stats.total_physical_size() as i64);
+        self.used_global_handles_size_bytes
+            .set(stats.used_global_handles_size() as i64);
+        self.used_heap_size_bytes.set(stats.used_heap_size() as i64);
+        self.heap_size_limit_bytes.set(stats.heap_size_limit() as i64);
+        self.external_memory_bytes.set(stats.external_memory() as i64);
+        self.native_contexts.set(stats.number_of_native_contexts() as i64);
+        self.detached_contexts.set(stats.number_of_detached_contexts() as i64);
+    }
+}
+
+fn sample_heap_stats(scope: &mut PinScope<'_, '_>, metrics: &V8HeapMetrics) -> v8::HeapStatistics {
+    let stats = scope.get_heap_statistics();
+    metrics.observe(&stats);
+    stats
+}
+
+fn heap_usage(stats: &v8::HeapStatistics) -> (usize, usize) {
+    (stats.used_heap_size(), stats.heap_size_limit())
+}
+
+fn heap_fraction_at_or_above(used: usize, limit: usize, fraction: f64) -> bool {
+    limit > 0 && ((used as f64) / (limit as f64)) >= fraction
+}
+
+/// The single JS worker can process an unbounded number of reducer calls over its lifetime.
+/// That is great for locality, but it also means any JS heap retention that would previously
+/// have been spread across several pooled isolates now accumulates in one isolate.
+///
+/// If heap usage is close to the configured limit even after manually invoking GC,
+/// we'll instantiate a new isolate to reclaim memory and avoid OOMing the current one.
+fn should_retire_worker_for_heap(
+    scope: &mut PinScope<'_, '_>,
+    metrics: &V8HeapMetrics,
+    config: V8HeapPolicyConfig,
+) -> Option<(usize, usize)> {
+    let stats = sample_heap_stats(scope, metrics);
+    let (used, limit) = heap_usage(&stats);
+    if !heap_fraction_at_or_above(used, limit, config.heap_gc_trigger_fraction) {
+        return None;
+    }
+
+    scope.low_memory_notification();
+    let stats = sample_heap_stats(scope, metrics);
+    let (used, limit) = heap_usage(&stats);
+    if heap_fraction_at_or_above(used, limit, config.heap_retire_fraction) {
+        Some((used, limit))
+    } else {
+        None
+    }
+}
+
 struct JsInstanceLaneState {
     // Instance-lane calls stay on one active worker for locality. The hot path clones
     // this handle and feeds work straight into the worker-owned FIFO; trap
@@ -596,7 +719,7 @@ struct JsInstanceLaneState {
     active: RwLock<JsInstance>,
 
     // Replacement must be serialized because multiple callers can all observe
-    // the same trapped worker and attempt recovery at once.
+    // the same worker becoming unusable and attempt recovery at once.
     //
     // This must be an async mutex rather than a blocking mutex because recovery
     // may need to call `create_instance().await`.
@@ -654,7 +777,7 @@ impl JsInstanceLane {
             return;
         }
 
-        log::warn!("instance lane worker trapped; creating a fresh instance-lane worker");
+        log::warn!("instance lane worker needs replacement; creating a fresh instance-lane worker");
 
         // Keep the awaited instance creation outside of any `parking_lot` guard.
         // The only lock held across this await is `replace_lock`, which is why it
@@ -884,8 +1007,13 @@ fn startup_instance_worker<'scope>(
 }
 
 /// Returns a new isolate.
-fn new_isolate() -> OwnedIsolate {
-    let mut isolate = Isolate::new(<_>::default());
+fn new_isolate(heap_policy: V8HeapPolicyConfig) -> OwnedIsolate {
+    let params = if let Some(heap_limit_bytes) = heap_policy.heap_limit_bytes {
+        v8::CreateParams::default().heap_limits(0, heap_limit_bytes)
+    } else {
+        v8::CreateParams::default()
+    };
+    let mut isolate = Isolate::new(params);
     isolate.set_capture_stack_trace_for_uncaught_exceptions(true, 1024);
     isolate
 }
@@ -908,6 +1036,7 @@ async fn spawn_instance_worker(
     module_or_mcc: Either<ModuleCommon, ModuleCreationContext>,
     load_balance_guard: Arc<LoadBalanceOnDropGuard>,
     mut core_pinner: CorePinner,
+    heap_policy: V8HeapPolicyConfig,
 ) -> anyhow::Result<(ModuleCommon, JsInstance)> {
     // Spawn a rendezvous queue for requests to the worker.
     // Multiple callers can wait to hand work to the worker, but with
@@ -917,6 +1046,8 @@ async fn spawn_instance_worker(
 
     // This one-shot channel is used for initial startup error handling within the thread.
     let (result_tx, result_rx) = oneshot::channel();
+    let trapped = Arc::new(AtomicBool::new(false));
+    let worker_trapped = trapped.clone();
 
     let rt = tokio::runtime::Handle::current();
 
@@ -927,7 +1058,7 @@ async fn spawn_instance_worker(
         let _entered = rt.enter();
 
         // Create the isolate and scope.
-        let mut isolate = new_isolate();
+        let mut isolate = new_isolate(heap_policy);
         scope_with_context!(let scope, &mut isolate, Context::new(scope, Default::default()));
 
         // Setup the instance environment.
@@ -976,6 +1107,7 @@ async fn spawn_instance_worker(
         let info = &module_common.info();
         let mut instance_common = InstanceCommon::new(&module_common);
         let replica_ctx: &Arc<ReplicaContext> = module_common.replica_ctx();
+        let heap_metrics = V8HeapMetrics::new(&info.database_identity);
 
         // Create a zero-initialized buffer for holding reducer args.
         // Arguments needing more space will not use this.
@@ -988,11 +1120,14 @@ async fn spawn_instance_worker(
             hooks: &hooks,
             reducer_args_buf,
         };
+        let _initial_heap_stats = sample_heap_stats(inst.scope, &heap_metrics);
 
         // Process requests to the worker.
         //
         // The loop is terminated when the last `JsInstance` handle is dropped.
         // This will cause channels, scopes, and the isolate to be cleaned up.
+        let mut requests_since_heap_check = 0u64;
+        let mut last_heap_check_at = Instant::now();
         for request in request_rx.iter() {
             let mut call_reducer = |tx, params| instance_common.call_reducer_with_tx(tx, params, &mut inst);
             let mut should_exit = false;
@@ -1012,11 +1147,13 @@ async fn spawn_instance_worker(
                 }
                 JsWorkerRequest::CallReducer { reply_tx, params } => {
                     let (res, trapped) = call_reducer(None, params);
+                    worker_trapped.store(trapped, Ordering::Relaxed);
                     send_worker_reply("call_reducer", reply_tx, res, trapped);
                     should_exit = trapped;
                 }
                 JsWorkerRequest::CallView { reply_tx, cmd } => {
                     let (res, trapped) = instance_common.handle_cmd(cmd, &mut inst);
+                    worker_trapped.store(trapped, Ordering::Relaxed);
                     send_worker_reply("call_view", reply_tx, res, trapped);
                     should_exit = trapped;
                 }
@@ -1025,6 +1162,7 @@ async fn spawn_instance_worker(
                         .call_procedure(params, &mut inst)
                         .now_or_never()
                         .expect("our call_procedure implementation is not actually async");
+                    worker_trapped.store(trapped, Ordering::Relaxed);
                     send_worker_reply("call_procedure", reply_tx, res, trapped);
                     should_exit = trapped;
                 }
@@ -1040,6 +1178,7 @@ async fn spawn_instance_worker(
                     let mut trapped = false;
                     let res =
                         call_identity_connected(caller_auth, caller_connection_id, info, call_reducer, &mut trapped);
+                    worker_trapped.store(trapped, Ordering::Relaxed);
                     send_worker_reply("call_identity_connected", reply_tx, res, trapped);
                     should_exit = trapped;
                 }
@@ -1056,18 +1195,21 @@ async fn spawn_instance_worker(
                         call_reducer,
                         &mut trapped,
                     );
+                    worker_trapped.store(trapped, Ordering::Relaxed);
                     send_worker_reply("call_identity_disconnected", reply_tx, res, trapped);
                     should_exit = trapped;
                 }
                 JsWorkerRequest::DisconnectClient { reply_tx, client_id } => {
                     let mut trapped = false;
                     let res = ModuleHost::disconnect_client_inner(client_id, info, call_reducer, &mut trapped);
+                    worker_trapped.store(trapped, Ordering::Relaxed);
                     send_worker_reply("disconnect_client", reply_tx, res, trapped);
                     should_exit = trapped;
                 }
                 JsWorkerRequest::InitDatabase { reply_tx, program } => {
                     let (res, trapped): (Result<Option<ReducerCallResult>, anyhow::Error>, bool) =
                         init_database(replica_ctx, &module_common.info().module_def, program, call_reducer);
+                    worker_trapped.store(trapped, Ordering::Relaxed);
                     send_worker_reply("init_database", reply_tx, res, trapped);
                     should_exit = trapped;
                 }
@@ -1076,8 +1218,32 @@ async fn spawn_instance_worker(
                         .call_scheduled_function(params, &mut inst)
                         .now_or_never()
                         .expect("our call_procedure implementation is not actually async");
+                    worker_trapped.store(trapped, Ordering::Relaxed);
                     send_worker_reply("call_scheduled_function", reply_tx, res, trapped);
                     should_exit = trapped;
+                }
+            }
+
+            if !should_exit {
+                let request_check_due = heap_policy.heap_check_request_interval.is_some_and(|interval| {
+                    requests_since_heap_check += 1;
+                    requests_since_heap_check >= interval
+                });
+                let time_check_due = heap_policy
+                    .heap_check_time_interval
+                    .is_some_and(|interval| last_heap_check_at.elapsed() >= interval);
+                if request_check_due || time_check_due {
+                    requests_since_heap_check = 0;
+                    last_heap_check_at = Instant::now();
+                    if let Some((used, limit)) = should_retire_worker_for_heap(inst.scope, &heap_metrics, heap_policy) {
+                        worker_trapped.store(true, Ordering::Relaxed);
+                        should_exit = true;
+                        log::warn!(
+                            "retiring JS worker after V8 heap stayed high post-GC: used={}MiB limit={}MiB",
+                            used / (1024 * 1024),
+                            limit / (1024 * 1024),
+                        );
+                    }
                 }
             }
 
@@ -1085,6 +1251,11 @@ async fn spawn_instance_worker(
             // on that poisoned isolate. We reply to the trapping request first so
             // the caller can observe the actual reducer/procedure error, and then
             // shut the worker down so later callers retry on a fresh instance.
+            //
+            // We also retire workers when they stay near the V8 heap limit after
+            // a GC. The instance lane intentionally keeps a JS worker alive for
+            // a long time, so this gives it a bounded-memory replacement policy
+            // instead of letting one isolate absorb the entire module lifetime.
             if should_exit {
                 break;
             }
@@ -1097,7 +1268,7 @@ async fn spawn_instance_worker(
         let inst = JsInstance {
             id: NEXT_JS_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
             request_tx,
-            trapped: Arc::new(AtomicBool::new(false)),
+            trapped,
         };
         (opt_mc, inst)
     })

--- a/crates/core/src/host/v8/to_value.rs
+++ b/crates/core/src/host/v8/to_value.rs
@@ -113,7 +113,7 @@ pub(in super::super) mod test {
     pub(in super::super) fn with_scope<R>(logic: impl FnOnce(&mut PinScope<'_, '_>) -> R) -> R {
         V8Runtime::init_for_test();
 
-        let mut isolate = new_isolate();
+        let mut isolate = new_isolate(Default::default());
         scope_with_context!(let scope, &mut isolate, Context::new(scope, Default::default()));
 
         logic(scope)

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -287,6 +287,46 @@ metrics_group!(
         #[labels(database_identity: Identity)]
         pub wasm_memory_bytes: IntGaugeVec,
 
+        #[name = spacetime_worker_v8_total_heap_size_bytes]
+        #[help = "The total size of the V8 heap for a database's JS worker isolate"]
+        #[labels(database_identity: Identity)]
+        pub v8_total_heap_size_bytes: IntGaugeVec,
+
+        #[name = spacetime_worker_v8_total_physical_size_bytes]
+        #[help = "The total committed physical V8 heap memory for a database's JS worker isolate"]
+        #[labels(database_identity: Identity)]
+        pub v8_total_physical_size_bytes: IntGaugeVec,
+
+        #[name = spacetime_worker_v8_used_global_handles_size_bytes]
+        #[help = "The used size of V8 global handles for a database's JS worker isolate"]
+        #[labels(database_identity: Identity)]
+        pub v8_used_global_handles_size_bytes: IntGaugeVec,
+
+        #[name = spacetime_worker_v8_used_heap_size_bytes]
+        #[help = "The live V8 heap size for a database's JS worker isolate"]
+        #[labels(database_identity: Identity)]
+        pub v8_used_heap_size_bytes: IntGaugeVec,
+
+        #[name = spacetime_worker_v8_heap_size_limit_bytes]
+        #[help = "The V8 heap size limit for a database's JS worker isolate"]
+        #[labels(database_identity: Identity)]
+        pub v8_heap_size_limit_bytes: IntGaugeVec,
+
+        #[name = spacetime_worker_v8_external_memory_bytes]
+        #[help = "The external memory tracked by V8 for a database's JS worker isolate"]
+        #[labels(database_identity: Identity)]
+        pub v8_external_memory_bytes: IntGaugeVec,
+
+        #[name = spacetime_worker_v8_native_contexts]
+        #[help = "The number of native V8 contexts for a database's JS worker isolate"]
+        #[labels(database_identity: Identity)]
+        pub v8_native_contexts: IntGaugeVec,
+
+        #[name = spacetime_worker_v8_detached_contexts]
+        #[help = "The number of detached V8 contexts for a database's JS worker isolate"]
+        #[labels(database_identity: Identity)]
+        pub v8_detached_contexts: IntGaugeVec,
+
         #[name = spacetime_active_queries]
         #[help = "The number of active subscription queries"]
         #[labels(database_identity: Identity)]

--- a/crates/standalone/config.toml
+++ b/crates/standalone/config.toml
@@ -18,4 +18,20 @@ directives = [
     "axum::rejection=trace",
 ]
 
+[v8-heap-policy]
+# Check the V8 heap after this many requests. Set to 0 to disable.
+# heap-check-request-interval = 65536
+
+# Also check the V8 heap after this much wall-clock time. Set to "0s" to disable.
+# heap-check-time-interval = "30s"
+
+# Trigger a GC when the heap reaches this fraction of the limit.
+# heap-gc-trigger-fraction = 0.67
+
+# Retire the worker if the heap is still this full after GC.
+# heap-retire-fraction = 0.75
+
+# Apply a V8 heap limit in MiB. Set to 0 to use V8's default limit.
+# heap-limit-mb = 0
+
 # vim: set nowritebackup: << otherwise triggers cargo-watch

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use clap::{ArgMatches, Command};
 use http::StatusCode;
 use spacetimedb::client::ClientActorIndex;
-use spacetimedb::config::{CertificateAuthority, MetadataFile};
+use spacetimedb::config::{CertificateAuthority, MetadataFile, V8HeapPolicyConfig};
 use spacetimedb::db;
 use spacetimedb::db::persistence::LocalPersistenceProvider;
 use spacetimedb::energy::{EnergyBalance, EnergyQuanta, NullEnergyMonitor};
@@ -42,6 +42,7 @@ pub use spacetimedb_client_api::routes::subscribe::{BIN_PROTOCOL, TEXT_PROTOCOL}
 pub struct StandaloneOptions {
     pub db_config: db::Config,
     pub websocket: WebSocketOptions,
+    pub v8_heap_policy: V8HeapPolicyConfig,
 }
 
 pub struct StandaloneEnv {
@@ -78,6 +79,7 @@ impl StandaloneEnv {
         let host_controller = HostController::new(
             data_dir,
             config.db_config,
+            config.v8_heap_policy,
             program_store.clone(),
             energy_monitor,
             persistence_provider,
@@ -648,6 +650,7 @@ mod tests {
                 page_pool_max_size: None,
             },
             websocket: WebSocketOptions::default(),
+            v8_heap_policy: V8HeapPolicyConfig::default(),
         };
 
         let _env = StandaloneEnv::init(config, &ca, data_dir.clone(), JobCores::without_pinned_cores()).await?;

--- a/crates/standalone/src/subcommands/start.rs
+++ b/crates/standalone/src/subcommands/start.rs
@@ -182,6 +182,7 @@ pub async fn exec(args: &ArgMatches, db_cores: JobCores) -> anyhow::Result<()> {
         StandaloneOptions {
             db_config,
             websocket: config.websocket,
+            v8_heap_policy: config.common.v8_heap_policy,
         },
         &certs,
         data_dir,
@@ -506,6 +507,13 @@ mod tests {
             [websocket]
             idle-timeout = "1min"
             close-handshake-timeout = "500ms"
+
+            [v8-heap-policy]
+            heap-check-request-interval = 0
+            heap-check-time-interval = "45s"
+            heap-gc-trigger-fraction = 0.6
+            heap-retire-fraction = 0.8
+            heap-limit-mb = 128
 "#;
 
         let config: ConfigFile = toml::from_str(toml).unwrap();
@@ -514,6 +522,14 @@ mod tests {
         // so check `common` in a pedestrian way.
         assert_eq!(&config.common.logs.directives, &["banana_shake=strawberry"]);
         assert!(config.common.certificate_authority.is_none());
+        assert_eq!(config.common.v8_heap_policy.heap_check_request_interval, None);
+        assert_eq!(
+            config.common.v8_heap_policy.heap_check_time_interval,
+            Some(Duration::from_secs(45))
+        );
+        assert_eq!(config.common.v8_heap_policy.heap_gc_trigger_fraction, 0.6);
+        assert_eq!(config.common.v8_heap_policy.heap_retire_fraction, 0.8);
+        assert_eq!(config.common.v8_heap_policy.heap_limit_bytes, Some(128 * 1024 * 1024));
 
         assert_eq!(
             config.websocket,

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -201,6 +201,7 @@ impl CompiledModule {
             spacetimedb_standalone::StandaloneOptions {
                 db_config: config,
                 websocket: WebSocketOptions::default(),
+                v8_heap_policy: Default::default(),
             },
             &certs,
             paths.data_dir.into(),


### PR DESCRIPTION
# Description of Changes

While testing #4663, I discovered the server would crash from a V8 out of memory error after processing many requests. Before #4663, this would not happen. I theorized that because we now have a single JS worker that can process an unbounded number of reducer calls over its lifetime, any V8 heap retention that would previously have been spread across several pooled isolates now accumulates in one isolate.

This patch now periodically collects heap statistics and forces GC or replaces the isolate if memory cannot be reclaimed. This greatly reduces the risk of hitting the V8 heap limit and crashing the server. It doesn't remove the risk entirely however. But this risk was still present before we switched to a single worker model in #4663. In order to remove the risk of crashing the server entirely, we would need to run V8 in a separate process.

# API and ABI breaking changes

None

# Expected complexity level and risk

3

# Testing

TBD
