### PR TITLE
core: Enable instrumentation of multiple tokio runtimes

### DIFF
--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -110,97 +110,97 @@ metrics_group!(
 
         #[name = tokio_num_workers]
         #[help = "Number of core tokio workers"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_num_workers: IntGaugeVec,
 
         #[name = tokio_num_blocking_threads]
         #[help = "Number of extra tokio threads for blocking tasks"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_num_blocking_threads: IntGaugeVec,
 
         #[name = tokio_num_idle_blocking_threads]
         #[help = "Number of tokio blocking threads that are idle"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_num_idle_blocking_threads: IntGaugeVec,
 
         #[name = tokio_num_alive_tasks]
         #[help = "Number of tokio tasks that are still alive"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_num_alive_tasks: IntGaugeVec,
 
         #[name = tokio_global_queue_depth]
         #[help = "Number of tasks in tokios global queue"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_global_queue_depth: IntGaugeVec,
 
         #[name = tokio_blocking_queue_depth]
         #[help = "Number of tasks in tokios blocking task queue"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_blocking_queue_depth: IntGaugeVec,
 
         #[name = tokio_spawned_tasks_count]
         #[help = "Number of tokio tasks spawned"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_spawned_tasks_count: IntCounterVec,
 
         #[name = tokio_remote_schedule_count]
         #[help = "Number of tasks spawned from outside the tokio runtime"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_remote_schedule_count: IntCounterVec,
 
         #[name = tokio_local_queue_depth_total]
         #[help = "Total size of all tokio workers local queues"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_local_queue_depth_total: IntGaugeVec,
 
         #[name = tokio_local_queue_depth_max]
         #[help = "Length of the longest tokio worker local queue"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_local_queue_depth_max: IntGaugeVec,
 
         #[name = tokio_local_queue_depth_min]
         #[help = "Length of the shortest tokio worker local queue"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_local_queue_depth_min: IntGaugeVec,
 
         #[name = tokio_steal_total]
         #[help = "Total number of tasks stolen from other workers"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_steal_total: IntCounterVec,
 
         #[name = tokio_steal_operations_total]
         #[help = "Total number of times a worker tried to steal a chunk of tasks"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_steal_operations_total: IntCounterVec,
 
         #[name = tokio_local_schedule_total]
         #[help = "Total number of tasks scheduled from worker threads"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_local_schedule_total: IntCounterVec,
 
         #[name = tokio_overflow_total]
         #[help = "Total number of times a tokio worker overflowed its local queue"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_overflow_total: IntCounterVec,
 
         #[name = tokio_busy_ratio_min]
         #[help = "Busy ratio of the least busy tokio worker"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_busy_ratio_min: GaugeVec,
 
         #[name = tokio_busy_ratio_max]
         #[help = "Busy ratio of the most busy tokio worker"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_busy_ratio_max: GaugeVec,
 
         #[name = tokio_busy_ratio_avg]
         #[help = "Avg busy ratio of tokio workers"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_busy_ratio_avg: GaugeVec,
 
         #[name = tokio_mean_polls_per_park]
         #[help = "Number of tasks polls divided by the times an idle worker was parked"]
-        #[labels(node_id: str)]
+        #[labels(node_id: str, rt_id: str)]
         pub tokio_mean_polls_per_park: GaugeVec,
 
         #[name = spacetime_websocket_sent_msg_size_bytes]
@@ -527,52 +527,86 @@ pub fn spawn_bsatn_rlb_pool_stats(node_id: String, pool: BsatnRowListBuilderPool
     });
 }
 
-// How frequently to update the tokio stats.
-#[cfg(all(target_has_atomic = "64", tokio_unstable))]
-const TOKIO_STATS_INTERVAL: Duration = Duration::from_secs(10);
-#[cfg(all(target_has_atomic = "64", tokio_unstable))]
-static SPAWN_TOKIO_STATS_GUARD: Once = Once::new();
-pub fn spawn_tokio_stats(node_id: String) {
-    // Some of these metrics could still be reported without these settings,
-    // but it is simpler to just skip all the tokio metrics if they aren't set.
-
-    #[cfg(not(all(target_has_atomic = "64", tokio_unstable)))]
+// Some of these metrics could still be reported without these settings,
+// but it is simpler to just skip all the tokio metrics if they aren't set.
+#[cfg(not(all(target_has_atomic = "64", tokio_unstable)))]
+pub fn spawn_tokio_stats(node_id: String, _: String, _: tokio::runtime::Handle) {
     log::warn!("Skipping tokio metrics for {node_id}, as they are not enabled in this build.");
+}
 
-    #[cfg(all(target_has_atomic = "64", tokio_unstable))]
-    SPAWN_TOKIO_STATS_GUARD.call_once(|| {
+#[cfg(all(target_has_atomic = "64", tokio_unstable))]
+pub fn spawn_tokio_stats(node_id: String, rt_id: String, rt: tokio::runtime::Handle) {
+    use spacetimedb_data_structures::map::HashMap;
+    use std::sync::{Arc, Mutex};
+
+    // How frequently to update the tokio stats.
+    const TOKIO_STATS_INTERVAL: Duration = Duration::from_secs(10);
+    // Map of tokio runtimes to `Once` guards, so that only a single stats
+    // task is spawned per runtime.
+    static TOKIO_RUNTIMES: Lazy<Mutex<HashMap<tokio::runtime::Id, Arc<Once>>>> =
+        Lazy::new(|| Mutex::new(HashMap::default()));
+
+    let once_guard: Arc<Once> = {
+        TOKIO_RUNTIMES
+            .lock()
+            .unwrap()
+            .entry(rt.id())
+            .or_insert_with(|| Arc::new(Once::new()))
+            .clone()
+    };
+    once_guard.call_once(|| {
         spawn(async move {
             // Set up our metric handles, so we don't keep calling `with_label_values`.
-            let num_worker_metric = WORKER_METRICS.tokio_num_workers.with_label_values(&node_id);
-            let num_blocking_threads_metric = WORKER_METRICS.tokio_num_blocking_threads.with_label_values(&node_id);
-            let num_alive_tasks_metric = WORKER_METRICS.tokio_num_alive_tasks.with_label_values(&node_id);
-            let global_queue_depth_metric = WORKER_METRICS.tokio_global_queue_depth.with_label_values(&node_id);
+            let num_worker_metric = WORKER_METRICS.tokio_num_workers.with_label_values(&node_id, &rt_id);
+            let num_blocking_threads_metric = WORKER_METRICS
+                .tokio_num_blocking_threads
+                .with_label_values(&node_id, &rt_id);
+            let num_alive_tasks_metric = WORKER_METRICS.tokio_num_alive_tasks.with_label_values(&node_id, &rt_id);
+            let global_queue_depth_metric = WORKER_METRICS
+                .tokio_global_queue_depth
+                .with_label_values(&node_id, &rt_id);
             let num_idle_blocking_threads_metric = WORKER_METRICS
                 .tokio_num_idle_blocking_threads
-                .with_label_values(&node_id);
-            let blocking_queue_depth_metric = WORKER_METRICS.tokio_blocking_queue_depth.with_label_values(&node_id);
-            let spawned_tasks_count_metric = WORKER_METRICS.tokio_spawned_tasks_count.with_label_values(&node_id);
-            let remote_schedule_count_metric = WORKER_METRICS.tokio_remote_schedule_count.with_label_values(&node_id);
+                .with_label_values(&node_id, &rt_id);
+            let blocking_queue_depth_metric = WORKER_METRICS
+                .tokio_blocking_queue_depth
+                .with_label_values(&node_id, &rt_id);
+            let spawned_tasks_count_metric = WORKER_METRICS
+                .tokio_spawned_tasks_count
+                .with_label_values(&node_id, &rt_id);
+            let remote_schedule_count_metric = WORKER_METRICS
+                .tokio_remote_schedule_count
+                .with_label_values(&node_id, &rt_id);
 
-            let local_queue_depth_total_metric =
-                WORKER_METRICS.tokio_local_queue_depth_total.with_label_values(&node_id);
-            let local_queue_depth_max_metric = WORKER_METRICS.tokio_local_queue_depth_max.with_label_values(&node_id);
-            let local_queue_depth_min_metric = WORKER_METRICS.tokio_local_queue_depth_min.with_label_values(&node_id);
-            let steal_total_metric = WORKER_METRICS.tokio_steal_total.with_label_values(&node_id);
-            let steal_operations_total_metric = WORKER_METRICS.tokio_steal_operations_total.with_label_values(&node_id);
-            let local_schedule_total_metric = WORKER_METRICS.tokio_local_schedule_total.with_label_values(&node_id);
-            let overflow_total_metric = WORKER_METRICS.tokio_overflow_total.with_label_values(&node_id);
-            let busy_ratio_min_metric = WORKER_METRICS.tokio_busy_ratio_min.with_label_values(&node_id);
-            let busy_ratio_max_metric = WORKER_METRICS.tokio_busy_ratio_max.with_label_values(&node_id);
-            let busy_ratio_avg_metric = WORKER_METRICS.tokio_busy_ratio_avg.with_label_values(&node_id);
-            let mean_polls_per_park_metric = WORKER_METRICS.tokio_mean_polls_per_park.with_label_values(&node_id);
+            let local_queue_depth_total_metric = WORKER_METRICS
+                .tokio_local_queue_depth_total
+                .with_label_values(&node_id, &rt_id);
+            let local_queue_depth_max_metric = WORKER_METRICS
+                .tokio_local_queue_depth_max
+                .with_label_values(&node_id, &rt_id);
+            let local_queue_depth_min_metric = WORKER_METRICS
+                .tokio_local_queue_depth_min
+                .with_label_values(&node_id, &rt_id);
+            let steal_total_metric = WORKER_METRICS.tokio_steal_total.with_label_values(&node_id, &rt_id);
+            let steal_operations_total_metric = WORKER_METRICS
+                .tokio_steal_operations_total
+                .with_label_values(&node_id, &rt_id);
+            let local_schedule_total_metric = WORKER_METRICS
+                .tokio_local_schedule_total
+                .with_label_values(&node_id, &rt_id);
+            let overflow_total_metric = WORKER_METRICS.tokio_overflow_total.with_label_values(&node_id, &rt_id);
+            let busy_ratio_min_metric = WORKER_METRICS.tokio_busy_ratio_min.with_label_values(&node_id, &rt_id);
+            let busy_ratio_max_metric = WORKER_METRICS.tokio_busy_ratio_max.with_label_values(&node_id, &rt_id);
+            let busy_ratio_avg_metric = WORKER_METRICS.tokio_busy_ratio_avg.with_label_values(&node_id, &rt_id);
+            let mean_polls_per_park_metric = WORKER_METRICS
+                .tokio_mean_polls_per_park
+                .with_label_values(&node_id, &rt_id);
 
-            let handle = tokio::runtime::Handle::current();
             // The tokio_metrics library gives us some helpers for aggregating per-worker metrics.
-            let runtime_monitor = tokio_metrics::RuntimeMonitor::new(&handle);
+            let runtime_monitor = tokio_metrics::RuntimeMonitor::new(&rt);
             let mut intervals = runtime_monitor.intervals();
             loop {
-                let metrics = tokio::runtime::Handle::current().metrics();
+                let metrics = rt.metrics();
                 let interval_delta = intervals.next();
 
                 num_worker_metric.set(metrics.num_workers() as i64);

--- a/crates/standalone/src/subcommands/start.rs
+++ b/crates/standalone/src/subcommands/start.rs
@@ -189,7 +189,11 @@ pub async fn exec(args: &ArgMatches, db_cores: JobCores) -> anyhow::Result<()> {
     )
     .await?;
     worker_metrics::spawn_jemalloc_stats(listen_addr.clone());
-    worker_metrics::spawn_tokio_stats(listen_addr.clone());
+    worker_metrics::spawn_tokio_stats(
+        listen_addr.clone(),
+        "main".to_string(),
+        tokio::runtime::Handle::current(),
+    );
     worker_metrics::spawn_page_pool_stats(listen_addr.clone(), ctx.page_pool().clone());
     worker_metrics::spawn_bsatn_rlb_pool_stats(listen_addr.clone(), ctx.bsatn_rlb_pool().clone());
     let mut db_routes = DatabaseRoutes::default();


### PR DESCRIPTION
Require a runtime handle and identifier for `spawn_tokio_stats`, so multiple runtimes can be instrumented.


# Expected complexity level and risk

1

# Testing

n/a