### PR TITLE
fix: Replace unwrap with proper error handling in WebSocket subscribe handler

### DIFF
--- a/crates/client-api/src/routes/subscribe.rs
+++ b/crates/client-api/src/routes/subscribe.rs
@@ -189,7 +189,7 @@ where
     let database = ctx
         .get_database_by_identity(&db_identity)
         .await
-        .unwrap()
+        .map_err(log_and_500)?
         .ok_or(StatusCode::NOT_FOUND)?;
 
     let leader = ctx.leader(database.id).await.map_err(log_and_500)?;


### PR DESCRIPTION
# Description of Changes

Replace `.unwrap()` with `.map_err(log_and_500)?` on the `get_database_by_identity()` call in the WebSocket subscribe handler (`crates/client-api/src/routes/subscribe.rs`).

This was the only call site in the codebase using `.unwrap()` for this method — all four other call sites in `database.rs` already use `.map_err(log_and_500)?`. A transient database error during WebSocket connection setup would panic the server instead of returning an HTTP 500.

Closes #4686

# API and ABI breaking changes

None.

# Expected complexity level and risk

1 — Single-token replacement matching the established pattern used everywhere else.

# Testing

- [ ] Verified the fix matches the error-handling pattern used at all other `get_database_by_identity` call sites
- [ ] Confirmed `log_and_500` is already imported in the file