### PR TITLE
[Rust] Add possibility to be generic over `DbContext`

### DIFF
--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -1457,16 +1457,12 @@ pub trait DbContext {
     ///
     /// This method is provided for times when a programmer wants to be generic over the `DbContext` type.
     /// Concrete-typed code is expected to read the `.db` field off the particular `DbContext` implementor.
-    /// Currently, being this generic is only meaningful in clients,
-    /// as `ReducerContext` is the only implementor of `DbContext` within modules.
     fn db(&self) -> &Self::DbView;
 
     /// Get a read-only view into the tables.
     ///
     /// This method is provided for times when a programmer wants to be generic over the `DbContext` type.
     /// Concrete-typed code is expected to read the `.db` field off the particular `DbContext` implementor.
-    /// Currently, being this generic is only meaningful in clients,
-    /// as `ReducerContext` is the only implementor of `DbContext` within modules.
     #[cfg(feature = "unstable")]
     fn db_read_only(&self) -> &LocalReadOnly;
 }

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -1460,12 +1460,26 @@ pub trait DbContext {
     /// Currently, being this generic is only meaningful in clients,
     /// as `ReducerContext` is the only implementor of `DbContext` within modules.
     fn db(&self) -> &Self::DbView;
+
+    /// Get a read-only view into the tables.
+    ///
+    /// This method is provided for times when a programmer wants to be generic over the `DbContext` type.
+    /// Concrete-typed code is expected to read the `.db` field off the particular `DbContext` implementor.
+    /// Currently, being this generic is only meaningful in clients,
+    /// as `ReducerContext` is the only implementor of `DbContext` within modules.
+    #[cfg(feature = "unstable")]
+    fn db_read_only(&self) -> &LocalReadOnly;
 }
 
 impl DbContext for AnonymousViewContext {
     type DbView = LocalReadOnly;
 
     fn db(&self) -> &Self::DbView {
+        &self.db
+    }
+
+    #[cfg(feature = "unstable")]
+    fn db_read_only(&self) -> &LocalReadOnly {
         &self.db
     }
 }
@@ -1476,6 +1490,11 @@ impl DbContext for ReducerContext {
     fn db(&self) -> &Self::DbView {
         &self.db
     }
+
+    #[cfg(feature = "unstable")]
+    fn db_read_only(&self) -> &LocalReadOnly {
+        self.db.get_read_only()
+    }
 }
 
 #[cfg(feature = "unstable")]
@@ -1485,12 +1504,21 @@ impl DbContext for TxContext {
     fn db(&self) -> &Self::DbView {
         &self.db
     }
+
+    fn db_read_only(&self) -> &LocalReadOnly {
+        self.db.get_read_only()
+    }
 }
 
 impl DbContext for ViewContext {
     type DbView = LocalReadOnly;
 
     fn db(&self) -> &Self::DbView {
+        &self.db
+    }
+
+    #[cfg(feature = "unstable")]
+    fn db_read_only(&self) -> &LocalReadOnly {
         &self.db
     }
 }
@@ -1505,6 +1533,12 @@ impl DbContext for ViewContext {
 /// These are generated methods that allow you to access specific tables.
 #[non_exhaustive]
 pub struct Local {}
+
+impl Local {
+    fn get_read_only(&self) -> &LocalReadOnly {
+        &LocalReadOnly {}
+    }
+}
 
 /// The [JWT] of an [`AuthCtx`].
 ///

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -1531,6 +1531,7 @@ impl DbContext for ViewContext {
 pub struct Local {}
 
 impl Local {
+    #[cfg(feature = "unstable")]
     fn get_read_only(&self) -> &LocalReadOnly {
         &LocalReadOnly {}
     }


### PR DESCRIPTION
# Description of Changes

This patch aims to improve the situation for the need of a generic function over multiple `ctxs`.
The `DbContext` was introduced for this but due to the associated type amibguity when trying to implement it another mmethod is needed.

This pr implements a `db_read_only()` method which always results in a `LocalReadOnly` hence Rust can infer the types of a the returned type (which prior to this was either `__view , __query and a 3rd one i cent remember right now 😓`.

I have chosen to be defensive by implementing it as `unstable` but i can also remove this if that is desired.

It allows the following pattern which has been workig great in my project so its time to contribute it :> 

```rust
pub(crate) trait YourTableNameRead {
   // Your methods which only need read access
  fn test(&self,args);

}

// The read version is a supertrait to give access to the read methods.
pub(crate) trait YourTableNameWrite: YourTableNameRead {
  // Your methods which need read-write access
}

// The read version gets implemented for every DbContext since we can always read.
impl<Db: DbContext> YourTableNameRead for Db {
  fn test(&self,args) {
   self.db_read_only().table_name().whatever(args);
}

// By constraining the associated type to Local we only get this for writeable ctxs.
impl<Db: DbContext<DbView = Local>> YourTableNameWrite for Db {}

```

These allow you to do on the calling site:
```rust
use YourTableNameRead;

#[view|reducer|procedure]
fn my_func(ctx: Reducer|(Anon)View|Tx, args ) {
   ctx.test(args);
}
```



# API and ABI breaking changes

None

# Expected complexity level and risk

1. Minor api and qol adition which is furthermore unstable.

# Testing

- [x] Works in my project
