### PR TITLE
fix: single-column BTree index Range filter/delete

### DIFF
--- a/crates/bindings-typescript/src/server/runtime.ts
+++ b/crates/bindings-typescript/src/server/runtime.ts
@@ -667,9 +667,37 @@ function makeTableView(
       index = base as UniqueIndex<any, any>;
     } else if (serializeSinglePoint) {
       // numColumns == 1
+
+      const serializeSingleRange = !isHashIndex
+        ? (buffer: ResizableBuffer, range: Range<any>): IndexScanArgs => {
+            BINARY_WRITER.reset(buffer);
+            const writer = BINARY_WRITER;
+            const writeBound = (bound: Bound<any>) => {
+              const tags = { included: 0, excluded: 1, unbounded: 2 };
+              writer.writeU8(tags[bound.tag]);
+              if (bound.tag !== 'unbounded')
+                serializeSingleElement!(writer, bound.value);
+            };
+            writeBound(range.from);
+            const rstartLen = writer.offset;
+            writeBound(range.to);
+            const rendLen = writer.offset - rstartLen;
+            return [0, 0, rstartLen, rendLen];
+          }
+        : null;
+
       const rawIndex = {
         filter: (range: any): IteratorObject<RowType<any>> => {
           const buf = LEAF_BUF;
+          if (serializeSingleRange && range instanceof Range) {
+            const args = serializeSingleRange(buf, range);
+            const iter_id = sys.datastore_index_scan_range_bsatn(
+              index_id,
+              buf.buffer,
+              ...args
+            );
+            return tableIterator(iter_id, deserializeRow);
+          }
           const point_len = serializeSinglePoint(buf, range);
           const iter_id = sys.datastore_index_scan_point_bsatn(
             index_id,
@@ -680,6 +708,14 @@ function makeTableView(
         },
         delete: (range: any): u32 => {
           const buf = LEAF_BUF;
+          if (serializeSingleRange && range instanceof Range) {
+            const args = serializeSingleRange(buf, range);
+            return sys.datastore_delete_by_index_scan_range_bsatn(
+              index_id,
+              buf.buffer,
+              ...args
+            );
+          }
           const point_len = serializeSinglePoint(buf, range);
           return sys.datastore_delete_by_index_scan_point_bsatn(
             index_id,


### PR DESCRIPTION
Fixes #4736

# Description of Changes
Single-column BTree indexes accepted `Range<T>` in their type signatures (via `IndexScanRangeBounds`), but the runtime `filter()` and `delete()` implementations always serialized the argument as a point value using `datastore_index_scan_point_bsatn`. Passing a `Range` object caused `SyntaxError: Cannot convert [object Object] to a BigInt` because the Range object was fed directly to the column serializer.

The fix adds `Range` detection to the single-column BTree index code path in `runtime.ts`. When a `Range` is passed, it serializes the bounds and calls `datastore_index_scan_range_bsatn` / `datastore_delete_by_index_scan_range_bsatn` instead. Point queries continue to use the existing fast path. The multi-column index code already handled `Range` correctly — this brings single-column indexes to parity.

# API and ABI breaking changes
None. This is a pure bugfix. Existing queries are unaffected, and Range queries that previously crashed now work as the types imply.

# Expected complexity level and risk
Low. The change is localized to one code path in `runtime.ts` and mirrors the existing multi-column range serialization logic. All 170 existing tests pass.

# Testing
- All 170 vitest tests pass
- Manually confirmed the fix resolves the reported `SyntaxError` in a production SpacetimeDB TypeScript module using `ctx.db.players.fooId.filter(new Range(...))` on a single-column BTree index