### PR TITLE
Reduce overhead in the typescript sdk

### DIFF
--- a/crates/bindings-typescript/src/lib/binary_reader.ts
+++ b/crates/bindings-typescript/src/lib/binary_reader.ts
@@ -25,8 +25,11 @@ export default class BinaryReader {
     this.offset = 0;
   }
 
-  reset(view: DataView) {
-    this.view = view;
+  reset(input: Uint8Array | DataView) {
+    this.view =
+      input instanceof DataView
+        ? input
+        : new DataView(input.buffer, input.byteOffset, input.byteLength);
     this.offset = 0;
   }
 

--- a/crates/bindings-typescript/src/sdk/db_connection_impl.ts
+++ b/crates/bindings-typescript/src/sdk/db_connection_impl.ts
@@ -98,6 +98,26 @@ export type DbConnectionConfig<RemoteModule extends UntypedRemoteModule> = {
 
 type ProcedureCallback = (result: ProcedureResultMessage['result']) => void;
 
+const TEXT_ENCODER = new TextEncoder();
+
+function getClientMessageVariantTag(name: string): number {
+  if (ClientMessage.algebraicType.tag !== 'Sum') {
+    throw new TypeError('ClientMessage must be a sum type');
+  }
+  const tag = ClientMessage.algebraicType.value.variants.findIndex(
+    variant => variant.name === name
+  );
+  if (tag === -1) {
+    throw new RangeError(`Unknown ClientMessage variant: ${name}`);
+  }
+  return tag;
+}
+
+const CLIENT_MESSAGE_CALL_REDUCER_TAG =
+  getClientMessageVariantTag('CallReducer');
+const CLIENT_MESSAGE_CALL_PROCEDURE_TAG =
+  getClientMessageVariantTag('CallProcedure');
+
 export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
   implements DbContext<RemoteModule>
 {
@@ -141,13 +161,16 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
    * The `ConnectionId` of the connection to to the database.
    */
   connectionId: ConnectionId = ConnectionId.random();
+  #connectionIdHex = this.connectionId.toHexString();
 
   // These fields are meant to be strictly private.
   #queryId = 0;
   #requestId = 0;
   #eventId = 0;
   #emitter: EventEmitter<ConnectionEvent>;
-  #messageQueue = Promise.resolve();
+  #inboundQueue: Uint8Array[] = [];
+  #inboundQueueOffset = 0;
+  #isDrainingInboundQueue = false;
   #outboundQueue: Uint8Array[] = [];
   #subscriptionManager = new SubscriptionManager<RemoteModule>();
   #remoteModule: RemoteModule;
@@ -170,7 +193,13 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
     string,
     { serializeArgs: Serializer<any>; deserializeReturn: Deserializer<any> }
   >;
+  #reducerNameBytes: Record<string, Uint8Array>;
+  #procedureNameBytes: Record<string, Uint8Array>;
   #sourceNameToTableDef: Record<string, Values<RemoteModule['tables']>>;
+  #messageReader = new BinaryReader(new Uint8Array());
+  #rowListReader = new BinaryReader(new Uint8Array());
+  #boundSubscriptionBuilder!: () => SubscriptionBuilderImpl<RemoteModule>;
+  #boundDisconnect!: () => void;
 
   // These fields are not part of the public API, but in a pinch you
   // could use JavaScript to access them by bypassing TypeScript's
@@ -207,6 +236,8 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
 
     this.#remoteModule = remoteModule;
     this.#emitter = emitter;
+    this.#boundSubscriptionBuilder = this.subscriptionBuilder.bind(this);
+    this.#boundDisconnect = this.disconnect.bind(this);
 
     this.#rowDeserializers = Object.create(null);
     this.#rowIdMetadata = Object.create(null);
@@ -230,14 +261,17 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
     }
 
     this.#reducerArgsSerializers = Object.create(null);
+    this.#reducerNameBytes = Object.create(null);
     for (const reducer of remoteModule.reducers) {
       this.#reducerArgsSerializers[reducer.name] = {
         serialize: ProductType.makeSerializer(reducer.paramsType),
         deserialize: ProductType.makeDeserializer(reducer.paramsType),
       };
+      this.#reducerNameBytes[reducer.name] = TEXT_ENCODER.encode(reducer.name);
     }
 
     this.#procedureSerializers = Object.create(null);
+    this.#procedureNameBytes = Object.create(null);
     for (const procedure of remoteModule.procedures) {
       this.#procedureSerializers[procedure.name] = {
         serializeArgs: ProductType.makeSerializer(
@@ -247,10 +281,12 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
           procedure.returnType.algebraicType
         ),
       };
+      this.#procedureNameBytes[procedure.name] = TEXT_ENCODER.encode(
+        procedure.name
+      );
     }
 
-    const connectionId = this.connectionId.toHexString();
-    url.searchParams.set('connection_id', connectionId);
+    url.searchParams.set('connection_id', this.#connectionIdHex);
 
     this.clientCache = new ClientCache<RemoteModule>();
     this.db = this.#makeDbView();
@@ -318,6 +354,7 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
 
     for (const reducer of def.reducers) {
       const reducerName = reducer.name;
+      const encodedReducerName = this.#reducerNameBytes[reducerName];
       const key = reducer.accessorName;
 
       const { serialize: serializeArgs } =
@@ -328,7 +365,12 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
         writer.clear();
         serializeArgs(writer, params);
         const argsBuffer = writer.getBuffer();
-        return this.callReducer(reducerName, argsBuffer, params);
+        return this.#callReducerWithEncodedName(
+          reducerName,
+          encodedReducerName,
+          argsBuffer,
+          params
+        );
       };
     }
 
@@ -342,6 +384,7 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
 
     for (const procedure of def.procedures) {
       const procedureName = procedure.name;
+      const encodedProcedureName = this.#procedureNameBytes[procedureName];
       const key = procedure.accessorName;
 
       const { serializeArgs, deserializeReturn } =
@@ -353,7 +396,11 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
         writer.clear();
         serializeArgs(writer, params);
         const argsBuffer = writer.getBuffer();
-        return this.callProcedure(procedureName, argsBuffer).then(returnBuf => {
+        return this.#callProcedureWithEncodedName(
+          procedureName,
+          encodedProcedureName,
+          argsBuffer
+        ).then(returnBuf => {
           return deserializeReturn(new BinaryReader(returnBuf));
         });
       };
@@ -370,13 +417,12 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
       >
     >
   ): EventContextInterface<RemoteModule> {
-    // Bind methods to preserve `this` (#private fields safe)
     return {
       db: this.db,
       reducers: this.reducers,
       isActive: this.isActive,
-      subscriptionBuilder: this.subscriptionBuilder.bind(this),
-      disconnect: this.disconnect.bind(this),
+      subscriptionBuilder: this.#boundSubscriptionBuilder,
+      disconnect: this.#boundDisconnect,
       event,
     };
   }
@@ -437,7 +483,8 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
     rowList: BsatnRowList
   ): Operation[] {
     const buffer = rowList.rowsData;
-    const reader = new BinaryReader(buffer);
+    const reader = this.#rowListReader;
+    reader.reset(buffer);
     const rows: Operation[] = [];
 
     const deserializeRow = this.#rowDeserializers[tableName];
@@ -556,33 +603,78 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
 
   #reducerArgsEncoder = new BinaryWriter(1024);
   #clientMessageEncoder = new BinaryWriter(1024);
-  #sendMessage(message: ClientMessage): void {
-    const writer = this.#clientMessageEncoder;
-    writer.clear();
-    ClientMessage.serialize(writer, message);
-    const encoded = writer.getBuffer();
-
+  #sendEncodedMessage(encoded: Uint8Array, describe: () => string): void {
     if (this.ws && this.isActive) {
       if (this.#outboundQueue.length) this.#flushOutboundQueue(this.ws);
 
-      stdbLogger(
-        'trace',
-        () => `Sending message to server: ${stringify(message)}`
-      );
+      stdbLogger('trace', describe);
       this.ws.send(encoded);
     } else {
-      stdbLogger(
-        'trace',
-        () => `Queuing message to server: ${stringify(message)}`
-      );
+      stdbLogger('trace', describe);
       // use slice() to copy, in case the clientMessageEncoder's buffer gets used
       this.#outboundQueue.push(encoded.slice());
     }
   }
 
+  #sendMessage(message: ClientMessage): void {
+    const writer = this.#clientMessageEncoder;
+    writer.clear();
+    ClientMessage.serialize(writer, message);
+    const encoded = writer.getBuffer();
+    const isLive = !!(this.ws && this.isActive);
+    this.#sendEncodedMessage(encoded, () =>
+      isLive
+        ? `Sending message to server: ${stringify(message)}`
+        : `Queuing message to server: ${stringify(message)}`
+    );
+  }
+
+  #sendCallReducerMessage(
+    requestId: number,
+    reducerNameBytes: Uint8Array,
+    argsBuffer: Uint8Array
+  ): void {
+    const writer = this.#clientMessageEncoder;
+    writer.clear();
+    writer.writeByte(CLIENT_MESSAGE_CALL_REDUCER_TAG);
+    writer.writeU32(requestId);
+    writer.writeU8(0);
+    writer.writeUInt8Array(reducerNameBytes);
+    writer.writeUInt8Array(argsBuffer);
+    const encoded = writer.getBuffer();
+    this.#sendEncodedMessage(
+      encoded,
+      () => `Sending reducer call message to server: requestId=${requestId}`
+    );
+  }
+
+  #sendCallProcedureMessage(
+    requestId: number,
+    procedureNameBytes: Uint8Array,
+    argsBuffer: Uint8Array
+  ): void {
+    const writer = this.#clientMessageEncoder;
+    writer.clear();
+    writer.writeByte(CLIENT_MESSAGE_CALL_PROCEDURE_TAG);
+    writer.writeU32(requestId);
+    writer.writeU8(0);
+    writer.writeUInt8Array(procedureNameBytes);
+    writer.writeUInt8Array(argsBuffer);
+    const encoded = writer.getBuffer();
+    this.#sendEncodedMessage(
+      encoded,
+      () => `Sending procedure call message to server: requestId=${requestId}`
+    );
+  }
+
+  #setConnectionId(connectionId: ConnectionId): void {
+    this.connectionId = connectionId;
+    this.#connectionIdHex = connectionId.toHexString();
+  }
+
   #nextEventId(): string {
     this.#eventId += 1;
-    return `${this.connectionId.toHexString()}:${this.#eventId}`;
+    return `${this.#connectionIdHex}:${this.#eventId}`;
   }
 
   /**
@@ -636,8 +728,10 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
     );
   }
 
-  async #processMessage(data: Uint8Array): Promise<void> {
-    const serverMessage = ServerMessage.deserialize(new BinaryReader(data));
+  #processMessage(data: Uint8Array): void {
+    const reader = this.#messageReader;
+    reader.reset(data);
+    const serverMessage = ServerMessage.deserialize(reader);
     stdbLogger(
       'trace',
       () => `Processing server message: ${stringify(serverMessage)}`
@@ -648,7 +742,7 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
         if (!this.token && serverMessage.value.token) {
           this.token = serverMessage.value.token;
         }
-        this.connectionId = serverMessage.value.connectionId;
+        this.#setConnectionId(serverMessage.value.connectionId);
         this.#emitter.emit('connect', this, this.identity, this.token);
         break;
       }
@@ -845,13 +939,35 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
    * @param wsMessage MessageEvent object.
    */
   #handleOnMessage(wsMessage: { data: Uint8Array }): void {
-    // Utilize promise chaining to ensure that we process messages in order
-    // even though we are processing them asyncronously. This will not begin
-    // processing the next message until we await the processing of the
-    // current message.
-    this.#messageQueue = this.#messageQueue.then(() => {
-      return this.#processMessage(wsMessage.data);
-    });
+    // Queue inbound messages so they are processed strictly in arrival order.
+    // We deliberately drain synchronously instead of promise-chaining each
+    // message, but this still guarantees that we do not begin processing the
+    // next message until the current message has been fully handled.
+    this.#inboundQueue.push(wsMessage.data);
+    if (this.#isDrainingInboundQueue) {
+      return;
+    }
+
+    this.#isDrainingInboundQueue = true;
+    try {
+      // TODO: If this loop starts monopolizing the event loop under sustained
+      // inbound traffic, switch to a chunked drain that periodically yields.
+      while (this.#inboundQueueOffset < this.#inboundQueue.length) {
+        const data = this.#inboundQueue[this.#inboundQueueOffset];
+        this.#inboundQueueOffset += 1;
+        if (data) {
+          this.#processMessage(data);
+        }
+      }
+    } finally {
+      if (this.#inboundQueueOffset >= this.#inboundQueue.length) {
+        this.#inboundQueue.length = 0;
+      } else if (this.#inboundQueueOffset > 0) {
+        this.#inboundQueue = this.#inboundQueue.slice(this.#inboundQueueOffset);
+      }
+      this.#inboundQueueOffset = 0;
+      this.#isDrainingInboundQueue = false;
+    }
   }
 
   /**
@@ -861,6 +977,59 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
    * @param argsSerializer The arguments to pass to the reducer
    */
   callReducer(
+    reducerName: string,
+    argsBuffer: Uint8Array,
+    reducerArgs?: object
+  ): Promise<void> {
+    const encodedReducerName = this.#reducerNameBytes[reducerName];
+    if (encodedReducerName) {
+      return this.#callReducerWithEncodedName(
+        reducerName,
+        encodedReducerName,
+        argsBuffer,
+        reducerArgs
+      );
+    }
+    return this.#callReducerGeneric(reducerName, argsBuffer, reducerArgs);
+  }
+
+  #callReducerWithEncodedName(
+    reducerName: string,
+    encodedReducerName: Uint8Array,
+    argsBuffer: Uint8Array,
+    reducerArgs?: object
+  ): Promise<void> {
+    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const requestId = this.#getNextRequestId();
+    this.#sendCallReducerMessage(requestId, encodedReducerName, argsBuffer);
+    if (reducerArgs) {
+      this.#reducerCallInfo.set(requestId, {
+        name: reducerName,
+        args: reducerArgs,
+      });
+    }
+    this.#reducerCallbacks.set(requestId, result => {
+      if (result.tag === 'Ok' || result.tag === 'OkEmpty') {
+        resolve();
+      } else {
+        if (result.tag === 'Err') {
+          /// Interpret the user-returned error as a string.
+          const reader = new BinaryReader(result.value);
+          const errorString = reader.readString();
+          reject(new SenderError(errorString));
+        } else if (result.tag === 'InternalError') {
+          reject(new InternalError(result.value));
+        } else {
+          const unreachable: never = result;
+          reject(new Error('Unexpected reducer result'));
+          void unreachable;
+        }
+      }
+    });
+    return promise;
+  }
+
+  #callReducerGeneric(
     reducerName: string,
     argsBuffer: Uint8Array,
     reducerArgs?: object
@@ -927,6 +1096,39 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
    * @param argsBuffer The arguments to pass to the reducer
    */
   callProcedure(
+    procedureName: string,
+    argsBuffer: Uint8Array
+  ): Promise<Uint8Array> {
+    const encodedProcedureName = this.#procedureNameBytes[procedureName];
+    if (encodedProcedureName) {
+      return this.#callProcedureWithEncodedName(
+        procedureName,
+        encodedProcedureName,
+        argsBuffer
+      );
+    }
+    return this.#callProcedureGeneric(procedureName, argsBuffer);
+  }
+
+  #callProcedureWithEncodedName(
+    procedureName: string,
+    encodedProcedureName: Uint8Array,
+    argsBuffer: Uint8Array
+  ): Promise<Uint8Array> {
+    const { promise, resolve, reject } = Promise.withResolvers<Uint8Array>();
+    const requestId = this.#getNextRequestId();
+    this.#sendCallProcedureMessage(requestId, encodedProcedureName, argsBuffer);
+    this.#procedureCallbacks.set(requestId, result => {
+      if (result.tag === 'Ok') {
+        resolve(result.value);
+      } else {
+        reject(result.value);
+      }
+    });
+    return promise;
+  }
+
+  #callProcedureGeneric(
     procedureName: string,
     argsBuffer: Uint8Array
   ): Promise<Uint8Array> {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -362,7 +362,7 @@ importers:
     devDependencies:
       '@types/bun':
         specifier: latest
-        version: 1.3.10
+        version: 1.3.11
       bun:
         specifier: ^1.3.2
         version: 1.3.9
@@ -524,7 +524,7 @@ importers:
     dependencies:
       nuxt:
         specifier: ~3.16.0
-        version: 3.16.2(@parcel/watcher@2.5.6)(@types/node@24.3.0)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0)))(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0))(encoding@0.1.13)(eslint@9.33.0(jiti@2.6.1))(ioredis@5.9.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.56.0)(sass@1.97.1)(terser@5.43.1)(tsx@4.21.0)(typescript@5.6.3)(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(sass@1.97.1)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.6.3))(yaml@2.8.2)
+        version: 3.16.2(@parcel/watcher@2.5.6)(@types/node@24.3.0)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0)))(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0))(encoding@0.1.13)(eslint@9.33.0(jiti@2.6.1))(ioredis@5.9.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.56.0)(sass@1.97.1)(terser@5.43.1)(tsx@4.21.0)(typescript@5.6.3)(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(sass@1.97.1)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.6.3))(yaml@2.8.2)
       spacetimedb:
         specifier: workspace:*
         version: link:../../crates/bindings-typescript
@@ -5917,8 +5917,8 @@ packages:
   '@types/bonjour@3.5.13':
     resolution: {integrity: sha512-z9fJ5Im06zvUL548KvYNecEVlA7cVDkGUi6kZusb04mpyEFKCIZJvloCcmpmLaIahDpOQGHaHmG6imtPMmPXGQ==}
 
-  '@types/bun@1.3.10':
-    resolution: {integrity: sha512-0+rlrUrOrTSskibryHbvQkDOWRJwJZqZlxrUs1u4oOoTln8+WIXBPmAuCF35SWB2z4Zl3E84Nl/D0P7803nigQ==}
+  '@types/bun@1.3.11':
+    resolution: {integrity: sha512-5vPne5QvtpjGpsGYXiFyycfpDF2ECyPcTSsFBMa0fraoxiQyMJ3SmuQIGhzPg2WJuWxVBoxWJ2kClYTcw/4fAg==}
 
   '@types/bun@1.3.9':
     resolution: {integrity: sha512-KQ571yULOdWJiMH+RIWIOZ7B2RXQGpL1YQrBtLIV3FqDcCu6FsbFUBwhdKUlCKUpS3PJDsHlJ1QKlpxoVR+xtw==}
@@ -7281,8 +7281,8 @@ packages:
   buffer@6.0.3:
     resolution: {integrity: sha512-FTiCpNxtwiZZHEZbcbTIcZjERVICn9yq/pDFkTl95/AxzD1naBctN7YO68riM/gLSDY7sdrMby8hofADYuuqOA==}
 
-  bun-types@1.3.10:
-    resolution: {integrity: sha512-tcpfCCl6XWo6nCVnpcVrxQ+9AYN1iqMIzgrSKYMB/fjLtV2eyAVEg7AxQJuCq/26R6HpKWykQXuSOq/21RYcbg==}
+  bun-types@1.3.11:
+    resolution: {integrity: sha512-1KGPpoxQWl9f6wcZh57LvrPIInQMn2TQ7jsgxqpRzg+l0QPOFvJVH7HmvHo/AiPgwXy+/Thf6Ov3EdVn1vOabg==}
 
   bun-types@1.3.9:
     resolution: {integrity: sha512-+UBWWOakIP4Tswh0Bt0QD0alpTY8cb5hvgiYeWCMet9YukHbzuruIEeXC2D7nMJPB12kbh8C7XJykSexEqGKJg==}
@@ -21624,9 +21624,9 @@ snapshots:
     dependencies:
       '@types/node': 22.18.0
 
-  '@types/bun@1.3.10':
+  '@types/bun@1.3.11':
     dependencies:
-      bun-types: 1.3.10
+      bun-types: 1.3.11
 
   '@types/bun@1.3.9':
     dependencies:
@@ -23946,7 +23946,7 @@ snapshots:
       base64-js: 1.5.1
       ieee754: 1.2.1
 
-  bun-types@1.3.10:
+  bun-types@1.3.11:
     dependencies:
       '@types/node': 22.18.0
 
@@ -24695,10 +24695,10 @@ snapshots:
       whatwg-mimetype: 4.0.0
       whatwg-url: 14.2.0
 
-  db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0)):
+  db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0)):
     optionalDependencies:
       better-sqlite3: 12.6.2
-      drizzle-orm: 0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0)
+      drizzle-orm: 0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0)
 
   de-indent@1.0.2: {}
 
@@ -24871,14 +24871,14 @@ snapshots:
 
   dotenv@17.2.3: {}
 
-  drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0):
+  drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0):
     optionalDependencies:
       '@opentelemetry/api': 1.9.0
       '@types/better-sqlite3': 7.6.13
       '@types/pg': 8.16.0
       '@types/sql.js': 1.4.9
       better-sqlite3: 12.6.2
-      bun-types: 1.3.10
+      bun-types: 1.3.11
       pg: 8.18.0
       sql.js: 1.14.0
     optional: true
@@ -28128,7 +28128,7 @@ snapshots:
 
   neo-async@2.6.2: {}
 
-  nitropack@2.13.1(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0))(encoding@0.1.13):
+  nitropack@2.13.1(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0))(encoding@0.1.13):
     dependencies:
       '@cloudflare/kv-asset-handler': 0.4.2
       '@rollup/plugin-alias': 6.0.0(rollup@4.56.0)
@@ -28149,7 +28149,7 @@ snapshots:
       cookie-es: 2.0.0
       croner: 9.1.0
       crossws: 0.3.5
-      db0: 0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0))
+      db0: 0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0))
       defu: 6.1.4
       destr: 2.0.5
       dot-prop: 10.1.0
@@ -28195,7 +28195,7 @@ snapshots:
       unenv: 2.0.0-rc.24
       unimport: 5.6.0
       unplugin-utils: 0.3.1
-      unstorage: 1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0)))(ioredis@5.9.2)
+      unstorage: 1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0)))(ioredis@5.9.2)
       untyped: 2.0.0
       unwasm: 0.5.3
       youch: 4.1.0-beta.13
@@ -28403,7 +28403,7 @@ snapshots:
       schema-utils: 3.3.0
       webpack: 5.102.0
 
-  nuxt@3.16.2(@parcel/watcher@2.5.6)(@types/node@24.3.0)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0)))(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0))(encoding@0.1.13)(eslint@9.33.0(jiti@2.6.1))(ioredis@5.9.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.56.0)(sass@1.97.1)(terser@5.43.1)(tsx@4.21.0)(typescript@5.6.3)(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(sass@1.97.1)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.6.3))(yaml@2.8.2):
+  nuxt@3.16.2(@parcel/watcher@2.5.6)(@types/node@24.3.0)(better-sqlite3@12.6.2)(cac@6.7.14)(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0)))(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0))(encoding@0.1.13)(eslint@9.33.0(jiti@2.6.1))(ioredis@5.9.2)(magicast@0.3.5)(optionator@0.9.4)(rollup@4.56.0)(sass@1.97.1)(terser@5.43.1)(tsx@4.21.0)(typescript@5.6.3)(vite@6.4.1(@types/node@24.3.0)(jiti@2.6.1)(sass@1.97.1)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.2))(vue-tsc@2.2.12(typescript@5.6.3))(yaml@2.8.2):
     dependencies:
       '@nuxt/cli': 3.33.1(@nuxt/schema@3.16.2)(cac@6.7.14)(magicast@0.3.5)
       '@nuxt/devalue': 2.0.2
@@ -28440,7 +28440,7 @@ snapshots:
       mlly: 1.8.0
       mocked-exports: 0.1.1
       nanotar: 0.2.1
-      nitropack: 2.13.1(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0))(encoding@0.1.13)
+      nitropack: 2.13.1(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0))(encoding@0.1.13)
       nypm: 0.6.4
       ofetch: 1.5.1
       ohash: 2.0.11
@@ -28462,7 +28462,7 @@ snapshots:
       unimport: 4.2.0
       unplugin: 2.3.11
       unplugin-vue-router: 0.12.0(vue-router@4.6.4(vue@3.5.26(typescript@5.6.3)))(vue@3.5.26(typescript@5.6.3))
-      unstorage: 1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0)))(ioredis@5.9.2)
+      unstorage: 1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0)))(ioredis@5.9.2)
       untyped: 2.0.0
       vue: 3.5.26(typescript@5.6.3)
       vue-bundle-renderer: 2.2.0
@@ -31710,7 +31710,7 @@ snapshots:
       picomatch: 4.0.3
       webpack-virtual-modules: 0.6.2
 
-  unstorage@1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0)))(ioredis@5.9.2):
+  unstorage@1.17.4(db0@0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0)))(ioredis@5.9.2):
     dependencies:
       anymatch: 3.1.3
       chokidar: 5.0.0
@@ -31721,7 +31721,7 @@ snapshots:
       ofetch: 1.5.1
       ufo: 1.6.3
     optionalDependencies:
-      db0: 0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.10)(pg@8.18.0)(sql.js@1.14.0))
+      db0: 0.3.4(better-sqlite3@12.6.2)(drizzle-orm@0.44.7(@opentelemetry/api@1.9.0)(@types/better-sqlite3@7.6.13)(@types/pg@8.16.0)(@types/sql.js@1.4.9)(better-sqlite3@12.6.2)(bun-types@1.3.11)(pg@8.18.0)(sql.js@1.14.0))
       ioredis: 5.9.2
 
   untun@0.1.3:
@@ -32552,6 +32552,7 @@ snapshots:
   ws@8.18.0: {}
 
   ws@8.18.3: {}
+
 
   wsl-utils@0.1.0:
     dependencies:


### PR DESCRIPTION
# Description of Changes

#### 1. Cache the connection-id hex prefix and reuse it when generating event IDs
Previously, the SDK rebuilt the connection-id string on every event. Now it computes the prefix once per connection-id update and reuses it.

#### 2. Replace Promise-chained inbound message processing with a synchronous ordered drain loop
Now inbound messages are still processed through a direct drain loop instead of a promise chain to reduce scheduler overhead.

#### 3. Cache encoded reducer/procedure names and use specialized CallReducer/CallProcedure writers
Previously, reducer/procedure calls always went through the generic `ClientMessage` object path and re-encoded the method name each time. Now the SDK caches UTF-8 encoded reducer/procedure names and uses direct `CallReducer` / `CallProcedure` writers on the hot path, while keeping the generic path as fallback.

# API and ABI breaking changes

None

# Expected complexity level and risk

2

# Testing

Manual: 100K -> 130K TPS running keynote-2 benchmark on apple m2
```
MAX_INFLIGHT_PER_WORKER=512 pnpm run bench test-1 --seconds 10 --concurrency 50 --alpha 1.5 --connectors spacetimedb
```
