### PR TITLE
Update client defaults in keynote bench

### DIFF
--- a/templates/keynote-2/src/connectors/spacetimedb.ts
+++ b/templates/keynote-2/src/connectors/spacetimedb.ts
@@ -76,7 +76,7 @@ export function spacetimedb(config: SpacetimeConnectorConfig): ReducerConnector 
 
   return {
     name: 'spacetimedb',
-    maxInflightPerWorker: 16384,
+    maxInflightPerWorker: 512,
 
     async open() {
       try {

--- a/templates/keynote-2/src/opts.ts
+++ b/templates/keynote-2/src/opts.ts
@@ -370,7 +370,7 @@ export function parseBenchOptions(argv: string[] = process.argv): BenchOptions {
     testName: args[0] ?? defaultBenchTestName,
     seconds: options.seconds ?? 1,
     concurrency:
-      contentionTests?.concurrency ?? options.concurrency ?? 10,
+      contentionTests?.concurrency ?? options.concurrency ?? 50,
     alpha: concurrencyTests?.alpha ?? options.alpha ?? 1.5,
     connectors: options.connectors ?? options.systems ?? null,
     contentionTests,


### PR DESCRIPTION
# Description of Changes

Updates ts client defaults for keynote-2 bench to optimize throughput. These numbers were derived from runs on an apple m2, but I'd be surprised if this configuration was sub-optimal on other platforms.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Manual
