### PR TITLE
fix(ts-sdk): prevent uncaught exceptions from breaking message pipeline

### DIFF
--- a/crates/bindings-typescript/src/sdk/db_connection_impl.ts
+++ b/crates/bindings-typescript/src/sdk/db_connection_impl.ts
@@ -752,7 +752,7 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
           this.#subscriptionManager.subscriptions.get(querySetId);
         if (!subscription) {
           stdbLogger(
-            'error',
+            'warn',
             `Received SubscribeApplied for unknown querySetId ${querySetId}.`
           );
           return;
@@ -784,7 +784,7 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
           this.#subscriptionManager.subscriptions.get(querySetId);
         if (!subscription) {
           stdbLogger(
-            'error',
+            'warn',
             `Received UnsubscribeApplied for unknown querySetId ${querySetId}.`
           );
           return;
@@ -844,7 +844,7 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
           this.#subscriptionManager.subscriptions.delete(querySetId);
         } else {
           stdbLogger(
-            'error',
+            'warn',
             `Received SubscriptionError for unknown querySetId ${querySetId}:`,
             error
           );
@@ -956,7 +956,15 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
         const data = this.#inboundQueue[this.#inboundQueueOffset];
         this.#inboundQueueOffset += 1;
         if (data) {
-          this.#processMessage(data);
+          try {
+            this.#processMessage(data);
+          } catch (e) {
+            stdbLogger(
+              'error',
+              'Uncaught error while processing server message:',
+              e
+            );
+          }
         }
       }
     } finally {


### PR DESCRIPTION
Fixes #4755

After #4744 replaced promise chained message processing with a synchronous drain loop, we started seeing false `Received SubscriptionError for unknown querySetId` console errors.

The old promise chain approach had a subtle bug: if any `#processMessage` call threw an exception (e.g. from a user callback in `onInsert`/`onApplied`), the promise chain broke and **all subsequent messages were silently dropped forever and into the void**. The new drain loop correctly recovers from exceptions via `try/finally`, but defers remaining messages until the next `onmessage` event. This means messages that were previously swallowed, including benign `SubscriptionError` responses for already-cleaned-up subscriptions, are now actually processed and logged as errors.

This PR makes two changes:

1. **Isolate message failures in the drain loop**: wrap `#processMessage` in `try/catch` so a failure in one message (e.g. a user callback throwing) doesn't interrupt processing of subsequent messages. The error is logged and the loop continues.

2. **Downgrade "unknown querySetId" logs from `error` to `warn`**: these are benign race conditions (e.g. server responding to a failed unsubscribe after the subscription was already cleaned up by a prior `SubscriptionError` or `UnsubscribeApplied`) and don't indicate data corruption.


# API and ABI breaking changes

None


# Expected complexity level and risk

1 -- minimal, localized change to error handling and log levels.


# Testing

- Existing test suite passes (170/170).
- My local use continues to function without the error