### PR TITLE
Update rust sdk to use v3 websocket api

### DIFF
--- a/sdks/rust/src/websocket.rs
+++ b/sdks/rust/src/websocket.rs
@@ -2,7 +2,6 @@
 //!
 //! This module is internal, and may incompatibly change without warning.
 
-#[cfg(not(feature = "browser"))]
 use bytes::Bytes;
 #[cfg(not(feature = "browser"))]
 use futures::TryStreamExt;
@@ -11,6 +10,8 @@ use futures_channel::mpsc;
 use http::uri::{InvalidUri, Scheme, Uri};
 use spacetimedb_client_api_messages::websocket as ws;
 use spacetimedb_lib::{bsatn, ConnectionId};
+#[cfg(not(feature = "browser"))]
+use std::collections::VecDeque;
 #[cfg(not(feature = "browser"))]
 use std::fs::File;
 #[cfg(not(feature = "browser"))]
@@ -107,10 +108,48 @@ pub enum WsError {
 pub(crate) struct WsConnection {
     db_name: Box<str>,
     #[cfg(not(feature = "browser"))]
+    protocol: NegotiatedWsProtocol,
+    #[cfg(not(feature = "browser"))]
     sock: WebSocketStream<MaybeTlsStream<TcpStream>>,
     #[cfg(feature = "browser")]
     sock: WebSocketStream,
 }
+
+#[cfg(not(feature = "browser"))]
+#[derive(Clone, Copy, Debug, Default, PartialEq, Eq)]
+enum NegotiatedWsProtocol {
+    #[default]
+    V2,
+    V3,
+}
+
+#[cfg(not(feature = "browser"))]
+impl NegotiatedWsProtocol {
+    /// Maps the negotiated websocket subprotocol string onto the transport
+    /// framing rules understood by the native SDK.
+    fn from_negotiated_protocol(protocol: &str) -> Self {
+        match protocol {
+            ws::v3::BIN_PROTOCOL => Self::V3,
+            "" | ws::v2::BIN_PROTOCOL => Self::V2,
+            unknown => {
+                log::warn!(
+                    "Unexpected websocket subprotocol \"{unknown}\", falling back to {}",
+                    ws::v2::BIN_PROTOCOL
+                );
+                Self::V2
+            }
+        }
+    }
+}
+
+#[cfg(not(feature = "browser"))]
+#[allow(clippy::declare_interior_mutable_const)]
+const V3_PREFERRED_PROTOCOL_HEADER: http::HeaderValue =
+    http::HeaderValue::from_static("v3.bsatn.spacetimedb, v2.bsatn.spacetimedb");
+#[cfg(not(feature = "browser"))]
+const MAX_V3_OUTBOUND_FRAME_BYTES: usize = 256 * 1024;
+#[cfg(not(feature = "browser"))]
+const EMPTY_V3_SERVER_PAYLOAD_ERR: &str = "v3 websocket binary payload must contain at least one v2 server message";
 
 fn parse_scheme(scheme: Option<Scheme>) -> Result<Scheme, UriError> {
     Ok(match scheme {
@@ -245,10 +284,10 @@ fn make_request(
 
 #[cfg(not(feature = "browser"))]
 fn request_insert_protocol_header(req: &mut http::Request<()>) {
-    req.headers_mut().insert(
-        http::header::SEC_WEBSOCKET_PROTOCOL,
-        const { http::HeaderValue::from_static(ws::v2::BIN_PROTOCOL) },
-    );
+    // Prefer v3 for transport batching, but continue advertising v2 so older
+    // servers can negotiate the legacy wire format unchanged.
+    req.headers_mut()
+        .insert(http::header::SEC_WEBSOCKET_PROTOCOL, V3_PREFERRED_PROTOCOL_HEADER);
 }
 
 #[cfg(not(feature = "browser"))]
@@ -256,6 +295,141 @@ fn request_insert_auth_header(req: &mut http::Request<()>, token: Option<&str>) 
     if let Some(token) = token {
         let auth = ["Bearer ", token].concat().try_into().unwrap();
         req.headers_mut().insert(http::header::AUTHORIZATION, auth);
+    }
+}
+
+/// Decodes one logical v2 server message from an already-decompressed payload.
+fn decode_v2_server_message(bytes: &[u8]) -> Result<ws::v2::ServerMessage, WsError> {
+    bsatn::from_slice(bytes).map_err(|source| WsError::DeserializeMessage { source })
+}
+
+#[cfg(not(feature = "browser"))]
+fn parse_v3_server_messages(bytes: &[u8]) -> Result<Vec<ws::v2::ServerMessage>, WsError> {
+    let mut remaining = bytes;
+    if remaining.is_empty() {
+        return Err(WsError::DeserializeMessage {
+            source: bsatn::DecodeError::Other(EMPTY_V3_SERVER_PAYLOAD_ERR.into()),
+        });
+    }
+
+    let mut messages = Vec::new();
+    while !remaining.is_empty() {
+        messages.push(bsatn::from_reader(&mut remaining).map_err(|source| WsError::DeserializeMessage { source })?);
+    }
+    Ok(messages)
+}
+
+/// Encodes one logical v2 client message into raw BSATN bytes.
+fn encode_v2_client_message_bytes(msg: &ws::v2::ClientMessage) -> Bytes {
+    Bytes::from(bsatn::to_vec(msg).expect("should be able to bsatn encode v2 client message"))
+}
+
+#[cfg(not(feature = "browser"))]
+fn concatenate_v3_client_messages(messages: Vec<Bytes>) -> Bytes {
+    if messages.len() == 1 {
+        return messages.into_iter().next().unwrap();
+    }
+
+    let total_len = messages.iter().map(Bytes::len).sum();
+    let mut encoded = Vec::with_capacity(total_len);
+    for message in messages {
+        encoded.extend_from_slice(&message);
+    }
+    encoded.into()
+}
+
+/// Builds one bounded v3 transport frame from `first_message` and as many
+/// queued logical messages as fit under the configured frame-size cap.
+#[cfg(not(feature = "browser"))]
+fn encode_v3_outbound_frame<F>(
+    first_message: ws::v2::ClientMessage,
+    pending_outgoing: &mut VecDeque<ws::v2::ClientMessage>,
+    mut try_next_outgoing_now: F,
+) -> Bytes
+where
+    F: FnMut() -> Option<ws::v2::ClientMessage>,
+{
+    let first_message = encode_v2_client_message_bytes(&first_message);
+    // Oversized logical messages are still sent alone so they cannot block the
+    // queue forever behind the frame-size limit.
+    if first_message.len() > MAX_V3_OUTBOUND_FRAME_BYTES {
+        if pending_outgoing.is_empty()
+            && let Some(next_message) = try_next_outgoing_now()
+        {
+            pending_outgoing.push_front(next_message);
+        }
+
+        return first_message;
+    }
+
+    let mut messages = vec![first_message];
+    let mut batch_size = messages.first().unwrap().len();
+
+    loop {
+        let Some(next_message) = pending_outgoing.pop_front().or_else(&mut try_next_outgoing_now) else {
+            break;
+        };
+        let next_message_bytes = encode_v2_client_message_bytes(&next_message);
+        let next_batch_size = batch_size + next_message_bytes.len();
+        if next_batch_size > MAX_V3_OUTBOUND_FRAME_BYTES {
+            pending_outgoing.push_front(next_message);
+            break;
+        }
+        batch_size = next_batch_size;
+        messages.push(next_message_bytes);
+    }
+
+    concatenate_v3_client_messages(messages)
+}
+
+/// Encodes the next outbound logical message according to the negotiated
+/// transport and reports whether a capped v3 flush left queued work behind.
+#[cfg(not(feature = "browser"))]
+fn encode_outgoing_message<F>(
+    protocol: NegotiatedWsProtocol,
+    first_message: ws::v2::ClientMessage,
+    pending_outgoing: &mut VecDeque<ws::v2::ClientMessage>,
+    try_next_outgoing_now: F,
+) -> (Bytes, bool)
+where
+    F: FnMut() -> Option<ws::v2::ClientMessage>,
+{
+    match protocol {
+        NegotiatedWsProtocol::V2 => (encode_v2_client_message_bytes(&first_message), false),
+        NegotiatedWsProtocol::V3 => {
+            let frame = encode_v3_outbound_frame(first_message, pending_outgoing, try_next_outgoing_now);
+            (frame, !pending_outgoing.is_empty())
+        }
+    }
+}
+
+/// Parses one native websocket payload and forwards each decoded logical v2
+/// server message to the SDK's inbound queue, logging decode or enqueue
+/// failures locally.
+#[cfg(not(feature = "browser"))]
+fn forward_parsed_responses_native(
+    protocol: NegotiatedWsProtocol,
+    incoming_messages: &mpsc::UnboundedSender<ws::v2::ServerMessage>,
+    extra_logging: &Option<Arc<Mutex<File>>>,
+    bytes: &[u8],
+) {
+    match WsConnection::parse_responses(protocol, bytes) {
+        Err(e) => {
+            debug_log(extra_logging, |file| {
+                writeln!(file, "Error decoding WebSocketMessage::Binary payload: {e:?}")
+            });
+            log::warn!("Error decoding WebSocketMessage::Binary payload: {e:?}");
+        }
+        Ok(messages) => {
+            for msg in messages {
+                if let Err(e) = incoming_messages.unbounded_send(msg) {
+                    debug_log(extra_logging, |file| {
+                        writeln!(file, "Error sending decoded message to incoming_messages queue: {e:?}")
+                    });
+                    log::warn!("Error sending decoded message to incoming_messages queue: {e:?}");
+                }
+            }
+        }
     }
 }
 
@@ -334,7 +508,7 @@ impl WsConnection {
         // Grab the URI for error-reporting.
         let uri = req.uri().clone();
 
-        let (sock, _): (WebSocketStream<MaybeTlsStream<TcpStream>>, _) = connect_async_with_config(
+        let (sock, response): (WebSocketStream<MaybeTlsStream<TcpStream>>, _) = connect_async_with_config(
             req,
             // TODO(kim): In order to be able to replicate module WASM blobs,
             // `cloud-next` cannot have message / frame size limits. That's
@@ -347,8 +521,15 @@ impl WsConnection {
             uri,
             source: Arc::new(source),
         })?;
+        let negotiated_protocol = response
+            .headers()
+            .get(http::header::SEC_WEBSOCKET_PROTOCOL)
+            .and_then(|protocol| protocol.to_str().ok())
+            .map(NegotiatedWsProtocol::from_negotiated_protocol)
+            .unwrap_or_default();
         Ok(WsConnection {
             db_name: db_name.into(),
+            protocol: negotiated_protocol,
             sock,
         })
     }
@@ -368,6 +549,9 @@ impl WsConnection {
         };
 
         let uri = make_uri(host, db_name, connection_id, params, token.as_deref())?;
+        // Browser targets stay on v2 for now. `tokio-tungstenite-wasm` does not
+        // expose the negotiated subprotocol, so we cannot safely offer v3 with
+        // a real v2 fallback here without replacing the wrapper entirely.
         let sock = tokio_tungstenite_wasm::connect_with_protocols(&uri.to_string(), &[ws::v2::BIN_PROTOCOL])
             .await
             .map_err(|source| WsError::Tungstenite {
@@ -381,13 +565,22 @@ impl WsConnection {
         })
     }
 
-    pub(crate) fn parse_response(bytes: &[u8]) -> Result<ws::v2::ServerMessage, WsError> {
+    /// Parses one native websocket payload into the ordered logical v2 server
+    /// messages carried by the negotiated transport.
+    #[cfg(not(feature = "browser"))]
+    fn parse_responses(protocol: NegotiatedWsProtocol, bytes: &[u8]) -> Result<Vec<ws::v2::ServerMessage>, WsError> {
         let bytes = &*decompress_server_message(bytes)?;
-        bsatn::from_slice(bytes).map_err(|source| WsError::DeserializeMessage { source })
+        match protocol {
+            NegotiatedWsProtocol::V2 => Ok(vec![decode_v2_server_message(bytes)?]),
+            NegotiatedWsProtocol::V3 => parse_v3_server_messages(bytes),
+        }
     }
 
-    pub(crate) fn encode_message(msg: ws::v2::ClientMessage) -> WebSocketMessage {
-        WebSocketMessage::Binary(bsatn::to_vec(&msg).unwrap().into())
+    /// Parses one browser websocket payload, which always uses legacy v2 framing.
+    #[cfg(feature = "browser")]
+    fn parse_v2_response(bytes: &[u8]) -> Result<ws::v2::ServerMessage, WsError> {
+        let bytes = &*decompress_server_message(bytes)?;
+        decode_v2_server_message(bytes)
     }
 
     #[cfg(not(feature = "browser"))]
@@ -439,7 +632,17 @@ impl WsConnection {
         let mut want_pong = false;
 
         let mut outgoing_messages = Some(outgoing_messages);
+        let mut pending_outgoing = VecDeque::new();
+        let mut yield_after_capped_flush = false;
         loop {
+            if yield_after_capped_flush {
+                // Under v3 we emit at most one bounded frame per flush. If there
+                // are still queued messages after hitting the cap, yield before
+                // sending the next frame so inbound socket work is not starved by
+                // a tight outbound-only drain loop.
+                yield_after_capped_flush = false;
+                tokio::task::yield_now().await;
+            }
             tokio::select! {
                 incoming = self.sock.try_next() => match incoming {
                     Err(tokio_tungstenite::tungstenite::error::Error::ConnectionClosed) | Ok(None) => {
@@ -459,18 +662,7 @@ impl WsConnection {
                     Ok(Some(WebSocketMessage::Binary(bytes))) => {
                         idle = false;
                         record_metrics(bytes.len());
-                        match Self::parse_response(&bytes) {
-                            Err(e) => maybe_log_error!(
-                                &extra_logging,
-                                "Error decoding WebSocketMessage::Binary payload",
-                                Result::<(), _>::Err(e)
-                            ),
-                            Ok(msg) => maybe_log_error!(
-                                &extra_logging,
-                                "Error sending decoded message to incoming_messages queue",
-                                incoming_messages.unbounded_send(msg)
-                            ),
-                        }
+                        forward_parsed_responses_native(self.protocol, &incoming_messages, &extra_logging, &bytes);
                     }
 
                     Ok(Some(WebSocketMessage::Ping(payload))) => {
@@ -518,14 +710,26 @@ impl WsConnection {
                 },
 
                 // this is stupid. we want to handle the channel close *once*, and then disable this branch
-                Some(outgoing) = async { Some(outgoing_messages.as_mut()?.next().await) } => match outgoing {
+                Some(outgoing) = async {
+                    Some(if let Some(outgoing) = pending_outgoing.pop_front() {
+                        Some(outgoing)
+                    } else {
+                        outgoing_messages.as_mut()?.next().await
+                    })
+                } => match outgoing {
                     Some(outgoing) => {
-                        let msg = Self::encode_message(outgoing);
-                        if let Err(e) = self.sock.send(msg).await {
+                        let (msg, has_leftover_pending_outgoing) = encode_outgoing_message(
+                            self.protocol,
+                            outgoing,
+                            &mut pending_outgoing,
+                            || outgoing_messages.as_mut().and_then(|outgoing| outgoing.try_next().ok().flatten()),
+                        );
+                        if let Err(e) = self.sock.send(WebSocketMessage::Binary(msg)).await {
                             debug_log(&extra_logging, |file| writeln!(file, "Error sending outgoing message: {e:?}"));
                             log::warn!("Error sending outgoing message: {e:?}");
                             break;
                         }
+                        yield_after_capped_flush = has_leftover_pending_outgoing;
                     }
                     None => {
                         maybe_log_error!(&extra_logging, "Error sending close frame", SinkExt::close(&mut self.sock).await);
@@ -570,7 +774,6 @@ impl WsConnection {
 
         let (outgoing_tx, outgoing_rx) = mpsc::unbounded::<ws::v2::ClientMessage>();
         let (incoming_tx, incoming_rx) = mpsc::unbounded::<ws::v2::ServerMessage>();
-
         let (mut ws_writer, ws_reader) = self.sock.split();
 
         wasm_bindgen_futures::spawn_local(async move {
@@ -588,18 +791,17 @@ impl WsConnection {
 
                         Some(Ok(WebSocketMessage::Binary(bytes))) => {
                             record_metrics(bytes.len());
-                            // parse + forward into `incoming_tx`
-                            match Self::parse_response(&bytes) {
+                            match Self::parse_v2_response(&bytes) {
                                 Ok(msg) => if let Err(_e) = incoming_tx.unbounded_send(msg) {
                                     gloo_console::warn!("Incoming receiver dropped.");
                                     break;
                                 },
                                 Err(e) => {
                                     gloo_console::warn!(
-                                        "Error decoding WebSocketMessage::Binay payload: ",
+                                        "Error decoding WebSocketMessage::Binary payload: ",
                                         format!("{:?}", e)
                                     );
-                                },
+                                }
                             }
                         },
 
@@ -623,12 +825,12 @@ impl WsConnection {
                         Some(Ok(other)) => {
                             record_metrics(other.len());
                             gloo_console::warn!("Unexpected WebSocket message: ", format!("{:?}",other));
-                        }
+                        },
                     },
 
                     // 2) outbound messages
                     outbound = outgoing.next() => if let Some(client_msg) = outbound {
-                        let raw = Self::encode_message(client_msg);
+                        let raw = WebSocketMessage::Binary(encode_v2_client_message_bytes(&client_msg));
                         if let Err(e) = ws_writer.send(raw).await {
                             gloo_console::warn!("Error sending outgoing message:", format!("{:?}",e));
                             break;
@@ -645,5 +847,155 @@ impl WsConnection {
         });
 
         (incoming_rx, outgoing_tx)
+    }
+}
+
+#[cfg(all(test, not(feature = "browser")))]
+mod tests {
+    use super::*;
+    use spacetimedb_lib::{Identity, TimeDuration, Timestamp};
+
+    fn reducer_call(request_id: u32, arg_len: usize) -> ws::v2::ClientMessage {
+        ws::v2::ClientMessage::CallReducer(ws::v2::CallReducer {
+            request_id,
+            flags: ws::v2::CallReducerFlags::Default,
+            reducer: "reducer".into(),
+            args: Bytes::from(vec![0; arg_len]),
+        })
+    }
+
+    fn procedure_result(request_id: u32) -> ws::v2::ServerMessage {
+        ws::v2::ServerMessage::ProcedureResult(ws::v2::ProcedureResult {
+            status: ws::v2::ProcedureStatus::Returned(Bytes::new()),
+            timestamp: Timestamp::UNIX_EPOCH,
+            total_host_execution_duration: TimeDuration::ZERO,
+            request_id,
+        })
+    }
+
+    fn encode_server_message(message: &ws::v2::ServerMessage) -> Vec<u8> {
+        let mut encoded = vec![ws::common::SERVER_MSG_COMPRESSION_TAG_NONE];
+        encoded.extend(bsatn::to_vec(message).unwrap());
+        encoded
+    }
+
+    fn encode_server_messages(messages: &[ws::v2::ServerMessage]) -> Vec<u8> {
+        let mut encoded = vec![ws::common::SERVER_MSG_COMPRESSION_TAG_NONE];
+        for message in messages {
+            encoded.extend(bsatn::to_vec(message).unwrap());
+        }
+        encoded
+    }
+
+    fn decode_client_messages(mut bytes: &[u8]) -> Vec<ws::v2::ClientMessage> {
+        let mut messages = Vec::new();
+        while !bytes.is_empty() {
+            messages.push(bsatn::from_reader(&mut bytes).unwrap());
+        }
+        messages
+    }
+
+    #[test]
+    fn negotiated_protocol_defaults_to_v2() {
+        assert_eq!(
+            NegotiatedWsProtocol::from_negotiated_protocol(""),
+            NegotiatedWsProtocol::V2
+        );
+        assert_eq!(
+            NegotiatedWsProtocol::from_negotiated_protocol(ws::v2::BIN_PROTOCOL),
+            NegotiatedWsProtocol::V2
+        );
+        assert_eq!(
+            NegotiatedWsProtocol::from_negotiated_protocol("unexpected-protocol"),
+            NegotiatedWsProtocol::V2
+        );
+    }
+
+    #[test]
+    fn negotiated_protocol_recognizes_v3() {
+        assert_eq!(
+            NegotiatedWsProtocol::from_negotiated_protocol(ws::v3::BIN_PROTOCOL),
+            NegotiatedWsProtocol::V3
+        );
+    }
+
+    #[test]
+    fn encode_outgoing_message_batches_small_v3_messages() {
+        let mut pending = VecDeque::new();
+        let (raw, has_leftover_pending_outgoing) =
+            encode_outgoing_message(NegotiatedWsProtocol::V3, reducer_call(1, 8), &mut pending, {
+                let mut extra = VecDeque::from([reducer_call(2, 8)]);
+                move || extra.pop_front()
+            });
+
+        assert!(!has_leftover_pending_outgoing);
+        assert!(pending.is_empty());
+
+        let messages = decode_client_messages(&raw);
+        assert_eq!(messages.len(), 2);
+        for (expected_request_id, message) in [1, 2].into_iter().zip(messages) {
+            match message {
+                ws::v2::ClientMessage::CallReducer(call) => assert_eq!(call.request_id, expected_request_id),
+                _ => panic!("expected CallReducer v3 client message"),
+            }
+        }
+    }
+
+    #[test]
+    fn encode_outgoing_message_caps_v3_frames_at_256_kib() {
+        let mut pending = VecDeque::new();
+        let oversized = 200 * 1024;
+        let (raw, has_leftover_pending_outgoing) =
+            encode_outgoing_message(NegotiatedWsProtocol::V3, reducer_call(1, oversized), &mut pending, {
+                let mut extra = VecDeque::from([reducer_call(2, oversized)]);
+                move || extra.pop_front()
+            });
+
+        assert!(has_leftover_pending_outgoing);
+        assert_eq!(pending.len(), 1);
+
+        let messages = decode_client_messages(&raw);
+        assert_eq!(messages.len(), 1);
+        match &messages[0] {
+            ws::v2::ClientMessage::CallReducer(call) => assert_eq!(call.request_id, 1),
+            _ => panic!("expected CallReducer inner message"),
+        }
+    }
+
+    #[test]
+    fn parse_response_supports_v2_messages() {
+        let encoded = encode_server_message(&ws::v2::ServerMessage::InitialConnection(ws::v2::InitialConnection {
+            identity: Identity::ZERO,
+            connection_id: ConnectionId::ZERO,
+            token: "token".into(),
+        }));
+
+        let messages = WsConnection::parse_responses(NegotiatedWsProtocol::V2, &encoded).unwrap();
+        assert_eq!(messages.len(), 1);
+        match &messages[0] {
+            ws::v2::ServerMessage::InitialConnection(message) => {
+                assert_eq!(message.identity, Identity::ZERO);
+                assert_eq!(message.connection_id, ConnectionId::ZERO);
+            }
+            other => panic!("unexpected v2 message: {other:?}"),
+        }
+    }
+
+    #[test]
+    fn parse_response_unwraps_v3_batches() {
+        let first = procedure_result(1);
+        let second = procedure_result(2);
+        let encoded = encode_server_messages(&[first, second]);
+
+        let messages = WsConnection::parse_responses(NegotiatedWsProtocol::V3, &encoded).unwrap();
+        assert_eq!(messages.len(), 2);
+        for (expected_request_id, message) in [1, 2].into_iter().zip(messages) {
+            match message {
+                ws::v2::ServerMessage::ProcedureResult(result) => {
+                    assert_eq!(result.request_id, expected_request_id);
+                }
+                other => panic!("unexpected v3 inner message: {other:?}"),
+            }
+        }
     }
 }


### PR DESCRIPTION
# Description of Changes

Adds Rust SDK support for the `v3.bsatn.spacetimedb` WebSocket API which was added in #4761.

`v3` is treated as a transport wrapper around existing v2 logical messages. On the Rust SDK side, that means:

- the native client offers `v3` first and falls back to `v2`
- when `v3` is negotiated, outbound client messages are batched into a single websocket frame up to `256 KiB`
- inbound `v3` server frames are unwrapped back into ordered v2 `ServerMessage`s
- `v2` behavior remains unchanged

The browser SDK path stays on `v2` for now because the current wasm websocket wrapper does not expose the negotiated subprotocol, so safe `v3`/`v2` fallback would require replacing that wrapper.

# API and ABI breaking changes

None. The Rust SDK public API is unchanged. Existing `v2` servers continue to work via fallback, and the browser path remains on `v2`.

# Expected complexity level and risk

3

The surface area is small, but this changes transport negotiation, websocket framing, batching behavior, and inbound/outbound message handling in the native Rust SDK. The main risk is preserving correct `v2` fallback and ordered handling while introducing capped v3 batching.

# Testing

- [x] Negotiated protocol handling
- [X] Outbound v3 batching and frame capping
- [X] Inbound v3 batch decoding
