### PR TITLE
Increase timeout for typescript query builder tests

### DIFF
--- a/crates/bindings-typescript/tests/query_error_message.test.ts
+++ b/crates/bindings-typescript/tests/query_error_message.test.ts
@@ -71,17 +71,27 @@ describe('query builder diagnostics', () => {
     'Cannot combine predicates from different table scopes with and/or.';
   const messageHint = 'move extra predicates to .where(...)';
 
-  it('reports a clear message for free-floating and(...) in semijoin predicates', () => {
-    const { status, output } = runTypecheck('and(l.id.eq(r.id), r.id.eq(5))');
-    expect(status).not.toBe(0);
-    expect(output).toContain(messageStart);
-    expect(output).toContain(messageHint);
-  });
+  // This test invokes the TypeScript compiler directly, so it uses an explicit timeout for CI variability.
+  it(
+    'reports a clear message for free-floating and(...) in semijoin predicates',
+    () => {
+      const { status, output } = runTypecheck('and(l.id.eq(r.id), r.id.eq(5))');
+      expect(status).not.toBe(0);
+      expect(output).toContain(messageStart);
+      expect(output).toContain(messageHint);
+    },
+    15000
+  );
 
-  it('reports a clear message for method-style .and(...) in semijoin predicates', () => {
-    const { status, output } = runTypecheck('l.id.eq(r.id).and(r.id.eq(5))');
-    expect(status).not.toBe(0);
-    expect(output).toContain(messageStart);
-    expect(output).toContain(messageHint);
-  });
+  // This test invokes the TypeScript compiler directly, so it uses an explicit timeout for CI variability.
+  it(
+    'reports a clear message for method-style .and(...) in semijoin predicates',
+    () => {
+      const { status, output } = runTypecheck('l.id.eq(r.id).and(r.id.eq(5))');
+      expect(status).not.toBe(0);
+      expect(output).toContain(messageStart);
+      expect(output).toContain(messageHint);
+    },
+    15000
+  );
 });

--- a/crates/bindings-typescript/tests/query_error_message.test.ts
+++ b/crates/bindings-typescript/tests/query_error_message.test.ts
@@ -72,26 +72,18 @@ describe('query builder diagnostics', () => {
   const messageHint = 'move extra predicates to .where(...)';
 
   // This test invokes the TypeScript compiler directly, so it uses an explicit timeout for CI variability.
-  it(
-    'reports a clear message for free-floating and(...) in semijoin predicates',
-    () => {
-      const { status, output } = runTypecheck('and(l.id.eq(r.id), r.id.eq(5))');
-      expect(status).not.toBe(0);
-      expect(output).toContain(messageStart);
-      expect(output).toContain(messageHint);
-    },
-    15000
-  );
+  it('reports a clear message for free-floating and(...) in semijoin predicates', () => {
+    const { status, output } = runTypecheck('and(l.id.eq(r.id), r.id.eq(5))');
+    expect(status).not.toBe(0);
+    expect(output).toContain(messageStart);
+    expect(output).toContain(messageHint);
+  }, 15000);
 
   // This test invokes the TypeScript compiler directly, so it uses an explicit timeout for CI variability.
-  it(
-    'reports a clear message for method-style .and(...) in semijoin predicates',
-    () => {
-      const { status, output } = runTypecheck('l.id.eq(r.id).and(r.id.eq(5))');
-      expect(status).not.toBe(0);
-      expect(output).toContain(messageStart);
-      expect(output).toContain(messageHint);
-    },
-    15000
-  );
+  it('reports a clear message for method-style .and(...) in semijoin predicates', () => {
+    const { status, output } = runTypecheck('l.id.eq(r.id).and(r.id.eq(5))');
+    expect(status).not.toBe(0);
+    expect(output).toContain(messageStart);
+    expect(output).toContain(messageHint);
+  }, 15000);
 });


### PR DESCRIPTION
# Description of Changes

Bumps the timeout for two typescript query builder tests. Both tests were using the default 5 second timeout, and recently they seem to be hitting it pretty consistently. I've increased the timeout to 15 seconds for these two tests.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Typescript `build-and-test` should now pass in CI
