### PR TITLE
Fix `spacetime dev` bug when running with a project path

### DIFF
--- a/crates/cli/src/subcommands/dev.rs
+++ b/crates/cli/src/subcommands/dev.rs
@@ -435,6 +435,12 @@ pub async fn exec(mut config: Config, args: &ArgMatches) -> Result<(), anyhow::E
             if !spacetimedb_dir.exists() {
                 anyhow::bail!("Project initialization did not create spacetimedb directory");
             }
+
+            // Clear publish_configs so they're rebuilt after init with the correct
+            // spacetimedb_dir. Without this, configs built before init contain the
+            // pre-init (stale) module path and the block below would overwrite the
+            // correctly-updated spacetimedb_dir.
+            publish_configs.clear();
         } else {
             anyhow::bail!("Not in a SpacetimeDB project directory");
         }


### PR DESCRIPTION
# Description of Changes

Fixes an issue where running `spacetime dev <database name> --template chat-react-ts --server maincloud` for an existing database and a new local project folder would fail with this error:

```sh
  Building...
  Error: Failed to build project

  Caused by:
      Module directory does not exist: '/Users/aasoni/./spacetimedb'. Check your --module-path flag or the module-path setting in spacetime.json.
```

Summary of the bug:
  - determine_publish_configs was called at line 373 before the project existed, storing <cwd>/./spacetimedb as the module path
  - After init correctly updated spacetimedb_dir to the new project's path, a later block (lines 454-468) re-read the stale path from the early publish config and overwrote the correct value
  - The rebuild guard at line 498 never triggered because publish_configs was non-empty (due to the database name CLI argument)

The fix clears publish_configs at the end of the init block, causing the rebuild at line 498 to run with the correct, post-init spacetimedb_dir.

# API and ABI breaking changes

No

# Expected complexity level and risk

1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] Re-ran `spacetime dev` with various flags to confirm they all still worked
- [x] Verified that the specific error case was fixed
