### PR TITLE
Make Tyler a codeowner for CI and tools

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -8,9 +8,9 @@ LICENSE.txt @cloutiertyler
 
 /crates/cli/src/ @bfops @cloutiertyler @jdetter
 /tools/ci/ @bfops @cloutiertyler @jdetter
-/tools/upgrade-version/ @bfops @jdetter
-/tools/license-check/ @bfops @jdetter
-/.github/ @bfops @jdetter
+/tools/upgrade-version/ @bfops @jdetter @cloutiertyler
+/tools/license-check/ @bfops @jdetter @cloutiertyler
+/.github/ @bfops @jdetter @cloutiertyler
 
 /crates/sdk/examples/quickstart-chat/ @gefjon
 /modules/quickstart-chat/ @gefjon

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,6 +1,5 @@
 /crates/core/src/db/datastore/traits.rs @cloutiertyler
 /rust-toolchain.toml @cloutiertyler
-/.github/CODEOWNERS @cloutiertyler
 LICENSE @cloutiertyler
 LICENSE.txt @cloutiertyler
 /licenses/ @cloutiertyler
@@ -14,3 +13,5 @@ LICENSE.txt @cloutiertyler
 
 /crates/sdk/examples/quickstart-chat/ @gefjon
 /modules/quickstart-chat/ @gefjon
+
+/.github/CODEOWNERS @cloutiertyler


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Adds Tyler to codeowners for:
- `.github/` - this also gives Tyler codeowner over the `CODEOWNERS` file
- `/tools/upgrade-version/`
- `/tools/license-check/`

# API and ABI breaking changes

None

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

1 - this is just a codeowner change

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

NA
