### PR TITLE
Add `cargo lint` as alias for `cargo ci lint`

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -7,6 +7,7 @@ llm = "run --package xtask-llm-benchmark --bin llm_benchmark --"
 ci = "run -p ci --"
 smoketest = "ci smoketests --"
 smoketests = "smoketest"
+lint = "ci lint --"
 
 [target.x86_64-pc-windows-msvc]
 # Use a different linker. Otherwise, the build fails with some obscure linker error that


### PR DESCRIPTION
# Description of Changes

Just a one-line alias as requested

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

`cargo lint` properly runs `cargo ci lint`.