### PR TITLE
CI - move `pnpm build` into `cargo ci test`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -262,10 +262,6 @@ jobs:
 
           wasm-bindgen --version
 
-      - name: Build typescript module sdk
-        working-directory: crates/bindings-typescript
-        run: pnpm build
-
         # Source emsdk environment to make emcc (Emscripten compiler) available in PATH.
       - name: Run tests
         run: |

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -368,6 +368,7 @@ fn main() -> Result<()> {
                 "--test-threads=1",
             )
             .run()?;
+            cmd!("pnpm", "build").dir("crates/bindings-typescript").run()?;
             cmd!("bash", "tools/check-diff.sh").run()?;
             cmd!(
                 "cargo",

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -306,6 +306,8 @@ fn main() -> Result<()> {
 
     match cli.cmd {
         Some(CiCmd::Test) => {
+            cmd!("pnpm", "build").dir("crates/bindings-typescript").run()?;
+
             // TODO: This doesn't work on at least user Linux machines, because something here apparently uses `sudo`?
 
             // Exclude smoketests from `cargo test --all` since they require pre-built binaries.
@@ -368,7 +370,6 @@ fn main() -> Result<()> {
                 "--test-threads=1",
             )
             .run()?;
-            cmd!("pnpm", "build").dir("crates/bindings-typescript").run()?;
             cmd!("bash", "tools/check-diff.sh").run()?;
             cmd!(
                 "cargo",


### PR DESCRIPTION
# Description of Changes

To make `cargo ci test` more properly include the full test logic.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

1

# Testing

honestly none