### PR TITLE
`cargo ci self-docs` uses doc comments as well as explicit helptext

### DIFF
--- a/tools/ci/README.md
+++ b/tools/ci/README.md
@@ -103,7 +103,7 @@ Usage: smoketests [OPTIONS] [ARGS]... [COMMAND]
 When specified, tests will connect to the given URL instead of starting local server instances. Tests that require local server control (like restart tests) will be skipped.
 
 - `--dotnet`: 
-- `args`: 
+- `args`: Additional arguments to pass to the test runner
 - `--help`: Print help (see a summary with '-h')
 
 #### `prepare`
@@ -130,7 +130,7 @@ Usage: check-mod-list
 
 **Options:**
 
-- `--help`: 
+- `--help`: Print help
 
 #### `help`
 
@@ -141,7 +141,7 @@ Usage: help [COMMAND]...
 
 **Options:**
 
-- `subcommand`: 
+- `subcommand`: Print help for the subcommand(s)
 
 ### `update-flow`
 
@@ -193,7 +193,7 @@ Usage: global-json-policy
 
 **Options:**
 
-- `--help`: 
+- `--help`: Print help
 
 ### `help`
 
@@ -204,7 +204,7 @@ Usage: help [COMMAND]...
 
 **Options:**
 
-- `subcommand`: 
+- `subcommand`: Print help for the subcommand(s)
 
 
 ---

--- a/tools/ci/src/ci_docs.rs
+++ b/tools/ci/src/ci_docs.rs
@@ -46,12 +46,19 @@ fn generate_markdown(cmd: &mut Command, heading_level: usize) -> String {
             .map(|l| format!("--{}", l))
             .or_else(|| arg.get_short().map(|s| format!("-{}", s)))
             .unwrap_or_else(|| arg.get_id().to_string());
-        let help = arg.get_long_help().unwrap_or_default();
+        let help = arg
+            .get_long_help()
+            .or_else(|| arg.get_help())
+            .map(|help| help.to_string())
+            .unwrap_or_else(|| {
+                eprintln!("Warning: argument `{}` is missing help text", arg.get_id()));
+                ""
+            });
         options.push_str(&format!(
             "- `{}`: {}\n{}",
             names,
             help,
-            if help.to_string().lines().count() > 1 { "\n" } else { "" }
+            if help.lines().count() > 1 { "\n" } else { "" }
         ));
     }
 

--- a/tools/ci/src/ci_docs.rs
+++ b/tools/ci/src/ci_docs.rs
@@ -51,8 +51,8 @@ fn generate_markdown(cmd: &mut Command, heading_level: usize) -> String {
             .or_else(|| arg.get_help())
             .map(|help| help.to_string())
             .unwrap_or_else(|| {
-                eprintln!("Warning: argument `{}` is missing help text", arg.get_id()));
-                ""
+                eprintln!("Warning: argument `{}` is missing help text", arg.get_id());
+                "".to_string()
             });
         options.push_str(&format!(
             "- `{}`: {}\n{}",


### PR DESCRIPTION
# Description of Changes

Several args for `cargo ci` had empty helptext, because we were only printing the explicitly-annotated helptext. This PR updates it so that inline helptext also shows in the README.

# API and ABI breaking changes

None. CI only.

# Expected complexity level and risk

1

# Testing
- [x] Updated README has more helptext