### PR TITLE
Fix for V8 OOM crash issue

### DIFF
--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -1291,6 +1291,25 @@ fn startup_instance_worker<'scope>(
     Ok((hook_functions, module_common))
 }
 
+/// Amount by which the V8 heap limit is extended each time V8 signals it is
+/// close to OOM. V8 will call the callback repeatedly as the isolate keeps
+/// growing, so this just needs to be enough slack to avoid hot-looping the
+/// callback on every allocation.
+const NEAR_HEAP_LIMIT_SLACK_BYTES: usize = 256 * 1024 * 1024;
+
+/// Called by V8 right before it would abort the process on heap exhaustion.
+///
+/// Without this hook, V8 aborts the entire host when a module's working set
+/// outgrows V8's default ~1.4 GiB soft limit. We instead grant more heap on
+/// demand so the module can keep running.
+unsafe extern "C" fn grow_heap_limit_callback(
+    _data: *mut core::ffi::c_void,
+    current_heap_limit: usize,
+    _initial_heap_limit: usize,
+) -> usize {
+    current_heap_limit.saturating_add(NEAR_HEAP_LIMIT_SLACK_BYTES)
+}
+
 /// Returns a new isolate.
 fn new_isolate(heap_policy: V8HeapPolicyConfig) -> OwnedIsolate {
     let params = if let Some(heap_limit_bytes) = heap_policy.heap_limit_bytes {
@@ -1300,6 +1319,7 @@ fn new_isolate(heap_policy: V8HeapPolicyConfig) -> OwnedIsolate {
     };
     let mut isolate = Isolate::new(params);
     isolate.set_capture_stack_trace_for_uncaught_exceptions(true, 1024);
+    isolate.add_near_heap_limit_callback(grow_heap_limit_callback, core::ptr::null_mut());
     isolate
 }
 


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

Note: the changes here were 100% generated by claude code but the PR description was written by me.

- This fixes the issue where when a V8 module uses a ton of RAM (more than 100GB) it causes an OOM crash which crashes the actual SpacetimeDB process. Here is an example:

```
<--- Last few GCs --->

[1:0x7fcd4c001000]  1114272 ms: Mark-Compact 1388.8 (1401.3) -> 1388.8 (1401.3) MB, pooled: 3.0 MB, 2419.09 / 0.00 ms (average mu = 0.080, current mu = 0.000) allocation failure; GC in old space requested
[1:0x7fcd4c001000]  1116691 ms: Mark-Compact (reduce) 1388.8 (1401.3) -> 1388.8 (1401.3) MB, pooled: 0.0 MB, 2418.83 / 0.00 ms (average mu = 0.042, current mu = 0.000) last resort; GC in old space requested



#
# Fatal JavaScript out of memory: Ineffective mark-compacts near heap limit
#
==== C stack trace ===============================

    spacetimedb-cloud(+0x60b0773) [0x556765742773]
    spacetimedb-cloud(+0x60af5db) [0x5567657415db]
    spacetimedb-cloud(+0x60b19c8) [0x5567657439c8]
    spacetimedb-cloud(+0x6108c14) [0x55676579ac14]
    spacetimedb-cloud(+0x62ce1f7) [0x5567659601f7]
    spacetimedb-cloud(+0x62cc587) [0x55676595e587]
    spacetimedb-cloud(+0x62ccd42) [0x55676595ed42]
    spacetimedb-cloud(+0x62c062c) [0x55676595262c]
    spacetimedb-cloud(+0x62bff66) [0x556765951f66]
    spacetimedb-cloud(+0x62a08cf) [0x5567659328cf]
    spacetimedb-cloud(+0x62b1d3f) [0x556765943d3f]
    spacetimedb-cloud(+0x611311a) [0x5567657a511a]
    spacetimedb-cloud(+0x3b86d9a) [0x556763218d9a]
    spacetimedb-cloud(+0x7792c21) [0x556766e24c21]
```

This fixes the issue by registering a callback for when the V8 runtime is almost out of heap space.

# API and ABI breaking changes

None

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

1 - This just registers a callback for the V8 runtime

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] I loaded up the large database we've been debugging (over 50GB snapshot) and it didn't load on master but it did load after this patch.
