### PR TITLE
bindings: reuse panic message for datastore_index_scan_point_bsatn

### DIFF
--- a/crates/bindings/src/table.rs
+++ b/crates/bindings/src/table.rs
@@ -436,8 +436,7 @@ fn find<Tbl: Table, Col: Index + Column<Table = Tbl>>(col_val: &Col::ColType) ->
     let index_id = Col::index_id();
     let point = IterBuf::serialize(col_val).unwrap();
 
-    let iter = sys::datastore_index_scan_point_bsatn(index_id, &point)
-        .unwrap_or_else(|e| panic!("unique: unexpected error from `datastore_index_scan_point_bsatn`: {e}"));
+    let iter = datastore_index_scan_point_bsatn(index_id, &point);
     let mut iter = TableIter::new_with_buf(iter, point);
 
     // We will always find either 0 or 1 rows here due to the unique constraint.
@@ -447,6 +446,13 @@ fn find<Tbl: Table, Col: Index + Column<Table = Tbl>>(col_val: &Col::ColType) ->
         "`datastore_index_scan_point_bsatn` on unique field cannot return >1 rows"
     );
     row
+}
+
+/// See `sys::datastore_index_scan_point_bsatn`.
+/// Panics when the aforementioned errors.
+fn datastore_index_scan_point_bsatn(index_id: IndexId, point: &[u8]) -> sys::RowIter {
+    sys::datastore_index_scan_point_bsatn(index_id, point)
+        .unwrap_or_else(|e| panic!("unexpected error from `datastore_index_scan_point_bsatn`: {e}"))
 }
 
 /// A read-only handle to a unique (single-column) index.
@@ -654,10 +660,7 @@ where
     Idx: IndexIsPointed,
 {
     let index_id = Idx::index_id();
-    let iter = point.with_point_arg(|point| {
-        sys::datastore_index_scan_point_bsatn(index_id, point)
-            .unwrap_or_else(|e| panic!("unexpected error from `datastore_index_scan_point_bsatn`: {e}"))
-    });
+    let iter = point.with_point_arg(|point| datastore_index_scan_point_bsatn(index_id, point));
     TableIter::new(iter)
 }
 
@@ -980,10 +983,7 @@ where
     let index_id = Idx::index_id();
 
     let iter = if const { is_point_scan::<Idx, B, _, _>() } {
-        b.with_point_arg(|point| {
-            sys::datastore_index_scan_point_bsatn(index_id, point)
-                .unwrap_or_else(|e| panic!("unexpected error from `datastore_index_scan_point_bsatn`: {e}"))
-        })
+        b.with_point_arg(|point| datastore_index_scan_point_bsatn(index_id, point))
     } else {
         let args = b.get_range_args();
         let (prefix, prefix_elems, rstart, rend) = args.args_for_syscall();


### PR DESCRIPTION
# Description of Changes

See tin.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Covered by existing tests.