### PR TITLE
paths: fdatasync PidFile

### DIFF
--- a/crates/paths/src/server.rs
+++ b/crates/paths/src/server.rs
@@ -49,6 +49,8 @@ impl ServerDataDir {
         pidfile.file.set_len(0)?;
         write!(pidfile.file, "{}", std::process::id())?;
         pidfile.file.flush()?;
+        pidfile.file.sync_data()?;
+
         Ok(pidfile)
     }
 


### PR DESCRIPTION
We do want to know the pid of the process holding the lock, so the information should be durable.

# Expected complexity level and risk

1