### PR TITLE
CLI - Hide the `--server-issued-login` param

### DIFF
--- a/crates/cli/src/subcommands/login.rs
+++ b/crates/cli/src/subcommands/login.rs
@@ -22,6 +22,7 @@ pub fn cli() -> Command {
         .arg(
             Arg::new("server")
                 .long("server-issued-login")
+                .hide(true)
                 .group("login-method")
                 .help("Log in to a SpacetimeDB server directly, without going through a global auth server"),
         )

--- a/docs/docs/00300-resources/00200-reference/00100-cli-reference/00100-cli-reference.md
+++ b/docs/docs/00300-resources/00200-reference/00100-cli-reference/00100-cli-reference.md
@@ -367,7 +367,6 @@ Manage your login to the SpacetimeDB CLI
 * `--auth-host <AUTH-HOST>` — Fetch login token from a different host
 
   Default value: `https://spacetimedb.com`
-* `--server-issued-login <SERVER>` — Log in to a SpacetimeDB server directly, without going through a global auth server
 * `--token <SPACETIMEDB-TOKEN>` — Bypass the login flow and use a login token directly
 * `--no-browser` — Do not open a browser window
 


### PR DESCRIPTION
# Description of Changes

Users have an odd tendency to overuse this param, which is really meant for testing and some exceptional circumstances.

This PR hides it from the help so that it is less discoverable.

# API and ABI breaking changes

None.

# Expected complexity level and risk

1

# Testing

- [x] Helptext no longer includes `--server-issued-login`