### PR TITLE
CI - C# test scripts accept `SPACETIMEDB_SERVER_URL` override

### DIFF
--- a/sdks/csharp/examples~/regression-tests/client/Program.cs
+++ b/sdks/csharp/examples~/regression-tests/client/Program.cs
@@ -12,7 +12,7 @@ using RegressionTests.Shared;
 using SpacetimeDB;
 using SpacetimeDB.Types;
 
-const string HOST = "http://localhost:3000";
+string HOST = Environment.GetEnvironmentVariable("SPACETIMEDB_SERVER_URL") ?? "http://localhost:3000";
 const string DBNAME = "btree-repro";
 const string THROW_ERROR_MESSAGE = "this is an error";
 const uint UPDATED_WHERE_TEST_VALUE = 42;

--- a/sdks/csharp/examples~/regression-tests/procedure-client/Program.cs
+++ b/sdks/csharp/examples~/regression-tests/procedure-client/Program.cs
@@ -9,7 +9,7 @@ using RegressionTests.Shared;
 using SpacetimeDB;
 using SpacetimeDB.Types;
 
-const string HOST = "http://localhost:3000";
+string HOST = Environment.GetEnvironmentVariable("SPACETIMEDB_SERVER_URL") ?? "http://localhost:3000";
 const string DBNAME = "procedure-tests";
 
 uint waiting = 0;

--- a/sdks/csharp/examples~/regression-tests/republishing/client/Program.cs
+++ b/sdks/csharp/examples~/regression-tests/republishing/client/Program.cs
@@ -9,7 +9,7 @@ using RegressionTests.Shared;
 using SpacetimeDB;
 using SpacetimeDB.Types;
 
-const string HOST = "http://localhost:3000";
+string HOST = Environment.GetEnvironmentVariable("SPACETIMEDB_SERVER_URL") ?? "http://localhost:3000";
 const string DBNAME = "republish-test";
 
 uint waiting = 0;

--- a/sdks/csharp/tools~/run-regression-tests.sh
+++ b/sdks/csharp/tools~/run-regression-tests.sh
@@ -7,6 +7,7 @@ set -ueo pipefail
 SDK_PATH="$(dirname "$0")/.."
 SDK_PATH="$(realpath "$SDK_PATH")"
 STDB_PATH="$SDK_PATH/../.."
+SPACETIMEDB_SERVER_URL="${SPACETIMEDB_SERVER_URL:-local}"
 
 # Regenerate Bindings
 "$SDK_PATH/tools~/gen-regression-tests.sh"
@@ -15,13 +16,13 @@ STDB_PATH="$SDK_PATH/../.."
 cargo build --manifest-path "$STDB_PATH/crates/standalone/Cargo.toml"
 
 # Publish module for btree test
-cargo run --manifest-path "$STDB_PATH/crates/cli/Cargo.toml" -- publish -c -y --server local -p "$SDK_PATH/examples~/regression-tests/server" btree-repro
+cargo run --manifest-path "$STDB_PATH/crates/cli/Cargo.toml" -- publish -c -y --server "$SPACETIMEDB_SERVER_URL" -p "$SDK_PATH/examples~/regression-tests/server" btree-repro
 
 # Publish module for republishing module test
-cargo run --manifest-path "$STDB_PATH/crates/cli/Cargo.toml" -- publish -c -y --server local -p "$SDK_PATH/examples~/regression-tests/republishing/server-initial" republish-test
-cargo run --manifest-path "$STDB_PATH/crates/cli/Cargo.toml" call --server local republish-test insert 1
-cargo run --manifest-path "$STDB_PATH/crates/cli/Cargo.toml" -- publish  --server local -p "$SDK_PATH/examples~/regression-tests/republishing/server-republish" --break-clients republish-test
-cargo run --manifest-path "$STDB_PATH/crates/cli/Cargo.toml" call --server local republish-test insert 2
+cargo run --manifest-path "$STDB_PATH/crates/cli/Cargo.toml" -- publish -c -y --server "$SPACETIMEDB_SERVER_URL" -p "$SDK_PATH/examples~/regression-tests/republishing/server-initial" republish-test
+cargo run --manifest-path "$STDB_PATH/crates/cli/Cargo.toml" call --server "$SPACETIMEDB_SERVER_URL" republish-test insert 1
+cargo run --manifest-path "$STDB_PATH/crates/cli/Cargo.toml" -- publish  --server "$SPACETIMEDB_SERVER_URL" -p "$SDK_PATH/examples~/regression-tests/republishing/server-republish" --break-clients republish-test
+cargo run --manifest-path "$STDB_PATH/crates/cli/Cargo.toml" call --server "$SPACETIMEDB_SERVER_URL" republish-test insert 2
 
 echo "Cleanup obj~ folders generated in $SDK_PATH/examples~/regression-tests/procedure-client"
 # There is a bug in the code generator that creates obj~ folders in the output directory using a Rust project.
@@ -29,7 +30,7 @@ rm -rf "$SDK_PATH/examples~/regression-tests/procedure-client"/*/obj~
 rm -rf "$SDK_PATH/examples~/regression-tests/procedure-client/module_bindings"/*/obj~
 
 # Publish module for procedure tests
-cargo run --manifest-path "$STDB_PATH/crates/cli/Cargo.toml" -- publish -c -y --server local -p "$STDB_PATH/modules/sdk-test-procedure" procedure-tests
+cargo run --manifest-path "$STDB_PATH/crates/cli/Cargo.toml" -- publish -c -y --server "$SPACETIMEDB_SERVER_URL" -p "$STDB_PATH/modules/sdk-test-procedure" procedure-tests
 
 # Run client for btree test
 cd "$SDK_PATH/examples~/regression-tests/client" && dotnet run -c Debug


### PR DESCRIPTION
# Description of Changes

The regression tests in `sdks/csharp` accept a `SPACETIMEDB_SERVER_URL` environment variable override. This makes it easier to run the tests through the same infrastructure as our other tests (see https://github.com/clockworklabs/SpacetimeDB/pull/4921).

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

actually none. I could be convinced to test. It will be exercised in https://github.com/clockworklabs/SpacetimeDB/pull/4921.