### PR TITLE
fix: connection lifecycle callbacks

### DIFF
--- a/docs/docs/00200-core-concepts/00600-clients/00500-rust-reference.md
+++ b/docs/docs/00200-core-concepts/00600-clients/00500-rust-reference.md
@@ -132,7 +132,7 @@ impl DbConnectionBuilder {
 }
 ```
 
-Chain a call to `.on_connect(callback)` to your builder to register a callback to run when your new `DbConnection` successfully initiates its connection to the remote database. The callback accepts three arguments: a reference to the `DbConnection`, the `Identity` by which SpacetimeDB identifies this connection, and a private access token which can be saved and later passed to [`with_token`](#method-with_token) to authenticate the same user in future connections.
+Chain a call to `.on_connect(callback)` to your builder to register a callback to run when your new `DbConnection` receives the server's initial connection message. The callback accepts three arguments: a reference to the `DbConnection`, the `Identity` by which SpacetimeDB identifies this connection, and a private access token which can be saved and later passed to [`with_token`](#method-with_token) to authenticate the same user in future connections.
 
 This interface may change in an upcoming release as we rework SpacetimeDB's authentication model.
 
@@ -147,9 +147,7 @@ impl DbConnectionBuilder {
 }
 ```
 
-Chain a call to `.on_connect_error(callback)` to your builder to register a callback to run when your connection fails.
-
-A known bug in the SpacetimeDB Rust client SDK currently causes this callback never to be invoked. [`on_disconnect`](#callback-on_disconnect) callbacks are invoked instead.
+Chain a call to `.on_connect_error(callback)` to your builder to register a callback to run when a connection attempt fails after [`build`](#method-build) has created a connection object, but before the server sends the initial connection message. Errors which prevent `build` from creating the connection are returned by `build` instead.
 
 #### Callback `on_disconnect`
 
@@ -162,7 +160,7 @@ impl DbConnectionBuilder {
 }
 ```
 
-Chain a call to `.on_disconnect(callback)` to your builder to register a callback to run when your `DbConnection` disconnects from the remote database, either as a result of a call to [`disconnect`](#method-disconnect) or due to an error.
+Chain a call to `.on_disconnect(callback)` to your builder to register a callback to run when an established `DbConnection` disconnects from the remote database, either as a result of a call to [`disconnect`](#method-disconnect) or due to an error. Connection attempts which fail before the server sends the initial connection message invoke [`on_connect_error`](#callback-on_connect_error) instead.
 
 #### Method `with_token`
 

--- a/docs/docs/00200-core-concepts/00600-clients/00500-rust-reference.md
+++ b/docs/docs/00200-core-concepts/00600-clients/00500-rust-reference.md
@@ -132,7 +132,7 @@ impl DbConnectionBuilder {
 }
 ```
 
-Chain a call to `.on_connect(callback)` to your builder to register a callback to run when your new `DbConnection` receives the server's initial connection message. The callback accepts three arguments: a reference to the `DbConnection`, the `Identity` by which SpacetimeDB identifies this connection, and a private access token which can be saved and later passed to [`with_token`](#method-with_token) to authenticate the same user in future connections.
+Chain a call to `.on_connect(callback)` to your builder to register a callback to run when your new `DbConnection` successfully initiates its connection to the remote database. The callback accepts three arguments: a reference to the `DbConnection`, the `Identity` by which SpacetimeDB identifies this connection, and a private access token which can be saved and later passed to [`with_token`](#method-with_token) to authenticate the same user in future connections.
 
 This interface may change in an upcoming release as we rework SpacetimeDB's authentication model.
 
@@ -147,7 +147,7 @@ impl DbConnectionBuilder {
 }
 ```
 
-Chain a call to `.on_connect_error(callback)` to your builder to register a callback to run when a connection attempt fails after [`build`](#method-build) has created a connection object, but before the server sends the initial connection message. Errors which prevent `build` from creating the connection are returned by `build` instead.
+Chain a call to `.on_connect_error(callback)` to your builder to register a callback to run when a connection attempt fails asynchronously. Errors which prevent `build` from creating the connection are returned by `build` instead.
 
 #### Callback `on_disconnect`
 
@@ -160,7 +160,7 @@ impl DbConnectionBuilder {
 }
 ```
 
-Chain a call to `.on_disconnect(callback)` to your builder to register a callback to run when an established `DbConnection` disconnects from the remote database, either as a result of a call to [`disconnect`](#method-disconnect) or due to an error. Connection attempts which fail before the server sends the initial connection message invoke [`on_connect_error`](#callback-on_connect_error) instead.
+Chain a call to `.on_disconnect(callback)` to your builder to register a callback to run when your established `DbConnection` disconnects from the remote database, either as a result of a call to [`disconnect`](#method-disconnect) or due to an error.
 
 #### Method `with_token`
 

--- a/sdks/rust/src/db_connection.rs
+++ b/sdks/rust/src/db_connection.rs
@@ -1132,9 +1132,10 @@ but you must call one of them, or else the connection will never progress.
         self
     }
 
-    /// Register a callback to run when the connection is successfully initiated.
+    /// Register a callback to run when the connection is successfully established.
     ///
-    /// The callback will receive three arguments:
+    /// The connection is established after the initial connection message is
+    /// received from the host. The callback will receive three arguments:
     /// - The `DbConnection` which has successfully connected.
     /// - The `Identity` of the successful connection.
     /// - The private access token which can be used to later re-authenticate as the same `Identity`.
@@ -1155,9 +1156,9 @@ Instead of registering multiple `on_connect` callbacks, register a single callba
 
     /// Register a callback to run when a connection attempt fails asynchronously.
     ///
-    /// Errors which prevent [`Self::build`] from creating a connection are returned
-    /// by [`Self::build`] instead. Errors reported after the WebSocket is established
-    /// but before the initial connection message invoke this callback.
+    /// This callback is invoked only before the initial connection message is
+    /// received from the host. Errors which prevent [`Self::build`] from creating
+    /// a connection are returned by [`Self::build`] instead.
     pub fn on_connect_error(mut self, callback: impl FnOnce(&M::ErrorContext, crate::Error) + Send + 'static) -> Self {
         if self.on_connect_error.is_some() {
             panic!(
@@ -1172,6 +1173,10 @@ Instead of registering multiple `on_connect_error` callbacks, register a single 
     }
 
     /// Register a callback to run when an established connection is closed.
+    ///
+    /// The connection is established after the initial connection message is
+    /// received from the host. Connection failures before that point invoke
+    /// [`Self::on_connect_error`] instead.
     pub fn on_disconnect(
         mut self,
         callback: impl FnOnce(&M::ErrorContext, Option<crate::Error>) + Send + 'static,

--- a/sdks/rust/src/db_connection.rs
+++ b/sdks/rust/src/db_connection.rs
@@ -152,7 +152,8 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
                             inner.connection_lifecycle = ConnectionLifecycle::Connected;
                             inner.on_connect.take()
                         }
-                        ConnectionLifecycle::Connected | ConnectionLifecycle::Ended => return Ok(()),
+                        ConnectionLifecycle::Connected => None,
+                        ConnectionLifecycle::Ended => return Ok(()),
                     }
                 };
                 {

--- a/sdks/rust/src/db_connection.rs
+++ b/sdks/rust/src/db_connection.rs
@@ -139,7 +139,7 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
         match msg {
             // Error: route as a connection error if we never finished connecting,
             // otherwise treat it as an erroneous disconnect.
-            ParsedMessage::Error(e) => Err(self.finish_connection(Some(e))),
+            ParsedMessage::Error(e) => Err(self.end_connection(Some(e))),
 
             // Initial `IdentityToken` message:
             // confirm that the received identity and connection ID are what we expect,
@@ -314,9 +314,11 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
 
     /// Mark the connection lifecycle as ended, route the terminal event to the
     /// appropriate connection callback, and mark [`Self::is_active`] false.
-    fn finish_connection(&self, error: Option<crate::Error>) -> crate::Error {
+    ///
+    /// Returns the terminal error that should be returned from `advance_*` methods.
+    fn end_connection(&self, callback_error: Option<crate::Error>) -> crate::Error {
         let mut inner = self.inner.lock().unwrap();
-        let return_error = error.clone().unwrap_or(crate::Error::Disconnected);
+        let return_error = callback_error.clone().unwrap_or(crate::Error::Disconnected);
 
         let lifecycle = inner.connection_lifecycle;
         if lifecycle == ConnectionLifecycle::Ended {
@@ -329,19 +331,19 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
 
         match lifecycle {
             ConnectionLifecycle::Connecting => {
-                let error = error.unwrap_or_else(|| crate::Error::FailedToConnect {
+                let callback_error = callback_error.unwrap_or_else(|| crate::Error::FailedToConnect {
                     source: InternalError::new("Connection closed before receiving the initial connection message"),
                 });
-                let ctx: M::ErrorContext = self.make_event_ctx(Some(error.clone()));
+                let ctx: M::ErrorContext = self.make_event_ctx(Some(callback_error.clone()));
                 if let Some(connect_error_callback) = inner.on_connect_error.take() {
-                    connect_error_callback(&ctx, error.clone());
+                    connect_error_callback(&ctx, callback_error.clone());
                 }
-                error
+                callback_error
             }
             ConnectionLifecycle::Connected => {
-                let ctx: M::ErrorContext = self.make_event_ctx(error.clone());
+                let ctx: M::ErrorContext = self.make_event_ctx(callback_error.clone());
                 if let Some(disconnect_callback) = inner.on_disconnect.take() {
-                    disconnect_callback(&ctx, error.clone());
+                    disconnect_callback(&ctx, callback_error.clone());
                 }
 
                 // Call the `on_disconnect` method for all subscriptions.
@@ -577,7 +579,7 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
         // `Stream::poll_next`. No comment on whether this is a good mental
         // model or not.
         let res = match get_lock_sync(&self.recv).try_next() {
-            Ok(None) => Err(self.finish_connection(None)),
+            Ok(None) => Err(self.end_connection(None)),
             Err(_) => Ok(false),
             Ok(Some(msg)) => self.process_message(msg).map(|_| true),
         };
@@ -632,7 +634,7 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
     pub fn advance_one_message_blocking(&self) -> crate::Result<()> {
         match self.runtime.block_on(self.get_message()) {
             Message::Local(pending) => self.apply_mutation(pending),
-            Message::Ws(None) => Err(self.finish_connection(None)),
+            Message::Ws(None) => Err(self.end_connection(None)),
             Message::Ws(Some(msg)) => self.process_message(msg),
         }
     }
@@ -643,7 +645,7 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
     pub async fn advance_one_message_async(&self) -> crate::Result<()> {
         match self.get_message().await {
             Message::Local(pending) => self.apply_mutation(pending),
-            Message::Ws(None) => Err(self.finish_connection(None)),
+            Message::Ws(None) => Err(self.end_connection(None)),
             Message::Ws(Some(msg)) => self.process_message(msg),
         }
     }

--- a/sdks/rust/src/db_connection.rs
+++ b/sdks/rust/src/db_connection.rs
@@ -1073,10 +1073,7 @@ but you must call one of them, or else the connection will never progress.
     /// If this method is not invoked, or `None` is supplied,
     /// the SpacetimeDB host will generate a new anonymous `Identity`.
     ///
-    /// If the passed token is invalid or rejected while establishing the connection,
-    /// the connection attempt will fail. Errors which prevent [`Self::build`] from creating
-    /// a connection are returned by `build`; failures after `build` succeeds but before
-    /// the initial connection message is received invoke [`Self::on_connect_error`].
+    /// If the passed token is invalid or rejected, the connection attempt will fail.
     pub fn with_token(mut self, token: Option<impl Into<String>>) -> Self {
         self.token = token.map(|token| token.into());
         self
@@ -1152,9 +1149,7 @@ Instead of registering multiple `on_connect` callbacks, register a single callba
 
     /// Register a callback to run when a connection attempt fails asynchronously.
     ///
-    /// This callback is invoked for failures after [`Self::build`] has successfully
-    /// created a connection object, but before the server sends the initial connection message.
-    /// Errors which prevent [`Self::build`] from creating the connection are returned by `build` instead.
+    /// Errors which prevent [`Self::build`] from creating a connection are returned by `build` instead.
     pub fn on_connect_error(mut self, callback: impl FnOnce(&M::ErrorContext, crate::Error) + Send + 'static) -> Self {
         if self.on_connect_error.is_some() {
             panic!(
@@ -1169,9 +1164,6 @@ Instead of registering multiple `on_connect_error` callbacks, register a single 
     }
 
     /// Register a callback to run when an established connection is closed.
-    ///
-    /// This callback is invoked only after the server has sent the initial connection message.
-    /// Connection attempts which fail before that point invoke [`Self::on_connect_error`] instead.
     pub fn on_disconnect(
         mut self,
         callback: impl FnOnce(&M::ErrorContext, Option<crate::Error>) + Send + 'static,

--- a/sdks/rust/src/db_connection.rs
+++ b/sdks/rust/src/db_connection.rs
@@ -143,12 +143,18 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
 
             // Initial `IdentityToken` message:
             // confirm that the received identity and connection ID are what we expect,
-            // store them,
-            // then invoke the on_connect callback.
+            // store them, then invoke the on_connect callback.
             ParsedMessage::IdentityToken(identity, token, conn_id) => {
-                if !self.transition_to_connected() {
-                    return Ok(());
-                }
+                let on_connect = {
+                    let mut inner = self.inner.lock().unwrap();
+                    match inner.connection_lifecycle {
+                        ConnectionLifecycle::Connecting => {
+                            inner.connection_lifecycle = ConnectionLifecycle::Connected;
+                            inner.on_connect.take()
+                        }
+                        ConnectionLifecycle::Connected | ConnectionLifecycle::Ended => return Ok(()),
+                    }
+                };
                 {
                     // Don't hold the `self.identity` lock while running callbacks.
                     // Callbacks can (will) call [`DbContext::identity`], which acquires that lock,
@@ -170,7 +176,10 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
                     }
                     *conn_id_store = Some(conn_id);
                 }
-                self.invoke_connected(identity, &token);
+                if let Some(on_connect) = on_connect {
+                    let ctx = <M::DbConnection as DbConnection>::new(self.clone());
+                    on_connect(&ctx, identity, &token);
+                }
                 Ok(())
             }
 
@@ -300,30 +309,6 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
         let event = get_event(&mut inner);
         let row_event_ctx = self.make_event_ctx(event);
         applied_diff.invoke_row_callbacks(&row_event_ctx, &mut inner.db_callbacks);
-    }
-
-    /// Mark the connection as established and ready to run the `on_connect` callback.
-    ///
-    /// Returns `false` if the connection lifecycle has already ended, e.g. because
-    /// the user requested `disconnect` before the initial connection completed.
-    fn transition_to_connected(&self) -> bool {
-        let mut inner = self.inner.lock().unwrap();
-        match inner.connection_lifecycle {
-            ConnectionLifecycle::Connecting => {
-                inner.connection_lifecycle = ConnectionLifecycle::Connected;
-                true
-            }
-            ConnectionLifecycle::Connected | ConnectionLifecycle::Ended => false,
-        }
-    }
-
-    /// Invoke the on-connect callback after receiving the initial connection message.
-    fn invoke_connected(&self, identity: Identity, token: &str) {
-        let mut inner = self.inner.lock().unwrap();
-        if let Some(on_connect) = inner.on_connect.take() {
-            let ctx = <M::DbConnection as DbConnection>::new(self.clone());
-            on_connect(&ctx, identity, token);
-        }
     }
 
     /// Mark the connection lifecycle as ended, route the terminal event to the
@@ -1086,9 +1071,10 @@ but you must call one of them, or else the connection will never progress.
     /// If this method is not invoked, or `None` is supplied,
     /// the SpacetimeDB host will generate a new anonymous `Identity`.
     ///
-    /// If the passed token is invalid or rejected by the host after the WebSocket connection is established,
-    /// but before the initial connection message is received,
-    /// the [`Self::on_connect_error`] callback will be invoked.
+    /// If the passed token is invalid or rejected while establishing the connection,
+    /// the connection attempt will fail. Errors which prevent [`Self::build`] from creating
+    /// a connection are returned by `build`; failures after `build` succeeds but before
+    /// the initial connection message is received invoke [`Self::on_connect_error`].
     pub fn with_token(mut self, token: Option<impl Into<String>>) -> Self {
         self.token = token.map(|token| token.into());
         self
@@ -1633,323 +1619,5 @@ static NEXT_QUERY_SET_ID: AtomicU32 = AtomicU32::new(1);
 pub(crate) fn next_query_set_id() -> QuerySetId {
     QuerySetId {
         id: NEXT_QUERY_SET_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
-    }
-}
-
-#[cfg(all(test, not(feature = "browser")))]
-mod test {
-    use super::*;
-    use crate::{
-        callbacks::DbCallbacks,
-        spacetime_module::{
-            AppliedDiff, DbConnection as _, DbUpdate, EventContext, InModule, ProcedureEventContext, Reducer as _,
-            ReducerEventContext, SubscriptionEventContext, SubscriptionHandle,
-        },
-    };
-    use spacetimedb_client_api_messages::websocket as ws;
-    use std::sync::{Arc, Mutex};
-
-    #[derive(Debug)]
-    struct TestModule;
-
-    struct TestDbConnection(DbContextImpl<TestModule>);
-
-    impl InModule for TestDbConnection {
-        type Module = TestModule;
-    }
-
-    impl crate::spacetime_module::DbConnection for TestDbConnection {
-        fn new(imp: DbContextImpl<TestModule>) -> Self {
-            Self(imp)
-        }
-    }
-
-    struct TestContext<E> {
-        event: E,
-        _imp: DbContextImpl<TestModule>,
-    }
-
-    impl<E: Send + 'static> InModule for TestContext<E> {
-        type Module = TestModule;
-    }
-
-    impl<E: Send + 'static> AbstractEventContext for TestContext<E> {
-        type Event = E;
-
-        fn event(&self) -> &Self::Event {
-            &self.event
-        }
-
-        fn new(imp: DbContextImpl<Self::Module>, event: Self::Event) -> Self {
-            Self { event, _imp: imp }
-        }
-    }
-
-    impl EventContext for TestContext<Event<TestReducer>> {}
-    impl ReducerEventContext for TestContext<ReducerEvent<TestReducer>> {}
-    impl ProcedureEventContext for TestContext<()> {}
-    impl SubscriptionEventContext for TestContext<()> {}
-    impl crate::spacetime_module::ErrorContext for TestContext<Option<crate::Error>> {}
-
-    #[derive(Debug, Clone)]
-    enum TestReducer {}
-
-    impl InModule for TestReducer {
-        type Module = TestModule;
-    }
-
-    impl crate::spacetime_module::Reducer for TestReducer {
-        fn reducer_name(&self) -> &'static str {
-            match *self {}
-        }
-
-        fn args_bsatn(&self) -> Result<Vec<u8>, bsatn::EncodeError> {
-            match *self {}
-        }
-    }
-
-    struct TestDbView;
-    struct TestReducers;
-    struct TestProcedures;
-    struct TestQueryBuilder;
-
-    impl InModule for TestDbView {
-        type Module = TestModule;
-    }
-
-    impl InModule for TestReducers {
-        type Module = TestModule;
-    }
-
-    impl InModule for TestProcedures {
-        type Module = TestModule;
-    }
-
-    impl InModule for TestQueryBuilder {
-        type Module = TestModule;
-    }
-
-    impl Default for TestQueryBuilder {
-        fn default() -> Self {
-            Self
-        }
-    }
-
-    #[derive(Clone)]
-    struct TestSubscriptionHandle(SubscriptionHandleImpl<TestModule>);
-
-    impl InModule for TestSubscriptionHandle {
-        type Module = TestModule;
-    }
-
-    impl SubscriptionHandle for TestSubscriptionHandle {
-        fn new(imp: SubscriptionHandleImpl<TestModule>) -> Self {
-            Self(imp)
-        }
-
-        fn is_ended(&self) -> bool {
-            self.0.is_ended()
-        }
-
-        fn is_active(&self) -> bool {
-            self.0.is_active()
-        }
-
-        fn unsubscribe_then(self, on_end: crate::subscription::OnEndedCallback<Self::Module>) -> crate::Result<()> {
-            self.0.unsubscribe_then(Some(on_end))
-        }
-
-        fn unsubscribe(self) -> crate::Result<()> {
-            self.0.unsubscribe_then(None)
-        }
-    }
-
-    #[derive(Debug, Default)]
-    struct TestUpdate;
-
-    impl InModule for TestUpdate {
-        type Module = TestModule;
-    }
-
-    impl TryFrom<ws::v2::TransactionUpdate> for TestUpdate {
-        type Error = crate::Error;
-
-        fn try_from(_value: ws::v2::TransactionUpdate) -> Result<Self, Self::Error> {
-            Ok(Self)
-        }
-    }
-
-    impl DbUpdate for TestUpdate {
-        fn apply_to_client_cache(&self, _cache: &mut ClientCache<Self::Module>) -> TestAppliedDiff {
-            TestAppliedDiff
-        }
-
-        fn parse_initial_rows(_rows: ws::v2::QueryRows) -> crate::Result<Self> {
-            Ok(Self)
-        }
-
-        fn parse_unsubscribe_rows(_rows: ws::v2::QueryRows) -> crate::Result<Self> {
-            Ok(Self)
-        }
-    }
-
-    struct TestAppliedDiff;
-
-    impl InModule for TestAppliedDiff {
-        type Module = TestModule;
-    }
-
-    impl AppliedDiff<'_> for TestAppliedDiff {
-        fn invoke_row_callbacks(
-            &self,
-            _event: &TestContext<Event<TestReducer>>,
-            _callbacks: &mut DbCallbacks<TestModule>,
-        ) {
-        }
-    }
-
-    impl SpacetimeModule for TestModule {
-        type DbConnection = TestDbConnection;
-        type EventContext = TestContext<Event<TestReducer>>;
-        type ReducerEventContext = TestContext<ReducerEvent<TestReducer>>;
-        type ProcedureEventContext = TestContext<()>;
-        type SubscriptionEventContext = TestContext<()>;
-        type ErrorContext = TestContext<Option<crate::Error>>;
-        type Reducer = TestReducer;
-        type DbView = TestDbView;
-        type Reducers = TestReducers;
-        type Procedures = TestProcedures;
-        type DbUpdate = TestUpdate;
-        type AppliedDiff<'r> = TestAppliedDiff;
-        type SubscriptionHandle = TestSubscriptionHandle;
-        type QueryBuilder = TestQueryBuilder;
-
-        fn register_tables(_client_cache: &mut ClientCache<Self>) {}
-
-        const ALL_TABLE_NAMES: &'static [&'static str] = &[];
-    }
-
-    fn test_connection(
-        on_connect: Option<OnConnectCallback<TestModule>>,
-        on_connect_error: Option<OnConnectErrorCallback<TestModule>>,
-        on_disconnect: Option<OnDisconnectCallback<TestModule>>,
-    ) -> (
-        DbContextImpl<TestModule>,
-        mpsc::UnboundedSender<ParsedMessage<TestModule>>,
-    ) {
-        let (runtime, handle) = enter_or_create_runtime().unwrap();
-        let inner_ctx = build_db_ctx_inner(runtime, on_connect, on_connect_error, on_disconnect);
-        let (raw_msg_send, _raw_msg_recv) = mpsc::unbounded();
-        let (parsed_msg_send, parsed_msg_recv) = mpsc::unbounded();
-        let (pending_mutations_send, pending_mutations_recv) = mpsc::unbounded();
-
-        let conn = build_db_ctx(
-            handle,
-            inner_ctx,
-            raw_msg_send,
-            Arc::new(TokioMutex::new(parsed_msg_recv)),
-            pending_mutations_send,
-            Arc::new(TokioMutex::new(pending_mutations_recv)),
-            None,
-            None,
-        );
-
-        (conn, parsed_msg_send)
-    }
-
-    fn record_event(events: &Arc<Mutex<Vec<&'static str>>>, event: &'static str) {
-        events.lock().unwrap().push(event);
-    }
-
-    fn initial_connection_message() -> ParsedMessage<TestModule> {
-        ParsedMessage::IdentityToken(Identity::from_byte_array([1; 32]), "token".into(), ConnectionId::ZERO)
-    }
-
-    fn test_error() -> crate::Error {
-        crate::Error::Internal(InternalError::new("test error"))
-    }
-
-    #[test]
-    fn error_before_initial_connection_invokes_on_connect_error() {
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let connect_events = Arc::clone(&events);
-        let connect_error_events = Arc::clone(&events);
-        let disconnect_events = Arc::clone(&events);
-
-        let (conn, _parsed_msg_send) = test_connection(
-            Some(Box::new(move |_, _, _| record_event(&connect_events, "connect"))),
-            Some(Box::new(move |_, _| {
-                record_event(&connect_error_events, "connect_error")
-            })),
-            Some(Box::new(move |_, _| record_event(&disconnect_events, "disconnect"))),
-        );
-
-        assert!(conn.process_message(ParsedMessage::Error(test_error())).is_err());
-        assert_eq!(&*events.lock().unwrap(), &["connect_error"]);
-    }
-
-    #[test]
-    fn error_after_initial_connection_invokes_on_disconnect() {
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let connect_events = Arc::clone(&events);
-        let connect_error_events = Arc::clone(&events);
-        let disconnect_events = Arc::clone(&events);
-
-        let (conn, _parsed_msg_send) = test_connection(
-            Some(Box::new(move |_, _, _| record_event(&connect_events, "connect"))),
-            Some(Box::new(move |_, _| {
-                record_event(&connect_error_events, "connect_error")
-            })),
-            Some(Box::new(move |_, error| {
-                assert!(error.is_some());
-                record_event(&disconnect_events, "disconnect");
-            })),
-        );
-
-        conn.process_message(initial_connection_message()).unwrap();
-        assert!(conn.process_message(ParsedMessage::Error(test_error())).is_err());
-        assert_eq!(&*events.lock().unwrap(), &["connect", "disconnect"]);
-    }
-
-    #[test]
-    fn closed_receiver_before_initial_connection_invokes_on_connect_error() {
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let connect_error_events = Arc::clone(&events);
-        let disconnect_events = Arc::clone(&events);
-
-        let (conn, parsed_msg_send) = test_connection(
-            None,
-            Some(Box::new(move |_, error| {
-                assert!(matches!(error, crate::Error::FailedToConnect { .. }));
-                record_event(&connect_error_events, "connect_error");
-            })),
-            Some(Box::new(move |_, _| record_event(&disconnect_events, "disconnect"))),
-        );
-        drop(parsed_msg_send);
-
-        let err = conn.advance_one_message().unwrap_err();
-        assert!(matches!(err, crate::Error::FailedToConnect { .. }));
-        assert_eq!(&*events.lock().unwrap(), &["connect_error"]);
-    }
-
-    #[test]
-    fn disconnect_before_initial_connection_does_not_invoke_lifecycle_callbacks() {
-        let events = Arc::new(Mutex::new(Vec::new()));
-        let connect_events = Arc::clone(&events);
-        let connect_error_events = Arc::clone(&events);
-        let disconnect_events = Arc::clone(&events);
-
-        let (conn, parsed_msg_send) = test_connection(
-            Some(Box::new(move |_, _, _| record_event(&connect_events, "connect"))),
-            Some(Box::new(move |_, _| {
-                record_event(&connect_error_events, "connect_error")
-            })),
-            Some(Box::new(move |_, _| record_event(&disconnect_events, "disconnect"))),
-        );
-        conn.disconnect().unwrap();
-        drop(parsed_msg_send);
-
-        assert!(matches!(conn.advance_one_message(), Err(crate::Error::Disconnected)));
-        assert!(events.lock().unwrap().is_empty());
     }
 }

--- a/sdks/rust/src/db_connection.rs
+++ b/sdks/rust/src/db_connection.rs
@@ -328,7 +328,9 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
 
         match lifecycle {
             ConnectionLifecycle::Connecting => {
-                let error = error.unwrap_or_else(connection_closed_before_initial_connection_error);
+                let error = error.unwrap_or_else(|| crate::Error::FailedToConnect {
+                    source: InternalError::new("Connection closed before receiving the initial connection message"),
+                });
                 let ctx: M::ErrorContext = self.make_event_ctx(Some(error.clone()));
                 if let Some(connect_error_callback) = inner.on_connect_error.take() {
                     connect_error_callback(&ctx, error.clone());
@@ -1594,12 +1596,6 @@ impl<M: SpacetimeModule> std::fmt::Debug for PendingMutation<M> {
 enum Message<M: SpacetimeModule> {
     Ws(Option<ParsedMessage<M>>),
     Local(PendingMutation<M>),
-}
-
-fn connection_closed_before_initial_connection_error() -> crate::Error {
-    crate::Error::FailedToConnect {
-        source: InternalError::new("Connection closed before receiving the initial connection message"),
-    }
 }
 
 fn error_is_normal_disconnect(e: &crate::Error) -> bool {

--- a/sdks/rust/src/db_connection.rs
+++ b/sdks/rust/src/db_connection.rs
@@ -137,18 +137,18 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
     fn process_message(&self, msg: ParsedMessage<M>) -> crate::Result<()> {
         self.debug_log(|out| writeln!(out, "`process_message`: {msg:?}"));
         match msg {
-            // Error: treat this as an erroneous disconnect.
-            ParsedMessage::Error(e) => {
-                let disconnect_ctx = self.make_event_ctx(Some(e.clone()));
-                self.invoke_disconnected(&disconnect_ctx);
-                Err(e)
-            }
+            // Error: route as a connection error if we never finished connecting,
+            // otherwise treat it as an erroneous disconnect.
+            ParsedMessage::Error(e) => Err(self.finish_connection(Some(e))),
 
             // Initial `IdentityToken` message:
             // confirm that the received identity and connection ID are what we expect,
             // store them,
             // then invoke the on_connect callback.
             ParsedMessage::IdentityToken(identity, token, conn_id) => {
+                if !self.transition_to_connected() {
+                    return Ok(());
+                }
                 {
                     // Don't hold the `self.identity` lock while running callbacks.
                     // Callbacks can (will) call [`DbContext::identity`], which acquires that lock,
@@ -170,11 +170,7 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
                     }
                     *conn_id_store = Some(conn_id);
                 }
-                let mut inner = self.inner.lock().unwrap();
-                if let Some(on_connect) = inner.on_connect.take() {
-                    let ctx = <M::DbConnection as DbConnection>::new(self.clone());
-                    on_connect(&ctx, identity, &token);
-                }
+                self.invoke_connected(identity, &token);
                 Ok(())
             }
 
@@ -306,23 +302,67 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
         applied_diff.invoke_row_callbacks(&row_event_ctx, &mut inner.db_callbacks);
     }
 
-    /// Invoke the on-disconnect callback, and mark [`Self::is_active`] false.
-    fn invoke_disconnected(&self, ctx: &M::ErrorContext) {
+    /// Mark the connection as established and ready to run the `on_connect` callback.
+    ///
+    /// Returns `false` if the connection lifecycle has already ended, e.g. because
+    /// the user requested `disconnect` before the initial connection completed.
+    fn transition_to_connected(&self) -> bool {
         let mut inner = self.inner.lock().unwrap();
-        // When we disconnect, we first call the on_disconnect method,
-        // then we call the `on_error` method for all subscriptions.
-        // We don't change the client cache at all.
+        match inner.connection_lifecycle {
+            ConnectionLifecycle::Connecting => {
+                inner.connection_lifecycle = ConnectionLifecycle::Connected;
+                true
+            }
+            ConnectionLifecycle::Connected | ConnectionLifecycle::Ended => false,
+        }
+    }
+
+    /// Invoke the on-connect callback after receiving the initial connection message.
+    fn invoke_connected(&self, identity: Identity, token: &str) {
+        let mut inner = self.inner.lock().unwrap();
+        if let Some(on_connect) = inner.on_connect.take() {
+            let ctx = <M::DbConnection as DbConnection>::new(self.clone());
+            on_connect(&ctx, identity, token);
+        }
+    }
+
+    /// Mark the connection lifecycle as ended, route the terminal event to the
+    /// appropriate connection callback, and mark [`Self::is_active`] false.
+    fn finish_connection(&self, error: Option<crate::Error>) -> crate::Error {
+        let mut inner = self.inner.lock().unwrap();
+        let return_error = error.clone().unwrap_or(crate::Error::Disconnected);
+
+        let lifecycle = inner.connection_lifecycle;
+        if lifecycle == ConnectionLifecycle::Ended {
+            return return_error;
+        }
+        inner.connection_lifecycle = ConnectionLifecycle::Ended;
 
         // Set `send_chan` to `None`, since `Self::is_active` checks that.
         *self.send_chan.lock().unwrap() = None;
 
-        // Grap the `on_disconnect` callback and invoke it.
-        if let Some(disconnect_callback) = inner.on_disconnect.take() {
-            disconnect_callback(ctx, ctx.event().clone());
-        }
+        match lifecycle {
+            ConnectionLifecycle::Connecting => {
+                let error = error.unwrap_or_else(connection_closed_before_initial_connection_error);
+                let ctx: M::ErrorContext = self.make_event_ctx(Some(error.clone()));
+                if let Some(connect_error_callback) = inner.on_connect_error.take() {
+                    connect_error_callback(&ctx, error.clone());
+                }
+                error
+            }
+            ConnectionLifecycle::Connected => {
+                let ctx: M::ErrorContext = self.make_event_ctx(error.clone());
+                if let Some(disconnect_callback) = inner.on_disconnect.take() {
+                    disconnect_callback(&ctx, error.clone());
+                }
 
-        // Call the `on_disconnect` method for all subscriptions.
-        inner.subscriptions.on_disconnect(ctx);
+                // Call the `on_disconnect` method for all subscriptions.
+                inner.subscriptions.on_disconnect(&ctx);
+
+                return_error
+            }
+            ConnectionLifecycle::Ended => return_error,
+        }
     }
 
     fn make_event_ctx<E, Ctx: AbstractEventContext<Module = M, Event = E>>(&self, event: E) -> Ctx {
@@ -447,10 +487,19 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
 
             // Disconnect: close the connection.
             PendingMutation::Disconnect => {
+                {
+                    let mut inner = self.inner.lock().unwrap();
+                    if inner.connection_lifecycle == ConnectionLifecycle::Connecting {
+                        // If the user cancels before the initial connection finishes,
+                        // don't report that as a connection error.
+                        inner.connection_lifecycle = ConnectionLifecycle::Ended;
+                    }
+                }
                 // Set `send_chan` to `None`, since `Self::is_active` checks that.
                 // This will close the WebSocket loop in websocket.rs,
                 // sending a close frame to the server,
-                // eventually resulting in disconnect callbacks being called.
+                // eventually resulting in disconnect callbacks being called
+                // if the initial connection had completed.
                 *self.send_chan.lock().unwrap() = None;
             }
 
@@ -540,11 +589,7 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
         // `Stream::poll_next`. No comment on whether this is a good mental
         // model or not.
         let res = match get_lock_sync(&self.recv).try_next() {
-            Ok(None) => {
-                let disconnect_ctx = self.make_event_ctx(None);
-                self.invoke_disconnected(&disconnect_ctx);
-                Err(crate::Error::Disconnected)
-            }
+            Ok(None) => Err(self.finish_connection(None)),
             Err(_) => Ok(false),
             Ok(Some(msg)) => self.process_message(msg).map(|_| true),
         };
@@ -599,11 +644,7 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
     pub fn advance_one_message_blocking(&self) -> crate::Result<()> {
         match self.runtime.block_on(self.get_message()) {
             Message::Local(pending) => self.apply_mutation(pending),
-            Message::Ws(None) => {
-                let disconnect_ctx = self.make_event_ctx(None);
-                self.invoke_disconnected(&disconnect_ctx);
-                Err(crate::Error::Disconnected)
-            }
+            Message::Ws(None) => Err(self.finish_connection(None)),
             Message::Ws(Some(msg)) => self.process_message(msg),
         }
     }
@@ -614,11 +655,7 @@ impl<M: SpacetimeModule> DbContextImpl<M> {
     pub async fn advance_one_message_async(&self) -> crate::Result<()> {
         match self.get_message().await {
             Message::Local(pending) => self.apply_mutation(pending),
-            Message::Ws(None) => {
-                let disconnect_ctx = self.make_event_ctx(None);
-                self.invoke_disconnected(&disconnect_ctx);
-                Err(crate::Error::Disconnected)
-            }
+            Message::Ws(None) => Err(self.finish_connection(None)),
             Message::Ws(Some(msg)) => self.process_message(msg),
         }
     }
@@ -784,6 +821,16 @@ type OnConnectErrorCallback<M> = Box<dyn FnOnce(&<M as SpacetimeModule>::ErrorCo
 type OnDisconnectCallback<M> =
     Box<dyn FnOnce(&<M as SpacetimeModule>::ErrorContext, Option<crate::Error>) + Send + 'static>;
 
+#[derive(Clone, Copy, Debug, Eq, PartialEq)]
+enum ConnectionLifecycle {
+    /// Waiting for the server's initial connection message.
+    Connecting,
+    /// The server has sent the initial connection message.
+    Connected,
+    /// The connection has already reached a terminal lifecycle state.
+    Ended,
+}
+
 /// All the stuff in a [`DbContextImpl`] which can safely be locked while invoking callbacks.
 pub(crate) struct DbContextImplInner<M: SpacetimeModule> {
     /// `Some` if not within the context of an outer runtime. The `Runtime` must
@@ -796,9 +843,8 @@ pub(crate) struct DbContextImplInner<M: SpacetimeModule> {
     reducer_callbacks: ReducerCallbacks<M>,
     pub(crate) subscriptions: SubscriptionManager<M>,
 
+    connection_lifecycle: ConnectionLifecycle,
     on_connect: Option<OnConnectCallback<M>>,
-    #[allow(unused)]
-    // TODO: Make use of this to handle `ParsedMessage::Error` before receiving `IdentityToken`.
     on_connect_error: Option<OnConnectErrorCallback<M>>,
     on_disconnect: Option<OnDisconnectCallback<M>>,
 
@@ -1040,9 +1086,9 @@ but you must call one of them, or else the connection will never progress.
     /// If this method is not invoked, or `None` is supplied,
     /// the SpacetimeDB host will generate a new anonymous `Identity`.
     ///
-    /// If the passed token is invalid or rejected by the host,
-    /// the connection will fail asynchrnonously.
-    // FIXME: currently this causes `disconnect` to be called rather than `on_connect_error`.
+    /// If the passed token is invalid or rejected by the host after the WebSocket connection is established,
+    /// but before the initial connection message is received,
+    /// the [`Self::on_connect_error`] callback will be invoked.
     pub fn with_token(mut self, token: Option<impl Into<String>>) -> Self {
         self.token = token.map(|token| token.into());
         self
@@ -1116,9 +1162,11 @@ Instead of registering multiple `on_connect` callbacks, register a single callba
         self
     }
 
-    /// Register a callback to run when the connection fails asynchronously,
-    /// e.g. due to invalid credentials.
-    // FIXME: currently never called; `on_disconnect` is called instead.
+    /// Register a callback to run when a connection attempt fails asynchronously.
+    ///
+    /// This callback is invoked for failures after [`Self::build`] has successfully
+    /// created a connection object, but before the server sends the initial connection message.
+    /// Errors which prevent [`Self::build`] from creating the connection are returned by `build` instead.
     pub fn on_connect_error(mut self, callback: impl FnOnce(&M::ErrorContext, crate::Error) + Send + 'static) -> Self {
         if self.on_connect_error.is_some() {
             panic!(
@@ -1132,8 +1180,10 @@ Instead of registering multiple `on_connect_error` callbacks, register a single 
         self
     }
 
-    /// Register a callback to run when the connection is closed.
-    // FIXME: currently also called when the connection fails asynchronously, instead of `on_connect_error`.
+    /// Register a callback to run when an established connection is closed.
+    ///
+    /// This callback is invoked only after the server has sent the initial connection message.
+    /// Connection attempts which fail before that point invoke [`Self::on_connect_error`] instead.
     pub fn on_disconnect(
         mut self,
         callback: impl FnOnce(&M::ErrorContext, Option<crate::Error>) + Send + 'static,
@@ -1166,6 +1216,7 @@ fn build_db_ctx_inner<M: SpacetimeModule>(
         reducer_callbacks: ReducerCallbacks::default(),
         subscriptions: SubscriptionManager::default(),
 
+        connection_lifecycle: ConnectionLifecycle::Connecting,
         on_connect: on_connect_cb,
         on_connect_error: on_connect_error_cb,
         on_disconnect: on_disconnect_cb,
@@ -1559,6 +1610,12 @@ enum Message<M: SpacetimeModule> {
     Local(PendingMutation<M>),
 }
 
+fn connection_closed_before_initial_connection_error() -> crate::Error {
+    crate::Error::FailedToConnect {
+        source: InternalError::new("Connection closed before receiving the initial connection message"),
+    }
+}
+
 fn error_is_normal_disconnect(e: &crate::Error) -> bool {
     matches!(e, crate::Error::Disconnected)
 }
@@ -1576,5 +1633,323 @@ static NEXT_QUERY_SET_ID: AtomicU32 = AtomicU32::new(1);
 pub(crate) fn next_query_set_id() -> QuerySetId {
     QuerySetId {
         id: NEXT_QUERY_SET_ID.fetch_add(1, std::sync::atomic::Ordering::Relaxed),
+    }
+}
+
+#[cfg(all(test, not(feature = "browser")))]
+mod test {
+    use super::*;
+    use crate::{
+        callbacks::DbCallbacks,
+        spacetime_module::{
+            AppliedDiff, DbConnection as _, DbUpdate, EventContext, InModule, ProcedureEventContext, Reducer as _,
+            ReducerEventContext, SubscriptionEventContext, SubscriptionHandle,
+        },
+    };
+    use spacetimedb_client_api_messages::websocket as ws;
+    use std::sync::{Arc, Mutex};
+
+    #[derive(Debug)]
+    struct TestModule;
+
+    struct TestDbConnection(DbContextImpl<TestModule>);
+
+    impl InModule for TestDbConnection {
+        type Module = TestModule;
+    }
+
+    impl crate::spacetime_module::DbConnection for TestDbConnection {
+        fn new(imp: DbContextImpl<TestModule>) -> Self {
+            Self(imp)
+        }
+    }
+
+    struct TestContext<E> {
+        event: E,
+        _imp: DbContextImpl<TestModule>,
+    }
+
+    impl<E: Send + 'static> InModule for TestContext<E> {
+        type Module = TestModule;
+    }
+
+    impl<E: Send + 'static> AbstractEventContext for TestContext<E> {
+        type Event = E;
+
+        fn event(&self) -> &Self::Event {
+            &self.event
+        }
+
+        fn new(imp: DbContextImpl<Self::Module>, event: Self::Event) -> Self {
+            Self { event, _imp: imp }
+        }
+    }
+
+    impl EventContext for TestContext<Event<TestReducer>> {}
+    impl ReducerEventContext for TestContext<ReducerEvent<TestReducer>> {}
+    impl ProcedureEventContext for TestContext<()> {}
+    impl SubscriptionEventContext for TestContext<()> {}
+    impl crate::spacetime_module::ErrorContext for TestContext<Option<crate::Error>> {}
+
+    #[derive(Debug, Clone)]
+    enum TestReducer {}
+
+    impl InModule for TestReducer {
+        type Module = TestModule;
+    }
+
+    impl crate::spacetime_module::Reducer for TestReducer {
+        fn reducer_name(&self) -> &'static str {
+            match *self {}
+        }
+
+        fn args_bsatn(&self) -> Result<Vec<u8>, bsatn::EncodeError> {
+            match *self {}
+        }
+    }
+
+    struct TestDbView;
+    struct TestReducers;
+    struct TestProcedures;
+    struct TestQueryBuilder;
+
+    impl InModule for TestDbView {
+        type Module = TestModule;
+    }
+
+    impl InModule for TestReducers {
+        type Module = TestModule;
+    }
+
+    impl InModule for TestProcedures {
+        type Module = TestModule;
+    }
+
+    impl InModule for TestQueryBuilder {
+        type Module = TestModule;
+    }
+
+    impl Default for TestQueryBuilder {
+        fn default() -> Self {
+            Self
+        }
+    }
+
+    #[derive(Clone)]
+    struct TestSubscriptionHandle(SubscriptionHandleImpl<TestModule>);
+
+    impl InModule for TestSubscriptionHandle {
+        type Module = TestModule;
+    }
+
+    impl SubscriptionHandle for TestSubscriptionHandle {
+        fn new(imp: SubscriptionHandleImpl<TestModule>) -> Self {
+            Self(imp)
+        }
+
+        fn is_ended(&self) -> bool {
+            self.0.is_ended()
+        }
+
+        fn is_active(&self) -> bool {
+            self.0.is_active()
+        }
+
+        fn unsubscribe_then(self, on_end: crate::subscription::OnEndedCallback<Self::Module>) -> crate::Result<()> {
+            self.0.unsubscribe_then(Some(on_end))
+        }
+
+        fn unsubscribe(self) -> crate::Result<()> {
+            self.0.unsubscribe_then(None)
+        }
+    }
+
+    #[derive(Debug, Default)]
+    struct TestUpdate;
+
+    impl InModule for TestUpdate {
+        type Module = TestModule;
+    }
+
+    impl TryFrom<ws::v2::TransactionUpdate> for TestUpdate {
+        type Error = crate::Error;
+
+        fn try_from(_value: ws::v2::TransactionUpdate) -> Result<Self, Self::Error> {
+            Ok(Self)
+        }
+    }
+
+    impl DbUpdate for TestUpdate {
+        fn apply_to_client_cache(&self, _cache: &mut ClientCache<Self::Module>) -> TestAppliedDiff {
+            TestAppliedDiff
+        }
+
+        fn parse_initial_rows(_rows: ws::v2::QueryRows) -> crate::Result<Self> {
+            Ok(Self)
+        }
+
+        fn parse_unsubscribe_rows(_rows: ws::v2::QueryRows) -> crate::Result<Self> {
+            Ok(Self)
+        }
+    }
+
+    struct TestAppliedDiff;
+
+    impl InModule for TestAppliedDiff {
+        type Module = TestModule;
+    }
+
+    impl AppliedDiff<'_> for TestAppliedDiff {
+        fn invoke_row_callbacks(
+            &self,
+            _event: &TestContext<Event<TestReducer>>,
+            _callbacks: &mut DbCallbacks<TestModule>,
+        ) {
+        }
+    }
+
+    impl SpacetimeModule for TestModule {
+        type DbConnection = TestDbConnection;
+        type EventContext = TestContext<Event<TestReducer>>;
+        type ReducerEventContext = TestContext<ReducerEvent<TestReducer>>;
+        type ProcedureEventContext = TestContext<()>;
+        type SubscriptionEventContext = TestContext<()>;
+        type ErrorContext = TestContext<Option<crate::Error>>;
+        type Reducer = TestReducer;
+        type DbView = TestDbView;
+        type Reducers = TestReducers;
+        type Procedures = TestProcedures;
+        type DbUpdate = TestUpdate;
+        type AppliedDiff<'r> = TestAppliedDiff;
+        type SubscriptionHandle = TestSubscriptionHandle;
+        type QueryBuilder = TestQueryBuilder;
+
+        fn register_tables(_client_cache: &mut ClientCache<Self>) {}
+
+        const ALL_TABLE_NAMES: &'static [&'static str] = &[];
+    }
+
+    fn test_connection(
+        on_connect: Option<OnConnectCallback<TestModule>>,
+        on_connect_error: Option<OnConnectErrorCallback<TestModule>>,
+        on_disconnect: Option<OnDisconnectCallback<TestModule>>,
+    ) -> (
+        DbContextImpl<TestModule>,
+        mpsc::UnboundedSender<ParsedMessage<TestModule>>,
+    ) {
+        let (runtime, handle) = enter_or_create_runtime().unwrap();
+        let inner_ctx = build_db_ctx_inner(runtime, on_connect, on_connect_error, on_disconnect);
+        let (raw_msg_send, _raw_msg_recv) = mpsc::unbounded();
+        let (parsed_msg_send, parsed_msg_recv) = mpsc::unbounded();
+        let (pending_mutations_send, pending_mutations_recv) = mpsc::unbounded();
+
+        let conn = build_db_ctx(
+            handle,
+            inner_ctx,
+            raw_msg_send,
+            Arc::new(TokioMutex::new(parsed_msg_recv)),
+            pending_mutations_send,
+            Arc::new(TokioMutex::new(pending_mutations_recv)),
+            None,
+            None,
+        );
+
+        (conn, parsed_msg_send)
+    }
+
+    fn record_event(events: &Arc<Mutex<Vec<&'static str>>>, event: &'static str) {
+        events.lock().unwrap().push(event);
+    }
+
+    fn initial_connection_message() -> ParsedMessage<TestModule> {
+        ParsedMessage::IdentityToken(Identity::from_byte_array([1; 32]), "token".into(), ConnectionId::ZERO)
+    }
+
+    fn test_error() -> crate::Error {
+        crate::Error::Internal(InternalError::new("test error"))
+    }
+
+    #[test]
+    fn error_before_initial_connection_invokes_on_connect_error() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let connect_events = Arc::clone(&events);
+        let connect_error_events = Arc::clone(&events);
+        let disconnect_events = Arc::clone(&events);
+
+        let (conn, _parsed_msg_send) = test_connection(
+            Some(Box::new(move |_, _, _| record_event(&connect_events, "connect"))),
+            Some(Box::new(move |_, _| {
+                record_event(&connect_error_events, "connect_error")
+            })),
+            Some(Box::new(move |_, _| record_event(&disconnect_events, "disconnect"))),
+        );
+
+        assert!(conn.process_message(ParsedMessage::Error(test_error())).is_err());
+        assert_eq!(&*events.lock().unwrap(), &["connect_error"]);
+    }
+
+    #[test]
+    fn error_after_initial_connection_invokes_on_disconnect() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let connect_events = Arc::clone(&events);
+        let connect_error_events = Arc::clone(&events);
+        let disconnect_events = Arc::clone(&events);
+
+        let (conn, _parsed_msg_send) = test_connection(
+            Some(Box::new(move |_, _, _| record_event(&connect_events, "connect"))),
+            Some(Box::new(move |_, _| {
+                record_event(&connect_error_events, "connect_error")
+            })),
+            Some(Box::new(move |_, error| {
+                assert!(error.is_some());
+                record_event(&disconnect_events, "disconnect");
+            })),
+        );
+
+        conn.process_message(initial_connection_message()).unwrap();
+        assert!(conn.process_message(ParsedMessage::Error(test_error())).is_err());
+        assert_eq!(&*events.lock().unwrap(), &["connect", "disconnect"]);
+    }
+
+    #[test]
+    fn closed_receiver_before_initial_connection_invokes_on_connect_error() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let connect_error_events = Arc::clone(&events);
+        let disconnect_events = Arc::clone(&events);
+
+        let (conn, parsed_msg_send) = test_connection(
+            None,
+            Some(Box::new(move |_, error| {
+                assert!(matches!(error, crate::Error::FailedToConnect { .. }));
+                record_event(&connect_error_events, "connect_error");
+            })),
+            Some(Box::new(move |_, _| record_event(&disconnect_events, "disconnect"))),
+        );
+        drop(parsed_msg_send);
+
+        let err = conn.advance_one_message().unwrap_err();
+        assert!(matches!(err, crate::Error::FailedToConnect { .. }));
+        assert_eq!(&*events.lock().unwrap(), &["connect_error"]);
+    }
+
+    #[test]
+    fn disconnect_before_initial_connection_does_not_invoke_lifecycle_callbacks() {
+        let events = Arc::new(Mutex::new(Vec::new()));
+        let connect_events = Arc::clone(&events);
+        let connect_error_events = Arc::clone(&events);
+        let disconnect_events = Arc::clone(&events);
+
+        let (conn, parsed_msg_send) = test_connection(
+            Some(Box::new(move |_, _, _| record_event(&connect_events, "connect"))),
+            Some(Box::new(move |_, _| {
+                record_event(&connect_error_events, "connect_error")
+            })),
+            Some(Box::new(move |_, _| record_event(&disconnect_events, "disconnect"))),
+        );
+        conn.disconnect().unwrap();
+        drop(parsed_msg_send);
+
+        assert!(matches!(conn.advance_one_message(), Err(crate::Error::Disconnected)));
+        assert!(events.lock().unwrap().is_empty());
     }
 }

--- a/sdks/rust/src/db_connection.rs
+++ b/sdks/rust/src/db_connection.rs
@@ -1076,7 +1076,10 @@ but you must call one of them, or else the connection will never progress.
     /// If this method is not invoked, or `None` is supplied,
     /// the SpacetimeDB host will generate a new anonymous `Identity`.
     ///
-    /// If the passed token is invalid or rejected, the connection attempt will fail.
+    /// If the token is rejected before a connection context is created, [`Self::build`]
+    /// returns an error. If the host reports the rejection after the WebSocket is
+    /// established but before the initial connection message, [`Self::on_connect_error`]
+    /// is invoked.
     pub fn with_token(mut self, token: Option<impl Into<String>>) -> Self {
         self.token = token.map(|token| token.into());
         self

--- a/sdks/rust/src/db_connection.rs
+++ b/sdks/rust/src/db_connection.rs
@@ -1155,7 +1155,9 @@ Instead of registering multiple `on_connect` callbacks, register a single callba
 
     /// Register a callback to run when a connection attempt fails asynchronously.
     ///
-    /// Errors which prevent [`Self::build`] from creating a connection are returned by `build` instead.
+    /// Errors which prevent [`Self::build`] from creating a connection are returned
+    /// by [`Self::build`] instead. Errors reported after the WebSocket is established
+    /// but before the initial connection message invoke this callback.
     pub fn on_connect_error(mut self, callback: impl FnOnce(&M::ErrorContext, crate::Error) + Send + 'static) -> Self {
         if self.on_connect_error.is_some() {
             panic!(


### PR DESCRIPTION
# Description of Changes

This pull request improves the handling of connection lifecycle events in the Rust client SDK for SpacetimeDB, particularly distinguishing between connection failures and disconnections. It introduces a new `ConnectionLifecycle` state machine to track connection progress, ensures that the correct callback (`on_connect_error` or `on_disconnect`) is invoked based on the connection state.

**Changes**

* `ConnectionLifecycle` enum to track the connection state (`Connecting`, `Connected`, `Ended`)
* Refactored error handling so that if a connection fails before establishment, the `on_connect_error` callback is invoked; if the connection fails after establishment, the `on_disconnect` callback is invoked. See `end_connection`.
* Updated where disconnections are handled (`advance_one_message_blocking`, `advance_one_message_async`, and message processing) to use `finish_connection`
* Improved handling of user-initiated disconnects during the connection process to avoid reporting them as connection errors and to ensure proper cleanup.

# API and ABI breaking changes

I guess maybe if people relied on the `on_connect_error` to actually fire the `on_disconnect` then this changes that behavior.

# Expected complexity level and risk

Maybe a 2? Seems pretty low risk but I'm still new to the codebase, please double check.

This doesn't fix the websocket issues, that'll be for another day. I noticed websocket.rs has some places it just drops and the error isn't handled properly. We could technically surface that information and run our callbacks with more specific error messages.

# Testing

I had an agent build and run loads of tests for this but didn't commit those since it would have made the PR massive. I was planning on testing locally though to see if I could trigger a connection failure at some point, maybe via an invalid access token.
