### PR TITLE
CI - Try to fix Internal Tests on `master`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -889,6 +889,10 @@ jobs:
             const publicRef = (context.eventName === 'pull_request') ? context.payload.pull_request.head.ref : context.sha;
             const publicPrNumber = context.payload.pull_request?.number ?? context.payload.inputs?.pr_number;
             const preDispatch = new Date().toISOString();
+            const inputs = { public_ref: publicRef };
+            if (publicPrNumber) {
+              inputs.public_pr_number = String(publicPrNumber);
+            }
 
             // Dispatch the workflow in the target repository
             await github.rest.actions.createWorkflowDispatch({
@@ -896,7 +900,7 @@ jobs:
               repo: targetRepo,
               workflow_id: workflowId,
               ref: targetRef,
-              inputs: { public_ref: publicRef, public_pr_number: String(publicPrNumber) }
+              inputs,
             });
   
             const sleep = (ms) => new Promise(r => setTimeout(r, ms));


### PR DESCRIPTION
# Description of Changes

https://github.com/clockworklabs/SpacetimeDB/pull/4231 changed our CI to always pass a parameter corresponding to the PR number, which.. broke on `master` commits since they don't have a PR number.

# API and ABI breaking changes

None. CI only.

# Expected complexity level and risk

1.

# Testing

I think I don't know how to test this. But it's basically the old behavior on `master` commits, so it should work fine? One hopes?