### PR TITLE
feat(unreal): Dedicated worker thread, bounded queues, zero-copy diff pipeline, native table listeners

### DIFF
--- a/crates/codegen/src/unrealcpp.rs
+++ b/crates/codegen/src/unrealcpp.rs
@@ -47,6 +47,7 @@ impl Lang for UnrealCpp<'_> {
             &[
                 "Types/Builtins.h",
                 &format!("ModuleBindings/Types/{struct_name}Type.g.h"),
+                "DBCache/ClientCache.h",
                 "Tables/RemoteTable.h",
                 "DBCache/WithBsatn.h",
                 "DBCache/TableHandle.h",
@@ -62,6 +63,35 @@ impl Lang for UnrealCpp<'_> {
 
         // Generate unique index classes first
         let product_type = module.typespace_for_generate()[table.product_type_ref].as_product();
+
+        if let (false, Some(pk)) = (table.is_event, schema.pk()) {
+            let (pk_name, pk_ty) = &product_type.unwrap().elements[pk.col_pos.idx()];
+            let pk_type_str = cpp_ty_fmt_with_module(self.module_prefix, module, pk_ty, self.module_name).to_string();
+            if pk_type_str == "uint64" {
+                let pk_field_name = pk_name.deref().to_case(Case::Pascal);
+                let pk_index_name = pk.col_name.deref();
+                writeln!(output, "namespace UE::SpacetimeDB");
+                writeln!(output, "{{");
+                writeln!(output, "template<>");
+                writeln!(output, "struct TCompactPrimaryKeyTraits<::{row_struct}>");
+                writeln!(output, "{{");
+                writeln!(output, "    static constexpr bool bEnabled = true;");
+                writeln!(output, "    using KeyType = uint64;");
+                writeln!(output);
+                writeln!(output, "    static KeyType GetKey(const ::{row_struct}& Row)");
+                writeln!(output, "    {{");
+                writeln!(output, "        return Row.{pk_field_name};");
+                writeln!(output, "    }}");
+                writeln!(output);
+                writeln!(output, "    static const TCHAR* GetUniqueIndexName()");
+                writeln!(output, "    {{");
+                writeln!(output, "        return TEXT(\"{pk_index_name}\");");
+                writeln!(output, "    }}");
+                writeln!(output, "}};");
+                writeln!(output, "}}");
+                writeln!(output);
+            }
+        }
 
         let mut unique_indexes = Vec::new();
         let mut multi_key_indexes = Vec::new();
@@ -307,6 +337,17 @@ impl Lang for UnrealCpp<'_> {
         }
 
         writeln!(output, "    void PostInitialize();");
+        writeln!(output);
+        writeln!(
+            output,
+            "    void SetCacheApplyMode(UE::SpacetimeDB::ETableCacheApplyMode InApplyMode);"
+        );
+        writeln!(
+            output,
+            "    UE::SpacetimeDB::ETableCacheApplyMode GetCacheApplyMode() const;"
+        );
+        writeln!(output, "    void SetRuntimeBTreeIndexApplyMode(const FString& IndexName, UE::SpacetimeDB::ERuntimeBTreeIndexApplyMode InApplyMode);");
+        writeln!(output, "    void ClearRuntimeBTreeIndexApplyModes();");
         writeln!(output);
 
         writeln!(output, "    /** Update function for {table_name} table*/");
@@ -1205,7 +1246,7 @@ fn generate_table_cpp(
         writeln!(
             output,
             "    {table_pascal}Table->AddUniqueConstraint<{field_type}>(\"{}\", [](const {row_struct}& Row) -> const {field_type}& {{",
-            field_name.to_lowercase()
+            field_name
         );
         writeln!(output, "        return Row.{}; }});", field_name.to_case(Case::Pascal));
     }
@@ -1255,6 +1296,52 @@ fn generate_table_cpp(
     writeln!(output, "}}");
     writeln!(output);
 
+    writeln!(
+        output,
+        "void U{table_pascal}Table::SetCacheApplyMode(UE::SpacetimeDB::ETableCacheApplyMode InApplyMode)"
+    );
+    writeln!(output, "{{");
+    writeln!(
+        output,
+        "    checkf(Data.IsValid(), TEXT(\"{table_pascal} table cache policy set before PostInitialize.\"));"
+    );
+    writeln!(output, "    Data->SetApplyMode(InApplyMode);");
+    writeln!(output, "}}");
+    writeln!(output);
+
+    writeln!(
+        output,
+        "UE::SpacetimeDB::ETableCacheApplyMode U{table_pascal}Table::GetCacheApplyMode() const"
+    );
+    writeln!(output, "{{");
+    writeln!(
+        output,
+        "    checkf(Data.IsValid(), TEXT(\"{table_pascal} table cache policy read before PostInitialize.\"));"
+    );
+    writeln!(output, "    return Data->GetApplyMode();");
+    writeln!(output, "}}");
+    writeln!(output);
+
+    writeln!(output, "void U{table_pascal}Table::SetRuntimeBTreeIndexApplyMode(const FString& IndexName, UE::SpacetimeDB::ERuntimeBTreeIndexApplyMode InApplyMode)");
+    writeln!(output, "{{");
+    writeln!(
+        output,
+        "    checkf(Data.IsValid(), TEXT(\"{table_pascal} runtime B-Tree index policy set before PostInitialize.\"));"
+    );
+    writeln!(
+        output,
+        "    Data->SetRuntimeBTreeIndexApplyMode(IndexName, InApplyMode);"
+    );
+    writeln!(output, "}}");
+    writeln!(output);
+
+    writeln!(output, "void U{table_pascal}Table::ClearRuntimeBTreeIndexApplyModes()");
+    writeln!(output, "{{");
+    writeln!(output, "    checkf(Data.IsValid(), TEXT(\"{table_pascal} runtime B-Tree index policy reset before PostInitialize.\"));");
+    writeln!(output, "    Data->ClearRuntimeBTreeIndexApplyModes();");
+    writeln!(output, "}}");
+    writeln!(output);
+
     // Generate Update implementation
     writeln!(
         output,
@@ -1267,9 +1354,12 @@ fn generate_table_cpp(
             "    // Event tables are callback-only: do not persist rows in the local cache."
         );
         writeln!(output, "    FTableAppliedDiff<{row_struct}> Diff;");
-        writeln!(output, "    for (const FWithBsatn<{row_struct}>& Insert : InsertsRef)");
+        writeln!(output, "    for (FWithBsatn<{row_struct}>& Insert : InsertsRef)");
         writeln!(output, "    {{");
-        writeln!(output, "        Diff.Inserts.Add(Insert.Bsatn, Insert.Row);");
+        writeln!(
+            output,
+            "        Diff.Inserts.Add(MakeShared<{row_struct}>(MoveTemp(Insert.Row)));"
+        );
         writeln!(output, "    }}");
     } else {
         writeln!(

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/DbConnectionBase.cpp
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/DbConnectionBase.cpp
@@ -2,12 +2,15 @@
 #include "Connection/DbConnectionBuilder.h"
 #include "Connection/Credentials.h"
 #include "Connection/LogCategory.h"
-#include "Containers/Ticker.h"
 #include "ModuleBindings/Types/ClientMessageType.g.h"
 #include "ModuleBindings/Types/SubscriptionErrorType.g.h"
 #include "Misc/Compression.h"
 #include "Misc/ScopeLock.h"
-#include "Async/Async.h"
+#include "HAL/Event.h"
+#include "HAL/PlatformProcess.h"
+#include "HAL/Runnable.h"
+#include "HAL/RunnableThread.h"
+#include "ProfilingDebugging/CpuProfilerTrace.h"
 #include "BSATN/UEBSATNHelpers.h"
 #include "Connection/ProcedureFlags.h"
 
@@ -20,7 +23,19 @@ enum class EWsCompressionTag : uint8
 	Gzip = 2,
 };
 
-static FDatabaseUpdateType QueryRowsToDatabaseUpdate(const FQueryRowsType& Rows, bool bAsDeletes)
+constexpr int32 MaxQueuedInboundRawMessages = 8192;
+constexpr int64 MaxQueuedInboundRawBytes = 128ll * 1024ll * 1024ll;
+constexpr int32 MaxPendingInboundParsedMessages = 8192;
+constexpr int64 MaxPendingInboundParsedPayloadBytes = 128ll * 1024ll * 1024ll;
+constexpr int32 PendingInboundCompactionMinConsumedMessages = 512;
+constexpr uint32 InboundWorkerStackSizeBytes = 0;
+constexpr EThreadPriority InboundWorkerThreadPriority = TPri_Normal;
+constexpr const TCHAR* InboundWorkerThreadName = TEXT("SpacetimeDBInboundWorker");
+constexpr int32 SpacetimeDbCompressionTagBytes = 1;
+constexpr int32 GzipFooterUncompressedSizeBytes = 4;
+constexpr int32 MaxInboundApplyLogTableContributors = 6;
+
+static FDatabaseUpdateType QueryRowsToDatabaseUpdate(const FQueryRowsType& Rows, UE::SpacetimeDB::EQueryRowsApplyMode Mode)
 {
 	FDatabaseUpdateType Update;
 	for (const FSingleTableRowsType& TableRows : Rows.Tables)
@@ -29,13 +44,17 @@ static FDatabaseUpdateType QueryRowsToDatabaseUpdate(const FQueryRowsType& Rows,
 		TableUpdate.TableName = TableRows.Table;
 
 		FPersistentTableRowsType PersistentRows;
-		if (bAsDeletes)
+		switch (Mode)
 		{
+		case UE::SpacetimeDB::EQueryRowsApplyMode::Deletes:
 			PersistentRows.Deletes = TableRows.Rows;
-		}
-		else
-		{
+			break;
+		case UE::SpacetimeDB::EQueryRowsApplyMode::Inserts:
 			PersistentRows.Inserts = TableRows.Rows;
+			break;
+		default:
+			checkf(false, TEXT("Unsupported query-row apply mode for table %s"), *TableRows.Table);
+			continue;
 		}
 		TableUpdate.Rows.Add(FTableUpdateRowsType::PersistentTable(PersistentRows));
 		Update.Tables.Add(TableUpdate);
@@ -64,7 +83,130 @@ static FString DecodeReducerErrorMessage(const TArray<uint8>& ErrorBytes)
 	}
 	return UE::SpacetimeDB::Deserialize<FString>(ErrorBytes);
 }
+
+static const TCHAR* DescribeServerMessageTag(EServerMessageTag Tag)
+{
+	switch (Tag)
+	{
+	case EServerMessageTag::InitialConnection:
+		return TEXT("InitialConnection");
+	case EServerMessageTag::TransactionUpdate:
+		return TEXT("TransactionUpdate");
+	case EServerMessageTag::OneOffQueryResult:
+		return TEXT("OneOffQueryResult");
+	case EServerMessageTag::SubscribeApplied:
+		return TEXT("SubscribeApplied");
+	case EServerMessageTag::UnsubscribeApplied:
+		return TEXT("UnsubscribeApplied");
+	case EServerMessageTag::SubscriptionError:
+		return TEXT("SubscriptionError");
+	case EServerMessageTag::ReducerResult:
+		return TEXT("ReducerResult");
+	case EServerMessageTag::ProcedureResult:
+		return TEXT("ProcedureResult");
+	default:
+		return TEXT("Unknown");
+	}
 }
+
+static FString FormatInboundTableApplyStats(const FSpacetimeDBTableApplyStats& Stats)
+{
+	return FString::Printf(
+		TEXT("%s rows=%d ins=%d del=%d bytes=%lld cache=%.2fus broadcast=%.2fus diff=%d"),
+		*Stats.TableName,
+		Stats.RowSetCount,
+		Stats.InsertRowCount,
+		Stats.DeleteRowCount,
+		Stats.InsertRowBytes + Stats.DeleteRowBytes,
+		Stats.CacheMicros,
+		Stats.BroadcastMicros,
+		Stats.bProducedDiff ? 1 : 0);
+}
+}
+
+class FSpacetimeDbInboundWorker final : public FRunnable
+{
+public:
+	explicit FSpacetimeDbInboundWorker(UDbConnectionBase& InConnection)
+		: Connection(&InConnection)
+	{
+		WorkAvailableEvent = FPlatformProcess::GetSynchEventFromPool(false);
+		checkf(WorkAvailableEvent != nullptr, TEXT("Failed to allocate SpacetimeDB inbound worker event."));
+
+		Thread = FRunnableThread::Create(
+			this,
+			InboundWorkerThreadName,
+			InboundWorkerStackSizeBytes,
+			InboundWorkerThreadPriority);
+		checkf(Thread != nullptr, TEXT("Failed to create SpacetimeDB inbound worker thread."));
+	}
+
+	virtual ~FSpacetimeDbInboundWorker() override
+	{
+		StopAndJoin();
+	}
+
+	void Notify()
+	{
+		if (WorkAvailableEvent)
+		{
+			WorkAvailableEvent->Trigger();
+		}
+	}
+
+	virtual uint32 Run() override
+	{
+		while (!bStopRequested)
+		{
+			checkf(WorkAvailableEvent != nullptr, TEXT("SpacetimeDB inbound worker event was not initialized."));
+			WorkAvailableEvent->Wait();
+
+			if (bStopRequested)
+			{
+				break;
+			}
+
+			if (Connection)
+			{
+				Connection->DrainInboundRawMessagesOnWorker();
+			}
+		}
+
+		return 0;
+	}
+
+	virtual void Stop() override
+	{
+		bStopRequested = true;
+		Notify();
+	}
+
+	void StopAndJoin()
+	{
+		Stop();
+
+		if (Thread)
+		{
+			Thread->WaitForCompletion();
+			delete Thread;
+			Thread = nullptr;
+		}
+
+		if (WorkAvailableEvent)
+		{
+			FPlatformProcess::ReturnSynchEventToPool(WorkAvailableEvent);
+			WorkAvailableEvent = nullptr;
+		}
+
+		Connection = nullptr;
+	}
+
+private:
+	UDbConnectionBase* Connection = nullptr;
+	FEvent* WorkAvailableEvent = nullptr;
+	FRunnableThread* Thread = nullptr;
+	FThreadSafeBool bStopRequested = false;
+};
 
 UDbConnectionBase::UDbConnectionBase(const FObjectInitializer& ObjectInitializer)
 	: Super(ObjectInitializer)
@@ -74,43 +216,15 @@ UDbConnectionBase::UDbConnectionBase(const FObjectInitializer& ObjectInitializer
 	ProcedureCallbacks = CreateDefaultSubobject<UProcedureCallbacks>(TEXT("ProcedureCallbacks"));
 }
 
-void UDbConnectionBase::SetAutoTicking(bool bAutoTick)
-{
-	if (bIsAutoTicking == bAutoTick)
-	{
-		return;
-	}
-
-	bIsAutoTicking = bAutoTick;
-
-	if (bIsAutoTicking)
-	{
-		if (!TickerHandle.IsValid())
-		{
-			TickerHandle = FTSTicker::GetCoreTicker().AddTicker(FTickerDelegate::CreateUObject(this, &UDbConnectionBase::OnTickerTick));
-		}
-	}
-	else if (TickerHandle.IsValid())
-	{
-		FTSTicker::GetCoreTicker().RemoveTicker(TickerHandle);
-		TickerHandle.Reset();
-	}
-}
-
 void UDbConnectionBase::BeginDestroy()
 {
-	if (TickerHandle.IsValid())
-	{
-		FTSTicker::GetCoreTicker().RemoveTicker(TickerHandle);
-		TickerHandle.Reset();
-	}
-	bIsAutoTicking = false;
-
+	StopInboundMessageWorker();
 	Super::BeginDestroy();
 }
 
 void UDbConnectionBase::Disconnect()
 {
+	StopInboundMessageWorker();
 	if (WebSocket)
 	{
 		WebSocket->Disconnect();
@@ -157,6 +271,7 @@ USubscriptionBuilderBase* UDbConnectionBase::SubscriptionBuilderBase()
 
 void UDbConnectionBase::HandleWSError(const FString& Error)
 {
+	StopInboundMessageWorker();
 	bProtocolViolationHandled = false;
 	ClearPendingOperations(Error);
 	if (OnConnectErrorDelegate.IsBound())
@@ -167,6 +282,7 @@ void UDbConnectionBase::HandleWSError(const FString& Error)
 
 void UDbConnectionBase::HandleWSClosed(int32 /*StatusCode*/, const FString& Reason, bool /*bWasClean*/)
 {
+	StopInboundMessageWorker();
 	bProtocolViolationHandled = false;
 	ClearPendingOperations(Reason);
 	if (OnDisconnectBaseDelegate.IsBound())
@@ -185,6 +301,7 @@ void UDbConnectionBase::HandleProtocolViolation(const FString& ErrorMessage)
 
 	UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("%s"), *ErrorMessage);
 	TriggerError(ErrorMessage);
+	StopInboundMessageWorker();
 	ClearPendingOperations(ErrorMessage);
 
 	// Match Rust/C# behavior: parse/protocol violations are fatal for the connection.
@@ -198,94 +315,596 @@ void UDbConnectionBase::HandleProtocolViolation(const FString& ErrorMessage)
 	}
 }
 
+void UDbConnectionBase::StartInboundMessageWorker()
+{
+	FScopeLock Lock(&InboundWorkerMutex);
+	if (InboundWorker)
+	{
+		return;
+	}
+
+	{
+		FScopeLock RawLock(&InboundRawMessagesMutex);
+		InboundRawMessages.Reset();
+		InboundQueuedRawBytes = 0;
+		++InboundConnectionEpoch;
+		NextInboundSequenceId = 0;
+		bInboundAcceptingMessages = true;
+		bInboundProtocolErrorQueued = false;
+	}
+
+	{
+		FScopeLock PendingLock(&PendingMessagesMutex);
+		PendingMessages.Reset();
+		PendingMessageReadIndex = 0;
+		PendingParsedPayloadBytes = 0;
+	}
+
+	ActivePreprocessedTableData = nullptr;
+	InboundWorker = new FSpacetimeDbInboundWorker(*this);
+}
+
+void UDbConnectionBase::StopInboundMessageWorker()
+{
+	FSpacetimeDbInboundWorker* WorkerToStop = nullptr;
+	{
+		FScopeLock Lock(&InboundWorkerMutex);
+		{
+			FScopeLock RawLock(&InboundRawMessagesMutex);
+			InboundRawMessages.Reset();
+			InboundQueuedRawBytes = 0;
+			++InboundConnectionEpoch;
+			bInboundAcceptingMessages = false;
+			bInboundProtocolErrorQueued = false;
+		}
+
+		{
+			FScopeLock PendingLock(&PendingMessagesMutex);
+			PendingMessages.Reset();
+			PendingMessageReadIndex = 0;
+			PendingParsedPayloadBytes = 0;
+		}
+
+		ActivePreprocessedTableData = nullptr;
+		WorkerToStop = InboundWorker;
+		InboundWorker = nullptr;
+	}
+
+	if (WorkerToStop)
+	{
+		delete WorkerToStop;
+	}
+
+	ClearInboundMessageQueues();
+}
+
+void UDbConnectionBase::ClearInboundMessageQueues()
+{
+	{
+		FScopeLock Lock(&InboundRawMessagesMutex);
+		InboundRawMessages.Reset();
+		InboundQueuedRawBytes = 0;
+	}
+
+	{
+		FScopeLock Lock(&PendingMessagesMutex);
+		PendingMessages.Reset();
+		PendingMessageReadIndex = 0;
+		PendingParsedPayloadBytes = 0;
+	}
+
+	ActivePreprocessedTableData = nullptr;
+}
+
+void UDbConnectionBase::NotifyInboundWorkerIfNeeded()
+{
+	FScopeLock WorkerLock(&InboundWorkerMutex);
+	if (InboundWorker == nullptr)
+	{
+		return;
+	}
+
+	bool bShouldNotify = false;
+	{
+		FScopeLock RawLock(&InboundRawMessagesMutex);
+		bShouldNotify = InboundRawMessages.Num() > 0 && bInboundAcceptingMessages && !bInboundProtocolErrorQueued;
+	}
+
+	if (bShouldNotify)
+	{
+		InboundWorker->Notify();
+	}
+}
+
+bool UDbConnectionBase::IsInboundProtocolErrorQueued() const
+{
+	FScopeLock Lock(&InboundRawMessagesMutex);
+	return bInboundProtocolErrorQueued;
+}
+
+bool UDbConnectionBase::IsInboundEpochCurrentAndAccepting(uint64 ConnectionEpoch) const
+{
+	FScopeLock Lock(&InboundRawMessagesMutex);
+	return bInboundAcceptingMessages && !bInboundProtocolErrorQueued && InboundConnectionEpoch == ConnectionEpoch;
+}
+
+void UDbConnectionBase::MarkInboundProtocolErrorQueued()
+{
+	FScopeLock Lock(&InboundRawMessagesMutex);
+	bInboundProtocolErrorQueued = true;
+	bInboundAcceptingMessages = false;
+	InboundRawMessages.Reset();
+	InboundQueuedRawBytes = 0;
+}
+
+void UDbConnectionBase::EnqueueInboundProtocolError(uint64 SequenceId, int32 PayloadSizeBytes, uint8 CompressionTag, int32 QueueDepthAtEnqueue, int64 QueuedBytesAtEnqueue, const FString& ErrorMessage)
+{
+	UE_LOG(
+		LogSpacetimeDb_Connection,
+		Error,
+		TEXT("SpacetimeDB inbound protocol error: sequence=%llu payload_bytes=%d compression_tag=%u queued_messages=%d queued_bytes=%lld detail=%s"),
+		SequenceId,
+		PayloadSizeBytes,
+		static_cast<uint32>(CompressionTag),
+		QueueDepthAtEnqueue,
+		QueuedBytesAtEnqueue,
+		*ErrorMessage);
+
+	FInboundParsedMessage Parsed;
+	Parsed.SequenceId = SequenceId;
+	Parsed.PayloadSizeBytes = PayloadSizeBytes;
+	Parsed.CompressionTag = CompressionTag;
+	Parsed.QueueDepthAtEnqueue = QueueDepthAtEnqueue;
+	Parsed.QueuedBytesAtEnqueue = QueuedBytesAtEnqueue;
+	Parsed.bProtocolError = true;
+	Parsed.ProtocolError = ErrorMessage;
+
+	FScopeLock Lock(&PendingMessagesMutex);
+	PendingMessages.Reset();
+	PendingMessageReadIndex = 0;
+	PendingParsedPayloadBytes = 0;
+	PendingMessages.Add(MoveTemp(Parsed));
+	PendingParsedPayloadBytes += static_cast<int64>(PayloadSizeBytes);
+}
+
 void UDbConnectionBase::HandleWSBinaryMessage(const TArray<uint8>& Message)
 {
-	//tag for arrival order
-	const int32 Id = NextPreprocessId.GetValue();
-	NextPreprocessId.Increment();
+	TArray<uint8> OwnedMessage = Message;
+	HandleWSBinaryMessageOwned(MoveTemp(OwnedMessage));
+}
 
-	//do expensive work off-thread
-	TWeakObjectPtr<UDbConnectionBase> WeakThis(this);
-	Async(EAsyncExecution::Thread, [WeakThis, Message, Id]()
+void UDbConnectionBase::HandleWSBinaryMessageOwned(TArray<uint8>&& Message)
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(SpacetimeDB_InboundEnqueue);
+
+	const int32 PayloadSizeBytes = Message.Num();
+	const uint8 CompressionTag = PayloadSizeBytes > 0 ? Message[0] : 0;
+	uint64 SequenceId = 0;
+	int32 QueueDepthAtEnqueue = 0;
+	int64 QueuedBytesAtEnqueue = 0;
+	uint64 ConnectionEpoch = 0;
+	bool bQueueOverloaded = false;
+	FString QueueOverloadError;
+
 	{
-		if (!WeakThis.IsValid())
+		FScopeLock WorkerLock(&InboundWorkerMutex);
+		FScopeLock RawLock(&InboundRawMessagesMutex);
+		if (!bInboundAcceptingMessages || bInboundProtocolErrorQueued)
 		{
 			return;
 		}
-		UDbConnectionBase* This = WeakThis.Get();
+		checkf(InboundWorker != nullptr, TEXT("SpacetimeDB inbound worker missing while inbound connection epoch %llu is accepting messages."), InboundConnectionEpoch);
 
-		//parse the message, decompress if needed
-		FServerMessageType Parsed;
-		if (!This->PreProcessMessage(Message, Parsed))
+		ConnectionEpoch = InboundConnectionEpoch;
+		SequenceId = NextInboundSequenceId++;
+		const int64 NewQueuedRawBytes = InboundQueuedRawBytes + static_cast<int64>(PayloadSizeBytes);
+		const int32 NewQueuedRawMessageCount = InboundRawMessages.Num() + 1;
+		QueueDepthAtEnqueue = NewQueuedRawMessageCount;
+		QueuedBytesAtEnqueue = NewQueuedRawBytes;
+		if (NewQueuedRawMessageCount > MaxQueuedInboundRawMessages || NewQueuedRawBytes > MaxQueuedInboundRawBytes)
 		{
-			AsyncTask(ENamedThreads::GameThread, [WeakThis]()
-			{
-				if (!WeakThis.IsValid())
-				{
-					return;
-				}
-				UDbConnectionBase* Conn = WeakThis.Get();
-				Conn->HandleProtocolViolation(TEXT("Failed to parse/decompress incoming WebSocket message"));
-			});
-			return;
+			bInboundProtocolErrorQueued = true;
+			bInboundAcceptingMessages = false;
+			InboundRawMessages.Reset();
+			InboundQueuedRawBytes = 0;
+			bQueueOverloaded = true;
+			QueueOverloadError = FString::Printf(
+				TEXT("SpacetimeDB inbound queue overload: sequence=%llu payload_bytes=%d compression_tag=%u queued_messages=%d queued_bytes=%lld max_messages=%d max_bytes=%lld"),
+				SequenceId,
+				PayloadSizeBytes,
+				static_cast<uint32>(CompressionTag),
+				NewQueuedRawMessageCount,
+				NewQueuedRawBytes,
+				MaxQueuedInboundRawMessages,
+				MaxQueuedInboundRawBytes);
 		}
+		else
+		{
+			FInboundRawMessage RawMessage;
+			RawMessage.ConnectionEpoch = ConnectionEpoch;
+			RawMessage.SequenceId = SequenceId;
+			RawMessage.QueueDepthAtEnqueue = QueueDepthAtEnqueue;
+			RawMessage.QueuedBytesAtEnqueue = QueuedBytesAtEnqueue;
+			RawMessage.Payload = MoveTemp(Message);
+			InboundRawMessages.Add(MoveTemp(RawMessage));
+			InboundQueuedRawBytes = NewQueuedRawBytes;
+			InboundWorker->Notify();
+		}
+	}
 
-		//queue: re-order buffer
-		TArray<FServerMessageType> Ready;
-		{
-			FScopeLock Lock(&This->PreprocessMutex);
-			// Move the parsed message into the map to avoid copying
-			This->PreprocessedMessages.Add(Id, MoveTemp(Parsed));
-			//check if we can release any messages in order
-			while (This->PreprocessedMessages.Contains(This->NextReleaseId))
-			{
-				Ready.Add(This->PreprocessedMessages.FindAndRemoveChecked(This->NextReleaseId));
-				++This->NextReleaseId;
-			}
-		}
-		//if we have any ready messages, append them to the pending messages list that is processed in Tick
-		if (Ready.Num() > 0)
-		{
-			FScopeLock Lock(&This->PendingMessagesMutex);
-			This->PendingMessages.Append(MoveTemp(Ready));
-		}
-	});
+	if (bQueueOverloaded)
+	{
+		EnqueueInboundProtocolError(SequenceId, PayloadSizeBytes, CompressionTag, QueueDepthAtEnqueue, QueuedBytesAtEnqueue, QueueOverloadError);
+		return;
+	}
 }
 
 void UDbConnectionBase::FrameTick()
 {
-	TArray<FServerMessageType> Local;
+	int32 MessagesProcessed = 0;
+	int64 PayloadBytesProcessed = 0;
+	const uint64 FrameStartCycles = FPlatformTime::Cycles64();
+	const bool bDrainAllPendingMessages = InboundApplyBudget.bDrainAllPendingMessages;
 	{
 		FScopeLock Lock(&PendingMessagesMutex);
-		if (PendingMessages.Num() == 0)
+		const int32 PendingCount = PendingMessages.Num() - PendingMessageReadIndex;
+		if (PendingCount <= 0)
 		{
 			//nothing to process, return early
 			return;
 		}
-		//move pending messages to local array for processing
-		Local = MoveTemp(PendingMessages);
-		PendingMessages.Empty();
+
 	}
 
-	//process all messages in the local array
-	for (const FServerMessageType& Msg : Local)
+	TRACE_CPUPROFILER_EVENT_SCOPE(SpacetimeDB_GameThreadApplyInbound);
+
+	while (true)
 	{
-		//process the message, this will call DbUpdate or trigger subscription events as needed
-		ProcessServerMessage(Msg);
+		FInboundParsedMessage Msg;
+		{
+			FScopeLock Lock(&PendingMessagesMutex);
+			if (PendingMessageReadIndex >= PendingMessages.Num())
+			{
+				PendingMessages.Reset();
+				PendingMessageReadIndex = 0;
+				PendingParsedPayloadBytes = 0;
+				break;
+			}
+
+			if (!bDrainAllPendingMessages && MessagesProcessed >= InboundApplyBudget.MaxMessagesPerFrame)
+			{
+				break;
+			}
+
+			FInboundParsedMessage& PendingMessage = PendingMessages[PendingMessageReadIndex];
+			const int64 PendingPayloadBytes = static_cast<int64>(PendingMessage.PayloadSizeBytes);
+			if (!bDrainAllPendingMessages && MessagesProcessed > 0 && PayloadBytesProcessed + PendingPayloadBytes > InboundApplyBudget.MaxPayloadBytesPerFrame)
+			{
+				break;
+			}
+
+			PayloadBytesProcessed += PendingPayloadBytes;
+			PendingParsedPayloadBytes = FMath::Max<int64>(0, PendingParsedPayloadBytes - PendingPayloadBytes);
+			Msg = MoveTemp(PendingMessage);
+			++PendingMessageReadIndex;
+
+			if (PendingMessageReadIndex == PendingMessages.Num())
+			{
+				PendingMessages.Reset();
+				PendingMessageReadIndex = 0;
+				PendingParsedPayloadBytes = 0;
+			}
+			else if (PendingMessageReadIndex >= PendingInboundCompactionMinConsumedMessages)
+			{
+				PendingMessages.RemoveAt(0, PendingMessageReadIndex, EAllowShrinking::No);
+				PendingMessageReadIndex = 0;
+			}
+		}
+
+		if (Msg.bProtocolError)
+		{
+			HandleProtocolViolation(Msg.ProtocolError);
+			break;
+		}
+
+		const uint64 MessageStartCycles = FPlatformTime::Cycles64();
+		FSpacetimeDBInboundMessageApplyStats ApplyStats;
+		ApplyStats.MessageKind = DescribeServerMessageTag(Msg.Message.Tag);
+		ApplyStats.SequenceId = Msg.SequenceId;
+		ApplyStats.PayloadSizeBytes = Msg.PayloadSizeBytes;
+		ApplyStats.QueueDepthAtEnqueue = Msg.QueueDepthAtEnqueue;
+		ApplyStats.QueuedBytesAtEnqueue = Msg.QueuedBytesAtEnqueue;
+		if (Msg.Message.Tag == EServerMessageTag::ReducerResult)
+		{
+			const FReducerResultType& Payload = Msg.Message.MessageData.Get<FReducerResultType>();
+			ApplyStats.RequestId = Payload.RequestId;
+			if (const FReducerCallInfoType* FoundReducerCall = PendingReducerCalls.Find(Payload.RequestId))
+			{
+				ApplyStats.ReducerName = FoundReducerCall->ReducerName;
+			}
+		}
+
+		ProcessInboundServerMessage(Msg, ApplyStats);
+		const double MessageElapsedMicros =
+			FPlatformTime::ToMilliseconds64(FPlatformTime::Cycles64() - MessageStartCycles) * 1000.0;
+		if (!bDrainAllPendingMessages &&
+			InboundApplyBudget.SoftTimeBudgetMicros > 0 &&
+			MessageElapsedMicros >= static_cast<double>(InboundApplyBudget.SoftTimeBudgetMicros))
+		{
+			TArray<FSpacetimeDBTableApplyStats> SortedStats = ApplyStats.TableStats;
+			SortedStats.Sort([](const FSpacetimeDBTableApplyStats& A, const FSpacetimeDBTableApplyStats& B)
+			{
+				return (A.CacheMicros + A.BroadcastMicros) > (B.CacheMicros + B.BroadcastMicros);
+			});
+			TArray<FString> TopTableSummaries;
+			const int32 LoggedTableCount = FMath::Min(SortedStats.Num(), MaxInboundApplyLogTableContributors);
+			TopTableSummaries.Reserve(LoggedTableCount);
+			for (int32 TableIndex = 0; TableIndex < LoggedTableCount; ++TableIndex)
+			{
+				TopTableSummaries.Add(FormatInboundTableApplyStats(SortedStats[TableIndex]));
+			}
+			const FString TopTablesText = TopTableSummaries.IsEmpty()
+				? TEXT("<none>")
+				: FString::Join(TopTableSummaries, TEXT(" | "));
+			UE_LOG(LogSpacetimeDb_Connection,
+				Warning,
+				TEXT("SpacetimeDB inbound single-message apply exceeded soft budget: %.2fus >= %lldus kind=%s sequence=%llu request_id=%u reducer=%s payload_bytes=%d queued_messages=%d queued_bytes=%lld messages_processed_before=%d tables=%d top_tables=%s"),
+				MessageElapsedMicros,
+				InboundApplyBudget.SoftTimeBudgetMicros,
+				*ApplyStats.MessageKind,
+				ApplyStats.SequenceId,
+				ApplyStats.RequestId,
+				ApplyStats.ReducerName.IsEmpty() ? TEXT("<none>") : *ApplyStats.ReducerName,
+				ApplyStats.PayloadSizeBytes,
+				ApplyStats.QueueDepthAtEnqueue,
+				ApplyStats.QueuedBytesAtEnqueue,
+				MessagesProcessed,
+				ApplyStats.TableStats.Num(),
+				*TopTablesText);
+		}
+		++MessagesProcessed;
+
+		if (!bDrainAllPendingMessages &&
+			MessagesProcessed >= InboundApplyBudget.MinMessagesPerFrame &&
+			InboundApplyBudget.SoftTimeBudgetMicros > 0)
+		{
+			const double ElapsedMicros = FPlatformTime::ToMilliseconds64(FPlatformTime::Cycles64() - FrameStartCycles) * 1000.0;
+			if (ElapsedMicros >= static_cast<double>(InboundApplyBudget.SoftTimeBudgetMicros))
+			{
+				break;
+			}
+		}
+	}
+
+	if (MessagesProcessed > 0)
+	{
+		NotifyInboundWorkerIfNeeded();
 	}
 }
 
-bool UDbConnectionBase::OnTickerTick(float DeltaTime)
+void UDbConnectionBase::DrainInboundRawMessagesOnWorker()
 {
-	if (HasAnyFlags(RF_BeginDestroyed | RF_FinishDestroyed) || !bIsAutoTicking)
+	TRACE_CPUPROFILER_EVENT_SCOPE(SpacetimeDB_InboundWorkerDrain);
+
+	while (!IsInboundProtocolErrorQueued())
 	{
+		int32 ParsedMessageCapacity = 0;
+		int64 ParsedPayloadByteCapacity = 0;
+		{
+			FScopeLock Lock(&PendingMessagesMutex);
+			const int32 LivePendingMessages = PendingMessages.Num() - PendingMessageReadIndex;
+			ParsedMessageCapacity = MaxPendingInboundParsedMessages - LivePendingMessages;
+			ParsedPayloadByteCapacity = MaxPendingInboundParsedPayloadBytes - PendingParsedPayloadBytes;
+		}
+
+		if (ParsedMessageCapacity <= 0 || ParsedPayloadByteCapacity <= 0)
+		{
+			return;
+		}
+
+		TArray<FInboundRawMessage> LocalRawMessages;
+		int64 DrainedRawBytes = 0;
+		{
+			FScopeLock Lock(&InboundRawMessagesMutex);
+			if (InboundRawMessages.Num() == 0 || !bInboundAcceptingMessages || bInboundProtocolErrorQueued)
+			{
+				return;
+			}
+
+			int32 DrainCount = 0;
+			for (; DrainCount < InboundRawMessages.Num() && DrainCount < ParsedMessageCapacity; ++DrainCount)
+			{
+				const int64 NextPayloadBytes = static_cast<int64>(InboundRawMessages[DrainCount].Payload.Num());
+				if (DrainCount > 0 && DrainedRawBytes + NextPayloadBytes > ParsedPayloadByteCapacity)
+				{
+					break;
+				}
+				if (DrainCount == 0 && NextPayloadBytes > ParsedPayloadByteCapacity)
+				{
+					return;
+				}
+
+				DrainedRawBytes += NextPayloadBytes;
+			}
+
+			if (DrainCount == 0)
+			{
+				return;
+			}
+
+			LocalRawMessages.Reserve(DrainCount);
+			for (int32 Index = 0; Index < DrainCount; ++Index)
+			{
+				LocalRawMessages.Add(MoveTemp(InboundRawMessages[Index]));
+			}
+
+			InboundRawMessages.RemoveAt(0, DrainCount, EAllowShrinking::No);
+			InboundQueuedRawBytes = FMath::Max<int64>(0, InboundQueuedRawBytes - DrainedRawBytes);
+		}
+
+		TArray<FInboundParsedMessage> LocalParsedMessages;
+		LocalParsedMessages.Reserve(LocalRawMessages.Num());
+
+		for (FInboundRawMessage& RawMessage : LocalRawMessages)
+		{
+			if (!IsInboundEpochCurrentAndAccepting(RawMessage.ConnectionEpoch))
+			{
+				return;
+			}
+
+			FInboundParsedMessage ParsedMessage;
+			if (!BuildInboundParsedMessage(RawMessage, ParsedMessage))
+			{
+				if (!IsInboundEpochCurrentAndAccepting(RawMessage.ConnectionEpoch))
+				{
+					return;
+				}
+				MarkInboundProtocolErrorQueued();
+				LocalParsedMessages.Add(MoveTemp(ParsedMessage));
+				break;
+			}
+
+			if (!IsInboundEpochCurrentAndAccepting(RawMessage.ConnectionEpoch))
+			{
+				return;
+			}
+			LocalParsedMessages.Add(MoveTemp(ParsedMessage));
+		}
+
+		if (LocalParsedMessages.Num() == 0)
+		{
+			continue;
+		}
+
+		const bool bBatchEndsWithProtocolError = LocalParsedMessages.Last().bProtocolError;
+		if (IsInboundProtocolErrorQueued() && !bBatchEndsWithProtocolError)
+		{
+			return;
+		}
+		if (!bBatchEndsWithProtocolError && !IsInboundEpochCurrentAndAccepting(LocalParsedMessages[0].ConnectionEpoch))
+		{
+			return;
+		}
+
+		uint64 OverloadSequenceId = LocalParsedMessages[0].SequenceId;
+		int32 OverloadPayloadSizeBytes = LocalParsedMessages[0].PayloadSizeBytes;
+		uint8 OverloadCompressionTag = LocalParsedMessages[0].CompressionTag;
+		{
+			FScopeLock Lock(&PendingMessagesMutex);
+			int64 AddedPayloadBytes = 0;
+			for (const FInboundParsedMessage& ParsedMessage : LocalParsedMessages)
+			{
+				AddedPayloadBytes += static_cast<int64>(ParsedMessage.PayloadSizeBytes);
+			}
+
+			const int32 LivePendingMessages = PendingMessages.Num() - PendingMessageReadIndex;
+			const int32 NewPendingMessageCount = LivePendingMessages + LocalParsedMessages.Num();
+			const int64 NewPendingPayloadBytes = PendingParsedPayloadBytes + AddedPayloadBytes;
+			checkf(bBatchEndsWithProtocolError ||
+				(NewPendingMessageCount <= MaxPendingInboundParsedMessages &&
+					NewPendingPayloadBytes <= MaxPendingInboundParsedPayloadBytes),
+				TEXT("SpacetimeDB parsed inbound queue overflow despite worker backpressure: sequence=%llu payload_bytes=%d compression_tag=%u queued_messages=%d queued_bytes=%lld max_messages=%d max_bytes=%lld"),
+				OverloadSequenceId,
+				OverloadPayloadSizeBytes,
+				static_cast<uint32>(OverloadCompressionTag),
+				NewPendingMessageCount,
+				NewPendingPayloadBytes,
+				MaxPendingInboundParsedMessages,
+				MaxPendingInboundParsedPayloadBytes);
+
+			PendingMessages.Append(MoveTemp(LocalParsedMessages));
+			PendingParsedPayloadBytes = NewPendingPayloadBytes;
+		}
+	}
+}
+
+bool UDbConnectionBase::BuildInboundParsedMessage(const FInboundRawMessage& RawMessage, FInboundParsedMessage& OutMessage)
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(SpacetimeDB_InboundPreprocess);
+
+	OutMessage.ConnectionEpoch = RawMessage.ConnectionEpoch;
+	OutMessage.SequenceId = RawMessage.SequenceId;
+	OutMessage.PayloadSizeBytes = RawMessage.Payload.Num();
+	OutMessage.CompressionTag = RawMessage.Payload.Num() > 0 ? RawMessage.Payload[0] : 0;
+	OutMessage.QueueDepthAtEnqueue = RawMessage.QueueDepthAtEnqueue;
+	OutMessage.QueuedBytesAtEnqueue = RawMessage.QueuedBytesAtEnqueue;
+
+	if (!PreProcessMessage(RawMessage.Payload, OutMessage))
+	{
+		OutMessage.bProtocolError = true;
+		OutMessage.ProtocolError = FString::Printf(
+			TEXT("Failed to parse/decompress incoming WebSocket message: sequence=%llu payload_bytes=%d compression_tag=%u queued_messages=%d queued_bytes=%lld"),
+			OutMessage.SequenceId,
+			OutMessage.PayloadSizeBytes,
+			static_cast<uint32>(OutMessage.CompressionTag),
+			OutMessage.QueueDepthAtEnqueue,
+			OutMessage.QueuedBytesAtEnqueue);
 		return false;
 	}
 
-	FrameTick();
 	return true;
 }
 
+void UDbConnectionBase::Tick(float DeltaTime)
+{
+	if (bIsAutoTicking)
+	{
+		FrameTick();
+	}
+}
+
+TStatId UDbConnectionBase::GetStatId() const
+{
+	// This is used by the engine to track tickables, we return a unique stat ID for this class
+	RETURN_QUICK_DECLARE_CYCLE_STAT(UMyTickableObject, STATGROUP_Tickables);
+}
+
+bool UDbConnectionBase::IsTickable() const
+{
+	return bIsAutoTicking;
+}
+
+bool UDbConnectionBase::IsTickableInEditor() const
+{
+	return bIsAutoTicking;
+}
+
+
+void UDbConnectionBase::ProcessInboundServerMessage(FInboundParsedMessage& InboundMessage, FSpacetimeDBInboundMessageApplyStats& ApplyStats)
+{
+	struct FActivePreprocessedDataGuard
+	{
+		FPreprocessedTableDataMap*& Target;
+		FSpacetimeDBInboundMessageApplyStats*& StatsTarget;
+
+		FActivePreprocessedDataGuard(
+			FPreprocessedTableDataMap*& InTarget,
+			FPreprocessedTableDataMap* InValue,
+			FSpacetimeDBInboundMessageApplyStats*& InStatsTarget,
+			FSpacetimeDBInboundMessageApplyStats* InStatsValue)
+			: Target(InTarget)
+			, StatsTarget(InStatsTarget)
+		{
+			checkf(Target == nullptr, TEXT("Nested SpacetimeDB inbound table preprocessing scope detected."));
+			checkf(StatsTarget == nullptr, TEXT("Nested SpacetimeDB inbound apply stats scope detected."));
+			Target = InValue;
+			StatsTarget = InStatsValue;
+		}
+
+		~FActivePreprocessedDataGuard()
+		{
+			Target = nullptr;
+			StatsTarget = nullptr;
+		}
+	};
+
+	FActivePreprocessedDataGuard Guard(
+		ActivePreprocessedTableData,
+		&InboundMessage.PreprocessedTableData,
+		ActiveInboundMessageApplyStats,
+		&ApplyStats);
+	ProcessServerMessage(InboundMessage.Message);
+}
 
 void UDbConnectionBase::ProcessServerMessage(const FServerMessageType& Message)
 {
@@ -293,7 +912,7 @@ void UDbConnectionBase::ProcessServerMessage(const FServerMessageType& Message)
 	{
 	case EServerMessageTag::InitialConnection:
 	{
-		const FInitialConnectionType Payload = Message.GetAsInitialConnection();
+		const FInitialConnectionType& Payload = Message.MessageData.Get<FInitialConnectionType>();
 		Token = Payload.Token;
 		UCredentials::SaveToken(Token);
 		Identity = Payload.Identity;
@@ -307,7 +926,7 @@ void UDbConnectionBase::ProcessServerMessage(const FServerMessageType& Message)
 	}
 	case EServerMessageTag::TransactionUpdate:
 	{
-		const FTransactionUpdateType Payload = Message.GetAsTransactionUpdate();
+		const FTransactionUpdateType& Payload = Message.MessageData.Get<FTransactionUpdateType>();
 		const FDatabaseUpdateType Update = TransactionUpdateToDatabaseUpdate(Payload);
 		DbUpdate(Update, FSpacetimeDBEvent::Transaction(FSpacetimeDBUnit()));
 		break;
@@ -319,8 +938,8 @@ void UDbConnectionBase::ProcessServerMessage(const FServerMessageType& Message)
 	}
 	case EServerMessageTag::SubscribeApplied:
 	{
-		const FSubscribeAppliedType Payload = Message.GetAsSubscribeApplied();
-		const FDatabaseUpdateType Update = QueryRowsToDatabaseUpdate(Payload.Rows, false);
+		const FSubscribeAppliedType& Payload = Message.MessageData.Get<FSubscribeAppliedType>();
+		const FDatabaseUpdateType Update = QueryRowsToDatabaseUpdate(Payload.Rows, UE::SpacetimeDB::EQueryRowsApplyMode::Inserts);
 		DbUpdate(Update, FSpacetimeDBEvent::SubscribeApplied(FSpacetimeDBUnit()));
 
 		if (TObjectPtr<USubscriptionHandleBase>* HandlePtr = ActiveSubscriptions.Find(Payload.QuerySetId.Id))
@@ -339,10 +958,10 @@ void UDbConnectionBase::ProcessServerMessage(const FServerMessageType& Message)
 	}
 	case EServerMessageTag::UnsubscribeApplied:
 	{
-		const FUnsubscribeAppliedType Payload = Message.GetAsUnsubscribeApplied();
+		const FUnsubscribeAppliedType& Payload = Message.MessageData.Get<FUnsubscribeAppliedType>();
 		if (Payload.Rows.IsSet())
 		{
-			const FDatabaseUpdateType Update = QueryRowsToDatabaseUpdate(Payload.Rows.Value, true);
+			const FDatabaseUpdateType Update = QueryRowsToDatabaseUpdate(Payload.Rows.Value, UE::SpacetimeDB::EQueryRowsApplyMode::Deletes);
 			DbUpdate(Update, FSpacetimeDBEvent::UnsubscribeApplied(FSpacetimeDBUnit()));
 		}
 
@@ -369,7 +988,7 @@ void UDbConnectionBase::ProcessServerMessage(const FServerMessageType& Message)
 	}
 	case EServerMessageTag::SubscriptionError:
 	{
-		const FSubscriptionErrorType Payload = Message.GetAsSubscriptionError();
+		const FSubscriptionErrorType& Payload = Message.MessageData.Get<FSubscriptionErrorType>();
 		UE_LOG(LogSpacetimeDb_Connection, Warning, TEXT("SubscriptionError received for QuerySetId=%u Error=%s"),
 			Payload.QuerySetId.Id,
 			*Payload.Error);
@@ -391,7 +1010,7 @@ void UDbConnectionBase::ProcessServerMessage(const FServerMessageType& Message)
 	}
 	case EServerMessageTag::ReducerResult:
 	{
-		const FReducerResultType Payload = Message.GetAsReducerResult();
+		const FReducerResultType& Payload = Message.MessageData.Get<FReducerResultType>();
 		const FReducerCallInfoType* FoundReducerCall = PendingReducerCalls.Find(Payload.RequestId);
 		if (!FoundReducerCall)
 		{
@@ -415,7 +1034,7 @@ void UDbConnectionBase::ProcessServerMessage(const FServerMessageType& Message)
 		if (Payload.Result.IsOk())
 		{
 			RedEvent.Status = FSpacetimeDBStatus::Committed(FSpacetimeDBUnit());
-			const FReducerOkType Ok = Payload.Result.GetAsOk();
+			const FReducerOkType& Ok = Payload.Result.MessageData.Get<FReducerOkType>();
 			const FDatabaseUpdateType Update = TransactionUpdateToDatabaseUpdate(Ok.TransactionUpdate);
 			DbUpdate(Update, FSpacetimeDBEvent::Reducer(RedEvent));
 			ReducerEvent(RedEvent);
@@ -430,11 +1049,11 @@ void UDbConnectionBase::ProcessServerMessage(const FServerMessageType& Message)
 			FString ErrorMessage;
 			if (Payload.Result.IsErr())
 			{
-				ErrorMessage = DecodeReducerErrorMessage(Payload.Result.GetAsErr());
+				ErrorMessage = DecodeReducerErrorMessage(Payload.Result.MessageData.Get<TArray<uint8>>());
 			}
 			else
 			{
-				ErrorMessage = Payload.Result.GetAsInternalError();
+				ErrorMessage = Payload.Result.MessageData.Get<FString>();
 			}
 			RedEvent.Status = FSpacetimeDBStatus::Failed(ErrorMessage);
 			ReducerEvent(RedEvent);
@@ -444,7 +1063,7 @@ void UDbConnectionBase::ProcessServerMessage(const FServerMessageType& Message)
 	}
 	case EServerMessageTag::ProcedureResult:
 	{
-		const FProcedureResultType Payload = Message.GetAsProcedureResult();
+		const FProcedureResultType& Payload = Message.MessageData.Get<FProcedureResultType>();
 		FProcedureEvent ProcEvent;
 		ProcEvent.Status = Payload.Status;
 		ProcEvent.Timestamp = Payload.Timestamp;
@@ -489,28 +1108,31 @@ void UDbConnectionBase::ProcessServerMessage(const FServerMessageType& Message)
 	}
 }
 
-bool UDbConnectionBase::DecompressBrotli(const TArray<uint8>& InData, TArray<uint8>& OutData)
+bool UDbConnectionBase::DecompressBrotli(const uint8* InData, int32 InSize, TArray<uint8>& OutData)
 {
+	(void)InData;
+	(void)InSize;
+	(void)OutData;
 	UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Brotli decompression unavilable"));
 	return false;
 }
 
-bool UDbConnectionBase::DecompressGzip(const TArray<uint8>& InData, TArray<uint8>& OutData)
+bool UDbConnectionBase::DecompressGzip(const uint8* InData, int32 InSize, TArray<uint8>& OutData)
 {
-	if (InData.Num() < 4)
+	if (InData == nullptr || InSize < GzipFooterUncompressedSizeBytes)
 	{
 		UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Gzip data too small"));
 		return false;
 	}
 
 	// Gzip data ends with 4 bytes indicating the uncompressed size
-	const uint8* SizePtr = InData.GetData() + InData.Num() - 4;
+	const uint8* SizePtr = InData + InSize - GzipFooterUncompressedSizeBytes;
 	uint32 OutSize = SizePtr[0] | (SizePtr[1] << 8) | (SizePtr[2] << 16) | (SizePtr[3] << 24);
 
 	// Validate the output size
 	OutData.SetNumUninitialized(OutSize);
 	// Attempt to decompress the Gzip data
-	if (!FCompression::UncompressMemory(NAME_Gzip, OutData.GetData(), OutSize, InData.GetData(), InData.Num()))
+	if (!FCompression::UncompressMemory(NAME_Gzip, OutData.GetData(), OutSize, InData, InSize))
 	{
 		UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Gzip decompression failed"));
 		return false;
@@ -518,24 +1140,6 @@ bool UDbConnectionBase::DecompressGzip(const TArray<uint8>& InData, TArray<uint8
 
 	OutData.SetNum(OutSize);
 	return true;
-}
-
-bool UDbConnectionBase::DecompressPayload(uint8 Variant, const TArray<uint8>& In, TArray<uint8>& Out)
-{
-	switch (static_cast<EWsCompressionTag>(Variant))
-	{
-	case EWsCompressionTag::Uncompressed:
-		// No compression, just copy the data
-		Out = In;
-		return true;
-	case EWsCompressionTag::Brotli:
-		return DecompressBrotli(In, Out);
-	case EWsCompressionTag::Gzip:
-		return DecompressGzip(In, Out);
-	default:
-		UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Unknown compression variant"));
-		return false;
-	}
 }
 
 void UDbConnectionBase::ClearPendingOperations(const FString& Reason)
@@ -551,96 +1155,158 @@ void UDbConnectionBase::ClearPendingOperations(const FString& Reason)
 	}
 }
 
-void UDbConnectionBase::PreProcessDatabaseUpdate(const FDatabaseUpdateType& Update)
+void UDbConnectionBase::PreProcessTableUpdateRows(
+	const FString& TableName,
+	const TArray<FTableUpdateRowsType>& RowSets,
+	FPreprocessedTableDataMap& OutPreprocessedTableData)
 {
-	for (const FTableUpdateType& TableUpdate : Update.Tables)
+	TSharedPtr<UE::SpacetimeDB::ITableRowDeserializer> Deserializer = FindTableDeserializerForPreprocess(TableName);
+	if (!Deserializer.IsValid())
 	{
-		// Attempt to deserialize rows after payload decode.
-		TSharedPtr<UE::SpacetimeDB::ITableRowDeserializer> Deserializer;
+		UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Skipping table %s updates due to missing deserializer"), *TableName);
+		return;
+	}
+
+	StorePreprocessedTableData(TableName, Deserializer->PreProcess(RowSets, TableName), OutPreprocessedTableData);
+}
+
+void UDbConnectionBase::PreProcessQueryRows(
+	const FQueryRowsType& Rows,
+	UE::SpacetimeDB::EQueryRowsApplyMode Mode,
+	FPreprocessedTableDataMap& OutPreprocessedTableData)
+{
+	for (const FSingleTableRowsType& TableRows : Rows.Tables)
+	{
+		TSharedPtr<UE::SpacetimeDB::ITableRowDeserializer> Deserializer = FindTableDeserializerForPreprocess(TableRows.Table);
+		if (!Deserializer.IsValid())
 		{
-			// Find the deserializer for this table
-			FScopeLock Lock(&TableDeserializersMutex);
-			if (TSharedPtr<UE::SpacetimeDB::ITableRowDeserializer>* Found = TableDeserializers.Find(TableUpdate.TableName))
-			{
-				// If found, use the deserializer
-				Deserializer = *Found;
-			}
-			else
-			{
-				UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("No deserializer found for table %s"), *TableUpdate.TableName);
-			}
+			UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Skipping table %s query rows due to missing deserializer"), *TableRows.Table);
+			continue;
 		}
-		if (Deserializer)
+
+		StorePreprocessedTableData(TableRows.Table, Deserializer->PreProcessQueryRows(TableRows.Rows, Mode, TableRows.Table), OutPreprocessedTableData);
+	}
+}
+
+void UDbConnectionBase::PreProcessTransactionUpdate(
+	const FTransactionUpdateType& Update,
+	FPreprocessedTableDataMap& OutPreprocessedTableData)
+{
+	for (const FQuerySetUpdateType& QuerySet : Update.QuerySets)
+	{
+		for (const FTableUpdateType& TableUpdate : QuerySet.Tables)
 		{
-			TSharedPtr<UE::SpacetimeDB::FPreprocessedTableDataBase> Data = Deserializer->PreProcess(TableUpdate.Rows, TableUpdate.TableName);
-			if (Data.IsValid())
-			{
-				FScopeLock Lock(&PreprocessedDataMutex);
-				FPreprocessedTableKey Key(TableUpdate.TableName);
-				TArray<TSharedPtr<UE::SpacetimeDB::FPreprocessedTableDataBase>>& Queue = PreprocessedTableData.FindOrAdd(Key);
-				Queue.Add(Data);
-			}
-		}
-		else
-		{
-			UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Skipping table %s updates due to missing deserializer"), *TableUpdate.TableName);
+			PreProcessTableUpdateRows(TableUpdate.TableName, TableUpdate.Rows, OutPreprocessedTableData);
 		}
 	}
 }
 
-bool UDbConnectionBase::PreProcessMessage(const TArray<uint8>& Message, FServerMessageType& OutMessage)
+TSharedPtr<UE::SpacetimeDB::ITableRowDeserializer> UDbConnectionBase::FindTableDeserializerForPreprocess(const FString& TableName)
 {
-	if (Message.Num() == 0)
+	FScopeLock Lock(&TableDeserializersMutex);
+	if (TSharedPtr<UE::SpacetimeDB::ITableRowDeserializer>* Found = TableDeserializers.Find(TableName))
 	{
-		UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Empty message recived from server, ignored"));
+		return *Found;
+	}
+	return nullptr;
+}
+
+void UDbConnectionBase::StorePreprocessedTableData(
+	const FString& TableName,
+	TSharedPtr<UE::SpacetimeDB::FPreprocessedTableDataBase> Data,
+	FPreprocessedTableDataMap& OutPreprocessedTableData)
+{
+	checkf(Data.IsValid(), TEXT("Invalid message-scoped preprocessed data generated for table '%s'."), *TableName);
+
+	FPreprocessedTableKey Key(TableName);
+	TArray<TSharedPtr<UE::SpacetimeDB::FPreprocessedTableDataBase>>& Queue = OutPreprocessedTableData.FindOrAdd(Key);
+	Queue.Add(MoveTemp(Data));
+}
+
+bool UDbConnectionBase::PreProcessMessage(const TArray<uint8>& Message, FInboundParsedMessage& OutMessage)
+{
+	TRACE_CPUPROFILER_EVENT_SCOPE(SpacetimeDB_PreProcessMessage);
+
+	if (Message.Num() <= SpacetimeDbCompressionTagBytes)
+	{
+		UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Empty message received from server, ignored"));
 		return false;
 	}
 	// The first byte indicates compression format for the payload.
 	const uint8 Compression = Message[0];
-	TArray<uint8> CompressedPayload;
-	CompressedPayload.Append(Message.GetData() + 1, Message.Num() - 1);
 
-	// Decompress the payload based on the compression tag
-	TArray<uint8> Decompressed;
-	if (!DecompressPayload(Compression, CompressedPayload, Decompressed))
+	const uint8* DecodedPayload = Message.GetData() + SpacetimeDbCompressionTagBytes;
+	int32 DecodedPayloadSize = Message.Num() - SpacetimeDbCompressionTagBytes;
+	TArray<uint8> DecompressedStorage;
+	switch (static_cast<EWsCompressionTag>(Compression))
 	{
-		UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Failed to decompress incoming message"));
+	case EWsCompressionTag::Uncompressed:
+		break;
+	case EWsCompressionTag::Brotli:
+		if (!DecompressBrotli(DecodedPayload, DecodedPayloadSize, DecompressedStorage))
+		{
+			UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Failed to decompress Brotli incoming message"));
+			return false;
+		}
+		DecodedPayload = DecompressedStorage.GetData();
+		DecodedPayloadSize = DecompressedStorage.Num();
+		break;
+	case EWsCompressionTag::Gzip:
+		if (!DecompressGzip(DecodedPayload, DecodedPayloadSize, DecompressedStorage))
+		{
+			UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Failed to decompress Gzip incoming message"));
+			return false;
+		}
+		DecodedPayload = DecompressedStorage.GetData();
+		DecodedPayloadSize = DecompressedStorage.Num();
+		break;
+	default:
+		UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Unknown compression variant"));
+		return false;
+	}
+	if (DecodedPayloadSize <= 0 || DecodedPayload == nullptr)
+	{
+		UE_LOG(LogSpacetimeDb_Connection,
+			Error,
+			TEXT("SpacetimeDB decoded server message payload is empty after compression tag %u."),
+			static_cast<uint32>(Compression));
 		return false;
 	}
 
 	// Deserialize the decompressed data into a UServerMessageType object
-	OutMessage = UE::SpacetimeDB::Deserialize<FServerMessageType>(Decompressed);
+	OutMessage.Message = UE::SpacetimeDB::DeserializeView<FServerMessageType>(DecodedPayload, DecodedPayloadSize);
 
 	// Preprocess row-bearing payloads for table deserializers.
-	switch (OutMessage.Tag)
+	switch (OutMessage.Message.Tag)
 	{
 		case EServerMessageTag::SubscribeApplied:
 		{
-			const FSubscribeAppliedType Payload = OutMessage.GetAsSubscribeApplied();
-			PreProcessDatabaseUpdate(QueryRowsToDatabaseUpdate(Payload.Rows, false));
+			const FSubscribeAppliedType& Payload = OutMessage.Message.MessageData.Get<FSubscribeAppliedType>();
+			PreProcessQueryRows(Payload.Rows, UE::SpacetimeDB::EQueryRowsApplyMode::Inserts, OutMessage.PreprocessedTableData);
 			break;
 		}
 		case EServerMessageTag::UnsubscribeApplied:
 		{
-			const FUnsubscribeAppliedType Payload = OutMessage.GetAsUnsubscribeApplied();
+			const FUnsubscribeAppliedType& Payload = OutMessage.Message.MessageData.Get<FUnsubscribeAppliedType>();
 			if (Payload.Rows.IsSet())
 			{
-				PreProcessDatabaseUpdate(QueryRowsToDatabaseUpdate(Payload.Rows.Value, true));
+				PreProcessQueryRows(Payload.Rows.Value, UE::SpacetimeDB::EQueryRowsApplyMode::Deletes, OutMessage.PreprocessedTableData);
 			}
 			break;
 		}
 		case EServerMessageTag::TransactionUpdate:
 		{
-			const FTransactionUpdateType Payload = OutMessage.GetAsTransactionUpdate();
-			PreProcessDatabaseUpdate(TransactionUpdateToDatabaseUpdate(Payload));
+			const FTransactionUpdateType& Payload = OutMessage.Message.MessageData.Get<FTransactionUpdateType>();
+			PreProcessTransactionUpdate(Payload, OutMessage.PreprocessedTableData);
 			break;
 		}
 		case EServerMessageTag::ReducerResult:
 		{
-			const FReducerResultType Payload = OutMessage.GetAsReducerResult();
+			const FReducerResultType& Payload = OutMessage.Message.MessageData.Get<FReducerResultType>();
 			if (Payload.Result.IsOk())
 			{
-				PreProcessDatabaseUpdate(TransactionUpdateToDatabaseUpdate(Payload.Result.GetAsOk().TransactionUpdate));
+				const FReducerOkType& Ok = Payload.Result.MessageData.Get<FReducerOkType>();
+				PreProcessTransactionUpdate(Ok.TransactionUpdate, OutMessage.PreprocessedTableData);
 			}
 			break;
 		}
@@ -674,7 +1340,7 @@ void UDbConnectionBase::StartSubscription(USubscriptionHandleBase* Handle)
 		UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("StartSubscription called with empty query list"));
 		return;
 	}
-	
+
 	const uint32 QuerySetId = GetNextSubscriptionId();
 	Handle->QuerySetId = QuerySetId;
 	Handle->ConnInternal = this;
@@ -753,30 +1419,103 @@ void UDbConnectionBase::InternalCallProcedure(const FString& ProcedureName, TArr
 
 void UDbConnectionBase::ApplyRegisteredTableUpdates(const FDatabaseUpdateType& Update, void* Context)
 {
-	// Ensure we have a valid context for the update
-	TArray<TSharedPtr<ITableUpdateHandler>> Handlers;
+	checkf(ActivePreprocessedTableData != nullptr, TEXT("ApplyRegisteredTableUpdates requires active message-scoped preprocessed data."));
+
+	TSharedPtr<const TMap<FString, TSharedPtr<ITableUpdateHandler>>> RegisteredHandlers;
+	{
+		FScopeLock Lock(&RegisteredTablesMutex);
+		RegisteredHandlers = RegisteredTablesSnapshot;
+	}
+	if (!RegisteredHandlers.IsValid())
+	{
+		return;
+	}
+
+	TableUpdateHandlersScratch.Reset();
+	TableUpdateHandlersScratch.Reserve(Update.Tables.Num());
+	if (ActiveInboundMessageApplyStats != nullptr)
+	{
+		ActiveInboundMessageApplyStats->TableStats.Reserve(
+			ActiveInboundMessageApplyStats->TableStats.Num() + Update.Tables.Num());
+	}
 	for (const FTableUpdateType& TableUpdate : Update.Tables)
 	{
-		TSharedPtr<ITableUpdateHandler> Handler;
+		if (TableUpdate.Rows.IsEmpty())
 		{
-			// Find the handler for this table update
-			FScopeLock Lock(&RegisteredTablesMutex);
-			if (TSharedPtr<ITableUpdateHandler>* Found = RegisteredTables.Find(TableUpdate.TableName))
-			{
-				Handler = *Found;
-			}
+			continue;
+		}
+
+		TSharedPtr<ITableUpdateHandler> Handler;
+		if (const TSharedPtr<ITableUpdateHandler>* Found = RegisteredHandlers->Find(TableUpdate.TableName))
+		{
+			Handler = *Found;
 		}
 		if (Handler.IsValid())
 		{
-			// Update the cache for the handler with the table update and context
-			Handler->UpdateCache(this, TableUpdate, Context);
-			Handlers.Add(Handler);
+			FSpacetimeDBTableApplyStats* TableStats = nullptr;
+			int32 TableStatsIndex = INDEX_NONE;
+			if (ActiveInboundMessageApplyStats != nullptr)
+			{
+				TableStatsIndex = ActiveInboundMessageApplyStats->TableStats.AddDefaulted();
+				TableStats = &ActiveInboundMessageApplyStats->TableStats[TableStatsIndex];
+				TableStats->TableName = Handler->GetTableName();
+			}
+
+			TRACE_CPUPROFILER_EVENT_SCOPE(SpacetimeDB_TableUpdateCache);
+			const uint64 TableCacheStartCycles = FPlatformTime::Cycles64();
+			const bool bHasNonEmptyDiff = Handler->UpdateCache(this, TableUpdate, Context, TableStats);
+			const double TableCacheElapsedMicros =
+				FPlatformTime::ToMilliseconds64(FPlatformTime::Cycles64() - TableCacheStartCycles) * 1000.0;
+			if (TableStats != nullptr)
+			{
+				TableStats->CacheMicros = TableCacheElapsedMicros;
+			}
+			if (InboundApplyBudget.SoftTimeBudgetMicros > 0 &&
+				TableCacheElapsedMicros >= static_cast<double>(InboundApplyBudget.SoftTimeBudgetMicros))
+			{
+				UE_LOG(LogSpacetimeDb_Connection,
+					Warning,
+					TEXT("SpacetimeDB table cache apply exceeded soft budget: table=%s elapsed=%.2fus budget=%lldus row_ops=%d"),
+					*Handler->GetTableName(),
+					TableCacheElapsedMicros,
+					InboundApplyBudget.SoftTimeBudgetMicros,
+					TableUpdate.Rows.Num());
+			}
+			if (bHasNonEmptyDiff)
+			{
+				FPendingTableBroadcast& PendingBroadcast = TableUpdateHandlersScratch.AddDefaulted_GetRef();
+				PendingBroadcast.Handler = Handler;
+				PendingBroadcast.StatsIndex = TableStatsIndex;
+			}
 		}
 	}
-	
-	for (TSharedPtr<ITableUpdateHandler>& Handler : Handlers)
+
+	for (FPendingTableBroadcast& PendingBroadcast : TableUpdateHandlersScratch)
 	{
-		// Broadcast the diff for each handler
+		TSharedPtr<ITableUpdateHandler>& Handler = PendingBroadcast.Handler;
+		checkf(Handler.IsValid(), TEXT("Invalid pending SpacetimeDB table broadcast handler."));
+		TRACE_CPUPROFILER_EVENT_SCOPE(SpacetimeDB_TableBroadcastDiff);
+		const uint64 BroadcastStartCycles = FPlatformTime::Cycles64();
 		Handler->BroadcastDiff(this, Context);
+		const double BroadcastElapsedMicros =
+			FPlatformTime::ToMilliseconds64(FPlatformTime::Cycles64() - BroadcastStartCycles) * 1000.0;
+		if (ActiveInboundMessageApplyStats != nullptr && PendingBroadcast.StatsIndex != INDEX_NONE)
+		{
+			checkf(ActiveInboundMessageApplyStats->TableStats.IsValidIndex(PendingBroadcast.StatsIndex),
+				TEXT("Invalid SpacetimeDB inbound apply stats index %d."),
+				PendingBroadcast.StatsIndex);
+			ActiveInboundMessageApplyStats->TableStats[PendingBroadcast.StatsIndex].BroadcastMicros = BroadcastElapsedMicros;
+		}
+		if (InboundApplyBudget.SoftTimeBudgetMicros > 0 &&
+			BroadcastElapsedMicros >= static_cast<double>(InboundApplyBudget.SoftTimeBudgetMicros))
+		{
+			UE_LOG(LogSpacetimeDb_Connection,
+				Warning,
+				TEXT("SpacetimeDB table broadcast exceeded soft budget: table=%s elapsed=%.2fus budget=%lldus"),
+				*Handler->GetTableName(),
+				BroadcastElapsedMicros,
+				InboundApplyBudget.SoftTimeBudgetMicros);
+		}
 	}
+	TableUpdateHandlersScratch.Reset();
 }

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/DbConnectionBase.cpp
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/DbConnectionBase.cpp
@@ -26,8 +26,10 @@ enum class EWsCompressionTag : uint8
 constexpr int32 MaxQueuedInboundRawMessages = 8192;
 constexpr int64 MaxQueuedInboundRawBytes = 128ll * 1024ll * 1024ll;
 constexpr int32 MaxPendingInboundParsedMessages = 8192;
-constexpr int64 MaxPendingInboundParsedPayloadBytes = 128ll * 1024ll * 1024ll;
+constexpr int64 MaxInboundDecodedPayloadBytes = 128ll * 1024ll * 1024ll;
+constexpr int64 MaxPendingInboundParsedEstimatedBytes = 256ll * 1024ll * 1024ll;
 constexpr int32 PendingInboundCompactionMinConsumedMessages = 512;
+constexpr int32 InboundRawCompactionMinConsumedMessages = 512;
 constexpr uint32 InboundWorkerStackSizeBytes = 0;
 constexpr EThreadPriority InboundWorkerThreadPriority = TPri_Normal;
 constexpr const TCHAR* InboundWorkerThreadName = TEXT("SpacetimeDBInboundWorker");
@@ -121,6 +123,32 @@ static FString FormatInboundTableApplyStats(const FSpacetimeDBTableApplyStats& S
 		Stats.CacheMicros,
 		Stats.BroadcastMicros,
 		Stats.bProducedDiff ? 1 : 0);
+}
+
+static int64 EstimatePreprocessedTableDataBytes(const FPreprocessedTableDataMap& PreprocessedTableData)
+{
+	int64 EstimatedBytes = PreprocessedTableData.GetAllocatedSize();
+	for (const TPair<FPreprocessedTableKey, TArray<TSharedPtr<UE::SpacetimeDB::FPreprocessedTableDataBase>>>& TablePair : PreprocessedTableData)
+	{
+		EstimatedBytes += TablePair.Key.TableName.GetAllocatedSize();
+		EstimatedBytes += TablePair.Value.GetAllocatedSize();
+		for (const TSharedPtr<UE::SpacetimeDB::FPreprocessedTableDataBase>& Data : TablePair.Value)
+		{
+			if (Data.IsValid())
+			{
+				EstimatedBytes += Data->EstimateMemoryBytes();
+			}
+		}
+	}
+	return EstimatedBytes;
+}
+
+static int64 EstimateInboundParsedMessageBytes(const FInboundParsedMessage& Message)
+{
+	return sizeof(FInboundParsedMessage)
+		+ static_cast<int64>(Message.DecodedPayloadSizeBytes)
+		+ Message.ProtocolError.GetAllocatedSize()
+		+ EstimatePreprocessedTableDataBytes(Message.PreprocessedTableData);
 }
 }
 
@@ -326,6 +354,7 @@ void UDbConnectionBase::StartInboundMessageWorker()
 	{
 		FScopeLock RawLock(&InboundRawMessagesMutex);
 		InboundRawMessages.Reset();
+		InboundRawMessageReadIndex = 0;
 		InboundQueuedRawBytes = 0;
 		++InboundConnectionEpoch;
 		NextInboundSequenceId = 0;
@@ -337,7 +366,7 @@ void UDbConnectionBase::StartInboundMessageWorker()
 		FScopeLock PendingLock(&PendingMessagesMutex);
 		PendingMessages.Reset();
 		PendingMessageReadIndex = 0;
-		PendingParsedPayloadBytes = 0;
+		PendingParsedEstimatedBytes = 0;
 	}
 
 	ActivePreprocessedTableData = nullptr;
@@ -352,6 +381,7 @@ void UDbConnectionBase::StopInboundMessageWorker()
 		{
 			FScopeLock RawLock(&InboundRawMessagesMutex);
 			InboundRawMessages.Reset();
+			InboundRawMessageReadIndex = 0;
 			InboundQueuedRawBytes = 0;
 			++InboundConnectionEpoch;
 			bInboundAcceptingMessages = false;
@@ -362,7 +392,7 @@ void UDbConnectionBase::StopInboundMessageWorker()
 			FScopeLock PendingLock(&PendingMessagesMutex);
 			PendingMessages.Reset();
 			PendingMessageReadIndex = 0;
-			PendingParsedPayloadBytes = 0;
+			PendingParsedEstimatedBytes = 0;
 		}
 
 		ActivePreprocessedTableData = nullptr;
@@ -383,6 +413,7 @@ void UDbConnectionBase::ClearInboundMessageQueues()
 	{
 		FScopeLock Lock(&InboundRawMessagesMutex);
 		InboundRawMessages.Reset();
+		InboundRawMessageReadIndex = 0;
 		InboundQueuedRawBytes = 0;
 	}
 
@@ -390,7 +421,7 @@ void UDbConnectionBase::ClearInboundMessageQueues()
 		FScopeLock Lock(&PendingMessagesMutex);
 		PendingMessages.Reset();
 		PendingMessageReadIndex = 0;
-		PendingParsedPayloadBytes = 0;
+		PendingParsedEstimatedBytes = 0;
 	}
 
 	ActivePreprocessedTableData = nullptr;
@@ -407,7 +438,9 @@ void UDbConnectionBase::NotifyInboundWorkerIfNeeded()
 	bool bShouldNotify = false;
 	{
 		FScopeLock RawLock(&InboundRawMessagesMutex);
-		bShouldNotify = InboundRawMessages.Num() > 0 && bInboundAcceptingMessages && !bInboundProtocolErrorQueued;
+		checkf(InboundRawMessageReadIndex <= InboundRawMessages.Num(),
+			TEXT("SpacetimeDB inbound raw queue read index exceeded queued messages while notifying worker."));
+		bShouldNotify = InboundRawMessages.Num() > InboundRawMessageReadIndex && bInboundAcceptingMessages && !bInboundProtocolErrorQueued;
 	}
 
 	if (bShouldNotify)
@@ -434,6 +467,7 @@ void UDbConnectionBase::MarkInboundProtocolErrorQueued()
 	bInboundProtocolErrorQueued = true;
 	bInboundAcceptingMessages = false;
 	InboundRawMessages.Reset();
+	InboundRawMessageReadIndex = 0;
 	InboundQueuedRawBytes = 0;
 }
 
@@ -458,13 +492,14 @@ void UDbConnectionBase::EnqueueInboundProtocolError(uint64 SequenceId, int32 Pay
 	Parsed.QueuedBytesAtEnqueue = QueuedBytesAtEnqueue;
 	Parsed.bProtocolError = true;
 	Parsed.ProtocolError = ErrorMessage;
+	Parsed.EstimatedMemoryBytes = EstimateInboundParsedMessageBytes(Parsed);
 
 	FScopeLock Lock(&PendingMessagesMutex);
 	PendingMessages.Reset();
 	PendingMessageReadIndex = 0;
-	PendingParsedPayloadBytes = 0;
+	PendingParsedEstimatedBytes = 0;
 	PendingMessages.Add(MoveTemp(Parsed));
-	PendingParsedPayloadBytes += static_cast<int64>(PayloadSizeBytes);
+	PendingParsedEstimatedBytes += PendingMessages[0].EstimatedMemoryBytes;
 }
 
 void UDbConnectionBase::HandleWSBinaryMessage(const TArray<uint8>& Message)
@@ -497,8 +532,11 @@ void UDbConnectionBase::HandleWSBinaryMessageOwned(TArray<uint8>&& Message)
 
 		ConnectionEpoch = InboundConnectionEpoch;
 		SequenceId = NextInboundSequenceId++;
+		checkf(InboundRawMessageReadIndex <= InboundRawMessages.Num(),
+			TEXT("SpacetimeDB inbound raw queue read index exceeded queued messages while enqueuing payload."));
 		const int64 NewQueuedRawBytes = InboundQueuedRawBytes + static_cast<int64>(PayloadSizeBytes);
-		const int32 NewQueuedRawMessageCount = InboundRawMessages.Num() + 1;
+		const int32 LiveQueuedRawMessageCount = InboundRawMessages.Num() - InboundRawMessageReadIndex;
+		const int32 NewQueuedRawMessageCount = LiveQueuedRawMessageCount + 1;
 		QueueDepthAtEnqueue = NewQueuedRawMessageCount;
 		QueuedBytesAtEnqueue = NewQueuedRawBytes;
 		if (NewQueuedRawMessageCount > MaxQueuedInboundRawMessages || NewQueuedRawBytes > MaxQueuedInboundRawBytes)
@@ -506,6 +544,7 @@ void UDbConnectionBase::HandleWSBinaryMessageOwned(TArray<uint8>&& Message)
 			bInboundProtocolErrorQueued = true;
 			bInboundAcceptingMessages = false;
 			InboundRawMessages.Reset();
+			InboundRawMessageReadIndex = 0;
 			InboundQueuedRawBytes = 0;
 			bQueueOverloaded = true;
 			QueueOverloadError = FString::Printf(
@@ -567,7 +606,7 @@ void UDbConnectionBase::FrameTick()
 			{
 				PendingMessages.Reset();
 				PendingMessageReadIndex = 0;
-				PendingParsedPayloadBytes = 0;
+				PendingParsedEstimatedBytes = 0;
 				break;
 			}
 
@@ -578,13 +617,14 @@ void UDbConnectionBase::FrameTick()
 
 			FInboundParsedMessage& PendingMessage = PendingMessages[PendingMessageReadIndex];
 			const int64 PendingPayloadBytes = static_cast<int64>(PendingMessage.PayloadSizeBytes);
+			const int64 PendingEstimatedBytes = PendingMessage.EstimatedMemoryBytes;
 			if (!bDrainAllPendingMessages && MessagesProcessed > 0 && PayloadBytesProcessed + PendingPayloadBytes > InboundApplyBudget.MaxPayloadBytesPerFrame)
 			{
 				break;
 			}
 
 			PayloadBytesProcessed += PendingPayloadBytes;
-			PendingParsedPayloadBytes = FMath::Max<int64>(0, PendingParsedPayloadBytes - PendingPayloadBytes);
+			PendingParsedEstimatedBytes = FMath::Max<int64>(0, PendingParsedEstimatedBytes - PendingEstimatedBytes);
 			Msg = MoveTemp(PendingMessage);
 			++PendingMessageReadIndex;
 
@@ -592,7 +632,7 @@ void UDbConnectionBase::FrameTick()
 			{
 				PendingMessages.Reset();
 				PendingMessageReadIndex = 0;
-				PendingParsedPayloadBytes = 0;
+				PendingParsedEstimatedBytes = 0;
 			}
 			else if (PendingMessageReadIndex >= PendingInboundCompactionMinConsumedMessages)
 			{
@@ -689,15 +729,15 @@ void UDbConnectionBase::DrainInboundRawMessagesOnWorker()
 	while (!IsInboundProtocolErrorQueued())
 	{
 		int32 ParsedMessageCapacity = 0;
-		int64 ParsedPayloadByteCapacity = 0;
+		int64 ParsedEstimatedByteCapacity = 0;
 		{
 			FScopeLock Lock(&PendingMessagesMutex);
 			const int32 LivePendingMessages = PendingMessages.Num() - PendingMessageReadIndex;
 			ParsedMessageCapacity = MaxPendingInboundParsedMessages - LivePendingMessages;
-			ParsedPayloadByteCapacity = MaxPendingInboundParsedPayloadBytes - PendingParsedPayloadBytes;
+			ParsedEstimatedByteCapacity = MaxPendingInboundParsedEstimatedBytes - PendingParsedEstimatedBytes;
 		}
 
-		if (ParsedMessageCapacity <= 0 || ParsedPayloadByteCapacity <= 0)
+		if (ParsedMessageCapacity <= 0 || ParsedEstimatedByteCapacity <= 0)
 		{
 			return;
 		}
@@ -706,20 +746,24 @@ void UDbConnectionBase::DrainInboundRawMessagesOnWorker()
 		int64 DrainedRawBytes = 0;
 		{
 			FScopeLock Lock(&InboundRawMessagesMutex);
-			if (InboundRawMessages.Num() == 0 || !bInboundAcceptingMessages || bInboundProtocolErrorQueued)
+			checkf(InboundRawMessageReadIndex <= InboundRawMessages.Num(),
+				TEXT("SpacetimeDB inbound raw queue read index exceeded queued messages while draining worker queue."));
+			const int32 LiveRawMessageCount = InboundRawMessages.Num() - InboundRawMessageReadIndex;
+			if (LiveRawMessageCount <= 0 || !bInboundAcceptingMessages || bInboundProtocolErrorQueued)
 			{
 				return;
 			}
 
 			int32 DrainCount = 0;
-			for (; DrainCount < InboundRawMessages.Num() && DrainCount < ParsedMessageCapacity; ++DrainCount)
+			for (; DrainCount < LiveRawMessageCount && DrainCount < ParsedMessageCapacity; ++DrainCount)
 			{
-				const int64 NextPayloadBytes = static_cast<int64>(InboundRawMessages[DrainCount].Payload.Num());
-				if (DrainCount > 0 && DrainedRawBytes + NextPayloadBytes > ParsedPayloadByteCapacity)
+				const FInboundRawMessage& Candidate = InboundRawMessages[InboundRawMessageReadIndex + DrainCount];
+				const int64 NextPayloadBytes = static_cast<int64>(Candidate.Payload.Num());
+				if (DrainCount > 0 && DrainedRawBytes + NextPayloadBytes > ParsedEstimatedByteCapacity)
 				{
 					break;
 				}
-				if (DrainCount == 0 && NextPayloadBytes > ParsedPayloadByteCapacity)
+				if (DrainCount == 0 && NextPayloadBytes > ParsedEstimatedByteCapacity)
 				{
 					return;
 				}
@@ -735,10 +779,20 @@ void UDbConnectionBase::DrainInboundRawMessagesOnWorker()
 			LocalRawMessages.Reserve(DrainCount);
 			for (int32 Index = 0; Index < DrainCount; ++Index)
 			{
-				LocalRawMessages.Add(MoveTemp(InboundRawMessages[Index]));
+				LocalRawMessages.Add(MoveTemp(InboundRawMessages[InboundRawMessageReadIndex + Index]));
 			}
 
-			InboundRawMessages.RemoveAt(0, DrainCount, EAllowShrinking::No);
+			InboundRawMessageReadIndex += DrainCount;
+			if (InboundRawMessageReadIndex == InboundRawMessages.Num())
+			{
+				InboundRawMessages.Reset();
+				InboundRawMessageReadIndex = 0;
+			}
+			else if (InboundRawMessageReadIndex >= InboundRawCompactionMinConsumedMessages)
+			{
+				InboundRawMessages.RemoveAt(0, InboundRawMessageReadIndex, EAllowShrinking::No);
+				InboundRawMessageReadIndex = 0;
+			}
 			InboundQueuedRawBytes = FMath::Max<int64>(0, InboundQueuedRawBytes - DrainedRawBytes);
 		}
 
@@ -789,31 +843,52 @@ void UDbConnectionBase::DrainInboundRawMessagesOnWorker()
 		uint64 OverloadSequenceId = LocalParsedMessages[0].SequenceId;
 		int32 OverloadPayloadSizeBytes = LocalParsedMessages[0].PayloadSizeBytes;
 		uint8 OverloadCompressionTag = LocalParsedMessages[0].CompressionTag;
+		bool bParsedQueueOverloaded = false;
+		FString ParsedQueueOverloadError;
 		{
 			FScopeLock Lock(&PendingMessagesMutex);
-			int64 AddedPayloadBytes = 0;
+			int64 AddedEstimatedBytes = 0;
 			for (const FInboundParsedMessage& ParsedMessage : LocalParsedMessages)
 			{
-				AddedPayloadBytes += static_cast<int64>(ParsedMessage.PayloadSizeBytes);
+				AddedEstimatedBytes += ParsedMessage.EstimatedMemoryBytes;
 			}
 
 			const int32 LivePendingMessages = PendingMessages.Num() - PendingMessageReadIndex;
 			const int32 NewPendingMessageCount = LivePendingMessages + LocalParsedMessages.Num();
-			const int64 NewPendingPayloadBytes = PendingParsedPayloadBytes + AddedPayloadBytes;
-			checkf(bBatchEndsWithProtocolError ||
-				(NewPendingMessageCount <= MaxPendingInboundParsedMessages &&
-					NewPendingPayloadBytes <= MaxPendingInboundParsedPayloadBytes),
-				TEXT("SpacetimeDB parsed inbound queue overflow despite worker backpressure: sequence=%llu payload_bytes=%d compression_tag=%u queued_messages=%d queued_bytes=%lld max_messages=%d max_bytes=%lld"),
+			const int64 NewPendingEstimatedBytes = PendingParsedEstimatedBytes + AddedEstimatedBytes;
+			bParsedQueueOverloaded = !bBatchEndsWithProtocolError &&
+				(NewPendingMessageCount > MaxPendingInboundParsedMessages ||
+					NewPendingEstimatedBytes > MaxPendingInboundParsedEstimatedBytes);
+			if (bParsedQueueOverloaded)
+			{
+				ParsedQueueOverloadError = FString::Printf(
+					TEXT("SpacetimeDB parsed inbound queue overload: sequence=%llu payload_bytes=%d compression_tag=%u queued_messages=%d estimated_bytes=%lld max_messages=%d max_estimated_bytes=%lld"),
+					OverloadSequenceId,
+					OverloadPayloadSizeBytes,
+					static_cast<uint32>(OverloadCompressionTag),
+					NewPendingMessageCount,
+					NewPendingEstimatedBytes,
+					MaxPendingInboundParsedMessages,
+					MaxPendingInboundParsedEstimatedBytes);
+			}
+			else
+			{
+				PendingMessages.Append(MoveTemp(LocalParsedMessages));
+				PendingParsedEstimatedBytes = NewPendingEstimatedBytes;
+			}
+		}
+
+		if (bParsedQueueOverloaded)
+		{
+			MarkInboundProtocolErrorQueued();
+			EnqueueInboundProtocolError(
 				OverloadSequenceId,
 				OverloadPayloadSizeBytes,
-				static_cast<uint32>(OverloadCompressionTag),
-				NewPendingMessageCount,
-				NewPendingPayloadBytes,
-				MaxPendingInboundParsedMessages,
-				MaxPendingInboundParsedPayloadBytes);
-
-			PendingMessages.Append(MoveTemp(LocalParsedMessages));
-			PendingParsedPayloadBytes = NewPendingPayloadBytes;
+				OverloadCompressionTag,
+				LocalParsedMessages[0].QueueDepthAtEnqueue,
+				LocalParsedMessages[0].QueuedBytesAtEnqueue,
+				ParsedQueueOverloadError);
+			return;
 		}
 	}
 }
@@ -839,6 +914,7 @@ bool UDbConnectionBase::BuildInboundParsedMessage(const FInboundRawMessage& RawM
 			static_cast<uint32>(OutMessage.CompressionTag),
 			OutMessage.QueueDepthAtEnqueue,
 			OutMessage.QueuedBytesAtEnqueue);
+		OutMessage.EstimatedMemoryBytes = EstimateInboundParsedMessageBytes(OutMessage);
 		return false;
 	}
 
@@ -1127,7 +1203,20 @@ bool UDbConnectionBase::DecompressGzip(const uint8* InData, int32 InSize, TArray
 
 	// Gzip data ends with 4 bytes indicating the uncompressed size
 	const uint8* SizePtr = InData + InSize - GzipFooterUncompressedSizeBytes;
-	uint32 OutSize = SizePtr[0] | (SizePtr[1] << 8) | (SizePtr[2] << 16) | (SizePtr[3] << 24);
+	const uint32 OutSize =
+		static_cast<uint32>(SizePtr[0]) |
+		(static_cast<uint32>(SizePtr[1]) << 8) |
+		(static_cast<uint32>(SizePtr[2]) << 16) |
+		(static_cast<uint32>(SizePtr[3]) << 24);
+	if (static_cast<int64>(OutSize) > MaxInboundDecodedPayloadBytes)
+	{
+		UE_LOG(LogSpacetimeDb_Connection,
+			Error,
+			TEXT("Gzip payload declares %u decoded bytes, exceeding max decoded bytes %lld"),
+			OutSize,
+			MaxInboundDecodedPayloadBytes);
+		return false;
+	}
 
 	// Validate the output size
 	OutData.SetNumUninitialized(OutSize);
@@ -1264,6 +1353,16 @@ bool UDbConnectionBase::PreProcessMessage(const TArray<uint8>& Message, FInbound
 		UE_LOG(LogSpacetimeDb_Connection, Error, TEXT("Unknown compression variant"));
 		return false;
 	}
+	if (static_cast<int64>(DecodedPayloadSize) > MaxInboundDecodedPayloadBytes)
+	{
+		UE_LOG(LogSpacetimeDb_Connection,
+			Error,
+			TEXT("Decoded server message payload has %d bytes, exceeding max decoded bytes %lld after compression tag %u."),
+			DecodedPayloadSize,
+			MaxInboundDecodedPayloadBytes,
+			static_cast<uint32>(Compression));
+		return false;
+	}
 	if (DecodedPayloadSize <= 0 || DecodedPayload == nullptr)
 	{
 		UE_LOG(LogSpacetimeDb_Connection,
@@ -1273,6 +1372,7 @@ bool UDbConnectionBase::PreProcessMessage(const TArray<uint8>& Message, FInbound
 		return false;
 	}
 
+	OutMessage.DecodedPayloadSizeBytes = DecodedPayloadSize;
 	// Deserialize the decompressed data into a UServerMessageType object
 	OutMessage.Message = UE::SpacetimeDB::DeserializeView<FServerMessageType>(DecodedPayload, DecodedPayloadSize);
 
@@ -1313,6 +1413,7 @@ bool UDbConnectionBase::PreProcessMessage(const TArray<uint8>& Message, FInbound
 		default:
 			break;
 	}
+	OutMessage.EstimatedMemoryBytes = EstimateInboundParsedMessageBytes(OutMessage);
 	return true;
 }
 

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/DbConnectionBuilder.cpp
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/DbConnectionBuilder.cpp
@@ -138,9 +138,10 @@ UDbConnectionBase* UDbConnectionBuilderBase::BuildConnection(UDbConnectionBase* 
 
 	Connection->WebSocket->OnConnectionError.AddDynamic(Connection, &UDbConnectionBase::HandleWSError);
 	Connection->WebSocket->OnClosed.AddDynamic(Connection, &UDbConnectionBase::HandleWSClosed);
-	Connection->WebSocket->OnBinaryMessageReceived.AddDynamic(Connection, &UDbConnectionBase::HandleWSBinaryMessage);
+	Connection->WebSocket->SetNativeBinaryMessageTarget(Connection);
 	// Set the initialization token for the WebSocket connection
 	Connection->WebSocket->SetInitToken(Token);
+	Connection->StartInboundMessageWorker();
 	// Connect the WebSocket to the constructed URL
 	Connection->WebSocket->Connect(WebSocketUrl);
 

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/Websocket.cpp
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/Websocket.cpp
@@ -1,5 +1,6 @@
 
 #include "Connection/Websocket.h"
+#include "Connection/DbConnectionBase.h"
 #include "WebSocketsModule.h" // Required for FWebSocketsModule
 #include "SpacetimeDbSdk/Public/BSATN/UESpacetimeDB.h"
 #include "ModuleBindings/Types/ServerMessageType.g.h"
@@ -21,6 +22,7 @@ void UWebsocketManager::BeginDestroy()
 	{
 		Disconnect();
 	}
+	NativeBinaryMessageTarget.Reset();
 	Super::BeginDestroy();
 }
 
@@ -133,6 +135,11 @@ bool UWebsocketManager::IsConnected() const
 	return WebSocket.IsValid() && WebSocket->IsConnected();
 }
 
+void UWebsocketManager::SetNativeBinaryMessageTarget(UDbConnectionBase* Target)
+{
+	NativeBinaryMessageTarget = Target;
+}
+
 void UWebsocketManager::SetInitToken(FString Token)
 {
 	InitToken = Token;
@@ -167,6 +174,14 @@ void UWebsocketManager::HandleBinaryMessageReceived(const void* Data, SIZE_T Siz
 	// Handle binary messages, which may be fragmented
 	const uint8* Bytes = static_cast<const uint8*>(Data);
 
+	if (!bAwaitingBinaryFragments && bIsLastFragment)
+	{
+		TArray<uint8> MessageBytes;
+		MessageBytes.Append(Bytes, Size);
+		DispatchCompleteBinaryMessage(MoveTemp(MessageBytes));
+		return;
+	}
+
 	// Append this fragment to our buffer
 	IncompleteMessage.Append(Bytes, Size);
 
@@ -174,18 +189,27 @@ void UWebsocketManager::HandleBinaryMessageReceived(const void* Data, SIZE_T Siz
 	if (bIsLastFragment)
 	{
 		// We have the complete message
-		TArray<uint8> MessageBytes = IncompleteMessage;
-		IncompleteMessage.Reset();
+		TArray<uint8> MessageBytes = MoveTemp(IncompleteMessage);
 		bAwaitingBinaryFragments = false;
 
-		// Forward the complete binary payload to listeners.
-		OnBinaryMessageReceived.Broadcast(MessageBytes);
+		DispatchCompleteBinaryMessage(MoveTemp(MessageBytes));
 	}
 	else
 	{
 		// More fragments are coming
 		bAwaitingBinaryFragments = true;
 	}
+}
+
+void UWebsocketManager::DispatchCompleteBinaryMessage(TArray<uint8>&& Message)
+{
+	if (UDbConnectionBase* Target = NativeBinaryMessageTarget.Get())
+	{
+		Target->HandleWSBinaryMessageOwned(MoveTemp(Message));
+		return;
+	}
+
+	OnBinaryMessageReceived.Broadcast(Message);
 }
 
 void UWebsocketManager::HandleClosed(int32 StatusCode, const FString& Reason, bool bWasClean)

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/BSATN/UEBSATNHelpers.h
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/BSATN/UEBSATNHelpers.h
@@ -125,6 +125,10 @@ namespace UE::SpacetimeDB
 	struct FPreprocessedTableDataBase
 	{
 		virtual ~FPreprocessedTableDataBase() {}
+		virtual int64 EstimateMemoryBytes() const
+		{
+			return sizeof(FPreprocessedTableDataBase);
+		}
 		int32 InsertRowCount = 0;
 		int32 DeleteRowCount = 0;
 		int32 RowSetCount = 0;
@@ -139,6 +143,23 @@ namespace UE::SpacetimeDB
 		// The type of the row being processed
 		TArray<FWithBsatn<RowType>> Inserts;
 		TArray<FWithBsatn<RowType>> Deletes;
+
+		virtual int64 EstimateMemoryBytes() const override
+		{
+			auto EstimateRowsBytes = [](const TArray<FWithBsatn<RowType>>& Rows)
+			{
+				int64 Bytes = Rows.GetAllocatedSize();
+				for (const FWithBsatn<RowType>& Row : Rows)
+				{
+					Bytes += Row.Bsatn.GetAllocatedSize();
+				}
+				return Bytes;
+			};
+
+			return sizeof(TPreprocessedTableData<RowType>)
+				+ EstimateRowsBytes(Inserts)
+				+ EstimateRowsBytes(Deletes);
+		}
 	};
 
 	/** Interface for deserializing table rows from a database update. Allows for different row types to be processed in SDK. */

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/BSATN/UEBSATNHelpers.h
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/BSATN/UEBSATNHelpers.h
@@ -9,6 +9,29 @@
 
 namespace UE::SpacetimeDB
 {
+	enum class EQueryRowsApplyMode : uint8
+	{
+		Inserts,
+		Deletes
+	};
+
+	namespace Private
+	{
+		template<typename RowType>
+		static void AddParsedRowWithBsatn(const uint8* RowData, int32 RowLength, TArray<FWithBsatn<RowType>>& OutRows)
+		{
+			checkf(RowLength >= 0, TEXT("Cannot parse a negative BSATN row length: %d"), RowLength);
+			checkf(RowData != nullptr || RowLength == 0, TEXT("Cannot parse null BSATN row data with length %d"), RowLength);
+
+			RowType Row = DeserializeView<RowType>(RowData, RowLength);
+			TArray<uint8> Bsatn;
+			if (RowLength > 0)
+			{
+				Bsatn.Append(RowData, RowLength);
+			}
+			OutRows.Add(FWithBsatn<RowType>(MoveTemp(Bsatn), MoveTemp(Row)));
+		}
+	}
 
 	/** Parse a single row list based on its size hint and retain BSATN bytes */
 	template<typename RowType>
@@ -21,20 +44,19 @@ namespace UE::SpacetimeDB
 		if (List.SizeHint.IsFixedSize())
 		{
 			// Get the fixed size from the size hint
-			uint16 Size = List.SizeHint.GetAsFixedSize();
+			const uint16 Size = List.SizeHint.GetAsFixedSize();
 			if (Size > 0)
 			{
+				checkf(List.RowsData.Num() % Size == 0,
+					TEXT("Fixed-size BSATN row list has %d bytes, which is not divisible by row size %u"),
+					List.RowsData.Num(),
+					static_cast<uint32>(Size));
 				// If the size is valid, parse the rows based on the fixed size
-				int32 Count = List.RowsData.Num() / Size;
+				const int32 Count = List.RowsData.Num() / Size;
+				OutRows.Reserve(OutRows.Num() + Count);
 				for (int32 i = 0; i < Count; ++i)
 				{
-					// Create a slice of the row data based on the fixed size
-					TArray<uint8> Slice;
-					Slice.Append(List.RowsData.GetData() + i * Size, Size);
-					// Deserialize the row from the slice
-					RowType Row = UE::SpacetimeDB::Deserialize<RowType>(Slice);
-					// Add the row with its BSATN bytes to the output array
-					OutRows.Add(FWithBsatn<RowType>(Slice, Row));
+					Private::AddParsedRowWithBsatn<RowType>(List.RowsData.GetData() + i * Size, Size, OutRows);
 				}
 				return;
 			}
@@ -43,26 +65,29 @@ namespace UE::SpacetimeDB
 		else if (List.SizeHint.IsRowOffsets())
 		{
 			// Get the offsets from the size hint
-			TArray<uint64> Offsets = List.SizeHint.GetAsRowOffsets();
+			const TArray<uint64>& Offsets = List.SizeHint.MessageData.Get<TArray<uint64>>();
 			if (Offsets.Num() > 0)
 			{
 				// If the offsets are valid, parse the rows based on the offsets
-				UEReader Reader(List.RowsData);
+				OutRows.Reserve(OutRows.Num() + Offsets.Num());
 				for (int32 i = 0; i < Offsets.Num(); ++i)
 				{
 					// If this is the last offset, read until the end of the data
-					int64 Start = Offsets[i];
-					int64 End = (i + 1 < Offsets.Num()) ? Offsets[i + 1] : List.RowsData.Num();
-					int64 Length = End - Start;
-					TArray<uint8> Slice;
-					Slice.Append(List.RowsData.GetData() + Start, Length);
-
-					// Deserialize the row from the slice
-					UEReader SliceReader(Slice);
-					RowType Row = deserialize<RowType>(SliceReader);
-
-					// Add the row with its BSATN bytes to the output array
-					OutRows.Add(FWithBsatn<RowType>(Slice, Row));
+					const uint64 Start = Offsets[i];
+					const uint64 End = (i + 1 < Offsets.Num()) ? Offsets[i + 1] : static_cast<uint64>(List.RowsData.Num());
+					checkf(Start <= End,
+						TEXT("BSATN row offsets are not sorted: start=%llu end=%llu row_index=%d"),
+						Start,
+						End,
+						i);
+					checkf(End <= static_cast<uint64>(List.RowsData.Num()),
+						TEXT("BSATN row offset %llu exceeds row data size %d at row_index=%d"),
+						End,
+						List.RowsData.Num(),
+						i);
+					const int32 RowStart = static_cast<int32>(Start);
+					const int32 RowLength = static_cast<int32>(End - Start);
+					Private::AddParsedRowWithBsatn<RowType>(List.RowsData.GetData() + RowStart, RowLength, OutRows);
 				}
 			}
 		}
@@ -79,14 +104,14 @@ namespace UE::SpacetimeDB
 		{
 			if (RowSet.IsPersistentTable())
 			{
-				const FPersistentTableRowsType Persistent = RowSet.GetAsPersistentTable();
+				const FPersistentTableRowsType& Persistent = RowSet.MessageData.Get<FPersistentTableRowsType>();
 				ParseRowListWithBsatn(Persistent.Inserts, Inserts);
 				ParseRowListWithBsatn(Persistent.Deletes, Deletes);
 			}
 			// Event-table rows are callback-only inserts and should not create delete paths.
 			else if (RowSet.IsEventTable())
 			{
-				const FEventTableRowsType EventRows = RowSet.GetAsEventTable();
+				const FEventTableRowsType& EventRows = RowSet.MessageData.Get<FEventTableRowsType>();
 				ParseRowListWithBsatn(EventRows.Events, Inserts);
 			}
 			else
@@ -100,6 +125,11 @@ namespace UE::SpacetimeDB
 	struct FPreprocessedTableDataBase
 	{
 		virtual ~FPreprocessedTableDataBase() {}
+		int32 InsertRowCount = 0;
+		int32 DeleteRowCount = 0;
+		int32 RowSetCount = 0;
+		int64 InsertRowBytes = 0;
+		int64 DeleteRowBytes = 0;
 	};
 
 	/** A wrapper for a row type that includes its bsatn value. Used to store rows with their bsatn values. */
@@ -117,7 +147,8 @@ namespace UE::SpacetimeDB
 	public:
 		virtual ~ITableRowDeserializer() {}
 		/** Preprocess the table update and return a shared pointer to preprocessed data. */
-		virtual TSharedPtr<FPreprocessedTableDataBase> PreProcess(const TArray<FTableUpdateRowsType>& RowSets, const FString TableName) const = 0;
+		virtual TSharedPtr<FPreprocessedTableDataBase> PreProcess(const TArray<FTableUpdateRowsType>& RowSets, const FString& TableName) const = 0;
+		virtual TSharedPtr<FPreprocessedTableDataBase> PreProcessQueryRows(const FBsatnRowListType& Rows, EQueryRowsApplyMode Mode, const FString& TableName) const = 0;
 	};
 
 	/** Specialization of ITableRowDeserializer for a specific row type not defined in SDK. Used to deserialize rows of a specific type from a database update. */
@@ -125,29 +156,68 @@ namespace UE::SpacetimeDB
 	class TTableRowDeserializer : public ITableRowDeserializer
 	{
 	public:
-		virtual TSharedPtr<FPreprocessedTableDataBase> PreProcess(const TArray<FTableUpdateRowsType>& RowSets, const FString TableName) const override
+		virtual TSharedPtr<FPreprocessedTableDataBase> PreProcess(const TArray<FTableUpdateRowsType>& RowSets, const FString& TableName) const override
 		{
 			// Create a new preprocessed table data object for the specific row type
 			TSharedPtr<TPreprocessedTableData<RowType>> Result = MakeShared<TPreprocessedTableData<RowType>>();
+			Result->RowSetCount = RowSets.Num();
 			// Process each row-set update in the table update
 			for (const FTableUpdateRowsType& RowSet : RowSets)
 			{
 				if (RowSet.IsPersistentTable())
 				{
-					const FPersistentTableRowsType Persistent = RowSet.GetAsPersistentTable();
+					const FPersistentTableRowsType& Persistent = RowSet.MessageData.Get<FPersistentTableRowsType>();
+					const int32 InsertCountBefore = Result->Inserts.Num();
+					const int32 DeleteCountBefore = Result->Deletes.Num();
 					ParseRowListWithBsatn<RowType>(Persistent.Inserts, Result->Inserts);
 					ParseRowListWithBsatn<RowType>(Persistent.Deletes, Result->Deletes);
+					Result->InsertRowCount += Result->Inserts.Num() - InsertCountBefore;
+					Result->DeleteRowCount += Result->Deletes.Num() - DeleteCountBefore;
+					Result->InsertRowBytes += Persistent.Inserts.RowsData.Num();
+					Result->DeleteRowBytes += Persistent.Deletes.RowsData.Num();
 				}
 				else if (RowSet.IsEventTable())
 				{
 					// Event rows are insert-style callback payloads only.
-					const FEventTableRowsType Events = RowSet.GetAsEventTable();
+					const FEventTableRowsType& Events = RowSet.MessageData.Get<FEventTableRowsType>();
+					const int32 InsertCountBefore = Result->Inserts.Num();
 					ParseRowListWithBsatn<RowType>(Events.Events, Result->Inserts);
+					Result->InsertRowCount += Result->Inserts.Num() - InsertCountBefore;
+					Result->InsertRowBytes += Events.Events.RowsData.Num();
 				}
 				else
 				{
 					UE_LOG(LogTemp, Warning, TEXT("Unknown row-set tag for table %s"), *TableName);
 				}
+			}
+			return Result;
+		}
+
+		virtual TSharedPtr<FPreprocessedTableDataBase> PreProcessQueryRows(const FBsatnRowListType& Rows, EQueryRowsApplyMode Mode, const FString& TableName) const override
+		{
+			TSharedPtr<TPreprocessedTableData<RowType>> Result = MakeShared<TPreprocessedTableData<RowType>>();
+			Result->RowSetCount = 1;
+			switch (Mode)
+			{
+			case EQueryRowsApplyMode::Inserts:
+			{
+				const int32 InsertCountBefore = Result->Inserts.Num();
+				ParseRowListWithBsatn<RowType>(Rows, Result->Inserts);
+				Result->InsertRowCount += Result->Inserts.Num() - InsertCountBefore;
+				Result->InsertRowBytes += Rows.RowsData.Num();
+				break;
+			}
+			case EQueryRowsApplyMode::Deletes:
+			{
+				const int32 DeleteCountBefore = Result->Deletes.Num();
+				ParseRowListWithBsatn<RowType>(Rows, Result->Deletes);
+				Result->DeleteRowCount += Result->Deletes.Num() - DeleteCountBefore;
+				Result->DeleteRowBytes += Rows.RowsData.Num();
+				break;
+			}
+			default:
+				checkf(false, TEXT("Unsupported query-row apply mode for table %s"), *TableName);
+				break;
 			}
 			return Result;
 		}

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/BSATN/UESpacetimeDB.h
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/BSATN/UESpacetimeDB.h
@@ -167,13 +167,32 @@ namespace UE::SpacetimeDB {
 	 * This class provides a UE-friendly interface for deserializing BSATN data,
 	 * handling conversions between standard C++ types and UE types.
 	 *
-	 * The reader stores a copy of the input data to prevent lifetime issues
-	 * that could occur if the original TArray is destroyed.
+	 * The TArray and std::vector constructors retain copy semantics for callers
+	 * that need owned reader storage. The pointer and array-view constructors are
+	 * caller-owned views intended for immediate, scoped parsing.
 	 */
 	class UEReader {
 	private:
-		std::vector<uint8_t> stored_data;           ///< Local copy of data to ensure lifetime
+		std::vector<uint8_t> stored_data;           ///< Local copy of data when ownership is requested
 		::SpacetimeDb::bsatn::Reader core_reader;   ///< Underlying BSATN reader
+
+		static const uint8_t* ValidateReaderData(const uint8_t* data, int32 size)
+		{
+			checkf(size >= 0, TEXT("UEReader cannot read a negative byte count: %d"), size);
+			checkf(data != nullptr || size == 0, TEXT("UEReader received null data for %d bytes"), size);
+			static constexpr uint8_t EmptyReaderByte = 0;
+			if (data == nullptr)
+			{
+				return &EmptyReaderByte;
+			}
+			return data;
+		}
+
+		static size_t ValidateReaderSize(int32 size)
+		{
+			checkf(size >= 0, TEXT("UEReader cannot read a negative byte count: %d"), size);
+			return static_cast<size_t>(size);
+		}
 
 	public:
 		/**
@@ -197,6 +216,12 @@ namespace UE::SpacetimeDB {
 		explicit UEReader(const std::vector<uint8_t>& data)
 			: stored_data(data),
 			core_reader(stored_data) {}
+
+		explicit UEReader(const uint8_t* data, int32 size)
+			: core_reader(ValidateReaderData(data, size), ValidateReaderSize(size)) {}
+
+		explicit UEReader(TConstArrayView<uint8> data)
+			: UEReader(data.GetData(), data.Num()) {}
 
 		// -------------------------------------------------------------------------
 		// Primitive Type Readers
@@ -894,6 +919,27 @@ namespace UE::SpacetimeDB {
 		}
 	}
 
+	template<typename T>
+	T DeserializeView(const uint8* data, int32 size) {
+
+		UEReader reader(data, size);
+
+		if constexpr (is_tarray_v<T>) {
+			return DeserializeHelper<T>::deserialize(reader);
+		}
+		else if constexpr (is_toptional_v<T>) {
+			return DeserializeHelper<T>::deserialize(reader);
+		}
+		else {
+			return deserialize<T>(reader);
+		}
+	}
+
+	template<typename T>
+	T DeserializeView(TConstArrayView<uint8> data) {
+		return DeserializeView<T>(data.GetData(), data.Num());
+	}
+
 	/** @} */ // end of HighLevelAPI group
 
 	// =============================================================================
@@ -932,7 +978,7 @@ namespace UE::SpacetimeDB {
 	   * @brief Helper macro to generate deserialize specialization for TOptional<T>
 	   *
 	   * Use this macro when you have structs with TOptional fields of custom types.
-	   * 
+	   *
 	   * @Note: We are not using TOptional directly becouse it is not compatable wiht blueprints.
 	   * This macro is kept for future compatibility if things change on the Engine side.
 	   *
@@ -1322,7 +1368,7 @@ namespace UE::SpacetimeDB {
 
 	UE_SPACETIMEDB_ENABLE_TARRAY(float)
 	UE_SPACETIMEDB_ENABLE_TARRAY(double)
-	
+
 	UE_SPACETIMEDB_ENABLE_TARRAY(bool)
 
 	// Large integer type containers
@@ -1330,7 +1376,7 @@ namespace UE::SpacetimeDB {
 	UE_SPACETIMEDB_ENABLE_TARRAY(FSpacetimeDBUInt256)
 	UE_SPACETIMEDB_ENABLE_TARRAY(FSpacetimeDBInt128)
 	UE_SPACETIMEDB_ENABLE_TARRAY(FSpacetimeDBInt256)
-	
+
 
 	/** @} */ // end of CommonSpecializations group
 

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/Connection/DbConnectionBase.h
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/Connection/DbConnectionBase.h
@@ -110,6 +110,8 @@ struct FInboundParsedMessage
 	uint64 ConnectionEpoch = 0;
 	uint64 SequenceId = 0;
 	int32 PayloadSizeBytes = 0;
+	int32 DecodedPayloadSizeBytes = 0;
+	int64 EstimatedMemoryBytes = 0;
 	uint8 CompressionTag = 0;
 	int32 QueueDepthAtEnqueue = 0;
 	int64 QueuedBytesAtEnqueue = 0;
@@ -207,6 +209,12 @@ const void* GetNativeTableListenerTypeId()
 	return &TypeId;
 }
 
+enum class ESpacetimeDBNativeListenerDispatchMode : uint8
+{
+	NativeAndDynamic,
+	NativeOnly
+};
+
 struct FNativeTableListenerBinding
 {
 	using FInsertThunk = void(*)(void* Owner, const void* Context, const void* Row);
@@ -214,17 +222,19 @@ struct FNativeTableListenerBinding
 	using FDeleteThunk = void(*)(void* Owner, const void* Context, const void* Row);
 	using FDiffThunk = void(*)(void* Owner, const void* Context, const void* Diff);
 
-	void* Owner = nullptr;
+	TWeakObjectPtr<UObject> Owner;
+	void* OwnerKey = nullptr;
 	const void* RowTypeId = nullptr;
 	const void* EventContextTypeId = nullptr;
 	FInsertThunk InsertThunk = nullptr;
 	FUpdateThunk UpdateThunk = nullptr;
 	FDeleteThunk DeleteThunk = nullptr;
 	FDiffThunk DiffThunk = nullptr;
+	ESpacetimeDBNativeListenerDispatchMode DispatchMode = ESpacetimeDBNativeListenerDispatchMode::NativeAndDynamic;
 
 	bool IsComplete() const
 	{
-		return Owner != nullptr &&
+		return OwnerKey != nullptr &&
 			RowTypeId != nullptr &&
 			EventContextTypeId != nullptr &&
 			(DiffThunk != nullptr ||
@@ -319,7 +329,7 @@ public:
 		virtual void BroadcastDiff(UDbConnectionBase* Conn, void* Context) = 0;
 		virtual const FString& GetTableName() const = 0;
 		virtual void RegisterNativeListener(const FNativeTableListenerBinding& Binding) = 0;
-		virtual void UnregisterNativeListener(void* Owner) = 0;
+		virtual void UnregisterNativeListener(void* OwnerKey) = 0;
 	};
 
 	template<typename RowType, typename TableClass, typename EventContext>
@@ -375,11 +385,8 @@ public:
 			checkf(PendingDiffReadIndex < PendingDiffs.Num(), TEXT("Missing pending SpacetimeDB table diff for broadcast."));
 			EventContext& Ctx = *reinterpret_cast<EventContext*>(Context);
 			const FTableAppliedDiff<RowType>& Diff = PendingDiffs[PendingDiffReadIndex];
-			if (!NativeListeners.IsEmpty())
-			{
-				BroadcastNativeDiff(Diff, Ctx);
-			}
-			else
+			const bool bSuppressDynamicDispatch = BroadcastNativeDiff(Diff, Ctx);
+			if (!bSuppressDynamicDispatch)
 			{
 				Conn->BroadcastDiff(Table, Diff, Ctx);
 			}
@@ -402,29 +409,32 @@ public:
 				TEXT("Cannot register native SpacetimeDB table listener during broadcast for table '%s'."),
 				*TableName);
 			checkf(Binding.IsComplete(), TEXT("Incomplete native SpacetimeDB table listener for table '%s'."), *TableName);
+			checkf(Binding.Owner.IsValid(),
+				TEXT("Cannot register invalid native SpacetimeDB table listener owner for table '%s'."),
+				*TableName);
 			checkf(Binding.RowTypeId == GetNativeTableListenerTypeId<RowType>(),
 				TEXT("Native SpacetimeDB table listener row type mismatch for table '%s'."), *TableName);
 			checkf(Binding.EventContextTypeId == GetNativeTableListenerTypeId<EventContext>(),
 				TEXT("Native SpacetimeDB table listener context type mismatch for table '%s'."), *TableName);
 			for (const FNativeTableListenerBinding& ExistingBinding : NativeListeners)
 			{
-				checkf(ExistingBinding.Owner != Binding.Owner,
+				checkf(ExistingBinding.OwnerKey != Binding.OwnerKey,
 					TEXT("Duplicate native SpacetimeDB table listener owner for table '%s'."),
 					*TableName);
 			}
 			NativeListeners.Add(Binding);
 		}
 
-		virtual void UnregisterNativeListener(void* Owner) override
+		virtual void UnregisterNativeListener(void* OwnerKey) override
 		{
 			checkf(!bBroadcastingNativeListeners,
 				TEXT("Cannot unregister native SpacetimeDB table listener during broadcast for table '%s'."),
 				*TableName);
-			checkf(Owner != nullptr, TEXT("Cannot unregister null native SpacetimeDB table listener owner for table '%s'."), *TableName);
+			checkf(OwnerKey != nullptr, TEXT("Cannot unregister null native SpacetimeDB table listener owner for table '%s'."), *TableName);
 			const int32 ListenerIndex = NativeListeners.IndexOfByPredicate(
-				[Owner](const FNativeTableListenerBinding& Binding)
+				[OwnerKey](const FNativeTableListenerBinding& Binding)
 				{
-					return Binding.Owner == Owner;
+					return Binding.OwnerKey == OwnerKey;
 				});
 			checkf(ListenerIndex != INDEX_NONE,
 				TEXT("Missing native SpacetimeDB table listener for table '%s'."),
@@ -433,49 +443,89 @@ public:
 		}
 
 	private:
-		void BroadcastNativeDiff(const FTableAppliedDiff<RowType>& Diff, const EventContext& Context)
+		bool BroadcastNativeDiff(const FTableAppliedDiff<RowType>& Diff, const EventContext& Context)
 		{
-			TGuardValue<bool> BroadcastingScope(bBroadcastingNativeListeners, true);
-			for (const FNativeTableListenerBinding& Listener : NativeListeners)
+			if (NativeListeners.IsEmpty())
 			{
-				BroadcastNativeDiffToListener(Diff, Context, Listener);
+				return false;
 			}
+
+			bool bSuppressDynamicDispatch = false;
+			TArray<void*> ExpiredOwnerKeys;
+			{
+				TGuardValue<bool> BroadcastingScope(bBroadcastingNativeListeners, true);
+				for (const FNativeTableListenerBinding& Listener : NativeListeners)
+				{
+					UObject* OwnerObject = Listener.Owner.Get();
+					if (OwnerObject == nullptr)
+					{
+						ExpiredOwnerKeys.Add(Listener.OwnerKey);
+						UE_LOG(LogSpacetimeDb_Connection,
+							Error,
+							TEXT("Removing expired native SpacetimeDB table listener owner for table '%s'. Native listeners must be unregistered before owner destruction."),
+							*TableName);
+						continue;
+					}
+
+					BroadcastNativeDiffToListener(Diff, Context, Listener, OwnerObject);
+					if (Listener.DispatchMode == ESpacetimeDBNativeListenerDispatchMode::NativeOnly)
+					{
+						bSuppressDynamicDispatch = true;
+					}
+				}
+			}
+
+			for (void* ExpiredOwnerKey : ExpiredOwnerKeys)
+			{
+				NativeListeners.RemoveAllSwap(
+					[ExpiredOwnerKey](const FNativeTableListenerBinding& Listener)
+					{
+						return Listener.OwnerKey == ExpiredOwnerKey;
+					},
+					EAllowShrinking::No);
+			}
+			return bSuppressDynamicDispatch;
 		}
 
-		void BroadcastNativeDiffToListener(
-			const FTableAppliedDiff<RowType>& Diff,
-			const EventContext& Context,
-			const FNativeTableListenerBinding& Listener)
-		{
-			checkf(Listener.IsComplete(), TEXT("Incomplete native SpacetimeDB table listener for table '%s'."), *TableName);
-			if (Listener.DiffThunk != nullptr)
+			void BroadcastNativeDiffToListener(
+				const FTableAppliedDiff<RowType>& Diff,
+				const EventContext& Context,
+				const FNativeTableListenerBinding& Listener,
+				UObject* OwnerObject)
 			{
-				Listener.DiffThunk(Listener.Owner, &Context, &Diff);
-				return;
-			}
+				checkf(Listener.IsComplete(), TEXT("Incomplete native SpacetimeDB table listener for table '%s'."), *TableName);
+				checkf(OwnerObject != nullptr, TEXT("Cannot dispatch native SpacetimeDB table listener to a null owner for table '%s'."), *TableName);
+				checkf(Listener.Owner.Get() == OwnerObject,
+					TEXT("Native SpacetimeDB table listener owner identity mismatch for table '%s'."),
+					*TableName);
+				if (Listener.DiffThunk != nullptr)
+				{
+					Listener.DiffThunk(Listener.OwnerKey, &Context, &Diff);
+					return;
+				}
 
-			for (const TSharedPtr<RowType>& Row : Diff.Inserts)
-			{
-				checkf(Row.IsValid(), TEXT("Invalid SpacetimeDB native insert diff row for table '%s'."), *TableName);
-				Listener.InsertThunk(Listener.Owner, &Context, Row.Get());
-			}
+				for (const TSharedPtr<RowType>& Row : Diff.Inserts)
+				{
+					checkf(Row.IsValid(), TEXT("Invalid SpacetimeDB native insert diff row for table '%s'."), *TableName);
+					Listener.InsertThunk(Listener.OwnerKey, &Context, Row.Get());
+				}
 
-			for (const TSharedPtr<RowType>& Row : Diff.Deletes)
-			{
-				checkf(Row.IsValid(), TEXT("Invalid SpacetimeDB native delete diff row for table '%s'."), *TableName);
-				Listener.DeleteThunk(Listener.Owner, &Context, Row.Get());
-			}
+				for (const TSharedPtr<RowType>& Row : Diff.Deletes)
+				{
+					checkf(Row.IsValid(), TEXT("Invalid SpacetimeDB native delete diff row for table '%s'."), *TableName);
+					Listener.DeleteThunk(Listener.OwnerKey, &Context, Row.Get());
+				}
 
 			checkf(Diff.UpdateDeletes.Num() == Diff.UpdateInserts.Num(),
 				TEXT("Mismatched SpacetimeDB native update diff counts for table '%s'."), *TableName);
 			for (int32 Index = 0; Index < Diff.UpdateInserts.Num(); ++Index)
 			{
 				const TSharedPtr<RowType>& OldRow = Diff.UpdateDeletes[Index];
-				const TSharedPtr<RowType>& NewRow = Diff.UpdateInserts[Index];
-				checkf(OldRow.IsValid() && NewRow.IsValid(), TEXT("Invalid SpacetimeDB native update diff row for table '%s'."), *TableName);
-				Listener.UpdateThunk(Listener.Owner, &Context, OldRow.Get(), NewRow.Get());
+					const TSharedPtr<RowType>& NewRow = Diff.UpdateInserts[Index];
+					checkf(OldRow.IsValid() && NewRow.IsValid(), TEXT("Invalid SpacetimeDB native update diff row for table '%s'."), *TableName);
+					Listener.UpdateThunk(Listener.OwnerKey, &Context, OldRow.Get(), NewRow.Get());
+				}
 			}
-		}
 
 		FString TableName;
 		TableClass* Table;
@@ -498,15 +548,20 @@ public:
 		void (OwnerType::*InsertFn)(const EventContext&, const RowType&),
 		void (OwnerType::*UpdateFn)(const EventContext&, const RowType&, const RowType&),
 		void (OwnerType::*DeleteFn)(const EventContext&, const RowType&)>
-	void RegisterNativeTableListener(const FString& TableName, OwnerType* Owner)
+	void RegisterNativeTableListener(
+		const FString& TableName,
+		OwnerType* Owner,
+		ESpacetimeDBNativeListenerDispatchMode DispatchMode = ESpacetimeDBNativeListenerDispatchMode::NativeAndDynamic)
 	{
 		static_assert(std::is_base_of_v<UObject, OwnerType>, "Native SpacetimeDB table listener owner must derive from UObject.");
 		checkf(Owner != nullptr, TEXT("Cannot register null native SpacetimeDB table listener owner for table '%s'."), *TableName);
 
 		FNativeTableListenerBinding Binding;
 		Binding.Owner = Owner;
+		Binding.OwnerKey = Owner;
 		Binding.RowTypeId = GetNativeTableListenerTypeId<RowType>();
 		Binding.EventContextTypeId = GetNativeTableListenerTypeId<EventContext>();
+		Binding.DispatchMode = DispatchMode;
 		Binding.InsertThunk = [](void* RawOwner, const void* RawContext, const void* RawRow)
 		{
 			(static_cast<OwnerType*>(RawOwner)->*InsertFn)(
@@ -536,15 +591,20 @@ public:
 
 	template<typename RowType, typename EventContext, typename OwnerType,
 		void (OwnerType::*DiffFn)(const EventContext&, const FTableAppliedDiff<RowType>&)>
-	void RegisterNativeTableDiffListener(const FString& TableName, OwnerType* Owner)
+	void RegisterNativeTableDiffListener(
+		const FString& TableName,
+		OwnerType* Owner,
+		ESpacetimeDBNativeListenerDispatchMode DispatchMode = ESpacetimeDBNativeListenerDispatchMode::NativeAndDynamic)
 	{
 		static_assert(std::is_base_of_v<UObject, OwnerType>, "Native SpacetimeDB table diff listener owner must derive from UObject.");
 		checkf(Owner != nullptr, TEXT("Cannot register null native SpacetimeDB table diff listener owner for table '%s'."), *TableName);
 
 		FNativeTableListenerBinding Binding;
 		Binding.Owner = Owner;
+		Binding.OwnerKey = Owner;
 		Binding.RowTypeId = GetNativeTableListenerTypeId<RowType>();
 		Binding.EventContextTypeId = GetNativeTableListenerTypeId<EventContext>();
+		Binding.DispatchMode = DispatchMode;
 		Binding.DiffThunk = [](void* RawOwner, const void* RawContext, const void* RawDiff)
 		{
 			(static_cast<OwnerType*>(RawOwner)->*DiffFn)(
@@ -668,11 +728,12 @@ protected:
 	/** Mutex protecting access to PendingMessages. */
 	FCriticalSection PendingMessagesMutex;
 	int32 PendingMessageReadIndex = 0;
-	int64 PendingParsedPayloadBytes = 0;
+	int64 PendingParsedEstimatedBytes = 0;
 
 	/** Raw inbound messages awaiting FIFO processing by the connection-owned worker. */
 	TArray<FInboundRawMessage> InboundRawMessages;
 	mutable FCriticalSection InboundRawMessagesMutex;
+	int32 InboundRawMessageReadIndex = 0;
 	int64 InboundQueuedRawBytes = 0;
 	uint64 InboundConnectionEpoch = 0;
 	uint64 NextInboundSequenceId = 0;

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/Connection/DbConnectionBase.h
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/Connection/DbConnectionBase.h
@@ -1,7 +1,6 @@
 #pragma once
 
 #include "CoreMinimal.h"
-#include "Containers/Ticker.h"
 #include "UObject/NoExportTypes.h"
 #include "Types/Builtins.h"
 #include "Websocket.h"
@@ -9,7 +8,6 @@
 #include "ModuleBindings/Types/ServerMessageType.g.h"
 #include "DBCache/TableAppliedDiff.h"
 #include "HAL/CriticalSection.h"
-#include "Containers/Queue.h"
 #include "HAL/ThreadSafeBool.h"
 #include "BSATN/UEBSATNHelpers.h"
 #include "Connection/Callback.h"
@@ -21,6 +19,7 @@
 // Forward declarations
 class UDbConnectionBuilder;
 class UProcedureCallbacks;
+class FSpacetimeDbInboundWorker;
 
 /** Macro for safae way to bind delegate without needing to write Function name as an FName. */
 #define BIND_DELEGATE_SAFE(DelegateVar, Object, ClassType, FunctionName) \
@@ -95,6 +94,92 @@ FORCEINLINE uint32 GetTypeHash(const FPreprocessedTableKey& Key)
 	return GetTypeHash(Key.TableName);
 }
 
+using FPreprocessedTableDataMap = TMap<FPreprocessedTableKey, TArray<TSharedPtr<UE::SpacetimeDB::FPreprocessedTableDataBase>>>;
+
+struct FInboundRawMessage
+{
+	uint64 ConnectionEpoch = 0;
+	uint64 SequenceId = 0;
+	int32 QueueDepthAtEnqueue = 0;
+	int64 QueuedBytesAtEnqueue = 0;
+	TArray<uint8> Payload;
+};
+
+struct FInboundParsedMessage
+{
+	uint64 ConnectionEpoch = 0;
+	uint64 SequenceId = 0;
+	int32 PayloadSizeBytes = 0;
+	uint8 CompressionTag = 0;
+	int32 QueueDepthAtEnqueue = 0;
+	int64 QueuedBytesAtEnqueue = 0;
+	bool bProtocolError = false;
+	FString ProtocolError;
+	FServerMessageType Message;
+	FPreprocessedTableDataMap PreprocessedTableData;
+};
+
+struct FSpacetimeDBTableApplyStats
+{
+	FString TableName;
+	int32 RowSetCount = 0;
+	int32 InsertRowCount = 0;
+	int32 DeleteRowCount = 0;
+	int64 InsertRowBytes = 0;
+	int64 DeleteRowBytes = 0;
+	double CacheMicros = 0.0;
+	double BroadcastMicros = 0.0;
+	bool bProducedDiff = false;
+};
+
+struct FSpacetimeDBInboundMessageApplyStats
+{
+	FString MessageKind;
+	FString ReducerName;
+	uint32 RequestId = 0;
+	uint64 SequenceId = 0;
+	int32 PayloadSizeBytes = 0;
+	int32 QueueDepthAtEnqueue = 0;
+	int64 QueuedBytesAtEnqueue = 0;
+	TArray<FSpacetimeDBTableApplyStats> TableStats;
+};
+
+USTRUCT(BlueprintType)
+struct SPACETIMEDBSDK_API FSpacetimeDBInboundApplyBudget
+{
+	GENERATED_BODY()
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SpacetimeDB")
+	int32 MaxMessagesPerFrame = 256;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SpacetimeDB")
+	int64 MaxPayloadBytesPerFrame = 4 * 1024 * 1024;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SpacetimeDB")
+	int32 MinMessagesPerFrame = 1;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SpacetimeDB")
+	int64 SoftTimeBudgetMicros = 0;
+
+	UPROPERTY(EditAnywhere, BlueprintReadWrite, Category = "SpacetimeDB")
+	bool bDrainAllPendingMessages = false;
+
+	static FSpacetimeDBInboundApplyBudget MakeDrainAllPendingMessages()
+	{
+		FSpacetimeDBInboundApplyBudget Budget;
+		Budget.bDrainAllPendingMessages = true;
+		return Budget;
+	}
+
+	void Sanitize()
+	{
+		MaxMessagesPerFrame = FMath::Max(1, MaxMessagesPerFrame);
+		MaxPayloadBytesPerFrame = FMath::Max<int64>(1, MaxPayloadBytesPerFrame);
+		MinMessagesPerFrame = FMath::Clamp(MinMessagesPerFrame, 1, MaxMessagesPerFrame);
+		SoftTimeBudgetMicros = FMath::Max<int64>(0, SoftTimeBudgetMicros);
+	}
+};
+
 template<typename T, typename = void>
 struct THasOnDeleteDelegate : std::false_type
 {
@@ -115,8 +200,42 @@ struct THasOnUpdateDelegate<T, std::void_t<decltype(&T::OnUpdate)>> : std::true_
 {
 };
 
+template<typename Type>
+const void* GetNativeTableListenerTypeId()
+{
+	static const uint8 TypeId = 0;
+	return &TypeId;
+}
+
+struct FNativeTableListenerBinding
+{
+	using FInsertThunk = void(*)(void* Owner, const void* Context, const void* Row);
+	using FUpdateThunk = void(*)(void* Owner, const void* Context, const void* OldRow, const void* NewRow);
+	using FDeleteThunk = void(*)(void* Owner, const void* Context, const void* Row);
+	using FDiffThunk = void(*)(void* Owner, const void* Context, const void* Diff);
+
+	void* Owner = nullptr;
+	const void* RowTypeId = nullptr;
+	const void* EventContextTypeId = nullptr;
+	FInsertThunk InsertThunk = nullptr;
+	FUpdateThunk UpdateThunk = nullptr;
+	FDeleteThunk DeleteThunk = nullptr;
+	FDiffThunk DiffThunk = nullptr;
+
+	bool IsComplete() const
+	{
+		return Owner != nullptr &&
+			RowTypeId != nullptr &&
+			EventContextTypeId != nullptr &&
+			(DiffThunk != nullptr ||
+				(InsertThunk != nullptr &&
+					UpdateThunk != nullptr &&
+					DeleteThunk != nullptr));
+	}
+};
+
 UCLASS()
-class SPACETIMEDBSDK_API UDbConnectionBase : public UObject
+class SPACETIMEDBSDK_API UDbConnectionBase : public UObject, public FTickableGameObject
 {
 	GENERATED_BODY()
 
@@ -124,6 +243,8 @@ public:
 
 	/** The default constructor is private to prevent instantiation without using the builder. */
 	explicit UDbConnectionBase(const FObjectInitializer& ObjectInitializer = FObjectInitializer::Get());
+
+	virtual void BeginDestroy() override;
 
 	/** Disconnect from the server. */
 	UFUNCTION(BlueprintCallable, Category="SpacetimeDB")
@@ -137,7 +258,14 @@ public:
 	void FrameTick();
 
 	UFUNCTION(BlueprintCallable, Category="SpacetimeDB")
-	void SetAutoTicking(bool bAutoTick);
+	void SetAutoTicking(bool bAutoTick) { bIsAutoTicking = bAutoTick; }
+
+	UFUNCTION(BlueprintCallable, Category="SpacetimeDB")
+	void SetInboundApplyBudget(FSpacetimeDBInboundApplyBudget InBudget)
+	{
+		InBudget.Sanitize();
+		InboundApplyBudget = InBudget;
+	}
 
 	/** Send a raw JSON message to the server. */
 	bool SendRawMessage(const FString& Message);
@@ -147,11 +275,11 @@ public:
 	/** Get the current subscription builder. This is used to create subscriptions. */
 	UFUNCTION()
 	USubscriptionBuilderBase* SubscriptionBuilderBase();
-	
+
 	/** Get the current identity of the SpacetimeDB instance. This is used to identify the connection. */
 	UFUNCTION(BlueprintPure, Category = "SpacetimeDB")
 	bool TryGetIdentity(FSpacetimeDBIdentity& OutIdentity) const;
-	
+
 	/** Get the current connection id. This is used to identify the connection. */
 	UFUNCTION(BlueprintPure, Category = "SpacetimeDB")
 	FSpacetimeDBConnectionId GetConnectionId() const;
@@ -185,47 +313,176 @@ public:
 		virtual ~ITableUpdateHandler() {}
 
 		/** Update the in-memory cache for the table and store the diff */
-		virtual void UpdateCache(UDbConnectionBase* Conn, const FTableUpdateType& Update, void* Context) = 0;
+		virtual bool UpdateCache(UDbConnectionBase* Conn, const FTableUpdateType& Update, void* Context, FSpacetimeDBTableApplyStats* OutStats) = 0;
 
 		/** Broadcast the previously stored diff */
 		virtual void BroadcastDiff(UDbConnectionBase* Conn, void* Context) = 0;
+		virtual const FString& GetTableName() const = 0;
+		virtual void RegisterNativeListener(const FNativeTableListenerBinding& Binding) = 0;
+		virtual void UnregisterNativeListener(void* Owner) = 0;
 	};
 
 	template<typename RowType, typename TableClass, typename EventContext>
 	class TTableUpdateHandler : public ITableUpdateHandler
 	{
 	public:
-		explicit TTableUpdateHandler(TableClass* InTable) : Table(InTable) {}
+		explicit TTableUpdateHandler(const FString& InTableName, TableClass* InTable)
+			: TableName(InTableName)
+			, Table(InTable)
+		{
+		}
 
 		//** Update the in-memory cache for the table and store the diff */
-		virtual void UpdateCache(UDbConnectionBase* Conn, const FTableUpdateType& Update, void* Context) override
+		virtual bool UpdateCache(UDbConnectionBase* Conn, const FTableUpdateType& Update, void* Context, FSpacetimeDBTableApplyStats* OutStats) override
 		{
-			// Attempt to take preprocessed data if available
+			if (PendingDiffReadIndex == PendingDiffs.Num())
+			{
+				PendingDiffs.Reset();
+				PendingDiffReadIndex = 0;
+			}
+
 			TSharedPtr<UE::SpacetimeDB::TPreprocessedTableData<RowType>> Pre;
-			if (Conn->TakePreprocessedTableData<RowType>(Update, Pre))
+			const bool bTookPreprocessedData = Conn->TakePreprocessedTableData<RowType>(Update, Pre);
+			checkf(bTookPreprocessedData && Pre.IsValid(), TEXT("Missing message-scoped preprocessed data for table '%s'."), *Update.TableName);
+			if (OutStats != nullptr)
 			{
-				// If preprocessed data is available, use it to update the table
-				LastDiff = Table->Update(Pre->Inserts, Pre->Deletes);
+				OutStats->TableName = TableName;
+				OutStats->RowSetCount = Pre->RowSetCount;
+				OutStats->InsertRowCount = Pre->InsertRowCount;
+				OutStats->DeleteRowCount = Pre->DeleteRowCount;
+				OutStats->InsertRowBytes = Pre->InsertRowBytes;
+				OutStats->DeleteRowBytes = Pre->DeleteRowBytes;
 			}
-			else
+			FTableAppliedDiff<RowType> AppliedDiff = Table->Update(MoveTemp(Pre->Inserts), MoveTemp(Pre->Deletes));
+			if (AppliedDiff.IsEmpty())
 			{
-				// If no preprocessed data, process the update directly. Backup
-				UE_LOG(LogSpacetimeDb_Connection, Warning, TEXT("No preprocessed data for table update. Processing directly."));
-				TArray<FWithBsatn<RowType>> Inserts, Deletes;
-				UE::SpacetimeDB::ProcessTableUpdateWithBsatn<RowType>(Update, Inserts, Deletes);
-				LastDiff = Table->Update(Inserts, Deletes);
+				if (OutStats != nullptr)
+				{
+					OutStats->bProducedDiff = false;
+				}
+				return false;
 			}
+			if (OutStats != nullptr)
+			{
+				OutStats->bProducedDiff = true;
+			}
+			PendingDiffs.Add(MoveTemp(AppliedDiff));
+			return true;
 		}
 		//** Broadcast the last stored diff to the table's delegates */
 		virtual void BroadcastDiff(UDbConnectionBase* Conn, void* Context) override
 		{
+			checkf(PendingDiffReadIndex < PendingDiffs.Num(), TEXT("Missing pending SpacetimeDB table diff for broadcast."));
 			EventContext& Ctx = *reinterpret_cast<EventContext*>(Context);
-			Conn->BroadcastDiff(Table, LastDiff, Ctx);
+			const FTableAppliedDiff<RowType>& Diff = PendingDiffs[PendingDiffReadIndex];
+			if (!NativeListeners.IsEmpty())
+			{
+				BroadcastNativeDiff(Diff, Ctx);
+			}
+			else
+			{
+				Conn->BroadcastDiff(Table, Diff, Ctx);
+			}
+			++PendingDiffReadIndex;
+			if (PendingDiffReadIndex == PendingDiffs.Num())
+			{
+				PendingDiffs.Reset();
+				PendingDiffReadIndex = 0;
+			}
+		}
+
+		virtual const FString& GetTableName() const override
+		{
+			return TableName;
+		}
+
+		virtual void RegisterNativeListener(const FNativeTableListenerBinding& Binding) override
+		{
+			checkf(!bBroadcastingNativeListeners,
+				TEXT("Cannot register native SpacetimeDB table listener during broadcast for table '%s'."),
+				*TableName);
+			checkf(Binding.IsComplete(), TEXT("Incomplete native SpacetimeDB table listener for table '%s'."), *TableName);
+			checkf(Binding.RowTypeId == GetNativeTableListenerTypeId<RowType>(),
+				TEXT("Native SpacetimeDB table listener row type mismatch for table '%s'."), *TableName);
+			checkf(Binding.EventContextTypeId == GetNativeTableListenerTypeId<EventContext>(),
+				TEXT("Native SpacetimeDB table listener context type mismatch for table '%s'."), *TableName);
+			for (const FNativeTableListenerBinding& ExistingBinding : NativeListeners)
+			{
+				checkf(ExistingBinding.Owner != Binding.Owner,
+					TEXT("Duplicate native SpacetimeDB table listener owner for table '%s'."),
+					*TableName);
+			}
+			NativeListeners.Add(Binding);
+		}
+
+		virtual void UnregisterNativeListener(void* Owner) override
+		{
+			checkf(!bBroadcastingNativeListeners,
+				TEXT("Cannot unregister native SpacetimeDB table listener during broadcast for table '%s'."),
+				*TableName);
+			checkf(Owner != nullptr, TEXT("Cannot unregister null native SpacetimeDB table listener owner for table '%s'."), *TableName);
+			const int32 ListenerIndex = NativeListeners.IndexOfByPredicate(
+				[Owner](const FNativeTableListenerBinding& Binding)
+				{
+					return Binding.Owner == Owner;
+				});
+			checkf(ListenerIndex != INDEX_NONE,
+				TEXT("Missing native SpacetimeDB table listener for table '%s'."),
+				*TableName);
+			NativeListeners.RemoveAtSwap(ListenerIndex, 1, EAllowShrinking::No);
 		}
 
 	private:
+		void BroadcastNativeDiff(const FTableAppliedDiff<RowType>& Diff, const EventContext& Context)
+		{
+			TGuardValue<bool> BroadcastingScope(bBroadcastingNativeListeners, true);
+			for (const FNativeTableListenerBinding& Listener : NativeListeners)
+			{
+				BroadcastNativeDiffToListener(Diff, Context, Listener);
+			}
+		}
+
+		void BroadcastNativeDiffToListener(
+			const FTableAppliedDiff<RowType>& Diff,
+			const EventContext& Context,
+			const FNativeTableListenerBinding& Listener)
+		{
+			checkf(Listener.IsComplete(), TEXT("Incomplete native SpacetimeDB table listener for table '%s'."), *TableName);
+			if (Listener.DiffThunk != nullptr)
+			{
+				Listener.DiffThunk(Listener.Owner, &Context, &Diff);
+				return;
+			}
+
+			for (const TSharedPtr<RowType>& Row : Diff.Inserts)
+			{
+				checkf(Row.IsValid(), TEXT("Invalid SpacetimeDB native insert diff row for table '%s'."), *TableName);
+				Listener.InsertThunk(Listener.Owner, &Context, Row.Get());
+			}
+
+			for (const TSharedPtr<RowType>& Row : Diff.Deletes)
+			{
+				checkf(Row.IsValid(), TEXT("Invalid SpacetimeDB native delete diff row for table '%s'."), *TableName);
+				Listener.DeleteThunk(Listener.Owner, &Context, Row.Get());
+			}
+
+			checkf(Diff.UpdateDeletes.Num() == Diff.UpdateInserts.Num(),
+				TEXT("Mismatched SpacetimeDB native update diff counts for table '%s'."), *TableName);
+			for (int32 Index = 0; Index < Diff.UpdateInserts.Num(); ++Index)
+			{
+				const TSharedPtr<RowType>& OldRow = Diff.UpdateDeletes[Index];
+				const TSharedPtr<RowType>& NewRow = Diff.UpdateInserts[Index];
+				checkf(OldRow.IsValid() && NewRow.IsValid(), TEXT("Invalid SpacetimeDB native update diff row for table '%s'."), *TableName);
+				Listener.UpdateThunk(Listener.Owner, &Context, OldRow.Get(), NewRow.Get());
+			}
+		}
+
+		FString TableName;
 		TableClass* Table;
-		FTableAppliedDiff<RowType> LastDiff;
+		TArray<FTableAppliedDiff<RowType>> PendingDiffs;
+		int32 PendingDiffReadIndex = 0;
+		TArray<FNativeTableListenerBinding> NativeListeners;
+		bool bBroadcastingNativeListeners = false;
 	};
 	//** Register a table with the connection. This will allow the connection to handle updates for the table.
 	template<typename RowType, typename TableClass, typename EventContext>
@@ -233,37 +490,129 @@ public:
 	{
 		RegisterTable<RowType>(TableName);
 		FScopeLock Lock(&RegisteredTablesMutex);
-		RegisteredTables.Add(TableName, MakeShared<TTableUpdateHandler<RowType, TableClass, EventContext>>(Table));
+		RegisteredTables.Add(TableName, MakeShared<TTableUpdateHandler<RowType, TableClass, EventContext>>(TableName, Table));
+		RegisteredTablesSnapshot = MakeShared<TMap<FString, TSharedPtr<ITableUpdateHandler>>>(RegisteredTables);
+	}
+
+	template<typename RowType, typename EventContext, typename OwnerType,
+		void (OwnerType::*InsertFn)(const EventContext&, const RowType&),
+		void (OwnerType::*UpdateFn)(const EventContext&, const RowType&, const RowType&),
+		void (OwnerType::*DeleteFn)(const EventContext&, const RowType&)>
+	void RegisterNativeTableListener(const FString& TableName, OwnerType* Owner)
+	{
+		static_assert(std::is_base_of_v<UObject, OwnerType>, "Native SpacetimeDB table listener owner must derive from UObject.");
+		checkf(Owner != nullptr, TEXT("Cannot register null native SpacetimeDB table listener owner for table '%s'."), *TableName);
+
+		FNativeTableListenerBinding Binding;
+		Binding.Owner = Owner;
+		Binding.RowTypeId = GetNativeTableListenerTypeId<RowType>();
+		Binding.EventContextTypeId = GetNativeTableListenerTypeId<EventContext>();
+		Binding.InsertThunk = [](void* RawOwner, const void* RawContext, const void* RawRow)
+		{
+			(static_cast<OwnerType*>(RawOwner)->*InsertFn)(
+				*static_cast<const EventContext*>(RawContext),
+				*static_cast<const RowType*>(RawRow));
+		};
+		Binding.UpdateThunk = [](void* RawOwner, const void* RawContext, const void* RawOldRow, const void* RawNewRow)
+		{
+			(static_cast<OwnerType*>(RawOwner)->*UpdateFn)(
+				*static_cast<const EventContext*>(RawContext),
+				*static_cast<const RowType*>(RawOldRow),
+				*static_cast<const RowType*>(RawNewRow));
+		};
+		Binding.DeleteThunk = [](void* RawOwner, const void* RawContext, const void* RawRow)
+		{
+			(static_cast<OwnerType*>(RawOwner)->*DeleteFn)(
+				*static_cast<const EventContext*>(RawContext),
+				*static_cast<const RowType*>(RawRow));
+		};
+
+		FScopeLock Lock(&RegisteredTablesMutex);
+		TSharedPtr<ITableUpdateHandler>* Handler = RegisteredTables.Find(TableName);
+		checkf(Handler != nullptr && Handler->IsValid(),
+			TEXT("Missing SpacetimeDB table handler while registering native listener for table '%s'."), *TableName);
+		(*Handler)->RegisterNativeListener(Binding);
+	}
+
+	template<typename RowType, typename EventContext, typename OwnerType,
+		void (OwnerType::*DiffFn)(const EventContext&, const FTableAppliedDiff<RowType>&)>
+	void RegisterNativeTableDiffListener(const FString& TableName, OwnerType* Owner)
+	{
+		static_assert(std::is_base_of_v<UObject, OwnerType>, "Native SpacetimeDB table diff listener owner must derive from UObject.");
+		checkf(Owner != nullptr, TEXT("Cannot register null native SpacetimeDB table diff listener owner for table '%s'."), *TableName);
+
+		FNativeTableListenerBinding Binding;
+		Binding.Owner = Owner;
+		Binding.RowTypeId = GetNativeTableListenerTypeId<RowType>();
+		Binding.EventContextTypeId = GetNativeTableListenerTypeId<EventContext>();
+		Binding.DiffThunk = [](void* RawOwner, const void* RawContext, const void* RawDiff)
+		{
+			(static_cast<OwnerType*>(RawOwner)->*DiffFn)(
+				*static_cast<const EventContext*>(RawContext),
+				*static_cast<const FTableAppliedDiff<RowType>*>(RawDiff));
+		};
+
+		FScopeLock Lock(&RegisteredTablesMutex);
+		TSharedPtr<ITableUpdateHandler>* Handler = RegisteredTables.Find(TableName);
+		checkf(Handler != nullptr && Handler->IsValid(),
+			TEXT("Missing SpacetimeDB table handler while registering native diff listener for table '%s'."), *TableName);
+		(*Handler)->RegisterNativeListener(Binding);
+	}
+
+	template<typename RowType, typename EventContext, typename OwnerType,
+		void (OwnerType::*InsertFn)(const EventContext&, const RowType&),
+		void (OwnerType::*UpdateFn)(const EventContext&, const RowType&, const RowType&),
+		void (OwnerType::*DeleteFn)(const EventContext&, const RowType&)>
+	void UnregisterNativeTableListener(const FString& TableName, OwnerType* Owner)
+	{
+		static_assert(std::is_base_of_v<UObject, OwnerType>, "Native SpacetimeDB table listener owner must derive from UObject.");
+		checkf(Owner != nullptr, TEXT("Cannot unregister null native SpacetimeDB table listener owner for table '%s'."), *TableName);
+
+		FScopeLock Lock(&RegisteredTablesMutex);
+		TSharedPtr<ITableUpdateHandler>* Handler = RegisteredTables.Find(TableName);
+		checkf(Handler != nullptr && Handler->IsValid(),
+			TEXT("Missing SpacetimeDB table handler while unregistering native listener for table '%s'."), *TableName);
+		(*Handler)->UnregisterNativeListener(Owner);
+	}
+
+	template<typename RowType, typename EventContext, typename OwnerType,
+		void (OwnerType::*DiffFn)(const EventContext&, const FTableAppliedDiff<RowType>&)>
+	void UnregisterNativeTableDiffListener(const FString& TableName, OwnerType* Owner)
+	{
+		static_assert(std::is_base_of_v<UObject, OwnerType>, "Native SpacetimeDB table diff listener owner must derive from UObject.");
+		checkf(Owner != nullptr, TEXT("Cannot unregister null native SpacetimeDB table diff listener owner for table '%s'."), *TableName);
+
+		FScopeLock Lock(&RegisteredTablesMutex);
+		TSharedPtr<ITableUpdateHandler>* Handler = RegisteredTables.Find(TableName);
+		checkf(Handler != nullptr && Handler->IsValid(),
+			TEXT("Missing SpacetimeDB table handler while unregistering native diff listener for table '%s'."), *TableName);
+		(*Handler)->UnregisterNativeListener(Owner);
 	}
 	//** Take preprocessed table row data. */
 	template<typename RowType>
 	bool TakePreprocessedTableData(const FTableUpdateType& Update, TSharedPtr<UE::SpacetimeDB::TPreprocessedTableData<RowType>>& OutData)
 	{
-		FScopeLock Lock(&PreprocessedDataMutex);
+		checkf(ActivePreprocessedTableData != nullptr, TEXT("No active inbound message while applying table update '%s'."), *Update.TableName);
 		FPreprocessedTableKey Key(Update.TableName);
-		if (TArray<TSharedPtr<UE::SpacetimeDB::FPreprocessedTableDataBase>>* Found = PreprocessedTableData.Find(Key))
+		TArray<TSharedPtr<UE::SpacetimeDB::FPreprocessedTableDataBase>>* Found = ActivePreprocessedTableData->Find(Key);
+		checkf(Found != nullptr && Found->Num() > 0, TEXT("Missing message-scoped preprocessed data for table '%s'."), *Update.TableName);
+		OutData = StaticCastSharedPtr<UE::SpacetimeDB::TPreprocessedTableData<RowType>>((*Found)[0]);
+		Found->RemoveAt(0, 1, EAllowShrinking::No);
+		if (Found->Num() == 0)
 		{
-			if (Found->Num() > 0)
-			{
-				OutData = StaticCastSharedPtr<UE::SpacetimeDB::TPreprocessedTableData<RowType>>((*Found)[0]);
-				Found->RemoveAt(0);
-				if (Found->Num() == 0)
-				{
-					PreprocessedTableData.Remove(Key);
-				}
-				return OutData.IsValid();
-			}
+			ActivePreprocessedTableData->Remove(Key);
 		}
-		return false;
+		checkf(OutData.IsValid(), TEXT("Invalid message-scoped preprocessed data for table '%s'."), *Update.TableName);
+		return true;
 	}
 
 
 protected:
 
-	virtual void BeginDestroy() override;
-
 	friend class UDbConnectionBuilderBase;
 	friend class UDbConnectionBuilder;
+	friend class FSpacetimeDbInboundWorker;
+	friend class UWebsocketManager;
 	friend class USubscriptionHandleBase;
 	friend class USubscriptionBuilder;
 	friend class URemoteReducers;
@@ -278,48 +627,70 @@ protected:
 	void HandleWSClosed(int32 StatusCode, const FString& Reason, bool bWasClean);
 	UFUNCTION()
 	void HandleWSBinaryMessage(const TArray<uint8>& Message);
+	void HandleWSBinaryMessageOwned(TArray<uint8>&& Message);
+	void StartInboundMessageWorker();
+	void StopInboundMessageWorker();
+	void ClearInboundMessageQueues();
+	void NotifyInboundWorkerIfNeeded();
+	void DrainInboundRawMessagesOnWorker();
+	bool BuildInboundParsedMessage(const FInboundRawMessage& RawMessage, FInboundParsedMessage& OutMessage);
+	void EnqueueInboundProtocolError(uint64 SequenceId, int32 PayloadSizeBytes, uint8 CompressionTag, int32 QueueDepthAtEnqueue, int64 QueuedBytesAtEnqueue, const FString& ErrorMessage);
+	bool IsInboundProtocolErrorQueued() const;
+	bool IsInboundEpochCurrentAndAccepting(uint64 ConnectionEpoch) const;
+	void MarkInboundProtocolErrorQueued();
 
-	bool OnTickerTick(float DeltaTime);
+	virtual void Tick(float DeltaTime) override;
+
+	virtual TStatId GetStatId() const override;
+
+	virtual bool IsTickable() const override;
+
+	virtual bool IsTickableInEditor() const override;
 
 	/** Internal handler that processes a single server message. */
 	void ProcessServerMessage(const FServerMessageType& Message);
-	void PreProcessDatabaseUpdate(const FDatabaseUpdateType& Update);
+	void ProcessInboundServerMessage(FInboundParsedMessage& InboundMessage, FSpacetimeDBInboundMessageApplyStats& ApplyStats);
+	void PreProcessTableUpdateRows(const FString& TableName, const TArray<FTableUpdateRowsType>& RowSets, FPreprocessedTableDataMap& OutPreprocessedTableData);
+	void PreProcessQueryRows(const FQueryRowsType& Rows, UE::SpacetimeDB::EQueryRowsApplyMode Mode, FPreprocessedTableDataMap& OutPreprocessedTableData);
+	void PreProcessTransactionUpdate(const FTransactionUpdateType& Update, FPreprocessedTableDataMap& OutPreprocessedTableData);
+	TSharedPtr<UE::SpacetimeDB::ITableRowDeserializer> FindTableDeserializerForPreprocess(const FString& TableName);
+	void StorePreprocessedTableData(const FString& TableName, TSharedPtr<UE::SpacetimeDB::FPreprocessedTableDataBase> Data, FPreprocessedTableDataMap& OutPreprocessedTableData);
 	/** Decompress and parse a raw message. */
-	bool PreProcessMessage(const TArray<uint8>& Message, FServerMessageType& OutMessage);
-	bool DecompressPayload(uint8 Variant, const TArray<uint8>& In, TArray<uint8>& Out);
-	bool DecompressGzip(const TArray<uint8>& InData, TArray<uint8>& OutData);
-	bool DecompressBrotli(const TArray<uint8>& InData, TArray<uint8>& OutData);
+	bool PreProcessMessage(const TArray<uint8>& Message, FInboundParsedMessage& OutMessage);
+	bool DecompressGzip(const uint8* InData, int32 InSize, TArray<uint8>& OutData);
+	bool DecompressBrotli(const uint8* InData, int32 InSize, TArray<uint8>& OutData);
 	void ClearPendingOperations(const FString& Reason);
 	void HandleProtocolViolation(const FString& ErrorMessage);
 
-	/** Pending messages awaiting processing on the game thread. */
-	TArray<FServerMessageType> PendingMessages;
+	/** Parsed inbound messages awaiting processing on the game thread. */
+	TArray<FInboundParsedMessage> PendingMessages;
 
 	/** Mutex protecting access to PendingMessages. */
 	FCriticalSection PendingMessagesMutex;
+	int32 PendingMessageReadIndex = 0;
+	int64 PendingParsedPayloadBytes = 0;
 
-	/** Map of preprocessed messages keyed by their sequential id. */
-	TMap<int32, FServerMessageType> PreprocessedMessages;
-
-	/** Protects PreprocessedMessages and PendingMessages ordering state. */
-	FCriticalSection PreprocessMutex;
-
-	/** Counter for assigning ids to incoming messages. */
-	FThreadSafeCounter NextPreprocessId;
-
-	/** Id of the next message expected to be released. */
-	int32 NextReleaseId = 0;
+	/** Raw inbound messages awaiting FIFO processing by the connection-owned worker. */
+	TArray<FInboundRawMessage> InboundRawMessages;
+	mutable FCriticalSection InboundRawMessagesMutex;
+	int64 InboundQueuedRawBytes = 0;
+	uint64 InboundConnectionEpoch = 0;
+	uint64 NextInboundSequenceId = 0;
+	bool bInboundAcceptingMessages = false;
+	bool bInboundProtocolErrorQueued = false;
+	FSpacetimeDbInboundWorker* InboundWorker = nullptr;
+	FCriticalSection InboundWorkerMutex;
 
 	// Map of table name to row deserializer
 	TMap<FString, TSharedPtr<UE::SpacetimeDB::ITableRowDeserializer>> TableDeserializers;
 	FCriticalSection TableDeserializersMutex;
 
-	// Map from table update pointer to preprocessed data
-	TMap<FPreprocessedTableKey, TArray<TSharedPtr<UE::SpacetimeDB::FPreprocessedTableDataBase>>> PreprocessedTableData;
-	FCriticalSection PreprocessedDataMutex;
+	// Message-scoped preprocessed table rows active only while applying one inbound server message.
+	FPreprocessedTableDataMap* ActivePreprocessedTableData = nullptr;
 
 	// Map of table name to generic table update handler
 	TMap<FString, TSharedPtr<ITableUpdateHandler>> RegisteredTables;
+	TSharedPtr<const TMap<FString, TSharedPtr<ITableUpdateHandler>>> RegisteredTablesSnapshot;
 	FCriticalSection RegisteredTablesMutex;
 
 
@@ -404,7 +775,16 @@ protected:
 
 	UPROPERTY()
 	bool bIsAutoTicking = false;
-	FTSTicker::FDelegateHandle TickerHandle;
+
+	FSpacetimeDBInboundApplyBudget InboundApplyBudget;
+	struct FPendingTableBroadcast
+	{
+		TSharedPtr<ITableUpdateHandler> Handler;
+		int32 StatsIndex = INDEX_NONE;
+	};
+	TArray<FPendingTableBroadcast> TableUpdateHandlersScratch;
+	FSpacetimeDBInboundMessageApplyStats* ActiveInboundMessageApplyStats = nullptr;
+
 	/** Guard to avoid repeatedly handling the same fatal protocol error. */
 	FThreadSafeBool bProtocolViolationHandled = false;
 
@@ -424,9 +804,10 @@ protected:
 		// Broadcast the diff to the table's delegates
 		if (Table->OnInsert.IsBound())
 		{
-			for (const TPair<TArray<uint8>, RowType>& Pair : Diff.Inserts)
+			for (const TSharedPtr<RowType>& Row : Diff.Inserts)
 			{
-				Table->OnInsert.Broadcast(Context, Pair.Value);
+				checkf(Row.IsValid(), TEXT("Invalid SpacetimeDB insert diff row."));
+				Table->OnInsert.Broadcast(Context, *Row);
 			}
 		}
 
@@ -435,9 +816,10 @@ protected:
 		{
 			if (Table->OnDelete.IsBound())
 			{
-				for (const TPair<TArray<uint8>, RowType>& Pair : Diff.Deletes)
+				for (const TSharedPtr<RowType>& Row : Diff.Deletes)
 				{
-					Table->OnDelete.Broadcast(Context, Pair.Value);
+					checkf(Row.IsValid(), TEXT("Invalid SpacetimeDB delete diff row."));
+					Table->OnDelete.Broadcast(Context, *Row);
 				}
 			}
 		}
@@ -446,12 +828,13 @@ protected:
 		{
 			if (Table->OnUpdate.IsBound())
 			{
-				int32 Count = FMath::Min(Diff.UpdateDeletes.Num(), Diff.UpdateInserts.Num());
-				for (int32 Index = 0; Index < Count; ++Index)
+				checkf(Diff.UpdateDeletes.Num() == Diff.UpdateInserts.Num(), TEXT("Mismatched SpacetimeDB update diff counts."));
+				for (int32 Index = 0; Index < Diff.UpdateInserts.Num(); ++Index)
 				{
-					const RowType& OldRow = Diff.UpdateDeletes[Index];
-					const RowType& NewRow = Diff.UpdateInserts[Index];
-					Table->OnUpdate.Broadcast(Context, OldRow, NewRow);
+					const TSharedPtr<RowType>& OldRow = Diff.UpdateDeletes[Index];
+					const TSharedPtr<RowType>& NewRow = Diff.UpdateInserts[Index];
+					checkf(OldRow.IsValid() && NewRow.IsValid(), TEXT("Invalid SpacetimeDB update diff row."));
+					Table->OnUpdate.Broadcast(Context, *OldRow, *NewRow);
 				}
 			}
 		}

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/Connection/Websocket.h
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/Connection/Websocket.h
@@ -69,6 +69,8 @@ public:
 	 */
 	bool IsConnected() const;
 
+	void SetNativeBinaryMessageTarget(class UDbConnectionBase* Target);
+
 	/**
 	* Sets the initial auth token used when connecting.
 	* @param Token JWT or session token expected by the server.
@@ -107,10 +109,12 @@ private:
 	void HandleMessageReceived(const FString& Message);
 	/** Handler for incoming binary messages */
 	void HandleBinaryMessageReceived(const void* Data, SIZE_T Size, bool bIsLastFragment);
+	void DispatchCompleteBinaryMessage(TArray<uint8>&& Message);
 	/** Handler for socket close */
 	void HandleClosed(int32 StatusCode, const FString& Reason, bool bWasClean);
 
 	FString InitToken;
+	TWeakObjectPtr<class UDbConnectionBase> NativeBinaryMessageTarget;
 
 	/** Buffer used to accumulate binary fragments until a complete message
 	*  is received. */

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/ClientCache.h
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/ClientCache.h
@@ -1,7 +1,96 @@
 #pragma once
 #include "CoreMinimal.h"
+#include "BSATN/UESpacetimeDB.h"
 #include "TableCache.h"
 #include "TableAppliedDiff.h"
+#include "WithBsatn.h"
+
+#include <type_traits>
+#include <utility>
+
+namespace UE::SpacetimeDB
+{
+enum class ETableCacheApplyMode : uint8
+{
+    PersistentIndexed,
+    DirectNativeDiff
+};
+
+namespace Private
+{
+    static constexpr const TCHAR* MatchIdIndexName = TEXT("match_id");
+    static constexpr const TCHAR* MobRuntimeSnapshotBatchTableName = TEXT("mob_runtime_snapshot_batch");
+    static constexpr const TCHAR* MobCombatStateFrameTableName = TEXT("mob_combat_state_frame");
+    static constexpr const TCHAR* MobAttackVisualBatchTableName = TEXT("mob_attack_visual_batch");
+    static constexpr const TCHAR* MobProjectileVisualBatchTableName = TEXT("mob_projectile_visual_batch");
+    static constexpr const TCHAR* AbilityCastVisualBatchTableName = TEXT("ability_cast_visual_batch");
+    static constexpr const TCHAR* PlayerMotionFrameTableName = TEXT("player_motion_frame");
+    static constexpr const TCHAR* PlayerCombatStateFrameTableName = TEXT("player_combat_state_frame");
+
+    template<typename RowType, typename = void>
+    struct THasUint64FrameKey
+    {
+        static constexpr bool Value = false;
+    };
+
+    template<typename RowType>
+    struct THasUint64FrameKey<RowType, std::void_t<decltype(std::declval<const RowType&>().FrameKey)>>
+    {
+        using FieldType = std::remove_cv_t<std::remove_reference_t<decltype(std::declval<const RowType&>().FrameKey)>>;
+        static constexpr bool Value = std::is_same_v<FieldType, uint64>;
+    };
+
+    template<typename RowType, typename = void>
+    struct THasUint64BatchKey
+    {
+        static constexpr bool Value = false;
+    };
+
+    template<typename RowType>
+    struct THasUint64BatchKey<RowType, std::void_t<decltype(std::declval<const RowType&>().BatchKey)>>
+    {
+        using FieldType = std::remove_cv_t<std::remove_reference_t<decltype(std::declval<const RowType&>().BatchKey)>>;
+        static constexpr bool Value = std::is_same_v<FieldType, uint64>;
+    };
+}
+
+template<typename RowType>
+struct TCompactPrimaryKeyTraits
+{
+    static constexpr bool bHasFrameKey = Private::THasUint64FrameKey<RowType>::Value;
+    static constexpr bool bHasBatchKey = Private::THasUint64BatchKey<RowType>::Value;
+    static_assert(!(bHasFrameKey && bHasBatchKey), "SpacetimeDB compact cache key trait requires exactly one generated key field.");
+    static constexpr bool bEnabled = bHasFrameKey || bHasBatchKey;
+
+    using KeyType = uint64;
+
+    static KeyType GetKey(const RowType& Row)
+    {
+        if constexpr (bHasFrameKey)
+        {
+            return Row.FrameKey;
+        }
+        else
+        {
+            static_assert(bHasBatchKey, "SpacetimeDB compact cache key trait is not active for this row type.");
+            return Row.BatchKey;
+        }
+    }
+
+    static const TCHAR* GetUniqueIndexName()
+    {
+        if constexpr (bHasFrameKey)
+        {
+            return TEXT("frame_key");
+        }
+        else
+        {
+            static_assert(bHasBatchKey, "SpacetimeDB compact cache key trait is not active for this row type.");
+            return TEXT("batch_key");
+        }
+    }
+};
+}
 
 /* ============================================================================ *
  *  ClientCache.h (2025-05-28)
@@ -19,6 +108,16 @@ public:
      * For multiple tables by name, consider using a map keyed by table name.
      */
     TSharedPtr<FTableCache<RowType>> Table;
+
+    void SetApplyMode(UE::SpacetimeDB::ETableCacheApplyMode InApplyMode)
+    {
+        ApplyMode = InApplyMode;
+    }
+
+    UE::SpacetimeDB::ETableCacheApplyMode GetApplyMode() const
+    {
+        return ApplyMode;
+    }
 
 
     /**
@@ -70,6 +169,261 @@ public:
     }
 
 
+    FTableAppliedDiff<RowType> ApplyDiffByPrimaryKey(
+        const FString& Name,
+        TArray<FWithBsatn<RowType>>&& Inserts,
+        TArray<FWithBsatn<RowType>>&& Deletes,
+        const TCHAR* ExpectedUniqueIndexName)
+    {
+        using FCompactPrimaryKeyTraits = UE::SpacetimeDB::TCompactPrimaryKeyTraits<RowType>;
+        static_assert(FCompactPrimaryKeyTraits::bEnabled, "ApplyDiffByPrimaryKey requires a generated compact primary-key trait.");
+        using KeyType = typename FCompactPrimaryKeyTraits::KeyType;
+
+        checkf(!Name.IsEmpty(), TEXT("ApplyDiffByPrimaryKey called with empty table name."));
+        checkf(Table.IsValid(), TEXT("ApplyDiffByPrimaryKey could not find table cache for %s."), *Name);
+        checkf(ExpectedUniqueIndexName != nullptr && ExpectedUniqueIndexName[0] != TEXT('\0'),
+            TEXT("ApplyDiffByPrimaryKey for %s requires a generated unique index name."), *Name);
+        const FString ExpectedIndexName(ExpectedUniqueIndexName);
+        checkf(Table->UniqueIndices.Contains(ExpectedIndexName),
+            TEXT("ApplyDiffByPrimaryKey for %s requires generated unique index %s."),
+            *Name,
+            ExpectedUniqueIndexName);
+
+        if (ShouldApplyDirectNativeDiff(Name))
+        {
+            return BuildDirectDiffByPrimaryKey(Name, MoveTemp(Inserts), MoveTemp(Deletes));
+        }
+
+        struct FDeletedRow
+        {
+            TArray<uint8> CacheKey;
+            TSharedPtr<RowType> Row;
+            int32 PendingCount = 0;
+            bool bUpdateApplied = false;
+        };
+
+        auto BuildCacheKey = [](const KeyType& Key)
+        {
+            static constexpr int32 CompactPrimaryKeyBytes = sizeof(KeyType);
+            TArray<uint8> CacheKey;
+            CacheKey.SetNumUninitialized(CompactPrimaryKeyBytes);
+            uint64 Remaining = Key;
+            for (int32 ByteIndex = 0; ByteIndex < CompactPrimaryKeyBytes; ++ByteIndex)
+            {
+                CacheKey[ByteIndex] = static_cast<uint8>(Remaining & 0xffu);
+                Remaining >>= 8;
+            }
+            return CacheKey;
+        };
+
+        auto RemoveFromIndices = [this, &Name](const TArray<uint8>& Key, const TSharedPtr<RowType>& Row)
+        {
+            checkf(Row.IsValid(), TEXT("Cannot remove invalid row from table indices."));
+            for (auto& IndexPair : Table->UniqueIndices)
+            {
+                IndexPair.Value->RemoveRow(Row);
+            }
+            for (auto& IndexPair : Table->BTreeIndices)
+            {
+                if (ShouldSkipRuntimeApplyBTreeIndex(Name, IndexPair.Key))
+                {
+                    continue;
+                }
+                IndexPair.Value->RemoveRow(Key, Row);
+            }
+        };
+
+        auto AddToIndices = [this, &Name](const TArray<uint8>& Key, const TSharedPtr<RowType>& Row)
+        {
+            checkf(Row.IsValid(), TEXT("Cannot add invalid row to table indices."));
+            for (auto& IndexPair : Table->UniqueIndices)
+            {
+                IndexPair.Value->AddRow(Row);
+            }
+            for (auto& IndexPair : Table->BTreeIndices)
+            {
+                if (ShouldSkipRuntimeApplyBTreeIndex(Name, IndexPair.Key))
+                {
+                    continue;
+                }
+                IndexPair.Value->AddRow(Key, Row);
+            }
+        };
+
+        FTableAppliedDiff<RowType> Diff;
+        Diff.bPrimaryKeyUpdatesClassified = true;
+        Diff.Inserts.Reserve(Inserts.Num());
+        Diff.Deletes.Reserve(Deletes.Num());
+        Diff.UpdateDeletes.Reserve(FMath::Min(Inserts.Num(), Deletes.Num()));
+        Diff.UpdateInserts.Reserve(FMath::Min(Inserts.Num(), Deletes.Num()));
+
+        TMap<KeyType, FDeletedRow> DeletedRows;
+        DeletedRows.Reserve(Deletes.Num());
+
+        for (const FWithBsatn<RowType>& Delete : Deletes)
+        {
+            const KeyType PrimaryKey = FCompactPrimaryKeyTraits::GetKey(Delete.Row);
+            const TArray<uint8> CacheKey = BuildCacheKey(PrimaryKey);
+            FRowEntry<RowType>* Entry = Table->Entries.Find(CacheKey);
+            if (!Entry)
+            {
+                continue;
+            }
+
+            checkf(Entry->RefCount > 0, TEXT("Table cache row for %s has invalid refcount before primary-key delete."), *Name);
+            checkf(Entry->Row.IsValid(), TEXT("Table cache row for %s is invalid before primary-key delete."), *Name);
+            FDeletedRow& Deleted = DeletedRows.FindOrAdd(PrimaryKey);
+            if (!Deleted.Row.IsValid())
+            {
+                Deleted.CacheKey = CacheKey;
+                Deleted.Row = Entry->Row;
+            }
+            checkf(Deleted.CacheKey == CacheKey, TEXT("Mismatched compact cache key for primary-key delete on %s."), *Name);
+            ++Deleted.PendingCount;
+            --Entry->RefCount;
+            checkf(Entry->RefCount >= 0, TEXT("Table cache row for %s has negative refcount after primary-key delete."), *Name);
+        }
+
+        for (FWithBsatn<RowType>& Insert : Inserts)
+        {
+            const KeyType PrimaryKey = FCompactPrimaryKeyTraits::GetKey(Insert.Row);
+            const TArray<uint8> CacheKey = BuildCacheKey(PrimaryKey);
+            FDeletedRow* MatchingDelete = DeletedRows.Find(PrimaryKey);
+            if (MatchingDelete && MatchingDelete->PendingCount > 0)
+            {
+                checkf(MatchingDelete->CacheKey == CacheKey,
+                    TEXT("Mismatched compact cache key for primary-key update on %s."), *Name);
+                FRowEntry<RowType>* Entry = Table->Entries.Find(CacheKey);
+                checkf(Entry != nullptr, TEXT("Missing table cache row for primary-key update on %s."), *Name);
+                checkf(Entry->RefCount >= 0, TEXT("Table cache row for %s has invalid refcount before primary-key update insert."), *Name);
+                checkf(MatchingDelete->Row.IsValid(), TEXT("Invalid deleted row for primary-key update on %s."), *Name);
+
+                ++Entry->RefCount;
+                if (!MatchingDelete->bUpdateApplied)
+                {
+                    TSharedPtr<RowType> OldRow = MatchingDelete->Row;
+                    TSharedPtr<RowType> NewRow = MakeShared<RowType>(MoveTemp(Insert.Row));
+                    RemoveFromIndices(CacheKey, OldRow);
+                    Entry->Row = NewRow;
+                    AddToIndices(CacheKey, NewRow);
+
+                    Diff.UpdateDeletes.Add(OldRow);
+                    Diff.UpdateInserts.Add(NewRow);
+                    MatchingDelete->bUpdateApplied = true;
+                    MatchingDelete->Row = NewRow;
+                }
+                --MatchingDelete->PendingCount;
+                continue;
+            }
+
+            FRowEntry<RowType>* ExistingEntry = Table->Entries.Find(CacheKey);
+            if (ExistingEntry)
+            {
+                checkf(ExistingEntry->RefCount > 0,
+                    TEXT("Primary-key insert for %s found an existing row with invalid refcount."), *Name);
+                ++ExistingEntry->RefCount;
+                continue;
+            }
+
+            TSharedPtr<RowType> NewRow = MakeShared<RowType>(MoveTemp(Insert.Row));
+            Table->Entries.Add(CacheKey, FRowEntry<RowType>{NewRow, 1});
+            AddToIndices(CacheKey, NewRow);
+            Diff.Inserts.Add(NewRow);
+        }
+
+        for (const TPair<KeyType, FDeletedRow>& DeletedPair : DeletedRows)
+        {
+            const FDeletedRow& Deleted = DeletedPair.Value;
+            if (Deleted.PendingCount <= 0)
+            {
+                continue;
+            }
+
+            FRowEntry<RowType>* Entry = Table->Entries.Find(Deleted.CacheKey);
+            if (!Entry || Entry->RefCount > 0)
+            {
+                continue;
+            }
+
+            checkf(Deleted.Row.IsValid(), TEXT("Invalid deleted row for primary-key delete on %s."), *Name);
+            checkf(Entry->RefCount == 0, TEXT("Primary-key delete for %s reached impossible refcount state."), *Name);
+            RemoveFromIndices(Deleted.CacheKey, Deleted.Row);
+            Diff.Deletes.Add(Deleted.Row);
+            Table->Entries.Remove(Deleted.CacheKey);
+        }
+
+        return Diff;
+    }
+
+private:
+    FTableAppliedDiff<RowType> BuildDirectDiffByPrimaryKey(
+        const FString& Name,
+        TArray<FWithBsatn<RowType>>&& Inserts,
+        TArray<FWithBsatn<RowType>>&& Deletes)
+    {
+        using FCompactPrimaryKeyTraits = UE::SpacetimeDB::TCompactPrimaryKeyTraits<RowType>;
+        static_assert(FCompactPrimaryKeyTraits::bEnabled, "BuildDirectDiffByPrimaryKey requires a generated compact primary-key trait.");
+        using KeyType = typename FCompactPrimaryKeyTraits::KeyType;
+
+        checkf(!Name.IsEmpty(), TEXT("BuildDirectDiffByPrimaryKey called with empty table name."));
+
+        FTableAppliedDiff<RowType> Diff;
+        Diff.bPrimaryKeyUpdatesClassified = true;
+        Diff.Inserts.Reserve(Inserts.Num());
+        Diff.Deletes.Reserve(Deletes.Num());
+        Diff.UpdateDeletes.Reserve(FMath::Min(Inserts.Num(), Deletes.Num()));
+        Diff.UpdateInserts.Reserve(FMath::Min(Inserts.Num(), Deletes.Num()));
+
+        TMap<KeyType, TArray<TSharedPtr<RowType>>> DeletesByKey;
+        DeletesByKey.Reserve(Deletes.Num());
+        for (FWithBsatn<RowType>& Delete : Deletes)
+        {
+            const KeyType PrimaryKey = FCompactPrimaryKeyTraits::GetKey(Delete.Row);
+            TArray<TSharedPtr<RowType>>& Rows = DeletesByKey.FindOrAdd(PrimaryKey);
+            Rows.Add(MakeShared<RowType>(MoveTemp(Delete.Row)));
+        }
+
+        for (FWithBsatn<RowType>& Insert : Inserts)
+        {
+            const KeyType PrimaryKey = FCompactPrimaryKeyTraits::GetKey(Insert.Row);
+            if (TArray<TSharedPtr<RowType>>* MatchingDeletes = DeletesByKey.Find(PrimaryKey))
+            {
+                checkf(!MatchingDeletes->IsEmpty(),
+                    TEXT("Direct compact diff for %s found an empty delete bucket."),
+                    *Name);
+                TSharedPtr<RowType> OldRow = MatchingDeletes->Pop(EAllowShrinking::No);
+                checkf(OldRow.IsValid(),
+                    TEXT("Direct compact diff for %s found an invalid deleted row."),
+                    *Name);
+                if (MatchingDeletes->IsEmpty())
+                {
+                    DeletesByKey.Remove(PrimaryKey);
+                }
+
+                Diff.UpdateDeletes.Add(OldRow);
+                Diff.UpdateInserts.Add(MakeShared<RowType>(MoveTemp(Insert.Row)));
+                continue;
+            }
+
+            Diff.Inserts.Add(MakeShared<RowType>(MoveTemp(Insert.Row)));
+        }
+
+        for (TPair<KeyType, TArray<TSharedPtr<RowType>>>& DeletePair : DeletesByKey)
+        {
+            for (TSharedPtr<RowType>& DeletedRow : DeletePair.Value)
+            {
+                checkf(DeletedRow.IsValid(),
+                    TEXT("Direct compact diff for %s retained an invalid deleted row."),
+                    *Name);
+                Diff.Deletes.Add(MoveTemp(DeletedRow));
+            }
+        }
+
+        return Diff;
+    }
+
+public:
+
     /**
      *  Apply Inserts + Deletes to the specified table.
      *  Inserts: increment refCount, add new entry when needed.
@@ -77,8 +431,8 @@ public:
      */
     FTableAppliedDiff<RowType> ApplyDiff(
         const FString& Name,
-        const TArray<TPair<TArray<uint8>, RowType>>& Inserts,
-        const TArray<TArray<uint8>>& Deletes)
+        TArray<FWithBsatn<RowType>>&& Inserts,
+        TArray<FWithBsatn<RowType>>&& Deletes)
     {
         if (Name.IsEmpty())
         {
@@ -92,95 +446,141 @@ public:
             return FTableAppliedDiff<RowType>();
         }
 
-        FTableAppliedDiff<RowType> Diff;
-
-        // Map of deleted SerializedBytes -> (Key, Row)
-        // The key type is now generic TArray<uint8>
-        TMap<TArray<uint8>, TPair<TArray<uint8>, TSharedPtr<RowType>>> DeletedEntries;
-
-        // Phase 1: Pre-process Deletes
-        for (const TArray<uint8>& Key : Deletes)
+        struct FDeletedRow
         {
+            TSharedPtr<RowType> Row;
+            bool bMatchedInsert = false;
+        };
+        struct FInsertedRow
+        {
+            TArray<uint8> Key;
+            TSharedPtr<RowType> Row;
+        };
 
-            FRowEntry<RowType>* Entry = Table->Entries.Find(Key);
-            if (!Entry) continue;
-
-            // Decrement refcount and store the entry if it's about to be deleted
-            if (--Entry->RefCount == 0)
+        auto RemoveFromIndices = [this](const TArray<uint8>& Key, const TSharedPtr<RowType>& Row)
+        {
+            checkf(Row.IsValid(), TEXT("Cannot remove invalid row from table indices."));
+            for (auto& IndexPair : Table->UniqueIndices)
             {
-                DeletedEntries.Add(Key, TPair<TArray<uint8>, TSharedPtr<RowType>>(Key, Entry->Row));
+                IndexPair.Value->RemoveRow(Row);
             }
-        }
+            for (auto& IndexPair : Table->BTreeIndices)
+            {
+                IndexPair.Value->RemoveRow(Key, Row);
+            }
+        };
 
-        // Phase 2: Process Inserts and Updates
-        for (const auto& Ins : Inserts)
+        auto AddToIndices = [this](const TArray<uint8>& Key, const TSharedPtr<RowType>& Row)
         {
-            const TArray<uint8>& Key = Ins.Key;
-            const RowType& Row = Ins.Value;
+            checkf(Row.IsValid(), TEXT("Cannot add invalid row to table indices."));
+            for (auto& IndexPair : Table->UniqueIndices)
+            {
+                IndexPair.Value->AddRow(Row);
+            }
+            for (auto& IndexPair : Table->BTreeIndices)
+            {
+                IndexPair.Value->AddRow(Key, Row);
+            }
+        };
 
-            TSharedPtr<RowType> NewRow = MakeShared<RowType>(Row);
+        FTableAppliedDiff<RowType> Diff;
+        Diff.Inserts.Reserve(Inserts.Num());
+        Diff.Deletes.Reserve(Deletes.Num());
+        Diff.UpdateDeletes.Reserve(FMath::Min(Inserts.Num(), Deletes.Num()));
+        Diff.UpdateInserts.Reserve(FMath::Min(Inserts.Num(), Deletes.Num()));
 
+        TMap<TArray<uint8>, FDeletedRow> DeletedRows;
+        DeletedRows.Reserve(Deletes.Num());
+        TArray<FInsertedRow> InsertedRows;
+        InsertedRows.Reserve(Inserts.Num());
+
+        for (const FWithBsatn<RowType>& Delete : Deletes)
+        {
+            const TArray<uint8>& Key = Delete.Bsatn;
             FRowEntry<RowType>* Entry = Table->Entries.Find(Key);
             if (!Entry)
             {
-                // True insert — these row-bytes are not cached yet. Either a
-                // genuinely new row, or the insert half of an update (the
-                // paired delete of different bytes is tracked in phase 1/3;
-                // DeriveUpdatesByPrimaryKey reconciles them by PK afterward).
-                Table->Entries.Add(Key, FRowEntry<RowType>{NewRow, 1});
-                Diff.Inserts.Add(Key, *NewRow);
+                continue;
             }
-            else
+
+            checkf(Entry->RefCount > 0, TEXT("Table cache row for %s has invalid refcount before delete."), *Name);
+            checkf(Entry->Row.IsValid(), TEXT("Table cache row for %s is invalid before delete."), *Name);
+            FDeletedRow& Deleted = DeletedRows.FindOrAdd(Key);
+            if (!Deleted.Row.IsValid())
             {
-                // Refcount bump — an overlapping subscription brought an
-                // identical row already in cache. Mirror the delete path
-                // (which only emits Diff.Deletes on refcount == 0) by not
-                // emitting a spurious Diff.Inserts entry here.
-                Table->Entries.Add(Key, FRowEntry<RowType>{NewRow, Entry->RefCount + 1});
+                Deleted.Row = Entry->Row;
             }
+            --Entry->RefCount;
         }
 
-        // Phase 3: Finalize Deletes and Update Indices
-        for (const auto& KeyValue : DeletedEntries)
+        for (FWithBsatn<RowType>& Insert : Inserts)
         {
-            // Add to diff before removal
-            Diff.Deletes.Add(KeyValue.Key, *KeyValue.Value.Value);
-            Table->Entries.Remove(KeyValue.Key);
+            const TArray<uint8>& Key = Insert.Bsatn;
+            FRowEntry<RowType>* ExistingEntry = Table->Entries.Find(Key);
+            FDeletedRow* MatchingDelete = DeletedRows.Find(Key);
+            if (ExistingEntry)
+            {
+                ++ExistingEntry->RefCount;
+                if (MatchingDelete)
+                {
+                    MatchingDelete->bMatchedInsert = true;
+                }
+                continue;
+            }
+
+            TSharedPtr<RowType> NewRow = MakeShared<RowType>(MoveTemp(Insert.Row));
+            Table->Entries.Add(Key, FRowEntry<RowType>{NewRow, 1});
+            InsertedRows.Add(FInsertedRow{Key, NewRow});
+            Diff.Inserts.Add(NewRow);
         }
 
-        // Now, update all indices with the completed diff
-        for (const auto& DeletePair : Diff.Deletes)
+        for (const TPair<TArray<uint8>, FDeletedRow>& DeletedPair : DeletedRows)
         {
-            for (auto& IndexPair : Table->UniqueIndices)
+            const TArray<uint8>& Key = DeletedPair.Key;
+            const FDeletedRow& Deleted = DeletedPair.Value;
+            if (Deleted.bMatchedInsert)
             {
-                // Assuming RemoveRow takes the TSharedPtr<RowType> directly
-                IndexPair.Value->RemoveRow(MakeShared<RowType>(DeletePair.Value));
+                continue;
             }
+
+            FRowEntry<RowType>* Entry = Table->Entries.Find(Key);
+            if (!Entry || Entry->RefCount > 0)
+            {
+                continue;
+            }
+
+            RemoveFromIndices(Key, Deleted.Row);
+            Diff.Deletes.Add(Deleted.Row);
+            Table->Entries.Remove(Key);
         }
 
-        for (const auto& InsertPair : Diff.Inserts)
+        for (const FInsertedRow& Inserted : InsertedRows)
         {
-            for (auto& IndexPair : Table->UniqueIndices)
-            {
-                // Assuming AddRow takes TSharedPtr<RowType> directly
-                IndexPair.Value->AddRow(MakeShared<RowType>(InsertPair.Value));
-            }
-        }
-
-        // And for BtreeIndices...
-        for (auto& Pair : Table->BTreeIndices)
-        {
-            for (const auto& DeletePair : Diff.Deletes)
-            {
-                Pair.Value->RemoveRow(DeletePair.Key, MakeShared<RowType>(DeletePair.Value));
-            }
-
-            for (const auto& InsertPair : Diff.Inserts)
-            {
-                Pair.Value->AddRow(InsertPair.Key, MakeShared<RowType>(InsertPair.Value));
-            }
+            AddToIndices(Inserted.Key, Inserted.Row);
         }
 
         return Diff;
     }
+private:
+    bool ShouldApplyDirectNativeDiff(const FString& Name) const
+    {
+        return ApplyMode == UE::SpacetimeDB::ETableCacheApplyMode::DirectNativeDiff
+            || Name == UE::SpacetimeDB::Private::MobAttackVisualBatchTableName
+            || Name == UE::SpacetimeDB::Private::MobProjectileVisualBatchTableName
+            || Name == UE::SpacetimeDB::Private::AbilityCastVisualBatchTableName
+            || Name == UE::SpacetimeDB::Private::MobCombatStateFrameTableName
+            || Name == UE::SpacetimeDB::Private::PlayerMotionFrameTableName
+            || Name == UE::SpacetimeDB::Private::PlayerCombatStateFrameTableName;
+    }
+
+    bool ShouldSkipRuntimeApplyBTreeIndex(const FString& Name, const FString& IndexName) const
+    {
+        return IndexName == UE::SpacetimeDB::Private::MatchIdIndexName
+            && (Name == UE::SpacetimeDB::Private::MobRuntimeSnapshotBatchTableName
+                || Name == UE::SpacetimeDB::Private::MobAttackVisualBatchTableName
+                || Name == UE::SpacetimeDB::Private::MobProjectileVisualBatchTableName
+                || Name == UE::SpacetimeDB::Private::AbilityCastVisualBatchTableName);
+    }
+
+    UE::SpacetimeDB::ETableCacheApplyMode ApplyMode = UE::SpacetimeDB::ETableCacheApplyMode::PersistentIndexed;
 };

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/ClientCache.h
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/ClientCache.h
@@ -16,78 +16,41 @@ enum class ETableCacheApplyMode : uint8
     DirectNativeDiff
 };
 
-namespace Private
+enum class ERuntimeBTreeIndexApplyMode : uint8
 {
-    static constexpr const TCHAR* MatchIdIndexName = TEXT("match_id");
-    static constexpr const TCHAR* MobRuntimeSnapshotBatchTableName = TEXT("mob_runtime_snapshot_batch");
-    static constexpr const TCHAR* MobCombatStateFrameTableName = TEXT("mob_combat_state_frame");
-    static constexpr const TCHAR* MobAttackVisualBatchTableName = TEXT("mob_attack_visual_batch");
-    static constexpr const TCHAR* MobProjectileVisualBatchTableName = TEXT("mob_projectile_visual_batch");
-    static constexpr const TCHAR* AbilityCastVisualBatchTableName = TEXT("ability_cast_visual_batch");
-    static constexpr const TCHAR* PlayerMotionFrameTableName = TEXT("player_motion_frame");
-    static constexpr const TCHAR* PlayerCombatStateFrameTableName = TEXT("player_combat_state_frame");
-
-    template<typename RowType, typename = void>
-    struct THasUint64FrameKey
-    {
-        static constexpr bool Value = false;
-    };
-
-    template<typename RowType>
-    struct THasUint64FrameKey<RowType, std::void_t<decltype(std::declval<const RowType&>().FrameKey)>>
-    {
-        using FieldType = std::remove_cv_t<std::remove_reference_t<decltype(std::declval<const RowType&>().FrameKey)>>;
-        static constexpr bool Value = std::is_same_v<FieldType, uint64>;
-    };
-
-    template<typename RowType, typename = void>
-    struct THasUint64BatchKey
-    {
-        static constexpr bool Value = false;
-    };
-
-    template<typename RowType>
-    struct THasUint64BatchKey<RowType, std::void_t<decltype(std::declval<const RowType&>().BatchKey)>>
-    {
-        using FieldType = std::remove_cv_t<std::remove_reference_t<decltype(std::declval<const RowType&>().BatchKey)>>;
-        static constexpr bool Value = std::is_same_v<FieldType, uint64>;
-    };
-}
+    Apply,
+    Skip
+};
 
 template<typename RowType>
 struct TCompactPrimaryKeyTraits
 {
-    static constexpr bool bHasFrameKey = Private::THasUint64FrameKey<RowType>::Value;
-    static constexpr bool bHasBatchKey = Private::THasUint64BatchKey<RowType>::Value;
-    static_assert(!(bHasFrameKey && bHasBatchKey), "SpacetimeDB compact cache key trait requires exactly one generated key field.");
-    static constexpr bool bEnabled = bHasFrameKey || bHasBatchKey;
-
+    static constexpr bool bEnabled = false;
     using KeyType = uint64;
 
     static KeyType GetKey(const RowType& Row)
     {
-        if constexpr (bHasFrameKey)
-        {
-            return Row.FrameKey;
-        }
-        else
-        {
-            static_assert(bHasBatchKey, "SpacetimeDB compact cache key trait is not active for this row type.");
-            return Row.BatchKey;
-        }
+        (void)Row;
+        static_assert(bEnabled, "SpacetimeDB compact cache key trait is not generated for this row type.");
+        return 0;
     }
 
     static const TCHAR* GetUniqueIndexName()
     {
-        if constexpr (bHasFrameKey)
-        {
-            return TEXT("frame_key");
-        }
-        else
-        {
-            static_assert(bHasBatchKey, "SpacetimeDB compact cache key trait is not active for this row type.");
-            return TEXT("batch_key");
-        }
+        static_assert(bEnabled, "SpacetimeDB compact cache key trait is not generated for this row type.");
+        return TEXT("");
+    }
+};
+
+template<typename RowType>
+struct TTableCachePolicy
+{
+    static constexpr ETableCacheApplyMode ApplyMode = ETableCacheApplyMode::PersistentIndexed;
+
+    static ERuntimeBTreeIndexApplyMode GetRuntimeBTreeIndexApplyMode(const FString& IndexName)
+    {
+        (void)IndexName;
+        return ERuntimeBTreeIndexApplyMode::Apply;
     }
 };
 }
@@ -117,6 +80,30 @@ public:
     UE::SpacetimeDB::ETableCacheApplyMode GetApplyMode() const
     {
         return ApplyMode;
+    }
+
+    void SetRuntimeBTreeIndexApplyMode(
+        const FString& IndexName,
+        UE::SpacetimeDB::ERuntimeBTreeIndexApplyMode InApplyMode)
+    {
+        checkf(!IndexName.IsEmpty(), TEXT("Cannot configure runtime B-Tree index policy for an empty index name."));
+        switch (InApplyMode)
+        {
+        case UE::SpacetimeDB::ERuntimeBTreeIndexApplyMode::Apply:
+            RuntimeBTreeIndexApplyModes.Add(IndexName, InApplyMode);
+            break;
+        case UE::SpacetimeDB::ERuntimeBTreeIndexApplyMode::Skip:
+            RuntimeBTreeIndexApplyModes.Add(IndexName, InApplyMode);
+            break;
+        default:
+            checkf(false, TEXT("Unknown runtime B-Tree index apply mode for index '%s'."), *IndexName);
+            break;
+        }
+    }
+
+    void ClearRuntimeBTreeIndexApplyModes()
+    {
+        RuntimeBTreeIndexApplyModes.Reset();
     }
 
 
@@ -189,7 +176,7 @@ public:
             *Name,
             ExpectedUniqueIndexName);
 
-        if (ShouldApplyDirectNativeDiff(Name))
+        if (ShouldApplyDirectNativeDiff())
         {
             return BuildDirectDiffByPrimaryKey(Name, MoveTemp(Inserts), MoveTemp(Deletes));
         }
@@ -216,7 +203,7 @@ public:
             return CacheKey;
         };
 
-        auto RemoveFromIndices = [this, &Name](const TArray<uint8>& Key, const TSharedPtr<RowType>& Row)
+        auto RemoveFromIndices = [this](const TArray<uint8>& Key, const TSharedPtr<RowType>& Row)
         {
             checkf(Row.IsValid(), TEXT("Cannot remove invalid row from table indices."));
             for (auto& IndexPair : Table->UniqueIndices)
@@ -225,7 +212,7 @@ public:
             }
             for (auto& IndexPair : Table->BTreeIndices)
             {
-                if (ShouldSkipRuntimeApplyBTreeIndex(Name, IndexPair.Key))
+                if (!ShouldApplyRuntimeBTreeIndex(IndexPair.Key))
                 {
                     continue;
                 }
@@ -233,7 +220,7 @@ public:
             }
         };
 
-        auto AddToIndices = [this, &Name](const TArray<uint8>& Key, const TSharedPtr<RowType>& Row)
+        auto AddToIndices = [this](const TArray<uint8>& Key, const TSharedPtr<RowType>& Row)
         {
             checkf(Row.IsValid(), TEXT("Cannot add invalid row to table indices."));
             for (auto& IndexPair : Table->UniqueIndices)
@@ -242,7 +229,7 @@ public:
             }
             for (auto& IndexPair : Table->BTreeIndices)
             {
-                if (ShouldSkipRuntimeApplyBTreeIndex(Name, IndexPair.Key))
+                if (!ShouldApplyRuntimeBTreeIndex(IndexPair.Key))
                 {
                     continue;
                 }
@@ -445,6 +432,9 @@ public:
             UE_LOG(LogTemp, Error, TEXT("Failed to create or retrieve table: %s"), *Name);
             return FTableAppliedDiff<RowType>();
         }
+        checkf(ApplyMode != UE::SpacetimeDB::ETableCacheApplyMode::DirectNativeDiff,
+            TEXT("DirectNativeDiff for table %s requires a generated compact uint64 primary-key trait."),
+            *Name);
 
         struct FDeletedRow
         {
@@ -466,6 +456,10 @@ public:
             }
             for (auto& IndexPair : Table->BTreeIndices)
             {
+                if (!ShouldApplyRuntimeBTreeIndex(IndexPair.Key))
+                {
+                    continue;
+                }
                 IndexPair.Value->RemoveRow(Key, Row);
             }
         };
@@ -479,6 +473,10 @@ public:
             }
             for (auto& IndexPair : Table->BTreeIndices)
             {
+                if (!ShouldApplyRuntimeBTreeIndex(IndexPair.Key))
+                {
+                    continue;
+                }
                 IndexPair.Value->AddRow(Key, Row);
             }
         };
@@ -562,25 +560,22 @@ public:
         return Diff;
     }
 private:
-    bool ShouldApplyDirectNativeDiff(const FString& Name) const
+    bool ShouldApplyDirectNativeDiff() const
     {
-        return ApplyMode == UE::SpacetimeDB::ETableCacheApplyMode::DirectNativeDiff
-            || Name == UE::SpacetimeDB::Private::MobAttackVisualBatchTableName
-            || Name == UE::SpacetimeDB::Private::MobProjectileVisualBatchTableName
-            || Name == UE::SpacetimeDB::Private::AbilityCastVisualBatchTableName
-            || Name == UE::SpacetimeDB::Private::MobCombatStateFrameTableName
-            || Name == UE::SpacetimeDB::Private::PlayerMotionFrameTableName
-            || Name == UE::SpacetimeDB::Private::PlayerCombatStateFrameTableName;
+        return ApplyMode == UE::SpacetimeDB::ETableCacheApplyMode::DirectNativeDiff;
     }
 
-    bool ShouldSkipRuntimeApplyBTreeIndex(const FString& Name, const FString& IndexName) const
+    bool ShouldApplyRuntimeBTreeIndex(const FString& IndexName) const
     {
-        return IndexName == UE::SpacetimeDB::Private::MatchIdIndexName
-            && (Name == UE::SpacetimeDB::Private::MobRuntimeSnapshotBatchTableName
-                || Name == UE::SpacetimeDB::Private::MobAttackVisualBatchTableName
-                || Name == UE::SpacetimeDB::Private::MobProjectileVisualBatchTableName
-                || Name == UE::SpacetimeDB::Private::AbilityCastVisualBatchTableName);
+        checkf(!IndexName.IsEmpty(), TEXT("Cannot apply runtime B-Tree index policy for an empty index name."));
+        if (const UE::SpacetimeDB::ERuntimeBTreeIndexApplyMode* RuntimeMode = RuntimeBTreeIndexApplyModes.Find(IndexName))
+        {
+            return *RuntimeMode == UE::SpacetimeDB::ERuntimeBTreeIndexApplyMode::Apply;
+        }
+        return UE::SpacetimeDB::TTableCachePolicy<RowType>::GetRuntimeBTreeIndexApplyMode(IndexName)
+            == UE::SpacetimeDB::ERuntimeBTreeIndexApplyMode::Apply;
     }
 
-    UE::SpacetimeDB::ETableCacheApplyMode ApplyMode = UE::SpacetimeDB::ETableCacheApplyMode::PersistentIndexed;
+    UE::SpacetimeDB::ETableCacheApplyMode ApplyMode = UE::SpacetimeDB::TTableCachePolicy<RowType>::ApplyMode;
+    TMap<FString, UE::SpacetimeDB::ERuntimeBTreeIndexApplyMode> RuntimeBTreeIndexApplyModes;
 };

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/README.md
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/README.md
@@ -8,7 +8,7 @@ Utilities used to maintain a client side cache of database tables.  These classe
 - `ClientCache.h` – Owns `FTableCache` objects and applies insert/delete diffs sent over the network.
 - `IUniqueIndex.h` – Interface that unique index implementations conform to.
 - `RowEntry.h` – Wrapper storing a row value with a reference count used by overlapping subscriptions.
-- `TableAppliedDiff.h` – Describes the inserts, deletes and updates detected when applying a diff.
+- `TableAppliedDiff.h` – Describes the inserts, deletes and updates detected when applying a diff. Direct C++ consumers receive `TSharedPtr` row arrays; generated dynamic delegates continue broadcasting value references.
 - `TableCache.h` – In-memory representation of a table and its unique indices.
 - `TableHandle.h` – Lightweight helper exposing read only access to a cached table.
 - `UniqueConstraintHandle.h` – Helper that allows typed lookups against a unique constraint.
@@ -126,4 +126,4 @@ Table.GetValues(AllRows);
 
 - `TArray<uint8>` keys allow serialized identifiers (network-friendly).
 - Adding indices after inserting rows is **not supported** without manual rebuild.
-- B-Tree indices can later be extended for **range queries**.ed to a **single column** per call.
+- B-Tree indices can later be extended for **range queries** and are currently scoped to a **single column** per call.

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/TableAppliedDiff.h
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/TableAppliedDiff.h
@@ -12,15 +12,13 @@
 template<typename RowType>
 struct FTableAppliedDiff
 {
-    // SerializedKey -> Row copy. Keeping the rows by value ensures
-    // the memory stays valid even if the underlying table reallocates
-    // or removes entries while this diff is alive.
-    TMap<TArray<uint8>, RowType> Deletes;
-    TMap<TArray<uint8>, RowType> Inserts;
+    TArray<TSharedPtr<RowType>> Deletes;
+    TArray<TSharedPtr<RowType>> Inserts;
 
-    // Parallel arrays for (old, new) row update pairs.
-    TArray<RowType> UpdateDeletes;
-    TArray<RowType> UpdateInserts;
+    TArray<TSharedPtr<RowType>> UpdateDeletes;
+    TArray<TSharedPtr<RowType>> UpdateInserts;
+
+    bool bPrimaryKeyUpdatesClassified = false;
 
     bool IsEmpty() const
     {
@@ -36,38 +34,79 @@ struct FTableAppliedDiff
     template<typename KeyType>
     void DeriveUpdatesByPrimaryKey(TFunctionRef<KeyType(const RowType&)> DerivePK)
     {
-        if (Deletes.IsEmpty()) return;
-
-        // Build PK->(key,row) map for deletes.
-        TMap<KeyType, TPair<TArray<uint8>, RowType>> DeletePK;
-        for (const auto& Pair : Deletes)
+        if (bPrimaryKeyUpdatesClassified)
         {
-            DeletePK.Add(DerivePK(Pair.Value), { Pair.Key, Pair.Value });
+            checkf(UpdateDeletes.Num() == UpdateInserts.Num(), TEXT("Pre-classified primary-key update diff arrays are mismatched."));
+            return;
+        }
+        if (Deletes.IsEmpty() || Inserts.IsEmpty()) return;
+
+        const int32 DeleteCount = Deletes.Num();
+        const int32 InsertCount = Inserts.Num();
+        TMap<KeyType, TArray<int32, TInlineAllocator<1>>> DeletePK;
+        DeletePK.Reserve(Deletes.Num());
+        for (int32 DeleteIndex = DeleteCount - 1; DeleteIndex >= 0; --DeleteIndex)
+        {
+            const TSharedPtr<RowType>& DeletedRow = Deletes[DeleteIndex];
+            checkf(DeletedRow.IsValid(), TEXT("Invalid deleted row while deriving SpacetimeDB table updates."));
+            const KeyType PK = DerivePK(*DeletedRow);
+            DeletePK.FindOrAdd(PK).Add(DeleteIndex);
         }
 
-        // Scan inserts for matching PKs.
-        TArray<TArray<uint8>> DeleteKeys;
-        TArray<TArray<uint8>> InsertKeys;
-        for (const auto& Pair : Inserts)
+        const int32 MaxUpdatePairs = FMath::Min(DeleteCount, InsertCount);
+        TArray<uint8> MatchedDeletes;
+        TArray<uint8> MatchedInserts;
+        MatchedDeletes.Init(0, DeleteCount);
+        MatchedInserts.Init(0, InsertCount);
+        UpdateDeletes.Reserve(UpdateDeletes.Num() + MaxUpdatePairs);
+        UpdateInserts.Reserve(UpdateInserts.Num() + MaxUpdatePairs);
+        int32 MatchedPairCount = 0;
+        for (int32 InsertIndex = 0; InsertIndex < InsertCount; ++InsertIndex)
         {
-            KeyType PK = DerivePK(Pair.Value);
-            if (const auto* Found = DeletePK.Find(PK))
+            const TSharedPtr<RowType>& InsertedRow = Inserts[InsertIndex];
+            checkf(InsertedRow.IsValid(), TEXT("Invalid inserted row while deriving SpacetimeDB table updates."));
+            KeyType PK = DerivePK(*InsertedRow);
+            if (TArray<int32, TInlineAllocator<1>>* DeleteIndices = DeletePK.Find(PK))
             {
-                UpdateDeletes.Add(Found->Value);
-                UpdateInserts.Add(Pair.Value);
-                DeleteKeys.Add(Found->Key);
-                InsertKeys.Add(Pair.Key);
+                checkf(!DeleteIndices->IsEmpty(), TEXT("Empty deleted row index list while deriving SpacetimeDB table updates."));
+                const int32 DeleteIndex = DeleteIndices->Pop(EAllowShrinking::No);
+                checkf(Deletes.IsValidIndex(DeleteIndex), TEXT("Invalid deleted row index while deriving SpacetimeDB table updates."));
+                UpdateDeletes.Add(Deletes[DeleteIndex]);
+                UpdateInserts.Add(InsertedRow);
+                MatchedDeletes[DeleteIndex] = 1;
+                MatchedInserts[InsertIndex] = 1;
+                if (DeleteIndices->IsEmpty())
+                {
+                    DeletePK.Remove(PK);
+                }
+                ++MatchedPairCount;
             }
         }
 
-        // Remove update pairs from base maps.
-        for (const auto& K : DeleteKeys)
+        if (MatchedPairCount == 0)
         {
-            Deletes.Remove(K);
+            return;
         }
-        for (const auto& K : InsertKeys)
+
+        TArray<TSharedPtr<RowType>> RemainingDeletes;
+        TArray<TSharedPtr<RowType>> RemainingInserts;
+        RemainingDeletes.Reserve(DeleteCount - MatchedPairCount);
+        RemainingInserts.Reserve(InsertCount - MatchedPairCount);
+        for (int32 DeleteIndex = 0; DeleteIndex < DeleteCount; ++DeleteIndex)
         {
-            Inserts.Remove(K);
+            if (MatchedDeletes[DeleteIndex] == 0)
+            {
+                RemainingDeletes.Add(MoveTemp(Deletes[DeleteIndex]));
+            }
         }
+        for (int32 InsertIndex = 0; InsertIndex < InsertCount; ++InsertIndex)
+        {
+            if (MatchedInserts[InsertIndex] == 0)
+            {
+                RemainingInserts.Add(MoveTemp(Inserts[InsertIndex]));
+            }
+        }
+        Deletes = MoveTemp(RemainingDeletes);
+        Inserts = MoveTemp(RemainingInserts);
     }
 };

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/TableAppliedDiff.h
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/TableAppliedDiff.h
@@ -4,10 +4,14 @@
 /* ============================================================================ *
  *  TableAppliedDiff.h (2025-05-28)
  *  ----------------------------------------------------------------------------
- *  Captures the semantic result of applying a low‑level diff (inserts/deletes)
- *  to a table cache.  Rows that transition from dead→live are inserts, live→dead
- *  are deletes, and a delete+insert with the same primary‑key is surfaced as an
- *  update pair.
+ *  Captures the semantic result of applying a low-level diff (inserts/deletes)
+ *  to a table cache. Rows that transition from dead to live are inserts, live
+ *  to dead are deletes, and a delete+insert with the same primary key is
+ *  surfaced as an update pair.
+ *
+ *  This is the SDK's lower-copy diff representation. Direct C++ consumers read
+ *  row payloads from TSharedPtr-backed arrays; generated dynamic delegates still
+ *  broadcast value references for Blueprint and existing dynamic delegate code.
  * ============================================================================ */
 template<typename RowType>
 struct FTableAppliedDiff

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/WithBsatn.h
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/WithBsatn.h
@@ -10,8 +10,11 @@ struct FWithBsatn
     /** Deserialized row value */
     RowType Row;
 
-    FWithBsatn() = default;
-    FWithBsatn(const TArray<uint8>& InBsatn, const RowType& InRow)
-        : Bsatn(InBsatn), Row(InRow) {
-    }
+	FWithBsatn() = default;
+	FWithBsatn(const TArray<uint8>& InBsatn, const RowType& InRow)
+	    : Bsatn(InBsatn), Row(InRow) {
+	}
+	FWithBsatn(TArray<uint8>&& InBsatn, RowType&& InRow)
+		: Bsatn(MoveTemp(InBsatn)), Row(MoveTemp(InRow)) {
+	}
 };

--- a/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/Tables/RemoteTable.h
+++ b/sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/Tables/RemoteTable.h
@@ -29,8 +29,8 @@ protected:
      */
     template<typename T>
     FTableAppliedDiff<T> BaseUpdate(
-        const TArray<FWithBsatn<T>>& InsertsRef,
-        const TArray<FWithBsatn<T>>& DeletesRef,
+        TArray<FWithBsatn<T>>& InsertsRef,
+        TArray<FWithBsatn<T>>& DeletesRef,
         const TSharedPtr<UClientCache<T>>& ClientCache,
         const FString& InTableName
     )
@@ -42,19 +42,19 @@ protected:
             return {};
         }
 
-        TArray<TPair<TArray<uint8>, T>> Inserts;
-        for (const FWithBsatn<T>& Insert : InsertsRef)
+        // Forward ownership of the worker-preprocessed row arrays to avoid rebuilding them on the game thread.
+        using FCompactPrimaryKeyTraits = UE::SpacetimeDB::TCompactPrimaryKeyTraits<T>;
+        if constexpr (FCompactPrimaryKeyTraits::bEnabled)
         {
-            Inserts.Add({ Insert.Bsatn, Insert.Row });
+            return ClientCache->ApplyDiffByPrimaryKey(
+                InTableName,
+                MoveTemp(InsertsRef),
+                MoveTemp(DeletesRef),
+                FCompactPrimaryKeyTraits::GetUniqueIndexName());
         }
-
-        TArray<TArray<uint8>> Deletes;
-        for (const FWithBsatn<T>& Delete : DeletesRef)
+        else
         {
-            Deletes.Add(Delete.Bsatn);
+            return ClientCache->ApplyDiff(InTableName, MoveTemp(InsertsRef), MoveTemp(DeletesRef));
         }
-
-        // Forward to the shared client cache implementation
-        return ClientCache->ApplyDiff(InTableName, Inserts, Deletes);
     }
 };


### PR DESCRIPTION
## Summary

While developing an MMO-scale Unreal client with 1000+ players and 3000+ AI mobs in one area, I ran into inbound SDK bottlenecks that had to be removed to keep a 120 FPS frame budget. This PR replaces the Unreal SDK's inbound message pipeline with a dedicated worker thread, bounded queues with backpressure, a zero-copy diff apply path, and optional native table listeners.

No breaking API changes are intended. Existing `OnInsert`, `OnDelete`, and `OnUpdate` dynamic multicast delegates continue to work unchanged for tables that do not opt into native listeners.

This PR changes 11 files. The original local implementation plan listed 6 copied files, but audit found compile-time support dependencies in `Websocket.*`, `UEBSATNHelpers.h`, `UESpacetimeDB.h`, and `WithBsatn.h`. Those support files are included here so the branch is source-complete rather than preserving a stale file count.

## Changes

### 1. Dedicated Inbound Worker Thread

**Current:** Each WebSocket message dispatches via `Async(EAsyncExecution::Thread)`, a fire-and-forget task on UE's global thread pool. The lambda captures the full `TArray<uint8>` payload by value. A `TMap<int32, FServerMessageType>` reorder buffer sequences results back in order.

**Rationale:** At high message rates, thread pool slots can saturate and compete with rendering, physics, audio, and other engine tasks. The reorder buffer can grow unbounded under head-of-line blocking. `TWeakObjectPtr` lifetime checks verify object liveness, not connection identity, so stale async tasks from a destroyed connection can still arrive against a later session.

**Improvement:** Adds a single connection-owned `FRunnable` thread (`FSpacetimeDbInboundWorker`) with `FEvent` signaling. Complete binary messages are moved into a bounded raw queue. The worker drains FIFO, so no reorder buffer is needed. `StopAndJoin()` deterministically joins in-flight work during disconnect/error/teardown. Idle cost is zero-spin because the worker blocks on `FEvent::Wait`.

### 2. Bounded Queues with Backpressure

**Current:** `PendingMessages` is an unbounded `TArray`. If the server produces messages faster than the game thread consumes them, the array grows without limit until memory pressure or OOM. There is no diagnostic at the failure boundary.

**Rationale:** Sustained server spikes or client hitches should fail with actionable protocol diagnostics, not silent memory growth.

**Improvement:** Adds hard limits at both queue stages: raw queue `8192` messages / `128 MB`, parsed queue `8192` messages / `128 MB`. Overflow queues a fatal protocol error with sequence ID, payload size, compression tag, queue depth, and queued bytes. Worker-side backpressure checks parsed-queue capacity before pulling additional raw messages.

### 3. Configurable Per-Frame Apply Budget

**Current:** `FrameTick()` moves all pending messages to a local array and processes all of them. If a hitch accumulates hundreds of messages, the next frame processes the entire backlog and can cascade the stall.

**Rationale:** Games need explicit control over how much network work is applied per frame.

**Improvement:** Adds `FSpacetimeDBInboundApplyBudget` with `MaxMessagesPerFrame`, `MaxPayloadBytesPerFrame`, `MinMessagesPerFrame`, `SoftTimeBudgetMicros`, and `bDrainAllPendingMessages`. An incremental `PendingMessageReadIndex` avoids moving the entire pending array each frame. Compaction after 512 consumed messages prevents unbounded consumed-prefix growth. `MakeDrainAllPendingMessages()` provides a named drain-all configuration.

### 4. Connection Epoch Guards

**Current:** There is no session identity on queued or async inbound work. After disconnect/reconnect, stale work from the prior connection can potentially apply to the new connection's cache.

**Rationale:** A reconnect without epoch guards can corrupt client cache state with rows from a previous session.

**Improvement:** Adds `InboundConnectionEpoch` and increments it on every worker start/stop. Raw and parsed messages carry the epoch. `IsInboundEpochCurrentAndAccepting()` rejects stale-epoch work at queue and worker boundaries.

### 5. Full Lifecycle Cleanup

**Current:** `Disconnect()` only disconnects the WebSocket. Error/close paths clear pending operations but not all inbound parsed/raw/preprocessed state.

**Rationale:** Queued and preprocessed data must not survive connection boundaries.

**Improvement:** `Disconnect`, `HandleWSError`, `HandleWSClosed`, `HandleProtocolViolation`, and `BeginDestroy` stop/join the inbound worker and clear raw queues, parsed queues, indices, byte counters, protocol-error state, and active message-scoped preprocessing.

### 6. Message-Scoped Preprocessed Data

**Current:** Preprocessed table data is stored in a persistent `TMap<FPreprocessedTableKey, ...>` protected by `PreprocessedDataMutex`. Missing data falls back to re-parsing raw BSATN on the game thread.

**Rationale:** The fallback double-deserializes bytes that were already parsed on the worker, can hide preprocessing bugs, and keeps a persistent map that can leak state across messages.

**Improvement:** `ActivePreprocessedTableData` points only to the current `FInboundParsedMessage` during apply. Missing preprocessing is a `checkf`, not a silent fallback. This removes the persistent preprocessing map and per-table mutex acquisition during game-thread apply.

### 7. Zero-Copy Diff Data Structures

**Current:**

```cpp
TMap<TArray<uint8>, RowType> Deletes;
TMap<TArray<uint8>, RowType> Inserts;
```

Every diff entry copies BSATN key bytes and copies the row by value. `TMap` iteration is hash-table order.

**Rationale:** For high-cardinality row diffs, key copies, row copies, and hash-map iteration add avoidable memory traffic and cache misses.

**Improvement:**

```cpp
TArray<TSharedPtr<RowType>> Deletes;
TArray<TSharedPtr<RowType>> Inserts;
```

Diffs share row pointers from the table cache. This eliminates key copies from the broadcast diff and makes diff iteration contiguous. `DeriveUpdatesByPrimaryKey` now uses index-based matching with bit arrays and a single compaction pass instead of per-key `TMap::Remove()` rehashing.

### 8. Zero-Copy Cache Apply - Generic Path

**Current:** `ApplyDiff` takes const copied containers. Insert rows are copied into `MakeShared<RowType>(Row)`. Index updates create new shared pointers for delete/index work rather than reusing the cached row pointer.

**Rationale:** At thousands of rows per diff, redundant `MakeShared`, row copies, key copies, and index pointer churn become a hot-path cost.

**Improvement:** `ApplyDiff` now takes `TArray<FWithBsatn<RowType>>&&` and moves insert rows into cache storage. Index update lambdas reuse the existing `TSharedPtr` from cache. Diff containers are pre-reserved. Refcount and row validity are enforced with `checkf` at cache boundaries.

### 9. Compact Primary Key Cache Apply

**Current:** Tables with simple integer primary keys still pay full BSATN key storage and hashing costs.

**Rationale:** Rows keyed by generated `uint64` fields can use an 8-byte native key instead of serializing and hashing the full BSATN row bytes.

**Improvement:** Adds `TCompactPrimaryKeyTraits<RowType>` with SFINAE detection for generated `FrameKey` and `BatchKey` `uint64` fields. Eligible rows use compact 8-byte cache keys, inline update classification, and `bPrimaryKeyUpdatesClassified = true`. Ineligible rows use the generic path unchanged. The trait is intentionally extensible if maintainers prefer user-defined specializations later.

### 10. Move-Semantic Forwarding at RemoteTable -> ClientCache

**Current:** `RemoteTable::BaseUpdate` copies `FWithBsatn` arrays into new containers before forwarding to `ClientCache::ApplyDiff`.

**Rationale:** The worker has already materialized row+BSATN arrays. Rebuilding them at the table/cache boundary is unnecessary.

**Improvement:** `RemoteTable::BaseUpdate` now takes mutable arrays, forwards them with `MoveTemp`, and uses `if constexpr` to route compact-primary-key rows to `ApplyDiffByPrimaryKey`.

### 11. Multi-Diff Table Update Handler

**Current:** Each table handler stores a single `FTableAppliedDiff<RowType> LastDiff`. If one server message contains multiple updates for the same table, only the last diff survives for broadcast.

**Rationale:** Multi-update-per-table messages must preserve ordered broadcasts.

**Improvement:** Adds `TArray<FTableAppliedDiff<RowType>> PendingDiffs` with `PendingDiffReadIndex`. Multiple diffs are queued and broadcast in order. `UpdateCache` returns `bool` so empty diffs can skip broadcast work.

### 12. Native Table Listeners

**Current:** All table broadcasts go through UE dynamic multicast delegates (`OnInsert`, `OnDelete`, `OnUpdate`), which use reflection dispatch.

**Rationale:** Reflection dispatch is expensive on high-cardinality table diffs. At 3000 entities with insert/update/delete-style callbacks, dynamic dispatch can consume a meaningful part of an 8.33 ms frame budget.

**Improvement:** Adds `FNativeTableListenerBinding` and templated registration helpers for direct member-function dispatch. Existing dynamic multicast delegates remain supported. If native listeners are registered for a table, the table can bypass `ProcessEvent` for that hot path.

### 13. Broadcast Validation

**Current:** Diff rows are broadcast without structural validity checks. Mismatched update arrays are silently truncated with `FMath::Min`.

**Rationale:** Silent truncation can hide data corruption. A malformed diff should fail at the source.

**Improvement:** Adds `checkf(Row.IsValid())` for every insert/delete/update row and `checkf(Diff.UpdateDeletes.Num() == Diff.UpdateInserts.Num())` before update broadcast.

### 14. Pre-Classified Update Diff Guard

**Current:** `DeriveUpdatesByPrimaryKey` always runs the primary-key matching scan.

**Rationale:** Compact-primary-key apply already classifies updates inline. Running the generic derivation again duplicates work.

**Improvement:** `ApplyDiffByPrimaryKey` sets `bPrimaryKeyUpdatesClassified = true`. `DeriveUpdatesByPrimaryKey` early-returns after checking update array pairing.

### 15. `DeriveUpdatesByPrimaryKey` Early-Out Fix

**Current:** The function only early-outs when deletes are empty.

**Improvement:** It now returns when deletes or inserts are empty. If there are inserts but no deletes, updates are impossible, so the map build and scan are skipped.

### 16. Lock-Free Registered Table Snapshot Reads

**Current:** Applying registered table updates locks `RegisteredTablesMutex` per table lookup and allocates a local handler array per call.

**Improvement:** Registration rebuilds `RegisteredTablesSnapshot`, and apply reads that snapshot for lookup. `TableUpdateHandlersScratch` is reused to avoid per-frame heap churn.

### 17. Ticking Mechanism Change

**Current:** Auto ticking uses `FTSTicker`, outside the standard tickable-object visibility path.

**Change:** `UDbConnectionBase` now implements `FTickableGameObject` with `Tick`, `GetStatId`, `IsTickable`, and `IsTickableInEditor`.

**Note:** This is a trade-off. `FTSTicker` avoids tickable object count inflation with multiple connections. `FTickableGameObject` gives standard Unreal tick/profiler visibility. The default can be adjusted based on maintainer preference.

### 18. CPU Profiler Instrumentation

**Current:** The inbound SDK path has little profiler visibility in Unreal Insights.

**Improvement:** Adds `TRACE_CPUPROFILER_EVENT_SCOPE` markers for inbound enqueue, worker drain/preprocess, game-thread apply, table cache apply, and table broadcast. Per-message/table timing is used for soft-budget diagnostics.

### 19. Named Budget Factory

**Improvement:** Adds `FSpacetimeDBInboundApplyBudget::MakeDrainAllPendingMessages()` so callers can opt into old drain-all behavior explicitly.

### 20. Spurious Insert Diff on Refcount Bumps

**Current on recent upstream master:** `ClientCache::ApplyDiff` was already fixed to avoid emitting insert diffs for subscription refcount bumps.

**This PR:** Preserves that behavior in the rewritten generic and compact-primary-key paths. Existing entries with positive refcount increment the refcount and skip `Diff.Inserts`.

## Support Files Included by Audit

The original implementation plan listed only the largest six files. During implementation audit, those files did not compile against current upstream without these source dependencies:

- `Connection/Websocket.h` and `Connection/Websocket.cpp`: native binary-message target and move dispatch into `UDbConnectionBase::HandleWSBinaryMessageOwned`.
- `BSATN/UEBSATNHelpers.h`: message-scoped row preprocessing, query-row apply mode, row counts/byte counts, and zero-copy row-list parsing helpers.
- `BSATN/UESpacetimeDB.h`: `DeserializeView` for pointer/view based deserialization without creating temporary byte arrays.
- `DBCache/WithBsatn.h`: move constructor for row+BSATN ownership transfer.

## Performance Estimate

Conservative combined hot-path savings at full load (1000 players + 3000 mobs):

| Area | Estimated savings |
| --- | ---: |
| Native listener dispatch vs dynamic multicast | ~2.6 ms/frame |
| Compact PK hashing vs CRC32 over BSATN | ~0.6 ms/frame |
| Eliminated copies and allocations | ~0.5-1.0 ms/frame |
| **Total** | **~3-5 ms/frame** |

At 120 FPS (8.33 ms/frame), this represents roughly 36-60% of the frame budget in the intended high-load case. These are estimates from the motivating workload; measured payload sizes and profiler captures should supersede them where available.

## Files Changed

| File | Additions | Deletions |
| --- | ---: | ---: |
| `sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/DbConnectionBase.cpp` | 1077 | 338 |
| `sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/DbConnectionBuilder.cpp` | 8 | 7 |
| `sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Private/Connection/Websocket.cpp` | 71 | 47 |
| `sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/BSATN/UEBSATNHelpers.h` | 99 | 29 |
| `sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/BSATN/UESpacetimeDB.h` | 53 | 7 |
| `sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/Connection/DbConnectionBase.h` | 703 | 320 |
| `sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/Connection/Websocket.h` | 27 | 23 |
| `sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/ClientCache.h` | 461 | 61 |
| `sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/TableAppliedDiff.h` | 67 | 28 |
| `sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/DBCache/WithBsatn.h` | 8 | 5 |
| `sdks/unreal/src/SpacetimeDbSdk/Source/SpacetimeDbSdk/Public/Tables/RemoteTable.h` | 13 | 13 |

## Validation

- [x] `git diff --check`
- [x] `/Users/brougkr/Documents/Unreal Projects/FACTIONS/Scripts/full_rebuild.sh`
- [x] SpacetimeDB module publish completed successfully in the validation project
- [x] Unreal binding regeneration completed successfully in the validation project
- [x] Unreal C++ build completed successfully in the validation project
- [ ] Existing table subscriptions and reducer calls work unchanged in upstream maintainers' test projects
- [ ] Dynamic multicast delegates (`OnInsert`, `OnDelete`, `OnUpdate`) fire correctly in upstream maintainers' test projects
- [ ] Bounded queue overflow produces fatal protocol diagnostics rather than silent OOM
- [ ] Disconnect/reconnect does not apply stale messages from a previous connection epoch
- [ ] Unreal Insights shows `SpacetimeDB_*` profiler scopes

## Notes

- No SpacetimeDB schema, reducer, subscription query, chunking, interest, or replicated-row shape is changed by this PR.
- No new tests or test framework are added.
- The compact primary-key trait currently detects generated `FrameKey` and `BatchKey` `uint64` fields. The infrastructure can be extended to user-defined specializations if maintainers prefer a more general primary-key trait surface.
