### PR TITLE
Fix some warnings in C#

### DIFF
--- a/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
@@ -1,6 +1,8 @@
 namespace SpacetimeDB;
 
+#if !NET5_0_OR_GREATER
 using System.Diagnostics;
+#endif
 using System.Runtime.InteropServices;
 using SpacetimeDB.BSATN;
 

--- a/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/Builtins.cs
@@ -1,10 +1,10 @@
 namespace SpacetimeDB;
 
+using System.Runtime.InteropServices;
+using SpacetimeDB.BSATN;
 #if !NET5_0_OR_GREATER
 using System.Diagnostics;
 #endif
-using System.Runtime.InteropServices;
-using SpacetimeDB.BSATN;
 
 internal static class Util
 {

--- a/crates/bindings-csharp/BSATN.Runtime/QueryBuilder.cs
+++ b/crates/bindings-csharp/BSATN.Runtime/QueryBuilder.cs
@@ -877,10 +877,14 @@ internal static class SqlFormat
 
     public static string FormatHexLiteral(string hex)
     {
+#if NET6_0_OR_GREATER
+        ArgumentNullException.ThrowIfNull(hex);
+#else
         if (hex is null)
         {
             throw new ArgumentNullException(nameof(hex));
         }
+#endif
 
         var s = hex;
         if (s.StartsWith("0x", StringComparison.OrdinalIgnoreCase))


### PR DESCRIPTION
# Description of Changes

This comes up when doing a fresh `dotnet test`, which causes `dotnet test -warnaserror` to fail in CI:
```
➜ dotnet test -warnaserror
  Determining projects to restore...
  Restored /home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/Runtime/Runtime.csproj (in 126 ms).
  Restored /home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj (in 133 ms).
  Restored /home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/BSATN.Runtime.Tests/BSATN.Runtime.Tests.csproj (in 142 ms).
  Restored /home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj (in 148 ms).
  Restored /home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/Codegen/Codegen.csproj (in 148 ms).
  Restored /home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/Codegen.Tests/Codegen.Tests.csproj (in 280 ms).
  BSATN.Codegen -> /home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/BSATN.Codegen/bin/Debug/netstandard2.0/SpacetimeDB.BSATN.Codegen.dll
  BSATN.Runtime -> /home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/BSATN.Runtime/bin/Debug/netstandard2.1/SpacetimeDB.BSATN.Runtime.dll
  Codegen -> /home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/Codegen/bin/Debug/netstandard2.0/SpacetimeDB.Codegen.dll
/home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/BSATN.Runtime/QueryBuilder.cs(880,9): error CA1510: Use 'ArgumentNullException.ThrowIfNull' instead of explicitly throwing a new exception instance (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/quality-rules/ca1510) [/home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj::TargetFramework=net8.0]
/home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/BSATN.Runtime/Builtins.cs(3,1): error IDE0005: Using directive is unnecessary. (https://learn.microsoft.com/dotnet/fundamentals/code-analysis/style-rules/ide0005) [/home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj::TargetFramework=net8.0]
  BSATN.Runtime -> /home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/BSATN.Runtime/bin/Debug/net8.0/SpacetimeDB.BSATN.Runtime.dll
  Codegen.Tests -> /home/work/SpacetimeDBPrivate/public/crates/bindings-csharp/Codegen.Tests/bin/Debug/net8.0/Codegen.Tests.dll
```

The fix is done by AI.

# API and ABI breaking changes

None. Behavior should be the same.

# Expected complexity level and risk

1

# Testing

`git  clean -fdx . && dotnet test -warnaserror` no longer fails