### PR TITLE
[C#] [Unity 6] Added logic to use either `getWasmTableEntry` or `dynCall` for C# WebGL

### DIFF
--- a/sdks/csharp/src/Plugins/WebSocket.jslib
+++ b/sdks/csharp/src/Plugins/WebSocket.jslib
@@ -1,4 +1,13 @@
 mergeInto(LibraryManager.library, {
+    $WebSocketDynCall: function(sig, ptr, args) {
+        if (typeof getWasmTableEntry !== 'undefined') {
+            getWasmTableEntry(ptr).apply(null, args);
+        } else {
+            dynCall(sig, ptr, args);
+        }
+    },
+
+    WebSocket_Init__deps: ['$WebSocketDynCall'],
     WebSocket_Init: function(openCallback, messageCallback, closeCallback, errorCallback) {
         this._webSocketManager = {
             instances: {},
@@ -54,7 +63,7 @@ mergeInto(LibraryManager.library, {
 
             socket.onopen = function() {
                 if (manager.callbacks.open) {
-                    dynCall('vi', manager.callbacks.open, [socketId]);
+                    WebSocketDynCall('vi', manager.callbacks.open, [socketId]);
                 }
             };
 
@@ -62,7 +71,7 @@ mergeInto(LibraryManager.library, {
                 if (manager.callbacks.message && event.data instanceof ArrayBuffer) {
                     var buffer = _malloc(event.data.byteLength);
                     HEAPU8.set(new Uint8Array(event.data), buffer);
-                    dynCall('viii', manager.callbacks.message, [socketId, buffer, event.data.byteLength]);
+                    WebSocketDynCall('viii', manager.callbacks.message, [socketId, buffer, event.data.byteLength]);
                     _free(buffer);
                 }
             };
@@ -72,7 +81,7 @@ mergeInto(LibraryManager.library, {
                     var reasonArray = intArrayFromString(reasonStr);
                     var reasonPtr = _malloc(reasonArray.length);
                     HEAP8.set(reasonArray, reasonPtr);
-                    dynCall('viii', manager.callbacks.close, [socketId, event.code, reasonPtr]);
+                    WebSocketDynCall('viii', manager.callbacks.close, [socketId, event.code, reasonPtr]);
                     _free(reasonPtr);
                 }
                 delete manager.instances[socketId];
@@ -80,14 +89,14 @@ mergeInto(LibraryManager.library, {
 
             socket.onerror = function(error) {
                 if (manager.callbacks.error) {
-                    dynCall('vi', manager.callbacks.error, [socketId]);
+                    WebSocketDynCall('vi', manager.callbacks.error, [socketId]);
                 }
             };
 
-            dynCall('vi', callbackPtr, [socketId]);
+            WebSocketDynCall('vi', callbackPtr, [socketId]);
         } catch (e) {
             console.error("WebSocket connection error:", e);
-            dynCall('vi', callbackPtr, [-1]);
+            WebSocketDynCall('vi', callbackPtr, [-1]);
         }
     },
 


### PR DESCRIPTION
# Description of Changes

This is a fix for #4959.

Unity 6 upgraded to a newer Emscripten version that removed the `dynCall()` library function. The SpacetimeDB C# SDK's [WebSocket.jslib](cci:7://file:///D:/Projects/ClockworkLabs/SpacetimeDB/sdks/csharp/src/Plugins/WebSocket.jslib:0:0-0:0) plugin used `dynCall()` in 6 places to invoke C# callbacks from JavaScript WebSocket events.

This PR adds a `$WebSocketDynCall` helper function that detects which API is available at runtime:
- On Unity 6+: uses `getWasmTableEntry(ptr).apply(null, args)` (direct WASM function table access)
- On Unity 2022 and earlier: uses the legacy `dynCall(sig, ptr, args)`

All `dynCall` call sites in `WebSocket.jslib` now route through this helper, ensuring we maintain backward-compatiblity.

# API and ABI breaking changes

No breaking changes. This is a backward-compatible fix that works on both older and newer Unity versions.

# Expected complexity level and risk

1. Very low risk. The change is isolated to the WebGL `jslib` plugin and uses runtime feature detection to choose the appropriate calling mechanism. Both code paths are well-tested:
   - Unity 2022.3.62f2: uses legacy `dynCall` path
   - Unity 6000.4.5f1: uses `getWasmTableEntry` path

# Testing

- [x] Create test server module with reducers and tables
- [x] Unity 2022.3.62f2 Editor: Connect and subscribe works
- [x] Unity 2022.3.62f2 WebGL Build: Connect and subscribe works
- [x] Unity 6000.4.5f1 Editor: Connect and subscribe works
- [x] Unity 6000.4.5f1 WebGL Build: Connect and subscribe works (was previously failing with `dynCall is not defined`)