### PR TITLE
Pipeline js module operations

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2303,17 +2303,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "flume"
-version = "0.11.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "da0e4dd2a88388a1f4ccc7c9ce104604dab68d9f408dc34cd45823d5a9069095"
-dependencies = [
- "futures-core",
- "futures-sink",
- "spin",
-]
-
-[[package]]
 name = "fnv"
 version = "1.0.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -8039,7 +8028,6 @@ dependencies = [
  "env_logger 0.10.2",
  "faststr",
  "flate2",
- "flume",
  "fs2",
  "fs_extra",
  "futures",
@@ -8818,9 +8806,6 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
-dependencies = [
- "lock_api",
-]
 
 [[package]]
 name = "sqllogictest"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -194,7 +194,6 @@ enum-map = "2.6.3"
 env_logger = "0.10"
 ethnum = { version = "1.5.0", features = ["serde"] }
 flate2 = "1.0.24"
-flume = { version = "0.11", default-features = false, features = ["async"] }
 foldhash = "0.2.0"
 fs-err = "2.9.0"
 fs_extra = "1.3.0"

--- a/crates/client-api/src/lib.rs
+++ b/crates/client-api/src/lib.rs
@@ -137,7 +137,7 @@ impl Host {
     pub async fn exec_sql(
         &self,
         auth: AuthCtx,
-        database: Database,
+        _database: Database,
         confirmed_read: bool,
         body: String,
     ) -> axum::response::Result<Vec<SqlStmtResult<ProductValue>>> {
@@ -146,51 +146,44 @@ impl Host {
             .await
             .map_err(|_| (StatusCode::NOT_FOUND, "module not found".to_string()))?;
 
-        let (tx_offset, durable_offset, json) = self
-            .host_controller
-            .using_database(database, self.replica_id, move |db| async move {
-                tracing::info!(sql = body);
-                let mut header = vec![];
-                let sql_start = std::time::Instant::now();
-                let sql_span = tracing::trace_span!("execute_sql", total_duration = tracing::field::Empty,);
-                let _guard = sql_span.enter();
+        tracing::info!(sql = body);
+        let mut header = vec![];
+        let sql_start = std::time::Instant::now();
+        let sql_span = tracing::trace_span!("execute_sql", total_duration = tracing::field::Empty,);
+        let _guard = sql_span.enter();
+        let db = module_host.relational_db().clone();
+        let durable_offset = db.durable_tx_offset();
 
-                let result = sql::execute::run(
-                    db.clone(),
-                    body,
-                    auth,
-                    Some(module_host.info.subscriptions.clone()),
-                    Some(module_host),
-                    &mut header,
-                )
-                .await
-                .map_err(|e| {
-                    log::warn!("{e}");
-                    (StatusCode::BAD_REQUEST, e.to_string())
-                })?;
+        let result = sql::execute::run(
+            db,
+            body,
+            auth,
+            Some(module_host.info.subscriptions.clone()),
+            Some(module_host),
+            &mut header,
+        )
+        .await
+        .map_err(|e| {
+            log::warn!("{e}");
+            (StatusCode::BAD_REQUEST, e.to_string())
+        })?;
 
-                let total_duration = sql_start.elapsed();
-                drop(_guard);
-                sql_span.record("total_duration", tracing::field::debug(total_duration));
+        let total_duration = sql_start.elapsed();
+        drop(_guard);
+        sql_span.record("total_duration", tracing::field::debug(total_duration));
 
-                let schema = header
-                    .into_iter()
-                    .map(|(col_name, col_type)| ProductTypeElement::new(col_type, Some(col_name)))
-                    .collect();
+        let schema = header
+            .into_iter()
+            .map(|(col_name, col_type)| ProductTypeElement::new(col_type, Some(col_name)))
+            .collect();
 
-                Ok::<_, (StatusCode, String)>((
-                    result.tx_offset,
-                    db.durable_tx_offset(),
-                    vec![SqlStmtResult {
-                        schema,
-                        rows: result.rows,
-                        total_duration_micros: total_duration.as_micros() as u64,
-                        stats: SqlStmtStats::from_metrics(&result.metrics),
-                    }],
-                ))
-            })
-            .await
-            .map_err(log_and_500)??;
+        let tx_offset = result.tx_offset;
+        let json = vec![SqlStmtResult {
+            schema,
+            rows: result.rows,
+            total_duration_micros: total_duration.as_micros() as u64,
+            stats: SqlStmtStats::from_metrics(&result.metrics),
+        }];
 
         if confirmed_read && let Some(mut durable_offset) = durable_offset {
             let tx_offset = tx_offset.await.map_err(|_| log_and_500("transaction aborted"))?;

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -56,7 +56,6 @@ dirs.workspace = true
 enum-as-inner.workspace = true
 enum-map.workspace = true
 flate2.workspace = true
-flume.workspace = true
 fs2.workspace = true
 futures.workspace = true
 futures-util.workspace = true

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -146,9 +146,8 @@ spacetimedb-wasm-instance-env-times = []
 test = ["spacetimedb-commitlog/test", "spacetimedb-datastore/test"]
 # Perfmaps for profiling modules
 perfmap = []
-# Disables core pinning
-no-core-pinning = []
-no-job-core-pinning = []
+# Enables core pinning.
+core-pinning = []
 
 [dev-dependencies]
 spacetimedb-lib = { path = "../lib", features = ["proptest", "test"] }

--- a/crates/core/src/client.rs
+++ b/crates/core/src/client.rs
@@ -12,7 +12,8 @@ pub mod messages;
 
 pub use client_connection::{
     ClientConfig, ClientConnection, ClientConnectionReceiver, ClientConnectionSender, ClientSendError, DataMessage,
-    MeteredDeque, MeteredReceiver, MeteredSender, Protocol, WsVersion,
+    MeteredDeque, MeteredReceiver, MeteredSender, MeteredUnboundedReceiver, MeteredUnboundedSender, Protocol,
+    WsVersion,
 };
 pub use client_connection_index::ClientActorIndex;
 pub use message_handlers::MessageHandleError;

--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -7,7 +7,7 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Instant, SystemTime};
 
-use super::messages::{OneOffQueryResponseMessage, ProcedureResultMessage};
+use super::messages::ProcedureResultMessage;
 use super::{message_handlers, ClientActorId, MessageHandleError, OutboundMessage};
 use crate::db::relational_db::RelationalDB;
 use crate::error::DBError;
@@ -17,8 +17,6 @@ use crate::host::{
     ReducerCallResult,
 };
 use crate::subscription::module_subscription_manager::BroadcastError;
-use crate::subscription::row_list_builder_pool::JsonRowListBuilderFakePool;
-use crate::util::asyncify;
 use crate::util::prometheus_handle::IntGaugeExt;
 use crate::worker_metrics::WORKER_METRICS;
 use bytes::Bytes;
@@ -965,15 +963,9 @@ impl ClientConnection {
         subscription: ws_v1::SubscribeSingle,
         timer: Instant,
     ) -> Result<Option<ExecutionMetrics>, DBError> {
-        let me = self.clone();
         self.module()
-            .on_module_thread_async("subscribe_single", async move || {
-                let host = me.module();
-                host.subscriptions()
-                    .add_single_subscription(Some(&host), me.sender, me.auth.clone(), subscription, timer, None)
-                    .await
-            })
-            .await?
+            .call_view_add_single_subscription(self.sender(), self.auth.clone(), subscription, timer)
+            .await
     }
 
     pub async fn unsubscribe(
@@ -981,13 +973,9 @@ impl ClientConnection {
         request: ws_v1::Unsubscribe,
         timer: Instant,
     ) -> Result<Option<ExecutionMetrics>, DBError> {
-        let me = self.clone();
-        asyncify(move || {
-            me.module()
-                .subscriptions()
-                .remove_single_subscription(me.sender, me.auth.clone(), request, timer)
-        })
-        .await
+        self.module()
+            .call_view_remove_single_subscription(self.sender(), self.auth.clone(), request, timer)
+            .await
     }
 
     pub async fn subscribe_v2(
@@ -995,30 +983,18 @@ impl ClientConnection {
         request: ws_v2::Subscribe,
         timer: Instant,
     ) -> Result<Option<ExecutionMetrics>, DBError> {
-        let me = self.clone();
         self.module()
-            .on_module_thread_async("subscribe_v2", async move || {
-                let host = me.module();
-                host.subscriptions()
-                    .add_v2_subscription(Some(&host), me.sender, me.auth.clone(), request, timer, None)
-                    .await
-            })
-            .await?
+            .call_view_add_v2_subscription(self.sender(), self.auth.clone(), request, timer)
+            .await
     }
     pub async fn subscribe_multi(
         &self,
         request: ws_v1::SubscribeMulti,
         timer: Instant,
     ) -> Result<Option<ExecutionMetrics>, DBError> {
-        let me = self.clone();
         self.module()
-            .on_module_thread_async("subscribe_multi", async move || {
-                let host = me.module();
-                host.subscriptions()
-                    .add_multi_subscription(Some(&host), me.sender, me.auth.clone(), request, timer, None)
-                    .await
-            })
-            .await?
+            .call_view_add_multi_subscription(self.sender(), self.auth.clone(), request, timer)
+            .await
     }
 
     pub async fn unsubscribe_multi(
@@ -1026,14 +1002,9 @@ impl ClientConnection {
         request: ws_v1::UnsubscribeMulti,
         timer: Instant,
     ) -> Result<Option<ExecutionMetrics>, DBError> {
-        let me = self.clone();
         self.module()
-            .on_module_thread("unsubscribe_multi", move || {
-                me.module()
-                    .subscriptions()
-                    .remove_multi_subscription(me.sender, me.auth.clone(), request, timer)
-            })
-            .await?
+            .call_view_remove_multi_subscription(self.sender(), self.auth.clone(), request, timer)
+            .await
     }
 
     pub async fn unsubscribe_v2(
@@ -1041,27 +1012,16 @@ impl ClientConnection {
         request: ws_v2::Unsubscribe,
         timer: Instant,
     ) -> Result<Option<ExecutionMetrics>, DBError> {
-        let me = self.clone();
         self.module()
-            .on_module_thread_async("unsubscribe_v2", async move || {
-                let host = me.module();
-                host.subscriptions()
-                    .remove_v2_subscription(Some(&host), me.sender, me.auth.clone(), request, timer)
-                    .await
-            })
-            .await?
+            .call_view_remove_v2_subscription(self.sender(), self.auth.clone(), request, timer)
+            .await
     }
 
     pub async fn subscribe(&self, subscription: ws_v1::Subscribe, timer: Instant) -> Result<ExecutionMetrics, DBError> {
-        let me = self.clone();
         self.module()
-            .on_module_thread_async("subscribe", async move || {
-                let host = me.module();
-                host.subscriptions()
-                    .add_legacy_subscriber(Some(&host), me.sender, me.auth.clone(), subscription, timer, None)
-                    .await
-            })
-            .await?
+            .call_view_add_legacy_subscription(self.sender(), self.auth.clone(), subscription, timer)
+            .await
+            .map(|metrics| metrics.unwrap_or_default())
     }
 
     pub async fn one_off_query_json(
@@ -1071,14 +1031,12 @@ impl ClientConnection {
         timer: Instant,
     ) -> Result<(), anyhow::Error> {
         self.module()
-            .one_off_query::<ws_v1::JsonFormat>(
+            .one_off_query_json(
                 self.auth.clone(),
                 query.to_owned(),
                 self.sender.clone(),
                 message_id.to_owned(),
                 timer,
-                JsonRowListBuilderFakePool,
-                |msg: OneOffQueryResponseMessage<ws_v1::JsonFormat>| msg.into(),
             )
             .await
     }
@@ -1091,14 +1049,13 @@ impl ClientConnection {
     ) -> Result<(), anyhow::Error> {
         let bsatn_rlb_pool = self.module().replica_ctx().subscriptions.bsatn_rlb_pool.clone();
         self.module()
-            .one_off_query::<ws_v1::BsatnFormat>(
+            .one_off_query_bsatn(
                 self.auth.clone(),
                 query.to_owned(),
                 self.sender.clone(),
                 message_id.to_owned(),
                 timer,
                 bsatn_rlb_pool,
-                |msg: OneOffQueryResponseMessage<ws_v1::BsatnFormat>| msg.into(),
             )
             .await
     }

--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -680,7 +680,9 @@ impl<T> MeteredUnboundedReceiver<T> {
 
     pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
         let poll = self.inner.poll_recv(cx);
-        if let Poll::Ready(Some(_)) = poll && let Some(gauge) = &self.gauge {
+        if let Poll::Ready(Some(_)) = poll
+            && let Some(gauge) = &self.gauge
+        {
             gauge.dec()
         }
         poll

--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -679,13 +679,11 @@ impl<T> MeteredUnboundedReceiver<T> {
     }
 
     pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
-        self.inner.poll_recv(cx).map(|maybe_item| {
-            maybe_item.inspect(|_| {
-                if let Some(gauge) = &self.gauge {
-                    gauge.dec()
-                }
-            })
-        })
+        let poll = self.inner.poll_recv(cx);
+        if let Poll::Ready(Some(_)) = poll && let Some(gauge) = &self.gauge {
+            gauge.dec()
+        }
+        poll
     }
 
     pub fn len(&self) -> usize {

--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -7,15 +7,11 @@ use std::sync::Arc;
 use std::task::{Context, Poll};
 use std::time::{Instant, SystemTime};
 
-use super::messages::ProcedureResultMessage;
 use super::{message_handlers, ClientActorId, MessageHandleError, OutboundMessage};
 use crate::db::relational_db::RelationalDB;
 use crate::error::DBError;
-use crate::host::module_host::ClientConnectedError;
-use crate::host::{
-    CallProcedureReturn, FunctionArgs, ModuleHost, NoSuchModule, ProcedureCallResult, ReducerCallError,
-    ReducerCallResult,
-};
+use crate::host::module_host::{ClientConnectedError, ProcedureResultTarget};
+use crate::host::{FunctionArgs, ModuleHost, NoSuchModule, ReducerCallError};
 use crate::subscription::module_subscription_manager::BroadcastError;
 use crate::util::prometheus_handle::IntGaugeExt;
 use crate::worker_metrics::WORKER_METRICS;
@@ -29,7 +25,7 @@ use spacetimedb_client_api_messages::websocket::{common as ws_common, v1 as ws_v
 use spacetimedb_durability::{DurableOffset, TxOffset};
 use spacetimedb_lib::identity::{AuthCtx, RequestId};
 use spacetimedb_lib::metrics::ExecutionMetrics;
-use spacetimedb_lib::{bsatn, Identity, TimeDuration, Timestamp};
+use spacetimedb_lib::Identity;
 use tokio::sync::mpsc::error::{SendError, TrySendError};
 use tokio::sync::{mpsc, oneshot, watch};
 use tokio::task::AbortHandle;
@@ -839,7 +835,7 @@ impl ClientConnection {
         request_id: RequestId,
         timer: Instant,
         flags: ws_v1::CallReducerFlags,
-    ) -> Result<ReducerCallResult, ReducerCallError> {
+    ) -> Result<crate::host::ReducerCallResult, ReducerCallError> {
         let caller = match flags {
             ws_v1::CallReducerFlags::FullUpdate => Some(self.sender()),
             // Setting `sender = None` causes `eval_updates` to skip sending to the caller
@@ -867,9 +863,56 @@ impl ClientConnection {
         request_id: RequestId,
         timer: Instant,
         _flags: ws_v2::CallReducerFlags,
-    ) -> Result<ReducerCallResult, ReducerCallError> {
+    ) -> Result<crate::host::ReducerCallResult, ReducerCallError> {
         self.module()
             .call_reducer(
+                self.id.identity,
+                Some(self.id.connection_id),
+                Some(self.sender()),
+                Some(request_id),
+                Some(timer),
+                reducer,
+                FunctionArgs::Bsatn(args),
+            )
+            .await
+    }
+
+    pub async fn enqueue_reducer(
+        &self,
+        reducer: &str,
+        args: FunctionArgs,
+        request_id: RequestId,
+        timer: Instant,
+        flags: ws_v1::CallReducerFlags,
+    ) -> Result<(), ReducerCallError> {
+        let caller = match flags {
+            ws_v1::CallReducerFlags::FullUpdate => Some(self.sender()),
+            ws_v1::CallReducerFlags::NoSuccessNotify => None,
+        };
+
+        self.module()
+            .enqueue_reducer(
+                self.id.identity,
+                Some(self.id.connection_id),
+                caller,
+                Some(request_id),
+                Some(timer),
+                reducer,
+                args,
+            )
+            .await
+    }
+
+    pub async fn enqueue_reducer_v2(
+        &self,
+        reducer: &str,
+        args: Bytes,
+        request_id: RequestId,
+        timer: Instant,
+        _flags: ws_v2::CallReducerFlags,
+    ) -> Result<(), ReducerCallError> {
+        self.module()
+            .enqueue_reducer(
                 self.id.identity,
                 Some(self.id.connection_id),
                 Some(self.sender()),
@@ -888,22 +931,16 @@ impl ClientConnection {
         request_id: RequestId,
         timer: Instant,
     ) -> Result<(), BroadcastError> {
-        let CallProcedureReturn { result, tx_offset } = self
-            .module()
-            .call_procedure(
+        self.module()
+            .enqueue_procedure(
                 self.id.identity,
                 Some(self.id.connection_id),
                 Some(timer),
                 procedure,
                 args,
+                ProcedureResultTarget::new(self.sender(), request_id),
             )
-            .await;
-
-        let message = ProcedureResultMessage::from_result(&result, request_id);
-
-        self.module()
-            .subscriptions()
-            .send_procedure_message(self.sender(), message, tx_offset)
+            .await
     }
 
     pub async fn call_procedure_v2(
@@ -914,48 +951,16 @@ impl ClientConnection {
         timer: Instant,
         _flags: ws_v2::CallProcedureFlags,
     ) -> Result<(), BroadcastError> {
-        let CallProcedureReturn { result, tx_offset } = self
-            .module()
-            .call_procedure(
+        self.module()
+            .enqueue_procedure(
                 self.id.identity,
                 Some(self.id.connection_id),
                 Some(timer),
                 procedure,
                 FunctionArgs::Bsatn(args),
+                ProcedureResultTarget::new(self.sender(), request_id),
             )
-            .await;
-
-        let (status, timestamp, execution_duration) = match result {
-            Ok(ProcedureCallResult {
-                return_val,
-                execution_duration,
-                start_timestamp,
-            }) => (
-                ws_v2::ProcedureStatus::Returned(
-                    bsatn::to_vec(&return_val)
-                        .expect("Procedure return value failed to serialize to BSATN")
-                        .into(),
-                ),
-                start_timestamp,
-                TimeDuration::from(execution_duration),
-            ),
-            Err(err) => (
-                ws_v2::ProcedureStatus::InternalError(err.to_string().into()),
-                Timestamp::UNIX_EPOCH,
-                TimeDuration::ZERO,
-            ),
-        };
-
-        let message = ws_v2::ProcedureResult {
-            status,
-            timestamp,
-            total_host_execution_duration: execution_duration,
-            request_id,
-        };
-
-        self.module()
-            .subscriptions()
-            .send_procedure_message_v2(self.sender(), message, tx_offset)
+            .await
     }
 
     pub async fn subscribe_single(

--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -873,13 +873,26 @@ impl ClientConnection {
         replica_id: u64,
         module_rx: watch::Receiver<ModuleHost>,
     ) -> Self {
+        Self::dummy_with_receiver(id, config, replica_id, module_rx).0
+    }
+
+    pub fn dummy_with_receiver(
+        id: ClientActorId,
+        config: ClientConfig,
+        replica_id: u64,
+        module_rx: watch::Receiver<ModuleHost>,
+    ) -> (Self, ClientConnectionReceiver) {
         let auth = AuthCtx::new(module_rx.borrow().database_info().database_identity, id.identity);
-        Self {
-            sender: Arc::new(ClientConnectionSender::dummy(id, config, module_rx.clone())),
-            replica_id,
-            module_rx,
-            auth,
-        }
+        let (sender, receiver) = ClientConnectionSender::dummy_with_channel(id, config, module_rx.clone());
+        (
+            Self {
+                sender: Arc::new(sender),
+                replica_id,
+                module_rx,
+                auth,
+            },
+            receiver,
+        )
     }
 
     pub fn sender(&self) -> Arc<ClientConnectionSender> {

--- a/crates/core/src/client/client_connection.rs
+++ b/crates/core/src/client/client_connection.rs
@@ -647,6 +647,110 @@ impl<T> MeteredSender<T> {
     }
 }
 
+/// Wraps the receiving end of an unbounded channel with a gauge for tracking the size of the channel.
+/// We subtract the size of the channel from the gauge on drop to avoid leaking the metric.
+pub struct MeteredUnboundedReceiver<T> {
+    inner: mpsc::UnboundedReceiver<T>,
+    gauge: Option<IntGauge>,
+}
+
+impl<T> MeteredUnboundedReceiver<T> {
+    pub fn new(inner: mpsc::UnboundedReceiver<T>) -> Self {
+        Self { inner, gauge: None }
+    }
+
+    pub fn with_gauge(inner: mpsc::UnboundedReceiver<T>, gauge: IntGauge) -> Self {
+        Self {
+            inner,
+            gauge: Some(gauge),
+        }
+    }
+
+    pub async fn recv(&mut self) -> Option<T> {
+        poll_fn(|cx| self.poll_recv(cx)).await
+    }
+
+    pub fn blocking_recv(&mut self) -> Option<T> {
+        self.inner.blocking_recv().inspect(|_| {
+            if let Some(gauge) = &self.gauge {
+                gauge.dec();
+            }
+        })
+    }
+
+    pub fn poll_recv(&mut self, cx: &mut Context<'_>) -> Poll<Option<T>> {
+        self.inner.poll_recv(cx).map(|maybe_item| {
+            maybe_item.inspect(|_| {
+                if let Some(gauge) = &self.gauge {
+                    gauge.dec()
+                }
+            })
+        })
+    }
+
+    pub fn len(&self) -> usize {
+        self.inner.len()
+    }
+
+    pub fn is_empty(&self) -> bool {
+        self.inner.is_empty()
+    }
+
+    pub fn close(&mut self) {
+        self.inner.close();
+    }
+}
+
+impl<T> Drop for MeteredUnboundedReceiver<T> {
+    fn drop(&mut self) {
+        // Record the number of elements still in the channel on drop
+        if let Some(gauge) = &self.gauge {
+            gauge.sub(self.inner.len() as _);
+        }
+    }
+}
+
+/// Wraps the transmitting end of an unbounded channel with a gauge for tracking the size of the channel.
+pub struct MeteredUnboundedSender<T> {
+    inner: mpsc::UnboundedSender<T>,
+    gauge: Option<IntGauge>,
+}
+
+impl<T> Clone for MeteredUnboundedSender<T> {
+    fn clone(&self) -> Self {
+        Self {
+            inner: self.inner.clone(),
+            gauge: self.gauge.clone(),
+        }
+    }
+}
+
+impl<T> MeteredUnboundedSender<T> {
+    pub fn new(inner: mpsc::UnboundedSender<T>) -> Self {
+        Self { inner, gauge: None }
+    }
+
+    pub fn with_gauge(inner: mpsc::UnboundedSender<T>, gauge: IntGauge) -> Self {
+        Self {
+            inner,
+            gauge: Some(gauge),
+        }
+    }
+
+    pub fn send(&self, value: T) -> Result<(), SendError<T>> {
+        if let Some(gauge) = &self.gauge {
+            gauge.inc();
+        }
+        if let Err(err) = self.inner.send(value) {
+            if let Some(gauge) = &self.gauge {
+                gauge.dec();
+            }
+            return Err(err);
+        }
+        Ok(())
+    }
+}
+
 // if a client racks up this many messages in the queue without ACK'ing
 // anything, we boot 'em.
 const CLIENT_CHANNEL_CAPACITY: usize = 16 * KB;

--- a/crates/core/src/client/message_handlers_v1.rs
+++ b/crates/core/src/client/message_handlers_v1.rs
@@ -4,9 +4,7 @@ use crate::energy::EnergyQuanta;
 use crate::host::module_host::{EventStatus, ModuleEvent, ModuleFunctionCall};
 use crate::host::{FunctionArgs, ReducerId};
 use crate::identity::Identity;
-use crate::worker_metrics::WORKER_METRICS;
 use spacetimedb_client_api_messages::websocket::v1 as ws_v1;
-use spacetimedb_datastore::execution_context::WorkloadType;
 use spacetimedb_lib::de::serde::DeserializeWrapper;
 use spacetimedb_lib::identity::RequestId;
 use spacetimedb_lib::{bsatn, ConnectionId, Timestamp};
@@ -38,18 +36,6 @@ pub async fn handle(client: &ClientConnection, message: DataMessage, timer: Inst
 
     let module = client.module();
     let mod_info = module.info();
-    let mod_metrics = &mod_info.metrics;
-    let database_identity = mod_info.database_identity;
-    let db = module.relational_db();
-    let record_metrics = |wl| {
-        move |metrics| {
-            if let Some(metrics) = metrics {
-                db.exec_counters_for(wl).record(&metrics);
-            }
-        }
-    };
-    let sub_metrics = record_metrics(WorkloadType::Subscribe);
-    let unsub_metrics = record_metrics(WorkloadType::Unsubscribe);
 
     type HandleResult<'a> = Result<(), (Option<&'a RawIdentifier>, Option<ReducerId>, anyhow::Error)>;
     let res: HandleResult<'_> = match message {
@@ -59,12 +45,8 @@ pub async fn handle(client: &ClientConnection, message: DataMessage, timer: Inst
             request_id,
             flags,
         }) => {
-            let res = client.call_reducer(reducer, args, request_id, timer, flags).await;
-            WORKER_METRICS
-                .request_round_trip
-                .with_label_values(&WorkloadType::Reducer, &database_identity, reducer)
-                .observe(timer.elapsed().as_secs_f64());
-            res.map(drop).map_err(|e| {
+            let res = client.enqueue_reducer(reducer, args, request_id, timer, flags).await;
+            res.map_err(|e| {
                 (
                     Some(reducer),
                     mod_info.module_def.reducer_full(&**reducer).map(|(id, _)| id),
@@ -73,39 +55,24 @@ pub async fn handle(client: &ClientConnection, message: DataMessage, timer: Inst
             })
         }
         ws_v1::ClientMessage::SubscribeMulti(subscription) => {
-            let res = client.subscribe_multi(subscription, timer).await.map(sub_metrics);
-            mod_metrics
-                .request_round_trip_subscribe
-                .observe(timer.elapsed().as_secs_f64());
-            res.map_err(|e| (None, None, e.into()))
+            let res = client.subscribe_multi(subscription, timer).await;
+            res.map(drop).map_err(|e| (None, None, e.into()))
         }
         ws_v1::ClientMessage::UnsubscribeMulti(request) => {
-            let res = client.unsubscribe_multi(request, timer).await.map(unsub_metrics);
-            mod_metrics
-                .request_round_trip_unsubscribe
-                .observe(timer.elapsed().as_secs_f64());
-            res.map_err(|e| (None, None, e.into()))
+            let res = client.unsubscribe_multi(request, timer).await;
+            res.map(drop).map_err(|e| (None, None, e.into()))
         }
         ws_v1::ClientMessage::SubscribeSingle(subscription) => {
-            let res = client.subscribe_single(subscription, timer).await.map(sub_metrics);
-            mod_metrics
-                .request_round_trip_subscribe
-                .observe(timer.elapsed().as_secs_f64());
-            res.map_err(|e| (None, None, e.into()))
+            let res = client.subscribe_single(subscription, timer).await;
+            res.map(drop).map_err(|e| (None, None, e.into()))
         }
         ws_v1::ClientMessage::Unsubscribe(request) => {
-            let res = client.unsubscribe(request, timer).await.map(unsub_metrics);
-            mod_metrics
-                .request_round_trip_unsubscribe
-                .observe(timer.elapsed().as_secs_f64());
-            res.map_err(|e| (None, None, e.into()))
+            let res = client.unsubscribe(request, timer).await;
+            res.map(drop).map_err(|e| (None, None, e.into()))
         }
         ws_v1::ClientMessage::Subscribe(subscription) => {
-            let res = client.subscribe(subscription, timer).await.map(Some).map(sub_metrics);
-            mod_metrics
-                .request_round_trip_subscribe
-                .observe(timer.elapsed().as_secs_f64());
-            res.map_err(|e| (None, None, e.into()))
+            let res = client.subscribe(subscription, timer).await;
+            res.map(drop).map_err(|e| (None, None, e.into()))
         }
         ws_v1::ClientMessage::OneOffQuery(ws_v1::OneOffQuery {
             query_string: query,
@@ -115,9 +82,6 @@ pub async fn handle(client: &ClientConnection, message: DataMessage, timer: Inst
                 Protocol::Binary => client.one_off_query_bsatn(&query, &message_id, timer).await,
                 Protocol::Text => client.one_off_query_json(&query, &message_id, timer).await,
             };
-            mod_metrics
-                .request_round_trip_sql
-                .observe(timer.elapsed().as_secs_f64());
             res.map_err(|err| (None, None, err))
         }
         ws_v1::ClientMessage::CallProcedure(ws_v1::CallProcedure {
@@ -127,10 +91,6 @@ pub async fn handle(client: &ClientConnection, message: DataMessage, timer: Inst
             flags: _,
         }) => {
             let res = client.call_procedure(procedure, args, request_id, timer).await;
-            WORKER_METRICS
-                .request_round_trip
-                .with_label_values(&WorkloadType::Procedure, &database_identity, procedure)
-                .observe(timer.elapsed().as_secs_f64());
             if let Err(e) = res {
                 log::warn!("Procedure call failed: {e:#}");
             }

--- a/crates/core/src/client/message_handlers_v2.rs
+++ b/crates/core/src/client/message_handlers_v2.rs
@@ -1,10 +1,8 @@
 use crate::client::MessageExecutionError;
 
 use super::{ClientConnection, DataMessage, MessageHandleError};
-use crate::worker_metrics::WORKER_METRICS;
 use serde::de::Error as _;
 use spacetimedb_client_api_messages::websocket::v2 as ws_v2;
-use spacetimedb_datastore::execution_context::WorkloadType;
 use spacetimedb_lib::{bsatn, Timestamp};
 use spacetimedb_primitives::ReducerId;
 use spacetimedb_sats::raw_identifier::RawIdentifier;
@@ -28,44 +26,21 @@ pub(super) async fn handle_decoded_message(
     message: ws_v2::ClientMessage,
     timer: Instant,
 ) -> Result<(), MessageHandleError> {
-    let module = client.module();
-    let mod_info = module.info();
-    let mod_metrics = &mod_info.metrics;
-    let database_identity = mod_info.database_identity;
-    let db = module.relational_db();
-    let record_metrics = |wl| {
-        move |metrics| {
-            if let Some(metrics) = metrics {
-                db.exec_counters_for(wl).record(&metrics);
-            }
-        }
-    };
-    let sub_metrics = record_metrics(WorkloadType::Subscribe);
-    let unsub_metrics = record_metrics(WorkloadType::Unsubscribe);
     type HandleResult<'a> = Result<(), (Option<&'a RawIdentifier>, Option<ReducerId>, anyhow::Error)>;
     let res: HandleResult<'_> = match message {
         ws_v2::ClientMessage::Subscribe(subscribe) => {
-            let res = client.subscribe_v2(subscribe, timer).await.map(sub_metrics);
-            mod_metrics
-                .request_round_trip_subscribe
-                .observe(timer.elapsed().as_secs_f64());
-            res.map_err(|e| (None, None, e.into()))
+            let res = client.subscribe_v2(subscribe, timer).await;
+            res.map(drop).map_err(|e| (None, None, e.into()))
         }
         ws_v2::ClientMessage::Unsubscribe(unsubscribe) => {
-            let res = client.unsubscribe_v2(unsubscribe, timer).await.map(unsub_metrics);
-            mod_metrics
-                .request_round_trip_unsubscribe
-                .observe(timer.elapsed().as_secs_f64());
-            res.map_err(|e| (None, None, e.into()))
+            let res = client.unsubscribe_v2(unsubscribe, timer).await;
+            res.map(drop).map_err(|e| (None, None, e.into()))
         }
         ws_v2::ClientMessage::OneOffQuery(ws_v2::OneOffQuery {
             request_id,
             query_string,
         }) => {
             let res = client.one_off_query_v2(&query_string, request_id, timer).await;
-            mod_metrics
-                .request_round_trip_sql
-                .observe(timer.elapsed().as_secs_f64());
             res.map_err(|err| (None, None, err))
         }
         ws_v2::ClientMessage::CallReducer(ws_v2::CallReducer {
@@ -74,11 +49,7 @@ pub(super) async fn handle_decoded_message(
             request_id,
             flags,
         }) => {
-            let res = client.call_reducer_v2(reducer, args, request_id, timer, flags).await;
-            WORKER_METRICS
-                .request_round_trip
-                .with_label_values(&WorkloadType::Reducer, &database_identity, reducer)
-                .observe(timer.elapsed().as_secs_f64());
+            let res = client.enqueue_reducer_v2(reducer, args, request_id, timer, flags).await;
             match res {
                 Ok(_) => {
                     // If this was not a success, we would have already sent an error message.
@@ -109,10 +80,6 @@ pub(super) async fn handle_decoded_message(
             let res = client
                 .call_procedure_v2(procedure, args, request_id, timer, flags)
                 .await;
-            WORKER_METRICS
-                .request_round_trip
-                .with_label_values(&WorkloadType::Procedure, &database_identity, procedure)
-                .observe(timer.elapsed().as_secs_f64());
             if let Err(e) = res {
                 log::warn!("Procedure call failed: {e:#}");
             }

--- a/crates/core/src/config.rs
+++ b/crates/core/src/config.rs
@@ -1,3 +1,4 @@
+use std::num::NonZeroUsize;
 use std::path::Path;
 use std::time::Duration;
 use std::{fmt, io};
@@ -132,15 +133,41 @@ impl fmt::Display for MetadataFile {
     }
 }
 
+#[derive(Default)]
+pub struct ConfigFile {
+    pub certificate_authority: Option<CertificateAuthority>,
+    pub logs: LogConfig,
+    pub v8: V8Config,
+}
+
 #[derive(serde::Deserialize, Default)]
 #[serde(rename_all = "kebab-case")]
-pub struct ConfigFile {
+struct ConfigFileToml {
     #[serde(default)]
-    pub certificate_authority: Option<CertificateAuthority>,
+    certificate_authority: Option<CertificateAuthority>,
     #[serde(default)]
-    pub logs: LogConfig,
+    logs: LogConfig,
     #[serde(default)]
-    pub v8_heap_policy: V8HeapPolicyConfig,
+    v8: V8ConfigToml,
+    #[serde(default)]
+    v8_heap_policy: V8HeapPolicyConfig,
+}
+
+impl<'de> serde::Deserialize<'de> for ConfigFile {
+    fn deserialize<D>(deserializer: D) -> Result<Self, D::Error>
+    where
+        D: serde::Deserializer<'de>,
+    {
+        let config = ConfigFileToml::deserialize(deserializer)?;
+        Ok(Self {
+            certificate_authority: config.certificate_authority,
+            logs: config.logs,
+            v8: V8Config {
+                procedure_instance_pool_size: config.v8.procedure_instance_pool_size,
+                heap_policy: config.v8_heap_policy,
+            },
+        })
+    }
 }
 
 impl ConfigFile {
@@ -177,6 +204,46 @@ pub struct LogConfig {
     pub level: Option<tracing_core::LevelFilter>,
     #[serde(default)]
     pub directives: Vec<String>,
+}
+
+#[derive(Clone, Copy, Debug)]
+pub struct V8Config {
+    pub procedure_instance_pool_size: NonZeroUsize,
+    pub heap_policy: V8HeapPolicyConfig,
+}
+
+impl Default for V8Config {
+    fn default() -> Self {
+        Self {
+            procedure_instance_pool_size: default_v8_procedure_instance_pool_size(),
+            heap_policy: V8HeapPolicyConfig::default(),
+        }
+    }
+}
+
+impl V8Config {
+    pub fn normalized(mut self) -> Self {
+        self.heap_policy = self.heap_policy.normalized();
+        self
+    }
+}
+
+#[derive(Clone, Copy, Debug, serde::Deserialize)]
+#[serde(rename_all = "kebab-case")]
+struct V8ConfigToml {
+    #[serde(
+        default = "default_v8_procedure_instance_pool_size",
+        deserialize_with = "de_nz_usize"
+    )]
+    pub procedure_instance_pool_size: NonZeroUsize,
+}
+
+impl Default for V8ConfigToml {
+    fn default() -> Self {
+        Self {
+            procedure_instance_pool_size: default_v8_procedure_instance_pool_size(),
+        }
+    }
 }
 
 #[derive(Clone, Copy, Debug, serde::Deserialize)]
@@ -250,6 +317,18 @@ fn def_retire() -> f64 {
 fn def_heap_limit() -> usize {
     // 1 GiB
     1024 * 1024 * 1024
+}
+
+fn default_v8_procedure_instance_pool_size() -> NonZeroUsize {
+    std::thread::available_parallelism().unwrap_or_else(|_| NonZeroUsize::new(1).unwrap())
+}
+
+fn de_nz_usize<'de, D>(deserializer: D) -> Result<NonZeroUsize, D::Error>
+where
+    D: serde::Deserializer<'de>,
+{
+    let value = usize::deserialize(deserializer)?;
+    NonZeroUsize::new(value).ok_or_else(|| serde::de::Error::custom("value must be greater than 0"))
 }
 
 fn de_nz_u64<'de, D>(deserializer: D) -> Result<Option<u64>, D::Error>
@@ -442,19 +521,26 @@ mod tests {
     fn v8_heap_policy_defaults_when_omitted() {
         let config: ConfigFile = toml::from_str("").unwrap();
 
-        assert_eq!(config.v8_heap_policy.heap_check_request_interval, Some(4_096));
         assert_eq!(
-            config.v8_heap_policy.heap_check_time_interval,
+            config.v8.procedure_instance_pool_size,
+            default_v8_procedure_instance_pool_size()
+        );
+        assert_eq!(config.v8.heap_policy.heap_check_request_interval, Some(4_096));
+        assert_eq!(
+            config.v8.heap_policy.heap_check_time_interval,
             Some(Duration::from_secs(5))
         );
-        assert_eq!(config.v8_heap_policy.heap_gc_trigger_fraction, 0.67);
-        assert_eq!(config.v8_heap_policy.heap_retire_fraction, 0.75);
-        assert_eq!(config.v8_heap_policy.heap_limit_bytes, 1024 * 1024 * 1024);
+        assert_eq!(config.v8.heap_policy.heap_gc_trigger_fraction, 0.67);
+        assert_eq!(config.v8.heap_policy.heap_retire_fraction, 0.75);
+        assert_eq!(config.v8.heap_policy.heap_limit_bytes, 1024 * 1024 * 1024);
     }
 
     #[test]
     fn v8_heap_policy_parses_from_toml() {
         let toml = r#"
+            [v8]
+            procedure-instance-pool-size = 3
+
             [v8-heap-policy]
             heap-check-request-interval = 0
             heap-check-time-interval = "45s"
@@ -465,13 +551,14 @@ mod tests {
 
         let config: ConfigFile = toml::from_str(toml).unwrap();
 
-        assert_eq!(config.v8_heap_policy.heap_check_request_interval, None);
+        assert_eq!(config.v8.procedure_instance_pool_size.get(), 3);
+        assert_eq!(config.v8.heap_policy.heap_check_request_interval, None);
         assert_eq!(
-            config.v8_heap_policy.heap_check_time_interval,
+            config.v8.heap_policy.heap_check_time_interval,
             Some(Duration::from_secs(45))
         );
-        assert_eq!(config.v8_heap_policy.heap_gc_trigger_fraction, 0.6);
-        assert_eq!(config.v8_heap_policy.heap_retire_fraction, 0.8);
-        assert_eq!(config.v8_heap_policy.heap_limit_bytes, 256 * 1024 * 1024);
+        assert_eq!(config.v8.heap_policy.heap_gc_trigger_fraction, 0.6);
+        assert_eq!(config.v8.heap_policy.heap_retire_fraction, 0.8);
+        assert_eq!(config.v8.heap_policy.heap_limit_bytes, 256 * 1024 * 1024);
     }
 }

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -366,30 +366,6 @@ impl HostController {
         Ok(launched.module_host.info)
     }
 
-    /// Run a computation on the [`RelationalDB`] of a [`ModuleHost`] managed by
-    /// this controller, launching the host if necessary.
-    ///
-    /// If the computation `F` panics, the host is removed from this controller,
-    /// releasing its resources.
-    #[tracing::instrument(level = "trace", skip_all)]
-    pub async fn using_database<F, Fut, T>(&self, database: Database, replica_id: u64, f: F) -> anyhow::Result<T>
-    where
-        F: FnOnce(Arc<RelationalDB>) -> Fut + Send + 'static,
-        Fut: std::future::Future<Output = T> + Send + 'static,
-        T: Send + 'static,
-    {
-        trace!("using database {}/{}", database.database_identity, replica_id);
-        let module = self.get_or_launch_module_host(database, replica_id).await?;
-        let on_panic = self.unregister_fn(replica_id);
-        scopeguard::defer_on_unwind!({
-            warn!("database operation panicked");
-            on_panic();
-        });
-
-        let db = module.relational_db().clone();
-        let result = module.on_module_thread_async("using_database", move || f(db)).await?;
-        Ok(result)
-    }
     /// Update the [`ModuleHost`] identified by `replica_id` to the given
     /// program.
     ///

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -1420,4 +1420,5 @@ where
         .remove_label_values(db, worker_kind);
     let _ = WORKER_METRICS.v8_native_contexts.remove_label_values(db, worker_kind);
     let _ = WORKER_METRICS.v8_detached_contexts.remove_label_values(db, worker_kind);
+    let _ = WORKER_METRICS.v8_request_queue_length.remove_label_values(db);
 }

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -3,7 +3,7 @@ use super::scheduler::SchedulerStarter;
 use super::wasmtime::WasmtimeRuntime;
 use super::{Scheduler, UpdateDatabaseResult};
 use crate::client::{ClientActorId, ClientName};
-use crate::config::V8HeapPolicyConfig;
+use crate::config::V8Config;
 use crate::database_logger::DatabaseLogger;
 use crate::db::persistence::PersistenceProvider;
 use crate::db::relational_db::{self, spawn_view_cleanup_loop, DiskSizeFn, RelationalDB, Txdata};
@@ -125,9 +125,9 @@ pub(crate) struct HostRuntimes {
 }
 
 impl HostRuntimes {
-    fn new(data_dir: Option<&ServerDataDir>, v8_heap_policy: V8HeapPolicyConfig) -> Arc<Self> {
+    fn new(data_dir: Option<&ServerDataDir>, v8_config: V8Config) -> Arc<Self> {
         let wasmtime = WasmtimeRuntime::new(data_dir);
-        let v8 = V8Runtime::new(v8_heap_policy);
+        let v8 = V8Runtime::new(v8_config);
         Arc::new(Self { wasmtime, v8 })
     }
 }
@@ -211,7 +211,7 @@ impl HostController {
     pub fn new(
         data_dir: Arc<ServerDataDir>,
         default_config: db::Config,
-        v8_heap_policy: V8HeapPolicyConfig,
+        v8_config: V8Config,
         program_storage: ProgramStorage,
         energy_monitor: Arc<impl EnergyMonitor>,
         persistence: Arc<dyn PersistenceProvider>,
@@ -223,7 +223,7 @@ impl HostController {
             program_storage,
             energy_monitor,
             persistence,
-            runtimes: HostRuntimes::new(Some(&data_dir), v8_heap_policy),
+            runtimes: HostRuntimes::new(Some(&data_dir), v8_config),
             data_dir,
             page_pool: PagePool::new(default_config.page_pool_max_size),
             bsatn_rlb_pool: BsatnRowListBuilderPool::new(),
@@ -1365,7 +1365,7 @@ pub async fn extract_schema(program_bytes: Box<[u8]>, host_type: HostType) -> an
     extract_schema_with_pools(
         PagePool::new(None),
         BsatnRowListBuilderPool::new(),
-        &HostRuntimes::new(None, V8HeapPolicyConfig::default()),
+        &HostRuntimes::new(None, V8Config::default()),
         program_bytes,
         host_type,
     )

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -1423,7 +1423,7 @@ where
         .data_size_blob_store_bytes_used_by_blobs
         .remove_label_values(db);
     let _ = WORKER_METRICS.wasm_memory_bytes.remove_label_values(db);
-    let worker_kind = crate::host::v8::V8_WORKER_KIND_INSTANCE_LANE;
+    let worker_kind = crate::host::v8::V8_WORKER_KIND_MAIN;
     let _ = WORKER_METRICS
         .v8_total_heap_size_bytes
         .remove_label_values(db, worker_kind);

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -401,13 +401,13 @@ impl InstanceEnv {
         table_id: TableId,
         row_ptr: RowPointer,
     ) -> Result<(), NodesError> {
-        let function_name: Box<str> = {
+        let function_name: Arc<str> = {
             let table = stdb.schema_for_table_mut(tx, table_id)?;
             let schedule = table
                 .schedule
                 .as_ref()
                 .expect("schedule_row should only be called for scheduled tables");
-            (&schedule.function_name[..]).into()
+            Arc::from(&schedule.function_name[..])
         };
         let (id_column, at_column) = stdb
             .table_scheduled_id_and_at(tx, table_id)?

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -401,6 +401,14 @@ impl InstanceEnv {
         table_id: TableId,
         row_ptr: RowPointer,
     ) -> Result<(), NodesError> {
+        let function_name: Box<str> = {
+            let table = stdb.schema_for_table_mut(tx, table_id)?;
+            let schedule = table
+                .schedule
+                .as_ref()
+                .expect("schedule_row should only be called for scheduled tables");
+            (&schedule.function_name[..]).into()
+        };
         let (id_column, at_column) = stdb
             .table_scheduled_id_and_at(tx, table_id)?
             .expect("schedule_row should only be called when we know its a scheduler table");
@@ -417,6 +425,7 @@ impl InstanceEnv {
                 schedule_at,
                 id_column,
                 at_column,
+                function_name,
                 self.start_time,
             )
             .map_err(NodesError::ScheduleError)?;

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -1583,22 +1583,13 @@ impl ModuleHost {
                     .call_view_command(label, cmd)
                     .await
                     .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?;
-                Self::record_view_command_metrics_for_result(&self.info, self.relational_db(), metric, &result);
+                Self::record_view_command_round_trip(&self.info, metric);
                 result
             }
         }
     }
 
-    pub(in crate::host) fn record_view_command_metrics_for_result(
-        info: &ModuleInfo,
-        db: &RelationalDB,
-        metric: ViewCommandMetric,
-        result: &ViewCommandResult,
-    ) {
-        if let Ok(Some(metrics)) = result {
-            db.exec_counters_for(metric.workload).record(metrics);
-        }
-
+    pub(in crate::host) fn record_view_command_round_trip(info: &ModuleInfo, metric: ViewCommandMetric) {
         match metric.workload {
             WorkloadType::Subscribe => info
                 .metrics
@@ -2753,7 +2744,7 @@ impl ModuleHost {
                         async |_, _| unreachable!("one-off query JS path is handled before Self::call"),
                     )
                     .await?;
-                Self::record_one_off_query_metrics_for_result(&self.info, self.relational_db(), timer, &result);
+                Self::record_one_off_query_round_trip(&self.info, timer);
                 result.map(|_| ())
             }
         }
@@ -2843,7 +2834,7 @@ impl ModuleHost {
         into_message: impl FnOnce(OneOffQueryResponseMessage<F>) -> SerializableMessage,
     ) -> OneOffQueryResult {
         let (tx_offset_sender, tx_offset_receiver) = oneshot::channel();
-        let tx = scopeguard::guard(db.begin_tx(Workload::Sql), |tx| {
+        let mut tx = scopeguard::guard(db.begin_tx(Workload::Sql), |tx| {
             let (tx_offset, tx_metrics, reducer) = db.release_tx(tx);
             let _ = tx_offset_sender.send(tx_offset);
             db.report_read_tx_metrics(reducer, tx_metrics);
@@ -2914,15 +2905,18 @@ impl ModuleHost {
 
         let total_host_execution_duration = timer.elapsed().into();
         let (message, metrics): (SerializableMessage, Option<ExecutionMetrics>) = match result {
-            Ok((rows, metrics)) => (
-                into_message(OneOffQueryResponseMessage {
-                    message_id,
-                    error: None,
-                    results: vec![rows],
-                    total_host_execution_duration,
-                }),
-                Some(metrics),
-            ),
+            Ok((rows, metrics)) => {
+                tx.metrics.merge(metrics);
+                (
+                    into_message(OneOffQueryResponseMessage {
+                        message_id,
+                        error: None,
+                        results: vec![rows],
+                        total_host_execution_duration,
+                    }),
+                    Some(metrics),
+                )
+            }
             Err(err) => (
                 into_message(OneOffQueryResponseMessage {
                     message_id,
@@ -2986,7 +2980,7 @@ impl ModuleHost {
             rlb_pool,
         } = params;
         let (tx_offset_sender, tx_offset_receiver) = oneshot::channel();
-        let tx = scopeguard::guard(db.begin_tx(Workload::Sql), |tx| {
+        let mut tx = scopeguard::guard(db.begin_tx(Workload::Sql), |tx| {
             let (tx_offset, tx_metrics, reducer) = db.release_tx(tx);
             let _ = tx_offset_sender.send(tx_offset);
             db.report_read_tx_metrics(reducer, tx_metrics);
@@ -3048,15 +3042,18 @@ impl ModuleHost {
         })();
 
         let (message, metrics) = match result {
-            Ok((rows, metrics)) => (
-                ws_v2::OneOffQueryResult {
-                    request_id,
-                    result: Ok(ws_v2::QueryRows {
-                        tables: vec![rows].into_boxed_slice(),
-                    }),
-                },
-                Some(metrics),
-            ),
+            Ok((rows, metrics)) => {
+                tx.metrics.merge(metrics);
+                (
+                    ws_v2::OneOffQueryResult {
+                        request_id,
+                        result: Ok(ws_v2::QueryRows {
+                            tables: vec![rows].into_boxed_slice(),
+                        }),
+                    },
+                    Some(metrics),
+                )
+            }
             Err(err) => (
                 ws_v2::OneOffQueryResult {
                     request_id,
@@ -3070,15 +3067,7 @@ impl ModuleHost {
         Ok(metrics)
     }
 
-    pub(in crate::host) fn record_one_off_query_metrics_for_result(
-        info: &ModuleInfo,
-        db: &RelationalDB,
-        timer: Instant,
-        result: &OneOffQueryResult,
-    ) {
-        if let Ok(Some(metrics)) = result {
-            db.exec_counters_for(WorkloadType::Sql).record(metrics);
-        }
+    pub(in crate::host) fn record_one_off_query_round_trip(info: &ModuleInfo, timer: Instant) {
         info.metrics
             .request_round_trip_sql
             .observe(timer.elapsed().as_secs_f64());

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -2385,17 +2385,32 @@ impl ModuleHost {
         .await
     }
 
-    pub(super) async fn call_scheduled_function(
+    pub(super) async fn call_scheduled_reducer(
+        &self,
+        params: ScheduledFunctionParams,
+    ) -> Result<CallScheduledFunctionResult, CallScheduledFunctionError> {
+        self.call(
+            "scheduled reducer",
+            params,
+            async move |params, inst| inst.call_scheduled_function(params).await,
+            async move |params, inst| inst.call_scheduled_reducer(params).await,
+        )
+        .await
+        .map_err(Into::into)
+    }
+
+    pub(super) async fn call_scheduled_procedure(
         &self,
         params: ScheduledFunctionParams,
     ) -> Result<CallScheduledFunctionResult, CallScheduledFunctionError> {
         self.call_pooled(
-            "unknown scheduled function",
+            "scheduled procedure",
             params,
-            async move |params, inst| Ok(inst.call_scheduled_function(params).await),
-            async move |params, inst| Ok(inst.call_scheduled_function(params).await),
+            async move |params, inst| inst.call_scheduled_function(params).await,
+            async move |params, inst| inst.call_scheduled_procedure(params).await,
         )
-        .await?
+        .await
+        .map_err(Into::into)
     }
 
     /// Materializes the views return by the `view_collector`, if not already materialized,

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -35,6 +35,7 @@ use derive_more::From;
 use futures::lock::Mutex;
 use indexmap::IndexSet;
 use itertools::Itertools;
+use parking_lot::RwLock;
 use prometheus::{Histogram, IntGauge};
 use scopeguard::ScopeGuard;
 use smallvec::SmallVec;
@@ -73,6 +74,7 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 use tokio::sync::oneshot;
+use tokio::sync::Mutex as AsyncMutex;
 
 #[derive(Debug, Default, Clone, From)]
 pub struct DatabaseUpdate {
@@ -359,7 +361,7 @@ struct WasmtimeModuleHost {
 
 struct V8ModuleHost {
     module: super::v8::JsModule,
-    instance_lane: super::v8::JsInstanceLane,
+    main_instance: SharedJsInstanceManager,
     procedure_instances: ModuleInstanceManager<super::v8::JsModule>,
 }
 
@@ -372,6 +374,10 @@ trait GenericModule {
 
 trait GenericModuleInstance {
     fn trapped(&self) -> bool;
+
+    fn needs_replacement(&self) -> bool {
+        self.trapped()
+    }
 }
 
 impl<T: WasmInstance> GenericModuleInstance for super::wasm_common::module_host_actor::WasmModuleInstance<T> {
@@ -383,6 +389,10 @@ impl<T: WasmInstance> GenericModuleInstance for super::wasm_common::module_host_
 impl<T: GenericModuleInstance + ?Sized> GenericModuleInstance for Box<T> {
     fn trapped(&self) -> bool {
         (**self).trapped()
+    }
+
+    fn needs_replacement(&self) -> bool {
+        (**self).needs_replacement()
     }
 }
 
@@ -409,6 +419,10 @@ impl GenericModule for super::v8::JsModule {
 impl GenericModuleInstance for super::v8::JsInstance {
     fn trapped(&self) -> bool {
         self.trapped()
+    }
+
+    fn needs_replacement(&self) -> bool {
+        self.needs_replacement()
     }
 }
 
@@ -755,13 +769,36 @@ impl CallProcedureParams {
 struct ModuleInstanceManager<M: GenericModule> {
     instances: Mutex<VecDeque<M::Instance>>,
     module: M,
-    module_instances_metric: ModuleInstancesMetric,
-    create_instance_time_metric: CreateInstanceTimeMetric,
+    metrics: InstanceManagerMetrics,
+}
+
+/// Holds the single shared instance used by the JS main execution path.
+///
+/// Unlike [`ModuleInstanceManager`], checkout is not exclusive: callers get a
+/// clone of the active instance handle immediately and enqueue work on its
+/// sender. Replacement is serialized only after that active instance traps or
+/// otherwise becomes unusable.
+struct SharedJsInstanceManager {
+    active: RwLock<JsInstance>,
+    module: super::v8::JsModule,
+    metrics: InstanceManagerMetrics,
+    replace_lock: AsyncMutex<()>,
+}
+
+#[derive(Clone)]
+struct InstanceManagerMetrics {
+    module_instances: ModuleInstancesMetric,
+    create_instance_time: CreateInstanceTimeMetric,
 }
 
 /// Handle on the `spacetime_module_create_instance_time_seconds` label for a particular database
 /// which calls `remove_label_values` to clean up on drop.
+#[derive(Clone)]
 struct CreateInstanceTimeMetric {
+    inner: Arc<CreateInstanceTimeMetricInner>,
+}
+
+struct CreateInstanceTimeMetricInner {
     metric: Histogram,
     host_type: HostType,
     database_identity: Identity,
@@ -769,14 +806,19 @@ struct CreateInstanceTimeMetric {
 
 /// Handle on the `spacetime_module_instances` label for a particular database
 /// which calls `remove_label_values` to clean up on drop.
+#[derive(Clone)]
 struct ModuleInstancesMetric {
+    inner: Arc<ModuleInstancesMetricInner>,
+}
+
+struct ModuleInstancesMetricInner {
     metric: IntGauge,
     host_type: HostType,
     database_identity: Identity,
     count: std::sync::Mutex<i64>,
 }
 
-impl Drop for CreateInstanceTimeMetric {
+impl Drop for CreateInstanceTimeMetricInner {
     fn drop(&mut self) {
         let _ = WORKER_METRICS
             .module_create_instance_time_seconds
@@ -784,7 +826,7 @@ impl Drop for CreateInstanceTimeMetric {
     }
 }
 
-impl Drop for ModuleInstancesMetric {
+impl Drop for ModuleInstancesMetricInner {
     fn drop(&mut self) {
         let _ = WORKER_METRICS
             .module_instances
@@ -792,57 +834,96 @@ impl Drop for ModuleInstancesMetric {
     }
 }
 
+impl InstanceManagerMetrics {
+    fn new(host_type: HostType, database_identity: Identity) -> Self {
+        Self {
+            module_instances: ModuleInstancesMetric::new(host_type, database_identity),
+            create_instance_time: CreateInstanceTimeMetric::new(host_type, database_identity),
+        }
+    }
+
+    fn observe_instance_created(&self, duration: std::time::Duration) {
+        self.create_instance_time.observe(duration);
+        self.module_instances.inc();
+    }
+
+    fn track_initial_instance(&self) {
+        self.module_instances.inc();
+    }
+
+    fn track_instance_removed(&self) {
+        self.module_instances.dec();
+    }
+}
+
 impl ModuleInstancesMetric {
+    fn new(host_type: HostType, database_identity: Identity) -> Self {
+        let metric = WORKER_METRICS
+            .module_instances
+            .with_label_values(&database_identity, &host_type);
+        metric.set(0);
+
+        Self {
+            inner: Arc::new(ModuleInstancesMetricInner {
+                metric,
+                host_type,
+                database_identity,
+                count: std::sync::Mutex::new(0),
+            }),
+        }
+    }
+
     fn inc(&self) {
-        let mut count = self.count.lock().unwrap();
+        let mut count = self.inner.count.lock().unwrap();
         *count += 1;
-        self.metric.set(*count);
+        self.inner.metric.set(*count);
     }
 
     fn dec(&self) {
-        let mut count = self.count.lock().unwrap();
+        let mut count = self.inner.count.lock().unwrap();
         if *count == 0 {
             return;
         }
         *count -= 1;
-        self.metric.set(*count);
+        self.inner.metric.set(*count);
     }
 }
 
 impl CreateInstanceTimeMetric {
+    fn new(host_type: HostType, database_identity: Identity) -> Self {
+        Self {
+            inner: Arc::new(CreateInstanceTimeMetricInner {
+                metric: WORKER_METRICS
+                    .module_create_instance_time_seconds
+                    .with_label_values(&database_identity, &host_type),
+                host_type,
+                database_identity,
+            }),
+        }
+    }
+
     fn observe(&self, duration: std::time::Duration) {
-        self.metric.observe(duration.as_secs_f64());
+        self.inner.metric.observe(duration.as_secs_f64());
     }
 }
 
 impl<M: GenericModule> ModuleInstanceManager<M> {
     fn new(module: M, init_inst: Option<M::Instance>, database_identity: Identity) -> Self {
-        let host_type = module.host_type();
-        let module_instances_metric = ModuleInstancesMetric {
-            metric: WORKER_METRICS
-                .module_instances
-                .with_label_values(&database_identity, &host_type),
-            host_type,
-            database_identity,
-            count: std::sync::Mutex::new(1),
-        };
+        let metrics = InstanceManagerMetrics::new(module.host_type(), database_identity);
+        Self::new_with_metrics(module, init_inst, metrics)
+    }
 
-        let create_instance_time_metric = CreateInstanceTimeMetric {
-            metric: WORKER_METRICS
-                .module_create_instance_time_seconds
-                .with_label_values(&database_identity, &host_type),
-            host_type,
-            database_identity,
-        };
-
+    fn new_with_metrics(module: M, init_inst: Option<M::Instance>, metrics: InstanceManagerMetrics) -> Self {
         let mut instances = VecDeque::new();
         instances.extend(init_inst);
+        for _ in 0..instances.len() {
+            metrics.track_initial_instance();
+        }
 
         Self {
             instances: Mutex::new(instances),
             module,
-            module_instances_metric,
-            create_instance_time_metric,
+            metrics,
         }
     }
 
@@ -861,22 +942,71 @@ impl<M: GenericModule> ModuleInstanceManager<M> {
             let start_time = std::time::Instant::now();
             let res = self.module.create_instance().await;
             let elapsed_time = start_time.elapsed();
-            self.create_instance_time_metric.observe(elapsed_time);
-            self.module_instances_metric.inc();
+            self.metrics.observe_instance_created(elapsed_time);
             res
         }
     }
 
     async fn return_instance(&self, inst: M::Instance) {
-        if inst.trapped() {
+        if inst.needs_replacement() {
             // Don't return trapped instances;
             // they may have left internal data structures in the guest `Instance`
             // (WASM linear memory, V8 global scope) in a bad state.
-            self.module_instances_metric.dec();
+            self.metrics.track_instance_removed();
             return;
         }
 
         self.instances.lock().await.push_front(inst);
+    }
+}
+
+impl SharedJsInstanceManager {
+    fn new(module: super::v8::JsModule, init_inst: JsInstance, metrics: InstanceManagerMetrics) -> Self {
+        metrics.track_initial_instance();
+        Self {
+            active: RwLock::new(init_inst),
+            module,
+            metrics,
+            replace_lock: AsyncMutex::new(()),
+        }
+    }
+
+    async fn with_instance<R>(&self, f: impl AsyncFnOnce(JsInstance) -> R) -> R {
+        let inst = self.get_instance().await;
+        let observed = inst.clone();
+        let res = f(inst).await;
+        self.replace_if_needed(&observed).await;
+        res
+    }
+
+    async fn get_instance(&self) -> JsInstance {
+        let inst = self.active.read().clone();
+        if !inst.needs_replacement() {
+            return inst;
+        }
+
+        self.replace_if_needed(&inst).await;
+        self.active.read().clone()
+    }
+
+    async fn replace_if_needed(&self, observed: &JsInstance) {
+        if !observed.needs_replacement() {
+            return;
+        }
+
+        let _replace_guard = self.replace_lock.lock().await;
+        if !self.active.read().needs_replacement() {
+            return;
+        }
+
+        self.metrics.track_instance_removed();
+
+        let start_time = std::time::Instant::now();
+        let next = self.module.create_main_instance().await;
+        let elapsed_time = start_time.elapsed();
+        self.metrics.observe_instance_created(elapsed_time);
+
+        *self.active.write() = next;
     }
 }
 
@@ -1090,11 +1220,13 @@ impl ModuleHost {
             }
             ModuleWithInstance::Js { module, init_inst } => {
                 info = module.info();
-                let instance_lane = super::v8::JsInstanceLane::new(module.clone(), init_inst);
-                let procedure_instances = ModuleInstanceManager::new(module.clone(), None, database_identity);
+                let metrics = InstanceManagerMetrics::new(module.host_type(), database_identity);
+                let host_module = module.clone();
+                let main_instance = SharedJsInstanceManager::new(module.clone(), init_inst, metrics.clone());
+                let procedure_instances = ModuleInstanceManager::new_with_metrics(module, None, metrics);
                 Arc::new(ModuleHostInner::Js(Box::new(V8ModuleHost {
-                    module,
-                    instance_lane,
+                    module: host_module,
+                    main_instance,
                     procedure_instances,
                 })))
             }
@@ -1166,13 +1298,15 @@ impl ModuleHost {
                     .await
             }
             ModuleHostInner::Js(js) => {
-                let instance_lane = &js.instance_lane;
-                instance_lane
-                    .run_on_thread(async move || {
-                        drop(timer_guard);
-                        f().await
+                js.main_instance
+                    .with_instance(async |inst| {
+                        inst.run_on_thread(async move || {
+                            drop(timer_guard);
+                            f().await
+                        })
+                        .await
                     })
-                    .await?
+                    .await
             }
         })
     }
@@ -1211,7 +1345,7 @@ impl ModuleHost {
         arg: A,
         timer: impl FnOnce(&str) -> Guard,
         work_wasm: impl AsyncFnOnce(Guard, &SingleCoreExecutor, Box<ModuleInstance>, A) -> (R, Box<ModuleInstance>),
-        work_js: impl AsyncFnOnce(Guard, &super::v8::JsInstanceLane, A) -> R,
+        work_js: impl AsyncFnOnce(Guard, &JsInstance, A) -> R,
     ) -> Result<R, NoSuchModule> {
         self.guard_closed()?;
         let timer_guard = timer(label);
@@ -1237,7 +1371,11 @@ impl ModuleHost {
                     .with_instance(async |inst| work_wasm(timer_guard, executor, inst, arg).await)
                     .await
             }
-            ModuleHostInner::Js(js) => work_js(timer_guard, &js.instance_lane, arg).await,
+            ModuleHostInner::Js(js) => {
+                js.main_instance
+                    .with_instance(async |inst| work_js(timer_guard, &inst, arg).await)
+                    .await
+            }
         })
     }
 
@@ -1250,7 +1388,7 @@ impl ModuleHost {
         label: &str,
         arg: A,
         wasm: impl AsyncFnOnce(A, &mut ModuleInstance) -> R + Send + 'static,
-        js: impl AsyncFnOnce(A, &super::v8::JsInstanceLane) -> R,
+        js: impl AsyncFnOnce(A, &JsInstance) -> R,
     ) -> Result<R, NoSuchModule>
     where
         R: Send + 'static,
@@ -1287,7 +1425,7 @@ impl ModuleHost {
     ///
     /// For WASM, this is identical to [`Self::call`].
     /// For V8/JS, this uses the pooled procedure instances instead of the
-    /// single instance lane.
+    /// shared main instance.
     async fn call_pooled<A, R>(
         &self,
         label: &str,
@@ -1337,7 +1475,7 @@ impl ModuleHost {
             label,
             cmd,
             async |cmd, inst| Ok::<_, ViewCallError>(inst.call_view(cmd)),
-            async |cmd, inst| Ok::<_, ViewCallError>(inst.call_view(cmd).await),
+            async |cmd, inst| inst.call_view(cmd).await,
         )
         .await?
     }

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -36,7 +36,6 @@ use derive_more::From;
 use futures::lock::Mutex;
 use indexmap::IndexSet;
 use itertools::Itertools;
-use parking_lot::RwLock;
 use prometheus::{Histogram, IntGauge};
 use scopeguard::ScopeGuard;
 use smallvec::SmallVec;
@@ -75,7 +74,6 @@ use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
 use tokio::sync::oneshot;
-use tokio::sync::Mutex as AsyncMutex;
 
 #[derive(Debug, Default, Clone, From)]
 pub struct DatabaseUpdate {
@@ -419,7 +417,11 @@ impl GenericModule for super::v8::JsModule {
 
 impl GenericModuleInstance for super::v8::JsProcedureInstance {
     fn trapped(&self) -> bool {
-        self.trapped()
+        false
+    }
+
+    fn needs_replacement(&self) -> bool {
+        self.is_closed()
     }
 }
 
@@ -815,17 +817,15 @@ struct ModuleInstanceManager<M: GenericModule> {
 ///
 /// Unlike [`ModuleInstanceManager`], checkout is not exclusive: callers get a
 /// clone of the active instance handle immediately and enqueue work on its
-/// sender. Replacement is serialized only after that active instance traps or
-/// otherwise becomes unusable.
+/// sender. Trap and heap-limit recovery happens inside the worker thread, so
+/// the manager is only responsible for keeping the sender handle alive.
 struct SharedJsMainInstanceManager {
-    active: RwLock<JsMainInstance>,
-    module: super::v8::JsModule,
-    metrics: InstanceManagerMetrics,
-    replace_lock: AsyncMutex<()>,
+    active: JsMainInstance,
+    _metrics: InstanceManagerMetrics,
 }
 
 #[derive(Clone)]
-struct InstanceManagerMetrics {
+pub(in crate::host) struct InstanceManagerMetrics {
     module_instances: ModuleInstancesMetric,
     create_instance_time: CreateInstanceTimeMetric,
 }
@@ -874,14 +874,14 @@ impl Drop for ModuleInstancesMetricInner {
 }
 
 impl InstanceManagerMetrics {
-    fn new(host_type: HostType, database_identity: Identity) -> Self {
+    pub(in crate::host) fn new(host_type: HostType, database_identity: Identity) -> Self {
         Self {
             module_instances: ModuleInstancesMetric::new(host_type, database_identity),
             create_instance_time: CreateInstanceTimeMetric::new(host_type, database_identity),
         }
     }
 
-    fn observe_instance_created(&self, duration: std::time::Duration) {
+    pub(in crate::host) fn observe_instance_created(&self, duration: std::time::Duration) {
         self.create_instance_time.observe(duration);
         self.module_instances.inc();
     }
@@ -890,7 +890,7 @@ impl InstanceManagerMetrics {
         self.module_instances.inc();
     }
 
-    fn track_instance_removed(&self) {
+    pub(in crate::host) fn track_instance_removed(&self) {
         self.module_instances.dec();
     }
 }
@@ -988,9 +988,9 @@ impl<M: GenericModule> ModuleInstanceManager<M> {
 
     async fn return_instance(&self, inst: M::Instance) {
         if inst.needs_replacement() {
-            // Don't return trapped instances;
-            // they may have left internal data structures in the guest `Instance`
-            // (WASM linear memory, V8 global scope) in a bad state.
+            // Don't return unusable instances; they may have left internal data
+            // structures in the guest `Instance` in a bad state, or the backing
+            // worker may have already exited.
             self.metrics.track_instance_removed();
             return;
         }
@@ -1000,52 +1000,16 @@ impl<M: GenericModule> ModuleInstanceManager<M> {
 }
 
 impl SharedJsMainInstanceManager {
-    fn new(module: super::v8::JsModule, init_inst: JsMainInstance, metrics: InstanceManagerMetrics) -> Self {
+    fn new(init_inst: JsMainInstance, metrics: InstanceManagerMetrics) -> Self {
         metrics.track_initial_instance();
         Self {
-            active: RwLock::new(init_inst),
-            module,
-            metrics,
-            replace_lock: AsyncMutex::new(()),
+            active: init_inst,
+            _metrics: metrics,
         }
     }
 
     async fn with_instance<R>(&self, f: impl AsyncFnOnce(JsMainInstance) -> R) -> R {
-        let inst = self.get_instance().await;
-        let observed = inst.clone();
-        let res = f(inst).await;
-        self.replace_if_needed(&observed).await;
-        res
-    }
-
-    async fn get_instance(&self) -> JsMainInstance {
-        let inst = self.active.read().clone();
-        if !inst.needs_replacement() {
-            return inst;
-        }
-
-        self.replace_if_needed(&inst).await;
-        self.active.read().clone()
-    }
-
-    async fn replace_if_needed(&self, observed: &JsMainInstance) {
-        if !observed.needs_replacement() {
-            return;
-        }
-
-        let _replace_guard = self.replace_lock.lock().await;
-        if !self.active.read().needs_replacement() {
-            return;
-        }
-
-        self.metrics.track_instance_removed();
-
-        let start_time = std::time::Instant::now();
-        let next = self.module.create_main_instance().await;
-        let elapsed_time = start_time.elapsed();
-        self.metrics.observe_instance_created(elapsed_time);
-
-        *self.active.write() = next;
+        f(self.active.clone()).await
     }
 }
 
@@ -1259,9 +1223,9 @@ impl ModuleHost {
             }
             ModuleWithInstance::Js { module, init_inst } => {
                 info = module.info();
-                let metrics = InstanceManagerMetrics::new(module.host_type(), database_identity);
+                let metrics = module.metrics();
                 let host_module = module.clone();
-                let main_instance = SharedJsMainInstanceManager::new(module.clone(), init_inst, metrics.clone());
+                let main_instance = SharedJsMainInstanceManager::new(init_inst, metrics.clone());
                 let procedure_instances = ModuleInstanceManager::new_with_metrics(module, None, metrics);
                 Arc::new(ModuleHostInner::Js(Box::new(V8ModuleHost {
                     module: host_module,
@@ -1464,10 +1428,11 @@ impl ModuleHost {
         self.call(
             label,
             cmd,
-            async |cmd, inst| Ok::<_, ViewCallError>(inst.call_view(cmd)),
+            async |cmd, inst| inst.call_view(cmd),
             async |cmd, inst| inst.call_view(cmd).await,
         )
-        .await?
+        .await
+        .map_err(Into::into)
     }
 
     async fn call_sql_command(&self, cmd: SqlCommand) -> Result<SqlCommandResult, DBError> {
@@ -1478,7 +1443,7 @@ impl ModuleHost {
             async |cmd, inst| inst.call_sql(cmd).await,
         )
         .await
-        .map_err(|_| DBError::Other(anyhow::anyhow!("no such module")))?
+        .map_err(|_| DBError::Other(anyhow::anyhow!("no such module")))
     }
 
     pub async fn disconnect_client(&self, client_id: ClientActorId) {
@@ -1751,10 +1716,11 @@ impl ModuleHost {
         self.call(
             &reducer_def.name,
             call_reducer_params,
-            async |p, inst| Ok(inst.call_reducer(p)),
+            async |p, inst| inst.call_reducer(p),
             async |p, inst| inst.call_reducer(p).await,
         )
-        .await?
+        .await
+        .map_err(Into::into)
     }
 
     pub async fn call_reducer(

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -1010,11 +1010,6 @@ impl CreateInstanceTimeMetric {
     }
 }
 
-fn default_procedure_instance_limit() -> NonZeroUsize {
-    let num_cores = std::thread::available_parallelism().map(NonZeroUsize::get).unwrap_or(1);
-    NonZeroUsize::new(num_cores.saturating_mul(2)).expect("procedure instance limit should be non-zero")
-}
-
 impl<M: GenericModule> ModuleInstanceManager<M> {
     fn new(module: M, init_inst: Option<M::Instance>, database_identity: Identity) -> Self {
         let metrics = InstanceManagerMetrics::new(module.host_type(), database_identity);
@@ -1335,13 +1330,14 @@ impl ModuleHost {
             ModuleWithInstance::Js { module, init_inst } => {
                 info = module.info();
                 let metrics = module.metrics();
+                let procedure_instance_pool_size = module.procedure_instance_pool_size();
                 let host_module = module.clone();
                 let main_instance = SharedJsMainInstanceManager::new(init_inst, metrics.clone());
                 let procedure_instances = ModuleInstanceManager::new_bounded_with_metrics(
                     module,
                     None,
                     metrics,
-                    default_procedure_instance_limit(),
+                    procedure_instance_pool_size,
                 );
                 Arc::new(ModuleHostInner::Js(Box::new(V8ModuleHost {
                     module: host_module,

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -12,7 +12,7 @@ use crate::estimation::{check_row_limit, estimate_rows_scanned};
 use crate::hash::Hash;
 use crate::host::host_controller::CallProcedureReturn;
 use crate::host::scheduler::{CallScheduledFunctionError, CallScheduledFunctionResult, ScheduledFunctionParams};
-use crate::host::v8::JsInstance;
+use crate::host::v8::{JsMainInstance, JsProcedureInstance};
 pub use crate::host::wasm_common::module_host_actor::{InstanceCommon, WasmInstance};
 use crate::host::wasmtime::ModuleInstance;
 use crate::host::{InvalidFunctionArguments, InvalidViewArguments};
@@ -345,7 +345,7 @@ pub enum ModuleWithInstance {
     },
     Js {
         module: super::v8::JsModule,
-        init_inst: super::v8::JsInstance,
+        init_inst: super::v8::JsMainInstance,
     },
 }
 
@@ -361,7 +361,7 @@ struct WasmtimeModuleHost {
 
 struct V8ModuleHost {
     module: super::v8::JsModule,
-    main_instance: SharedJsInstanceManager,
+    main_instance: SharedJsMainInstanceManager,
     procedure_instances: ModuleInstanceManager<super::v8::JsModule>,
 }
 
@@ -407,7 +407,7 @@ impl GenericModule for super::wasmtime::Module {
 }
 
 impl GenericModule for super::v8::JsModule {
-    type Instance = super::v8::JsInstance;
+    type Instance = super::v8::JsProcedureInstance;
     async fn create_instance(&self) -> Self::Instance {
         self.create_instance().await
     }
@@ -416,13 +416,9 @@ impl GenericModule for super::v8::JsModule {
     }
 }
 
-impl GenericModuleInstance for super::v8::JsInstance {
+impl GenericModuleInstance for super::v8::JsProcedureInstance {
     fn trapped(&self) -> bool {
         self.trapped()
-    }
-
-    fn needs_replacement(&self) -> bool {
-        self.needs_replacement()
     }
 }
 
@@ -763,9 +759,9 @@ impl CallProcedureParams {
 ///
 /// Capable of managing and allocating multiple instances of the same module,
 /// but this functionality is currently unused, as only one reducer runs at a time.
-/// When we introduce procedures, it will be necessary to have multiple instances,
-/// as each procedure invocation will have its own sandboxed instance,
-/// and multiple procedures can run concurrently with up to one reducer.
+/// Procedures need multiple instances, as each procedure invocation has its own
+/// sandboxed instance and multiple procedures can run concurrently with up to
+/// one reducer.
 struct ModuleInstanceManager<M: GenericModule> {
     instances: Mutex<VecDeque<M::Instance>>,
     module: M,
@@ -778,8 +774,8 @@ struct ModuleInstanceManager<M: GenericModule> {
 /// clone of the active instance handle immediately and enqueue work on its
 /// sender. Replacement is serialized only after that active instance traps or
 /// otherwise becomes unusable.
-struct SharedJsInstanceManager {
-    active: RwLock<JsInstance>,
+struct SharedJsMainInstanceManager {
+    active: RwLock<JsMainInstance>,
     module: super::v8::JsModule,
     metrics: InstanceManagerMetrics,
     replace_lock: AsyncMutex<()>,
@@ -960,8 +956,8 @@ impl<M: GenericModule> ModuleInstanceManager<M> {
     }
 }
 
-impl SharedJsInstanceManager {
-    fn new(module: super::v8::JsModule, init_inst: JsInstance, metrics: InstanceManagerMetrics) -> Self {
+impl SharedJsMainInstanceManager {
+    fn new(module: super::v8::JsModule, init_inst: JsMainInstance, metrics: InstanceManagerMetrics) -> Self {
         metrics.track_initial_instance();
         Self {
             active: RwLock::new(init_inst),
@@ -971,7 +967,7 @@ impl SharedJsInstanceManager {
         }
     }
 
-    async fn with_instance<R>(&self, f: impl AsyncFnOnce(JsInstance) -> R) -> R {
+    async fn with_instance<R>(&self, f: impl AsyncFnOnce(JsMainInstance) -> R) -> R {
         let inst = self.get_instance().await;
         let observed = inst.clone();
         let res = f(inst).await;
@@ -979,7 +975,7 @@ impl SharedJsInstanceManager {
         res
     }
 
-    async fn get_instance(&self) -> JsInstance {
+    async fn get_instance(&self) -> JsMainInstance {
         let inst = self.active.read().clone();
         if !inst.needs_replacement() {
             return inst;
@@ -989,7 +985,7 @@ impl SharedJsInstanceManager {
         self.active.read().clone()
     }
 
-    async fn replace_if_needed(&self, observed: &JsInstance) {
+    async fn replace_if_needed(&self, observed: &JsMainInstance) {
         if !observed.needs_replacement() {
             return;
         }
@@ -1222,7 +1218,7 @@ impl ModuleHost {
                 info = module.info();
                 let metrics = InstanceManagerMetrics::new(module.host_type(), database_identity);
                 let host_module = module.clone();
-                let main_instance = SharedJsInstanceManager::new(module.clone(), init_inst, metrics.clone());
+                let main_instance = SharedJsMainInstanceManager::new(module.clone(), init_inst, metrics.clone());
                 let procedure_instances = ModuleInstanceManager::new_with_metrics(module, None, metrics);
                 Arc::new(ModuleHostInner::Js(Box::new(V8ModuleHost {
                     module: host_module,
@@ -1345,7 +1341,7 @@ impl ModuleHost {
         arg: A,
         timer: impl FnOnce(&str) -> Guard,
         work_wasm: impl AsyncFnOnce(Guard, &SingleCoreExecutor, Box<ModuleInstance>, A) -> (R, Box<ModuleInstance>),
-        work_js: impl AsyncFnOnce(Guard, &JsInstance, A) -> R,
+        work_js: impl AsyncFnOnce(Guard, &JsMainInstance, A) -> R,
     ) -> Result<R, NoSuchModule> {
         self.guard_closed()?;
         let timer_guard = timer(label);
@@ -1388,7 +1384,7 @@ impl ModuleHost {
         label: &str,
         arg: A,
         wasm: impl AsyncFnOnce(A, &mut ModuleInstance) -> R + Send + 'static,
-        js: impl AsyncFnOnce(A, &JsInstance) -> R,
+        js: impl AsyncFnOnce(A, &JsMainInstance) -> R,
     ) -> Result<R, NoSuchModule>
     where
         R: Send + 'static,
@@ -1431,7 +1427,7 @@ impl ModuleHost {
         label: &str,
         arg: A,
         wasm: impl AsyncFnOnce(A, &mut ModuleInstance) -> R + Send + 'static,
-        js: impl AsyncFnOnce(A, &JsInstance) -> R,
+        js: impl AsyncFnOnce(A, &JsProcedureInstance) -> R,
     ) -> Result<R, NoSuchModule>
     where
         R: Send + 'static,
@@ -1471,7 +1467,7 @@ impl ModuleHost {
     }
 
     async fn call_view_command(&self, label: &str, cmd: ViewCommand) -> Result<ViewCommandResult, ViewCallError> {
-        self.call_pooled(
+        self.call(
             label,
             cmd,
             async |cmd, inst| Ok::<_, ViewCallError>(inst.call_view(cmd)),

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -70,10 +70,11 @@ use spacetimedb_schema::schema::{Schema, TableSchema};
 use spacetimedb_schema::table_name::TableName;
 use std::collections::VecDeque;
 use std::fmt;
+use std::num::NonZeroUsize;
 use std::sync::atomic::AtomicBool;
 use std::sync::{Arc, Weak};
 use std::time::{Duration, Instant};
-use tokio::sync::oneshot;
+use tokio::sync::{oneshot, OwnedSemaphorePermit, Semaphore};
 
 #[derive(Debug, Default, Clone, From)]
 pub struct DatabaseUpdate {
@@ -811,6 +812,12 @@ struct ModuleInstanceManager<M: GenericModule> {
     instances: Mutex<VecDeque<M::Instance>>,
     module: M,
     metrics: InstanceManagerMetrics,
+    instance_slots: Option<Arc<Semaphore>>,
+}
+
+struct ModuleInstanceLease<I> {
+    instance: I,
+    slot: Option<OwnedSemaphorePermit>,
 }
 
 /// Holds the single shared instance used by the JS main execution path.
@@ -946,6 +953,11 @@ impl CreateInstanceTimeMetric {
     }
 }
 
+fn default_procedure_instance_limit() -> NonZeroUsize {
+    let num_cores = std::thread::available_parallelism().map(NonZeroUsize::get).unwrap_or(1);
+    NonZeroUsize::new(num_cores.saturating_mul(2)).expect("procedure instance limit should be non-zero")
+}
+
 impl<M: GenericModule> ModuleInstanceManager<M> {
     fn new(module: M, init_inst: Option<M::Instance>, database_identity: Identity) -> Self {
         let metrics = InstanceManagerMetrics::new(module.host_type(), database_identity);
@@ -953,8 +965,33 @@ impl<M: GenericModule> ModuleInstanceManager<M> {
     }
 
     fn new_with_metrics(module: M, init_inst: Option<M::Instance>, metrics: InstanceManagerMetrics) -> Self {
+        Self::new_inner(module, init_inst, metrics, None)
+    }
+
+    fn new_bounded_with_metrics(
+        module: M,
+        init_inst: Option<M::Instance>,
+        metrics: InstanceManagerMetrics,
+        max_instances: NonZeroUsize,
+    ) -> Self {
+        Self::new_inner(module, init_inst, metrics, Some(max_instances))
+    }
+
+    fn new_inner(
+        module: M,
+        init_inst: Option<M::Instance>,
+        metrics: InstanceManagerMetrics,
+        max_instances: Option<NonZeroUsize>,
+    ) -> Self {
         let mut instances = VecDeque::new();
         instances.extend(init_inst);
+        let initial_instances = instances.len();
+        if let Some(max_instances) = max_instances {
+            assert!(
+                initial_instances <= max_instances.get(),
+                "initial module instance count exceeds bounded pool size"
+            );
+        }
         for _ in 0..instances.len() {
             metrics.track_initial_instance();
         }
@@ -963,31 +1000,47 @@ impl<M: GenericModule> ModuleInstanceManager<M> {
             instances: Mutex::new(instances),
             module,
             metrics,
+            instance_slots: max_instances.map(|max_instances| Arc::new(Semaphore::new(max_instances.get()))),
         }
     }
 
     async fn with_instance<R>(&self, f: impl AsyncFnOnce(M::Instance) -> (R, M::Instance)) -> R {
-        let inst = self.get_instance().await;
-        let (res, inst) = f(inst).await;
-        self.return_instance(inst).await;
+        let ModuleInstanceLease { instance, slot } = self.get_instance().await;
+        let (res, instance) = f(instance).await;
+        self.return_instance(ModuleInstanceLease { instance, slot }).await;
         res
     }
 
-    async fn get_instance(&self) -> M::Instance {
-        let inst = self.instances.lock().await.pop_back();
-        if let Some(inst) = inst {
-            inst
+    async fn get_instance(&self) -> ModuleInstanceLease<M::Instance> {
+        let slot = if let Some(instance_slots) = &self.instance_slots {
+            Some(
+                instance_slots
+                    .clone()
+                    .acquire_owned()
+                    .await
+                    .expect("module instance slot semaphore should not close"),
+            )
+        } else {
+            None
+        };
+
+        let instance = self.instances.lock().await.pop_back();
+        let instance = if let Some(instance) = instance {
+            instance
         } else {
             let start_time = std::time::Instant::now();
             let res = self.module.create_instance().await;
             let elapsed_time = start_time.elapsed();
             self.metrics.observe_instance_created(elapsed_time);
             res
-        }
+        };
+
+        ModuleInstanceLease { instance, slot }
     }
 
-    async fn return_instance(&self, inst: M::Instance) {
-        if inst.needs_replacement() {
+    async fn return_instance(&self, lease: ModuleInstanceLease<M::Instance>) {
+        let ModuleInstanceLease { instance, slot } = lease;
+        if instance.needs_replacement() {
             // Don't return unusable instances; they may have left internal data
             // structures in the guest `Instance` in a bad state, or the backing
             // worker may have already exited.
@@ -995,7 +1048,8 @@ impl<M: GenericModule> ModuleInstanceManager<M> {
             return;
         }
 
-        self.instances.lock().await.push_front(inst);
+        self.instances.lock().await.push_front(instance);
+        drop(slot);
     }
 }
 
@@ -1226,7 +1280,12 @@ impl ModuleHost {
                 let metrics = module.metrics();
                 let host_module = module.clone();
                 let main_instance = SharedJsMainInstanceManager::new(init_inst, metrics.clone());
-                let procedure_instances = ModuleInstanceManager::new_with_metrics(module, None, metrics);
+                let procedure_instances = ModuleInstanceManager::new_bounded_with_metrics(
+                    module,
+                    None,
+                    metrics,
+                    default_procedure_instance_limit(),
+                );
                 Arc::new(ModuleHostInner::Js(Box::new(V8ModuleHost {
                     module: host_module,
                     main_instance,

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -24,6 +24,7 @@ use crate::sql::execute::SqlResult;
 use crate::sql::parser::RowLevelExpr;
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
 pub use crate::subscription::module_subscription_manager::TransactionOffset;
+use crate::subscription::row_list_builder_pool::{BsatnRowListBuilderPool, JsonRowListBuilderFakePool};
 use crate::subscription::tx::DeltaTx;
 use crate::subscription::websocket_building::{BuildableWebsocketFormat, RowListBuilderSource};
 use crate::subscription::{execute_plan, execute_plan_for_view};
@@ -684,31 +685,73 @@ pub enum ViewCommand {
         request: ws_v2::Subscribe,
         _timer: Instant,
     },
+    RemoveSingleSubscription {
+        sender: Arc<ClientConnectionSender>,
+        auth: AuthCtx,
+        request: ws_v1::Unsubscribe,
+        timer: Instant,
+    },
+    RemoveMultiSubscription {
+        sender: Arc<ClientConnectionSender>,
+        auth: AuthCtx,
+        request: ws_v1::UnsubscribeMulti,
+        timer: Instant,
+    },
     RemoveSubscriptionV2 {
         sender: Arc<ClientConnectionSender>,
         auth: AuthCtx,
         request: ws_v2::Unsubscribe,
         timer: Instant,
     },
-    Sql {
-        db: Arc<RelationalDB>,
-        sql_text: String,
-        auth: AuthCtx,
-        subs: Option<ModuleSubscriptions>,
-    },
 }
 
-#[derive(Debug)]
-pub enum ViewCommandResult {
-    Subscription {
-        result: Result<Option<ExecutionMetrics>, DBError>,
-    },
+pub type ViewCommandResult = Result<Option<ExecutionMetrics>, DBError>;
 
-    Sql {
-        result: Result<SqlResult, DBError>,
-        head: Vec<(RawIdentifier, AlgebraicType)>,
-    },
+pub(in crate::host) struct SqlCommand {
+    pub(in crate::host) db: Arc<RelationalDB>,
+    pub(in crate::host) sql_text: String,
+    pub(in crate::host) auth: AuthCtx,
+    pub(in crate::host) subs: Option<ModuleSubscriptions>,
 }
+
+pub(in crate::host) struct SqlCommandResult {
+    pub(in crate::host) result: Result<SqlResult, DBError>,
+    pub(in crate::host) head: Vec<(RawIdentifier, AlgebraicType)>,
+}
+
+pub(in crate::host) type OneOffQueryResult = anyhow::Result<Option<ExecutionMetrics>>;
+
+pub(in crate::host) struct OneOffQueryJsonParams {
+    db: Arc<RelationalDB>,
+    subscriptions: ModuleSubscriptions,
+    auth: AuthCtx,
+    query: String,
+    client: Arc<ClientConnectionSender>,
+    message_id: Vec<u8>,
+    timer: Instant,
+}
+
+pub(in crate::host) struct OneOffQueryBsatnParams {
+    db: Arc<RelationalDB>,
+    subscriptions: ModuleSubscriptions,
+    auth: AuthCtx,
+    query: String,
+    client: Arc<ClientConnectionSender>,
+    message_id: Vec<u8>,
+    timer: Instant,
+    rlb_pool: BsatnRowListBuilderPool,
+}
+
+pub(in crate::host) struct OneOffQueryV2Params {
+    db: Arc<RelationalDB>,
+    subscriptions: ModuleSubscriptions,
+    auth: AuthCtx,
+    query: String,
+    client: Arc<ClientConnectionSender>,
+    request_id: u32,
+    rlb_pool: BsatnRowListBuilderPool,
+}
+
 pub struct CallViewParams {
     pub view_name: Identifier,
     pub view_id: ViewId,
@@ -1261,52 +1304,6 @@ impl ModuleHost {
         }
     }
 
-    /// Run a function on the JobThread for this module.
-    /// This would deadlock if it is called within another call to `on_module_thread`.
-    /// Since this is async, and `f` is sync, deadlocking shouldn't be a problem.
-    pub async fn on_module_thread<F, R>(&self, label: &str, f: F) -> Result<R, anyhow::Error>
-    where
-        F: FnOnce() -> R + Send + 'static,
-        R: Send + 'static,
-    {
-        self.on_module_thread_async(label, async move || f()).await
-    }
-
-    /// Run an async function on the JobThread for this module.
-    /// Similar to `on_module_thread`, but for async functions.
-    pub async fn on_module_thread_async<F, R>(&self, label: &str, f: F) -> Result<R, anyhow::Error>
-    where
-        F: AsyncFnOnce() -> R + Send + 'static,
-        R: Send + 'static,
-    {
-        self.guard_closed()?;
-
-        let timer_guard = self.start_call_timer(label);
-
-        Ok(match &*self.inner {
-            ModuleHostInner::Wasm(wasm) => {
-                let executor = &wasm.executor;
-                executor
-                    .run_job(async move || {
-                        drop(timer_guard);
-                        f().await
-                    })
-                    .await
-            }
-            ModuleHostInner::Js(js) => {
-                js.main_instance
-                    .with_instance(async |inst| {
-                        inst.run_on_thread(async move || {
-                            drop(timer_guard);
-                            f().await
-                        })
-                        .await
-                    })
-                    .await
-            }
-        })
-    }
-
     fn start_call_timer(&self, label: &str) -> ScopeGuard<(), impl FnOnce(()) + use<>> {
         // Record the time until our function starts running.
         let queue_timer = WORKER_METRICS
@@ -1336,7 +1333,6 @@ impl ModuleHost {
     /// Run a function for this module which has access to the module instance.
     async fn with_instance<Guard, A, R>(
         &self,
-        kind: &str,
         label: &str,
         arg: A,
         timer: impl FnOnce(&str) -> Guard,
@@ -1355,7 +1351,7 @@ impl ModuleHost {
         // If a function call panics, we **must** ensure to call `self.on_panic`
         // so that the module is discarded by the host controller.
         scopeguard::defer_on_unwind!({
-            log::warn!("{kind} {label} panicked");
+            log::warn!("module operation {label} panicked");
             (self.on_panic)();
         });
 
@@ -1391,7 +1387,6 @@ impl ModuleHost {
         A: Send + 'static,
     {
         self.with_instance(
-            "reducer",
             label,
             arg,
             |l| self.start_call_timer(l),
@@ -1409,7 +1404,6 @@ impl ModuleHost {
                     .await
             },
             async move |timer_guard, inst, arg| {
-                super::v8::assert_not_on_js_module_thread(label);
                 drop(timer_guard);
                 js(arg, inst).await
             },
@@ -1474,6 +1468,17 @@ impl ModuleHost {
             async |cmd, inst| inst.call_view(cmd).await,
         )
         .await?
+    }
+
+    async fn call_sql_command(&self, cmd: SqlCommand) -> Result<SqlCommandResult, DBError> {
+        self.call(
+            "call_sql",
+            cmd,
+            async |cmd, inst| inst.call_sql(cmd),
+            async |cmd, inst| inst.call_sql(cmd).await,
+        )
+        .await
+        .map_err(|_| DBError::Other(anyhow::anyhow!("no such module")))?
     }
 
     pub async fn disconnect_client(&self, client_id: ClientActorId) {
@@ -1816,18 +1821,10 @@ impl ModuleHost {
             _timer: timer,
         };
 
-        let res = self
-            .call_view_command("call_view_add_single_subscription", cmd)
+        self.call_view_command("call_view_add_single_subscription", cmd)
             .await
             //TODO: handle error better
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?;
-
-        match res {
-            ViewCommandResult::Subscription { result } => result,
-            ViewCommandResult::Sql { .. } => {
-                unreachable!("unexpected SQL result in call_view_add_single_subscription")
-            }
-        }
+            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
     }
 
     pub async fn call_view_add_v2_subscription(
@@ -1844,18 +1841,29 @@ impl ModuleHost {
             _timer: timer,
         };
 
-        let res = self
-            .call_view_command("call_view_add_multi_subscription", cmd)
+        self.call_view_command("call_view_add_multi_subscription", cmd)
             .await
             //TODO: handle error better
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?;
+            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
+    }
 
-        match res {
-            ViewCommandResult::Subscription { result } => result,
-            ViewCommandResult::Sql { .. } => {
-                unreachable!("unexpected SQL result in call_view_add_single_subscription")
-            }
-        }
+    pub async fn call_view_remove_single_subscription(
+        &self,
+        sender: Arc<ClientConnectionSender>,
+        auth: AuthCtx,
+        request: ws_v1::Unsubscribe,
+        timer: Instant,
+    ) -> Result<Option<ExecutionMetrics>, DBError> {
+        let cmd = ViewCommand::RemoveSingleSubscription {
+            sender,
+            auth,
+            request,
+            timer,
+        };
+
+        self.call_view_command("call_view_remove_single_subscription", cmd)
+            .await
+            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
     }
 
     pub async fn call_view_remove_v2_subscription(
@@ -1872,17 +1880,28 @@ impl ModuleHost {
             timer,
         };
 
-        let res = self
-            .call_view_command("call_view_remove_v2_subscription", cmd)
+        self.call_view_command("call_view_remove_v2_subscription", cmd)
             .await
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?;
+            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
+    }
 
-        match res {
-            ViewCommandResult::Subscription { result } => result,
-            ViewCommandResult::Sql { .. } => {
-                unreachable!("unexpected SQL result in call_view_remove_v2_subscription")
-            }
-        }
+    pub async fn call_view_remove_multi_subscription(
+        &self,
+        sender: Arc<ClientConnectionSender>,
+        auth: AuthCtx,
+        request: ws_v1::UnsubscribeMulti,
+        timer: Instant,
+    ) -> Result<Option<ExecutionMetrics>, DBError> {
+        let cmd = ViewCommand::RemoveMultiSubscription {
+            sender,
+            auth,
+            request,
+            timer,
+        };
+
+        self.call_view_command("call_view_remove_multi_subscription", cmd)
+            .await
+            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
     }
 
     pub async fn call_view_add_multi_subscription(
@@ -1899,18 +1918,10 @@ impl ModuleHost {
             _timer: timer,
         };
 
-        let res = self
-            .call_view_command("call_view_add_multi_subscription", cmd)
+        self.call_view_command("call_view_add_multi_subscription", cmd)
             .await
             //TODO: handle error better
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?;
-
-        match res {
-            ViewCommandResult::Subscription { result } => result,
-            ViewCommandResult::Sql { .. } => {
-                unreachable!("unexpected SQL result in call_view_add_single_subscription")
-            }
-        }
+            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
     }
 
     pub async fn call_view_add_legacy_subscription(
@@ -1927,21 +1938,13 @@ impl ModuleHost {
             _timer: timer,
         };
 
-        let res = self
-            .call_view_command("call_view_add_legacy_subscription", cmd)
+        self.call_view_command("call_view_add_legacy_subscription", cmd)
             .await
             //TODO: handle error better
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?;
-
-        match res {
-            ViewCommandResult::Subscription { result } => result,
-            ViewCommandResult::Sql { .. } => {
-                unreachable!("unexpected SQL result in call_view_add_single_subscription")
-            }
-        }
+            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
     }
 
-    pub async fn call_view_sql(
+    pub async fn call_sql(
         &self,
         db: Arc<RelationalDB>,
         sql_text: String,
@@ -1949,28 +1952,17 @@ impl ModuleHost {
         subs: Option<ModuleSubscriptions>,
         head: &mut Vec<(RawIdentifier, AlgebraicType)>,
     ) -> Result<SqlResult, DBError> {
-        let cmd = ViewCommand::Sql {
+        let cmd = SqlCommand {
             db,
             sql_text,
             auth,
             subs,
         };
 
-        let res = self
-            .call_view_command("call_view_sql", cmd)
-            .await
-            //TODO: handle error better
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?;
+        let res = self.call_sql_command(cmd).await?;
 
-        match res {
-            ViewCommandResult::Sql { result, head: new_head } => {
-                *head = new_head;
-                result
-            }
-            ViewCommandResult::Subscription { .. } => {
-                unreachable!("unexpected subscription result in call_view_sql")
-            }
-        }
+        *head = res.head;
+        res.result
     }
 
     pub async fn call_procedure(
@@ -2342,132 +2334,229 @@ impl ModuleHost {
         )
     }
 
-    /// Execute a one-off query and send the results to the given client.
+    /// Execute a JSON one-off query and send the results to the given client.
     /// This only returns an error if there is a db-level problem.
     /// An error with the query itself will be sent to the client.
     #[tracing::instrument(level = "trace", skip_all)]
-    pub async fn one_off_query<F: BuildableWebsocketFormat>(
+    pub async fn one_off_query_json(
         &self,
         auth: AuthCtx,
         query: String,
         client: Arc<ClientConnectionSender>,
         message_id: Vec<u8>,
         timer: Instant,
-        rlb_pool: impl 'static + Send + RowListBuilderSource<F>,
-        // We take this because we only have a way to convert with the concrete types (Bsatn and Json)
-        into_message: impl FnOnce(OneOffQueryResponseMessage<F>) -> SerializableMessage + Send + 'static,
     ) -> Result<(), anyhow::Error> {
-        let replica_ctx = self.replica_ctx();
-        let db = self.relational_db().clone();
-        let subscriptions = replica_ctx.subscriptions.clone();
-        log::debug!("One-off query: {query}");
+        let params = OneOffQueryJsonParams {
+            db: self.relational_db().clone(),
+            subscriptions: self.replica_ctx().subscriptions.clone(),
+            auth,
+            query,
+            client,
+            message_id,
+            timer,
+        };
+        log::debug!("One-off query: {}", params.query);
         let metrics = self
-            .on_module_thread("one_off_query", move || {
-                let (tx_offset_sender, tx_offset_receiver) = oneshot::channel();
-                let tx = scopeguard::guard(db.begin_tx(Workload::Sql), |tx| {
-                    let (tx_offset, tx_metrics, reducer) = db.release_tx(tx);
-                    let _ = tx_offset_sender.send(tx_offset);
-                    db.report_read_tx_metrics(reducer, tx_metrics);
-                });
-
-                // We wrap the actual query in a closure so we can use ? to handle errors without making
-                // the entire transaction abort with an error.
-                let result: Result<(ws_v1::OneOffTable<F>, ExecutionMetrics), anyhow::Error> = (|| {
-                    let tx = SchemaViewer::new(&*tx, &auth);
-
-                    let (
-                        // A query may compile down to several plans.
-                        // This happens when there are multiple RLS rules per table.
-                        // The original query is the union of these plans.
-                        plans,
-                        _,
-                        table_name,
-                        _,
-                    ) = compile_subscription(&query, &tx, &auth)?;
-
-                    // Optimize each fragment
-                    let optimized = plans
-                        .into_iter()
-                        .map(|plan| plan.optimize(&auth))
-                        .collect::<Result<Vec<_>, _>>()?;
-
-                    check_row_limit(
-                        &optimized,
-                        &db,
-                        &tx,
-                        // Estimate the number of rows this query will scan
-                        |plan, tx| estimate_rows_scanned(tx, plan),
-                        &auth,
-                    )?;
-
-                    let return_table = || optimized.first().and_then(|plan| plan.return_table());
-
-                    let returns_view_table = optimized.first().is_some_and(|plan| plan.returns_view_table());
-                    let num_cols = return_table().map(|schema| schema.num_cols()).unwrap_or_default();
-                    let num_private_cols = return_table()
-                        .map(|schema| schema.num_private_cols())
-                        .unwrap_or_default();
-
-                    let optimized = optimized
-                        .into_iter()
-                        // Convert into something we can execute
-                        .map(PipelinedProject::from)
-                        .collect::<Vec<_>>();
-
-                    let table_name = table_name.into();
-
-                    if returns_view_table && num_private_cols > 0 {
-                        let optimized = optimized
-                            .into_iter()
-                            .map(|plan| ViewProject::new(plan, num_cols, num_private_cols))
-                            .collect::<Vec<_>>();
-                        // Execute the union and return the results
-                        return execute_plan_for_view::<F>(&optimized, &DeltaTx::from(&*tx), &rlb_pool)
-                            .map(|(rows, _, metrics)| (ws_v1::OneOffTable { table_name, rows }, metrics))
-                            .context("One-off queries are not allowed to modify the database");
-                    }
-
-                    // Execute the union and return the results
-                    execute_plan::<F>(&optimized, &DeltaTx::from(&*tx), &rlb_pool)
-                        .map(|(rows, _, metrics)| (ws_v1::OneOffTable { table_name, rows }, metrics))
-                        .context("One-off queries are not allowed to modify the database")
-                })();
-
-                let total_host_execution_duration = timer.elapsed().into();
-                let (message, metrics): (SerializableMessage, Option<ExecutionMetrics>) = match result {
-                    Ok((rows, metrics)) => (
-                        into_message(OneOffQueryResponseMessage {
-                            message_id,
-                            error: None,
-                            results: vec![rows],
-                            total_host_execution_duration,
-                        }),
-                        Some(metrics),
-                    ),
-                    Err(err) => (
-                        into_message(OneOffQueryResponseMessage {
-                            message_id,
-                            error: Some(format!("{err}")),
-                            results: vec![],
-                            total_host_execution_duration,
-                        }),
-                        None,
-                    ),
-                };
-
-                subscriptions.send_client_message(client, message, (&*tx, tx_offset_receiver))?;
-                Ok::<Option<ExecutionMetrics>, anyhow::Error>(metrics)
-            })
+            .call(
+                "one_off_query_json",
+                params,
+                async |params, _inst| Self::one_off_query_json_inner(params),
+                async |params, inst| inst.one_off_query_json(params).await,
+            )
             .await??;
-
-        if let Some(metrics) = metrics {
-            // Record the metrics for the one-off query
-            self.relational_db()
-                .exec_counters_for(WorkloadType::Sql)
-                .record(&metrics);
-        }
-
+        self.record_one_off_query_metrics(metrics);
         Ok(())
+    }
+
+    /// Execute a BSATN one-off query and send the results to the given client.
+    /// This only returns an error if there is a db-level problem.
+    /// An error with the query itself will be sent to the client.
+    #[tracing::instrument(level = "trace", skip_all)]
+    pub async fn one_off_query_bsatn(
+        &self,
+        auth: AuthCtx,
+        query: String,
+        client: Arc<ClientConnectionSender>,
+        message_id: Vec<u8>,
+        timer: Instant,
+        rlb_pool: BsatnRowListBuilderPool,
+    ) -> Result<(), anyhow::Error> {
+        let params = OneOffQueryBsatnParams {
+            db: self.relational_db().clone(),
+            subscriptions: self.replica_ctx().subscriptions.clone(),
+            auth,
+            query,
+            client,
+            message_id,
+            timer,
+            rlb_pool,
+        };
+        log::debug!("One-off query: {}", params.query);
+        let metrics = self
+            .call(
+                "one_off_query_bsatn",
+                params,
+                async |params, _inst| Self::one_off_query_bsatn_inner(params),
+                async |params, inst| inst.one_off_query_bsatn(params).await,
+            )
+            .await??;
+        self.record_one_off_query_metrics(metrics);
+        Ok(())
+    }
+
+    pub(in crate::host) fn one_off_query_json_inner(params: OneOffQueryJsonParams) -> OneOffQueryResult {
+        let OneOffQueryJsonParams {
+            db,
+            subscriptions,
+            auth,
+            query,
+            client,
+            message_id,
+            timer,
+        } = params;
+        Self::one_off_query_v1_inner(
+            db,
+            subscriptions,
+            auth,
+            query,
+            client,
+            message_id,
+            timer,
+            JsonRowListBuilderFakePool,
+            |msg: OneOffQueryResponseMessage<ws_v1::JsonFormat>| msg.into(),
+        )
+    }
+
+    pub(in crate::host) fn one_off_query_bsatn_inner(params: OneOffQueryBsatnParams) -> OneOffQueryResult {
+        let OneOffQueryBsatnParams {
+            db,
+            subscriptions,
+            auth,
+            query,
+            client,
+            message_id,
+            timer,
+            rlb_pool,
+        } = params;
+        Self::one_off_query_v1_inner(
+            db,
+            subscriptions,
+            auth,
+            query,
+            client,
+            message_id,
+            timer,
+            rlb_pool,
+            |msg: OneOffQueryResponseMessage<ws_v1::BsatnFormat>| msg.into(),
+        )
+    }
+
+    fn one_off_query_v1_inner<F: BuildableWebsocketFormat>(
+        db: Arc<RelationalDB>,
+        subscriptions: ModuleSubscriptions,
+        auth: AuthCtx,
+        query: String,
+        client: Arc<ClientConnectionSender>,
+        message_id: Vec<u8>,
+        timer: Instant,
+        rlb_pool: impl RowListBuilderSource<F>,
+        // We take this because we only have a way to convert with the concrete types (Bsatn and Json)
+        into_message: impl FnOnce(OneOffQueryResponseMessage<F>) -> SerializableMessage,
+    ) -> OneOffQueryResult {
+        let (tx_offset_sender, tx_offset_receiver) = oneshot::channel();
+        let tx = scopeguard::guard(db.begin_tx(Workload::Sql), |tx| {
+            let (tx_offset, tx_metrics, reducer) = db.release_tx(tx);
+            let _ = tx_offset_sender.send(tx_offset);
+            db.report_read_tx_metrics(reducer, tx_metrics);
+        });
+
+        // We wrap the actual query in a closure so we can use ? to handle errors without making
+        // the entire transaction abort with an error.
+        let result: Result<(ws_v1::OneOffTable<F>, ExecutionMetrics), anyhow::Error> = (|| {
+            let tx = SchemaViewer::new(&*tx, &auth);
+
+            let (
+                // A query may compile down to several plans.
+                // This happens when there are multiple RLS rules per table.
+                // The original query is the union of these plans.
+                plans,
+                _,
+                table_name,
+                _,
+            ) = compile_subscription(&query, &tx, &auth)?;
+
+            // Optimize each fragment
+            let optimized = plans
+                .into_iter()
+                .map(|plan| plan.optimize(&auth))
+                .collect::<Result<Vec<_>, _>>()?;
+
+            check_row_limit(
+                &optimized,
+                &db,
+                &tx,
+                // Estimate the number of rows this query will scan
+                |plan, tx| estimate_rows_scanned(tx, plan),
+                &auth,
+            )?;
+
+            let return_table = || optimized.first().and_then(|plan| plan.return_table());
+
+            let returns_view_table = optimized.first().is_some_and(|plan| plan.returns_view_table());
+            let num_cols = return_table().map(|schema| schema.num_cols()).unwrap_or_default();
+            let num_private_cols = return_table()
+                .map(|schema| schema.num_private_cols())
+                .unwrap_or_default();
+
+            let optimized = optimized
+                .into_iter()
+                // Convert into something we can execute
+                .map(PipelinedProject::from)
+                .collect::<Vec<_>>();
+
+            let table_name = table_name.into();
+
+            if returns_view_table && num_private_cols > 0 {
+                let optimized = optimized
+                    .into_iter()
+                    .map(|plan| ViewProject::new(plan, num_cols, num_private_cols))
+                    .collect::<Vec<_>>();
+                // Execute the union and return the results
+                return execute_plan_for_view::<F>(&optimized, &DeltaTx::from(&*tx), &rlb_pool)
+                    .map(|(rows, _, metrics)| (ws_v1::OneOffTable { table_name, rows }, metrics))
+                    .context("One-off queries are not allowed to modify the database");
+            }
+
+            // Execute the union and return the results
+            execute_plan::<F>(&optimized, &DeltaTx::from(&*tx), &rlb_pool)
+                .map(|(rows, _, metrics)| (ws_v1::OneOffTable { table_name, rows }, metrics))
+                .context("One-off queries are not allowed to modify the database")
+        })();
+
+        let total_host_execution_duration = timer.elapsed().into();
+        let (message, metrics): (SerializableMessage, Option<ExecutionMetrics>) = match result {
+            Ok((rows, metrics)) => (
+                into_message(OneOffQueryResponseMessage {
+                    message_id,
+                    error: None,
+                    results: vec![rows],
+                    total_host_execution_duration,
+                }),
+                Some(metrics),
+            ),
+            Err(err) => (
+                into_message(OneOffQueryResponseMessage {
+                    message_id,
+                    error: Some(format!("{err}")),
+                    results: vec![],
+                    total_host_execution_duration,
+                }),
+                None,
+            ),
+        };
+
+        subscriptions.send_client_message(client, message, (&*tx, tx_offset_receiver))?;
+        Ok(metrics)
     }
 
     /// Execute a one-off query for v2 clients and send the results to the given client.
@@ -2482,36 +2571,41 @@ impl ModuleHost {
         client: Arc<ClientConnectionSender>,
         request_id: u32,
         _timer: Instant,
-        rlb_pool: impl 'static + Send + RowListBuilderSource<ws_v1::BsatnFormat>,
+        rlb_pool: BsatnRowListBuilderPool,
     ) -> Result<(), anyhow::Error> {
-        let replica_ctx = self.replica_ctx();
-        let db = self.relational_db().clone();
-        let subscriptions = replica_ctx.subscriptions.clone();
-        log::debug!("One-off query: {query}");
+        let params = OneOffQueryV2Params {
+            db: self.relational_db().clone(),
+            subscriptions: self.replica_ctx().subscriptions.clone(),
+            auth,
+            query,
+            client,
+            request_id,
+            rlb_pool,
+        };
+        log::debug!("One-off query: {}", params.query);
         let metrics = self
-            .on_module_thread("one_off_query_v2", move || {
-                Self::one_off_query_v2_inner(db, subscriptions, auth, query, client, request_id, rlb_pool)
-            })
+            .call(
+                "one_off_query_v2",
+                params,
+                async |params, _inst| Self::one_off_query_v2_inner(params),
+                async |params, inst| inst.one_off_query_v2(params).await,
+            )
             .await??;
 
-        if let Some(metrics) = metrics {
-            self.relational_db()
-                .exec_counters_for(WorkloadType::Sql)
-                .record(&metrics);
-        }
-
+        self.record_one_off_query_metrics(metrics);
         Ok(())
     }
 
-    fn one_off_query_v2_inner(
-        db: Arc<RelationalDB>,
-        subscriptions: ModuleSubscriptions,
-        auth: AuthCtx,
-        query: String,
-        client: Arc<ClientConnectionSender>,
-        request_id: u32,
-        rlb_pool: impl 'static + Send + RowListBuilderSource<ws_v1::BsatnFormat>,
-    ) -> Result<Option<ExecutionMetrics>, anyhow::Error> {
+    pub(in crate::host) fn one_off_query_v2_inner(params: OneOffQueryV2Params) -> OneOffQueryResult {
+        let OneOffQueryV2Params {
+            db,
+            subscriptions,
+            auth,
+            query,
+            client,
+            request_id,
+            rlb_pool,
+        } = params;
         let (tx_offset_sender, tx_offset_receiver) = oneshot::channel();
         let tx = scopeguard::guard(db.begin_tx(Workload::Sql), |tx| {
             let (tx_offset, tx_metrics, reducer) = db.release_tx(tx);
@@ -2595,6 +2689,14 @@ impl ModuleHost {
 
         subscriptions.send_one_off_query_message_v2(client, message, tx_offset_receiver)?;
         Ok(metrics)
+    }
+
+    fn record_one_off_query_metrics(&self, metrics: Option<ExecutionMetrics>) {
+        if let Some(metrics) = metrics {
+            self.relational_db()
+                .exec_counters_for(WorkloadType::Sql)
+                .record(&metrics);
+        }
     }
 
     /// FIXME(jgilles): this is a temporary workaround for deleting not currently being supported
@@ -2732,15 +2834,15 @@ mod tests {
 
         let (sender, mut receiver) = setup_client(&db);
         let auth = AuthCtx::new(db.owner_identity(), sender.id.identity);
-        ModuleHost::one_off_query_v2_inner(
-            db.clone(),
-            subs.clone(),
+        ModuleHost::one_off_query_v2_inner(super::OneOffQueryV2Params {
+            db: db.clone(),
+            subscriptions: subs.clone(),
             auth,
-            "select * from t".to_string(),
-            sender,
-            42,
-            subs.bsatn_rlb_pool.clone(),
-        )?;
+            query: "select * from t".to_string(),
+            client: sender,
+            request_id: 42,
+            rlb_pool: subs.bsatn_rlb_pool.clone(),
+        })?;
 
         runtime.block_on(async {
             match receiver.recv().await {
@@ -2767,15 +2869,15 @@ mod tests {
 
         let (sender, mut receiver) = setup_client(&db);
         let auth = AuthCtx::new(db.owner_identity(), sender.id.identity);
-        ModuleHost::one_off_query_v2_inner(
-            db.clone(),
-            subs.clone(),
+        ModuleHost::one_off_query_v2_inner(super::OneOffQueryV2Params {
+            db: db.clone(),
+            subscriptions: subs.clone(),
             auth,
-            "select * from missing_table".to_string(),
-            sender,
-            7,
-            subs.bsatn_rlb_pool.clone(),
-        )?;
+            query: "select * from missing_table".to_string(),
+            client: sender,
+            request_id: 7,
+            rlb_pool: subs.bsatn_rlb_pool.clone(),
+        })?;
 
         runtime.block_on(async {
             match receiver.recv().await {

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -2,17 +2,17 @@ use super::{
     ArgsTuple, FunctionArgs, InvalidProcedureArguments, InvalidReducerArguments, ReducerCallResult, ReducerId,
     ReducerOutcome, Scheduler,
 };
-use crate::client::messages::{OneOffQueryResponseMessage, SerializableMessage};
-use crate::client::{ClientActorId, ClientConnectionSender};
+use crate::client::messages::{OneOffQueryResponseMessage, ProcedureResultMessage, SerializableMessage};
+use crate::client::{ClientActorId, ClientConnectionSender, WsVersion};
 use crate::database_logger::{DatabaseLogger, LogLevel, Record};
 use crate::db::relational_db::RelationalDB;
 use crate::energy::EnergyQuanta;
 use crate::error::DBError;
 use crate::estimation::{check_row_limit, estimate_rows_scanned};
 use crate::hash::Hash;
-use crate::host::host_controller::CallProcedureReturn;
+use crate::host::host_controller::{CallProcedureReturn, ProcedureCallResult};
 use crate::host::scheduler::{CallScheduledFunctionError, CallScheduledFunctionResult, ScheduledFunctionParams};
-use crate::host::v8::{JsMainInstance, JsProcedureInstance};
+use crate::host::v8::{JsFatalHook, JsMainInstance, JsProcedureCallCompletion, JsProcedureInstance};
 pub use crate::host::wasm_common::module_host_actor::{InstanceCommon, WasmInstance};
 use crate::host::wasmtime::ModuleInstance;
 use crate::host::{InvalidFunctionArguments, InvalidViewArguments};
@@ -23,6 +23,7 @@ use crate::sql::ast::SchemaViewer;
 use crate::sql::execute::SqlResult;
 use crate::sql::parser::RowLevelExpr;
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
+use crate::subscription::module_subscription_manager::BroadcastError;
 pub use crate::subscription::module_subscription_manager::TransactionOffset;
 use crate::subscription::row_list_builder_pool::{BsatnRowListBuilderPool, JsonRowListBuilderFakePool};
 use crate::subscription::tx::DeltaTx;
@@ -57,7 +58,7 @@ use spacetimedb_expr::expr::CollectViews;
 use spacetimedb_lib::db::raw_def::v9::Lifecycle;
 use spacetimedb_lib::identity::{AuthCtx, RequestId};
 use spacetimedb_lib::metrics::ExecutionMetrics;
-use spacetimedb_lib::{ConnectionId, Timestamp};
+use spacetimedb_lib::{bsatn, ConnectionId, TimeDuration, Timestamp};
 use spacetimedb_primitives::{ArgId, ProcedureId, TableId, ViewFnPtr, ViewId};
 use spacetimedb_query::compile_subscription;
 use spacetimedb_sats::raw_identifier::RawIdentifier;
@@ -710,6 +711,32 @@ pub enum ViewCommand {
 
 pub type ViewCommandResult = Result<Option<ExecutionMetrics>, DBError>;
 
+#[derive(Clone, Copy)]
+pub(in crate::host) struct ViewCommandMetric {
+    workload: WorkloadType,
+    timer: Instant,
+}
+
+impl ViewCommand {
+    pub(in crate::host) fn metric(&self) -> ViewCommandMetric {
+        match self {
+            Self::AddSingleSubscription { _timer, .. }
+            | Self::AddMultiSubscription { _timer, .. }
+            | Self::AddLegacySubscription { _timer, .. }
+            | Self::AddSubscriptionV2 { _timer, .. } => ViewCommandMetric {
+                workload: WorkloadType::Subscribe,
+                timer: *_timer,
+            },
+            Self::RemoveSingleSubscription { timer, .. }
+            | Self::RemoveMultiSubscription { timer, .. }
+            | Self::RemoveSubscriptionV2 { timer, .. } => ViewCommandMetric {
+                workload: WorkloadType::Unsubscribe,
+                timer: *timer,
+            },
+        }
+    }
+}
+
 pub(in crate::host) struct SqlCommand {
     pub(in crate::host) db: Arc<RelationalDB>,
     pub(in crate::host) sql_text: String,
@@ -734,6 +761,12 @@ pub(in crate::host) struct OneOffQueryJsonParams {
     timer: Instant,
 }
 
+impl OneOffQueryJsonParams {
+    pub(in crate::host) fn timer(&self) -> Instant {
+        self.timer
+    }
+}
+
 pub(in crate::host) struct OneOffQueryBsatnParams {
     db: Arc<RelationalDB>,
     subscriptions: ModuleSubscriptions,
@@ -745,6 +778,12 @@ pub(in crate::host) struct OneOffQueryBsatnParams {
     rlb_pool: BsatnRowListBuilderPool,
 }
 
+impl OneOffQueryBsatnParams {
+    pub(in crate::host) fn timer(&self) -> Instant {
+        self.timer
+    }
+}
+
 pub(in crate::host) struct OneOffQueryV2Params {
     db: Arc<RelationalDB>,
     subscriptions: ModuleSubscriptions,
@@ -752,7 +791,25 @@ pub(in crate::host) struct OneOffQueryV2Params {
     query: String,
     client: Arc<ClientConnectionSender>,
     request_id: u32,
+    timer: Instant,
     rlb_pool: BsatnRowListBuilderPool,
+}
+
+impl OneOffQueryV2Params {
+    pub(in crate::host) fn timer(&self) -> Instant {
+        self.timer
+    }
+}
+
+pub(crate) struct ProcedureResultTarget {
+    sender: Arc<ClientConnectionSender>,
+    request_id: RequestId,
+}
+
+impl ProcedureResultTarget {
+    pub(crate) fn new(sender: Arc<ClientConnectionSender>, request_id: RequestId) -> Self {
+        Self { sender, request_id }
+    }
 }
 
 pub struct CallViewParams {
@@ -1313,6 +1370,11 @@ impl ModuleHost {
         &self.info.subscriptions
     }
 
+    #[inline]
+    pub fn is_js(&self) -> bool {
+        matches!(&*self.inner, ModuleHostInner::Js(_))
+    }
+
     fn is_marked_closed(&self) -> bool {
         // `self.closed` isn't used for any synchronization, it's just a shared flag,
         // so `Ordering::Relaxed` is sufficient.
@@ -1492,6 +1554,62 @@ impl ModuleHost {
         )
         .await
         .map_err(Into::into)
+    }
+
+    async fn call_view_command_for_websocket(
+        &self,
+        label: &'static str,
+        cmd: ViewCommand,
+    ) -> Result<Option<ExecutionMetrics>, DBError> {
+        let metric = cmd.metric();
+
+        scopeguard::defer_on_unwind!({
+            log::warn!("websocket view operation {label} panicked");
+            (self.on_panic)();
+        });
+
+        match &*self.inner {
+            ModuleHostInner::Js(js) => {
+                self.guard_closed()
+                    .map_err(|err| DBError::Other(anyhow::anyhow!(err)))?;
+                let on_panic = self.on_panic.clone();
+                js.main_instance
+                    .with_instance(async |inst| inst.enqueue_call_view(cmd, metric, on_panic).await)
+                    .await;
+                Ok(None)
+            }
+            ModuleHostInner::Wasm(_) => {
+                let result = self
+                    .call_view_command(label, cmd)
+                    .await
+                    .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?;
+                Self::record_view_command_metrics_for_result(&self.info, self.relational_db(), metric, &result);
+                result
+            }
+        }
+    }
+
+    pub(in crate::host) fn record_view_command_metrics_for_result(
+        info: &ModuleInfo,
+        db: &RelationalDB,
+        metric: ViewCommandMetric,
+        result: &ViewCommandResult,
+    ) {
+        if let Ok(Some(metrics)) = result {
+            db.exec_counters_for(metric.workload).record(metrics);
+        }
+
+        match metric.workload {
+            WorkloadType::Subscribe => info
+                .metrics
+                .request_round_trip_subscribe
+                .observe(metric.timer.elapsed().as_secs_f64()),
+            WorkloadType::Unsubscribe => info
+                .metrics
+                .request_round_trip_unsubscribe
+                .observe(metric.timer.elapsed().as_secs_f64()),
+            _ => {}
+        }
     }
 
     async fn call_sql_command(&self, cmd: SqlCommand) -> Result<SqlCommandResult, DBError> {
@@ -1746,40 +1864,70 @@ impl ModuleHost {
         })
     }
 
-    async fn call_reducer_inner(
-        &self,
+    fn reducer_call_params<'a>(
+        &'a self,
         caller_identity: Identity,
         caller_connection_id: Option<ConnectionId>,
         client: Option<Arc<ClientConnectionSender>>,
         request_id: Option<RequestId>,
         timer: Option<Instant>,
-        reducer_id: ReducerId,
-        reducer_def: &ReducerDef,
+        reducer_name: &str,
         args: FunctionArgs,
-    ) -> Result<ReducerCallResult, ReducerCallError> {
-        let args = args
-            .into_tuple_for_def(&self.info.module_def, reducer_def)
-            .map_err(InvalidReducerArguments)?;
-        let caller_connection_id = caller_connection_id.unwrap_or(ConnectionId::ZERO);
-        let call_reducer_params = CallReducerParams {
-            timestamp: Timestamp::now(),
-            caller_identity,
-            caller_connection_id,
-            client,
-            request_id,
-            timer,
-            reducer_id,
-            args,
-        };
+    ) -> Result<(&'a ReducerDef, CallReducerParams), ReducerCallError> {
+        let (reducer_id, reducer_def) = self
+            .info
+            .module_def
+            .reducer_full(reducer_name)
+            .ok_or(ReducerCallError::NoSuchReducer)?;
+        if let Some(lifecycle) = reducer_def.lifecycle {
+            return Err(ReducerCallError::LifecycleReducer(lifecycle));
+        }
 
+        if reducer_def.visibility.is_private() && !self.is_database_owner(caller_identity) {
+            return Err(ReducerCallError::NoSuchReducer);
+        }
+
+        Ok((
+            reducer_def,
+            Self::call_reducer_params(
+                &self.info,
+                caller_identity,
+                caller_connection_id,
+                client,
+                request_id,
+                timer,
+                reducer_id,
+                reducer_def,
+                args,
+            )?,
+        ))
+    }
+
+    async fn call_reducer_with_params(
+        &self,
+        reducer_def: &ReducerDef,
+        params: CallReducerParams,
+    ) -> Result<ReducerCallResult, ReducerCallError> {
         self.call(
             &reducer_def.name,
-            call_reducer_params,
+            params,
             async |p, inst| inst.call_reducer(p),
             async |p, inst| inst.call_reducer(p).await,
         )
         .await
         .map_err(Into::into)
+    }
+
+    fn log_reducer_submit_error(&self, reducer_name: &str, err: &ReducerCallError) {
+        let log_message = match err {
+            ReducerCallError::NoSuchReducer => Some(no_such_function_log_message("reducer", reducer_name)),
+            ReducerCallError::Args(_) => Some(args_error_log_message("reducer", reducer_name)),
+            _ => None,
+        };
+
+        if let Some(log_message) = log_message {
+            self.inject_logs(LogLevel::Error, reducer_name, &log_message)
+        }
     }
 
     pub async fn call_reducer(
@@ -1793,40 +1941,68 @@ impl ModuleHost {
         args: FunctionArgs,
     ) -> Result<ReducerCallResult, ReducerCallError> {
         let res = async {
-            let (reducer_id, reducer_def) = self
-                .info
-                .module_def
-                .reducer_full(reducer_name)
-                .ok_or(ReducerCallError::NoSuchReducer)?;
-            if let Some(lifecycle) = reducer_def.lifecycle {
-                return Err(ReducerCallError::LifecycleReducer(lifecycle));
-            }
-
-            if reducer_def.visibility.is_private() && !self.is_database_owner(caller_identity) {
-                return Err(ReducerCallError::NoSuchReducer);
-            }
-
-            self.call_reducer_inner(
+            let (reducer_def, params) = self.reducer_call_params(
                 caller_identity,
                 caller_connection_id,
                 client,
                 request_id,
                 timer,
-                reducer_id,
-                reducer_def,
+                reducer_name,
                 args,
-            )
-            .await
+            )?;
+            self.call_reducer_with_params(reducer_def, params).await
         }
         .await;
 
-        let log_message = match &res {
-            Err(ReducerCallError::NoSuchReducer) => Some(no_such_function_log_message("reducer", reducer_name)),
-            Err(ReducerCallError::Args(_)) => Some(args_error_log_message("reducer", reducer_name)),
-            _ => None,
-        };
-        if let Some(log_message) = log_message {
-            self.inject_logs(LogLevel::Error, reducer_name, &log_message)
+        if let Err(err) = &res {
+            self.log_reducer_submit_error(reducer_name, err);
+        }
+
+        res
+    }
+
+    pub async fn enqueue_reducer(
+        &self,
+        caller_identity: Identity,
+        caller_connection_id: Option<ConnectionId>,
+        client: Option<Arc<ClientConnectionSender>>,
+        request_id: Option<RequestId>,
+        timer: Option<Instant>,
+        reducer_name: &str,
+        args: FunctionArgs,
+    ) -> Result<(), ReducerCallError> {
+        let res = async {
+            let (reducer_def, params) = self.reducer_call_params(
+                caller_identity,
+                caller_connection_id,
+                client,
+                request_id,
+                timer,
+                reducer_name,
+                args,
+            )?;
+
+            scopeguard::defer_on_unwind!({
+                log::warn!("websocket reducer operation {reducer_name} panicked");
+                (self.on_panic)();
+            });
+
+            match &*self.inner {
+                ModuleHostInner::Js(js) => {
+                    self.guard_closed()?;
+                    let on_panic = self.on_panic.clone();
+                    js.main_instance
+                        .with_instance(async |inst| inst.enqueue_reducer(params, on_panic).await)
+                        .await;
+                    Ok(())
+                }
+                ModuleHostInner::Wasm(_) => self.call_reducer_with_params(reducer_def, params).await.map(drop),
+            }
+        }
+        .await;
+
+        if let Err(err) = &res {
+            self.log_reducer_submit_error(reducer_name, err);
         }
 
         res
@@ -1846,10 +2022,8 @@ impl ModuleHost {
             _timer: timer,
         };
 
-        self.call_view_command("call_view_add_single_subscription", cmd)
+        self.call_view_command_for_websocket("call_view_add_single_subscription", cmd)
             .await
-            //TODO: handle error better
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
     }
 
     pub async fn call_view_add_v2_subscription(
@@ -1866,10 +2040,8 @@ impl ModuleHost {
             _timer: timer,
         };
 
-        self.call_view_command("call_view_add_multi_subscription", cmd)
+        self.call_view_command_for_websocket("call_view_add_multi_subscription", cmd)
             .await
-            //TODO: handle error better
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
     }
 
     pub async fn call_view_remove_single_subscription(
@@ -1886,9 +2058,8 @@ impl ModuleHost {
             timer,
         };
 
-        self.call_view_command("call_view_remove_single_subscription", cmd)
+        self.call_view_command_for_websocket("call_view_remove_single_subscription", cmd)
             .await
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
     }
 
     pub async fn call_view_remove_v2_subscription(
@@ -1905,9 +2076,8 @@ impl ModuleHost {
             timer,
         };
 
-        self.call_view_command("call_view_remove_v2_subscription", cmd)
+        self.call_view_command_for_websocket("call_view_remove_v2_subscription", cmd)
             .await
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
     }
 
     pub async fn call_view_remove_multi_subscription(
@@ -1924,9 +2094,8 @@ impl ModuleHost {
             timer,
         };
 
-        self.call_view_command("call_view_remove_multi_subscription", cmd)
+        self.call_view_command_for_websocket("call_view_remove_multi_subscription", cmd)
             .await
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
     }
 
     pub async fn call_view_add_multi_subscription(
@@ -1943,10 +2112,8 @@ impl ModuleHost {
             _timer: timer,
         };
 
-        self.call_view_command("call_view_add_multi_subscription", cmd)
+        self.call_view_command_for_websocket("call_view_add_multi_subscription", cmd)
             .await
-            //TODO: handle error better
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
     }
 
     pub async fn call_view_add_legacy_subscription(
@@ -1963,10 +2130,8 @@ impl ModuleHost {
             _timer: timer,
         };
 
-        self.call_view_command("call_view_add_legacy_subscription", cmd)
+        self.call_view_command_for_websocket("call_view_add_legacy_subscription", cmd)
             .await
-            //TODO: handle error better
-            .map_err(|e| DBError::Other(anyhow::anyhow!(e)))?
     }
 
     pub async fn call_sql(
@@ -1999,25 +2164,11 @@ impl ModuleHost {
         args: FunctionArgs,
     ) -> CallProcedureReturn {
         let res = async {
-            let (procedure_id, procedure_def) = self
-                .info
-                .module_def
-                .procedure_full(procedure_name)
-                .ok_or(ProcedureCallError::NoSuchProcedure)?;
-
-            if procedure_def.visibility.is_private() && !self.is_database_owner(caller_identity) {
-                return Err(ProcedureCallError::NoSuchProcedure);
-            }
-
-            self.call_procedure_inner(
-                caller_identity,
-                caller_connection_id,
-                timer,
-                procedure_id,
-                procedure_def,
-                args,
-            )
-            .await
+            let (procedure_def, params) =
+                self.procedure_call_params(caller_identity, caller_connection_id, timer, procedure_name, args)?;
+            self.call_procedure_with_params(&procedure_def.name, params)
+                .await
+                .map_err(Into::into)
         }
         .await;
 
@@ -2029,6 +2180,98 @@ impl ModuleHost {
             },
         };
 
+        self.log_procedure_validation_result(procedure_name, &ret);
+
+        ret
+    }
+
+    pub(crate) async fn enqueue_procedure(
+        &self,
+        caller_identity: Identity,
+        caller_connection_id: Option<ConnectionId>,
+        timer: Option<Instant>,
+        procedure_name: &str,
+        args: FunctionArgs,
+        target: ProcedureResultTarget,
+    ) -> Result<(), BroadcastError> {
+        let res = async {
+            let (procedure_def, params) =
+                self.procedure_call_params(caller_identity, caller_connection_id, timer, procedure_name, args)?;
+            Ok((procedure_def.name.to_string(), params))
+        }
+        .await;
+
+        let (procedure_name, params) = match res {
+            Ok(value) => value,
+            Err(err) => {
+                let ret = CallProcedureReturn {
+                    result: Err(err),
+                    tx_offset: None,
+                };
+                self.log_procedure_validation_result(procedure_name, &ret);
+                return self.send_procedure_result(procedure_name, timer, target, ret);
+            }
+        };
+
+        let guard_procedure_name = procedure_name.clone();
+        scopeguard::defer_on_unwind!({
+            log::warn!("websocket procedure operation {guard_procedure_name} panicked");
+            (self.on_panic)();
+        });
+
+        if let Err(err) = self.guard_closed() {
+            let ret = CallProcedureReturn {
+                result: Err(err.into()),
+                tx_offset: None,
+            };
+            self.log_procedure_validation_result(&procedure_name, &ret);
+            return self.send_procedure_result(&procedure_name, timer, target, ret);
+        }
+
+        match &*self.inner {
+            ModuleHostInner::Js(host) => {
+                let lease = host.procedure_instances.get_instance().await;
+                let call = lease.instance.enqueue_procedure(params).await;
+                let module = self.clone();
+                tokio::spawn(async move {
+                    match call.receive().await {
+                        JsProcedureCallCompletion::Completed(ret) => {
+                            module.log_procedure_validation_result(&procedure_name, &ret);
+                            if let Err(err) = module.send_procedure_result(&procedure_name, timer, target, ret) {
+                                log::warn!("failed to send procedure result: {err:#}");
+                            }
+                        }
+                        JsProcedureCallCompletion::Panicked | JsProcedureCallCompletion::WorkerExited => {
+                            log::warn!("detached JS procedure worker failed before returning a result");
+                            (module.on_panic)();
+                        }
+                    }
+                    module.return_js_procedure_instance(lease).await;
+                });
+                Ok(())
+            }
+            ModuleHostInner::Wasm(_) => {
+                let ret = match self.call_procedure_with_params(&procedure_name, params).await {
+                    Ok(ret) => ret,
+                    Err(err) => CallProcedureReturn {
+                        result: Err(err.into()),
+                        tx_offset: None,
+                    },
+                };
+                self.log_procedure_validation_result(&procedure_name, &ret);
+                self.send_procedure_result(&procedure_name, timer, target, ret)
+            }
+        }
+    }
+
+    async fn return_js_procedure_instance(&self, lease: ModuleInstanceLease<JsProcedureInstance>) {
+        let ModuleHostInner::Js(host) = &*self.inner else {
+            return;
+        };
+        host.procedure_instances.return_instance(lease).await;
+    }
+
+    fn log_procedure_validation_result(&self, procedure_name: &str, ret: &CallProcedureReturn) {
         let log_message = match &ret.result {
             Err(ProcedureCallError::NoSuchProcedure) => Some(no_such_function_log_message("procedure", procedure_name)),
             Err(ProcedureCallError::Args(_)) => Some(args_error_log_message("procedure", procedure_name)),
@@ -2038,34 +2281,98 @@ impl ModuleHost {
         if let Some(log_message) = log_message {
             self.inject_logs(LogLevel::Error, procedure_name, &log_message)
         }
-
-        ret
     }
 
-    async fn call_procedure_inner(
+    fn send_procedure_result(
         &self,
+        procedure_name: &str,
+        timer: Option<Instant>,
+        target: ProcedureResultTarget,
+        ret: CallProcedureReturn,
+    ) -> Result<(), BroadcastError> {
+        if let Some(timer) = timer {
+            WORKER_METRICS
+                .request_round_trip
+                .with_label_values(&WorkloadType::Procedure, &self.info.database_identity, procedure_name)
+                .observe(timer.elapsed().as_secs_f64());
+        }
+
+        let ProcedureResultTarget { sender, request_id } = target;
+        let CallProcedureReturn { result, tx_offset } = ret;
+        match sender.config.version {
+            WsVersion::V1 => {
+                let message = ProcedureResultMessage::from_result(&result, request_id);
+                self.subscriptions().send_procedure_message(sender, message, tx_offset)
+            }
+            WsVersion::V2 | WsVersion::V3 => {
+                let (status, timestamp, execution_duration) = match result {
+                    Ok(ProcedureCallResult {
+                        return_val,
+                        execution_duration,
+                        start_timestamp,
+                    }) => (
+                        ws_v2::ProcedureStatus::Returned(
+                            bsatn::to_vec(&return_val)
+                                .expect("Procedure return value failed to serialize to BSATN")
+                                .into(),
+                        ),
+                        start_timestamp,
+                        TimeDuration::from(execution_duration),
+                    ),
+                    Err(err) => (
+                        ws_v2::ProcedureStatus::InternalError(err.to_string().into()),
+                        Timestamp::UNIX_EPOCH,
+                        TimeDuration::ZERO,
+                    ),
+                };
+
+                let message = ws_v2::ProcedureResult {
+                    status,
+                    timestamp,
+                    total_host_execution_duration: execution_duration,
+                    request_id,
+                };
+
+                self.subscriptions()
+                    .send_procedure_message_v2(sender, message, tx_offset)
+            }
+        }
+    }
+
+    fn procedure_call_params<'a>(
+        &'a self,
         caller_identity: Identity,
         caller_connection_id: Option<ConnectionId>,
         timer: Option<Instant>,
-        procedure_id: ProcedureId,
-        procedure_def: &ProcedureDef,
+        procedure_name: &str,
         args: FunctionArgs,
-    ) -> Result<CallProcedureReturn, ProcedureCallError> {
+    ) -> Result<(&'a ProcedureDef, CallProcedureParams), ProcedureCallError> {
+        let (procedure_id, procedure_def) = self
+            .info
+            .module_def
+            .procedure_full(procedure_name)
+            .ok_or(ProcedureCallError::NoSuchProcedure)?;
+
+        if procedure_def.visibility.is_private() && !self.is_database_owner(caller_identity) {
+            return Err(ProcedureCallError::NoSuchProcedure);
+        }
+
         let args = args
             .into_tuple_for_def(&self.info.module_def, procedure_def)
             .map_err(InvalidProcedureArguments)?;
         let caller_connection_id = caller_connection_id.unwrap_or(ConnectionId::ZERO);
 
-        let params = CallProcedureParams {
-            timestamp: Timestamp::now(),
-            caller_identity,
-            caller_connection_id,
-            timer,
-            procedure_id,
-            args,
-        };
-
-        Ok(self.call_procedure_with_params(&procedure_def.name, params).await?)
+        Ok((
+            procedure_def,
+            CallProcedureParams {
+                timestamp: Timestamp::now(),
+                caller_identity,
+                caller_connection_id,
+                timer,
+                procedure_id,
+                args,
+            },
+        ))
     }
 
     //TODO(shub) #4195: Also allow for collaborators along with owner
@@ -2381,16 +2688,7 @@ impl ModuleHost {
             timer,
         };
         log::debug!("One-off query: {}", params.query);
-        let metrics = self
-            .call(
-                "one_off_query_json",
-                params,
-                async |params, _inst| Self::one_off_query_json_inner(params),
-                async |params, inst| inst.one_off_query_json(params).await,
-            )
-            .await??;
-        self.record_one_off_query_metrics(metrics);
-        Ok(())
+        self.one_off_query_json_with_params(params).await
     }
 
     /// Execute a BSATN one-off query and send the results to the given client.
@@ -2417,16 +2715,72 @@ impl ModuleHost {
             rlb_pool,
         };
         log::debug!("One-off query: {}", params.query);
-        let metrics = self
-            .call(
-                "one_off_query_bsatn",
-                params,
-                async |params, _inst| Self::one_off_query_bsatn_inner(params),
-                async |params, inst| inst.one_off_query_bsatn(params).await,
-            )
-            .await??;
-        self.record_one_off_query_metrics(metrics);
-        Ok(())
+        self.one_off_query_bsatn_with_params(params).await
+    }
+
+    async fn one_off_query_for_websocket<P, Fut>(
+        &self,
+        label: &'static str,
+        params: P,
+        timer: Instant,
+        run_inner: impl FnOnce(P) -> OneOffQueryResult + Send + 'static,
+        enqueue_js: impl FnOnce(P, JsMainInstance, JsFatalHook) -> Fut + Send + 'static,
+    ) -> Result<(), anyhow::Error>
+    where
+        P: Send + 'static,
+        Fut: Future<Output = ()> + Send + 'static,
+    {
+        scopeguard::defer_on_unwind!({
+            log::warn!("websocket one-off query operation {label} panicked");
+            (self.on_panic)();
+        });
+
+        match &*self.inner {
+            ModuleHostInner::Js(js) => {
+                self.guard_closed()?;
+                let on_panic = self.on_panic.clone();
+                js.main_instance
+                    .with_instance(async |inst| enqueue_js(params, inst, on_panic).await)
+                    .await;
+                Ok(())
+            }
+            ModuleHostInner::Wasm(_) => {
+                let result = self
+                    .call(
+                        label,
+                        params,
+                        async move |params, _inst| run_inner(params),
+                        async |_, _| unreachable!("one-off query JS path is handled before Self::call"),
+                    )
+                    .await?;
+                Self::record_one_off_query_metrics_for_result(&self.info, self.relational_db(), timer, &result);
+                result.map(|_| ())
+            }
+        }
+    }
+
+    async fn one_off_query_json_with_params(&self, params: OneOffQueryJsonParams) -> Result<(), anyhow::Error> {
+        let timer = params.timer;
+        self.one_off_query_for_websocket(
+            "one_off_query_json",
+            params,
+            timer,
+            Self::one_off_query_json_inner,
+            |params, inst, on_panic| async move { inst.enqueue_one_off_query_json(params, on_panic).await },
+        )
+        .await
+    }
+
+    async fn one_off_query_bsatn_with_params(&self, params: OneOffQueryBsatnParams) -> Result<(), anyhow::Error> {
+        let timer = params.timer;
+        self.one_off_query_for_websocket(
+            "one_off_query_bsatn",
+            params,
+            timer,
+            Self::one_off_query_bsatn_inner,
+            |params, inst, on_panic| async move { inst.enqueue_one_off_query_bsatn(params, on_panic).await },
+        )
+        .await
     }
 
     pub(in crate::host) fn one_off_query_json_inner(params: OneOffQueryJsonParams) -> OneOffQueryResult {
@@ -2605,20 +2959,19 @@ impl ModuleHost {
             query,
             client,
             request_id,
+            timer: _timer,
             rlb_pool,
         };
         log::debug!("One-off query: {}", params.query);
-        let metrics = self
-            .call(
-                "one_off_query_v2",
-                params,
-                async |params, _inst| Self::one_off_query_v2_inner(params),
-                async |params, inst| inst.one_off_query_v2(params).await,
-            )
-            .await??;
-
-        self.record_one_off_query_metrics(metrics);
-        Ok(())
+        let timer = params.timer;
+        self.one_off_query_for_websocket(
+            "one_off_query_v2",
+            params,
+            timer,
+            Self::one_off_query_v2_inner,
+            |params, inst, on_panic| async move { inst.enqueue_one_off_query_v2(params, on_panic).await },
+        )
+        .await
     }
 
     pub(in crate::host) fn one_off_query_v2_inner(params: OneOffQueryV2Params) -> OneOffQueryResult {
@@ -2629,6 +2982,7 @@ impl ModuleHost {
             query,
             client,
             request_id,
+            timer: _,
             rlb_pool,
         } = params;
         let (tx_offset_sender, tx_offset_receiver) = oneshot::channel();
@@ -2716,12 +3070,18 @@ impl ModuleHost {
         Ok(metrics)
     }
 
-    fn record_one_off_query_metrics(&self, metrics: Option<ExecutionMetrics>) {
-        if let Some(metrics) = metrics {
-            self.relational_db()
-                .exec_counters_for(WorkloadType::Sql)
-                .record(&metrics);
+    pub(in crate::host) fn record_one_off_query_metrics_for_result(
+        info: &ModuleInfo,
+        db: &RelationalDB,
+        timer: Instant,
+        result: &OneOffQueryResult,
+    ) {
+        if let Ok(Some(metrics)) = result {
+            db.exec_counters_for(WorkloadType::Sql).record(metrics);
         }
+        info.metrics
+            .request_round_trip_sql
+            .observe(timer.elapsed().as_secs_f64());
     }
 
     /// FIXME(jgilles): this is a temporary workaround for deleting not currently being supported
@@ -2866,6 +3226,7 @@ mod tests {
             query: "select * from t".to_string(),
             client: sender,
             request_id: 42,
+            timer: std::time::Instant::now(),
             rlb_pool: subs.bsatn_rlb_pool.clone(),
         })?;
 
@@ -2901,6 +3262,7 @@ mod tests {
             query: "select * from missing_table".to_string(),
             client: sender,
             request_id: 7,
+            timer: std::time::Instant::now(),
             rlb_pool: subs.bsatn_rlb_pool.clone(),
         })?;
 

--- a/crates/core/src/host/scheduler.rs
+++ b/crates/core/src/host/scheduler.rs
@@ -13,7 +13,7 @@ use rustc_hash::FxHashMap;
 use spacetimedb_client_api_messages::energy::EnergyQuanta;
 use spacetimedb_datastore::execution_context::{ExecutionContext, ReducerContext, Workload};
 use spacetimedb_datastore::locking_tx_datastore::MutTxId;
-use spacetimedb_datastore::system_tables::{StFields, StScheduledFields, ST_SCHEDULED_ID};
+use spacetimedb_datastore::system_tables::{StScheduledFields, ST_SCHEDULED_ID};
 use spacetimedb_datastore::traits::IsolationLevel;
 use spacetimedb_lib::scheduler::ScheduleAt;
 use spacetimedb_lib::Timestamp;
@@ -53,6 +53,7 @@ enum MsgOrExit<T> {
 enum SchedulerMessage {
     Schedule {
         id: ScheduledFunctionId,
+        function_name: Box<str>,
         /// The timestamp we'll tell the reducer it is.
         effective_at: Timestamp,
         /// The actual instant we're scheduling for.
@@ -62,11 +63,6 @@ enum SchedulerMessage {
         function_name: String,
         args: FunctionArgs,
     },
-}
-
-pub struct ScheduledFunction {
-    function: Box<str>,
-    bsatn_args: Vec<u8>,
 }
 
 #[derive(Clone)]
@@ -107,6 +103,7 @@ impl SchedulerStarter {
         // Find all Scheduled tables
         for st_scheduled_row in self.db.iter(&tx, ST_SCHEDULED_ID)? {
             let table_id = st_scheduled_row.read_col(StScheduledFields::TableId)?;
+            let function_name = st_scheduled_row.read_col::<Box<str>>(StScheduledFields::ReducerName)?;
             let (id_column, at_column) = self
                 .db
                 .table_scheduled_id_and_at(&tx, table_id)?
@@ -127,7 +124,14 @@ impl SchedulerStarter {
                     id_column,
                     at_column,
                 };
-                let key = queue.insert_at(QueueItem::Id { id, at }, now_instant + duration);
+                let key = queue.insert_at(
+                    QueueItem::Id {
+                        id,
+                        function_name: function_name.clone(),
+                        at,
+                    },
+                    now_instant + duration,
+                );
 
                 // This should never happen as duplicate entries should be gated by unique
                 // constraint violation in scheduled tables.
@@ -198,6 +202,7 @@ impl Scheduler {
     /// Schedule a reducer/procedure to run from a scheduled table.
     ///
     /// `fn_start` is the timestamp of the start of the current reducer/procedure.
+    #[allow(clippy::too_many_arguments)]
     pub(super) fn schedule(
         &self,
         table_id: TableId,
@@ -205,6 +210,7 @@ impl Scheduler {
         schedule_at: ScheduleAt,
         id_column: ColId,
         at_column: ColId,
+        function_name: Box<str>,
         fn_start: Timestamp,
     ) -> Result<(), ScheduleError> {
         // if `Timestamp::now()` is properly monotonic, use it; otherwise, use
@@ -238,6 +244,7 @@ impl Scheduler {
                 id_column,
                 at_column,
             },
+            function_name,
             effective_at,
             real_at,
         }));
@@ -270,12 +277,32 @@ struct SchedulerActor {
 
 #[derive(Clone)]
 enum QueueItem {
-    Id { id: ScheduledFunctionId, at: Timestamp },
-    VolatileNonatomicImmediate { function_name: String, args: FunctionArgs },
+    Id {
+        id: ScheduledFunctionId,
+        function_name: Box<str>,
+        at: Timestamp,
+    },
+    VolatileNonatomicImmediate {
+        function_name: String,
+        args: FunctionArgs,
+    },
 }
 
 #[derive(Clone)]
 pub(crate) struct ScheduledFunctionParams(QueueItem);
+
+impl ScheduledFunctionParams {
+    fn function_name(&self) -> &str {
+        match &self.0 {
+            QueueItem::Id { function_name, .. } => function_name,
+            QueueItem::VolatileNonatomicImmediate { function_name, .. } => function_name,
+        }
+    }
+
+    pub(crate) fn is_procedure(&self, module: &ModuleInfo) -> bool {
+        module.module_def.procedure_full(self.function_name()).is_some()
+    }
+}
 
 #[derive(thiserror::Error, Debug)]
 pub(crate) enum CallScheduledFunctionError {
@@ -307,6 +334,7 @@ impl SchedulerActor {
         match msg {
             SchedulerMessage::Schedule {
                 id,
+                function_name,
                 effective_at,
                 real_at,
             } => {
@@ -314,7 +342,14 @@ impl SchedulerActor {
                 if let Some(key) = self.key_map.get(&id) {
                     self.queue.remove(key);
                 }
-                let key = self.queue.insert_at(QueueItem::Id { id, at: effective_at }, real_at);
+                let key = self.queue.insert_at(
+                    QueueItem::Id {
+                        id,
+                        function_name,
+                        at: effective_at,
+                    },
+                    real_at,
+                );
                 self.key_map.insert(id, key);
             }
             SchedulerMessage::ScheduleImmediate { function_name, args } => {
@@ -328,7 +363,7 @@ impl SchedulerActor {
 
     async fn handle_queued(&mut self, id: Expired<QueueItem>) {
         let item = id.into_inner();
-        let id: Option<ScheduledFunctionId> = match &item {
+        let id = match &item {
             QueueItem::Id { id, .. } => Some(*id),
             QueueItem::VolatileNonatomicImmediate { .. } => None,
         };
@@ -340,7 +375,12 @@ impl SchedulerActor {
             return;
         };
 
-        let result = module_host.call_scheduled_function(ScheduledFunctionParams(item)).await;
+        let params = ScheduledFunctionParams(item.clone());
+        let result = if params.is_procedure(module_host.info()) {
+            module_host.call_scheduled_procedure(params).await
+        } else {
+            module_host.call_scheduled_reducer(params).await
+        };
 
         match result {
             // If the module already exited, leave the `ScheduledFunction` in
@@ -352,9 +392,16 @@ impl SchedulerActor {
             Ok(CallScheduledFunctionResult {
                 reschedule: Some(Reschedule { at_ts, at_real }),
             }) => {
-                if let Some(id) = id {
+                if let QueueItem::Id { id, function_name, .. } = item {
                     // If this was repeated, we need to add it back to the queue.
-                    let key = self.queue.insert_at(QueueItem::Id { id, at: at_ts }, at_real);
+                    let key = self.queue.insert_at(
+                        QueueItem::Id {
+                            id,
+                            function_name,
+                            at: at_ts,
+                        },
+                        at_real,
+                    );
                     self.key_map.insert(id, key);
                 }
             }
@@ -381,8 +428,8 @@ pub(super) async fn call_scheduled_function(
 ) -> (CallScheduledFunctionResult, bool) {
     let ScheduledFunctionParams(item) = params;
 
-    let id: Option<ScheduledFunctionId> = match item {
-        QueueItem::Id { id, .. } => Some(id),
+    let id = match &item {
+        QueueItem::Id { id, .. } => Some(*id),
         QueueItem::VolatileNonatomicImmediate { .. } => None,
     };
     let db = &**module_info.relational_db();
@@ -606,15 +653,13 @@ fn call_params_for_queued_item(
     item: QueueItem,
 ) -> anyhow::Result<Option<(Timestamp, Instant, CallParams)>> {
     Ok(Some(match item {
-        QueueItem::Id { id, at } => {
+        QueueItem::Id { id, function_name, at } => {
             let Some(schedule_row) = get_schedule_row_mut(tx, db, id)? else {
                 // If the row is not found, it means the schedule is cancelled by the user.
                 return Ok(None);
             };
-            let ScheduledFunction { function, bsatn_args } = process_schedule(tx, db, id.table_id, &schedule_row)?;
-
-            let fun_args = FunctionArgs::Bsatn(bsatn_args.into());
-            function_to_call_params(module, &function, fun_args, Some(at))?
+            let fun_args = FunctionArgs::Bsatn(schedule_row.to_bsatn_vec()?.into());
+            function_to_call_params(module, &function_name, fun_args, Some(at))?
         }
         QueueItem::VolatileNonatomicImmediate { function_name, args } => {
             function_to_call_params(module, &function_name, args, None)?
@@ -665,28 +710,6 @@ fn function_to_call_params(
     };
 
     Ok((ts, instant, params))
-}
-
-/// Generate [`ScheduledFunction`] for given [`ScheduledFunctionId`].
-fn process_schedule(
-    tx: &MutTxId,
-    db: &RelationalDB,
-    table_id: TableId,
-    schedule_row: &RowRef<'_>,
-) -> Result<ScheduledFunction, anyhow::Error> {
-    // Get reducer name from `ST_SCHEDULED` table.
-    let table_id_col = StScheduledFields::TableId.col_id();
-    let function_name_col = StScheduledFields::ReducerName.col_id();
-    let st_scheduled_row = db
-        .iter_by_col_eq_mut(tx, ST_SCHEDULED_ID, table_id_col, &table_id.into())?
-        .next()
-        .ok_or_else(|| anyhow!("Scheduled table with id {table_id} entry does not exist in `st_scheduled`"))?;
-    let function = st_scheduled_row.read_col::<Box<str>>(function_name_col)?;
-
-    Ok(ScheduledFunction {
-        function,
-        bsatn_args: schedule_row.to_bsatn_vec()?,
-    })
 }
 
 /// Returns the `schedule_row` for `id`.

--- a/crates/core/src/host/scheduler.rs
+++ b/crates/core/src/host/scheduler.rs
@@ -53,7 +53,7 @@ enum MsgOrExit<T> {
 enum SchedulerMessage {
     Schedule {
         id: ScheduledFunctionId,
-        function_name: Box<str>,
+        function_name: Arc<str>,
         /// The timestamp we'll tell the reducer it is.
         effective_at: Timestamp,
         /// The actual instant we're scheduling for.
@@ -103,7 +103,8 @@ impl SchedulerStarter {
         // Find all Scheduled tables
         for st_scheduled_row in self.db.iter(&tx, ST_SCHEDULED_ID)? {
             let table_id = st_scheduled_row.read_col(StScheduledFields::TableId)?;
-            let function_name = st_scheduled_row.read_col::<Box<str>>(StScheduledFields::ReducerName)?;
+            let function_name =
+                Arc::<str>::from(st_scheduled_row.read_col::<Box<str>>(StScheduledFields::ReducerName)?);
             let (id_column, at_column) = self
                 .db
                 .table_scheduled_id_and_at(&tx, table_id)?
@@ -210,7 +211,7 @@ impl Scheduler {
         schedule_at: ScheduleAt,
         id_column: ColId,
         at_column: ColId,
-        function_name: Box<str>,
+        function_name: Arc<str>,
         fn_start: Timestamp,
     ) -> Result<(), ScheduleError> {
         // if `Timestamp::now()` is properly monotonic, use it; otherwise, use
@@ -279,7 +280,7 @@ struct SchedulerActor {
 enum QueueItem {
     Id {
         id: ScheduledFunctionId,
-        function_name: Box<str>,
+        function_name: Arc<str>,
         at: Timestamp,
     },
     VolatileNonatomicImmediate {

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -14,11 +14,13 @@ use super::module_host::{CallProcedureParams, CallReducerParams, ModuleInfo, Mod
 use super::UpdateDatabaseResult;
 use crate::client::ClientActorId;
 use crate::config::V8HeapPolicyConfig;
+use crate::error::DBError;
 use crate::host::host_controller::CallProcedureReturn;
 use crate::host::instance_env::{ChunkPool, InstanceEnv, TxSlot};
 use crate::host::module_host::{
-    call_identity_connected, init_database, ClientConnectedError, ProcedureCallError, ViewCallError, ViewCommand,
-    ViewCommandResult,
+    call_identity_connected, init_database, ClientConnectedError, OneOffQueryBsatnParams, OneOffQueryJsonParams,
+    OneOffQueryResult, OneOffQueryV2Params, ProcedureCallError, SqlCommand, SqlCommandResult, ViewCallError,
+    ViewCommand, ViewCommandResult,
 };
 use crate::host::scheduler::{CallScheduledFunctionResult, ScheduledFunctionParams};
 use crate::host::wasm_common::instrumentation::CallTimes;
@@ -34,9 +36,7 @@ use crate::replica_context::ReplicaContext;
 use crate::subscription::module_subscription_manager::TransactionOffset;
 use crate::util::jobs::{AllocatedJobCore, CorePinner, LoadBalanceOnDropGuard};
 use crate::worker_metrics::WORKER_METRICS;
-use core::any::type_name;
 use core::str;
-use futures::future::LocalBoxFuture;
 use futures::FutureExt;
 use itertools::Either;
 use prometheus::{IntCounter, IntGauge};
@@ -51,12 +51,10 @@ use spacetimedb_schema::identifier::Identifier;
 use spacetimedb_table::static_assert_size;
 use std::cell::Cell;
 use std::os::raw::c_void;
-use std::panic::AssertUnwindSafe;
 use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 use tokio::sync::{mpsc, oneshot};
-use tracing::Instrument;
 use v8::script_compiler::{compile_module, Source};
 use v8::{
     scope_with_context, ArrayBuffer, Context, Function, Global, Isolate, Local, MapFnTo, OwnedIsolate, PinScope,
@@ -117,42 +115,6 @@ const JS_MAIN_INSTANCE_QUEUE_CAPACITY: usize = 1024;
 const JS_PROCEDURE_INSTANCE_QUEUE_CAPACITY: usize = 1;
 pub(crate) const V8_WORKER_KIND_MAIN: &str = "main";
 
-thread_local! {
-    // Note, `on_module_thread` runs host closures on a single JS module thread.
-    // Enqueuing more JS module-thread work from one of those closures waits on the
-    // same worker thread that is already busy running the current closure.
-    // And this deadlocks.
-    static ON_JS_MODULE_THREAD: Cell<bool> = const { Cell::new(false) };
-}
-
-struct EnteredJsModuleThread;
-
-impl EnteredJsModuleThread {
-    fn new() -> Self {
-        ON_JS_MODULE_THREAD.with(|entered| {
-            assert!(
-                !entered.get(),
-                "reentrancy into the JS module thread; this would deadlock. \
-                 Do not enqueue onto this worker from inside `on_module_thread` work."
-            );
-            entered.set(true);
-        });
-        Self
-    }
-}
-
-impl Drop for EnteredJsModuleThread {
-    fn drop(&mut self) {
-        ON_JS_MODULE_THREAD.with(|entered| {
-            debug_assert!(
-                entered.get(),
-                "JS module thread marker should only be cleared after entry"
-            );
-            entered.set(false);
-        });
-    }
-}
-
 #[derive(Copy, Clone)]
 enum JsWorkerKind {
     Main,
@@ -170,16 +132,6 @@ impl JsWorkerKind {
             Self::Procedure => JS_PROCEDURE_INSTANCE_QUEUE_CAPACITY,
         }
     }
-}
-
-pub(crate) fn assert_not_on_js_module_thread(label: &str) {
-    ON_JS_MODULE_THREAD.with(|entered| {
-        assert!(
-            !entered.get(),
-            "{label} attempted to re-enter the JS module thread from code already \
-             running on that thread; this would deadlock"
-        );
-    });
 }
 
 /// The actual V8 runtime, with initialization of V8.
@@ -482,41 +434,6 @@ impl JsMainInstance {
         send_js_request(&self.tx, &self.trapped, request).await
     }
 
-    pub async fn run_on_thread<F, R>(&self, f: F) -> R
-    where
-        F: AsyncFnOnce() -> R + Send + 'static,
-        R: Send + 'static,
-    {
-        assert_not_on_js_module_thread("run_on_thread");
-        let span = tracing::Span::current();
-        let (tx, rx) = oneshot::channel();
-
-        self.tx
-            .send(JsMainWorkerRequest::RunFunction(Box::new(move || {
-                async move {
-                    let _on_js_module_thread = EnteredJsModuleThread::new();
-                    let result = AssertUnwindSafe(f().instrument(span)).catch_unwind().await;
-                    if let Err(Err(_panic)) = tx.send(result) {
-                        tracing::warn!("uncaught panic on `SingleCoreExecutor`")
-                    }
-                }
-                .boxed_local()
-            })))
-            .await
-            .unwrap_or_else(|_| {
-                self.trapped.store(true, Ordering::Relaxed);
-                panic!("worker should stay live while handling {}", type_name::<R>())
-            });
-
-        match rx.await.unwrap_or_else(|_| {
-            self.trapped.store(true, Ordering::Relaxed);
-            panic!("worker should stay live while handling {}", type_name::<R>())
-        }) {
-            Ok(r) => r,
-            Err(e) => std::panic::resume_unwind(e),
-        }
-    }
-
     pub async fn update_database(
         &self,
         program: Program,
@@ -594,6 +511,30 @@ impl JsMainInstance {
             .await
             .map_err(|_| ViewCallError::InternalError(js_worker_disconnected_error("call_view")))
     }
+
+    pub(in crate::host) async fn call_sql(&self, cmd: SqlCommand) -> Result<SqlCommandResult, DBError> {
+        self.send_request(|reply_tx| JsMainWorkerRequest::CallSql { reply_tx, cmd })
+            .await
+            .map_err(|_| DBError::Other(anyhow::anyhow!(js_worker_disconnected_error("call_sql"))))
+    }
+
+    pub(in crate::host) async fn one_off_query_json(&self, params: OneOffQueryJsonParams) -> OneOffQueryResult {
+        self.send_request(|reply_tx| JsMainWorkerRequest::OneOffQueryJson { reply_tx, params })
+            .await
+            .unwrap_or_else(|_| Err(anyhow::anyhow!(js_worker_disconnected_error("one_off_query_json"))))
+    }
+
+    pub(in crate::host) async fn one_off_query_bsatn(&self, params: OneOffQueryBsatnParams) -> OneOffQueryResult {
+        self.send_request(|reply_tx| JsMainWorkerRequest::OneOffQueryBsatn { reply_tx, params })
+            .await
+            .unwrap_or_else(|_| Err(anyhow::anyhow!(js_worker_disconnected_error("one_off_query_bsatn"))))
+    }
+
+    pub(in crate::host) async fn one_off_query_v2(&self, params: OneOffQueryV2Params) -> OneOffQueryResult {
+        self.send_request(|reply_tx| JsMainWorkerRequest::OneOffQueryV2 { reply_tx, params })
+            .await
+            .unwrap_or_else(|_| Err(anyhow::anyhow!(js_worker_disconnected_error("one_off_query_v2"))))
+    }
 }
 
 impl JsProcedureInstance {
@@ -663,10 +604,6 @@ type JsReplyTx<T> = oneshot::Sender<T>;
 /// executes the request there, and then has to send the typed result back to
 /// the async caller.
 enum JsMainWorkerRequest {
-    /// See [`JsMainInstance::run_on_thread`].
-    ///
-    /// This variant carries its own reply channel.
-    RunFunction(Box<dyn FnOnce() -> LocalBoxFuture<'static, ()> + Send>),
     /// See [`JsMainInstance::update_database`].
     UpdateDatabase {
         reply_tx: JsReplyTx<anyhow::Result<UpdateDatabaseResult>>,
@@ -683,6 +620,26 @@ enum JsMainWorkerRequest {
     CallView {
         reply_tx: JsReplyTx<ViewCommandResult>,
         cmd: ViewCommand,
+    },
+    /// See [`JsMainInstance::call_sql`].
+    CallSql {
+        reply_tx: JsReplyTx<SqlCommandResult>,
+        cmd: SqlCommand,
+    },
+    /// See [`JsMainInstance::one_off_query_json`].
+    OneOffQueryJson {
+        reply_tx: JsReplyTx<OneOffQueryResult>,
+        params: OneOffQueryJsonParams,
+    },
+    /// See [`JsMainInstance::one_off_query_bsatn`].
+    OneOffQueryBsatn {
+        reply_tx: JsReplyTx<OneOffQueryResult>,
+        params: OneOffQueryBsatnParams,
+    },
+    /// See [`JsMainInstance::one_off_query_v2`].
+    OneOffQueryV2 {
+        reply_tx: JsReplyTx<OneOffQueryResult>,
+        params: OneOffQueryV2Params,
     },
     /// See [`JsMainInstance::clear_all_clients`].
     ClearAllClients(JsReplyTx<anyhow::Result<()>>),
@@ -1068,7 +1025,7 @@ impl JsWorkerSpec for ProcedureJsWorker {
 
 fn handle_main_worker_request(
     request: JsMainWorkerRequest,
-    rt: &tokio::runtime::Handle,
+    _rt: &tokio::runtime::Handle,
     instance_common: &mut InstanceCommon,
     inst: &mut V8Instance<'_, '_, '_>,
     module_common: &ModuleCommon,
@@ -1079,7 +1036,6 @@ fn handle_main_worker_request(
     let mut should_exit = false;
 
     match request {
-        JsMainWorkerRequest::RunFunction(f) => rt.block_on(f()),
         JsMainWorkerRequest::UpdateDatabase {
             reply_tx,
             program,
@@ -1098,6 +1054,23 @@ fn handle_main_worker_request(
             let (res, trapped) = instance_common.handle_cmd(cmd, inst);
             send_worker_reply("call_view", reply_tx, res);
             should_exit = trapped;
+        }
+        JsMainWorkerRequest::CallSql { reply_tx, cmd } => {
+            let (res, trapped) = instance_common.handle_sql_cmd(cmd, inst);
+            send_worker_reply("call_sql", reply_tx, res);
+            should_exit = trapped;
+        }
+        JsMainWorkerRequest::OneOffQueryJson { reply_tx, params } => {
+            let res = ModuleHost::one_off_query_json_inner(params);
+            send_worker_reply("one_off_query_json", reply_tx, res);
+        }
+        JsMainWorkerRequest::OneOffQueryBsatn { reply_tx, params } => {
+            let res = ModuleHost::one_off_query_bsatn_inner(params);
+            send_worker_reply("one_off_query_bsatn", reply_tx, res);
+        }
+        JsMainWorkerRequest::OneOffQueryV2 { reply_tx, params } => {
+            let res = ModuleHost::one_off_query_v2_inner(params);
+            send_worker_reply("one_off_query_v2", reply_tx, res);
         }
         JsMainWorkerRequest::ClearAllClients(reply_tx) => {
             let res = instance_common.clear_all_clients();

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -14,7 +14,7 @@ use super::module_host::{
     CallProcedureParams, CallReducerParams, InstanceManagerMetrics, ModuleInfo, ModuleWithInstance,
 };
 use super::UpdateDatabaseResult;
-use crate::client::ClientActorId;
+use crate::client::{ClientActorId, MeteredUnboundedReceiver, MeteredUnboundedSender};
 use crate::config::V8HeapPolicyConfig;
 use crate::host::host_controller::CallProcedureReturn;
 use crate::host::instance_env::{ChunkPool, InstanceEnv, TxSlot};
@@ -112,7 +112,6 @@ impl V8Runtime {
 
 static V8_RUNTIME_GLOBAL: LazyLock<V8RuntimeInner> = LazyLock::new(V8RuntimeInner::init);
 const REDUCER_ARGS_BUFFER_SIZE: usize = 4_096;
-const JS_MAIN_INSTANCE_QUEUE_CAPACITY: usize = 1024;
 const JS_PROCEDURE_INSTANCE_QUEUE_CAPACITY: usize = 1;
 pub(crate) const V8_WORKER_KIND_MAIN: &str = "main";
 
@@ -125,13 +124,6 @@ enum JsWorkerKind {
 impl JsWorkerKind {
     const fn checks_heap(self) -> bool {
         matches!(self, Self::Main)
-    }
-
-    const fn request_queue_capacity(self) -> usize {
-        match self {
-            Self::Main => JS_MAIN_INSTANCE_QUEUE_CAPACITY,
-            Self::Procedure => JS_PROCEDURE_INSTANCE_QUEUE_CAPACITY,
-        }
     }
 }
 
@@ -397,7 +389,7 @@ impl JsInstanceEnv {
 /// and friends.
 #[derive(Clone)]
 pub struct JsMainInstance {
-    tx: mpsc::Sender<JsMainWorkerRequest>,
+    tx: MeteredUnboundedSender<JsMainWorkerRequest>,
 }
 
 /// A procedure instance for a [`JsModule`].
@@ -410,11 +402,11 @@ pub struct JsProcedureInstance {
 
 impl JsMainInstance {
     async fn request<R: JsMainRequest>(&self, request: R) -> R::Response {
-        send_js_request(R::CTX, &self.tx, |reply_tx| request.into_worker_request(reply_tx)).await
+        send_js_unbounded_request(R::CTX, &self.tx, |reply_tx| request.into_worker_request(reply_tx)).await
     }
 
     async fn send_detached_request(&self, ctx: &'static str, request: JsMainWorkerRequest) {
-        if self.tx.send(request).await.is_err() {
+        if self.tx.send(request).is_err() {
             panic!("JS worker exited before accepting `{ctx}`");
         }
     }
@@ -778,6 +770,22 @@ where
 {
     let (reply_tx, reply_rx) = oneshot::channel();
     if tx.send(request(reply_tx)).await.is_err() {
+        panic!("JS worker exited before accepting `{ctx}`");
+    }
+    match reply_rx.await {
+        Ok(Ok(value)) => value,
+        Ok(Err(panic)) => panic::resume_unwind(panic),
+        Err(_) => panic!("JS worker exited before replying to `{ctx}`"),
+    }
+}
+
+async fn send_js_unbounded_request<T>(
+    ctx: &'static str,
+    tx: &MeteredUnboundedSender<JsMainWorkerRequest>,
+    request: impl FnOnce(JsReplyTx<T>) -> JsMainWorkerRequest,
+) -> T {
+    let (reply_tx, reply_rx) = oneshot::channel();
+    if tx.send(request(reply_tx)).is_err() {
         panic!("JS worker exited before accepting `{ctx}`");
     }
     match reply_rx.await {
@@ -1274,10 +1282,16 @@ struct ProcedureJsWorker;
 trait JsWorkerSpec {
     type Request: Send + 'static;
     type Instance;
+    type Sender: Send + 'static;
+    type Receiver: Send + 'static;
 
     const KIND: JsWorkerKind;
 
-    fn make_instance(tx: mpsc::Sender<Self::Request>) -> Self::Instance;
+    fn channel(database_identity: &Identity) -> (Self::Sender, Self::Receiver);
+
+    fn make_instance(tx: Self::Sender) -> Self::Instance;
+
+    fn blocking_recv(rx: &mut Self::Receiver) -> Option<Self::Request>;
 
     fn handle_request(
         request: Self::Request,
@@ -1292,11 +1306,28 @@ trait JsWorkerSpec {
 impl JsWorkerSpec for MainJsWorker {
     type Request = JsMainWorkerRequest;
     type Instance = JsMainInstance;
+    type Sender = MeteredUnboundedSender<Self::Request>;
+    type Receiver = MeteredUnboundedReceiver<Self::Request>;
 
     const KIND: JsWorkerKind = JsWorkerKind::Main;
 
-    fn make_instance(tx: mpsc::Sender<Self::Request>) -> Self::Instance {
+    fn channel(database_identity: &Identity) -> (Self::Sender, Self::Receiver) {
+        let queue_length = WORKER_METRICS
+            .v8_request_queue_length
+            .with_label_values(database_identity);
+        let (tx, rx) = mpsc::unbounded_channel();
+        (
+            MeteredUnboundedSender::with_gauge(tx, queue_length.clone()),
+            MeteredUnboundedReceiver::with_gauge(rx, queue_length),
+        )
+    }
+
+    fn make_instance(tx: Self::Sender) -> Self::Instance {
         JsMainInstance { tx }
+    }
+
+    fn blocking_recv(rx: &mut Self::Receiver) -> Option<Self::Request> {
+        rx.blocking_recv()
     }
 
     fn handle_request(
@@ -1314,11 +1345,21 @@ impl JsWorkerSpec for MainJsWorker {
 impl JsWorkerSpec for ProcedureJsWorker {
     type Request = JsProcedureWorkerRequest;
     type Instance = JsProcedureInstance;
+    type Sender = mpsc::Sender<Self::Request>;
+    type Receiver = mpsc::Receiver<Self::Request>;
 
     const KIND: JsWorkerKind = JsWorkerKind::Procedure;
 
-    fn make_instance(tx: mpsc::Sender<Self::Request>) -> Self::Instance {
+    fn channel(_database_identity: &Identity) -> (Self::Sender, Self::Receiver) {
+        mpsc::channel(JS_PROCEDURE_INSTANCE_QUEUE_CAPACITY)
+    }
+
+    fn make_instance(tx: Self::Sender) -> Self::Instance {
         JsProcedureInstance { tx }
+    }
+
+    fn blocking_recv(rx: &mut Self::Receiver) -> Option<Self::Request> {
+        rx.blocking_recv()
     }
 
     fn handle_request(
@@ -1525,7 +1566,11 @@ where
     // This one-shot channel is used for initial startup error handling within the thread.
     let (result_tx, result_rx) = oneshot::channel();
     let worker_kind = W::KIND;
-    let (request_tx, mut request_rx) = mpsc::channel(worker_kind.request_queue_capacity());
+    let database_identity = match &module_or_mcc {
+        Either::Left(module_common) => module_common.info().database_identity,
+        Either::Right(mcc) => mcc.replica_ctx.database_identity,
+    };
+    let (request_tx, mut request_rx) = W::channel(&database_identity);
 
     let rt = tokio::runtime::Handle::current();
 
@@ -1653,7 +1698,7 @@ where
                 // This will cause channels, scopes, and the isolate to be cleaned up.
                 let mut requests_since_heap_check = 0u64;
                 let mut last_heap_check_at = Instant::now();
-                while let Some(request) = request_rx.blocking_recv() {
+                while let Some(request) = W::blocking_recv(&mut request_rx) {
                     core_pinner.pin_if_changed();
 
                     let mut outcome = W::handle_request(

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -17,7 +17,8 @@ use crate::config::V8HeapPolicyConfig;
 use crate::host::host_controller::CallProcedureReturn;
 use crate::host::instance_env::{ChunkPool, InstanceEnv, TxSlot};
 use crate::host::module_host::{
-    call_identity_connected, init_database, ClientConnectedError, ViewCallError, ViewCommand, ViewCommandResult,
+    call_identity_connected, init_database, ClientConnectedError, ProcedureCallError, ViewCallError, ViewCommand,
+    ViewCommandResult,
 };
 use crate::host::scheduler::{CallScheduledFunctionResult, ScheduledFunctionParams};
 use crate::host::wasm_common::instrumentation::CallTimes;
@@ -38,7 +39,6 @@ use core::str;
 use futures::future::LocalBoxFuture;
 use futures::FutureExt;
 use itertools::Either;
-use parking_lot::RwLock;
 use prometheus::{IntCounter, IntGauge};
 use spacetimedb_auth::identity::ConnectionAuthCtx;
 use spacetimedb_client_api_messages::energy::FunctionBudget;
@@ -52,10 +52,10 @@ use spacetimedb_table::static_assert_size;
 use std::cell::Cell;
 use std::os::raw::c_void;
 use std::panic::AssertUnwindSafe;
-use std::sync::atomic::{AtomicBool, AtomicU64, Ordering};
+use std::sync::atomic::{AtomicBool, Ordering};
 use std::sync::{Arc, LazyLock};
 use std::time::Instant;
-use tokio::sync::{oneshot, Mutex as AsyncMutex, Notify};
+use tokio::sync::{mpsc, oneshot};
 use tracing::Instrument;
 use v8::script_compiler::{compile_module, Source};
 use v8::{
@@ -112,9 +112,10 @@ impl V8Runtime {
 }
 
 static V8_RUNTIME_GLOBAL: LazyLock<V8RuntimeInner> = LazyLock::new(V8RuntimeInner::init);
-static NEXT_JS_INSTANCE_ID: AtomicU64 = AtomicU64::new(1);
 const REDUCER_ARGS_BUFFER_SIZE: usize = 4_096;
-pub(crate) const V8_WORKER_KIND_INSTANCE_LANE: &str = "instance_lane";
+const JS_MAIN_INSTANCE_QUEUE_CAPACITY: usize = 1024;
+const JS_POOLED_INSTANCE_QUEUE_CAPACITY: usize = 1;
+pub(crate) const V8_WORKER_KIND_MAIN: &str = "main";
 
 thread_local! {
     // Note, `on_module_thread` runs host closures on a single JS module thread.
@@ -154,13 +155,20 @@ impl Drop for EnteredJsModuleThread {
 
 #[derive(Copy, Clone)]
 enum JsWorkerKind {
-    InstanceLane,
+    Main,
     Pooled,
 }
 
 impl JsWorkerKind {
     const fn checks_heap(self) -> bool {
-        matches!(self, Self::InstanceLane)
+        matches!(self, Self::Main)
+    }
+
+    const fn request_queue_capacity(self) -> usize {
+        match self {
+            Self::Main => JS_MAIN_INSTANCE_QUEUE_CAPACITY,
+            Self::Pooled => JS_POOLED_INSTANCE_QUEUE_CAPACITY,
+        }
     }
 }
 
@@ -225,12 +233,6 @@ impl V8RuntimeInner {
 
         // Convert program to a string.
         let program: Arc<str> = str::from_utf8(program_bytes)?.into();
-        let database_identity = mcc.replica_ctx.database_identity;
-        let lane_queue = JsWorkerQueue::unbounded_with_metric(
-            WORKER_METRICS
-                .v8_instance_lane_queue_length
-                .with_label_values(&database_identity),
-        );
 
         // Validate/create the module and spawn the first instance.
         let mcc = Either::Right(mcc);
@@ -242,8 +244,7 @@ impl V8RuntimeInner {
             load_balance_guard.clone(),
             core_pinner.clone(),
             heap_policy,
-            JsWorkerKind::InstanceLane,
-            lane_queue.clone(),
+            JsWorkerKind::Main,
         )
         .await?;
         let module = JsModule {
@@ -252,7 +253,6 @@ impl V8RuntimeInner {
             load_balance_guard,
             core_pinner,
             heap_policy,
-            lane_queue,
         };
 
         Ok(ModuleWithInstance::Js { module, init_inst })
@@ -266,7 +266,6 @@ pub struct JsModule {
     load_balance_guard: Arc<LoadBalanceOnDropGuard>,
     core_pinner: CorePinner,
     heap_policy: V8HeapPolicyConfig,
-    lane_queue: Arc<JsWorkerQueue>,
 }
 
 impl JsModule {
@@ -282,7 +281,7 @@ impl JsModule {
         self.common.info().clone()
     }
 
-    async fn create_instance_with_queue(&self, request_queue: Arc<JsWorkerQueue>) -> JsInstance {
+    async fn create_instance_with_kind(&self, worker_kind: JsWorkerKind) -> JsInstance {
         let program = self.program.clone();
         let common = self.common.clone();
         let load_balance_guard = self.load_balance_guard.clone();
@@ -296,8 +295,7 @@ impl JsModule {
             load_balance_guard,
             core_pinner,
             heap_policy,
-            JsWorkerKind::Pooled,
-            request_queue,
+            worker_kind,
         )
         .await
         .expect("`spawn_instance_worker` should succeed when passed `ModuleCommon`");
@@ -305,14 +303,11 @@ impl JsModule {
     }
 
     pub async fn create_instance(&self) -> JsInstance {
-        // We use a rendezvous channel for pooled instances, because they are checked
-        // out one request at a time and subsequently returned to the pool, unlike the
-        // long lived instance used for executing reducers.
-        self.create_instance_with_queue(JsWorkerQueue::bounded(0)).await
+        self.create_instance_with_kind(JsWorkerKind::Pooled).await
     }
 
-    async fn create_lane_instance(&self) -> JsInstance {
-        self.create_instance_with_queue(self.lane_queue.clone()).await
+    pub(in crate::host) async fn create_main_instance(&self) -> JsInstance {
+        self.create_instance_with_kind(JsWorkerKind::Main).await
     }
 }
 
@@ -445,172 +440,32 @@ impl JsInstanceEnv {
 /// and friends.
 #[derive(Clone)]
 pub struct JsInstance {
-    /// Stable identifier for the underlying worker generation.
-    ///
-    /// All clones of the same handle share the same `id`. The instance lane uses
-    /// it to tell whether the currently active worker has already been replaced
-    /// after a trap or disconnect.
-    id: u64,
-    /// Shared across cloned handles and JS instances so callers keep inserting
-    /// into the same queue while recovery swaps in a replacement instance.
-    ///
-    /// The `Arc` is intentional here because `JsWorkerQueue` owns the `rx` handle
-    /// that gets cloned into each worker during replacement, and cloning that wrapper
-    /// by value would clone the `Receiver` too, which changes flume’s receiver count.
-    /// It would also run `JsWorkerQueue::drop` once per `JsInstance` clone, which
-    /// would over-adjust the queue-length metric. So the outer `Arc` is there to keep
-    /// one queue wrapper identity shared across all `JsInstance` clones, and to make
-    /// its `Drop` run exactly once.
-    request_queue: Arc<JsWorkerQueue>,
-    /// Lifecycle flags for this specific worker generation.
-    worker_state: Arc<JsWorkerState>,
-}
-
-/// Shared request queue for a JS instance lane.
-///
-/// Async callers enqueue [`JsWorkerRequest`] values here
-/// and wait on their per-request one-shot replies sent back via [`JsReplyTx`].
-/// The dedicated JS worker thread, spawned in [`spawn_instance_worker`]
-/// drains this queue and executes those requests on the isolate.
-///
-/// Note, this queue outlives any single JS worker or V8 isolate.
-/// When the active worker traps or is retired for heap growth,
-/// [`JsInstanceLane::replace_active_if_current`] waits for it to fully exit
-/// and spawns a fresh worker which then starts reading from the queue so that
-/// buffered requests are not dropped.
-struct JsWorkerQueue {
-    /// Sending side used by async callers to enqueue work for the active worker.
-    tx: flume::Sender<JsWorkerRequest>,
-    /// Receiving side kept outside of the worker thread so a replacement worker can
-    /// resume draining the exact same queue after trap recovery or heap retirement.
-    rx: flume::Receiver<JsWorkerRequest>,
-    /// Optional backlog gauge for the long-lived instance-lane queue.
-    metric: Option<IntGauge>,
-}
-
-impl JsWorkerQueue {
-    /// Builds a rendezvous queue for pooled instances, where the caller and worker
-    /// synchronize directly on each handoff instead of buffering backlog.
-    fn bounded(capacity: usize) -> Arc<Self> {
-        let (tx, rx) = flume::bounded(capacity);
-        Arc::new(Self { tx, rx, metric: None })
-    }
-
-    /// Builds the long-lived instance-lane queue and wires in backlog accounting.
-    fn unbounded_with_metric(metric: IntGauge) -> Arc<Self> {
-        let (tx, rx) = flume::unbounded();
-        Arc::new(Self {
-            tx,
-            rx,
-            metric: Some(metric),
-        })
-    }
-
-    /// Enqueues a request for the active worker and increments the backlog gauge
-    /// after the request is accepted by the channel.
-    async fn send_async(&self, request: JsWorkerRequest) -> Result<(), flume::SendError<JsWorkerRequest>> {
-        self.tx.send_async(request).await?;
-        if let Some(metric) = &self.metric {
-            metric.inc();
-        }
-        Ok(())
-    }
-
-    /// Clones the receiving handle so a newly spawned worker can
-    /// resume draining this same queue after the previous one exits.
-    fn receiver(&self) -> flume::Receiver<JsWorkerRequest> {
-        self.rx.clone()
-    }
-}
-
-impl Drop for JsWorkerQueue {
-    fn drop(&mut self) {
-        if let Some(metric) = &self.metric {
-            metric.sub(self.tx.len() as _);
-        }
-    }
-}
-
-/// Lifecycle state for a single JS worker.
-///
-/// The `trapped` bit tells the lane that this worker must not keep serving
-/// future work. The `exited` bit and [`Notify`] are what make the [JsWorkerQueue]
-/// remain single-consumer. Recovery waits on [`Self::wait_exited`] before spawning
-/// the replacement worker, so there is no overlap where two workers can both drain
-/// the queue.
-#[derive(Default)]
-struct JsWorkerState {
-    /// Set once this JS instance has trapped or been retired and must not
-    /// accept any further work from the instance lane.
-    trapped: AtomicBool,
-    /// Set once the worker thread has actually exited and stopped draining the queue.
-    exited: AtomicBool,
-    /// Wakes replacement logic waiting for this worker to finish exiting.
-    exited_notify: Notify,
-}
-
-impl JsWorkerState {
-    /// Returns whether this JS instance has been marked unusable.
-    fn trapped(&self) -> bool {
-        self.trapped.load(Ordering::Relaxed)
-    }
-
-    /// Returns whether the worker thread has fully exited.
-    fn exited(&self) -> bool {
-        self.exited.load(Ordering::Relaxed)
-    }
-
-    /// Returns whether the instance lane should replace this JS instance.
-    fn needs_recovery(&self) -> bool {
-        self.trapped() || self.exited()
-    }
-
-    /// Marks the JS instance as poisoned so no further requests should target it.
-    fn mark_trapped(&self) {
-        self.trapped.store(true, Ordering::Relaxed);
-    }
-
-    /// Marks the worker thread as exited and wakes any replacement task waiting on it.
-    fn mark_exited(&self) {
-        self.exited.store(true, Ordering::Relaxed);
-        self.exited_notify.notify_waiters();
-    }
-
-    /// Waits until the worker thread has fully exited before replacement proceeds.
-    async fn wait_exited(&self) {
-        while !self.exited() {
-            self.exited_notify.notified().await;
-        }
-    }
+    tx: mpsc::Sender<JsWorkerRequest>,
+    trapped: Arc<AtomicBool>,
 }
 
 impl JsInstance {
-    fn id(&self) -> u64 {
-        self.id
-    }
-
     pub fn trapped(&self) -> bool {
-        self.worker_state.trapped()
+        self.trapped.load(Ordering::Relaxed)
     }
 
-    fn needs_recovery(&self) -> bool {
-        self.worker_state.needs_recovery()
-    }
-
-    async fn wait_exited(&self) {
-        self.worker_state.wait_exited().await;
+    pub(in crate::host) fn needs_replacement(&self) -> bool {
+        self.trapped() || self.tx.is_closed()
     }
 
     async fn send_request<T>(
         &self,
         request: impl FnOnce(JsReplyTx<T>) -> JsWorkerRequest,
-    ) -> Result<T, WorkerDisconnected> {
+    ) -> Result<T, JsWorkerDisconnected> {
         let (reply_tx, reply_rx) = oneshot::channel();
-        self.request_queue
-            .send_async(request(reply_tx))
-            .await
-            .map_err(|_| WorkerDisconnected)?;
-        reply_rx.await.map_err(|_| WorkerDisconnected)
+        self.tx.send(request(reply_tx)).await.map_err(|_| {
+            self.trapped.store(true, Ordering::Relaxed);
+            JsWorkerDisconnected
+        })?;
+        reply_rx.await.map_err(|_| {
+            self.trapped.store(true, Ordering::Relaxed);
+            JsWorkerDisconnected
+        })
     }
 
     pub async fn run_on_thread<F, R>(&self, f: F) -> R
@@ -618,12 +473,14 @@ impl JsInstance {
         F: AsyncFnOnce() -> R + Send + 'static,
         R: Send + 'static,
     {
+        assert_not_on_js_module_thread("run_on_thread");
         let span = tracing::Span::current();
         let (tx, rx) = oneshot::channel();
 
-        self.request_queue
-            .send_async(JsWorkerRequest::RunFunction(Box::new(move || {
+        self.tx
+            .send(JsWorkerRequest::RunFunction(Box::new(move || {
                 async move {
+                    let _on_js_module_thread = EnteredJsModuleThread::new();
                     let result = AssertUnwindSafe(f().instrument(span)).catch_unwind().await;
                     if let Err(Err(_panic)) = tx.send(result) {
                         tracing::warn!("uncaught panic on `SingleCoreExecutor`")
@@ -632,12 +489,15 @@ impl JsInstance {
                 .boxed_local()
             })))
             .await
-            .unwrap_or_else(|_| panic!("worker should stay live while handling {}", type_name::<R>()));
+            .unwrap_or_else(|_| {
+                self.trapped.store(true, Ordering::Relaxed);
+                panic!("worker should stay live while handling {}", type_name::<R>())
+            });
 
-        match rx
-            .await
-            .unwrap_or_else(|_| panic!("worker should stay live while handling {}", type_name::<R>()))
-        {
+        match rx.await.unwrap_or_else(|_| {
+            self.trapped.store(true, Ordering::Relaxed);
+            panic!("worker should stay live while handling {}", type_name::<R>())
+        }) {
             Ok(r) => r,
             Err(e) => std::panic::resume_unwind(e),
         }
@@ -656,19 +516,19 @@ impl JsInstance {
             policy,
         })
         .await
-        .unwrap_or_else(|_| panic!("worker should stay live while updating the database"))
+        .map_err(|_| anyhow::anyhow!(js_worker_disconnected_error("update_database")))?
     }
 
-    pub async fn call_reducer(&self, params: CallReducerParams) -> ReducerCallResult {
+    pub async fn call_reducer(&self, params: CallReducerParams) -> Result<ReducerCallResult, ReducerCallError> {
         self.send_request(|reply_tx| JsWorkerRequest::CallReducer { reply_tx, params })
             .await
-            .unwrap_or_else(|_| panic!("worker should stay live while calling a reducer"))
+            .map_err(|_| ReducerCallError::WorkerError(js_worker_disconnected_error("call_reducer")))
     }
 
     pub async fn clear_all_clients(&self) -> anyhow::Result<()> {
         self.send_request(JsWorkerRequest::ClearAllClients)
             .await
-            .unwrap_or_else(|_| panic!("worker should stay live while clearing clients"))
+            .map_err(|_| anyhow::anyhow!(js_worker_disconnected_error("clear_all_clients")))?
     }
 
     pub async fn call_identity_connected(
@@ -682,7 +542,11 @@ impl JsInstance {
             caller_connection_id,
         })
         .await
-        .unwrap_or_else(|_| panic!("worker should stay live while running client_connected"))
+        .map_err(|_| {
+            ClientConnectedError::from(ReducerCallError::WorkerError(js_worker_disconnected_error(
+                "call_identity_connected",
+            )))
+        })?
     }
 
     pub async fn call_identity_disconnected(
@@ -696,31 +560,36 @@ impl JsInstance {
             caller_connection_id,
         })
         .await
-        .unwrap_or_else(|_| panic!("worker should stay live while running client_disconnected"))
+        .map_err(|_| ReducerCallError::WorkerError(js_worker_disconnected_error("call_identity_disconnected")))?
     }
 
     pub async fn disconnect_client(&self, client_id: ClientActorId) -> Result<(), ReducerCallError> {
         self.send_request(|reply_tx| JsWorkerRequest::DisconnectClient { reply_tx, client_id })
             .await
-            .unwrap_or_else(|_| panic!("worker should stay live while disconnecting a client"))
+            .map_err(|_| ReducerCallError::WorkerError(js_worker_disconnected_error("disconnect_client")))?
     }
 
     pub async fn init_database(&self, program: Program) -> anyhow::Result<Option<ReducerCallResult>> {
         self.send_request(|reply_tx| JsWorkerRequest::InitDatabase { reply_tx, program })
             .await
-            .unwrap_or_else(|_| panic!("worker should stay live while initializing the database"))
+            .map_err(|_| anyhow::anyhow!(js_worker_disconnected_error("init_database")))?
     }
 
     pub async fn call_procedure(&self, params: CallProcedureParams) -> CallProcedureReturn {
         self.send_request(|reply_tx| JsWorkerRequest::CallProcedure { reply_tx, params })
             .await
-            .unwrap_or_else(|_| panic!("worker should stay live while calling a procedure"))
+            .unwrap_or_else(|_| CallProcedureReturn {
+                result: Err(ProcedureCallError::InternalError(js_worker_disconnected_error(
+                    "call_procedure",
+                ))),
+                tx_offset: None,
+            })
     }
 
-    pub async fn call_view(&self, cmd: ViewCommand) -> ViewCommandResult {
+    pub async fn call_view(&self, cmd: ViewCommand) -> Result<ViewCommandResult, ViewCallError> {
         self.send_request(|reply_tx| JsWorkerRequest::CallView { reply_tx, cmd })
             .await
-            .unwrap_or_else(|_| panic!("worker should stay live while calling a view"))
+            .map_err(|_| ViewCallError::InternalError(js_worker_disconnected_error("call_view")))
     }
 
     pub(in crate::host) async fn call_scheduled_function(
@@ -734,10 +603,10 @@ impl JsInstance {
 }
 
 #[derive(Clone, Copy, Debug)]
-struct WorkerDisconnected;
+struct JsWorkerDisconnected;
 
-fn instance_lane_worker_error(label: &'static str) -> String {
-    format!("instance lane worker exited while handling {label}")
+fn js_worker_disconnected_error(label: &'static str) -> String {
+    format!("JS worker exited while handling {label}")
 }
 
 type JsReplyTx<T> = oneshot::Sender<T>;
@@ -857,28 +726,28 @@ impl V8HeapMetrics {
         Self {
             total_heap_size_bytes: WORKER_METRICS
                 .v8_total_heap_size_bytes
-                .with_label_values(database_identity, V8_WORKER_KIND_INSTANCE_LANE),
+                .with_label_values(database_identity, V8_WORKER_KIND_MAIN),
             total_physical_size_bytes: WORKER_METRICS
                 .v8_total_physical_size_bytes
-                .with_label_values(database_identity, V8_WORKER_KIND_INSTANCE_LANE),
+                .with_label_values(database_identity, V8_WORKER_KIND_MAIN),
             used_global_handles_size_bytes: WORKER_METRICS
                 .v8_used_global_handles_size_bytes
-                .with_label_values(database_identity, V8_WORKER_KIND_INSTANCE_LANE),
+                .with_label_values(database_identity, V8_WORKER_KIND_MAIN),
             used_heap_size_bytes: WORKER_METRICS
                 .v8_used_heap_size_bytes
-                .with_label_values(database_identity, V8_WORKER_KIND_INSTANCE_LANE),
+                .with_label_values(database_identity, V8_WORKER_KIND_MAIN),
             heap_size_limit_bytes: WORKER_METRICS
                 .v8_heap_size_limit_bytes
-                .with_label_values(database_identity, V8_WORKER_KIND_INSTANCE_LANE),
+                .with_label_values(database_identity, V8_WORKER_KIND_MAIN),
             external_memory_bytes: WORKER_METRICS
                 .v8_external_memory_bytes
-                .with_label_values(database_identity, V8_WORKER_KIND_INSTANCE_LANE),
+                .with_label_values(database_identity, V8_WORKER_KIND_MAIN),
             native_contexts: WORKER_METRICS
                 .v8_native_contexts
-                .with_label_values(database_identity, V8_WORKER_KIND_INSTANCE_LANE),
+                .with_label_values(database_identity, V8_WORKER_KIND_MAIN),
             detached_contexts: WORKER_METRICS
                 .v8_detached_contexts
-                .with_label_values(database_identity, V8_WORKER_KIND_INSTANCE_LANE),
+                .with_label_values(database_identity, V8_WORKER_KIND_MAIN),
             last_observed: V8HeapSnapshot::default(),
         }
     }
@@ -981,285 +850,6 @@ fn should_retire_worker_for_heap(
     }
 }
 
-struct JsInstanceLaneState {
-    // Instance-lane calls stay on one active worker for locality. The hot path clones
-    // this handle and feeds work straight into the worker-owned FIFO; trap
-    // recovery very rarely swaps it out for a fresh instance.
-    active: RwLock<JsInstance>,
-
-    // Replacement must be serialized because multiple callers can all observe
-    // the same worker becoming unusable and attempt recovery at once.
-    //
-    // This must be an async mutex rather than a blocking mutex because recovery
-    // may need to call `create_lane_instance().await`.
-    //
-    // This stays safe as long as these invariants hold:
-    // - `replace_lock` is only for trap/disconnect recovery, never the hot path.
-    // - no `parking_lot` guard is held across the `.await` in replacement.
-    // - `create_lane_instance()` must not call back into `JsInstanceLane` or try to
-    //   take `replace_lock`.
-    replace_lock: AsyncMutex<()>,
-}
-
-/// A single serialized execution lane for JS module work.
-///
-/// Callers share one active [`JsInstance`] so hot requests stay on the same
-/// worker thread for locality. The lane only steps in on the rare path, where
-/// a trap or disconnect forces that active worker to be replaced.
-#[derive(Clone)]
-pub struct JsInstanceLane {
-    module: JsModule,
-    state: Arc<JsInstanceLaneState>,
-}
-
-impl JsInstanceLane {
-    pub fn new(module: JsModule, init_inst: JsInstance) -> Self {
-        Self {
-            module,
-            state: Arc::new(JsInstanceLaneState {
-                active: RwLock::new(init_inst),
-                replace_lock: AsyncMutex::new(()),
-            }),
-        }
-    }
-
-    fn active_instance(&self) -> JsInstance {
-        self.state.active.read().clone()
-    }
-
-    async fn after_successful_call(&self, active: &JsInstance) {
-        if active.trapped() {
-            self.replace_active_if_current(active).await;
-        }
-    }
-
-    async fn replace_active_if_current(&self, stale: &JsInstance) {
-        // `replace_lock` intentionally serializes the rare recovery path. This
-        // prevents a trap observed by many callers from spawning many replacement
-        // workers and racing to install them.
-        let _replace_guard = self.state.replace_lock.lock().await;
-
-        // The same trapped instance can be observed by multiple callers at once.
-        // We only want the first one to do the swap; everybody else should notice
-        // that the active handle already changed and get out of the way.
-        if self.state.active.read().id() != stale.id() {
-            return;
-        }
-
-        // Wait for the stale worker generation to finish exiting before we
-        // install a replacement. That keeps the shared queue single-consumer.
-        if stale.needs_recovery() {
-            stale.wait_exited().await;
-        }
-
-        if self.state.active.read().id() != stale.id() {
-            return;
-        }
-
-        log::warn!("instance lane worker needs replacement; creating a fresh instance-lane worker");
-
-        // Keep the awaited instance creation outside of any `parking_lot` guard.
-        // The only lock held across this await is `replace_lock`, which is why it
-        // has to be async.
-        let next = self.module.create_lane_instance().await;
-        *self.state.active.write() = next;
-    }
-
-    /// Run an instance-lane operation exactly once.
-    ///
-    /// If the worker disappears before replying, we replace it for future
-    /// requests but surface the disconnect to the caller instead of retrying.
-    /// This keeps instance-lane semantics closer to the old pooled-instance
-    /// model while still preserving one-at-a-time execution on the worker.
-    async fn run_once<R>(
-        &self,
-        label: &'static str,
-        work: impl AsyncFnOnce(JsInstance) -> Result<R, WorkerDisconnected>,
-    ) -> Result<R, WorkerDisconnected> {
-        assert_not_on_js_module_thread(label);
-
-        let mut active = self.active_instance();
-        // Another caller may already have observed a trap or heap-triggered retirement
-        // and left the current active handle stale by the time we enter. Swap in the
-        // replacement before enqueueing more work.
-        if active.needs_recovery() {
-            self.replace_active_if_current(&active).await;
-            active = self.active_instance();
-        }
-        let result = work(active.clone()).await;
-        match result {
-            Ok(value) => {
-                self.after_successful_call(&active).await;
-                Ok(value)
-            }
-            Err(err) => {
-                self.replace_active_if_current(&active).await;
-                log::error!("instance-lane operation {label} lost its worker before replying");
-                Err(err)
-            }
-        }
-    }
-
-    /// Run an arbitrary closure on the instance-lane worker thread without replay.
-    ///
-    /// This is non-replayable because the closure is opaque host code, not a
-    /// cloneable request payload, and it may have already produced host-side
-    /// effects before a worker disconnect is observed.
-    pub async fn run_on_thread<F, R>(&self, f: F) -> anyhow::Result<R>
-    where
-        F: AsyncFnOnce() -> R + Send + 'static,
-        R: Send + 'static,
-    {
-        let span = tracing::Span::current();
-        self.run_once("run_on_thread", async move |inst| {
-            let (tx, rx) = oneshot::channel();
-
-            inst.request_queue
-                .send_async(JsWorkerRequest::RunFunction(Box::new(move || {
-                    async move {
-                        let _on_js_module_thread = EnteredJsModuleThread::new();
-                        let result = AssertUnwindSafe(f().instrument(span)).catch_unwind().await;
-                        if let Err(Err(_panic)) = tx.send(result) {
-                            tracing::warn!("uncaught panic on `SingleCoreExecutor`")
-                        }
-                    }
-                    .boxed_local()
-                })))
-                .await
-                .map_err(|_| WorkerDisconnected)?;
-
-            Ok(match rx.await.map_err(|_| WorkerDisconnected)? {
-                Ok(r) => r,
-                Err(e) => std::panic::resume_unwind(e),
-            })
-        })
-        .await
-        .map_err(|_| anyhow::anyhow!("instance lane worker exited while running a non-replayable module-thread task"))
-    }
-
-    /// Run a database update on the instance lane exactly once.
-    ///
-    /// If the worker disappears before replying, we replace it for future
-    /// requests and surface an internal host error to the caller.
-    pub async fn update_database(
-        &self,
-        program: Program,
-        old_module_info: Arc<ModuleInfo>,
-        policy: MigrationPolicy,
-    ) -> anyhow::Result<UpdateDatabaseResult> {
-        self.run_once("update_database", |inst: JsInstance| async move {
-            inst.send_request(|reply_tx| JsWorkerRequest::UpdateDatabase {
-                reply_tx,
-                program,
-                old_module_info,
-                policy,
-            })
-            .await
-        })
-        .await
-        .map_err(|_| anyhow::anyhow!(instance_lane_worker_error("update_database")))?
-    }
-
-    /// Run a reducer on the instance lane exactly once.
-    ///
-    /// A real reducer trap still returns the reducer's own outcome before the
-    /// worker is replaced. If the worker disappears before any reply, we surface
-    /// that as `ReducerCallError::WorkerError`.
-    pub async fn call_reducer(&self, params: CallReducerParams) -> Result<ReducerCallResult, ReducerCallError> {
-        self.run_once("call_reducer", |inst: JsInstance| async move {
-            inst.send_request(|reply_tx| JsWorkerRequest::CallReducer { reply_tx, params })
-                .await
-        })
-        .await
-        .map_err(|_| ReducerCallError::WorkerError(instance_lane_worker_error("call_reducer")))
-    }
-
-    /// Clear all instance-lane client state exactly once.
-    pub async fn clear_all_clients(&self) -> anyhow::Result<()> {
-        self.run_once("clear_all_clients", |inst: JsInstance| async move {
-            inst.send_request(JsWorkerRequest::ClearAllClients).await
-        })
-        .await
-        .map_err(|_| anyhow::anyhow!(instance_lane_worker_error("clear_all_clients")))?
-    }
-
-    /// Run the `client_connected` lifecycle reducer exactly once.
-    ///
-    /// If the worker disappears before replying, we replace it for future
-    /// requests and reject the connection with `ReducerCallError::WorkerError`.
-    pub async fn call_identity_connected(
-        &self,
-        caller_auth: ConnectionAuthCtx,
-        caller_connection_id: ConnectionId,
-    ) -> Result<(), ClientConnectedError> {
-        self.run_once("call_identity_connected", |inst: JsInstance| async move {
-            inst.send_request(|reply_tx| JsWorkerRequest::CallIdentityConnected {
-                reply_tx,
-                caller_auth,
-                caller_connection_id,
-            })
-            .await
-        })
-        .await
-        .map_err(|_| {
-            ClientConnectedError::from(ReducerCallError::WorkerError(instance_lane_worker_error(
-                "call_identity_connected",
-            )))
-        })?
-    }
-
-    /// Run the `client_disconnected` lifecycle reducer exactly once.
-    pub async fn call_identity_disconnected(
-        &self,
-        caller_identity: Identity,
-        caller_connection_id: ConnectionId,
-    ) -> Result<(), ReducerCallError> {
-        self.run_once("call_identity_disconnected", |inst: JsInstance| async move {
-            inst.send_request(|reply_tx| JsWorkerRequest::CallIdentityDisconnected {
-                reply_tx,
-                caller_identity,
-                caller_connection_id,
-            })
-            .await
-        })
-        .await
-        .map_err(|_| ReducerCallError::WorkerError(instance_lane_worker_error("call_identity_disconnected")))?
-    }
-
-    /// Run disconnect cleanup on the instance lane exactly once.
-    pub async fn disconnect_client(&self, client_id: ClientActorId) -> Result<(), ReducerCallError> {
-        self.run_once("disconnect_client", |inst: JsInstance| async move {
-            inst.send_request(|reply_tx| JsWorkerRequest::DisconnectClient { reply_tx, client_id })
-                .await
-        })
-        .await
-        .map_err(|_| ReducerCallError::WorkerError(instance_lane_worker_error("disconnect_client")))?
-    }
-
-    /// Run reducer-style database initialization exactly once.
-    pub async fn init_database(&self, program: Program) -> anyhow::Result<Option<ReducerCallResult>> {
-        self.run_once("init_database", |inst: JsInstance| async move {
-            inst.send_request(|reply_tx| JsWorkerRequest::InitDatabase { reply_tx, program })
-                .await
-        })
-        .await
-        .map_err(|_| anyhow::anyhow!(instance_lane_worker_error("init_database")))?
-    }
-
-    /// Run a view/subscription command on the instance lane exactly once.
-    ///
-    /// If the worker disappears before replying, we replace it for future
-    /// requests and surface a `ViewCallError::InternalError`.
-    pub async fn call_view(&self, cmd: ViewCommand) -> Result<ViewCommandResult, ViewCallError> {
-        self.run_once("call_view", |inst: JsInstance| async move {
-            inst.send_request(|reply_tx| JsWorkerRequest::CallView { reply_tx, cmd })
-                .await
-        })
-        .await
-        .map_err(|_| ViewCallError::InternalError(instance_lane_worker_error("call_view")))
-    }
-}
-
 /// Performs some of the startup work of [`spawn_instance_worker`].
 ///
 /// NOTE(centril): in its own function due to lack of `try` blocks.
@@ -1359,22 +949,16 @@ async fn spawn_instance_worker(
     mut core_pinner: CorePinner,
     heap_policy: V8HeapPolicyConfig,
     worker_kind: JsWorkerKind,
-    request_queue: Arc<JsWorkerQueue>,
 ) -> anyhow::Result<(ModuleCommon, JsInstance)> {
     // This one-shot channel is used for initial startup error handling within the thread.
     let (result_tx, result_rx) = oneshot::channel();
-    let worker_state = Arc::<JsWorkerState>::default();
-    let worker_state_in_thread = worker_state.clone();
+    let (request_tx, mut request_rx) = mpsc::channel(worker_kind.request_queue_capacity());
+    let trapped = Arc::new(AtomicBool::new(false));
+    let trapped_in_thread = trapped.clone();
 
     let rt = tokio::runtime::Handle::current();
-    let request_rx = request_queue.receiver();
-    let worker_queue_metric = request_queue.metric.clone();
 
     std::thread::spawn(move || {
-        scopeguard::defer! {
-            worker_state_in_thread.mark_exited();
-        }
-
         let _guard = load_balance_guard;
         core_pinner.pin_now();
 
@@ -1459,10 +1043,7 @@ async fn spawn_instance_worker(
         // This will cause channels, scopes, and the isolate to be cleaned up.
         let mut requests_since_heap_check = 0u64;
         let mut last_heap_check_at = Instant::now();
-        for request in request_rx.iter() {
-            if let Some(metric) = &worker_queue_metric {
-                metric.dec();
-            }
+        while let Some(request) = request_rx.blocking_recv() {
             let mut call_reducer = |tx, params| instance_common.call_reducer_with_tx(tx, params, &mut inst);
             let mut should_exit = false;
 
@@ -1482,7 +1063,7 @@ async fn spawn_instance_worker(
                 JsWorkerRequest::CallReducer { reply_tx, params } => {
                     let (res, trapped) = call_reducer(None, params);
                     if trapped {
-                        worker_state_in_thread.mark_trapped();
+                        trapped_in_thread.store(true, Ordering::Relaxed);
                     }
                     send_worker_reply("call_reducer", reply_tx, res);
                     should_exit = trapped;
@@ -1490,7 +1071,7 @@ async fn spawn_instance_worker(
                 JsWorkerRequest::CallView { reply_tx, cmd } => {
                     let (res, trapped) = instance_common.handle_cmd(cmd, &mut inst);
                     if trapped {
-                        worker_state_in_thread.mark_trapped();
+                        trapped_in_thread.store(true, Ordering::Relaxed);
                     }
                     send_worker_reply("call_view", reply_tx, res);
                     should_exit = trapped;
@@ -1501,7 +1082,7 @@ async fn spawn_instance_worker(
                         .now_or_never()
                         .expect("our call_procedure implementation is not actually async");
                     if trapped {
-                        worker_state_in_thread.mark_trapped();
+                        trapped_in_thread.store(true, Ordering::Relaxed);
                     }
                     send_worker_reply("call_procedure", reply_tx, res);
                     should_exit = trapped;
@@ -1519,7 +1100,7 @@ async fn spawn_instance_worker(
                     let res =
                         call_identity_connected(caller_auth, caller_connection_id, info, call_reducer, &mut trapped);
                     if trapped {
-                        worker_state_in_thread.mark_trapped();
+                        trapped_in_thread.store(true, Ordering::Relaxed);
                     }
                     send_worker_reply("call_identity_connected", reply_tx, res);
                     should_exit = trapped;
@@ -1538,7 +1119,7 @@ async fn spawn_instance_worker(
                         &mut trapped,
                     );
                     if trapped {
-                        worker_state_in_thread.mark_trapped();
+                        trapped_in_thread.store(true, Ordering::Relaxed);
                     }
                     send_worker_reply("call_identity_disconnected", reply_tx, res);
                     should_exit = trapped;
@@ -1547,7 +1128,7 @@ async fn spawn_instance_worker(
                     let mut trapped = false;
                     let res = ModuleHost::disconnect_client_inner(client_id, info, call_reducer, &mut trapped);
                     if trapped {
-                        worker_state_in_thread.mark_trapped();
+                        trapped_in_thread.store(true, Ordering::Relaxed);
                     }
                     send_worker_reply("disconnect_client", reply_tx, res);
                     should_exit = trapped;
@@ -1556,7 +1137,7 @@ async fn spawn_instance_worker(
                     let (res, trapped): (Result<Option<ReducerCallResult>, anyhow::Error>, bool) =
                         init_database(replica_ctx, &module_common.info().module_def, program, call_reducer);
                     if trapped {
-                        worker_state_in_thread.mark_trapped();
+                        trapped_in_thread.store(true, Ordering::Relaxed);
                     }
                     send_worker_reply("init_database", reply_tx, res);
                     should_exit = trapped;
@@ -1567,7 +1148,7 @@ async fn spawn_instance_worker(
                         .now_or_never()
                         .expect("our call_procedure implementation is not actually async");
                     if trapped {
-                        worker_state_in_thread.mark_trapped();
+                        trapped_in_thread.store(true, Ordering::Relaxed);
                     }
                     send_worker_reply("call_scheduled_function", reply_tx, res);
                     should_exit = trapped;
@@ -1586,7 +1167,7 @@ async fn spawn_instance_worker(
                     requests_since_heap_check = 0;
                     last_heap_check_at = Instant::now();
                     if let Some((used, limit)) = should_retire_worker_for_heap(inst.scope, heap_metrics, heap_policy) {
-                        worker_state_in_thread.mark_trapped();
+                        trapped_in_thread.store(true, Ordering::Relaxed);
                         should_exit = true;
                         log::warn!(
                             "retiring JS worker after V8 heap stayed high post-GC: used={}MiB limit={}MiB",
@@ -1600,13 +1181,13 @@ async fn spawn_instance_worker(
             // Once a JS instance traps, we must not let later queued work execute
             // on that poisoned isolate. We reply to the trapping request first so
             // the caller can observe the actual reducer/procedure error, and then
-            // shut the worker down so the shared queue can continue on a fresh
-            // instance.
+            // shut the worker down. The instance manager will create a replacement
+            // for subsequent requests.
             //
             // We also retire workers when they stay near the V8 heap limit after
-            // a GC. The instance lane intentionally keeps a JS worker alive for
-            // a long time, so this gives it a bounded-memory replacement policy
-            // instead of letting one isolate absorb the entire module lifetime.
+            // a GC. The main JS worker intentionally lives for a long time, so
+            // this gives it a bounded-memory replacement policy instead of
+            // letting one isolate absorb the entire module lifetime.
             if should_exit {
                 break;
             }
@@ -1617,9 +1198,8 @@ async fn spawn_instance_worker(
     let res: Result<ModuleCommon, anyhow::Error> = result_rx.await.expect("should have a sender");
     res.map(|opt_mc| {
         let inst = JsInstance {
-            id: NEXT_JS_INSTANCE_ID.fetch_add(1, Ordering::Relaxed),
-            request_queue,
-            worker_state,
+            tx: request_tx,
+            trapped,
         };
         (opt_mc, inst)
     })

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -1707,13 +1707,12 @@ where
                 let (hooks, module_common) = match startup_result {
                     Err(_) => {
                         if let Some(result_tx) = startup_result_tx.take() {
-                            let _ = result_tx
+                            if result_tx
                                 .send(Err(anyhow::anyhow!("JS worker panicked during startup")))
-                                .inspect_err(|_| {
-                                    // This should never happen as we immediately `.recv` on the
-                                    // other end of the channel, but sometimes it gets cancelled.
-                                    log::error!("startup result receiver disconnected");
-                                });
+                                .is_err()
+                            {
+                                log::error!("startup result receiver disconnected");
+                            }
                         } else {
                             log::error!("JS worker panicked while recreating isolate");
                         }
@@ -1721,11 +1720,9 @@ where
                     }
                     Ok(Err(err)) => {
                         if let Some(result_tx) = startup_result_tx.take() {
-                            let _ = result_tx.send(Err(err)).inspect_err(|_| {
-                                // This should never happen as we immediately `.recv` on the
-                                // other end of the channel, but sometimes it gets cancelled.
+                            if result_tx.send(Err(err)).is_err() {
                                 log::error!("startup result receiver disconnected");
-                            });
+                            }
                         } else {
                             log::error!("failed to restart JS worker: {err:#}");
                         }

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -114,7 +114,7 @@ impl V8Runtime {
 static V8_RUNTIME_GLOBAL: LazyLock<V8RuntimeInner> = LazyLock::new(V8RuntimeInner::init);
 const REDUCER_ARGS_BUFFER_SIZE: usize = 4_096;
 const JS_MAIN_INSTANCE_QUEUE_CAPACITY: usize = 1024;
-const JS_POOLED_INSTANCE_QUEUE_CAPACITY: usize = 1;
+const JS_PROCEDURE_INSTANCE_QUEUE_CAPACITY: usize = 1;
 pub(crate) const V8_WORKER_KIND_MAIN: &str = "main";
 
 thread_local! {
@@ -156,7 +156,7 @@ impl Drop for EnteredJsModuleThread {
 #[derive(Copy, Clone)]
 enum JsWorkerKind {
     Main,
-    Pooled,
+    Procedure,
 }
 
 impl JsWorkerKind {
@@ -167,7 +167,7 @@ impl JsWorkerKind {
     const fn request_queue_capacity(self) -> usize {
         match self {
             Self::Main => JS_MAIN_INSTANCE_QUEUE_CAPACITY,
-            Self::Pooled => JS_POOLED_INSTANCE_QUEUE_CAPACITY,
+            Self::Procedure => JS_PROCEDURE_INSTANCE_QUEUE_CAPACITY,
         }
     }
 }
@@ -238,13 +238,12 @@ impl V8RuntimeInner {
         let mcc = Either::Right(mcc);
         let load_balance_guard = Arc::new(core.guard);
         let core_pinner = core.pinner;
-        let (common, init_inst) = spawn_instance_worker(
+        let (common, init_inst) = spawn_main_instance_worker(
             program.clone(),
             mcc,
             load_balance_guard.clone(),
             core_pinner.clone(),
             heap_policy,
-            JsWorkerKind::Main,
         )
         .await?;
         let module = JsModule {
@@ -281,7 +280,7 @@ impl JsModule {
         self.common.info().clone()
     }
 
-    async fn create_instance_with_kind(&self, worker_kind: JsWorkerKind) -> JsInstance {
+    async fn create_procedure_instance(&self) -> JsProcedureInstance {
         let program = self.program.clone();
         let common = self.common.clone();
         let load_balance_guard = self.load_balance_guard.clone();
@@ -289,25 +288,39 @@ impl JsModule {
         let heap_policy = self.heap_policy;
 
         // This has to be done in a blocking context because of `blocking_recv`.
-        let (_, instance) = spawn_instance_worker(
+        let (_, instance) = spawn_procedure_instance_worker(
             program,
             Either::Left(common),
             load_balance_guard,
             core_pinner,
             heap_policy,
-            worker_kind,
         )
         .await
-        .expect("`spawn_instance_worker` should succeed when passed `ModuleCommon`");
+        .expect("`spawn_procedure_instance_worker` should succeed when passed `ModuleCommon`");
         instance
     }
 
-    pub async fn create_instance(&self) -> JsInstance {
-        self.create_instance_with_kind(JsWorkerKind::Pooled).await
+    pub async fn create_instance(&self) -> JsProcedureInstance {
+        self.create_procedure_instance().await
     }
 
-    pub(in crate::host) async fn create_main_instance(&self) -> JsInstance {
-        self.create_instance_with_kind(JsWorkerKind::Main).await
+    pub(in crate::host) async fn create_main_instance(&self) -> JsMainInstance {
+        let program = self.program.clone();
+        let common = self.common.clone();
+        let load_balance_guard = self.load_balance_guard.clone();
+        let core_pinner = self.core_pinner.clone();
+        let heap_policy = self.heap_policy;
+
+        let (_, instance) = spawn_main_instance_worker(
+            program,
+            Either::Left(common),
+            load_balance_guard,
+            core_pinner,
+            heap_policy,
+        )
+        .await
+        .expect("`spawn_main_instance_worker` should succeed when passed `ModuleCommon`");
+        instance
     }
 }
 
@@ -321,7 +334,7 @@ fn env_on_isolate_unwrap(isolate: &mut Isolate) -> &mut JsInstanceEnv {
     env_on_isolate(isolate).expect("there should be a `JsInstanceEnv`")
 }
 
-/// The environment of a [`JsInstance`].
+/// The environment bound to a JS worker isolate.
 struct JsInstanceEnv {
     instance_env: InstanceEnv,
     module_def: Option<Arc<ModuleDef>>,
@@ -425,7 +438,7 @@ impl JsInstanceEnv {
     }
 }
 
-/// An instance for a [`JsModule`].
+/// The main instance for a [`JsModule`].
 ///
 /// The actual work happens in a worker thread,
 /// which the instance communicates with through channels.
@@ -439,12 +452,21 @@ impl JsInstanceEnv {
 /// which will cause the worker's loop to terminate and cleanup the isolate
 /// and friends.
 #[derive(Clone)]
-pub struct JsInstance {
-    tx: mpsc::Sender<JsWorkerRequest>,
+pub struct JsMainInstance {
+    tx: mpsc::Sender<JsMainWorkerRequest>,
     trapped: Arc<AtomicBool>,
 }
 
-impl JsInstance {
+/// A procedure instance for a [`JsModule`].
+///
+/// Procedure instances are checked out exclusively from the procedure pool and
+/// only execute procedure-style requests.
+pub struct JsProcedureInstance {
+    tx: mpsc::Sender<JsProcedureWorkerRequest>,
+    trapped: Arc<AtomicBool>,
+}
+
+impl JsMainInstance {
     pub fn trapped(&self) -> bool {
         self.trapped.load(Ordering::Relaxed)
     }
@@ -455,17 +477,9 @@ impl JsInstance {
 
     async fn send_request<T>(
         &self,
-        request: impl FnOnce(JsReplyTx<T>) -> JsWorkerRequest,
+        request: impl FnOnce(JsReplyTx<T>) -> JsMainWorkerRequest,
     ) -> Result<T, JsWorkerDisconnected> {
-        let (reply_tx, reply_rx) = oneshot::channel();
-        self.tx.send(request(reply_tx)).await.map_err(|_| {
-            self.trapped.store(true, Ordering::Relaxed);
-            JsWorkerDisconnected
-        })?;
-        reply_rx.await.map_err(|_| {
-            self.trapped.store(true, Ordering::Relaxed);
-            JsWorkerDisconnected
-        })
+        send_js_request(&self.tx, &self.trapped, request).await
     }
 
     pub async fn run_on_thread<F, R>(&self, f: F) -> R
@@ -478,7 +492,7 @@ impl JsInstance {
         let (tx, rx) = oneshot::channel();
 
         self.tx
-            .send(JsWorkerRequest::RunFunction(Box::new(move || {
+            .send(JsMainWorkerRequest::RunFunction(Box::new(move || {
                 async move {
                     let _on_js_module_thread = EnteredJsModuleThread::new();
                     let result = AssertUnwindSafe(f().instrument(span)).catch_unwind().await;
@@ -509,7 +523,7 @@ impl JsInstance {
         old_module_info: Arc<ModuleInfo>,
         policy: MigrationPolicy,
     ) -> anyhow::Result<UpdateDatabaseResult> {
-        self.send_request(|reply_tx| JsWorkerRequest::UpdateDatabase {
+        self.send_request(|reply_tx| JsMainWorkerRequest::UpdateDatabase {
             reply_tx,
             program,
             old_module_info,
@@ -520,13 +534,13 @@ impl JsInstance {
     }
 
     pub async fn call_reducer(&self, params: CallReducerParams) -> Result<ReducerCallResult, ReducerCallError> {
-        self.send_request(|reply_tx| JsWorkerRequest::CallReducer { reply_tx, params })
+        self.send_request(|reply_tx| JsMainWorkerRequest::CallReducer { reply_tx, params })
             .await
             .map_err(|_| ReducerCallError::WorkerError(js_worker_disconnected_error("call_reducer")))
     }
 
     pub async fn clear_all_clients(&self) -> anyhow::Result<()> {
-        self.send_request(JsWorkerRequest::ClearAllClients)
+        self.send_request(JsMainWorkerRequest::ClearAllClients)
             .await
             .map_err(|_| anyhow::anyhow!(js_worker_disconnected_error("clear_all_clients")))?
     }
@@ -536,7 +550,7 @@ impl JsInstance {
         caller_auth: ConnectionAuthCtx,
         caller_connection_id: ConnectionId,
     ) -> Result<(), ClientConnectedError> {
-        self.send_request(|reply_tx| JsWorkerRequest::CallIdentityConnected {
+        self.send_request(|reply_tx| JsMainWorkerRequest::CallIdentityConnected {
             reply_tx,
             caller_auth,
             caller_connection_id,
@@ -554,7 +568,7 @@ impl JsInstance {
         caller_identity: Identity,
         caller_connection_id: ConnectionId,
     ) -> Result<(), ReducerCallError> {
-        self.send_request(|reply_tx| JsWorkerRequest::CallIdentityDisconnected {
+        self.send_request(|reply_tx| JsMainWorkerRequest::CallIdentityDisconnected {
             reply_tx,
             caller_identity,
             caller_connection_id,
@@ -564,19 +578,38 @@ impl JsInstance {
     }
 
     pub async fn disconnect_client(&self, client_id: ClientActorId) -> Result<(), ReducerCallError> {
-        self.send_request(|reply_tx| JsWorkerRequest::DisconnectClient { reply_tx, client_id })
+        self.send_request(|reply_tx| JsMainWorkerRequest::DisconnectClient { reply_tx, client_id })
             .await
             .map_err(|_| ReducerCallError::WorkerError(js_worker_disconnected_error("disconnect_client")))?
     }
 
     pub async fn init_database(&self, program: Program) -> anyhow::Result<Option<ReducerCallResult>> {
-        self.send_request(|reply_tx| JsWorkerRequest::InitDatabase { reply_tx, program })
+        self.send_request(|reply_tx| JsMainWorkerRequest::InitDatabase { reply_tx, program })
             .await
             .map_err(|_| anyhow::anyhow!(js_worker_disconnected_error("init_database")))?
     }
 
+    pub async fn call_view(&self, cmd: ViewCommand) -> Result<ViewCommandResult, ViewCallError> {
+        self.send_request(|reply_tx| JsMainWorkerRequest::CallView { reply_tx, cmd })
+            .await
+            .map_err(|_| ViewCallError::InternalError(js_worker_disconnected_error("call_view")))
+    }
+}
+
+impl JsProcedureInstance {
+    pub fn trapped(&self) -> bool {
+        self.trapped.load(Ordering::Relaxed)
+    }
+
+    async fn send_request<T>(
+        &self,
+        request: impl FnOnce(JsReplyTx<T>) -> JsProcedureWorkerRequest,
+    ) -> Result<T, JsWorkerDisconnected> {
+        send_js_request(&self.tx, &self.trapped, request).await
+    }
+
     pub async fn call_procedure(&self, params: CallProcedureParams) -> CallProcedureReturn {
-        self.send_request(|reply_tx| JsWorkerRequest::CallProcedure { reply_tx, params })
+        self.send_request(|reply_tx| JsProcedureWorkerRequest::CallProcedure { reply_tx, params })
             .await
             .unwrap_or_else(|_| CallProcedureReturn {
                 result: Err(ProcedureCallError::InternalError(js_worker_disconnected_error(
@@ -586,20 +619,33 @@ impl JsInstance {
             })
     }
 
-    pub async fn call_view(&self, cmd: ViewCommand) -> Result<ViewCommandResult, ViewCallError> {
-        self.send_request(|reply_tx| JsWorkerRequest::CallView { reply_tx, cmd })
-            .await
-            .map_err(|_| ViewCallError::InternalError(js_worker_disconnected_error("call_view")))
-    }
-
     pub(in crate::host) async fn call_scheduled_function(
         &self,
         params: ScheduledFunctionParams,
     ) -> CallScheduledFunctionResult {
-        self.send_request(|reply_tx| JsWorkerRequest::CallScheduledFunction { reply_tx, params })
+        self.send_request(|reply_tx| JsProcedureWorkerRequest::CallScheduledFunction { reply_tx, params })
             .await
             .unwrap_or_else(|_| panic!("worker should stay live while calling a scheduled function"))
     }
+}
+
+async fn send_js_request<Req, T>(
+    tx: &mpsc::Sender<Req>,
+    trapped: &AtomicBool,
+    request: impl FnOnce(JsReplyTx<T>) -> Req,
+) -> Result<T, JsWorkerDisconnected>
+where
+    Req: Send + 'static,
+{
+    let (reply_tx, reply_rx) = oneshot::channel();
+    tx.send(request(reply_tx)).await.map_err(|_| {
+        trapped.store(true, Ordering::Relaxed);
+        JsWorkerDisconnected
+    })?;
+    reply_rx.await.map_err(|_| {
+        trapped.store(true, Ordering::Relaxed);
+        JsWorkerDisconnected
+    })
 }
 
 #[derive(Clone, Copy, Debug)]
@@ -611,63 +657,67 @@ fn js_worker_disconnected_error(label: &'static str) -> String {
 
 type JsReplyTx<T> = oneshot::Sender<T>;
 
-/// Requests sent to the dedicated JS worker thread.
+/// Requests sent to the main JS worker thread.
 ///
 /// Most variants carry a `reply_tx` because the worker thread owns the isolate,
 /// executes the request there, and then has to send the typed result back to
 /// the async caller.
-enum JsWorkerRequest {
-    /// See [`JsInstance::run_on_thread`].
+enum JsMainWorkerRequest {
+    /// See [`JsMainInstance::run_on_thread`].
     ///
-    /// This variant does not expect a [`JsWorkerReply`].
+    /// This variant carries its own reply channel.
     RunFunction(Box<dyn FnOnce() -> LocalBoxFuture<'static, ()> + Send>),
-    /// See [`JsInstance::update_database`].
+    /// See [`JsMainInstance::update_database`].
     UpdateDatabase {
         reply_tx: JsReplyTx<anyhow::Result<UpdateDatabaseResult>>,
         program: Program,
         old_module_info: Arc<ModuleInfo>,
         policy: MigrationPolicy,
     },
-    /// See [`JsInstance::call_reducer`].
+    /// See [`JsMainInstance::call_reducer`].
     CallReducer {
         reply_tx: JsReplyTx<ReducerCallResult>,
         params: CallReducerParams,
     },
-    /// See [`JsInstance::call_view`].
+    /// See [`JsMainInstance::call_view`].
     CallView {
         reply_tx: JsReplyTx<ViewCommandResult>,
         cmd: ViewCommand,
     },
-    /// See [`JsInstance::call_procedure`].
-    CallProcedure {
-        reply_tx: JsReplyTx<CallProcedureReturn>,
-        params: CallProcedureParams,
-    },
-    /// See [`JsInstance::clear_all_clients`].
+    /// See [`JsMainInstance::clear_all_clients`].
     ClearAllClients(JsReplyTx<anyhow::Result<()>>),
-    /// See [`JsInstance::call_identity_connected`].
+    /// See [`JsMainInstance::call_identity_connected`].
     CallIdentityConnected {
         reply_tx: JsReplyTx<Result<(), ClientConnectedError>>,
         caller_auth: ConnectionAuthCtx,
         caller_connection_id: ConnectionId,
     },
-    /// See [`JsInstance::call_identity_disconnected`].
+    /// See [`JsMainInstance::call_identity_disconnected`].
     CallIdentityDisconnected {
         reply_tx: JsReplyTx<Result<(), ReducerCallError>>,
         caller_identity: Identity,
         caller_connection_id: ConnectionId,
     },
-    /// See [`JsInstance::disconnect_client`].
+    /// See [`JsMainInstance::disconnect_client`].
     DisconnectClient {
         reply_tx: JsReplyTx<Result<(), ReducerCallError>>,
         client_id: ClientActorId,
     },
-    /// See [`JsInstance::init_database`].
+    /// See [`JsMainInstance::init_database`].
     InitDatabase {
         reply_tx: JsReplyTx<anyhow::Result<Option<ReducerCallResult>>>,
         program: Program,
     },
-    /// See [`JsInstance::call_scheduled_function`].
+}
+
+/// Requests sent to a procedure JS worker thread.
+enum JsProcedureWorkerRequest {
+    /// See [`JsProcedureInstance::call_procedure`].
+    CallProcedure {
+        reply_tx: JsReplyTx<CallProcedureReturn>,
+        params: CallProcedureParams,
+    },
+    /// See [`JsProcedureInstance::call_scheduled_function`].
     CallScheduledFunction {
         reply_tx: JsReplyTx<CallScheduledFunctionResult>,
         params: ScheduledFunctionParams,
@@ -850,7 +900,7 @@ fn should_retire_worker_for_heap(
     }
 }
 
-/// Performs some of the startup work of [`spawn_instance_worker`].
+/// Performs some of the shared startup work for JS worker isolates.
 ///
 /// NOTE(centril): in its own function due to lack of `try` blocks.
 fn startup_instance_worker<'scope>(
@@ -929,29 +979,222 @@ where
     f(&mut guard)
 }
 
-/// Spawns an instance worker for `program`
-/// and returns on success the corresponding [`JsInstance`]
-/// that talks to the worker.
+async fn spawn_main_instance_worker(
+    program: Arc<str>,
+    module_or_mcc: Either<ModuleCommon, ModuleCreationContext>,
+    load_balance_guard: Arc<LoadBalanceOnDropGuard>,
+    core_pinner: CorePinner,
+    heap_policy: V8HeapPolicyConfig,
+) -> anyhow::Result<(ModuleCommon, JsMainInstance)> {
+    spawn_instance_worker::<MainJsWorker>(program, module_or_mcc, load_balance_guard, core_pinner, heap_policy).await
+}
+
+async fn spawn_procedure_instance_worker(
+    program: Arc<str>,
+    module_or_mcc: Either<ModuleCommon, ModuleCreationContext>,
+    load_balance_guard: Arc<LoadBalanceOnDropGuard>,
+    core_pinner: CorePinner,
+    heap_policy: V8HeapPolicyConfig,
+) -> anyhow::Result<(ModuleCommon, JsProcedureInstance)> {
+    spawn_instance_worker::<ProcedureJsWorker>(program, module_or_mcc, load_balance_guard, core_pinner, heap_policy)
+        .await
+}
+
+struct MainJsWorker;
+
+struct ProcedureJsWorker;
+
+trait JsWorkerSpec {
+    type Request: Send + 'static;
+    type Instance;
+
+    const KIND: JsWorkerKind;
+
+    fn make_instance(tx: mpsc::Sender<Self::Request>, trapped: Arc<AtomicBool>) -> Self::Instance;
+
+    fn handle_request(
+        request: Self::Request,
+        rt: &tokio::runtime::Handle,
+        instance_common: &mut InstanceCommon,
+        inst: &mut V8Instance<'_, '_, '_>,
+        module_common: &ModuleCommon,
+        replica_ctx: &Arc<ReplicaContext>,
+    ) -> bool;
+}
+
+impl JsWorkerSpec for MainJsWorker {
+    type Request = JsMainWorkerRequest;
+    type Instance = JsMainInstance;
+
+    const KIND: JsWorkerKind = JsWorkerKind::Main;
+
+    fn make_instance(tx: mpsc::Sender<Self::Request>, trapped: Arc<AtomicBool>) -> Self::Instance {
+        JsMainInstance { tx, trapped }
+    }
+
+    fn handle_request(
+        request: Self::Request,
+        rt: &tokio::runtime::Handle,
+        instance_common: &mut InstanceCommon,
+        inst: &mut V8Instance<'_, '_, '_>,
+        module_common: &ModuleCommon,
+        replica_ctx: &Arc<ReplicaContext>,
+    ) -> bool {
+        handle_main_worker_request(request, rt, instance_common, inst, module_common, replica_ctx)
+    }
+}
+
+impl JsWorkerSpec for ProcedureJsWorker {
+    type Request = JsProcedureWorkerRequest;
+    type Instance = JsProcedureInstance;
+
+    const KIND: JsWorkerKind = JsWorkerKind::Procedure;
+
+    fn make_instance(tx: mpsc::Sender<Self::Request>, trapped: Arc<AtomicBool>) -> Self::Instance {
+        JsProcedureInstance { tx, trapped }
+    }
+
+    fn handle_request(
+        request: Self::Request,
+        _rt: &tokio::runtime::Handle,
+        instance_common: &mut InstanceCommon,
+        inst: &mut V8Instance<'_, '_, '_>,
+        _module_common: &ModuleCommon,
+        _replica_ctx: &Arc<ReplicaContext>,
+    ) -> bool {
+        handle_procedure_worker_request(request, instance_common, inst)
+    }
+}
+
+fn handle_main_worker_request(
+    request: JsMainWorkerRequest,
+    rt: &tokio::runtime::Handle,
+    instance_common: &mut InstanceCommon,
+    inst: &mut V8Instance<'_, '_, '_>,
+    module_common: &ModuleCommon,
+    replica_ctx: &Arc<ReplicaContext>,
+) -> bool {
+    let info = module_common.info();
+    let mut call_reducer = |tx, params| instance_common.call_reducer_with_tx(tx, params, inst);
+    let mut should_exit = false;
+
+    match request {
+        JsMainWorkerRequest::RunFunction(f) => rt.block_on(f()),
+        JsMainWorkerRequest::UpdateDatabase {
+            reply_tx,
+            program,
+            old_module_info,
+            policy,
+        } => {
+            let res = instance_common.update_database(program, old_module_info, policy, inst);
+            send_worker_reply("update_database", reply_tx, res);
+        }
+        JsMainWorkerRequest::CallReducer { reply_tx, params } => {
+            let (res, trapped) = call_reducer(None, params);
+            send_worker_reply("call_reducer", reply_tx, res);
+            should_exit = trapped;
+        }
+        JsMainWorkerRequest::CallView { reply_tx, cmd } => {
+            let (res, trapped) = instance_common.handle_cmd(cmd, inst);
+            send_worker_reply("call_view", reply_tx, res);
+            should_exit = trapped;
+        }
+        JsMainWorkerRequest::ClearAllClients(reply_tx) => {
+            let res = instance_common.clear_all_clients();
+            send_worker_reply("clear_all_clients", reply_tx, res);
+        }
+        JsMainWorkerRequest::CallIdentityConnected {
+            reply_tx,
+            caller_auth,
+            caller_connection_id,
+        } => {
+            let mut trapped = false;
+            let res = call_identity_connected(caller_auth, caller_connection_id, &info, call_reducer, &mut trapped);
+            send_worker_reply("call_identity_connected", reply_tx, res);
+            should_exit = trapped;
+        }
+        JsMainWorkerRequest::CallIdentityDisconnected {
+            reply_tx,
+            caller_identity,
+            caller_connection_id,
+        } => {
+            let mut trapped = false;
+            let res = ModuleHost::call_identity_disconnected_inner(
+                caller_identity,
+                caller_connection_id,
+                &info,
+                call_reducer,
+                &mut trapped,
+            );
+            send_worker_reply("call_identity_disconnected", reply_tx, res);
+            should_exit = trapped;
+        }
+        JsMainWorkerRequest::DisconnectClient { reply_tx, client_id } => {
+            let mut trapped = false;
+            let res = ModuleHost::disconnect_client_inner(client_id, &info, call_reducer, &mut trapped);
+            send_worker_reply("disconnect_client", reply_tx, res);
+            should_exit = trapped;
+        }
+        JsMainWorkerRequest::InitDatabase { reply_tx, program } => {
+            let (res, trapped): (Result<Option<ReducerCallResult>, anyhow::Error>, bool) =
+                init_database(replica_ctx, &info.module_def, program, call_reducer);
+            send_worker_reply("init_database", reply_tx, res);
+            should_exit = trapped;
+        }
+    }
+
+    should_exit
+}
+
+fn handle_procedure_worker_request(
+    request: JsProcedureWorkerRequest,
+    instance_common: &mut InstanceCommon,
+    inst: &mut V8Instance<'_, '_, '_>,
+) -> bool {
+    match request {
+        JsProcedureWorkerRequest::CallProcedure { reply_tx, params } => {
+            let (res, trapped) = instance_common
+                .call_procedure(params, inst)
+                .now_or_never()
+                .expect("our call_procedure implementation is not actually async");
+            send_worker_reply("call_procedure", reply_tx, res);
+            trapped
+        }
+        JsProcedureWorkerRequest::CallScheduledFunction { reply_tx, params } => {
+            let (res, trapped) = instance_common
+                .call_scheduled_function(params, inst)
+                .now_or_never()
+                .expect("our call_procedure implementation is not actually async");
+            send_worker_reply("call_scheduled_function", reply_tx, res);
+            trapped
+        }
+    }
+}
+
+/// Spawns an instance worker for `program` and returns on success the
+/// corresponding instance handle that talks to the worker.
 ///
-/// When [`ModuleCommon`] is passed, it's assumed that `spawn_instance_worker`
-/// has already happened once for this `program` and that it has been
-/// validated. In that case, `Ok(_)` should be returned.
+/// When [`ModuleCommon`] is passed, it's assumed that this program has already
+/// been validated. In that case, `Ok(_)` should be returned.
 ///
-/// Otherwise, when [`ModuleCreationContext`] is passed,
-/// this is the first time both the module and instance are created.
+/// Otherwise, when [`ModuleCreationContext`] is passed, this is the first time
+/// both the module and instance are created.
 ///
 /// `load_balance_guard` and `core_pinner` should both be from the same
 /// [`AllocatedJobCore`], and are used to manage the core pinning of this thread.
-async fn spawn_instance_worker(
+async fn spawn_instance_worker<W>(
     program: Arc<str>,
     module_or_mcc: Either<ModuleCommon, ModuleCreationContext>,
     load_balance_guard: Arc<LoadBalanceOnDropGuard>,
     mut core_pinner: CorePinner,
     heap_policy: V8HeapPolicyConfig,
-    worker_kind: JsWorkerKind,
-) -> anyhow::Result<(ModuleCommon, JsInstance)> {
+) -> anyhow::Result<(ModuleCommon, W::Instance)>
+where
+    W: JsWorkerSpec + 'static,
+{
     // This one-shot channel is used for initial startup error handling within the thread.
     let (result_tx, result_rx) = oneshot::channel();
+    let worker_kind = W::KIND;
     let (request_tx, mut request_rx) = mpsc::channel(worker_kind.request_queue_capacity());
     let trapped = Arc::new(AtomicBool::new(false));
     let trapped_in_thread = trapped.clone();
@@ -1039,121 +1282,21 @@ async fn spawn_instance_worker(
 
         // Process requests to the worker.
         //
-        // The loop is terminated when the last `JsInstance` handle is dropped.
+        // The loop is terminated when the last worker instance handle is dropped.
         // This will cause channels, scopes, and the isolate to be cleaned up.
         let mut requests_since_heap_check = 0u64;
         let mut last_heap_check_at = Instant::now();
         while let Some(request) = request_rx.blocking_recv() {
-            let mut call_reducer = |tx, params| instance_common.call_reducer_with_tx(tx, params, &mut inst);
-            let mut should_exit = false;
-
             core_pinner.pin_if_changed();
 
-            match request {
-                JsWorkerRequest::RunFunction(f) => rt.block_on(f()),
-                JsWorkerRequest::UpdateDatabase {
-                    reply_tx,
-                    program,
-                    old_module_info,
-                    policy,
-                } => {
-                    let res = instance_common.update_database(program, old_module_info, policy, &mut inst);
-                    send_worker_reply("update_database", reply_tx, res);
-                }
-                JsWorkerRequest::CallReducer { reply_tx, params } => {
-                    let (res, trapped) = call_reducer(None, params);
-                    if trapped {
-                        trapped_in_thread.store(true, Ordering::Relaxed);
-                    }
-                    send_worker_reply("call_reducer", reply_tx, res);
-                    should_exit = trapped;
-                }
-                JsWorkerRequest::CallView { reply_tx, cmd } => {
-                    let (res, trapped) = instance_common.handle_cmd(cmd, &mut inst);
-                    if trapped {
-                        trapped_in_thread.store(true, Ordering::Relaxed);
-                    }
-                    send_worker_reply("call_view", reply_tx, res);
-                    should_exit = trapped;
-                }
-                JsWorkerRequest::CallProcedure { reply_tx, params } => {
-                    let (res, trapped) = instance_common
-                        .call_procedure(params, &mut inst)
-                        .now_or_never()
-                        .expect("our call_procedure implementation is not actually async");
-                    if trapped {
-                        trapped_in_thread.store(true, Ordering::Relaxed);
-                    }
-                    send_worker_reply("call_procedure", reply_tx, res);
-                    should_exit = trapped;
-                }
-                JsWorkerRequest::ClearAllClients(reply_tx) => {
-                    let res = instance_common.clear_all_clients();
-                    send_worker_reply("clear_all_clients", reply_tx, res);
-                }
-                JsWorkerRequest::CallIdentityConnected {
-                    reply_tx,
-                    caller_auth,
-                    caller_connection_id,
-                } => {
-                    let mut trapped = false;
-                    let res =
-                        call_identity_connected(caller_auth, caller_connection_id, info, call_reducer, &mut trapped);
-                    if trapped {
-                        trapped_in_thread.store(true, Ordering::Relaxed);
-                    }
-                    send_worker_reply("call_identity_connected", reply_tx, res);
-                    should_exit = trapped;
-                }
-                JsWorkerRequest::CallIdentityDisconnected {
-                    reply_tx,
-                    caller_identity,
-                    caller_connection_id,
-                } => {
-                    let mut trapped = false;
-                    let res = ModuleHost::call_identity_disconnected_inner(
-                        caller_identity,
-                        caller_connection_id,
-                        info,
-                        call_reducer,
-                        &mut trapped,
-                    );
-                    if trapped {
-                        trapped_in_thread.store(true, Ordering::Relaxed);
-                    }
-                    send_worker_reply("call_identity_disconnected", reply_tx, res);
-                    should_exit = trapped;
-                }
-                JsWorkerRequest::DisconnectClient { reply_tx, client_id } => {
-                    let mut trapped = false;
-                    let res = ModuleHost::disconnect_client_inner(client_id, info, call_reducer, &mut trapped);
-                    if trapped {
-                        trapped_in_thread.store(true, Ordering::Relaxed);
-                    }
-                    send_worker_reply("disconnect_client", reply_tx, res);
-                    should_exit = trapped;
-                }
-                JsWorkerRequest::InitDatabase { reply_tx, program } => {
-                    let (res, trapped): (Result<Option<ReducerCallResult>, anyhow::Error>, bool) =
-                        init_database(replica_ctx, &module_common.info().module_def, program, call_reducer);
-                    if trapped {
-                        trapped_in_thread.store(true, Ordering::Relaxed);
-                    }
-                    send_worker_reply("init_database", reply_tx, res);
-                    should_exit = trapped;
-                }
-                JsWorkerRequest::CallScheduledFunction { reply_tx, params } => {
-                    let (res, trapped) = instance_common
-                        .call_scheduled_function(params, &mut inst)
-                        .now_or_never()
-                        .expect("our call_procedure implementation is not actually async");
-                    if trapped {
-                        trapped_in_thread.store(true, Ordering::Relaxed);
-                    }
-                    send_worker_reply("call_scheduled_function", reply_tx, res);
-                    should_exit = trapped;
-                }
-            }
+            let mut should_exit = W::handle_request(
+                request,
+                &rt,
+                &mut instance_common,
+                &mut inst,
+                &module_common,
+                replica_ctx,
+            );
 
             if !should_exit && let Some(heap_metrics) = heap_metrics.as_mut() {
                 let request_check_due = heap_policy.heap_check_request_interval.is_some_and(|interval| {
@@ -1167,7 +1310,6 @@ async fn spawn_instance_worker(
                     requests_since_heap_check = 0;
                     last_heap_check_at = Instant::now();
                     if let Some((used, limit)) = should_retire_worker_for_heap(inst.scope, heap_metrics, heap_policy) {
-                        trapped_in_thread.store(true, Ordering::Relaxed);
                         should_exit = true;
                         log::warn!(
                             "retiring JS worker after V8 heap stayed high post-GC: used={}MiB limit={}MiB",
@@ -1189,6 +1331,7 @@ async fn spawn_instance_worker(
             // this gives it a bounded-memory replacement policy instead of
             // letting one isolate absorb the entire module lifetime.
             if should_exit {
+                trapped_in_thread.store(true, Ordering::Relaxed);
                 break;
             }
         }
@@ -1197,10 +1340,7 @@ async fn spawn_instance_worker(
     // Get the module, if any, and get any setup errors from the worker.
     let res: Result<ModuleCommon, anyhow::Error> = result_rx.await.expect("should have a sender");
     res.map(|opt_mc| {
-        let inst = JsInstance {
-            tx: request_tx,
-            trapped,
-        };
+        let inst = W::make_instance(request_tx, trapped);
         (opt_mc, inst)
     })
 }

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -15,7 +15,7 @@ use super::module_host::{
 };
 use super::UpdateDatabaseResult;
 use crate::client::{ClientActorId, MeteredUnboundedReceiver, MeteredUnboundedSender};
-use crate::config::V8HeapPolicyConfig;
+use crate::config::{V8Config, V8HeapPolicyConfig};
 use crate::host::host_controller::CallProcedureReturn;
 use crate::host::instance_env::{ChunkPool, InstanceEnv, TxSlot};
 use crate::host::module_host::{
@@ -51,6 +51,7 @@ use spacetimedb_schema::def::ModuleDef;
 use spacetimedb_schema::identifier::Identifier;
 use spacetimedb_table::static_assert_size;
 use std::cell::Cell;
+use std::num::NonZeroUsize;
 use std::os::raw::c_void;
 use std::panic::{self, AssertUnwindSafe};
 use std::sync::{Arc, LazyLock};
@@ -75,19 +76,19 @@ mod util;
 
 /// The V8 runtime, for modules written in e.g., JS or TypeScript.
 pub struct V8Runtime {
-    heap_policy: V8HeapPolicyConfig,
+    config: V8Config,
 }
 
 impl Default for V8Runtime {
     fn default() -> Self {
-        Self::new(V8HeapPolicyConfig::default())
+        Self::new(V8Config::default())
     }
 }
 
 impl V8Runtime {
-    pub fn new(heap_policy: V8HeapPolicyConfig) -> Self {
+    pub fn new(config: V8Config) -> Self {
         Self {
-            heap_policy: heap_policy.normalized(),
+            config: config.normalized(),
         }
     }
 
@@ -98,7 +99,7 @@ impl V8Runtime {
         core: AllocatedJobCore,
     ) -> anyhow::Result<ModuleWithInstance> {
         V8_RUNTIME_GLOBAL
-            .make_actor(mcc, program_bytes, core, self.heap_policy)
+            .make_actor(mcc, program_bytes, core, self.config)
             .await
     }
 }
@@ -166,7 +167,7 @@ impl V8RuntimeInner {
         mcc: ModuleCreationContext,
         program_bytes: &[u8],
         core: AllocatedJobCore,
-        heap_policy: V8HeapPolicyConfig,
+        config: V8Config,
     ) -> anyhow::Result<ModuleWithInstance> {
         #![allow(unreachable_code, unused_variables)]
 
@@ -184,6 +185,7 @@ impl V8RuntimeInner {
         let mcc = Either::Right(mcc);
         let load_balance_guard = Arc::new(core.guard);
         let core_pinner = core.pinner;
+        let heap_policy = config.heap_policy;
         let (common, init_inst) = spawn_main_instance_worker(
             program.clone(),
             mcc,
@@ -198,7 +200,8 @@ impl V8RuntimeInner {
             program,
             load_balance_guard,
             core_pinner,
-            heap_policy,
+            procedure_instance_pool_size: config.procedure_instance_pool_size,
+            heap_policy: config.heap_policy,
             metrics,
         };
 
@@ -212,6 +215,7 @@ pub struct JsModule {
     program: Arc<str>,
     load_balance_guard: Arc<LoadBalanceOnDropGuard>,
     core_pinner: CorePinner,
+    procedure_instance_pool_size: NonZeroUsize,
     heap_policy: V8HeapPolicyConfig,
     metrics: InstanceManagerMetrics,
 }
@@ -231,6 +235,10 @@ impl JsModule {
 
     pub(in crate::host) fn metrics(&self) -> InstanceManagerMetrics {
         self.metrics.clone()
+    }
+
+    pub(in crate::host) fn procedure_instance_pool_size(&self) -> NonZeroUsize {
+        self.procedure_instance_pool_size
     }
 
     async fn create_procedure_instance(&self) -> JsProcedureInstance {

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -1541,6 +1541,29 @@ fn handle_procedure_worker_request(
     }
 }
 
+const THREAD_NAME_DATABASE_ID_SUFFIX_LEN: usize = 8;
+
+fn js_main_worker_thread_name(database_identity: Identity) -> String {
+    let hex = database_identity.to_hex();
+    // We use the tail of the identity to avoid the common structured prefix.
+    let suffix = &hex.as_str()[hex.as_str().len() - THREAD_NAME_DATABASE_ID_SUFFIX_LEN..];
+    format!("js-main-{suffix}")
+}
+
+fn spawn_v8_worker_thread(worker_kind: JsWorkerKind, database_identity: Identity, f: impl FnOnce() + Send + 'static) {
+    match worker_kind {
+        JsWorkerKind::Main => {
+            std::thread::Builder::new()
+                .name(js_main_worker_thread_name(database_identity))
+                .spawn(f)
+                .expect("failed to spawn V8 worker thread");
+        }
+        JsWorkerKind::Procedure => {
+            std::thread::spawn(f);
+        }
+    }
+}
+
 /// Spawns an instance worker for `program` and returns on success the
 /// corresponding instance handle that talks to the worker.
 ///
@@ -1574,7 +1597,7 @@ where
 
     let rt = tokio::runtime::Handle::current();
 
-    std::thread::spawn(move || {
+    spawn_v8_worker_thread(worker_kind, database_identity, move || {
         let _guard = load_balance_guard;
         core_pinner.pin_now();
 

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -1344,13 +1344,8 @@ fn handle_main_worker_request(
         }),
         JsMainWorkerRequest::CallViewDetached { cmd, metric, on_panic } => {
             handle_detached_worker_request("call_view", on_panic, || {
-                let (res, trapped) = instance_common.handle_cmd(cmd, inst);
-                ModuleHost::record_view_command_metrics_for_result(
-                    &module_common.info(),
-                    module_common.replica_ctx().relational_db(),
-                    metric,
-                    &res,
-                );
+                let (_, trapped) = instance_common.handle_cmd(cmd, inst);
+                ModuleHost::record_view_command_round_trip(&module_common.info(), metric);
                 trapped
             })
         }
@@ -1365,12 +1360,7 @@ fn handle_main_worker_request(
                 if let Err(err) = &res {
                     log::warn!("detached one-off query failed: {err:#}");
                 }
-                ModuleHost::record_one_off_query_metrics_for_result(
-                    &module_common.info(),
-                    module_common.replica_ctx().relational_db(),
-                    timer,
-                    &res,
-                );
+                ModuleHost::record_one_off_query_round_trip(&module_common.info(), timer);
                 false
             })
         }
@@ -1381,12 +1371,7 @@ fn handle_main_worker_request(
                 if let Err(err) = &res {
                     log::warn!("detached one-off query failed: {err:#}");
                 }
-                ModuleHost::record_one_off_query_metrics_for_result(
-                    &module_common.info(),
-                    module_common.replica_ctx().relational_db(),
-                    timer,
-                    &res,
-                );
+                ModuleHost::record_one_off_query_round_trip(&module_common.info(), timer);
                 false
             })
         }
@@ -1397,12 +1382,7 @@ fn handle_main_worker_request(
                 if let Err(err) = &res {
                     log::warn!("detached one-off query failed: {err:#}");
                 }
-                ModuleHost::record_one_off_query_metrics_for_result(
-                    &module_common.info(),
-                    module_common.replica_ctx().relational_db(),
-                    timer,
-                    &res,
-                );
+                ModuleHost::record_one_off_query_round_trip(&module_common.info(), timer);
                 false
             })
         }

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -20,7 +20,7 @@ use crate::host::host_controller::CallProcedureReturn;
 use crate::host::instance_env::{ChunkPool, InstanceEnv, TxSlot};
 use crate::host::module_host::{
     call_identity_connected, init_database, ClientConnectedError, OneOffQueryBsatnParams, OneOffQueryJsonParams,
-    OneOffQueryResult, OneOffQueryV2Params, SqlCommand, SqlCommandResult, ViewCommand, ViewCommandResult,
+    OneOffQueryV2Params, SqlCommand, SqlCommandResult, ViewCommand, ViewCommandMetric, ViewCommandResult,
 };
 use crate::host::scheduler::{CallScheduledFunctionResult, ScheduledFunctionParams};
 use crate::host::wasm_common::instrumentation::CallTimes;
@@ -409,8 +409,14 @@ pub struct JsProcedureInstance {
 }
 
 impl JsMainInstance {
-    async fn send_request<T>(&self, ctx: &'static str, request: impl FnOnce(JsReplyTx<T>) -> JsMainWorkerRequest) -> T {
-        send_js_request(ctx, &self.tx, request).await
+    async fn request<R: JsMainRequest>(&self, request: R) -> R::Response {
+        send_js_request(R::CTX, &self.tx, |reply_tx| request.into_worker_request(reply_tx)).await
+    }
+
+    async fn send_detached_request(&self, ctx: &'static str, request: JsMainWorkerRequest) {
+        if self.tx.send(request).await.is_err() {
+            panic!("JS worker exited before accepting `{ctx}`");
+        }
     }
 
     pub async fn update_database(
@@ -419,8 +425,7 @@ impl JsMainInstance {
         old_module_info: Arc<ModuleInfo>,
         policy: MigrationPolicy,
     ) -> anyhow::Result<UpdateDatabaseResult> {
-        self.send_request("update_database", |reply_tx| JsMainWorkerRequest::UpdateDatabase {
-            reply_tx,
+        self.request(UpdateDatabaseRequest {
             program,
             old_module_info,
             policy,
@@ -429,16 +434,19 @@ impl JsMainInstance {
     }
 
     pub async fn call_reducer(&self, params: CallReducerParams) -> ReducerCallResult {
-        self.send_request("call_reducer", |reply_tx| JsMainWorkerRequest::CallReducer {
-            reply_tx,
-            params,
-        })
+        self.request(CallReducerRequest { params }).await
+    }
+
+    pub(in crate::host) async fn enqueue_reducer(&self, params: CallReducerParams, on_panic: JsFatalHook) {
+        self.send_detached_request(
+            "call_reducer",
+            JsMainWorkerRequest::CallReducerDetached { params, on_panic },
+        )
         .await
     }
 
     pub async fn clear_all_clients(&self) -> anyhow::Result<()> {
-        self.send_request("clear_all_clients", JsMainWorkerRequest::ClearAllClients)
-            .await
+        self.request(ClearAllClientsRequest).await
     }
 
     pub async fn call_identity_connected(
@@ -446,12 +454,9 @@ impl JsMainInstance {
         caller_auth: ConnectionAuthCtx,
         caller_connection_id: ConnectionId,
     ) -> Result<(), ClientConnectedError> {
-        self.send_request("call_identity_connected", |reply_tx| {
-            JsMainWorkerRequest::CallIdentityConnected {
-                reply_tx,
-                caller_auth,
-                caller_connection_id,
-            }
+        self.request(CallIdentityConnectedRequest {
+            caller_auth,
+            caller_connection_id,
         })
         .await
     }
@@ -461,63 +466,236 @@ impl JsMainInstance {
         caller_identity: Identity,
         caller_connection_id: ConnectionId,
     ) -> Result<(), ReducerCallError> {
-        self.send_request("call_identity_disconnected", |reply_tx| {
-            JsMainWorkerRequest::CallIdentityDisconnected {
-                reply_tx,
-                caller_identity,
-                caller_connection_id,
-            }
+        self.request(CallIdentityDisconnectedRequest {
+            caller_identity,
+            caller_connection_id,
         })
         .await
     }
 
     pub async fn disconnect_client(&self, client_id: ClientActorId) -> Result<(), ReducerCallError> {
-        self.send_request("disconnect_client", |reply_tx| JsMainWorkerRequest::DisconnectClient {
-            reply_tx,
-            client_id,
-        })
-        .await
+        self.request(DisconnectClientRequest { client_id }).await
     }
 
     pub async fn init_database(&self, program: Program) -> anyhow::Result<Option<ReducerCallResult>> {
-        self.send_request("init_database", |reply_tx| JsMainWorkerRequest::InitDatabase {
-            reply_tx,
-            program,
-        })
-        .await
+        self.request(InitDatabaseRequest { program }).await
     }
 
     pub async fn call_view(&self, cmd: ViewCommand) -> ViewCommandResult {
-        self.send_request("call_view", |reply_tx| JsMainWorkerRequest::CallView { reply_tx, cmd })
-            .await
+        self.request(CallViewRequest { cmd }).await
+    }
+
+    pub(in crate::host) async fn enqueue_call_view(
+        &self,
+        cmd: ViewCommand,
+        metric: ViewCommandMetric,
+        on_panic: JsFatalHook,
+    ) {
+        self.send_detached_request(
+            "call_view",
+            JsMainWorkerRequest::CallViewDetached { cmd, metric, on_panic },
+        )
+        .await
     }
 
     pub(in crate::host) async fn call_sql(&self, cmd: SqlCommand) -> SqlCommandResult {
-        self.send_request("call_sql", |reply_tx| JsMainWorkerRequest::CallSql { reply_tx, cmd })
-            .await
+        self.request(CallSqlRequest { cmd }).await
     }
 
-    pub(in crate::host) async fn one_off_query_json(&self, params: OneOffQueryJsonParams) -> OneOffQueryResult {
-        self.send_request("one_off_query_json", |reply_tx| JsMainWorkerRequest::OneOffQueryJson {
+    pub(in crate::host) async fn enqueue_one_off_query_json(
+        &self,
+        params: OneOffQueryJsonParams,
+        on_panic: JsFatalHook,
+    ) {
+        self.send_detached_request(
+            "one_off_query_json",
+            JsMainWorkerRequest::OneOffQueryJsonDetached { params, on_panic },
+        )
+        .await
+    }
+
+    pub(in crate::host) async fn enqueue_one_off_query_bsatn(
+        &self,
+        params: OneOffQueryBsatnParams,
+        on_panic: JsFatalHook,
+    ) {
+        self.send_detached_request(
+            "one_off_query_bsatn",
+            JsMainWorkerRequest::OneOffQueryBsatnDetached { params, on_panic },
+        )
+        .await
+    }
+
+    pub(in crate::host) async fn enqueue_one_off_query_v2(&self, params: OneOffQueryV2Params, on_panic: JsFatalHook) {
+        self.send_detached_request(
+            "one_off_query_v2",
+            JsMainWorkerRequest::OneOffQueryV2Detached { params, on_panic },
+        )
+        .await
+    }
+}
+
+trait JsMainRequest {
+    type Response;
+
+    const CTX: &'static str;
+
+    fn into_worker_request(self, reply_tx: JsReplyTx<Self::Response>) -> JsMainWorkerRequest;
+}
+
+struct UpdateDatabaseRequest {
+    program: Program,
+    old_module_info: Arc<ModuleInfo>,
+    policy: MigrationPolicy,
+}
+
+impl JsMainRequest for UpdateDatabaseRequest {
+    type Response = anyhow::Result<UpdateDatabaseResult>;
+
+    const CTX: &'static str = "update_database";
+
+    fn into_worker_request(self, reply_tx: JsReplyTx<Self::Response>) -> JsMainWorkerRequest {
+        JsMainWorkerRequest::UpdateDatabase {
             reply_tx,
-            params,
-        })
-        .await
+            program: self.program,
+            old_module_info: self.old_module_info,
+            policy: self.policy,
+        }
     }
+}
 
-    pub(in crate::host) async fn one_off_query_bsatn(&self, params: OneOffQueryBsatnParams) -> OneOffQueryResult {
-        self.send_request("one_off_query_bsatn", |reply_tx| {
-            JsMainWorkerRequest::OneOffQueryBsatn { reply_tx, params }
-        })
-        .await
-    }
+struct CallReducerRequest {
+    params: CallReducerParams,
+}
 
-    pub(in crate::host) async fn one_off_query_v2(&self, params: OneOffQueryV2Params) -> OneOffQueryResult {
-        self.send_request("one_off_query_v2", |reply_tx| JsMainWorkerRequest::OneOffQueryV2 {
+impl JsMainRequest for CallReducerRequest {
+    type Response = ReducerCallResult;
+
+    const CTX: &'static str = "call_reducer";
+
+    fn into_worker_request(self, reply_tx: JsReplyTx<Self::Response>) -> JsMainWorkerRequest {
+        JsMainWorkerRequest::CallReducer {
             reply_tx,
-            params,
-        })
-        .await
+            params: self.params,
+        }
+    }
+}
+
+struct ClearAllClientsRequest;
+
+impl JsMainRequest for ClearAllClientsRequest {
+    type Response = anyhow::Result<()>;
+
+    const CTX: &'static str = "clear_all_clients";
+
+    fn into_worker_request(self, reply_tx: JsReplyTx<Self::Response>) -> JsMainWorkerRequest {
+        JsMainWorkerRequest::ClearAllClients(reply_tx)
+    }
+}
+
+struct CallIdentityConnectedRequest {
+    caller_auth: ConnectionAuthCtx,
+    caller_connection_id: ConnectionId,
+}
+
+impl JsMainRequest for CallIdentityConnectedRequest {
+    type Response = Result<(), ClientConnectedError>;
+
+    const CTX: &'static str = "call_identity_connected";
+
+    fn into_worker_request(self, reply_tx: JsReplyTx<Self::Response>) -> JsMainWorkerRequest {
+        JsMainWorkerRequest::CallIdentityConnected {
+            reply_tx,
+            caller_auth: self.caller_auth,
+            caller_connection_id: self.caller_connection_id,
+        }
+    }
+}
+
+struct CallIdentityDisconnectedRequest {
+    caller_identity: Identity,
+    caller_connection_id: ConnectionId,
+}
+
+impl JsMainRequest for CallIdentityDisconnectedRequest {
+    type Response = Result<(), ReducerCallError>;
+
+    const CTX: &'static str = "call_identity_disconnected";
+
+    fn into_worker_request(self, reply_tx: JsReplyTx<Self::Response>) -> JsMainWorkerRequest {
+        JsMainWorkerRequest::CallIdentityDisconnected {
+            reply_tx,
+            caller_identity: self.caller_identity,
+            caller_connection_id: self.caller_connection_id,
+        }
+    }
+}
+
+struct DisconnectClientRequest {
+    client_id: ClientActorId,
+}
+
+impl JsMainRequest for DisconnectClientRequest {
+    type Response = Result<(), ReducerCallError>;
+
+    const CTX: &'static str = "disconnect_client";
+
+    fn into_worker_request(self, reply_tx: JsReplyTx<Self::Response>) -> JsMainWorkerRequest {
+        JsMainWorkerRequest::DisconnectClient {
+            reply_tx,
+            client_id: self.client_id,
+        }
+    }
+}
+
+struct InitDatabaseRequest {
+    program: Program,
+}
+
+impl JsMainRequest for InitDatabaseRequest {
+    type Response = anyhow::Result<Option<ReducerCallResult>>;
+
+    const CTX: &'static str = "init_database";
+
+    fn into_worker_request(self, reply_tx: JsReplyTx<Self::Response>) -> JsMainWorkerRequest {
+        JsMainWorkerRequest::InitDatabase {
+            reply_tx,
+            program: self.program,
+        }
+    }
+}
+
+struct CallViewRequest {
+    cmd: ViewCommand,
+}
+
+impl JsMainRequest for CallViewRequest {
+    type Response = ViewCommandResult;
+
+    const CTX: &'static str = "call_view";
+
+    fn into_worker_request(self, reply_tx: JsReplyTx<Self::Response>) -> JsMainWorkerRequest {
+        JsMainWorkerRequest::CallView {
+            reply_tx,
+            cmd: self.cmd,
+        }
+    }
+}
+
+struct CallSqlRequest {
+    cmd: SqlCommand,
+}
+
+impl JsMainRequest for CallSqlRequest {
+    type Response = SqlCommandResult;
+
+    const CTX: &'static str = "call_sql";
+
+    fn into_worker_request(self, reply_tx: JsReplyTx<Self::Response>) -> JsMainWorkerRequest {
+        JsMainWorkerRequest::CallSql {
+            reply_tx,
+            cmd: self.cmd,
+        }
     }
 }
 
@@ -540,6 +718,19 @@ impl JsProcedureInstance {
             params,
         })
         .await
+    }
+
+    pub(in crate::host) async fn enqueue_procedure(&self, params: CallProcedureParams) -> JsProcedureCall {
+        let (reply_tx, reply_rx) = oneshot::channel();
+        if self
+            .tx
+            .send(JsProcedureWorkerRequest::CallProcedure { reply_tx, params })
+            .await
+            .is_err()
+        {
+            panic!("JS worker exited before accepting `call_procedure`");
+        }
+        JsProcedureCall { reply_rx }
     }
 
     pub(in crate::host) async fn call_scheduled_function(
@@ -575,6 +766,27 @@ where
 type JsPanicPayload = Box<dyn std::any::Any + Send + 'static>;
 type JsReply<T> = Result<T, JsPanicPayload>;
 type JsReplyTx<T> = oneshot::Sender<JsReply<T>>;
+pub(in crate::host) type JsFatalHook = Arc<dyn Fn() + Send + Sync + 'static>;
+
+pub(in crate::host) struct JsProcedureCall {
+    reply_rx: oneshot::Receiver<JsReply<CallProcedureReturn>>,
+}
+
+pub(in crate::host) enum JsProcedureCallCompletion {
+    Completed(CallProcedureReturn),
+    Panicked,
+    WorkerExited,
+}
+
+impl JsProcedureCall {
+    pub(in crate::host) async fn receive(self) -> JsProcedureCallCompletion {
+        match self.reply_rx.await {
+            Ok(Ok(ret)) => JsProcedureCallCompletion::Completed(ret),
+            Ok(Err(_panic)) => JsProcedureCallCompletion::Panicked,
+            Err(_) => JsProcedureCallCompletion::WorkerExited,
+        }
+    }
+}
 
 /// Requests sent to the main JS worker thread.
 ///
@@ -594,30 +806,41 @@ enum JsMainWorkerRequest {
         reply_tx: JsReplyTx<ReducerCallResult>,
         params: CallReducerParams,
     },
+    /// See [`JsMainInstance::enqueue_reducer`].
+    CallReducerDetached {
+        params: CallReducerParams,
+        on_panic: JsFatalHook,
+    },
     /// See [`JsMainInstance::call_view`].
     CallView {
         reply_tx: JsReplyTx<ViewCommandResult>,
         cmd: ViewCommand,
+    },
+    /// See [`JsMainInstance::enqueue_call_view`].
+    CallViewDetached {
+        cmd: ViewCommand,
+        metric: ViewCommandMetric,
+        on_panic: JsFatalHook,
     },
     /// See [`JsMainInstance::call_sql`].
     CallSql {
         reply_tx: JsReplyTx<SqlCommandResult>,
         cmd: SqlCommand,
     },
-    /// See [`JsMainInstance::one_off_query_json`].
-    OneOffQueryJson {
-        reply_tx: JsReplyTx<OneOffQueryResult>,
+    /// See [`JsMainInstance::enqueue_one_off_query_json`].
+    OneOffQueryJsonDetached {
         params: OneOffQueryJsonParams,
+        on_panic: JsFatalHook,
     },
-    /// See [`JsMainInstance::one_off_query_bsatn`].
-    OneOffQueryBsatn {
-        reply_tx: JsReplyTx<OneOffQueryResult>,
+    /// See [`JsMainInstance::enqueue_one_off_query_bsatn`].
+    OneOffQueryBsatnDetached {
         params: OneOffQueryBsatnParams,
+        on_panic: JsFatalHook,
     },
-    /// See [`JsMainInstance::one_off_query_v2`].
-    OneOffQueryV2 {
-        reply_tx: JsReplyTx<OneOffQueryResult>,
+    /// See [`JsMainInstance::enqueue_one_off_query_v2`].
+    OneOffQueryV2Detached {
         params: OneOffQueryV2Params,
+        on_panic: JsFatalHook,
     },
     /// See [`JsMainInstance::clear_all_clients`].
     ClearAllClients(JsReplyTx<anyhow::Result<()>>),
@@ -704,6 +927,27 @@ fn handle_worker_request<T: 'static>(
         }
         Err(panic) => {
             send_worker_panic_reply(ctx, reply_tx, panic);
+            WorkerRequestOutcome::Fatal
+        }
+    }
+}
+
+fn handle_detached_worker_request(
+    ctx: &'static str,
+    on_panic: JsFatalHook,
+    f: impl FnOnce() -> bool,
+) -> WorkerRequestOutcome {
+    match panic::catch_unwind(AssertUnwindSafe(f)) {
+        Ok(recreate_instance) => {
+            if recreate_instance {
+                WorkerRequestOutcome::RecreateInstance
+            } else {
+                WorkerRequestOutcome::Continue
+            }
+        }
+        Err(_) => {
+            log::warn!("detached JS worker request `{ctx}` panicked");
+            on_panic();
             WorkerRequestOutcome::Fatal
         }
     }
@@ -1087,30 +1331,79 @@ fn handle_main_worker_request(
                 (res, trapped)
             })
         }
+        JsMainWorkerRequest::CallReducerDetached { params, on_panic } => {
+            handle_detached_worker_request("call_reducer", on_panic, || {
+                let mut call_reducer = |tx, params| instance_common.call_reducer_with_tx(tx, params, inst);
+                let (_res, trapped) = call_reducer(None, params);
+                trapped
+            })
+        }
         JsMainWorkerRequest::CallView { reply_tx, cmd } => handle_worker_request("call_view", reply_tx, || {
             let (res, trapped) = instance_common.handle_cmd(cmd, inst);
             (res, trapped)
         }),
+        JsMainWorkerRequest::CallViewDetached { cmd, metric, on_panic } => {
+            handle_detached_worker_request("call_view", on_panic, || {
+                let (res, trapped) = instance_common.handle_cmd(cmd, inst);
+                ModuleHost::record_view_command_metrics_for_result(
+                    &module_common.info(),
+                    module_common.replica_ctx().relational_db(),
+                    metric,
+                    &res,
+                );
+                trapped
+            })
+        }
         JsMainWorkerRequest::CallSql { reply_tx, cmd } => handle_worker_request("call_sql", reply_tx, || {
             let (res, trapped) = instance_common.handle_sql_cmd(cmd, inst);
             (res, trapped)
         }),
-        JsMainWorkerRequest::OneOffQueryJson { reply_tx, params } => {
-            handle_worker_request("one_off_query_json", reply_tx, || {
+        JsMainWorkerRequest::OneOffQueryJsonDetached { params, on_panic } => {
+            handle_detached_worker_request("one_off_query_json", on_panic, || {
+                let timer = params.timer();
                 let res = ModuleHost::one_off_query_json_inner(params);
-                (res, false)
+                if let Err(err) = &res {
+                    log::warn!("detached one-off query failed: {err:#}");
+                }
+                ModuleHost::record_one_off_query_metrics_for_result(
+                    &module_common.info(),
+                    module_common.replica_ctx().relational_db(),
+                    timer,
+                    &res,
+                );
+                false
             })
         }
-        JsMainWorkerRequest::OneOffQueryBsatn { reply_tx, params } => {
-            handle_worker_request("one_off_query_bsatn", reply_tx, || {
+        JsMainWorkerRequest::OneOffQueryBsatnDetached { params, on_panic } => {
+            handle_detached_worker_request("one_off_query_bsatn", on_panic, || {
+                let timer = params.timer();
                 let res = ModuleHost::one_off_query_bsatn_inner(params);
-                (res, false)
+                if let Err(err) = &res {
+                    log::warn!("detached one-off query failed: {err:#}");
+                }
+                ModuleHost::record_one_off_query_metrics_for_result(
+                    &module_common.info(),
+                    module_common.replica_ctx().relational_db(),
+                    timer,
+                    &res,
+                );
+                false
             })
         }
-        JsMainWorkerRequest::OneOffQueryV2 { reply_tx, params } => {
-            handle_worker_request("one_off_query_v2", reply_tx, || {
+        JsMainWorkerRequest::OneOffQueryV2Detached { params, on_panic } => {
+            handle_detached_worker_request("one_off_query_v2", on_panic, || {
+                let timer = params.timer();
                 let res = ModuleHost::one_off_query_v2_inner(params);
-                (res, false)
+                if let Err(err) = &res {
+                    log::warn!("detached one-off query failed: {err:#}");
+                }
+                ModuleHost::record_one_off_query_metrics_for_result(
+                    &module_common.info(),
+                    module_common.replica_ctx().relational_db(),
+                    timer,
+                    &res,
+                );
+                false
             })
         }
         JsMainWorkerRequest::ClearAllClients(reply_tx) => handle_worker_request("clear_all_clients", reply_tx, || {

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -10,17 +10,17 @@ use self::syscall::{
     process_thrown_exception, resolve_sys_module, FnRet, HookFunctions,
 };
 use super::module_common::{build_common_module_from_raw, run_describer, ModuleCommon};
-use super::module_host::{CallProcedureParams, CallReducerParams, ModuleInfo, ModuleWithInstance};
+use super::module_host::{
+    CallProcedureParams, CallReducerParams, InstanceManagerMetrics, ModuleInfo, ModuleWithInstance,
+};
 use super::UpdateDatabaseResult;
 use crate::client::ClientActorId;
 use crate::config::V8HeapPolicyConfig;
-use crate::error::DBError;
 use crate::host::host_controller::CallProcedureReturn;
 use crate::host::instance_env::{ChunkPool, InstanceEnv, TxSlot};
 use crate::host::module_host::{
     call_identity_connected, init_database, ClientConnectedError, OneOffQueryBsatnParams, OneOffQueryJsonParams,
-    OneOffQueryResult, OneOffQueryV2Params, ProcedureCallError, SqlCommand, SqlCommandResult, ViewCallError,
-    ViewCommand, ViewCommandResult,
+    OneOffQueryResult, OneOffQueryV2Params, SqlCommand, SqlCommandResult, ViewCommand, ViewCommandResult,
 };
 use crate::host::scheduler::{CallScheduledFunctionResult, ScheduledFunctionParams};
 use crate::host::wasm_common::instrumentation::CallTimes;
@@ -31,6 +31,7 @@ use crate::host::wasm_common::module_host_actor::{
 };
 use crate::host::wasm_common::{RowIters, TimingSpanSet};
 use crate::host::{ModuleHost, ReducerCallError, ReducerCallResult, Scheduler};
+use crate::messages::control_db::HostType;
 use crate::module_host_context::ModuleCreationContext;
 use crate::replica_context::ReplicaContext;
 use crate::subscription::module_subscription_manager::TransactionOffset;
@@ -51,7 +52,7 @@ use spacetimedb_schema::identifier::Identifier;
 use spacetimedb_table::static_assert_size;
 use std::cell::Cell;
 use std::os::raw::c_void;
-use std::sync::atomic::{AtomicBool, Ordering};
+use std::panic::{self, AssertUnwindSafe};
 use std::sync::{Arc, LazyLock};
 use std::time::Instant;
 use tokio::sync::{mpsc, oneshot};
@@ -187,6 +188,7 @@ impl V8RuntimeInner {
         let program: Arc<str> = str::from_utf8(program_bytes)?.into();
 
         // Validate/create the module and spawn the first instance.
+        let metrics = InstanceManagerMetrics::new(HostType::Js, mcc.replica_ctx.database_identity);
         let mcc = Either::Right(mcc);
         let load_balance_guard = Arc::new(core.guard);
         let core_pinner = core.pinner;
@@ -196,6 +198,7 @@ impl V8RuntimeInner {
             load_balance_guard.clone(),
             core_pinner.clone(),
             heap_policy,
+            metrics.clone(),
         )
         .await?;
         let module = JsModule {
@@ -204,6 +207,7 @@ impl V8RuntimeInner {
             load_balance_guard,
             core_pinner,
             heap_policy,
+            metrics,
         };
 
         Ok(ModuleWithInstance::Js { module, init_inst })
@@ -217,6 +221,7 @@ pub struct JsModule {
     load_balance_guard: Arc<LoadBalanceOnDropGuard>,
     core_pinner: CorePinner,
     heap_policy: V8HeapPolicyConfig,
+    metrics: InstanceManagerMetrics,
 }
 
 impl JsModule {
@@ -232,12 +237,17 @@ impl JsModule {
         self.common.info().clone()
     }
 
+    pub(in crate::host) fn metrics(&self) -> InstanceManagerMetrics {
+        self.metrics.clone()
+    }
+
     async fn create_procedure_instance(&self) -> JsProcedureInstance {
         let program = self.program.clone();
         let common = self.common.clone();
         let load_balance_guard = self.load_balance_guard.clone();
         let core_pinner = self.core_pinner.clone();
         let heap_policy = self.heap_policy;
+        let metrics = self.metrics.clone();
 
         // This has to be done in a blocking context because of `blocking_recv`.
         let (_, instance) = spawn_procedure_instance_worker(
@@ -246,6 +256,7 @@ impl JsModule {
             load_balance_guard,
             core_pinner,
             heap_policy,
+            metrics,
         )
         .await
         .expect("`spawn_procedure_instance_worker` should succeed when passed `ModuleCommon`");
@@ -254,25 +265,6 @@ impl JsModule {
 
     pub async fn create_instance(&self) -> JsProcedureInstance {
         self.create_procedure_instance().await
-    }
-
-    pub(in crate::host) async fn create_main_instance(&self) -> JsMainInstance {
-        let program = self.program.clone();
-        let common = self.common.clone();
-        let load_balance_guard = self.load_balance_guard.clone();
-        let core_pinner = self.core_pinner.clone();
-        let heap_policy = self.heap_policy;
-
-        let (_, instance) = spawn_main_instance_worker(
-            program,
-            Either::Left(common),
-            load_balance_guard,
-            core_pinner,
-            heap_policy,
-        )
-        .await
-        .expect("`spawn_main_instance_worker` should succeed when passed `ModuleCommon`");
-        instance
     }
 }
 
@@ -406,7 +398,6 @@ impl JsInstanceEnv {
 #[derive(Clone)]
 pub struct JsMainInstance {
     tx: mpsc::Sender<JsMainWorkerRequest>,
-    trapped: Arc<AtomicBool>,
 }
 
 /// A procedure instance for a [`JsModule`].
@@ -415,23 +406,11 @@ pub struct JsMainInstance {
 /// only execute procedure-style requests.
 pub struct JsProcedureInstance {
     tx: mpsc::Sender<JsProcedureWorkerRequest>,
-    trapped: Arc<AtomicBool>,
 }
 
 impl JsMainInstance {
-    pub fn trapped(&self) -> bool {
-        self.trapped.load(Ordering::Relaxed)
-    }
-
-    pub(in crate::host) fn needs_replacement(&self) -> bool {
-        self.trapped() || self.tx.is_closed()
-    }
-
-    async fn send_request<T>(
-        &self,
-        request: impl FnOnce(JsReplyTx<T>) -> JsMainWorkerRequest,
-    ) -> Result<T, JsWorkerDisconnected> {
-        send_js_request(&self.tx, &self.trapped, request).await
+    async fn send_request<T>(&self, ctx: &'static str, request: impl FnOnce(JsReplyTx<T>) -> JsMainWorkerRequest) -> T {
+        send_js_request(ctx, &self.tx, request).await
     }
 
     pub async fn update_database(
@@ -440,26 +419,26 @@ impl JsMainInstance {
         old_module_info: Arc<ModuleInfo>,
         policy: MigrationPolicy,
     ) -> anyhow::Result<UpdateDatabaseResult> {
-        self.send_request(|reply_tx| JsMainWorkerRequest::UpdateDatabase {
+        self.send_request("update_database", |reply_tx| JsMainWorkerRequest::UpdateDatabase {
             reply_tx,
             program,
             old_module_info,
             policy,
         })
         .await
-        .map_err(|_| anyhow::anyhow!(js_worker_disconnected_error("update_database")))?
     }
 
-    pub async fn call_reducer(&self, params: CallReducerParams) -> Result<ReducerCallResult, ReducerCallError> {
-        self.send_request(|reply_tx| JsMainWorkerRequest::CallReducer { reply_tx, params })
-            .await
-            .map_err(|_| ReducerCallError::WorkerError(js_worker_disconnected_error("call_reducer")))
+    pub async fn call_reducer(&self, params: CallReducerParams) -> ReducerCallResult {
+        self.send_request("call_reducer", |reply_tx| JsMainWorkerRequest::CallReducer {
+            reply_tx,
+            params,
+        })
+        .await
     }
 
     pub async fn clear_all_clients(&self) -> anyhow::Result<()> {
-        self.send_request(JsMainWorkerRequest::ClearAllClients)
+        self.send_request("clear_all_clients", JsMainWorkerRequest::ClearAllClients)
             .await
-            .map_err(|_| anyhow::anyhow!(js_worker_disconnected_error("clear_all_clients")))?
     }
 
     pub async fn call_identity_connected(
@@ -467,17 +446,14 @@ impl JsMainInstance {
         caller_auth: ConnectionAuthCtx,
         caller_connection_id: ConnectionId,
     ) -> Result<(), ClientConnectedError> {
-        self.send_request(|reply_tx| JsMainWorkerRequest::CallIdentityConnected {
-            reply_tx,
-            caller_auth,
-            caller_connection_id,
+        self.send_request("call_identity_connected", |reply_tx| {
+            JsMainWorkerRequest::CallIdentityConnected {
+                reply_tx,
+                caller_auth,
+                caller_connection_id,
+            }
         })
         .await
-        .map_err(|_| {
-            ClientConnectedError::from(ReducerCallError::WorkerError(js_worker_disconnected_error(
-                "call_identity_connected",
-            )))
-        })?
     }
 
     pub async fn call_identity_disconnected(
@@ -485,118 +461,120 @@ impl JsMainInstance {
         caller_identity: Identity,
         caller_connection_id: ConnectionId,
     ) -> Result<(), ReducerCallError> {
-        self.send_request(|reply_tx| JsMainWorkerRequest::CallIdentityDisconnected {
-            reply_tx,
-            caller_identity,
-            caller_connection_id,
+        self.send_request("call_identity_disconnected", |reply_tx| {
+            JsMainWorkerRequest::CallIdentityDisconnected {
+                reply_tx,
+                caller_identity,
+                caller_connection_id,
+            }
         })
         .await
-        .map_err(|_| ReducerCallError::WorkerError(js_worker_disconnected_error("call_identity_disconnected")))?
     }
 
     pub async fn disconnect_client(&self, client_id: ClientActorId) -> Result<(), ReducerCallError> {
-        self.send_request(|reply_tx| JsMainWorkerRequest::DisconnectClient { reply_tx, client_id })
-            .await
-            .map_err(|_| ReducerCallError::WorkerError(js_worker_disconnected_error("disconnect_client")))?
+        self.send_request("disconnect_client", |reply_tx| JsMainWorkerRequest::DisconnectClient {
+            reply_tx,
+            client_id,
+        })
+        .await
     }
 
     pub async fn init_database(&self, program: Program) -> anyhow::Result<Option<ReducerCallResult>> {
-        self.send_request(|reply_tx| JsMainWorkerRequest::InitDatabase { reply_tx, program })
-            .await
-            .map_err(|_| anyhow::anyhow!(js_worker_disconnected_error("init_database")))?
+        self.send_request("init_database", |reply_tx| JsMainWorkerRequest::InitDatabase {
+            reply_tx,
+            program,
+        })
+        .await
     }
 
-    pub async fn call_view(&self, cmd: ViewCommand) -> Result<ViewCommandResult, ViewCallError> {
-        self.send_request(|reply_tx| JsMainWorkerRequest::CallView { reply_tx, cmd })
+    pub async fn call_view(&self, cmd: ViewCommand) -> ViewCommandResult {
+        self.send_request("call_view", |reply_tx| JsMainWorkerRequest::CallView { reply_tx, cmd })
             .await
-            .map_err(|_| ViewCallError::InternalError(js_worker_disconnected_error("call_view")))
     }
 
-    pub(in crate::host) async fn call_sql(&self, cmd: SqlCommand) -> Result<SqlCommandResult, DBError> {
-        self.send_request(|reply_tx| JsMainWorkerRequest::CallSql { reply_tx, cmd })
+    pub(in crate::host) async fn call_sql(&self, cmd: SqlCommand) -> SqlCommandResult {
+        self.send_request("call_sql", |reply_tx| JsMainWorkerRequest::CallSql { reply_tx, cmd })
             .await
-            .map_err(|_| DBError::Other(anyhow::anyhow!(js_worker_disconnected_error("call_sql"))))
     }
 
     pub(in crate::host) async fn one_off_query_json(&self, params: OneOffQueryJsonParams) -> OneOffQueryResult {
-        self.send_request(|reply_tx| JsMainWorkerRequest::OneOffQueryJson { reply_tx, params })
-            .await
-            .unwrap_or_else(|_| Err(anyhow::anyhow!(js_worker_disconnected_error("one_off_query_json"))))
+        self.send_request("one_off_query_json", |reply_tx| JsMainWorkerRequest::OneOffQueryJson {
+            reply_tx,
+            params,
+        })
+        .await
     }
 
     pub(in crate::host) async fn one_off_query_bsatn(&self, params: OneOffQueryBsatnParams) -> OneOffQueryResult {
-        self.send_request(|reply_tx| JsMainWorkerRequest::OneOffQueryBsatn { reply_tx, params })
-            .await
-            .unwrap_or_else(|_| Err(anyhow::anyhow!(js_worker_disconnected_error("one_off_query_bsatn"))))
+        self.send_request("one_off_query_bsatn", |reply_tx| {
+            JsMainWorkerRequest::OneOffQueryBsatn { reply_tx, params }
+        })
+        .await
     }
 
     pub(in crate::host) async fn one_off_query_v2(&self, params: OneOffQueryV2Params) -> OneOffQueryResult {
-        self.send_request(|reply_tx| JsMainWorkerRequest::OneOffQueryV2 { reply_tx, params })
-            .await
-            .unwrap_or_else(|_| Err(anyhow::anyhow!(js_worker_disconnected_error("one_off_query_v2"))))
+        self.send_request("one_off_query_v2", |reply_tx| JsMainWorkerRequest::OneOffQueryV2 {
+            reply_tx,
+            params,
+        })
+        .await
     }
 }
 
 impl JsProcedureInstance {
-    pub fn trapped(&self) -> bool {
-        self.trapped.load(Ordering::Relaxed)
+    pub(in crate::host) fn is_closed(&self) -> bool {
+        self.tx.is_closed()
     }
 
     async fn send_request<T>(
         &self,
+        ctx: &'static str,
         request: impl FnOnce(JsReplyTx<T>) -> JsProcedureWorkerRequest,
-    ) -> Result<T, JsWorkerDisconnected> {
-        send_js_request(&self.tx, &self.trapped, request).await
+    ) -> T {
+        send_js_request(ctx, &self.tx, request).await
     }
 
     pub async fn call_procedure(&self, params: CallProcedureParams) -> CallProcedureReturn {
-        self.send_request(|reply_tx| JsProcedureWorkerRequest::CallProcedure { reply_tx, params })
-            .await
-            .unwrap_or_else(|_| CallProcedureReturn {
-                result: Err(ProcedureCallError::InternalError(js_worker_disconnected_error(
-                    "call_procedure",
-                ))),
-                tx_offset: None,
-            })
+        self.send_request("call_procedure", |reply_tx| JsProcedureWorkerRequest::CallProcedure {
+            reply_tx,
+            params,
+        })
+        .await
     }
 
     pub(in crate::host) async fn call_scheduled_function(
         &self,
         params: ScheduledFunctionParams,
     ) -> CallScheduledFunctionResult {
-        self.send_request(|reply_tx| JsProcedureWorkerRequest::CallScheduledFunction { reply_tx, params })
-            .await
-            .unwrap_or_else(|_| panic!("worker should stay live while calling a scheduled function"))
+        self.send_request("call_scheduled_function", |reply_tx| {
+            JsProcedureWorkerRequest::CallScheduledFunction { reply_tx, params }
+        })
+        .await
     }
 }
 
 async fn send_js_request<Req, T>(
+    ctx: &'static str,
     tx: &mpsc::Sender<Req>,
-    trapped: &AtomicBool,
     request: impl FnOnce(JsReplyTx<T>) -> Req,
-) -> Result<T, JsWorkerDisconnected>
+) -> T
 where
     Req: Send + 'static,
 {
     let (reply_tx, reply_rx) = oneshot::channel();
-    tx.send(request(reply_tx)).await.map_err(|_| {
-        trapped.store(true, Ordering::Relaxed);
-        JsWorkerDisconnected
-    })?;
-    reply_rx.await.map_err(|_| {
-        trapped.store(true, Ordering::Relaxed);
-        JsWorkerDisconnected
-    })
+    if tx.send(request(reply_tx)).await.is_err() {
+        panic!("JS worker exited before accepting `{ctx}`");
+    }
+    match reply_rx.await {
+        Ok(Ok(value)) => value,
+        Ok(Err(panic)) => panic::resume_unwind(panic),
+        Err(_) => panic!("JS worker exited before replying to `{ctx}`"),
+    }
 }
 
-#[derive(Clone, Copy, Debug)]
-struct JsWorkerDisconnected;
-
-fn js_worker_disconnected_error(label: &'static str) -> String {
-    format!("JS worker exited while handling {label}")
-}
-
-type JsReplyTx<T> = oneshot::Sender<T>;
+type JsPanicPayload = Box<dyn std::any::Any + Send + 'static>;
+type JsReply<T> = Result<T, JsPanicPayload>;
+type JsReplyTx<T> = oneshot::Sender<JsReply<T>>;
 
 /// Requests sent to the main JS worker thread.
 ///
@@ -684,8 +662,50 @@ enum JsProcedureWorkerRequest {
 static_assert_size!(CallReducerParams, 192);
 
 fn send_worker_reply<T>(ctx: &str, reply_tx: JsReplyTx<T>, value: T) {
-    if reply_tx.send(value).is_err() {
+    if reply_tx.send(Ok(value)).is_err() {
         log::error!("should have receiver for `{ctx}` response");
+    }
+}
+
+fn send_worker_panic_reply<T>(ctx: &str, reply_tx: JsReplyTx<T>, panic: JsPanicPayload) {
+    if reply_tx.send(Err(panic)).is_err() {
+        log::error!("should have receiver for `{ctx}` response");
+    }
+}
+
+enum WorkerRequestOutcome {
+    Continue,
+    RecreateInstance,
+    Fatal,
+}
+
+impl WorkerRequestOutcome {
+    fn recreate_instance(self) -> Self {
+        match self {
+            Self::Continue | Self::RecreateInstance => Self::RecreateInstance,
+            Self::Fatal => Self::Fatal,
+        }
+    }
+}
+
+fn handle_worker_request<T: 'static>(
+    ctx: &'static str,
+    reply_tx: JsReplyTx<T>,
+    f: impl FnOnce() -> (T, bool),
+) -> WorkerRequestOutcome {
+    match panic::catch_unwind(AssertUnwindSafe(f)) {
+        Ok((value, recreate_instance)) => {
+            send_worker_reply(ctx, reply_tx, value);
+            if recreate_instance {
+                WorkerRequestOutcome::RecreateInstance
+            } else {
+                WorkerRequestOutcome::Continue
+            }
+        }
+        Err(panic) => {
+            send_worker_panic_reply(ctx, reply_tx, panic);
+            WorkerRequestOutcome::Fatal
+        }
     }
 }
 
@@ -942,8 +962,17 @@ async fn spawn_main_instance_worker(
     load_balance_guard: Arc<LoadBalanceOnDropGuard>,
     core_pinner: CorePinner,
     heap_policy: V8HeapPolicyConfig,
+    metrics: InstanceManagerMetrics,
 ) -> anyhow::Result<(ModuleCommon, JsMainInstance)> {
-    spawn_instance_worker::<MainJsWorker>(program, module_or_mcc, load_balance_guard, core_pinner, heap_policy).await
+    spawn_instance_worker::<MainJsWorker>(
+        program,
+        module_or_mcc,
+        load_balance_guard,
+        core_pinner,
+        heap_policy,
+        metrics,
+    )
+    .await
 }
 
 async fn spawn_procedure_instance_worker(
@@ -952,9 +981,17 @@ async fn spawn_procedure_instance_worker(
     load_balance_guard: Arc<LoadBalanceOnDropGuard>,
     core_pinner: CorePinner,
     heap_policy: V8HeapPolicyConfig,
+    metrics: InstanceManagerMetrics,
 ) -> anyhow::Result<(ModuleCommon, JsProcedureInstance)> {
-    spawn_instance_worker::<ProcedureJsWorker>(program, module_or_mcc, load_balance_guard, core_pinner, heap_policy)
-        .await
+    spawn_instance_worker::<ProcedureJsWorker>(
+        program,
+        module_or_mcc,
+        load_balance_guard,
+        core_pinner,
+        heap_policy,
+        metrics,
+    )
+    .await
 }
 
 struct MainJsWorker;
@@ -967,7 +1004,7 @@ trait JsWorkerSpec {
 
     const KIND: JsWorkerKind;
 
-    fn make_instance(tx: mpsc::Sender<Self::Request>, trapped: Arc<AtomicBool>) -> Self::Instance;
+    fn make_instance(tx: mpsc::Sender<Self::Request>) -> Self::Instance;
 
     fn handle_request(
         request: Self::Request,
@@ -976,7 +1013,7 @@ trait JsWorkerSpec {
         inst: &mut V8Instance<'_, '_, '_>,
         module_common: &ModuleCommon,
         replica_ctx: &Arc<ReplicaContext>,
-    ) -> bool;
+    ) -> WorkerRequestOutcome;
 }
 
 impl JsWorkerSpec for MainJsWorker {
@@ -985,8 +1022,8 @@ impl JsWorkerSpec for MainJsWorker {
 
     const KIND: JsWorkerKind = JsWorkerKind::Main;
 
-    fn make_instance(tx: mpsc::Sender<Self::Request>, trapped: Arc<AtomicBool>) -> Self::Instance {
-        JsMainInstance { tx, trapped }
+    fn make_instance(tx: mpsc::Sender<Self::Request>) -> Self::Instance {
+        JsMainInstance { tx }
     }
 
     fn handle_request(
@@ -996,7 +1033,7 @@ impl JsWorkerSpec for MainJsWorker {
         inst: &mut V8Instance<'_, '_, '_>,
         module_common: &ModuleCommon,
         replica_ctx: &Arc<ReplicaContext>,
-    ) -> bool {
+    ) -> WorkerRequestOutcome {
         handle_main_worker_request(request, rt, instance_common, inst, module_common, replica_ctx)
     }
 }
@@ -1007,8 +1044,8 @@ impl JsWorkerSpec for ProcedureJsWorker {
 
     const KIND: JsWorkerKind = JsWorkerKind::Procedure;
 
-    fn make_instance(tx: mpsc::Sender<Self::Request>, trapped: Arc<AtomicBool>) -> Self::Instance {
-        JsProcedureInstance { tx, trapped }
+    fn make_instance(tx: mpsc::Sender<Self::Request>) -> Self::Instance {
+        JsProcedureInstance { tx }
     }
 
     fn handle_request(
@@ -1018,7 +1055,7 @@ impl JsWorkerSpec for ProcedureJsWorker {
         inst: &mut V8Instance<'_, '_, '_>,
         _module_common: &ModuleCommon,
         _replica_ctx: &Arc<ReplicaContext>,
-    ) -> bool {
+    ) -> WorkerRequestOutcome {
         handle_procedure_worker_request(request, instance_common, inst)
     }
 }
@@ -1030,10 +1067,8 @@ fn handle_main_worker_request(
     inst: &mut V8Instance<'_, '_, '_>,
     module_common: &ModuleCommon,
     replica_ctx: &Arc<ReplicaContext>,
-) -> bool {
+) -> WorkerRequestOutcome {
     let info = module_common.info();
-    let mut call_reducer = |tx, params| instance_common.call_reducer_with_tx(tx, params, inst);
-    let mut should_exit = false;
 
     match request {
         JsMainWorkerRequest::UpdateDatabase {
@@ -1041,56 +1076,63 @@ fn handle_main_worker_request(
             program,
             old_module_info,
             policy,
-        } => {
+        } => handle_worker_request("update_database", reply_tx, || {
             let res = instance_common.update_database(program, old_module_info, policy, inst);
-            send_worker_reply("update_database", reply_tx, res);
-        }
+            (res, false)
+        }),
         JsMainWorkerRequest::CallReducer { reply_tx, params } => {
-            let (res, trapped) = call_reducer(None, params);
-            send_worker_reply("call_reducer", reply_tx, res);
-            should_exit = trapped;
+            handle_worker_request("call_reducer", reply_tx, || {
+                let mut call_reducer = |tx, params| instance_common.call_reducer_with_tx(tx, params, inst);
+                let (res, trapped) = call_reducer(None, params);
+                (res, trapped)
+            })
         }
-        JsMainWorkerRequest::CallView { reply_tx, cmd } => {
+        JsMainWorkerRequest::CallView { reply_tx, cmd } => handle_worker_request("call_view", reply_tx, || {
             let (res, trapped) = instance_common.handle_cmd(cmd, inst);
-            send_worker_reply("call_view", reply_tx, res);
-            should_exit = trapped;
-        }
-        JsMainWorkerRequest::CallSql { reply_tx, cmd } => {
+            (res, trapped)
+        }),
+        JsMainWorkerRequest::CallSql { reply_tx, cmd } => handle_worker_request("call_sql", reply_tx, || {
             let (res, trapped) = instance_common.handle_sql_cmd(cmd, inst);
-            send_worker_reply("call_sql", reply_tx, res);
-            should_exit = trapped;
-        }
+            (res, trapped)
+        }),
         JsMainWorkerRequest::OneOffQueryJson { reply_tx, params } => {
-            let res = ModuleHost::one_off_query_json_inner(params);
-            send_worker_reply("one_off_query_json", reply_tx, res);
+            handle_worker_request("one_off_query_json", reply_tx, || {
+                let res = ModuleHost::one_off_query_json_inner(params);
+                (res, false)
+            })
         }
         JsMainWorkerRequest::OneOffQueryBsatn { reply_tx, params } => {
-            let res = ModuleHost::one_off_query_bsatn_inner(params);
-            send_worker_reply("one_off_query_bsatn", reply_tx, res);
+            handle_worker_request("one_off_query_bsatn", reply_tx, || {
+                let res = ModuleHost::one_off_query_bsatn_inner(params);
+                (res, false)
+            })
         }
         JsMainWorkerRequest::OneOffQueryV2 { reply_tx, params } => {
-            let res = ModuleHost::one_off_query_v2_inner(params);
-            send_worker_reply("one_off_query_v2", reply_tx, res);
+            handle_worker_request("one_off_query_v2", reply_tx, || {
+                let res = ModuleHost::one_off_query_v2_inner(params);
+                (res, false)
+            })
         }
-        JsMainWorkerRequest::ClearAllClients(reply_tx) => {
+        JsMainWorkerRequest::ClearAllClients(reply_tx) => handle_worker_request("clear_all_clients", reply_tx, || {
             let res = instance_common.clear_all_clients();
-            send_worker_reply("clear_all_clients", reply_tx, res);
-        }
+            (res, false)
+        }),
         JsMainWorkerRequest::CallIdentityConnected {
             reply_tx,
             caller_auth,
             caller_connection_id,
-        } => {
+        } => handle_worker_request("call_identity_connected", reply_tx, || {
+            let call_reducer = |tx, params| instance_common.call_reducer_with_tx(tx, params, inst);
             let mut trapped = false;
             let res = call_identity_connected(caller_auth, caller_connection_id, &info, call_reducer, &mut trapped);
-            send_worker_reply("call_identity_connected", reply_tx, res);
-            should_exit = trapped;
-        }
+            (res, trapped)
+        }),
         JsMainWorkerRequest::CallIdentityDisconnected {
             reply_tx,
             caller_identity,
             caller_connection_id,
-        } => {
+        } => handle_worker_request("call_identity_disconnected", reply_tx, || {
+            let call_reducer = |tx, params| instance_common.call_reducer_with_tx(tx, params, inst);
             let mut trapped = false;
             let res = ModuleHost::call_identity_disconnected_inner(
                 caller_identity,
@@ -1099,47 +1141,50 @@ fn handle_main_worker_request(
                 call_reducer,
                 &mut trapped,
             );
-            send_worker_reply("call_identity_disconnected", reply_tx, res);
-            should_exit = trapped;
-        }
+            (res, trapped)
+        }),
         JsMainWorkerRequest::DisconnectClient { reply_tx, client_id } => {
-            let mut trapped = false;
-            let res = ModuleHost::disconnect_client_inner(client_id, &info, call_reducer, &mut trapped);
-            send_worker_reply("disconnect_client", reply_tx, res);
-            should_exit = trapped;
+            handle_worker_request("disconnect_client", reply_tx, || {
+                let call_reducer = |tx, params| instance_common.call_reducer_with_tx(tx, params, inst);
+                let mut trapped = false;
+                let res = ModuleHost::disconnect_client_inner(client_id, &info, call_reducer, &mut trapped);
+                (res, trapped)
+            })
         }
         JsMainWorkerRequest::InitDatabase { reply_tx, program } => {
-            let (res, trapped): (Result<Option<ReducerCallResult>, anyhow::Error>, bool) =
-                init_database(replica_ctx, &info.module_def, program, call_reducer);
-            send_worker_reply("init_database", reply_tx, res);
-            should_exit = trapped;
+            handle_worker_request("init_database", reply_tx, || {
+                let call_reducer = |tx, params| instance_common.call_reducer_with_tx(tx, params, inst);
+                let (res, trapped): (Result<Option<ReducerCallResult>, anyhow::Error>, bool) =
+                    init_database(replica_ctx, &info.module_def, program, call_reducer);
+                (res, trapped)
+            })
         }
     }
-
-    should_exit
 }
 
 fn handle_procedure_worker_request(
     request: JsProcedureWorkerRequest,
     instance_common: &mut InstanceCommon,
     inst: &mut V8Instance<'_, '_, '_>,
-) -> bool {
+) -> WorkerRequestOutcome {
     match request {
         JsProcedureWorkerRequest::CallProcedure { reply_tx, params } => {
-            let (res, trapped) = instance_common
-                .call_procedure(params, inst)
-                .now_or_never()
-                .expect("our call_procedure implementation is not actually async");
-            send_worker_reply("call_procedure", reply_tx, res);
-            trapped
+            handle_worker_request("call_procedure", reply_tx, || {
+                let (res, trapped) = instance_common
+                    .call_procedure(params, inst)
+                    .now_or_never()
+                    .expect("our call_procedure implementation is not actually async");
+                (res, trapped)
+            })
         }
         JsProcedureWorkerRequest::CallScheduledFunction { reply_tx, params } => {
-            let (res, trapped) = instance_common
-                .call_scheduled_function(params, inst)
-                .now_or_never()
-                .expect("our call_procedure implementation is not actually async");
-            send_worker_reply("call_scheduled_function", reply_tx, res);
-            trapped
+            handle_worker_request("call_scheduled_function", reply_tx, || {
+                let (res, trapped) = instance_common
+                    .call_scheduled_function(params, inst)
+                    .now_or_never()
+                    .expect("our call_procedure implementation is not actually async");
+                (res, trapped)
+            })
         }
     }
 }
@@ -1161,6 +1206,7 @@ async fn spawn_instance_worker<W>(
     load_balance_guard: Arc<LoadBalanceOnDropGuard>,
     mut core_pinner: CorePinner,
     heap_policy: V8HeapPolicyConfig,
+    instance_metrics: InstanceManagerMetrics,
 ) -> anyhow::Result<(ModuleCommon, W::Instance)>
 where
     W: JsWorkerSpec + 'static,
@@ -1169,8 +1215,6 @@ where
     let (result_tx, result_rx) = oneshot::channel();
     let worker_kind = W::KIND;
     let (request_tx, mut request_rx) = mpsc::channel(worker_kind.request_queue_capacity());
-    let trapped = Arc::new(AtomicBool::new(false));
-    let trapped_in_thread = trapped.clone();
 
     let rt = tokio::runtime::Handle::current();
 
@@ -1179,133 +1223,173 @@ where
         core_pinner.pin_now();
 
         let _entered = rt.enter();
+        let mut initial_module_or_mcc = Some(module_or_mcc);
+        let mut startup_result_tx = Some(result_tx);
+        let mut module_common_for_recreate = None::<ModuleCommon>;
 
-        // Create the isolate and enter one long-lived worker scope/context.
-        //
-        // This outer scope is intentionally reused for the life of the worker so the
-        // isolate and current context stay entered, but individual reducer/view/procedure
-        // calls should still create their own nested handle scopes for temporary locals.
-        let mut isolate = new_isolate(heap_policy);
-        scope_with_context!(let scope, &mut isolate, Context::new(scope, Default::default()));
+        'worker: loop {
+            let replacing_instance = module_common_for_recreate.is_some();
+            let generation_start_time = replacing_instance.then(Instant::now);
+            let generation_module_or_mcc = match module_common_for_recreate.clone() {
+                Some(module_common) => Either::Left(module_common),
+                None => initial_module_or_mcc
+                    .take()
+                    .expect("first JS worker generation should have startup input"),
+            };
 
-        // Setup the instance environment.
-        let (replica_ctx, scheduler) = match &module_or_mcc {
-            Either::Left(module) => (module.replica_ctx(), module.scheduler()),
-            Either::Right(mcc) => (&mcc.replica_ctx, &mcc.scheduler),
-        };
-        let instance_env = InstanceEnv::new(replica_ctx.clone(), scheduler.clone());
-        scope.set_slot(JsInstanceEnv::new(instance_env));
+            // Create the isolate and enter one worker scope/context for this generation.
+            //
+            // Traps and heap-limit retirement both end the current generation. The worker
+            // thread itself stays alive, immediately rebuilds the isolate, and then continues
+            // draining the same request queue.
+            {
+                let mut isolate = new_isolate(heap_policy);
+                scope_with_context!(let scope, &mut isolate, Context::new(scope, Default::default()));
 
-        catch_exception(scope, |scope| Ok(builtins::evaluate_builtins(scope)?))
-            .expect("our builtin code shouldn't error");
+                // Setup the instance environment.
+                let (replica_ctx, scheduler) = match &generation_module_or_mcc {
+                    Either::Left(module) => (module.replica_ctx(), module.scheduler()),
+                    Either::Right(mcc) => (&mcc.replica_ctx, &mcc.scheduler),
+                };
+                let instance_env = InstanceEnv::new(replica_ctx.clone(), scheduler.clone());
+                scope.set_slot(JsInstanceEnv::new(instance_env));
 
-        // Setup the JS module, find call_reducer, and maybe build the module.
-        let send_result = |res| {
-            result_tx.send(res).inspect_err(|_| {
-                // This should never happen as we immediately `.recv` on the
-                // other end of the channel, but sometimes it gets cancelled.
-                log::error!("startup result receiver disconnected");
-            })
-        };
-        let (hooks, module_common) = match startup_instance_worker(scope, program, module_or_mcc) {
-            Err(err) => {
-                // There was some error in module setup.
-                // Return the error and terminate the worker.
-                let _ = send_result(Err(err));
-                return;
-            }
-            Ok((crf, module_common)) => {
-                env_on_isolate_unwrap(scope).set_module_def(module_common.info().module_def.clone());
-                // Success! Send `module_common` to the spawner.
-                if send_result(Ok(module_common.clone())).is_err() {
-                    return;
+                let startup_result = panic::catch_unwind(AssertUnwindSafe(|| {
+                    catch_exception(scope, |scope| Ok(builtins::evaluate_builtins(scope)?))
+                        .expect("our builtin code shouldn't error");
+
+                    // Setup the JS module, find call_reducer, and maybe build the module.
+                    startup_instance_worker(scope, program.clone(), generation_module_or_mcc)
+                }));
+
+                let (hooks, module_common) = match startup_result {
+                    Err(_) => {
+                        if let Some(result_tx) = startup_result_tx.take() {
+                            let _ = result_tx
+                                .send(Err(anyhow::anyhow!("JS worker panicked during startup")))
+                                .inspect_err(|_| {
+                                    // This should never happen as we immediately `.recv` on the
+                                    // other end of the channel, but sometimes it gets cancelled.
+                                    log::error!("startup result receiver disconnected");
+                                });
+                        } else {
+                            log::error!("JS worker panicked while recreating isolate");
+                        }
+                        return;
+                    }
+                    Ok(Err(err)) => {
+                        if let Some(result_tx) = startup_result_tx.take() {
+                            let _ = result_tx.send(Err(err)).inspect_err(|_| {
+                                // This should never happen as we immediately `.recv` on the
+                                // other end of the channel, but sometimes it gets cancelled.
+                                log::error!("startup result receiver disconnected");
+                            });
+                        } else {
+                            log::error!("failed to restart JS worker: {err:#}");
+                        }
+                        return;
+                    }
+                    Ok(Ok((crf, module_common))) => {
+                        env_on_isolate_unwrap(scope).set_module_def(module_common.info().module_def.clone());
+
+                        if let Some(result_tx) = startup_result_tx.take()
+                            && result_tx.send(Ok(module_common.clone())).is_err()
+                        {
+                            log::error!("startup result receiver disconnected");
+                            return;
+                        }
+
+                        module_common_for_recreate = Some(module_common.clone());
+                        if let Some(start_time) = generation_start_time {
+                            instance_metrics.observe_instance_created(start_time.elapsed());
+                        }
+                        (crf, module_common)
+                    }
+                };
+
+                if let Some(get_error_constructor) = hooks.get_error_constructor {
+                    scope
+                        .get_current_context()
+                        .set_embedder_data(GET_ERROR_CONSTRUCTOR_SLOT, get_error_constructor.into());
                 }
-                (crf, module_common)
-            }
-        };
 
-        if let Some(get_error_constructor) = hooks.get_error_constructor {
-            scope
-                .get_current_context()
-                .set_embedder_data(GET_ERROR_CONSTRUCTOR_SLOT, get_error_constructor.into());
-        }
+                // Setup the instance common.
+                let args = Global::new(scope, ArrayBuffer::new(scope, REDUCER_ARGS_BUFFER_SIZE));
+                let info = &module_common.info();
+                let mut instance_common = InstanceCommon::new(&module_common);
+                let replica_ctx: &Arc<ReplicaContext> = module_common.replica_ctx();
+                let mut heap_metrics = worker_kind
+                    .checks_heap()
+                    .then(|| V8HeapMetrics::new(&info.database_identity));
 
-        // Setup the instance common.
-        let args = Global::new(scope, ArrayBuffer::new(scope, REDUCER_ARGS_BUFFER_SIZE));
-        let info = &module_common.info();
-        let mut instance_common = InstanceCommon::new(&module_common);
-        let replica_ctx: &Arc<ReplicaContext> = module_common.replica_ctx();
-        let mut heap_metrics = worker_kind
-            .checks_heap()
-            .then(|| V8HeapMetrics::new(&info.database_identity));
+                let mut inst = V8Instance {
+                    scope,
+                    replica_ctx,
+                    hooks: &hooks,
+                    args: &args,
+                    heap_limit_hit_metric: &WORKER_METRICS
+                        .v8_heap_limit_hit
+                        .with_label_values(&info.database_identity),
+                    initial_heap_limit: heap_policy.heap_limit_bytes,
+                };
+                if let Some(heap_metrics) = heap_metrics.as_mut() {
+                    let _initial_heap_stats = sample_heap_stats(inst.scope, heap_metrics);
+                }
 
-        let mut inst = V8Instance {
-            scope,
-            replica_ctx,
-            hooks: &hooks,
-            args: &args,
-            heap_limit_hit_metric: &WORKER_METRICS
-                .v8_heap_limit_hit
-                .with_label_values(&info.database_identity),
-            initial_heap_limit: heap_policy.heap_limit_bytes,
-        };
-        if let Some(heap_metrics) = heap_metrics.as_mut() {
-            let _initial_heap_stats = sample_heap_stats(inst.scope, heap_metrics);
-        }
+                // Process requests to the worker.
+                //
+                // The loop is terminated when the last worker instance handle is dropped.
+                // This will cause channels, scopes, and the isolate to be cleaned up.
+                let mut requests_since_heap_check = 0u64;
+                let mut last_heap_check_at = Instant::now();
+                while let Some(request) = request_rx.blocking_recv() {
+                    core_pinner.pin_if_changed();
 
-        // Process requests to the worker.
-        //
-        // The loop is terminated when the last worker instance handle is dropped.
-        // This will cause channels, scopes, and the isolate to be cleaned up.
-        let mut requests_since_heap_check = 0u64;
-        let mut last_heap_check_at = Instant::now();
-        while let Some(request) = request_rx.blocking_recv() {
-            core_pinner.pin_if_changed();
+                    let mut outcome = W::handle_request(
+                        request,
+                        &rt,
+                        &mut instance_common,
+                        &mut inst,
+                        &module_common,
+                        replica_ctx,
+                    );
 
-            let mut should_exit = W::handle_request(
-                request,
-                &rt,
-                &mut instance_common,
-                &mut inst,
-                &module_common,
-                replica_ctx,
-            );
+                    if let WorkerRequestOutcome::Continue = outcome
+                        && let Some(heap_metrics) = heap_metrics.as_mut()
+                    {
+                        let request_check_due = heap_policy.heap_check_request_interval.is_some_and(|interval| {
+                            requests_since_heap_check += 1;
+                            requests_since_heap_check >= interval
+                        });
+                        let time_check_due = heap_policy
+                            .heap_check_time_interval
+                            .is_some_and(|interval| last_heap_check_at.elapsed() >= interval);
+                        if request_check_due || time_check_due {
+                            requests_since_heap_check = 0;
+                            last_heap_check_at = Instant::now();
+                            if let Some((used, limit)) =
+                                should_retire_worker_for_heap(inst.scope, heap_metrics, heap_policy)
+                            {
+                                outcome = outcome.recreate_instance();
+                                log::warn!(
+                                    "recreating JS isolate after V8 heap stayed high post-GC: used={}MiB limit={}MiB",
+                                    used / (1024 * 1024),
+                                    limit / (1024 * 1024),
+                                );
+                            }
+                        }
+                    }
 
-            if !should_exit && let Some(heap_metrics) = heap_metrics.as_mut() {
-                let request_check_due = heap_policy.heap_check_request_interval.is_some_and(|interval| {
-                    requests_since_heap_check += 1;
-                    requests_since_heap_check >= interval
-                });
-                let time_check_due = heap_policy
-                    .heap_check_time_interval
-                    .is_some_and(|interval| last_heap_check_at.elapsed() >= interval);
-                if request_check_due || time_check_due {
-                    requests_since_heap_check = 0;
-                    last_heap_check_at = Instant::now();
-                    if let Some((used, limit)) = should_retire_worker_for_heap(inst.scope, heap_metrics, heap_policy) {
-                        should_exit = true;
-                        log::warn!(
-                            "retiring JS worker after V8 heap stayed high post-GC: used={}MiB limit={}MiB",
-                            used / (1024 * 1024),
-                            limit / (1024 * 1024),
-                        );
+                    match outcome {
+                        WorkerRequestOutcome::Continue => {}
+                        WorkerRequestOutcome::RecreateInstance => {
+                            instance_metrics.track_instance_removed();
+                            continue 'worker;
+                        }
+                        WorkerRequestOutcome::Fatal => return,
                     }
                 }
-            }
-
-            // Once a JS instance traps, we must not let later queued work execute
-            // on that poisoned isolate. We reply to the trapping request first so
-            // the caller can observe the actual reducer/procedure error, and then
-            // shut the worker down. The instance manager will create a replacement
-            // for subsequent requests.
-            //
-            // We also retire workers when they stay near the V8 heap limit after
-            // a GC. The main JS worker intentionally lives for a long time, so
-            // this gives it a bounded-memory replacement policy instead of
-            // letting one isolate absorb the entire module lifetime.
-            if should_exit {
-                trapped_in_thread.store(true, Ordering::Relaxed);
-                break;
+                return;
             }
         }
     });
@@ -1313,7 +1397,7 @@ where
     // Get the module, if any, and get any setup errors from the worker.
     let res: Result<ModuleCommon, anyhow::Error> = result_rx.await.expect("should have a sender");
     res.map(|opt_mc| {
-        let inst = W::make_instance(request_tx, trapped);
+        let inst = W::make_instance(request_tx);
         (opt_mc, inst)
     })
 }

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -1,3 +1,58 @@
+//! V8 has two independent execution lanes. Non-procedure work uses the main lane and
+//! is serialized through a single queue. Websocket operations enqueue and return to
+//! the caller immediately. Blocking/sync callers, such as HTTP, also enqueue onto the
+//! worker but do not resume the caller until their operation completes.
+//!
+//! Procedures use a separate bounded instance pool. A procedure call waits to check
+//! out an exclusive procedure instance from the pool, and that instance is held
+//! until the procedure finishes. Because procedures do not use the main lane, there
+//! is no ordering guarantee between procedure work and non-procedure work, even when
+//! both come from the same connection.
+//!
+//! Each worker owns its V8 isolate and replaces it inline after a trap or heap
+//! retirement. Client-visible responses are emitted through SendWorker.
+//!
+//! Current V8 ModuleHost topology:
+//!
+//! ```text
+//!                         +-------------------------------------------+
+//!                         |              V8ModuleHost                 |
+//!                         |                                           |
+//!                         |  +-------------------------------------+  |
+//!   reducers              |  | SharedJsMainInstanceManager         |  |
+//!   subscriptions         |  | mpsc queue feeding a single worker  |--+----+
+//!   one-off queries  ---->|  | thread                              |       |
+//!                         |  +-------------------------------------+  |    v
+//!                         |                                           |  +----------------------+
+//!                         |                                           |  | os thread            |
+//!                         |                                           |  | one V8 isolate       |
+//!                         |                                           |  | inline replacement   |
+//!                         |                                           |  +----------+-----------+
+//!                         |                                           |             |
+//!                         |                                           |             v
+//!                         |                                           |       SendWorker
+//!                         |                                           |
+//!   procedure work        |  +-------------------------------------+  |
+//!   waits here if   ----->|  | ModuleInstanceManager<JsModule>     |  |
+//!   pool is full          |  | bounded procedure instance pool     |  |
+//!                         |  | checkout held until procedure done  |--+----+
+//!                         |  +-------------------------------------+  |    |
+//!                         +-------------------------------------------+    |
+//!                                                                          |
+//!                              +-------------------------------------------+
+//!                              |
+//!                              v
+//!                  +----------------------+      +----------------------+
+//!                  | os thread 1          |      | os thread N          |
+//!                  | one V8 isolate       |      | one V8 isolate       |
+//!                  | inline replacement   |      | inline replacement   |
+//!                  +----------+-----------+      +----------+-----------+
+//!                             |                             |
+//!                             +-------------+---------------+
+//!                                           |
+//!                                           v
+//!                                      SendWorker
+//! ```
 use self::budget::energy_from_elapsed;
 use self::error::{
     catch_exception, exception_already_thrown, log_traceback, ErrorOrException, ExcResult, ExceptionThrown,

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -437,6 +437,13 @@ impl JsMainInstance {
         self.request(CallReducerRequest { params }).await
     }
 
+    pub(in crate::host) async fn call_scheduled_reducer(
+        &self,
+        params: ScheduledFunctionParams,
+    ) -> CallScheduledFunctionResult {
+        self.request(ScheduledReducerRequest { params }).await
+    }
+
     pub(in crate::host) async fn enqueue_reducer(&self, params: CallReducerParams, on_panic: JsFatalHook) {
         self.send_detached_request(
             "call_reducer",
@@ -575,6 +582,23 @@ impl JsMainRequest for CallReducerRequest {
 
     fn into_worker_request(self, reply_tx: JsReplyTx<Self::Response>) -> JsMainWorkerRequest {
         JsMainWorkerRequest::CallReducer {
+            reply_tx,
+            params: self.params,
+        }
+    }
+}
+
+struct ScheduledReducerRequest {
+    params: ScheduledFunctionParams,
+}
+
+impl JsMainRequest for ScheduledReducerRequest {
+    type Response = CallScheduledFunctionResult;
+
+    const CTX: &'static str = "scheduled_reducer";
+
+    fn into_worker_request(self, reply_tx: JsReplyTx<Self::Response>) -> JsMainWorkerRequest {
+        JsMainWorkerRequest::ScheduledReducer {
             reply_tx,
             params: self.params,
         }
@@ -733,12 +757,12 @@ impl JsProcedureInstance {
         JsProcedureCall { reply_rx }
     }
 
-    pub(in crate::host) async fn call_scheduled_function(
+    pub(in crate::host) async fn call_scheduled_procedure(
         &self,
         params: ScheduledFunctionParams,
     ) -> CallScheduledFunctionResult {
-        self.send_request("call_scheduled_function", |reply_tx| {
-            JsProcedureWorkerRequest::CallScheduledFunction { reply_tx, params }
+        self.send_request("scheduled_procedure", |reply_tx| {
+            JsProcedureWorkerRequest::ScheduledProcedure { reply_tx, params }
         })
         .await
     }
@@ -811,6 +835,11 @@ enum JsMainWorkerRequest {
         params: CallReducerParams,
         on_panic: JsFatalHook,
     },
+    /// See [`JsMainInstance::call_scheduled_reducer`].
+    ScheduledReducer {
+        reply_tx: JsReplyTx<CallScheduledFunctionResult>,
+        params: ScheduledFunctionParams,
+    },
     /// See [`JsMainInstance::call_view`].
     CallView {
         reply_tx: JsReplyTx<ViewCommandResult>,
@@ -875,8 +904,8 @@ enum JsProcedureWorkerRequest {
         reply_tx: JsReplyTx<CallProcedureReturn>,
         params: CallProcedureParams,
     },
-    /// See [`JsProcedureInstance::call_scheduled_function`].
-    CallScheduledFunction {
+    /// See [`JsProcedureInstance::call_scheduled_procedure`].
+    ScheduledProcedure {
         reply_tx: JsReplyTx<CallScheduledFunctionResult>,
         params: ScheduledFunctionParams,
     },
@@ -1338,6 +1367,15 @@ fn handle_main_worker_request(
                 trapped
             })
         }
+        JsMainWorkerRequest::ScheduledReducer { reply_tx, params } => {
+            handle_worker_request("scheduled_reducer", reply_tx, || {
+                let (res, trapped) = instance_common
+                    .call_scheduled_function(params, inst)
+                    .now_or_never()
+                    .expect("our call_scheduled_function implementation is not actually async");
+                (res, trapped)
+            })
+        }
         JsMainWorkerRequest::CallView { reply_tx, cmd } => handle_worker_request("call_view", reply_tx, || {
             let (res, trapped) = instance_common.handle_cmd(cmd, inst);
             (res, trapped)
@@ -1450,12 +1488,12 @@ fn handle_procedure_worker_request(
                 (res, trapped)
             })
         }
-        JsProcedureWorkerRequest::CallScheduledFunction { reply_tx, params } => {
-            handle_worker_request("call_scheduled_function", reply_tx, || {
+        JsProcedureWorkerRequest::ScheduledProcedure { reply_tx, params } => {
+            handle_worker_request("scheduled_procedure", reply_tx, || {
                 let (res, trapped) = instance_common
                     .call_scheduled_function(params, inst)
                     .now_or_never()
-                    .expect("our call_procedure implementation is not actually async");
+                    .expect("our call_scheduled_function implementation is not actually async");
                 (res, trapped)
             })
         }

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -552,10 +552,10 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         res
     }
 
-    pub(in crate::host) fn call_sql(&mut self, cmd: SqlCommand) -> Result<SqlCommandResult, DBError> {
+    pub(in crate::host) fn call_sql(&mut self, cmd: SqlCommand) -> SqlCommandResult {
         let (res, trapped) = self.common.handle_sql_cmd(cmd, &mut self.instance);
         self.trapped = trapped;
-        Ok(res)
+        res
     }
 }
 

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -10,7 +10,7 @@ use crate::host::module_common::{build_common_module_from_raw, ModuleCommon};
 use crate::host::module_host::{
     call_identity_connected, init_database, CallProcedureParams, CallReducerParams, CallViewParams,
     ClientConnectedError, DatabaseUpdate, EventStatus, ModuleEvent, ModuleFunctionCall, ModuleInfo, RefInstance,
-    ViewCallResult, ViewCommand, ViewCommandResult, ViewOutcome,
+    SqlCommand, SqlCommandResult, ViewCallResult, ViewCommand, ViewCommandResult, ViewOutcome,
 };
 use crate::host::scheduler::{CallScheduledFunctionResult, ScheduledFunctionParams};
 use crate::host::{
@@ -551,6 +551,12 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         self.trapped = trapped;
         res
     }
+
+    pub(in crate::host) fn call_sql(&mut self, cmd: SqlCommand) -> Result<SqlCommandResult, DBError> {
+        let (res, trapped) = self.common.handle_sql_cmd(cmd, &mut self.instance);
+        self.trapped = trapped;
+        Ok(res)
+    }
 }
 
 pub struct InstanceCommon {
@@ -1052,8 +1058,8 @@ impl InstanceCommon {
                     .add_single_subscription_with_instance(&mut inst, sender, auth, request, timer, None);
 
                 match res {
-                    Ok((metrics, trapped)) => (ViewCommandResult::Subscription { result: Ok(metrics) }, trapped),
-                    Err(err) => (ViewCommandResult::Subscription { result: Err(err) }, false),
+                    Ok((metrics, trapped)) => (Ok(metrics), trapped),
+                    Err(err) => (Err(err), false),
                 }
             }
             ViewCommand::AddLegacySubscription {
@@ -1067,13 +1073,8 @@ impl InstanceCommon {
                     .add_legacy_subscriber_with_instance(&mut inst, sender, auth, subscribe, timer, None);
 
                 match res {
-                    Ok((metrics, trapped)) => (
-                        ViewCommandResult::Subscription {
-                            result: Ok(Some(metrics)),
-                        },
-                        trapped,
-                    ),
-                    Err(err) => (ViewCommandResult::Subscription { result: Err(err) }, false),
+                    Ok((metrics, trapped)) => (Ok(Some(metrics)), trapped),
+                    Err(err) => (Err(err), false),
                 }
             }
             ViewCommand::AddSubscriptionV2 {
@@ -1087,10 +1088,20 @@ impl InstanceCommon {
                     .add_v2_subscription_with_instance(&mut inst, sender, auth, request, timer, None);
 
                 match res {
-                    Ok((metrics, trapped)) => (ViewCommandResult::Subscription { result: Ok(metrics) }, trapped),
-                    Err(err) => (ViewCommandResult::Subscription { result: Err(err) }, false),
+                    Ok((metrics, trapped)) => (Ok(metrics), trapped),
+                    Err(err) => (Err(err), false),
                 }
             }
+            ViewCommand::RemoveSingleSubscription {
+                sender,
+                auth,
+                request,
+                timer,
+            } => (
+                info.subscriptions
+                    .remove_single_subscription(sender, auth, request, timer),
+                false,
+            ),
             ViewCommand::RemoveSubscriptionV2 {
                 sender,
                 auth,
@@ -1102,10 +1113,20 @@ impl InstanceCommon {
                     .remove_v2_subscription_with_instance(&mut inst, sender, auth, request, timer, None);
 
                 match res {
-                    Ok((metrics, trapped)) => (ViewCommandResult::Subscription { result: Ok(metrics) }, trapped),
-                    Err(err) => (ViewCommandResult::Subscription { result: Err(err) }, false),
+                    Ok((metrics, trapped)) => (Ok(metrics), trapped),
+                    Err(err) => (Err(err), false),
                 }
             }
+            ViewCommand::RemoveMultiSubscription {
+                sender,
+                auth,
+                request,
+                timer,
+            } => (
+                info.subscriptions
+                    .remove_multi_subscription(sender, auth, request, timer),
+                false,
+            ),
             ViewCommand::AddMultiSubscription {
                 sender,
                 auth,
@@ -1117,30 +1138,40 @@ impl InstanceCommon {
                     .add_multi_subscription_with_instance(&mut inst, sender, auth, request, timer, None);
 
                 match res {
-                    Ok((metrics, trapped)) => (ViewCommandResult::Subscription { result: Ok(metrics) }, trapped),
-                    Err(err) => (ViewCommandResult::Subscription { result: Err(err) }, false),
+                    Ok((metrics, trapped)) => (Ok(metrics), trapped),
+                    Err(err) => (Err(err), false),
                 }
             }
-            ViewCommand::Sql {
-                db,
-                sql_text,
-                auth,
-                subs,
-            } => {
-                let mut head = vec![];
-                let res = run_with_instance(&mut inst, db, sql_text, auth, subs, &mut head);
+        }
+    }
 
-                match res {
-                    Ok((result, trapped)) => (
-                        ViewCommandResult::Sql {
-                            result: Ok(result),
-                            head,
-                        },
-                        trapped,
-                    ),
-                    Err(err) => (ViewCommandResult::Sql { result: Err(err), head }, false),
-                }
-            }
+    pub(in crate::host) fn handle_sql_cmd<I: WasmInstance>(
+        &mut self,
+        cmd: SqlCommand,
+        inst: &mut I,
+    ) -> (SqlCommandResult, bool) {
+        let mut inst = RefInstance {
+            instance: inst,
+            common: self,
+        };
+        let SqlCommand {
+            db,
+            sql_text,
+            auth,
+            subs,
+        } = cmd;
+        let mut head = vec![];
+        let res = run_with_instance(&mut inst, db, sql_text, auth, subs, &mut head);
+
+        match res {
+            Ok((result, trapped)) => (
+                SqlCommandResult {
+                    result: Ok(result),
+                    head,
+                },
+                trapped,
+            ),
+            Err(err) => (SqlCommandResult { result: Err(err), head }, false),
         }
     }
 

--- a/crates/core/src/host/wasmtime/mod.rs
+++ b/crates/core/src/host/wasmtime/mod.rs
@@ -106,6 +106,15 @@ impl WasmtimeRuntime {
 pub type Module = WasmModuleHostActor<WasmtimeModule>;
 pub type ModuleInstance = WasmModuleInstance<WasmtimeInstance>;
 
+const THREAD_NAME_DATABASE_ID_SUFFIX_LEN: usize = 8;
+
+fn wasm_executor_thread_name(database_identity: &spacetimedb_lib::Identity) -> String {
+    let hex = database_identity.to_hex();
+    // We use the tail of the identity to avoid the common structured prefix.
+    let suffix = &hex.as_str()[hex.as_str().len() - THREAD_NAME_DATABASE_ID_SUFFIX_LEN..];
+    format!("wasm-{suffix}")
+}
+
 impl WasmtimeRuntime {
     pub fn make_actor(
         &self,
@@ -129,11 +138,12 @@ impl WasmtimeRuntime {
             .map_err(InitializationError::Instantiation)?;
 
         let module = WasmtimeModule::new(module);
+        let executor_thread_name = wasm_executor_thread_name(&mcc.replica_ctx.database_identity);
 
         let (module, init_inst) = WasmModuleHostActor::new(mcc, module)?;
         Ok(super::module_host::ModuleWithInstance::Wasm {
             module,
-            executor: core.spawn_async_executor(),
+            executor: core.spawn_named_async_executor(executor_thread_name),
             init_inst: Box::new(init_inst),
         })
     }

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -58,7 +58,7 @@ pub async fn run(
     head: &mut Vec<(RawIdentifier, AlgebraicType)>,
 ) -> Result<SqlResult, DBError> {
     match module {
-        Some(module) => module.call_view_sql(db, sql_text, auth, subs, head).await,
+        Some(module) => module.call_sql(db, sql_text, auth, subs, head).await,
         None => run_inner::<crate::host::wasmtime::WasmtimeInstance>(None, db, sql_text, auth, subs, head).map(|x| x.0),
     }
 }

--- a/crates/core/src/startup.rs
+++ b/crates/core/src/startup.rs
@@ -319,10 +319,10 @@ impl Cores {
     /// Get the cores of the local host, as reported by the operating system.
     ///
     /// Returns `None` if `num_cpus` is less than 8
-    /// or if core pinning is disabled.
+    /// or if core pinning is not enabled.
     /// If `Some` is returned, the `Vec` is non-empty.
     pub fn get_core_ids() -> Option<Vec<CoreId>> {
-        if cfg!(feature = "no-core-pinning") {
+        if cfg!(not(feature = "core-pinning")) {
             return None;
         }
 

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -666,7 +666,7 @@ impl ModuleSubscriptions {
 
         let mut_tx = ScopeGuard::<MutTxId, _>::into_inner(mut_tx);
 
-        let (tx, tx_offset, trapped) =
+        let (mut tx, tx_offset, trapped) =
             self.materialize_views_and_downgrade_tx(mut_tx, instance, &query, auth.caller())?;
 
         let (table_rows, metrics) = return_on_err_with_sql_bool!(
@@ -674,6 +674,7 @@ impl ModuleSubscriptions {
             query.sql(),
             send_err_msg
         );
+        tx.metrics.merge(metrics);
 
         // It acquires the subscription lock after `eval`, allowing `add_subscription` to run concurrently.
         // This also makes it possible for `broadcast_event` to get scheduled before the subsequent part here
@@ -751,13 +752,14 @@ impl ModuleSubscriptions {
             return Ok(None);
         };
 
-        let (tx, tx_offset) = self.unsubscribe_views(query, auth.caller())?;
+        let (mut tx, tx_offset) = self.unsubscribe_views(query, auth.caller())?;
 
         let (table_rows, metrics) = return_on_err_with_sql!(
             self.evaluate_initial_subscription(sender.clone(), query.clone(), &tx, &auth, TableUpdateType::Unsubscribe),
             query.sql(),
             send_err_msg
         );
+        tx.metrics.merge(metrics);
 
         // Note: to make sure transaction updates are consistent, we need to put this in the broadcast
         // queue while we are still holding a read-lock on the database.
@@ -831,7 +833,7 @@ impl ModuleSubscriptions {
         };
 
         let mut_tx = ScopeGuard::<MutTxId, _>::into_inner(mut_tx);
-        let (tx, tx_offset) = self.unsubscribe_views_and_downgrade_tx(mut_tx, &removed_queries, auth.caller())?;
+        let (mut tx, tx_offset) = self.unsubscribe_views_and_downgrade_tx(mut_tx, &removed_queries, auth.caller())?;
 
         let (update, metrics) = return_on_err!(
             self.evaluate_queries(
@@ -844,6 +846,7 @@ impl ModuleSubscriptions {
             send_err_msg,
             None
         );
+        tx.metrics.merge(metrics);
 
         // How many queries did we evaluate?
         subscription_metrics
@@ -947,7 +950,7 @@ impl ModuleSubscriptions {
         };
 
         let mut_tx = ScopeGuard::<MutTxId, _>::into_inner(mut_tx);
-        let (tx, tx_offset) = self.unsubscribe_views_and_downgrade_tx(mut_tx, &removed_queries, auth.caller())?;
+        let (mut tx, tx_offset) = self.unsubscribe_views_and_downgrade_tx(mut_tx, &removed_queries, auth.caller())?;
 
         let (rows, metrics) = if request.flags == ws_v2::UnsubscribeFlags::SendDroppedRows {
             let (update, metrics) = return_on_err!(
@@ -977,6 +980,9 @@ impl ModuleSubscriptions {
         } else {
             (None, None)
         };
+        if let Some(metrics) = metrics {
+            tx.metrics.merge(metrics);
+        }
 
         let _ = self.broadcast_queue.send_client_message_v2(
             sender.clone(),
@@ -1257,11 +1263,12 @@ impl ModuleSubscriptions {
 
         let mut_tx = ScopeGuard::<MutTxId, _>::into_inner(mut_tx);
 
-        let (tx, tx_offset, trapped) =
+        let (mut tx, tx_offset, trapped) =
             self.materialize_views_and_downgrade_tx(mut_tx, instance, &queries, auth.caller())?;
 
         let (update, metrics) =
             self.evaluate_queries(sender.clone(), &queries, &tx, &auth, TableUpdateType::Subscribe)?;
+        tx.metrics.merge(metrics);
 
         subscription_metrics.num_queries_evaluated.inc_by(queries.len() as _);
 
@@ -1362,7 +1369,7 @@ impl ModuleSubscriptions {
 
         let mut_tx = ScopeGuard::<MutTxId, _>::into_inner(mut_tx);
 
-        let (tx, tx_offset, trapped) =
+        let (mut tx, tx_offset, trapped) =
             self.materialize_views_and_downgrade_tx(mut_tx, instance, &queries, auth.caller())?;
 
         let Ok((update, metrics)) =
@@ -1383,6 +1390,7 @@ impl ModuleSubscriptions {
             send_err_msg("Internal error evaluating queries".into());
             return Ok((None, trapped));
         };
+        tx.metrics.merge(metrics);
 
         // How many queries did we actually evaluate?
         subscription_metrics.num_queries_evaluated.inc_by(queries.len() as _);
@@ -1479,7 +1487,7 @@ impl ModuleSubscriptions {
             subscription_metrics,
         )?;
 
-        let (tx, tx_offset, trapped) =
+        let (mut tx, tx_offset, trapped) =
             self.materialize_views_and_downgrade_tx(mut_tx, instance, &queries, auth.caller())?;
 
         check_row_limit(
@@ -1497,16 +1505,22 @@ impl ModuleSubscriptions {
         // Record how long it took to compile the subscription
         drop(compile_timer);
 
-        let tx = DeltaTx::from(&*tx);
+        let delta_tx = DeltaTx::from(&*tx);
         let (database_update, metrics, query_metrics) = match sender.config.protocol {
-            Protocol::Binary => execute_plans(&auth, &queries, &tx, TableUpdateType::Subscribe, &self.bsatn_rlb_pool)
-                .map(|(table_update, metrics, query_metrics)| {
+            Protocol::Binary => execute_plans(
+                &auth,
+                &queries,
+                &delta_tx,
+                TableUpdateType::Subscribe,
+                &self.bsatn_rlb_pool,
+            )
+            .map(|(table_update, metrics, query_metrics)| {
                 (ws_v1::FormatSwitch::Bsatn(table_update), metrics, query_metrics)
             })?,
             Protocol::Text => execute_plans(
                 &auth,
                 &queries,
-                &tx,
+                &delta_tx,
                 TableUpdateType::Subscribe,
                 &JsonRowListBuilderFakePool,
             )
@@ -1516,6 +1530,7 @@ impl ModuleSubscriptions {
         };
 
         record_query_metrics(&self.relational_db.database_identity(), query_metrics);
+        tx.metrics.merge(metrics);
 
         // It acquires the subscription lock after `eval`, allowing `add_subscription` to run concurrently.
         // This also makes it possible for `broadcast_event` to get scheduled before the subsequent part here
@@ -1730,7 +1745,7 @@ impl ModuleSubscriptions {
         sender: Identity,
     ) -> Result<(TxGuard<impl FnOnce(TxId) + '_>, TransactionOffset), DBError> {
         Self::_unsubscribe_views(&mut tx, view_collector, sender)?;
-        let (tx_data, tx_metrics_mut, tx) = self.relational_db.commit_tx_downgrade(tx, Workload::Subscribe);
+        let (tx_data, tx_metrics_mut, tx) = self.relational_db.commit_tx_downgrade(tx, Workload::Unsubscribe);
         let opts = GuardTxOptions::from_mut(tx_data, tx_metrics_mut);
         Ok(self.guard_tx(tx, opts))
     }

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -1612,16 +1612,6 @@ impl ModuleSubscriptions {
         tx: MutTx,
     ) -> Result<CommitAndBroadcastEventResult, DBError> {
         let subscription_metrics = &self.metrics.update;
-        if let (Some(timer), Some(reducer)) = (event.timer, event.function_call.reducer.as_ref()) {
-            WORKER_METRICS
-                .request_round_trip
-                .with_label_values(
-                    &WorkloadType::Reducer,
-                    &self.relational_db.database_identity(),
-                    reducer.as_ref(),
-                )
-                .observe(timer.elapsed().as_secs_f64());
-        }
 
         // Take a read lock on `subscriptions` before committing tx
         // else it can result in subscriber receiving duplicate updates.

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -1597,6 +1597,16 @@ impl ModuleSubscriptions {
         tx: MutTx,
     ) -> Result<CommitAndBroadcastEventResult, DBError> {
         let subscription_metrics = &self.metrics.update;
+        if let (Some(timer), Some(reducer)) = (event.timer, event.function_call.reducer.as_ref()) {
+            WORKER_METRICS
+                .request_round_trip
+                .with_label_values(
+                    &WorkloadType::Reducer,
+                    &self.relational_db.database_identity(),
+                    reducer.as_ref(),
+                )
+                .observe(timer.elapsed().as_secs_f64());
+        }
 
         // Take a read lock on `subscriptions` before committing tx
         // else it can result in subscriber receiving duplicate updates.

--- a/crates/core/src/util/jobs.rs
+++ b/crates/core/src/util/jobs.rs
@@ -86,7 +86,7 @@ impl JobCores {
     /// and runs all databases in the `global_runtime`.
     pub fn from_pinned_cores(cores: impl IntoIterator<Item = CoreId>) -> Self {
         let cores: IndexMap<_, _> = cores.into_iter().map(|id| (id, CoreInfo::default())).collect();
-        let inner = if cfg!(feature = "no-job-core-pinning") || cores.is_empty() {
+        let inner = if cfg!(not(feature = "core-pinning")) || cores.is_empty() {
             JobCoresInner::NoPinning
         } else {
             JobCoresInner::PinnedCores(Arc::new(Mutex::new(PinnedCoresExecutorManager {

--- a/crates/core/src/util/jobs.rs
+++ b/crates/core/src/util/jobs.rs
@@ -221,7 +221,12 @@ pub struct AllocatedJobCore {
 impl AllocatedJobCore {
     /// Spawn a [`SingleCoreExecutor`] allocated to this core.
     pub fn spawn_async_executor(self) -> SingleCoreExecutor {
-        SingleCoreExecutor::spawn(self)
+        SingleCoreExecutor::spawn(self, None)
+    }
+
+    /// Spawn a named [`SingleCoreExecutor`] allocated to this core.
+    pub fn spawn_named_async_executor(self, name: impl Into<String>) -> SingleCoreExecutor {
+        SingleCoreExecutor::spawn(self, Some(name.into()))
     }
 }
 
@@ -293,7 +298,7 @@ struct SingleCoreExecutorInner {
 
 impl SingleCoreExecutor {
     /// Spawn a `SingleCoreExecutor` on the given core.
-    fn spawn(core: AllocatedJobCore) -> Self {
+    fn spawn(core: AllocatedJobCore, name: Option<String>) -> Self {
         let AllocatedJobCore { guard, mut pinner } = core;
 
         let (job_tx, mut job_rx) = mpsc::unbounded_channel();
@@ -301,7 +306,11 @@ impl SingleCoreExecutor {
         let inner = Arc::new(SingleCoreExecutorInner { job_tx });
 
         let rt = runtime::Handle::current();
-        std::thread::spawn(move || {
+        let mut thread = std::thread::Builder::new();
+        if let Some(name) = name {
+            thread = thread.name(name);
+        }
+        let worker = move || {
             let _guard = guard;
             pinner.pin_now();
 
@@ -322,7 +331,8 @@ impl SingleCoreExecutor {
             // This is very important to do - otherwise, in-progress tasks will be
             // dropped and cancelled.
             rt.block_on(local)
-        });
+        };
+        thread.spawn(worker).expect("failed to spawn SingleCoreExecutor thread");
 
         Self { inner }
     }
@@ -334,7 +344,7 @@ impl SingleCoreExecutor {
     /// This method should only be used for short-lived instances which do not perform intense computation,
     /// e.g. to extract the schema by calling `describe_module`.
     pub fn in_current_tokio_runtime() -> Self {
-        Self::spawn(AllocatedJobCore::default())
+        Self::spawn(AllocatedJobCore::default(), None)
     }
 
     /// Run a job for this database executor.

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -288,27 +288,27 @@ metrics_group!(
         pub wasm_memory_bytes: IntGaugeVec,
 
         #[name = spacetime_worker_v8_total_heap_size_bytes]
-        #[help = "The total size of the V8 heap for a database's tracked JS worker kind (currently instance_lane only)"]
+        #[help = "The total size of the V8 heap for a database's tracked JS worker kind (currently main only)"]
         #[labels(database_identity: Identity, worker_kind: str)]
         pub v8_total_heap_size_bytes: IntGaugeVec,
 
         #[name = spacetime_worker_v8_total_physical_size_bytes]
-        #[help = "The total committed physical V8 heap memory for a database's tracked JS worker kind (currently instance_lane only)"]
+        #[help = "The total committed physical V8 heap memory for a database's tracked JS worker kind (currently main only)"]
         #[labels(database_identity: Identity, worker_kind: str)]
         pub v8_total_physical_size_bytes: IntGaugeVec,
 
         #[name = spacetime_worker_v8_used_global_handles_size_bytes]
-        #[help = "The used size of V8 global handles for a database's tracked JS worker kind (currently instance_lane only)"]
+        #[help = "The used size of V8 global handles for a database's tracked JS worker kind (currently main only)"]
         #[labels(database_identity: Identity, worker_kind: str)]
         pub v8_used_global_handles_size_bytes: IntGaugeVec,
 
         #[name = spacetime_worker_v8_used_heap_size_bytes]
-        #[help = "The live V8 heap size for a database's tracked JS worker kind (currently instance_lane only)"]
+        #[help = "The live V8 heap size for a database's tracked JS worker kind (currently main only)"]
         #[labels(database_identity: Identity, worker_kind: str)]
         pub v8_used_heap_size_bytes: IntGaugeVec,
 
         #[name = spacetime_worker_v8_heap_size_limit_bytes]
-        #[help = "The V8 heap size limit for a database's tracked JS worker kind (currently instance_lane only)"]
+        #[help = "The V8 heap size limit for a database's tracked JS worker kind (currently main only)"]
         #[labels(database_identity: Identity, worker_kind: str)]
         pub v8_heap_size_limit_bytes: IntGaugeVec,
 
@@ -317,23 +317,18 @@ metrics_group!(
         #[labels(database_identity: Identity)]
         pub v8_heap_limit_hit: IntCounterVec,
 
-        #[name = spacetime_worker_v8_instance_lane_queue_length]
-        #[help = "The number of queued requests waiting for a database's JS instance lane worker"]
-        #[labels(database_identity: Identity)]
-        pub v8_instance_lane_queue_length: IntGaugeVec,
-
         #[name = spacetime_worker_v8_external_memory_bytes]
-        #[help = "The external memory tracked by V8 for a database's tracked JS worker kind (currently instance_lane only)"]
+        #[help = "The external memory tracked by V8 for a database's tracked JS worker kind (currently main only)"]
         #[labels(database_identity: Identity, worker_kind: str)]
         pub v8_external_memory_bytes: IntGaugeVec,
 
         #[name = spacetime_worker_v8_native_contexts]
-        #[help = "The number of native V8 contexts for a database's tracked JS worker kind (currently instance_lane only)"]
+        #[help = "The number of native V8 contexts for a database's tracked JS worker kind (currently main only)"]
         #[labels(database_identity: Identity, worker_kind: str)]
         pub v8_native_contexts: IntGaugeVec,
 
         #[name = spacetime_worker_v8_detached_contexts]
-        #[help = "The number of detached V8 contexts for a database's tracked JS worker kind (currently instance_lane only)"]
+        #[help = "The number of detached V8 contexts for a database's tracked JS worker kind (currently main only)"]
         #[labels(database_identity: Identity, worker_kind: str)]
         pub v8_detached_contexts: IntGaugeVec,
 

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -332,6 +332,11 @@ metrics_group!(
         #[labels(database_identity: Identity, worker_kind: str)]
         pub v8_detached_contexts: IntGaugeVec,
 
+        #[name = spacetime_worker_v8_request_queue_length]
+        #[help = "The number of requests waiting in a database's tracked JS worker request queue"]
+        #[labels(database_identity: Identity)]
+        pub v8_request_queue_length: IntGaugeVec,
+
         #[name = spacetime_active_queries]
         #[help = "The number of active subscription queries"]
         #[labels(database_identity: Identity)]

--- a/crates/standalone/Cargo.toml
+++ b/crates/standalone/Cargo.toml
@@ -21,9 +21,8 @@ unstable = ["spacetimedb-client-api/unstable"]
 allow_loopback_http_for_tests = ["spacetimedb-core/allow_loopback_http_for_tests"]
 # Perfmaps for profiling modules
 perfmap = ["spacetimedb-core/perfmap"]
-# Disables core pinning
-no-core-pinning = ["spacetimedb-core/no-core-pinning"]
-no-job-core-pinning = ["spacetimedb-core/no-job-core-pinning"]
+# Enables core pinning.
+core-pinning = ["spacetimedb-core/core-pinning"]
 
 [dependencies]
 spacetimedb-client-api-messages.workspace = true

--- a/crates/standalone/config.toml
+++ b/crates/standalone/config.toml
@@ -18,6 +18,11 @@ directives = [
     "axum::rejection=trace",
 ]
 
+[v8]
+# Maximum number of JS procedure isolates per database. Omit to use the number
+# of cores reported by the OS.
+# procedure-instance-pool-size = 8
+
 [v8-heap-policy]
 # Check the V8 heap after this many requests. Set to 0 to disable.
 # heap-check-request-interval = 65536

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -10,7 +10,7 @@ use async_trait::async_trait;
 use clap::{ArgMatches, Command};
 use http::StatusCode;
 use spacetimedb::client::ClientActorIndex;
-use spacetimedb::config::{CertificateAuthority, MetadataFile, V8HeapPolicyConfig};
+use spacetimedb::config::{CertificateAuthority, MetadataFile, V8Config};
 use spacetimedb::db;
 use spacetimedb::db::persistence::LocalPersistenceProvider;
 use spacetimedb::energy::{EnergyBalance, EnergyQuanta, NullEnergyMonitor};
@@ -42,7 +42,7 @@ pub use spacetimedb_client_api::routes::subscribe::{BIN_PROTOCOL, TEXT_PROTOCOL}
 pub struct StandaloneOptions {
     pub db_config: db::Config,
     pub websocket: WebSocketOptions,
-    pub v8_heap_policy: V8HeapPolicyConfig,
+    pub v8: V8Config,
 }
 
 pub struct StandaloneEnv {
@@ -79,7 +79,7 @@ impl StandaloneEnv {
         let host_controller = HostController::new(
             data_dir,
             config.db_config,
-            config.v8_heap_policy,
+            config.v8,
             program_store.clone(),
             energy_monitor,
             persistence_provider,
@@ -650,7 +650,7 @@ mod tests {
                 page_pool_max_size: None,
             },
             websocket: WebSocketOptions::default(),
-            v8_heap_policy: V8HeapPolicyConfig::default(),
+            v8: V8Config::default(),
         };
 
         let _env = StandaloneEnv::init(config, &ca, data_dir.clone(), JobCores::without_pinned_cores()).await?;

--- a/crates/standalone/src/subcommands/start.rs
+++ b/crates/standalone/src/subcommands/start.rs
@@ -182,7 +182,7 @@ pub async fn exec(args: &ArgMatches, db_cores: JobCores) -> anyhow::Result<()> {
         StandaloneOptions {
             db_config,
             websocket: config.websocket,
-            v8_heap_policy: config.common.v8_heap_policy,
+            v8: config.common.v8,
         },
         &certs,
         data_dir,
@@ -512,6 +512,9 @@ mod tests {
             idle-timeout = "1min"
             close-handshake-timeout = "500ms"
 
+            [v8]
+            procedure-instance-pool-size = 3
+
             [v8-heap-policy]
             heap-check-request-interval = 0
             heap-check-time-interval = "45s"
@@ -526,14 +529,15 @@ mod tests {
         // so check `common` in a pedestrian way.
         assert_eq!(&config.common.logs.directives, &["banana_shake=strawberry"]);
         assert!(config.common.certificate_authority.is_none());
-        assert_eq!(config.common.v8_heap_policy.heap_check_request_interval, None);
+        assert_eq!(config.common.v8.procedure_instance_pool_size.get(), 3);
+        assert_eq!(config.common.v8.heap_policy.heap_check_request_interval, None);
         assert_eq!(
-            config.common.v8_heap_policy.heap_check_time_interval,
+            config.common.v8.heap_policy.heap_check_time_interval,
             Some(Duration::from_secs(45))
         );
-        assert_eq!(config.common.v8_heap_policy.heap_gc_trigger_fraction, 0.6);
-        assert_eq!(config.common.v8_heap_policy.heap_retire_fraction, 0.8);
-        assert_eq!(config.common.v8_heap_policy.heap_limit_bytes, 128 * 1024 * 1024);
+        assert_eq!(config.common.v8.heap_policy.heap_gc_trigger_fraction, 0.6);
+        assert_eq!(config.common.v8.heap_policy.heap_retire_fraction, 0.8);
+        assert_eq!(config.common.v8.heap_policy.heap_limit_bytes, 128 * 1024 * 1024);
 
         assert_eq!(
             config.websocket,

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -18,11 +18,16 @@ use spacetimedb_schema::auto_migrate::MigrationPolicy;
 use spacetimedb_schema::def::ModuleDef;
 use tokio::runtime::{Builder, Runtime};
 
-use spacetimedb::client::{ClientActorId, ClientConfig, ClientConnection, DataMessage};
+use spacetimedb::client::messages::SerializableMessage;
+use spacetimedb::client::{
+    ClientActorId, ClientConfig, ClientConnection, ClientConnectionReceiver, DataMessage, OutboundMessage,
+};
 use spacetimedb::db::{Config, Storage};
+use spacetimedb::host::module_host::EventStatus;
 use spacetimedb::host::FunctionArgs;
 use spacetimedb_client_api::{ControlStateReadAccess, ControlStateWriteAccess, DatabaseDef, NodeDelegate};
 use spacetimedb_client_api_messages::websocket::v1 as ws_v1;
+use spacetimedb_lib::identity::RequestId;
 use spacetimedb_lib::{bsatn, sats};
 
 pub use spacetimedb::database_logger::LogLevel;
@@ -47,11 +52,11 @@ pub(crate) fn module_path(name: &str) -> PathBuf {
     root.join("../../modules").join(name)
 }
 
-#[derive(Clone)]
 pub struct ModuleHandle {
     // Needs to hold a reference to the standalone env.
     _env: Arc<StandaloneEnv>,
     pub client: ClientConnection,
+    receiver: ClientConnectionReceiver,
     pub db_identity: Identity,
 }
 
@@ -84,6 +89,36 @@ impl ModuleHandle {
     pub async fn send(&self, message: impl Into<DataMessage>) -> anyhow::Result<()> {
         let timer = Instant::now();
         self.client.handle_message(message, timer).await.map_err(Into::into)
+    }
+
+    pub async fn recv_message(&mut self) -> Option<OutboundMessage> {
+        self.receiver.recv().await
+    }
+
+    pub async fn recv_reducer_update(&mut self, request_id: RequestId) -> anyhow::Result<()> {
+        let message = self
+            .recv_message()
+            .await
+            .ok_or_else(|| anyhow::anyhow!("client receiver closed before reducer update {request_id}"))?;
+        let OutboundMessage::V1(SerializableMessage::TxUpdate(update)) = message else {
+            anyhow::bail!("expected reducer transaction update {request_id}, got {message:?}");
+        };
+        let Some(event) = update.event else {
+            anyhow::bail!("expected full reducer transaction update {request_id}, got light update");
+        };
+        if event.request_id != Some(request_id) {
+            anyhow::bail!(
+                "expected reducer transaction update {request_id}, got request id {:?}",
+                event.request_id
+            );
+        }
+        match &event.status {
+            EventStatus::Committed(_) => Ok(()),
+            EventStatus::FailedUser(err) | EventStatus::FailedInternal(err) => {
+                anyhow::bail!("reducer transaction update {request_id} failed: {err}")
+            }
+            EventStatus::OutOfEnergy => anyhow::bail!("reducer transaction update {request_id} ran out of energy"),
+        }
     }
 
     pub async fn read_log(&self, size: Option<u32>) -> String {
@@ -245,9 +280,13 @@ impl CompiledModule {
         // it easier to interact with the database. For example it could include
         // the runtime on which a module was created and then we could add impl
         // for stuff like "get logs" or "get message log"
+        let (client, receiver) =
+            ClientConnection::dummy_with_receiver(client_id, ClientConfig::for_test(), instance.id, module_rx);
+
         ModuleHandle {
             _env: env,
-            client: ClientConnection::dummy(client_id, ClientConfig::for_test(), instance.id, module_rx),
+            client,
+            receiver,
             db_identity,
         }
     }

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -201,7 +201,7 @@ impl CompiledModule {
             spacetimedb_standalone::StandaloneOptions {
                 db_config: config,
                 websocket: WebSocketOptions::default(),
-                v8_heap_policy: Default::default(),
+                v8: Default::default(),
             },
             &certs,
             paths.data_dir.into(),

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -46,7 +46,7 @@ fn test_calling_a_reducer_in_module(module_name: &'static str) {
 
     CompiledModule::compile(module_name, CompilationMode::Debug).with_module_async(
         DEFAULT_CONFIG,
-        |module| async move {
+        |mut module| async move {
             let json =
                 r#"{"CallReducer": {"reducer": "add", "args": "[\"Tyrion\", 24]", "request_id": 0, "flags": 0 }}"#
                     .to_string();
@@ -69,6 +69,10 @@ fn test_calling_a_reducer_in_module(module_name: &'static str) {
                 r#"{"CallReducer": {"reducer": "log_module_identity", "args": "[]", "request_id": 4, "flags": 0 }}"#
                     .to_string();
             module.send(json).await.unwrap();
+
+            for request_id in 0..=4 {
+                module.recv_reducer_update(request_id).await.unwrap();
+            }
 
             assert_eq!(
                 read_logs(&module).await,
@@ -283,11 +287,11 @@ fn test_calling_with_tx() {
 ///     TestF::Baz("buzz".to_string()),
 /// ]
 /// ```
-fn test_call_query_macro_with_caller<F: Future<Output = ()>>(caller: impl FnOnce(ModuleHandle) -> F) {
+fn test_call_query_macro_with_caller<F: Future<Output = ModuleHandle>>(caller: impl FnOnce(ModuleHandle) -> F) {
     CompiledModule::compile("module-test", CompilationMode::Debug).with_module_async(
         DEFAULT_CONFIG,
         |module| async move {
-            caller(module.clone()).await;
+            let module = caller(module).await;
             let logs = read_logs(&module)
                 .await
                 .into_iter()
@@ -330,9 +334,10 @@ fn test_call_query_macro() {
     "[ { \"x\": 0, \"y\": 2, \"z\": \"Macro\" }, { \"foo\": \"Foo\" }, { \"foo\": {} }, { \"baz\": \"buzz\" } ]",
   "request_id": 0,
   "flags": 0
-} }"#
+	} }"#
             .to_string();
         module.send(json).await.unwrap();
+        module
     });
 
     let args_pv = &product![
@@ -345,11 +350,13 @@ fn test_call_query_macro() {
     // JSON via the `Serialize` path.
     test_call_query_macro_with_caller(|module| async move {
         module.call_reducer_json("test", args_pv).await.unwrap();
+        module
     });
 
     // BSATN via the `Serialize` path.
     test_call_query_macro_with_caller(|module| async move {
         module.call_reducer_binary("test", args_pv).await.unwrap();
+        module
     });
 }
 


### PR DESCRIPTION
# Description of Changes

The core motivation for this change is simple: avoid cross-thread handoffs and synchronization on the main execution path.

Before this change, the ingress task for each websocket connection would wait for a completion response on each request before submitting the next request to the database. This was mainly used to guarantee that we delivered message responses in receive-order per connection. However it also meant that for every request, we notified a waiting Tokio task, which potentially incurred kernel-assisted wakeup and scheduler overhead.

Note this design existed mainly for historical reasons. Before the database had a dedicated job thread, requests were not serialized through a single queue. The module instance was gated behind a semaphore which guaranteed mutual exclusion, but it did not guarantee FIFO ordering. Awaiting the completion of each request in `ws_recv_task` was therefore the mechanism that enforced per-connection receive-order semantics. However it now serves primarily as a source of overhead.

Procedures are the important exception. They are not serialized through the main worker queue. Instead they use their own instance pool so as to be able to run concurrently with other requests. However procedures may be composed of multiple transactions and they may effectively yield between transactions. This means that before this change, if a procedure were to yield, it would effectively block all subsequent requests from that client until it returned which is quite undesirable.

So with this change, procedures may execute out of order with other operations received on the same WebSocket. Hence if this is not a desirable property, clients must enforce ordering themselves by waiting for a response before submitting the next request.

## What changed?

### 1. Different instance managers for procedures and everything else

Procedures use a bounded instance pool where each instance is backed by an isolate running in a thread. Reducers and all other operations are serialized through an mpsc queue that feeds a single isolate running in a thread.

Trapped isolates are replaced inline. Only a fatal error within one of the instance threads results in the `ModuleHost` and all its connections being dropped. The host controller will recreate a new `ModuleHost` lazily on the next request.

### 2. New enqueue-only `ModuleHost` interface

`ClientConnection` now calls enqueue-only methods on `ModuleHost` which return immediately after enqueuing on the main instance lane or in the case of a procedure, checking out an available instance and starting the operation.

### 3. Separate `ModuleHost` interfaces for scheduled reducers and scheduled procedures

Scheduled reducers now target the main js instance/worker, while scheduled procedures go through the pool. The scheduler now distinguishes between reducers and procedures and calls the appropriate method.

Note, the scheduler does not pipeline its operations. It waits for each one to complete before scheduling the next operation. This means that a long running procedure will block all other operations from being scheduled. This will need to be fixed at some point, but this patch doesn't change the current behavior.

### 4. Misc

This patch also names the main js worker thread for better diagnostics. It also disables core pinning by default and makes it an explicit opt-in.

This last one is pretty important. The current architecture reduces thread and context switching significantly such that naive core pinning may perform worse than just deferring to the OS scheduler on certain platforms. As it stands, the main motivation which led us to our original core pinning strategy no longer exists, so we should probably just defer to the OS until we've designed a proper scheduler that suits our needs.

# API and ABI breaking changes

As mentioned above, with this change, procedures may execute out of order with other operations received on the same WebSocket. Hence if this is not a desirable property, clients must enforce ordering themselves by waiting for a response before submitting the next request.

# Expected complexity level and risk

4

# Testing

This is mainly a performance oriented refactor, so no additional correctness tests were added. However this patch does touch a lot of code that could probably use more coverage in general. Benchmarks were run to verify expected performance characteristics.
