### PR TITLE
Minor docs additions based on a discussion in the public Discord

### DIFF
--- a/docs/docs/00100-intro/00100-getting-started/00400-key-architecture.md
+++ b/docs/docs/00100-intro/00100-getting-started/00400-key-architecture.md
@@ -556,7 +556,7 @@ See [Views](../../00200-core-concepts/00200-functions/00500-views.md) for more d
 
 A **client** is an application that connects to a [database](#database). A client logs in using an [identity](#identity) and receives an [connection id](#connectionid) to identify the connection. After that, it can call [reducers](#reducer) and query public [tables](#table).
 
-Clients are written using the [client-side SDKs](../../00200-core-concepts/00600-clients.md). The `spacetime` CLI tool allows automatically generating code that works with the client-side SDKs to talk to a particular database.
+Clients are written using the [client-side SDKs](../../00200-core-concepts/00600-clients.md). The `spacetime` CLI tool allows automatically generating code that works with the client-side SDKs to talk to a particular database. The client SDKs internally maintain a long-lived streaming connection to SpacetimeDB, allowing high-performance real-time interactions.
 
 Clients are regular software applications that developers can choose how to deploy (through Steam, app stores, package managers, or any other software deployment method, depending on the needs of the application.)
 

--- a/docs/docs/00300-resources/00200-reference/00200-http-api/00300-database.md
+++ b/docs/docs/00300-resources/00200-reference/00200-http-api/00300-database.md
@@ -4,7 +4,7 @@ slug: /http/database
 
 # `/v1/database`
 
-The HTTP endpoints in `/v1/database` allow clients to interact with Spacetime databases in a variety of ways, including retrieving information, creating and deleting databases, invoking reducers and evaluating SQL queries.
+The HTTP endpoints in `/v1/database` allow clients to interact with Spacetime databases in a variety of ways, including retrieving information, creating and deleting databases, invoking reducers and evaluating SQL queries. These APIs are intended primarily for management, debugging and interactive developer use, and have not been optimized for performance to the same extent as the WebSocket API used by [the SpacetimeDB client SDKs](../../../00200-core-concepts/00600-clients.md).
 
 ## At a glance
 


### PR DESCRIPTION
# Description of Changes

A user in the public Discord was confused about the intended way(s) to interact with SpacetimeDB, and was attempting to (mis)use the HTTP API's SQL endpoint in production rather than or in addition to the WebSocket API.
After some discussion, we determined these additions to the documentation would be helpful.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

1

# Testing

N/a
