### PR TITLE
Fix segfault in v8

### DIFF
--- a/crates/core/src/host/v8/syscall/hooks.rs
+++ b/crates/core/src/host/v8/syscall/hooks.rs
@@ -93,7 +93,7 @@ impl ModuleHookKey {
 }
 
 /// Context embedder slot holding the receiver (`this`) value used for hook calls.
-const RECV_SLOT_INDEX: i32 = ModuleHookKey::SenderErrorClass as i32 + 1;
+pub(super) const RECV_SLOT_INDEX: i32 = ModuleHookKey::SenderErrorClass as i32 + 1;
 
 /// Holds the `AbiVersion` used by the module
 /// and the module hooks registered by the module

--- a/crates/core/src/host/v8/syscall/mod.rs
+++ b/crates/core/src/host/v8/syscall/mod.rs
@@ -125,6 +125,11 @@ pub(super) fn get_hooks<'scope>(
     scope: &mut PinScope<'scope, '_>,
     exports_obj: Local<'_, v8::Object>,
 ) -> Result<Option<HookFunctions<'scope>>, ErrorOrException<ExceptionThrown>> {
+    // We only set RECV_SLOT_INDEX in set_registered_hooks, which is only called in
+    // the v2 code path. Set it to undefined ahead of time so it's not a garbage value.
+    scope
+        .get_current_context()
+        .set_embedder_data(hooks::RECV_SLOT_INDEX, v8::undefined(scope).into());
     if let Some(hooks) = get_registered_hooks(scope) {
         return Ok(Some(hooks));
     }


### PR DESCRIPTION
# Description of Changes

This was originally introduced in #4302; essentially, we stopped unconditionally setting `HookFunctions.recv` to undefined and started setting it to the value stored in `ctx.get_embedder_data(RECV_SLOT_INDEX)`. However, in the code path for v1 js modules, we never actually set that embedder data slot, and so recv was a garbage value.

# Expected complexity level and risk

1: concentrated fix

# Testing

- [x] Repro no longer segfaults.
