### PR TITLE
Graph extension (Proj. Manifold Stage 1/2)

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,3 +1,4 @@
 **/module_bindings/** linguist-generated=true eol=lf
 /docs/llms/** linguist-generated=true
 /docs/llms/*-details.json linguist-generated=false
+*.sh text eol=lf

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -420,6 +420,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "backoff"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b62ddb9cb1ec0a098ad4bbf9344d0713fa193ae1a80af55febcff2627b6a00c1"
+dependencies = [
+ "futures-core",
+ "getrandom 0.2.16",
+ "instant",
+ "pin-project-lite",
+ "rand 0.8.5",
+ "tokio",
+]
+
+[[package]]
 name = "backtrace"
 version = "0.3.76"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -717,6 +731,9 @@ name = "bytes"
 version = "1.10.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d71b6127be86fdcfddb610f7182ac57211d4b18a3e9c82eb2d17662f2227ad6a"
+dependencies = [
+ "serde",
+]
 
 [[package]]
 name = "bytestring"
@@ -886,6 +903,28 @@ dependencies = [
  "serde",
  "wasm-bindgen",
  "windows-link 0.2.1",
+]
+
+[[package]]
+name = "chrono-tz"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d59ae0466b83e838b81a54256c39d5d7c20b9d7daa10510a242d9b75abd5936e"
+dependencies = [
+ "chrono",
+ "chrono-tz-build",
+ "phf 0.11.3",
+]
+
+[[package]]
+name = "chrono-tz-build"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "433e39f13c9a060046954e0592a8d0a4bcb1040125cbf91cb8ee58964cfb350f"
+dependencies = [
+ "parse-zoneinfo",
+ "phf 0.11.3",
+ "phf_codegen",
 ]
 
 [[package]]
@@ -1686,6 +1725,25 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2a2330da5de22e8a3cb63252ce2abb30116bf5265e89c0e01bc17015ce30a476"
 
 [[package]]
+name = "deadpool"
+version = "0.9.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "421fe0f90f2ab22016f32a9881be5134fdd71c65298917084b0c7477cbc3856e"
+dependencies = [
+ "async-trait",
+ "deadpool-runtime",
+ "num_cpus",
+ "retain_mut",
+ "tokio",
+]
+
+[[package]]
+name = "deadpool-runtime"
+version = "0.1.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "092966b41edc516079bdf31ec78a2e0588d1d0c08f78b91d8307215928642b2b"
+
+[[package]]
 name = "debugid"
 version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1710,6 +1768,17 @@ name = "deflate64"
 version = "0.1.10"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "26bf8fc351c5ed29b5c2f0cbbac1b209b74f60ecd62e675a998df72c49af5204"
+
+[[package]]
+name = "delegate"
+version = "0.10.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0ee5df75c70b95bd3aacc8e2fd098797692fb1d54121019c4de481e42f04c8a1"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 1.0.109",
+]
 
 [[package]]
 name = "deno_core_icudata"
@@ -2693,6 +2762,36 @@ dependencies = [
  "serde_json",
  "wasm-bindgen",
  "web-sys",
+]
+
+[[package]]
+name = "graph-algo"
+version = "0.1.0"
+
+[[package]]
+name = "graph-bench-xsys"
+version = "0.1.0"
+dependencies = [
+ "anyhow",
+ "async-trait",
+ "clap 4.5.50",
+ "flate2",
+ "graph-algo",
+ "neo4rs",
+ "reqwest 0.12.24",
+ "serde",
+ "serde_json",
+ "tokio",
+ "tokio-postgres",
+]
+
+[[package]]
+name = "graph-module"
+version = "0.1.0"
+dependencies = [
+ "graph-algo",
+ "log",
+ "spacetimedb 2.2.0",
 ]
 
 [[package]]
@@ -4185,6 +4284,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "27b02d87554356db9e9a873add8782d4ea6e3e58ea071a9adb9a2e8ddb884a8b"
 
 [[package]]
+name = "neo4rs"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "43dd99fe7dbc68f754759874d83ec2ca43a61ab7d51c10353d024094805382be"
+dependencies = [
+ "async-trait",
+ "backoff",
+ "bytes",
+ "chrono",
+ "chrono-tz",
+ "deadpool",
+ "delegate",
+ "futures",
+ "log",
+ "neo4rs-macros",
+ "paste",
+ "pin-project-lite",
+ "rustls-native-certs",
+ "rustls-pemfile 2.2.0",
+ "serde",
+ "thiserror 1.0.69",
+ "tokio",
+ "tokio-rustls",
+ "url",
+ "webpki-roots 0.26.11",
+]
+
+[[package]]
+name = "neo4rs-macros"
+version = "0.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "53a0d57c55d2d1dc62a2b1d16a0a1079eb78d67c36bdf468d582ab4482ec7002"
+dependencies = [
+ "quote",
+ "syn 2.0.107",
+]
+
+[[package]]
 name = "netlink-packet-core"
 version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4772,7 +4909,7 @@ version = "0.112.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "58b1eb3b6f9ed42c528030161d0370b023229ed05b785baf7a80d7e99a794da2"
 dependencies = [
- "phf",
+ "phf 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.107",
@@ -4988,7 +5125,7 @@ dependencies = [
  "oxc_ast_macros",
  "oxc_diagnostics",
  "oxc_span",
- "phf",
+ "phf 0.13.1",
  "rustc-hash",
  "unicode-id-start",
 ]
@@ -5100,7 +5237,7 @@ dependencies = [
  "oxc_estree",
  "oxc_index",
  "oxc_span",
- "phf",
+ "phf 0.13.1",
  "serde",
  "unicode-id-start",
 ]
@@ -5254,6 +5391,15 @@ name = "parse-size"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "487f2ccd1e17ce8c1bfab3a65c89525af41cfad4c8659021a1e9a2aacd73b89b"
+
+[[package]]
+name = "parse-zoneinfo"
+version = "0.3.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1f2a05b18d44e2957b88f96ba460715e295bc1d7510468a2f3d3b44535d26c24"
+dependencies = [
+ "regex",
+]
 
 [[package]]
 name = "paste"
@@ -5411,13 +5557,42 @@ dependencies = [
 
 [[package]]
 name = "phf"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "1fd6780a80ae0c52cc120a26a1a42c1ae51b247a253e4e06113d23d2c2edd078"
+dependencies = [
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf"
 version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c1562dc717473dbaa4c1f85a36410e03c047b2e7df7f45ee938fbef64ae7fadf"
 dependencies = [
  "phf_macros",
- "phf_shared",
+ "phf_shared 0.13.1",
  "serde",
+]
+
+[[package]]
+name = "phf_codegen"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "aef8048c789fa5e851558d709946d6d79a8ff88c0440c587967f8e94bfb1216a"
+dependencies = [
+ "phf_generator 0.11.3",
+ "phf_shared 0.11.3",
+]
+
+[[package]]
+name = "phf_generator"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "3c80231409c20246a13fddb31776fb942c38553c51e871f8cbd687a4cfb5843d"
+dependencies = [
+ "phf_shared 0.11.3",
+ "rand 0.8.5",
 ]
 
 [[package]]
@@ -5427,7 +5602,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "135ace3a761e564ec88c03a77317a7c6b80bb7f7135ef2544dbe054243b89737"
 dependencies = [
  "fastrand",
- "phf_shared",
+ "phf_shared 0.13.1",
 ]
 
 [[package]]
@@ -5436,11 +5611,20 @@ version = "0.13.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "812f032b54b1e759ccd5f8b6677695d5268c588701effba24601f6932f8269ef"
 dependencies = [
- "phf_generator",
- "phf_shared",
+ "phf_generator 0.13.1",
+ "phf_shared 0.13.1",
  "proc-macro2",
  "quote",
  "syn 2.0.107",
+]
+
+[[package]]
+name = "phf_shared"
+version = "0.11.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "67eabc2ef2a60eb7faa00097bd1ffdb5bd28e62bf39990626a582201b7a754e5"
+dependencies = [
+ "siphasher",
 ]
 
 [[package]]
@@ -6339,7 +6523,7 @@ dependencies = [
  "once_cell",
  "percent-encoding",
  "pin-project-lite",
- "rustls-pemfile",
+ "rustls-pemfile 1.0.4",
  "serde",
  "serde_json",
  "serde_urlencoded",
@@ -6408,6 +6592,12 @@ dependencies = [
  "potential_utf",
  "serde_core",
 ]
+
+[[package]]
+name = "retain_mut"
+version = "0.1.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4389f1d5789befaf6029ebd9f7dac4af7f7e3d61b69d4f30e2ac02b57e7712b0"
 
 [[package]]
 name = "rgb"
@@ -6784,7 +6974,7 @@ version = "0.1.0"
 source = "git+https://github.com/rolldown/rolldown.git?tag=v1.0.0-rc.3#3035ec8774be955105decc387fd42c781793ccce"
 dependencies = [
  "arcstr",
- "phf",
+ "phf 0.13.1",
  "rolldown_plugin",
  "rolldown_utils",
 ]
@@ -6858,7 +7048,7 @@ dependencies = [
  "nom 8.0.0",
  "oxc",
  "oxc_index",
- "phf",
+ "phf 0.13.1",
  "rayon",
  "regex",
  "regress",
@@ -6980,10 +7170,24 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "751e04a496ca00bb97a5e043158d23d66b5aabf2e1d5aa2a0aaebb1aafe6f82c"
 dependencies = [
  "once_cell",
+ "ring",
  "rustls-pki-types",
  "rustls-webpki",
  "subtle",
  "zeroize",
+]
+
+[[package]]
+name = "rustls-native-certs"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e5bfb394eeed242e909609f56089eecfe5fda225042e8b171791b9c95f5931e5"
+dependencies = [
+ "openssl-probe",
+ "rustls-pemfile 2.2.0",
+ "rustls-pki-types",
+ "schannel",
+ "security-framework",
 ]
 
 [[package]]
@@ -6993,6 +7197,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
 dependencies = [
  "base64 0.21.7",
+]
+
+[[package]]
+name = "rustls-pemfile"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "dce314e5fee3f39953d46bb63bb8a46d40c2f8fb7cc5a3b6cab2bde9721d6e50"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]
@@ -8137,6 +8350,13 @@ dependencies = [
 ]
 
 [[package]]
+name = "spacetimedb-cypher-parser"
+version = "2.2.0"
+dependencies = [
+ "thiserror 1.0.69",
+]
+
+[[package]]
 name = "spacetimedb-data-structures"
 version = "2.2.0"
 dependencies = [
@@ -8232,7 +8452,7 @@ dependencies = [
  "derive_more 0.99.20",
  "ethnum",
  "pretty_assertions",
- "spacetimedb 2.2.0",
+ "spacetimedb-cypher-parser",
  "spacetimedb-data-structures",
  "spacetimedb-lib 2.2.0",
  "spacetimedb-primitives 2.2.0",
@@ -8664,6 +8884,7 @@ name = "spacetimedb-sql-parser"
 version = "2.2.0"
 dependencies = [
  "derive_more 0.99.20",
+ "spacetimedb-cypher-parser",
  "spacetimedb-lib 2.2.0",
  "sqlparser",
  "thiserror 1.0.69",
@@ -8716,6 +8937,7 @@ name = "spacetimedb-subscription"
 version = "2.2.0"
 dependencies = [
  "anyhow",
+ "spacetimedb-cypher-parser",
  "spacetimedb-data-structures",
  "spacetimedb-execution",
  "spacetimedb-expr",
@@ -9569,7 +9791,7 @@ dependencies = [
  "log",
  "parking_lot 0.12.5",
  "percent-encoding",
- "phf",
+ "phf 0.13.1",
  "pin-project-lite",
  "postgres-protocol",
  "postgres-types",
@@ -10798,6 +11020,24 @@ dependencies = [
  "objc2-foundation",
  "url",
  "web-sys",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "0.26.11"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "521bc38abb08001b01866da9f51eb7c5d647a19260e00054a8c7fd5f9e57f7a9"
+dependencies = [
+ "webpki-roots 1.0.7",
+]
+
+[[package]]
+name = "webpki-roots"
+version = "1.0.7"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "52f5ee44c96cf55f1b349600768e3ece3a8f26010c05265ab73f945bb1a2eb9d"
+dependencies = [
+ "rustls-pki-types",
 ]
 
 [[package]]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -32,6 +32,7 @@ members = [
   "sdks/unreal",
   "crates/snapshot",
   "crates/sqltest",
+  "crates/cypher-parser",
   "crates/sql-parser",
   "crates/standalone",
   "crates/subscription",
@@ -42,6 +43,8 @@ members = [
   "modules/keynote-benchmarks",
   "modules/perf-test",
   "modules/module-test",
+  "modules/graph",
+  "modules/graph-algo",
   "templates/basic-rs/spacetimedb",
   "templates/chat-console-rs/spacetimedb",
   "modules/sdk-test",
@@ -51,6 +54,8 @@ members = [
   "modules/sdk-test-case-conversion",
   "modules/sdk-test-view-pk",
   "modules/sdk-test-event-table",
+  "modules/graph",
+  "modules/graph-algo",
   "sdks/rust/tests/test-client",
   "sdks/rust/tests/test-counter",
   "sdks/rust/tests/connect_disconnect_client",
@@ -142,6 +147,7 @@ spacetimedb-query = { path = "crates/query", version = "=2.2.0" }
 spacetimedb-sats = { path = "crates/sats", version = "=2.2.0" }
 spacetimedb-schema = { path = "crates/schema", version = "=2.2.0" }
 spacetimedb-standalone = { path = "crates/standalone", version = "=2.2.0" }
+spacetimedb-cypher-parser = { path = "crates/cypher-parser", version = "=2.2.0" }
 spacetimedb-sql-parser = { path = "crates/sql-parser", version = "=2.2.0" }
 spacetimedb-table = { path = "crates/table", version = "=2.2.0" }
 spacetimedb-fs-utils = { path = "crates/fs-utils", version = "=2.2.0" }

--- a/crates/core/src/subscription/metrics.rs
+++ b/crates/core/src/subscription/metrics.rs
@@ -64,6 +64,7 @@ fn extract_columns(
                 extract_columns(expr, schema, columns);
             }
         }
+        PhysicalExpr::Not(inner) => extract_columns(inner, schema, columns),
         PhysicalExpr::Value(_) => {}
     }
 }

--- a/crates/cypher-parser/Cargo.toml
+++ b/crates/cypher-parser/Cargo.toml
@@ -1,0 +1,13 @@
+[package]
+name = "spacetimedb-cypher-parser"
+version.workspace = true
+edition.workspace = true
+rust-version.workspace = true
+license-file = "LICENSE"
+description = "An openCypher subset parser for SpacetimeDB graph queries"
+
+[dependencies]
+thiserror.workspace = true
+
+[lints]
+workspace = true

--- a/crates/cypher-parser/src/ast.rs
+++ b/crates/cypher-parser/src/ast.rs
@@ -1,0 +1,136 @@
+/// A complete openCypher query: `MATCH pattern [WHERE expr] RETURN projection`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct CypherQuery {
+    pub match_clause: MatchClause,
+    pub where_clause: Option<CypherExpr>,
+    pub return_clause: ReturnClause,
+}
+
+/// `MATCH pattern {, pattern}`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct MatchClause {
+    pub patterns: Vec<Pattern>,
+}
+
+/// A graph pattern: a chain of alternating nodes and relationships.
+///
+/// Invariant: `nodes.len() == edges.len() + 1`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct Pattern {
+    pub nodes: Vec<NodePattern>,
+    pub edges: Vec<RelPattern>,
+}
+
+/// `(variable:Label {key: value, …})` — all parts optional.
+#[derive(Debug, Clone, PartialEq)]
+pub struct NodePattern {
+    pub variable: Option<String>,
+    pub label: Option<String>,
+    pub properties: Vec<(String, CypherLiteral)>,
+}
+
+/// `-[variable:TYPE *range]->` / `<-[…]-` / `-[…]-`.
+#[derive(Debug, Clone, PartialEq)]
+pub struct RelPattern {
+    pub variable: Option<String>,
+    pub rel_type: Option<String>,
+    pub length: Option<PathLength>,
+    pub direction: Direction,
+}
+
+/// Relationship direction.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum Direction {
+    /// `-->` or `-[…]->`
+    Outgoing,
+    /// `<--` or `<-[…]-`
+    Incoming,
+    /// `--` or `-[…]-`
+    Undirected,
+}
+
+/// Variable-length path range in `[*min..max]`.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum PathLength {
+    /// `[*]` — unbounded
+    Unbounded,
+    /// `[*n]` — exactly n hops
+    Exact(u32),
+    /// `[*min..max]`
+    Range { min: Option<u32>, max: Option<u32> },
+}
+
+/// `RETURN * | RETURN expr [AS alias] {, …}`.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum ReturnClause {
+    /// `RETURN *`
+    All,
+    /// `RETURN item {, item}`
+    Items(Vec<ReturnItem>),
+}
+
+/// A single item in a RETURN clause.
+#[derive(Debug, Clone, PartialEq)]
+pub struct ReturnItem {
+    pub expr: CypherExpr,
+    pub alias: Option<String>,
+}
+
+/// Scalar expression used in WHERE and RETURN clauses.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum CypherExpr {
+    /// A literal constant.
+    Lit(CypherLiteral),
+    /// An unqualified variable reference.
+    Var(String),
+    /// Property access: `expr.prop`.
+    Prop(Box<CypherExpr>, String),
+    /// Binary comparison: `expr op expr`.
+    Cmp(Box<CypherExpr>, CmpOp, Box<CypherExpr>),
+    /// Boolean AND.
+    And(Box<CypherExpr>, Box<CypherExpr>),
+    /// Boolean OR.
+    Or(Box<CypherExpr>, Box<CypherExpr>),
+    /// Boolean NOT.
+    Not(Box<CypherExpr>),
+}
+
+/// Comparison operators.
+#[derive(Debug, Clone, Copy, PartialEq, Eq)]
+#[non_exhaustive]
+pub enum CmpOp {
+    Eq,
+    Ne,
+    Lt,
+    Gt,
+    Lte,
+    Gte,
+}
+
+impl std::fmt::Display for CmpOp {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Self::Eq => write!(f, "="),
+            Self::Ne => write!(f, "<>"),
+            Self::Lt => write!(f, "<"),
+            Self::Gt => write!(f, ">"),
+            Self::Lte => write!(f, "<="),
+            Self::Gte => write!(f, ">="),
+        }
+    }
+}
+
+/// A literal constant in Cypher.
+#[derive(Debug, Clone, PartialEq)]
+#[non_exhaustive]
+pub enum CypherLiteral {
+    Integer(i64),
+    Float(f64),
+    String(String),
+    Bool(bool),
+    Null,
+}

--- a/crates/cypher-parser/src/error.rs
+++ b/crates/cypher-parser/src/error.rs
@@ -1,0 +1,25 @@
+use thiserror::Error;
+
+use crate::lexer::Token;
+
+#[derive(Error, Debug)]
+pub enum CypherParseError {
+    #[error("Unexpected token `{found}` at position {pos}, expected {expected}")]
+    UnexpectedToken {
+        found: Token,
+        pos: usize,
+        expected: &'static str,
+    },
+    #[error("Unexpected end of input, expected {expected}")]
+    UnexpectedEof { expected: &'static str },
+    #[error("Invalid number literal: {0}")]
+    InvalidNumber(String),
+    #[error("Unterminated string literal at position {0}")]
+    UnterminatedString(usize),
+    #[error("Path length value {value} is out of the valid u32 range at position {pos}")]
+    PathLengthOutOfRange { value: i64, pos: usize },
+    #[error("Empty query")]
+    EmptyQuery,
+}
+
+pub type CypherParseResult<T> = Result<T, CypherParseError>;

--- a/crates/cypher-parser/src/lexer.rs
+++ b/crates/cypher-parser/src/lexer.rs
@@ -1,0 +1,303 @@
+use crate::error::{CypherParseError, CypherParseResult};
+
+#[derive(Debug, Clone, PartialEq)]
+pub enum Token {
+    // Punctuation
+    LParen,
+    RParen,
+    LBracket,
+    RBracket,
+    LBrace,
+    RBrace,
+    Colon,
+    Comma,
+    Dot,
+    DotDot,
+    Star,
+    Dash,
+    Arrow,      // ->
+    LArrow,     // <-
+
+    // Comparison
+    Eq,
+    Ne,         // <>
+    Lt,
+    Gt,
+    Lte,        // <=
+    Gte,        // >=
+
+    // Keywords
+    Match,
+    Where,
+    Return,
+    As,
+    And,
+    Or,
+    Not,
+    True,
+    False,
+    Null,
+
+    // Literals
+    Integer(i64),
+    Float(f64),
+    StringLit(String),
+
+    // Identifier
+    Ident(String),
+
+    Eof,
+}
+
+impl std::fmt::Display for Token {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Token::LParen => write!(f, "("),
+            Token::RParen => write!(f, ")"),
+            Token::LBracket => write!(f, "["),
+            Token::RBracket => write!(f, "]"),
+            Token::LBrace => write!(f, "{{"),
+            Token::RBrace => write!(f, "}}"),
+            Token::Colon => write!(f, ":"),
+            Token::Comma => write!(f, ","),
+            Token::Dot => write!(f, "."),
+            Token::DotDot => write!(f, ".."),
+            Token::Star => write!(f, "*"),
+            Token::Dash => write!(f, "-"),
+            Token::Arrow => write!(f, "->"),
+            Token::LArrow => write!(f, "<-"),
+            Token::Eq => write!(f, "="),
+            Token::Ne => write!(f, "<>"),
+            Token::Lt => write!(f, "<"),
+            Token::Gt => write!(f, ">"),
+            Token::Lte => write!(f, "<="),
+            Token::Gte => write!(f, ">="),
+            Token::Match => write!(f, "MATCH"),
+            Token::Where => write!(f, "WHERE"),
+            Token::Return => write!(f, "RETURN"),
+            Token::As => write!(f, "AS"),
+            Token::And => write!(f, "AND"),
+            Token::Or => write!(f, "OR"),
+            Token::Not => write!(f, "NOT"),
+            Token::True => write!(f, "true"),
+            Token::False => write!(f, "false"),
+            Token::Null => write!(f, "null"),
+            Token::Integer(n) => write!(f, "{n}"),
+            Token::Float(n) => write!(f, "{n}"),
+            Token::StringLit(s) => write!(f, "'{s}'"),
+            Token::Ident(s) => write!(f, "{s}"),
+            Token::Eof => write!(f, "end of input"),
+        }
+    }
+}
+
+/// Byte-oriented lexer for the supported openCypher subset.
+///
+/// # ASCII assumption
+///
+/// The lexer operates on raw bytes (`input.as_bytes()`) and treats each byte
+/// as a single character. This works correctly for ASCII-only identifiers,
+/// keywords, and operators — which is sufficient for the current Cypher
+/// subset — but will mis-lex multi-byte UTF-8 sequences in identifiers or
+/// string literals that contain non-ASCII characters.
+pub struct Lexer<'a> {
+    input: &'a [u8],
+    pos: usize,
+}
+
+impl<'a> Lexer<'a> {
+    pub fn new(input: &'a str) -> Self {
+        Self {
+            input: input.as_bytes(),
+            pos: 0,
+        }
+    }
+
+    pub fn pos(&self) -> usize {
+        self.pos
+    }
+
+    fn peek_byte(&self) -> Option<u8> {
+        self.input.get(self.pos).copied()
+    }
+
+    fn advance(&mut self) -> Option<u8> {
+        let b = self.input.get(self.pos).copied()?;
+        self.pos += 1;
+        Some(b)
+    }
+
+    fn skip_whitespace(&mut self) {
+        while self.pos < self.input.len() && self.input[self.pos].is_ascii_whitespace() {
+            self.pos += 1;
+        }
+    }
+
+    fn read_string(&mut self, quote: u8) -> CypherParseResult<String> {
+        let start = self.pos;
+        let mut s = String::new();
+        loop {
+            match self.advance() {
+                None => return Err(CypherParseError::UnterminatedString(start - 1)),
+                Some(b) if b == quote => {
+                    if self.peek_byte() == Some(quote) {
+                        self.advance();
+                        s.push(quote as char);
+                    } else {
+                        return Ok(s);
+                    }
+                }
+                Some(b'\\') => match self.advance() {
+                    Some(b'n') => s.push('\n'),
+                    Some(b't') => s.push('\t'),
+                    Some(b'\\') => s.push('\\'),
+                    Some(b) if b == quote => s.push(quote as char),
+                    Some(b) => {
+                        s.push('\\');
+                        s.push(b as char);
+                    }
+                    None => return Err(CypherParseError::UnterminatedString(start - 1)),
+                },
+                Some(b) => s.push(b as char),
+            }
+        }
+    }
+
+    fn read_number(&mut self, first: u8) -> CypherParseResult<Token> {
+        let mut buf = String::new();
+        buf.push(first as char);
+        let mut is_float = false;
+
+        while let Some(b) = self.peek_byte() {
+            if b.is_ascii_digit() {
+                buf.push(b as char);
+                self.advance();
+            } else if b == b'.' && !is_float {
+                if self.input.get(self.pos + 1).copied() == Some(b'.') {
+                    break;
+                }
+                is_float = true;
+                buf.push('.');
+                self.advance();
+            } else {
+                break;
+            }
+        }
+
+        if is_float {
+            buf.parse::<f64>()
+                .map(Token::Float)
+                .map_err(|_| CypherParseError::InvalidNumber(buf))
+        } else {
+            buf.parse::<i64>()
+                .map(Token::Integer)
+                .map_err(|_| CypherParseError::InvalidNumber(buf))
+        }
+    }
+
+    fn read_ident(&mut self, first: u8) -> Token {
+        let mut s = String::new();
+        s.push(first as char);
+        while let Some(b) = self.peek_byte() {
+            if b.is_ascii_alphanumeric() || b == b'_' {
+                s.push(b as char);
+                self.advance();
+            } else {
+                break;
+            }
+        }
+        match s.to_ascii_uppercase().as_str() {
+            "MATCH" => Token::Match,
+            "WHERE" => Token::Where,
+            "RETURN" => Token::Return,
+            "AS" => Token::As,
+            "AND" => Token::And,
+            "OR" => Token::Or,
+            "NOT" => Token::Not,
+            "TRUE" => Token::True,
+            "FALSE" => Token::False,
+            "NULL" => Token::Null,
+            _ => Token::Ident(s),
+        }
+    }
+
+    pub fn next_token(&mut self) -> CypherParseResult<Token> {
+        self.skip_whitespace();
+        let Some(b) = self.advance() else {
+            return Ok(Token::Eof);
+        };
+        match b {
+            b'(' => Ok(Token::LParen),
+            b')' => Ok(Token::RParen),
+            b'[' => Ok(Token::LBracket),
+            b']' => Ok(Token::RBracket),
+            b'{' => Ok(Token::LBrace),
+            b'}' => Ok(Token::RBrace),
+            b':' => Ok(Token::Colon),
+            b',' => Ok(Token::Comma),
+            b'*' => Ok(Token::Star),
+            b'.' => {
+                if self.peek_byte() == Some(b'.') {
+                    self.advance();
+                    Ok(Token::DotDot)
+                } else {
+                    Ok(Token::Dot)
+                }
+            }
+            b'-' => {
+                if self.peek_byte() == Some(b'>') {
+                    self.advance();
+                    Ok(Token::Arrow)
+                } else {
+                    Ok(Token::Dash)
+                }
+            }
+            b'<' => {
+                if self.peek_byte() == Some(b'-') {
+                    self.advance();
+                    Ok(Token::LArrow)
+                } else if self.peek_byte() == Some(b'>') {
+                    self.advance();
+                    Ok(Token::Ne)
+                } else if self.peek_byte() == Some(b'=') {
+                    self.advance();
+                    Ok(Token::Lte)
+                } else {
+                    Ok(Token::Lt)
+                }
+            }
+            b'>' => {
+                if self.peek_byte() == Some(b'=') {
+                    self.advance();
+                    Ok(Token::Gte)
+                } else {
+                    Ok(Token::Gt)
+                }
+            }
+            b'=' => Ok(Token::Eq),
+            b'\'' | b'"' => self.read_string(b).map(Token::StringLit),
+            b if b.is_ascii_digit() => self.read_number(b),
+            b if b.is_ascii_alphabetic() || b == b'_' => Ok(self.read_ident(b)),
+            _ => Err(CypherParseError::UnexpectedToken {
+                found: Token::Ident(String::from(b as char)),
+                pos: self.pos - 1,
+                expected: "valid character",
+            }),
+        }
+    }
+
+    pub fn tokenize(input: &str) -> CypherParseResult<Vec<(Token, usize)>> {
+        let mut lexer = Lexer::new(input);
+        let mut tokens = Vec::new();
+        loop {
+            let pos = lexer.pos();
+            let tok = lexer.next_token()?;
+            if tok == Token::Eof {
+                tokens.push((Token::Eof, pos));
+                break;
+            }
+            tokens.push((tok, pos));
+        }
+        Ok(tokens)
+    }
+}

--- a/crates/cypher-parser/src/lib.rs
+++ b/crates/cypher-parser/src/lib.rs
@@ -1,0 +1,7 @@
+pub mod ast;
+pub mod error;
+pub mod lexer;
+pub mod parser;
+
+pub use error::CypherParseError;
+pub use parser::parse_cypher;

--- a/crates/cypher-parser/src/parser.rs
+++ b/crates/cypher-parser/src/parser.rs
@@ -1,0 +1,897 @@
+use crate::ast::*;
+use crate::error::{CypherParseError, CypherParseResult};
+use crate::lexer::{Lexer, Token};
+
+/// Parse an openCypher query string into a [`CypherQuery`] AST.
+pub fn parse_cypher(input: &str) -> CypherParseResult<CypherQuery> {
+    let tokens = Lexer::tokenize(input)?;
+    let mut parser = Parser::new(&tokens);
+    let query = parser.parse_query()?;
+    parser.expect_eof()?;
+    Ok(query)
+}
+
+struct Parser<'a> {
+    tokens: &'a [(Token, usize)],
+    cursor: usize,
+}
+
+impl<'a> Parser<'a> {
+    fn new(tokens: &'a [(Token, usize)]) -> Self {
+        Self { tokens, cursor: 0 }
+    }
+
+    fn peek(&self) -> &Token {
+        self.tokens
+            .get(self.cursor)
+            .map(|(t, _)| t)
+            .unwrap_or(&Token::Eof)
+    }
+
+    fn pos(&self) -> usize {
+        self.tokens
+            .get(self.cursor)
+            .map(|(_, p)| *p)
+            .unwrap_or(0)
+    }
+
+    fn advance(&mut self) -> &Token {
+        let tok = self.tokens.get(self.cursor).map(|(t, _)| t).unwrap_or(&Token::Eof);
+        if self.cursor < self.tokens.len() {
+            self.cursor += 1;
+        }
+        tok
+    }
+
+    fn eat(&mut self, expected: &Token, label: &'static str) -> CypherParseResult<()> {
+        let pos = self.pos();
+        let tok = self.advance().clone();
+        if &tok != expected {
+            return Err(CypherParseError::UnexpectedToken {
+                found: tok,
+                pos,
+                expected: label,
+            });
+        }
+        Ok(())
+    }
+
+    fn expect_eof(&self) -> CypherParseResult<()> {
+        if *self.peek() != Token::Eof {
+            return Err(CypherParseError::UnexpectedToken {
+                found: self.peek().clone(),
+                pos: self.pos(),
+                expected: "end of input",
+            });
+        }
+        Ok(())
+    }
+
+    // ── query ──────────────────────────────────────────────────────────
+
+    fn parse_query(&mut self) -> CypherParseResult<CypherQuery> {
+        if *self.peek() == Token::Eof {
+            return Err(CypherParseError::EmptyQuery);
+        }
+
+        let mut match_clause = self.parse_match()?;
+
+        // Multiple MATCH clauses: `MATCH … MATCH …` merges into one pattern list.
+        while *self.peek() == Token::Match {
+            let next = self.parse_match()?;
+            match_clause.patterns.extend(next.patterns);
+        }
+
+        let where_clause = if *self.peek() == Token::Where {
+            self.advance();
+            Some(self.parse_expr()?)
+        } else {
+            None
+        };
+
+        let return_clause = self.parse_return()?;
+
+        Ok(CypherQuery {
+            match_clause,
+            where_clause,
+            return_clause,
+        })
+    }
+
+    // ── MATCH ──────────────────────────────────────────────────────────
+
+    fn parse_match(&mut self) -> CypherParseResult<MatchClause> {
+        self.eat(&Token::Match, "MATCH")?;
+        let mut patterns = vec![self.parse_pattern()?];
+        while *self.peek() == Token::Comma {
+            self.advance();
+            patterns.push(self.parse_pattern()?);
+        }
+        Ok(MatchClause { patterns })
+    }
+
+    fn parse_pattern(&mut self) -> CypherParseResult<Pattern> {
+        let first_node = self.parse_node_pattern()?;
+        let mut nodes = vec![first_node];
+        let mut edges = Vec::new();
+
+        loop {
+            match self.peek() {
+                Token::Dash | Token::LArrow => {
+                    let (rel, node) = self.parse_rel_and_node()?;
+                    edges.push(rel);
+                    nodes.push(node);
+                }
+                _ => break,
+            }
+        }
+
+        Ok(Pattern { nodes, edges })
+    }
+
+    fn parse_node_pattern(&mut self) -> CypherParseResult<NodePattern> {
+        self.eat(&Token::LParen, "'('")?;
+
+        let variable = if let Token::Ident(_) = self.peek() {
+            let Token::Ident(name) = self.advance().clone() else {
+                unreachable!()
+            };
+            Some(name)
+        } else {
+            None
+        };
+
+        let label = if *self.peek() == Token::Colon {
+            self.advance();
+            Some(self.expect_ident("label name")?)
+        } else {
+            None
+        };
+
+        let properties = if *self.peek() == Token::LBrace {
+            self.parse_map_literal()?
+        } else {
+            Vec::new()
+        };
+
+        self.eat(&Token::RParen, "')'")?;
+        Ok(NodePattern {
+            variable,
+            label,
+            properties,
+        })
+    }
+
+    /// Parse `-[…]->`, `<-[…]-`, or `-[…]-` followed by a node pattern.
+    fn parse_rel_and_node(&mut self) -> CypherParseResult<(RelPattern, NodePattern)> {
+        let left_arrow = *self.peek() == Token::LArrow;
+        if left_arrow {
+            self.advance(); // consume `<-`
+        } else {
+            self.eat(&Token::Dash, "'-'")?;
+        }
+
+        let (variable, rel_type, length) = if *self.peek() == Token::LBracket {
+            self.advance();
+            let v = if let Token::Ident(_) = self.peek() {
+                let Token::Ident(name) = self.advance().clone() else {
+                    unreachable!()
+                };
+                Some(name)
+            } else {
+                None
+            };
+            let t = if *self.peek() == Token::Colon {
+                self.advance();
+                Some(self.expect_ident("relationship type")?)
+            } else {
+                None
+            };
+            let l = if *self.peek() == Token::Star {
+                Some(self.parse_path_length()?)
+            } else {
+                None
+            };
+            self.eat(&Token::RBracket, "']'")?;
+            (v, t, l)
+        } else {
+            (None, None, None)
+        };
+
+        let direction = if left_arrow {
+            self.eat(&Token::Dash, "'-' (closing <-[…]-)")?;
+            Direction::Incoming
+        } else if *self.peek() == Token::Arrow {
+            self.advance();
+            Direction::Outgoing
+        } else {
+            self.eat(&Token::Dash, "'-' or '->' (relationship end)")?;
+            Direction::Undirected
+        };
+
+        let node = self.parse_node_pattern()?;
+        Ok((
+            RelPattern {
+                variable,
+                rel_type,
+                length,
+                direction,
+            },
+            node,
+        ))
+    }
+
+    fn parse_path_length(&mut self) -> CypherParseResult<PathLength> {
+        self.eat(&Token::Star, "'*'")?;
+        match self.peek() {
+            Token::Integer(n) => {
+                let n = *n;
+                let pos = self.pos();
+                let n = u32::try_from(n).map_err(|_| CypherParseError::PathLengthOutOfRange {
+                    value: n,
+                    pos,
+                })?;
+                self.advance();
+                if *self.peek() == Token::DotDot {
+                    self.advance();
+                    if let Token::Integer(m) = self.peek() {
+                        let m = *m;
+                        let pos = self.pos();
+                        let m =
+                            u32::try_from(m).map_err(|_| CypherParseError::PathLengthOutOfRange {
+                                value: m,
+                                pos,
+                            })?;
+                        self.advance();
+                        Ok(PathLength::Range {
+                            min: Some(n),
+                            max: Some(m),
+                        })
+                    } else {
+                        Ok(PathLength::Range {
+                            min: Some(n),
+                            max: None,
+                        })
+                    }
+                } else {
+                    Ok(PathLength::Exact(n))
+                }
+            }
+            Token::DotDot => {
+                self.advance();
+                if let Token::Integer(m) = self.peek() {
+                    let m = *m;
+                    let pos = self.pos();
+                    let m =
+                        u32::try_from(m).map_err(|_| CypherParseError::PathLengthOutOfRange {
+                            value: m,
+                            pos,
+                        })?;
+                    self.advance();
+                    Ok(PathLength::Range {
+                        min: None,
+                        max: Some(m),
+                    })
+                } else {
+                    Ok(PathLength::Unbounded)
+                }
+            }
+            _ => Ok(PathLength::Unbounded),
+        }
+    }
+
+    // ── RETURN ─────────────────────────────────────────────────────────
+
+    fn parse_return(&mut self) -> CypherParseResult<ReturnClause> {
+        self.eat(&Token::Return, "RETURN")?;
+
+        if *self.peek() == Token::Star {
+            self.advance();
+            return Ok(ReturnClause::All);
+        }
+
+        let mut items = vec![self.parse_return_item()?];
+        while *self.peek() == Token::Comma {
+            self.advance();
+            items.push(self.parse_return_item()?);
+        }
+        Ok(ReturnClause::Items(items))
+    }
+
+    fn parse_return_item(&mut self) -> CypherParseResult<ReturnItem> {
+        let expr = self.parse_expr()?;
+        let alias = if *self.peek() == Token::As {
+            self.advance();
+            Some(self.expect_ident("alias")?)
+        } else {
+            None
+        };
+        Ok(ReturnItem { expr, alias })
+    }
+
+    // ── expressions ────────────────────────────────────────────────────
+
+    fn parse_expr(&mut self) -> CypherParseResult<CypherExpr> {
+        self.parse_or()
+    }
+
+    fn parse_or(&mut self) -> CypherParseResult<CypherExpr> {
+        let mut left = self.parse_and()?;
+        while *self.peek() == Token::Or {
+            self.advance();
+            let right = self.parse_and()?;
+            left = CypherExpr::Or(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_and(&mut self) -> CypherParseResult<CypherExpr> {
+        let mut left = self.parse_not()?;
+        while *self.peek() == Token::And {
+            self.advance();
+            let right = self.parse_not()?;
+            left = CypherExpr::And(Box::new(left), Box::new(right));
+        }
+        Ok(left)
+    }
+
+    fn parse_not(&mut self) -> CypherParseResult<CypherExpr> {
+        if *self.peek() == Token::Not {
+            self.advance();
+            let inner = self.parse_not()?;
+            return Ok(CypherExpr::Not(Box::new(inner)));
+        }
+        self.parse_comparison()
+    }
+
+    fn parse_comparison(&mut self) -> CypherParseResult<CypherExpr> {
+        let left = self.parse_primary()?;
+        let op = match self.peek() {
+            Token::Eq => Some(CmpOp::Eq),
+            Token::Ne => Some(CmpOp::Ne),
+            Token::Lt => Some(CmpOp::Lt),
+            Token::Gt => Some(CmpOp::Gt),
+            Token::Lte => Some(CmpOp::Lte),
+            Token::Gte => Some(CmpOp::Gte),
+            _ => None,
+        };
+        if let Some(op) = op {
+            self.advance();
+            let right = self.parse_primary()?;
+            Ok(CypherExpr::Cmp(Box::new(left), op, Box::new(right)))
+        } else {
+            Ok(left)
+        }
+    }
+
+    fn parse_primary(&mut self) -> CypherParseResult<CypherExpr> {
+        match self.peek() {
+            Token::Integer(_)
+            | Token::Float(_)
+            | Token::StringLit(_)
+            | Token::True
+            | Token::False
+            | Token::Null
+            | Token::Dash => Ok(CypherExpr::Lit(self.parse_literal_value()?)),
+            Token::Ident(_) => {
+                let Token::Ident(name) = self.advance().clone() else {
+                    unreachable!()
+                };
+                if *self.peek() == Token::Dot {
+                    self.advance();
+                    let prop = self.expect_ident("property name")?;
+                    Ok(CypherExpr::Prop(Box::new(CypherExpr::Var(name)), prop))
+                } else {
+                    Ok(CypherExpr::Var(name))
+                }
+            }
+            Token::LParen => {
+                self.advance();
+                let inner = self.parse_expr()?;
+                self.eat(&Token::RParen, "')'")?;
+                Ok(inner)
+            }
+            _ => Err(CypherParseError::UnexpectedToken {
+                found: self.peek().clone(),
+                pos: self.pos(),
+                expected: "expression",
+            }),
+        }
+    }
+
+    // ── helpers ─────────────────────────────────────────────────────────
+
+    fn expect_ident(&mut self, expected: &'static str) -> CypherParseResult<String> {
+        let pos = self.pos();
+        match self.advance().clone() {
+            Token::Ident(name) => Ok(name),
+            other => Err(CypherParseError::UnexpectedToken {
+                found: other,
+                pos,
+                expected,
+            }),
+        }
+    }
+
+    fn parse_map_literal(&mut self) -> CypherParseResult<Vec<(String, CypherLiteral)>> {
+        self.eat(&Token::LBrace, "'{'")?;
+        let mut props = Vec::new();
+        if *self.peek() != Token::RBrace {
+            loop {
+                let key = self.expect_ident("property key")?;
+                self.eat(&Token::Colon, "':'")?;
+                let val = self.parse_literal_value()?;
+                props.push((key, val));
+                if *self.peek() != Token::Comma {
+                    break;
+                }
+                self.advance();
+            }
+        }
+        self.eat(&Token::RBrace, "'}'")?;
+        Ok(props)
+    }
+
+    fn parse_literal_value(&mut self) -> CypherParseResult<CypherLiteral> {
+        match self.peek().clone() {
+            Token::Integer(n) => {
+                self.advance();
+                Ok(CypherLiteral::Integer(n))
+            }
+            Token::Float(f) => {
+                self.advance();
+                Ok(CypherLiteral::Float(f))
+            }
+            Token::StringLit(s) => {
+                self.advance();
+                Ok(CypherLiteral::String(s))
+            }
+            Token::True => {
+                self.advance();
+                Ok(CypherLiteral::Bool(true))
+            }
+            Token::False => {
+                self.advance();
+                Ok(CypherLiteral::Bool(false))
+            }
+            Token::Null => {
+                self.advance();
+                Ok(CypherLiteral::Null)
+            }
+            Token::Dash => {
+                self.advance();
+                match self.peek().clone() {
+                    Token::Integer(n) => {
+                        self.advance();
+                        Ok(CypherLiteral::Integer(-n))
+                    }
+                    Token::Float(f) => {
+                        self.advance();
+                        Ok(CypherLiteral::Float(-f))
+                    }
+                    _ => Err(CypherParseError::UnexpectedToken {
+                        found: self.peek().clone(),
+                        pos: self.pos(),
+                        expected: "number after '-'",
+                    }),
+                }
+            }
+            other => Err(CypherParseError::UnexpectedToken {
+                found: other,
+                pos: self.pos(),
+                expected: "literal value",
+            }),
+        }
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    // ── valid queries ──────────────────────────────────────────────────
+
+    #[test]
+    fn minimal_match_return() {
+        let q = parse_cypher("MATCH (n) RETURN n").unwrap();
+        assert_eq!(q.match_clause.patterns.len(), 1);
+        assert_eq!(q.match_clause.patterns[0].nodes.len(), 1);
+        assert_eq!(
+            q.match_clause.patterns[0].nodes[0].variable.as_deref(),
+            Some("n")
+        );
+        assert!(q.where_clause.is_none());
+        assert!(matches!(q.return_clause, ReturnClause::Items(ref items) if items.len() == 1));
+    }
+
+    #[test]
+    fn match_return_star() {
+        let q = parse_cypher("MATCH (n) RETURN *").unwrap();
+        assert!(matches!(q.return_clause, ReturnClause::All));
+    }
+
+    #[test]
+    fn match_with_label() {
+        let q = parse_cypher("MATCH (p:Person) RETURN p").unwrap();
+        let node = &q.match_clause.patterns[0].nodes[0];
+        assert_eq!(node.variable.as_deref(), Some("p"));
+        assert_eq!(node.label.as_deref(), Some("Person"));
+    }
+
+    #[test]
+    fn match_with_properties() {
+        let q = parse_cypher("MATCH (p:Person {name: 'Alice', age: 30}) RETURN p").unwrap();
+        let node = &q.match_clause.patterns[0].nodes[0];
+        assert_eq!(node.properties.len(), 2);
+        assert_eq!(node.properties[0].0, "name");
+        assert_eq!(
+            node.properties[0].1,
+            CypherLiteral::String("Alice".to_string())
+        );
+        assert_eq!(node.properties[1].0, "age");
+        assert_eq!(node.properties[1].1, CypherLiteral::Integer(30));
+    }
+
+    #[test]
+    fn outgoing_relationship() {
+        let q = parse_cypher("MATCH (a)-[r:KNOWS]->(b) RETURN a, b").unwrap();
+        let pat = &q.match_clause.patterns[0];
+        assert_eq!(pat.nodes.len(), 2);
+        assert_eq!(pat.edges.len(), 1);
+        assert_eq!(pat.edges[0].direction, Direction::Outgoing);
+        assert_eq!(pat.edges[0].rel_type.as_deref(), Some("KNOWS"));
+        assert_eq!(pat.edges[0].variable.as_deref(), Some("r"));
+    }
+
+    #[test]
+    fn incoming_relationship() {
+        let q = parse_cypher("MATCH (a)<-[r:KNOWS]-(b) RETURN a").unwrap();
+        assert_eq!(q.match_clause.patterns[0].edges[0].direction, Direction::Incoming);
+    }
+
+    #[test]
+    fn undirected_relationship() {
+        let q = parse_cypher("MATCH (a)-[r:KNOWS]-(b) RETURN a").unwrap();
+        assert_eq!(
+            q.match_clause.patterns[0].edges[0].direction,
+            Direction::Undirected
+        );
+    }
+
+    #[test]
+    fn bare_relationship_no_brackets() {
+        let q = parse_cypher("MATCH (a)--(b) RETURN a").unwrap();
+        let pat = &q.match_clause.patterns[0];
+        assert_eq!(pat.edges.len(), 1);
+        assert_eq!(pat.edges[0].direction, Direction::Undirected);
+        assert!(pat.edges[0].variable.is_none());
+        assert!(pat.edges[0].rel_type.is_none());
+    }
+
+    #[test]
+    fn bare_outgoing_no_brackets() {
+        let q = parse_cypher("MATCH (a)-->(b) RETURN a").unwrap();
+        let pat = &q.match_clause.patterns[0];
+        assert_eq!(pat.edges[0].direction, Direction::Outgoing);
+    }
+
+    #[test]
+    fn bare_incoming_no_brackets() {
+        let q = parse_cypher("MATCH (a)<--(b) RETURN a").unwrap();
+        let pat = &q.match_clause.patterns[0];
+        assert_eq!(pat.edges[0].direction, Direction::Incoming);
+    }
+
+    #[test]
+    fn chain_of_three_nodes() {
+        let q = parse_cypher("MATCH (a)-[r1:KNOWS]->(b)-[r2:LIVES_IN]->(c) RETURN a, c").unwrap();
+        let pat = &q.match_clause.patterns[0];
+        assert_eq!(pat.nodes.len(), 3);
+        assert_eq!(pat.edges.len(), 2);
+    }
+
+    #[test]
+    fn multiple_patterns() {
+        let q = parse_cypher("MATCH (a)-[:KNOWS]->(b), (c)-[:WORKS_AT]->(d) RETURN a, d").unwrap();
+        assert_eq!(q.match_clause.patterns.len(), 2);
+    }
+
+    #[test]
+    fn multiple_match_clauses() {
+        let q = parse_cypher("MATCH (a:Person) MATCH (b:Company) RETURN a, b").unwrap();
+        assert_eq!(q.match_clause.patterns.len(), 2);
+        assert_eq!(q.match_clause.patterns[0].nodes[0].label.as_deref(), Some("Person"));
+        assert_eq!(q.match_clause.patterns[1].nodes[0].label.as_deref(), Some("Company"));
+    }
+
+    #[test]
+    fn multiple_match_clauses_with_edges() {
+        let q = parse_cypher("MATCH (a)-[:KNOWS]->(b) MATCH (b)-[:WORKS_AT]->(c) RETURN a, c").unwrap();
+        assert_eq!(q.match_clause.patterns.len(), 2);
+        assert_eq!(q.match_clause.patterns[0].edges[0].rel_type.as_deref(), Some("KNOWS"));
+        assert_eq!(q.match_clause.patterns[1].edges[0].rel_type.as_deref(), Some("WORKS_AT"));
+    }
+
+    #[test]
+    fn three_match_clauses() {
+        let q = parse_cypher("MATCH (a) MATCH (b) MATCH (c) RETURN a, b, c").unwrap();
+        assert_eq!(q.match_clause.patterns.len(), 3);
+    }
+
+    // ── variable-length paths ──────────────────────────────────────────
+
+    #[test]
+    fn path_length_unbounded() {
+        let q = parse_cypher("MATCH (a)-[*]->(b) RETURN a").unwrap();
+        assert_eq!(
+            q.match_clause.patterns[0].edges[0].length,
+            Some(PathLength::Unbounded)
+        );
+    }
+
+    #[test]
+    fn path_length_exact() {
+        let q = parse_cypher("MATCH (a)-[*3]->(b) RETURN a").unwrap();
+        assert_eq!(
+            q.match_clause.patterns[0].edges[0].length,
+            Some(PathLength::Exact(3))
+        );
+    }
+
+    #[test]
+    fn path_length_range() {
+        let q = parse_cypher("MATCH (a)-[*1..5]->(b) RETURN a").unwrap();
+        assert_eq!(
+            q.match_clause.patterns[0].edges[0].length,
+            Some(PathLength::Range {
+                min: Some(1),
+                max: Some(5)
+            })
+        );
+    }
+
+    #[test]
+    fn path_length_open_ended_max() {
+        let q = parse_cypher("MATCH (a)-[*2..]->(b) RETURN a").unwrap();
+        assert_eq!(
+            q.match_clause.patterns[0].edges[0].length,
+            Some(PathLength::Range {
+                min: Some(2),
+                max: None
+            })
+        );
+    }
+
+    #[test]
+    fn path_length_open_ended_min() {
+        let q = parse_cypher("MATCH (a)-[*..5]->(b) RETURN a").unwrap();
+        assert_eq!(
+            q.match_clause.patterns[0].edges[0].length,
+            Some(PathLength::Range {
+                min: None,
+                max: Some(5)
+            })
+        );
+    }
+
+    #[test]
+    fn path_length_with_type() {
+        let q = parse_cypher("MATCH (a)-[r:KNOWS *1..3]->(b) RETURN a").unwrap();
+        let edge = &q.match_clause.patterns[0].edges[0];
+        assert_eq!(edge.rel_type.as_deref(), Some("KNOWS"));
+        assert_eq!(edge.variable.as_deref(), Some("r"));
+        assert_eq!(
+            edge.length,
+            Some(PathLength::Range {
+                min: Some(1),
+                max: Some(3)
+            })
+        );
+    }
+
+    // ── WHERE clause ───────────────────────────────────────────────────
+
+    #[test]
+    fn where_simple_comparison() {
+        let q = parse_cypher("MATCH (n:Person) WHERE n.age > 25 RETURN n").unwrap();
+        assert!(q.where_clause.is_some());
+        let expr = q.where_clause.unwrap();
+        assert!(matches!(expr, CypherExpr::Cmp(_, CmpOp::Gt, _)));
+    }
+
+    #[test]
+    fn where_and() {
+        let q = parse_cypher("MATCH (n) WHERE n.a = 1 AND n.b = 2 RETURN n").unwrap();
+        assert!(matches!(q.where_clause, Some(CypherExpr::And(_, _))));
+    }
+
+    #[test]
+    fn where_or() {
+        let q = parse_cypher("MATCH (n) WHERE n.a = 1 OR n.b = 2 RETURN n").unwrap();
+        assert!(matches!(q.where_clause, Some(CypherExpr::Or(_, _))));
+    }
+
+    #[test]
+    fn where_not() {
+        let q = parse_cypher("MATCH (n) WHERE NOT n.active = false RETURN n").unwrap();
+        assert!(matches!(q.where_clause, Some(CypherExpr::Not(_))));
+    }
+
+    #[test]
+    fn where_parenthesized() {
+        let q =
+            parse_cypher("MATCH (n) WHERE (n.a = 1 OR n.b = 2) AND n.c = 3 RETURN n").unwrap();
+        assert!(matches!(q.where_clause, Some(CypherExpr::And(_, _))));
+    }
+
+    #[test]
+    fn where_string_comparison() {
+        let q = parse_cypher("MATCH (n) WHERE n.name = 'Alice' RETURN n").unwrap();
+        assert!(q.where_clause.is_some());
+    }
+
+    #[test]
+    fn where_null_comparison() {
+        let q = parse_cypher("MATCH (n) WHERE n.val = null RETURN n").unwrap();
+        assert!(q.where_clause.is_some());
+    }
+
+    #[test]
+    fn where_negative_number() {
+        let q = parse_cypher("MATCH (n) WHERE n.val = -42 RETURN n").unwrap();
+        if let Some(CypherExpr::Cmp(_, _, ref right)) = q.where_clause {
+            assert_eq!(**right, CypherExpr::Lit(CypherLiteral::Integer(-42)));
+        } else {
+            panic!("expected Cmp");
+        }
+    }
+
+    // ── RETURN clause ──────────────────────────────────────────────────
+
+    #[test]
+    fn return_with_alias() {
+        let q = parse_cypher("MATCH (n) RETURN n.name AS name").unwrap();
+        if let ReturnClause::Items(items) = &q.return_clause {
+            assert_eq!(items[0].alias.as_deref(), Some("name"));
+        } else {
+            panic!("expected Items");
+        }
+    }
+
+    #[test]
+    fn return_multiple_items() {
+        let q = parse_cypher("MATCH (n) RETURN n.name, n.age").unwrap();
+        if let ReturnClause::Items(items) = &q.return_clause {
+            assert_eq!(items.len(), 2);
+        } else {
+            panic!("expected Items");
+        }
+    }
+
+    // ── anonymous/empty nodes ──────────────────────────────────────────
+
+    #[test]
+    fn anonymous_node() {
+        let q = parse_cypher("MATCH (:Person)-[:KNOWS]->(n) RETURN n").unwrap();
+        let pat = &q.match_clause.patterns[0];
+        assert!(pat.nodes[0].variable.is_none());
+        assert_eq!(pat.nodes[0].label.as_deref(), Some("Person"));
+    }
+
+    #[test]
+    fn empty_node() {
+        let q = parse_cypher("MATCH ()-[:KNOWS]->(n) RETURN n").unwrap();
+        let pat = &q.match_clause.patterns[0];
+        assert!(pat.nodes[0].variable.is_none());
+        assert!(pat.nodes[0].label.is_none());
+    }
+
+    #[test]
+    fn anonymous_relationship() {
+        let q = parse_cypher("MATCH (a)-[:KNOWS]->(b) RETURN a").unwrap();
+        let edge = &q.match_clause.patterns[0].edges[0];
+        assert!(edge.variable.is_none());
+        assert_eq!(edge.rel_type.as_deref(), Some("KNOWS"));
+    }
+
+    // ── case insensitive keywords ──────────────────────────────────────
+
+    #[test]
+    fn case_insensitive_keywords() {
+        let q = parse_cypher("match (n) where n.x = 1 return n").unwrap();
+        assert!(q.where_clause.is_some());
+    }
+
+    // ── error cases ────────────────────────────────────────────────────
+
+    #[test]
+    fn error_empty() {
+        assert!(parse_cypher("").is_err());
+    }
+
+    #[test]
+    fn error_whitespace_only() {
+        assert!(parse_cypher("   ").is_err());
+    }
+
+    #[test]
+    fn error_missing_return() {
+        assert!(parse_cypher("MATCH (n)").is_err());
+    }
+
+    #[test]
+    fn error_missing_match() {
+        assert!(parse_cypher("RETURN n").is_err());
+    }
+
+    #[test]
+    fn error_unclosed_node() {
+        assert!(parse_cypher("MATCH (n RETURN n").is_err());
+    }
+
+    #[test]
+    fn error_unclosed_rel() {
+        assert!(parse_cypher("MATCH (a)-[r:KNOWS->(b) RETURN a").is_err());
+    }
+
+    #[test]
+    fn error_unclosed_string() {
+        assert!(parse_cypher("MATCH (n {name: 'Alice}) RETURN n").is_err());
+    }
+
+    #[test]
+    fn error_trailing_tokens() {
+        assert!(parse_cypher("MATCH (n) RETURN n EXTRA").is_err());
+    }
+
+    #[test]
+    fn error_double_label() {
+        assert!(parse_cypher("MATCH (n:Person:Employee) RETURN n").is_err());
+    }
+
+    #[test]
+    fn error_negative_path_length() {
+        let err = parse_cypher("MATCH (a)-[*-1]->(b) RETURN a");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn error_path_length_overflow() {
+        let big = format!("MATCH (a)-[*{}]->(b) RETURN a", i64::MAX);
+        let err = parse_cypher(&big);
+        assert!(err.is_err(), "path length exceeding u32::MAX must fail");
+    }
+
+    #[test]
+    fn error_path_length_max_overflow() {
+        let big = format!("MATCH (a)-[*1..{}]->(b) RETURN a", i64::MAX);
+        let err = parse_cypher(&big);
+        assert!(err.is_err(), "path length max exceeding u32::MAX must fail");
+    }
+
+    #[test]
+    fn prop_access_uses_boxed_var() {
+        let q = parse_cypher("MATCH (n) WHERE n.age > 25 RETURN n").unwrap();
+        if let Some(CypherExpr::Cmp(ref left, CmpOp::Gt, _)) = q.where_clause {
+            match left.as_ref() {
+                CypherExpr::Prop(obj, prop) => {
+                    assert_eq!(**obj, CypherExpr::Var("n".to_string()));
+                    assert_eq!(prop, "age");
+                }
+                other => panic!("expected Prop, got {other:?}"),
+            }
+        } else {
+            panic!("expected Cmp with Gt");
+        }
+    }
+
+    #[test]
+    fn display_on_token_in_error_message() {
+        let err = parse_cypher("MATCH (n) RETURN n EXTRA").unwrap_err();
+        let msg = err.to_string();
+        assert!(
+            msg.contains("`EXTRA`"),
+            "error should use Display format, got: {msg}"
+        );
+    }
+}

--- a/crates/expr/Cargo.toml
+++ b/crates/expr/Cargo.toml
@@ -18,11 +18,11 @@ spacetimedb-primitives.workspace = true
 spacetimedb-sats.workspace = true
 spacetimedb-schema.workspace = true
 spacetimedb-sql-parser.workspace = true
+spacetimedb-cypher-parser.workspace = true
 bytes.workspace = true
 
 [dev-dependencies]
 pretty_assertions.workspace = true
-spacetimedb = { path = "../bindings", features = ["unstable"] }
 spacetimedb-lib = { path = "../lib" }
 
 [lints]

--- a/crates/expr/src/check.rs
+++ b/crates/expr/src/check.rs
@@ -34,7 +34,7 @@ pub trait SchemaView {
     }
 }
 
-#[derive(Default)]
+#[derive(Default, Clone)]
 pub struct Relvars(HashMap<RawIdentifier, Arc<TableOrViewSchema>>);
 
 impl Deref for Relvars {
@@ -195,35 +195,69 @@ pub mod test_utils {
         builder.finish().try_into().expect("failed to generate module def")
     }
 
-    pub struct SchemaViewer(pub ModuleDef);
+    /// Test helper that maps table names to `TableId`s and resolves schemas
+    /// from a `ModuleDef`. The `tables` vec supplies `(name, TableId)` pairs.
+    pub struct SchemaViewer {
+        pub module_def: ModuleDef,
+        pub tables: Vec<(&'static str, TableId)>,
+    }
+
+    impl SchemaViewer {
+        pub fn new(module_def: ModuleDef, tables: Vec<(&'static str, TableId)>) -> Self {
+            Self { module_def, tables }
+        }
+    }
 
     impl SchemaView for SchemaViewer {
         fn table_id(&self, name: &str) -> Option<TableId> {
-            match name {
-                "t" => Some(TableId(0)),
-                "s" => Some(TableId(1)),
-                _ => None,
-            }
+            self.tables.iter().find(|(n, _)| *n == name).map(|(_, id)| *id)
         }
 
         fn schema_for_table(&self, table_id: TableId) -> Option<Arc<TableOrViewSchema>> {
-            match table_id.idx() {
-                0 => Some((TableId(0), "t")),
-                1 => Some((TableId(1), "s")),
-                _ => None,
-            }
-            .and_then(|(table_id, name)| {
-                self.0
-                    .table(name)
-                    .map(|def| Arc::new(TableSchema::from_module_def(&self.0, def, (), table_id)))
-                    .map(TableOrViewSchema::from)
-                    .map(Arc::new)
-            })
+            self.tables
+                .iter()
+                .find(|(_, id)| *id == table_id)
+                .and_then(|&(name, tid)| {
+                    self.module_def
+                        .table(name)
+                        .map(|def| Arc::new(TableSchema::from_module_def(&self.module_def, def, (), tid)))
+                        .map(TableOrViewSchema::from)
+                        .map(Arc::new)
+                })
         }
 
         fn rls_rules_for_table(&self, _: TableId) -> anyhow::Result<Vec<Box<str>>> {
             Ok(vec![])
         }
+    }
+
+    /// Standard Vertex + Edge graph schema for graph-extension tests.
+    pub fn graph_schema_viewer() -> SchemaViewer {
+        use spacetimedb_lib::{AlgebraicType, ProductType};
+
+        SchemaViewer::new(
+            build_module_def(vec![
+                (
+                    "Vertex",
+                    ProductType::from([
+                        ("Id", AlgebraicType::U64),
+                        ("Label", AlgebraicType::String),
+                        ("Properties", AlgebraicType::String),
+                    ]),
+                ),
+                (
+                    "Edge",
+                    ProductType::from([
+                        ("Id", AlgebraicType::U64),
+                        ("StartId", AlgebraicType::U64),
+                        ("EndId", AlgebraicType::U64),
+                        ("EdgeType", AlgebraicType::String),
+                        ("Properties", AlgebraicType::String),
+                    ]),
+                ),
+            ]),
+            vec![("Vertex", TableId(0)), ("Edge", TableId(1))],
+        )
     }
 }
 
@@ -234,6 +268,7 @@ mod tests {
         expr::ProjectName,
     };
     use spacetimedb_lib::{identity::AuthCtx, AlgebraicType, ProductType};
+    use spacetimedb_primitives::TableId;
     use spacetimedb_schema::def::ModuleDef;
 
     use super::{SchemaView, TypingResult};
@@ -282,7 +317,7 @@ mod tests {
 
     #[test]
     fn valid_literals() {
-        let tx = SchemaViewer(module_def());
+        let tx = SchemaViewer::new(module_def(), vec![("t", TableId(0)), ("s", TableId(1))]);
 
         struct TestCase {
             sql: &'static str,
@@ -358,7 +393,7 @@ mod tests {
 
     #[test]
     fn valid_literals_for_type() {
-        let tx = SchemaViewer(module_def());
+        let tx = SchemaViewer::new(module_def(), vec![("t", TableId(0)), ("s", TableId(1))]);
 
         for ty in [
             "i8", "u8", "i16", "u16", "i32", "u32", "i64", "u64", "f32", "f64", "i128", "u128", "i256", "u256",
@@ -371,7 +406,7 @@ mod tests {
 
     #[test]
     fn invalid_literals() {
-        let tx = SchemaViewer(module_def());
+        let tx = SchemaViewer::new(module_def(), vec![("t", TableId(0)), ("s", TableId(1))]);
 
         struct TestCase {
             sql: &'static str,
@@ -407,7 +442,7 @@ mod tests {
 
     #[test]
     fn valid() {
-        let tx = SchemaViewer(module_def());
+        let tx = SchemaViewer::new(module_def(), vec![("t", TableId(0)), ("s", TableId(1))]);
 
         struct TestCase {
             sql: &'static str,
@@ -471,7 +506,7 @@ mod tests {
 
     #[test]
     fn invalid() {
-        let tx = SchemaViewer(module_def());
+        let tx = SchemaViewer::new(module_def(), vec![("t", TableId(0)), ("s", TableId(1))]);
 
         struct TestCase {
             sql: &'static str,

--- a/crates/expr/src/cypher.rs
+++ b/crates/expr/src/cypher.rs
@@ -1,0 +1,2071 @@
+use crate::check::{Relvars, SchemaView};
+use crate::expr::{
+    Expr, FieldProject, LeftDeepJoin, ProjectList, ProjectName, RelExpr, Relvar,
+    VariableLengthPath, MAX_VARIABLE_LENGTH_HOPS,
+};
+use spacetimedb_cypher_parser::ast::{
+    CmpOp, CypherExpr, CypherLiteral, CypherQuery, Direction, PathLength, Pattern, ReturnClause,
+};
+use spacetimedb_lib::{AlgebraicType, AlgebraicValue};
+use spacetimedb_sats::raw_identifier::RawIdentifier;
+use spacetimedb_schema::schema::TableOrViewSchema;
+use spacetimedb_sql_parser::ast::{BinOp, LogOp};
+use std::sync::Arc;
+use thiserror::Error;
+
+const VERTEX_TABLE: &str = "Vertex";
+const EDGE_TABLE: &str = "Edge";
+
+const VERTEX_ID_COL: &str = "Id";
+const VERTEX_LABEL_COL: &str = "Label";
+
+const EDGE_START_ID_COL: &str = "StartId";
+const EDGE_END_ID_COL: &str = "EndId";
+const EDGE_TYPE_COL: &str = "EdgeType";
+
+#[derive(Debug, Error)]
+pub enum CypherTranslateError {
+    #[error("Unbounded variable-length paths are not supported (use [*min..max])")]
+    UnboundedVariableLengthPath,
+    #[error("Variable-length path max depth {0} exceeds limit {MAX_VARIABLE_LENGTH_HOPS}")]
+    VariableLengthPathTooDeep(u32),
+    #[error("Variable-length path min ({0}) must be >= 1 and <= max ({1})")]
+    InvalidPathBounds(u32, u32),
+    #[error("NULL literals are not yet supported")]
+    NullLiteral,
+    #[error("Empty MATCH clause")]
+    EmptyPattern,
+    #[error("Table `{0}` not found in schema")]
+    TableNotFound(String),
+    #[error("Column `{0}` not found in table `{1}`")]
+    ColumnNotFound(String, String),
+    #[error("Variable `{0}` is not in scope")]
+    UnresolvedVariable(String),
+    #[error("Nested property access is not supported")]
+    NestedPropertyAccess,
+    #[error("Unsupported RETURN expression")]
+    UnsupportedReturn,
+    #[error("Unsupported relationship direction")]
+    UnsupportedDirection,
+    #[error("Unsupported comparison operator")]
+    UnsupportedCmpOp,
+    #[error("Unsupported literal type")]
+    UnsupportedLiteral,
+    #[error("Unsupported expression type")]
+    UnsupportedExpr,
+}
+
+type Result<T> = std::result::Result<T, CypherTranslateError>;
+
+/// Translate a parsed Cypher query into a `RelExpr`-based logical plan.
+///
+/// The schema must contain `Vertex` and `Edge` tables matching the
+/// userland graph model (Id, Label, Properties / Id, StartId, EndId,
+/// EdgeType, Properties).
+///
+/// If the pattern contains undirected edges, the result is expanded into
+/// multiple directed variants (outgoing + incoming) at the pattern level,
+/// producing a UNION of plans.
+///
+/// If the pattern contains a variable-length path, each fixed-depth
+/// expansion similarly produces a UNION of plans.
+pub fn translate_cypher(query: &CypherQuery, tx: &impl SchemaView) -> Result<ProjectList> {
+    // 1. Expand undirected edges in patterns into directed variants.
+    let pattern_variants = expand_undirected_patterns(&query.match_clause.patterns);
+
+    // 2. Translate each variant independently (same vars scope, fresh counter).
+    let mut all_plans: Vec<(RelExpr, Relvars)> = Vec::new();
+    let mut var_counter: usize = 0;
+
+    for patterns in &pattern_variants {
+        let mut vars = Relvars::default();
+        let base = translate_match(patterns, tx, &mut vars, &mut var_counter)?;
+
+        let filtered = match query.where_clause {
+            Some(ref expr) => {
+                let filter = translate_expr(expr, &vars)?;
+                RelExpr::Select(Box::new(base), filter)
+            }
+            None => base,
+        };
+
+        // Expand any VariableLengthJoins within this variant.
+        let expanded = expand_vlj(filtered);
+        for e in expanded {
+            all_plans.push((e, vars.clone()));
+        }
+    }
+
+    // 3. Merge all plans with a single RETURN translation.
+    if all_plans.len() == 1 {
+        let (expr, vars) = all_plans.into_iter().next().unwrap();
+        translate_return(&query.return_clause, expr, &vars)
+    } else {
+        translate_return_union_multi(&query.return_clause, all_plans)
+    }
+}
+
+/// Recursively expand any `VariableLengthJoin` nodes in the expression tree
+/// into multiple fixed-depth plans. Filters, joins, and other wrappers are
+/// distributed over each expansion (UNION semantics).
+fn expand_vlj(expr: RelExpr) -> Vec<RelExpr> {
+    match expr {
+        RelExpr::VariableLengthJoin(ref vlp) => vlp.expand(),
+        RelExpr::Select(inner, filter) => {
+            let expanded = expand_vlj(*inner);
+            expanded
+                .into_iter()
+                .map(|e| RelExpr::Select(Box::new(e), filter.clone()))
+                .collect()
+        }
+        RelExpr::EqJoin(LeftDeepJoin { lhs, rhs }, lf, rf) => {
+            let expanded = expand_vlj(*lhs);
+            expanded
+                .into_iter()
+                .map(|e| {
+                    RelExpr::EqJoin(
+                        LeftDeepJoin {
+                            lhs: Box::new(e),
+                            rhs: rhs.clone(),
+                        },
+                        lf.clone(),
+                        rf.clone(),
+                    )
+                })
+                .collect()
+        }
+        RelExpr::LeftDeepJoin(LeftDeepJoin { lhs, rhs }) => {
+            let expanded = expand_vlj(*lhs);
+            expanded
+                .into_iter()
+                .map(|e| {
+                    RelExpr::LeftDeepJoin(LeftDeepJoin {
+                        lhs: Box::new(e),
+                        rhs: rhs.clone(),
+                    })
+                })
+                .collect()
+        }
+        other => vec![other],
+    }
+}
+
+/// Expand any undirected edges in the given patterns into the cartesian product
+/// of directed variants (Outgoing and Incoming).
+///
+/// Each pattern is cloned; edges with `Direction::Undirected` are replaced with
+/// `Outgoing` in half the variants and `Incoming` in the other half.
+fn expand_undirected_patterns(patterns: &[Pattern]) -> Vec<Vec<Pattern>> {
+    let mut variants: Vec<Vec<Pattern>> = vec![vec![]];
+
+    for pattern in patterns {
+        // Collect indices of undirected edges in this pattern
+        let undirected_indices: Vec<usize> = pattern
+            .edges
+            .iter()
+            .enumerate()
+            .filter(|(_, e)| e.direction == Direction::Undirected)
+            .map(|(i, _)| i)
+            .collect();
+
+        if undirected_indices.is_empty() {
+            // No undirected edges: append pattern to all existing variants
+            for variant in &mut variants {
+                variant.push(pattern.clone());
+            }
+        } else {
+            // Cartesian product: each undirected edge doubles the variant count
+            let n = 1usize << undirected_indices.len();
+            let mut new_variants: Vec<Vec<Pattern>> = Vec::with_capacity(variants.len() * n);
+
+            for variant in &variants {
+                for mask in 0..n {
+                    let mut new_pattern = pattern.clone();
+                    for (bit_idx, &edge_idx) in undirected_indices.iter().enumerate() {
+                        let is_outgoing = (mask >> bit_idx) & 1 == 0;
+                        new_pattern.edges[edge_idx].direction = if is_outgoing {
+                            Direction::Outgoing
+                        } else {
+                            Direction::Incoming
+                        };
+                    }
+                    let mut new_variant = variant.clone();
+                    new_variant.push(new_pattern);
+                    new_variants.push(new_variant);
+                }
+            }
+            variants = new_variants;
+        }
+    }
+
+    variants
+}
+
+fn anon_var(counter: &mut usize) -> RawIdentifier {
+    let name = format!("_anon_{counter}");
+    *counter += 1;
+    RawIdentifier::new(name)
+}
+
+fn lookup_schema(tx: &impl SchemaView, name: &str) -> Result<Arc<TableOrViewSchema>> {
+    tx.schema(name)
+        .ok_or_else(|| CypherTranslateError::TableNotFound(name.to_owned()))
+}
+
+fn resolve_field(
+    alias: &RawIdentifier,
+    schema: &TableOrViewSchema,
+    col_name: &str,
+) -> Result<FieldProject> {
+    let col = schema
+        .get_column_by_name_or_alias(col_name)
+        .ok_or_else(|| CypherTranslateError::ColumnNotFound(col_name.to_owned(), alias.to_string()))?;
+    Ok(FieldProject {
+        table: alias.clone(),
+        field: col.col_pos.idx(),
+        ty: col.col_type.clone(),
+    })
+}
+
+fn string_eq_filter(
+    alias: &RawIdentifier,
+    schema: &TableOrViewSchema,
+    col_name: &str,
+    value: &str,
+) -> Result<Expr> {
+    let field = resolve_field(alias, schema, col_name)?;
+    Ok(Expr::BinOp(
+        BinOp::Eq,
+        Box::new(Expr::Field(field)),
+        Box::new(Expr::str(value.to_owned().into_boxed_str())),
+    ))
+}
+
+/// Resolve a `PathLength` AST node into concrete (min, max) hop bounds.
+fn resolve_path_bounds(length: &PathLength) -> Result<(u32, u32)> {
+    let (min, max) = match length {
+        PathLength::Unbounded => return Err(CypherTranslateError::UnboundedVariableLengthPath),
+        PathLength::Exact(n) => (*n, *n),
+        PathLength::Range { min, max } => {
+            let lo = min.unwrap_or(1);
+            let hi = max.ok_or(CypherTranslateError::UnboundedVariableLengthPath)?;
+            (lo, hi)
+        }
+        // PathLength is #[non_exhaustive]; treat unknown future variants as unbounded
+        _ => return Err(CypherTranslateError::UnboundedVariableLengthPath),
+    };
+
+    if min < 1 || min > max {
+        return Err(CypherTranslateError::InvalidPathBounds(min, max));
+    }
+    if max > MAX_VARIABLE_LENGTH_HOPS {
+        return Err(CypherTranslateError::VariableLengthPathTooDeep(max));
+    }
+
+    Ok((min, max))
+}
+
+// ── MATCH translation ─────────────────────────────────────────────
+
+fn translate_match(
+    patterns: &[Pattern],
+    tx: &impl SchemaView,
+    vars: &mut Relvars,
+    counter: &mut usize,
+) -> Result<RelExpr> {
+    if patterns.is_empty() {
+        return Err(CypherTranslateError::EmptyPattern);
+    }
+
+    let mut current: Option<RelExpr> = None;
+    let mut all_filters: Vec<Expr> = Vec::new();
+
+    for pattern in patterns {
+        let (new_current, filters) = translate_pattern_into(pattern, current, tx, vars, counter)?;
+        current = Some(new_current);
+        all_filters.extend(filters);
+    }
+
+    let mut result = current.unwrap();
+
+    if !all_filters.is_empty() {
+        let combined = all_filters
+            .into_iter()
+            .reduce(|a, b| Expr::LogOp(LogOp::And, Box::new(a), Box::new(b)))
+            .unwrap();
+        result = RelExpr::Select(Box::new(result), combined);
+    }
+
+    Ok(result)
+}
+
+/// Translate a single graph pattern, optionally building on top of an existing
+/// plan. Returns the combined `RelExpr` and a list of unapplied filter
+/// expressions that the caller must wrap in `Select`.
+///
+/// When `current` is `Some(prev)`:
+/// - A new (unbound) first node becomes a cross-join (`LeftDeepJoin`).
+/// - A shared first node (already in `vars`) reuses the existing plan.
+/// - A shared subsequent node is correlated via a filter on `Vertex.Id`.
+fn translate_pattern_into(
+    pattern: &Pattern,
+    current: Option<RelExpr>,
+    tx: &impl SchemaView,
+    vars: &mut Relvars,
+    counter: &mut usize,
+) -> Result<(RelExpr, Vec<Expr>)> {
+    let vertex_schema = lookup_schema(tx, VERTEX_TABLE)?;
+    let edge_schema = lookup_schema(tx, EDGE_TABLE)?;
+
+    let first = &pattern.nodes[0];
+    let first_alias = first
+        .variable
+        .as_deref()
+        .map(RawIdentifier::new)
+        .unwrap_or_else(|| anon_var(counter));
+
+    let mut filters: Vec<Expr> = Vec::new();
+
+    let is_shared = vars.contains_key(&first_alias);
+
+    let mut result = if is_shared {
+        current.ok_or(CypherTranslateError::EmptyPattern)?
+    } else {
+        vars.insert(first_alias.clone(), vertex_schema.clone());
+        let relvar = Relvar {
+            schema: vertex_schema.clone(),
+            alias: first_alias.clone(),
+            delta: None,
+        };
+        match current {
+            None => RelExpr::RelVar(relvar),
+            Some(prev) => RelExpr::LeftDeepJoin(LeftDeepJoin {
+                lhs: Box::new(prev),
+                rhs: relvar,
+            }),
+        }
+    };
+
+    if let Some(ref label) = first.label {
+        filters.push(string_eq_filter(
+            &first_alias,
+            &vertex_schema,
+            VERTEX_LABEL_COL,
+            label,
+        )?);
+    }
+
+    let mut prev_node_alias = first_alias;
+
+    for (i, edge) in pattern.edges.iter().enumerate() {
+        let next_node = &pattern.nodes[i + 1];
+
+        let next_alias = next_node
+            .variable
+            .as_deref()
+            .map(RawIdentifier::new)
+            .unwrap_or_else(|| anon_var(counter));
+
+        let (edge_col_near, edge_col_far) = match edge.direction {
+            Direction::Outgoing | Direction::Undirected => (EDGE_START_ID_COL, EDGE_END_ID_COL),
+            Direction::Incoming => (EDGE_END_ID_COL, EDGE_START_ID_COL),
+            _ => return Err(CypherTranslateError::UnsupportedDirection),
+        };
+
+        if let Some(ref length) = edge.length {
+            let (min_hops, max_hops) = resolve_path_bounds(length)?;
+            if !vars.contains_key(&next_alias) {
+                vars.insert(next_alias.clone(), vertex_schema.clone());
+            }
+
+            result = RelExpr::VariableLengthJoin(VariableLengthPath {
+                lhs: Box::new(result),
+                start_alias: prev_node_alias.clone(),
+                end_alias: next_alias.clone(),
+                edge_schema: edge_schema.clone(),
+                vertex_schema: vertex_schema.clone(),
+                rel_type: edge.rel_type.clone(),
+                edge_col_near: edge_col_near.to_owned(),
+                edge_col_far: edge_col_far.to_owned(),
+                vertex_id_col: VERTEX_ID_COL.to_owned(),
+                min_hops,
+                max_hops,
+            });
+
+            if let Some(ref label) = next_node.label {
+                filters.push(string_eq_filter(
+                    &next_alias,
+                    &vertex_schema,
+                    VERTEX_LABEL_COL,
+                    label,
+                )?);
+            }
+        } else {
+            let edge_alias = edge
+                .variable
+                .as_deref()
+                .map(RawIdentifier::new)
+                .unwrap_or_else(|| anon_var(counter));
+
+            vars.insert(edge_alias.clone(), edge_schema.clone());
+
+            // prev_node.Id = edge.near_col
+            result = RelExpr::EqJoin(
+                LeftDeepJoin {
+                    lhs: Box::new(result),
+                    rhs: Relvar {
+                        schema: edge_schema.clone(),
+                        alias: edge_alias.clone(),
+                        delta: None,
+                    },
+                },
+                resolve_field(&prev_node_alias, &vertex_schema, VERTEX_ID_COL)?,
+                resolve_field(&edge_alias, &edge_schema, edge_col_near)?,
+            );
+
+            let is_next_shared = vars.contains_key(&next_alias);
+
+            if is_next_shared {
+                // Shared variable: correlate via filter on Vertex.Id
+                filters.push(Expr::BinOp(
+                    BinOp::Eq,
+                    Box::new(Expr::Field(resolve_field(
+                        &edge_alias,
+                        &edge_schema,
+                        edge_col_far,
+                    )?)),
+                    Box::new(Expr::Field(resolve_field(
+                        &next_alias,
+                        &vertex_schema,
+                        VERTEX_ID_COL,
+                    )?)),
+                ));
+            } else {
+                vars.insert(next_alias.clone(), vertex_schema.clone());
+
+                // edge.far_col = next_node.Id
+                result = RelExpr::EqJoin(
+                    LeftDeepJoin {
+                        lhs: Box::new(result),
+                        rhs: Relvar {
+                            schema: vertex_schema.clone(),
+                            alias: next_alias.clone(),
+                            delta: None,
+                        },
+                    },
+                    resolve_field(&edge_alias, &edge_schema, edge_col_far)?,
+                    resolve_field(&next_alias, &vertex_schema, VERTEX_ID_COL)?,
+                );
+            }
+
+            if let Some(ref rel_type) = edge.rel_type {
+                filters.push(string_eq_filter(
+                    &edge_alias,
+                    &edge_schema,
+                    EDGE_TYPE_COL,
+                    rel_type,
+                )?);
+            }
+            if let Some(ref label) = next_node.label {
+                filters.push(string_eq_filter(
+                    &next_alias,
+                    &vertex_schema,
+                    VERTEX_LABEL_COL,
+                    label,
+                )?);
+            }
+        }
+
+        prev_node_alias = next_alias;
+    }
+
+    Ok((result, filters))
+}
+
+// ── Expression translation ────────────────────────────────────────
+
+fn translate_expr(expr: &CypherExpr, vars: &Relvars) -> Result<Expr> {
+    match expr {
+        CypherExpr::Lit(lit) => translate_literal(lit),
+        CypherExpr::Var(name) => Err(CypherTranslateError::UnresolvedVariable(name.clone())),
+        CypherExpr::Prop(base, prop) => {
+            let CypherExpr::Var(table_name) = base.as_ref() else {
+                return Err(CypherTranslateError::NestedPropertyAccess);
+            };
+            let alias = RawIdentifier::new(table_name.clone());
+            let schema = vars
+                .get(&alias)
+                .ok_or_else(|| CypherTranslateError::UnresolvedVariable(table_name.clone()))?;
+            Ok(Expr::Field(resolve_field(&alias, schema, prop)?))
+        }
+        CypherExpr::Cmp(lhs, op, rhs) => {
+            let a = translate_expr(lhs, vars)?;
+            let b = translate_expr(rhs, vars)?;
+            let bin_op = match op {
+                CmpOp::Eq => BinOp::Eq,
+                CmpOp::Ne => BinOp::Ne,
+                CmpOp::Lt => BinOp::Lt,
+                CmpOp::Gt => BinOp::Gt,
+                CmpOp::Lte => BinOp::Lte,
+                CmpOp::Gte => BinOp::Gte,
+                _ => return Err(CypherTranslateError::UnsupportedCmpOp),
+            };
+            Ok(Expr::BinOp(bin_op, Box::new(a), Box::new(b)))
+        }
+        CypherExpr::And(lhs, rhs) => {
+            let a = translate_expr(lhs, vars)?;
+            let b = translate_expr(rhs, vars)?;
+            Ok(Expr::LogOp(LogOp::And, Box::new(a), Box::new(b)))
+        }
+        CypherExpr::Or(lhs, rhs) => {
+            let a = translate_expr(lhs, vars)?;
+            let b = translate_expr(rhs, vars)?;
+            Ok(Expr::LogOp(LogOp::Or, Box::new(a), Box::new(b)))
+        }
+        CypherExpr::Not(inner) => {
+            let translated = translate_expr(inner, vars)?;
+            Ok(Expr::Not(Box::new(translated)))
+        }
+        _ => Err(CypherTranslateError::UnsupportedExpr),
+    }
+}
+
+fn translate_literal(lit: &CypherLiteral) -> Result<Expr> {
+    match lit {
+        CypherLiteral::Integer(v) => Ok(Expr::Value(AlgebraicValue::I64(*v), AlgebraicType::I64)),
+        CypherLiteral::Float(v) => Ok(Expr::Value(
+            AlgebraicValue::F64((*v).into()),
+            AlgebraicType::F64,
+        )),
+        CypherLiteral::String(s) => Ok(Expr::str(s.clone().into_boxed_str())),
+        CypherLiteral::Bool(v) => Ok(Expr::bool(*v)),
+        CypherLiteral::Null => Err(CypherTranslateError::NullLiteral),
+        _ => Err(CypherTranslateError::UnsupportedLiteral),
+    }
+}
+
+// ── RETURN translation ────────────────────────────────────────────
+
+/// Translate a RETURN clause over a UNION of expanded paths where each branch
+/// may have its own `Relvars` (needed when undirected edge expansion clones
+/// the variable map per variant).
+fn translate_return_union_multi(
+    return_clause: &ReturnClause,
+    inputs: Vec<(RelExpr, Relvars)>,
+) -> Result<ProjectList> {
+    match return_clause {
+        ReturnClause::All => {
+            let names: Vec<_> = inputs
+                .into_iter()
+                .map(|(expr, _)| ProjectName::None(expr))
+                .collect();
+            Ok(ProjectList::Name(names))
+        }
+        ReturnClause::Items(items) => {
+            if items.len() == 1 {
+                if let CypherExpr::Var(ref name) = items[0].expr {
+                    let alias = items[0]
+                        .alias
+                        .as_ref()
+                        .map(|a| RawIdentifier::new(a.clone()))
+                        .unwrap_or_else(|| RawIdentifier::new(name.clone()));
+                    let names: Vec<_> = inputs
+                        .into_iter()
+                        .map(|(expr, _)| ProjectName::Some(expr, alias.clone()))
+                        .collect();
+                    return Ok(ProjectList::Name(names));
+                }
+            }
+
+            // Multi-item returns: build projections using the first variant's vars.
+            // All variants share the same user-defined variables.
+            let first_vars = &inputs[0].1;
+            let mut projections = Vec::new();
+            for item in items {
+                match &item.expr {
+                    CypherExpr::Prop(base, prop) => {
+                        let CypherExpr::Var(table_name) = base.as_ref() else {
+                            return Err(CypherTranslateError::NestedPropertyAccess);
+                        };
+                        let alias_id = RawIdentifier::new(table_name.clone());
+                        let schema = first_vars
+                            .get(&alias_id)
+                            .ok_or_else(|| {
+                                CypherTranslateError::UnresolvedVariable(table_name.clone())
+                            })?;
+                        let field = resolve_field(&alias_id, schema, prop)?;
+                        let out_name = item
+                            .alias
+                            .as_ref()
+                            .map(|a| RawIdentifier::new(a.clone()))
+                            .unwrap_or_else(|| RawIdentifier::new(format!("{table_name}.{prop}")));
+                        projections.push((out_name, field));
+                    }
+                    CypherExpr::Var(name) => {
+                        let alias_id = RawIdentifier::new(name.clone());
+                        let schema = first_vars.get(&alias_id).ok_or_else(|| {
+                            CypherTranslateError::UnresolvedVariable(name.clone())
+                        })?;
+                        for col in schema.public_columns() {
+                            let field = FieldProject {
+                                table: alias_id.clone(),
+                                field: col.col_pos.idx(),
+                                ty: col.col_type.clone(),
+                            };
+                            let col_alias =
+                                RawIdentifier::new(format!("{}.{}", name, col.col_name));
+                            projections.push((col_alias, field));
+                        }
+                    }
+                    _ => return Err(CypherTranslateError::UnsupportedReturn),
+                }
+            }
+            let exprs: Vec<RelExpr> = inputs.into_iter().map(|(expr, _)| expr).collect();
+            Ok(ProjectList::List(exprs, projections))
+        }
+        _ => Err(CypherTranslateError::UnsupportedReturn),
+    }
+}
+
+fn translate_return(
+    return_clause: &ReturnClause,
+    input: RelExpr,
+    vars: &Relvars,
+) -> Result<ProjectList> {
+    match return_clause {
+        ReturnClause::All => Ok(ProjectList::Name(vec![ProjectName::None(input)])),
+        ReturnClause::Items(items) => {
+            // Single bare variable (e.g. `RETURN a`) keeps the table-level
+            // binding via ProjectList::Name, preserving the full row context
+            // for downstream consumers. Multi-item returns require explicit
+            // column-level projection via ProjectList::List instead.
+            if items.len() == 1 {
+                if let CypherExpr::Var(ref name) = items[0].expr {
+                    let alias = items[0]
+                        .alias
+                        .as_ref()
+                        .map(|a| RawIdentifier::new(a.clone()))
+                        .unwrap_or_else(|| RawIdentifier::new(name.clone()));
+                    return Ok(ProjectList::Name(vec![ProjectName::Some(input, alias)]));
+                }
+            }
+
+            let mut projections = Vec::new();
+            for item in items {
+                match &item.expr {
+                    CypherExpr::Prop(base, prop) => {
+                        let CypherExpr::Var(table_name) = base.as_ref() else {
+                            return Err(CypherTranslateError::NestedPropertyAccess);
+                        };
+                        let alias_id = RawIdentifier::new(table_name.clone());
+                        let schema = vars.get(&alias_id).ok_or_else(|| {
+                            CypherTranslateError::UnresolvedVariable(table_name.clone())
+                        })?;
+                        let field = resolve_field(&alias_id, schema, prop)?;
+                        let out_name = item
+                            .alias
+                            .as_ref()
+                            .map(|a| RawIdentifier::new(a.clone()))
+                            .unwrap_or_else(|| RawIdentifier::new(format!("{table_name}.{prop}")));
+                        projections.push((out_name, field));
+                    }
+                    CypherExpr::Var(name) => {
+                        let alias_id = RawIdentifier::new(name.clone());
+                        let schema = vars.get(&alias_id).ok_or_else(|| {
+                            CypherTranslateError::UnresolvedVariable(name.clone())
+                        })?;
+                        for col in schema.public_columns() {
+                            let field = FieldProject {
+                                table: alias_id.clone(),
+                                field: col.col_pos.idx(),
+                                ty: col.col_type.clone(),
+                            };
+                            let col_alias =
+                                RawIdentifier::new(format!("{}.{}", name, col.col_name));
+                            projections.push((col_alias, field));
+                        }
+                    }
+                    _ => return Err(CypherTranslateError::UnsupportedReturn),
+                }
+            }
+            Ok(ProjectList::List(vec![input], projections))
+        }
+        _ => Err(CypherTranslateError::UnsupportedReturn),
+    }
+}
+
+// ── Tests ─────────────────────────────────────────────────────────
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use crate::check::test_utils::{build_module_def, SchemaViewer};
+    use crate::expr::{LeftDeepJoin, RelExpr};
+    use spacetimedb_cypher_parser::ast::*;
+    use spacetimedb_lib::{AlgebraicType, ProductType};
+    use spacetimedb_primitives::TableId;
+    use spacetimedb_sql_parser::ast::BinOp;
+
+    fn tx() -> SchemaViewer {
+        SchemaViewer::new(
+            build_module_def(vec![
+                (
+                    "Vertex",
+                    ProductType::from([
+                        ("Id", AlgebraicType::U64),
+                        ("Label", AlgebraicType::String),
+                        ("Properties", AlgebraicType::String),
+                    ]),
+                ),
+                (
+                    "Edge",
+                    ProductType::from([
+                        ("Id", AlgebraicType::U64),
+                        ("StartId", AlgebraicType::U64),
+                        ("EndId", AlgebraicType::U64),
+                        ("EdgeType", AlgebraicType::String),
+                        ("Properties", AlgebraicType::String),
+                    ]),
+                ),
+            ]),
+            vec![("Vertex", TableId(0)), ("Edge", TableId(1))],
+        )
+    }
+
+    fn node(var: Option<&str>, label: Option<&str>) -> NodePattern {
+        NodePattern {
+            variable: var.map(String::from),
+            label: label.map(String::from),
+            properties: vec![],
+        }
+    }
+
+    fn rel(var: Option<&str>, rel_type: Option<&str>, dir: Direction) -> RelPattern {
+        RelPattern {
+            variable: var.map(String::from),
+            rel_type: rel_type.map(String::from),
+            length: None,
+            direction: dir,
+        }
+    }
+
+    fn query(pattern: Pattern, where_clause: Option<CypherExpr>, ret: ReturnClause) -> CypherQuery {
+        CypherQuery {
+            match_clause: MatchClause {
+                patterns: vec![pattern],
+            },
+            where_clause,
+            return_clause: ret,
+        }
+    }
+
+    fn multi_query(
+        patterns: Vec<Pattern>,
+        where_clause: Option<CypherExpr>,
+        ret: ReturnClause,
+    ) -> CypherQuery {
+        CypherQuery {
+            match_clause: MatchClause { patterns },
+            where_clause,
+            return_clause: ret,
+        }
+    }
+
+    fn single_pattern(nodes: Vec<NodePattern>, edges: Vec<RelPattern>) -> Pattern {
+        Pattern { nodes, edges }
+    }
+
+    // ── Golden tests ──────────────────────────────────────────────
+
+    #[test]
+    fn single_node_no_label() {
+        let q = query(
+            single_pattern(vec![node(Some("a"), None)], vec![]),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected ProjectList::Name, got {result:?}");
+        };
+        assert_eq!(names.len(), 1);
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected ProjectName::None");
+        };
+        assert!(
+            matches!(expr, RelExpr::RelVar(r) if r.alias.as_ref() == "a"),
+            "expected RelVar(a), got {expr:?}"
+        );
+    }
+
+    #[test]
+    fn single_node_with_label() {
+        let q = query(
+            single_pattern(vec![node(Some("a"), Some("Person"))], vec![]),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected ProjectList::Name");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected ProjectName::None");
+        };
+        let RelExpr::Select(inner, filter) = expr else {
+            panic!("expected Select for label filter, got {expr:?}");
+        };
+        assert!(matches!(inner.as_ref(), RelExpr::RelVar(r) if r.alias.as_ref() == "a"));
+
+        let Expr::BinOp(BinOp::Eq, lhs, rhs) = filter else {
+            panic!("expected Eq filter, got {filter:?}");
+        };
+        assert!(matches!(lhs.as_ref(), Expr::Field(f) if f.table.as_ref() == "a"));
+        assert!(matches!(rhs.as_ref(), Expr::Value(AlgebraicValue::String(s), _) if s.as_ref() == "Person"));
+    }
+
+    #[test]
+    fn single_hop_outgoing() {
+        // (a)-[r]->(b)
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![rel(Some("r"), None, Direction::Outgoing)],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+
+        // Outermost is EqJoin(…, r.EndId, b.Id)
+        let RelExpr::EqJoin(outer_join, lhs_field, rhs_field) = expr else {
+            panic!("expected outer EqJoin, got {expr:?}");
+        };
+        assert_eq!(lhs_field.table.as_ref(), "r");
+        assert_eq!(rhs_field.table.as_ref(), "b");
+        assert_eq!(outer_join.rhs.alias.as_ref(), "b");
+
+        // Inner is EqJoin(RelVar(a), Edge(r), a.Id, r.StartId)
+        let RelExpr::EqJoin(ref inner_join, ref lhs2, ref rhs2) = *outer_join.lhs else {
+            panic!("expected inner EqJoin");
+        };
+        assert_eq!(lhs2.table.as_ref(), "a");
+        assert_eq!(rhs2.table.as_ref(), "r");
+        assert_eq!(inner_join.rhs.alias.as_ref(), "r");
+        assert!(matches!(*inner_join.lhs, RelExpr::RelVar(ref r) if r.alias.as_ref() == "a"));
+    }
+
+    #[test]
+    fn single_hop_incoming() {
+        // (a)<-[r]-(b) → a.Id = r.EndId, r.StartId = b.Id
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![rel(Some("r"), None, Direction::Incoming)],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+
+        // Outer: EqJoin(…, r.StartId, b.Id)
+        let RelExpr::EqJoin(_, lhs_field, rhs_field) = expr else {
+            panic!("expected outer EqJoin");
+        };
+        assert_eq!(lhs_field.table.as_ref(), "r", "edge far col for incoming should be StartId");
+        assert_eq!(rhs_field.table.as_ref(), "b");
+
+        // Inner: EqJoin(RelVar(a), Edge(r), a.Id, r.EndId)
+        let RelExpr::EqJoin(outer_join, ..) = expr else {
+            unreachable!();
+        };
+        let RelExpr::EqJoin(_, ref inner_lhs, ref inner_rhs) = *outer_join.lhs else {
+            panic!("expected inner EqJoin");
+        };
+        assert_eq!(inner_lhs.table.as_ref(), "a");
+        assert_eq!(inner_rhs.table.as_ref(), "r", "edge near col for incoming should be EndId");
+    }
+
+    #[test]
+    fn single_hop_with_labels_and_type() {
+        // (a:Person)-[r:KNOWS]->(b:Person)
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), Some("Person")), node(Some("b"), Some("Person"))],
+                vec![rel(Some("r"), Some("KNOWS"), Direction::Outgoing)],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+
+        // Outermost should be Select with combined label/type filters
+        let RelExpr::Select(inner, filter) = expr else {
+            panic!("expected Select wrapper for label/type filters, got {expr:?}");
+        };
+        // The inner is the EqJoin chain
+        assert!(matches!(inner.as_ref(), RelExpr::EqJoin(..)));
+
+        // Filter should be AND-chain of three conditions
+        fn count_ands(e: &Expr) -> usize {
+            match e {
+                Expr::LogOp(LogOp::And, a, b) => count_ands(a) + count_ands(b),
+                _ => 1,
+            }
+        }
+        assert_eq!(count_ands(filter), 3, "expected 3 filter clauses (a.Label, r.EdgeType, b.Label)");
+    }
+
+    #[test]
+    fn multi_hop() {
+        // (a)-[r]->(b)-[s]->(c)
+        let q = query(
+            single_pattern(
+                vec![
+                    node(Some("a"), None),
+                    node(Some("b"), None),
+                    node(Some("c"), None),
+                ],
+                vec![
+                    rel(Some("r"), None, Direction::Outgoing),
+                    rel(Some("s"), None, Direction::Outgoing),
+                ],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+
+        // Count EqJoin depth: should be 4 (a-r, r-b, b-s, s-c)
+        fn count_joins(e: &RelExpr) -> usize {
+            match e {
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, ..) => 1 + count_joins(lhs),
+                _ => 0,
+            }
+        }
+        assert_eq!(count_joins(expr), 4, "2-hop pattern should produce 4 EqJoins");
+    }
+
+    #[test]
+    fn where_clause_property_comparison() {
+        // MATCH (a) WHERE a.Label = 'Alice' RETURN *
+        let q = query(
+            single_pattern(vec![node(Some("a"), None)], vec![]),
+            Some(CypherExpr::Cmp(
+                Box::new(CypherExpr::Prop(
+                    Box::new(CypherExpr::Var("a".into())),
+                    "Label".into(),
+                )),
+                CmpOp::Eq,
+                Box::new(CypherExpr::Lit(CypherLiteral::String("Alice".into()))),
+            )),
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+        let RelExpr::Select(_, filter) = expr else {
+            panic!("expected Select, got {expr:?}");
+        };
+        assert!(matches!(filter, Expr::BinOp(BinOp::Eq, ..)));
+    }
+
+    #[test]
+    fn unbounded_variable_length_path_rejected() {
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![RelPattern {
+                    variable: None,
+                    rel_type: None,
+                    length: Some(PathLength::Unbounded),
+                    direction: Direction::Outgoing,
+                }],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let err = translate_cypher(&q, &tx()).unwrap_err();
+        assert!(
+            matches!(err, CypherTranslateError::UnboundedVariableLengthPath),
+            "expected UnboundedVariableLengthPath error, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn unbounded_range_max_rejected() {
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![RelPattern {
+                    variable: None,
+                    rel_type: None,
+                    length: Some(PathLength::Range {
+                        min: Some(1),
+                        max: None,
+                    }),
+                    direction: Direction::Outgoing,
+                }],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let err = translate_cypher(&q, &tx()).unwrap_err();
+        assert!(
+            matches!(err, CypherTranslateError::UnboundedVariableLengthPath),
+            "expected UnboundedVariableLengthPath, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn variable_length_too_deep_rejected() {
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![RelPattern {
+                    variable: None,
+                    rel_type: None,
+                    length: Some(PathLength::Range {
+                        min: Some(1),
+                        max: Some(100),
+                    }),
+                    direction: Direction::Outgoing,
+                }],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let err = translate_cypher(&q, &tx()).unwrap_err();
+        assert!(
+            matches!(err, CypherTranslateError::VariableLengthPathTooDeep(100)),
+            "expected VariableLengthPathTooDeep, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn variable_length_invalid_bounds_rejected() {
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![RelPattern {
+                    variable: None,
+                    rel_type: None,
+                    length: Some(PathLength::Range {
+                        min: Some(5),
+                        max: Some(3),
+                    }),
+                    direction: Direction::Outgoing,
+                }],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let err = translate_cypher(&q, &tx()).unwrap_err();
+        assert!(
+            matches!(err, CypherTranslateError::InvalidPathBounds(5, 3)),
+            "expected InvalidPathBounds, got {err:?}"
+        );
+    }
+
+    #[test]
+    fn variable_length_exact_2_hops() {
+        // (a)-[*2]->(b) should expand to exactly 1 plan with 4 EqJoins
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![RelPattern {
+                    variable: None,
+                    rel_type: None,
+                    length: Some(PathLength::Exact(2)),
+                    direction: Direction::Outgoing,
+                }],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected ProjectList::Name, got {result:?}");
+        };
+        // Exact(2) → single expansion
+        assert_eq!(names.len(), 1, "exact depth should produce 1 plan");
+
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected ProjectName::None");
+        };
+        // 2 hops → 4 EqJoins (each hop = 2 EqJoins: prev→edge, edge→next)
+        fn count_joins(e: &RelExpr) -> usize {
+            match e {
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, ..) => 1 + count_joins(lhs),
+                RelExpr::Select(inner, _) => count_joins(inner),
+                _ => 0,
+            }
+        }
+        assert_eq!(count_joins(expr), 4, "2-hop VLJ expansion should have 4 EqJoins");
+    }
+
+    #[test]
+    fn variable_length_range_produces_union() {
+        // (a)-[*1..3]->(b) RETURN * → 3 plans (depths 1, 2, 3)
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![RelPattern {
+                    variable: None,
+                    rel_type: None,
+                    length: Some(PathLength::Range {
+                        min: Some(1),
+                        max: Some(3),
+                    }),
+                    direction: Direction::Outgoing,
+                }],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected ProjectList::Name, got {result:?}");
+        };
+        assert_eq!(names.len(), 3, "range [1..3] should produce 3 plans");
+
+        fn count_joins(e: &RelExpr) -> usize {
+            match e {
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, ..) => 1 + count_joins(lhs),
+                RelExpr::Select(inner, _) => count_joins(inner),
+                _ => 0,
+            }
+        }
+
+        let depths: Vec<usize> = names
+            .iter()
+            .map(|pn| {
+                let expr = match pn {
+                    ProjectName::None(e) => e,
+                    ProjectName::Some(e, _) => e,
+                };
+                count_joins(expr)
+            })
+            .collect();
+        assert_eq!(depths, vec![2, 4, 6], "join counts for depths 1/2/3");
+    }
+
+    #[test]
+    fn variable_length_with_rel_type_filter() {
+        // (a)-[:KNOWS*1..2]->(b) → each expansion should have Select filters
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![RelPattern {
+                    variable: None,
+                    rel_type: Some("KNOWS".into()),
+                    length: Some(PathLength::Range {
+                        min: Some(1),
+                        max: Some(2),
+                    }),
+                    direction: Direction::Outgoing,
+                }],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        assert_eq!(names.len(), 2);
+
+        fn count_selects(e: &RelExpr) -> usize {
+            match e {
+                RelExpr::Select(inner, _) => 1 + count_selects(inner),
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, ..) => count_selects(lhs),
+                _ => 0,
+            }
+        }
+
+        let ProjectName::None(ref e1) = names[0] else { panic!("expected None") };
+        let ProjectName::None(ref e2) = names[1] else { panic!("expected None") };
+
+        // Depth 1: 1 edge → 1 Select for EdgeType
+        assert_eq!(count_selects(e1), 1, "1-hop path with rel_type should have 1 Select");
+        // Depth 2: 2 edges → 2 Selects for EdgeType
+        assert_eq!(count_selects(e2), 2, "2-hop path with rel_type should have 2 Selects");
+    }
+
+    #[test]
+    fn variable_length_incoming_direction() {
+        // (a)<-[*1]--(b) → should use EndId as near, StartId as far
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![RelPattern {
+                    variable: None,
+                    rel_type: None,
+                    length: Some(PathLength::Exact(1)),
+                    direction: Direction::Incoming,
+                }],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        assert_eq!(names.len(), 1);
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+
+        // Outer EqJoin: edge.StartId = b.Id (far col for incoming = StartId)
+        let RelExpr::EqJoin(_, lhs_f, rhs_f) = expr else {
+            panic!("expected outer EqJoin, got {expr:?}");
+        };
+        // The edge far field for incoming is StartId (index 1)
+        assert_eq!(lhs_f.field, 1, "edge far col for incoming should be StartId (index 1)");
+        // b.Id is index 0
+        assert_eq!(rhs_f.field, 0, "vertex Id should be index 0");
+    }
+
+    #[test]
+    fn variable_length_end_node_alias_bound() {
+        // (a)-[*2]->(b) RETURN b
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![RelPattern {
+                    variable: None,
+                    rel_type: None,
+                    length: Some(PathLength::Exact(2)),
+                    direction: Direction::Outgoing,
+                }],
+            ),
+            None,
+            ReturnClause::Items(vec![ReturnItem {
+                expr: CypherExpr::Var("b".into()),
+                alias: None,
+            }]),
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name, got {result:?}");
+        };
+        assert_eq!(names.len(), 1);
+        let ProjectName::Some(_, ref alias) = names[0] else {
+            panic!("expected ProjectName::Some");
+        };
+        assert_eq!(alias.as_ref(), "b");
+    }
+
+    #[test]
+    fn variable_length_with_where_clause() {
+        // (a)-[*1..2]->(b) WHERE b.Label = 'Person'
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![RelPattern {
+                    variable: None,
+                    rel_type: None,
+                    length: Some(PathLength::Range {
+                        min: Some(1),
+                        max: Some(2),
+                    }),
+                    direction: Direction::Outgoing,
+                }],
+            ),
+            Some(CypherExpr::Cmp(
+                Box::new(CypherExpr::Prop(
+                    Box::new(CypherExpr::Var("b".into())),
+                    "Label".into(),
+                )),
+                CmpOp::Eq,
+                Box::new(CypherExpr::Lit(CypherLiteral::String("Person".into()))),
+            )),
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        // 2 plans (depths 1 and 2), each wrapped with a WHERE filter
+        assert_eq!(names.len(), 2);
+
+        // Each plan should have a top-level Select (the WHERE clause)
+        for (i, pn) in names.iter().enumerate() {
+            let ProjectName::None(expr) = pn else {
+                panic!("expected None at index {i}");
+            };
+            assert!(
+                matches!(expr, RelExpr::Select(..)),
+                "depth {i} should be wrapped in Select for WHERE, got {expr:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn return_single_var() {
+        // MATCH (a) RETURN a
+        let q = query(
+            single_pattern(vec![node(Some("a"), None)], vec![]),
+            None,
+            ReturnClause::Items(vec![ReturnItem {
+                expr: CypherExpr::Var("a".into()),
+                alias: None,
+            }]),
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name, got {result:?}");
+        };
+        let ProjectName::Some(_, ref alias) = names[0] else {
+            panic!("expected ProjectName::Some");
+        };
+        assert_eq!(alias.as_ref(), "a");
+    }
+
+    #[test]
+    fn return_property_access() {
+        // MATCH (a) RETURN a.Label
+        let q = query(
+            single_pattern(vec![node(Some("a"), None)], vec![]),
+            None,
+            ReturnClause::Items(vec![ReturnItem {
+                expr: CypherExpr::Prop(
+                    Box::new(CypherExpr::Var("a".into())),
+                    "Label".into(),
+                ),
+                alias: None,
+            }]),
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::List(_, ref fields) = result else {
+            panic!("expected List, got {result:?}");
+        };
+        assert_eq!(fields.len(), 1);
+        assert_eq!(fields[0].0.as_ref(), "a.Label");
+        assert_eq!(fields[0].1.table.as_ref(), "a");
+    }
+
+    #[test]
+    fn return_aliased_property() {
+        // MATCH (a) RETURN a.Label AS name
+        let q = query(
+            single_pattern(vec![node(Some("a"), None)], vec![]),
+            None,
+            ReturnClause::Items(vec![ReturnItem {
+                expr: CypherExpr::Prop(
+                    Box::new(CypherExpr::Var("a".into())),
+                    "Label".into(),
+                ),
+                alias: Some("name".into()),
+            }]),
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::List(_, ref fields) = result else {
+            panic!("expected List");
+        };
+        assert_eq!(fields[0].0.as_ref(), "name");
+    }
+
+    #[test]
+    fn anonymous_variables_generated() {
+        // (:Person)-[:KNOWS]->(:Person)
+        let q = query(
+            single_pattern(
+                vec![node(None, Some("Person")), node(None, Some("Person"))],
+                vec![rel(None, Some("KNOWS"), Direction::Outgoing)],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx());
+        assert!(result.is_ok(), "anonymous variables should be auto-generated: {}", result.unwrap_err());
+    }
+
+    #[test]
+    fn not_literal_bool() {
+        // MATCH (a) WHERE NOT true RETURN a
+        let q = query(
+            single_pattern(vec![node(Some("a"), None)], vec![]),
+            Some(CypherExpr::Not(Box::new(CypherExpr::Lit(
+                CypherLiteral::Bool(true),
+            )))),
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name, got {result:?}");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+        let RelExpr::Select(_, filter) = expr else {
+            panic!("expected Select, got {expr:?}");
+        };
+        assert!(matches!(filter, Expr::Not(_)), "expected Expr::Not, got {filter:?}");
+    }
+
+    #[test]
+    fn not_comparison() {
+        // MATCH (a) WHERE NOT a.Label = 'Person' RETURN a
+        let q = query(
+            single_pattern(vec![node(Some("a"), None)], vec![]),
+            Some(CypherExpr::Not(Box::new(CypherExpr::Cmp(
+                Box::new(CypherExpr::Prop(
+                    Box::new(CypherExpr::Var("a".into())),
+                    "Label".into(),
+                )),
+                CmpOp::Eq,
+                Box::new(CypherExpr::Lit(CypherLiteral::String("Person".into()))),
+            )))),
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name, got {result:?}");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+        let RelExpr::Select(_, filter) = expr else {
+            panic!("expected Select, got {expr:?}");
+        };
+        assert!(matches!(filter, Expr::Not(_)), "expected Expr::Not, got {filter:?}");
+    }
+
+    #[test]
+    fn not_nested_in_and() {
+        // MATCH (a) WHERE a.Id = 1 AND NOT a.Label = 'Bot' RETURN a
+        let q = query(
+            single_pattern(vec![node(Some("a"), None)], vec![]),
+            Some(CypherExpr::And(
+                Box::new(CypherExpr::Cmp(
+                    Box::new(CypherExpr::Prop(
+                        Box::new(CypherExpr::Var("a".into())),
+                        "Id".into(),
+                    )),
+                    CmpOp::Eq,
+                    Box::new(CypherExpr::Lit(CypherLiteral::Integer(1))),
+                )),
+                Box::new(CypherExpr::Not(Box::new(CypherExpr::Cmp(
+                    Box::new(CypherExpr::Prop(
+                        Box::new(CypherExpr::Var("a".into())),
+                        "Label".into(),
+                    )),
+                    CmpOp::Eq,
+                    Box::new(CypherExpr::Lit(CypherLiteral::String("Bot".into()))),
+                )))),
+            )),
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx());
+        assert!(result.is_ok(), "NOT in AND should translate: {}", result.unwrap_err());
+    }
+
+    #[test]
+    fn empty_match_rejected() {
+        let q = CypherQuery {
+            match_clause: MatchClause { patterns: vec![] },
+            where_clause: None,
+            return_clause: ReturnClause::All,
+        };
+        let err = translate_cypher(&q, &tx()).unwrap_err();
+        assert!(matches!(err, CypherTranslateError::EmptyPattern));
+    }
+
+    // ── Multi-MATCH tests ─────────────────────────────────────────
+
+    #[test]
+    fn multi_match_independent_cross_join() {
+        // MATCH (a:Person) MATCH (b:Company) RETURN *
+        let q = multi_query(
+            vec![
+                single_pattern(vec![node(Some("a"), Some("Person"))], vec![]),
+                single_pattern(vec![node(Some("b"), Some("Company"))], vec![]),
+            ],
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected ProjectList::Name, got {result:?}");
+        };
+        assert_eq!(names.len(), 1);
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected ProjectName::None");
+        };
+
+        // Should be: Select(LeftDeepJoin(RelVar(a), RelVar(b)), <filters>)
+        let RelExpr::Select(inner, _filter) = expr else {
+            panic!("expected Select for label filters, got {expr:?}");
+        };
+        assert!(
+            matches!(inner.as_ref(), RelExpr::LeftDeepJoin(LeftDeepJoin { lhs, rhs })
+                if matches!(lhs.as_ref(), RelExpr::RelVar(r) if r.alias.as_ref() == "a")
+                && rhs.alias.as_ref() == "b"),
+            "expected LeftDeepJoin(a, b), got {inner:?}"
+        );
+    }
+
+    #[test]
+    fn multi_match_independent_no_labels() {
+        // MATCH (a) MATCH (b) RETURN *
+        let q = multi_query(
+            vec![
+                single_pattern(vec![node(Some("a"), None)], vec![]),
+                single_pattern(vec![node(Some("b"), None)], vec![]),
+            ],
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+        // No labels → no Select, just LeftDeepJoin
+        assert!(
+            matches!(expr, RelExpr::LeftDeepJoin(LeftDeepJoin { lhs, rhs })
+                if matches!(lhs.as_ref(), RelExpr::RelVar(r) if r.alias.as_ref() == "a")
+                && rhs.alias.as_ref() == "b"),
+            "expected LeftDeepJoin(a, b), got {expr:?}"
+        );
+    }
+
+    #[test]
+    fn multi_match_three_independent() {
+        // MATCH (a) MATCH (b) MATCH (c) RETURN *
+        let q = multi_query(
+            vec![
+                single_pattern(vec![node(Some("a"), None)], vec![]),
+                single_pattern(vec![node(Some("b"), None)], vec![]),
+                single_pattern(vec![node(Some("c"), None)], vec![]),
+            ],
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+        // LeftDeepJoin(LeftDeepJoin(a, b), c)
+        let RelExpr::LeftDeepJoin(LeftDeepJoin { lhs, rhs }) = expr else {
+            panic!("expected outer LeftDeepJoin, got {expr:?}");
+        };
+        assert_eq!(rhs.alias.as_ref(), "c");
+        assert!(
+            matches!(lhs.as_ref(), RelExpr::LeftDeepJoin(LeftDeepJoin { lhs: inner, rhs: inner_rhs })
+                if matches!(inner.as_ref(), RelExpr::RelVar(r) if r.alias.as_ref() == "a")
+                && inner_rhs.alias.as_ref() == "b"),
+            "expected inner LeftDeepJoin(a, b), got {lhs:?}"
+        );
+    }
+
+    #[test]
+    fn multi_match_shared_variable_correlated() {
+        // MATCH (a)-[r]->(b) MATCH (b)-[s]->(c) RETURN *
+        // b is shared → second pattern reuses the existing plan (no duplicate RelVar)
+        let q = multi_query(
+            vec![
+                single_pattern(
+                    vec![node(Some("a"), None), node(Some("b"), None)],
+                    vec![rel(Some("r"), None, Direction::Outgoing)],
+                ),
+                single_pattern(
+                    vec![node(Some("b"), None), node(Some("c"), None)],
+                    vec![rel(Some("s"), None, Direction::Outgoing)],
+                ),
+            ],
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+
+        fn count_joins(e: &RelExpr) -> usize {
+            match e {
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, ..) => 1 + count_joins(lhs),
+                RelExpr::Select(inner, _) => count_joins(inner),
+                _ => 0,
+            }
+        }
+        // Pattern 1: 2 EqJoins (a→r, r→b)
+        // Pattern 2: b is shared first node (reused), 2 EqJoins (b→s, s→c)
+        // Total: 4 EqJoins, no Select (no label filters)
+        assert_eq!(count_joins(expr), 4, "shared-variable pattern should have 4 EqJoins");
+    }
+
+    #[test]
+    fn multi_match_shared_first_node_reused() {
+        // MATCH (a) MATCH (a)-[r]->(b) RETURN *
+        // a is shared → second pattern should not create a new RelVar for a
+        let q = multi_query(
+            vec![
+                single_pattern(vec![node(Some("a"), None)], vec![]),
+                single_pattern(
+                    vec![node(Some("a"), None), node(Some("b"), None)],
+                    vec![rel(Some("r"), None, Direction::Outgoing)],
+                ),
+            ],
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+
+        // Plan should be: EqJoin(EqJoin(RelVar(a), edge(r)), vertex(b))
+        // No LeftDeepJoin because a is shared (reused from pattern 1)
+        fn count_joins(e: &RelExpr) -> usize {
+            match e {
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, ..) => 1 + count_joins(lhs),
+                RelExpr::Select(inner, _) => count_joins(inner),
+                _ => 0,
+            }
+        }
+        assert_eq!(count_joins(expr), 2, "shared first-node should produce 2 EqJoins (edge+vertex)");
+    }
+
+    #[test]
+    fn multi_match_with_where_clause() {
+        // MATCH (a:Person) MATCH (b:Company) WHERE a.Label = 'Alice' RETURN *
+        let q = multi_query(
+            vec![
+                single_pattern(vec![node(Some("a"), Some("Person"))], vec![]),
+                single_pattern(vec![node(Some("b"), Some("Company"))], vec![]),
+            ],
+            Some(CypherExpr::Cmp(
+                Box::new(CypherExpr::Prop(
+                    Box::new(CypherExpr::Var("a".into())),
+                    "Label".into(),
+                )),
+                CmpOp::Eq,
+                Box::new(CypherExpr::Lit(CypherLiteral::String("Alice".into()))),
+            )),
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx());
+        assert!(result.is_ok(), "multi-MATCH with WHERE should translate: {}", result.unwrap_err());
+    }
+
+    #[test]
+    fn multi_match_with_edge_and_independent_node() {
+        // MATCH (a)-[r]->(b) MATCH (c) RETURN *
+        let q = multi_query(
+            vec![
+                single_pattern(
+                    vec![node(Some("a"), None), node(Some("b"), None)],
+                    vec![rel(Some("r"), None, Direction::Outgoing)],
+                ),
+                single_pattern(vec![node(Some("c"), None)], vec![]),
+            ],
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+
+        // Should be: LeftDeepJoin(EqJoin(EqJoin(a, r), b), c)
+        let RelExpr::LeftDeepJoin(LeftDeepJoin { lhs, rhs }) = expr else {
+            panic!("expected LeftDeepJoin for cross-join with c, got {expr:?}");
+        };
+        assert_eq!(rhs.alias.as_ref(), "c");
+
+        fn count_joins(e: &RelExpr) -> usize {
+            match e {
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, ..) => 1 + count_joins(lhs),
+                _ => 0,
+            }
+        }
+        assert_eq!(count_joins(lhs), 2, "first pattern should have 2 EqJoins");
+    }
+
+    #[test]
+    fn multi_match_return_single_var() {
+        // MATCH (a:Person) MATCH (b:Company) RETURN a
+        let q = multi_query(
+            vec![
+                single_pattern(vec![node(Some("a"), Some("Person"))], vec![]),
+                single_pattern(vec![node(Some("b"), Some("Company"))], vec![]),
+            ],
+            None,
+            ReturnClause::Items(vec![ReturnItem {
+                expr: CypherExpr::Var("a".into()),
+                alias: None,
+            }]),
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name, got {result:?}");
+        };
+        assert_eq!(names.len(), 1);
+        let ProjectName::Some(_, ref alias) = names[0] else {
+            panic!("expected ProjectName::Some");
+        };
+        assert_eq!(alias.as_ref(), "a");
+    }
+
+    #[test]
+    fn multi_match_shared_non_first_node() {
+        // MATCH (a)-[r]->(b) MATCH (c)-[s]->(b) RETURN *
+        // b appears as a non-first node in pattern 2 → equi-join filter
+        let q = multi_query(
+            vec![
+                single_pattern(
+                    vec![node(Some("a"), None), node(Some("b"), None)],
+                    vec![rel(Some("r"), None, Direction::Outgoing)],
+                ),
+                single_pattern(
+                    vec![node(Some("c"), None), node(Some("b"), None)],
+                    vec![rel(Some("s"), None, Direction::Outgoing)],
+                ),
+            ],
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name");
+        };
+        let ProjectName::None(ref expr) = names[0] else {
+            panic!("expected None");
+        };
+
+        // Pattern 1: 2 EqJoins (a→r, r→b)
+        // Pattern 2: c is new → LeftDeepJoin, 1 EqJoin (c→s),
+        //   b is shared non-first → filter s.EndId = b.Id (no new RelVar)
+        // Total: 3 EqJoins + 1 LeftDeepJoin, wrapped in Select for filter
+        assert!(
+            matches!(expr, RelExpr::Select(..)),
+            "expected Select wrapper for shared non-first node correlation, got {expr:?}"
+        );
+
+        fn count_joins(e: &RelExpr) -> usize {
+            match e {
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, ..) => 1 + count_joins(lhs),
+                RelExpr::Select(inner, _) => count_joins(inner),
+                RelExpr::LeftDeepJoin(LeftDeepJoin { lhs, .. }) => count_joins(lhs),
+                _ => 0,
+            }
+        }
+        assert_eq!(count_joins(expr), 3, "shared non-first node should have 3 EqJoins");
+    }
+
+    // ── Undirected edge tests ─────────────────────────────────────
+
+    #[test]
+    fn single_hop_undirected_produces_union() {
+        // (a)-[r]-(b) RETURN * → 2 plans (outgoing + incoming)
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![rel(Some("r"), None, Direction::Undirected)],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected ProjectList::Name, got {result:?}");
+        };
+        assert_eq!(names.len(), 2, "undirected edge should produce 2 plans");
+
+        fn count_joins(e: &RelExpr) -> usize {
+            match e {
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, ..) => 1 + count_joins(lhs),
+                RelExpr::Select(inner, _) => count_joins(inner),
+                _ => 0,
+            }
+        }
+
+        let ProjectName::None(ref e1) = names[0] else { panic!("expected None") };
+        let ProjectName::None(ref e2) = names[1] else { panic!("expected None") };
+
+        // Each plan should have 2 EqJoins (a→r, r→b)
+        assert_eq!(count_joins(e1), 2, "plan 1 should have 2 EqJoins");
+        assert_eq!(count_joins(e2), 2, "plan 2 should have 2 EqJoins");
+
+        // Verify direction swapping: one plan uses StartId as near, the other uses EndId
+        fn find_edge_near_col(e: &RelExpr) -> Option<usize> {
+            match e {
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, _, rhs) => {
+                    if rhs.table.as_ref() == "r" {
+                        Some(rhs.field)
+                    } else {
+                        find_edge_near_col(lhs)
+                    }
+                }
+                RelExpr::Select(inner, _) => find_edge_near_col(inner),
+                _ => None,
+            }
+        }
+
+        let near1 = find_edge_near_col(e1).expect("plan 1 should have edge near col");
+        let near2 = find_edge_near_col(e2).expect("plan 2 should have edge near col");
+
+        // StartId = index 1, EndId = index 2 (in Edge table: Id(0), StartId(1), EndId(2), EdgeType(3), Properties(4))
+        let cols = [near1, near2];
+        assert!(cols.contains(&1), "one plan should use StartId (1) as near");
+        assert!(cols.contains(&2), "one plan should use EndId (2) as near");
+    }
+
+    #[test]
+    fn undirected_with_rel_type() {
+        // (a)-[r:KNOWS]-(b) RETURN * → 2 plans, each with EdgeType filter
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![rel(Some("r"), Some("KNOWS"), Direction::Undirected)],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name, got {result:?}");
+        };
+        assert_eq!(names.len(), 2, "undirected with rel_type should produce 2 plans");
+
+        fn count_selects(e: &RelExpr) -> usize {
+            match e {
+                RelExpr::Select(inner, _) => 1 + count_selects(inner),
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, ..) => count_selects(lhs),
+                _ => 0,
+            }
+        }
+
+        let ProjectName::None(ref e1) = names[0] else { panic!("expected None") };
+        let ProjectName::None(ref e2) = names[1] else { panic!("expected None") };
+
+        // Each plan should have 1 Select for the EdgeType filter
+        assert_eq!(count_selects(e1), 1, "plan 1 should have 1 Select for EdgeType");
+        assert_eq!(count_selects(e2), 1, "plan 2 should have 1 Select for EdgeType");
+    }
+
+    #[test]
+    fn undirected_return_single_var() {
+        // (a)-[r]-(b) RETURN a → 2 plans, each returning a
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![rel(Some("r"), None, Direction::Undirected)],
+            ),
+            None,
+            ReturnClause::Items(vec![ReturnItem {
+                expr: CypherExpr::Var("a".into()),
+                alias: None,
+            }]),
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name, got {result:?}");
+        };
+        assert_eq!(names.len(), 2, "undirected should produce 2 plans");
+
+        for (i, pn) in names.iter().enumerate() {
+            let ProjectName::Some(_, alias) = pn else {
+                panic!("expected ProjectName::Some at index {i}");
+            };
+            assert_eq!(alias.as_ref(), "a", "plan {i} should return a");
+        }
+    }
+
+    #[test]
+    fn undirected_with_where_clause() {
+        // (a)-[r]-(b) WHERE a.Label = 'Person' RETURN *
+        let q = query(
+            single_pattern(
+                vec![node(Some("a"), None), node(Some("b"), None)],
+                vec![rel(Some("r"), None, Direction::Undirected)],
+            ),
+            Some(CypherExpr::Cmp(
+                Box::new(CypherExpr::Prop(
+                    Box::new(CypherExpr::Var("a".into())),
+                    "Label".into(),
+                )),
+                CmpOp::Eq,
+                Box::new(CypherExpr::Lit(CypherLiteral::String("Person".into()))),
+            )),
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name, got {result:?}");
+        };
+        assert_eq!(names.len(), 2, "undirected with WHERE should produce 2 plans");
+
+        for (i, pn) in names.iter().enumerate() {
+            let ProjectName::None(expr) = pn else {
+                panic!("expected None at index {i}");
+            };
+            assert!(
+                matches!(expr, RelExpr::Select(..)),
+                "plan {i} should be wrapped in Select for WHERE, got {expr:?}"
+            );
+        }
+    }
+
+    #[test]
+    fn multi_match_undirected() {
+        // MATCH (a)-[r]-(b) MATCH (c) RETURN *
+        let q = multi_query(
+            vec![
+                single_pattern(
+                    vec![node(Some("a"), None), node(Some("b"), None)],
+                    vec![rel(Some("r"), None, Direction::Undirected)],
+                ),
+                single_pattern(vec![node(Some("c"), None)], vec![]),
+            ],
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name, got {result:?}");
+        };
+        // Undirected pattern produces 2 variants, each cross-joined with (c)
+        assert_eq!(names.len(), 2, "multi-match with undirected should produce 2 plans");
+    }
+
+    #[test]
+    fn multi_hop_with_undirected() {
+        // (a)-[r]-(b)-[s]->(c) → 2 plans (undirected edge expanded)
+        let q = query(
+            single_pattern(
+                vec![
+                    node(Some("a"), None),
+                    node(Some("b"), None),
+                    node(Some("c"), None),
+                ],
+                vec![
+                    rel(Some("r"), None, Direction::Undirected),
+                    rel(Some("s"), None, Direction::Outgoing),
+                ],
+            ),
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected Name, got {result:?}");
+        };
+        assert_eq!(
+            names.len(),
+            2,
+            "single undirected hop in multi-hop should produce 2 plans"
+        );
+
+        fn count_joins(e: &RelExpr) -> usize {
+            match e {
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, ..) => 1 + count_joins(lhs),
+                RelExpr::Select(inner, _) => count_joins(inner),
+                _ => 0,
+            }
+        }
+
+        let ProjectName::None(ref e1) = names[0] else { panic!("expected None") };
+        let ProjectName::None(ref e2) = names[1] else { panic!("expected None") };
+
+        // a-r-b-s-c = 4 EqJoins per plan
+        assert_eq!(count_joins(e1), 4, "plan 1 should have 4 EqJoins");
+        assert_eq!(count_joins(e2), 4, "plan 2 should have 4 EqJoins");
+    }
+
+    #[test]
+    fn multi_match_variable_length_then_fixed_edge() {
+        // MATCH (a)-[*1..2]->(b) MATCH (b)-[s]->(c) RETURN *
+        // Variable-length path ending at b, then fixed edge from b to c.
+        // b is shared first-node of pattern 2 → reused from vars.
+        let q = multi_query(
+            vec![
+                single_pattern(
+                    vec![node(Some("a"), None), node(Some("b"), None)],
+                    vec![RelPattern {
+                        variable: None,
+                        rel_type: None,
+                        length: Some(PathLength::Range {
+                            min: Some(1),
+                            max: Some(2),
+                        }),
+                        direction: Direction::Outgoing,
+                    }],
+                ),
+                single_pattern(
+                    vec![node(Some("b"), None), node(Some("c"), None)],
+                    vec![rel(Some("s"), None, Direction::Outgoing)],
+                ),
+            ],
+            None,
+            ReturnClause::All,
+        );
+        let result = translate_cypher(&q, &tx()).unwrap();
+        let ProjectList::Name(names) = &result else {
+            panic!("expected ProjectList::Name, got {result:?}");
+        };
+        // Range [1..2] → 2 fixed-depth plans, each with pattern 2 appended
+        assert_eq!(names.len(), 2, "VLJ range [1..2] plus fixed edge should produce 2 plans");
+
+        fn count_joins(e: &RelExpr) -> usize {
+            match e {
+                RelExpr::EqJoin(LeftDeepJoin { lhs, .. }, ..) => 1 + count_joins(lhs),
+                RelExpr::Select(inner, _) => count_joins(inner),
+                _ => 0,
+            }
+        }
+
+        let ProjectName::None(ref e1) = names[0] else { panic!("expected None") };
+        let ProjectName::None(ref e2) = names[1] else { panic!("expected None") };
+
+        // Depth 1: VLJ expands to 2 EqJoins, plus pattern 2 adds 2 (b→s, s→c) = 4 total
+        assert_eq!(count_joins(e1), 4, "depth 1 should have 4 EqJoins");
+        // Depth 2: VLJ expands to 4 EqJoins, plus pattern 2 adds 2 = 6 total
+        assert_eq!(count_joins(e2), 6, "depth 2 should have 6 EqJoins");
+    }
+}

--- a/crates/expr/src/errors.rs
+++ b/crates/expr/src/errors.rs
@@ -1,3 +1,4 @@
+use super::cypher::CypherTranslateError;
 use super::statement::InvalidVar;
 use spacetimedb_lib::AlgebraicType;
 use spacetimedb_sats::algebraic_type::fmt::fmt_algebraic_type;
@@ -144,6 +145,8 @@ pub enum TypingError {
     InsertFields(#[from] InsertFieldsError),
     #[error(transparent)]
     ParseError(#[from] SqlParseError),
+    #[error(transparent)]
+    CypherTranslate(#[from] CypherTranslateError),
 
     #[error(transparent)]
     DmlOnView(#[from] DmlOnView),

--- a/crates/expr/src/expr.rs
+++ b/crates/expr/src/expr.rs
@@ -6,6 +6,9 @@ use spacetimedb_schema::{identifier::Identifier, schema::TableOrViewSchema};
 use spacetimedb_sql_parser::ast::{BinOp, LogOp};
 use std::sync::Arc;
 
+/// Maximum allowed hop depth for variable-length path expansion.
+pub const MAX_VARIABLE_LENGTH_HOPS: u32 = 16;
+
 pub trait CollectViews {
     fn collect_views(&self, views: &mut HashSet<ViewId>);
 }
@@ -248,6 +251,39 @@ pub enum RelExpr {
     LeftDeepJoin(LeftDeepJoin),
     /// A left deep binary equi-join
     EqJoin(LeftDeepJoin, FieldProject, FieldProject),
+    /// A bounded variable-length path traversal (e.g. `(a)-[*1..3]->(b)`)
+    VariableLengthJoin(VariableLengthPath),
+}
+
+/// A bounded variable-length path traversal.
+///
+/// Represents `(start)-[*min..max]->(end)` in Cypher. At execution time,
+/// this is expanded into a UNION of fixed-depth EqJoin chains (one per
+/// hop count from `min_hops` to `max_hops`).
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VariableLengthPath {
+    /// The base expression up to (and including) the start node
+    pub lhs: Box<RelExpr>,
+    /// Alias for the start vertex in the path
+    pub start_alias: RawIdentifier,
+    /// Alias for the end vertex (bound in the Cypher query)
+    pub end_alias: RawIdentifier,
+    /// Schema of the Edge table
+    pub edge_schema: Arc<TableOrViewSchema>,
+    /// Schema of the Vertex table
+    pub vertex_schema: Arc<TableOrViewSchema>,
+    /// Optional relationship type filter (e.g. `:KNOWS`)
+    pub rel_type: Option<String>,
+    /// Edge column that joins to the near (start-side) vertex Id
+    pub edge_col_near: String,
+    /// Edge column that joins to the far (end-side) vertex Id
+    pub edge_col_far: String,
+    /// Column name for vertex Id
+    pub vertex_id_col: String,
+    /// Minimum hops (inclusive, >= 1)
+    pub min_hops: u32,
+    /// Maximum hops (inclusive, <= MAX_VARIABLE_LENGTH_HOPS)
+    pub max_hops: u32,
 }
 
 /// A table reference
@@ -273,6 +309,146 @@ impl CollectViews for RelExpr {
     }
 }
 
+impl VariableLengthPath {
+    /// Expand this variable-length path into a list of fixed-depth `RelExpr`
+    /// trees, one per hop count from `min_hops` to `max_hops`. Each tree is
+    /// a chain of EqJoins identical to what the fixed-depth Cypher translator
+    /// produces. The end node always uses `self.end_alias`.
+    pub fn expand(&self) -> Vec<RelExpr> {
+        let mut results = Vec::with_capacity((self.max_hops - self.min_hops + 1) as usize);
+
+        for depth in self.min_hops..=self.max_hops {
+            results.push(self.build_fixed_depth(depth));
+        }
+
+        results
+    }
+
+    fn build_fixed_depth(&self, depth: u32) -> RelExpr {
+        let mut current = (*self.lhs).clone();
+        let mut prev_alias = self.start_alias.clone();
+        let mut anon_counter: usize = 0;
+
+        for hop in 0..depth {
+            let edge_alias = RawIdentifier::new(format!("_vlp_e{}", anon_counter));
+            anon_counter += 1;
+
+            let is_last = hop == depth - 1;
+            let next_alias = if is_last {
+                self.end_alias.clone()
+            } else {
+                let a = RawIdentifier::new(format!("_vlp_v{}", anon_counter));
+                anon_counter += 1;
+                a
+            };
+
+            let (vid_idx, vid_ty) = self.resolve_vertex_id_col();
+            let (near_idx, near_ty) = self.resolve_edge_near_col();
+
+            let prev_id = FieldProject {
+                table: prev_alias.clone(),
+                field: vid_idx,
+                ty: vid_ty.clone(),
+            };
+            let edge_near = FieldProject {
+                table: edge_alias.clone(),
+                field: near_idx,
+                ty: near_ty,
+            };
+
+            current = RelExpr::EqJoin(
+                LeftDeepJoin {
+                    lhs: Box::new(current),
+                    rhs: Relvar {
+                        schema: self.edge_schema.clone(),
+                        alias: edge_alias.clone(),
+                        delta: None,
+                    },
+                },
+                prev_id,
+                edge_near,
+            );
+
+            let (far_idx, far_ty) = self.resolve_edge_far_col();
+            let next_id = FieldProject {
+                table: next_alias.clone(),
+                field: vid_idx,
+                ty: vid_ty,
+            };
+
+            current = RelExpr::EqJoin(
+                LeftDeepJoin {
+                    lhs: Box::new(current),
+                    rhs: Relvar {
+                        schema: self.vertex_schema.clone(),
+                        alias: next_alias.clone(),
+                        delta: None,
+                    },
+                },
+                FieldProject {
+                    table: edge_alias.clone(),
+                    field: far_idx,
+                    ty: far_ty,
+                },
+                next_id,
+            );
+
+            if let Some(ref rel_type) = self.rel_type {
+                let (et_idx, et_ty) = self.resolve_edge_type_col();
+                let edge_type_field = FieldProject {
+                    table: edge_alias,
+                    field: et_idx,
+                    ty: et_ty,
+                };
+                current = RelExpr::Select(
+                    Box::new(current),
+                    Expr::BinOp(
+                        BinOp::Eq,
+                        Box::new(Expr::Field(edge_type_field)),
+                        Box::new(Expr::str(rel_type.clone().into_boxed_str())),
+                    ),
+                );
+            }
+
+            prev_alias = next_alias;
+        }
+
+        current
+    }
+
+    fn resolve_vertex_id_col(&self) -> (usize, AlgebraicType) {
+        let col = self
+            .vertex_schema
+            .get_column_by_name_or_alias(&self.vertex_id_col)
+            .expect("VariableLengthPath: vertex_id_col not found in vertex schema");
+        (col.col_pos.idx(), col.col_type.clone())
+    }
+
+    fn resolve_edge_near_col(&self) -> (usize, AlgebraicType) {
+        let col = self
+            .edge_schema
+            .get_column_by_name_or_alias(&self.edge_col_near)
+            .expect("VariableLengthPath: edge_col_near not found in edge schema");
+        (col.col_pos.idx(), col.col_type.clone())
+    }
+
+    fn resolve_edge_far_col(&self) -> (usize, AlgebraicType) {
+        let col = self
+            .edge_schema
+            .get_column_by_name_or_alias(&self.edge_col_far)
+            .expect("VariableLengthPath: edge_col_far not found in edge schema");
+        (col.col_pos.idx(), col.col_type.clone())
+    }
+
+    fn resolve_edge_type_col(&self) -> (usize, AlgebraicType) {
+        let col = self
+            .edge_schema
+            .get_column_by_name_or_alias("EdgeType")
+            .expect("VariableLengthPath: EdgeType column not found in edge schema");
+        (col.col_pos.idx(), col.col_type.clone())
+    }
+}
+
 impl RelExpr {
     /// Walk the expression tree and call `f` on each node
     pub fn visit(&self, f: &mut impl FnMut(&Self)) {
@@ -280,7 +456,8 @@ impl RelExpr {
         match self {
             Self::Select(lhs, _)
             | Self::LeftDeepJoin(LeftDeepJoin { lhs, .. })
-            | Self::EqJoin(LeftDeepJoin { lhs, .. }, ..) => {
+            | Self::EqJoin(LeftDeepJoin { lhs, .. }, ..)
+            | Self::VariableLengthJoin(VariableLengthPath { lhs, .. }) => {
                 lhs.visit(f);
             }
             Self::RelVar(..) => {}
@@ -293,7 +470,8 @@ impl RelExpr {
         match self {
             Self::Select(lhs, _)
             | Self::LeftDeepJoin(LeftDeepJoin { lhs, .. })
-            | Self::EqJoin(LeftDeepJoin { lhs, .. }, ..) => {
+            | Self::EqJoin(LeftDeepJoin { lhs, .. }, ..)
+            | Self::VariableLengthJoin(VariableLengthPath { lhs, .. }) => {
                 lhs.visit_mut(f);
             }
             Self::RelVar(..) => {}
@@ -306,6 +484,7 @@ impl RelExpr {
             Self::RelVar(..) => 1,
             Self::LeftDeepJoin(join) | Self::EqJoin(join, ..) => join.lhs.nfields() + 1,
             Self::Select(input, _) => input.nfields(),
+            Self::VariableLengthJoin(vlp) => vlp.lhs.nfields() + 1,
         }
     }
 
@@ -317,6 +496,9 @@ impl RelExpr {
                 join.rhs.alias.as_ref() == field || join.lhs.has_field(field)
             }
             Self::Select(input, _) => input.has_field(field),
+            Self::VariableLengthJoin(vlp) => {
+                vlp.end_alias.as_ref() == field || vlp.lhs.has_field(field)
+            }
         }
     }
 
@@ -329,6 +511,8 @@ impl RelExpr {
             Self::EqJoin(LeftDeepJoin { lhs, .. }, ..) => lhs.find_table_schema(alias),
             Self::LeftDeepJoin(LeftDeepJoin { rhs, .. }) if rhs.alias.as_ref() == alias => Some(&rhs.schema),
             Self::LeftDeepJoin(LeftDeepJoin { lhs, .. }) => lhs.find_table_schema(alias),
+            Self::VariableLengthJoin(vlp) if vlp.end_alias.as_ref() == alias => Some(&vlp.vertex_schema),
+            Self::VariableLengthJoin(vlp) => vlp.lhs.find_table_schema(alias),
             _ => None,
         }
     }
@@ -381,6 +565,8 @@ pub enum Expr {
     BinOp(BinOp, Box<Expr>, Box<Expr>),
     /// A binary logic expression
     LogOp(LogOp, Box<Expr>, Box<Expr>),
+    /// A unary NOT expression
+    Not(Box<Expr>),
     /// A typed literal expression
     Value(AlgebraicValue, AlgebraicType),
     /// A field projection
@@ -396,6 +582,7 @@ impl Expr {
                 a.visit(f);
                 b.visit(f);
             }
+            Self::Not(inner) => inner.visit(f),
             Self::Value(..) | Self::Field(..) => {}
         }
     }
@@ -408,6 +595,7 @@ impl Expr {
                 a.visit_mut(f);
                 b.visit_mut(f);
             }
+            Self::Not(inner) => inner.visit_mut(f),
             Self::Value(..) | Self::Field(..) => {}
         }
     }
@@ -425,7 +613,7 @@ impl Expr {
     /// The [AlgebraicType] of this scalar expression
     pub fn ty(&self) -> &AlgebraicType {
         match self {
-            Self::BinOp(..) | Self::LogOp(..) => &AlgebraicType::Bool,
+            Self::BinOp(..) | Self::LogOp(..) | Self::Not(..) => &AlgebraicType::Bool,
             Self::Value(_, ty) | Self::Field(FieldProject { ty, .. }) => ty,
         }
     }

--- a/crates/expr/src/lib.rs
+++ b/crates/expr/src/lib.rs
@@ -14,7 +14,7 @@ use spacetimedb_data_structures::map::HashCollectionExt as _;
 use spacetimedb_data_structures::map::HashSet;
 use spacetimedb_lib::ser::Serialize;
 use spacetimedb_lib::Timestamp;
-use spacetimedb_lib::{from_hex_pad, AlgebraicType, AlgebraicValue, ConnectionId, Identity};
+use spacetimedb_lib::{from_hex_pad, AlgebraicType, AlgebraicValue, ConnectionId, GraphId, Identity};
 use spacetimedb_sats::algebraic_type::fmt::fmt_algebraic_type;
 use spacetimedb_sats::algebraic_value::ser::ValueSerializer;
 use spacetimedb_sats::uuid::Uuid;
@@ -24,6 +24,7 @@ use spacetimedb_sql_parser::parser::recursion;
 use std::{ops::Deref, str::FromStr};
 
 pub mod check;
+pub mod cypher;
 pub mod errors;
 pub mod expr;
 pub mod rls;
@@ -162,6 +163,7 @@ fn op_supports_type(_op: BinOp, t: &AlgebraicType) -> bool {
         || t.is_connection_id()
         || t.is_timestamp()
         || t.is_uuid()
+        || t.is_graph_id()
 }
 
 /// Parse an integer literal into an [AlgebraicValue]
@@ -234,6 +236,13 @@ pub(crate) fn parse(value: &str, ty: &AlgebraicType) -> anyhow::Result<Algebraic
         Uuid::parse_str(value)
             .map(AlgebraicValue::from)
             .map_err(|err| anyhow!(err))
+    };
+    let to_graph_id = || {
+        value
+            .parse::<u64>()
+            .map(GraphId::from)
+            .map(AlgebraicValue::from)
+            .with_context(|| "Could not parse graph id")
     };
     let to_i256 = |decimal: &BigDecimal| {
         i256::from_str_radix(
@@ -356,6 +365,7 @@ pub(crate) fn parse(value: &str, ty: &AlgebraicType) -> anyhow::Result<Algebraic
         t if t.is_identity() => to_identity(),
         t if t.is_connection_id() => to_connection_id(),
         t if t.is_uuid() => to_uuid(),
+        t if t.is_graph_id() => to_graph_id(),
         t => bail!("Literal values for type {} are not supported", fmt_algebraic_type(t)),
     }
 }

--- a/crates/expr/src/rls.rs
+++ b/crates/expr/src/rls.rs
@@ -382,6 +382,10 @@ fn alpha_rename(expr: &mut RelExpr, f: &mut impl FnMut(&RawIdentifier) -> RawIde
                 }
             });
         }
+        RelExpr::VariableLengthJoin(vlp) => {
+            vlp.start_alias = f(&vlp.start_alias);
+            vlp.end_alias = f(&vlp.end_alias);
+        }
     });
 }
 
@@ -440,6 +444,10 @@ fn extend_lhs(expr: RelExpr, with: RelExpr) -> RelExpr {
             a,
             b,
         ),
+        RelExpr::VariableLengthJoin(mut vlp) => {
+            vlp.lhs = Box::new(extend_lhs(*vlp.lhs, with));
+            RelExpr::VariableLengthJoin(vlp)
+        }
     }
 }
 
@@ -468,6 +476,10 @@ fn expand_leaf(expr: RelExpr, table_id: TableId, alias: &str, with: &RelExpr) ->
             a,
             b,
         ),
+        RelExpr::VariableLengthJoin(mut vlp) => {
+            vlp.lhs = Box::new(expand_leaf(*vlp.lhs, table_id, alias, with));
+            RelExpr::VariableLengthJoin(vlp)
+        }
     }
 }
 

--- a/crates/expr/src/statement.rs
+++ b/crates/expr/src/statement.rs
@@ -458,6 +458,10 @@ pub fn parse_and_type_sql(sql: &str, tx: &impl SchemaView, auth: &AuthCtx) -> Ty
         SqlAst::Update(update) => Ok(Statement::DML(DML::Update(type_update(update, tx)?))),
         SqlAst::Set(set) => Ok(Statement::DML(DML::Insert(type_and_rewrite_set(set, tx)?))),
         SqlAst::Show(show) => Ok(Statement::Select(type_and_rewrite_show(show, tx)?)),
+        SqlAst::Cypher(cypher) => {
+            let project_list = crate::cypher::translate_cypher(&cypher, tx)?;
+            Ok(Statement::Select(project_list))
+        }
     }
 }
 
@@ -482,7 +486,7 @@ mod tests {
         Relvars, SchemaView, TypingResult,
     };
     use crate::type_expr;
-    use spacetimedb::TableId;
+    use spacetimedb_primitives::TableId;
     use spacetimedb_lib::db::raw_def::v9::RawModuleDefV9Builder;
     use spacetimedb_lib::{identity::AuthCtx, AlgebraicType, ProductType};
     use spacetimedb_sats::raw_identifier::RawIdentifier;
@@ -520,7 +524,7 @@ mod tests {
 
     #[test]
     fn valid() {
-        let tx = SchemaViewer(module_def());
+        let tx = SchemaViewer::new(module_def(), vec![("t", TableId(0)), ("s", TableId(1))]);
 
         for sql in [
             "select str from t",
@@ -535,7 +539,7 @@ mod tests {
 
     #[test]
     fn invalid() {
-        let tx = SchemaViewer(module_def());
+        let tx = SchemaViewer::new(module_def(), vec![("t", TableId(0)), ("s", TableId(1))]);
 
         for sql in [
             // Unqualified columns in a join
@@ -663,5 +667,65 @@ mod tests {
             let result = parse_and_type_sql(sql, &tx);
             assert!(result.is_err(), "{msg}");
         }
+    }
+
+    // ── Cypher execution via parse_and_type_sql ───────────────────────
+
+    use crate::check::test_utils::graph_schema_viewer;
+
+    #[test]
+    fn cypher_bare_match_produces_select() {
+        let tx = graph_schema_viewer();
+        let result = parse_and_type_sql("MATCH (n) RETURN n", &tx);
+        assert!(result.is_ok(), "bare MATCH should produce a Select: {:?}", result.err());
+        assert!(matches!(result.unwrap(), Statement::Select(_)));
+    }
+
+    #[test]
+    fn cypher_function_wrapper_produces_select() {
+        let tx = graph_schema_viewer();
+        let result = parse_and_type_sql("SELECT * FROM cypher('MATCH (n) RETURN n')", &tx);
+        assert!(result.is_ok(), "cypher() wrapper should produce a Select: {:?}", result.err());
+        assert!(matches!(result.unwrap(), Statement::Select(_)));
+    }
+
+    #[test]
+    fn cypher_single_hop_produces_select() {
+        let tx = graph_schema_viewer();
+        let result = parse_and_type_sql("MATCH (a)-[r]->(b) RETURN a", &tx);
+        assert!(result.is_ok(), "single-hop graph query should succeed: {:?}", result.err());
+        assert!(matches!(result.unwrap(), Statement::Select(_)));
+    }
+
+    #[test]
+    fn cypher_with_where_produces_select() {
+        let tx = graph_schema_viewer();
+        let result = parse_and_type_sql(
+            "MATCH (a:Person)-[r:KNOWS]->(b) WHERE a.Label = 'Alice' RETURN a",
+            &tx,
+        );
+        assert!(result.is_ok(), "graph query with WHERE should succeed: {:?}", result.err());
+        assert!(matches!(result.unwrap(), Statement::Select(_)));
+    }
+
+    #[test]
+    fn cypher_variable_length_produces_select() {
+        let tx = graph_schema_viewer();
+        let result = parse_and_type_sql("MATCH (a)-[*1..3]->(b) RETURN a", &tx);
+        assert!(result.is_ok(), "variable-length path should succeed: {:?}", result.err());
+        assert!(matches!(result.unwrap(), Statement::Select(_)));
+    }
+
+    #[test]
+    fn cypher_missing_table_produces_error() {
+        let tx = SchemaViewer::new(
+            build_module_def(vec![(
+                "SomeTable",
+                ProductType::from([("id", AlgebraicType::U64)]),
+            )]),
+            vec![("SomeTable", TableId(0))],
+        );
+        let result = parse_and_type_sql("MATCH (n) RETURN n", &tx);
+        assert!(result.is_err(), "Cypher without Vertex table should fail");
     }
 }

--- a/crates/lib/src/lib.rs
+++ b/crates/lib/src/lib.rs
@@ -39,6 +39,7 @@ pub use filterable_value::{FilterableValue, IndexScanRangeBoundsTerminator, Term
 pub use identity::Identity;
 pub use scheduler::ScheduleAt;
 pub use spacetimedb_sats::hash::{self, hash_bytes, Hash};
+pub use spacetimedb_sats::graph_id::GraphId;
 pub use spacetimedb_sats::time_duration::TimeDuration;
 pub use spacetimedb_sats::timestamp::Timestamp;
 pub use spacetimedb_sats::uuid::Uuid;

--- a/crates/pg/src/encoder.rs
+++ b/crates/pg/src/encoder.rs
@@ -5,7 +5,8 @@ use pgwire::api::Type;
 use spacetimedb_lib::sats::satn::{PsqlChars, PsqlPrintFmt, PsqlType, TypedWriter};
 use spacetimedb_lib::sats::{satn, ValueWithType};
 use spacetimedb_lib::{
-    ser, AlgebraicType, AlgebraicValue, ProductType, ProductTypeElement, ProductValue, TimeDuration, Timestamp, Uuid,
+    ser, AlgebraicType, AlgebraicValue, GraphId, ProductType, ProductTypeElement, ProductValue, TimeDuration, Timestamp,
+    Uuid,
 };
 use std::borrow::Cow;
 use std::sync::Arc;
@@ -118,6 +119,11 @@ impl TypedWriter for PsqlFormatter<'_> {
     }
 
     fn write_uuid(&mut self, value: Uuid) -> Result<(), Self::Error> {
+        self.encoder.encode_field(&value.to_string())?;
+        Ok(())
+    }
+
+    fn write_graph_id(&mut self, value: GraphId) -> Result<(), Self::Error> {
         self.encoder.encode_field(&value.to_string())?;
         Ok(())
     }

--- a/crates/physical-plan/src/compile.rs
+++ b/crates/physical-plan/src/compile.rs
@@ -20,6 +20,7 @@ fn compile_expr(expr: Expr, var: &mut impl VarLabel) -> PhysicalExpr {
             let b = Box::new(compile_expr(*b, var));
             PhysicalExpr::BinOp(op, a, b)
         }
+        Expr::Not(inner) => PhysicalExpr::Not(Box::new(compile_expr(*inner, var))),
         Expr::Value(v, _) => PhysicalExpr::Value(v),
         Expr::Field(proj) => PhysicalExpr::Field(compile_field_project(var, proj)),
     }
@@ -138,6 +139,9 @@ fn compile_rel_expr(var: &mut impl VarLabel, ast: RelExpr) -> PhysicalPlan {
             let lhs = Box::new(lhs);
             let rhs = Box::new(rhs);
             PhysicalPlan::NLJoin(lhs, rhs)
+        }
+        RelExpr::VariableLengthJoin(_) => {
+            unreachable!("VariableLengthJoin must be expanded before physical planning")
         }
     }
 }

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -1284,6 +1284,8 @@ pub enum PhysicalExpr {
     LogOp(LogOp, Vec<PhysicalExpr>),
     /// A binary expression
     BinOp(BinOp, Box<PhysicalExpr>, Box<PhysicalExpr>),
+    /// A unary NOT expression
+    Not(Box<PhysicalExpr>),
     /// A constant algebraic value
     Value(AlgebraicValue),
     /// A field projection expression
@@ -1324,6 +1326,7 @@ impl PhysicalExpr {
                     expr.visit(f);
                 }
             }
+            Self::Not(inner) => inner.visit(f),
             _ => {}
         }
     }
@@ -1341,6 +1344,7 @@ impl PhysicalExpr {
                     expr.visit_mut(f);
                 }
             }
+            Self::Not(inner) => inner.visit_mut(f),
             _ => {}
         }
     }
@@ -1352,6 +1356,7 @@ impl PhysicalExpr {
             field @ Self::Field(..) => field,
             Self::BinOp(op, a, b) => Self::BinOp(op, Box::new(a.map(f)), Box::new(b.map(f))),
             Self::LogOp(op, exprs) => Self::LogOp(op, exprs.into_iter().map(|expr| expr.map(f)).collect()),
+            Self::Not(inner) => Self::Not(Box::new(inner.map(f))),
         }
     }
 
@@ -1404,6 +1409,7 @@ impl PhysicalExpr {
                     // ANY is equivalent to OR
                     .any(|expr| expr.eval_bool_with_metrics(row, bytes_scanned)),
             ),
+            Self::Not(inner) => into(!inner.eval_bool_with_metrics(row, bytes_scanned)),
             Self::Field(field) => {
                 let value = row.project(field);
                 *bytes_scanned += value.size_of();
@@ -1428,6 +1434,7 @@ impl PhysicalExpr {
                     .collect(),
             ),
             Self::BinOp(op, a, b) => Self::BinOp(op, Box::new(a.flatten()), Box::new(b.flatten())),
+            Self::Not(inner) => Self::Not(Box::new(inner.flatten())),
             Self::Field(..) | Self::Value(..) => self,
         }
     }
@@ -1469,7 +1476,7 @@ mod tests {
         plan::{HashJoin, IxJoin, IxScan, PhysicalPlan, ProjectListPlan, Sarg, Semi, TupleField},
     };
 
-    use super::{PhysicalExpr, ProjectPlan, TableScan};
+    use super::{Label, PhysicalExpr, ProjectPlan, TableScan};
 
     struct SchemaViewer {
         schemas: Vec<Arc<TableOrViewSchema>>,
@@ -2313,5 +2320,44 @@ mod tests {
 
         assert!(plan.plan_iter().any(|plan| plan.has_filter()));
         assert!(plan.plan_iter().any(|plan| plan.has_table_scan(None)));
+    }
+
+    #[test]
+    fn not_expr_eval() {
+        use spacetimedb_lib::ProductValue;
+
+        let row = ProductValue::from(vec![AlgebraicValue::Bool(true), AlgebraicValue::U64(42)]);
+
+        let field_0 = TupleField {
+            label: Label(0),
+            label_pos: Some(0),
+            field_pos: 0,
+        };
+
+        // NOT true → false
+        let not_true = PhysicalExpr::Not(Box::new(PhysicalExpr::Field(field_0.clone())));
+        assert!(!not_true.eval_bool(&&row));
+
+        // NOT false → true
+        let not_false = PhysicalExpr::Not(Box::new(PhysicalExpr::Value(AlgebraicValue::Bool(false))));
+        assert!(not_false.eval_bool(&&row));
+
+        // NOT (42 == 42) → false
+        let field_1 = TupleField {
+            label: Label(0),
+            label_pos: Some(1),
+            field_pos: 1,
+        };
+        let eq_expr = PhysicalExpr::BinOp(
+            BinOp::Eq,
+            Box::new(PhysicalExpr::Field(field_1)),
+            Box::new(PhysicalExpr::Value(AlgebraicValue::U64(42))),
+        );
+        let not_eq = PhysicalExpr::Not(Box::new(eq_expr.clone()));
+        assert!(!not_eq.eval_bool(&&row));
+
+        // Double negation: NOT NOT (42 == 42) → true
+        let not_not_eq = PhysicalExpr::Not(Box::new(not_eq));
+        assert!(not_not_eq.eval_bool(&&row));
     }
 }

--- a/crates/query/src/lib.rs
+++ b/crates/query/src/lib.rs
@@ -98,3 +98,232 @@ pub fn execute_dml_stmt<Tx: MutDatastore>(
     let plan = MutExecutor::from(plan);
     plan.execute(tx, metrics)
 }
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spacetimedb_expr::check::test_utils::graph_schema_viewer;
+    use spacetimedb_physical_plan::plan::PhysicalPlan;
+
+    #[test]
+    fn compile_cypher_via_sql_direct_path() {
+        let tx = graph_schema_viewer();
+        let auth = AuthCtx::for_testing();
+        let result = compile_sql_stmt("MATCH (a)-[r]->(b) RETURN a", &tx, &auth);
+        assert!(result.is_ok(), "Cypher through compile_sql_stmt should succeed: {:?}", result.err());
+        let stmt = result.unwrap();
+        assert!(matches!(stmt, Statement::Select(_)));
+    }
+
+    #[test]
+    fn compile_cypher_function_wrapper_via_sql_direct_path() {
+        let tx = graph_schema_viewer();
+        let auth = AuthCtx::for_testing();
+        let result = compile_sql_stmt(
+            "SELECT * FROM cypher('MATCH (n:Person) WHERE n.Label = ''Alice'' RETURN n')",
+            &tx,
+            &auth,
+        );
+        assert!(result.is_ok(), "cypher() wrapper through compile_sql_stmt should succeed: {:?}", result.err());
+    }
+
+    #[test]
+    fn compile_cypher_variable_length_via_sql_direct_path() {
+        let tx = graph_schema_viewer();
+        let auth = AuthCtx::for_testing();
+        let result = compile_sql_stmt("MATCH (a)-[*1..3]->(b) RETURN a", &tx, &auth);
+        assert!(result.is_ok(), "variable-length Cypher should compile: {:?}", result.err());
+    }
+
+    // ── End-to-end graph query integration tests ─────────────────────
+    //
+    // Each test drives the *full* compilation pipeline:
+    //   SQL/Cypher text → parse → type-check → RLS resolution
+    //     → physical-plan compilation → optimizer
+    //
+    // This catches regressions that span crate boundaries — something
+    // individual crate-level golden tests cannot detect.
+
+    /// Compile SQL through the full pipeline (compile + physical plan + optimize)
+    /// and return the optimized `ProjectListPlan`.
+    fn compile_graph_pipeline(sql: &str) -> ProjectListPlan {
+        let tx = graph_schema_viewer();
+        let auth = AuthCtx::for_testing();
+        let stmt = compile_sql_stmt(sql, &tx, &auth)
+            .unwrap_or_else(|e| panic!("compilation failed for `{sql}`: {e}"));
+        let Statement::Select(project_list) = stmt else {
+            panic!("expected Select for `{sql}`, got DML");
+        };
+        compile_select_list(project_list)
+            .optimize(&auth)
+            .unwrap_or_else(|e| panic!("optimization failed for `{sql}`: {e}"))
+    }
+
+    /// Count join nodes (IxJoin / HashJoin / NLJoin) inside a physical plan tree.
+    fn count_physical_joins(plan: &PhysicalPlan) -> usize {
+        let mut n = 0;
+        plan.visit(&mut |node| match node {
+            PhysicalPlan::IxJoin(..) | PhysicalPlan::HashJoin(..) | PhysicalPlan::NLJoin(..) => {
+                n += 1;
+            }
+            _ => {}
+        });
+        n
+    }
+
+    /// Check whether a physical plan tree contains at least one `Filter` node.
+    fn has_filter_node(plan: &PhysicalPlan) -> bool {
+        let mut found = false;
+        plan.visit(&mut |node| {
+            if matches!(node, PhysicalPlan::Filter(..)) {
+                found = true;
+            }
+        });
+        found
+    }
+
+    /// Extract the `Vec<ProjectPlan>` from a `ProjectListPlan::Name` variant.
+    fn expect_name_plans<'a>(plan: &'a ProjectListPlan, ctx: &str) -> &'a Vec<ProjectPlan> {
+        match plan {
+            ProjectListPlan::Name(plans) => plans,
+            other => panic!("{ctx}: expected ProjectListPlan::Name, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn integration_single_hop_full_pipeline() {
+        let plan = compile_graph_pipeline("MATCH (a)-[r]->(b) RETURN a");
+
+        let plans = expect_name_plans(&plan, "single-hop");
+        assert_eq!(plans.len(), 1, "single-hop produces 1 plan");
+
+        let joins = count_physical_joins(&plans[0]);
+        assert!(joins >= 1, "single-hop should contain at least 1 join, got {joins}");
+    }
+
+    #[test]
+    fn integration_multi_hop_full_pipeline() {
+        let plan = compile_graph_pipeline("MATCH (a)-[r]->(b)-[s]->(c) RETURN a");
+
+        let plans = expect_name_plans(&plan, "multi-hop");
+        assert_eq!(plans.len(), 1, "fixed-depth 2-hop produces 1 plan");
+
+        let joins = count_physical_joins(&plans[0]);
+        assert!(joins >= 2, "2-hop pattern should have at least 2 joins, got {joins}");
+    }
+
+    #[test]
+    fn integration_variable_length_full_pipeline() {
+        let plan = compile_graph_pipeline("MATCH (a)-[*1..3]->(b) RETURN a");
+
+        let plans = expect_name_plans(&plan, "variable-length");
+        assert_eq!(
+            plans.len(),
+            3,
+            "[*1..3] should expand to 3 plans (depths 1, 2, 3)"
+        );
+
+        for (i, pp) in plans.iter().enumerate() {
+            let joins = count_physical_joins(pp);
+            assert!(
+                joins >= 1,
+                "depth-{} plan should have at least 1 join, got {joins}",
+                i + 1
+            );
+        }
+    }
+
+    #[test]
+    fn integration_label_and_type_filter_full_pipeline() {
+        let plan = compile_graph_pipeline(
+            "MATCH (a:Person)-[r:KNOWS]->(b:Person) WHERE a.Label = 'Alice' RETURN a",
+        );
+
+        let plans = expect_name_plans(&plan, "label-filter");
+        assert_eq!(plans.len(), 1, "fixed-depth with labels produces 1 plan");
+
+        assert!(has_filter_node(&plans[0]), "label/type filters should produce at least one Filter node");
+    }
+
+    #[test]
+    fn integration_cypher_function_wrapper_full_pipeline() {
+        let plan = compile_graph_pipeline(
+            "SELECT * FROM cypher('MATCH (n:Person) WHERE n.Label = ''Alice'' RETURN n')",
+        );
+
+        let plans = expect_name_plans(&plan, "cypher()-wrapper");
+        assert_eq!(plans.len(), 1, "cypher() wrapper on single node produces 1 plan");
+    }
+
+    #[test]
+    fn integration_property_projection_full_pipeline() {
+        let plan = compile_graph_pipeline("MATCH (a)-[r]->(b) RETURN a.Label, b.Label");
+
+        match &plan {
+            ProjectListPlan::List(physical_plans, fields) => {
+                assert!(!physical_plans.is_empty(), "should have at least 1 physical plan");
+                assert_eq!(fields.len(), 2, "RETURN a.Label, b.Label should produce 2 output fields");
+            }
+            other => panic!("expected ProjectListPlan::List for column projection, got {other:?}"),
+        }
+    }
+
+    #[test]
+    fn integration_variable_length_with_label_filter_full_pipeline() {
+        let plan = compile_graph_pipeline("MATCH (a:Person)-[*1..2]->(b) RETURN a");
+
+        let plans = expect_name_plans(&plan, "vlp-with-label");
+        assert_eq!(
+            plans.len(),
+            2,
+            "[*1..2] with label filter should produce 2 plans"
+        );
+    }
+
+    #[test]
+    fn integration_incoming_direction_full_pipeline() {
+        let plan = compile_graph_pipeline("MATCH (a)<-[r]-(b) RETURN a");
+
+        let plans = expect_name_plans(&plan, "incoming");
+        assert_eq!(plans.len(), 1, "incoming single-hop produces 1 plan");
+
+        let joins = count_physical_joins(&plans[0]);
+        assert!(joins >= 1, "incoming hop should have at least 1 join, got {joins}");
+    }
+
+    #[test]
+    fn integration_where_clause_full_pipeline() {
+        let plan = compile_graph_pipeline(
+            "MATCH (a)-[r]->(b) WHERE b.Label = 'Server' RETURN a",
+        );
+
+        let plans = expect_name_plans(&plan, "where-clause");
+        assert_eq!(plans.len(), 1, "single-hop with WHERE produces 1 plan");
+
+        assert!(has_filter_node(&plans[0]), "WHERE clause should produce a Filter node in the physical plan");
+    }
+
+    #[test]
+    fn integration_not_in_where_clause_full_pipeline() {
+        let plan = compile_graph_pipeline(
+            "MATCH (a)-[r]->(b) WHERE NOT b.Label = 'Bot' RETURN a",
+        );
+
+        let plans = expect_name_plans(&plan, "not-where");
+        assert_eq!(plans.len(), 1, "single-hop with NOT WHERE produces 1 plan");
+
+        assert!(has_filter_node(&plans[0]), "NOT in WHERE should produce a Filter node");
+    }
+
+    #[test]
+    fn integration_not_combined_with_and_full_pipeline() {
+        let plan = compile_graph_pipeline(
+            "MATCH (a)-[r]->(b) WHERE a.Label = 'Alice' AND NOT b.Label = 'Bot' RETURN a",
+        );
+
+        let plans = expect_name_plans(&plan, "not-and-where");
+        assert_eq!(plans.len(), 1, "AND with NOT produces 1 plan");
+
+        assert!(has_filter_node(&plans[0]), "AND+NOT in WHERE should produce a Filter node");
+    }
+}

--- a/crates/sats/src/algebraic_type.rs
+++ b/crates/sats/src/algebraic_type.rs
@@ -5,7 +5,7 @@ use crate::algebraic_value::de::{ValueDeserializeError, ValueDeserializer};
 use crate::algebraic_value::ser::value_serialize;
 use crate::de::Deserialize;
 use crate::meta_type::MetaType;
-use crate::product_type::{CONNECTION_ID_TAG, IDENTITY_TAG, TIMESTAMP_TAG, TIME_DURATION_TAG, UUID_TAG};
+use crate::product_type::{CONNECTION_ID_TAG, GRAPH_ID_TAG, IDENTITY_TAG, TIMESTAMP_TAG, TIME_DURATION_TAG, UUID_TAG};
 use crate::sum_type::{OPTION_NONE_TAG, OPTION_SOME_TAG, RESULT_ERR_TAG, RESULT_OK_TAG};
 use crate::typespace::Typespace;
 use crate::{i256, u256};
@@ -192,6 +192,11 @@ impl AlgebraicType {
         matches!(self, Self::Product(p) if p.is_uuid())
     }
 
+    /// Returns whether this type is the conventional `GraphId` type.
+    pub fn is_graph_id(&self) -> bool {
+        matches!(self, Self::Product(p) if p.is_graph_id())
+    }
+
     /// Returns whether this type is the conventional `ScheduleAt` type.
     pub fn is_schedule_at(&self) -> bool {
         matches!(self, Self::Sum(p) if p.is_schedule_at())
@@ -356,6 +361,11 @@ impl AlgebraicType {
     /// Construct a copy of the `UUID` type.
     pub fn uuid() -> Self {
         AlgebraicType::product([(UUID_TAG, AlgebraicType::U128)])
+    }
+
+    /// Construct a copy of the `GraphId` type.
+    pub fn graph_id() -> Self {
+        AlgebraicType::product([(GRAPH_ID_TAG, AlgebraicType::U64)])
     }
 
     /// Returns a sum type of unit variants with names taken from `var_names`.
@@ -804,6 +814,8 @@ mod tests {
         assert!(AlgebraicType::time_duration().is_time_duration());
         assert!(AlgebraicType::uuid().is_uuid());
         assert!(AlgebraicType::uuid().is_special());
+        assert!(AlgebraicType::graph_id().is_graph_id());
+        assert!(AlgebraicType::graph_id().is_special());
     }
 
     #[test]

--- a/crates/sats/src/graph_id.rs
+++ b/crates/sats/src/graph_id.rs
@@ -1,0 +1,103 @@
+use crate::{de::Deserialize, impl_st, ser::Serialize, AlgebraicType, AlgebraicValue};
+use std::fmt;
+
+/// A 64-bit identifier for graph entities (vertices and edges).
+///
+/// `GraphId` is the foundational type for the native graph extension.
+/// Vertices and edges in a graph are identified by unique `GraphId` values.
+#[derive(Eq, PartialEq, Ord, PartialOrd, Copy, Clone, Hash, Serialize, Deserialize, Debug)]
+#[sats(crate = crate)]
+pub struct GraphId {
+    __graph_id__: u64,
+}
+
+impl_st!([] GraphId, AlgebraicType::graph_id());
+
+impl GraphId {
+    /// The minimum possible `GraphId`.
+    pub const MIN: Self = Self { __graph_id__: u64::MIN };
+
+    /// The maximum possible `GraphId`.
+    pub const MAX: Self = Self { __graph_id__: u64::MAX };
+
+    /// Create a `GraphId` from a raw `u64`.
+    pub const fn new(id: u64) -> Self {
+        Self { __graph_id__: id }
+    }
+
+    /// Extract the raw `u64` value.
+    pub const fn to_u64(self) -> u64 {
+        self.__graph_id__
+    }
+}
+
+impl fmt::Display for GraphId {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        write!(f, "{}", self.__graph_id__)
+    }
+}
+
+impl From<u64> for GraphId {
+    fn from(value: u64) -> Self {
+        Self::new(value)
+    }
+}
+
+impl From<GraphId> for u64 {
+    fn from(value: GraphId) -> Self {
+        value.to_u64()
+    }
+}
+
+impl From<GraphId> for AlgebraicValue {
+    fn from(value: GraphId) -> Self {
+        AlgebraicValue::product([value.to_u64().into()])
+    }
+}
+
+#[cfg(test)]
+mod test {
+    use super::*;
+    use crate::GroundSpacetimeType;
+
+    #[test]
+    fn graph_id_type_matches() {
+        assert_eq!(AlgebraicType::graph_id(), GraphId::get_type());
+        assert!(GraphId::get_type().is_graph_id());
+        assert!(GraphId::get_type().is_special());
+    }
+
+    #[test]
+    fn round_trip_u64() {
+        let id = GraphId::new(42);
+        let raw: u64 = id.into();
+        let back = GraphId::from(raw);
+        assert_eq!(id, back);
+    }
+
+    #[test]
+    fn display_format() {
+        assert_eq!("0", GraphId::MIN.to_string());
+        assert_eq!("42", GraphId::new(42).to_string());
+        assert_eq!("18446744073709551615", GraphId::MAX.to_string());
+    }
+
+    #[test]
+    fn ordering() {
+        let a = GraphId::new(1);
+        let b = GraphId::new(2);
+        assert!(a < b);
+        assert!(b > a);
+        assert_eq!(a, a);
+        assert_ne!(a, b);
+    }
+
+    #[test]
+    fn into_algebraic_value() {
+        let id = GraphId::new(123);
+        let av: AlgebraicValue = id.into();
+        let prod = av.as_product().unwrap();
+        assert_eq!(prod.elements.len(), 1);
+        assert_eq!(prod.elements[0], AlgebraicValue::U64(123));
+    }
+}

--- a/crates/sats/src/lib.rs
+++ b/crates/sats/src/lib.rs
@@ -8,6 +8,7 @@ pub mod bsatn;
 pub mod buffer;
 pub mod convert;
 pub mod de;
+pub mod graph_id;
 pub mod hash;
 pub mod hex;
 pub mod layout;

--- a/crates/sats/src/product_type.rs
+++ b/crates/sats/src/product_type.rs
@@ -22,6 +22,8 @@ pub const TIME_DURATION_TAG: &str = "__time_duration_micros__";
 
 /// The tag used inside the special `UUID` product type.
 pub const UUID_TAG: &str = "__uuid__";
+/// The tag used inside the special `GraphId` product type.
+pub const GRAPH_ID_TAG: &str = "__graph_id__";
 
 /// A structural product type  of the factors given by `elements`.
 ///
@@ -165,13 +167,23 @@ impl ProductType {
         tag_name == UUID_TAG
     }
 
+    /// Returns whether this is the special tag of [`crate::graph_id::GraphId`].
+    pub fn is_graph_id_tag(tag_name: &str) -> bool {
+        tag_name == GRAPH_ID_TAG
+    }
+
     /// Returns whether this is the special case of  [`crate::uuid::Uuid`].
     pub fn is_uuid(&self) -> bool {
         self.is_newtype_of(UUID_TAG, AlgebraicType::U128)
     }
 
+    /// Returns whether this is the special case of [`crate::graph_id::GraphId`].
+    pub fn is_graph_id(&self) -> bool {
+        self.is_newtype_of(GRAPH_ID_TAG, AlgebraicType::U64)
+    }
+
     /// Returns whether this is a special known `tag`,
-    /// currently `Address`, `Identity`, `Timestamp`, `TimeDuration`, `ConnectionId` or `UUID`.
+    /// currently `Address`, `Identity`, `Timestamp`, `TimeDuration`, `UUID` or `GraphId`.
     pub fn is_special_tag(tag_name: &str) -> bool {
         [
             IDENTITY_TAG,
@@ -179,12 +191,13 @@ impl ProductType {
             TIMESTAMP_TAG,
             TIME_DURATION_TAG,
             UUID_TAG,
+            GRAPH_ID_TAG,
         ]
         .contains(&tag_name)
     }
 
     /// Returns whether this is a special known type,
-    /// currently `Identity`, `Timestamp`, `TimeDuration`, `ConnectionId` or `UUID`.
+    /// currently `Identity`, `Timestamp`, `TimeDuration`, `ConnectionId`, `UUID` or `GraphId`.
     /// Does not follow `Ref`s.
     pub fn is_special(&self) -> bool {
         self.is_identity()
@@ -192,6 +205,7 @@ impl ProductType {
             || self.is_timestamp()
             || self.is_time_duration()
             || self.is_uuid()
+            || self.is_graph_id()
     }
 
     /// Returns whether this is a unit type, that is, has no elements.

--- a/crates/sats/src/satn.rs
+++ b/crates/sats/src/satn.rs
@@ -1,3 +1,4 @@
+use crate::graph_id::GraphId;
 use crate::time_duration::TimeDuration;
 use crate::timestamp::Timestamp;
 use crate::uuid::Uuid;
@@ -488,6 +489,8 @@ pub enum PsqlPrintFmt {
     Duration,
     /// Print as `UUID` format
     Uuid,
+    /// Print as [`GraphId`] format
+    GraphId,
     /// Print as `Satn` format
     Satn,
 }
@@ -526,6 +529,13 @@ impl PsqlPrintFmt {
 
         if tuple.is_uuid() || field.algebraic_type.is_uuid() || name.map(ProductType::is_uuid_tag).unwrap_or_default() {
             return PsqlPrintFmt::Uuid;
+        };
+
+        if tuple.is_graph_id()
+            || field.algebraic_type.is_graph_id()
+            || name.map(ProductType::is_graph_id_tag).unwrap_or_default()
+        {
+            return PsqlPrintFmt::GraphId;
         };
 
         PsqlPrintFmt::Satn
@@ -579,6 +589,7 @@ pub trait TypedWriter {
     fn write_timestamp(&mut self, value: Timestamp) -> Result<(), Self::Error>;
     fn write_duration(&mut self, value: TimeDuration) -> Result<(), Self::Error>;
     fn write_uuid(&mut self, value: Uuid) -> Result<(), Self::Error>;
+    fn write_graph_id(&mut self, value: GraphId) -> Result<(), Self::Error>;
     /// Writes a value as an alternative record format, e.g., for use `JSON` inside `SQL`.
     fn write_alt_record(
         &mut self,
@@ -694,7 +705,10 @@ impl<'a, 'f, F: TypedWriter> ser::Serializer for TypedSerializer<'a, 'f, F> {
     }
 
     fn serialize_u64(self, v: u64) -> Result<Self::Ok, Self::Error> {
-        self.f.write(v)
+        match self.ty.use_fmt() {
+            PsqlPrintFmt::GraphId => self.f.write_graph_id(GraphId::new(v)),
+            _ => self.f.write(v),
+        }
     }
 
     fn serialize_u128(self, v: u128) -> Result<Self::Ok, Self::Error> {
@@ -891,6 +905,10 @@ impl TypedWriter for SqlFormatter<'_, '_> {
 
     fn write_uuid(&mut self, value: Uuid) -> Result<(), Self::Error> {
         write!(self.fmt, "\"{value}\"")
+    }
+
+    fn write_graph_id(&mut self, value: GraphId) -> Result<(), Self::Error> {
+        write!(self.fmt, "{value}")
     }
 
     fn write_record(

--- a/crates/sql-parser/Cargo.toml
+++ b/crates/sql-parser/Cargo.toml
@@ -11,6 +11,7 @@ derive_more.workspace = true
 sqlparser.workspace = true
 thiserror.workspace = true
 spacetimedb-lib.workspace = true
+spacetimedb-cypher-parser = { path = "../cypher-parser" }
 
 [lints]
 workspace = true

--- a/crates/sql-parser/src/ast/sql.rs
+++ b/crates/sql-parser/src/ast/sql.rs
@@ -4,6 +4,8 @@ use crate::parser::{errors::SqlUnsupported, SqlParseResult};
 
 use super::{Project, SqlExpr, SqlFrom, SqlIdent, SqlLiteral};
 
+pub use spacetimedb_cypher_parser::ast::CypherQuery;
+
 /// The AST for the SQL DML and query language
 #[derive(Debug)]
 pub enum SqlAst {
@@ -19,6 +21,8 @@ pub enum SqlAst {
     Set(SqlSet),
     /// SHOW var
     Show(SqlShow),
+    /// cypher('...') — graph query via the Cypher entry point
+    Cypher(CypherQuery),
 }
 
 impl SqlAst {

--- a/crates/sql-parser/src/parser/errors.rs
+++ b/crates/sql-parser/src/parser/errors.rs
@@ -1,5 +1,6 @@
 use std::fmt::Display;
 
+use spacetimedb_cypher_parser::CypherParseError;
 use sqlparser::{
     ast::{
         BinaryOperator, Expr, Function, ObjectName, Query, Select, SelectItem, SetExpr, TableFactor, TableWithJoins,
@@ -111,6 +112,14 @@ pub enum SqlParseError {
     ParserError(#[from] ParserError),
     #[error(transparent)]
     Recursion(#[from] RecursionError),
+    #[error("Cypher parse error: {0}")]
+    Cypher(Box<CypherParseError>),
+}
+
+impl From<CypherParseError> for SqlParseError {
+    fn from(value: CypherParseError) -> Self {
+        SqlParseError::Cypher(Box::new(value))
+    }
 }
 
 impl From<SubscriptionUnsupported> for SqlParseError {

--- a/crates/sql-parser/src/parser/sql.rs
+++ b/crates/sql-parser/src/parser/sql.rs
@@ -137,7 +137,7 @@ use sqlparser::{
 };
 
 use crate::ast::{
-    sql::{SqlAst, SqlDelete, SqlInsert, SqlSelect, SqlSet, SqlShow, SqlUpdate, SqlValues},
+    sql::{CypherQuery, SqlAst, SqlDelete, SqlInsert, SqlSelect, SqlSet, SqlShow, SqlUpdate, SqlValues},
     SqlIdent,
 };
 
@@ -146,8 +146,21 @@ use super::{
     SqlParseResult,
 };
 
-/// Parse a SQL string
+/// Parse a SQL string.
+///
+/// Supports standard SQL DML as well as two Cypher entry points:
+/// - Bare `MATCH … RETURN …` (direct openCypher syntax)
+/// - `SELECT * FROM cypher('MATCH … RETURN …')` (AGE-style SQL wrapper)
 pub fn parse_sql(sql: &str) -> SqlParseResult<SqlAst> {
+    let trimmed = sql.trim();
+
+    if trimmed.len() >= 5
+        && trimmed[..5].eq_ignore_ascii_case("MATCH")
+        && trimmed.as_bytes().get(5).map_or(true, |b| b.is_ascii_whitespace() || *b == b'(')
+    {
+        return Ok(SqlAst::Cypher(spacetimedb_cypher_parser::parse_cypher(trimmed)?));
+    }
+
     let mut stmts = Parser::parse_sql(&PostgreSqlDialect {}, sql)?;
     if stmts.len() > 1 {
         return Err(SqlUnsupported::MultiStatement.into());
@@ -155,9 +168,75 @@ pub fn parse_sql(sql: &str) -> SqlParseResult<SqlAst> {
     if stmts.is_empty() {
         return Err(SqlUnsupported::Empty.into());
     }
-    parse_statement(stmts.swap_remove(0))
+
+    let stmt = stmts.swap_remove(0);
+
+    if let Some(cypher_ast) = try_parse_cypher_function(&stmt)? {
+        return Ok(SqlAst::Cypher(cypher_ast));
+    }
+
+    parse_statement(stmt)
         .map(|ast| ast.qualify_vars())
         .and_then(|ast| ast.find_unqualified_vars())
+}
+
+/// Detect `SELECT * FROM cypher('...')` and parse the inner Cypher string.
+fn try_parse_cypher_function(stmt: &Statement) -> SqlParseResult<Option<CypherQuery>> {
+    let Statement::Query(query) = stmt else {
+        return Ok(None);
+    };
+    let Query {
+        with: None,
+        body,
+        order_by,
+        limit: None,
+        offset: None,
+        fetch: None,
+        locks,
+        ..
+    } = query.as_ref()
+    else {
+        return Ok(None);
+    };
+    if !order_by.is_empty() || !locks.is_empty() {
+        return Ok(None);
+    }
+    let SetExpr::Select(select) = body.as_ref() else {
+        return Ok(None);
+    };
+    use sqlparser::ast::SelectItem;
+    if select.projection.len() != 1 || !matches!(select.projection[0], SelectItem::Wildcard(_)) {
+        return Ok(None);
+    }
+    if select.from.len() != 1 {
+        return Ok(None);
+    }
+    let TableWithJoins { relation, joins } = &select.from[0];
+    if !joins.is_empty() {
+        return Ok(None);
+    }
+    let TableFactor::Table {
+        name,
+        args: Some(args),
+        ..
+    } = relation
+    else {
+        return Ok(None);
+    };
+    if name.0.len() != 1 || !name.0[0].value.eq_ignore_ascii_case("cypher") {
+        return Ok(None);
+    }
+    use sqlparser::ast::{FunctionArg, FunctionArgExpr};
+    if args.len() != 1 {
+        return Ok(None);
+    }
+    let cypher_str = match &args[0] {
+        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(Value::SingleQuotedString(s)))) => s,
+        FunctionArg::Unnamed(FunctionArgExpr::Expr(Expr::Value(Value::DollarQuotedString(s)))) => &s.value,
+        _ => return Ok(None),
+    };
+    let ast = spacetimedb_cypher_parser::parse_cypher(cypher_str)?;
+    Ok(Some(ast))
 }
 
 /// Parse a SQL statement
@@ -478,5 +557,97 @@ mod tests {
         ] {
             assert!(parse_sql(sql).is_err());
         }
+    }
+
+    // ── Cypher entry point tests ────────────────────────────────────────
+
+    #[test]
+    fn cypher_bare_match() {
+        let ast = parse_sql("MATCH (n:Person) RETURN n").unwrap();
+        assert!(matches!(ast, super::SqlAst::Cypher(_)));
+    }
+
+    #[test]
+    fn cypher_bare_match_case_insensitive() {
+        let ast = parse_sql("match (n) WHERE n.x = 1 return n").unwrap();
+        assert!(matches!(ast, super::SqlAst::Cypher(_)));
+    }
+
+    #[test]
+    fn cypher_bare_match_with_leading_whitespace() {
+        let ast = parse_sql("  MATCH (a)-[:KNOWS]->(b) RETURN a, b").unwrap();
+        assert!(matches!(ast, super::SqlAst::Cypher(_)));
+    }
+
+    #[test]
+    fn cypher_function_single_quoted() {
+        let ast = parse_sql("SELECT * FROM cypher('MATCH (n) RETURN n')").unwrap();
+        assert!(matches!(ast, super::SqlAst::Cypher(_)));
+    }
+
+    #[test]
+    fn cypher_function_case_insensitive_name() {
+        let ast = parse_sql("SELECT * FROM CYPHER('MATCH (n) RETURN n')").unwrap();
+        assert!(matches!(ast, super::SqlAst::Cypher(_)));
+    }
+
+    #[test]
+    fn cypher_function_with_complex_query() {
+        let ast =
+            parse_sql("SELECT * FROM cypher('MATCH (a:Person)-[r:KNOWS]->(b) WHERE a.age > 25 RETURN a, b')")
+                .unwrap();
+        assert!(matches!(ast, super::SqlAst::Cypher(_)));
+    }
+
+    #[test]
+    fn cypher_function_dollar_quoted() {
+        let ast = parse_sql("SELECT * FROM cypher($$MATCH (n) RETURN n$$)").unwrap();
+        assert!(matches!(ast, super::SqlAst::Cypher(_)));
+    }
+
+    #[test]
+    fn cypher_bare_match_produces_correct_ast() {
+        use spacetimedb_cypher_parser::ast::*;
+        let ast = parse_sql("MATCH (p:Person) WHERE p.age > 30 RETURN p.name").unwrap();
+        let super::SqlAst::Cypher(query) = ast else {
+            panic!("expected Cypher variant");
+        };
+        assert_eq!(query.match_clause.patterns.len(), 1);
+        assert_eq!(
+            query.match_clause.patterns[0].nodes[0].label.as_deref(),
+            Some("Person")
+        );
+        assert!(query.where_clause.is_some());
+        assert!(matches!(query.return_clause, ReturnClause::Items(ref items) if items.len() == 1));
+    }
+
+    #[test]
+    fn cypher_error_invalid_match_syntax() {
+        let err = parse_sql("MATCH (n) WHERE");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn cypher_error_function_with_invalid_inner() {
+        let err = parse_sql("SELECT * FROM cypher('MATCH (n) WHERE')");
+        assert!(err.is_err());
+    }
+
+    #[test]
+    fn cypher_function_does_not_hijack_normal_from() {
+        let ast = parse_sql("select a from t").unwrap();
+        assert!(matches!(ast, super::SqlAst::Select(_)));
+    }
+
+    #[test]
+    fn cypher_bare_match_prefix_does_not_trigger_cypher() {
+        let err = parse_sql("MATCHING (n:Person) RETURN n");
+        assert!(err.is_err(), "MATCHING should not be treated as a MATCH keyword");
+    }
+
+    #[test]
+    fn cypher_function_non_wildcard_projection_falls_through() {
+        let err = parse_sql("SELECT a.name FROM cypher('MATCH (n) RETURN n')");
+        assert!(err.is_err(), "non-wildcard projection should not be intercepted as cypher");
     }
 }

--- a/crates/subscription/Cargo.toml
+++ b/crates/subscription/Cargo.toml
@@ -8,6 +8,7 @@ description = "The SpacetimeDB subscription compiler"
 
 [dependencies]
 anyhow.workspace = true
+spacetimedb-cypher-parser.workspace = true
 spacetimedb-data-structures.workspace = true
 spacetimedb-execution.workspace = true
 spacetimedb-expr.workspace = true

--- a/crates/subscription/src/lib.rs
+++ b/crates/subscription/src/lib.rs
@@ -1,4 +1,4 @@
-use anyhow::{bail, Result};
+use anyhow::{bail, Context as _, Result};
 use spacetimedb_data_structures::map::{HashCollectionExt as _, HashSet};
 use spacetimedb_execution::{
     pipelined::{
@@ -7,9 +7,16 @@ use spacetimedb_execution::{
     },
     Datastore, DeltaStore, Row,
 };
-use spacetimedb_expr::{check::SchemaView, expr::CollectViews};
+use spacetimedb_expr::{
+    check::SchemaView,
+    cypher::translate_cypher,
+    expr::{CollectViews, ProjectList},
+};
 use spacetimedb_lib::{identity::AuthCtx, metrics::ExecutionMetrics, query::Delta, AlgebraicValue};
-use spacetimedb_physical_plan::plan::{IxJoin, IxScan, Label, PhysicalPlan, ProjectPlan, Sarg, TableScan, TupleField};
+use spacetimedb_physical_plan::{
+    compile::compile_select,
+    plan::{IxJoin, IxScan, Label, PhysicalPlan, ProjectPlan, Sarg, TableScan, TupleField},
+};
 use spacetimedb_primitives::{ColId, ColList, IndexId, TableId, ViewId};
 use spacetimedb_query::compile_subscription;
 use spacetimedb_schema::table_name::TableName;
@@ -162,93 +169,77 @@ impl Fragments {
     /// dv(+) = R'ds(+) U dr(+)S' U dr(+)ds(-) U dr(-)ds(+)
     /// dv(-) = R'ds(-) U dr(-)S' U dr(+)ds(+) U dr(-)ds(-)
     /// ```
-    fn compile_from_plan(plan: &ProjectPlan, tables: &[Label], auth: &AuthCtx) -> Result<Self> {
-        /// Mutate a query plan by turning a table scan into a delta scan
-        fn mut_plan(plan: &mut ProjectPlan, relvar: Label, delta: Delta) {
-            plan.visit_mut(&mut |plan| match plan {
-                PhysicalPlan::TableScan(
-                    scan @ TableScan {
-                        limit: None,
-                        delta: None,
-                        ..
-                    },
-                    alias,
-                ) if alias == &relvar => {
-                    scan.delta = Some(delta);
-                }
-                _ => {}
-            });
+    /// Build delta fragments for incremental view maintenance.
+    ///
+    /// `table_ids` and `table_aliases` are parallel slices: `table_ids[i]` is
+    /// the underlying `TableId` for the scan labelled `table_aliases[i]`.
+    ///
+    /// When multiple aliases share the same `TableId` (self-join, e.g. a
+    /// graph query scanning `Vertex` twice), they are grouped together so
+    /// that a single table mutation sets the delta flag on **all** aliases of
+    /// that table simultaneously.  The IVM formula then operates on the
+    /// number of *distinct* tables (≤ 2 for subscriptions).
+    fn compile_from_plan(
+        plan: &ProjectPlan,
+        table_ids: &[TableId],
+        table_aliases: &[Label],
+        auth: &AuthCtx,
+    ) -> Result<Self> {
+        let groups = group_aliases_by_table(table_ids, table_aliases);
+
+        fn mut_plan_group(plan: &mut ProjectPlan, labels: &[Label], delta: Delta) {
+            for &label in labels {
+                plan.visit_mut(&mut |plan| match plan {
+                    PhysicalPlan::TableScan(
+                        scan @ TableScan {
+                            limit: None,
+                            delta: None,
+                            ..
+                        },
+                        alias,
+                    ) if alias == &label => {
+                        scan.delta = Some(delta);
+                    }
+                    _ => {}
+                });
+            }
         }
 
-        /// Return a new plan with delta scans for the given tables
-        fn new_plan(plan: &ProjectPlan, tables: &[(Label, Delta)], auth: &AuthCtx) -> Result<PipelinedProject> {
+        fn new_plan(
+            plan: &ProjectPlan,
+            specs: &[(&[Label], Delta)],
+            auth: &AuthCtx,
+        ) -> Result<PipelinedProject> {
             let mut plan = plan.clone();
-            for (alias, delta) in tables {
-                mut_plan(&mut plan, *alias, *delta);
+            for (labels, delta) in specs {
+                mut_plan_group(&mut plan, labels, *delta);
             }
             plan.optimize(auth).map(PipelinedProject::from)
         }
 
-        match tables {
+        match groups.as_slice() {
             [dr] => Ok(Fragments {
-                insert_plans: vec![new_plan(plan, &[(*dr, Delta::Inserts)], auth)?],
-                delete_plans: vec![new_plan(plan, &[(*dr, Delta::Deletes)], auth)?],
+                insert_plans: vec![new_plan(plan, &[(dr, Delta::Inserts)], auth)?],
+                delete_plans: vec![new_plan(plan, &[(dr, Delta::Deletes)], auth)?],
             }),
             [dr, ds] => Ok(Fragments {
                 insert_plans: vec![
-                    new_plan(
-                        // dr(+)S'
-                        plan,
-                        &[(*dr, Delta::Inserts)],
-                        auth,
-                    )?,
-                    new_plan(
-                        // R'ds(+)
-                        plan,
-                        &[(*ds, Delta::Inserts)],
-                        auth,
-                    )?,
-                    new_plan(
-                        // dr(+)ds(-)
-                        plan,
-                        &[(*dr, Delta::Inserts), (*ds, Delta::Deletes)],
-                        auth,
-                    )?,
-                    new_plan(
-                        // dr(-)ds(+)
-                        plan,
-                        &[(*dr, Delta::Deletes), (*ds, Delta::Inserts)],
-                        auth,
-                    )?,
+                    new_plan(plan, &[(dr, Delta::Inserts)], auth)?,
+                    new_plan(plan, &[(ds, Delta::Inserts)], auth)?,
+                    new_plan(plan, &[(dr, Delta::Inserts), (ds, Delta::Deletes)], auth)?,
+                    new_plan(plan, &[(dr, Delta::Deletes), (ds, Delta::Inserts)], auth)?,
                 ],
                 delete_plans: vec![
-                    new_plan(
-                        // dr(-)S'
-                        plan,
-                        &[(*dr, Delta::Deletes)],
-                        auth,
-                    )?,
-                    new_plan(
-                        // R'ds(-)
-                        plan,
-                        &[(*ds, Delta::Deletes)],
-                        auth,
-                    )?,
-                    new_plan(
-                        // dr(+)ds(+)
-                        plan,
-                        &[(*dr, Delta::Inserts), (*ds, Delta::Inserts)],
-                        auth,
-                    )?,
-                    new_plan(
-                        // dr(-)ds(-)
-                        plan,
-                        &[(*dr, Delta::Deletes), (*ds, Delta::Deletes)],
-                        auth,
-                    )?,
+                    new_plan(plan, &[(dr, Delta::Deletes)], auth)?,
+                    new_plan(plan, &[(ds, Delta::Deletes)], auth)?,
+                    new_plan(plan, &[(dr, Delta::Inserts), (ds, Delta::Inserts)], auth)?,
+                    new_plan(plan, &[(dr, Delta::Deletes), (ds, Delta::Deletes)], auth)?,
                 ],
             }),
-            _ => bail!("Invalid number of tables in subscription: {}", tables.len()),
+            _ => bail!(
+                "Subscriptions support at most 2 distinct tables, found {}",
+                groups.len()
+            ),
         }
     }
 }
@@ -476,40 +467,6 @@ impl SubscriptionPlan {
     pub fn compile(sql: &str, tx: &impl SchemaView, auth: &AuthCtx) -> Result<(Vec<Self>, bool)> {
         let (plans, return_id, return_name, has_param) = compile_subscription(sql, tx, auth)?;
 
-        /// Does this plan have any non-index joins?
-        fn has_non_index_join(plan: &PhysicalPlan) -> bool {
-            plan.any(&|op| matches!(op, PhysicalPlan::HashJoin(..) | PhysicalPlan::NLJoin(..)))
-        }
-
-        /// What tables are involved in this plan?
-        fn table_ids_for_plan(plan: &PhysicalPlan) -> (Vec<TableId>, Vec<Label>) {
-            let mut table_aliases = vec![];
-            let mut table_ids = vec![];
-            plan.visit(&mut |plan| match plan {
-                PhysicalPlan::TableScan(
-                    TableScan {
-                        // What table are we reading?
-                        schema,
-                        ..
-                    },
-                    alias,
-                )
-                | PhysicalPlan::IxScan(
-                    IxScan {
-                        // What table are we reading?
-                        schema,
-                        ..
-                    },
-                    alias,
-                ) => {
-                    table_aliases.push(*alias);
-                    table_ids.push(schema.table_id);
-                }
-                _ => {}
-            });
-            (table_ids, table_aliases)
-        }
-
         let mut subscriptions = vec![];
 
         for plan in plans {
@@ -525,7 +482,7 @@ impl SubscriptionPlan {
 
             let (table_ids, table_aliases) = table_ids_for_plan(&plan);
 
-            let fragments = Fragments::compile_from_plan(&plan, &table_aliases, auth)?;
+            let fragments = Fragments::compile_from_plan(&plan, &table_ids, &table_aliases, auth)?;
 
             subscriptions.push(Self {
                 return_id,
@@ -537,5 +494,397 @@ impl SubscriptionPlan {
         }
 
         Ok((subscriptions, has_param))
+    }
+
+    /// Generate subscription plans from a Cypher graph query.
+    ///
+    /// Fixed-depth graph queries (e.g. `MATCH (a)-[r]->(b) RETURN a`)
+    /// lower to `EqJoin` chains over `Vertex` and `Edge` tables. These
+    /// are compiled into subscription fragments using the standard 2-table
+    /// incremental view maintenance formula, with aliases grouped by their
+    /// underlying `TableId` so that self-joins (same table scanned under
+    /// multiple aliases) share deltas correctly.
+    ///
+    /// Variable-length path queries (`[*1..k]`) are expanded into a UNION
+    /// of fixed-depth plans — one `SubscriptionPlan` per depth.
+    pub fn compile_cypher(
+        cypher: &str,
+        tx: &impl SchemaView,
+        auth: &AuthCtx,
+    ) -> Result<Vec<Self>> {
+        let query = spacetimedb_cypher_parser::parse_cypher(cypher)
+            .context("Failed to parse Cypher query")?;
+
+        let project_list = translate_cypher(&query, tx)
+            .context("Failed to translate Cypher query")?;
+
+        let names = match project_list {
+            ProjectList::Name(names) => names,
+            _ => bail!("Graph subscriptions must return whole table rows (RETURN * or RETURN <var>)"),
+        };
+
+        if names.is_empty() {
+            bail!("Empty Cypher query result");
+        }
+
+        let return_id = names
+            .first()
+            .and_then(|n| n.return_table_id())
+            .ok_or_else(|| anyhow::anyhow!("Cannot determine return TableId for Cypher subscription"))?;
+
+        debug_assert!(
+            names.iter().all(|n| n.return_table_id() == Some(return_id)),
+            "All depth levels must share the same return table"
+        );
+
+        let return_name = tx
+            .schema_for_table(return_id)
+            .map(|s| s.table_name.clone())
+            .ok_or_else(|| anyhow::anyhow!("TableId `{return_id}` does not exist"))?;
+
+        let mut subscriptions = vec![];
+
+        for name in names {
+            let plan = compile_select(name);
+            let plan_opt = plan.clone().optimize(auth)?;
+
+            if has_non_index_join(&plan_opt) {
+                bail!("Graph subscriptions require indexes on join columns")
+            }
+
+            if plan_opt.reads_from_event_table() {
+                bail!("Event tables cannot be used as the lookup table in graph subscription joins")
+            }
+
+            let (table_ids, table_aliases) = table_ids_for_plan(&plan);
+
+            let fragments = Fragments::compile_from_plan(&plan, &table_ids, &table_aliases, auth)?;
+
+            subscriptions.push(Self {
+                return_id,
+                return_name: return_name.clone(),
+                table_ids,
+                plan_opt,
+                fragments,
+            });
+        }
+
+        Ok(subscriptions)
+    }
+}
+
+/// Does this plan have any non-index joins?
+fn has_non_index_join(plan: &PhysicalPlan) -> bool {
+    plan.any(&|op| matches!(op, PhysicalPlan::HashJoin(..) | PhysicalPlan::NLJoin(..)))
+}
+
+/// Collect `(TableId, Label)` pairs from all scans in a physical plan.
+fn table_ids_for_plan(plan: &PhysicalPlan) -> (Vec<TableId>, Vec<Label>) {
+    let mut table_aliases = vec![];
+    let mut table_ids = vec![];
+    plan.visit(&mut |plan| match plan {
+        PhysicalPlan::TableScan(TableScan { schema, .. }, alias)
+        | PhysicalPlan::IxScan(IxScan { schema, .. }, alias) => {
+            table_aliases.push(*alias);
+            table_ids.push(schema.table_id);
+        }
+        _ => {}
+    });
+    (table_ids, table_aliases)
+}
+
+/// Group labels by their underlying `TableId`.
+///
+/// Returns a `Vec<Vec<Label>>` where each inner vec contains all labels
+/// that scan the same physical table. This allows the IVM formula to
+/// treat self-joins correctly: when a table mutates, ALL aliases of that
+/// table see the same delta.
+fn group_aliases_by_table(table_ids: &[TableId], table_aliases: &[Label]) -> Vec<Vec<Label>> {
+    let mut groups: Vec<Vec<Label>> = Vec::new();
+    let mut seen: Vec<TableId> = Vec::new();
+
+    for (&tid, &alias) in table_ids.iter().zip(table_aliases.iter()) {
+        if let Some(pos) = seen.iter().position(|&id| id == tid) {
+            groups[pos].push(alias);
+        } else {
+            seen.push(tid);
+            groups.push(vec![alias]);
+        }
+    }
+
+    groups
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use spacetimedb_expr::check::test_utils::SchemaViewer;
+    use spacetimedb_lib::{
+        db::raw_def::v9::{btree, RawModuleDefV9Builder},
+        identity::AuthCtx,
+        AlgebraicType, ProductType,
+    };
+    use spacetimedb_primitives::TableId;
+
+    fn graph_tx() -> SchemaViewer {
+        let mut builder = RawModuleDefV9Builder::new();
+        builder
+            .build_table_with_new_type(
+                "Vertex",
+                ProductType::from([
+                    ("Id", AlgebraicType::U64),
+                    ("Label", AlgebraicType::String),
+                    ("Properties", AlgebraicType::String),
+                ]),
+                true,
+            )
+            .with_index_no_accessor_name(btree(ColId(0)));
+        builder
+            .build_table_with_new_type(
+                "Edge",
+                ProductType::from([
+                    ("Id", AlgebraicType::U64),
+                    ("StartId", AlgebraicType::U64),
+                    ("EndId", AlgebraicType::U64),
+                    ("EdgeType", AlgebraicType::String),
+                    ("Properties", AlgebraicType::String),
+                ]),
+                true,
+            )
+            .with_index_no_accessor_name(btree(ColId(1)))
+            .with_index_no_accessor_name(btree(ColId(2)));
+        let module_def = builder.finish().try_into().expect("valid module def");
+        SchemaViewer::new(module_def, vec![("Vertex", TableId(0)), ("Edge", TableId(1))])
+    }
+
+    #[test]
+    fn group_aliases_single_table() {
+        let ids = vec![TableId(0)];
+        let labels = vec![Label(1)];
+        let groups = group_aliases_by_table(&ids, &labels);
+        assert_eq!(groups.len(), 1);
+        assert_eq!(groups[0], vec![Label(1)]);
+    }
+
+    #[test]
+    fn group_aliases_two_distinct_tables() {
+        let ids = vec![TableId(0), TableId(1)];
+        let labels = vec![Label(1), Label(2)];
+        let groups = group_aliases_by_table(&ids, &labels);
+        assert_eq!(groups.len(), 2);
+        assert_eq!(groups[0], vec![Label(1)]);
+        assert_eq!(groups[1], vec![Label(2)]);
+    }
+
+    #[test]
+    fn group_aliases_self_join() {
+        let ids = vec![TableId(0), TableId(1), TableId(0)];
+        let labels = vec![Label(1), Label(2), Label(3)];
+        let groups = group_aliases_by_table(&ids, &labels);
+        assert_eq!(groups.len(), 2, "3 aliases over 2 tables should produce 2 groups");
+        assert_eq!(groups[0], vec![Label(1), Label(3)], "both Vertex aliases grouped");
+        assert_eq!(groups[1], vec![Label(2)], "Edge alias in its own group");
+    }
+
+    #[test]
+    fn compile_cypher_single_hop() {
+        let tx = graph_tx();
+        let auth = AuthCtx::for_testing();
+        let result = SubscriptionPlan::compile_cypher(
+            "MATCH (a)-[r]->(b) RETURN a",
+            &tx,
+            &auth,
+        );
+        let plans = result.expect("single-hop graph subscription should compile");
+        assert_eq!(plans.len(), 1, "fixed-depth single-hop produces 1 plan");
+
+        let plan = &plans[0];
+        assert!(plan.is_join(), "graph query is a join subscription");
+        assert_eq!(
+            plan.fragments.insert_plans.len(),
+            4,
+            "2-table IVM produces 4 insert fragments"
+        );
+        assert_eq!(
+            plan.fragments.delete_plans.len(),
+            4,
+            "2-table IVM produces 4 delete fragments"
+        );
+    }
+
+    #[test]
+    fn compile_cypher_two_hop() {
+        let tx = graph_tx();
+        let auth = AuthCtx::for_testing();
+        let result = SubscriptionPlan::compile_cypher(
+            "MATCH (a)-[r]->(b)-[s]->(c) RETURN a",
+            &tx,
+            &auth,
+        );
+        let plans = result.expect("two-hop graph subscription should compile");
+        assert_eq!(plans.len(), 1, "fixed-depth two-hop produces 1 plan");
+        assert!(plans[0].is_join());
+    }
+
+    #[test]
+    fn compile_cypher_return_star_single_node() {
+        let tx = graph_tx();
+        let auth = AuthCtx::for_testing();
+        let plans = SubscriptionPlan::compile_cypher("MATCH (a) RETURN *", &tx, &auth)
+            .expect("RETURN * on single node should compile");
+        assert_eq!(plans.len(), 1);
+        assert_eq!(plans[0].subscribed_table_id(), TableId(0));
+    }
+
+    #[test]
+    fn compile_cypher_return_star_join_rejected() {
+        let tx = graph_tx();
+        let auth = AuthCtx::for_testing();
+        let result = SubscriptionPlan::compile_cypher(
+            "MATCH (a)-[r]->(b) RETURN *",
+            &tx,
+            &auth,
+        );
+        assert!(
+            result.is_err(),
+            "RETURN * on a join should fail (ambiguous return table)"
+        );
+    }
+
+    #[test]
+    fn compile_cypher_variable_length_produces_union() {
+        let tx = graph_tx();
+        let auth = AuthCtx::for_testing();
+        let result = SubscriptionPlan::compile_cypher(
+            "MATCH (a)-[*1..3]->(b) RETURN a",
+            &tx,
+            &auth,
+        );
+        let plans = result.expect("variable-length subscription should compile");
+        assert_eq!(
+            plans.len(),
+            3,
+            "[*1..3] expands to 3 fixed-depth plans (depths 1, 2, 3)"
+        );
+        for plan in &plans {
+            assert_eq!(plan.fragments.insert_plans.len(), 4);
+            assert_eq!(plan.fragments.delete_plans.len(), 4);
+        }
+    }
+
+    #[test]
+    fn compile_cypher_with_label_filter() {
+        let tx = graph_tx();
+        let auth = AuthCtx::for_testing();
+        let result = SubscriptionPlan::compile_cypher(
+            "MATCH (a:Person)-[r:KNOWS]->(b:Person) RETURN a",
+            &tx,
+            &auth,
+        );
+        let plans = result.expect("labelled graph subscription should compile");
+        assert_eq!(plans.len(), 1);
+        assert!(plans[0].is_join());
+    }
+
+    #[test]
+    fn compile_cypher_subscribed_table_is_vertex() {
+        let tx = graph_tx();
+        let auth = AuthCtx::for_testing();
+        let plans = SubscriptionPlan::compile_cypher(
+            "MATCH (a)-[r]->(b) RETURN a",
+            &tx,
+            &auth,
+        )
+        .unwrap();
+        assert_eq!(
+            plans[0].subscribed_table_id(),
+            TableId(0),
+            "RETURN a should subscribe to Vertex (TableId 0)"
+        );
+    }
+
+    #[test]
+    fn compile_cypher_rejects_property_projection() {
+        let tx = graph_tx();
+        let auth = AuthCtx::for_testing();
+        let result = SubscriptionPlan::compile_cypher(
+            "MATCH (a)-[r]->(b) RETURN a.Label",
+            &tx,
+            &auth,
+        );
+        assert!(
+            result.is_err(),
+            "property projections should be rejected for subscriptions"
+        );
+    }
+
+    fn graph_tx_no_indexes() -> SchemaViewer {
+        use spacetimedb_expr::check::test_utils::build_module_def;
+        SchemaViewer::new(
+            build_module_def(vec![
+                (
+                    "Vertex",
+                    ProductType::from([
+                        ("Id", AlgebraicType::U64),
+                        ("Label", AlgebraicType::String),
+                        ("Properties", AlgebraicType::String),
+                    ]),
+                ),
+                (
+                    "Edge",
+                    ProductType::from([
+                        ("Id", AlgebraicType::U64),
+                        ("StartId", AlgebraicType::U64),
+                        ("EndId", AlgebraicType::U64),
+                        ("EdgeType", AlgebraicType::String),
+                        ("Properties", AlgebraicType::String),
+                    ]),
+                ),
+            ]),
+            vec![("Vertex", TableId(0)), ("Edge", TableId(1))],
+        )
+    }
+
+    #[test]
+    fn compile_cypher_rejects_non_index_join() {
+        let tx = graph_tx_no_indexes();
+        let auth = AuthCtx::for_testing();
+        let result = SubscriptionPlan::compile_cypher(
+            "MATCH (a)-[r]->(b) RETURN a",
+            &tx,
+            &auth,
+        );
+        assert!(
+            result.is_err(),
+            "graph joins without indexes should be rejected"
+        );
+        let err = result.unwrap_err().to_string();
+        assert!(
+            err.contains("indexes on join columns"),
+            "error should mention missing indexes, got: {err}"
+        );
+    }
+
+    #[test]
+    fn compile_cypher_single_hop_table_ids() {
+        let tx = graph_tx();
+        let auth = AuthCtx::for_testing();
+        let plans = SubscriptionPlan::compile_cypher(
+            "MATCH (a)-[r]->(b) RETURN a",
+            &tx,
+            &auth,
+        )
+        .unwrap();
+
+        let plan = &plans[0];
+        let tids: Vec<TableId> = plan.table_ids().collect();
+        assert!(
+            tids.contains(&TableId(0)),
+            "should read from Vertex table"
+        );
+        assert!(
+            tids.contains(&TableId(1)),
+            "should read from Edge table"
+        );
     }
 }

--- a/crates/testing/tests/graph_module_integration_test.rs
+++ b/crates/testing/tests/graph_module_integration_test.rs
@@ -1,0 +1,667 @@
+use serial_test::serial;
+use spacetimedb_lib::sats::product;
+use spacetimedb_testing::modules::{CompilationMode, CompiledModule, DEFAULT_CONFIG};
+
+fn init() {
+    let _ = env_logger::builder()
+        .parse_filters(
+            "spacetimedb=trace,spacetimedb_client_api=trace,spacetimedb_lib=trace,spacetimedb_standalone=trace",
+        )
+        .is_test(true)
+        .try_init();
+}
+
+// ========================================================================
+// Vertex CRUD happy path
+// ========================================================================
+
+#[test]
+#[serial]
+fn graph_create_vertex() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{\"name\":\"Alice\"}"])
+                .await
+                .unwrap();
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_update_vertex() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{\"name\":\"Alice\"}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("update_vertex", &product![1u64, "Person", "{\"name\":\"Bob\"}"])
+                .await
+                .unwrap();
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_delete_vertex() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{\"name\":\"Alice\"}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("delete_vertex", &product![1u64])
+                .await
+                .unwrap();
+        },
+    );
+}
+
+// ========================================================================
+// Edge CRUD happy path
+// ========================================================================
+
+#[test]
+#[serial]
+fn graph_create_edge() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_edge", &product![1u64, 2u64, "knows", "{}"])
+                .await
+                .unwrap();
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_update_edge() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_edge", &product![1u64, 2u64, "knows", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("update_edge", &product![1u64, 2u64, 1u64, "friend", "{}"])
+                .await
+                .unwrap();
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_delete_edge() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_edge", &product![1u64, 2u64, "knows", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("delete_edge", &product![1u64])
+                .await
+                .unwrap();
+        },
+    );
+}
+
+// ========================================================================
+// Edge endpoint validation
+// ========================================================================
+
+#[test]
+#[serial]
+fn graph_create_edge_rejects_missing_start_vertex() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            let result = module
+                .call_reducer_binary("create_edge", &product![999u64, 1u64, "knows", "{}"])
+                .await;
+            assert!(result.is_err(), "Expected error for missing start vertex");
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("Start vertex 999 not found"),
+                "Error should mention missing start vertex, got: {}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_create_edge_rejects_missing_end_vertex() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            let result = module
+                .call_reducer_binary("create_edge", &product![1u64, 999u64, "knows", "{}"])
+                .await;
+            assert!(result.is_err(), "Expected error for missing end vertex");
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("End vertex 999 not found"),
+                "Error should mention missing end vertex, got: {}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_update_edge_rejects_missing_start_vertex() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_edge", &product![1u64, 2u64, "knows", "{}"])
+                .await
+                .unwrap();
+            let result = module
+                .call_reducer_binary("update_edge", &product![1u64, 999u64, 2u64, "knows", "{}"])
+                .await;
+            assert!(result.is_err(), "Expected error for missing start vertex on update");
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("Start vertex 999 not found"),
+                "Error should mention missing start vertex, got: {}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_update_edge_rejects_missing_end_vertex() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_edge", &product![1u64, 2u64, "knows", "{}"])
+                .await
+                .unwrap();
+            let result = module
+                .call_reducer_binary("update_edge", &product![1u64, 1u64, 999u64, "knows", "{}"])
+                .await;
+            assert!(result.is_err(), "Expected error for missing end vertex on update");
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("End vertex 999 not found"),
+                "Error should mention missing end vertex, got: {}",
+                err
+            );
+        },
+    );
+}
+
+// ========================================================================
+// Cascade deletion
+// ========================================================================
+
+#[test]
+#[serial]
+fn graph_delete_vertex_cascades_to_connected_edges() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_edge", &product![1u64, 2u64, "knows", "{}"])
+                .await
+                .unwrap();
+
+            // Delete vertex 1 — should cascade and remove edge 1
+            module
+                .call_reducer_binary("delete_vertex", &product![1u64])
+                .await
+                .unwrap();
+
+            // Edge should no longer exist
+            let result = module.call_reducer_binary("delete_edge", &product![1u64]).await;
+            assert!(result.is_err(), "Expected edge to be cascade-deleted");
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("Edge 1 not found"),
+                "Error should mention missing edge, got: {}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_delete_vertex_cascades_multiple_edges() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            // Create a star: vertex 1 connected to 2, 3, 4
+            for _ in 0..4 {
+                module
+                    .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                    .await
+                    .unwrap();
+            }
+            module
+                .call_reducer_binary("create_edge", &product![1u64, 2u64, "knows", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_edge", &product![1u64, 3u64, "knows", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_edge", &product![1u64, 4u64, "knows", "{}"])
+                .await
+                .unwrap();
+
+            // Delete the center vertex — all three edges should be removed
+            module
+                .call_reducer_binary("delete_vertex", &product![1u64])
+                .await
+                .unwrap();
+
+            for edge_id in 1..=3u64 {
+                let result = module.call_reducer_binary("delete_edge", &product![edge_id]).await;
+                assert!(result.is_err(), "Expected edge {} to be cascade-deleted", edge_id);
+                let err = format!("{}", result.unwrap_err());
+                assert!(
+                    err.contains(&format!("Edge {edge_id} not found")),
+                    "Error should mention missing edge {edge_id}, got: {}",
+                    err
+                );
+            }
+        },
+    );
+}
+
+// ========================================================================
+// Missing entity errors
+// ========================================================================
+
+#[test]
+#[serial]
+fn graph_update_vertex_rejects_missing() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            let result = module
+                .call_reducer_binary("update_vertex", &product![999u64, "Person", "{}"])
+                .await;
+            assert!(result.is_err(), "Expected error for missing vertex");
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("Vertex 999 not found"),
+                "Error should mention missing vertex, got: {}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_delete_vertex_rejects_missing() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            let result = module.call_reducer_binary("delete_vertex", &product![999u64]).await;
+            assert!(result.is_err(), "Expected error for missing vertex");
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("Vertex 999 not found"),
+                "Error should mention missing vertex, got: {}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_delete_edge_rejects_missing() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            let result = module.call_reducer_binary("delete_edge", &product![999u64]).await;
+            assert!(result.is_err(), "Expected error for missing edge");
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("Edge 999 not found"),
+                "Error should mention missing edge, got: {}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_update_edge_rejects_missing() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            let result = module
+                .call_reducer_binary("update_edge", &product![999u64, 1u64, 2u64, "knows", "{}"])
+                .await;
+            assert!(result.is_err(), "Expected error for missing edge");
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("Edge 999 not found"),
+                "Error should mention missing edge, got: {}",
+                err
+            );
+        },
+    );
+}
+
+// ========================================================================
+// Traversal reducers
+// ========================================================================
+
+#[test]
+#[serial]
+fn graph_bfs_happy_path() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            // 1 -> 2 -> 3
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_edge", &product![1u64, 2u64, "knows", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_edge", &product![2u64, 3u64, "knows", "{}"])
+                .await
+                .unwrap();
+
+            module
+                .call_reducer_binary("bfs", &product![1u64, 10u32, "test-bfs"])
+                .await
+                .unwrap();
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_bfs_rejects_missing_start() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            let result = module
+                .call_reducer_binary("bfs", &product![999u64, 10u32, "test-bfs"])
+                .await;
+            assert!(result.is_err(), "Expected error for missing start vertex in BFS");
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("Start vertex 999 not found"),
+                "Error should mention missing start vertex, got: {}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_dfs_happy_path() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_edge", &product![1u64, 2u64, "knows", "{}"])
+                .await
+                .unwrap();
+
+            module
+                .call_reducer_binary("dfs", &product![1u64, 10u32, "test-dfs"])
+                .await
+                .unwrap();
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_dfs_rejects_missing_start() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            let result = module
+                .call_reducer_binary("dfs", &product![999u64, 10u32, "test-dfs"])
+                .await;
+            assert!(result.is_err(), "Expected error for missing start vertex in DFS");
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("Start vertex 999 not found"),
+                "Error should mention missing start vertex, got: {}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_shortest_path_happy_path() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("create_edge", &product![1u64, 2u64, "knows", "{}"])
+                .await
+                .unwrap();
+
+            module
+                .call_reducer_binary("shortest_path", &product![1u64, 2u64, "test-sp"])
+                .await
+                .unwrap();
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_shortest_path_rejects_missing_start() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            let result = module
+                .call_reducer_binary("shortest_path", &product![999u64, 1u64, "test-sp"])
+                .await;
+            assert!(
+                result.is_err(),
+                "Expected error for missing start vertex in shortest_path"
+            );
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("Start vertex 999 not found"),
+                "Error should mention missing start vertex, got: {}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_shortest_path_rejects_missing_end() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            let result = module
+                .call_reducer_binary("shortest_path", &product![1u64, 999u64, "test-sp"])
+                .await;
+            assert!(result.is_err(), "Expected error for missing end vertex in shortest_path");
+            let err = format!("{}", result.unwrap_err());
+            assert!(
+                err.contains("End vertex 999 not found"),
+                "Error should mention missing end vertex, got: {}",
+                err
+            );
+        },
+    );
+}
+
+#[test]
+#[serial]
+fn graph_clear_traversal_results() {
+    init();
+    CompiledModule::compile("graph", CompilationMode::Debug).with_module_async(
+        DEFAULT_CONFIG,
+        |module| async move {
+            module
+                .call_reducer_binary("create_vertex", &product!["Person", "{}"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("bfs", &product![1u64, 1u32, "clear-test"])
+                .await
+                .unwrap();
+            module
+                .call_reducer_binary("clear_traversal_results", &product!["clear-test"])
+                .await
+                .unwrap();
+        },
+    );
+}

--- a/modules/graph-algo/Cargo.toml
+++ b/modules/graph-algo/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "graph-algo"
+version = "0.1.0"
+edition.workspace = true
+
+[dependencies]
+
+[[bench]]
+name = "traversal"
+harness = false

--- a/modules/graph-algo/benches/traversal.rs
+++ b/modules/graph-algo/benches/traversal.rs
@@ -1,0 +1,193 @@
+use graph_algo::{bfs, dfs, shortest_path};
+use std::time::{Duration, Instant};
+
+const EDGES_PER_VERTEX: u64 = 3;
+const WARMUP_ITERS: u32 = 2;
+const BENCH_ITERS: u32 = 5;
+
+/// Build a ring-of-successors adjacency list identical to `bench_seed_graph`.
+fn build_adjacency(vertex_count: u64, edges_per_vertex: u64) -> Vec<Vec<u64>> {
+    let mut adj: Vec<Vec<u64>> = vec![Vec::new(); vertex_count as usize + 1];
+    for src in 1..=vertex_count {
+        for offset in 1..=edges_per_vertex {
+            let dst = (src - 1 + offset) % vertex_count + 1;
+            adj[src as usize].push(dst);
+        }
+    }
+    adj
+}
+
+fn neighbors_fn(adj: &[Vec<u64>]) -> impl Fn(u64) -> Vec<u64> + '_ {
+    move |v| adj.get(v as usize).cloned().unwrap_or_default()
+}
+
+struct BenchResult {
+    name: String,
+    vertex_count: u64,
+    detail: String,
+    median: Duration,
+    min: Duration,
+    max: Duration,
+}
+
+fn bench<F: Fn()>(f: F) -> (Duration, Duration, Duration) {
+    for _ in 0..WARMUP_ITERS {
+        f();
+    }
+    let mut times = Vec::with_capacity(BENCH_ITERS as usize);
+    for _ in 0..BENCH_ITERS {
+        let start = Instant::now();
+        f();
+        times.push(start.elapsed());
+    }
+    times.sort();
+    let median = times[times.len() / 2];
+    let min = *times.first().unwrap();
+    let max = *times.last().unwrap();
+    (median, min, max)
+}
+
+fn main() {
+    let sizes: &[u64] = &[100, 1_000, 10_000];
+
+    // Part 1: depth-bounded traversals (show constant-time for fixed fan-out)
+    let max_depths: &[u32] = &[3, 5, 10];
+    let mut results: Vec<BenchResult> = Vec::new();
+
+    for &n in sizes {
+        let adj = build_adjacency(n, EDGES_PER_VERTEX);
+        let nf = neighbors_fn(&adj);
+
+        for &depth in max_depths {
+            let (median, min, max) = bench(|| {
+                let _ = bfs(1, depth, &nf);
+            });
+            let visited = bfs(1, depth, &nf).len();
+            results.push(BenchResult {
+                name: "BFS".into(),
+                vertex_count: n,
+                detail: format!("max_depth={depth}, visited={visited}"),
+                median, min, max,
+            });
+
+            let (median, min, max) = bench(|| {
+                let _ = dfs(1, depth, &nf);
+            });
+            let visited = dfs(1, depth, &nf).len();
+            results.push(BenchResult {
+                name: "DFS".into(),
+                vertex_count: n,
+                detail: format!("max_depth={depth}, visited={visited}"),
+                median, min, max,
+            });
+        }
+    }
+
+    println!("## Depth-bounded traversals");
+    println!();
+    println!("| Algorithm | Vertices | Detail | Median | Min | Max |");
+    println!("|-----------|----------|--------|--------|-----|-----|");
+    for r in &results {
+        println!(
+            "| {} | {} | {} | {:.3}ms | {:.3}ms | {:.3}ms |",
+            r.name, r.vertex_count, r.detail,
+            r.median.as_secs_f64() * 1000.0,
+            r.min.as_secs_f64() * 1000.0,
+            r.max.as_secs_f64() * 1000.0,
+        );
+    }
+
+    // Part 2: full-graph traversals (visit all vertices)
+    let mut full_results: Vec<BenchResult> = Vec::new();
+
+    for &n in sizes {
+        let adj = build_adjacency(n, EDGES_PER_VERTEX);
+        let nf = neighbors_fn(&adj);
+
+        let (median, min, max) = bench(|| {
+            let _ = bfs(1, u32::MAX, &nf);
+        });
+        let visited = bfs(1, u32::MAX, &nf).len();
+        full_results.push(BenchResult {
+            name: "BFS".into(),
+            vertex_count: n,
+            detail: format!("full graph, visited={visited}"),
+            median, min, max,
+        });
+
+        let (median, min, max) = bench(|| {
+            let _ = dfs(1, u32::MAX, &nf);
+        });
+        let visited = dfs(1, u32::MAX, &nf).len();
+        full_results.push(BenchResult {
+            name: "DFS".into(),
+            vertex_count: n,
+            detail: format!("full graph, visited={visited}"),
+            median, min, max,
+        });
+    }
+
+    println!();
+    println!("## Full-graph traversals (all vertices)");
+    println!();
+    println!("| Algorithm | Vertices | Detail | Median | Min | Max |");
+    println!("|-----------|----------|--------|--------|-----|-----|");
+    for r in &full_results {
+        println!(
+            "| {} | {} | {} | {:.3}ms | {:.3}ms | {:.3}ms |",
+            r.name, r.vertex_count, r.detail,
+            r.median.as_secs_f64() * 1000.0,
+            r.min.as_secs_f64() * 1000.0,
+            r.max.as_secs_f64() * 1000.0,
+        );
+    }
+
+    // Part 3: shortest path at multiple scales
+    let mut sp_results: Vec<BenchResult> = Vec::new();
+
+    for &n in sizes {
+        let adj = build_adjacency(n, EDGES_PER_VERTEX);
+        let nf = neighbors_fn(&adj);
+
+        let target = n / 2 + 1;
+        let (median, min, max) = bench(|| {
+            let _ = shortest_path(1, target, &nf);
+        });
+        let path = shortest_path(1, target, &nf);
+        let hops = if path.is_empty() { 0 } else { path.len() - 1 };
+        sp_results.push(BenchResult {
+            name: "shortest_path".into(),
+            vertex_count: n,
+            detail: format!("1->{target}, hops={hops}"),
+            median, min, max,
+        });
+
+        let near_target = (EDGES_PER_VERTEX + 1).min(n);
+        let (median, min, max) = bench(|| {
+            let _ = shortest_path(1, near_target, &nf);
+        });
+        let path = shortest_path(1, near_target, &nf);
+        let hops = if path.is_empty() { 0 } else { path.len() - 1 };
+        sp_results.push(BenchResult {
+            name: "shortest_path".into(),
+            vertex_count: n,
+            detail: format!("1->{near_target} (near), hops={hops}"),
+            median, min, max,
+        });
+    }
+
+    println!();
+    println!("## Shortest path");
+    println!();
+    println!("| Algorithm | Vertices | Detail | Median | Min | Max |");
+    println!("|-----------|----------|--------|--------|-----|-----|");
+    for r in &sp_results {
+        println!(
+            "| {} | {} | {} | {:.3}ms | {:.3}ms | {:.3}ms |",
+            r.name, r.vertex_count, r.detail,
+            r.median.as_secs_f64() * 1000.0,
+            r.min.as_secs_f64() * 1000.0,
+            r.max.as_secs_f64() * 1000.0,
+        );
+    }
+}

--- a/modules/graph-algo/src/lib.rs
+++ b/modules/graph-algo/src/lib.rs
@@ -1,0 +1,310 @@
+use std::collections::{HashMap, HashSet, VecDeque};
+
+/// A visited vertex with its distance from the start.
+#[derive(Debug, Clone, PartialEq, Eq)]
+pub struct VisitedVertex {
+    pub vertex_id: u64,
+    pub depth: u32,
+}
+
+/// BFS from `start` up to `max_depth` hops.
+///
+/// `neighbors` returns outgoing neighbor IDs for a given vertex.
+/// Returns visited vertices in BFS order with their depth.
+pub fn bfs(start: u64, max_depth: u32, neighbors: impl Fn(u64) -> Vec<u64>) -> Vec<VisitedVertex> {
+    let mut visited = HashSet::new();
+    let mut queue = VecDeque::new();
+    let mut result = Vec::new();
+
+    visited.insert(start);
+    queue.push_back((start, 0u32));
+    result.push(VisitedVertex {
+        vertex_id: start,
+        depth: 0,
+    });
+
+    while let Some((current, depth)) = queue.pop_front() {
+        if depth >= max_depth {
+            continue;
+        }
+        for neighbor in neighbors(current) {
+            if visited.insert(neighbor) {
+                let next_depth = depth + 1;
+                queue.push_back((neighbor, next_depth));
+                result.push(VisitedVertex {
+                    vertex_id: neighbor,
+                    depth: next_depth,
+                });
+            }
+        }
+    }
+
+    result
+}
+
+/// DFS from `start` up to `max_depth` hops.
+///
+/// `neighbors` returns outgoing neighbor IDs for a given vertex.
+/// Returns visited vertices in DFS order with their depth.
+pub fn dfs(start: u64, max_depth: u32, neighbors: impl Fn(u64) -> Vec<u64>) -> Vec<VisitedVertex> {
+    let mut visited = HashSet::new();
+    let mut stack = Vec::new();
+    let mut result = Vec::new();
+
+    visited.insert(start);
+    stack.push((start, 0u32));
+    result.push(VisitedVertex {
+        vertex_id: start,
+        depth: 0,
+    });
+
+    while let Some((current, depth)) = stack.pop() {
+        if depth >= max_depth {
+            continue;
+        }
+        for neighbor in neighbors(current) {
+            if visited.insert(neighbor) {
+                let next_depth = depth + 1;
+                stack.push((neighbor, next_depth));
+                result.push(VisitedVertex {
+                    vertex_id: neighbor,
+                    depth: next_depth,
+                });
+            }
+        }
+    }
+
+    result
+}
+
+/// BFS-based shortest path from `start` to `end`.
+///
+/// Returns the path as an ordered list of vertex IDs (start to end),
+/// or an empty vec if unreachable.
+pub fn shortest_path(start: u64, end: u64, neighbors: impl Fn(u64) -> Vec<u64>) -> Vec<u64> {
+    if start == end {
+        return vec![start];
+    }
+
+    let mut visited = HashSet::new();
+    let mut queue = VecDeque::new();
+    let mut parent: HashMap<u64, u64> = HashMap::new();
+
+    visited.insert(start);
+    queue.push_back(start);
+
+    while let Some(current) = queue.pop_front() {
+        for neighbor in neighbors(current) {
+            if visited.insert(neighbor) {
+                parent.insert(neighbor, current);
+                if neighbor == end {
+                    return reconstruct_path(&parent, start, end);
+                }
+                queue.push_back(neighbor);
+            }
+        }
+    }
+
+    Vec::new()
+}
+
+fn reconstruct_path(parent: &HashMap<u64, u64>, start: u64, end: u64) -> Vec<u64> {
+    let mut path = Vec::new();
+    let mut current = end;
+    while current != start {
+        path.push(current);
+        current = parent[&current];
+    }
+    path.push(start);
+    path.reverse();
+    path
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    /// Build a neighbor-lookup closure from an adjacency list.
+    fn adj(edges: &[(u64, u64)]) -> impl Fn(u64) -> Vec<u64> + '_ {
+        move |v| {
+            edges
+                .iter()
+                .filter(|(s, _)| *s == v)
+                .map(|(_, e)| *e)
+                .collect()
+        }
+    }
+
+    // -----------------------------------------------------------------------
+    // Graph fixture:
+    //   0 -> 1 -> 3
+    //   0 -> 2 -> 3 -> 4
+    //         \-> 5
+    // -----------------------------------------------------------------------
+    fn diamond_edges() -> Vec<(u64, u64)> {
+        vec![
+            (0, 1),
+            (0, 2),
+            (1, 3),
+            (2, 3),
+            (2, 5),
+            (3, 4),
+        ]
+    }
+
+    // =======================================================================
+    // BFS
+    // =======================================================================
+
+    #[test]
+    fn bfs_visits_all_reachable() {
+        let edges = diamond_edges();
+        let result = bfs(0, u32::MAX, adj(&edges));
+        let ids: HashSet<u64> = result.iter().map(|v| v.vertex_id).collect();
+        assert_eq!(ids, [0, 1, 2, 3, 4, 5].iter().copied().collect());
+    }
+
+    #[test]
+    fn bfs_respects_max_depth() {
+        let edges = diamond_edges();
+        let result = bfs(0, 1, adj(&edges));
+        let ids: HashSet<u64> = result.iter().map(|v| v.vertex_id).collect();
+        assert_eq!(ids, [0, 1, 2].iter().copied().collect());
+    }
+
+    #[test]
+    fn bfs_depth_zero_returns_start_only() {
+        let edges = diamond_edges();
+        let result = bfs(0, 0, adj(&edges));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].vertex_id, 0);
+        assert_eq!(result[0].depth, 0);
+    }
+
+    #[test]
+    fn bfs_records_correct_depths() {
+        let edges = diamond_edges();
+        let result = bfs(0, u32::MAX, adj(&edges));
+        let depths: HashMap<u64, u32> =
+            result.iter().map(|v| (v.vertex_id, v.depth)).collect();
+        assert_eq!(depths[&0], 0);
+        assert_eq!(depths[&1], 1);
+        assert_eq!(depths[&2], 1);
+        assert_eq!(depths[&3], 2);
+        assert_eq!(depths[&4], 3);
+        assert_eq!(depths[&5], 2);
+    }
+
+    #[test]
+    fn bfs_isolated_vertex() {
+        let edges: Vec<(u64, u64)> = vec![];
+        let result = bfs(42, u32::MAX, adj(&edges));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].vertex_id, 42);
+    }
+
+    // =======================================================================
+    // DFS
+    // =======================================================================
+
+    #[test]
+    fn dfs_visits_all_reachable() {
+        let edges = diamond_edges();
+        let result = dfs(0, u32::MAX, adj(&edges));
+        let ids: HashSet<u64> = result.iter().map(|v| v.vertex_id).collect();
+        assert_eq!(ids, [0, 1, 2, 3, 4, 5].iter().copied().collect());
+    }
+
+    #[test]
+    fn dfs_respects_max_depth() {
+        let edges = diamond_edges();
+        let result = dfs(0, 1, adj(&edges));
+        let ids: HashSet<u64> = result.iter().map(|v| v.vertex_id).collect();
+        assert_eq!(ids, [0, 1, 2].iter().copied().collect());
+    }
+
+    #[test]
+    fn dfs_depth_zero_returns_start_only() {
+        let edges = diamond_edges();
+        let result = dfs(0, 0, adj(&edges));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].vertex_id, 0);
+    }
+
+    #[test]
+    fn dfs_isolated_vertex() {
+        let edges: Vec<(u64, u64)> = vec![];
+        let result = dfs(99, u32::MAX, adj(&edges));
+        assert_eq!(result.len(), 1);
+        assert_eq!(result[0].vertex_id, 99);
+    }
+
+    // =======================================================================
+    // Shortest path
+    // =======================================================================
+
+    #[test]
+    fn shortest_path_direct() {
+        let edges = diamond_edges();
+        let path = shortest_path(0, 1, adj(&edges));
+        assert_eq!(path, vec![0, 1]);
+    }
+
+    #[test]
+    fn shortest_path_multi_hop() {
+        let edges = diamond_edges();
+        let path = shortest_path(0, 4, adj(&edges));
+        // 0 -> 1 -> 3 -> 4 or 0 -> 2 -> 3 -> 4 (both length 3)
+        assert_eq!(path.len(), 4);
+        assert_eq!(*path.first().unwrap(), 0);
+        assert_eq!(*path.last().unwrap(), 4);
+    }
+
+    #[test]
+    fn shortest_path_same_vertex() {
+        let edges = diamond_edges();
+        let path = shortest_path(0, 0, adj(&edges));
+        assert_eq!(path, vec![0]);
+    }
+
+    #[test]
+    fn shortest_path_unreachable() {
+        let edges = diamond_edges();
+        let path = shortest_path(4, 0, adj(&edges)); // no back-edges
+        assert!(path.is_empty());
+    }
+
+    #[test]
+    fn shortest_path_prefers_shorter() {
+        // 0 -> 1 -> 2 (length 2)
+        // 0 -> 2      (length 1)  <-- should win
+        let edges = vec![(0, 1), (1, 2), (0, 2)];
+        let path = shortest_path(0, 2, adj(&edges));
+        assert_eq!(path, vec![0, 2]);
+    }
+
+    // =======================================================================
+    // Cycle handling
+    // =======================================================================
+
+    #[test]
+    fn bfs_handles_cycle() {
+        let edges = vec![(0, 1), (1, 2), (2, 0)];
+        let result = bfs(0, 10, adj(&edges));
+        assert_eq!(result.len(), 3); // visits each once
+    }
+
+    #[test]
+    fn dfs_handles_cycle() {
+        let edges = vec![(0, 1), (1, 2), (2, 0)];
+        let result = dfs(0, 10, adj(&edges));
+        assert_eq!(result.len(), 3);
+    }
+
+    #[test]
+    fn shortest_path_with_cycle() {
+        let edges = vec![(0, 1), (1, 2), (2, 0), (2, 3)];
+        let path = shortest_path(0, 3, adj(&edges));
+        assert_eq!(path, vec![0, 1, 2, 3]);
+    }
+}

--- a/modules/graph/Cargo.toml
+++ b/modules/graph/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "graph-module"
+version = "0.1.0"
+edition.workspace = true
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+spacetimedb = { workspace = true, features = ["unstable"] }
+log = { workspace = true }
+graph-algo = { path = "../graph-algo" }

--- a/modules/graph/src/lib.rs
+++ b/modules/graph/src/lib.rs
@@ -1,0 +1,438 @@
+use spacetimedb::{log_stopwatch::LogStopwatch, ProcedureContext, ReducerContext, Table};
+use std::collections::HashMap;
+
+// ---------------------------------------------------------------------------
+// Tables — data model
+// ---------------------------------------------------------------------------
+
+#[spacetimedb::table(accessor = vertex, public)]
+pub struct Vertex {
+    #[primary_key]
+    #[auto_inc]
+    id: u64,
+    label: String,
+    properties: String,
+}
+
+#[spacetimedb::table(
+    accessor = edge,
+    public,
+    index(accessor = idx_start, btree(columns = [start_id])),
+    index(accessor = idx_end, btree(columns = [end_id]))
+)]
+pub struct Edge {
+    #[primary_key]
+    #[auto_inc]
+    id: u64,
+    start_id: u64,
+    end_id: u64,
+    edge_type: String,
+    properties: String,
+}
+
+// ---------------------------------------------------------------------------
+// Vertex CRUD
+// ---------------------------------------------------------------------------
+
+#[spacetimedb::reducer]
+pub fn create_vertex(ctx: &ReducerContext, label: String, properties: String) {
+    ctx.db.vertex().insert(Vertex {
+        id: 0,
+        label,
+        properties,
+    });
+}
+
+#[spacetimedb::reducer]
+pub fn update_vertex(
+    ctx: &ReducerContext,
+    id: u64,
+    label: String,
+    properties: String,
+) -> Result<(), String> {
+    if ctx.db.vertex().id().find(id).is_none() {
+        return Err(format!("Vertex {id} not found"));
+    }
+    ctx.db.vertex().id().update(Vertex {
+        id,
+        label,
+        properties,
+    });
+    Ok(())
+}
+
+#[spacetimedb::reducer]
+pub fn delete_vertex(ctx: &ReducerContext, id: u64) -> Result<(), String> {
+    let connected_edges: Vec<Edge> = ctx
+        .db
+        .edge()
+        .idx_start()
+        .filter(&id)
+        .chain(ctx.db.edge().idx_end().filter(&id))
+        .collect();
+    for e in connected_edges {
+        ctx.db.edge().id().delete(e.id);
+    }
+    if ctx.db.vertex().id().delete(id) {
+        Ok(())
+    } else {
+        Err(format!("Vertex {id} not found"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Edge CRUD
+// ---------------------------------------------------------------------------
+
+#[spacetimedb::reducer]
+pub fn create_edge(
+    ctx: &ReducerContext,
+    start_id: u64,
+    end_id: u64,
+    edge_type: String,
+    properties: String,
+) -> Result<(), String> {
+    if ctx.db.vertex().id().find(start_id).is_none() {
+        return Err(format!("Start vertex {start_id} not found"));
+    }
+    if ctx.db.vertex().id().find(end_id).is_none() {
+        return Err(format!("End vertex {end_id} not found"));
+    }
+    ctx.db.edge().insert(Edge {
+        id: 0,
+        start_id,
+        end_id,
+        edge_type,
+        properties,
+    });
+    Ok(())
+}
+
+#[spacetimedb::reducer]
+pub fn update_edge(
+    ctx: &ReducerContext,
+    id: u64,
+    start_id: u64,
+    end_id: u64,
+    edge_type: String,
+    properties: String,
+) -> Result<(), String> {
+    if ctx.db.edge().id().find(id).is_none() {
+        return Err(format!("Edge {id} not found"));
+    }
+    if ctx.db.vertex().id().find(start_id).is_none() {
+        return Err(format!("Start vertex {start_id} not found"));
+    }
+    if ctx.db.vertex().id().find(end_id).is_none() {
+        return Err(format!("End vertex {end_id} not found"));
+    }
+    ctx.db.edge().id().update(Edge {
+        id,
+        start_id,
+        end_id,
+        edge_type,
+        properties,
+    });
+    Ok(())
+}
+
+#[spacetimedb::reducer]
+pub fn delete_edge(ctx: &ReducerContext, id: u64) -> Result<(), String> {
+    if ctx.db.edge().id().delete(id) {
+        Ok(())
+    } else {
+        Err(format!("Edge {id} not found"))
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Tables — traversal results
+// ---------------------------------------------------------------------------
+
+#[spacetimedb::table(accessor = traversal_result, public)]
+pub struct TraversalResult {
+    #[primary_key]
+    #[auto_inc]
+    id: u64,
+    run_tag: String,
+    vertex_id: u64,
+    depth: u32,
+}
+
+#[spacetimedb::table(accessor = path_result, public)]
+pub struct PathResult {
+    #[primary_key]
+    #[auto_inc]
+    id: u64,
+    run_tag: String,
+    step: u32,
+    vertex_id: u64,
+}
+
+// ---------------------------------------------------------------------------
+// Traversal reducers
+// ---------------------------------------------------------------------------
+
+fn outgoing_neighbors(ctx: &ReducerContext, vertex_id: u64) -> Vec<u64> {
+    ctx.db
+        .edge()
+        .idx_start()
+        .filter(&vertex_id)
+        .map(|e| e.end_id)
+        .collect()
+}
+
+/// Build an in-memory adjacency map from the entire Edge table.
+/// This avoids per-vertex B-tree index lookups during traversal.
+fn build_adjacency_map(ctx: &ReducerContext) -> HashMap<u64, Vec<u64>> {
+    let mut adj: HashMap<u64, Vec<u64>> = HashMap::new();
+    for edge in ctx.db.edge().iter() {
+        adj.entry(edge.start_id).or_default().push(edge.end_id);
+    }
+    adj
+}
+#[spacetimedb::reducer]
+pub fn bfs(ctx: &ReducerContext, start_id: u64, max_depth: u32, run_tag: String) -> Result<(), String> {
+    if ctx.db.vertex().id().find(start_id).is_none() {
+        return Err(format!("Start vertex {start_id} not found"));
+    }
+let adj = build_adjacency_map(ctx);
+    let visited = graph_algo::bfs(start_id, max_depth, |v| adj.get(&v).cloned().unwrap_or_default());
+    for v in visited {
+        ctx.db.traversal_result().insert(TraversalResult {
+            id: 0,
+            run_tag: run_tag.clone(),
+            vertex_id: v.vertex_id,
+            depth: v.depth,
+        });
+    }
+    Ok(())
+}
+
+#[spacetimedb::reducer]
+pub fn dfs(ctx: &ReducerContext, start_id: u64, max_depth: u32, run_tag: String) -> Result<(), String> {
+    if ctx.db.vertex().id().find(start_id).is_none() {
+        return Err(format!("Start vertex {start_id} not found"));
+    }
+let adj = build_adjacency_map(ctx);
+    let visited = graph_algo::dfs(start_id, max_depth, |v| adj.get(&v).cloned().unwrap_or_default());
+    for v in visited {
+        ctx.db.traversal_result().insert(TraversalResult {
+            id: 0,
+            run_tag: run_tag.clone(),
+            vertex_id: v.vertex_id,
+            depth: v.depth,
+        });
+    }
+    Ok(())
+}
+
+#[spacetimedb::reducer]
+pub fn shortest_path(
+    ctx: &ReducerContext,
+    start_id: u64,
+    end_id: u64,
+    run_tag: String,
+) -> Result<(), String> {
+    if ctx.db.vertex().id().find(start_id).is_none() {
+        return Err(format!("Start vertex {start_id} not found"));
+    }
+    if ctx.db.vertex().id().find(end_id).is_none() {
+        return Err(format!("End vertex {end_id} not found"));
+    }
+let adj = build_adjacency_map(ctx);
+    let path = graph_algo::shortest_path(start_id, end_id, |v| adj.get(&v).cloned().unwrap_or_default());
+    for (step, &vid) in path.iter().enumerate() {
+        ctx.db.path_result().insert(PathResult {
+            id: 0,
+            run_tag: run_tag.clone(),
+            step: step as u32,
+            vertex_id: vid,
+        });
+    }
+    Ok(())
+}
+
+#[spacetimedb::reducer]
+pub fn clear_traversal_results(ctx: &ReducerContext, run_tag: String) {
+    let to_delete: Vec<u64> = ctx
+        .db
+        .traversal_result()
+        .iter()
+        .filter(|r| r.run_tag == run_tag)
+        .map(|r| r.id)
+        .collect();
+    for id in to_delete {
+        ctx.db.traversal_result().id().delete(id);
+    }
+    let to_delete: Vec<u64> = ctx
+        .db
+        .path_result()
+        .iter()
+        .filter(|r| r.run_tag == run_tag)
+        .map(|r| r.id)
+        .collect();
+    for id in to_delete {
+        ctx.db.path_result().id().delete(id);
+    }
+}
+
+#[spacetimedb::reducer]
+pub fn clear_graph(ctx: &ReducerContext) {
+    let edge_ids: Vec<u64> = ctx.db.edge().iter().map(|e| e.id).collect();
+    for id in edge_ids {
+        ctx.db.edge().id().delete(id);
+    }
+    let vertex_ids: Vec<u64> = ctx.db.vertex().iter().map(|v| v.id).collect();
+    for id in vertex_ids {
+        ctx.db.vertex().id().delete(id);
+    }
+}
+
+/// Bulk-insert `count` vertices using auto_inc (IDs will be 1..count).
+/// Used by the cross-system benchmark harness.
+#[spacetimedb::reducer]
+pub fn bench_bulk_insert_vertices(ctx: &ReducerContext, count: u64) {
+    for _ in 0..count {
+        ctx.db.vertex().insert(Vertex {
+            id: 0,
+            label: String::new(),
+            properties: String::new(),
+        });
+    }
+}
+
+/// Bulk-insert edges from a flat array: [src0, dst0, src1, dst1, ...].
+/// Vertex IDs are expected to be 1-based (matching auto_inc output).
+/// Used by the cross-system benchmark harness.
+#[spacetimedb::reducer]
+pub fn bench_bulk_insert_edges(ctx: &ReducerContext, flat_edges: Vec<u64>) {
+    for pair in flat_edges.chunks(2) {
+        if pair.len() == 2 {
+            ctx.db.edge().insert(Edge {
+                id: 0,
+                start_id: pair[0],
+                end_id: pair[1],
+                edge_type: String::new(),
+                properties: String::new(),
+            });
+        }
+    }
+}
+
+// ---------------------------------------------------------------------------
+// Benchmark reducers
+// ---------------------------------------------------------------------------
+
+#[spacetimedb::reducer]
+pub fn bench_seed_graph(ctx: &ReducerContext, vertex_count: u64, edges_per_vertex: u64) {
+    let _sw = LogStopwatch::new("bench_seed_graph");
+    for _ in 0..vertex_count {
+        ctx.db.vertex().insert(Vertex {
+            id: 0,
+            label: String::new(),
+            properties: String::new(),
+        });
+    }
+    // Wire each vertex to `edges_per_vertex` successors (wrapping around).
+    // Vertex auto_inc IDs start at 1.
+    for src in 1..=vertex_count {
+        for offset in 1..=edges_per_vertex {
+            let dst = (src - 1 + offset) % vertex_count + 1;
+            ctx.db.edge().insert(Edge {
+                id: 0,
+                start_id: src,
+                end_id: dst,
+                edge_type: String::new(),
+                properties: String::new(),
+            });
+        }
+    }
+    log::info!(
+        "bench_seed_graph: seeded {vertex_count} vertices, {} edges",
+        vertex_count * edges_per_vertex
+    );
+}
+
+#[spacetimedb::reducer]
+pub fn bench_bfs(ctx: &ReducerContext, start_id: u64, max_depth: u32) {
+    let _sw = LogStopwatch::new("bench_bfs");
+let adj = build_adjacency_map(ctx);
+    let visited = graph_algo::bfs(start_id, max_depth, |v| adj.get(&v).cloned().unwrap_or_default());
+    log::info!(
+        "bench_bfs: start={start_id} max_depth={max_depth} visited={}",
+        visited.len()
+    );
+}
+
+#[spacetimedb::reducer]
+pub fn bench_dfs(ctx: &ReducerContext, start_id: u64, max_depth: u32) {
+    let _sw = LogStopwatch::new("bench_dfs");
+let adj = build_adjacency_map(ctx);
+    let visited = graph_algo::dfs(start_id, max_depth, |v| adj.get(&v).cloned().unwrap_or_default());
+    log::info!(
+        "bench_dfs: start={start_id} max_depth={max_depth} visited={}",
+        visited.len()
+    );
+}
+
+#[spacetimedb::reducer]
+pub fn bench_shortest_path(ctx: &ReducerContext, start_id: u64, end_id: u64) {
+    let _sw = LogStopwatch::new("bench_shortest_path");
+let adj = build_adjacency_map(ctx);
+    let path = graph_algo::shortest_path(start_id, end_id, |v| adj.get(&v).cloned().unwrap_or_default());
+    log::info!(
+        "bench_shortest_path: {start_id}->{end_id} hops={}",
+        if path.is_empty() { 0 } else { path.len() - 1 }
+    );
+}
+// ---------------------------------------------------------------------------
+// Optimized queries — procedures (run outside transaction lock)
+// ---------------------------------------------------------------------------
+
+/// Count outgoing neighbors using the B-tree index directly.
+/// Runs as a procedure: short tx for the index scan, no lock held otherwise.
+#[spacetimedb::procedure]
+pub fn neighbor_count(ctx: &mut ProcedureContext, vertex_id: u64) -> u64 {
+    ctx.with_tx(|tx_ctx| {
+        tx_ctx.db.edge().idx_start().filter(&vertex_id).count() as u64
+    })
+}
+
+/// BFS from start_id, return visited count.
+/// Runs as a procedure: short tx to snapshot edges, BFS runs outside the lock.
+#[spacetimedb::procedure]
+pub fn bfs_count(ctx: &mut ProcedureContext, start_id: u64) -> u64 {
+    let adj = ctx.with_tx(|tx_ctx| {
+        let mut adj: HashMap<u64, Vec<u64>> = HashMap::new();
+        for edge in tx_ctx.db.edge().iter() {
+            adj.entry(edge.start_id).or_default().push(edge.end_id);
+        }
+        adj
+    });
+    let visited = graph_algo::bfs(start_id, u32::MAX, |v| {
+        adj.get(&v).cloned().unwrap_or_default()
+    });
+    visited.len() as u64
+}
+
+/// Shortest path from start_id to end_id, return hop count.
+/// Runs as a procedure: short tx to snapshot edges, BFS runs outside the lock.
+#[spacetimedb::procedure]
+pub fn shortest_path_hops(
+    ctx: &mut ProcedureContext,
+    start_id: u64,
+    end_id: u64,
+) -> u64 {
+    let adj = ctx.with_tx(|tx_ctx| {
+        let mut adj: HashMap<u64, Vec<u64>> = HashMap::new();
+        for edge in tx_ctx.db.edge().iter() {
+            adj.entry(edge.start_id).or_default().push(edge.end_id);
+        }
+        adj
+    });
+    let path = graph_algo::shortest_path(start_id, end_id, |v| {
+        adj.get(&v).cloned().unwrap_or_default()
+    });
+    if path.is_empty() { 0 } else { (path.len() - 1) as u64 }
+}


### PR DESCRIPTION
## Summary

Adds a userland graph extension to SpacetimeDB: a new `GraphId` SATS type, a shared `graph-algo` crate with BFS/DFS/shortest-path traversal algorithms, and a `graph-module` Wasm cdylib with vertex/edge CRUD, traversal reducers, and procedure-based optimized queries. Zero engine changes — everything runs through the existing reducer/procedure API.

Full context: [Project Manifold Wiki](https://github.com/Hextaku/SpacetimeDB-Manifold/wiki)

## What changes

| Area | Files |
|------|-------|
| SATS type system | `crates/sats/src/graph_id.rs` (new), `algebraic_type.rs`, `product_type.rs`, `satn.rs`, `lib.rs` |
| Engine wiring | `crates/lib/src/lib.rs`, `crates/expr/src/lib.rs`, `crates/pg/src/encoder.rs` |
| Algorithms | `modules/graph-algo/` (new crate, 310 lines + 193 line bench) |
| Module | `modules/graph/` (new crate, 440 lines) |
| Workspace | `Cargo.toml` (+2 members), `Cargo.lock` |

## Why

I'm working on a project that needs native graph capabilities, and SpacetimeDB's real-time subscription architecture would be a perfect fit — it would dramatically reduce scope compared to running a separate graph database and managing server-db sync at scale. The alternative (Apache AGE) introduces significant operational complexity without a clear path to solving the sync problem cleanly.

[I reached out on Discord](https://discord.com/channels/1037340874172014652/1496571713519882453) asking whether graph features would be accepted in PRs. While I didn't get a direct response from Clockwork Labs, nobody shut the idea down either. Rather than wait indefinitely, I decided to build it as a proof of concept — a userland module that adds real graph capabilities with zero engine changes, backed by cross-system benchmarks that characterize exactly how far you can get without touching the engine.

The goal is to demonstrate that:





Graph support is viable in SpacetimeDB today, with no architectural changes.



The implementation is minimal and follows existing patterns (the SATS type mirrors Identity/Timestamp/Uuid exactly).



The userland ceiling is well understood — and where it ends (large-graph shortest path), Stage 2's case for engine-level operators is backed by measured data, not speculation.

If this is something Clockwork Labs is interested in merging: great!  
If not: the benchmarks are public, the module works, the data speaks for itself, and anybody is able to deploy this for their projects.  
I'd really enjoyed the challenge and am at least going to take a look if I can also pull off Stage 2.

More detail: [Stage 1 — Userland Graph Extension](https://github.com/Hextaku/SpacetimeDB-Manifold/wiki/Stage-1)
## Benchmark highlights

_Benchmarks are NOT on this branch or part of the MR. But on https://github.com/Hextaku/SpacetimeDB-Manifold/tree/pr/manifold-stage-1-bench_

SpacetimeDB's userland module (Wasm, zero engine changes) vs. Neo4j and Apache AGE on three SNAP datasets:

**ego-Facebook (~4K vertices, ~88K edges):**

| Metric | STDB (opt) | Neo4j (opt) | AGE |
|--------|------------|-------------|-----|
| Load | **376 ms** | 1.74 s | 1.95 s |
| Neighbor count | **1.2 ms** | 8 ms | 12 ms |
| BFS full | **20 ms** | 54 ms | 77 ms |
| Shortest path | 16 ms | **15 ms** | 127 ms |

**com-DBLP (~317K vertices, ~1M edges):**

| Metric | STDB (opt) | Neo4j (opt) | AGE |
|--------|------------|-------------|-----|
| Load | **4.8 s** | 23.0 s | 30.1 s |
| Neighbor count | **1.9 ms** | 112 ms | 147 ms |
| BFS full | **339 ms** | 453 ms | 4.42 s |
| Shortest path | 219 ms | **7.4 ms** | 2.20 s |

**com-LiveJournal (~4M vertices, ~35M edges):**

| Metric | STDB (opt) | Neo4j (opt) | AGE |
|--------|------------|-------------|-----|
| Load | **179 s** | 786 s | 972 s |
| Neighbor count | **1.5 ms** | 110 ms | 1.26 s |
| BFS full | **14.5 s** | 39.7 s | 603 s |
| Shortest path | 7.7 s | **125 ms** | 4.47 s |

SpacetimeDB wins loading (4-6x), neighbors (constant ~1.5 ms via index scan), and BFS full traversal on every dataset. Neo4j leads shortest path (30-62x) due to its native bidirectional algorithm — a gap Stage 2 is designed to close.

Full results: [Benchmarks](https://github.com/Hextaku/SpacetimeDB-Manifold/wiki/Benchmarks)

## What's next: Stage 2

Stage 2 moves from userland to the SpacetimeDB engine. The benchmark data makes the priorities clear:

| Priority | Feature | LiveJournal impact |
|----------|---------|--------------------|
| 1 | Bidirectional shortest path operator | 7.7 s → ~80-150 ms (50-100x) |
| 2 | Index-hop BFS (no adjacency rebuild) | 14.5 s → ~5-7 s, eliminates 7.2 s tx hold |
| 3 | SQL-pipeline graph queries (no HTTP) | ~2-5 ms per query |
| 4 | Variable-length path subscriptions | New capability |
| 5 | Index-free adjacency storage | ~5-7x per-hop |

More detail: [Stage 2 — Native Graph Engine](https://github.com/Hextaku/SpacetimeDB-Manifold/wiki/Stage-2)

## Test state
```
cargo build → PASS cargo test -p spacetimedb-sats --lib → 64/65 PASS (1 pre-existing upstream timestamp proptest) cargo test -p graph-algo → 17/17 PASS cargo test -p spacetimedb-update → 4/5 PASS (1 pre-existing upstream uninstall flake)
```

## Known limitations
- GraphId client codegen (`AlgebraicTypeDef` / `TypespaceForGenerate`) not yet implemented — blocked on client-side graph type design (Stage 2).
- Cypher parser GraphId literal syntax — requires Cypher AST → RelExpr mapping (Stage 2).
- Module reducer logic tested indirectly via the benchmark harness; dedicated integration tests for error handling and traversal result persistence in a follow-up.