### PR TITLE
chore: enable HTTP/2 support for backend server

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -158,7 +158,7 @@ arrayvec = "0.7.2"
 async-channel = "2.5"
 async-stream = "0.3.6"
 async-trait = "0.1.68"
-axum = { version = "0.7", features = ["tracing"] }
+axum = { version = "0.7", features = ["tracing", "http2"] }
 axum-extra = { version = "0.9", features = ["typed-header"] }
 backtrace = "0.3.66"
 base64 = "0.21.2"


### PR DESCRIPTION
# Description of Changes

Enables Axum's `http2` feature for SpacetimeDB, which enables Hyper's HTTP/2 support in the standalone/backend HTTP server.

This allows clients that explicitly speak cleartext HTTP/2 (`h2c`) to connect to the local standalone server over HTTP/2.

_Note: public HTTPS deployments may also require edge proxy or load balancer configuration, such as enabling HTTP/2 ALPN on nginx. For example, `curl --http2 -v https://maincloud.spacetimedb.com/v1/ping` currently negotiates `http/1.1` at the public edge._


Refs #4964

# API and ABI breaking changes

None.

# Expected complexity level and risk

1

This is a dependency feature flag change. It should not affect existing HTTP/1.1 clients, and the server continues to accept HTTP/1.1 requests.

# Testing

- Build the standalone server: `cargo build -p spacetimedb-standalone`
- Start the local standalone server and verify HTTP/2 cleartext prior knowledge support: `cargo run -p spacetimedb-standalone -- start --data-dir /tmp/spacetimedb-data --jwt-key-dir /tmp/spacetimedb-data --listen-addr 127.0.0.1:3000 --in-memory --non-interactive`
- Test using curl http prior knowledge flag with the local instance: `curl --http2-prior-knowledge -v http://127.0.0.1:3000/v1/ping`

**Output**
```bash
*   Trying 127.0.0.1:3000...
* Established connection to 127.0.0.1 (127.0.0.1 port 3000) from 127.0.0.1 port 42662
* using HTTP/2
* [HTTP/2] [1] OPENED stream for http://127.0.0.1:3000/v1/ping
* [HTTP/2] [1] [:method: GET]
* [HTTP/2] [1] [:scheme: http]
* [HTTP/2] [1] [:authority: 127.0.0.1:3000]
* [HTTP/2] [1] [:path: /v1/ping]
* [HTTP/2] [1] [user-agent: curl/8.20.0]
* [HTTP/2] [1] [accept: */*]
> GET /v1/ping HTTP/2
> Host: 127.0.0.1:3000
> User-Agent: curl/8.20.0
> Accept: */*
>
* Request completely sent off
< HTTP/2 200
< vary: origin, access-control-request-method, access-control-request-headers
< access-control-allow-origin: *
< content-length: 0
< date: Fri, 15 May 2026 10:25:12 GMT
<
* Connection #0 to host 127.0.0.1:3000 left intact
```

