### PR TITLE
CI - enforce minimum pnpm package age

### DIFF
--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,0 +1,20 @@
+name: Set up pnpm
+description: Install pnpm and configure repository package-age policy before any install.
+inputs:
+  run_install:
+    description: Run pnpm install after configuring pnpm.
+    required: false
+    default: "false"
+runs:
+  using: composite
+  steps:
+    - uses: pnpm/action-setup@v4
+
+    - name: Configure pnpm package age policy
+      shell: bash
+      run: pnpm config set --global minimumReleaseAge 1440
+
+    - name: Install dependencies
+      if: inputs.run_install == 'true'
+      shell: bash
+      run: pnpm install

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -1,5 +1,5 @@
 name: Set up pnpm
-description: Install pnpm and configure repository package-age policy before any install.
+description: Install pnpm and configure repository package-age policy before any install
 inputs:
   run_install:
     description: Run pnpm install after configuring pnpm

--- a/.github/actions/setup-pnpm/action.yml
+++ b/.github/actions/setup-pnpm/action.yml
@@ -2,7 +2,7 @@ name: Set up pnpm
 description: Install pnpm and configure repository package-age policy before any install.
 inputs:
   run_install:
-    description: Run pnpm install after configuring pnpm.
+    description: Run pnpm install after configuring pnpm
     required: false
     default: "false"
 runs:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -80,7 +80,7 @@ jobs:
         with:
           node-version: 18
 
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/setup-pnpm
         with:
           run_install: true
 
@@ -221,7 +221,7 @@ jobs:
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/setup-pnpm
         with:
           run_install: true
 
@@ -297,7 +297,7 @@ jobs:
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/setup-pnpm
         with:
           run_install: true
 
@@ -524,7 +524,7 @@ jobs:
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/setup-pnpm
         with:
           run_install: true
 
@@ -1063,7 +1063,7 @@ jobs:
         with:
           node-version: '22'
 
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/setup-pnpm
         with:
           run_install: true
 
@@ -1100,7 +1100,7 @@ jobs:
         with:
           node-version: 22
 
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/setup-pnpm
         with:
           run_install: true
 
@@ -1212,7 +1212,7 @@ jobs:
         uses: actions/setup-node@v4
         with:
           node-version: 20
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/setup-pnpm
         with:
           run_install: true
       - name: Verify that upgrade-version still works

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -20,7 +20,7 @@ jobs:
         with:
           node-version: '22'
       
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/setup-pnpm
         with:
           run_install: true
 

--- a/.github/workflows/docs-update-llms.yaml
+++ b/.github/workflows/docs-update-llms.yaml
@@ -26,7 +26,7 @@ jobs:
         with:
           node-version: '22'
 
-      - uses: pnpm/action-setup@v4
+      - uses: ./.github/actions/setup-pnpm
         with:
           run_install: true
 

--- a/.github/workflows/llm-benchmark-periodic.yml
+++ b/.github/workflows/llm-benchmark-periodic.yml
@@ -70,7 +70,7 @@ jobs:
           node-version: 22
 
       - name: Install pnpm
-        uses: pnpm/action-setup@v4
+        uses: ./.github/actions/setup-pnpm
 
       - name: Build llm-benchmark tool
         run: cargo install --path tools/xtask-llm-benchmark --locked

--- a/.github/workflows/llm-benchmark-validate-goldens.yml
+++ b/.github/workflows/llm-benchmark-validate-goldens.yml
@@ -65,7 +65,7 @@ jobs:
 
       - name: Install pnpm
         if: matrix.lang == 'typescript'
-        uses: pnpm/action-setup@v4
+        uses: ./.github/actions/setup-pnpm
 
       - name: Build llm-benchmark tool
         run: cargo install --path tools/xtask-llm-benchmark --locked

--- a/.npmrc
+++ b/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -899,6 +899,7 @@ dependencies = [
  "env_logger 0.10.2",
  "log",
  "regex",
+ "serde_json",
  "tempfile",
 ]
 

--- a/crates/bindings-typescript/.npmrc
+++ b/crates/bindings-typescript/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/crates/bindings-typescript/case-conversion-test-client/.npmrc
+++ b/crates/bindings-typescript/case-conversion-test-client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/crates/bindings-typescript/test-app/.npmrc
+++ b/crates/bindings-typescript/test-app/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/crates/bindings-typescript/test-react-router-app/.npmrc
+++ b/crates/bindings-typescript/test-react-router-app/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/docs/.npmrc
+++ b/docs/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/modules/benchmarks-ts/.npmrc
+++ b/modules/benchmarks-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/modules/module-test-ts/.npmrc
+++ b/modules/module-test-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/modules/sdk-test-case-conversion-ts/.npmrc
+++ b/modules/sdk-test-case-conversion-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/modules/sdk-test-connect-disconnect-ts/.npmrc
+++ b/modules/sdk-test-connect-disconnect-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/modules/sdk-test-procedure-ts/.npmrc
+++ b/modules/sdk-test-procedure-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/modules/sdk-test-ts/.npmrc
+++ b/modules/sdk-test-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/package.json
+++ b/package.json
@@ -1,9 +1,9 @@
 {
   "private": true,
-  "packageManager": "pnpm@9.7.0",
+  "packageManager": "pnpm@10.16.0",
   "engines": {
     "node": ">=18.0.0",
-    "pnpm": ">=9.0.0"
+    "pnpm": ">=10.16.0"
   },
   "type": "module",
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -28,6 +28,16 @@
     "prettier": "^3.3.3",
     "rimraf": "^6.0.1",
     "typescript": "~5.6.2",
+    "typescript-eslint": "^8.18.2",
     "vitest": "^3.2.4"
+  },
+  "pnpm": {
+    "onlyBuiltDependencies": [
+      "bun"
+    ],
+    "ignoredBuiltDependencies": [
+      "@parcel/watcher",
+      "esbuild"
+    ]
   }
 }

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -44,6 +44,9 @@ importers:
       typescript:
         specifier: ~5.6.2
         version: 5.6.3
+      typescript-eslint:
+        specifier: ^8.18.2
+        version: 8.40.0(eslint@9.33.0(jiti@2.6.1))(typescript@5.6.3)
       vitest:
         specifier: ^3.2.4
         version: 3.2.4(@types/debug@4.1.12)(@types/node@22.18.0)(jiti@2.6.1)(jsdom@26.1.0)(sass@1.97.1)(terser@5.43.1)(tsx@4.21.0)(yaml@2.8.2)

--- a/pnpm-workspace.yaml
+++ b/pnpm-workspace.yaml
@@ -22,3 +22,4 @@ packages:
   - 'modules/sdk-test-ts'
   - 'modules/sdk-test-case-conversion-ts'
   - 'docs'
+minimumReleaseAge: 1440

--- a/templates/angular-ts/.npmrc
+++ b/templates/angular-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/angular-ts/spacetimedb/.npmrc
+++ b/templates/angular-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/astro-ts/.npmrc
+++ b/templates/astro-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/astro-ts/spacetimedb/.npmrc
+++ b/templates/astro-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/basic-ts/.npmrc
+++ b/templates/basic-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/basic-ts/spacetimedb/.npmrc
+++ b/templates/basic-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/browser-ts/.npmrc
+++ b/templates/browser-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/browser-ts/spacetimedb/.npmrc
+++ b/templates/browser-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/bun-ts/.npmrc
+++ b/templates/bun-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/bun-ts/spacetimedb/.npmrc
+++ b/templates/bun-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/chat-react-ts/.npmrc
+++ b/templates/chat-react-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/chat-react-ts/spacetimedb/.npmrc
+++ b/templates/chat-react-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/deno-ts/.npmrc
+++ b/templates/deno-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/deno-ts/spacetimedb/.npmrc
+++ b/templates/deno-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/keynote-2/.npmrc
+++ b/templates/keynote-2/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/keynote-2/convex-app/.npmrc
+++ b/templates/keynote-2/convex-app/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/keynote-2/spacetimedb/.npmrc
+++ b/templates/keynote-2/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/nextjs-ts/.npmrc
+++ b/templates/nextjs-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/nextjs-ts/spacetimedb/.npmrc
+++ b/templates/nextjs-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/nodejs-ts/.npmrc
+++ b/templates/nodejs-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/nodejs-ts/spacetimedb/.npmrc
+++ b/templates/nodejs-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/nuxt-ts/.npmrc
+++ b/templates/nuxt-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/nuxt-ts/spacetimedb/.npmrc
+++ b/templates/nuxt-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/react-ts/.npmrc
+++ b/templates/react-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/react-ts/spacetimedb/.npmrc
+++ b/templates/react-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/remix-ts/.npmrc
+++ b/templates/remix-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/remix-ts/spacetimedb/.npmrc
+++ b/templates/remix-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/svelte-ts/.npmrc
+++ b/templates/svelte-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/svelte-ts/spacetimedb/.npmrc
+++ b/templates/svelte-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/tanstack-ts/.npmrc
+++ b/templates/tanstack-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/tanstack-ts/spacetimedb/.npmrc
+++ b/templates/tanstack-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/vue-ts/.npmrc
+++ b/templates/vue-ts/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/templates/vue-ts/spacetimedb/.npmrc
+++ b/templates/vue-ts/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/ci/Cargo.toml
+++ b/tools/ci/Cargo.toml
@@ -9,6 +9,7 @@ anyhow.workspace = true
 chrono = { workspace = true, features=["clock"] }
 clap.workspace = true
 regex.workspace = true
+serde_json.workspace = true
 duct.workspace = true
 tempfile.workspace = true
 env_logger.workspace = true

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -3,6 +3,7 @@
 use anyhow::{bail, Result};
 use clap::{CommandFactory, Parser, Subcommand};
 use duct::cmd;
+use serde_json::Value;
 use std::ffi::OsStr;
 use std::ffi::OsString;
 use std::path::Path;
@@ -86,6 +87,89 @@ fn check_global_json_policy() -> Result<()> {
 
     if !ok {
         bail!("global.json policy check failed");
+    }
+
+    Ok(())
+}
+
+fn package_json_pnpm_version(package_manager: &str) -> Option<&str> {
+    package_manager.strip_prefix("pnpm@")
+}
+
+fn git_tracked_files(pathspec: &str) -> Result<Vec<PathBuf>> {
+    let output = cmd!("git", "ls-files", pathspec).read()?;
+    Ok(output.lines().map(PathBuf::from).collect())
+}
+
+fn package_json_string_value(package_json: &Value, key: &str) -> Option<String> {
+    package_json.get(key)?.as_str().map(str::to_owned)
+}
+
+fn package_json_engines_pnpm(package_json: &Value) -> Option<String> {
+    package_json.get("engines")?.get("pnpm")?.as_str().map(str::to_owned)
+}
+
+fn read_package_json(path: &Path) -> Result<Value> {
+    let contents = fs::read_to_string(path)?;
+    Ok(serde_json::from_str(&contents)?)
+}
+
+fn minimum_release_age(path: &Path) -> Result<u64> {
+    let workspace = fs::read_to_string(path)?;
+    workspace
+        .lines()
+        .find_map(|line| {
+            let line = line.trim();
+            let value = line.strip_prefix("minimumReleaseAge:")?.trim();
+            value.parse::<u64>().ok()
+        })
+        .ok_or_else(|| anyhow::anyhow!("{} is missing minimumReleaseAge", path.display()))
+}
+
+fn check_pnpm_release_age_policy() -> Result<()> {
+    ensure_repo_root()?;
+
+    let root_package_json_path = Path::new("package.json");
+    let root_package_json = read_package_json(root_package_json_path)?;
+    let package_manager = package_json_string_value(&root_package_json, "packageManager")
+        .ok_or_else(|| anyhow::anyhow!("package.json is missing packageManager"))?;
+    let package_manager_version = package_json_pnpm_version(&package_manager)
+        .ok_or_else(|| anyhow::anyhow!("packageManager must be pnpm@<version>, found {package_manager:?}"))?;
+
+    let expected_engine_pnpm = format!(">={package_manager_version}");
+    let engine_pnpm = package_json_engines_pnpm(&root_package_json)
+        .ok_or_else(|| anyhow::anyhow!("package.json engines is missing pnpm"))?;
+    if engine_pnpm != expected_engine_pnpm {
+        bail!("package.json engines.pnpm must be {expected_engine_pnpm:?}, found {engine_pnpm:?}");
+    }
+
+    for package_json_path in git_tracked_files("package.json")? {
+        let package_json = read_package_json(&package_json_path)?;
+        let Some(found_package_manager) = package_json_string_value(&package_json, "packageManager") else {
+            continue;
+        };
+        if found_package_manager != package_manager {
+            bail!(
+                "{} packageManager must match root package.json: expected {:?}, found {:?}",
+                package_json_path.display(),
+                package_manager,
+                found_package_manager
+            );
+        }
+    }
+
+    let root_workspace_path = Path::new("pnpm-workspace.yaml");
+    let root_minimum_release_age = minimum_release_age(root_workspace_path)?;
+    for workspace_path in git_tracked_files("pnpm-workspace.yaml")? {
+        let found_minimum_release_age = minimum_release_age(&workspace_path)?;
+        if found_minimum_release_age != root_minimum_release_age {
+            bail!(
+                "{} minimumReleaseAge must match root pnpm-workspace.yaml: expected {}, found {}",
+                workspace_path.display(),
+                root_minimum_release_age,
+                found_minimum_release_age
+            );
+        }
     }
 
     Ok(())
@@ -352,6 +436,7 @@ fn main() -> Result<()> {
 
         Some(CiCmd::Lint) => {
             ensure_repo_root()?;
+            check_pnpm_release_age_policy()?;
             // `cargo fmt --all` only checks files that Cargo discovers through workspace/package targets.
             // However, we also keep Rust sources in a locations that are tracked but not part of our workspace,
             // so this approach properly catches all the files, where `cargo fmt` does not.

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -143,8 +143,21 @@ fn minimum_release_age(path: &Path) -> Result<u64> {
         .ok_or_else(|| anyhow::anyhow!("{} is missing minimumReleaseAge", path.display()))
 }
 
-fn npmrc_minimum_release_age(path: &Path) -> Result<u64> {
-    let contents = fs::read_to_string(path)?;
+fn npmrc_minimum_release_age(path: &Path, expected_minimum_release_age: u64) -> Result<u64> {
+    let contents = fs::read_to_string(path).map_err(|err| {
+        if err.kind() == std::io::ErrorKind::NotFound {
+            anyhow::anyhow!(
+                "{} is tracked but missing from the working tree. Restore it with:\nminimum-release-age={}",
+                path.display(),
+                expected_minimum_release_age
+            )
+        } else {
+            anyhow::anyhow!(
+                "failed to read {} while checking pnpm minimum package age: {err}",
+                path.display()
+            )
+        }
+    })?;
     contents
         .lines()
         .find_map(|line| {
@@ -152,7 +165,13 @@ fn npmrc_minimum_release_age(path: &Path) -> Result<u64> {
             let value = line.strip_prefix("minimum-release-age=")?.trim();
             value.parse::<u64>().ok()
         })
-        .ok_or_else(|| anyhow::anyhow!("{} is missing minimum-release-age", path.display()))
+        .ok_or_else(|| {
+            anyhow::anyhow!(
+                "{} must contain `minimum-release-age={}` to match root pnpm-workspace.yaml",
+                path.display(),
+                expected_minimum_release_age
+            )
+        })
 }
 
 fn check_pnpm_release_age_policy() -> Result<()> {
@@ -202,7 +221,7 @@ fn check_pnpm_release_age_policy() -> Result<()> {
     }
 
     for npmrc_path in git_tracked_files(":(glob)**/.npmrc")? {
-        let found_minimum_release_age = npmrc_minimum_release_age(&npmrc_path)?;
+        let found_minimum_release_age = npmrc_minimum_release_age(&npmrc_path, root_minimum_release_age)?;
         if found_minimum_release_age != root_minimum_release_age {
             bail!(
                 "{} minimum-release-age must match root pnpm-workspace.yaml: expected {}, found {}",
@@ -224,12 +243,14 @@ fn check_pnpm_release_age_policy() -> Result<()> {
         let npmrc_path = package_dir.join(".npmrc");
         if !npmrc_path.is_file() {
             bail!(
-                "{} has a package.json and must contain {}",
-                package_dir.display(),
-                npmrc_path.display()
+                "{} is required because {} is an npm/pnpm package manifest.\nAdd {} containing:\nminimum-release-age={}",
+                npmrc_path.display(),
+                package_json_path.display(),
+                npmrc_path.display(),
+                root_minimum_release_age
             );
         }
-        let found_minimum_release_age = npmrc_minimum_release_age(&npmrc_path)?;
+        let found_minimum_release_age = npmrc_minimum_release_age(&npmrc_path, root_minimum_release_age)?;
         if found_minimum_release_age != root_minimum_release_age {
             bail!(
                 "{} minimum-release-age must match root pnpm-workspace.yaml: expected {}, found {}",

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -114,6 +114,23 @@ fn read_package_json(path: &Path) -> Result<Value> {
     Ok(serde_json::from_str(&contents)?)
 }
 
+fn is_npm_package_json(package_json: &Value) -> bool {
+    [
+        "bin",
+        "dependencies",
+        "devDependencies",
+        "exports",
+        "main",
+        "optionalDependencies",
+        "packageManager",
+        "peerDependencies",
+        "scripts",
+        "type",
+    ]
+    .iter()
+    .any(|key| package_json.get(key).is_some())
+}
+
 fn minimum_release_age(path: &Path) -> Result<u64> {
     let workspace = fs::read_to_string(path)?;
     workspace
@@ -124,6 +141,18 @@ fn minimum_release_age(path: &Path) -> Result<u64> {
             value.parse::<u64>().ok()
         })
         .ok_or_else(|| anyhow::anyhow!("{} is missing minimumReleaseAge", path.display()))
+}
+
+fn npmrc_minimum_release_age(path: &Path) -> Result<u64> {
+    let contents = fs::read_to_string(path)?;
+    contents
+        .lines()
+        .find_map(|line| {
+            let line = line.trim();
+            let value = line.strip_prefix("minimum-release-age=")?.trim();
+            value.parse::<u64>().ok()
+        })
+        .ok_or_else(|| anyhow::anyhow!("{} is missing minimum-release-age", path.display()))
 }
 
 fn check_pnpm_release_age_policy() -> Result<()> {
@@ -143,7 +172,7 @@ fn check_pnpm_release_age_policy() -> Result<()> {
         bail!("package.json engines.pnpm must be {expected_engine_pnpm:?}, found {engine_pnpm:?}");
     }
 
-    for package_json_path in git_tracked_files("package.json")? {
+    for package_json_path in git_tracked_files(":(glob)**/package.json")? {
         let package_json = read_package_json(&package_json_path)?;
         let Some(found_package_manager) = package_json_string_value(&package_json, "packageManager") else {
             continue;
@@ -160,7 +189,7 @@ fn check_pnpm_release_age_policy() -> Result<()> {
 
     let root_workspace_path = Path::new("pnpm-workspace.yaml");
     let root_minimum_release_age = minimum_release_age(root_workspace_path)?;
-    for workspace_path in git_tracked_files("pnpm-workspace.yaml")? {
+    for workspace_path in git_tracked_files(":(glob)**/pnpm-workspace.yaml")? {
         let found_minimum_release_age = minimum_release_age(&workspace_path)?;
         if found_minimum_release_age != root_minimum_release_age {
             bail!(
@@ -168,6 +197,55 @@ fn check_pnpm_release_age_policy() -> Result<()> {
                 workspace_path.display(),
                 root_minimum_release_age,
                 found_minimum_release_age
+            );
+        }
+    }
+
+    for npmrc_path in git_tracked_files(":(glob)**/.npmrc")? {
+        let found_minimum_release_age = npmrc_minimum_release_age(&npmrc_path)?;
+        if found_minimum_release_age != root_minimum_release_age {
+            bail!(
+                "{} minimum-release-age must match root pnpm-workspace.yaml: expected {}, found {}",
+                npmrc_path.display(),
+                root_minimum_release_age,
+                found_minimum_release_age
+            );
+        }
+    }
+
+    for package_json_path in git_tracked_files(":(glob)**/package.json")? {
+        let package_json = read_package_json(&package_json_path)?;
+        if !is_npm_package_json(&package_json) {
+            continue;
+        }
+        let package_dir = package_json_path
+            .parent()
+            .expect("git-tracked package.json path should have a parent");
+        let npmrc_path = package_dir.join(".npmrc");
+        if !npmrc_path.is_file() {
+            bail!(
+                "{} has a package.json and must contain {}",
+                package_dir.display(),
+                npmrc_path.display()
+            );
+        }
+        let found_minimum_release_age = npmrc_minimum_release_age(&npmrc_path)?;
+        if found_minimum_release_age != root_minimum_release_age {
+            bail!(
+                "{} minimum-release-age must match root pnpm-workspace.yaml: expected {}, found {}",
+                npmrc_path.display(),
+                root_minimum_release_age,
+                found_minimum_release_age
+            );
+        }
+    }
+
+    for workflow_path in git_tracked_files(".github/workflows/*")? {
+        let contents = fs::read_to_string(&workflow_path)?;
+        if contents.contains("pnpm/action-setup@v4") {
+            bail!(
+                "{} must use ./.github/actions/setup-pnpm instead of pnpm/action-setup@v4",
+                workflow_path.display()
             );
         }
     }

--- a/tools/llm-oneshot/.npmrc
+++ b/tools/llm-oneshot/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/gemini-3-pro/postgres/chat-app-20260108-120000/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/gemini-3-pro/postgres/chat-app-20260108-120000/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/gemini-3-pro/postgres/chat-app-20260108-120000/server/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/gemini-3-pro/postgres/chat-app-20260108-120000/server/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/gemini-3-pro/spacetime/chat-app-20260107-120000/backend/spacetimedb/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/gemini-3-pro/spacetime/chat-app-20260107-120000/backend/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/gemini-3-pro/spacetime/chat-app-20260107-120000/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/gemini-3-pro/spacetime/chat-app-20260107-120000/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/gpt-5-2/postgres/chat-app-20260108-140800/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/gpt-5-2/postgres/chat-app-20260108-140800/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/gpt-5-2/postgres/chat-app-20260108-140800/server/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/gpt-5-2/postgres/chat-app-20260108-140800/server/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/gpt-5-2/spacetime/chat-app-20260107-092240/backend/spacetimedb/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/gpt-5-2/spacetime/chat-app-20260107-092240/backend/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/gpt-5-2/spacetime/chat-app-20260107-092240/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/gpt-5-2/spacetime/chat-app-20260107-092240/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/grok-code/postgres/chat-app-20260128-112222/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/grok-code/postgres/chat-app-20260128-112222/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/grok-code/postgres/chat-app-20260128-112222/server/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/grok-code/postgres/chat-app-20260128-112222/server/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/grok-code/spacetime/chat-app-20260107-120000/backend/spacetimedb/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/grok-code/spacetime/chat-app-20260107-120000/backend/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/grok-code/spacetime/chat-app-20260107-120000/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/grok-code/spacetime/chat-app-20260107-120000/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/postgres/chat-app-20260104-120000/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/postgres/chat-app-20260104-120000/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/postgres/chat-app-20260104-120000/server/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/postgres/chat-app-20260104-120000/server/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/postgres/chat-app-20260104-160000/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/postgres/chat-app-20260104-160000/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/postgres/chat-app-20260104-160000/server/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/postgres/chat-app-20260104-160000/server/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/postgres/chat-app-20260104-180000/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/postgres/chat-app-20260104-180000/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/postgres/chat-app-20260104-180000/server/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/postgres/chat-app-20260104-180000/server/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260102-162918/backend/spacetimedb/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260102-162918/backend/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260102-162918/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260102-162918/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260102-170500/backend/spacetimedb/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260102-170500/backend/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260102-170500/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260102-170500/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260102-171317/backend/spacetimedb/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260102-171317/backend/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260102-171317/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260102-171317/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260105-180000/backend/spacetimedb/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260105-180000/backend/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260105-180000/client/.npmrc
+++ b/tools/llm-oneshot/apps/chat-app/typescript/opus-4-5/spacetime/chat-app-20260105-180000/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/paint-app/typescript/opus-4-5/spacetime/paint-app-20260109-164112/backend/spacetimedb/.npmrc
+++ b/tools/llm-oneshot/apps/paint-app/typescript/opus-4-5/spacetime/paint-app-20260109-164112/backend/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/paint-app/typescript/opus-4-5/spacetime/paint-app-20260109-164112/client/.npmrc
+++ b/tools/llm-oneshot/apps/paint-app/typescript/opus-4-5/spacetime/paint-app-20260109-164112/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/paint-app/typescript/opus-4-5/spacetime/paint-app-20260112-154500/backend/spacetimedb/.npmrc
+++ b/tools/llm-oneshot/apps/paint-app/typescript/opus-4-5/spacetime/paint-app-20260112-154500/backend/spacetimedb/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/llm-oneshot/apps/paint-app/typescript/opus-4-5/spacetime/paint-app-20260112-154500/client/.npmrc
+++ b/tools/llm-oneshot/apps/paint-app/typescript/opus-4-5/spacetime/paint-app-20260112-154500/client/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/templates/.npmrc
+++ b/tools/templates/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440

--- a/tools/xtask-llm-benchmark/src/templates/typescript/server/.npmrc
+++ b/tools/xtask-llm-benchmark/src/templates/typescript/server/.npmrc
@@ -1,0 +1,1 @@
+minimum-release-age=1440


### PR DESCRIPTION
# Description of Changes

Due to the relatively frequent supply chain attacks on especially npm packages, we're instituting a minimum package age in the whole repo.

- Globally set a minimum npm package age in CI
- Best-effort set npm package age using `.npmrc` beside any `package.json`
- Add CI checks that pnpm version and minimum package age values are the same everywhere

# API and ABI breaking changes

None

# Expected complexity level and risk

2

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] CI passes
- [x] if I remove a `.npmrc` then `cargo ci lint` fails
- [x] if I change a value in `.npmrc` then `cargo ci lint` fails