### PR TITLE
Use IndexMap for mounts and validate duplicates [Namespaces Part 2]

### DIFF
--- a/crates/schema/src/def.rs
+++ b/crates/schema/src/def.rs
@@ -153,7 +153,7 @@ pub struct ModuleDef {
     raw_module_def_version: RawModuleDefVersion,
 
     /// Mounted submodules, keyed by the namespace they are mounted under.
-    mounts: Vec<(String, ModuleDef)>,
+    mounts: IndexMap<String, ModuleDef>,
 }
 
 #[derive(Debug, Clone, Copy, Eq, PartialEq)]
@@ -171,7 +171,7 @@ impl ModuleDef {
     }
 
     /// The mounted submodules of the module definition.
-    pub fn mounts(&self) -> &[(String, ModuleDef)] {
+    pub fn mounts(&self) -> &IndexMap<String, ModuleDef> {
         &self.mounts
     }
 

--- a/crates/schema/src/def/validate/v10.rs
+++ b/crates/schema/src/def/validate/v10.rs
@@ -308,9 +308,7 @@ fn validate_mount_names_are_unique(mounts: Vec<(String, ModuleDef)>) -> Result<I
 
     for (namespace, def) in mounts {
         if map.contains_key(&namespace) {
-            errors.push(ValidationError::DuplicateName {
-                name: namespace.into(),
-            });
+            errors.push(ValidationError::DuplicateName { name: namespace.into() });
         } else {
             map.insert(namespace, def);
         }

--- a/crates/schema/src/def/validate/v10.rs
+++ b/crates/schema/src/def/validate/v10.rs
@@ -271,8 +271,8 @@ pub fn validate(def: RawModuleDefV10) -> Result<ModuleDef> {
 
     let (tables, types, reducers, procedures, views, mounts) = (tables_types_reducers_procedures_views, mounts)
         .combine_errors()
-        .map(|((tables, types, reducers, procedures, views), mounts)| {
-            (tables, types, reducers, procedures, views, mounts)
+        .and_then(|((tables, types, reducers, procedures, views), mounts)| {
+            validate_mount_names_are_unique(mounts).map(|mounts| (tables, types, reducers, procedures, views, mounts))
         })
         .map_err(|errors: ValidationErrors| errors.sort_deduplicate())?;
 
@@ -300,6 +300,23 @@ fn validate_mount(mount: RawModuleMountV10) -> Result<(String, ModuleDef)> {
         .map_err(|error| ValidationErrors::from(ValidationError::IdentifierError { error }))?;
 
     Ok((mount.namespace, validate(mount.module)?))
+}
+
+fn validate_mount_names_are_unique(mounts: Vec<(String, ModuleDef)>) -> Result<IndexMap<String, ModuleDef>> {
+    let mut errors = vec![];
+    let mut map = IndexMap::with_capacity(mounts.len());
+
+    for (namespace, def) in mounts {
+        if map.contains_key(&namespace) {
+            errors.push(ValidationError::DuplicateName {
+                name: namespace.into(),
+            });
+        } else {
+            map.insert(namespace, def);
+        }
+    }
+
+    ValidationErrors::add_extra_errors(Ok(map), errors)
 }
 
 /// Change the visibility of scheduled functions and lifecycle reducers to Internal.
@@ -902,6 +919,7 @@ mod tests {
     use spacetimedb_lib::db::raw_def::*;
     use spacetimedb_lib::ScheduleAt;
     use spacetimedb_primitives::{ColId, ColList, ColSet};
+    use spacetimedb_sats::raw_identifier::RawIdentifier;
     use spacetimedb_sats::{AlgebraicType, AlgebraicTypeRef, AlgebraicValue, ProductType, SumValue};
     use v9::{Lifecycle, TableAccess, TableType};
 
@@ -1294,8 +1312,8 @@ mod tests {
         let mounts = def.mounts();
 
         assert_eq!(mounts.len(), 1);
-        assert_eq!(mounts[0].0, "authlib");
-        assert!(mounts[0].1.table(&expect_identifier("sessions")).is_some());
+        let mounted = mounts.get("authlib").expect("authlib mount should exist");
+        assert!(mounted.table(&expect_identifier("sessions")).is_some());
     }
 
     #[test]
@@ -1311,6 +1329,28 @@ mod tests {
 
         expect_error_matching!(result, ValidationError::IdentifierError { error } => {
             error == &IdentifierError::Empty {}
+        });
+    }
+
+    #[test]
+    fn duplicate_mount_namespace() {
+        let raw = RawModuleDefV10 {
+            sections: vec![RawModuleDefV10Section::Mounts(vec![
+                RawModuleMountV10 {
+                    namespace: "authlib".to_string(),
+                    module: RawModuleDefV10::default(),
+                },
+                RawModuleMountV10 {
+                    namespace: "authlib".to_string(),
+                    module: RawModuleDefV10::default(),
+                },
+            ])],
+        };
+
+        let result: Result<ModuleDef> = raw.try_into();
+
+        expect_error_matching!(result, ValidationError::DuplicateName { name } => {
+            name == &RawIdentifier::from("authlib")
         });
     }
 

--- a/crates/schema/src/def/validate/v9.rs
+++ b/crates/schema/src/def/validate/v9.rs
@@ -166,7 +166,7 @@ pub fn validate(def: RawModuleDefV9) -> Result<ModuleDef> {
         lifecycle_reducers,
         procedures,
         raw_module_def_version: RawModuleDefVersion::V9OrEarlier,
-        mounts: Vec::new(),
+        mounts: IndexMap::new(),
     })
 }
 


### PR DESCRIPTION
# Description of Changes

- Replace ModuleDef `mounts` type with IndexMap rather than Vec to explicitly require name uniqueness
- Validate mount name uniqueness

# API and ABI breaking changes

No

# Expected complexity level and risk

2 - Fairly simple change to new (as of yet unused) module def type

# Testing

- [ ] Added a test to check that the duplicate name check is working correctly
