### PR TITLE
Client binaries from DigitalOcean -> AWS

### DIFF
--- a/.github/workflows/attach-artifacts.yml
+++ b/.github/workflows/attach-artifacts.yml
@@ -60,3 +60,4 @@ jobs:
           gh release upload "$RELEASE_TAG" ./* \
             --repo "$GITHUB_REPOSITORY" \
             --clobber
+

--- a/.github/workflows/attach-artifacts.yml
+++ b/.github/workflows/attach-artifacts.yml
@@ -20,7 +20,7 @@ jobs:
       - name: Download artifacts from AWS base URL
         env:
           RELEASE_TAG: ${{ github.event.inputs.release_tag }}
-          BASE_URL: ${{ vars.ARTIFACT_BASE_URL }}
+          BASE_URL: https://${{ vars.AWS_BUCKET }}.s3.amazonaws.com/refs/tags
         run: |
           set -euo pipefail
 
@@ -60,4 +60,3 @@ jobs:
           gh release upload "$RELEASE_TAG" ./* \
             --repo "$GITHUB_REPOSITORY" \
             --clobber
-

--- a/.github/workflows/attach-artifacts.yml
+++ b/.github/workflows/attach-artifacts.yml
@@ -17,10 +17,10 @@ jobs:
       - name: Checkout
         uses: actions/checkout@v4
 
-      - name: Download artifacts from private base URL
+      - name: Download artifacts from AWS base URL
         env:
           RELEASE_TAG: ${{ github.event.inputs.release_tag }}
-          BASE_URL: ${{ secrets.ARTIFACT_BASE_URL }}
+          BASE_URL: ${{ vars.ARTIFACT_BASE_URL }}
         run: |
           set -euo pipefail
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -2,7 +2,6 @@ on:
   push:
     branches:
       - master
-      - jgilles/fix-callgrind-again
 
   workflow_dispatch:
     inputs:
@@ -24,8 +23,10 @@ jobs:
   benchmark:
     name: run criterion benchmarks
     runs-on: benchmarks-runner
+    # disable until we fix the benchmarks
+    if: false
     # filter for a comment containing 'benchmarks please'
-    if: ${{ github.event_name != 'issue_comment' || (github.event.issue.pull_request && contains(github.event.comment.body, 'benchmarks please')) }}
+    #if: ${{ github.event_name != 'issue_comment' || (github.event.issue.pull_request && contains(github.event.comment.body, 'benchmarks please')) }}
     env:
       PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.issue.number || null }}
     steps:
@@ -185,8 +186,10 @@ jobs:
     container:
       image: rust:1.93.0
       options: --privileged
+    # disable until we fix the benchmarks
+    if: false
     # filter for a comment containing 'benchmarks please'
-    if: ${{ github.event_name != 'issue_comment' || (github.event.issue.pull_request && contains(github.event.comment.body, 'benchmarks please')) }}
+    #if: ${{ github.event_name != 'issue_comment' || (github.event.issue.pull_request && contains(github.event.comment.body, 'benchmarks please')) }}
     env:
       PR_NUMBER: ${{ github.event.inputs.pr_number || github.event.issue.number || null }}
     steps:

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -142,12 +142,11 @@ jobs:
         run: echo "branch=${GITHUB_HEAD_REF:-${GITHUB_REF#refs/heads/}}" >> $GITHUB_OUTPUT
         id: extract_branch
 
-      - name: Upload to DO Spaces
+      - name: Upload to AWS S3
         uses: shallwefootball/s3-upload-action@master
         with:
           aws_key_id: ${{ secrets.AWS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
           aws_bucket: ${{ vars.AWS_BUCKET }}
           source_dir: build
-          endpoint: https://nyc3.digitaloceanspaces.com
           destination_dir: ${{ steps.extract_branch.outputs.branch }}

--- a/crates/update/spacetime-install.ps1
+++ b/crates/update/spacetime-install.ps1
@@ -32,7 +32,7 @@ function Install {
 
     $AssetName = "spacetimedb-update-x86_64-pc-windows-msvc.exe"
     $DownloadUrl = "https://github.com/clockworklabs/SpacetimeDB/releases/latest/download/$AssetName"
-    $MirrorBase = "https://spacetimedb-client-binaries.nyc3.digitaloceanspaces.com"
+    $MirrorBase = "https://spacetimedb-client-binaries.s3.amazonaws.com"
     Write-Output "Downloading installer..."
 
     function UpdatePathIfNotExists {

--- a/crates/update/spacetime-install.sh
+++ b/crates/update/spacetime-install.sh
@@ -65,7 +65,7 @@ main() {
     # Define the latest SpacetimeDB download url
     local _asset_name="spacetimedb-update-$_host$_ext"
     local _url="$SPACETIME_DOWNLOAD_ROOT/$_asset_name"
-    local _mirror_base="https://spacetimedb-client-binaries.nyc3.digitaloceanspaces.com"
+    local _mirror_base="https://spacetimedb-client-binaries.s3.amazonaws.com"
     echo "Downloading installer..."
     local _ok=false
     if [ "$_downloader" = curl ]; then

--- a/crates/update/src/cli/install.rs
+++ b/crates/update/src/cli/install.rs
@@ -59,7 +59,7 @@ fn releases_url() -> String {
         .unwrap_or_else(|_| "https://api.github.com/repos/clockworklabs/SpacetimeDB/releases".to_owned())
 }
 
-const MIRROR_BASE_URL: &str = "https://spacetimedb-client-binaries.nyc3.digitaloceanspaces.com";
+const MIRROR_BASE_URL: &str = "https://spacetimedb-client-binaries.s3.amazonaws.com";
 
 /// Fetch the latest version tag from the mirror.
 ///


### PR DESCRIPTION
# Description of Changes

Use an AWS bucket for client binaries instead of DigitalOcean.

Note that this will effectively hamstring the DigitalOcean mirror for any old clients (i.e. ones before this change is released). But it's only a mirror, and they can "fix" it by upgrading to a version with this change.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] Manually ran the package job on this PR and confirmed that some of the resulting URLs are indeed downloadable from the AWS urls