### PR TITLE
Undo `.npmrc` in templates

### DIFF
--- a/crates/smoketests/src/lib.rs
+++ b/crates/smoketests/src/lib.rs
@@ -280,6 +280,21 @@ pub fn pnpm_path() -> Option<PathBuf> {
     PNPM_PATH.get_or_init(|| which("pnpm").ok()).clone()
 }
 
+fn pnpm_minimum_release_age() -> Result<String> {
+    let workspace = fs::read_to_string(workspace_root().join("pnpm-workspace.yaml"))?;
+    workspace
+        .lines()
+        .find_map(|line| {
+            line.trim()
+                .strip_prefix("minimumReleaseAge:")?
+                .trim()
+                .parse::<u64>()
+                .ok()
+        })
+        .map(|age| age.to_string())
+        .context("pnpm-workspace.yaml is missing minimumReleaseAge")
+}
+
 /// Runs a command and returns stdout as a string.
 pub fn run_cmd(args: &[&str], cwd: &Path) -> Result<String> {
     run_cmd_inner(args, cwd, None)
@@ -332,10 +347,28 @@ fn run_cmd_inner(args: &[&str], cwd: &Path, stdin_input: Option<&str>) -> Result
 /// Runs a `pnpm` command and returns stdout as a string.
 pub fn pnpm(args: &[&str], cwd: &Path) -> Result<String> {
     let pnpm_path = pnpm_path().context("Could not locate pnpm")?;
-    let pnpm_path = pnpm_path.to_str().context("pnpm path is not valid UTF-8")?;
-    let mut full_args = vec![pnpm_path];
-    full_args.extend(args);
-    run_cmd(&full_args, cwd)
+    let minimum_release_age = pnpm_minimum_release_age()?;
+
+    // Smoketests often install inside temp projects created by `spacetime init`.
+    // Those projects intentionally do not carry the repo's .npmrc, so pass the
+    // repo policy through pnpm's environment variable instead.
+    let output = Command::new(&pnpm_path)
+        .args(args)
+        .current_dir(cwd)
+        .env("npm_config_minimum_release_age", minimum_release_age)
+        .output()
+        .with_context(|| format!("Failed to spawn pnpm {}", args.join(" ")))?;
+
+    if !output.status.success() {
+        bail!(
+            "pnpm {} (in {:?}) failed:\nstdout: {}\nstderr: {}",
+            args.join(" "),
+            cwd,
+            String::from_utf8_lossy(&output.stdout),
+            String::from_utf8_lossy(&output.stderr)
+        );
+    }
+    Ok(String::from_utf8_lossy(&output.stdout).to_string())
 }
 
 /// Builds the local TypeScript bindings package.

--- a/crates/smoketests/tests/smoketests/templates.rs
+++ b/crates/smoketests/tests/smoketests/templates.rs
@@ -12,7 +12,7 @@
 use anyhow::{bail, Context, Result};
 use regex::Regex;
 use serde_json::Value;
-use spacetimedb_smoketests::{pnpm_path, random_string, workspace_root, Smoketest};
+use spacetimedb_smoketests::{pnpm, random_string, workspace_root, Smoketest};
 use std::env;
 use std::fs;
 use std::path::{Path, PathBuf};
@@ -174,21 +174,7 @@ fn update_package_json_dependency(package_json_path: &Path, package_name: &str, 
 
 /// Runs pnpm with the given arguments in the given working directory.
 fn run_pnpm(args: &[&str], cwd: &Path) -> Result<()> {
-    let pnpm = pnpm_path().context("pnpm not found")?;
-    let output = Command::new(&pnpm)
-        .args(args)
-        .current_dir(cwd)
-        .output()
-        .with_context(|| format!("Failed to spawn pnpm {}", args.join(" ")))?;
-    if !output.status.success() {
-        bail!(
-            "pnpm {} (in {:?}) failed:\nstdout: {}\nstderr: {}",
-            args.join(" "),
-            cwd,
-            String::from_utf8_lossy(&output.stdout),
-            String::from_utf8_lossy(&output.stderr)
-        );
-    }
+    pnpm(args, cwd)?;
     Ok(())
 }
 

--- a/templates/angular-ts/.npmrc
+++ b/templates/angular-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/angular-ts/spacetimedb/.npmrc
+++ b/templates/angular-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/astro-ts/.npmrc
+++ b/templates/astro-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/astro-ts/spacetimedb/.npmrc
+++ b/templates/astro-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/basic-ts/.npmrc
+++ b/templates/basic-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/basic-ts/spacetimedb/.npmrc
+++ b/templates/basic-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/browser-ts/.npmrc
+++ b/templates/browser-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/browser-ts/spacetimedb/.npmrc
+++ b/templates/browser-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/bun-ts/.npmrc
+++ b/templates/bun-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/bun-ts/spacetimedb/.npmrc
+++ b/templates/bun-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/chat-react-ts/.npmrc
+++ b/templates/chat-react-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/chat-react-ts/spacetimedb/.npmrc
+++ b/templates/chat-react-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/deno-ts/.npmrc
+++ b/templates/deno-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/deno-ts/spacetimedb/.npmrc
+++ b/templates/deno-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/keynote-2/.npmrc
+++ b/templates/keynote-2/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/keynote-2/convex-app/.npmrc
+++ b/templates/keynote-2/convex-app/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/keynote-2/spacetimedb/.npmrc
+++ b/templates/keynote-2/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/nextjs-ts/.npmrc
+++ b/templates/nextjs-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/nextjs-ts/spacetimedb/.npmrc
+++ b/templates/nextjs-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/nodejs-ts/.npmrc
+++ b/templates/nodejs-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/nodejs-ts/spacetimedb/.npmrc
+++ b/templates/nodejs-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/nuxt-ts/.npmrc
+++ b/templates/nuxt-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/nuxt-ts/spacetimedb/.npmrc
+++ b/templates/nuxt-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/react-ts/.npmrc
+++ b/templates/react-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/react-ts/spacetimedb/.npmrc
+++ b/templates/react-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/remix-ts/.npmrc
+++ b/templates/remix-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/remix-ts/spacetimedb/.npmrc
+++ b/templates/remix-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/svelte-ts/.npmrc
+++ b/templates/svelte-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/svelte-ts/spacetimedb/.npmrc
+++ b/templates/svelte-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/tanstack-ts/.npmrc
+++ b/templates/tanstack-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/tanstack-ts/spacetimedb/.npmrc
+++ b/templates/tanstack-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/vue-ts/.npmrc
+++ b/templates/vue-ts/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/templates/vue-ts/spacetimedb/.npmrc
+++ b/templates/vue-ts/spacetimedb/.npmrc
@@ -1,1 +1,0 @@
-minimum-release-age=1440

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -225,6 +225,9 @@ fn check_pnpm_release_age_policy() -> Result<()> {
     }
 
     for npmrc_path in git_tracked_files(":(glob)**/.npmrc")? {
+        // Template package roots are copied into projects created by `spacetime init`.
+        // They must not embed this repo's package-age policy; smoketests enforce it
+        // at the pnpm process boundary instead.
         if is_template_path(&npmrc_path) {
             continue;
         }
@@ -240,6 +243,9 @@ fn check_pnpm_release_age_policy() -> Result<()> {
     }
 
     for package_json_path in git_tracked_files(":(glob)**/package.json")? {
+        // Template package roots are copied into projects created by `spacetime init`.
+        // They must not require adjacent .npmrc files for this repo's package-age
+        // policy; smoketests enforce it at the pnpm process boundary instead.
         if is_template_path(&package_json_path) {
             continue;
         }

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -131,6 +131,10 @@ fn is_npm_package_json(package_json: &Value) -> bool {
     .any(|key| package_json.get(key).is_some())
 }
 
+fn is_template_path(path: &Path) -> bool {
+    path.starts_with("templates")
+}
+
 fn minimum_release_age(path: &Path) -> Result<u64> {
     let workspace = fs::read_to_string(path)?;
     workspace
@@ -221,6 +225,9 @@ fn check_pnpm_release_age_policy() -> Result<()> {
     }
 
     for npmrc_path in git_tracked_files(":(glob)**/.npmrc")? {
+        if is_template_path(&npmrc_path) {
+            continue;
+        }
         let found_minimum_release_age = npmrc_minimum_release_age(&npmrc_path, root_minimum_release_age)?;
         if found_minimum_release_age != root_minimum_release_age {
             bail!(
@@ -233,6 +240,9 @@ fn check_pnpm_release_age_policy() -> Result<()> {
     }
 
     for package_json_path in git_tracked_files(":(glob)**/package.json")? {
+        if is_template_path(&package_json_path) {
+            continue;
+        }
         let package_json = read_package_json(&package_json_path)?;
         if !is_npm_package_json(&package_json) {
             continue;

--- a/tools/xtask-llm-benchmark/src/bench/publishers.rs
+++ b/tools/xtask-llm-benchmark/src/bench/publishers.rs
@@ -8,6 +8,29 @@ use std::path::{Path, PathBuf};
 use std::process::Command;
 use std::sync::LazyLock;
 
+fn workspace_root() -> PathBuf {
+    PathBuf::from(env!("CARGO_MANIFEST_DIR"))
+        .ancestors()
+        .nth(2)
+        .expect("xtask-llm-benchmark is under public/tools/xtask-llm-benchmark")
+        .to_path_buf()
+}
+
+fn pnpm_minimum_release_age() -> Result<String> {
+    let workspace = fs::read_to_string(workspace_root().join("pnpm-workspace.yaml"))?;
+    workspace
+        .lines()
+        .find_map(|line| {
+            line.trim()
+                .strip_prefix("minimumReleaseAge:")?
+                .trim()
+                .parse::<u64>()
+                .ok()
+        })
+        .map(|age| age.to_string())
+        .ok_or_else(|| anyhow::anyhow!("pnpm-workspace.yaml is missing minimumReleaseAge"))
+}
+
 /// Strip ANSI escape codes (color codes) from a string
 fn strip_ansi_codes(s: &str) -> Cow<'_, str> {
     static ANSI_RE: LazyLock<Regex> = LazyLock::new(|| {
@@ -298,7 +321,10 @@ impl Publisher for TypeScriptPublisher {
             .arg("install")
             .arg("--ignore-workspace")
             .current_dir(source)
-            .env("CI", "true");
+            .env("CI", "true")
+            // This install runs in a materialized project with workspace config
+            // ignored, so pass the repo's pnpm package-age policy explicitly.
+            .env("npm_config_minimum_release_age", pnpm_minimum_release_age()?);
         // When using NODEJS_DIR, prepend it to PATH so pnpm.cmd can find node.
         if let Some(ref dir) = pnpm_exe
             && let Some(parent) = dir.parent()


### PR DESCRIPTION
# Description of Changes

See https://github.com/clockworklabs/SpacetimeDB/issues/5083 for motivation.

# API and ABI breaking changes

None

# Expected complexity level and risk

2

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] `cargo run -pspcaetimedb-cli -- init --template nodejs-ts` no longer creates a directory with `.npmrc`