### PR TITLE
CI - `DOCKERHUB_PASSWORD` -> `DOCKERHUB_TOKEN`

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -689,12 +689,6 @@ jobs:
           key: Unity-${{ github.head_ref }}
           restore-keys: Unity-
 
-      - name: Login to DockerHub
-        uses: docker/login-action@v2
-        with:
-          username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
-
       - name: Run Unity tests
         uses: game-ci/unity-test-runner@v4
         with:

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,7 +6,6 @@ on:
       - master
       - staging
       - dev
-      - bfops/dockerhub-token
     tags:
       - 'v*'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,6 +6,7 @@ on:
       - master
       - staging
       - dev
+      - bfops/dockerhub-token
     tags:
       - 'v*'
 

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -40,7 +40,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          # Docker Hub access tokens are passed to docker/login-action via the password input.
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v4
         with:
@@ -101,7 +102,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          # Docker Hub access tokens are passed to docker/login-action via the password input.
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Build and push
         uses: docker/build-push-action@v4
         with:

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -14,7 +14,8 @@ jobs:
         uses: docker/login-action@v2
         with:
           username: ${{ vars.DOCKERHUB_USERNAME }}
-          password: ${{ secrets.DOCKERHUB_PASSWORD }}
+          # Docker Hub access tokens are passed to docker/login-action via the password input.
+          password: ${{ secrets.DOCKERHUB_TOKEN }}
  
       - name: Retag the image 
         run: |


### PR DESCRIPTION
# Description of Changes

Updating workflows to use a new secret

# API and ABI breaking changes
None. CI only.

# Expected complexity level and risk

1

# Testing

- [x] the `unity-testsuite` CI still passes
- [x] a test release successfully pushed an image (<https://github.com/clockworklabs/SpacetimeDB/actions/runs/26262521745>)
