### PR TITLE
Docs: Fix double logos when docs loading

### DIFF
--- a/docs/src/css/custom.css
+++ b/docs/src/css/custom.css
@@ -481,7 +481,6 @@ li.tabs__item--active,
 }
 
 .navbar__logo img {
-  display: block;
   width: 152px;
   height: 32px;
 }


### PR DESCRIPTION
# Description of Changes
- Fix style issue with double logos when docs loading

<!-- Please describe your change, mention any related tickets, and so on here. -->

# Demo
- Before

https://github.com/user-attachments/assets/283a2c2e-8b64-4f10-a3b7-4a96be81ecda

- After

https://github.com/user-attachments/assets/299aa69e-691e-4330-9979-84c6f7d6fb76

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
