### PR TITLE
Wait to unsubscribe in csharp-testsuite until required ops have finished

### DIFF
--- a/sdks/csharp/examples~/regression-tests/client/Program.cs
+++ b/sdks/csharp/examples~/regression-tests/client/Program.cs
@@ -23,6 +23,8 @@ const ulong EXPECTED_TEST_EVENT_VALUE = 42;
 DbConnection db = null!;
 uint waiting = 0;
 var runComplete = false;
+var mainPhaseScheduled = false;
+var mainUnsubscribeStarted = false;
 SubscriptionHandle? mainHandle = null;
 uint testEventInsertCount = 0;
 long viewPkIdCounter = DateTimeOffset.UtcNow.ToUnixTimeMilliseconds() * 10;
@@ -1621,10 +1623,28 @@ void OnSubscriptionApplied(SubscriptionEventContext context)
         }
     );
 
+    // The unsubscribe phase clears the subscribed cache.
+    // Start it only after the reducer and procedure callbacks above
+    // have finished validating rows in that cache.
+    mainPhaseScheduled = true;
+}
+
+void StartMainUnsubscribe()
+{
+    if (mainUnsubscribeStarted)
+    {
+        return;
+    }
+    mainUnsubscribeStarted = true;
+
+    var handle =
+        mainHandle
+        ?? throw new InvalidOperationException("Main subscription handle was not initialised.");
+
     // Now unsubscribe and check that the unsubscribing is actually applied.
     Log.Debug("Calling Unsubscribe");
     waiting++;
-    mainHandle?.UnsubscribeThen(
+    handle.UnsubscribeThen(
         (ctx) =>
         {
             Log.Debug("Received Unsubscribe");
@@ -1638,6 +1658,18 @@ void OnSubscriptionApplied(SubscriptionEventContext context)
 RegressionTestHarness.RegisterUnhandledExceptionExitHandler();
 db = RegressionTestHarness.ConnectToDatabase(HOST, DBNAME, OnConnected);
 const int TIMEOUT = 20; // seconds;
-RegressionTestHarness.FrameTickUntilComplete(db, () => runComplete && waiting == 0, TIMEOUT);
+RegressionTestHarness.FrameTickUntilComplete(
+    db,
+    () =>
+    {
+        if (mainPhaseScheduled && !mainUnsubscribeStarted && waiting == 0)
+        {
+            StartMainUnsubscribe();
+        }
+
+        return runComplete && waiting == 0;
+    },
+    TIMEOUT
+);
 Log.Info("Success");
 Environment.Exit(0);


### PR DESCRIPTION
# Description of Changes

After #4973, WASM procedures can execute concurrently with later operations on the same WebSocket.

Before this change, the C# regression testsuite queued several procedures, then immediately queued `UnsubscribeThen`. After #4973, the unsubscribe could be applied before the `SubscriptionEventOffset` procedure callback ran, clearing `MyTable` from the local subscribed cache. The callback then failed while asserting that the `offset-test:` row was present.

This change treats unsubscribe as a separate phase. It is scheduled after the main work is queued, but only starts once `waiting == 0`, so all callbacks that inspect subscribed state run before the cache is cleared.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1

# Testing

- [x] `csharp-testsuite` no longer flakes
