### PR TITLE
Isolate Godot NuGet restore from Unity package cache

### DIFF
--- a/sdks/csharp/SpacetimeDB.ClientSDK.Godot.csproj
+++ b/sdks/csharp/SpacetimeDB.ClientSDK.Godot.csproj
@@ -19,7 +19,7 @@
     <AssemblyVersion>2.3.0</AssemblyVersion>
     <Version>2.3.0</Version>
     <DefaultItemExcludes>$(DefaultItemExcludes);*~/**</DefaultItemExcludes>
-    <RestorePackagesPath>packages</RestorePackagesPath>
+    <RestorePackagesPath>obj~/godot/packages</RestorePackagesPath>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>
     <DefineConstants>$(DefineConstants);GODOT</DefineConstants>
     <!-- Godot.NET.Sdk defaults to .godot/mono/temp; build this package like the regular C# SDK. -->

--- a/tools/regen/src/csharp.rs
+++ b/tools/regen/src/csharp.rs
@@ -7,7 +7,6 @@ use std::fs;
 use std::path::{Path, PathBuf};
 
 const BSATN_PACKAGE_ID: &str = "spacetimedb.bsatn.runtime";
-const GODOTSHARP_PACKAGE_ID: &str = "godotsharp";
 const RUNTIME_PACKAGE_ID: &str = "spacetimedb.runtime";
 
 fn workspace_dir() -> PathBuf {
@@ -117,7 +116,7 @@ fn clear_restored_package_dirs(pkg_id: &str) -> Result<()> {
     Ok(())
 }
 
-fn clear_godot_intermediate_outputs() -> Result<()> {
+fn clear_godot_regen_dir() -> Result<()> {
     let godot_obj_dir = sdk_dir().join("obj~/godot");
     if godot_obj_dir.exists() {
         fs::remove_dir_all(&godot_obj_dir)?;
@@ -219,10 +218,11 @@ pub fn regen_dlls() -> Result<()> {
     clear_restored_package_dirs(RUNTIME_PACKAGE_ID)?;
 
     // Some Unity runners have had partially restored GodotSharp package state in the past.
-    // Clear the package and restore outputs so NuGet cannot reuse assets missing GodotSharp.dll.
+    // Godot restores packages under obj~/godot/packages, so clearing obj~/godot removes
+    // both intermediates and Godot-only packages without touching Unity-visible packages.
+    // This prevents NuGet from reusing assets missing GodotSharp.dll.
     // See https://github.com/clockworklabs/SpacetimeDB/pull/5133 for more details.
-    clear_restored_package_dirs(GODOTSHARP_PACKAGE_ID)?;
-    clear_godot_intermediate_outputs()?;
+    clear_godot_regen_dir()?;
 
     cmd!(
         "dotnet",
@@ -244,6 +244,7 @@ pub fn regen_dlls() -> Result<()> {
         "-p:BaseOutputPath=bin~/",
         "-p:BaseIntermediateOutputPath=obj~/godot/",
         "-p:MSBuildProjectExtensionsPath=obj~/godot/",
+        "-p:RestorePackagesPath=obj~/godot/packages",
     )
     .dir(&sdk)
     .run()?;
@@ -272,7 +273,8 @@ pub fn regen_dlls() -> Result<()> {
         "-p:BaseOutputPath=bin~/",
         // TODO: It should be possible to put this in Directory.Build.props, but it caused CI failures when we did.
         "-p:BaseIntermediateOutputPath=obj~/godot/",
-        "-p:MSBuildProjectExtensionsPath=obj~/godot/"
+        "-p:MSBuildProjectExtensionsPath=obj~/godot/",
+        "-p:RestorePackagesPath=obj~/godot/packages",
     )
     .dir(&sdk)
     .run()?;


### PR DESCRIPTION
# Description of Changes

A follow-on to #5133 that fixes another Godot flake that was observed after #5133 merged. Specifically a C# SDK regen flake where the Godot package restore path reused `sdks/csharp/packages`, which is also the Unity-visible package cache.

During `cargo regen csharp dlls`, the Godot flow previously did this:

- cleared `sdks/csharp/packages/godotsharp`
- cleared `sdks/csharp/obj~/godot`
- restored the Godot project back into `sdks/csharp/packages`
- packed the Godot project using that same Unity-visible package area

That meant a Godot-only cleanup could delete package content under the Unity SDK package cache. If a previous GodotSharp restore was partial or stale, regen tried to fix it by deleting `packages/godotsharp`, but that path is visible to Unity and can cause dirty/missing package content during regen.

With this change, Godot restore state is now isolated under `sdks/csharp/obj~/godot/packages`, and the regen flow becomes:

- clear only `sdks/csharp/obj~/godot`
- restore the Godot project into `sdks/csharp/obj~/godot/packages`
- pack the Godot project under the same path

Clearing `obj~/godot` now removes both Godot intermediates and Godot-only NuGet packages, while leaving the normal Unity SDK package cache under `sdks/csharp/packages` untouched.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1

# Testing

- [x] `unity-testsuite` passes
