### PR TITLE
Make `RelationalDB::commit_tx_downgrade` fallible

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -831,8 +831,11 @@ impl RelationalDB {
         Ok(Some((tx_offset, tx_data, tx_metrics, reducer)))
     }
 
+    /// Commits `tx`, applies its writes, and downgrades it to a read-only transaction.
+    ///
+    /// If this returns `Err`, `tx` has been consumed and cleaned up.
     #[tracing::instrument(level = "trace", skip_all)]
-    pub fn commit_tx_downgrade(&self, tx: MutTx, workload: Workload) -> (Arc<TxData>, TxMetrics, Tx) {
+    pub fn commit_tx_downgrade(&self, tx: MutTx, workload: Workload) -> Result<(Arc<TxData>, TxMetrics, Tx), DBError> {
         log::trace!("COMMIT MUT TX");
 
         let reducer_context = tx.ctx.reducer_context().cloned();
@@ -842,7 +845,7 @@ impl RelationalDB {
 
         self.maybe_do_snapshot(&tx_data);
 
-        (tx_data, tx_metrics, tx)
+        Ok((tx_data, tx_metrics, tx))
     }
 
     /// Get the [`DurableOffset`] of this database, or `None` if this is an

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -797,7 +797,7 @@ impl InstanceEnv {
             host_execution_duration: Duration::from_millis(0),
         };
         // Commit the tx and broadcast it.
-        let event = commit_and_broadcast_event(&subs, None, event, tx);
+        let event = commit_and_broadcast_event(&subs, None, event, tx)?;
         self.procedure_last_tx_offset = Some(event.tx_offset);
 
         Ok(())

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -659,7 +659,7 @@ impl InstanceCommon {
                                energy_quanta_used: EnergyQuanta,
                                host_execution_duration: Duration,
                                tx: MutTxId|
-                 -> TransactionOffset {
+                 -> anyhow::Result<TransactionOffset> {
                     let event = ModuleEvent {
                         timestamp: Timestamp::now(),
                         caller_identity: info.owner_identity,
@@ -673,15 +673,15 @@ impl InstanceCommon {
                         timer: None,
                     };
                     let CommitAndBroadcastEventSuccess { tx_offset, .. } =
-                        commit_and_broadcast_event(&info.subscriptions, None, event, tx);
+                        commit_and_broadcast_event(&info.subscriptions, None, event, tx)?;
 
-                    tx_offset
+                    Ok(tx_offset)
                 };
                 let durable_offset = stdb.durable_tx_offset();
 
                 let res: UpdateDatabaseResult = match res {
                     crate::db::update::UpdateResult::Success => {
-                        let tx_offset = succeed(self.info.clone(), FunctionBudget::ZERO.into(), Duration::ZERO, tx);
+                        let tx_offset = succeed(self.info.clone(), FunctionBudget::ZERO.into(), Duration::ZERO, tx)?;
                         UpdateDatabaseResult::UpdatePerformed {
                             tx_offset,
                             durable_offset,
@@ -703,7 +703,7 @@ impl InstanceCommon {
                             stdb.report_mut_tx_metrics(reducer, tx_metrics, None);
                             UpdateDatabaseResult::ErrorExecutingMigration(anyhow::anyhow!(msg))
                         } else {
-                            let tx_offset = succeed(self.info.clone(), out.energy_used.into(), out.total_duration, tx);
+                            let tx_offset = succeed(self.info.clone(), out.energy_used.into(), out.total_duration, tx)?;
                             UpdateDatabaseResult::UpdatePerformed {
                                 tx_offset,
                                 durable_offset,
@@ -711,7 +711,7 @@ impl InstanceCommon {
                         }
                     }
                     crate::db::update::UpdateResult::RequiresClientDisconnect => {
-                        let tx_offset = succeed(self.info.clone(), FunctionBudget::ZERO.into(), Duration::ZERO, tx);
+                        let tx_offset = succeed(self.info.clone(), FunctionBudget::ZERO.into(), Duration::ZERO, tx)?;
                         UpdateDatabaseResult::UpdatePerformedWithClientDisconnect {
                             tx_offset,
                             durable_offset,
@@ -990,10 +990,16 @@ impl InstanceCommon {
             request_id,
             timer,
         };
-        let event = commit_and_broadcast_event(&info.subscriptions, client, event, out.tx).event;
+        let outcome = match commit_and_broadcast_event(&info.subscriptions, client, event, out.tx) {
+            Ok(success) => ReducerOutcome::from(&success.event.status),
+            Err(err) => {
+                log::error!("failed to commit and broadcast reducer event: {err:#}");
+                ReducerOutcome::Failed(Box::new(err.to_string().into_boxed_str()))
+            }
+        };
 
         let res = ReducerCallResult {
-            outcome: ReducerOutcome::from(&event.status),
+            outcome,
             energy_used: energy_quanta_used,
             execution_duration: total_duration,
         };

--- a/crates/core/src/sql/execute.rs
+++ b/crates/core/src/sql/execute.rs
@@ -101,7 +101,7 @@ fn run_inner<I: WasmInstance>(
                 None => (tx, false),
             };
 
-            let (tx_data, tx_metrics_mut, tx) = db.commit_tx_downgrade(tx, Workload::Sql);
+            let (tx_data, tx_metrics_mut, tx) = db.commit_tx_downgrade(tx, Workload::Sql)?;
 
             let (tx_offset_send, tx_offset) = oneshot::channel();
             // Release the tx on drop, so that we record metrics
@@ -209,7 +209,7 @@ fn run_inner<I: WasmInstance>(
                 request_id: None,
                 timer: None,
             };
-            let res = commit_and_broadcast_event(&subs.unwrap(), None, event, tx);
+            let res = commit_and_broadcast_event(&subs.unwrap(), None, event, tx)?;
             Ok((
                 SqlResult {
                     tx_offset: res.tx_offset,

--- a/crates/core/src/subscription/module_subscription_actor.rs
+++ b/crates/core/src/subscription/module_subscription_actor.rs
@@ -197,11 +197,11 @@ pub(crate) fn commit_and_broadcast_event(
     client: Option<Arc<ClientConnectionSender>>,
     event: ModuleEvent,
     tx: MutTxId,
-) -> CommitAndBroadcastEventSuccess {
-    match subs.commit_and_broadcast_event(client, event, tx).unwrap() {
+) -> Result<CommitAndBroadcastEventSuccess, DBError> {
+    Ok(match subs.commit_and_broadcast_event(client, event, tx)? {
         Ok(res) => res,
         Err(WriteConflict) => todo!("Write skew, you need to implement retries my man, T-dawg."),
-    }
+    })
 }
 
 type AssertTxFn = Arc<dyn Fn(&Tx) + Send + Sync + 'static>;
@@ -1669,7 +1669,7 @@ impl ModuleSubscriptions {
         // We'll later ensure tx is released/cleaned up once out of scope.
         let (read_tx, tx_data, tx_metrics_mut) = match &mut event.status {
             EventStatus::Committed(db_update) => {
-                let (tx_data, tx_metrics, read_tx) = stdb.commit_tx_downgrade(tx, Workload::Update);
+                let (tx_data, tx_metrics, read_tx) = stdb.commit_tx_downgrade(tx, Workload::Update)?;
                 *db_update = DatabaseUpdate::from_writes(&tx_data);
                 (read_tx, tx_data, tx_metrics)
             }
@@ -1777,7 +1777,7 @@ impl ModuleSubscriptions {
         sender: Identity,
     ) -> Result<(TxGuard<impl FnOnce(TxId) + '_>, TransactionOffset), DBError> {
         Self::_unsubscribe_views(&mut tx, view_collector, sender)?;
-        let (tx_data, tx_metrics_mut, tx) = self.relational_db.commit_tx_downgrade(tx, Workload::Unsubscribe);
+        let (tx_data, tx_metrics_mut, tx) = self.relational_db.commit_tx_downgrade(tx, Workload::Unsubscribe)?;
         let opts = GuardTxOptions::from_mut(tx_data, tx_metrics_mut);
         Ok(self.guard_tx(tx, opts))
     }
@@ -1812,7 +1812,7 @@ impl ModuleSubscriptions {
             (tx, trapped) = ModuleHost::materialize_views(tx, instance, view_collector, sender, Workload::Subscribe)?;
         };
 
-        let (tx_data, tx_metrics_mut, tx) = self.relational_db.commit_tx_downgrade(tx, Workload::Subscribe);
+        let (tx_data, tx_metrics_mut, tx) = self.relational_db.commit_tx_downgrade(tx, Workload::Subscribe)?;
 
         let opts = GuardTxOptions::from_mut(tx_data, tx_metrics_mut);
         let (a, b) = self.guard_tx(tx, opts);
@@ -2784,7 +2784,7 @@ mod tests {
             db.insert(&mut tx, table_id, &bsatn::to_vec(&row)?)?;
         }
 
-        let success = commit_and_broadcast_event(subs, None, module_event(), tx);
+        let success = commit_and_broadcast_event(subs, None, module_event(), tx)?;
         Ok(success.metrics)
     }
 


### PR DESCRIPTION
# Description of Changes

`RelationalDB::commit_tx` is already fallible, so `commit_tx_downgrade` probably always should have been too.

This is mainly for the purpose of enforcing memory/resource limits. We could enforce such limits one level higher at the various call sites for reducers, procedures, sql etc. But we run the risk of missing a write path in that case. So we should probably have a failsafe mechanism in place which is to catch such errors at commit-time.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1

# Testing

Refactor
