### PR TITLE
Don't use ReadableStream as an asyncIterator

### DIFF
--- a/crates/bindings-typescript/src/sdk/decompress.ts
+++ b/crates/bindings-typescript/src/sdk/decompress.ts
@@ -28,9 +28,24 @@ export async function decompress(
   const decompressedStream = readableStream.pipeThrough(decompressionStream);
 
   // Collect the decompressed chunks efficiently
-  const chunks = [];
-  for await (const chunk of decompressedStream) {
-    chunks.push(chunk);
+  const reader = decompressedStream.getReader();
+  const chunks: Uint8Array[] = [];
+  let totalLength = 0;
+  let result: any;
+
+  while (!(result = await reader.read()).done) {
+    chunks.push(result.value);
+    totalLength += result.value.length;
   }
-  return new Blob(chunks).bytes();
+
+  // Allocate a single Uint8Array for the decompressed data
+  const decompressedArray = new Uint8Array(totalLength);
+  let chunkOffset = 0;
+
+  for (const chunk of chunks) {
+    decompressedArray.set(chunk, chunkOffset);
+    chunkOffset += chunk.length;
+  }
+
+  return decompressedArray;
 }


### PR DESCRIPTION
# Description of Changes

Reverts part of #4561. Fixes an issue with `ReadableStream[Symbol.asyncIterator]` not being defined on safari until recently.

# Expected complexity level and risk

1

# Testing

- [x] Chrome <!-- Confirmed by @coolreader18 -->
- [x] Firefox <!-- Confirmed by @coolreader18 -->
- [x] Safari <!-- Confirmed by @joshua-spacetime --> (Run a web template project in safari with `.withCompression('gzip')`)