### PR TITLE
Remove physical module layout info from read sets

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -16,7 +16,9 @@ use spacetimedb_datastore::locking_tx_datastore::datastore::TxMetrics;
 use spacetimedb_datastore::locking_tx_datastore::state_view::{
     IterByColEqMutTx, IterByColRangeMutTx, IterMutTx, StateView,
 };
-use spacetimedb_datastore::locking_tx_datastore::{ApplyHistoryCounters, IndexScanPointOrRange, MutTxId, TxId};
+use spacetimedb_datastore::locking_tx_datastore::{
+    ApplyHistoryCounters, IndexScanPointOrRange, MutTxId, TxId, ViewCallInfo,
+};
 use spacetimedb_datastore::system_tables::{
     system_tables, StModuleRow, ST_CLIENT_ID, ST_CONNECTION_CREDENTIALS_ID, ST_VIEW_SUB_ID,
 };
@@ -1597,6 +1599,26 @@ impl RelationalDB {
         self.clear_table(tx, table_id)?;
 
         self.write_view_rows(tx, table_id, rows, None)?;
+
+        Ok(())
+    }
+
+    /// Materialize a view call and replace its committed read set on transaction commit.
+    ///
+    /// The read set is only marked for replacement after materialization succeeds. If the
+    /// transaction rolls back, the replacement marker rolls back with it.
+    pub fn materialize_view_call(
+        &self,
+        tx: &mut MutTxId,
+        table_id: TableId,
+        view_call: ViewCallInfo,
+        rows: Vec<ProductValue>,
+    ) -> Result<(), DBError> {
+        match view_call.sender {
+            Some(sender) => self.materialize_view(tx, table_id, sender, rows)?,
+            None => self.materialize_anonymous_view(tx, table_id, rows)?,
+        }
+        tx.replace_view_read_set(view_call);
 
         Ok(())
     }

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -1089,6 +1089,66 @@ pub struct CallViewParams {
     pub timestamp: Timestamp,
 }
 
+pub(crate) struct ResolvedViewForRefresh<'a> {
+    pub view_id: ViewId,
+    pub table_id: TableId,
+    pub view_def: &'a ViewDef,
+}
+
+/// Lookup a module's [`ViewDef`] and check for consistency among
+/// its readset, `st_view`, and the [`ModuleDef`].
+pub(crate) fn resolve_view_for_refresh<'a>(
+    tx: &MutTxId,
+    module_def: &'a ModuleDef,
+    view_call: &ViewCallInfo,
+) -> anyhow::Result<ResolvedViewForRefresh<'a>> {
+    let st_view = tx
+        .lookup_st_view(view_call.view_id)
+        .with_context(|| format!("failed to look up view {}", view_call.view_id))?;
+
+    let view_id = st_view.view_id;
+    let table_id = st_view
+        .table_id
+        .ok_or_else(|| anyhow::anyhow!("view {:?} does not have a backing table", view_id))?;
+
+    let view_name: Identifier = st_view.view_name.into();
+    let view_def = module_def.view(&view_name).ok_or_else(|| {
+        anyhow::anyhow!(
+            "view `{}` for view id `{}` not found in current module",
+            view_name,
+            view_id
+        )
+    })?;
+
+    let is_anonymous = view_call.sender.is_none();
+
+    if st_view.is_anonymous != is_anonymous {
+        return Err(anyhow::anyhow!(
+            "found is_anonymous={} in st_view, but {} in readset when updating view `{}`",
+            st_view.is_anonymous,
+            is_anonymous,
+            view_name,
+        ));
+    }
+
+    let is_anonymous = view_def.is_anonymous;
+
+    if st_view.is_anonymous != is_anonymous {
+        return Err(anyhow::anyhow!(
+            "found is_anonymous={} in st_view, but {} in module when updating view `{}`",
+            st_view.is_anonymous,
+            is_anonymous,
+            view_name,
+        ));
+    }
+
+    Ok(ResolvedViewForRefresh {
+        view_id,
+        table_id,
+        view_def,
+    })
+}
+
 pub struct CallProcedureParams {
     pub timestamp: Timestamp,
     pub caller_identity: Identity,
@@ -2897,17 +2957,21 @@ impl ModuleHost {
         let mut total_duration = Duration::ZERO;
         let mut abi_duration = Duration::ZERO;
         let mut trapped = false;
-        for ViewCallInfo {
-            view_id,
-            table_id,
-            fn_ptr,
-            sender,
-        } in tx.views_for_refresh().cloned().collect::<Vec<_>>()
-        {
-            let Some(view_def) = module_def.get_view_by_id(fn_ptr, sender.is_none()) else {
-                outcome = ViewOutcome::Failed(format!("view with fn_ptr `{fn_ptr}` not found"));
-                break;
+        for view_call in tx.views_for_refresh().cloned().collect::<Vec<_>>() {
+            let sender = view_call.sender;
+            let resolved = match resolve_view_for_refresh(&tx, module_def, &view_call) {
+                Ok(resolved) => resolved,
+                Err(err) => {
+                    outcome = ViewOutcome::Failed(format!("failed to resolve view: {err}"));
+                    break;
+                }
             };
+            let ResolvedViewForRefresh {
+                view_id,
+                table_id,
+                view_def,
+            } = resolved;
+            let view_name = &view_def.name;
             let args = match FunctionArgs::Nullary.into_tuple_for_def(module_def, view_def) {
                 Ok(args) => args,
                 Err(err) => {
@@ -2919,7 +2983,7 @@ impl ModuleHost {
             let (result, trap) = Self::call_view_inner(
                 instance,
                 tx,
-                &view_def.name,
+                view_name,
                 view_id,
                 table_id,
                 view_def.fn_ptr,

--- a/crates/core/src/host/v8/syscall/common.rs
+++ b/crates/core/src/host/v8/syscall/common.rs
@@ -817,25 +817,14 @@ fn refresh_views(
                 })?,
             };
 
-            match view_call.sender {
-                Some(sender) => stdb
-                    .materialize_view(
-                        tx.as_mut()
-                            .expect("procedure tx missing while materializing authenticated view"),
-                        table_id,
-                        sender,
-                        rows,
-                    )
-                    .map_err(NodesError::from)?,
-                None => stdb
-                    .materialize_anonymous_view(
-                        tx.as_mut()
-                            .expect("procedure tx missing while materializing anonymous view"),
-                        table_id,
-                        rows,
-                    )
-                    .map_err(NodesError::from)?,
-            }
+            stdb.materialize_view_call(
+                tx.as_mut()
+                    .expect("procedure tx missing while materializing refreshed view"),
+                table_id,
+                view_call.clone(),
+                rows,
+            )
+            .map_err(NodesError::from)?;
 
             Ok(())
         })();

--- a/crates/core/src/host/v8/syscall/common.rs
+++ b/crates/core/src/host/v8/syscall/common.rs
@@ -766,7 +766,7 @@ fn refresh_views(
 
             let current_tx = tx.take().expect("procedure tx missing during view refresh");
             let (next_tx, call_result) = tx_slot.set(current_tx, || {
-                call_view(scope, hooks, &view_call, &view_name, table_id, fn_ptr)
+                call_view(scope, hooks, &view_call, view_name, table_id, fn_ptr)
             });
             tx = Some(next_tx);
             let return_data = call_result?;

--- a/crates/core/src/host/v8/syscall/common.rs
+++ b/crates/core/src/host/v8/syscall/common.rs
@@ -25,7 +25,7 @@ use anyhow::Context;
 use bytes::Bytes;
 use spacetimedb_datastore::locking_tx_datastore::{FuncCallType, MutTxId, ViewCallInfo};
 use spacetimedb_lib::{ConnectionId, Identity, RawModuleDef, Timestamp};
-use spacetimedb_primitives::{ColId, IndexId, ProcedureId, TableId};
+use spacetimedb_primitives::{ColId, IndexId, ProcedureId, TableId, ViewFnPtr};
 use spacetimedb_sats::bsatn;
 use spacetimedb_schema::def::ModuleDef;
 use spacetimedb_schema::identifier::Identifier;
@@ -752,19 +752,22 @@ fn refresh_views(
 
     for view_call in views_for_refresh {
         let res: SysCallResult<()> = (|| {
-            let view_def = module_def
-                .get_view_by_id(view_call.fn_ptr, view_call.sender.is_none())
-                .ok_or_else(|| {
-                    TypeError(format!(
-                        "view with fn_ptr `{}` not found while refreshing procedure transaction",
-                        view_call.fn_ptr
-                    ))
-                    .throw(scope)
-                })?;
+            let resolved = crate::host::module_host::resolve_view_for_refresh(
+                tx.as_ref().expect("procedure tx missing during view refresh"),
+                module_def,
+                &view_call,
+            )
+            .map_err(|err| TypeError(format!("view refresh failed after procedure call: {err}")).throw(scope))?;
+
+            let table_id = resolved.table_id;
+            let view_def = resolved.view_def;
+            let view_name = &view_def.name;
+            let fn_ptr = view_def.fn_ptr;
 
             let current_tx = tx.take().expect("procedure tx missing during view refresh");
-            let (next_tx, call_result) =
-                tx_slot.set(current_tx, || call_view(scope, hooks, &view_call, &view_def.name));
+            let (next_tx, call_result) = tx_slot.set(current_tx, || {
+                call_view(scope, hooks, &view_call, &view_name, table_id, fn_ptr)
+            });
             tx = Some(next_tx);
             let return_data = call_result?;
 
@@ -819,7 +822,7 @@ fn refresh_views(
                     .materialize_view(
                         tx.as_mut()
                             .expect("procedure tx missing while materializing authenticated view"),
-                        view_call.table_id,
+                        table_id,
                         sender,
                         rows,
                     )
@@ -828,7 +831,7 @@ fn refresh_views(
                     .materialize_anonymous_view(
                         tx.as_mut()
                             .expect("procedure tx missing while materializing anonymous view"),
-                        view_call.table_id,
+                        table_id,
                         rows,
                     )
                     .map_err(NodesError::from)?,
@@ -857,6 +860,8 @@ fn call_view(
     hooks: &HookFunctions<'_>,
     view_call: &ViewCallInfo,
     view_name: &Identifier,
+    table_id: TableId,
+    fn_ptr: ViewFnPtr,
 ) -> SysCallResult<ViewReturnData> {
     let prev_func_type = get_env(scope)?
         .instance_env
@@ -871,8 +876,8 @@ fn call_view(
                 ViewOp {
                     name: view_name,
                     view_id: view_call.view_id,
-                    table_id: view_call.table_id,
-                    fn_ptr: view_call.fn_ptr,
+                    table_id,
+                    fn_ptr,
                     args: &args,
                     sender: &sender,
                     timestamp: Timestamp::now(),
@@ -884,8 +889,8 @@ fn call_view(
                 AnonymousViewOp {
                     name: view_name,
                     view_id: view_call.view_id,
-                    table_id: view_call.table_id,
-                    fn_ptr: view_call.fn_ptr,
+                    table_id,
+                    fn_ptr,
                     args: &args,
                     timestamp: Timestamp::now(),
                 },

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -1371,17 +1371,7 @@ impl InstanceCommon {
                         ViewResult::Rows(bytes) => deserialize_view_rows(row_type, bytes, typespace)
                             .context("Error deserializing rows returned by view".to_string())?,
                         ViewResult::RawSql(query) => self
-                            .run_query_for_view(
-                                &mut tx,
-                                &query,
-                                &row_product_type,
-                                &ViewCallInfo {
-                                    view_id,
-                                    table_id,
-                                    fn_ptr,
-                                    sender,
-                                },
-                            )
+                            .run_query_for_view(&mut tx, &query, &row_product_type, &ViewCallInfo { view_id, sender })
                             .context("Error executing raw SQL returned by view".to_string())?,
                     };
 
@@ -1798,8 +1788,6 @@ impl InstanceOp for ViewOp<'_> {
     fn call_type(&self) -> FuncCallType {
         FuncCallType::View(ViewCallInfo {
             view_id: self.view_id,
-            table_id: self.table_id,
-            fn_ptr: self.fn_ptr,
             sender: Some(*self.sender),
         })
     }
@@ -1828,8 +1816,6 @@ impl InstanceOp for AnonymousViewOp<'_> {
     fn call_type(&self) -> FuncCallType {
         FuncCallType::View(ViewCallInfo {
             view_id: self.view_id,
-            table_id: self.table_id,
-            fn_ptr: self.fn_ptr,
             sender: None,
         })
     }

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -1359,6 +1359,7 @@ impl InstanceCommon {
             (Ok(raw), sender) => {
                 // This is wrapped in a closure to simplify error handling.
                 let outcome: Result<ViewOutcome, anyhow::Error> = (|| {
+                    let view_call = ViewCallInfo { view_id, sender };
                     let result = ViewResult::from_return_data(raw).context("Error parsing view result")?;
                     let typespace = self.info.module_def.typespace();
                     let row_product_type = typespace
@@ -1371,18 +1372,14 @@ impl InstanceCommon {
                         ViewResult::Rows(bytes) => deserialize_view_rows(row_type, bytes, typespace)
                             .context("Error deserializing rows returned by view".to_string())?,
                         ViewResult::RawSql(query) => self
-                            .run_query_for_view(&mut tx, &query, &row_product_type, &ViewCallInfo { view_id, sender })
+                            .run_query_for_view(&mut tx, &query, &row_product_type, &view_call)
                             .context("Error executing raw SQL returned by view".to_string())?,
                     };
 
                     let replica_ctx = inst.replica_ctx();
                     let stdb = replica_ctx.relational_db();
-                    let res = match sender {
-                        Some(sender) => stdb.materialize_view(&mut tx, table_id, sender, rows),
-                        None => stdb.materialize_anonymous_view(&mut tx, table_id, rows),
-                    };
-
-                    res.context("Error materializing view")?;
+                    stdb.materialize_view_call(&mut tx, table_id, view_call, rows)
+                        .context("Error materializing view")?;
 
                     Ok(ViewOutcome::Success)
                 })();

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -1710,7 +1710,7 @@ impl WasmInstanceEnv {
 
                 let current_tx = tx.take().expect("procedure tx missing during view refresh");
                 let (next_tx, call_result) =
-                    tx_slot.set(current_tx, || Self::call_view(caller, &view_call, &view_name, fn_ptr));
+                    tx_slot.set(current_tx, || Self::call_view(caller, &view_call, view_name, fn_ptr));
                 tx = Some(next_tx);
                 let return_data = call_result?;
 

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -19,7 +19,7 @@ use spacetimedb_data_structures::map::IntMap;
 use spacetimedb_datastore::locking_tx_datastore::{FuncCallType, MutTxId, ViewCallInfo};
 use spacetimedb_lib::{bsatn, ConnectionId, Timestamp};
 use spacetimedb_primitives::errno::HOST_CALL_FAILURE;
-use spacetimedb_primitives::{errno, ColId};
+use spacetimedb_primitives::{errno, ColId, ViewFnPtr};
 use spacetimedb_schema::def::ModuleDef;
 use spacetimedb_schema::identifier::Identifier;
 use std::future::Future;
@@ -1697,13 +1697,20 @@ impl WasmInstanceEnv {
 
         for view_call in views_for_refresh {
             let res: anyhow::Result<()> = (|| {
-                let view_def = module_def
-                    .get_view_by_id(view_call.fn_ptr, view_call.sender.is_none())
-                    .ok_or_else(|| anyhow!("view with fn_ptr `{}` not found", view_call.fn_ptr))?;
+                let resolved = crate::host::module_host::resolve_view_for_refresh(
+                    tx.as_ref().expect("procedure tx missing during view refresh"),
+                    &module_def,
+                    &view_call,
+                )?;
+
+                let table_id = resolved.table_id;
+                let view_def = resolved.view_def;
+                let view_name = &view_def.name;
+                let fn_ptr = view_def.fn_ptr;
 
                 let current_tx = tx.take().expect("procedure tx missing during view refresh");
                 let (next_tx, call_result) =
-                    tx_slot.set(current_tx, || Self::call_view(caller, &view_call, &view_def.name));
+                    tx_slot.set(current_tx, || Self::call_view(caller, &view_call, &view_name, fn_ptr));
                 tx = Some(next_tx);
                 let return_data = call_result?;
 
@@ -1731,14 +1738,14 @@ impl WasmInstanceEnv {
                     Some(sender) => stdb.materialize_view(
                         tx.as_mut()
                             .expect("procedure tx missing while materializing authenticated view"),
-                        view_call.table_id,
+                        table_id,
                         sender,
                         rows,
                     )?,
                     None => stdb.materialize_anonymous_view(
                         tx.as_mut()
                             .expect("procedure tx missing while materializing anonymous view"),
-                        view_call.table_id,
+                        table_id,
                         rows,
                     )?,
                 }
@@ -1766,6 +1773,7 @@ impl WasmInstanceEnv {
         caller: &mut Caller<'a, Self>,
         view_call: &ViewCallInfo,
         view_name: &Identifier,
+        fn_ptr: ViewFnPtr,
     ) -> anyhow::Result<ViewReturnData> {
         let prev_func_type = caller
             .data_mut()
@@ -1792,7 +1800,7 @@ impl WasmInstanceEnv {
                 call_view,
                 call_view_anon,
                 view_name,
-                view_call.fn_ptr.0,
+                fn_ptr.0,
                 view_call.sender,
                 args_source.0,
                 result_sink,

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -1734,21 +1734,13 @@ impl WasmInstanceEnv {
                 };
 
                 let stdb = caller.data().instance_env.relational_db().clone();
-                match view_call.sender {
-                    Some(sender) => stdb.materialize_view(
-                        tx.as_mut()
-                            .expect("procedure tx missing while materializing authenticated view"),
-                        table_id,
-                        sender,
-                        rows,
-                    )?,
-                    None => stdb.materialize_anonymous_view(
-                        tx.as_mut()
-                            .expect("procedure tx missing while materializing anonymous view"),
-                        table_id,
-                        rows,
-                    )?,
-                }
+                stdb.materialize_view_call(
+                    tx.as_mut()
+                        .expect("procedure tx missing while materializing refreshed view"),
+                    table_id,
+                    view_call.clone(),
+                    rows,
+                )?;
 
                 Ok(())
             })();

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -47,7 +47,7 @@ use spacetimedb_lib::{
     ConnectionId, Identity, Timestamp,
 };
 use spacetimedb_primitives::{
-    col_list, ArgId, ColId, ColList, ColSet, ConstraintId, IndexId, ScheduleId, SequenceId, TableId, ViewFnPtr, ViewId,
+    col_list, ArgId, ColId, ColList, ColSet, ConstraintId, IndexId, ScheduleId, SequenceId, TableId, ViewId,
 };
 use spacetimedb_sats::{
     bsatn::to_writer, memory_usage::MemoryUsage, raw_identifier::RawIdentifier, ser::Serialize, AlgebraicValue,
@@ -79,8 +79,6 @@ use std::{
 #[derive(Clone, Debug, Eq, PartialEq, Hash)]
 pub struct ViewCallInfo {
     pub view_id: ViewId,
-    pub table_id: TableId,
-    pub fn_ptr: ViewFnPtr,
     pub sender: Option<Identity>,
 }
 

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -86,6 +86,7 @@ pub struct ViewCallInfo {
 #[derive(Default)]
 pub struct ViewReadSets {
     tables: IntMap<TableId, TableReadSet>,
+    replacements: HashSet<ViewCallInfo>,
 }
 
 impl MemoryUsage for ViewReadSets {
@@ -97,7 +98,7 @@ impl MemoryUsage for ViewReadSets {
 impl ViewReadSets {
     /// Returns whether there are no read sets recorded.
     pub fn is_empty(&self) -> bool {
-        self.tables.is_empty()
+        self.tables.is_empty() && self.replacements.is_empty()
     }
 
     /// Returns the views that perform a full scan of this table
@@ -113,6 +114,14 @@ impl ViewReadSets {
         self.tables.entry(table_id).or_default().insert_table_scan(call);
     }
 
+    /// Record that `call` was successfully materialized in this transaction.
+    ///
+    /// On commit, the committed read set for this exact view call should be replaced
+    /// by the dependencies recorded in this transaction.
+    pub fn replace_view_read_set(&mut self, call: ViewCallInfo) {
+        self.replacements.insert(call);
+    }
+
     /// Removes keys for `view_id` from the read set
     pub fn remove_view(&mut self, view_id: ViewId, sender: Option<Identity>) {
         self.tables.retain(|_, readset| {
@@ -121,8 +130,20 @@ impl ViewReadSets {
         });
     }
 
+    /// Removes keys for exactly `call` from the read set.
+    fn remove_view_call(&mut self, call: &ViewCallInfo) {
+        self.tables.retain(|_, readset| {
+            readset.remove_view_call(call);
+            !readset.is_empty()
+        });
+    }
+
     /// Merge or union read sets together
     pub fn merge(&mut self, readset: Self) {
+        for call in readset.replacements {
+            self.remove_view_call(&call);
+        }
+
         for (table_id, rs) in readset.tables {
             self.tables.entry(table_id).or_default().merge(rs);
         }
@@ -210,6 +231,19 @@ impl TableReadSet {
         });
     }
 
+    /// Removes keys for exactly `call` from the read set.
+    fn remove_view_call(&mut self, call: &ViewCallInfo) {
+        self.table_scans.retain(|candidate| candidate != call);
+
+        self.index_reads.retain(|_cols, key_map| {
+            key_map.retain(|_key, views| {
+                views.retain(|candidate| candidate != call);
+                !views.is_empty()
+            });
+            !key_map.is_empty()
+        });
+    }
+
     /// Merge (union) another table read set into this one
     fn merge(&mut self, other: TableReadSet) {
         // merge table scans
@@ -253,7 +287,7 @@ pub struct MutTxId {
     pub(crate) _not_send: PhantomData<std::rc::Rc<()>>,
 }
 
-static_assert_size!(MutTxId, 432);
+static_assert_size!(MutTxId, 464);
 
 impl MutTxId {
     /// Record that a view performs a table scan in this transaction's read set
@@ -261,6 +295,14 @@ impl MutTxId {
         if let FuncCallType::View(view) = op {
             self.read_sets.insert_full_table_scan(table_id, view.clone());
         }
+    }
+
+    /// Replace the committed read set for `call` with the read set recorded in this transaction.
+    ///
+    /// This is transaction-local state. If the transaction rolls back, the committed read set is
+    /// left unchanged.
+    pub fn replace_view_read_set(&mut self, call: ViewCallInfo) {
+        self.read_sets.replace_view_read_set(call);
     }
 
     /// Record that a view performs a ranged index scan in this transaction's read set.

--- a/crates/smoketests/modules/Cargo.lock
+++ b/crates/smoketests/modules/Cargo.lock
@@ -881,6 +881,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoketest-module-views-auto-migrate-read-set"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "spacetimedb",
+]
+
+[[package]]
+name = "smoketest-module-views-auto-migrate-read-set-updated"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "spacetimedb",
+]
+
+[[package]]
 name = "smoketest-module-views-auto-migrate-stable"
 version = "0.1.0"
 dependencies = [
@@ -935,22 +951,6 @@ dependencies = [
 name = "smoketest-module-views-query"
 version = "0.1.0"
 dependencies = [
- "spacetimedb",
-]
-
-[[package]]
-name = "smoketest-module-views-auto-migrate-read-set"
-version = "0.1.0"
-dependencies = [
- "log",
- "spacetimedb",
-]
-
-[[package]]
-name = "smoketest-module-views-auto-migrate-read-set-updated"
-version = "0.1.0"
-dependencies = [
- "log",
  "spacetimedb",
 ]
 

--- a/crates/smoketests/modules/Cargo.lock
+++ b/crates/smoketests/modules/Cargo.lock
@@ -881,6 +881,20 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoketest-module-views-auto-migrate-stable"
+version = "0.1.0"
+dependencies = [
+ "spacetimedb",
+]
+
+[[package]]
+name = "smoketest-module-views-auto-migrate-stable-updated"
+version = "0.1.0"
+dependencies = [
+ "spacetimedb",
+]
+
+[[package]]
 name = "smoketest-module-views-auto-migrate-updated"
 version = "0.1.0"
 dependencies = [

--- a/crates/smoketests/modules/Cargo.lock
+++ b/crates/smoketests/modules/Cargo.lock
@@ -939,6 +939,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoketest-module-views-auto-migrate-read-set"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "spacetimedb",
+]
+
+[[package]]
+name = "smoketest-module-views-auto-migrate-read-set-updated"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "spacetimedb",
+]
+
+[[package]]
 name = "smoketest-module-views-recovered"
 version = "0.1.0"
 dependencies = [

--- a/crates/smoketests/modules/Cargo.toml
+++ b/crates/smoketests/modules/Cargo.toml
@@ -26,6 +26,8 @@ members = [
     "views-query",
     "views-callable",
     "views-count",
+    "views-auto-migrate-stable",
+    "views-auto-migrate-stable-updated",
 
     # Security and permissions
     "rls",

--- a/crates/smoketests/modules/Cargo.toml
+++ b/crates/smoketests/modules/Cargo.toml
@@ -28,6 +28,8 @@ members = [
     "views-count",
     "views-auto-migrate-stable",
     "views-auto-migrate-stable-updated",
+    "views-auto-migrate-read-set",
+    "views-auto-migrate-read-set-updated",
 
     # Security and permissions
     "rls",

--- a/crates/smoketests/modules/views-auto-migrate-read-set-updated/Cargo.toml
+++ b/crates/smoketests/modules/views-auto-migrate-read-set-updated/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "smoketest-module-views-auto-migrate-read-set-updated"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+spacetimedb.workspace = true
+log.workspace = true

--- a/crates/smoketests/modules/views-auto-migrate-read-set-updated/src/lib.rs
+++ b/crates/smoketests/modules/views-auto-migrate-read-set-updated/src/lib.rs
@@ -1,0 +1,51 @@
+use spacetimedb::{reducer, table, view, ReducerContext, SpacetimeType, Table, ViewContext};
+
+#[derive(Clone)]
+#[table(accessor = old, public)]
+pub struct OldSource {
+    #[primary_key]
+    id: u64,
+}
+
+#[derive(Clone)]
+#[table(accessor = new, public)]
+pub struct NewSource {
+    #[primary_key]
+    id: u64,
+}
+
+#[derive(Clone, SpacetimeType)]
+pub struct Row {
+    id: u64,
+}
+
+impl From<OldSource> for Row {
+    fn from(row: OldSource) -> Self {
+        Row { id: row.id }
+    }
+}
+
+impl From<NewSource> for Row {
+    fn from(row: NewSource) -> Self {
+        Row { id: row.id }
+    }
+}
+
+#[reducer]
+pub fn seed(ctx: &ReducerContext) {
+    ctx.db.old().insert(OldSource { id: 0 });
+    ctx.db.new().insert(NewSource { id: 0 });
+}
+
+#[reducer]
+pub fn touch_old(ctx: &ReducerContext) {
+    ctx.db.old().id().delete(&0);
+}
+
+const SWITCHED_LOG: &str = "Calling or updating view `switched`";
+
+#[view(accessor = switched, public)]
+pub fn switched(ctx: &ViewContext) -> Option<Row> {
+    log::info!("{SWITCHED_LOG}");
+    ctx.db.new().id().find(&0).map(|row| row.into())
+}

--- a/crates/smoketests/modules/views-auto-migrate-read-set/Cargo.toml
+++ b/crates/smoketests/modules/views-auto-migrate-read-set/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "smoketest-module-views-auto-migrate-read-set"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+spacetimedb.workspace = true
+log.workspace = true

--- a/crates/smoketests/modules/views-auto-migrate-read-set/src/lib.rs
+++ b/crates/smoketests/modules/views-auto-migrate-read-set/src/lib.rs
@@ -1,0 +1,51 @@
+use spacetimedb::{reducer, table, view, ReducerContext, SpacetimeType, Table, ViewContext};
+
+#[derive(Clone)]
+#[table(accessor = old, public)]
+pub struct OldSource {
+    #[primary_key]
+    id: u64,
+}
+
+#[derive(Clone)]
+#[table(accessor = new, public)]
+pub struct NewSource {
+    #[primary_key]
+    id: u64,
+}
+
+#[derive(Clone, SpacetimeType)]
+pub struct Row {
+    id: u64,
+}
+
+impl From<OldSource> for Row {
+    fn from(row: OldSource) -> Self {
+        Row { id: row.id }
+    }
+}
+
+impl From<NewSource> for Row {
+    fn from(row: NewSource) -> Self {
+        Row { id: row.id }
+    }
+}
+
+#[reducer]
+pub fn seed(ctx: &ReducerContext) {
+    ctx.db.old().insert(OldSource { id: 0 });
+    ctx.db.new().insert(NewSource { id: 0 });
+}
+
+#[reducer]
+pub fn touch_old(ctx: &ReducerContext) {
+    ctx.db.old().id().delete(&0);
+}
+
+const SWITCHED_LOG: &str = "Calling or updating view `switched`";
+
+#[view(accessor = switched, public)]
+pub fn switched(ctx: &ViewContext) -> Option<Row> {
+    log::info!("{SWITCHED_LOG}");
+    ctx.db.old().id().find(&0).map(|row| row.into())
+}

--- a/crates/smoketests/modules/views-auto-migrate-stable-updated/Cargo.toml
+++ b/crates/smoketests/modules/views-auto-migrate-stable-updated/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "smoketest-module-views-auto-migrate-stable-updated"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+spacetimedb.workspace = true

--- a/crates/smoketests/modules/views-auto-migrate-stable-updated/src/lib.rs
+++ b/crates/smoketests/modules/views-auto-migrate-stable-updated/src/lib.rs
@@ -1,0 +1,48 @@
+use spacetimedb::{reducer, table, view, ReducerContext, Table, ViewContext};
+
+// This is the table that gets updated during the test
+#[derive(Copy, Clone)]
+#[table(accessor = counter)]
+pub struct Counter {
+    #[primary_key]
+    id: u64,
+    value: u64,
+}
+
+// This table is not subscribed to or updated in the test.
+// Its main purpose is to have a different row size than `Counter`.
+#[table(accessor = marker)]
+pub struct Marker {
+    #[primary_key]
+    id: u64,
+    label: String,
+}
+
+#[reducer]
+pub fn seed(ctx: &ReducerContext) {
+    ctx.db.counter().insert(Counter { id: 0, value: 0 });
+    ctx.db.marker().insert(Marker {
+        id: 0,
+        label: "0".to_string(),
+    });
+}
+
+#[reducer]
+pub fn bump_counter(ctx: &ReducerContext) {
+    let mut counter = ctx.db.counter().id().find(&0).expect("counter row should exist");
+    ctx.db.counter().id().delete(&0);
+    counter.value += 1;
+    ctx.db.counter().insert(counter);
+}
+
+// This view is intentionally prefixed with `a_` to change the index of
+// `target_counter` in the module's internal view list.
+#[view(accessor = a_wrong_shape, public)]
+pub fn a_wrong_shape(ctx: &ViewContext) -> Option<Marker> {
+    ctx.db.marker().id().find(&0)
+}
+
+#[view(accessor = z_counter, public)]
+pub fn z_counter(ctx: &ViewContext) -> Option<Counter> {
+    ctx.db.counter().id().find(&0)
+}

--- a/crates/smoketests/modules/views-auto-migrate-stable-updated/src/lib.rs
+++ b/crates/smoketests/modules/views-auto-migrate-stable-updated/src/lib.rs
@@ -36,7 +36,7 @@ pub fn bump_counter(ctx: &ReducerContext) {
 }
 
 // This view is intentionally prefixed with `a_` to change the index of
-// `target_counter` in the module's internal view list.
+// `z_counter` in the module's internal view list.
 #[view(accessor = a_wrong_shape, public)]
 pub fn a_wrong_shape(ctx: &ViewContext) -> Option<Marker> {
     ctx.db.marker().id().find(&0)

--- a/crates/smoketests/modules/views-auto-migrate-stable/Cargo.toml
+++ b/crates/smoketests/modules/views-auto-migrate-stable/Cargo.toml
@@ -1,0 +1,11 @@
+[package]
+name = "smoketest-module-views-auto-migrate-stable"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+spacetimedb.workspace = true

--- a/crates/smoketests/modules/views-auto-migrate-stable/src/lib.rs
+++ b/crates/smoketests/modules/views-auto-migrate-stable/src/lib.rs
@@ -1,0 +1,41 @@
+use spacetimedb::{reducer, table, view, ReducerContext, Table, ViewContext};
+
+// This is the table that gets updated during the test
+#[derive(Copy, Clone)]
+#[table(accessor = counter)]
+pub struct Counter {
+    #[primary_key]
+    id: u64,
+    value: u64,
+}
+
+// This table is not subscribed to or updated in the test.
+// Its main purpose is to have a different row size than `Counter`.
+#[table(accessor = marker)]
+pub struct Marker {
+    #[primary_key]
+    id: u64,
+    label: String,
+}
+
+#[reducer]
+pub fn seed(ctx: &ReducerContext) {
+    ctx.db.counter().insert(Counter { id: 0, value: 0 });
+    ctx.db.marker().insert(Marker {
+        id: 0,
+        label: "0".to_string(),
+    });
+}
+
+#[reducer]
+pub fn bump_counter(ctx: &ReducerContext) {
+    let mut counter = ctx.db.counter().id().find(&0).expect("counter row should exist");
+    ctx.db.counter().id().delete(&0);
+    counter.value += 1;
+    ctx.db.counter().insert(counter);
+}
+
+#[view(accessor = z_counter, public)]
+pub fn z_counter(ctx: &ViewContext) -> Option<Counter> {
+    ctx.db.counter().id().find(&0)
+}

--- a/crates/smoketests/src/lib.rs
+++ b/crates/smoketests/src/lib.rs
@@ -1844,6 +1844,19 @@ impl SubscriptionHandle {
     }
 }
 
+impl Drop for SubscriptionHandle {
+    fn drop(&mut self) {
+        match self.child.try_wait() {
+            Ok(Some(_)) => {}
+            Ok(None) => {
+                let _ = self.child.kill();
+                let _ = self.child.wait();
+            }
+            Err(_) => {}
+        }
+    }
+}
+
 /// Normalizes whitespace by trimming trailing whitespace from each line.
 fn normalize_whitespace(s: &str) -> String {
     s.lines().map(|line| line.trim_end()).collect::<Vec<_>>().join("\n")

--- a/crates/smoketests/tests/smoketests/views.rs
+++ b/crates/smoketests/tests/smoketests/views.rs
@@ -495,6 +495,47 @@ fn test_views_auto_migration() {
 }
 
 #[test]
+fn test_views_auto_migration_stable() {
+    let mut test = Smoketest::builder()
+        .precompiled_module("views-auto-migrate-stable")
+        .build();
+
+    // Seed the initial row in the `counter` table
+    test.call("seed", &[]).unwrap();
+
+    // Subscribe to that row through the `z_counter` view
+    let sub = test.subscribe_background(&["SELECT * FROM z_counter"], 1).unwrap();
+
+    // Update the module by adding another view
+    test.use_precompiled_module("views-auto-migrate-stable-updated");
+    test.publish_module_clear(false).unwrap();
+
+    // Bump the counter and observe a subscription update.
+    let output = test.call_output("bump_counter", &[]);
+
+    assert!(
+        output.status.success(),
+        "bump_counter failed after module update\nstdout:\n{}\nstderr:\n{}",
+        String::from_utf8_lossy(&output.stdout),
+        String::from_utf8_lossy(&output.stderr),
+    );
+
+    let events = sub.collect().unwrap();
+    let projection = project_fields(events, "z_counter", &["id", "value"]);
+    assert_eq!(
+        serde_json::json!(projection),
+        json!([
+            {
+                "z_counter": {
+                    "deletes": [{ "id": 0, "value": 0 }],
+                    "inserts": [{ "id": 0, "value": 1 }]
+                }
+            }
+        ])
+    );
+}
+
+#[test]
 fn test_auto_migration_drop_view() {
     let mut test = Smoketest::builder().precompiled_module("views-auto-migrate").build();
     test.use_precompiled_module("views-drop-view");

--- a/crates/smoketests/tests/smoketests/views.rs
+++ b/crates/smoketests/tests/smoketests/views.rs
@@ -536,6 +536,42 @@ fn test_views_auto_migration_stable() {
 }
 
 #[test]
+fn test_views_auto_migration_read_set() {
+    const SWITCHED_LOG: &str = "Calling or updating view `switched`";
+
+    let mut test = Smoketest::builder()
+        .precompiled_module("views-auto-migrate-read-set")
+        .build();
+
+    test.call("seed", &[]).unwrap();
+
+    let _sub = test.subscribe_background(&["SELECT * FROM switched"], 2).unwrap();
+
+    test.use_precompiled_module("views-auto-migrate-read-set-updated");
+    test.publish_module_clear(false).unwrap();
+
+    let logs_after_publish = test.logs(100).unwrap();
+    let logs_after_publish_for_view = logs_after_publish
+        .iter()
+        .filter(|msg| msg.contains(SWITCHED_LOG))
+        .count();
+    assert!(
+        logs_after_publish_for_view > 0,
+        "expected the updated view to be evaluated during publish",
+    );
+
+    // This touches the view's old read set, so it should not be refreshed
+    test.call("touch_old", &[]).unwrap();
+
+    let logs_after_touch = test.logs(100).unwrap();
+    let logs_after_touch_for_view = logs_after_touch.iter().filter(|msg| msg.contains(SWITCHED_LOG)).count();
+    assert_eq!(
+        logs_after_touch_for_view, logs_after_publish_for_view,
+        "`switched` should not be evaluated when only the old source table is updated",
+    );
+}
+
+#[test]
 fn test_auto_migration_drop_view() {
     let mut test = Smoketest::builder().precompiled_module("views-auto-migrate").build();
     test.use_precompiled_module("views-drop-view");


### PR DESCRIPTION
# Description of Changes

I believe this to fix #4947.

Previously, committed read sets stored module-local indexes used for view dispatch. These indexes are not stable across module updates, but they were not removed from the committed state, so that later when a write triggered a view refresh, the runtime could dispatch the wrong view function or attempt to materialize into the wrong backing table which would result in a fatal error.

This patch removes these unstable indexes from read sets. The core behavior change is that committed read sets no longer depend on stale per-module layout details. They identify the logical view call, and refresh resolves the current module metadata when needed.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

2

# Testing

- [x] Auto-migrate smoketests
