### PR TITLE
Drop tps threshold for rust keynote-2 ci check

### DIFF
--- a/tools/ci/src/keynote_bench.rs
+++ b/tools/ci/src/keynote_bench.rs
@@ -33,7 +33,7 @@ const BENCHMARK_MODULES: &[BenchmarkModule] = &[
     BenchmarkModule {
         label: "Rust",
         module_dir: "templates/keynote-2/rust_module",
-        min_tps: 300_000.0,
+        min_tps: 275_000.0,
     },
 ];
 


### PR DESCRIPTION
# Description of Changes

The keynote benchmark check has had a couple spurious failures in CI recently, namely for the rust module. I set a higher TPS threshold for rust than I did for typescript since rust is a bit faster, but it looks like the threshold I set is within the margin of error, so this change drops it to 275K - exactly what it is for typescript.

A failure now almost certainly represents a real performance regression and requires deeper investigation.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

0 (one liner)

# Testing

Should have no more spurious failures for this CI job.
