### PR TITLE
[NS 3] TypeScript: server module runtime API for module mounts

### DIFF
--- a/crates/bindings-typescript/src/lib/query.ts
+++ b/crates/bindings-typescript/src/lib/query.ts
@@ -2,6 +2,7 @@ import { ConnectionId } from './connection_id';
 import { Identity } from './identity';
 import type { ColumnIndex, IndexColumns, IndexOpts } from './indexes';
 import type { UntypedSchemaDef } from './schema';
+import type { UntypedTableDef } from './table';
 import type { UntypedTableSchema } from './table_schema';
 import { Timestamp } from './timestamp';
 import type {
@@ -223,6 +224,25 @@ export type QueryBuilder<SchemaDef extends UntypedSchemaDef> = {
 } & {};
 
 /**
+ * The type of `q.from` in an `addQuery` callback.
+ *
+ * Root-level tables appear as direct properties (same as `QueryBuilder`).
+ * Declared namespaces appear as sub-objects — each is itself a `QueryBuilder` for that
+ * namespace's schema, so `q.from.<namespace>.<table>` is fully typed.
+ *
+ * When `SchemaDef['namespaces']` is absent or `{}`, no namespace properties appear —
+ * accessing an undeclared namespace is a compile error.
+ */
+export type SubscriptionFromBuilder<SchemaDef extends UntypedSchemaDef> =
+  QueryBuilder<SchemaDef> & {
+    readonly [NS in keyof NonNullable<SchemaDef['namespaces']>]: NonNullable<
+      SchemaDef['namespaces']
+    >[NS] extends UntypedSchemaDef
+      ? QueryBuilder<NonNullable<SchemaDef['namespaces']>[NS]>
+      : never;
+  };
+
+/**
  * A runtime reference to a table. This materializes the RowExpr for us.
  * TODO: Maybe add the full SchemaDef to the type signature depending on how joins will work.
  */
@@ -332,6 +352,38 @@ export function makeQueryBuilder<SchemaDef extends UntypedSchemaDef>(
     (qb as Record<string, TableRef<any>>)[table.accessorName] = ref;
   }
   return Object.freeze(qb) as QueryBuilder<SchemaDef>;
+}
+
+/**
+ * Builds the `q.from` object for use in `addQuery` callbacks.
+ *
+ * Tables whose `sourceName` contains no `.` are placed at the root.
+ * Tables with a dotted `sourceName` (e.g. `"namespace.table"`) are grouped under a
+ * sub-object keyed by the namespace alias, with the part after the dot as the
+ * property key within that namespace.
+ */
+export function makeFromBuilder<SchemaDef extends UntypedSchemaDef>(
+  tables: SchemaDef['tables']
+): SubscriptionFromBuilder<SchemaDef> {
+  const result: Record<string, unknown> = Object.create(null);
+  const namespaces: Record<string, Record<string, unknown>> = Object.create(null);
+
+  for (const table of Object.values(tables) as UntypedTableDef[]) {
+    const dotIdx = table.sourceName.indexOf('.');
+    if (dotIdx === -1) {
+      result[table.accessorName] = createTableRefFromDef(table as any);
+    } else {
+      const ns = table.sourceName.slice(0, dotIdx);
+      const key = table.sourceName.slice(dotIdx + 1);
+      (namespaces[ns] ??= Object.create(null))[key] = createTableRefFromDef(table as any);
+    }
+  }
+
+  for (const [ns, nsTables] of Object.entries(namespaces)) {
+    result[ns] = Object.freeze(nsTables);
+  }
+
+  return Object.freeze(result) as unknown as SubscriptionFromBuilder<SchemaDef>;
 }
 
 function createRowExpr<TableDef extends TypedTableDef>(
@@ -873,7 +925,10 @@ function literalValueToSql(value: unknown): string {
 }
 
 function quoteIdentifier(name: string): string {
-  return `"${name.replace(/"/g, '""')}"`;
+  return name
+    .split('.')
+    .map(part => `"${part.replace(/"/g, '""')}"`)
+    .join('.');
 }
 
 function isLiteralExpr<Value>(

--- a/crates/bindings-typescript/src/lib/reducers.ts
+++ b/crates/bindings-typescript/src/lib/reducers.ts
@@ -98,6 +98,11 @@ export interface JwtClaims {
   readonly fullPayload: JsonObject;
 }
 
+export type AliasViews<SchemaDef extends UntypedSchemaDef> =
+  SchemaDef extends { namespaces: infer NS extends Record<string, UntypedSchemaDef> }
+    ? { readonly [K in keyof NS]: ReducerCtx<NS[K]> }
+    : {};
+
 /**
  * Reducer context parametrized by the inferred Schema
  */
@@ -113,4 +118,5 @@ export type ReducerCtx<SchemaDef extends UntypedSchemaDef> = Readonly<{
   newUuidV4(): Uuid;
   newUuidV7(): Uuid;
   random: Random;
+  as: AliasViews<SchemaDef>;
 }>;

--- a/crates/bindings-typescript/src/lib/util.ts
+++ b/crates/bindings-typescript/src/lib/util.ts
@@ -113,7 +113,7 @@ export function toPascalCase(s: string): string {
  */
 export function toCamelCase<T extends string>(s: T): CamelCase<T> {
   const str = s
-    .replace(/[-_]+/g, '_') // collapse runs to a single separator (no backtracking issue)
+    .replace(/[-_]+/g, '_')
     .replace(/_([a-zA-Z0-9])/g, (_, c) => c.toUpperCase());
   return (str.charAt(0).toLowerCase() + str.slice(1)) as CamelCase<T>;
 }

--- a/crates/bindings-typescript/src/server/db_view.ts
+++ b/crates/bindings-typescript/src/server/db_view.ts
@@ -9,7 +9,9 @@ export type ReadonlyDbView<SchemaDef extends UntypedSchemaDef> = {
   readonly [Tbl in Values<
     SchemaDef['tables']
   > as Tbl['accessorName']]: ReadonlyTable<Tbl>;
-};
+} & (SchemaDef extends { namespaces: infer NS extends Record<string, UntypedSchemaDef> }
+  ? { readonly [K in keyof NS]: ReadonlyDbView<NS[K]> }
+  : {});
 
 /**
  * A type representing the database view, mapping table names to their corresponding Table handles.
@@ -18,4 +20,6 @@ export type DbView<SchemaDef extends UntypedSchemaDef> = {
   readonly [Tbl in Values<
     SchemaDef['tables']
   > as Tbl['accessorName']]: Table<Tbl>;
-};
+} & (SchemaDef extends { namespaces: infer NS extends Record<string, UntypedSchemaDef> }
+  ? { readonly [K in keyof NS]: DbView<NS[K]> }
+  : {});

--- a/crates/bindings-typescript/src/server/index.ts
+++ b/crates/bindings-typescript/src/server/index.ts
@@ -33,5 +33,6 @@ export {
   type ResponseInit,
 } from './http';
 export type { HandlerContext, HttpHandlerExport } from './http';
+export { ScheduleAt } from '../lib/schedule_at';
 
 import './polyfills'; // Ensure polyfills are loaded

--- a/crates/bindings-typescript/src/server/procedures.ts
+++ b/crates/bindings-typescript/src/server/procedures.ts
@@ -154,7 +154,7 @@ export type Procedures = Array<{
 }>;
 
 export function callProcedure(
-  moduleCtx: SchemaInner,
+  procedures: Procedures,
   id: number,
   sender: Identity,
   connectionId: ConnectionId | null,
@@ -163,7 +163,7 @@ export function callProcedure(
   dbView: () => DbView<any>
 ): Uint8Array {
   const { fn, deserializeArgs, serializeReturn, returnTypeBaseSize } =
-    moduleCtx.procedures[id];
+    procedures[id];
   const args = deserializeArgs(new BinaryReader(argsBuf));
 
   const ctx: ProcedureCtx<UntypedSchemaDef> = new ProcedureCtxImpl(

--- a/crates/bindings-typescript/src/server/runtime.ts
+++ b/crates/bindings-typescript/src/server/runtime.ts
@@ -10,6 +10,8 @@ import {
 import {
   RawModuleDef,
   ViewResultHeader,
+  type RawProcedureDefV10,
+  type RawReducerDefV10,
   type RawTableDefV10,
   type Typespace,
 } from '../lib/autogen/types';
@@ -27,6 +29,8 @@ import {
   type UniqueIndex,
 } from '../lib/indexes';
 import { callProcedure } from './procedures';
+import type { Procedures } from './procedures';
+import type { Reducers } from './reducers';
 import {
   type HandlerContext,
   Request,
@@ -40,6 +44,7 @@ import {
   serializeHeaders,
 } from './http_shared';
 import {
+  type AliasViews,
   type AuthCtx,
   type JsonObject,
   type JwtClaims,
@@ -48,13 +53,13 @@ import {
 import { type UntypedSchemaDef } from '../lib/schema';
 import { type RowType, type Table, type TableMethods } from '../lib/table';
 import { bsatnBaseSize, hasOwn } from '../lib/util';
-import { type AnonymousViewCtx, type ViewCtx } from './views';
+import { type AnonymousViewCtx, type AnonViews, type ViewCtx, type Views } from './views';
 import { isRowTypedQuery, makeQueryBuilder, toSql } from './query';
-import type { DbView } from './db_view';
+import type { DbView, ReadonlyDbView } from './db_view';
 import { getErrorConstructor, SenderError } from './errors';
 import { Range, type Bound } from './range';
 import { makeRandom, type Random } from './rng';
-import type { SchemaInner } from './schema';
+import type { MountedDispatchInfo, SchemaInner } from './schema';
 import { HttpRequest, HttpResponse } from '../lib/autogen/types';
 
 const { freeze } = Object;
@@ -226,18 +231,21 @@ export const ReducerCtxImpl = class ReducerCtx<
   timestamp: Timestamp;
   connectionId: ConnectionId | null;
   db: DbView<SchemaDef>;
+  as: AliasViews<SchemaDef>;
 
   constructor(
     sender: Identity,
     timestamp: Timestamp,
     connectionId: ConnectionId | null,
-    dbView: DbView<any>
+    dbView: DbView<any>,
+    asViews: object = {}
   ) {
     Object.seal(this);
     this.sender = sender;
     this.timestamp = timestamp;
     this.connectionId = connectionId;
-    this.db = dbView;
+    this.db = dbView as unknown as DbView<SchemaDef>;
+    this.as = asViews as AliasViews<SchemaDef>;
   }
 
   /** Reset the `ReducerCtx` to be used for a new transaction */
@@ -245,13 +253,21 @@ export const ReducerCtxImpl = class ReducerCtx<
     me: InstanceType<typeof this>,
     sender: Identity,
     timestamp: Timestamp,
-    connectionId: ConnectionId | null
+    connectionId: ConnectionId | null,
+    dbView?: DbView<any>,
+    asViews?: object
   ) {
     me.sender = sender;
     me.timestamp = timestamp;
     me.connectionId = connectionId;
     me.#uuidCounter = undefined;
     me.#senderAuth = undefined;
+    if (dbView !== undefined) {
+      me.db = dbView;
+    }
+    if (asViews !== undefined) {
+      me.as = asViews as AliasViews<any>;
+    }
   }
 
   get databaseIdentity() {
@@ -337,31 +353,102 @@ export function runWithTx<T, Ctx>(
   }
 }
 
+type FlatMountDispatch = {
+  reducerFns: Reducers;
+  reducerDefs: RawReducerDefV10[];
+  procedureFns: Procedures;
+  procedureDefs: RawProcedureDefV10[];
+  anonViewFns: AnonViews;
+  viewFns: Views;
+  tables: Array<{ accessorName: string; tableDef: RawTableDefV10 }>;
+  typespace: Typespace;
+  dbView_: DbView<any> | undefined;
+  /** e.g. "alias." for a mount with namespace alias "alias" */
+  namePrefix: string;
+};
+
+function flattenMountDispatches(
+  dispatches: MountedDispatchInfo[],
+  parentPrefix = ''
+): FlatMountDispatch[] {
+  const result: FlatMountDispatch[] = [];
+  for (const d of dispatches) {
+    const namePrefix = parentPrefix + d.namespace + '.';
+    result.push({
+      reducerFns: d.reducerFns,
+      reducerDefs: d.reducerDefs,
+      procedureFns: d.procedureFns,
+      procedureDefs: d.procedureDefs,
+      anonViewFns: d.anonViewFns,
+      viewFns: d.viewFns,
+      tables: d.tables,
+      typespace: d.typespace,
+      dbView_: undefined,
+      namePrefix,
+    });
+    result.push(...flattenMountDispatches(d.subDispatches, namePrefix));
+  }
+  return result;
+}
+
 export const makeHooks = (schema: SchemaInner): ModuleHooks =>
   new ModuleHooksImpl(schema);
 
 class ModuleHooksImpl implements ModuleHooks {
   #schema: SchemaInner;
   #dbView_: DbView<any> | undefined;
+  #consumerAs_: object | undefined;
   #reducerArgsDeserializers;
-  /** Cache the `ReducerCtx` object to avoid allocating anew for ever reducer call. */
+  #consumerReducerCount: number;
+  #consumerProcedureCount: number;
+  #flatMounts: FlatMountDispatch[];
+  #consumerAnonViewCount: number;
+  #consumerViewCount: number;
+  /** Cache the `ReducerCtx` object to avoid allocating anew for every reducer call. */
   #reducerCtx_: InstanceType<typeof ReducerCtxImpl> | undefined;
 
   constructor(schema: SchemaInner) {
     this.#schema = schema;
-    this.#reducerArgsDeserializers = schema.moduleDef.reducers.map(
+    this.#consumerReducerCount = schema.reducers.length;
+    this.#consumerProcedureCount = schema.procedures.length;
+    this.#consumerAnonViewCount = schema.anonViews.length;
+    this.#consumerViewCount = schema.views.length;
+    this.#flatMounts = flattenMountDispatches(schema.mountedDispatchInfos);
+
+    const consumerDeserializers = schema.moduleDef.reducers.map(
       ({ params }) => ProductType.makeDeserializer(params, schema.typespace)
     );
+    const mountedDeserializers = this.#flatMounts.flatMap(({ reducerDefs, typespace }) =>
+      reducerDefs.map(({ params }) => ProductType.makeDeserializer(params, typespace))
+    );
+    this.#reducerArgsDeserializers = [...consumerDeserializers, ...mountedDeserializers];
   }
 
   get #dbView() {
-    return (this.#dbView_ ??= freeze(
+    if (this.#dbView_ !== undefined) return this.#dbView_;
+    const rootTables = Object.values(this.#schema.schemaType.tables).map(
+      table => [
+        table.accessorName,
+        makeTableView(this.#schema.typespace, table.tableDef),
+      ]
+    );
+    const mountNs = this.#schema.mountedDispatchInfos.map(dispatch => [
+      dispatch.namespace,
+      buildDbViewForDispatch(dispatch, dispatch.namespace + '.'),
+    ]);
+    this.#dbView_ = freeze(Object.fromEntries([...rootTables, ...mountNs])) as DbView<any>;
+    return this.#dbView_;
+  }
+
+  #getMountDbView(mountIdx: number): DbView<any> {
+    const m = this.#flatMounts[mountIdx];
+    return (m.dbView_ ??= freeze(
       Object.fromEntries(
-        Object.values(this.#schema.schemaType.tables).map(table => [
-          table.accessorName,
-          makeTableView(this.#schema.typespace, table.tableDef),
+        m.tables.map(({ accessorName, tableDef }) => [
+          accessorName,
+          makeTableView(m.typespace, tableDef, m.namePrefix),
         ])
-      )
+      ) as DbView<any>
     ));
   }
 
@@ -371,6 +458,14 @@ class ModuleHooksImpl implements ModuleHooks {
       Timestamp.UNIX_EPOCH,
       null,
       this.#dbView
+    ));
+  }
+
+  get #consumerAs() {
+    return (this.#consumerAs_ ??= buildAliasCtxMap(
+      this.#reducerCtx,
+      this.#schema.mountedDispatchInfos,
+      ''
     ));
   }
 
@@ -398,19 +493,46 @@ class ModuleHooksImpl implements ModuleHooks {
     timestamp: bigint,
     argsBuf: DataView
   ): void {
-    const moduleCtx = this.#schema;
     const deserializeArgs = this.#reducerArgsDeserializers[reducerId];
     BINARY_READER.reset(argsBuf);
     const args = deserializeArgs(BINARY_READER);
     const senderIdentity = new Identity(sender);
+
+    let fn: ((...args: any[]) => any) | undefined;
+    let dbView: DbView<any>;
+    let asViews: object;
+
+    if (reducerId < this.#consumerReducerCount) {
+      fn = this.#schema.reducers[reducerId];
+      dbView = this.#dbView;
+      asViews = this.#consumerAs;
+    } else {
+      let offset = this.#consumerReducerCount;
+      for (let i = 0; i < this.#flatMounts.length; i++) {
+        const m = this.#flatMounts[i];
+        if (reducerId < offset + m.reducerFns.length) {
+          fn = m.reducerFns[reducerId - offset];
+          dbView = this.#getMountDbView(i);
+          break;
+        }
+        offset += m.reducerFns.length;
+      }
+      if (fn === undefined) {
+        throw new RangeError(`unknown reducerId ${reducerId}`);
+      }
+      asViews = {};
+    }
+
     const ctx = this.#reducerCtx;
     ReducerCtxImpl.reset(
       ctx,
       senderIdentity,
       new Timestamp(timestamp),
-      ConnectionId.nullIfZero(new ConnectionId(connId))
+      ConnectionId.nullIfZero(new ConnectionId(connId)),
+      dbView!,
+      asViews!
     );
-    callUserFunction(moduleCtx.reducers[reducerId], ctx, args);
+    callUserFunction(fn, ctx, args);
   }
 
   __call_view__(
@@ -419,14 +541,35 @@ class ModuleHooksImpl implements ModuleHooks {
     argsBuf: Uint8Array
   ): { data: Uint8Array } {
     const moduleCtx = this.#schema;
-    const { fn, deserializeParams, serializeReturn, returnTypeBaseSize } =
-      moduleCtx.views[id];
+    let viewFns: Views;
+    let localId: number;
+    let dbView: ReadonlyDbView<any>;
+
+    if (id < this.#consumerViewCount) {
+      viewFns = moduleCtx.views;
+      localId = id;
+      dbView = this.#dbView as ReadonlyDbView<any>;
+    } else {
+      let offset = this.#consumerViewCount;
+      let found = false;
+      for (let i = 0; i < this.#flatMounts.length; i++) {
+        const m = this.#flatMounts[i];
+        if (id < offset + m.viewFns.length) {
+          viewFns = m.viewFns;
+          localId = id - offset;
+          dbView = this.#getMountDbView(i) as ReadonlyDbView<any>;
+          found = true;
+          break;
+        }
+        offset += m.viewFns.length;
+      }
+      if (!found) throw new RangeError(`unknown viewId ${id}`);
+    }
+
+    const { fn, deserializeParams, serializeReturn, returnTypeBaseSize } = viewFns![localId!];
     const ctx: ViewCtx<any> = freeze({
       sender: new Identity(sender),
-      // this is the non-readonly DbView, but the typing for the user will be
-      // the readonly one, and if they do call mutating functions it will fail
-      // at runtime
-      db: this.#dbView,
+      db: dbView!,
       from: makeQueryBuilder(moduleCtx.schemaType),
     });
     const args = deserializeParams(new BinaryReader(argsBuf));
@@ -444,13 +587,34 @@ class ModuleHooksImpl implements ModuleHooks {
 
   __call_view_anon__(id: u32, argsBuf: Uint8Array): { data: Uint8Array } {
     const moduleCtx = this.#schema;
-    const { fn, deserializeParams, serializeReturn, returnTypeBaseSize } =
-      moduleCtx.anonViews[id];
+    let anonViewFns: AnonViews;
+    let localId: number;
+    let dbView: ReadonlyDbView<any>;
+
+    if (id < this.#consumerAnonViewCount) {
+      anonViewFns = moduleCtx.anonViews;
+      localId = id;
+      dbView = this.#dbView as ReadonlyDbView<any>;
+    } else {
+      let offset = this.#consumerAnonViewCount;
+      let found = false;
+      for (let i = 0; i < this.#flatMounts.length; i++) {
+        const m = this.#flatMounts[i];
+        if (id < offset + m.anonViewFns.length) {
+          anonViewFns = m.anonViewFns;
+          localId = id - offset;
+          dbView = this.#getMountDbView(i) as ReadonlyDbView<any>;
+          found = true;
+          break;
+        }
+        offset += m.anonViewFns.length;
+      }
+      if (!found) throw new RangeError(`unknown anonViewId ${id}`);
+    }
+
+    const { fn, deserializeParams, serializeReturn, returnTypeBaseSize } = anonViewFns![localId!];
     const ctx: AnonymousViewCtx<any> = freeze({
-      // this is the non-readonly DbView, but the typing for the user will be
-      // the readonly one, and if they do call mutating functions it will fail
-      // at runtime
-      db: this.#dbView,
+      db: dbView!,
       from: makeQueryBuilder(moduleCtx.schemaType),
     });
     const args = deserializeParams(new BinaryReader(argsBuf));
@@ -473,15 +637,40 @@ class ModuleHooksImpl implements ModuleHooks {
     timestamp: bigint,
     args: Uint8Array
   ): Uint8Array {
-    return callProcedure(
-      this.#schema,
-      id,
-      new Identity(sender),
-      ConnectionId.nullIfZero(new ConnectionId(connection_id)),
-      new Timestamp(timestamp),
-      args,
-      () => this.#dbView
-    );
+    const senderIdentity = new Identity(sender);
+    const connId = ConnectionId.nullIfZero(new ConnectionId(connection_id));
+    const ts = new Timestamp(timestamp);
+
+    if (id < this.#consumerProcedureCount) {
+      return callProcedure(
+        this.#schema.procedures,
+        id,
+        senderIdentity,
+        connId,
+        ts,
+        args,
+        () => this.#dbView as DbView<any>
+      );
+    }
+
+    let offset = this.#consumerProcedureCount;
+    for (let i = 0; i < this.#flatMounts.length; i++) {
+      const m = this.#flatMounts[i];
+      if (id < offset + m.procedureFns.length) {
+        return callProcedure(
+          m.procedureFns,
+          id - offset,
+          senderIdentity,
+          connId,
+          ts,
+          args,
+          () => this.#getMountDbView(i)
+        );
+      }
+      offset += m.procedureFns.length;
+    }
+
+    throw new RangeError(`unknown procedureId ${id}`);
   }
 
   __call_http_handler__(
@@ -559,11 +748,59 @@ class HandlerContextImpl<S extends UntypedSchemaDef = UntypedSchemaDef>
   }
 }
 
+function buildDbViewForDispatch(dispatch: MountedDispatchInfo, namePrefix: string): object {
+  const tableEntries = dispatch.tables.map(({ accessorName, tableDef }) => [
+    accessorName,
+    makeTableView(dispatch.typespace, tableDef, namePrefix),
+  ]);
+  const subNsEntries = dispatch.subDispatches.map(sub => [
+    sub.namespace,
+    buildDbViewForDispatch(sub, namePrefix + sub.namespace + '.'),
+  ]);
+  return freeze(Object.fromEntries([...tableEntries, ...subNsEntries]));
+}
+
+function buildAliasCtx(
+  parent: InstanceType<typeof ReducerCtxImpl>,
+  dispatch: MountedDispatchInfo,
+  namePrefix: string
+): object {
+  const nsDb = buildDbViewForDispatch(dispatch, namePrefix);
+  const subAs = buildAliasCtxMap(parent, dispatch.subDispatches, namePrefix);
+  return {
+    get sender() { return parent.sender; },
+    get databaseIdentity() { return parent.databaseIdentity; },
+    get identity() { return parent.identity; },
+    get timestamp() { return parent.timestamp; },
+    get connectionId() { return parent.connectionId; },
+    get senderAuth() { return parent.senderAuth; },
+    get random() { return parent.random; },
+    newUuidV4() { return parent.newUuidV4(); },
+    newUuidV7() { return parent.newUuidV7(); },
+    db: nsDb,
+    as: subAs,
+  };
+}
+
+function buildAliasCtxMap(
+  parent: InstanceType<typeof ReducerCtxImpl>,
+  dispatches: MountedDispatchInfo[],
+  parentPrefix: string
+): object {
+  return freeze(
+    Object.fromEntries(dispatches.map(d => [
+      d.namespace,
+      buildAliasCtx(parent, d, parentPrefix + d.namespace + '.'),
+    ]))
+  );
+}
+
 function makeTableView(
   typespace: Typespace,
-  table: RawTableDefV10
+  table: RawTableDefV10,
+  namePrefix = ''
 ): Table<any> {
-  const table_id = sys.table_id_from_name(table.sourceName);
+  const table_id = sys.table_id_from_name(namePrefix + table.sourceName);
   const rowType = typespace.types[table.productTypeRef];
   if (rowType.tag !== 'Product') {
     throw 'impossible';
@@ -659,7 +896,7 @@ function makeTableView(
 
   for (const indexDef of table.indexes) {
     const accessorName = indexDef.accessorName!;
-    const index_id = sys.index_id_from_name(indexDef.sourceName!);
+    const index_id = sys.index_id_from_name(namePrefix + indexDef.sourceName!);
 
     let column_ids: number[];
     let isHashIndex = false;

--- a/crates/bindings-typescript/src/server/schema.ts
+++ b/crates/bindings-typescript/src/server/schema.ts
@@ -3,6 +3,11 @@ import {
   CaseConversionPolicy,
   Lifecycle,
   type MethodOrAny,
+  type RawModuleDefV10,
+  type RawProcedureDefV10,
+  type RawReducerDefV10,
+  type RawTableDefV10,
+  type Typespace,
 } from '../lib/autogen/types';
 import {
   type ParamsAsObject,
@@ -18,6 +23,7 @@ import {
 } from '../lib/schema';
 import type { UntypedTableSchema } from '../lib/table_schema';
 import { ColumnBuilder, TypeBuilder } from '../lib/type_builders';
+import { hasOwn } from '../lib/util';
 import {
   Router,
   type HandlerFn,
@@ -55,10 +61,25 @@ import {
 } from './views';
 import type { UntypedTableDef } from '../lib/table';
 
+export type MountedDispatchInfo = {
+  namespace: string;
+  reducerFns: Reducers;
+  reducerDefs: RawReducerDefV10[];
+  procedureFns: Procedures;
+  procedureDefs: RawProcedureDefV10[];
+  anonViewFns: AnonViews;
+  viewFns: Views;
+  typespace: Typespace;
+  tables: Array<{ accessorName: string; tableDef: RawTableDefV10 }>;
+  subDispatches: MountedDispatchInfo[];
+};
+
 export class SchemaInner<
   S extends UntypedSchemaDef = UntypedSchemaDef,
 > extends ModuleContext {
   schemaType: S;
+  exportsRegistered = false;
+  schedulesResolved = false;
   existingFunctions = new Set<string>();
   existingHttpHandlers = new Set<string>();
   reducers: Reducers = [];
@@ -79,6 +100,7 @@ export class SchemaInner<
     new Map();
   pendingSchedules: PendingSchedule[] = [];
   pendingHttpRoutes: PendingHttpRoute[] = [];
+  mountedDispatchInfos: MountedDispatchInfo[] = [];
 
   constructor(getSchemaType: (ctx: SchemaInner<S>) => S) {
     super();
@@ -104,6 +126,10 @@ export class SchemaInner<
   }
 
   resolveSchedules() {
+    if (this.schedulesResolved) {
+      return;
+    }
+    this.schedulesResolved = true;
     for (const { reducer, scheduleAtCol, tableName } of this.pendingSchedules) {
       const functionName = this.functionExports.get(reducer());
       if (functionName === undefined) {
@@ -186,23 +212,9 @@ export class Schema<S extends UntypedSchemaDef> implements ModuleDefaultExport {
   }
 
   [moduleHooks](exports: object) {
-    // if (!(hasOwn(exports, 'default') && exports.default instanceof Schema)) {
-    //   throw new TypeError('must export schema as default export');
-    // }
-    const registeredSchema = this.#ctx;
-    for (const [name, moduleExport] of Object.entries(exports)) {
-      if (name === 'default') continue;
-      if (!isModuleExport(moduleExport)) {
-        throw new TypeError(
-          'exporting something that is not a spacetime export'
-        );
-      }
-      checkExportContext(moduleExport, registeredSchema);
-      moduleExport[registerExport](registeredSchema, name);
-    }
-    registeredSchema.resolveSchedules();
-    registeredSchema.resolveHttpRoutes();
-    return makeHooks(registeredSchema);
+    this.buildRawModuleDefV10(exports);
+    this.#ctx.resolveHttpRoutes();
+    return makeHooks(this.#ctx);
   }
 
   get schemaType(): S {
@@ -215,6 +227,53 @@ export class Schema<S extends UntypedSchemaDef> implements ModuleDefaultExport {
 
   get typespace() {
     return this.#ctx.typespace;
+  }
+
+  get mountedDispatchInfos(): MountedDispatchInfo[] {
+    return this.#ctx.mountedDispatchInfos;
+  }
+
+  /** Internal: register exports and materialize the RawModuleDefV10 for upload. */
+  buildRawModuleDefV10(
+    exports: object,
+    opts?: { ignoreNonModuleExports?: boolean }
+  ): RawModuleDefV10 {
+    registerModuleExports(this.#ctx, exports, {
+      ignoreNonModuleExports: opts?.ignoreNonModuleExports ?? false,
+    });
+    this.#ctx.resolveSchedules();
+    return this.#ctx.rawModuleDefV10();
+  }
+
+  /**
+   * @internal – called by schema() when processing a mounted namespace entry.
+   * Registers the library's exports and returns both the serialized module def
+   * and the runtime dispatch info needed by ModuleHooksImpl for __call_reducer__.
+   */
+  buildMountForDispatch(
+    exports: object
+  ): { rawDef: RawModuleDefV10; dispatch: MountedDispatchInfo } {
+    const rawDef = this.buildRawModuleDefV10(exports, {
+      ignoreNonModuleExports: true,
+    });
+    return {
+      rawDef,
+      dispatch: {
+        namespace: '',
+        reducerFns: [...this.#ctx.reducers],
+        reducerDefs: [...this.#ctx.moduleDef.reducers],
+        procedureFns: [...this.#ctx.procedures],
+        procedureDefs: [...this.#ctx.moduleDef.procedures],
+        anonViewFns: [...this.#ctx.anonViews],
+        viewFns: [...this.#ctx.views],
+        typespace: this.#ctx.moduleDef.typespace,
+        tables: Object.values(this.#ctx.schemaType.tables).map(t => ({
+          accessorName: t.accessorName,
+          tableDef: t.tableDef,
+        })),
+        subDispatches: [...this.#ctx.mountedDispatchInfos],
+      },
+    };
   }
 
   /**
@@ -625,18 +684,100 @@ export interface ModuleSettings {
   CASE_CONVERSION_POLICY?: CaseConversionPolicy;
 }
 
-export function schema<const H extends Record<string, UntypedTableSchema>>(
-  tables: H,
+type MountedModuleNamespace = {
+  default: Schema<any>;
+  [key: string]: unknown;
+};
+
+type SchemaEntry = UntypedTableSchema | MountedModuleNamespace;
+
+type ExtractTableEntries<H extends Record<string, SchemaEntry>> = {
+  [K in keyof H as H[K] extends UntypedTableSchema ? K : never]: Extract<
+    H[K],
+    UntypedTableSchema
+  >;
+};
+
+type ExtractMountSchemas<H extends Record<string, SchemaEntry>> = {
+  [K in keyof H as H[K] extends { default: Schema<any> }
+    ? K
+    : never]: H[K] extends { default: Schema<infer S extends UntypedSchemaDef> }
+    ? S
+    : never;
+};
+
+type SchemaDefForEntries<H extends Record<string, SchemaEntry>> =
+  TablesToSchema<ExtractTableEntries<H>> & {
+    namespaces: ExtractMountSchemas<H>;
+  };
+
+function isUntypedTableSchema(x: unknown): x is UntypedTableSchema {
+  return typeof x === 'object' && x !== null && hasOwn(x, 'tableDef');
+}
+
+function isMountedModuleNamespace(x: unknown): x is MountedModuleNamespace {
+  return (
+    typeof x === 'object' &&
+    x !== null &&
+    hasOwn(x, 'default') &&
+    x.default instanceof Schema
+  );
+}
+
+function registerModuleExports(
+  schema: SchemaInner,
+  exports: object,
+  opts?: { ignoreNonModuleExports?: boolean }
+) {
+  if (schema.exportsRegistered) {
+    return;
+  }
+  schema.exportsRegistered = true;
+
+  for (const [name, moduleExport] of Object.entries(exports)) {
+    if (name === 'default') continue;
+    if (!isModuleExport(moduleExport)) {
+      if (opts?.ignoreNonModuleExports) {
+        continue;
+      }
+      throw new TypeError('exporting something that is not a spacetime export');
+    }
+    checkExportContext(moduleExport, schema);
+    moduleExport[registerExport](schema, name);
+  }
+}
+
+export function schema<const H extends Record<string, SchemaEntry>>(
+  entries: H,
   moduleSettings?: ModuleSettings
-): Schema<TablesToSchema<H>> {
-  const ctx = new SchemaInner<TablesToSchema<H>>(ctx => {
+): Schema<SchemaDefForEntries<H>> {
+  const ctx = new SchemaInner<SchemaDefForEntries<H>>(ctx => {
     // Apply module settings.
     if (moduleSettings?.CASE_CONVERSION_POLICY != null) {
       ctx.setCaseConversionPolicy(moduleSettings.CASE_CONVERSION_POLICY);
     }
 
     const tableSchemas: Record<string, UntypedTableDef> = {};
-    for (const [accName, table] of Object.entries(tables)) {
+    for (const [accName, entry] of Object.entries(entries)) {
+      if (entry instanceof Schema) {
+        throw new TypeError(
+          `schema entry '${accName}' looks like a default import; use \`import * as ${accName} from '...'\` so the mount can see the library's named reducer exports.`
+        );
+      }
+      if (isMountedModuleNamespace(entry)) {
+        const { rawDef, dispatch } = entry.default.buildMountForDispatch(entry);
+        dispatch.namespace = accName;
+        ctx.addMount({ namespace: accName, module: rawDef });
+        ctx.mountedDispatchInfos.push(dispatch);
+        continue;
+      }
+      if (!isUntypedTableSchema(entry)) {
+        throw new TypeError(
+          `schema entry '${accName}' must be a table or a mounted module namespace object`
+        );
+      }
+
+      const table = entry;
       const tableDef = table.tableDef(ctx, accName);
       tableSchemas[accName] = tableToSchema(accName, table, tableDef);
       ctx.moduleDef.tables.push(tableDef);
@@ -656,7 +797,7 @@ export function schema<const H extends Record<string, UntypedTableSchema>>(
         });
       }
     }
-    return { tables: tableSchemas } as TablesToSchema<H>;
+    return { tables: tableSchemas } as SchemaDefForEntries<H>;
   });
 
   return new Schema(ctx);

--- a/crates/bindings-typescript/src/server/views.ts
+++ b/crates/bindings-typescript/src/server/views.ts
@@ -279,7 +279,7 @@ export function registerView<
   }
 
   (anon ? ctx.anonViews : ctx.views).push({
-    fn,
+    fn: fn as unknown as ViewFn<any, any, any>,
     deserializeParams: ProductType.makeDeserializer(paramType, typespace),
     serializeReturn: AlgebraicType.makeSerializer(returnType, typespace),
     returnTypeBaseSize: bsatnBaseSize(typespace, returnType),

--- a/crates/bindings-typescript/tests/ctx_as.test.ts
+++ b/crates/bindings-typescript/tests/ctx_as.test.ts
@@ -1,0 +1,117 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock(
+  'spacetime:sys@2.0',
+  () => ({
+    moduleHooks: Symbol('moduleHooks'),
+    table_id_from_name: () => 1,
+    index_id_from_name: () => 1,
+    row_iter_bsatn_close: () => {},
+  }),
+  { virtual: true }
+);
+
+vi.mock('spacetime:sys@2.1', () => ({}), { virtual: true });
+
+describe('ctx.as alias proxy', () => {
+  let schema: typeof import('../src/server/schema').schema;
+  let table: typeof import('../src/lib/table').table;
+  let t: typeof import('../src/lib/type_builders').t;
+  let moduleHooks: symbol;
+
+  beforeAll(async () => {
+    ({ schema } = await import('../src/server/schema'));
+    ({ table } = await import('../src/lib/table'));
+    ({ t } = await import('../src/lib/type_builders'));
+    ({ moduleHooks } = (await import('spacetime:sys@2.0')) as any);
+  });
+
+  it('ctx.as.<alias> provides a narrowed ctx with library db and delegating sender', async () => {
+    const sessions = table(
+      { name: 'sessions' },
+      { id: t.u64().primaryKey().autoInc() }
+    );
+    const authSchema = schema({ sessions });
+    const authLib = { default: authSchema };
+
+    const players = table({ name: 'players' }, { id: t.u32().primaryKey() });
+    const consumer = schema({ players, myauth: authLib });
+
+    let capturedCtx: any;
+    const myReducer = consumer.reducer((ctx: any) => {
+      capturedCtx = ctx;
+    });
+
+    const hooks = (consumer as any)[moduleHooks]({ myReducer });
+    hooks.__call_reducer__(
+      0,
+      0n,
+      0n,
+      0n,
+      new DataView(new ArrayBuffer(0))
+    );
+
+    expect(capturedCtx.as).toBeDefined();
+    expect(capturedCtx.as.myauth).toBeDefined();
+    expect(capturedCtx.as.myauth.db).toBeDefined();
+    expect(capturedCtx.as.myauth.db.sessions).toBeDefined();
+    expect(capturedCtx.as.myauth.sender).toBe(capturedCtx.sender);
+    expect(capturedCtx.as.myauth.timestamp).toBe(capturedCtx.timestamp);
+  });
+
+  it('ctx.as is empty object when there are no mounts', async () => {
+    const players = table({ name: 'players' }, { id: t.u32().primaryKey() });
+    const consumer = schema({ players });
+
+    let capturedCtx: any;
+    const myReducer = consumer.reducer((ctx: any) => {
+      capturedCtx = ctx;
+    });
+
+    const hooks = (consumer as any)[moduleHooks]({ myReducer });
+    hooks.__call_reducer__(
+      0,
+      0n,
+      0n,
+      0n,
+      new DataView(new ArrayBuffer(0))
+    );
+
+    expect(capturedCtx.as).toBeDefined();
+    expect(Object.keys(capturedCtx.as)).toHaveLength(0);
+  });
+
+  it('ctx.as.<alias>.as carries nested sub-mount aliases', async () => {
+    const bazTable = table({ name: 'baz_items' }, { id: t.u32().primaryKey() });
+    const bazSchema = schema({ bazTable });
+    const bazLib = { default: bazSchema };
+
+    const sessions = table(
+      { name: 'sessions' },
+      { id: t.u64().primaryKey().autoInc() }
+    );
+    const authSchema = schema({ sessions, baz: bazLib });
+    const authLib = { default: authSchema };
+
+    const players = table({ name: 'players' }, { id: t.u32().primaryKey() });
+    const consumer = schema({ players, myauth: authLib });
+
+    let capturedCtx: any;
+    const myReducer = consumer.reducer((ctx: any) => {
+      capturedCtx = ctx;
+    });
+
+    const hooks = (consumer as any)[moduleHooks]({ myReducer });
+    hooks.__call_reducer__(
+      0,
+      0n,
+      0n,
+      0n,
+      new DataView(new ArrayBuffer(0))
+    );
+
+    expect(capturedCtx.as.myauth.as.baz).toBeDefined();
+    expect(capturedCtx.as.myauth.as.baz.db.bazTable).toBeDefined();
+    expect(capturedCtx.as.myauth.as.baz.sender).toBe(capturedCtx.sender);
+  });
+});

--- a/crates/bindings-typescript/tests/schema_mounts.test.ts
+++ b/crates/bindings-typescript/tests/schema_mounts.test.ts
@@ -1,0 +1,222 @@
+import { beforeAll, describe, expect, it, vi } from 'vitest';
+
+vi.mock(
+  'spacetime:sys@2.0',
+  () => ({
+    moduleHooks: Symbol('moduleHooks'),
+  }),
+  { virtual: true }
+);
+
+vi.mock('spacetime:sys@2.1', () => ({}), { virtual: true });
+
+vi.mock('../src/server/runtime', () => ({
+  makeHooks: () => ({}),
+  callProcedure: () => new Uint8Array(),
+  callUserFunction: (fn: (...args: any[]) => any, ...args: any[]) =>
+    fn(...args),
+  ReducerCtxImpl: class {},
+  sys: {
+    row_iter_bsatn_close: () => {},
+  },
+}));
+
+describe('schema mounts', () => {
+  let schema: typeof import('../src/server/schema').schema;
+  let table: typeof import('../src/lib/table').table;
+  let t: typeof import('../src/lib/type_builders').t;
+
+  beforeAll(async () => {
+    ({ schema } = await import('../src/server/schema'));
+    ({ table } = await import('../src/lib/table'));
+    ({ t } = await import('../src/lib/type_builders'));
+  });
+
+  it('emits mounted submodule module defs and resolves mounted schedules', () => {
+    const players = table({ name: 'players' }, { id: t.u32().primaryKey() });
+
+    const sessionCleanupTick = table(
+      {
+        name: 'session_cleanup_tick',
+        scheduled: (): any => cleanExpiredSessions,
+      },
+      {
+        scheduledId: t.u64().primaryKey().autoInc(),
+        scheduledAt: t.scheduleAt(),
+      }
+    );
+
+    const sessions = table(
+      { name: 'sessions' },
+      {
+        id: t.u64().primaryKey().autoInc(),
+      }
+    );
+
+    const authSchema = schema({
+      sessions,
+      sessionCleanupTick,
+    });
+
+    const cleanExpiredSessions = authSchema.reducer(() => {});
+    const authLib = {
+      default: authSchema,
+      cleanExpiredSessions,
+    };
+
+    const consumer = schema({
+      players,
+      myauth: authLib,
+    });
+
+    const raw = consumer.buildRawModuleDefV10({});
+    const mounts = raw.sections.find(
+      section => section.tag === 'Mounts'
+    )?.value;
+
+    expect(mounts).toHaveLength(1);
+    expect(mounts?.[0]?.namespace).toBe('myauth');
+
+    const mountedSections = mounts?.[0]?.module.sections ?? [];
+    const mountedReducers = mountedSections.find(
+      section => section.tag === 'Reducers'
+    )?.value;
+    const mountedSchedules = mountedSections.find(
+      section => section.tag === 'Schedules'
+    )?.value;
+
+    expect(mountedReducers).toEqual(
+      expect.arrayContaining([
+        expect.objectContaining({ sourceName: 'cleanExpiredSessions' }),
+      ])
+    );
+    expect(mountedSchedules).toEqual([
+      expect.objectContaining({
+        tableName: 'sessionCleanupTick',
+        functionName: 'cleanExpiredSessions',
+      }),
+    ]);
+  });
+
+  it('rejects default-import style mounts with a clear error', () => {
+    const sessions = table(
+      { name: 'sessions' },
+      {
+        id: t.u64().primaryKey().autoInc(),
+      }
+    );
+
+    const authSchema = schema({ sessions });
+
+    expect(() =>
+      schema({
+        myauth: authSchema as any,
+      })
+    ).toThrow(/looks like a default import/);
+  });
+
+  it('populates mountedDispatchInfos with reducer fns and table metadata', () => {
+    const sessions = table(
+      { name: 'sessions' },
+      { id: t.u64().primaryKey().autoInc() }
+    );
+
+    const authSchema = schema({ sessions });
+    const cleanExpiredSessions = authSchema.reducer(() => {});
+    const authLib = { default: authSchema, cleanExpiredSessions };
+
+    const players = table({ name: 'players' }, { id: t.u32().primaryKey() });
+    const consumer = schema({ players, myauth: authLib });
+
+    const infos = consumer.mountedDispatchInfos;
+    expect(infos).toHaveLength(1);
+
+    const info = infos[0];
+    expect(info.reducerFns).toHaveLength(1);
+    expect(info.reducerDefs).toHaveLength(1);
+    expect(info.reducerDefs[0].sourceName).toBe('cleanExpiredSessions');
+    expect(info.tables).toHaveLength(1);
+    expect(info.tables[0].accessorName).toBe('sessions');
+    expect(info.subDispatches).toHaveLength(0);
+  });
+
+  it('flattens nested mount dispatches depth-first', () => {
+    // baz library: 1 reducer
+    const bazTable = table({ name: 'baz_items' }, { id: t.u32().primaryKey() });
+    const bazSchema = schema({ bazTable });
+    const bazReducer = bazSchema.reducer(() => {});
+    const bazLib = { default: bazSchema, bazReducer };
+
+    // auth library: 1 own reducer, mounts baz
+    const sessions = table(
+      { name: 'sessions' },
+      { id: t.u64().primaryKey().autoInc() }
+    );
+    const authSchema = schema({ sessions, baz: bazLib });
+    const authReducer = authSchema.reducer(() => {});
+    const authLib = { default: authSchema, authReducer };
+
+    // consumer: 1 own reducer, mounts auth
+    const players = table({ name: 'players' }, { id: t.u32().primaryKey() });
+    const consumer = schema({ players, myauth: authLib });
+    const consumerReducer = consumer.reducer(() => {});
+
+    // Verify depth-first structure:
+    // consumer.mountedDispatchInfos[0] = myauth (authReducer)
+    // consumer.mountedDispatchInfos[0].subDispatches[0] = myauth.baz (bazReducer)
+    const infos = consumer.mountedDispatchInfos;
+    expect(infos).toHaveLength(1);
+
+    const authInfo = infos[0];
+    expect(authInfo.reducerFns).toHaveLength(1);
+    expect(authInfo.reducerDefs[0].sourceName).toBe('authReducer');
+    expect(authInfo.subDispatches).toHaveLength(1);
+
+    const bazInfo = authInfo.subDispatches[0];
+    expect(bazInfo.reducerFns).toHaveLength(1);
+    expect(bazInfo.reducerDefs[0].sourceName).toBe('bazReducer');
+    expect(bazInfo.subDispatches).toHaveLength(0);
+
+    // Unused variable check
+    void consumerReducer;
+  });
+
+  it('mountedDispatchInfos carry namespace and nested namespace dispatches propagate', () => {
+    const sessions = table(
+      { name: 'sessions' },
+      { id: t.u64().primaryKey().autoInc() }
+    );
+    const authSchema = schema({ sessions });
+    const authLib = { default: authSchema };
+
+    const players = table({ name: 'players' }, { id: t.u32().primaryKey() });
+    const consumer = schema({ players, myauth: authLib });
+
+    const infos = consumer.mountedDispatchInfos;
+    expect(infos).toHaveLength(1);
+    expect(infos[0].namespace).toBe('myauth');
+    expect(infos[0].tables[0].accessorName).toBe('sessions');
+  });
+
+  it('nested mounts carry their own namespace on subDispatches', () => {
+    const bazTable = table({ name: 'baz_items' }, { id: t.u32().primaryKey() });
+    const bazSchema = schema({ bazTable });
+    const bazLib = { default: bazSchema };
+
+    const sessions = table(
+      { name: 'sessions' },
+      { id: t.u64().primaryKey().autoInc() }
+    );
+    const authSchema = schema({ sessions, baz: bazLib });
+    const authLib = { default: authSchema };
+
+    const players = table({ name: 'players' }, { id: t.u32().primaryKey() });
+    const consumer = schema({ players, myauth: authLib });
+
+    const authInfo = consumer.mountedDispatchInfos[0];
+    expect(authInfo.namespace).toBe('myauth');
+    expect(authInfo.subDispatches).toHaveLength(1);
+    expect(authInfo.subDispatches[0].namespace).toBe('baz');
+    expect(authInfo.subDispatches[0].tables[0].accessorName).toBe('bazTable');
+  });
+});


### PR DESCRIPTION
# Description of Changes

Changes the typescript runtime and query builder to handle mounted sub-modules. 

# API and ABI breaking changes

No
# Expected complexity level and risk

4 - Changes in runtime.ts are quite extensive as they require each dispatch (table/reducer/procedure/view) to go through mounts logic.

# Testing
Beyond the typescript tests in this PR, the following testing was done

Module:
- [x] root module can import another module and mount it with a namespace under its schema
- [x] root module and submodule can have the same function and table names without conflicting
- [x] ctx.db.lib.lib_table is readable/writable inside root module reducer
- [x] ctx.db.lib.lib_table is readable/writable inside root module procedure withTx block
- [x] library_reducer(ctx.as.lib) is callable inside root module reducer

Client
- [x] Client can subscribe to lib.library_table
- [x] Client can subscribe to lib.library_view
- [x] Client can call lib/library_reducer
- [x] Client can call lib/library_procedure
- [x] Client can subscribe to lib.sublib.sublib_table
- [x] Client can subscribe to lib.sublib.sublib_view
- [x] Client can call lib/sublib/sublib_reducer
- [x] Client can call lib/sublib/sublib_procedure

CLI
- [x] CLI can subscribe to lib.library_table
- [x] CLI can subscribe to lib.library_view
- [x] CLI can call lib/library_reducer
- [x] CLI can call lib/library_procedure
- [x] CLI can subscribe to lib.sublib.sublib_table
- [x] CLI can subscribe to lib.sublib.sublib_view
- [x] CLI can call lib/sublib/sublib_reducer
- [x] CLI can call lib/sublib/sublib_procedure

Migration
- [x] Module migrates without issue from having a submodule to not having a submodule
- [x] Module migrates without issue from not having a submodule to having a submodule
- [x] Module migrates without issue when having a submodule and root module change occurs (change reducer signature, add table, add column with default, change reducer function body, change index)
- [x] Module migrates without issue when having a submodule and a submodule change occurs (change reducer signature, add table, add column with default, change reducer function body, change index)

Commit Log
- [x] Module loads fine from commit log
- [x] Module snapshot is created without issue
- [x] Module loads fine from snapshot

