### PR TITLE
Add launchpad tag to llm-chat and chat-react

### DIFF
--- a/templates/chat-react-ts/.template.json
+++ b/templates/chat-react-ts/.template.json
@@ -2,6 +2,7 @@
   "description": "TypeScript server/client implementing quickstart chat",
   "client_lang": "typescript",
   "server_lang": "typescript",
+  "tags": ["Launchpad"],
   "builtWith": [
     "react",
     "react-dom",

--- a/templates/llm-chat-ts/.template.json
+++ b/templates/llm-chat-ts/.template.json
@@ -3,6 +3,7 @@
   "client_framework": "React",
   "client_lang": "typescript",
   "server_lang": "typescript",
+  "tags": ["Launchpad"],
   "builtWith": [
     "react",
     "react-dom",


### PR DESCRIPTION
# Description of Changes

Add the missing tag for `llm-chat-ts` and `chat-react-ts` to add them to `Launchpad` on the templates page.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1 - small template config

# Testing

Double checked both still work with `spacetime init` locally to create the project with latest template change.
