### PR TITLE
CI - fix LLM benchmark workflows

### DIFF
--- a/.github/workflows/llm-benchmark-periodic.yml
+++ b/.github/workflows/llm-benchmark-periodic.yml
@@ -29,11 +29,7 @@ concurrency:
 
 jobs:
   run-benchmarks:
-    runs-on: spacetimedb-new-runner
-    container:
-      image: localhost:5000/spacetimedb-ci:latest
-      options: >-
-        --privileged
+    runs-on: spacetimedb-new-runner-2
     timeout-minutes: 180
 
     steps:

--- a/.github/workflows/llm-benchmark-periodic.yml
+++ b/.github/workflows/llm-benchmark-periodic.yml
@@ -33,11 +33,6 @@ jobs:
     timeout-minutes: 180
 
     steps:
-      - name: Install spacetime CLI
-        run: |
-          curl -sSf https://install.spacetimedb.com | sh -s -- -y
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
       - name: Checkout master
         uses: actions/checkout@v4
         with:
@@ -70,6 +65,13 @@ jobs:
 
       - name: Build llm-benchmark tool
         run: cargo install --path tools/xtask-llm-benchmark --locked
+
+      - name: Build SpacetimeDB server for benchmark harness
+        run: |
+          cargo ci smoketests prepare
+          mkdir -p "$HOME/.local/bin"
+          ln -sf "$GITHUB_WORKSPACE/target/release/spacetimedb-cli" "$HOME/.local/bin/spacetime"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Run benchmarks
         env:

--- a/.github/workflows/llm-benchmark-validate-goldens.yml
+++ b/.github/workflows/llm-benchmark-validate-goldens.yml
@@ -24,11 +24,6 @@ jobs:
         lang: [rust, csharp, typescript]
 
     steps:
-      - name: Install spacetime CLI
-        run: |
-          curl -sSf https://install.spacetimedb.com | sh -s -- -y
-          echo "$HOME/.local/bin" >> $GITHUB_PATH
-
       - name: Checkout master
         uses: actions/checkout@v4
         with:
@@ -65,6 +60,13 @@ jobs:
 
       - name: Build llm-benchmark tool
         run: cargo install --path tools/xtask-llm-benchmark --locked
+
+      - name: Build SpacetimeDB server for benchmark harness
+        run: |
+          cargo ci smoketests prepare
+          mkdir -p "$HOME/.local/bin"
+          ln -sf "$GITHUB_WORKSPACE/target/release/spacetimedb-cli" "$HOME/.local/bin/spacetime"
+          echo "$HOME/.local/bin" >> "$GITHUB_PATH"
 
       - name: Validate golden answers (${{ matrix.lang }})
         env:

--- a/.github/workflows/llm-benchmark-validate-goldens.yml
+++ b/.github/workflows/llm-benchmark-validate-goldens.yml
@@ -15,11 +15,7 @@ concurrency:
 
 jobs:
   validate-goldens:
-    runs-on: spacetimedb-new-runner
-    container:
-      image: localhost:5000/spacetimedb-ci:latest
-      options: >-
-        --privileged
+    runs-on: spacetimedb-new-runner-2
     timeout-minutes: 60
 
     strategy:


### PR DESCRIPTION
# Description of Changes

Updates `llm-benchmark-periodic.yml` and `llm-benchmark-validate-goldens.yml` to new CI infrastructure.

- Switch to the current runner (`spacetimedb-new-runner-2`)
- Drop the dead `localhost:5000` container + `--privileged`
- Build the local SpacetimeDB server the benchmark harness needs, and use that
  same local CLI for publishing

# API and ABI breaking changes

None. CI-only.

# Expected complexity level and risk

1 — workflow-only, no production code.

# Testing

- [ ] Run both workflows via `workflow_dispatch` and confirm they pass