### PR TITLE
Bump the rest of the package versions to 2.4.1

### DIFF
--- a/crates/bindings-cpp/CMakeLists.txt
+++ b/crates/bindings-cpp/CMakeLists.txt
@@ -2,7 +2,7 @@
 
 cmake_minimum_required(VERSION 3.15)
 project(SpacetimeDBCppModuleLibrary 
-    VERSION 2.4.0
+    VERSION 2.4.1
     LANGUAGES CXX)
 
 # Generate version header from template

--- a/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
+++ b/crates/bindings-csharp/BSATN.Codegen/BSATN.Codegen.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Codegen</AssemblyName>
-    <Version>2.4.0</Version>
+    <Version>2.4.1</Version>
     <Title>SpacetimeDB BSATN Codegen</Title>
     <Description>The SpacetimeDB BSATN Codegen implements the Roslyn incremental generators for BSATN serialization/deserialization in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
+++ b/crates/bindings-csharp/BSATN.Runtime/BSATN.Runtime.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.BSATN.Runtime</AssemblyName>
-    <Version>2.4.0</Version>
+    <Version>2.4.1</Version>
     <Title>SpacetimeDB BSATN Runtime</Title>
     <Description>The SpacetimeDB BSATN Runtime implements APIs for BSATN serialization/deserialization in C#.</Description>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/crates/bindings-csharp/Codegen/Codegen.csproj
+++ b/crates/bindings-csharp/Codegen/Codegen.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Codegen</AssemblyName>
-    <Version>2.4.0</Version>
+    <Version>2.4.1</Version>
     <Title>SpacetimeDB Module Codegen</Title>
     <Description>The SpacetimeDB Codegen implements the Roslyn incremental generators for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-csharp/Runtime/Runtime.csproj
+++ b/crates/bindings-csharp/Runtime/Runtime.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <AssemblyName>SpacetimeDB.Runtime</AssemblyName>
-    <Version>2.4.0</Version>
+    <Version>2.4.1</Version>
     <Title>SpacetimeDB Module Runtime</Title>
     <Description>The SpacetimeDB Runtime implements the database runtime bindings for writing SpacetimeDB modules in C#.</Description>
   </PropertyGroup>

--- a/crates/bindings-typescript/package.json
+++ b/crates/bindings-typescript/package.json
@@ -1,6 +1,6 @@
 {
   "name": "spacetimedb",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "API and ABI bindings for the SpacetimeDB TypeScript module library",
   "homepage": "https://github.com/clockworklabs/SpacetimeDB#readme",
   "bugs": {

--- a/sdks/csharp/SpacetimeDB.ClientSDK.Godot.csproj
+++ b/sdks/csharp/SpacetimeDB.ClientSDK.Godot.csproj
@@ -16,8 +16,8 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk</RepositoryUrl>
-    <AssemblyVersion>2.4.0</AssemblyVersion>
-    <Version>2.4.0</Version>
+    <AssemblyVersion>2.4.1</AssemblyVersion>
+    <Version>2.4.1</Version>
     <DefaultItemExcludes>$(DefaultItemExcludes);*~/**</DefaultItemExcludes>
     <RestorePackagesPath>obj~/godot/packages</RestorePackagesPath>
     <EmitCompilerGeneratedFiles>true</EmitCompilerGeneratedFiles>

--- a/sdks/csharp/SpacetimeDB.ClientSDK.csproj
+++ b/sdks/csharp/SpacetimeDB.ClientSDK.csproj
@@ -16,8 +16,8 @@
     <PackageIcon>logo.png</PackageIcon>
     <PackageReadmeFile>README.md</PackageReadmeFile>
     <RepositoryUrl>https://github.com/clockworklabs/com.clockworklabs.spacetimedbsdk</RepositoryUrl>
-    <AssemblyVersion>2.4.0</AssemblyVersion>
-    <Version>2.4.0</Version>
+    <AssemblyVersion>2.4.1</AssemblyVersion>
+    <Version>2.4.1</Version>
     <DefaultItemExcludes>$(DefaultItemExcludes);*~/**</DefaultItemExcludes>
     <!-- We want to save DLLs for Unity which doesn't support NuGet. -->
     <RestorePackagesPath>packages</RestorePackagesPath>

--- a/sdks/csharp/package.json
+++ b/sdks/csharp/package.json
@@ -1,7 +1,7 @@
 {
   "name": "com.clockworklabs.spacetimedbsdk",
   "displayName": "SpacetimeDB SDK",
-  "version": "2.4.0",
+  "version": "2.4.1",
   "description": "The SpacetimeDB Client SDK is a software development kit (SDK) designed to interact with and manipulate SpacetimeDB modules..",
   "keywords": [],
   "author": {

--- a/templates/basic-cpp/spacetimedb/CMakeLists.txt
+++ b/templates/basic-cpp/spacetimedb/CMakeLists.txt
@@ -18,7 +18,7 @@ project(spacetime_cpp_module LANGUAGES C CXX)
 #     The directory should contain the bindings' CMakeLists.txt at its root.
 # ------------------------------------------------------------------------------
 
-set(SPACETIMEDB_CPP_VERSION "2.4.0" CACHE STRING "Version selector: MAJOR.MINOR (uses release/MAJOR.MINOR) or MAJOR.MINOR.PATCH (uses tag vMAJOR.MINOR.PATCH)")
+set(SPACETIMEDB_CPP_VERSION "2.4.1" CACHE STRING "Version selector: MAJOR.MINOR (uses release/MAJOR.MINOR) or MAJOR.MINOR.PATCH (uses tag vMAJOR.MINOR.PATCH)")
 set(SPACETIMEDB_CPP_REF "" CACHE STRING "Override Git ref directly (e.g. release/1.0, release/latest, v1.0.0)")  
 set(SPACETIMEDB_CPP_DIR "" CACHE PATH "Path to a local clone of SpacetimeDB C++ bindings (overrides FetchContent)")
 


### PR DESCRIPTION
# Description of Changes

The previous PR only bumped the Rust packages since that's what we were releasing. Since we may release more, we can now bump the rest of the versions.

(This is harmless if we don't end up releasing the other packages anyway; I could have just done this in the first place).

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

CI only