### PR TITLE
cli: Accept hex-ish strings as Identity parameters for call

### DIFF
--- a/crates/cli/src/subcommands/call.rs
+++ b/crates/cli/src/subcommands/call.rs
@@ -122,6 +122,15 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), Error> {
     let arguments = call_arguments
         .zip(&call_def.params().elements)
         .map(|(argument, element)| match &element.algebraic_type {
+            // Accept a hex-ish string as an [Identity] parameter.
+            AlgebraicType::Product(p) if p.is_identity() => {
+                let argument = argument.trim_matches('"');
+                match argument.as_bytes() {
+                    [b'0', b'x', ..] => format!("[\"{argument}\"]"),
+                    [b'c', b'2', b'0', b'0', ..] => format!("[\"0x{argument}\"]"),
+                    _ => argument.to_string(),
+                }
+            }
             AlgebraicType::String if !argument.starts_with('\"') || !argument.ends_with('\"') => {
                 format!("\"{argument}\"")
             }

--- a/crates/smoketests/modules/Cargo.lock
+++ b/crates/smoketests/modules/Cargo.lock
@@ -594,6 +594,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "smoketest-module-call-reducer-procedure-identity-arg"
+version = "0.1.0"
+dependencies = [
+ "log",
+ "spacetimedb",
+]
+
+[[package]]
 name = "smoketest-module-client-connection-disconnect-panic"
 version = "0.1.0"
 dependencies = [

--- a/crates/smoketests/modules/Cargo.toml
+++ b/crates/smoketests/modules/Cargo.toml
@@ -42,6 +42,7 @@ members = [
 
     # Call/procedure tests
     "call-reducer-procedure",
+    "call-reducer-procedure-identity-arg",
     "call-empty",
 
     # SQL format tests

--- a/crates/smoketests/modules/call-reducer-procedure-identity-arg/Cargo.toml
+++ b/crates/smoketests/modules/call-reducer-procedure-identity-arg/Cargo.toml
@@ -1,0 +1,12 @@
+[package]
+name = "smoketest-module-call-reducer-procedure-identity-arg"
+version = "0.1.0"
+edition = "2021"
+publish = false
+
+[lib]
+crate-type = ["cdylib"]
+
+[dependencies]
+spacetimedb.workspace = true
+log.workspace = true

--- a/crates/smoketests/modules/call-reducer-procedure-identity-arg/src/lib.rs
+++ b/crates/smoketests/modules/call-reducer-procedure-identity-arg/src/lib.rs
@@ -1,0 +1,16 @@
+use spacetimedb::{log, Identity, ProcedureContext, ReducerContext};
+
+#[spacetimedb::table(accessor = person)]
+pub struct Person {
+    name: String,
+}
+
+#[spacetimedb::reducer]
+pub fn say_my_identity(_ctx: &ReducerContext, identity: Identity) {
+    log::info!("Hello, {identity}!");
+}
+
+#[spacetimedb::procedure]
+pub fn return_my_identity(_ctx: &mut ProcedureContext, identity: Identity) -> Identity {
+    identity
+}

--- a/crates/smoketests/modules/call-reducer-procedure/src/lib.rs
+++ b/crates/smoketests/modules/call-reducer-procedure/src/lib.rs
@@ -1,4 +1,4 @@
-use spacetimedb::{log, Identity, ProcedureContext, ReducerContext};
+use spacetimedb::{log, ProcedureContext, ReducerContext};
 
 #[spacetimedb::table(accessor = person)]
 pub struct Person {
@@ -12,17 +12,7 @@ pub fn say_hello(_ctx: &ReducerContext) {
 
 #[spacetimedb::procedure]
 pub fn return_person(_ctx: &mut ProcedureContext) -> Person {
-    Person {
+    return Person {
         name: "World".to_owned(),
-    }
-}
-
-#[spacetimedb::reducer]
-pub fn say_my_identity(_ctx: &ReducerContext, identity: Identity) {
-    log::info!("Hello, {identity}!");
-}
-
-#[spacetimedb::procedure]
-pub fn return_my_identity(_ctx: &mut ProcedureContext, identity: Identity) -> Identity {
-    identity
+    };
 }

--- a/crates/smoketests/modules/call-reducer-procedure/src/lib.rs
+++ b/crates/smoketests/modules/call-reducer-procedure/src/lib.rs
@@ -1,4 +1,4 @@
-use spacetimedb::{log, ProcedureContext, ReducerContext};
+use spacetimedb::{log, Identity, ProcedureContext, ReducerContext};
 
 #[spacetimedb::table(accessor = person)]
 pub struct Person {
@@ -12,7 +12,17 @@ pub fn say_hello(_ctx: &ReducerContext) {
 
 #[spacetimedb::procedure]
 pub fn return_person(_ctx: &mut ProcedureContext) -> Person {
-    return Person {
+    Person {
         name: "World".to_owned(),
-    };
+    }
+}
+
+#[spacetimedb::reducer]
+pub fn say_my_identity(_ctx: &ReducerContext, identity: Identity) {
+    log::info!("Hello, {identity}!");
+}
+
+#[spacetimedb::procedure]
+pub fn return_my_identity(_ctx: &mut ProcedureContext, identity: Identity) -> Identity {
+    identity
 }

--- a/crates/smoketests/tests/smoketests/call.rs
+++ b/crates/smoketests/tests/smoketests/call.rs
@@ -21,7 +21,7 @@ fn test_call_reducer_procedure() {
 #[test]
 fn test_call_reducer_procedure_with_identity_argument() {
     let test = Smoketest::builder()
-        .precompiled_module("call-reducer-procedure")
+        .precompiled_module("call-reducer-procedure-identity-arg")
         .build();
 
     let identity = test.database_identity.as_ref().unwrap();

--- a/crates/smoketests/tests/smoketests/call.rs
+++ b/crates/smoketests/tests/smoketests/call.rs
@@ -16,6 +16,36 @@ fn test_call_reducer_procedure() {
     assert_eq!(msg.trim(), r#"["World"]"#);
 }
 
+/// Tests that both reducers and procedures that take a [spacetimedb::Identity]
+/// argument can be called using any of the various encodings for that type.
+#[test]
+fn test_call_reducer_procedure_with_identity_argument() {
+    let test = Smoketest::builder()
+        .precompiled_module("call-reducer-procedure")
+        .build();
+
+    let identity = test.database_identity.as_ref().unwrap();
+    let identity_tuple_encoding = format!("[\"0x{identity}\"]");
+
+    let identity_encodings = [
+        identity,
+        &format!("0x{identity}"),
+        &identity_tuple_encoding,
+        &format!("{{\"__identity__\": \"0x{identity}\"}}"),
+    ];
+
+    for argument in identity_encodings {
+        let msg = test.call("return_my_identity", &[argument]).unwrap();
+        assert_eq!(msg.trim(), &identity_tuple_encoding);
+
+        test.call("say_my_identity", &[argument]).unwrap();
+    }
+
+    let logs = test.logs(100).unwrap();
+    let log_string = format!("Hello, {identity}!");
+    assert_eq!(logs.iter().filter(|l| l.contains(&log_string)).count(), 4);
+}
+
 /// Check calling a non-existent reducer/procedure raises error
 #[test]
 fn test_call_errors() {


### PR DESCRIPTION
Makes the `call` command rewrite reducer arguments typed at `Identity`, but given as just a (hex) string, into a JSON 1-tuple.

Proper deserialization on the server is more complicated to change, so may be addressed separately.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Added a smoketest.