### PR TITLE
Timestamps can be primary keys in C#

### DIFF
--- a/crates/bindings-csharp/Codegen.Tests/Tests.cs
+++ b/crates/bindings-csharp/Codegen.Tests/Tests.cs
@@ -298,6 +298,13 @@ public static class GeneratorSnapshotTests
                 public int Id;
             }
 
+            [SpacetimeDB.Table]
+            public partial struct TimestampPrimaryKeyTable
+            {
+                [SpacetimeDB.PrimaryKey]
+                public Timestamp CreatedAt;
+            }
+
             public static partial class KeywordApis
             {
                 [SpacetimeDB.Reducer]

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -170,6 +170,7 @@ static class ColumnTypeValidation
                 SpecialType.None => type.ToString()
                     is "SpacetimeDB.ConnectionId"
                         or "SpacetimeDB.Identity"
+                        or "SpacetimeDB.Timestamp"
                         or "SpacetimeDB.Uuid",
                 _ => false,
             }


### PR DESCRIPTION
# Description of Changes

Makes C# consistent with the other module languages.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1

# Testing

Unit test
