### PR TITLE
Allow layout-altering automigrations of event tables

### DIFF
--- a/crates/core/src/db/relational_db.rs
+++ b/crates/core/src/db/relational_db.rs
@@ -1024,6 +1024,17 @@ impl RelationalDB {
         Ok(self.inner.alter_table_row_type_mut_tx(tx, table_id, column_schemas)?)
     }
 
+    pub(crate) fn alter_event_table_row_type(
+        &self,
+        tx: &mut MutTx,
+        table_id: TableId,
+        column_schemas: Vec<ColumnSchema>,
+    ) -> Result<(), DBError> {
+        Ok(self
+            .inner
+            .alter_event_table_row_type_mut_tx(tx, table_id, column_schemas)?)
+    }
+
     pub(crate) fn add_columns_to_table_mut_tx(
         &self,
         tx: &mut MutTx,

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -589,17 +589,25 @@ mod test {
 
         // Replay commitlog
         let stdb = stdb.reopen()?;
-        let tx = begin_mut_tx(&stdb);
-        let table_id = stdb
-            .table_id_from_name_mut(&tx, "events")?
-            .expect("`events` table should exist on reopen");
-        let schema = stdb.schema_for_table_mut(&tx, table_id)?;
+        let table_id = {
+            let tx = begin_mut_tx(&stdb);
+            let table_id = stdb
+                .table_id_from_name_mut(&tx, "events")?
+                .expect("`events` table should exist on reopen");
+            let schema = stdb.schema_for_table_mut(&tx, table_id)?;
 
-        assert!(schema.is_event);
-        assert_eq!(schema.columns.len(), 1);
-        assert_eq!(&*schema.columns[0].col_name, "payload");
-        assert_eq!(schema.columns[0].col_type, AlgebraicType::String);
-        assert_eq!(stdb.table_row_count_mut(&tx, table_id).unwrap_or(0), 0);
+            assert!(schema.is_event);
+            assert_eq!(schema.columns.len(), 1);
+            assert_eq!(&*schema.columns[0].col_name, "payload");
+            assert_eq!(schema.columns[0].col_type, AlgebraicType::String);
+            assert_eq!(stdb.table_row_count_mut(&tx, table_id).unwrap_or(0), 0);
+            table_id
+        };
+
+        // Insert row with the new schema
+        let mut tx = begin_mut_tx(&stdb);
+        insert(&stdb, &mut tx, table_id, &product!["hello"])?;
+        stdb.commit_tx(tx)?;
 
         Ok(())
     }

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -278,6 +278,15 @@ fn auto_migrate_database(
 
                 stdb.alter_table_row_type(tx, table_id, column_schemas)?;
             }
+            spacetimedb_schema::auto_migrate::AutoMigrateStep::ReschemaEventTable(table_name) => {
+                let table_def = plan.new.stored_in_table_def(&table_name.clone().into()).unwrap();
+                let table_id = stdb.table_id_from_name_mut(tx, table_name).unwrap().unwrap();
+                let column_schemas = column_schemas_from_defs(plan.new, &table_def.columns, table_id);
+
+                log!(logger, "Changing schema of event table `{}`", table_name);
+
+                stdb.alter_event_table_row_type(tx, table_id, column_schemas)?;
+            }
             spacetimedb_schema::auto_migrate::AutoMigrateStep::ChangeAccess(table_name) => {
                 let table_def = plan.new.stored_in_table_def(&table_name.clone().into()).unwrap();
                 stdb.alter_table_access(tx, table_name, table_def.table_access.into())?;

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -345,12 +345,21 @@ fn auto_migrate_database(
 mod test {
     use super::*;
     use crate::{
-        db::relational_db::tests_utils::{begin_mut_tx, insert, TestDB},
+        db::relational_db::{
+            open_snapshot_repo,
+            tests_utils::{begin_mut_tx, insert, TestDB},
+        },
         host::module_host::create_table_from_def,
     };
     use spacetimedb_datastore::locking_tx_datastore::PendingSchemaChange;
-    use spacetimedb_lib::db::raw_def::v9::{btree, RawIndexAlgorithm, RawModuleDefV9Builder, TableAccess};
-    use spacetimedb_sats::{product, AlgebraicType, AlgebraicType::U64};
+    use spacetimedb_lib::{
+        db::raw_def::{
+            v10::RawModuleDefV10Builder,
+            v9::{btree, RawIndexAlgorithm, RawModuleDefV9Builder, TableAccess},
+        },
+        Identity,
+    };
+    use spacetimedb_sats::{product, AlgebraicType, AlgebraicType::U64, ProductType};
     use spacetimedb_schema::{auto_migrate::ponder_migrate, def::ModuleDef};
 
     struct TestLogger;
@@ -521,6 +530,88 @@ mod test {
             .finish()
             .try_into()
             .expect("should be a valid module definition")
+    }
+
+    fn event_table_module(product_type: ProductType) -> ModuleDef {
+        let mut builder = RawModuleDefV10Builder::new();
+        builder
+            .build_table_with_new_type("events", product_type, true)
+            .with_event(true)
+            .with_access(TableAccess::Public)
+            .finish();
+        builder
+            .finish()
+            .try_into()
+            .expect("should be a valid module definition")
+    }
+
+    enum TakeSnapshot {
+        None,
+        BeforeAutomigration,
+    }
+
+    fn take_snapshot(stdb: &TestDB) -> anyhow::Result<()> {
+        let snapshot_repo = open_snapshot_repo(stdb.path().unwrap().snapshots(), Identity::ZERO, 0)?;
+        stdb.take_snapshot(snapshot_repo.as_ref())?
+            .expect("snapshot should succeed");
+        Ok(())
+    }
+
+    fn replay_event_table_schema_change(snapshot: TakeSnapshot) -> anyhow::Result<()> {
+        let auth_ctx = AuthCtx::for_testing();
+        let stdb = TestDB::durable()?;
+
+        let module_v1 = event_table_module(ProductType::from([
+            ("old_payload", AlgebraicType::U64),
+            ("payload", AlgebraicType::U64),
+        ]));
+        let module_v2 = event_table_module(ProductType::from([("payload", AlgebraicType::String)]));
+
+        {
+            let mut tx = begin_mut_tx(&stdb);
+            for def in module_v1.tables() {
+                create_table_from_def(&stdb, &mut tx, &module_v1, def)?;
+            }
+            stdb.commit_tx(tx)?;
+        }
+
+        if matches!(snapshot, TakeSnapshot::BeforeAutomigration) {
+            take_snapshot(&stdb)?;
+        }
+
+        {
+            let mut tx = begin_mut_tx(&stdb);
+            let plan = ponder_migrate(&module_v1, &module_v2)?;
+            let res = update_database(&stdb, &mut tx, auth_ctx, plan, &TestLogger)?;
+            assert!(matches!(res, UpdateResult::RequiresClientDisconnect));
+            stdb.commit_tx(tx)?;
+        }
+
+        // Replay commitlog
+        let stdb = stdb.reopen()?;
+        let tx = begin_mut_tx(&stdb);
+        let table_id = stdb
+            .table_id_from_name_mut(&tx, "events")?
+            .expect("`events` table should exist on reopen");
+        let schema = stdb.schema_for_table_mut(&tx, table_id)?;
+
+        assert!(schema.is_event);
+        assert_eq!(schema.columns.len(), 1);
+        assert_eq!(&*schema.columns[0].col_name, "payload");
+        assert_eq!(schema.columns[0].col_type, AlgebraicType::String);
+        assert_eq!(stdb.table_row_count_mut(&tx, table_id).unwrap_or(0), 0);
+
+        Ok(())
+    }
+
+    #[test]
+    fn replay_event_table_schema_change_no_snapshot() -> anyhow::Result<()> {
+        replay_event_table_schema_change(TakeSnapshot::None)
+    }
+
+    #[test]
+    fn replay_event_table_schema_change_after_snapshot() -> anyhow::Result<()> {
+        replay_event_table_schema_change(TakeSnapshot::BeforeAutomigration)
     }
 
     #[test]

--- a/crates/datastore/src/error.rs
+++ b/crates/datastore/src/error.rs
@@ -84,6 +84,12 @@ pub enum TableError {
     ChangeColumnsError(#[from] Box<table::ChangeColumnsError>),
     #[error(transparent)]
     AddColumnsError(#[from] Box<table::AddColumnsError>),
+    #[error("Table with ID `{0}` is an event table, but was non-empty during auto-migration")]
+    EventTableNonEmptyDuringAutoMigration(TableId),
+    #[error(
+        "Table with ID `{0}` attempted to reschema using `alter_event_table_row_type`, but it is not an event table"
+    )]
+    ReschemaNotAnEventTable(TableId),
 }
 
 #[derive(Error, Debug, PartialEq, Eq)]

--- a/crates/datastore/src/error.rs
+++ b/crates/datastore/src/error.rs
@@ -84,8 +84,8 @@ pub enum TableError {
     ChangeColumnsError(#[from] Box<table::ChangeColumnsError>),
     #[error(transparent)]
     AddColumnsError(#[from] Box<table::AddColumnsError>),
-    #[error("Table with ID `{0}` is an event table, but was non-empty during auto-migration")]
-    EventTableNonEmptyDuringAutoMigration(TableId),
+    #[error("Event table with ID `{0}` is not empty")]
+    EventTableNotEmpty(TableId),
     #[error(
         "Table with ID `{0}` attempted to reschema using `alter_event_table_row_type`, but it is not an event table"
     )]

--- a/crates/datastore/src/locking_tx_datastore/committed_state.rs
+++ b/crates/datastore/src/locking_tx_datastore/committed_state.rs
@@ -757,6 +757,15 @@ impl CommittedState {
                 unsafe { table.change_columns_to_unchecked(column_schemas, |_, _, _| Ok::<_, Infallible>(())) }
                     .unwrap_or_else(|e| match e {});
             }
+            ReschemaEventTable(table_id, column_schemas) => {
+                let table = self.tables.get_mut(&table_id)?;
+                // SAFETY:
+                // Same argument as in `TableAlterRowType` applies,
+                // except that rather than knowing the types to be compatible, we know the commit table to be empty,
+                // so there are no rows or pages to have a conflicting type.
+                unsafe { table.change_columns_to_unchecked(column_schemas, |_, _, _| Ok::<_, Infallible>(())) }
+                    .unwrap_or_else(|e| match e {});
+            }
             // A constraint was removed. Add it back.
             ConstraintRemoved(table_id, constraint_schema) => {
                 let table = self.tables.get_mut(&table_id)?;

--- a/crates/datastore/src/locking_tx_datastore/datastore.rs
+++ b/crates/datastore/src/locking_tx_datastore/datastore.rs
@@ -303,6 +303,15 @@ impl Locking {
         tx.alter_table_row_type(table_id, column_schemas)
     }
 
+    pub fn alter_event_table_row_type_mut_tx(
+        &self,
+        tx: &mut MutTxId,
+        table_id: TableId,
+        column_schemas: Vec<ColumnSchema>,
+    ) -> Result<()> {
+        tx.alter_event_table_row_type(table_id, column_schemas)
+    }
+
     pub fn add_columns_to_table_mut_tx(
         &self,
         tx: &mut MutTxId,

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -1221,34 +1221,20 @@ impl MutTxId {
         }
 
         // Write to the table in the tx state.
-        let ((tx_table, tx_blob_store, ..), (commit_table, commit_blob_store, ..)) =
-            self.get_or_create_insert_table_mut(table_id)?;
+        let ((tx_table, ..), (commit_table, ..)) = self.get_or_create_insert_table_mut(table_id)?;
 
         if tx_table.row_count != 0 || commit_table.row_count != 0 {
             // N.b. the delete table must also be empty, 'cause the committed table is empty.
-            return Err(TableError::EventTableNonEmptyDuringAutoMigration(table_id).into());
+            return Err(TableError::EventTableNotEmpty(table_id).into());
         }
 
-        // Make sure there aren't any pages with outdated layouts in either table,
-        // as page layout depends on row size.
-        // It should be redundant to do this for the commit table, which can't have ever had rows resident at any point in the past,
-        // but better safe than sorry.
-        // Safety: There aren't any pages here, so it's impossible for any of them to have the wrong schema.
-        unsafe {
-            tx_table.set_pages(Vec::new(), tx_blob_store);
-            commit_table.set_pages(Vec::new(), commit_blob_store);
-        }
+        let old_column_schemas = tx_table
+            .change_columns_of_empty_table_to(column_schemas.clone())
+            .map_err(|_| TableError::EventTableNotEmpty(table_id))?;
 
-        // Safety: we just checked that the table has zero rows resident, and then wiped all its pages,
-        // so there aren't any rows existing in the table for the new layout to conflict with.
-        let old_column_schemas = unsafe {
-            tx_table
-                .change_columns_to_unchecked(column_schemas.clone(), |_, _, _| Ok::<(), std::convert::Infallible>(()))
-        }
-        .expect("const Ok validation function to result in Ok column change");
-
-        // Safety: No rows resident, no pages resident, no possible conflicts.
-        unsafe { commit_table.set_layout_and_schema_to(tx_table) };
+        commit_table
+            .change_columns_of_empty_table_to(column_schemas.clone())
+            .map_err(|_| TableError::EventTableNotEmpty(table_id))?;
 
         // Update system tables.
         // We'll simply remove all rows in `st_columns` and then add the new ones.

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -1210,6 +1210,60 @@ impl MutTxId {
         Ok(())
     }
 
+    pub(crate) fn alter_event_table_row_type(
+        &mut self,
+        table_id: TableId,
+        column_schemas: Vec<ColumnSchema>,
+    ) -> Result<()> {
+        // Sanity check: is this actually an event table?
+        if self.find_st_event_table_row(table_id).is_err() {
+            return Err(TableError::ReschemaNotAnEventTable(table_id).into());
+        }
+
+        // Write to the table in the tx state.
+        let ((tx_table, tx_blob_store, ..), (commit_table, commit_blob_store, ..)) =
+            self.get_or_create_insert_table_mut(table_id)?;
+
+        if tx_table.row_count != 0 || commit_table.row_count != 0 {
+            // N.b. the delete table must also be empty, 'cause the committed table is empty.
+            return Err(TableError::EventTableNonEmptyDuringAutoMigration(table_id).into());
+        }
+
+        // Make sure there aren't any pages with outdated layouts in either table,
+        // as page layout depends on row size.
+        // It should be redundant to do this for the commit table, which can't have ever had rows resident at any point in the past,
+        // but better safe than sorry.
+        // Safety: There aren't any pages here, so it's impossible for any of them to have the wrong schema.
+        unsafe {
+            tx_table.set_pages(Vec::new(), tx_blob_store);
+            commit_table.set_pages(Vec::new(), commit_blob_store);
+        }
+
+        // Safety: we just checked that the table has zero rows resident, and then wiped all its pages,
+        // so there aren't any rows existing in the table for the new layout to conflict with.
+        let old_column_schemas = unsafe {
+            tx_table
+                .change_columns_to_unchecked(column_schemas.clone(), |_, _, _| Ok::<(), std::convert::Infallible>(()))
+        }
+        .expect("const Ok validation function to result in Ok column change");
+
+        // Safety: No rows resident, no pages resident, no possible conflicts.
+        unsafe { commit_table.set_layout_and_schema_to(tx_table) };
+
+        // Update system tables.
+        // We'll simply remove all rows in `st_columns` and then add the new ones.
+        // The datastore takes care of not persisting any no-op delete/inserts to the commitlog.
+        let table_name = self.find_st_table_row(table_id)?.table_name;
+        self.drop_st_column(table_id)?;
+        self.drop_st_column_accessor(&table_name)?;
+        self.insert_st_column(&table_name, &column_schemas)?;
+
+        // Remember the pending change so we can undo if necessary.
+        self.push_schema_change(PendingSchemaChange::ReschemaEventTable(table_id, old_column_schemas));
+
+        Ok(())
+    }
+
     /// Change the row type of the table identified by `table_id`.
     ///
     /// This is an incompatible change that requires a new table to be created.

--- a/crates/datastore/src/locking_tx_datastore/replay.rs
+++ b/crates/datastore/src/locking_tx_datastore/replay.rs
@@ -869,9 +869,16 @@ impl<'cs> ReplayCommittedState<'cs> {
         // because their initial insertion order matches their `col_pos` order.
         columns.sort_by_key(|col: &ColumnSchema| col.col_pos);
 
+        let is_event = self.find_st_event_table_row(table_id).is_ok();
         // Update the columns and layout of the the in-memory table.
         if let Some(table) = self.tables.get_mut(&table_id) {
-            table.change_columns_to(columns).map_err(TableError::from)?;
+            if is_event {
+                table
+                    .change_columns_of_empty_table_to(columns)
+                    .map_err(|_| TableError::EventTableNotEmpty(table_id))?;
+            } else {
+                table.change_columns_to(columns).map_err(TableError::from)?;
+            }
         }
 
         Ok(())

--- a/crates/datastore/src/locking_tx_datastore/replay.rs
+++ b/crates/datastore/src/locking_tx_datastore/replay.rs
@@ -869,7 +869,7 @@ impl<'cs> ReplayCommittedState<'cs> {
         // because their initial insertion order matches their `col_pos` order.
         columns.sort_by_key(|col: &ColumnSchema| col.col_pos);
 
-        let is_event = self.find_st_event_table_row(table_id).is_ok();
+        let is_event = self.is_event_table_for_replay(table_id)?;
         // Update the columns and layout of the the in-memory table.
         if let Some(table) = self.tables.get_mut(&table_id) {
             if is_event {
@@ -940,10 +940,23 @@ impl<'cs> ReplayCommittedState<'cs> {
             // and that there wasn't any corresponding insert at all.
             // If that's the case, `row_ptr` won't be in `self.replay_columns_to_ignore`,
             // which is fine.
+            let referenced_table_id = Self::read_table_id(row);
             self.replay_columns_to_ignore.remove(&row_ptr);
+
+            if self.is_event_table_for_replay(referenced_table_id)? {
+                self.st_column_changed(referenced_table_id)?;
+            }
         }
 
         Ok(())
+    }
+
+    fn is_event_table_for_replay(&self, table_id: TableId) -> Result<bool> {
+        match self.find_st_event_table_row(table_id) {
+            Ok(_) => Ok(true),
+            Err(DatastoreError::Table(TableError::IdNotFound(..))) => Ok(false),
+            Err(e) => Err(e),
+        }
     }
 
     /// Assuming that a `TableId` is stored as the first field in `row`, read it.

--- a/crates/datastore/src/locking_tx_datastore/state_view.rs
+++ b/crates/datastore/src/locking_tx_datastore/state_view.rs
@@ -5,9 +5,9 @@ use crate::locking_tx_datastore::mut_tx::{IndexScanPoint, IndexScanRanged};
 use crate::system_tables::{
     ConnectionIdViaU128, StColumnAccessorFields, StColumnAccessorRow, StColumnFields, StColumnRow,
     StConnectionCredentialsFields, StConnectionCredentialsRow, StConstraintFields, StConstraintRow, StEventTableFields,
-    StIndexAccessorFields, StIndexAccessorRow, StIndexFields, StIndexRow, StScheduledFields, StScheduledRow,
-    StSequenceFields, StSequenceRow, StTableAccessorFields, StTableAccessorRow, StTableFields, StTableRow,
-    StViewFields, StViewParamFields, StViewRow, SystemTable, ST_COLUMN_ACCESSOR_ID, ST_COLUMN_ID,
+    StEventTableRow, StIndexAccessorFields, StIndexAccessorRow, StIndexFields, StIndexRow, StScheduledFields,
+    StScheduledRow, StSequenceFields, StSequenceRow, StTableAccessorFields, StTableAccessorRow, StTableFields,
+    StTableRow, StViewFields, StViewParamFields, StViewRow, SystemTable, ST_COLUMN_ACCESSOR_ID, ST_COLUMN_ID,
     ST_CONNECTION_CREDENTIALS_ID, ST_CONSTRAINT_ID, ST_EVENT_TABLE_ID, ST_INDEX_ACCESSOR_ID, ST_INDEX_ID,
     ST_SCHEDULED_ID, ST_SEQUENCE_ID, ST_TABLE_ACCESSOR_ID, ST_TABLE_ID, ST_VIEW_ID, ST_VIEW_PARAM_ID,
 };
@@ -94,6 +94,14 @@ pub trait StateView {
             .next()
             .ok_or_else(|| TableError::IdNotFound(SystemTable::st_table, table_id.into()))?;
         StTableRow::try_from(row_ref)
+    }
+
+    fn find_st_event_table_row(&self, table_id: TableId) -> Result<StEventTableRow> {
+        let row_ref = self
+            .iter_by_col_eq(ST_EVENT_TABLE_ID, StEventTableFields::TableId, &table_id.into())?
+            .next()
+            .ok_or_else(|| TableError::IdNotFound(SystemTable::st_event_table, table_id.into()))?;
+        StEventTableRow::try_from(row_ref)
     }
 
     /// Look up an `st_table_accessor` row by its accessor name

--- a/crates/datastore/src/locking_tx_datastore/tx_state.rs
+++ b/crates/datastore/src/locking_tx_datastore/tx_state.rs
@@ -123,6 +123,12 @@ pub enum PendingSchemaChange {
     /// Only non-representational row-type changes are allowed here,
     /// so existing rows in the table will be compatible with the new row type.
     TableAlterRowType(TableId, Vec<ColumnSchema>),
+    /// The row type of the event table with [`TableId`] was changed.
+    /// The old column schemas was stored.
+    ///
+    /// As event tables never have rows resident across transactions or during automigrations,
+    /// we're fine to allow representational/layout-incompatible changes here.
+    ReschemaEventTable(TableId, Vec<ColumnSchema>),
     /// The primary key of the table with [`TableId`] was changed.
     /// The old primary key was stored.
     TableAlterPrimaryKey(TableId, Option<ColList>),
@@ -158,6 +164,7 @@ impl MemoryUsage for PendingSchemaChange {
                 table_id.heap_usage() + sequence.heap_usage() + sequence_schema.heap_usage()
             }
             Self::SequenceAdded(table_id, sequence_id) => table_id.heap_usage() + sequence_id.heap_usage(),
+            Self::ReschemaEventTable(table_id, column_schemas) => table_id.heap_usage() + column_schemas.heap_usage(),
         }
     }
 }

--- a/crates/datastore/src/system_tables.rs
+++ b/crates/datastore/src/system_tables.rs
@@ -203,6 +203,8 @@ pub enum SystemTable {
     st_constraint,
     st_row_level_security,
     st_table_accessor,
+
+    st_event_table = ST_EVENT_TABLE_ID.0 as _,
 }
 
 pub fn system_tables() -> [TableSchema; 20] {

--- a/crates/schema/src/auto_migrate.rs
+++ b/crates/schema/src/auto_migrate.rs
@@ -272,6 +272,10 @@ pub enum AutoMigrateStep<'def> {
     ///
     /// This should be done before any new indices are added.
     ChangeColumns(<TableDef as ModuleDefLookup>::Key<'def>),
+
+    /// Change the column types of an event table, in a way that may not be layout-compatible.
+    ReschemaEventTable(<TableDef as ModuleDefLookup>::Key<'def>),
+
     /// Add columns to a table, in a layout-INCOMPATIBLE way.
     ///
     /// This is a destructive operation that requires first running a `DisconnectAllUsers`.
@@ -686,6 +690,10 @@ fn auto_migrate_table<'def>(plan: &mut AutoMigratePlan<'def>, old: &'def TableDe
         }
         .into())
     };
+
+    // Combined with our validation of `event_ok`, `old.is_event` is sufficient to identify this as an event table.
+    let is_event = old.is_event;
+
     if old.table_access != new.table_access {
         plan.steps.push(AutoMigrateStep::ChangeAccess(key));
     }
@@ -708,9 +716,16 @@ fn auto_migrate_table<'def>(plan: &mut AutoMigratePlan<'def>, old: &'def TableDe
     .map(|col_diff| -> Result<_> {
         match col_diff {
             Diff::Add { new } => {
-                if new.default_value.is_some() {
-                    // `row_type_changed`, `columns_added`
-                    Ok(ProductMonoid(Any(false), Any(true)))
+                if is_event {
+                    // Event tables never have any resident rows.
+                    // As such, this is not a data migration; the table doesn't have any data in it to migrate.
+                    // However, changing the schema of an event table will break clients.
+
+                    // `row_type_changed`, `columns_added`, `event_schema_changed`
+                    Ok(ArrayMonoid([Any(false), Any(false), Any(true)]))
+                } else if new.default_value.is_some() {
+                    // `row_type_changed`, `columns_added`, `event_schema_changed`
+                    Ok(ArrayMonoid([Any(false), Any(true), Any(false)]))
                 } else {
                     Err(AutoMigrateError::AddColumn {
                         table: new.table_name.clone(),
@@ -719,11 +734,22 @@ fn auto_migrate_table<'def>(plan: &mut AutoMigratePlan<'def>, old: &'def TableDe
                     .into())
                 }
             }
-            Diff::Remove { old } => Err(AutoMigrateError::RemoveColumn {
-                table: old.table_name.clone(),
-                column: old.name.clone(),
+            Diff::Remove { old } => {
+                if is_event {
+                    // Event tables never have any resident rows.
+                    // As such, this is not a data migration; the table doesn't have any data in it to migrate.
+                    // However, changing the schema of an event table will break clients.
+
+                    // `row_type_changed`, `columns_added`, `event_schema_changed`
+                    Ok(ArrayMonoid([Any(false), Any(false), Any(true)]))
+                } else {
+                    Err(AutoMigrateError::RemoveColumn {
+                        table: old.table_name.clone(),
+                        column: old.name.clone(),
+                    }
+                    .into())
+                }
             }
-            .into()),
             Diff::MaybeChange { old, new } => {
                 // Check column type upgradability.
                 let old_ty = WithTypespace::new(plan.old.typespace(), &old.ty)
@@ -738,7 +764,16 @@ fn auto_migrate_table<'def>(plan: &mut AutoMigratePlan<'def>, old: &'def TableDe
                     &|| old.name.clone(),
                     &old_ty,
                     &new_ty,
-                );
+                )
+                .or_else(|err| {
+                    if is_event {
+                        // If this is an event table, it's fine to layout-incompatibly non-upgradably change the layout,
+                        // 'cause there can't be any rows to break.
+                        Ok(Any(true))
+                    } else {
+                        Err(err)
+                    }
+                });
 
                 // Note that the diff algorithm relies on `ModuleDefLookup` for `ColumnDef`,
                 // which looks up columns by NAME, NOT position: precisely to allow this step to work!
@@ -747,7 +782,9 @@ fn auto_migrate_table<'def>(plan: &mut AutoMigratePlan<'def>, old: &'def TableDe
                 // it must be in the same place in the new version of the table.
                 // This guarantees that any added columns live at the end of the table.
                 let positions_ok = if old.col_id == new.col_id {
-                    Ok(())
+                    Ok(Any(false))
+                } else if is_event {
+                    Ok(Any(true))
                 } else {
                     Err(AutoMigrateError::ReorderTable {
                         table: old.table_name.clone(),
@@ -757,19 +794,33 @@ fn auto_migrate_table<'def>(plan: &mut AutoMigratePlan<'def>, old: &'def TableDe
 
                 (types_ok, positions_ok)
                     .combine_errors()
-                    // row_type_changed, column_added
-                    .map(|(x, _)| ProductMonoid(x, Any(false)))
+                    // `row_type_changed`, `column_added`, `event_schema_changed`
+                    .map(|(types_changed, positions_changed)| {
+                        if is_event {
+                            // Event tables get a different auto-migrate step when their schema changes,
+                            // as they don't have any rows to rewrite. So we track a different element in the array of change types.
+                            ArrayMonoid([Any(false), Any(false), types_changed | positions_changed])
+                        } else {
+                            assert!(!positions_changed.0);
+                            ArrayMonoid([types_changed, Any(false), Any(false)])
+                        }
+                    })
             }
         }
     })
-    .collect_all_errors::<ProductMonoid<Any, Any>>();
+    .collect_all_errors::<ArrayMonoid<Any, 3>>();
 
-    let ((), (), ProductMonoid(Any(row_type_changed), Any(columns_added))) =
+    let ((), (), ArrayMonoid([Any(row_type_changed), Any(columns_added), Any(event_schema_changed)])) =
         (type_ok, event_ok, columns_ok).combine_errors()?;
 
-    // If we're adding a column, we'll rewrite the whole table.
-    // That makes any `ChangeColumns` moot, so we can skip it.
-    if columns_added {
+    if event_schema_changed {
+        // If we're rewriting an event table, there's no data migration to do.
+        // But incompatibly changing the schema can break clients.
+        plan.ensure_disconnect_all_users();
+        plan.steps.push(AutoMigrateStep::ReschemaEventTable(key));
+    } else if columns_added {
+        // If we're adding a column, we'll rewrite the whole table.
+        // That makes any `ChangeColumns` moot, so we can skip it.
         plan.ensure_disconnect_all_users();
         plan.steps.push(AutoMigrateStep::AddColumns(key));
     } else if row_type_changed {
@@ -780,7 +831,7 @@ fn auto_migrate_table<'def>(plan: &mut AutoMigratePlan<'def>, old: &'def TableDe
 }
 
 /// An "any" monoid with `false` as identity and `|` as the operator.
-#[derive(Default)]
+#[derive(Default, Copy, Clone)]
 struct Any(bool);
 
 impl FromIterator<Any> for Any {
@@ -796,22 +847,35 @@ impl BitOr for Any {
     }
 }
 
-/// A monoid that allows running two `Any`s in parallel.
-#[derive(Default)]
-struct ProductMonoid<M1, M2>(M1, M2);
+/// A monoid that allows running a number of `Any`s in parallel.
+struct ArrayMonoid<Monoid, const N: usize>([Monoid; N]);
 
-impl<M1: BitOr<Output = M1>, M2: BitOr<Output = M2>> BitOr for ProductMonoid<M1, M2> {
-    type Output = Self;
-
-    fn bitor(self, rhs: Self) -> Self::Output {
-        Self(self.0 | rhs.0, self.1 | rhs.1)
+impl<Monoid, const N: usize> Default for ArrayMonoid<Monoid, N>
+where
+    [Monoid; N]: Default,
+{
+    fn default() -> Self {
+        Self(Default::default())
     }
 }
 
-impl<M1: BitOr<Output = M1> + Default, M2: BitOr<Output = M2> + Default> FromIterator<ProductMonoid<M1, M2>>
-    for ProductMonoid<M1, M2>
+impl<Monoid: BitOr<Output = Monoid> + Copy, const N: usize> BitOr for ArrayMonoid<Monoid, N> {
+    type Output = Self;
+
+    fn bitor(mut self, rhs: Self) -> Self::Output {
+        for n in 0..N {
+            self.0[n] = self.0[n] | rhs.0[n]
+        }
+        self
+    }
+}
+
+impl<Monoid: BitOr<Output = Monoid> + Copy, const N: usize> FromIterator<ArrayMonoid<Monoid, N>>
+    for ArrayMonoid<Monoid, N>
+where
+    ArrayMonoid<Monoid, N>: Default,
 {
-    fn from_iter<T: IntoIterator<Item = ProductMonoid<M1, M2>>>(iter: T) -> Self {
+    fn from_iter<T: IntoIterator<Item = ArrayMonoid<Monoid, N>>>(iter: T) -> Self {
         iter.into_iter().reduce(|p1, p2| p1 | p2).unwrap_or_default()
     }
 }

--- a/crates/schema/src/auto_migrate/formatter.rs
+++ b/crates/schema/src/auto_migrate/formatter.rs
@@ -105,10 +105,17 @@ fn format_step<F: MigrationFormatter>(
             f.format_change_columns(&column_changes)
         }
         AutoMigrateStep::AddColumns(table) => {
+            // FIXME: It looks (pgoldman 2026-06-10) like `super::auto_migrate_table` will emit only `AddColumns`
+            // in the case where a table has both new columns and changed columns.
+            // As such, we probably need to call `extract_column_changes` here too.
             let new_columns = extract_new_columns(*table, plan)?;
             f.format_add_columns(&new_columns)
         }
         AutoMigrateStep::DisconnectAllUsers => f.format_disconnect_warning(),
+
+        // TODO(format-event-table-reschema): I (pgoldman 2026-06-10) didn't have time to meaningfully format event table reschemas,
+        // so for now we're just printing the table name.
+        AutoMigrateStep::ReschemaEventTable(table) => f.format_event_table_reschema(table),
     }?;
 
     Ok(())
@@ -167,6 +174,9 @@ pub trait MigrationFormatter {
     fn format_change_columns(&mut self, column_changes: &ColumnChanges) -> io::Result<()>;
     fn format_add_columns(&mut self, new_columns: &NewColumns) -> io::Result<()>;
     fn format_disconnect_warning(&mut self) -> io::Result<()>;
+    // TODO(format-event-table-reschema): I (pgoldman 2026-06-10) didn't have time to meaningfully format event table reschemas,
+    // so for now we're just printing the table name.
+    fn format_event_table_reschema(&mut self, table_name: &Identifier) -> io::Result<()>;
 }
 
 #[derive(Debug, Clone, PartialEq)]

--- a/crates/schema/src/auto_migrate/termcolor_formatter.rs
+++ b/crates/schema/src/auto_migrate/termcolor_formatter.rs
@@ -426,6 +426,18 @@ impl MigrationFormatter for TermColorFormatter {
         )?;
         self.buffer.write_all(b"\n")
     }
+
+    fn format_event_table_reschema(&mut self, table_name: &Identifier) -> io::Result<()> {
+        // TODO(format-event-table-reschema): I (pgoldman 2026-06-10) didn't have time to meaningfully format event table reschemas,
+        // so for now we're just printing the table name.
+
+        self.write_action_prefix(&Action::Changed)?;
+        self.buffer.write_all(format!(" schema of event table ").as_bytes())?;
+        self.write_colored(table_name, Some(self.colors.table_name), true)?;
+        self.buffer.write_all(b"\n")?;
+
+        Ok(())
+    }
 }
 
 trait ActionColorExt {

--- a/crates/schema/src/auto_migrate/termcolor_formatter.rs
+++ b/crates/schema/src/auto_migrate/termcolor_formatter.rs
@@ -432,7 +432,7 @@ impl MigrationFormatter for TermColorFormatter {
         // so for now we're just printing the table name.
 
         self.write_action_prefix(&Action::Changed)?;
-        self.buffer.write_all(format!(" schema of event table ").as_bytes())?;
+        self.buffer.write_all(b" schema of event table ")?;
         self.write_colored(table_name, Some(self.colors.table_name), true)?;
         self.buffer.write_all(b"\n")?;
 

--- a/crates/smoketests/tests/smoketests/auto_migration.rs
+++ b/crates/smoketests/tests/smoketests/auto_migration.rs
@@ -488,3 +488,58 @@ fn test_remove_primary_key_issue_3934() {
     test.publish_module_with_options(&identity, false, true)
         .expect("Publish after PK removal should succeed (issue #3934)");
 }
+
+const MODULE_CODE_WITH_EVENT_TABLE_BEFORE: &str = r#"
+use spacetimedb::{table, SpacetimeType};
+
+#[derive(SpacetimeType)]
+struct SomeProduct {
+    a: u32,
+    b: u64,
+}
+
+#[table(accessor = some_event, public, event)]
+struct SomeEvent {
+    foo: String,
+    prod: SomeProduct,
+}
+"#;
+
+const MODULE_CODE_WITH_EVENT_TABLE_AFTER: &str = r#"
+use spacetimedb::{table, SpacetimeType};
+
+#[derive(SpacetimeType)]
+struct SomeProduct {
+    a: u32,
+    b: u64,
+    c: u128,
+}
+
+#[table(accessor = some_event, public, event)]
+struct SomeEvent {
+    prod: SomeProduct,
+}
+"#;
+
+#[test]
+fn automigrate_reschema_event_table_arbitrarily() {
+    let mut test = Smoketest::builder()
+        .module_code(MODULE_CODE_WITH_EVENT_TABLE_BEFORE)
+        .build();
+
+    // Step 1: publish with event table.
+    let identity = test
+        .database_identity
+        .clone()
+        .expect("database should be published after build");
+
+    // Step 2: Reschema event table. Should work fine, even though we'd reject this change for a non-event table.
+    test.write_module_code(MODULE_CODE_WITH_EVENT_TABLE_AFTER).unwrap();
+    test.publish_module_with_options(&identity, false, true)
+        .expect("Changing schema of event table should succeed");
+
+    // Step 3: Reschema event table right back. Should still work fine.
+    test.write_module_code(MODULE_CODE_WITH_EVENT_TABLE_BEFORE).unwrap();
+    test.publish_module_with_options(&identity, false, true)
+        .expect("Changing schema of event table should succeed");
+}

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -343,6 +343,10 @@ fn table_row_type_dependents(row_type: ProductType) -> (RowTypeLayout, StaticLay
     (row_layout, static_layout, visitor_prog)
 }
 
+#[derive(Error, Debug)]
+#[error("Table is not empty")]
+pub struct TableNotEmptyError;
+
 // Public API:
 impl Table {
     /// Creates a new empty table with the given `schema` and `squashed_offset`.
@@ -364,6 +368,27 @@ impl Table {
         column_schemas: Vec<ColumnSchema>,
     ) -> Result<Vec<ColumnSchema>, Box<ChangeColumnsError>> {
         unsafe { self.change_columns_to_unchecked(column_schemas, Self::validate_row_type_layout) }
+    }
+
+    /// Like [`Self::change_columns_to`], but doesn't care if the new schema is compatible.
+    ///
+    /// Returns an error if there are any rows in `self`.
+    pub fn change_columns_of_empty_table_to(
+        &mut self,
+        column_schemas: Vec<ColumnSchema>,
+    ) -> Result<Vec<ColumnSchema>, TableNotEmptyError> {
+        if self.row_count > 0 {
+            return Err(TableNotEmptyError);
+        }
+        // Remove and drop any pages, as even though they must be empty,
+        // they may have residual layout-derived data which conflicts with the new schema.
+        // Safety: there aren't any pages here, so they cannot conflict with the schema or row layout.
+        unsafe { self.set_pages(Vec::new(), &NullBlobStore) };
+
+        // Safety: the table has no rows according to its row count,
+        // and no pages 'cause we just did `set_pages` to the empty vec.
+        unsafe { self.change_columns_to_unchecked(column_schemas, |_, _, _| Ok::<(), std::convert::Infallible>(())) }
+            .map_err(|e| match e {})
     }
 
     /// Validate that the old row type layout can be changed to the new.
@@ -477,6 +502,9 @@ impl Table {
     ///
     /// The caller must ensure, using `validate`,
     /// that `new_row_layout` is compatible with the rows existing in `self`.
+    ///
+    /// Or, the table must be entirely empty, containing zero rows and zero pages.
+    /// Zero pages is necessary because empty pages may contain layout-derived metadata.
     pub unsafe fn change_columns_to_unchecked<E>(
         &mut self,
         column_schemas: Vec<ColumnSchema>,


### PR DESCRIPTION
# Description of Changes

This commit adds special handling in automigrations to accept a broad set of schema- and layout-altering automigrations on event tables, including changes that we'd reject for non-event tables like removing or reordering columns, or layout-incompatibly changing the types of existing columns.

This is due to a change we want to make to the ControlDB schema, where we have a product type which is used both as a table type, and as the column type of an event table, and we want to add an element to that product type.

I've added a simple smoketest of the new behavior, `automigrate_reschema_event_table_arbitrarily`. Note that I have not tested commitlog replay of a database which has undergone one of these migrations, which has been a common place that bugs have appeared in similar changes in the past.

I have done a pretty lazy job with the migration plan formatter for the new step, just printing the name of the event table which is changing, not any information about the specific changes or the columns. This is in an effort to save time, as we'd like to release the ControlDB change blocked by this.

# API and ABI breaking changes

N/a

# Expected complexity level and risk

3 at least: new categories of automigrations have a high risk to introduce commitlog replay bugs, and it's also possible I have misunderstood or mis-remembered some of the safety invariants of the `table` crate.

# Testing

- [x] New (minimal) smoketest.
- [x] Manually tested replay:
  - Copied event table from the before version new smoketest into module-test.
  - Published module-test.
  - Replaced event table with after version, published, observed and approved client-breaking automigration.
  - Restarted SpacetimeDB.
  - Called the procedure `return_value` in the migrated module to force commitlog replay.
- [ ] Test the ControlDB change in staging, incl. restarting the control node.