### PR TITLE
Minor C# Cleanup

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -884,7 +884,8 @@ jobs:
         run: dotnet restore --configfile ../../../NuGet.Config blackholio.csproj
 
       - name: Build Godot project
-        run: godot --headless --verbose --path demo/Blackholio/client-godot --build-solutions --quit
+        working-directory: demo/Blackholio/client-godot
+        run: godot --headless --verbose --build-solutions --quit
 
       - name: Start SpacetimeDB
         run: |
@@ -898,7 +899,8 @@ jobs:
           bash ./publish.sh
 
       - name: Run Godot tests
-        run: godot --headless --path demo/Blackholio/client-godot --scene res://tests/GodotPlayModeTests.tscn
+        working-directory: demo/Blackholio/client-godot
+        run: godot --headless --scene res://tests/GodotPlayModeTests.tscn
 
   csharp-testsuite:
     needs: [lints]

--- a/crates/bindings-csharp/Runtime/Internal/Bounds.cs
+++ b/crates/bindings-csharp/Runtime/Internal/Bounds.cs
@@ -1,6 +1,3 @@
-using System.IO;
-using SpacetimeDB.BSATN;
-
 namespace SpacetimeDB
 {
     public readonly struct Bound<T>(T min, T max)
@@ -16,6 +13,8 @@ namespace SpacetimeDB
 
 namespace SpacetimeDB.Internal
 {
+    using SpacetimeDB.BSATN;
+
     enum BoundVariant : byte
     {
         Inclusive,

--- a/crates/bindings-csharp/Runtime/Internal/Module.cs
+++ b/crates/bindings-csharp/Runtime/Internal/Module.cs
@@ -567,7 +567,7 @@ public static class Module
         }
         catch (Exception e)
         {
-            var error_str = e.Message ?? e.GetType().FullName;
+            var error_str = e.Message;
             var error_bytes = System.Text.Encoding.UTF8.GetBytes(error_str);
             error.Write(error_bytes);
             return Errno.HOST_CALL_FAILURE;

--- a/crates/bindings-csharp/Runtime/TransactionalContextState.cs
+++ b/crates/bindings-csharp/Runtime/TransactionalContextState.cs
@@ -79,26 +79,26 @@ internal sealed class TransactionalContextState<TTxContext>(
         }
     }
 
-    private long StartMutTx()
+    private static long StartMutTx()
     {
         var status = FFI.procedure_start_mut_tx(out var micros);
         FFI.ErrnoHelpers.ThrowIfError(status);
         return micros;
     }
 
-    private void CommitMutTx()
+    private static void CommitMutTx()
     {
         var status = FFI.procedure_commit_mut_tx();
         FFI.ErrnoHelpers.ThrowIfError(status);
     }
 
-    private void AbortMutTx()
+    private static void AbortMutTx()
     {
         var status = FFI.procedure_abort_mut_tx();
         FFI.ErrnoHelpers.ThrowIfError(status);
     }
 
-    private bool CommitMutTxWithRetry(Func<bool> retryBody)
+    private static bool CommitMutTxWithRetry(Func<bool> retryBody)
     {
         try
         {

--- a/sdks/csharp/src/SpacetimeDBClient.cs
+++ b/sdks/csharp/src/SpacetimeDBClient.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Collections;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -133,6 +132,8 @@ namespace SpacetimeDB
         where DbConnection : DbConnectionBase<DbConnection, Tables, Reducer>, new()
         where Tables : RemoteTablesBase
     {
+        internal const bool IsTesting = false;
+
         public static DbConnectionBuilder<DbConnection> Builder() => new();
 
         internal event Action<Identity, string>? onConnect;
@@ -280,8 +281,7 @@ namespace SpacetimeDB
 
         private readonly BlockingCollection<ParsedMessage> _applyQueue =
             new(new ConcurrentQueue<ParsedMessage>());
-
-        internal static bool IsTesting;
+        
         internal bool HasMessageToApply => _applyQueue.Count > 0;
 
         private readonly CancellationTokenSource _parseCancellationTokenSource = new();

--- a/sdks/csharp/src/SpacetimeDBClient.cs
+++ b/sdks/csharp/src/SpacetimeDBClient.cs
@@ -281,7 +281,7 @@ namespace SpacetimeDB
 
         private readonly BlockingCollection<ParsedMessage> _applyQueue =
             new(new ConcurrentQueue<ParsedMessage>());
-        
+
         internal bool HasMessageToApply => _applyQueue.Count > 0;
 
         private readonly CancellationTokenSource _parseCancellationTokenSource = new();


### PR DESCRIPTION
# Description of Changes
Looking into failed `godot-testsuite` tests, I cleaned up some things that should remove some warnings from our logs.

# API and ABI breaking changes
None.

# Expected complexity level and risk
1. Extremely trivial.

# Testing
- [X] All tests still pass
