### PR TITLE
Unify index key representation in query plan

### DIFF
--- a/crates/core/src/estimation.rs
+++ b/crates/core/src/estimation.rs
@@ -4,7 +4,7 @@ use crate::{
 };
 use spacetimedb_datastore::locking_tx_datastore::{state_view::StateView as _, NumDistinctValues};
 use spacetimedb_lib::{identity::AuthCtx, query::Delta};
-use spacetimedb_physical_plan::plan::{HashJoin, IxJoin, IxScan, PhysicalPlan, Sarg, TableScan};
+use spacetimedb_physical_plan::plan::{HashJoin, IndexProbe, IxJoin, IxScan, PhysicalPlan, TableScan};
 use spacetimedb_primitives::{ColList, TableId};
 
 /// If the caller is not allowed to exceed the row limit,
@@ -43,16 +43,14 @@ pub fn estimate_rows_scanned(tx: &Tx, plan: &PhysicalPlan) -> u64 {
         PhysicalPlan::IxJoin(IxJoin { lhs, unique: true, .. }, _) => {
             estimate_rows_scanned(tx, lhs).saturating_add(row_estimate(tx, lhs))
         }
-        PhysicalPlan::IxJoin(
-            IxJoin {
-                lhs, rhs, rhs_field, ..
-            },
-            _,
-        ) => estimate_rows_scanned(tx, lhs).saturating_add(row_estimate(tx, lhs).saturating_mul(index_row_est(
-            tx,
-            rhs.table_id,
-            &ColList::from(*rhs_field),
-        ))),
+        PhysicalPlan::IxJoin(IxJoin { lhs, rhs, .. }, _) => {
+            let cols = plan_ix_join_cols(plan);
+            estimate_rows_scanned(tx, lhs).saturating_add(row_estimate(tx, lhs).saturating_mul(index_row_est(
+                tx,
+                rhs.table_id,
+                &cols,
+            )))
+        }
         PhysicalPlan::HashJoin(
             HashJoin {
                 lhs, rhs, unique: true, ..
@@ -90,13 +88,12 @@ pub fn row_estimate(tx: &Tx, plan: &PhysicalPlan) -> u64 {
         ) => 0,
         PhysicalPlan::IxScan(
             ix @ IxScan {
-                arg: Sarg::Eq(last_col, _),
+                probe: IndexProbe::Point(_),
                 ..
             },
             _,
         ) => {
-            let mut cols: ColList = ix.prefix.iter().map(|(c, _)| *c).collect();
-            cols.push(*last_col);
+            let cols = ix.index_cols().to_owned();
             index_row_est(tx, ix.schema.table_id, &cols)
         }
         PhysicalPlan::IxScan(IxScan { schema, .. }, _) => tx.table_row_count(schema.table_id).unwrap_or_default(),
@@ -104,16 +101,21 @@ pub fn row_estimate(tx: &Tx, plan: &PhysicalPlan) -> u64 {
         PhysicalPlan::NLJoin(lhs, rhs) => row_estimate(tx, lhs).saturating_mul(row_estimate(tx, rhs)),
         PhysicalPlan::IxJoin(IxJoin { lhs, unique: true, .. }, _)
         | PhysicalPlan::HashJoin(HashJoin { lhs, unique: true, .. }, _) => row_estimate(tx, lhs),
-        PhysicalPlan::IxJoin(
-            IxJoin {
-                lhs, rhs, rhs_field, ..
-            },
-            _,
-        ) => row_estimate(tx, lhs).saturating_mul(index_row_est(tx, rhs.table_id, &ColList::from(*rhs_field))),
+        PhysicalPlan::IxJoin(IxJoin { lhs, rhs, .. }, _) => {
+            let cols = plan_ix_join_cols(plan);
+            row_estimate(tx, lhs).saturating_mul(index_row_est(tx, rhs.table_id, &cols))
+        }
         PhysicalPlan::HashJoin(HashJoin { lhs, rhs, .. }, _) => {
             row_estimate(tx, lhs).saturating_mul(row_estimate(tx, rhs))
         }
     }
+}
+
+fn plan_ix_join_cols(plan: &PhysicalPlan) -> ColList {
+    let PhysicalPlan::IxJoin(join, _) = plan else {
+        unreachable!()
+    };
+    join.index_cols().to_owned()
 }
 
 /// The estimated number of rows that an index probe will return.

--- a/crates/core/src/subscription/metrics.rs
+++ b/crates/core/src/subscription/metrics.rs
@@ -64,6 +64,11 @@ fn extract_columns(
                 extract_columns(expr, schema, columns);
             }
         }
+        PhysicalExpr::Product(exprs) => {
+            for expr in exprs {
+                extract_columns(expr, schema, columns);
+            }
+        }
         PhysicalExpr::Value(_) => {}
     }
 }

--- a/crates/execution/src/pipelined.rs
+++ b/crates/execution/src/pipelined.rs
@@ -8,10 +8,10 @@ use itertools::Either;
 use spacetimedb_expr::expr::AggType;
 use spacetimedb_lib::{metrics::ExecutionMetrics, query::Delta, sats::size_of::SizeOf, AlgebraicValue, ProductValue};
 use spacetimedb_physical_plan::plan::{
-    HashJoin, IxJoin, IxScan, PhysicalExpr, PhysicalPlan, ProjectField, ProjectListPlan, ProjectPlan, Sarg, Semi,
+    HashJoin, IndexProbe, IxJoin, IxScan, PhysicalExpr, PhysicalPlan, ProjectField, ProjectListPlan, ProjectPlan, Semi,
     TableScan, TupleField,
 };
-use spacetimedb_primitives::{ColId, ColList, IndexId, TableId};
+use spacetimedb_primitives::{ColList, IndexId, TableId};
 use spacetimedb_sats::product;
 
 use crate::{Datastore, DeltaStore, Row, Tuple};
@@ -284,12 +284,8 @@ impl PipelinedProject {
 #[derive(Debug)]
 pub enum PipelinedExecutor {
     TableScan(PipelinedScan),
-    IxScanEq(PipelinedIxScanEq),
-    IxScanRange(PipelinedIxScanRange),
+    IxScan(PipelinedIxScan),
     IxJoin(PipelinedIxJoin),
-    IxDeltaScanEq(PipelinedIxDeltaScanEq),
-    IxDeltaScanRange(PipelinedIxDeltaScanRange),
-    IxDeltaJoin(PipelinedIxDeltaJoin),
     HashJoin(BlockingHashJoin),
     NLJoin(BlockingNLJoin),
     Filter(PipelinedFilter),
@@ -304,48 +300,15 @@ impl From<PhysicalPlan> for PipelinedExecutor {
                 limit,
                 delta,
             }),
-            PhysicalPlan::IxScan(
-                scan @ IxScan {
-                    delta: None,
-                    arg: Sarg::Eq(..),
-                    ..
-                },
-                _,
-            ) => Self::IxScanEq(scan.into()),
-            PhysicalPlan::IxScan(
-                scan @ IxScan {
-                    delta: None,
-                    arg: Sarg::Range(..),
-                    ..
-                },
-                _,
-            ) => Self::IxScanRange(scan.into()),
-            PhysicalPlan::IxScan(
-                scan @ IxScan {
-                    delta: Some(_),
-                    arg: Sarg::Eq(..),
-                    ..
-                },
-                _,
-            ) => Self::IxDeltaScanEq(scan.into()),
-            PhysicalPlan::IxScan(
-                scan @ IxScan {
-                    delta: Some(_),
-                    arg: Sarg::Range(..),
-                    ..
-                },
-                _,
-            ) => Self::IxDeltaScanRange(scan.into()),
+            PhysicalPlan::IxScan(scan, _) => Self::IxScan(scan.into()),
             PhysicalPlan::IxJoin(
                 IxJoin {
                     lhs,
                     rhs,
                     rhs_index,
-                    rhs_prefix,
-                    rhs_field,
                     unique,
-                    lhs_field,
-                    rhs_delta: None,
+                    probe,
+                    rhs_delta,
                     ..
                 },
                 semijoin,
@@ -353,33 +316,8 @@ impl From<PhysicalPlan> for PipelinedExecutor {
                 lhs: Box::new(Self::from(*lhs)),
                 rhs_table: rhs.table_id,
                 rhs_index,
-                rhs_prefix,
-                rhs_field,
-                lhs_field,
-                unique,
-                semijoin,
-            }),
-            PhysicalPlan::IxJoin(
-                IxJoin {
-                    lhs,
-                    rhs,
-                    rhs_index,
-                    rhs_prefix,
-                    rhs_field,
-                    unique,
-                    lhs_field,
-                    rhs_delta: Some(rhs_delta),
-                    ..
-                },
-                semijoin,
-            ) => Self::IxDeltaJoin(PipelinedIxDeltaJoin {
-                lhs: Box::new(Self::from(*lhs)),
-                rhs_table: rhs.table_id,
-                rhs_index,
-                rhs_prefix,
-                rhs_field,
-                rhs_delta,
-                lhs_field,
+                source: IndexSource::from_delta(rhs_delta),
+                probe,
                 unique,
                 semijoin,
             }),
@@ -418,7 +356,6 @@ impl PipelinedExecutor {
         f(self);
         match self {
             Self::IxJoin(PipelinedIxJoin { lhs: input, .. })
-            | Self::IxDeltaJoin(PipelinedIxDeltaJoin { lhs: input, .. })
             | Self::Filter(PipelinedFilter { input, .. })
             | Self::Limit(PipelinedLimit { input, .. }) => {
                 input.visit(f);
@@ -427,11 +364,7 @@ impl PipelinedExecutor {
                 lhs.visit(f);
                 rhs.visit(f);
             }
-            Self::TableScan(..)
-            | Self::IxScanEq(..)
-            | Self::IxScanRange(..)
-            | Self::IxDeltaScanEq(..)
-            | Self::IxDeltaScanRange(..) => {}
+            Self::TableScan(..) | Self::IxScan(..) => {}
         }
     }
 
@@ -439,12 +372,8 @@ impl PipelinedExecutor {
     pub fn is_empty(&self, tx: &impl DeltaStore) -> bool {
         match self {
             Self::TableScan(scan) => scan.is_empty(tx),
-            Self::IxScanEq(scan) => scan.is_empty(tx),
-            Self::IxScanRange(scan) => scan.is_empty(tx),
-            Self::IxDeltaScanEq(scan) => scan.is_empty(tx),
-            Self::IxDeltaScanRange(scan) => scan.is_empty(tx),
+            Self::IxScan(scan) => scan.is_empty(tx),
             Self::IxJoin(join) => join.is_empty(tx),
-            Self::IxDeltaJoin(join) => join.is_empty(tx),
             Self::HashJoin(join) => join.is_empty(tx),
             Self::NLJoin(join) => join.is_empty(tx),
             Self::Filter(filter) => filter.is_empty(tx),
@@ -460,12 +389,8 @@ impl PipelinedExecutor {
     ) -> Result<()> {
         match self {
             Self::TableScan(scan) => scan.execute(tx, metrics, f),
-            Self::IxScanEq(scan) => scan.execute(tx, metrics, f),
-            Self::IxScanRange(scan) => scan.execute(tx, metrics, f),
-            Self::IxDeltaScanEq(scan) => scan.execute(tx, metrics, f),
-            Self::IxDeltaScanRange(scan) => scan.execute(tx, metrics, f),
+            Self::IxScan(scan) => scan.execute(tx, metrics, f),
             Self::IxJoin(join) => join.execute(tx, metrics, f),
-            Self::IxDeltaJoin(join) => join.execute(tx, metrics, f),
             Self::HashJoin(join) => join.execute(tx, metrics, f),
             Self::NLJoin(join) => join.execute(tx, metrics, f),
             Self::Filter(filter) => filter.execute(tx, metrics, f),
@@ -548,426 +473,228 @@ impl PipelinedScan {
     }
 }
 
-/// A range index scan executor for a delta table.
-///
-/// TODO: There is much overlap between this executor and [PipelinedIxScanRange].
-/// But merging them requires merging the [Datastore] and [DeltaStore] traits,
-/// since the index scan interface is right now split between both.
+#[derive(Debug, Clone, Copy)]
+enum IndexSource {
+    Base,
+    Delta(Delta),
+}
+
+impl IndexSource {
+    fn from_delta(delta: Option<Delta>) -> Self {
+        match delta {
+            None => Self::Base,
+            Some(delta) => Self::Delta(delta),
+        }
+    }
+
+    fn is_empty(self, tx: &impl DeltaStore, table_id: TableId) -> bool {
+        match self {
+            Self::Base => false,
+            Self::Delta(Delta::Inserts) => !tx.has_inserts(table_id),
+            Self::Delta(Delta::Deletes) => !tx.has_deletes(table_id),
+        }
+    }
+}
+
 #[derive(Debug)]
-pub struct PipelinedIxDeltaScanRange {
-    /// The table id
-    pub table_id: TableId,
-    /// The index id
-    pub index_id: IndexId,
-    /// An equality prefix for multi-column scans
-    pub prefix: Vec<AlgebraicValue>,
-    /// The lower index bound
-    pub lower: Bound<AlgebraicValue>,
-    /// The upper index bound
-    pub upper: Bound<AlgebraicValue>,
-    /// Inserts or deletes?
-    pub delta: Delta,
+enum EvaluatedIndexProbe {
+    Point(AlgebraicValue),
+    Range(Bound<AlgebraicValue>, Bound<AlgebraicValue>),
 }
 
-impl From<IxScan> for PipelinedIxDeltaScanRange {
-    fn from(scan: IxScan) -> Self {
-        match scan {
-            IxScan {
-                schema,
-                index_id,
-                prefix,
-                arg: Sarg::Eq(_, v),
-                delta: Some(delta),
-                ..
-            } => Self {
-                table_id: schema.table_id,
-                index_id,
-                prefix: prefix.into_iter().map(|(_, v)| v).collect(),
-                lower: Bound::Included(v.clone()),
-                upper: Bound::Included(v),
-                delta,
-            },
-            IxScan {
-                schema,
-                index_id,
-                prefix,
-                arg: Sarg::Range(_, lower, upper),
-                delta: Some(delta),
-                ..
-            } => Self {
-                table_id: schema.table_id,
-                index_id,
-                prefix: prefix.into_iter().map(|(_, v)| v).collect(),
-                lower,
-                upper,
-                delta,
-            },
-            IxScan { delta: None, .. } => unreachable!(),
+impl From<IndexProbe> for EvaluatedIndexProbe {
+    fn from(probe: IndexProbe) -> Self {
+        match probe {
+            IndexProbe::Point(point) => Self::Point(eval_static_probe(point)),
+            IndexProbe::Range(lower, upper) => Self::Range(eval_static_bound(lower), eval_static_bound(upper)),
         }
     }
 }
 
-impl PipelinedIxDeltaScanRange {
-    /// Is the delta table empty?
-    pub fn is_empty(&self, tx: &impl DeltaStore) -> bool {
-        match self.delta {
-            Delta::Inserts => !tx.has_inserts(self.table_id),
-            Delta::Deletes => !tx.has_deletes(self.table_id),
-        }
-    }
-
-    pub fn execute<'a, Tx: Datastore + DeltaStore>(
-        &self,
-        tx: &'a Tx,
-        metrics: &mut ExecutionMetrics,
-        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
-    ) -> Result<()> {
-        let mut n = 0;
-        let mut f = |t| {
-            n += 1;
-            f(t)
-        };
-        match self.prefix.as_slice() {
-            [] => {
-                for ptr in tx
-                    .index_scan_range_for_delta(
-                        self.table_id,
-                        self.index_id,
-                        self.delta,
-                        (self.lower.as_ref(), self.upper.as_ref()),
-                    )
-                    .map(Tuple::Row)
-                {
-                    f(ptr)?;
-                }
-            }
-            prefix => {
-                for ptr in tx
-                    .index_scan_range_for_delta(
-                        self.table_id,
-                        self.index_id,
-                        self.delta,
-                        (
-                            self.lower
-                                .as_ref()
-                                .map(std::iter::once)
-                                .map(|iter| prefix.iter().chain(iter))
-                                .map(|iter| iter.cloned())
-                                .map(ProductValue::from_iter)
-                                .map(AlgebraicValue::Product),
-                            self.upper
-                                .as_ref()
-                                .map(std::iter::once)
-                                .map(|iter| prefix.iter().chain(iter))
-                                .map(|iter| iter.cloned())
-                                .map(ProductValue::from_iter)
-                                .map(AlgebraicValue::Product),
-                        ),
-                    )
-                    .map(Tuple::Row)
-                {
-                    f(ptr)?;
-                }
-            }
-        }
-        metrics.index_seeks += 1;
-        metrics.rows_scanned += n;
-        Ok(())
-    }
-}
-
-/// An equality index scan executor for a delta table.
-///
-/// TODO: There is much overlap between this executor and [PipelinedIxScanEq].
-/// But merging them requires merging the [Datastore] and [DeltaStore] traits,
-/// since the index scan interface is right now split between both.
+/// A pipelined executor for scanning an index.
 #[derive(Debug)]
-pub struct PipelinedIxDeltaScanEq {
-    /// The table id
+pub struct PipelinedIxScan {
+    /// The table id.
     pub table_id: TableId,
-    /// The index id
-    pub index_id: IndexId,
-    /// The point to scan the index for.
-    pub point: AlgebraicValue,
-    /// Inserts or deletes?
-    pub delta: Delta,
-}
-
-impl From<IxScan> for PipelinedIxDeltaScanEq {
-    fn from(scan: IxScan) -> Self {
-        match scan {
-            IxScan {
-                schema,
-                index_id,
-                prefix,
-                arg: Sarg::Eq(_, last),
-                delta: Some(delta),
-                ..
-            } => Self {
-                table_id: schema.table_id,
-                index_id,
-                point: combine_prefix_and_last(prefix, last),
-                delta,
-            },
-            IxScan { .. } => unreachable!(),
-        }
-    }
-}
-
-impl PipelinedIxDeltaScanEq {
-    /// Is the delta table empty?
-    pub fn is_empty(&self, tx: &impl DeltaStore) -> bool {
-        match self.delta {
-            Delta::Inserts => !tx.has_inserts(self.table_id),
-            Delta::Deletes => !tx.has_deletes(self.table_id),
-        }
-    }
-
-    pub fn execute<'a, Tx: Datastore + DeltaStore>(
-        &self,
-        tx: &'a Tx,
-        metrics: &mut ExecutionMetrics,
-        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
-    ) -> Result<()> {
-        let mut n = 0;
-        let mut f = |t| {
-            n += 1;
-            f(t)
-        };
-        for ptr in tx
-            .index_scan_point_for_delta(self.table_id, self.index_id, self.delta, &self.point)
-            .map(Tuple::Row)
-        {
-            f(ptr)?;
-        }
-
-        metrics.index_seeks += 1;
-        metrics.rows_scanned += n;
-        Ok(())
-    }
-}
-
-/// A pipelined executor for range scanning an index
-#[derive(Debug)]
-pub struct PipelinedIxScanRange {
-    /// The table id
-    pub table_id: TableId,
-    /// The index id
+    /// The index id.
     pub index_id: IndexId,
     pub limit: Option<u64>,
-    /// An equality prefix for multi-column scans
-    pub prefix: Vec<AlgebraicValue>,
-    /// The lower index bound
-    pub lower: Bound<AlgebraicValue>,
-    /// The upper index bound
-    pub upper: Bound<AlgebraicValue>,
+    source: IndexSource,
+    probe: EvaluatedIndexProbe,
 }
 
-impl From<IxScan> for PipelinedIxScanRange {
+impl From<IxScan> for PipelinedIxScan {
     fn from(scan: IxScan) -> Self {
-        match scan {
-            IxScan {
-                schema,
-                limit,
-                delta: None,
-                index_id,
-                prefix,
-                arg: Sarg::Eq(_, v),
-            } => Self {
-                table_id: schema.table_id,
-                index_id,
-                limit,
-                prefix: prefix.into_iter().map(|(_, v)| v).collect(),
-                lower: Bound::Included(v.clone()),
-                upper: Bound::Included(v),
-            },
-            IxScan {
-                schema,
-                limit,
-                delta: None,
-                index_id,
-                prefix,
-                arg: Sarg::Range(_, lower, upper),
-            } => Self {
-                table_id: schema.table_id,
-                index_id,
-                limit,
-                prefix: prefix.into_iter().map(|(_, v)| v).collect(),
-                lower,
-                upper,
-            },
-            IxScan { .. } => unreachable!(),
+        let IxScan {
+            schema,
+            index_id,
+            limit,
+            delta,
+            probe,
+        } = scan;
+        Self {
+            table_id: schema.table_id,
+            index_id,
+            limit,
+            source: IndexSource::from_delta(delta),
+            probe: probe.into(),
         }
     }
 }
 
-impl PipelinedIxScanRange {
-    /// We don't know statically if an index scan will return rows
-    pub fn is_empty(&self, _: &impl DeltaStore) -> bool {
-        false
-    }
+struct NoRow;
 
-    pub fn execute<'a, Tx: Datastore + DeltaStore>(
-        &self,
-        tx: &'a Tx,
-        metrics: &mut ExecutionMetrics,
-        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
-    ) -> Result<()> {
-        // A single column index scan
-        let single_col_scan = || {
-            tx.index_scan_range(
-                self.table_id,
-                self.index_id,
-                &(self.lower.as_ref(), self.upper.as_ref()),
-            )
-        };
-        // A single column index scan with optional row limit
-        let single_col_limit_scan = |limit| match limit {
-            None => single_col_scan().map(Either::Left),
-            Some(n) => single_col_scan().map(|iter| iter.take(n)).map(Either::Right),
-        };
-        // A multi-column index scan
-        let multi_col_scan = |prefix: &[AlgebraicValue]| {
-            tx.index_scan_range(
-                self.table_id,
-                self.index_id,
-                &(
-                    self.lower
-                        .as_ref()
-                        .map(std::iter::once)
-                        .map(|iter| prefix.iter().chain(iter))
-                        .map(|iter| iter.cloned())
-                        .map(ProductValue::from_iter)
-                        .map(AlgebraicValue::Product),
-                    self.upper
-                        .as_ref()
-                        .map(std::iter::once)
-                        .map(|iter| prefix.iter().chain(iter))
-                        .map(|iter| iter.cloned())
-                        .map(ProductValue::from_iter)
-                        .map(AlgebraicValue::Product),
-                ),
-            )
-        };
-        // A multi-column index scan with optional row limit
-        let multi_col_limit_scan = |prefix, limit| match limit {
-            None => multi_col_scan(prefix).map(Either::Left),
-            Some(n) => multi_col_scan(prefix).map(|iter| iter.take(n)).map(Either::Right),
-        };
-        let mut n = 0;
-        let mut f = |t| {
-            n += 1;
-            f(t)
-        };
-        match self.prefix.as_slice() {
-            [] => {
-                for ptr in single_col_limit_scan(self.limit.map(|n| n as usize))?
-                    .map(Row::Ptr)
-                    .map(Tuple::Row)
-                {
-                    f(ptr)?;
+impl ProjectField for NoRow {
+    fn project(&self, _: &TupleField) -> AlgebraicValue {
+        panic!("field expression in standalone index scan probe")
+    }
+}
+
+fn eval_static_probe(expr: PhysicalExpr) -> AlgebraicValue {
+    expr.eval_with_metrics(&NoRow, &mut 0).into_owned()
+}
+
+fn eval_static_bound(bound: Bound<PhysicalExpr>) -> Bound<AlgebraicValue> {
+    match bound {
+        Bound::Included(expr) => Bound::Included(eval_static_probe(expr)),
+        Bound::Excluded(expr) => Bound::Excluded(eval_static_probe(expr)),
+        Bound::Unbounded => Bound::Unbounded,
+    }
+}
+
+fn eval_probe(expr: &PhysicalExpr, row: &impl ProjectField, bytes_scanned: &mut usize) -> AlgebraicValue {
+    expr.eval_with_metrics(row, bytes_scanned).into_owned()
+}
+
+fn for_each_index_scan_row<'a, Tx: Datastore + DeltaStore>(
+    tx: &'a Tx,
+    source: IndexSource,
+    table_id: TableId,
+    index_id: IndexId,
+    probe: &EvaluatedIndexProbe,
+    limit: Option<u64>,
+    f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
+) -> Result<usize> {
+    // Datastore and DeltaStore expose different index iterator item types, so
+    // normalize both into Tuple at this boundary while keeping the traits split.
+    let mut n = 0;
+    let mut emit = |tuple| {
+        n += 1;
+        f(tuple)
+    };
+
+    match (source, probe) {
+        (IndexSource::Base, EvaluatedIndexProbe::Point(point)) => {
+            let scan = tx.index_scan_point(table_id, index_id, point)?;
+            match limit {
+                None => {
+                    for row in scan {
+                        emit(Tuple::Row(Row::Ptr(row)))?;
+                    }
                 }
-            }
-            prefix => {
-                for ptr in multi_col_limit_scan(prefix, self.limit.map(|n| n as usize))?
-                    .map(Row::Ptr)
-                    .map(Tuple::Row)
-                {
-                    f(ptr)?;
+                Some(limit) => {
+                    for row in scan.take(limit as usize) {
+                        emit(Tuple::Row(Row::Ptr(row)))?;
+                    }
                 }
             }
         }
-        metrics.index_seeks += 1;
-        metrics.rows_scanned += n;
-        Ok(())
-    }
-}
-
-/// A pipelined executor for equality scanning an index
-#[derive(Debug)]
-pub struct PipelinedIxScanEq {
-    /// The table id
-    pub table_id: TableId,
-    /// The index id
-    pub index_id: IndexId,
-    pub limit: Option<u64>,
-    /// The point to scan the index for.
-    pub point: AlgebraicValue,
-}
-
-impl From<IxScan> for PipelinedIxScanEq {
-    fn from(scan: IxScan) -> Self {
-        match scan {
-            IxScan {
-                schema,
-                limit,
-                delta: None,
-                index_id,
-                prefix,
-                arg: Sarg::Eq(_, last),
-            } => Self {
-                table_id: schema.table_id,
-                index_id,
-                limit,
-                point: combine_prefix_and_last(prefix, last),
-            },
-            IxScan { .. } => unreachable!(),
+        (IndexSource::Base, EvaluatedIndexProbe::Range(lower, upper)) => {
+            let scan = tx.index_scan_range(table_id, index_id, &(lower.as_ref(), upper.as_ref()))?;
+            match limit {
+                None => {
+                    for row in scan {
+                        emit(Tuple::Row(Row::Ptr(row)))?;
+                    }
+                }
+                Some(limit) => {
+                    for row in scan.take(limit as usize) {
+                        emit(Tuple::Row(Row::Ptr(row)))?;
+                    }
+                }
+            }
+        }
+        (IndexSource::Delta(delta), EvaluatedIndexProbe::Point(point)) => {
+            // Delta index scans did not apply IxScan::limit before this refactor.
+            for row in tx.index_scan_point_for_delta(table_id, index_id, delta, point) {
+                emit(Tuple::Row(row))?;
+            }
+        }
+        (IndexSource::Delta(delta), EvaluatedIndexProbe::Range(lower, upper)) => {
+            // Delta index scans did not apply IxScan::limit before this refactor.
+            for row in tx.index_scan_range_for_delta(table_id, index_id, delta, (lower.as_ref(), upper.as_ref())) {
+                emit(Tuple::Row(row))?;
+            }
         }
     }
+
+    Ok(n)
 }
 
-fn combine_prefix_and_last(prefix: Vec<(ColId, AlgebraicValue)>, last: AlgebraicValue) -> AlgebraicValue {
-    if prefix.is_empty() {
-        last
-    } else {
-        let mut elems = Vec::with_capacity(prefix.len() + 1);
-        elems.extend(prefix.into_iter().map(|(_, v)| v));
-        elems.push(last);
-        AlgebraicValue::product(elems)
+fn for_each_index_point<'a, Tx: Datastore + DeltaStore>(
+    tx: &'a Tx,
+    source: IndexSource,
+    table_id: TableId,
+    index_id: IndexId,
+    point: &AlgebraicValue,
+    f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
+) -> Result<()> {
+    match source {
+        IndexSource::Base => {
+            for row in tx.index_scan_point(table_id, index_id, point)? {
+                f(Tuple::Row(Row::Ptr(row)))?;
+            }
+        }
+        IndexSource::Delta(delta) => {
+            for row in tx.index_scan_point_for_delta(table_id, index_id, delta, point) {
+                f(Tuple::Row(row))?;
+            }
+        }
     }
+    Ok(())
 }
 
-fn combine_probe_prefix_and_last(prefix: &[AlgebraicValue], last: AlgebraicValue) -> AlgebraicValue {
-    if prefix.is_empty() {
-        last
-    } else {
-        AlgebraicValue::product(ProductValue::from_iter(
-            prefix.iter().cloned().chain(std::iter::once(last)),
-        ))
-    }
-}
-
-impl PipelinedIxScanEq {
-    /// We don't know statically if an index scan will return rows
-    pub fn is_empty(&self, _: &impl DeltaStore) -> bool {
-        false
-    }
-
-    pub fn execute<'a, Tx: Datastore + DeltaStore>(
-        &self,
-        tx: &'a Tx,
-        metrics: &mut ExecutionMetrics,
-        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
-    ) -> Result<()> {
-        // Scan without a row limit.
-        let scan = || tx.index_scan_point(self.table_id, self.index_id, &self.point);
-        // Scan with an optional row limit.
-        let scan_opt_limit = |limit| match limit {
-            None => scan().map(Either::Left),
-            Some(n) => scan().map(|iter| iter.take(n)).map(Either::Right),
-        };
-        let mut n = 0;
-        let mut f = |t| {
-            n += 1;
-            f(t)
-        };
-        for ptr in scan_opt_limit(self.limit.map(|n| n as usize))?
+fn first_index_point<'a, Tx: Datastore + DeltaStore>(
+    tx: &'a Tx,
+    source: IndexSource,
+    table_id: TableId,
+    index_id: IndexId,
+    point: &AlgebraicValue,
+) -> Result<Option<Tuple<'a>>> {
+    Ok(match source {
+        IndexSource::Base => tx
+            .index_scan_point(table_id, index_id, point)?
+            .next()
             .map(Row::Ptr)
-            .map(Tuple::Row)
-        {
-            f(ptr)?;
-        }
+            .map(Tuple::Row),
+        IndexSource::Delta(delta) => tx
+            .index_scan_point_for_delta(table_id, index_id, delta, point)
+            .next()
+            .map(Tuple::Row),
+    })
+}
 
+impl PipelinedIxScan {
+    /// Does this operation contain an empty delta scan?
+    pub fn is_empty(&self, tx: &impl DeltaStore) -> bool {
+        self.source.is_empty(tx, self.table_id)
+    }
+
+    pub fn execute<'a, Tx: Datastore + DeltaStore>(
+        &self,
+        tx: &'a Tx,
+        metrics: &mut ExecutionMetrics,
+        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
+    ) -> Result<()> {
+        let n = for_each_index_scan_row(
+            tx,
+            self.source,
+            self.table_id,
+            self.index_id,
+            &self.probe,
+            self.limit,
+            f,
+        )?;
         metrics.index_seeks += 1;
         metrics.rows_scanned += n;
         Ok(())
@@ -983,12 +710,9 @@ pub struct PipelinedIxJoin {
     pub rhs_table: TableId,
     /// The rhs index
     pub rhs_index: IndexId,
-    /// Constant prefix values for multi-column index probes.
-    pub rhs_prefix: Vec<AlgebraicValue>,
-    /// The rhs join field
-    pub rhs_field: ColId,
-    /// The lhs join field
-    pub lhs_field: TupleField,
+    source: IndexSource,
+    /// The point probe evaluated against each lhs tuple.
+    pub probe: PhysicalExpr,
     /// Is the index unique?
     pub unique: bool,
     /// Is this a semijoin?
@@ -998,7 +722,7 @@ pub struct PipelinedIxJoin {
 impl PipelinedIxJoin {
     /// Does this operation contain an empty delta scan?
     pub fn is_empty(&self, tx: &impl DeltaStore) -> bool {
-        self.lhs.is_empty(tx)
+        self.lhs.is_empty(tx) || self.source.is_empty(tx, self.rhs_table)
     }
 
     pub fn execute<'a, Tx: Datastore + DeltaStore>(
@@ -1011,312 +735,77 @@ impl PipelinedIxJoin {
         let mut index_seeks = 0;
         let mut bytes_scanned = 0;
 
-        let iter_rhs = |u: &Tuple, lhs_field: &TupleField, bytes_scanned: &mut usize| -> Result<_> {
-            let key = combine_probe_prefix_and_last(&self.rhs_prefix, project(u, lhs_field, bytes_scanned));
-            Ok(tx
-                .index_scan_point(self.rhs_table, self.rhs_index, &key)?
-                .map(Row::Ptr)
-                .map(Tuple::Row))
+        let iter_rhs =
+            |u: &Tuple, bytes_scanned: &mut usize, f: &mut dyn FnMut(Tuple<'a>) -> Result<()>| -> Result<()> {
+                let key = eval_probe(&self.probe, u, bytes_scanned);
+                for_each_index_point(tx, self.source, self.rhs_table, self.rhs_index, &key, f)
+            };
+
+        let probe_rhs = |u: &Tuple, bytes_scanned: &mut usize| -> Result<_> {
+            let key = eval_probe(&self.probe, u, bytes_scanned);
+            first_index_point(tx, self.source, self.rhs_table, self.rhs_index, &key)
         };
 
-        let probe_rhs = |u: &Tuple, lhs_field: &TupleField, bytes_scanned: &mut usize| -> Result<_> {
-            Ok(iter_rhs(u, lhs_field, bytes_scanned)?.next())
-        };
-
-        match self {
-            Self {
-                lhs,
-                lhs_field,
-                unique: true,
-                semijoin: Semi::Lhs,
-                ..
-            } => {
+        match (self.unique, self.semijoin) {
+            (true, Semi::Lhs) => {
                 // Should we evaluate the lhs tuple?
                 // Probe the index to see if there is a matching row.
-                lhs.execute(tx, metrics, &mut |u| {
+                self.lhs.execute(tx, metrics, &mut |u| {
                     n += 1;
                     index_seeks += 1;
-                    if probe_rhs(&u, lhs_field, &mut bytes_scanned)?.is_some() {
+                    if probe_rhs(&u, &mut bytes_scanned)?.is_some() {
                         f(u)?;
                     }
                     Ok(())
                 })?;
             }
-            Self {
-                lhs,
-                lhs_field,
-                unique: true,
-                semijoin: Semi::Rhs,
-                ..
-            } => {
+            (true, Semi::Rhs) => {
                 // Probe the index and evaluate the matching rhs row
-                lhs.execute(tx, metrics, &mut |u| {
+                self.lhs.execute(tx, metrics, &mut |u| {
                     n += 1;
                     index_seeks += 1;
-                    if let Some(v) = probe_rhs(&u, lhs_field, &mut bytes_scanned)? {
+                    if let Some(v) = probe_rhs(&u, &mut bytes_scanned)? {
                         f(v)?;
                     }
                     Ok(())
                 })?;
             }
-            Self {
-                lhs,
-                lhs_field,
-                unique: true,
-                semijoin: Semi::All,
-                ..
-            } => {
+            (true, Semi::All) => {
                 // Probe the index and evaluate the matching rhs row
-                lhs.execute(tx, metrics, &mut |u| {
+                self.lhs.execute(tx, metrics, &mut |u| {
                     n += 1;
                     index_seeks += 1;
-                    if let Some(v) = probe_rhs(&u, lhs_field, &mut bytes_scanned)? {
+                    if let Some(v) = probe_rhs(&u, &mut bytes_scanned)? {
                         f(u.join(v))?;
                     }
                     Ok(())
                 })?;
             }
-            Self {
-                lhs,
-                lhs_field,
-                unique: false,
-                semijoin: Semi::Lhs,
-                ..
-            } => {
+            (false, Semi::Lhs) => {
                 // How many times should we evaluate the lhs tuple?
                 // Probe the index for the number of matching rows.
-                lhs.execute(tx, metrics, &mut |u| {
+                self.lhs.execute(tx, metrics, &mut |u| {
                     n += 1;
                     index_seeks += 1;
-                    for _ in iter_rhs(&u, lhs_field, &mut bytes_scanned)? {
-                        f(u.clone())?;
-                    }
+                    iter_rhs(&u, &mut bytes_scanned, &mut |_| f(u.clone()))?;
                     Ok(())
                 })?;
             }
-            Self {
-                lhs,
-                lhs_field,
-                unique: false,
-                semijoin: Semi::Rhs,
-                ..
-            } => {
+            (false, Semi::Rhs) => {
                 // Probe the index and evaluate the matching rhs rows
-                lhs.execute(tx, metrics, &mut |u| {
+                self.lhs.execute(tx, metrics, &mut |u| {
                     n += 1;
                     index_seeks += 1;
-                    for v in iter_rhs(&u, lhs_field, &mut bytes_scanned)? {
-                        f(v)?;
-                    }
+                    iter_rhs(&u, &mut bytes_scanned, f)?;
                     Ok(())
                 })?;
             }
-            Self {
-                lhs,
-                lhs_field,
-                unique: false,
-                semijoin: Semi::All,
-                ..
-            } => {
+            (false, Semi::All) => {
                 // Probe the index and evaluate the matching rhs rows
-                lhs.execute(tx, metrics, &mut |u| {
+                self.lhs.execute(tx, metrics, &mut |u| {
                     n += 1;
                     index_seeks += 1;
-                    for v in iter_rhs(&u, lhs_field, &mut bytes_scanned)? {
-                        f(u.clone().join(v))?;
-                    }
-                    Ok(())
-                })?;
-            }
-        }
-        metrics.index_seeks += index_seeks;
-        metrics.rows_scanned += n;
-        metrics.bytes_scanned += bytes_scanned;
-        Ok(())
-    }
-}
-
-/// An index join executor where the index (rhs) side is a delta table.
-///
-/// TODO: There is much overlap between this executor and [PipelinedIxJoin].
-/// But merging them requires merging the [Datastore] and [DeltaStore] traits,
-/// since the index scan interface is right now split between both.
-#[derive(Debug)]
-pub struct PipelinedIxDeltaJoin {
-    /// The executor for the lhs of the join
-    pub lhs: Box<PipelinedExecutor>,
-    /// The rhs table
-    pub rhs_table: TableId,
-    /// Inserts or deletes?
-    pub rhs_delta: Delta,
-    /// The rhs index
-    pub rhs_index: IndexId,
-    /// Constant prefix values for multi-column index probes.
-    pub rhs_prefix: Vec<AlgebraicValue>,
-    /// The rhs join field
-    pub rhs_field: ColId,
-    /// The lhs join field
-    pub lhs_field: TupleField,
-    /// Is the index unique?
-    pub unique: bool,
-    /// Is this a semijoin?
-    pub semijoin: Semi,
-}
-
-impl PipelinedIxDeltaJoin {
-    /// Does this operation contain an empty delta scan?
-    pub fn is_empty(&self, tx: &impl DeltaStore) -> bool {
-        match self.rhs_delta {
-            Delta::Inserts => !tx.has_inserts(self.rhs_table) || self.lhs.is_empty(tx),
-            Delta::Deletes => !tx.has_deletes(self.rhs_table) || self.lhs.is_empty(tx),
-        }
-    }
-
-    pub fn execute<'a, Tx: Datastore + DeltaStore>(
-        &self,
-        tx: &'a Tx,
-        metrics: &mut ExecutionMetrics,
-        f: &mut dyn FnMut(Tuple<'a>) -> Result<()>,
-    ) -> Result<()> {
-        let mut n = 0;
-        let mut index_seeks = 0;
-        let mut bytes_scanned = 0;
-
-        match self {
-            Self {
-                lhs,
-                lhs_field,
-                unique: true,
-                semijoin: Semi::Lhs,
-                ..
-            } => {
-                // Should we evaluate the lhs tuple?
-                // Probe the index to see if there is a matching row.
-                lhs.execute(tx, metrics, &mut |u| {
-                    n += 1;
-                    index_seeks += 1;
-                    let key =
-                        combine_probe_prefix_and_last(&self.rhs_prefix, project(&u, lhs_field, &mut bytes_scanned));
-                    if tx
-                        .index_scan_point_for_delta(self.rhs_table, self.rhs_index, self.rhs_delta, &key)
-                        .next()
-                        .is_some()
-                    {
-                        f(u)?;
-                    }
-                    Ok(())
-                })?;
-            }
-            Self {
-                lhs,
-                lhs_field,
-                unique: true,
-                semijoin: Semi::Rhs,
-                ..
-            } => {
-                // Probe the index and evaluate the matching rhs row
-                lhs.execute(tx, metrics, &mut |u| {
-                    n += 1;
-                    index_seeks += 1;
-                    let key =
-                        combine_probe_prefix_and_last(&self.rhs_prefix, project(&u, lhs_field, &mut bytes_scanned));
-                    if let Some(v) = tx
-                        .index_scan_point_for_delta(self.rhs_table, self.rhs_index, self.rhs_delta, &key)
-                        .next()
-                        .map(Tuple::Row)
-                    {
-                        f(v)?;
-                    }
-                    Ok(())
-                })?;
-            }
-            Self {
-                lhs,
-                lhs_field,
-                unique: true,
-                semijoin: Semi::All,
-                ..
-            } => {
-                // Probe the index and evaluate the matching rhs row
-                lhs.execute(tx, metrics, &mut |u| {
-                    n += 1;
-                    index_seeks += 1;
-                    let key =
-                        combine_probe_prefix_and_last(&self.rhs_prefix, project(&u, lhs_field, &mut bytes_scanned));
-                    if let Some(v) = tx
-                        .index_scan_point_for_delta(self.rhs_table, self.rhs_index, self.rhs_delta, &key)
-                        .next()
-                        .map(Tuple::Row)
-                    {
-                        f(u.join(v))?;
-                    }
-                    Ok(())
-                })?;
-            }
-            Self {
-                lhs,
-                lhs_field,
-                unique: false,
-                semijoin: Semi::Lhs,
-                ..
-            } => {
-                // How many times should we evaluate the lhs tuple?
-                // Probe the index for the number of matching rows.
-                lhs.execute(tx, metrics, &mut |u| {
-                    n += 1;
-                    index_seeks += 1;
-                    let key =
-                        combine_probe_prefix_and_last(&self.rhs_prefix, project(&u, lhs_field, &mut bytes_scanned));
-                    for _ in 0..tx
-                        .index_scan_point_for_delta(self.rhs_table, self.rhs_index, self.rhs_delta, &key)
-                        .count()
-                    {
-                        f(u.clone())?;
-                    }
-                    Ok(())
-                })?;
-            }
-            Self {
-                lhs,
-                lhs_field,
-                unique: false,
-                semijoin: Semi::Rhs,
-                ..
-            } => {
-                // Probe the index and evaluate the matching rhs rows
-                lhs.execute(tx, metrics, &mut |u| {
-                    n += 1;
-                    index_seeks += 1;
-                    let key =
-                        combine_probe_prefix_and_last(&self.rhs_prefix, project(&u, lhs_field, &mut bytes_scanned));
-                    for v in tx
-                        .index_scan_point_for_delta(self.rhs_table, self.rhs_index, self.rhs_delta, &key)
-                        .map(Tuple::Row)
-                    {
-                        f(v)?;
-                    }
-                    Ok(())
-                })?;
-            }
-            Self {
-                lhs,
-                lhs_field,
-                unique: false,
-                semijoin: Semi::All,
-                ..
-            } => {
-                // Probe the index and evaluate the matching rhs rows
-                lhs.execute(tx, metrics, &mut |u| {
-                    n += 1;
-                    index_seeks += 1;
-                    let key =
-                        combine_probe_prefix_and_last(&self.rhs_prefix, project(&u, lhs_field, &mut bytes_scanned));
-                    for v in tx
-                        .index_scan_point_for_delta(self.rhs_table, self.rhs_index, self.rhs_delta, &key)
-                        .map(Tuple::Row)
-                    {
-                        f(u.clone().join(v.clone()))?;
-                    }
+                    iter_rhs(&u, &mut bytes_scanned, &mut |v| f(u.clone().join(v)))?;
                     Ok(())
                 })?;
             }

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -480,9 +480,9 @@ impl PhysicalPlan {
             .apply_rec::<PushConstAnd>()?
             .apply_rec::<PushConstEq>()?
             .apply_rec::<ReorderDeltaJoinRhs>()?
-            .apply_rec::<IxScanFromPredicates>()?
             .apply_rec::<ReorderHashJoin>()?
             .apply_rec::<HashToIxJoin>()?
+            .apply_rec::<IxScanFromPredicates>()?
             .apply_rec::<UniqueIxJoinRule>()?
             .apply_rec::<UniqueHashJoinRule>()?
             .introduce_semijoins(reqs)

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -1576,7 +1576,7 @@ mod tests {
 
     use crate::{
         compile::{compile_select, compile_select_list},
-        plan::{HashJoin, IndexProbe, IxScan, PhysicalPlan, ProjectListPlan, Semi, TupleField},
+        plan::{IndexProbe, IxScan, PhysicalPlan, ProjectListPlan, Semi, TupleField},
     };
 
     use super::{PhysicalExpr, ProjectPlan, TableScan};
@@ -2033,35 +2033,46 @@ mod tests {
         };
 
         // Plan:
-        //         rj
-        //        /  \
-        //       rx  ix(w)
+        //         s(v.employee = 5)
+        //          |
+        //          rx
+        //        /    \
+        //       rx     w
         //      /  \
         //     rx   w
         //    /  \
         // ix(m)  m
-        let (rhs, lhs) = match plan {
-            PhysicalPlan::HashJoin(
-                HashJoin {
-                    lhs,
-                    rhs,
-                    lhs_field: TupleField { field_pos: 1, .. },
-                    rhs_field: TupleField { field_pos: 1, .. },
-                    unique: true,
-                },
-                Semi::Rhs,
-            ) => (*rhs, *lhs),
+        let plan = match plan {
+            PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, lhs, rhs)) => {
+                assert!(matches!(
+                    (&*lhs, &*rhs),
+                    (
+                        PhysicalExpr::Field(TupleField { field_pos: 0, .. }),
+                        PhysicalExpr::Value(AlgebraicValue::U64(5))
+                    )
+                ));
+                *input
+            }
             plan => panic!("unexpected plan: {plan:#?}"),
         };
 
-        // Plan: ix(w)
-        match rhs {
-            PhysicalPlan::IxScan(IxScan { schema, probe, .. }, _) => {
-                assert_eq!(probe, IndexProbe::Point(value(AlgebraicValue::U64(5))));
-                assert_eq!(schema.table_id, w_id);
+        // Plan:
+        //         rx
+        //        /  \
+        //       rx   w
+        //      /  \
+        //     rx   w
+        //    /  \
+        // ix(m)  m
+        let plan = match plan {
+            PhysicalPlan::IxJoin(join, Semi::Rhs) => {
+                assert_eq!(join.rhs.table_id, w_id);
+                assert!(!join.unique);
+                assert_join_probe(&join, ColId(1), 1);
+                *join.lhs
             }
             plan => panic!("unexpected plan: {plan:#?}"),
-        }
+        };
 
         // Plan:
         //       rx
@@ -2069,7 +2080,7 @@ mod tests {
         //     rx   w
         //    /  \
         // ix(m)  m
-        let plan = match lhs {
+        let plan = match plan {
             PhysicalPlan::IxJoin(join, Semi::Rhs) => {
                 assert_eq!(join.rhs.table_id, w_id);
                 assert!(!join.unique);

--- a/crates/physical-plan/src/plan.rs
+++ b/crates/physical-plan/src/plan.rs
@@ -7,7 +7,7 @@ use spacetimedb_expr::{
     StatementSource,
 };
 use spacetimedb_lib::{identity::AuthCtx, query::Delta, sats::size_of::SizeOf, AlgebraicValue, ProductValue};
-use spacetimedb_primitives::{ColId, ColSet, IndexId, TableId, ViewId};
+use spacetimedb_primitives::{ColId, ColOrCols, ColSet, IndexId, TableId, ViewId};
 use spacetimedb_schema::schema::{IndexSchema, TableSchema};
 use spacetimedb_sql_parser::ast::{BinOp, LogOp};
 use spacetimedb_table::table::RowRef;
@@ -18,9 +18,8 @@ use std::{
 };
 
 use crate::rules::{
-    ComputePositions, HashToIxJoin, IxScanAnd, IxScanEq, IxScanEq2Col, IxScanEq3Col, PullFilterAboveHashJoin,
-    PushConstAnd, PushConstEq, PushLimit, ReorderDeltaJoinRhs, ReorderHashJoin, RewriteRule, UniqueHashJoinRule,
-    UniqueIxJoinRule,
+    ComputePositions, HashToIxJoin, IxScanFromPredicates, PushConstAnd, PushConstEq, PushLimit, ReorderDeltaJoinRhs,
+    ReorderHashJoin, RewriteRule, UniqueHashJoinRule, UniqueIxJoinRule,
 };
 
 /// Table aliases are replaced with labels in the physical plan
@@ -481,11 +480,7 @@ impl PhysicalPlan {
             .apply_rec::<PushConstAnd>()?
             .apply_rec::<PushConstEq>()?
             .apply_rec::<ReorderDeltaJoinRhs>()?
-            .apply_rec::<PullFilterAboveHashJoin>()?
-            .apply_rec::<IxScanEq3Col>()?
-            .apply_rec::<IxScanEq2Col>()?
-            .apply_rec::<IxScanEq>()?
-            .apply_rec::<IxScanAnd>()?
+            .apply_rec::<IxScanFromPredicates>()?
             .apply_rec::<ReorderHashJoin>()?
             .apply_rec::<HashToIxJoin>()?
             .apply_rec::<UniqueIxJoinRule>()?
@@ -505,14 +500,14 @@ impl PhysicalPlan {
                         }
                     });
                 }
-                Self::IxJoin(
-                    IxJoin {
-                        lhs_field: TupleField { label_pos: None, .. },
-                        ..
-                    },
-                    _,
-                )
-                | Self::HashJoin(
+                Self::IxJoin(IxJoin { probe, .. }, _) => {
+                    probe.visit(&mut |expr| {
+                        if let PhysicalExpr::Field(TupleField { label_pos: None, .. }) = expr {
+                            unresolved_name = true;
+                        }
+                    });
+                }
+                Self::HashJoin(
                     HashJoin {
                         lhs_field: TupleField { label_pos: None, .. },
                         ..
@@ -575,10 +570,8 @@ impl PhysicalPlan {
                     rhs,
                     rhs_label,
                     rhs_index,
-                    rhs_prefix,
-                    rhs_field,
                     unique,
-                    lhs_field,
+                    probe,
                     rhs_delta,
                 },
                 semi,
@@ -588,10 +581,8 @@ impl PhysicalPlan {
                     rhs,
                     rhs_label,
                     rhs_index,
-                    rhs_prefix,
-                    rhs_field,
                     unique,
-                    lhs_field,
+                    probe,
                     rhs_delta,
                 },
                 semi,
@@ -768,6 +759,13 @@ impl PhysicalPlan {
                 reqs.push(label);
             }
         };
+        let append_probe_required_labels = |plan: &PhysicalPlan, reqs: &mut Vec<Label>, probe: &PhysicalExpr| {
+            probe.visit(&mut |expr| {
+                if let PhysicalExpr::Field(TupleField { label, .. }) = expr {
+                    append_required_label(plan, reqs, *label);
+                }
+            });
+        };
         match self {
             Self::Filter(input, expr) => {
                 expr.visit(&mut |expr| {
@@ -831,23 +829,21 @@ impl PhysicalPlan {
                 )
             }
             Self::IxJoin(join, Semi::All) if reqs.len() == 1 && join.rhs_label == reqs[0] => {
-                let lhs = join.lhs.introduce_semijoins(vec![join.lhs_field.label]);
+                let mut lhs_reqs = vec![];
+                append_probe_required_labels(&join.lhs, &mut lhs_reqs, &join.probe);
+                let lhs = join.lhs.introduce_semijoins(lhs_reqs);
                 let lhs = Box::new(lhs);
                 Self::IxJoin(IxJoin { lhs, ..join }, Semi::Rhs)
             }
             Self::IxJoin(join, Semi::All) if reqs.iter().all(|var| *var != join.rhs_label) => {
-                if !reqs.contains(&join.lhs_field.label) {
-                    reqs.push(join.lhs_field.label);
-                }
+                append_probe_required_labels(&join.lhs, &mut reqs, &join.probe);
                 let lhs = join.lhs.introduce_semijoins(reqs);
                 let lhs = Box::new(lhs);
                 Self::IxJoin(IxJoin { lhs, ..join }, Semi::Lhs)
             }
             Self::IxJoin(join, Semi::All) => {
                 let mut reqs: Vec<_> = reqs.into_iter().filter(|label| label != &join.rhs_label).collect();
-                if !reqs.contains(&join.lhs_field.label) {
-                    reqs.push(join.lhs_field.label);
-                }
+                append_probe_required_labels(&join.lhs, &mut reqs, &join.probe);
                 let lhs = join.lhs.introduce_semijoins(reqs);
                 let lhs = Box::new(lhs);
                 Self::IxJoin(IxJoin { lhs, ..join }, Semi::All)
@@ -862,21 +858,12 @@ impl PhysicalPlan {
             // Is there a unique constraint for these cols?
             Self::TableScan(TableScan { schema, .. }, var) => var == label && schema.as_ref().is_unique(&**cols),
             // Is there a unique constraint for these cols + the index cols?
-            Self::IxScan(
-                IxScan {
-                    schema,
-                    prefix,
-                    arg: Sarg::Eq(col, _),
-                    ..
-                },
-                var,
-            ) => {
+            Self::IxScan(scan, var) if var == label && matches!(&scan.probe, IndexProbe::Point(_)) => {
                 var == label
-                    && schema.as_ref().is_unique(&*ColSet::from_iter(
-                        cols.iter()
-                            .chain(prefix.iter().map(|(col_id, _)| *col_id))
-                            .chain(vec![*col]),
-                    ))
+                    && scan
+                        .schema
+                        .as_ref()
+                        .is_unique(&*ColSet::from_iter(cols.iter().chain(scan.index_cols().iter())))
             }
             // If the table in question is on the lhs,
             // and if the lhs returns distinct values,
@@ -890,22 +877,11 @@ impl PhysicalPlan {
             // and if the rhs returns distinct values,
             // we must not probe the rhs for the same value more than once.
             // Hence the lhs must be distinct w.r.t the probe field.
-            Self::IxJoin(
-                IxJoin {
-                    lhs,
-                    rhs,
-                    lhs_field:
-                        TupleField {
-                            label: lhs_label,
-                            field_pos: lhs_field_pos,
-                            ..
-                        },
-                    ..
-                },
-                _,
-            ) => {
-                lhs.returns_distinct_values(lhs_label, &ColSet::from(ColId(*lhs_field_pos as u16)))
-                    && rhs.as_ref().is_unique(&**cols)
+            Self::IxJoin(join @ IxJoin { lhs, rhs, .. }, _) => {
+                join.single_probe_field().is_some_and(|(_, lhs_field)| {
+                    lhs.returns_distinct_values(&lhs_field.label, &ColSet::from(ColId(lhs_field.field_pos as u16)))
+                        && rhs.as_ref().is_unique(&**cols)
+                })
             }
             // If the table in question is on the lhs,
             // and if the lhs returns distinct values,
@@ -1097,14 +1073,10 @@ impl PhysicalPlan {
     pub fn search_args(&self) -> Vec<(TableId, ColId, AlgebraicValue)> {
         let mut args = vec![];
         self.visit(&mut |op| match op {
-            PhysicalPlan::IxScan(
-                scan @ IxScan {
-                    arg: Sarg::Eq(col_id, value),
-                    ..
-                },
-                _,
-            ) if scan.prefix.is_empty() => {
-                args.push((scan.schema.table_id, *col_id, value.clone()));
+            PhysicalPlan::IxScan(scan, _) => {
+                if let Some((col_id, value)) = scan.single_col_lit_point() {
+                    args.push((scan.schema.table_id, col_id, value.clone()));
+                }
             }
             PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, a, b)) => {
                 if let (PhysicalExpr::Field(field), PhysicalExpr::Value(value)) = (&**a, &**b) {
@@ -1205,16 +1177,14 @@ pub struct IxScan {
     pub delta: Option<Delta>,
     /// The index id
     pub index_id: IndexId,
-    /// An equality prefix for multi-column scans
-    pub prefix: Vec<(ColId, AlgebraicValue)>,
-    /// The index argument
-    pub arg: Sarg,
+    /// The expression used to probe the index.
+    pub probe: IndexProbe,
 }
 
-/// An index [S]earch [arg]ument
+/// The key expression for an index scan.
 #[derive(Debug, Clone, PartialEq, Eq)]
-pub enum Sarg {
-    Eq(ColId, AlgebraicValue),
+pub enum IndexProbe {
+    Point(PhysicalExpr),
     /// NOTE(centril): We currently never construct this variant.
     /// We do have non-ranged hash indices.
     /// This means that when we get around to using this variant,
@@ -1226,7 +1196,7 @@ pub enum Sarg {
     /// We also currently do not emit such `IxScan`s where the number
     /// of equalities provided are fewer than the number of columns in the index.
     /// When we do, we must also account for hash indices in the rewrite rules.
-    Range(ColId, Bound<AlgebraicValue>, Bound<AlgebraicValue>),
+    Range(Bound<PhysicalExpr>, Bound<PhysicalExpr>),
 }
 
 /// A join of two relations on a single equality condition.
@@ -1254,18 +1224,138 @@ pub struct IxJoin {
     pub rhs_label: Label,
     /// The index id
     pub rhs_index: IndexId,
-    /// Optional constant prefix values for multi-column index probes.
-    pub rhs_prefix: Vec<AlgebraicValue>,
-    /// The index field
-    pub rhs_field: ColId,
     /// Is the index a unique constraint index?
     pub unique: bool,
-    /// The expression for computing probe values.
-    /// Values are projected from the lhs,
-    /// and used to probe the index on the rhs.
-    pub lhs_field: TupleField,
+    /// The point expression for computing probe values from the lhs.
+    pub probe: PhysicalExpr,
     // Is the rhs a delta table?
     pub rhs_delta: Option<Delta>,
+}
+
+/// Build a single physical key expression for an index probe.
+///
+/// Single-column keys are represented directly. Composite keys are represented
+/// as products and evaluated at runtime. This intentionally does not fold
+/// all-literal products in the physical plan.
+pub fn index_key_expr(mut parts: Vec<PhysicalExpr>) -> PhysicalExpr {
+    if parts.len() == 1 {
+        parts.pop().unwrap()
+    } else {
+        PhysicalExpr::Product(parts)
+    }
+}
+
+fn schema_index_cols(schema: &TableSchema, index_id: IndexId) -> ColOrCols<'_> {
+    schema
+        .indexes
+        .iter()
+        .find(|index| index.index_id == index_id)
+        .expect("physical plan referenced missing index")
+        .index_algorithm
+        .columns()
+}
+
+fn align_index_key_components<'a>(
+    cols: ColOrCols<'_>,
+    expr: &'a PhysicalExpr,
+) -> Option<Vec<(ColId, &'a PhysicalExpr)>> {
+    let cols = cols.iter().collect::<Vec<_>>();
+    match expr {
+        PhysicalExpr::Product(parts) if parts.len() == cols.len() => Some(cols.into_iter().zip(parts.iter()).collect()),
+        _ if cols.len() == 1 => Some(vec![(cols[0], expr)]),
+        _ => None,
+    }
+}
+
+impl IndexProbe {
+    pub fn visit(&self, f: &mut impl FnMut(&PhysicalExpr)) {
+        match self {
+            Self::Point(expr) => expr.visit(f),
+            Self::Range(lower, upper) => {
+                match lower {
+                    Bound::Included(expr) | Bound::Excluded(expr) => expr.visit(f),
+                    Bound::Unbounded => {}
+                }
+                match upper {
+                    Bound::Included(expr) | Bound::Excluded(expr) => expr.visit(f),
+                    Bound::Unbounded => {}
+                }
+            }
+        }
+    }
+
+    pub fn visit_mut(&mut self, f: &mut impl FnMut(&mut PhysicalExpr)) {
+        match self {
+            Self::Point(expr) => expr.visit_mut(f),
+            Self::Range(lower, upper) => {
+                match lower {
+                    Bound::Included(expr) | Bound::Excluded(expr) => expr.visit_mut(f),
+                    Bound::Unbounded => {}
+                }
+                match upper {
+                    Bound::Included(expr) | Bound::Excluded(expr) => expr.visit_mut(f),
+                    Bound::Unbounded => {}
+                }
+            }
+        }
+    }
+}
+
+impl IxScan {
+    pub fn index_cols(&self) -> ColOrCols<'_> {
+        schema_index_cols(&self.schema, self.index_id)
+    }
+
+    pub fn literal_eq_terms(&self) -> Option<Vec<(ColId, AlgebraicValue)>> {
+        let IndexProbe::Point(expr) = &self.probe else {
+            return None;
+        };
+
+        let mut terms = Vec::new();
+        for (col, expr) in align_index_key_components(self.index_cols(), expr)? {
+            let PhysicalExpr::Value(value) = expr else {
+                return None;
+            };
+            terms.push((col, value.clone()));
+        }
+        Some(terms)
+    }
+
+    pub fn single_col_lit_point(&self) -> Option<(ColId, &AlgebraicValue)> {
+        let IndexProbe::Point(expr) = &self.probe else {
+            return None;
+        };
+        let components = align_index_key_components(self.index_cols(), expr)?;
+        let [(col, PhysicalExpr::Value(value))] = components.as_slice() else {
+            return None;
+        };
+        Some((*col, value))
+    }
+}
+
+impl IxJoin {
+    pub fn index_cols(&self) -> ColOrCols<'_> {
+        schema_index_cols(&self.rhs, self.rhs_index)
+    }
+
+    pub fn probe_field_components(&self) -> Vec<(ColId, &TupleField)> {
+        align_index_key_components(self.index_cols(), &self.probe)
+            .unwrap_or_default()
+            .into_iter()
+            .filter_map(|(col, expr)| match expr {
+                PhysicalExpr::Field(field) => Some((col, field)),
+                _ => None,
+            })
+            .collect()
+    }
+
+    pub fn single_probe_field(&self) -> Option<(ColId, &TupleField)> {
+        let fields = self.probe_field_components();
+        let [(col, field)] = fields.as_slice() else {
+            return None;
+        };
+        Some((*col, *field))
+    }
 }
 
 /// Is this a semijoin?
@@ -1282,6 +1372,8 @@ pub enum Semi {
 pub enum PhysicalExpr {
     /// An n-ary logic expression
     LogOp(LogOp, Vec<PhysicalExpr>),
+    /// A composite value expression, used primarily for multi-column index keys.
+    Product(Vec<PhysicalExpr>),
     /// A binary expression
     BinOp(BinOp, Box<PhysicalExpr>, Box<PhysicalExpr>),
     /// A constant algebraic value
@@ -1324,6 +1416,11 @@ impl PhysicalExpr {
                     expr.visit(f);
                 }
             }
+            Self::Product(exprs) => {
+                for expr in exprs {
+                    expr.visit(f);
+                }
+            }
             _ => {}
         }
     }
@@ -1341,6 +1438,11 @@ impl PhysicalExpr {
                     expr.visit_mut(f);
                 }
             }
+            Self::Product(exprs) => {
+                for expr in exprs {
+                    expr.visit_mut(f);
+                }
+            }
             _ => {}
         }
     }
@@ -1352,6 +1454,7 @@ impl PhysicalExpr {
             field @ Self::Field(..) => field,
             Self::BinOp(op, a, b) => Self::BinOp(op, Box::new(a.map(f)), Box::new(b.map(f))),
             Self::LogOp(op, exprs) => Self::LogOp(op, exprs.into_iter().map(|expr| expr.map(f)).collect()),
+            Self::Product(exprs) => Self::Product(exprs.into_iter().map(|expr| expr.map(f)).collect()),
         }
     }
 
@@ -1374,7 +1477,7 @@ impl PhysicalExpr {
     }
 
     /// Evaluate this expression over `row`
-    fn eval_with_metrics(&self, row: &impl ProjectField, bytes_scanned: &mut usize) -> Cow<'_, AlgebraicValue> {
+    pub fn eval_with_metrics(&self, row: &impl ProjectField, bytes_scanned: &mut usize) -> Cow<'_, AlgebraicValue> {
         fn eval_bin_op(op: BinOp, a: &AlgebraicValue, b: &AlgebraicValue) -> bool {
             match op {
                 BinOp::Eq => a == b,
@@ -1404,6 +1507,12 @@ impl PhysicalExpr {
                     // ANY is equivalent to OR
                     .any(|expr| expr.eval_bool_with_metrics(row, bytes_scanned)),
             ),
+            Self::Product(exprs) => Cow::Owned(AlgebraicValue::product(
+                exprs
+                    .iter()
+                    .map(|expr| expr.eval_with_metrics(row, bytes_scanned).into_owned())
+                    .collect::<ProductValue>(),
+            )),
             Self::Field(field) => {
                 let value = row.project(field);
                 *bytes_scanned += value.size_of();
@@ -1428,6 +1537,7 @@ impl PhysicalExpr {
                     .collect(),
             ),
             Self::BinOp(op, a, b) => Self::BinOp(op, Box::new(a.flatten()), Box::new(b.flatten())),
+            Self::Product(exprs) => Self::Product(exprs.into_iter().map(Self::flatten).collect()),
             Self::Field(..) | Self::Value(..) => self,
         }
     }
@@ -1466,7 +1576,7 @@ mod tests {
 
     use crate::{
         compile::{compile_select, compile_select_list},
-        plan::{HashJoin, IxJoin, IxScan, PhysicalPlan, ProjectListPlan, Sarg, Semi, TupleField},
+        plan::{HashJoin, IndexProbe, IxScan, PhysicalPlan, ProjectListPlan, Semi, TupleField},
     };
 
     use super::{PhysicalExpr, ProjectPlan, TableScan};
@@ -1553,6 +1663,21 @@ mod tests {
     /// A wrapper around [spacetimedb_expr::check::parse_and_type_sub] that takes a dummy [AuthCtx]
     fn parse_and_type_sub(sql: &str, tx: &impl SchemaView) -> TypingResult<ProjectName> {
         spacetimedb_expr::check::parse_and_type_sub(sql, tx, &AuthCtx::for_testing()).map(|(plan, _)| plan)
+    }
+
+    fn assert_join_probe(join: &super::IxJoin, rhs_col: ColId, lhs_field_pos: usize) {
+        assert_eq!(
+            join.single_probe_field().map(|(col, field)| (col, field.field_pos)),
+            Some((rhs_col, lhs_field_pos))
+        );
+    }
+
+    fn value(value: AlgebraicValue) -> PhysicalExpr {
+        PhysicalExpr::Value(value)
+    }
+
+    fn product(values: Vec<AlgebraicValue>) -> PhysicalExpr {
+        PhysicalExpr::Product(values.into_iter().map(value).collect())
     }
 
     /// No rewrites applied to a simple table scan
@@ -1733,19 +1858,11 @@ mod tests {
         //    /  \
         // ix(u)  l
         let plan = match plan {
-            PhysicalPlan::IxJoin(
-                IxJoin {
-                    lhs,
-                    rhs,
-                    rhs_field: ColId(0),
-                    unique: true,
-                    lhs_field: TupleField { field_pos: 0, .. },
-                    ..
-                },
-                Semi::Rhs,
-            ) => {
-                assert_eq!(rhs.table_id, b_id);
-                *lhs
+            PhysicalPlan::IxJoin(join, Semi::Rhs) => {
+                assert_eq!(join.rhs.table_id, b_id);
+                assert!(join.unique);
+                assert_join_probe(&join, ColId(0), 0);
+                *join.lhs
             }
             plan => panic!("unexpected plan: {plan:#?}"),
         };
@@ -1757,19 +1874,11 @@ mod tests {
         //    /  \
         // ix(u)  l
         let plan = match plan {
-            PhysicalPlan::IxJoin(
-                IxJoin {
-                    lhs,
-                    rhs,
-                    rhs_field: ColId(1),
-                    unique: false,
-                    lhs_field: TupleField { field_pos: 1, .. },
-                    ..
-                },
-                Semi::Rhs,
-            ) => {
-                assert_eq!(rhs.table_id, l_id);
-                *lhs
+            PhysicalPlan::IxJoin(join, Semi::Rhs) => {
+                assert_eq!(join.rhs.table_id, l_id);
+                assert!(!join.unique);
+                assert_join_probe(&join, ColId(1), 1);
+                *join.lhs
             }
             plan => panic!("unexpected plan: {plan:#?}"),
         };
@@ -1779,35 +1888,19 @@ mod tests {
         //    /  \
         // ix(u)  l
         let plan = match plan {
-            PhysicalPlan::IxJoin(
-                IxJoin {
-                    lhs,
-                    rhs,
-                    rhs_field: ColId(0),
-                    unique: true,
-                    lhs_field: TupleField { field_pos: 1, .. },
-                    ..
-                },
-                Semi::Rhs,
-            ) => {
-                assert_eq!(rhs.table_id, l_id);
-                *lhs
+            PhysicalPlan::IxJoin(join, Semi::Rhs) => {
+                assert_eq!(join.rhs.table_id, l_id);
+                assert!(join.unique);
+                assert_join_probe(&join, ColId(0), 1);
+                *join.lhs
             }
             plan => panic!("unexpected plan: {plan:#?}"),
         };
 
         // Plan: ix(u)
         match plan {
-            PhysicalPlan::IxScan(
-                IxScan {
-                    schema,
-                    prefix,
-                    arg: Sarg::Eq(ColId(0), AlgebraicValue::U64(5)),
-                    ..
-                },
-                _,
-            ) => {
-                assert!(prefix.is_empty());
+            PhysicalPlan::IxScan(IxScan { schema, probe, .. }, _) => {
+                assert_eq!(probe, IndexProbe::Point(value(AlgebraicValue::U64(5))));
                 assert_eq!(schema.table_id, u_id);
             }
             plan => panic!("unexpected plan: {plan:#?}"),
@@ -1930,19 +2023,11 @@ mod tests {
         //    /  \
         // ix(m)  m
         let plan = match plan {
-            PhysicalPlan::IxJoin(
-                IxJoin {
-                    lhs,
-                    rhs,
-                    rhs_field: ColId(0),
-                    unique: true,
-                    lhs_field: TupleField { field_pos: 1, .. },
-                    ..
-                },
-                Semi::Rhs,
-            ) => {
-                assert_eq!(rhs.table_id, p_id);
-                *lhs
+            PhysicalPlan::IxJoin(join, Semi::Rhs) => {
+                assert_eq!(join.rhs.table_id, p_id);
+                assert!(join.unique);
+                assert_join_probe(&join, ColId(0), 1);
+                *join.lhs
             }
             plan => panic!("unexpected plan: {plan:#?}"),
         };
@@ -1971,16 +2056,8 @@ mod tests {
 
         // Plan: ix(w)
         match rhs {
-            PhysicalPlan::IxScan(
-                IxScan {
-                    schema,
-                    prefix,
-                    arg: Sarg::Eq(ColId(0), AlgebraicValue::U64(5)),
-                    ..
-                },
-                _,
-            ) => {
-                assert!(prefix.is_empty());
+            PhysicalPlan::IxScan(IxScan { schema, probe, .. }, _) => {
+                assert_eq!(probe, IndexProbe::Point(value(AlgebraicValue::U64(5))));
                 assert_eq!(schema.table_id, w_id);
             }
             plan => panic!("unexpected plan: {plan:#?}"),
@@ -1993,19 +2070,11 @@ mod tests {
         //    /  \
         // ix(m)  m
         let plan = match lhs {
-            PhysicalPlan::IxJoin(
-                IxJoin {
-                    lhs,
-                    rhs,
-                    rhs_field: ColId(0),
-                    unique: false,
-                    lhs_field: TupleField { field_pos: 0, .. },
-                    ..
-                },
-                Semi::Rhs,
-            ) => {
-                assert_eq!(rhs.table_id, w_id);
-                *lhs
+            PhysicalPlan::IxJoin(join, Semi::Rhs) => {
+                assert_eq!(join.rhs.table_id, w_id);
+                assert!(!join.unique);
+                assert_join_probe(&join, ColId(0), 0);
+                *join.lhs
             }
             plan => panic!("unexpected plan: {plan:#?}"),
         };
@@ -2015,35 +2084,19 @@ mod tests {
         //    /  \
         // ix(m)  m
         let plan = match plan {
-            PhysicalPlan::IxJoin(
-                IxJoin {
-                    lhs,
-                    rhs,
-                    rhs_field: ColId(1),
-                    unique: false,
-                    lhs_field: TupleField { field_pos: 1, .. },
-                    ..
-                },
-                Semi::Rhs,
-            ) => {
-                assert_eq!(rhs.table_id, m_id);
-                *lhs
+            PhysicalPlan::IxJoin(join, Semi::Rhs) => {
+                assert_eq!(join.rhs.table_id, m_id);
+                assert!(!join.unique);
+                assert_join_probe(&join, ColId(1), 1);
+                *join.lhs
             }
             plan => panic!("unexpected plan: {plan:#?}"),
         };
 
         // Plan: ix(m)
         match plan {
-            PhysicalPlan::IxScan(
-                IxScan {
-                    schema,
-                    prefix,
-                    arg: Sarg::Eq(ColId(0), AlgebraicValue::U64(5)),
-                    ..
-                },
-                _,
-            ) => {
-                assert!(prefix.is_empty());
+            PhysicalPlan::IxScan(IxScan { schema, probe, .. }, _) => {
+                assert_eq!(probe, IndexProbe::Point(value(AlgebraicValue::U64(5))));
                 assert_eq!(schema.table_id, m_id);
             }
             plan => panic!("unexpected plan: {plan:#?}"),
@@ -2080,17 +2133,15 @@ mod tests {
 
         // Select index on (x, y, z)
         match pp {
-            ProjectPlan::None(PhysicalPlan::IxScan(
-                IxScan {
-                    schema, prefix, arg, ..
-                },
-                _,
-            )) => {
+            ProjectPlan::None(PhysicalPlan::IxScan(IxScan { schema, probe, .. }, _)) => {
                 assert_eq!(schema.table_id, t_id);
-                assert_eq!(arg, Sarg::Eq(ColId(3), AlgebraicValue::U8(5)));
                 assert_eq!(
-                    prefix,
-                    vec![(ColId(1), AlgebraicValue::U8(3)), (ColId(2), AlgebraicValue::U8(4))]
+                    probe,
+                    IndexProbe::Point(product(vec![
+                        AlgebraicValue::U8(3),
+                        AlgebraicValue::U8(4),
+                        AlgebraicValue::U8(5),
+                    ]))
                 );
             }
             proj => panic!("unexpected plan: {proj:#?}"),
@@ -2102,17 +2153,15 @@ mod tests {
         let pp = compile_select(lp).optimize(&auth).unwrap();
 
         match pp {
-            ProjectPlan::None(PhysicalPlan::IxScan(
-                IxScan {
-                    schema, prefix, arg, ..
-                },
-                _,
-            )) => {
+            ProjectPlan::None(PhysicalPlan::IxScan(IxScan { schema, probe, .. }, _)) => {
                 assert_eq!(schema.table_id, t_id);
-                assert_eq!(arg, Sarg::Eq(ColId(3), AlgebraicValue::U8(5)));
                 assert_eq!(
-                    prefix,
-                    vec![(ColId(1), AlgebraicValue::U8(3)), (ColId(2), AlgebraicValue::U8(4))]
+                    probe,
+                    IndexProbe::Point(product(vec![
+                        AlgebraicValue::U8(3),
+                        AlgebraicValue::U8(4),
+                        AlgebraicValue::U8(5),
+                    ]))
                 );
             }
             proj => panic!("unexpected plan: {proj:#?}"),
@@ -2133,15 +2182,9 @@ mod tests {
         };
 
         match plan {
-            PhysicalPlan::IxScan(
-                IxScan {
-                    schema, prefix, arg, ..
-                },
-                _,
-            ) => {
+            PhysicalPlan::IxScan(IxScan { schema, probe, .. }, _) => {
                 assert_eq!(schema.table_id, t_id);
-                assert_eq!(arg, Sarg::Eq(ColId(1), AlgebraicValue::U8(3)));
-                assert!(prefix.is_empty());
+                assert_eq!(probe, IndexProbe::Point(value(AlgebraicValue::U8(3))));
             }
             plan => panic!("unexpected plan: {plan:#?}"),
         };
@@ -2161,15 +2204,9 @@ mod tests {
         };
 
         match plan {
-            PhysicalPlan::IxScan(
-                IxScan {
-                    schema, prefix, arg, ..
-                },
-                _,
-            ) => {
+            PhysicalPlan::IxScan(IxScan { schema, probe, .. }, _) => {
                 assert_eq!(schema.table_id, t_id);
-                assert_eq!(arg, Sarg::Eq(ColId(1), AlgebraicValue::U8(4)));
-                assert!(prefix.is_empty());
+                assert_eq!(probe, IndexProbe::Point(value(AlgebraicValue::U8(4))));
             }
             plan => panic!("unexpected plan: {plan:#?}"),
         };
@@ -2194,15 +2231,12 @@ mod tests {
         let pp = compile_select(lp).optimize(&auth).unwrap();
 
         match pp {
-            ProjectPlan::None(PhysicalPlan::IxScan(
-                IxScan {
-                    schema, prefix, arg, ..
-                },
-                _,
-            )) => {
+            ProjectPlan::None(PhysicalPlan::IxScan(IxScan { schema, probe, .. }, _)) => {
                 assert_eq!(schema.table_id, t_id);
-                assert_eq!(arg, Sarg::Eq(ColId(3), AlgebraicValue::U8(2)));
-                assert_eq!(prefix, vec![(ColId(2), AlgebraicValue::U8(1))]);
+                assert_eq!(
+                    probe,
+                    IndexProbe::Point(product(vec![AlgebraicValue::U8(1), AlgebraicValue::U8(2)]))
+                );
             }
             proj => panic!("unexpected plan: {proj:#?}"),
         };
@@ -2213,15 +2247,12 @@ mod tests {
         let pp = compile_select(lp).optimize(&auth).unwrap();
 
         match pp {
-            ProjectPlan::None(PhysicalPlan::IxScan(
-                IxScan {
-                    schema, prefix, arg, ..
-                },
-                _,
-            )) => {
+            ProjectPlan::None(PhysicalPlan::IxScan(IxScan { schema, probe, .. }, _)) => {
                 assert_eq!(schema.table_id, t_id);
-                assert_eq!(arg, Sarg::Eq(ColId(3), AlgebraicValue::U8(2)));
-                assert_eq!(prefix, vec![(ColId(2), AlgebraicValue::U8(1))]);
+                assert_eq!(
+                    probe,
+                    IndexProbe::Point(product(vec![AlgebraicValue::U8(1), AlgebraicValue::U8(2)]))
+                );
             }
             proj => panic!("unexpected plan: {proj:#?}"),
         };
@@ -2241,15 +2272,12 @@ mod tests {
         };
 
         match plan {
-            PhysicalPlan::IxScan(
-                IxScan {
-                    schema, prefix, arg, ..
-                },
-                _,
-            ) => {
+            PhysicalPlan::IxScan(IxScan { schema, probe, .. }, _) => {
                 assert_eq!(schema.table_id, t_id);
-                assert_eq!(arg, Sarg::Eq(ColId(3), AlgebraicValue::U8(3)));
-                assert_eq!(prefix, vec![(ColId(2), AlgebraicValue::U8(2))]);
+                assert_eq!(
+                    probe,
+                    IndexProbe::Point(product(vec![AlgebraicValue::U8(2), AlgebraicValue::U8(3)]))
+                );
             }
             plan => panic!("unexpected plan: {plan:#?}"),
         };

--- a/crates/physical-plan/src/rules.rs
+++ b/crates/physical-plan/src/rules.rs
@@ -748,22 +748,6 @@ fn ix_join_candidate(
     })
 }
 
-/// Extract equality constants encoded directly in an `IxScan`.
-///
-/// We only support `Eq` SARGs here because index joins require exact probe
-/// values for all leading index columns.
-fn rhs_eq_constants_from_ixscan(scan: &IxScan) -> Option<Vec<EqConstFilterTerm>> {
-    scan.literal_eq_terms()
-}
-
-/// Ensure we do not drop predicates that were previously represented by an
-/// `IxScan` when rewriting to an `IxJoin`.
-fn all_terms_consumed(required: &[EqConstFilterTerm], consumed: &[EqConstFilterTerm]) -> bool {
-    required
-        .iter()
-        .all(|term| consumed.iter().any(|consumed_term| consumed_term == term))
-}
-
 fn remove_consumed_filter_terms(
     expr: PhysicalExpr,
     rhs_label: Label,
@@ -817,50 +801,23 @@ impl RewriteRule for HashToIxJoin {
                     ..
                 },
                 _,
-            ) => match &**rhs {
-                PhysicalPlan::TableScan(
-                    TableScan {
-                        schema,
-                        limit: None,
-                        delta: _,
-                    },
-                    _,
-                ) => ix_join_candidate(schema, *field_pos, lhs_field, &[]),
-                PhysicalPlan::IxScan(
-                    scan @ IxScan {
-                        schema,
-                        limit: None,
-                        delta: _,
-                        ..
-                    },
-                    _,
-                ) => {
-                    // If earlier rules already lowered an RHS filter to `IxScan(sender = const)`,
-                    // reuse those constants when proving that a multi-column join index can be probed.
-                    let constants = rhs_eq_constants_from_ixscan(scan)?;
-                    let info = ix_join_candidate(schema, *field_pos, lhs_field, &constants)?;
-                    // Guardrail: do not rewrite unless every scan-encoded predicate is
-                    // represented in the chosen point probe.
-                    all_terms_consumed(&constants, &info.consumed_filter_terms).then_some(info)
-                }
-                _ => {
-                    let (base, filters) = peel_filters_ref(rhs);
-                    match base {
-                        PhysicalPlan::TableScan(
-                            TableScan {
-                                schema,
-                                limit: None,
-                                delta: _,
-                            },
-                            rhs_label,
-                        ) => {
-                            let constants = rhs_eq_constants_from_filters(filters, *rhs_label);
-                            ix_join_candidate(schema, *field_pos, lhs_field, &constants)
-                        }
-                        _ => None,
+            ) => {
+                let (base, filters) = peel_filters_ref(rhs);
+                match base {
+                    PhysicalPlan::TableScan(
+                        TableScan {
+                            schema,
+                            limit: None,
+                            delta: _,
+                        },
+                        rhs_label,
+                    ) => {
+                        let constants = rhs_eq_constants_from_filters(filters, *rhs_label);
+                        ix_join_candidate(schema, *field_pos, lhs_field, &constants)
                     }
+                    _ => None,
                 }
-            },
+            }
             _ => None,
         }
     }
@@ -881,15 +838,6 @@ impl RewriteRule for HashToIxJoin {
                             schema: rhs,
                             limit: None,
                             delta: rhs_delta,
-                        },
-                        rhs_label,
-                    ) => (rhs, rhs_label, rhs_delta),
-                    PhysicalPlan::IxScan(
-                        IxScan {
-                            schema: rhs,
-                            limit: None,
-                            delta: rhs_delta,
-                            ..
                         },
                         rhs_label,
                     ) => (rhs, rhs_label, rhs_delta),

--- a/crates/physical-plan/src/rules.rs
+++ b/crates/physical-plan/src/rules.rs
@@ -6,20 +6,12 @@
 //!   Push down predicates of the form `x=1`
 //! * [PushConstAnd]
 //!   Push down predicates of the form `x=1 and y=2`
-//! * [IxScanEq]
-//!   Generate 1-column index scan for `x=1`
-//! * [IxScanAnd]
-//!   Generate 1-column index scan for `x=1 and y=2`
-//! * [IxScanEq2Col]
-//!   Generate 2-column index scan
-//! * [IxScanEq3Col]
-//!   Generate 3-column index scan
+//! * [IxScanFromPredicates]
+//!   Generate point index scans from equality predicates
 //! * [ReorderHashJoin]
 //!   Reorder the sides of a hash join
 //! * [ReorderDeltaJoinRhs]
 //!   Reorder the sides of a hash join with delta tables
-//! * [PullFilterAboveHashJoin]
-//!   Pull a filter above a hash join with delta tables
 //! * [HashToIxJoin]
 //!   Convert hash join to index join
 //! * [UniqueIxJoinRule]
@@ -29,12 +21,12 @@
 use anyhow::{bail, Result};
 use spacetimedb_lib::AlgebraicValue;
 use spacetimedb_primitives::{ColId, ColSet, IndexId};
-use spacetimedb_schema::schema::{IndexSchema, TableSchema};
+use spacetimedb_schema::schema::TableSchema;
 use spacetimedb_sql_parser::ast::{BinOp, LogOp};
 
 use crate::plan::{
-    HashJoin, IxJoin, IxScan, Label, PhysicalExpr, PhysicalPlan, ProjectListPlan, ProjectPlan, Sarg, Semi, TableScan,
-    TupleField,
+    index_key_expr, HashJoin, IndexProbe, IxJoin, IxScan, Label, PhysicalExpr, PhysicalPlan, ProjectListPlan,
+    ProjectPlan, Semi, TableScan, TupleField,
 };
 
 /// A rewrite will only fail due to an internal logic bug.
@@ -74,17 +66,19 @@ impl RewriteRule for ComputePositions {
                 });
                 name_and_position
             }
-            PhysicalPlan::IxJoin(
-                IxJoin {
-                    lhs: input,
-                    lhs_field: TupleField {
+            PhysicalPlan::IxJoin(IxJoin { lhs: input, probe, .. }, _) => {
+                let mut name_and_position = None;
+                probe.visit(&mut |expr| {
+                    if let PhysicalExpr::Field(TupleField {
                         label, label_pos: None, ..
-                    },
-                    ..
-                },
-                _,
-            )
-            | PhysicalPlan::HashJoin(
+                    }) = expr
+                    {
+                        name_and_position = input.position(label).map(|i| (*label, i));
+                    }
+                });
+                name_and_position
+            }
+            PhysicalPlan::HashJoin(
                 HashJoin {
                     lhs: input,
                     lhs_field: TupleField {
@@ -118,14 +112,15 @@ impl RewriteRule for ComputePositions {
                     _ => {}
                 });
             }
-            PhysicalPlan::IxJoin(
-                IxJoin {
-                    lhs_field: t @ TupleField { label_pos: None, .. },
-                    ..
-                },
-                _,
-            )
-            | PhysicalPlan::HashJoin(
+            PhysicalPlan::IxJoin(IxJoin { probe, .. }, _) => {
+                probe.visit_mut(&mut |expr| match expr {
+                    PhysicalExpr::Field(t @ TupleField { label_pos: None, .. }) if t.label == name => {
+                        t.label_pos = Some(pos);
+                    }
+                    _ => {}
+                });
+            }
+            PhysicalPlan::HashJoin(
                 HashJoin {
                     lhs_field: t @ TupleField { label_pos: None, .. },
                     ..
@@ -398,176 +393,41 @@ impl RewriteRule for PushConstAnd {
     }
 }
 
-/// Match single field equality predicates such as:
-///
-/// ```sql
-/// select * from t where x = 1
-/// ```
-///
-/// Rewrite as an index scan if applicable.
-///
-/// NOTE: This rule does not consider multi-column indexes.
-pub(crate) struct IxScanEq;
+/// The first pass preserves the old equality-scan support boundary while
+/// representing all exact keys through one physical probe expression.
+const MAX_EXACT_INDEX_COLS: usize = 3;
+
+pub(crate) struct IxScanFromPredicates;
 
 pub(crate) struct IxScanInfo {
     index_id: IndexId,
-    cols: Vec<(usize, ColId)>,
+    consumed_exprs: Vec<usize>,
+    probe: PhysicalExpr,
 }
 
-impl RewriteRule for IxScanEq {
-    type Plan = PhysicalPlan;
-    type Info = (IndexId, ColId);
-
-    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, expr, value)) = plan
-            && let PhysicalPlan::TableScan(
-                TableScan {
-                    schema,
-                    limit: None,
-                    delta: _,
-                },
-                _,
-            ) = &**input
-            && let (PhysicalExpr::Field(TupleField { field_pos: pos, .. }), PhysicalExpr::Value(_)) =
-                (&**expr, &**value)
-        {
-            return schema.indexes.iter().find_map(
-                |IndexSchema {
-                     index_id,
-                     index_algorithm,
-                     ..
-                 }| {
-                    // TODO: Support prefix scans.
-                    // Remember to consider non-ranged indices.
-                    if index_algorithm.columns().len() == 1 {
-                        Some((*index_id, index_algorithm.find_col_index(*pos)?))
-                    } else {
-                        None
-                    }
-                },
-            );
-        }
-        None
-    }
-
-    fn rewrite(plan: PhysicalPlan, (index_id, col_id): Self::Info) -> Result<PhysicalPlan> {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::BinOp(BinOp::Eq, _, value)) = plan
-            && let PhysicalPlan::TableScan(TableScan { schema, limit, delta }, var) = *input
-            && let PhysicalExpr::Value(v) = *value
-        {
-            return Ok(PhysicalPlan::IxScan(
-                IxScan {
-                    schema,
-                    limit,
-                    delta,
-                    index_id,
-                    prefix: vec![],
-                    arg: Sarg::Eq(col_id, v),
-                },
-                var,
-            ));
-        }
-        bail!("{INVARIANT_VIOLATION}: Failed to create single column index scan from equality condition")
+fn top_level_filter_exprs(expr: &PhysicalExpr) -> Vec<&PhysicalExpr> {
+    match expr {
+        PhysicalExpr::LogOp(LogOp::And, exprs) => exprs.iter().collect(),
+        expr => vec![expr],
     }
 }
 
-/// Match multi-field equality predicates such as:
-///
-/// ```sql
-/// select * from t where x = 1 and y = 1
-/// ```
-///
-/// Create an index scan for one of the equality conditions.
-///
-/// NOTE: This rule does not consider multi-column indexes.
-pub(crate) struct IxScanAnd;
-
-impl RewriteRule for IxScanAnd {
-    type Plan = PhysicalPlan;
-    type Info = (IndexId, usize, ColId);
-
-    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan
-            && let PhysicalPlan::TableScan(
-                TableScan {
-                    schema,
-                    limit: None,
-                    delta: _,
-                },
-                _,
-            ) = &**input
-        {
-            return exprs.iter().enumerate().find_map(|(i, expr)| {
-                if let PhysicalExpr::BinOp(BinOp::Eq, lhs, value) = expr
-                    && let (PhysicalExpr::Field(TupleField { field_pos: pos, .. }), PhysicalExpr::Value(_)) =
-                        (&**lhs, &**value)
-                {
-                    return schema.indexes.iter().find_map(
-                        |IndexSchema {
-                             index_id,
-                             index_algorithm,
-                             ..
-                         }| {
-                            index_algorithm
-                                .columns()
-                                // TODO: Support prefix scans
-                                .as_singleton()
-                                .filter(|col_id| col_id.idx() == *pos)
-                                .map(|col_id| (*index_id, i, col_id))
-                        },
-                    );
-                }
-                None
-            });
-        }
-        None
-    }
-
-    fn rewrite(plan: PhysicalPlan, (index_id, i, col_id): Self::Info) -> Result<PhysicalPlan> {
-        if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, mut exprs)) = plan
-            && let PhysicalPlan::TableScan(TableScan { schema, limit, delta }, label) = *input
-            && let PhysicalExpr::BinOp(BinOp::Eq, _, value) = exprs.swap_remove(i)
-            && let PhysicalExpr::Value(v) = *value
-        {
-            return Ok(PhysicalPlan::Filter(
-                Box::new(PhysicalPlan::IxScan(
-                    IxScan {
-                        schema,
-                        limit,
-                        delta,
-                        index_id,
-                        prefix: vec![],
-                        arg: Sarg::Eq(col_id, v),
-                    },
-                    label,
-                )),
-                match exprs.len() {
-                    1 => exprs.swap_remove(0),
-                    _ => PhysicalExpr::LogOp(LogOp::And, exprs),
-                },
-            ));
-        }
-        bail!("{INVARIANT_VIOLATION}: Failed to create single column index scan from conjunction")
-    }
+fn equality_term(expr: &PhysicalExpr, label: Label) -> Option<(ColId, AlgebraicValue)> {
+    let PhysicalExpr::BinOp(BinOp::Eq, lhs, rhs) = expr else {
+        return None;
+    };
+    let (PhysicalExpr::Field(field), PhysicalExpr::Value(value)) = (&**lhs, &**rhs) else {
+        return None;
+    };
+    (field.label == label).then(|| (ColId(field.field_pos as u16), value.clone()))
 }
 
-/// Match multi-field equality predicates such as:
-///
-/// ```sql
-/// select * from t where x = 1 and y = 1
-/// ```
-///
-/// Rewrite as a multi-column index scan if applicable.
-///
-/// NOTE: This rule does not consider indexes on 3 or more columns.
-pub(crate) struct IxScanEq2Col;
-
-impl RewriteRule for IxScanEq2Col {
+impl RewriteRule for IxScanFromPredicates {
     type Plan = PhysicalPlan;
     type Info = IxScanInfo;
 
     fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan else {
+        let PhysicalPlan::Filter(input, expr) = plan else {
             return None;
         };
 
@@ -577,312 +437,93 @@ impl RewriteRule for IxScanEq2Col {
                 limit: None,
                 delta: _,
             },
-            _,
+            label,
         ) = &**input
         else {
             return None;
         };
 
-        for (i, a) in exprs.iter().enumerate() {
-            for (j, b) in exprs.iter().enumerate().filter(|(j, _)| i != *j) {
-                let (PhysicalExpr::BinOp(BinOp::Eq, a, u), PhysicalExpr::BinOp(BinOp::Eq, b, v)) = (a, b) else {
-                    continue;
-                };
+        let exprs = top_level_filter_exprs(expr);
+        let equality_terms = exprs
+            .iter()
+            .enumerate()
+            .filter_map(|(i, expr)| equality_term(expr, *label).map(|(col, value)| (i, col, value)))
+            .collect::<Vec<_>>();
 
-                let (PhysicalExpr::Field(u), PhysicalExpr::Value(_), PhysicalExpr::Field(v), PhysicalExpr::Value(_)) =
-                    (&**a, &**u, &**b, &**v)
+        let mut best = None;
+        for index in &schema.indexes {
+            let cols = index.index_algorithm.columns();
+            let cols = cols.iter().collect::<Vec<_>>();
+            if cols.is_empty() || cols.len() > MAX_EXACT_INDEX_COLS {
+                continue;
+            }
+
+            let mut consumed_exprs = Vec::with_capacity(cols.len());
+            let mut key_parts = Vec::with_capacity(cols.len());
+            for col in &cols {
+                let Some((expr_pos, _, value)) = equality_terms.iter().find(|(_, candidate, _)| candidate == col)
                 else {
                     continue;
                 };
+                consumed_exprs.push(*expr_pos);
+                key_parts.push(PhysicalExpr::Value(value.clone()));
+            }
 
-                if let Some(scan) = schema
-                    .indexes
-                    .iter()
-                    .filter(|idx| idx.index_algorithm.columns().len() == 2) // TODO: Support prefix scans
-                    .map(|idx| (idx.index_id, idx.index_algorithm.columns()))
-                    .find_map(|(index_id, columns)| {
-                        let mut columns = columns.iter();
-                        let x = columns.next()?;
-                        if x.idx() != u.field_pos {
-                            return None;
-                        }
-                        let y = columns.next()?;
-                        if y.idx() != v.field_pos {
-                            return None;
-                        }
-                        Some(IxScanInfo {
-                            index_id,
-                            cols: vec![(i, x), (j, y)],
-                        })
-                    })
-                {
-                    return Some(scan);
-                }
+            if consumed_exprs.len() != cols.len() {
+                continue;
+            }
+
+            let candidate = IxScanInfo {
+                index_id: index.index_id,
+                consumed_exprs,
+                probe: index_key_expr(key_parts),
+            };
+
+            if best
+                .as_ref()
+                .is_none_or(|best: &IxScanInfo| cols.len() > best.consumed_exprs.len())
+            {
+                best = Some(candidate);
             }
         }
 
-        None
+        best
     }
 
     fn rewrite(plan: PhysicalPlan, info: Self::Info) -> Result<PhysicalPlan> {
-        match info.cols.as_slice() {
-            [(i, a), (j, b)] => {
-                if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan
-                    && let PhysicalPlan::TableScan(TableScan { schema, limit, delta }, label) = *input
-                    && let (Some(PhysicalExpr::BinOp(BinOp::Eq, _, u)), Some(PhysicalExpr::BinOp(BinOp::Eq, _, v))) =
-                        (exprs.get(*i), exprs.get(*j))
-                    && let (PhysicalExpr::Value(u), PhysicalExpr::Value(v)) = (&**u, &**v)
-                {
-                    return Ok(match exprs.len() {
-                        n @ 0 | n @ 1 => {
-                            bail!("{INVARIANT_VIOLATION}: Cannot create 2-column index scan from {n} conditions")
-                        }
-                        // If there are only 2 conditions in this filter,
-                        // we replace the filter with an index scan.
-                        2 => PhysicalPlan::IxScan(
-                            IxScan {
-                                schema,
-                                limit,
-                                delta,
-                                index_id: info.index_id,
-                                prefix: vec![(*a, u.clone())],
-                                arg: Sarg::Eq(*b, v.clone()),
-                            },
-                            label,
-                        ),
-                        // If there are 3 conditions in this filter,
-                        // we create an index scan from 2 of them.
-                        // The original conjunction is no longer well defined,
-                        // because it only has a single operand now.
-                        // Hence we must replace it with its operand.
-                        3 => PhysicalPlan::Filter(
-                            Box::new(PhysicalPlan::IxScan(
-                                IxScan {
-                                    schema,
-                                    limit,
-                                    delta,
-                                    index_id: info.index_id,
-                                    prefix: vec![(*a, u.clone())],
-                                    arg: Sarg::Eq(*b, v.clone()),
-                                },
-                                label,
-                            )),
-                            exprs
-                                .into_iter()
-                                .enumerate()
-                                .find(|(pos, _)| pos != i && pos != j)
-                                .map(|(_, expr)| expr)
-                                .unwrap(),
-                        ),
-                        // If there are more than 3 conditions in this filter,
-                        // we remove the 2 conditions used in the index scan.
-                        // The remaining conditions still form a conjunction.
-                        _ => PhysicalPlan::Filter(
-                            Box::new(PhysicalPlan::IxScan(
-                                IxScan {
-                                    schema,
-                                    limit,
-                                    delta,
-                                    index_id: info.index_id,
-                                    prefix: vec![(*a, u.clone())],
-                                    arg: Sarg::Eq(*b, v.clone()),
-                                },
-                                label,
-                            )),
-                            PhysicalExpr::LogOp(
-                                LogOp::And,
-                                exprs
-                                    .into_iter()
-                                    .enumerate()
-                                    .filter(|(pos, _)| pos != i && pos != j)
-                                    .map(|(_, expr)| expr)
-                                    .collect(),
-                            ),
-                        ),
-                    });
-                }
-                bail!("{INVARIANT_VIOLATION}: Failed to create 2-column index scan")
-            }
-            _ => Ok(plan),
-        }
-    }
-}
-
-/// Match multi-field equality predicates such as:
-///
-/// ```sql
-/// select * from t where x = 1 and y = 1 and z = 1
-/// ```
-///
-/// Rewrite as a multi-column index scan if applicable.
-///
-/// NOTE: This rule does not consider indexes on 4 or more columns.
-pub(crate) struct IxScanEq3Col;
-
-impl RewriteRule for IxScanEq3Col {
-    type Plan = PhysicalPlan;
-    type Info = IxScanInfo;
-
-    fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        // Match outer plan structure
-        let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan else {
-            return None;
+        let PhysicalPlan::Filter(input, expr) = plan else {
+            bail!("{INVARIANT_VIOLATION}: Failed to create index scan from predicates");
+        };
+        let PhysicalPlan::TableScan(TableScan { schema, limit, delta }, label) = *input else {
+            bail!("{INVARIANT_VIOLATION}: Failed to create index scan from predicates");
         };
 
-        let PhysicalPlan::TableScan(
-            TableScan {
+        let ix_scan = PhysicalPlan::IxScan(
+            IxScan {
                 schema,
-                limit: None,
-                delta: _,
+                limit,
+                delta,
+                index_id: info.index_id,
+                probe: IndexProbe::Point(info.probe),
             },
-            _,
-        ) = &**input
-        else {
-            return None;
+            label,
+        );
+
+        let residual_exprs = match expr {
+            PhysicalExpr::LogOp(LogOp::And, exprs) => exprs
+                .into_iter()
+                .enumerate()
+                .filter(|(pos, _)| !info.consumed_exprs.contains(pos))
+                .map(|(_, expr)| expr)
+                .collect(),
+            _ if info.consumed_exprs == [0] => vec![],
+            expr => vec![expr],
         };
 
-        for (i, a) in exprs.iter().enumerate() {
-            for (j, b) in exprs.iter().enumerate().filter(|(j, _)| i != *j) {
-                for (k, c) in exprs.iter().enumerate().filter(|(k, _)| i != *k && j != *k) {
-                    let (
-                        PhysicalExpr::BinOp(BinOp::Eq, a, u),
-                        PhysicalExpr::BinOp(BinOp::Eq, b, v),
-                        PhysicalExpr::BinOp(BinOp::Eq, c, w),
-                    ) = (a, b, c)
-                    else {
-                        continue;
-                    };
-
-                    let (
-                        PhysicalExpr::Field(u),
-                        PhysicalExpr::Value(_),
-                        PhysicalExpr::Field(v),
-                        PhysicalExpr::Value(_),
-                        PhysicalExpr::Field(w),
-                        PhysicalExpr::Value(_),
-                    ) = (&**a, &**u, &**b, &**v, &**c, &**w)
-                    else {
-                        continue;
-                    };
-
-                    if let Some(scan) = schema
-                        .indexes
-                        .iter()
-                        .filter(|idx| idx.index_algorithm.columns().len() == 3)
-                        .map(|idx| (idx.index_id, idx.index_algorithm.columns()))
-                        .find_map(|(index_id, columns)| {
-                            let mut columns = columns.iter();
-                            let x = columns.next()?;
-                            if x.idx() != u.field_pos {
-                                return None;
-                            }
-                            let y = columns.next()?;
-                            if y.idx() != v.field_pos {
-                                return None;
-                            }
-                            let z = columns.next()?;
-                            if z.idx() != w.field_pos {
-                                return None;
-                            }
-                            Some(IxScanInfo {
-                                index_id,
-                                cols: vec![(i, x), (j, y), (k, z)],
-                            })
-                        })
-                    {
-                        return Some(scan);
-                    }
-                }
-            }
-        }
-
-        None
-    }
-
-    fn rewrite(plan: PhysicalPlan, info: Self::Info) -> Result<PhysicalPlan> {
-        match info.cols.as_slice() {
-            [(i, a), (j, b), (k, c)] => {
-                if let PhysicalPlan::Filter(input, PhysicalExpr::LogOp(LogOp::And, exprs)) = plan
-                    && let PhysicalPlan::TableScan(TableScan { schema, limit, delta }, label) = *input
-                    && let (
-                        Some(PhysicalExpr::BinOp(BinOp::Eq, _, u)),
-                        Some(PhysicalExpr::BinOp(BinOp::Eq, _, v)),
-                        Some(PhysicalExpr::BinOp(BinOp::Eq, _, w)),
-                    ) = (exprs.get(*i), exprs.get(*j), exprs.get(*k))
-                    && let (PhysicalExpr::Value(u), PhysicalExpr::Value(v), PhysicalExpr::Value(w)) = (&**u, &**v, &**w)
-                {
-                    return Ok(match exprs.len() {
-                        n @ 0 | n @ 1 | n @ 2 => {
-                            bail!("{INVARIANT_VIOLATION}: Cannot create 3-column index scan from {n} conditions")
-                        }
-                        // If there are only 3 conditions in this filter,
-                        // we replace the filter with an index scan.
-                        3 => PhysicalPlan::IxScan(
-                            IxScan {
-                                schema,
-                                limit,
-                                delta,
-                                index_id: info.index_id,
-                                prefix: vec![(*a, u.clone()), (*b, v.clone())],
-                                arg: Sarg::Eq(*c, w.clone()),
-                            },
-                            label,
-                        ),
-                        // If there are 4 conditions in this filter,
-                        // we create an index scan from 3 of them.
-                        // The original conjunction is no longer well defined,
-                        // because it only has a single operand now.
-                        // Hence we must replace it with its operand.
-                        4 => PhysicalPlan::Filter(
-                            Box::new(PhysicalPlan::IxScan(
-                                IxScan {
-                                    schema,
-                                    limit,
-                                    delta,
-                                    index_id: info.index_id,
-                                    prefix: vec![(*a, u.clone()), (*b, v.clone())],
-                                    arg: Sarg::Eq(*c, w.clone()),
-                                },
-                                label,
-                            )),
-                            exprs
-                                .into_iter()
-                                .enumerate()
-                                .find(|(pos, _)| pos != i && pos != j && pos != k)
-                                .map(|(_, expr)| expr)
-                                .unwrap(),
-                        ),
-                        // If there are more than 4 conditions in this filter,
-                        // we remove the 3 conditions used in the index scan.
-                        // The remaining conditions still form a conjunction.
-                        _ => PhysicalPlan::Filter(
-                            Box::new(PhysicalPlan::IxScan(
-                                IxScan {
-                                    schema,
-                                    limit,
-                                    delta,
-                                    index_id: info.index_id,
-                                    prefix: vec![(*a, u.clone()), (*b, v.clone())],
-                                    arg: Sarg::Eq(*c, w.clone()),
-                                },
-                                label,
-                            )),
-                            PhysicalExpr::LogOp(
-                                LogOp::And,
-                                exprs
-                                    .into_iter()
-                                    .enumerate()
-                                    .filter(|(pos, _)| pos != i && pos != j && pos != k)
-                                    .map(|(_, expr)| expr)
-                                    .collect(),
-                            ),
-                        ),
-                    });
-                }
-                bail!("{INVARIANT_VIOLATION}: Failed to create 3-column index scan")
-            }
-            _ => Ok(plan),
-        }
+        Ok(match and_expr(residual_exprs) {
+            Some(expr) => PhysicalPlan::Filter(Box::new(ix_scan), expr),
+            None => ix_scan,
+        })
     }
 }
 
@@ -988,77 +629,6 @@ impl RewriteRule for ReorderDeltaJoinRhs {
     }
 }
 
-/// Pull a filter above a hash join if:
-///
-/// 1. The lhs is a delta scan or a selection
-/// 2. The rhs has an index for the join
-///
-/// ```text
-///   x
-///  / \
-/// a  s(b)
-///     |
-///     b
-///
-/// ... to ...
-///
-///  s(b)
-///   |
-///   x
-///  / \
-/// a   b
-/// ```
-pub(crate) struct PullFilterAboveHashJoin;
-
-impl RewriteRule for PullFilterAboveHashJoin {
-    type Plan = PhysicalPlan;
-    type Info = ();
-
-    fn matches(plan: &Self::Plan) -> Option<Self::Info> {
-        if let PhysicalPlan::HashJoin(
-            HashJoin {
-                lhs, rhs, rhs_field, ..
-            },
-            Semi::All,
-        ) = plan
-            && let PhysicalPlan::Filter(input, _) = &**rhs
-            && let PhysicalPlan::TableScan(TableScan { schema, .. }, _) = &**input
-        {
-            return ((lhs.is_delta_scan()
-                || matches!(**lhs, PhysicalPlan::Filter(..))
-                || matches!(**lhs, PhysicalPlan::IxScan(..)))
-                && schema.indexes.iter().any(|schema| {
-                    schema
-                        .index_algorithm
-                        .columns()
-                        .as_singleton()
-                        .is_some_and(|col_id| col_id.idx() == rhs_field.field_pos)
-                }))
-            .then_some(());
-        }
-        None
-    }
-
-    fn rewrite(plan: Self::Plan, _: Self::Info) -> Result<Self::Plan> {
-        if let PhysicalPlan::HashJoin(join, semi) = plan
-            && let PhysicalPlan::Filter(rhs, expr) = *join.rhs
-        {
-            return Ok(PhysicalPlan::Filter(
-                Box::new(PhysicalPlan::HashJoin(
-                    HashJoin {
-                        lhs: join.lhs,
-                        rhs,
-                        ..join
-                    },
-                    semi,
-                )),
-                expr,
-            ));
-        }
-        bail!("{INVARIANT_VIOLATION}: Failed to pull filter above hash join")
-    }
-}
-
 /// Always prefer an index join to a hash join
 pub(crate) struct HashToIxJoin;
 
@@ -1070,13 +640,9 @@ type EqConstFilterTerm = (ColId, AlgebraicValue);
 pub(crate) struct HashToIxJoinInfo {
     /// The index to probe on the RHS table.
     rhs_index: IndexId,
-    /// The join column on the RHS.
-    /// This must be the final probe component for the chosen index.
-    rhs_field: ColId,
-    /// Constant leading key components for a multi-column index probe.
-    /// For an index `(a, b, c)` and join on `c`, this stores `[a_const, b_const]`.
-    rhs_prefix: Vec<AlgebraicValue>,
-    /// RHS filter terms consumed into `rhs_prefix` and therefore removable
+    /// The point probe expression to evaluate against each lhs tuple.
+    probe: PhysicalExpr,
+    /// RHS filter terms consumed into the point probe and therefore removable
     /// from the residual filter.
     consumed_filter_terms: Vec<EqConstFilterTerm>,
 }
@@ -1152,6 +718,7 @@ fn and_expr(exprs: Vec<PhysicalExpr>) -> Option<PhysicalExpr> {
 fn ix_join_candidate(
     schema: &TableSchema,
     rhs_field_pos: usize,
+    lhs_field: &TupleField,
     constants: &[EqConstFilterTerm],
 ) -> Option<HashToIxJoinInfo> {
     let rhs_field = ColId(rhs_field_pos as u16);
@@ -1164,18 +731,18 @@ fn ix_join_candidate(
             return None;
         };
 
-        let mut rhs_prefix: Vec<AlgebraicValue> = vec![];
+        let mut key_parts = vec![];
         let mut consumed_filter_terms: Vec<EqConstFilterTerm> = vec![];
         for col in cols.iter().take(cols.len().saturating_sub(1).into()) {
             let (_, value) = constants.iter().find(|(candidate, _)| *candidate == col)?;
-            rhs_prefix.push(value.clone());
+            key_parts.push(PhysicalExpr::Value(value.clone()));
             consumed_filter_terms.push((col, value.clone()));
         }
+        key_parts.push(PhysicalExpr::Field(lhs_field.clone()));
 
         Some(HashToIxJoinInfo {
             rhs_index: ix.index_id,
-            rhs_field,
-            rhs_prefix,
+            probe: index_key_expr(key_parts),
             consumed_filter_terms,
         })
     })
@@ -1186,17 +753,7 @@ fn ix_join_candidate(
 /// We only support `Eq` SARGs here because index joins require exact probe
 /// values for all leading index columns.
 fn rhs_eq_constants_from_ixscan(scan: &IxScan) -> Option<Vec<EqConstFilterTerm>> {
-    let mut constants = scan
-        .prefix
-        .iter()
-        .map(|(col, value)| (*col, value.clone()))
-        .collect::<Vec<_>>();
-
-    let Sarg::Eq(col, value) = &scan.arg else {
-        return None;
-    };
-    constants.push((*col, value.clone()));
-    Some(constants)
+    scan.literal_eq_terms()
 }
 
 /// Ensure we do not drop predicates that were previously represented by an
@@ -1212,7 +769,7 @@ fn remove_consumed_filter_terms(
     rhs_label: Label,
     consumed_filter_terms: &[EqConstFilterTerm],
 ) -> Option<PhysicalExpr> {
-    // These terms are now represented by `rhs_prefix`; keeping them in a
+    // These terms are now represented by the point probe; keeping them in a
     // residual filter is redundant work.
     let is_consumed = |col_id: ColId, value: &AlgebraicValue| {
         consumed_filter_terms
@@ -1255,6 +812,7 @@ impl RewriteRule for HashToIxJoin {
             PhysicalPlan::HashJoin(
                 HashJoin {
                     rhs,
+                    lhs_field,
                     rhs_field: TupleField { field_pos, .. },
                     ..
                 },
@@ -1267,7 +825,7 @@ impl RewriteRule for HashToIxJoin {
                         delta: _,
                     },
                     _,
-                ) => ix_join_candidate(schema, *field_pos, &[]),
+                ) => ix_join_candidate(schema, *field_pos, lhs_field, &[]),
                 PhysicalPlan::IxScan(
                     scan @ IxScan {
                         schema,
@@ -1280,13 +838,12 @@ impl RewriteRule for HashToIxJoin {
                     // If earlier rules already lowered an RHS filter to `IxScan(sender = const)`,
                     // reuse those constants when proving that a multi-column join index can be probed.
                     let constants = rhs_eq_constants_from_ixscan(scan)?;
-                    let info = ix_join_candidate(schema, *field_pos, &constants)?;
+                    let info = ix_join_candidate(schema, *field_pos, lhs_field, &constants)?;
                     // Guardrail: do not rewrite unless every scan-encoded predicate is
-                    // represented in the chosen `rhs_prefix` + join key.
+                    // represented in the chosen point probe.
                     all_terms_consumed(&constants, &info.consumed_filter_terms).then_some(info)
                 }
                 _ => {
-                    // We prefer to pull filters above an index join where possible.
                     let (base, filters) = peel_filters_ref(rhs);
                     match base {
                         PhysicalPlan::TableScan(
@@ -1298,40 +855,12 @@ impl RewriteRule for HashToIxJoin {
                             rhs_label,
                         ) => {
                             let constants = rhs_eq_constants_from_filters(filters, *rhs_label);
-                            ix_join_candidate(schema, *field_pos, &constants)
+                            ix_join_candidate(schema, *field_pos, lhs_field, &constants)
                         }
                         _ => None,
                     }
                 }
             },
-            PhysicalPlan::Filter(input, expr) => {
-                let PhysicalPlan::HashJoin(
-                    HashJoin {
-                        rhs,
-                        rhs_field: TupleField { field_pos, .. },
-                        ..
-                    },
-                    _,
-                ) = &**input
-                else {
-                    return None;
-                };
-
-                let PhysicalPlan::TableScan(
-                    TableScan {
-                        schema,
-                        limit: None,
-                        delta: _,
-                    },
-                    rhs_label,
-                ) = &**rhs
-                else {
-                    return None;
-                };
-
-                let constants = rhs_eq_constants(expr, *rhs_label);
-                ix_join_candidate(schema, *field_pos, &constants)
-            }
             _ => None,
         }
     }
@@ -1341,8 +870,7 @@ impl RewriteRule for HashToIxJoin {
             PhysicalPlan::HashJoin(join, semi) => {
                 let HashToIxJoinInfo {
                     rhs_index,
-                    rhs_field,
-                    rhs_prefix,
+                    probe,
                     consumed_filter_terms,
                 } = info;
 
@@ -1374,11 +902,9 @@ impl RewriteRule for HashToIxJoin {
                         rhs,
                         rhs_label,
                         rhs_index,
-                        rhs_prefix,
-                        rhs_field,
                         rhs_delta,
                         unique: false,
-                        lhs_field: join.lhs_field,
+                        probe,
                     },
                     semi,
                 );
@@ -1389,51 +915,6 @@ impl RewriteRule for HashToIxJoin {
                     .collect();
 
                 if let Some(expr) = and_expr(residual_filters) {
-                    Ok(PhysicalPlan::Filter(Box::new(ix_join), expr))
-                } else {
-                    Ok(ix_join)
-                }
-            }
-            PhysicalPlan::Filter(input, expr) => {
-                let HashToIxJoinInfo {
-                    rhs_index,
-                    rhs_field,
-                    rhs_prefix,
-                    consumed_filter_terms,
-                } = info;
-
-                let PhysicalPlan::HashJoin(join, semi) = *input else {
-                    bail!("{INVARIANT_VIOLATION}: Failed to rewrite filtered hash join as index join");
-                };
-
-                let PhysicalPlan::TableScan(
-                    TableScan {
-                        schema: rhs,
-                        limit: None,
-                        delta: rhs_delta,
-                    },
-                    rhs_label,
-                ) = *join.rhs
-                else {
-                    bail!("{INVARIANT_VIOLATION}: Failed to rewrite filtered hash join as index join");
-                };
-
-                let ix_join = PhysicalPlan::IxJoin(
-                    IxJoin {
-                        lhs: join.lhs,
-                        rhs,
-                        rhs_label,
-                        rhs_index,
-                        rhs_prefix,
-                        rhs_field,
-                        rhs_delta,
-                        unique: false,
-                        lhs_field: join.lhs_field,
-                    },
-                    semi,
-                );
-
-                if let Some(expr) = remove_consumed_filter_terms(expr, rhs_label, &consumed_filter_terms) {
                     Ok(PhysicalPlan::Filter(Box::new(ix_join), expr))
                 } else {
                     Ok(ix_join)
@@ -1452,22 +933,15 @@ impl RewriteRule for UniqueIxJoinRule {
     type Info = ();
 
     fn matches(plan: &PhysicalPlan) -> Option<Self::Info> {
-        if let PhysicalPlan::IxJoin(
-            IxJoin {
-                unique: false,
-                rhs,
-                rhs_field,
-                ..
-            },
-            _,
-        ) = plan
+        if let PhysicalPlan::IxJoin(join @ IxJoin { unique: false, rhs, .. }, _) = plan
+            && let Some((rhs_field, _)) = join.single_probe_field()
         {
             return rhs
                 .constraints
                 .iter()
                 .filter_map(|cs| cs.data.unique_columns())
                 .filter_map(|cols| cols.as_singleton())
-                .find(|col_id| col_id == rhs_field)
+                .find(|col_id| *col_id == rhs_field)
                 .map(|_| ());
         }
         None

--- a/crates/subscription/src/lib.rs
+++ b/crates/subscription/src/lib.rs
@@ -1,15 +1,12 @@
 use anyhow::{bail, Result};
 use spacetimedb_data_structures::map::{HashCollectionExt as _, HashSet};
 use spacetimedb_execution::{
-    pipelined::{
-        PipelinedExecutor, PipelinedIxDeltaJoin, PipelinedIxDeltaScanEq, PipelinedIxDeltaScanRange, PipelinedIxJoin,
-        PipelinedIxScanEq, PipelinedIxScanRange, PipelinedProject,
-    },
+    pipelined::{PipelinedExecutor, PipelinedIxJoin, PipelinedIxScan, PipelinedProject},
     Datastore, DeltaStore, Row,
 };
 use spacetimedb_expr::{check::SchemaView, expr::CollectViews};
 use spacetimedb_lib::{identity::AuthCtx, metrics::ExecutionMetrics, query::Delta, AlgebraicValue};
-use spacetimedb_physical_plan::plan::{IxJoin, IxScan, Label, PhysicalPlan, ProjectPlan, Sarg, TableScan, TupleField};
+use spacetimedb_physical_plan::plan::{IxScan, Label, PhysicalPlan, ProjectPlan, TableScan};
 use spacetimedb_primitives::{ColId, ColList, IndexId, TableId, ViewId};
 use spacetimedb_query::compile_subscription;
 use spacetimedb_schema::table_name::TableName;
@@ -37,16 +34,8 @@ impl Fragments {
         let mut index_ids = HashSet::new();
         for plan in self.insert_plans.iter().chain(self.delete_plans.iter()) {
             plan.visit(&mut |plan| match plan {
-                PipelinedExecutor::IxScanEq(PipelinedIxScanEq { table_id, index_id, .. })
-                | PipelinedExecutor::IxScanRange(PipelinedIxScanRange { table_id, index_id, .. })
-                | PipelinedExecutor::IxDeltaScanEq(PipelinedIxDeltaScanEq { table_id, index_id, .. })
-                | PipelinedExecutor::IxDeltaScanRange(PipelinedIxDeltaScanRange { table_id, index_id, .. })
+                PipelinedExecutor::IxScan(PipelinedIxScan { table_id, index_id, .. })
                 | PipelinedExecutor::IxJoin(PipelinedIxJoin {
-                    rhs_table: table_id,
-                    rhs_index: index_id,
-                    ..
-                })
-                | PipelinedExecutor::IxDeltaJoin(PipelinedIxDeltaJoin {
                     rhs_table: table_id,
                     rhs_index: index_id,
                     ..
@@ -424,49 +413,31 @@ impl SubscriptionPlan {
         }
         let mut join_edge = None;
         self.plan_opt.visit(&mut |op| match op {
-            PhysicalPlan::IxJoin(
-                IxJoin {
-                    lhs,
-                    rhs,
-                    rhs_field: lhs_join_col,
-                    lhs_field:
-                        TupleField {
-                            field_pos: rhs_join_col,
-                            ..
-                        },
-                    ..
-                },
-                _,
-            ) if rhs.table_id == self.return_id => match &**lhs {
-                PhysicalPlan::IxScan(
-                    IxScan {
-                        schema,
-                        prefix,
-                        arg: Sarg::Eq(rhs_col, rhs_val),
-                        ..
-                    },
-                    _,
-                ) if schema.table_id != self.return_id
-                    && prefix.is_empty()
-                    && schema.is_unique(&ColList::new((*rhs_join_col).into())) =>
-                {
-                    let lhs_table = self.return_id;
-                    let rhs_table = schema.table_id;
-                    let rhs_col = *rhs_col;
-                    let rhs_val = rhs_val.clone();
-                    let lhs_join_col = *lhs_join_col;
-                    let rhs_join_col = (*rhs_join_col).into();
-                    let edge = JoinEdge {
-                        lhs_table,
-                        rhs_table,
-                        lhs_join_col,
-                        rhs_join_col,
-                        rhs_col,
-                    };
-                    join_edge = Some((edge, rhs_val));
+            PhysicalPlan::IxJoin(join, _) if join.rhs.table_id == self.return_id => {
+                let Some((lhs_join_col, lhs_field)) = join.single_probe_field() else {
+                    return;
+                };
+                let rhs_join_col = ColId(lhs_field.field_pos as u16);
+                match &*join.lhs {
+                    PhysicalPlan::IxScan(scan, _)
+                        if scan.schema.table_id != self.return_id
+                            && scan.schema.is_unique(&ColList::new(rhs_join_col)) =>
+                    {
+                        let Some((rhs_col, rhs_val)) = scan.single_col_lit_point() else {
+                            return;
+                        };
+                        let edge = JoinEdge {
+                            lhs_table: self.return_id,
+                            rhs_table: scan.schema.table_id,
+                            lhs_join_col,
+                            rhs_join_col,
+                            rhs_col,
+                        };
+                        join_edge = Some((edge, rhs_val.clone()));
+                    }
+                    _ => {}
                 }
-                _ => {}
-            },
+            }
             _ => {}
         });
         join_edge


### PR DESCRIPTION
# Description of Changes

Refactors index probes so that multi-column index keys are represented as a single product value expression `PhysicalExpr::Product` instead of being split across various fields and structs. As a result, this patch also simplifies the index-scan and index-join query executor variants now that index scans/probes share one physical shape.

This change is in preparation for adding formal parameters to query plans. Since index probe values now have single unified representation as a `PhysicalExpr`, a future parameterized plan can represent an index scan or index join as follows:

```rust
IndexProbe::Point(PhysicalExpr::Product(vec![
    PhysicalExpr::Param(sender_slot),
    PhysicalExpr::Value(other_const),
]))

PhysicalExpr::Product(vec![
    PhysicalExpr::Param(sender_slot),
    PhysicalExpr::Field(lhs_join_field),
])
```

This will avoid having to duplicate parameter handling in a bunch of different places or rules.

Note, a very nice consequence of this refactor is that it removes/consolidates a significant amount of code as the diff shows.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

...

# Testing

Existing coverage
