### PR TITLE
Fail if `spacetime subscribe -n N` doesn't receive exactly `N` updates

### DIFF
--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -324,6 +324,8 @@ enum Error {
     TransactionFailure { reason: Box<str> },
     #[error("encountered error in initial subscribe: {reason}")]
     SubscribeFailure { reason: Box<str> },
+    #[error("subscription closed after receiving {received}/{expected} updates")]
+    UpdateLimitNotReached { expected: u32, received: u32 },
     #[error("error formatting response: {source:#}")]
     Reformat {
         #[source]
@@ -353,6 +355,21 @@ impl Error {
                 source: WsError::ConnectionClosed
             }
         )
+    }
+}
+
+fn connection_closed_error(num: Option<u32>, num_received: u32) -> Error {
+    match num {
+        Some(expected) => Error::UpdateLimitNotReached {
+            expected,
+            received: num_received,
+        },
+        None => {
+            eprintln!("disconnected by server");
+            Error::Websocket {
+                source: WsError::ConnectionClosed,
+            }
+        }
     }
 }
 
@@ -484,16 +501,13 @@ where
     S: TryStream<Ok = WsMessage, Error = WsError> + Unpin,
 {
     let mut stdout = tokio::io::stdout();
-    let mut num_received = 0;
+    let mut num_received = 0_u32;
     loop {
         if num.is_some_and(|n| num_received >= n) {
             return Ok(());
         }
         let Some(msg) = ws.try_next().await.map_err(|source| Error::Websocket { source })? else {
-            eprintln!("disconnected by server");
-            return Err(Error::Websocket {
-                source: WsError::ConnectionClosed,
-            });
+            return Err(connection_closed_error(num, num_received));
         };
 
         let Some(msg) = parse_msg_json(&msg) else { continue };
@@ -532,16 +546,13 @@ where
     S: TryStream<Ok = WsMessage, Error = WsError> + Unpin,
 {
     let mut stdout = tokio::io::stdout();
-    let mut num_received = 0;
+    let mut num_received = 0_u32;
     loop {
         if num.is_some_and(|n| num_received >= n) {
             return Ok(());
         }
         let Some(msg) = next_server_message(ws, pending).await? else {
-            eprintln!("disconnected by server");
-            return Err(Error::Websocket {
-                source: WsError::ConnectionClosed,
-            });
+            return Err(connection_closed_error(num, num_received));
         };
 
         match msg {

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -206,12 +206,11 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error
     // Close the connection gracefully.
     // This will return an error if the server already closed,
     // or the connection is in a bad state.
-    // The error (if any) relevant to the user is already stored in `res`,
-    // so we can ignore errors here -- graceful close is basically a
-    // courtesy to the server.
+    // The error (if any) relevant to the user is already stored in `res`.
     conn.close().await;
-    // The server closing the connection is not considered an error,
-    // but any other error is.
+    // The server closing the connection is not considered an error
+    // if `-n` is not set, but any other error is. When `-n` is set,
+    // an early close from the update loop is reported as an error.
     res.or_else(|e| {
         if e.is_server_closed_connection() {
             Ok(())

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -394,6 +394,7 @@ impl Error {
 
 fn connection_closed_error(num: Option<u32>, num_received: u32) -> Error {
     match num {
+        // this is necessarily an error, because if we had received all the updates then we would have already closed the connection ourselves and would not have reached this point
         Some(expected) => Error::UpdateLimitNotReached {
             expected,
             received: num_received,

--- a/crates/cli/src/subcommands/subscribe.rs
+++ b/crates/cli/src/subcommands/subscribe.rs
@@ -15,6 +15,7 @@ use spacetimedb_lib::ser::serde::SerializeWrapper;
 use spacetimedb_lib::{bsatn, AlgebraicType};
 use std::collections::VecDeque;
 use std::io;
+use std::sync::atomic::AtomicU32;
 use std::time::Duration;
 use thiserror::Error;
 use tokio::io::AsyncWriteExt;
@@ -57,8 +58,8 @@ pub fn cli() -> clap::Command {
                 .value_parser(value_parser!(u32))
                 .help(
                     "The timeout, in seconds, after which to disconnect and stop receiving \
-                     subscription messages. If `-n` is specified, it will stop after whichever
-                     one comes first.",
+                     subscription messages. If `-n` is specified, it will stop after whichever \
+                     one comes first. Timing out before receiving `-n` updates is an error.",
                 ),
         )
         .arg(
@@ -127,10 +128,13 @@ impl SubscribeConnection {
         &mut self,
         num: Option<u32>,
         module_def: &RawModuleDefV9,
+        num_received: &UpdateCounter,
     ) -> Result<(), Error> {
         match self {
-            Self::V3 { ws, pending } => consume_transaction_updates_v3(ws, pending, num, module_def).await,
-            Self::V1 { ws } => consume_transaction_updates_v1(ws, num, module_def).await,
+            Self::V3 { ws, pending } => {
+                consume_transaction_updates_v3(ws, pending, num, module_def, num_received).await
+            }
+            Self::V1 { ws } => consume_transaction_updates_v1(ws, num, module_def, num_received).await,
         }
     }
 
@@ -181,13 +185,14 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error
     let api = ClientApi::new(conn);
     let module_def = api.module_def().await?;
     let mut conn = connect_with_fallback(&api, confirmed).await?;
+    let num_received = UpdateCounter::new();
 
     let task = async {
         conn.subscribe(queries.iter().cloned().map(Into::into).collect())
             .await?;
         conn.await_initial_update(print_initial_update.then_some(&module_def))
             .await?;
-        conn.consume_transaction_updates(num, &module_def).await
+        conn.consume_transaction_updates(num, &module_def, &num_received).await
     };
 
     let res = if let Some(timeout) = timeout {
@@ -195,8 +200,16 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error
         match tokio::time::timeout(timeout, task).await {
             Ok(res) => res,
             Err(_elapsed) => {
+                let received = num_received.get();
                 eprintln!("timed out after {}s", timeout.as_secs());
-                Ok(())
+                match num {
+                    Some(expected) if received < expected => Err(Error::UpdateLimitTimedOut {
+                        expected,
+                        received,
+                        timeout_secs: timeout.as_secs(),
+                    }),
+                    _ => Ok(()),
+                }
             }
         }
     } else {
@@ -210,7 +223,7 @@ pub async fn exec(config: Config, args: &ArgMatches) -> Result<(), anyhow::Error
     conn.close().await;
     // The server closing the connection is not considered an error
     // if `-n` is not set, but any other error is. When `-n` is set,
-    // an early close from the update loop is reported as an error.
+    // an early close or timeout from the update loop is reported as an error.
     res.or_else(|e| {
         if e.is_server_closed_connection() {
             Ok(())
@@ -325,6 +338,12 @@ enum Error {
     SubscribeFailure { reason: Box<str> },
     #[error("subscription closed after receiving {received}/{expected} updates")]
     UpdateLimitNotReached { expected: u32, received: u32 },
+    #[error("subscription timed out after {timeout_secs}s after receiving {received}/{expected} updates")]
+    UpdateLimitTimedOut {
+        expected: u32,
+        received: u32,
+        timeout_secs: u64,
+    },
     #[error("error formatting response: {source:#}")]
     Reformat {
         #[source]
@@ -344,6 +363,22 @@ enum Error {
     Serde(#[from] serde_json::Error),
     #[error(transparent)]
     Io(#[from] io::Error),
+}
+
+struct UpdateCounter(AtomicU32);
+
+impl UpdateCounter {
+    fn new() -> Self {
+        Self(AtomicU32::new(0))
+    }
+
+    fn get(&self) -> u32 {
+        self.0.load(std::sync::atomic::Ordering::Relaxed)
+    }
+
+    fn increment(&self) {
+        self.0.fetch_add(1, std::sync::atomic::Ordering::Relaxed);
+    }
 }
 
 impl Error {
@@ -495,18 +530,18 @@ async fn consume_transaction_updates_v1<S>(
     ws: &mut S,
     num: Option<u32>,
     module_def: &RawModuleDefV9,
+    num_received: &UpdateCounter,
 ) -> Result<(), Error>
 where
     S: TryStream<Ok = WsMessage, Error = WsError> + Unpin,
 {
     let mut stdout = tokio::io::stdout();
-    let mut num_received = 0_u32;
     loop {
-        if num.is_some_and(|n| num_received >= n) {
+        if num.is_some_and(|n| num_received.get() >= n) {
             return Ok(());
         }
         let Some(msg) = ws.try_next().await.map_err(|source| Error::Websocket { source })? else {
-            return Err(connection_closed_error(num, num_received));
+            return Err(connection_closed_error(num, num_received.get()));
         };
 
         let Some(msg) = parse_msg_json(&msg) else { continue };
@@ -526,7 +561,7 @@ where
             }) => {
                 let output = format_output_json_v1(&update, module_def)?;
                 stdout.write_all(output.as_bytes()).await?;
-                num_received += 1;
+                num_received.increment();
             }
             _ => continue,
         }
@@ -540,18 +575,18 @@ async fn consume_transaction_updates_v3<S>(
     pending: &mut VecDeque<ws_v2::ServerMessage>,
     num: Option<u32>,
     module_def: &RawModuleDefV9,
+    num_received: &UpdateCounter,
 ) -> Result<(), Error>
 where
     S: TryStream<Ok = WsMessage, Error = WsError> + Unpin,
 {
     let mut stdout = tokio::io::stdout();
-    let mut num_received = 0_u32;
     loop {
-        if num.is_some_and(|n| num_received >= n) {
+        if num.is_some_and(|n| num_received.get() >= n) {
             return Ok(());
         }
         let Some(msg) = next_server_message(ws, pending).await? else {
-            return Err(connection_closed_error(num, num_received));
+            return Err(connection_closed_error(num, num_received.get()));
         };
 
         match msg {
@@ -566,7 +601,7 @@ where
             ws_v2::ServerMessage::TransactionUpdate(update) => {
                 let output = format_output_json_transaction_update(&update, module_def)?;
                 stdout.write_all(output.as_bytes()).await?;
-                num_received += 1;
+                num_received.increment();
             }
             _ => continue,
         }

--- a/crates/smoketests/src/lib.rs
+++ b/crates/smoketests/src/lib.rs
@@ -1846,12 +1846,6 @@ impl SubscriptionHandle {
             bail!("subscribe failed:\nstderr: {}", stderr_buf);
         }
 
-        if let Some(n) = self.n
-            && updates.len() != n
-        {
-            bail!("subscribe returned {} updates, expected {n}", updates.len());
-        }
-
         Ok(updates)
     }
 }

--- a/crates/smoketests/src/lib.rs
+++ b/crates/smoketests/src/lib.rs
@@ -1693,21 +1693,25 @@ log = "0.4"
     /// This matches Python's subscribe semantics - start subscription first,
     /// perform actions, then call the handle to collect results.
     pub fn subscribe_background(&self, queries: &[&str], n: usize) -> Result<SubscriptionHandle> {
-        self.subscribe_background_opts(queries, n, None)
+        self.subscribe_background_opts(queries, Some(n), None)
+    }
+
+    pub fn subscribe_background_until_closed(&self, queries: &[&str]) -> Result<SubscriptionHandle> {
+        self.subscribe_background_opts(queries, None, None)
     }
 
     pub fn subscribe_background_on(&self, database: &str, queries: &[&str], n: usize) -> Result<SubscriptionHandle> {
-        self.subscribe_background_on_opts(database, queries, n, Some(false))
+        self.subscribe_background_on_opts(database, queries, Some(n), Some(false))
     }
 
     /// Starts a subscription in the background with --confirmed flag.
     pub fn subscribe_background_confirmed(&self, queries: &[&str], n: usize) -> Result<SubscriptionHandle> {
-        self.subscribe_background_opts(queries, n, Some(true))
+        self.subscribe_background_opts(queries, Some(n), Some(true))
     }
 
     /// Starts a subscription in the background with --confirmed flag.
     pub fn subscribe_background_unconfirmed(&self, queries: &[&str], n: usize) -> Result<SubscriptionHandle> {
-        self.subscribe_background_opts(queries, n, Some(false))
+        self.subscribe_background_opts(queries, Some(n), Some(false))
     }
 
     pub fn subscribe_background_on_confirmed(
@@ -1716,14 +1720,14 @@ log = "0.4"
         queries: &[&str],
         n: usize,
     ) -> Result<SubscriptionHandle> {
-        self.subscribe_background_on_opts(database, queries, n, Some(true))
+        self.subscribe_background_on_opts(database, queries, Some(n), Some(true))
     }
 
     /// Internal helper for background subscribe with options.
     fn subscribe_background_opts(
         &self,
         queries: &[&str],
-        n: usize,
+        n: Option<usize>,
         confirmed: Option<bool>,
     ) -> Result<SubscriptionHandle> {
         let identity = self
@@ -1739,7 +1743,7 @@ log = "0.4"
         &self,
         database: &str,
         queries: &[&str],
-        n: usize,
+        n: Option<usize>,
         confirmed: Option<bool>,
     ) -> Result<SubscriptionHandle> {
         self.subscribe_background_on_impl(database, queries, n, confirmed)
@@ -1749,7 +1753,7 @@ log = "0.4"
         &self,
         database: &str,
         queries: &[&str],
-        n: usize,
+        n: Option<usize>,
         confirmed: Option<bool>,
     ) -> Result<SubscriptionHandle> {
         let cli_path = ensure_binaries_built();
@@ -1765,10 +1769,12 @@ log = "0.4"
             database.to_string(),
             "-t".to_string(),
             "30".to_string(),
-            "-n".to_string(),
-            n.to_string(),
             "--print-initial-update".to_string(),
         ];
+        if let Some(n) = n {
+            args.push("-n".to_string());
+            args.push(n.to_string());
+        }
         if let Some(confirmed) = confirmed {
             args.push("--confirmed".to_string());
             args.push(confirmed.to_string());
@@ -1806,7 +1812,7 @@ pub struct SubscriptionHandle {
     child: std::process::Child,
     reader: std::io::BufReader<std::process::ChildStdout>,
     stderr: std::process::ChildStderr,
-    n: usize,
+    n: Option<usize>,
     start: Instant,
 }
 
@@ -1830,7 +1836,7 @@ impl SubscriptionHandle {
         let status = self.child.wait().context("Failed to wait for subscribe")?;
         eprintln!(
             "[TIMING] subscribe_background (n={}): {:?}",
-            self.n,
+            self.n.map(|n| n.to_string()).unwrap_or_else(|| "none".to_string()),
             self.start.elapsed()
         );
 
@@ -1838,6 +1844,12 @@ impl SubscriptionHandle {
             let mut stderr_buf = String::new();
             self.stderr.read_to_string(&mut stderr_buf).ok();
             bail!("subscribe failed:\nstderr: {}", stderr_buf);
+        }
+
+        if let Some(n) = self.n
+            && updates.len() != n
+        {
+            bail!("subscribe returned {} updates, expected {n}", updates.len());
         }
 
         Ok(updates)

--- a/crates/smoketests/tests/smoketests/auto_migration.rs
+++ b/crates/smoketests/tests/smoketests/auto_migration.rs
@@ -343,11 +343,9 @@ fn test_add_table_columns() {
     // Subscribe to person table changes multiple times to simulate active clients
     let mut subs = Vec::with_capacity(NUM_SUBSCRIBERS);
     for _ in 0..NUM_SUBSCRIBERS {
-        // We need unconfirmed reads for the updates to arrive properly.
-        // Otherwise, there's a race between module teardown in publish, vs subscribers
-        // getting the row deletion they expect.
+        // The migration below should disconnect all existing subscribers.
         subs.push(
-            test.subscribe_background_unconfirmed(&["select * from person"], 5)
+            test.subscribe_background_until_closed(&["select * from person"])
                 .unwrap(),
         );
     }
@@ -389,9 +387,8 @@ fn test_add_table_columns() {
     test.call("add_person", &["Robert2"]).unwrap();
 
     // Validate all subscribers were disconnected after first upgrade
-    for (i, sub) in subs.into_iter().enumerate() {
-        let rows = sub.collect().unwrap();
-        assert_eq!(rows.len(), 2, "Subscriber {i} received unexpected rows: {rows:?}");
+    for sub in subs {
+        sub.collect().unwrap();
     }
 
     // Second upgrade

--- a/crates/smoketests/tests/smoketests/auto_migration.rs
+++ b/crates/smoketests/tests/smoketests/auto_migration.rs
@@ -386,8 +386,8 @@ fn test_add_table_columns() {
     // Insert new data under upgraded schema
     test.call("add_person", &["Robert2"]).unwrap();
 
-    // Validate all subscribers were disconnected after first upgrade
     for sub in subs {
+        // Ensure the background cli subprocess observes the disconnect and exits cleanly
         sub.collect().unwrap();
     }
 

--- a/crates/smoketests/tests/smoketests/delete_database.rs
+++ b/crates/smoketests/tests/smoketests/delete_database.rs
@@ -45,9 +45,10 @@ fn test_delete_database_with_confirmation() {
     let name = format!("delete-database-{}", std::process::id());
     test.publish_module_named(&name, false).unwrap();
 
-    // Start subscription in background to collect updates
-    // We request many updates but will stop early when we delete the db
-    let sub = test.subscribe_background(&["SELECT * FROM counter"], 1000).unwrap();
+    // Start subscription in background to collect updates until deleting the database closes it.
+    let sub = test
+        .subscribe_background_until_closed(&["SELECT * FROM counter"])
+        .unwrap();
 
     // Let the scheduled reducer run for a bit
     thread::sleep(Duration::from_secs(2));

--- a/crates/smoketests/tests/smoketests/views.rs
+++ b/crates/smoketests/tests/smoketests/views.rs
@@ -592,7 +592,7 @@ fn test_view_primary_key_auto_migration_disconnects_clients() {
         .build();
 
     let sub = test
-        .subscribe_background_unconfirmed(&["select * from player"], 2)
+        .subscribe_background_until_closed(&["select * from player"])
         .unwrap();
 
     test.use_precompiled_module("views-primary-key-auto-migrate-updated");
@@ -672,7 +672,7 @@ fn test_subscribing_with_different_identities() {
 
     test.new_identity().unwrap();
 
-    let sub = test.subscribe_background(&["select * from my_player"], 2).unwrap();
+    let sub = test.subscribe_background(&["select * from my_player"], 1).unwrap();
     test.call("insert_player", &["Bob"]).unwrap();
     let events = sub.collect().unwrap();
 

--- a/docs/docs/00300-resources/00200-reference/00100-cli-reference/00100-cli-reference.md
+++ b/docs/docs/00300-resources/00200-reference/00100-cli-reference/00100-cli-reference.md
@@ -597,8 +597,7 @@ Subscribe to SQL queries on the database. WARNING: This command is UNSTABLE and 
 ###### **Options:**
 
 * `-n`, `--num-updates <NUM-UPDATES>` — The number of subscription updates to receive before exiting
-* `-t`, `--timeout <TIMEOUT>` — The timeout, in seconds, after which to disconnect and stop receiving subscription messages. If `-n` is specified, it will stop after whichever
-                     one comes first.
+* `-t`, `--timeout <TIMEOUT>` — The timeout, in seconds, after which to disconnect and stop receiving subscription messages. If `-n` is specified, it will stop after whichever one comes first. Timing out before receiving `-n` updates is an error.
 * `--print-initial-update` — Print the initial update for the queries.
 * `--confirmed <CONFIRMED>` — Instruct the server to deliver only updates of confirmed transactions
 


### PR DESCRIPTION
# Description of Changes

Previously, if the server closed the connection, it was not considered an error. The reason for this was because `-n` did not always mean the connection should receive **exactly** `n` updates. Sometimes it meant that the connection should receive **at most** `n` updates. This was the case for client disconnecting auto-migration tests.

However, as a consequence, if the server were to close the connection for some other reason - let's say it crashed before broadcasting all `n` updates - the cli would not report this as an error. If this happened during a smoketest, it would fail on some later assertion, but it wouldn't be immediately obvious why.

`spacetime subscribe -n N` now fails if the websocket closes before it receives `N` transaction updates. `subscribe_background(..., n)` also fails if the CLI exits successfully but produced fewer or more than `n` JSON update lines, where previously it did not. 

This change, makes it very clear when this happens that the connection to the server was closed before the test received its expected number of updates.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

The purpose of this change is to provide more diagnostic info for smoketest failures.
