### PR TITLE
Catch unwinding panics in the scheduler

### DIFF
--- a/crates/core/src/host/scheduler.rs
+++ b/crates/core/src/host/scheduler.rs
@@ -387,8 +387,23 @@ impl SchedulerActor {
 
         let params = ScheduledFunctionParams(item.clone());
         let result = match params.kind(module_host.info()) {
-            ScheduledFunctionKind::Procedure => module_host.call_scheduled_procedure(params).await,
-            ScheduledFunctionKind::Reducer => module_host.call_scheduled_reducer(params).await,
+            ScheduledFunctionKind::Procedure => {
+                panic::AssertUnwindSafe(module_host.call_scheduled_procedure(params))
+                    .catch_unwind()
+                    .await
+            }
+            ScheduledFunctionKind::Reducer => {
+                panic::AssertUnwindSafe(module_host.call_scheduled_reducer(params))
+                    .catch_unwind()
+                    .await
+            }
+        };
+        let result = match result {
+            Ok(result) => result,
+            Err(_) => {
+                log::warn!("scheduled function panicked");
+                return;
+            }
         };
 
         match result {


### PR DESCRIPTION
# Description of Changes

This fixes a scheduler crash where a panic from a scheduled JS reducer/procedure could unwind out of `SchedulerActor::handle_queued`.

The fix keeps the existing panic semantics through `ModuleHost`, so `defer_on_unwind` still runs and poisons the failed module host, but the scheduler now catches the unwind after that boundary, logs a warning, and returns without rescheduling that queue item.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1

# Testing

...
