### PR TITLE
Fix commitlog replay of dropped event tables

### DIFF
--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -622,6 +622,81 @@ mod test {
         replay_event_table_schema_change(TakeSnapshot::BeforeAutomigration)
     }
 
+    /// Regression test for replay of a dropped event table.
+    ///
+    /// Dropping an event table deletes its `st_table`, `st_column` and `st_event_table` rows
+    /// in a single transaction. During replay, deletes are applied in ascending table id order,
+    /// so the `st_table` row is deleted before the `st_column` rows,
+    /// while the `st_event_table` row is still present.
+    /// Replay of the `st_column` deletes therefore saw the table as an event table
+    /// and tried to refresh its layout via `st_column_changed`,
+    /// which failed with `Table with ID ... not found in st_table`,
+    /// permanently preventing the database from reopening.
+    fn replay_event_table_drop(snapshot: TakeSnapshot) -> anyhow::Result<()> {
+        let auth_ctx = AuthCtx::for_testing();
+        let stdb = TestDB::durable()?;
+
+        let module_v1 = event_table_module(ProductType::from([("payload", AlgebraicType::U64)]));
+        let module_v2 = empty_module();
+
+        // Publish v1 with the event table.
+        {
+            let mut tx = begin_mut_tx(&stdb);
+            for def in module_v1.tables() {
+                create_table_from_def(&stdb, &mut tx, &module_v1, def)?;
+            }
+            stdb.commit_tx(tx)?;
+        }
+
+        // Write an event row, so the commitlog also contains an insert into the table.
+        {
+            let mut tx = begin_mut_tx(&stdb);
+            let table_id = stdb
+                .table_id_from_name_mut(&tx, "events")?
+                .expect("`events` table should exist");
+            insert(&stdb, &mut tx, table_id, &product![42u64])?;
+            stdb.commit_tx(tx)?;
+        }
+
+        if matches!(snapshot, TakeSnapshot::BeforeAutomigration) {
+            take_snapshot(&stdb)?;
+        }
+
+        // Migrate v1 -> v2, dropping the event table.
+        {
+            let mut tx = begin_mut_tx(&stdb);
+            let plan = ponder_migrate(&module_v1, &module_v2)?;
+            let res = update_database(&stdb, &mut tx, auth_ctx, plan, &TestLogger)?;
+            assert!(
+                matches!(res, UpdateResult::RequiresClientDisconnect),
+                "removing a table should disconnect clients"
+            );
+            stdb.commit_tx(tx)?;
+        }
+
+        // Replay the commitlog. Prior to the fix, this failed with
+        // `Table with ID ... not found in st_table`
+        // while replaying the `st_column` deletes of the dropped event table.
+        let stdb = stdb.reopen()?;
+        let tx = begin_mut_tx(&stdb);
+        assert!(
+            stdb.table_id_from_name_mut(&tx, "events")?.is_none(),
+            "`events` table should be gone after replaying the drop"
+        );
+
+        Ok(())
+    }
+
+    #[test]
+    fn replay_event_table_drop_no_snapshot() -> anyhow::Result<()> {
+        replay_event_table_drop(TakeSnapshot::None)
+    }
+
+    #[test]
+    fn replay_event_table_drop_after_snapshot() -> anyhow::Result<()> {
+        replay_event_table_drop(TakeSnapshot::BeforeAutomigration)
+    }
+
     #[test]
     fn remove_empty_table_succeeds() -> anyhow::Result<()> {
         let auth_ctx = AuthCtx::for_testing();

--- a/crates/core/src/db/update.rs
+++ b/crates/core/src/db/update.rs
@@ -352,6 +352,7 @@ mod test {
         host::module_host::create_table_from_def,
     };
     use spacetimedb_datastore::locking_tx_datastore::PendingSchemaChange;
+    use spacetimedb_datastore::system_tables::ST_EVENT_TABLE_ID;
     use spacetimedb_lib::{
         db::raw_def::{
             v10::RawModuleDefV10Builder,
@@ -674,6 +675,17 @@ mod test {
             stdb.commit_tx(tx)?;
         }
 
+        // The drop must also remove the table's `st_event_table` row,
+        // rather than leaving it orphaned.
+        {
+            let tx = begin_mut_tx(&stdb);
+            assert_eq!(
+                stdb.table_row_count_mut(&tx, ST_EVENT_TABLE_ID).unwrap_or(0),
+                0,
+                "`st_event_table` should not contain rows for dropped tables"
+            );
+        }
+
         // Replay the commitlog. Prior to the fix, this failed with
         // `Table with ID ... not found in st_table`
         // while replaying the `st_column` deletes of the dropped event table.
@@ -682,6 +694,11 @@ mod test {
         assert!(
             stdb.table_id_from_name_mut(&tx, "events")?.is_none(),
             "`events` table should be gone after replaying the drop"
+        );
+        assert_eq!(
+            stdb.table_row_count_mut(&tx, ST_EVENT_TABLE_ID).unwrap_or(0),
+            0,
+            "`st_event_table` should not contain rows for dropped tables after replay"
         );
 
         Ok(())

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -20,12 +20,12 @@ use crate::{
     error::{IndexError, SequenceError, TableError},
     system_tables::{
         with_sys_table_buf, StClientFields, StClientRow, StColumnAccessorFields, StColumnAccessorRow, StColumnFields,
-        StColumnRow, StConstraintFields, StConstraintRow, StEventTableRow, StFields as _, StIndexAccessorFields,
-        StIndexAccessorRow, StIndexFields, StIndexRow, StRowLevelSecurityFields, StRowLevelSecurityRow,
-        StScheduledFields, StScheduledRow, StSequenceFields, StSequenceRow, StTableAccessorFields, StTableAccessorRow,
-        StTableFields, StTableRow, SystemTable, ST_CLIENT_ID, ST_COLUMN_ACCESSOR_ID, ST_COLUMN_ID, ST_CONSTRAINT_ID,
-        ST_EVENT_TABLE_ID, ST_INDEX_ACCESSOR_ID, ST_INDEX_ID, ST_ROW_LEVEL_SECURITY_ID, ST_SCHEDULED_ID,
-        ST_SEQUENCE_ID, ST_TABLE_ACCESSOR_ID, ST_TABLE_ID,
+        StColumnRow, StConstraintFields, StConstraintRow, StEventTableFields, StEventTableRow, StFields as _,
+        StIndexAccessorFields, StIndexAccessorRow, StIndexFields, StIndexRow, StRowLevelSecurityFields,
+        StRowLevelSecurityRow, StScheduledFields, StScheduledRow, StSequenceFields, StSequenceRow,
+        StTableAccessorFields, StTableAccessorRow, StTableFields, StTableRow, SystemTable, ST_CLIENT_ID,
+        ST_COLUMN_ACCESSOR_ID, ST_COLUMN_ID, ST_CONSTRAINT_ID, ST_EVENT_TABLE_ID, ST_INDEX_ACCESSOR_ID, ST_INDEX_ID,
+        ST_ROW_LEVEL_SECURITY_ID, ST_SCHEDULED_ID, ST_SEQUENCE_ID, ST_TABLE_ACCESSOR_ID, ST_TABLE_ID,
     },
 };
 use crate::{execution_context::ExecutionContext, system_tables::StViewColumnRow};
@@ -1014,6 +1014,15 @@ impl MutTxId {
                 ST_SCHEDULED_ID,
                 StScheduledFields::ScheduleId.col_id(),
                 &schedule.schedule_id.into(),
+            )?;
+        }
+
+        // Remove the table's row from `st_event_table`, if it is an event table.
+        if schema.is_event {
+            self.delete_col_eq(
+                ST_EVENT_TABLE_ID,
+                StEventTableFields::TableId.col_id(),
+                &table_id.into(),
             )?;
         }
 

--- a/crates/datastore/src/locking_tx_datastore/replay.rs
+++ b/crates/datastore/src/locking_tx_datastore/replay.rs
@@ -943,7 +943,16 @@ impl<'cs> ReplayCommittedState<'cs> {
             let referenced_table_id = Self::read_table_id(row);
             self.replay_columns_to_ignore.remove(&row_ptr);
 
-            if self.is_event_table_for_replay(referenced_table_id)? {
+            // If the referenced table was dropped earlier in this transaction,
+            // don't try to refresh its layout: its `st_table` row is already gone,
+            // so `st_column_changed` would fail to look up the table's name.
+            // This happens when dropping an event table,
+            // as the `st_table` delete (table id 1) is replayed
+            // before the `st_column` deletes (table id 2),
+            // while the table's `st_event_table` row (table id 17) is still present.
+            if !self.replay_table_dropped.contains(&referenced_table_id)
+                && self.is_event_table_for_replay(referenced_table_id)?
+            {
                 self.st_column_changed(referenced_table_id)?;
             }
         }

--- a/crates/smoketests/tests/smoketests/auto_migration.rs
+++ b/crates/smoketests/tests/smoketests/auto_migration.rs
@@ -1,4 +1,4 @@
-use spacetimedb_smoketests::Smoketest;
+use spacetimedb_smoketests::{require_local_server, Smoketest};
 
 const MODULE_CODE_SIMPLE: &str = r#"
 use spacetimedb::{log, ReducerContext, Table};
@@ -539,4 +539,96 @@ fn automigrate_reschema_event_table_arbitrarily() {
     test.write_module_code(MODULE_CODE_WITH_EVENT_TABLE_BEFORE).unwrap();
     test.publish_module_with_options(&identity, false, true)
         .expect("Changing schema of event table should succeed");
+}
+
+const MODULE_CODE_DROP_EVENT_TABLE_BEFORE: &str = r#"
+use spacetimedb::{ReducerContext, Table};
+
+#[spacetimedb::table(accessor = person, public)]
+pub struct Person {
+    name: String,
+}
+
+#[spacetimedb::table(accessor = some_event, public, event)]
+pub struct SomeEvent {
+    account_id: u32,
+    name: String,
+}
+
+#[spacetimedb::reducer]
+pub fn add_person(ctx: &ReducerContext, name: String) {
+    ctx.db.person().insert(Person { name });
+}
+
+#[spacetimedb::reducer]
+pub fn emit_event(ctx: &ReducerContext) {
+    ctx.db.some_event().insert(SomeEvent { account_id: 7, name: "alpha".to_string() });
+}
+"#;
+
+const MODULE_CODE_DROP_EVENT_TABLE_AFTER: &str = r#"
+use spacetimedb::{ReducerContext, Table};
+
+#[spacetimedb::table(accessor = person, public)]
+pub struct Person {
+    name: String,
+}
+
+#[spacetimedb::reducer]
+pub fn add_person(ctx: &ReducerContext, name: String) {
+    ctx.db.person().insert(Person { name });
+}
+"#;
+
+/// Regression test: dropping an event table must not brick commitlog replay.
+///
+/// Dropping an event table deletes its `st_table`, `st_column` and `st_event_table` rows
+/// in a single transaction. Replay applies deletes in ascending table id order,
+/// so the `st_table` row is already gone when the `st_column` deletes are replayed,
+/// while the `st_event_table` row is still present.
+/// Replay therefore treated the dropped table as a live event table
+/// and tried to refresh its layout, failing with
+/// `Table with ID ... not found in st_table`
+/// and permanently preventing the database from starting.
+#[test]
+fn automigrate_drop_event_table_replays_after_restart() {
+    require_local_server!();
+    let mut test = Smoketest::builder()
+        .module_code(MODULE_CODE_DROP_EVENT_TABLE_BEFORE)
+        .build();
+
+    let identity = test
+        .database_identity
+        .clone()
+        .expect("database should be published after build");
+
+    // Write some history, including an event row.
+    test.call("add_person", &["Robert"]).unwrap();
+    test.call("emit_event", &[]).unwrap();
+
+    // Drop the event table.
+    test.write_module_code(MODULE_CODE_DROP_EVENT_TABLE_AFTER).unwrap();
+    test.publish_module_with_options(&identity, false, true)
+        .expect("Dropping the event table should succeed");
+
+    // Wait until data written after the drop is durable,
+    // which implies the drop itself is durable too.
+    test.call("add_person", &["Julie"]).unwrap();
+    let output = test.sql_confirmed("SELECT * FROM person WHERE name = 'Julie'").unwrap();
+    assert!(output.contains("Julie"), "Data not confirmed before restart: {output}");
+
+    // Restarting forces a commitlog replay, which must replay the event table drop.
+    test.restart_server();
+
+    let output = test.sql("SELECT name FROM person").unwrap();
+    assert!(output.contains("Robert"), "Expected 'Robert' after restart: {output}");
+    assert!(output.contains("Julie"), "Expected 'Julie' after restart: {output}");
+
+    // The database should still accept writes after replay.
+    test.call("add_person", &["Samantha"]).unwrap();
+    let output = test.sql("SELECT name FROM person WHERE name = 'Samantha'").unwrap();
+    assert!(
+        output.contains("Samantha"),
+        "Expected 'Samantha' after restart: {output}"
+    );
 }


### PR DESCRIPTION
# Description of Changes

Fixes two bugs around dropping event tables.

**Bug 1:** a deterministic commitlog replay failure introduced in #5269 that permanently prevents a database from restarting after an event table is dropped. Observed in production on 2.5.0:

```
ERROR ... Failed to open database: DatastoreError: Error deleting row ProductValue { elements: [U32(4134), U16(0), String("account_id"), Array([13])] } from table "st_column" during transaction 26002 playback: ... TableError: Table with ID `4134` not found in `st_table`.
```

## Root cause

Dropping an event table (a `RemoveTable` automigration) deletes its `st_table`, `st_column`, and `st_event_table` rows in a single transaction. `prepare_tx_data_for_durability` sorts delete ops by ascending table id, so replay applies them in this order:

1. The `st_table` (table id 1) delete is replayed first. The table is recorded in `replay_table_dropped` and its `st_table` row is removed.
2. The `st_column` (table id 2) deletes are replayed next. The handling added in #5269 calls `is_event_table_for_replay`, which still finds the table's `st_event_table` (table id 17) row, since that delete has not been replayed yet.
3. `st_column_changed` is invoked to refresh the table's layout. It calls `find_st_table_row`, which fails because the `st_table` row is already gone.

Production replay runs with `ErrorBehavior::FailFast`, so the replica fails to launch on every restart. The commitlog itself is intact: databases bricked by this bug recover with no data loss once opened with this fix.

#5269 tested in-place event table reschemas (which keep the `st_table` row alive) but not drops.

## Fix

Skip the layout refresh when the referenced table was dropped earlier in the same transaction, as tracked by `replay_table_dropped`. That set is the existing mechanism for exactly this replay ordering hazard, and the `st_table` delete is always replayed before the `st_column` deletes due to the table id sort, so the guard is reliable.

**Bug 2:** `drop_table` never deletes the table's `st_event_table` row. It cleans up `st_table`, `st_column`, `st_index`, `st_sequence`, `st_constraint`, the accessor tables, and `st_scheduled`, but `st_event_table` was missed when event tables were introduced. Dropping an event table therefore leaves an orphaned `st_event_table` row, verified empirically:

```
> SELECT * FROM st_event_table     -- after dropping the only event table
 table_id
----------
 4097
> SELECT table_id FROM st_table WHERE table_id = 4097
 (no rows)
```

The orphan is latent today (`st_event_table` is only read via point lookups by live table ids), but it is the precondition that exposed bug 1, and it is incorrect catalog state. `drop_table` now deletes the row.

Note that both fixes are required independently: the replay guard is needed even with the `drop_table` fix, because the `st_event_table` delete replays after the `st_column` deletes (table id 17 vs. 2), and also because commitlogs already written by unfixed versions contain drop transactions with no `st_event_table` delete at all. Databases which already dropped an event table on an unfixed version keep their orphaned row; cleaning those up retroactively is left for a follow-up (e.g. a fixup in `rebuild_state_after_replay`, like `fixup_delete_duplicate_system_sequence_rows`).

# API and ABI breaking changes

None.

# Expected complexity level and risk

1. A guard on an existing replay invariant, plus tests.

# Testing

- [x] New unit regression tests `replay_event_table_drop_no_snapshot` and `replay_event_table_drop_after_snapshot` in `crates/core/src/db/update.rs`, following the structure of the #5269 replay tests (create event table, write an event row, drop the table via `RemoveTable` automigration, reopen to force replay). Verified both fail with the production error signature before the fix and pass after:

  ```
  ---- db::update::test::replay_event_table_drop_no_snapshot stdout ----
  Error: DatastoreError: Error deleting row ProductValue { elements: [U32(4096), U16(0), String("payload"), Array([13])] } from table "st_column" during transaction 3 playback
  ...
      1: TableError: Table with ID `4096` not found in `st_table`.
  ```

- [x] The pre-existing #5269 replay tests (`replay_event_table_schema_change_*`) still pass.
- [x] New smoketest `automigrate_drop_event_table_replays_after_restart`: publishes a module with an event table, emits an event, drops the table via automigration, restarts the server, and verifies the database replays and serves reads and writes. Passes locally.
- [x] Reproduced the production failure on a stock 2.5.0 standalone (publish module with event table, republish without it, restart, identical error), then opened the same bricked data directory with a standalone built from this branch and verified the database replays and serves queries with all data intact.
