### PR TITLE
Don't preallocate based on bsatn length prefix

### DIFF
--- a/crates/sats/src/de.rs
+++ b/crates/sats/src/de.rs
@@ -771,7 +771,12 @@ impl<T, const N: usize> GrowingVec<T> for SmallVec<[T; N]> {
 
 /// A basic implementation of `ArrayVisitor::visit` using the provided size hint.
 pub fn array_visit<'de, A: ArrayAccess<'de>, V: GrowingVec<A::Element>>(mut access: A) -> Result<V, A::Error> {
-    let mut v = V::try_with_capacity(access.size_hint().unwrap_or(0))?;
+    // Don’t blindly trust length prefixes when reserving initial capacity
+    // for decoding array elements, as malformed input could generate a huge allocation,
+    // potentially resulting in an OOM kill.
+    const RESERVE_ARRAY_ELEMENTS: usize = 4096;
+    let cap = access.size_hint().unwrap_or(0);
+    let mut v = V::try_with_capacity(cap.min(RESERVE_ARRAY_ELEMENTS))?;
     while let Some(x) = access.next_element()? {
         v.push(x)
     }


### PR DESCRIPTION
# Description of Changes

Fixes an OOM kill in the proptest `bsatn_invalid_wont_decode`.

`bsatn_invalid_wont_decode` generates arbitrary invalid bytes, proves validation fails, then still calls full AlgebraicValue::decode. For generated array-like types, decode reads a u32 length prefix, and the generic array visitor then reserves that capacity. But because they're random bytes, this could cause a huge initial allocation which could OOM kill the test process.

Now the visitor reserves a smaller initial capacity instead of assuming the binary input data is well formed.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1

# Testing

This should fix the flaky `spacetimedb-sats` `Test Suite` failures that occasionally end in a SIGKILL.
