### PR TITLE
Drop tps threshold in keynote bench

### DIFF
--- a/tools/ci/src/keynote_bench.rs
+++ b/tools/ci/src/keynote_bench.rs
@@ -37,12 +37,12 @@ const BENCHMARK_MODULES: &[BenchmarkModule] = &[
     BenchmarkModule {
         label: "TypeScript",
         module_dir: "templates/keynote-2/spacetimedb",
-        min_tps: 275_000.0,
+        min_tps: 250_000.0,
     },
     BenchmarkModule {
         label: "Rust",
         module_dir: "templates/keynote-2/rust_module",
-        min_tps: 275_000.0,
+        min_tps: 250_000.0,
     },
 ];
 


### PR DESCRIPTION
# Description of Changes

Reviewing recent benchmark runs, it appears that #5071 probably regressed TPS by around 3-5%. I don't want to revert that change because it has implications for replication, and so for now we'll just live with the slight regression.

# API and ABI breaking changes

None

# Expected complexity level and risk

0

# Testing

N/A
