### PR TITLE
Skip bsatn decode proptest

### DIFF
--- a/crates/sats/src/bsatn.rs
+++ b/crates/sats/src/bsatn.rs
@@ -269,6 +269,11 @@ mod tests {
         }
 
         #[test]
+        #[ignore = "This test needs to be refactored. \
+                    It can generate input that allocates a lot of memory during decode, \
+                    which can sometimes result in a SIGKILL. \
+                    This supposedly occurs for array types with zero-width elements, \
+                    but this has not been confirmed."]
         fn bsatn_invalid_wont_decode(ty in generate_algebraic_type(), bytes in vec(any::<u8>(), 0..4096)) {
             prop_assume!(type_non_empty(&ty));
             prop_assume!(WithTypespace::empty(&ty).validate(Deserializer::new(&mut &bytes[..])).is_err());


### PR DESCRIPTION
# Description of Changes

Attempted to fix this test in #5343, but we're still getting SIGKILLS, so ignoring for now. This will require more investigation to fix. I've included what I believe is the reason in the help text and created [this](#5362) tracker to unskip.

# API and ABI breaking changes

None

# Expected complexity level and risk

0

# Testing

N/A
