### PR TITLE
Svelte binding: programmatic reconnect / token-swap via ConnectionManager

### DIFF
--- a/crates/bindings-typescript/src/sdk/connection_manager.ts
+++ b/crates/bindings-typescript/src/sdk/connection_manager.ts
@@ -343,7 +343,21 @@ class ConnectionManagerImpl {
     }
     managed.connection = undefined;
 
-    return this.#buildManagedConnection(managed, builder) as T;
+    try {
+      return this.#buildManagedConnection(managed, builder) as T;
+    } catch (error) {
+      // The old connection is already torn down, so a failed rebuild would
+      // otherwise leave the pool reporting a stale "live" connection. Surface
+      // the failure into pool state (matching the onConnectError shape) so
+      // subscribers see a disconnected/errored connection, then re-throw so
+      // the caller can handle it.
+      this.#updateState(managed, {
+        isActive: false,
+        connectionError:
+          error instanceof Error ? error : new Error(String(error)),
+      });
+      throw error;
+    }
   }
 
   release(key: string): void {

--- a/crates/bindings-typescript/src/sdk/connection_manager.ts
+++ b/crates/bindings-typescript/src/sdk/connection_manager.ts
@@ -294,6 +294,58 @@ class ConnectionManagerImpl {
     return this.#buildManagedConnection(managed, builder);
   }
 
+  /**
+   * Tears down the current connection and builds a fresh one from `builder`,
+   * preserving the entry's ref count and listener set.
+   *
+   * `retain()` deliberately ignores the builder once a connection is live —
+   * the right behaviour for ref-counting, but it blocks "reconnect with a
+   * fresh token" flows (e.g. swapping an anonymous session for a signed-in one
+   * after an auth change). `rebuild()` is the supported escape hatch: pass a
+   * builder carrying the new token and the pool swaps the live connection
+   * under the same subscribers, so framework hooks (`useTable`, `useReducer`,
+   * …) re-bind to the new connection automatically.
+   *
+   * The old connection's callbacks are detached before it is closed, so its
+   * disconnect event never leaks into pool state, and any pending auto-reconnect
+   * is cancelled (the caller is driving the reconnect explicitly). Returns the
+   * newly-built connection, or `null` if the key has no retained entry.
+   *
+   * @param key - Unique identifier for the connection (use getKey to generate)
+   * @param builder - Fresh connection builder; its handlers are rewired into the pool
+   */
+  rebuild<T extends DbConnectionImpl<any>>(
+    key: string,
+    builder: DbConnectionBuilder<T>
+  ): T | null {
+    const managed = this.#connections.get(key);
+    if (!managed || managed.refCount <= 0) {
+      return null;
+    }
+
+    // The caller is taking over the connection lifecycle explicitly; cancel a
+    // deferred release or a pending auto-reconnect so neither races the fresh
+    // connection, and reset the backoff so the next unexpected drop starts over.
+    if (managed.pendingRelease) {
+      clearTimeout(managed.pendingRelease);
+      managed.pendingRelease = null;
+    }
+    if (managed.reconnectTimer) {
+      clearTimeout(managed.reconnectTimer);
+      managed.reconnectTimer = null;
+    }
+    managed.reconnectAttempt = 0;
+
+    const connection = managed.connection;
+    if (connection) {
+      this.#detachCallbacks(managed, connection);
+      connection.disconnect();
+    }
+    managed.connection = undefined;
+
+    return this.#buildManagedConnection(managed, builder) as T;
+  }
+
   release(key: string): void {
     const managed = this.#connections.get(key);
     if (!managed) {

--- a/crates/bindings-typescript/src/svelte/SpacetimeDBProvider.ts
+++ b/crates/bindings-typescript/src/svelte/SpacetimeDBProvider.ts
@@ -3,99 +3,75 @@ import { writable, type Writable } from 'svelte/store';
 import {
   DbConnectionBuilder,
   type DbConnectionImpl,
-  type ErrorContextInterface,
-  type RemoteModuleOf,
 } from '../sdk/db_connection_impl';
 import { ConnectionId } from '../lib/connection_id';
+import {
+  ConnectionManager,
+  type ConnectionState as ManagerConnectionState,
+} from '../sdk/connection_manager';
 import {
   SPACETIMEDB_CONTEXT_KEY,
   type ConnectionState,
 } from './connection_state';
 
-let connRef: DbConnectionImpl<any> | null = null;
-let cleanupTimeoutId: ReturnType<typeof setTimeout> | null = null;
-
+/**
+ * Establish a SpacetimeDB connection for the current component subtree and make
+ * it available to `useSpacetimeDB`, `useTable` and `useReducer`.
+ *
+ * The connection is owned by the shared `ConnectionManager` (the same pool the
+ * React and Solid bindings use), keyed by uri + database name. The manager's
+ * reference counting and deferred cleanup absorb rapid mount/unmount cycles
+ * (HMR, `{#key}` blocks), and it reconnects automatically with exponential
+ * backoff if the socket drops unexpectedly.
+ *
+ * To swap the connection's auth token without reloading the page (e.g. after a
+ * sign-in), call `reconnect(builder)` from the context value with a builder
+ * carrying the new token.
+ */
 export function createSpacetimeDBProvider<
   DbConnection extends DbConnectionImpl<any>,
 >(
   connectionBuilder: DbConnectionBuilder<DbConnection>
 ): Writable<ConnectionState> {
-  const getConnection = () => connRef as DbConnection | null;
+  const key = ConnectionManager.getKey(
+    connectionBuilder.getUri(),
+    connectionBuilder.getModuleName()
+  );
 
-  const store = writable<ConnectionState>({
+  const fallback: ManagerConnectionState = {
     isActive: false,
     identity: undefined,
     token: undefined,
     connectionId: ConnectionId.random(),
     connectionError: undefined,
-    getConnection: getConnection as ConnectionState['getConnection'],
+  };
+
+  const getConnection = () =>
+    ConnectionManager.getConnection<DbConnection>(key);
+  const reconnect = (builder: DbConnectionBuilder<DbConnection>): void => {
+    ConnectionManager.rebuild(key, builder);
+  };
+
+  const snapshot = (): ConnectionState => ({
+    ...(ConnectionManager.getSnapshot(key) ?? fallback),
+    getConnection,
+    reconnect,
   });
 
-  if (cleanupTimeoutId) {
-    clearTimeout(cleanupTimeoutId);
-    cleanupTimeoutId = null;
-  }
-
-  if (!connRef) {
-    connRef = connectionBuilder.build();
-  }
-
-  const onConnect = (conn: DbConnection) => {
-    store.update(s => ({
-      ...s,
-      isActive: conn.isActive,
-      identity: conn.identity,
-      token: conn.token,
-      connectionId: conn.connectionId,
-    }));
-  };
-
-  const onDisconnect = (
-    ctx: ErrorContextInterface<RemoteModuleOf<DbConnection>>
-  ) => {
-    store.update(s => ({
-      ...s,
-      isActive: ctx.isActive,
-    }));
-  };
-
-  const onConnectError = (
-    ctx: ErrorContextInterface<RemoteModuleOf<DbConnection>>,
-    err: Error
-  ) => {
-    store.update(s => ({
-      ...s,
-      isActive: ctx.isActive,
-      connectionError: err,
-    }));
-  };
-
-  connectionBuilder.onConnect(onConnect);
-  connectionBuilder.onDisconnect(onDisconnect);
-  connectionBuilder.onConnectError(onConnectError);
-
-  const conn = connRef;
-  store.update(s => ({
-    ...s,
-    isActive: conn.isActive,
-    identity: conn.identity,
-    token: conn.token,
-    connectionId: conn.connectionId,
-  }));
-
-  setContext(SPACETIMEDB_CONTEXT_KEY, store);
+  // Retain for this provider's lifetime, then mirror the manager's external
+  // store into a Svelte store. `getConnection` / `reconnect` are stable across
+  // updates; only the plain state fields change.
+  ConnectionManager.retain(key, connectionBuilder);
+  const store = writable<ConnectionState>(snapshot());
+  const unsubscribe = ConnectionManager.subscribe(key, () =>
+    store.set(snapshot())
+  );
 
   onDestroy(() => {
-    connRef?.removeOnConnect(onConnect as any);
-    connRef?.removeOnDisconnect(onDisconnect as any);
-    connRef?.removeOnConnectError(onConnectError as any);
-
-    cleanupTimeoutId = setTimeout(() => {
-      connRef?.disconnect();
-      connRef = null;
-      cleanupTimeoutId = null;
-    }, 0);
+    unsubscribe();
+    ConnectionManager.release(key);
   });
 
+  setContext(SPACETIMEDB_CONTEXT_KEY, store);
   return store;
 }

--- a/crates/bindings-typescript/src/svelte/connection_state.ts
+++ b/crates/bindings-typescript/src/svelte/connection_state.ts
@@ -1,16 +1,20 @@
-import type { ConnectionId } from '../lib/connection_id';
-import type { Identity } from '../lib/identity';
-import type { DbConnectionImpl } from '../sdk/db_connection_impl';
-
-export type ConnectionState = {
-  isActive: boolean;
-  identity?: Identity;
-  token?: string;
-  connectionId: ConnectionId;
-  connectionError?: Error;
-  getConnection<
-    DbConnection extends DbConnectionImpl<any>,
-  >(): DbConnection | null;
-};
+import type {
+  DbConnectionBuilder,
+  DbConnectionImpl,
+} from '../sdk/db_connection_impl';
+import type { ConnectionState as ManagerConnectionState } from '../sdk/connection_manager';
 
 export const SPACETIMEDB_CONTEXT_KEY = Symbol('spacetimedb');
+
+export type ConnectionState = ManagerConnectionState & {
+  /** The live connection, or `null` before it is first established. */
+  getConnection(): DbConnectionImpl<any> | null;
+  /**
+   * Tear down the current connection and reconnect using a fresh builder —
+   * typically to apply a new auth token after sign-in or sign-out. The builder
+   * should carry the new token and the same uri + database name. Table and
+   * reducer subscriptions re-bind automatically once the new connection is
+   * live, so there is no need to reload the page to swap a token.
+   */
+  reconnect(builder: DbConnectionBuilder<any>): void;
+};

--- a/crates/bindings-typescript/tests/connection_manager_reconnect.test.ts
+++ b/crates/bindings-typescript/tests/connection_manager_reconnect.test.ts
@@ -418,3 +418,134 @@ describe('ConnectionManager retained reconnect behavior', () => {
     );
   });
 });
+
+describe('ConnectionManager.rebuild', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  test('swaps the live connection for one built from a fresh builder', () => {
+    const key = nextKey();
+    const firstBuilder = new MockBuilder();
+    const secondBuilder = new MockBuilder();
+
+    const first = retainMock(key, firstBuilder);
+    first.simulateConnect();
+    expect(ConnectionManager.getSnapshot(key)?.isActive).toBe(true);
+
+    const second = ConnectionManager.rebuild(
+      key,
+      secondBuilder as any
+    ) as unknown as MockConnection;
+
+    // The new connection comes from the replacement builder...
+    expect(secondBuilder.buildCount).toBe(1);
+    expect(second).toBe(secondBuilder.connections[0]);
+    expect(second).not.toBe(first);
+    expect(ConnectionManager.getConnection(key)).toBe(second);
+    // ...and the old one is torn down.
+    expect(first.disconnected).toBe(true);
+
+    second.simulateConnect();
+    expect(ConnectionManager.getSnapshot(key)?.isActive).toBe(true);
+    expect(ConnectionManager.getSnapshot(key)?.connectionId).toBe(
+      second.connectionId
+    );
+
+    ConnectionManager.release(key);
+  });
+
+  test('preserves the ref count so a single release still tears down', () => {
+    const key = nextKey();
+    const firstBuilder = new MockBuilder();
+    const secondBuilder = new MockBuilder();
+
+    retainMock(key, firstBuilder);
+    retainMock(key, secondBuilder); // refCount: 2
+
+    const rebuilt = ConnectionManager.rebuild(
+      key,
+      new MockBuilder() as any
+    ) as unknown as MockConnection;
+    expect(rebuilt).not.toBeNull();
+
+    // refCount was 2 and is untouched: one release leaves the entry live.
+    ConnectionManager.release(key);
+    vi.advanceTimersByTime(0);
+    expect(ConnectionManager.getConnection(key)).toBe(rebuilt);
+
+    ConnectionManager.release(key);
+    vi.advanceTimersByTime(0);
+    expect(ConnectionManager.getConnection(key)).toBeNull();
+  });
+
+  test('detaches the old connection callbacks before closing it', () => {
+    const key = nextKey();
+    const first = retainMock(key, new MockBuilder());
+    expect(first.callbackCounts()).toEqual({
+      connect: 1,
+      disconnect: 1,
+      connectError: 1,
+    });
+
+    ConnectionManager.rebuild(key, new MockBuilder() as any);
+
+    expect(first.callbackCounts()).toEqual({
+      connect: 0,
+      disconnect: 0,
+      connectError: 0,
+    });
+
+    ConnectionManager.release(key);
+  });
+
+  test('cancels a pending auto-reconnect and resets the backoff', () => {
+    const key = nextKey();
+    const builder = new MockBuilder();
+
+    const first = retainMock(key, builder);
+    // Two consecutive failures so the backoff has advanced past the base delay.
+    first.simulateDisconnect();
+    vi.advanceTimersByTime(connectionManagerReconnectDelayMs(0));
+    builder.connections[1].simulateConnectError(new Error('still down'));
+    expect(builder.buildCount).toBe(2);
+
+    // rebuild() takes over: the scheduled reconnect must not also fire.
+    const replacement = new MockBuilder();
+    ConnectionManager.rebuild(key, replacement as any);
+    expect(replacement.buildCount).toBe(1);
+
+    vi.advanceTimersByTime(CONNECTION_MANAGER_RECONNECT_MAX_DELAY_MS);
+    // No stale timer rebuilt the old builder...
+    expect(builder.buildCount).toBe(2);
+    expect(replacement.buildCount).toBe(1);
+
+    // ...and the backoff was reset: a fresh drop reconnects after the base delay.
+    replacement.connections[0].simulateConnect();
+    replacement.connections[0].simulateDisconnect();
+    vi.advanceTimersByTime(connectionManagerReconnectDelayMs(0));
+    expect(replacement.buildCount).toBe(2);
+
+    ConnectionManager.release(key);
+  });
+
+  test('returns null when the key has no retained entry', () => {
+    const key = nextKey();
+    expect(ConnectionManager.rebuild(key, new MockBuilder() as any)).toBeNull();
+  });
+
+  test('returns null after the entry has been fully released', () => {
+    const key = nextKey();
+    const first = retainMock(key, new MockBuilder());
+    first.simulateConnect();
+    ConnectionManager.release(key);
+    vi.advanceTimersByTime(0); // let the deferred release run
+
+    expect(ConnectionManager.rebuild(key, new MockBuilder() as any)).toBeNull();
+  });
+});

--- a/crates/bindings-typescript/tests/connection_manager_reconnect.test.ts
+++ b/crates/bindings-typescript/tests/connection_manager_reconnect.test.ts
@@ -534,6 +534,47 @@ describe('ConnectionManager.rebuild', () => {
     ConnectionManager.release(key);
   });
 
+  test('surfaces a build failure into pool state and re-throws', () => {
+    const key = nextKey();
+    const builder = new MockBuilder();
+    const buildError = new Error('build failed');
+
+    const first = retainMock(key, builder);
+    first.simulateConnect();
+    expect(ConnectionManager.getSnapshot(key)?.isActive).toBe(true);
+
+    // A builder whose build() throws (e.g. the new token is rejected synchronously).
+    const failingBuilder = {
+      build() {
+        throw buildError;
+      },
+      onConnect() {
+        return this;
+      },
+      onDisconnect() {
+        return this;
+      },
+      onConnectError() {
+        return this;
+      },
+    };
+
+    expect(() => ConnectionManager.rebuild(key, failingBuilder as any)).toThrow(
+      buildError
+    );
+
+    // The old connection is gone and the pool reflects the failure rather than
+    // a stale "live" connection.
+    expect(first.disconnected).toBe(true);
+    expect(ConnectionManager.getConnection(key)).toBeNull();
+    expect(ConnectionManager.getSnapshot(key)?.isActive).toBe(false);
+    expect(ConnectionManager.getSnapshot(key)?.connectionError).toBe(
+      buildError
+    );
+
+    ConnectionManager.release(key);
+  });
+
   test('returns null when the key has no retained entry', () => {
     const key = nextKey();
     expect(ConnectionManager.rebuild(key, new MockBuilder() as any)).toBeNull();


### PR DESCRIPTION
Addresses #5373. Hangs off the reconnect tracking issue #1936.

A SpacetimeDB web app commonly starts a user on an **anonymous** connection and
then lets them **sign in** (e.g. via Google), at which point you want to
reconnect with the new token. The Svelte binding has no clean way to do this: it
holds its connection in a **module-level singleton** reused across remounts (so
even a `{#key}` swap keeps the old token), there's no reconnect path on the
context value, and a `DbConnection`'s token is immutable after `build()`. The
only thing that actually works today is `window.location.reload()`, which throws
away all client state and flickers the UI on every sign-in/sign-out. The Svelte
binding also lacks the exponential-backoff **auto-reconnect** that React and
Solid already get from `ConnectionManager`.

This is two focused commits that close both gaps:

# Description of Changes

**1. `Add ConnectionManager.rebuild()` for token-swap reconnects.** The shared
`ConnectionManager` (used by the React and Solid providers) can hold and
reference-count a connection but has no way to swap a live connection's builder.
`rebuild(key, builder)` tears down the live connection and builds a fresh one
from a new builder under the same ref count and listener set, so framework hooks
(`useTable`, `useReducer`, …) re-bind automatically — swap the token in the
builder, call `rebuild`, done. The old connection's callbacks are detached
before it is closed (so its disconnect event can't leak into pool state), any
deferred release or pending auto-reconnect is cancelled, and the backoff counter
is reset. This is the `rebuild()` primitive from the open multi-module-provider
PR #4887 (original design by @Ludv1gL), lifted into a focused change, adapted to
the current post-#5185 reconnect machinery, and reusing the existing
`#buildManagedConnection` / `#detachCallbacks` helpers rather than that PR's
`#install` / `#teardown` refactor.

**2. Put the Svelte binding on `ConnectionManager`; add `reconnect()` for token
swaps.** `createSpacetimeDBProvider` is rebuilt on top of the shared
`ConnectionManager` — the same pool React and Solid already use — replacing the
bespoke module-level singleton with the manager's reference counting and
deferred cleanup (which absorb HMR / `{#key}` remounts), and getting
exponential-backoff auto-reconnect for free. The context value gains
`reconnect(builder)` (backed by the new `ConnectionManager.rebuild`): tear down
the current connection and reconnect with a fresh builder carrying a new token,
no page reload. `useTable` / `useReducer` / `useSpacetimeDB` are unchanged and
re-bind to the new connection automatically.

# API and ABI breaking changes

Minor, TypeScript-only: `ConnectionState.getConnection` on the Svelte binding is
no longer generic — it returns `DbConnectionImpl<any> | null`, matching the
React and Solid bindings. Call sites that wrote `getConnection<MyConn>()` lose
the type argument; `getConnection()` is unchanged. The provider's return type
stays `Writable<ConnectionState>`. `ConnectionManager.rebuild` is purely
additive.

# Expected complexity level and risk

2. Low. `rebuild()` is a small method reusing the same build/teardown helpers as
`retain`/`release` and the auto-reconnect path; the only subtlety is ordering
(detach-then-close + cancel pending timers so a stale disconnect or scheduled
auto-reconnect can't race the new connection). The Svelte provider is now a thin
adapter: it mirrors the manager's store into a Svelte store and wires up
`getConnection` / `reconnect` / `retain` / `release`. The connection-lifecycle
logic that used to be bespoke here — the singleton, deferred cleanup, reconnect
— now lives in the well-tested, shared `ConnectionManager` that React and Solid
already depend on.

# Testing

- [x] Six new unit tests against the real `ConnectionManager` singleton
  (`tests/connection_manager_reconnect.test.ts`): builder swap, ref-count
  preservation, callback detachment, pending-reconnect cancellation + backoff
  reset, and both `null`-return cases.
- [x] Full vitest suite green; `tsc -p tsconfig.build.json` typechecks;
  `build:js` emits the Svelte ESM/CJS + browser bundles cleanly; eslint +
  prettier clean.
- [x] Manually smoke-tested end-to-end in a real Svelte app (anonymous →
  Google sign-in → signed-in): the token swaps and the board state survives
  with **no page reload**, and sign-out reconnects anonymously the same way.
- [ ] Reviewer: this package has no Svelte component-test harness today (the
  pre-existing binding had none), so the provider wiring is covered indirectly
  through the `ConnectionManager` unit tests. Worth a call on whether to add
  `@testing-library/svelte` coverage here. Vue has the same singleton shape and
  can follow this pattern as a follow-up.
