### PR TITLE
Remove `Promise.withResolvers` and replace with deferred pattern

### DIFF
--- a/crates/bindings-typescript/src/sdk/db_connection_impl.ts
+++ b/crates/bindings-typescript/src/sdk/db_connection_impl.ts
@@ -112,7 +112,23 @@ export type DbConnectionConfig<RemoteModule extends UntypedRemoteModule> = {
 
 type ProcedureCallback = (result: ProcedureResultMessage['result']) => void;
 
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
 const TEXT_ENCODER = new TextEncoder();
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  let reject!: Deferred<T>['reject'];
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
 
 function getClientMessageVariantTag(name: string): number {
   if (ClientMessage.algebraicType.tag !== 'Sum') {
@@ -1119,7 +1135,7 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
     argsBuffer: Uint8Array,
     reducerArgs?: object
   ): Promise<void> {
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const { promise, resolve, reject } = createDeferred<void>();
     const requestId = this.#getNextRequestId();
     this.#sendCallReducerMessage(requestId, encodedReducerName, argsBuffer);
     if (reducerArgs) {
@@ -1154,7 +1170,7 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
     argsBuffer: Uint8Array,
     reducerArgs?: object
   ): Promise<void> {
-    const { promise, resolve, reject } = Promise.withResolvers<void>();
+    const { promise, resolve, reject } = createDeferred<void>();
     const requestId = this.#getNextRequestId();
     const message = ClientMessage.CallReducer({
       reducer: reducerName,
@@ -1235,7 +1251,7 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
     encodedProcedureName: Uint8Array,
     argsBuffer: Uint8Array
   ): Promise<Uint8Array> {
-    const { promise, resolve, reject } = Promise.withResolvers<Uint8Array>();
+    const { promise, resolve, reject } = createDeferred<Uint8Array>();
     const requestId = this.#getNextRequestId();
     this.#sendCallProcedureMessage(requestId, encodedProcedureName, argsBuffer);
     this.#procedureCallbacks.set(requestId, result => {
@@ -1252,7 +1268,7 @@ export class DbConnectionImpl<RemoteModule extends UntypedRemoteModule>
     procedureName: string,
     argsBuffer: Uint8Array
   ): Promise<Uint8Array> {
-    const { promise, resolve, reject } = Promise.withResolvers<Uint8Array>();
+    const { promise, resolve, reject } = createDeferred<Uint8Array>();
     const requestId = this.#getNextRequestId();
     const message = ClientMessage.CallProcedure({
       procedure: procedureName,

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -23,6 +23,19 @@ export default tseslint.config(
       '**/templates/angular-ts/.angular/**',
     ],
   },
+  {
+    rules: {
+      'no-restricted-properties': [
+        'error',
+        {
+          object: 'Promise',
+          property: 'withResolvers',
+          message:
+            'Use createDeferred() instead; Promise.withResolvers is ES2024 and not supported in all SDK runtimes.',
+        },
+      ],
+    },
+  },
   js.configs.recommended,
   {
     files: ['**/*.{js,cjs,mjs}'],

--- a/templates/keynote-2/src/connectors/spacetimedb.ts
+++ b/templates/keynote-2/src/connectors/spacetimedb.ts
@@ -3,7 +3,25 @@ import * as mod from '../../module_bindings';
 import { deriveWebsocketUrl } from '../core/stdbUrl';
 import type { SpacetimeConnectorConfig } from '../config.ts';
 
-export function spacetimedb(config: SpacetimeConnectorConfig): ReducerConnector {
+type Deferred<T> = {
+  promise: Promise<T>;
+  resolve: (value: T | PromiseLike<T>) => void;
+  reject: (reason?: unknown) => void;
+};
+
+function createDeferred<T>(): Deferred<T> {
+  let resolve!: Deferred<T>['resolve'];
+  let reject!: Deferred<T>['reject'];
+  const promise = new Promise<T>((res, rej) => {
+    resolve = res;
+    reject = rej;
+  });
+  return { promise, resolve, reject };
+}
+
+export function spacetimedb(
+  config: SpacetimeConnectorConfig,
+): ReducerConnector {
   const {
     initialBalance,
     stdbCompression,
@@ -12,7 +30,7 @@ export function spacetimedb(config: SpacetimeConnectorConfig): ReducerConnector 
     stdbUrl: url,
   } = config;
 
-  let ready: ReturnType<typeof Promise.withResolvers<void>>;
+  let ready: Deferred<void>;
   let conn: mod.DbConnection;
 
   async function connectWithBindings() {
@@ -21,14 +39,14 @@ export function spacetimedb(config: SpacetimeConnectorConfig): ReducerConnector 
 
     const Db = mod.DbConnection;
 
-    ready = Promise.withResolvers<void>();
+    ready = createDeferred<void>();
 
     const subscriptions: string[] = [];
     if (process.env.VERIFY === '1') {
       console.log('[spacetimedb] subscribing to accounts');
       subscriptions.push('SELECT * FROM accounts');
     }
-    const subscribed = Promise.withResolvers<void>();
+    const subscribed = createDeferred<void>();
     if (subscriptions.length === 0) subscribed.resolve();
 
     const builder = Db.builder()


### PR DESCRIPTION
# Description of Changes

Removes all references to `Promise.withResolvers` from the codebase since it's not supported universally and replaces it with the classic pre-ES2024 deferred pattern. See #5031 and #5342.

Also adds a lint to avoid re-introducing it in the future.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

...
