### PR TITLE
Report module instance memory usage

### DIFF
--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -15,6 +15,7 @@ use crate::host::ProcedureCallError;
 use crate::messages::control_db::{Database, HostType};
 use crate::module_host_context::ModuleCreationContext;
 use crate::replica_context::ReplicaContext;
+use crate::resource::{MemoryObserver, ModuleInstanceMemoryTracker};
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
 use crate::subscription::module_subscription_manager::{spawn_send_worker, SubscriptionManager, TransactionOffset};
 use crate::subscription::row_list_builder_pool::BsatnRowListBuilderPool;
@@ -108,6 +109,8 @@ pub struct HostController {
     program_storage: ProgramStorage,
     /// The [`EnergyMonitor`] used by this controller.
     energy_monitor: Arc<dyn EnergyMonitor>,
+    /// The [`MemoryObserver`] used by this controller.
+    memory_observer: Arc<dyn MemoryObserver>,
     /// Provides persistence services for each replica.
     persistence: Arc<dyn PersistenceProvider>,
     /// The page pool all databases will use by cloning the ref counted pool.
@@ -221,12 +224,14 @@ pub struct CallProcedureReturn {
 }
 
 impl HostController {
+    #[allow(clippy::too_many_arguments)]
     pub fn new(
         data_dir: Arc<ServerDataDir>,
         default_config: db::Config,
         runtime_config: HostRuntimeConfig,
         program_storage: ProgramStorage,
         energy_monitor: Arc<impl EnergyMonitor>,
+        memory_observer: Arc<dyn MemoryObserver>,
         persistence: Arc<dyn PersistenceProvider>,
         db_cores: JobCores,
     ) -> Self {
@@ -235,6 +240,7 @@ impl HostController {
             default_config,
             program_storage,
             energy_monitor,
+            memory_observer,
             persistence,
             runtimes: HostRuntimes::new(Some(&data_dir), runtime_config),
             data_dir,
@@ -653,6 +659,7 @@ async fn make_replica_ctx(
     replica_id: u64,
     relational_db: Arc<RelationalDB>,
     bsatn_rlb_pool: BsatnRowListBuilderPool,
+    memory_observer: Arc<dyn MemoryObserver>,
 ) -> anyhow::Result<ReplicaContext> {
     let logger = match module_logs {
         Some(path) => asyncify(move || Arc::new(DatabaseLogger::open_today(path))).await,
@@ -680,11 +687,14 @@ async fn make_replica_ctx(
         }
     });
 
+    let module_instance_memory_tracker = ModuleInstanceMemoryTracker::new(database.database_identity, memory_observer);
+
     Ok(ReplicaContext {
         database,
         replica_id,
         logger,
         subscriptions,
+        module_instance_memory_tracker,
     })
 }
 
@@ -756,6 +766,7 @@ struct ModuleLauncher<F> {
     on_panic: F,
     relational_db: Arc<RelationalDB>,
     energy_monitor: Arc<dyn EnergyMonitor>,
+    memory_observer: Arc<dyn MemoryObserver>,
     module_logs: Option<ModuleLogsDir>,
     runtimes: Arc<HostRuntimes>,
     core: AllocatedJobCore,
@@ -779,6 +790,7 @@ impl<F: Fn() + Send + Sync + 'static> ModuleLauncher<F> {
             self.replica_id,
             self.relational_db,
             self.bsatn_rlb_pool,
+            self.memory_observer,
         )
         .await
         .map(Arc::new)?;
@@ -886,6 +898,7 @@ impl Host {
             persistence,
             page_pool,
             bsatn_rlb_pool,
+            memory_observer,
             ..
         } = host_controller;
         let replica_dir = data_dir.replica(replica_id);
@@ -979,6 +992,7 @@ impl Host {
                     on_panic: host_controller.unregister_fn(replica_id),
                     relational_db,
                     energy_monitor: energy_monitor.clone(),
+                    memory_observer: memory_observer.clone(),
                     module_logs: match config.storage {
                         db::Storage::Memory => None,
                         db::Storage::Disk => Some(replica_dir.module_logs()),
@@ -1008,6 +1022,7 @@ impl Host {
                     on_panic: host_controller.unregister_fn(replica_id),
                     relational_db: relational_db.clone(),
                     energy_monitor: energy_monitor.clone(),
+                    memory_observer: memory_observer.clone(),
                     module_logs: match config.storage {
                         db::Storage::Memory => None,
                         db::Storage::Disk => Some(replica_dir.clone().module_logs()),
@@ -1031,6 +1046,7 @@ impl Host {
                             on_panic: host_controller.unregister_fn(replica_id),
                             relational_db: relational_db.clone(),
                             energy_monitor: energy_monitor.clone(),
+                            memory_observer: memory_observer.clone(),
                             module_logs: match config.storage {
                                 db::Storage::Memory => None,
                                 db::Storage::Disk => Some(replica_dir.module_logs()),
@@ -1131,6 +1147,7 @@ impl Host {
             None,
             page_pool,
         )?;
+        let memory_observer: Arc<dyn MemoryObserver> = Arc::new(());
 
         ModuleLauncher {
             database,
@@ -1142,6 +1159,7 @@ impl Host {
             on_panic: || log::error!("launch_module on_panic called for temporary publish in-memory instance"),
             relational_db: Arc::new(db),
             energy_monitor: Arc::new(NullEnergyMonitor),
+            memory_observer,
             module_logs: None,
             runtimes: runtimes.clone(),
             core,

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -955,6 +955,7 @@ impl Host {
                 (db, clients)
             }
         };
+        let db = db.with_memory_observer(memory_observer.clone());
         let (mut program, program_needs_init) = match db.program()? {
             // Launch module with program from existing database.
             Some(program) => {

--- a/crates/core/src/host/instance_env.rs
+++ b/crates/core/src/host/instance_env.rs
@@ -1347,6 +1347,7 @@ mod test {
         host::Scheduler,
         messages::control_db::{Database, HostType},
         replica_context::ReplicaContext,
+        resource::ModuleInstanceMemoryTracker,
         subscription::module_subscription_actor::ModuleSubscriptions,
     };
     use anyhow::{anyhow, Result};
@@ -1380,6 +1381,7 @@ mod test {
                 replica_id: 0,
                 logger,
                 subscriptions: subs,
+                module_instance_memory_tracker: ModuleInstanceMemoryTracker::new(Identity::ZERO, Arc::new(())),
             },
             runtime,
         ))

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -89,6 +89,7 @@ use crate::host::{ModuleHost, ReducerCallError, ReducerCallResult, Scheduler};
 use crate::messages::control_db::HostType;
 use crate::module_host_context::ModuleCreationContext;
 use crate::replica_context::ReplicaContext;
+use crate::resource::ModuleInstanceMemoryTracker;
 use crate::subscription::module_subscription_manager::TransactionOffset;
 use crate::util::jobs::{AllocatedJobCore, CorePinner, LoadBalanceOnDropGuard};
 use crate::worker_metrics::WORKER_METRICS;
@@ -965,6 +966,7 @@ pub(in crate::host) struct V8HeapMetrics {
     external_memory_bytes: IntGauge,
     native_contexts: IntGauge,
     detached_contexts: IntGauge,
+    module_instance_memory_tracker: ModuleInstanceMemoryTracker,
 
     /// Previous values observed by this instance.
     ///
@@ -1035,7 +1037,7 @@ impl V8HeapMetrics {
         }
     }
 
-    fn new(database_identity: &Identity, worker_kind: JsWorkerKind) -> Self {
+    fn new(database_identity: &Identity, worker_kind: JsWorkerKind, mem_tracker: ModuleInstanceMemoryTracker) -> Self {
         Self {
             total_heap_size_bytes: WORKER_METRICS
                 .v8_total_heap_size_bytes
@@ -1061,6 +1063,7 @@ impl V8HeapMetrics {
             detached_contexts: WORKER_METRICS
                 .v8_detached_contexts
                 .with_label_values(database_identity, &worker_kind),
+            module_instance_memory_tracker: mem_tracker,
             last_observed: V8HeapSnapshot::default(),
         }
     }
@@ -1077,6 +1080,11 @@ impl V8HeapMetrics {
         adjust_gauge(&self.external_memory_bytes, delta.external_memory_bytes);
         adjust_gauge(&self.native_contexts, delta.native_contexts);
         adjust_gauge(&self.detached_contexts, delta.detached_contexts);
+        // Each live V8 isolate reports only the delta from its last heap sample.
+        // The shared tracker folds those deltas into a database-wide aggregate
+        // used tor memory-limit enforcement.
+        self.module_instance_memory_tracker
+            .adjust_v8_physical(delta.total_physical_size_bytes);
     }
 
     fn observe(&mut self, stats: &v8::HeapStatistics) {
@@ -1679,7 +1687,11 @@ where
                 let info = &module_common.info();
                 let mut instance_common = InstanceCommon::new(&module_common);
                 let replica_ctx: &Arc<ReplicaContext> = module_common.replica_ctx();
-                let mut heap_metrics = V8HeapMetrics::new(&info.database_identity, worker_kind);
+                let mut heap_metrics = V8HeapMetrics::new(
+                    &info.database_identity,
+                    worker_kind,
+                    replica_ctx.module_instance_memory_tracker.clone(),
+                );
 
                 let mut inst = V8Instance {
                     scope,

--- a/crates/core/src/host/wasmtime/wasm_instance_env.rs
+++ b/crates/core/src/host/wasmtime/wasm_instance_env.rs
@@ -13,6 +13,7 @@ use crate::host::wasm_common::module_host_actor::{
 };
 use crate::host::wasm_common::{err_to_errno_and_log, RowIterIdx, RowIters, TimingSpan, TimingSpanIdx, TimingSpanSet};
 use crate::host::AbiCall;
+use crate::resource::ModuleInstanceMemoryTracker;
 use crate::subscription::module_subscription_manager::TransactionOffset;
 use crate::worker_metrics::WORKER_METRICS;
 use anyhow::{anyhow, Context as _};
@@ -144,6 +145,7 @@ pub(super) struct WasmInstanceEnv {
 
 pub(in crate::host) struct WasmMemoryBytesMetric {
     wasm_memory_bytes: IntGauge,
+    tracker: ModuleInstanceMemoryTracker,
 
     /// Previous value observed by this intance.
     ///
@@ -158,9 +160,10 @@ pub(in crate::host) struct WasmMemoryBytesMetric {
 }
 
 impl WasmMemoryBytesMetric {
-    fn new(database_identity: Identity) -> Self {
+    fn new(database_identity: Identity, tracker: ModuleInstanceMemoryTracker) -> Self {
         Self {
             wasm_memory_bytes: WORKER_METRICS.wasm_memory_bytes.with_label_values(&database_identity),
+            tracker,
             last_observed: 0,
         }
     }
@@ -176,6 +179,10 @@ impl WasmMemoryBytesMetric {
             self.wasm_memory_bytes.sub(-delta);
         }
 
+        // Each WASM instance reports only its own delta.
+        // The shared tracker folds those deltas into a database-wide aggregate
+        // used for memory-limit enforcement.
+        self.tracker.adjust_wasm_linear(delta);
         self.last_observed = memory_usage;
     }
 
@@ -188,6 +195,8 @@ impl Drop for WasmMemoryBytesMetric {
     fn drop(&mut self) {
         // Clean up this instance's metric value by subtracting its part of the usage.
         self.wasm_memory_bytes.sub(self.last_observed);
+        // Remove this instance's contribution from the database-wide aggregate.
+        self.tracker.adjust_wasm_linear(-self.last_observed);
     }
 }
 
@@ -200,6 +209,7 @@ impl WasmInstanceEnv {
     /// Create a new `WasmEnstanceEnv` from the given `InstanceEnv`.
     pub fn new(instance_env: InstanceEnv) -> Self {
         let database_identity = *instance_env.database_identity();
+        let instance_memory_tracker = instance_env.replica_ctx.module_instance_memory_tracker.clone();
         Self {
             instance_env,
             module_def: None,
@@ -214,7 +224,7 @@ impl WasmInstanceEnv {
             timing_spans: Default::default(),
             call_times: CallTimes::new(),
             chunk_pool: <_>::default(),
-            linear_memory_size_metric: WasmMemoryBytesMetric::new(database_identity),
+            linear_memory_size_metric: WasmMemoryBytesMetric::new(database_identity, instance_memory_tracker),
         }
     }
 

--- a/crates/core/src/lib.rs
+++ b/crates/core/src/lib.rs
@@ -19,6 +19,7 @@ pub mod estimation;
 pub mod host;
 pub mod module_host_context;
 pub mod replica_context;
+pub use spacetimedb_engine::resource;
 pub mod startup;
 pub mod subscription;
 pub mod util;

--- a/crates/core/src/replica_context.rs
+++ b/crates/core/src/replica_context.rs
@@ -4,6 +4,7 @@ use super::database_logger::DatabaseLogger;
 use crate::db::relational_db::RelationalDB;
 use crate::error::DBError;
 use crate::messages::control_db::Database;
+use crate::resource::ModuleInstanceMemoryTracker;
 use crate::subscription::module_subscription_actor::ModuleSubscriptions;
 use std::io;
 use std::ops::Deref;
@@ -18,6 +19,7 @@ pub struct ReplicaContext {
     pub replica_id: u64,
     pub logger: Arc<DatabaseLogger>,
     pub subscriptions: ModuleSubscriptions,
+    pub module_instance_memory_tracker: ModuleInstanceMemoryTracker,
 }
 
 impl ReplicaContext {

--- a/crates/datastore/src/locking_tx_datastore/committed_state.rs
+++ b/crates/datastore/src/locking_tx_datastore/committed_state.rs
@@ -209,6 +209,17 @@ impl CommittedState {
         self.datastore_page_bytes
     }
 
+    /// Returns committed datastore bytes.
+    ///
+    /// This currently includes the pages allocated by the datastore
+    /// and the objects stored in the [`BlobStore`].
+    ///
+    /// TODO: Eventually this should also include index bytes
+    /// once indexes are managed by the page cache.
+    pub fn datastore_memory_bytes(&self) -> u64 {
+        self.datastore_page_bytes + self.blob_store.physical_bytes_used_by_blobs()
+    }
+
     /// Recomputes `datastore_page_bytes` from committed tables.
     ///
     /// This is only used for bootstrap, snapshot restore, and replay paths.

--- a/crates/datastore/src/locking_tx_datastore/committed_state.rs
+++ b/crates/datastore/src/locking_tx_datastore/committed_state.rs
@@ -75,6 +75,8 @@ pub struct CommittedState {
     /// Pages are shared between all modules running on a particular host,
     /// not allocated per-module.
     pub(super) page_pool: PagePool,
+    /// Total bytes occupied by physical pages in committed tables.
+    datastore_page_bytes: u64,
     /// We track the read sets for each view in the committed state.
     /// We check each reducer's write set against these read sets.
     /// Any overlap will trigger a re-evaluation of the affected view,
@@ -117,6 +119,7 @@ impl MemoryUsage for CommittedState {
             blob_store,
             index_id_map,
             page_pool: _,
+            datastore_page_bytes,
             read_sets,
             ephemeral_tables,
         } = self;
@@ -125,6 +128,7 @@ impl MemoryUsage for CommittedState {
             + tables.heap_usage()
             + blob_store.heap_usage()
             + index_id_map.heap_usage()
+            + datastore_page_bytes.heap_usage()
             + read_sets.heap_usage()
             + ephemeral_tables.heap_usage()
     }
@@ -195,8 +199,31 @@ impl CommittedState {
             index_id_map: <_>::default(),
             read_sets: <_>::default(),
             page_pool,
+            datastore_page_bytes: 0,
             ephemeral_tables: <_>::default(),
         }
+    }
+
+    /// Returns committed datastore table page bytes.
+    pub fn datastore_page_bytes(&self) -> u64 {
+        self.datastore_page_bytes
+    }
+
+    /// Recomputes `datastore_page_bytes` from committed tables.
+    ///
+    /// This is only used for bootstrap, snapshot restore, and replay paths.
+    pub(super) fn rebuild_datastore_page_bytes(&mut self) {
+        self.datastore_page_bytes = self.tables.values().map(Table::page_bytes).sum();
+    }
+
+    /// Called when a new page is added to committed state.
+    fn add_datastore_page_bytes(&mut self, bytes: u64) {
+        self.datastore_page_bytes += bytes;
+    }
+
+    /// Called when a page is removed from committed state.
+    pub(super) fn sub_datastore_page_bytes(&mut self, bytes: u64) {
+        self.datastore_page_bytes -= bytes;
     }
 
     /// Extremely delicate function to bootstrap the system tables.
@@ -339,6 +366,7 @@ impl CommittedState {
 
         // This is purely a sanity check to ensure that we are setting the ids correctly.
         self.assert_system_table_schemas_match()?;
+        self.rebuild_datastore_page_bytes();
         Ok(())
     }
 
@@ -621,13 +649,20 @@ impl CommittedState {
                 // we just want to include them in subscriptions and the commitlog.
                 Self::collect_inserts(page_pool, truncates, tx_data, &tx_bs, table_id, tx_table, |_| {});
             } else {
-                let (commit_table, commit_blob_store, page_pool) =
-                    self.get_table_and_blob_store_or_create(table_id, schema);
-                Self::collect_inserts(page_pool, truncates, tx_data, &tx_bs, table_id, tx_table, |row| {
-                    commit_table
-                        .insert(page_pool, commit_blob_store, row)
-                        .expect("Failed to insert when merging commit");
-                });
+                let page_bytes_added = {
+                    let (commit_table, commit_blob_store, page_pool) =
+                        self.get_table_and_blob_store_or_create(table_id, schema);
+                    let page_bytes_before = commit_table.page_bytes();
+                    Self::collect_inserts(page_pool, truncates, tx_data, &tx_bs, table_id, tx_table, |row| {
+                        commit_table
+                            .insert(page_pool, commit_blob_store, row)
+                            .expect("Failed to insert when merging commit");
+                    });
+                    let page_bytes_after = commit_table.page_bytes();
+                    debug_assert!(page_bytes_after >= page_bytes_before);
+                    page_bytes_after - page_bytes_before
+                };
+                self.add_datastore_page_bytes(page_bytes_added);
             }
         }
     }
@@ -713,6 +748,7 @@ impl CommittedState {
                 // We don't need to deal with sub-components.
                 // That is, we don't need to add back indices and such.
                 // Instead, there will be separate pending schema changes like `IndexRemoved`.
+                self.add_datastore_page_bytes(table.page_bytes());
                 self.tables.insert(table_id, table);
 
                 // Incase, the table was ephemeral, add it back to that set as well.
@@ -725,7 +761,9 @@ impl CommittedState {
                 // We don't need to deal with sub-components.
                 // That is, we don't need to remove indices and such.
                 // Instead, there will be separate pending schema changes like `IndexAdded`.
-                self.tables.remove(&table_id);
+                if let Some(table) = self.tables.remove(&table_id) {
+                    self.sub_datastore_page_bytes(table.page_bytes());
+                }
                 // Incase, the table was ephemeral, remove it from that set as well.
                 self.ephemeral_tables.remove(&table_id);
             }

--- a/crates/datastore/src/locking_tx_datastore/datastore.rs
+++ b/crates/datastore/src/locking_tx_datastore/datastore.rs
@@ -246,6 +246,13 @@ impl Locking {
         self.committed_state.read().datastore_page_bytes()
     }
 
+    /// Returns committed datastore bytes.
+    ///
+    /// Currently just page and blobstore bytes.
+    pub fn datastore_memory_bytes(&self) -> u64 {
+        self.committed_state.read().datastore_memory_bytes()
+    }
+
     pub fn take_snapshot_internal(
         committed_state: &RwLock<CommittedState>,
         repo: &DynSnapshotRepo,

--- a/crates/datastore/src/locking_tx_datastore/datastore.rs
+++ b/crates/datastore/src/locking_tx_datastore/datastore.rs
@@ -198,6 +198,7 @@ impl Locking {
                 .with_label_values(&database_identity, &table_id.into(), &schema.table_name)
                 .set(table_size as i64);
         }
+        committed_state.rebuild_datastore_page_bytes();
 
         // Double check that our in-memory system table ids match the on-disk schemas.
         // committed_state.assert_system_table_schemas_match()?;
@@ -236,6 +237,13 @@ impl Locking {
     pub fn assert_system_tables_match(&self) -> Result<()> {
         let committed_state = self.committed_state.read_arc();
         committed_state.assert_system_table_schemas_match()
+    }
+
+    /// Returns committed datastore table page bytes.
+    ///
+    /// This reads the cached committed-state aggregate.
+    pub fn datastore_page_bytes(&self) -> u64 {
+        self.committed_state.read().datastore_page_bytes()
     }
 
     pub fn take_snapshot_internal(

--- a/crates/datastore/src/locking_tx_datastore/datastore.rs
+++ b/crates/datastore/src/locking_tx_datastore/datastore.rs
@@ -986,7 +986,7 @@ impl Locking {
         &self,
         tx: MutTxId,
         before_release: impl FnOnce(&Arc<TxData>),
-    ) -> Result<Option<(TxOffset, Arc<TxData>, TxMetrics, Option<ReducerName>)>> {
+    ) -> Result<Option<(TxOffset, Arc<TxData>, TxMetrics, Option<ReducerName>, u64)>> {
         Ok(Some(tx.commit_and_then(before_release)))
     }
 
@@ -997,7 +997,7 @@ impl Locking {
         tx: MutTxId,
         workload: Workload,
         before_downgrade: impl FnOnce(&Arc<TxData>),
-    ) -> (Arc<TxData>, TxMetrics, TxId) {
+    ) -> (Arc<TxData>, TxMetrics, TxId, u64) {
         tx.commit_downgrade_and_then(workload, before_downgrade)
     }
 }

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -2107,7 +2107,7 @@ impl MutTxId {
     /// - [`TxMetrics`], various measurements of the work performed by this transaction.
     /// - `String`, the name of the reducer which ran during this transaction.
     pub(super) fn commit(self) -> (TxOffset, TxData, TxMetrics, Option<ReducerName>) {
-        let (tx_offset, tx_data, tx_metrics, reducer) = self.commit_and_then(|_| {});
+        let (tx_offset, tx_data, tx_metrics, reducer, _) = self.commit_and_then(|_| {});
         let tx_data =
             Arc::try_unwrap(tx_data).unwrap_or_else(|_| panic!("noop commit callback must not retain tx data"));
         (tx_offset, tx_data, tx_metrics, reducer)
@@ -2116,7 +2116,7 @@ impl MutTxId {
     pub(super) fn commit_and_then(
         mut self,
         before_release: impl FnOnce(&Arc<TxData>),
-    ) -> (TxOffset, Arc<TxData>, TxMetrics, Option<ReducerName>) {
+    ) -> (TxOffset, Arc<TxData>, TxMetrics, Option<ReducerName>, u64) {
         let tx_offset = self.committed_state_write_lock.next_tx_offset;
         let tx_data = self
             .committed_state_write_lock
@@ -2151,9 +2151,12 @@ impl MutTxId {
         };
 
         let tx_data = Arc::new(tx_data);
+        // Capture the cached committed memory total while this transaction still owns the write lock.
+        // Callers can observe this value after commit without re-entering `committed_state`.
+        let datastore_memory_bytes = self.committed_state_write_lock.datastore_memory_bytes();
         before_release(&tx_data);
 
-        (tx_offset, tx_data, tx_metrics, reducer)
+        (tx_offset, tx_data, tx_metrics, reducer, datastore_memory_bytes)
     }
 
     /// Commits this transaction, applying its changes to the committed state.
@@ -2170,7 +2173,7 @@ impl MutTxId {
     /// - [`TxMetrics`], various measurements of the work performed by this transaction.
     /// - [`TxId`], a read-only transaction with a shared lock on the committed state.
     pub(super) fn commit_downgrade(self, workload: Workload) -> (TxData, TxMetrics, TxId) {
-        let (tx_data, tx_metrics, tx) = self.commit_downgrade_and_then(workload, |_| {});
+        let (tx_data, tx_metrics, tx, _) = self.commit_downgrade_and_then(workload, |_| {});
         let tx_data =
             Arc::try_unwrap(tx_data).unwrap_or_else(|_| panic!("noop commit callback must not retain tx data"));
         (tx_data, tx_metrics, tx)
@@ -2180,7 +2183,7 @@ impl MutTxId {
         mut self,
         workload: Workload,
         before_downgrade: impl FnOnce(&Arc<TxData>),
-    ) -> (Arc<TxData>, TxMetrics, TxId) {
+    ) -> (Arc<TxData>, TxMetrics, TxId, u64) {
         let tx_data = self
             .committed_state_write_lock
             .merge(self.tx_state, self.read_sets, &self.ctx);
@@ -2200,6 +2203,7 @@ impl MutTxId {
         );
 
         let tx_data = Arc::new(tx_data);
+        let datastore_memory_bytes = self.committed_state_write_lock.datastore_memory_bytes();
         before_downgrade(&tx_data);
 
         // Update the workload type of the execution context
@@ -2211,7 +2215,7 @@ impl MutTxId {
             ctx: self.ctx,
             metrics: ExecutionMetrics::default(),
         };
-        (tx_data, tx_metrics, tx)
+        (tx_data, tx_metrics, tx, datastore_memory_bytes)
     }
 
     /// Rolls back this transaction, discarding its changes.

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -1040,6 +1040,8 @@ impl MutTxId {
             .tables
             .remove(&table_id)
             .expect("there should be a schema in the committed state if we reach here");
+        self.committed_state_write_lock
+            .sub_datastore_page_bytes(commit_table.page_bytes());
         self.push_schema_change(PendingSchemaChange::TableRemoved(table_id, commit_table));
 
         Ok(())

--- a/crates/datastore/src/locking_tx_datastore/replay.rs
+++ b/crates/datastore/src/locking_tx_datastore/replay.rs
@@ -510,6 +510,7 @@ impl<'cs> ReplayCommittedState<'cs> {
         self.build_missing_tables()?;
         self.build_indexes()?;
         self.collect_ephemeral_tables()?;
+        self.rebuild_datastore_page_bytes();
 
         // Figure out where to pick up for each sequence.
         build_sequence_state(datastore, self)?;

--- a/crates/datastore/src/locking_tx_datastore/tx_state.rs
+++ b/crates/datastore/src/locking_tx_datastore/tx_state.rs
@@ -76,7 +76,7 @@ pub(super) struct TxState {
     pub(super) pending_schema_changes: ThinVec<PendingSchemaChange>,
 }
 
-static_assert_size!(TxState, 88);
+static_assert_size!(TxState, 96);
 
 impl MemoryUsage for TxState {
     fn heap_usage(&self) -> usize {

--- a/crates/engine/src/lib.rs
+++ b/crates/engine/src/lib.rs
@@ -3,6 +3,7 @@ pub mod error;
 pub mod metrics;
 pub mod persistence;
 pub mod relational_db;
+pub mod resource;
 pub mod snapshot;
 pub mod sql;
 pub mod update;

--- a/crates/engine/src/relational_db.rs
+++ b/crates/engine/src/relational_db.rs
@@ -179,15 +179,15 @@ impl RelationalDB {
 
     pub fn with_memory_observer(mut self, memory_observer: Arc<dyn MemoryObserver>) -> Self {
         self.memory_observer = memory_observer;
-        self.observe_datastore_pages();
+        self.observe_datastore_memory();
         self
     }
 
-    fn observe_datastore_pages(&self) {
+    fn observe_datastore_memory(&self) {
         self.memory_observer.memory_observed(MemoryObservation {
             database_identity: self.database_identity,
             kind: DatabaseMemoryType::Datastore,
-            bytes: self.inner.datastore_page_bytes(),
+            bytes: self.inner.datastore_memory_bytes(),
         });
     }
 
@@ -849,7 +849,7 @@ impl RelationalDB {
         };
 
         self.maybe_do_snapshot(&tx_data);
-        self.observe_datastore_pages();
+        self.observe_datastore_memory();
 
         Ok(Some((tx_offset, tx_data, tx_metrics, reducer)))
     }
@@ -864,7 +864,7 @@ impl RelationalDB {
         });
 
         self.maybe_do_snapshot(&tx_data);
-        self.observe_datastore_pages();
+        self.observe_datastore_memory();
 
         (tx_data, tx_metrics, tx)
     }

--- a/crates/engine/src/relational_db.rs
+++ b/crates/engine/src/relational_db.rs
@@ -2,6 +2,7 @@ use crate::durability::{request_durability, spawn_close as spawn_durability_clos
 use crate::error::{DBError, RestoreSnapshotError};
 use crate::metrics::ExecutionCounters;
 use crate::metrics::ENGINE_METRICS;
+use crate::resource::{DatabaseMemoryType, MemoryObservation, MemoryObserver};
 use crate::util::asyncify;
 use crate::MetricsRecorderQueue;
 use anyhow::{anyhow, Context};
@@ -114,6 +115,9 @@ pub struct RelationalDB {
 
     /// An async queue for recording transaction metrics off the main thread
     metrics_recorder_queue: Option<MetricsRecorderQueue>,
+
+    /// An observer for memory usage changes in this database.
+    memory_observer: Arc<dyn MemoryObserver>,
 }
 
 /// Perform a snapshot every `SNAPSHOT_FREQUENCY` transactions.
@@ -169,7 +173,22 @@ impl RelationalDB {
 
             workload_type_to_exec_counters,
             metrics_recorder_queue,
+            memory_observer: Arc::new(()),
         }
+    }
+
+    pub fn with_memory_observer(mut self, memory_observer: Arc<dyn MemoryObserver>) -> Self {
+        self.memory_observer = memory_observer;
+        self.observe_datastore_pages();
+        self
+    }
+
+    fn observe_datastore_pages(&self) {
+        self.memory_observer.memory_observed(MemoryObservation {
+            database_identity: self.database_identity,
+            kind: DatabaseMemoryType::Datastore,
+            bytes: self.inner.datastore_page_bytes(),
+        });
     }
 
     /// Open a database, which may or may not already exist.
@@ -830,6 +849,7 @@ impl RelationalDB {
         };
 
         self.maybe_do_snapshot(&tx_data);
+        self.observe_datastore_pages();
 
         Ok(Some((tx_offset, tx_data, tx_metrics, reducer)))
     }
@@ -844,6 +864,7 @@ impl RelationalDB {
         });
 
         self.maybe_do_snapshot(&tx_data);
+        self.observe_datastore_pages();
 
         (tx_data, tx_metrics, tx)
     }

--- a/crates/engine/src/relational_db.rs
+++ b/crates/engine/src/relational_db.rs
@@ -179,15 +179,15 @@ impl RelationalDB {
 
     pub fn with_memory_observer(mut self, memory_observer: Arc<dyn MemoryObserver>) -> Self {
         self.memory_observer = memory_observer;
-        self.observe_datastore_memory();
+        self.observe_datastore_memory(self.inner.datastore_memory_bytes());
         self
     }
 
-    fn observe_datastore_memory(&self) {
+    fn observe_datastore_memory(&self, bytes: u64) {
         self.memory_observer.memory_observed(MemoryObservation {
             database_identity: self.database_identity,
             kind: DatabaseMemoryType::Datastore,
-            bytes: self.inner.datastore_memory_bytes(),
+            bytes,
         });
     }
 
@@ -841,15 +841,16 @@ impl RelationalDB {
 
         let reducer_context = tx.ctx.reducer_context().cloned();
         // TODO: Never returns `None` -- should it?
-        let Some((tx_offset, tx_data, tx_metrics, reducer)) = self.inner.commit_mut_tx_and_then(tx, |tx_data| {
-            self.request_durability(reducer_context, tx_data);
-        })?
+        let Some((tx_offset, tx_data, tx_metrics, reducer, datastore_memory_bytes)) =
+            self.inner.commit_mut_tx_and_then(tx, |tx_data| {
+                self.request_durability(reducer_context, tx_data);
+            })?
         else {
             return Ok(None);
         };
 
         self.maybe_do_snapshot(&tx_data);
-        self.observe_datastore_memory();
+        self.observe_datastore_memory(datastore_memory_bytes);
 
         Ok(Some((tx_offset, tx_data, tx_metrics, reducer)))
     }
@@ -859,12 +860,13 @@ impl RelationalDB {
         log::trace!("COMMIT MUT TX");
 
         let reducer_context = tx.ctx.reducer_context().cloned();
-        let (tx_data, tx_metrics, tx) = self.inner.commit_mut_tx_downgrade_and_then(tx, workload, |tx_data| {
-            self.request_durability(reducer_context, tx_data);
-        });
+        let (tx_data, tx_metrics, tx, datastore_memory_bytes) =
+            self.inner.commit_mut_tx_downgrade_and_then(tx, workload, |tx_data| {
+                self.request_durability(reducer_context, tx_data);
+            });
 
         self.maybe_do_snapshot(&tx_data);
-        self.observe_datastore_memory();
+        self.observe_datastore_memory(datastore_memory_bytes);
 
         (tx_data, tx_metrics, tx)
     }

--- a/crates/engine/src/resource.rs
+++ b/crates/engine/src/resource.rs
@@ -1,0 +1,79 @@
+use spacetimedb_lib::Identity;
+use std::sync::{
+    atomic::{AtomicU64, Ordering},
+    Arc,
+};
+
+#[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
+pub enum DatabaseMemoryType {
+    /// Module instance memory such as Wasmtime linear memory and V8 physical heap memory.
+    Instance,
+}
+
+#[derive(Clone, Debug)]
+pub struct MemoryObservation {
+    pub database_identity: Identity,
+    pub kind: DatabaseMemoryType,
+    pub bytes: u64,
+}
+
+pub trait MemoryObserver: Send + Sync + 'static {
+    fn memory_observed(&self, _: MemoryObservation) {}
+}
+
+impl MemoryObserver for () {}
+
+#[derive(Clone)]
+pub struct ModuleInstanceMemoryTracker {
+    inner: Arc<ModuleInstanceMemoryTrackerInner>,
+}
+
+struct ModuleInstanceMemoryTrackerInner {
+    database_identity: Identity,
+    observer: Arc<dyn MemoryObserver>,
+    /// Database-wide aggregate across all live module instances.
+    ///
+    /// Wasm and V8 instances each keep their own `last_observed` value and
+    /// report only the delta when they are sampled or dropped,
+    /// so that we can compare against a single limit for the entire database.
+    instance_bytes: AtomicU64,
+}
+
+impl ModuleInstanceMemoryTracker {
+    pub fn new(database_identity: Identity, observer: Arc<dyn MemoryObserver>) -> Self {
+        Self {
+            inner: Arc::new(ModuleInstanceMemoryTrackerInner {
+                database_identity,
+                observer,
+                instance_bytes: AtomicU64::new(0),
+            }),
+        }
+    }
+
+    pub fn adjust_wasm_linear(&self, delta: i64) {
+        self.adjust_instance(delta);
+    }
+
+    pub fn adjust_v8_physical(&self, total_physical_delta: i64) {
+        self.adjust_instance(total_physical_delta);
+    }
+
+    fn adjust_instance(&self, delta: i64) {
+        let bytes = adjust_atomic_u64(&self.inner.instance_bytes, delta);
+        self.inner.observer.memory_observed(MemoryObservation {
+            database_identity: self.inner.database_identity,
+            kind: DatabaseMemoryType::Instance,
+            bytes,
+        });
+    }
+}
+
+fn adjust_atomic_u64(value: &AtomicU64, delta: i64) -> u64 {
+    if delta >= 0 {
+        let delta = delta as u64;
+        value.fetch_add(delta, Ordering::Relaxed) + delta
+    } else {
+        let delta = delta.unsigned_abs();
+        value.fetch_sub(delta, Ordering::Relaxed) - delta
+    }
+}

--- a/crates/engine/src/resource.rs
+++ b/crates/engine/src/resource.rs
@@ -7,7 +7,11 @@ use std::sync::{
 #[derive(Clone, Copy, Debug, Eq, Hash, PartialEq)]
 pub enum DatabaseMemoryType {
     /// Module instance memory such as Wasmtime linear memory and V8 physical heap memory.
-    Instance,
+    Module,
+    /// Memory allocated and managed by the datastore.
+    ///
+    /// Currently only page-level memory.
+    Datastore,
 }
 
 #[derive(Clone, Debug)]
@@ -62,7 +66,7 @@ impl ModuleInstanceMemoryTracker {
         let bytes = adjust_atomic_u64(&self.inner.instance_bytes, delta);
         self.inner.observer.memory_observed(MemoryObservation {
             database_identity: self.inner.database_identity,
-            kind: DatabaseMemoryType::Instance,
+            kind: DatabaseMemoryType::Module,
             bytes,
         });
     }

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -86,6 +86,7 @@ impl StandaloneEnv {
             HostRuntimeConfig::new(config.wasm, config.v8),
             program_store.clone(),
             energy_monitor,
+            Arc::new(()),
             persistence_provider,
             db_cores,
         );

--- a/crates/table/src/blob_store.rs
+++ b/crates/table/src/blob_store.rs
@@ -117,6 +117,16 @@ pub trait BlobStore: Sync {
             .sum()
     }
 
+    /// Returns the physical bytes represented by unique blob entries.
+    ///
+    /// This counts each unique [`BlobHash`] key once plus the payload bytes for that key.
+    /// It intentionally does not consider refcounts, as it is primarily used for memory tracking.
+    fn physical_bytes_used_by_blobs(&self) -> u64 {
+        self.iter_blobs()
+            .map(|(_, _, data)| data.len() as u64 + mem::size_of::<BlobHash>() as u64)
+            .sum()
+    }
+
     /// Returns the number of blobs, or more precisely, blob-usages, recorded in this `BlobStore`.
     ///
     /// Duplicate blobs are counted a number of times equal to their refcount.
@@ -165,11 +175,16 @@ pub struct HashMapBlobStore {
     /// For testing, we use a hash map with a reference count
     /// to handle freeing and cloning correctly.
     map: HashMap<BlobHash, BlobObject>,
+    /// Total number of bytes in the map used by blobs and their keys
+    physical_blob_payload_bytes: u64,
 }
 
 impl MemoryUsage for HashMapBlobStore {
     fn heap_usage(&self) -> usize {
-        let Self { map } = self;
+        let Self {
+            map,
+            physical_blob_payload_bytes: _,
+        } = self;
         map.heap_usage()
     }
 }
@@ -198,22 +213,28 @@ impl BlobStore for HashMapBlobStore {
 
     fn insert_blob(&mut self, bytes: &[u8]) -> BlobHash {
         let hash = BlobHash::hash_from_bytes(bytes);
-        self.map
-            .entry(hash)
-            .and_modify(|v| v.uses += 1)
-            .or_insert_with(|| BlobObject {
-                blob: bytes.into(),
-                uses: 1,
-            });
+        match self.map.entry(hash) {
+            Entry::Occupied(mut entry) => entry.get_mut().uses += 1,
+            Entry::Vacant(entry) => {
+                self.physical_blob_payload_bytes += bytes.len() as u64;
+                entry.insert(BlobObject {
+                    blob: bytes.into(),
+                    uses: 1,
+                });
+            }
+        }
         hash
     }
 
     fn insert_with_uses(&mut self, hash: &BlobHash, uses: usize, bytes: Box<[u8]>) {
         debug_assert_eq!(hash, &BlobHash::hash_from_bytes(&bytes));
-        self.map
-            .entry(*hash)
-            .and_modify(|v| v.uses += uses)
-            .or_insert_with(|| BlobObject { blob: bytes, uses });
+        match self.map.entry(*hash) {
+            Entry::Occupied(mut entry) => entry.get_mut().uses += uses,
+            Entry::Vacant(entry) => {
+                self.physical_blob_payload_bytes += bytes.len() as u64;
+                entry.insert(BlobObject { blob: bytes, uses });
+            }
+        }
     }
 
     fn retrieve_blob(&self, hash: &BlobHash) -> Result<&[u8], NoSuchBlobError> {
@@ -223,7 +244,10 @@ impl BlobStore for HashMapBlobStore {
     fn free_blob(&mut self, hash: &BlobHash) -> Result<(), NoSuchBlobError> {
         match self.map.entry(*hash) {
             Entry::Vacant(_) => return Err(NoSuchBlobError),
-            Entry::Occupied(entry) if entry.get().uses == 1 => drop(entry.remove()),
+            Entry::Occupied(entry) if entry.get().uses == 1 => {
+                let removed = entry.remove();
+                self.physical_blob_payload_bytes -= removed.blob.len() as u64;
+            }
             Entry::Occupied(mut entry) => entry.get_mut().uses -= 1,
         }
         Ok(())
@@ -232,14 +256,27 @@ impl BlobStore for HashMapBlobStore {
     fn iter_blobs(&self) -> BlobsIter<'_> {
         Box::new(self.map.iter().map(|(hash, obj)| (hash, obj.uses, &obj.blob[..])))
     }
+
+    fn physical_bytes_used_by_blobs(&self) -> u64 {
+        self.physical_blob_payload_bytes + self.map.len() as u64 * mem::size_of::<BlobHash>() as u64
+    }
 }
 
 impl HashMapBlobStore {
     /// Merge `src_bs` into `self`.
     pub fn merge_from(&mut self, src_bs: Self) {
-        for (hash, mut obj) in src_bs.map {
-            let uses = mem::take(&mut obj.uses);
-            self.map.entry(hash).or_insert(obj).uses += uses;
+        let Self {
+            map,
+            physical_blob_payload_bytes: _,
+        } = src_bs;
+        for (hash, obj) in map {
+            match self.map.entry(hash) {
+                Entry::Occupied(mut entry) => entry.get_mut().uses += obj.uses,
+                Entry::Vacant(entry) => {
+                    self.physical_blob_payload_bytes += obj.blob.len() as u64;
+                    entry.insert(obj);
+                }
+            }
         }
     }
 }

--- a/crates/table/src/table.rs
+++ b/crates/table/src/table.rs
@@ -1622,6 +1622,11 @@ impl Table {
         (self.num_pages() * PAGE_DATA_SIZE) + (self.blob_store_bytes.0)
     }
 
+    /// Returns the bytes occupied by this table's allocated physical row pages.
+    pub fn page_bytes(&self) -> u64 {
+        (self.num_pages() * mem::size_of::<Page>()) as u64
+    }
+
     /// Reset the internal storage of `self` to be `pages`.
     ///
     /// This recomputes the pointer map based on the `pages`,


### PR DESCRIPTION
# Description of Changes

In order to be able to suspend databases based on memory usage.

Reports memory usage for wasm linear memory as well as the v8 heap. Also reports page-level memory for tables.

It does not report memory usage for indexes.

# API and ABI breaking changes

None

# Expected complexity level and risk

1.5

# Testing

Testing added in the private counterpart which handles enforcement of memory limits.
