### PR TITLE
Fix one-column prefix scan on a multi-column index

### DIFF
--- a/crates/bindings-typescript/src/server/runtime.ts
+++ b/crates/bindings-typescript/src/server/runtime.ts
@@ -559,7 +559,7 @@ class HandlerContextImpl<S extends UntypedSchemaDef = UntypedSchemaDef>
   }
 }
 
-function makeTableView(
+export function makeTableView(
   typespace: Typespace,
   table: RawTableDefV10
 ): Table<any> {
@@ -932,6 +932,10 @@ function makeTableView(
       };
       index = {
         filter: (range: any[]): IteratorObject<RowType<any>> => {
+          // A bare scalar or `Range` is the only type-valid way to express a
+          // one-column prefix scan; normalize it to a single-element array so
+          // `.length` and `serializeRange` see a prefix rather than NaN.
+          if (!Array.isArray(range)) range = [range];
           if (range.length === numColumns) {
             const buf = LEAF_BUF;
             const point_len = serializePoint(buf, range);
@@ -953,6 +957,7 @@ function makeTableView(
           }
         },
         delete: (range: any[]): u32 => {
+          if (!Array.isArray(range)) range = [range];
           if (range.length === numColumns) {
             const buf = LEAF_BUF;
             const point_len = serializePoint(buf, range);

--- a/crates/bindings-typescript/tests/__mocks__/spacetime-sys.ts
+++ b/crates/bindings-typescript/tests/__mocks__/spacetime-sys.ts
@@ -1,0 +1,93 @@
+/**
+ * Test stub for the host-provided `spacetime:sys@2.0` / `spacetime:sys@2.1`
+ * virtual modules.
+ *
+ * In a real module these syscalls are injected by the SpacetimeDB V8 host. For
+ * unit tests we only need enough behaviour to drive the pure-JS portions of
+ * `runtime.ts` (e.g. index `serializeRange`). Every iterator-producing call
+ * returns a dummy iterator id whose `advance` immediately reports "empty", so
+ * `[...filter(...)]` deserializes zero rows without touching a real datastore.
+ */
+
+export const moduleHooks: unique symbol = Symbol('moduleHooks') as any;
+
+export const table_id_from_name = (_name: string): number => 1;
+export const index_id_from_name = (_name: string): number => 1;
+
+export const datastore_table_row_count = (_table_id: number): bigint => 0n;
+export const datastore_table_scan_bsatn = (_table_id: number): number => 1;
+
+export const datastore_index_scan_range_bsatn = (
+  _index_id: number,
+  _buf: ArrayBuffer,
+  _prefix_len: number,
+  _prefix_elems: number,
+  _rstart_len: number,
+  _rend_len: number
+): number => 1;
+
+export const datastore_index_scan_point_bsatn = (
+  _index_id: number,
+  _point: ArrayBuffer,
+  _point_len: number
+): number => 1;
+
+export const datastore_delete_by_index_scan_range_bsatn = (
+  _index_id: number,
+  _buf: ArrayBuffer,
+  _prefix_len: number,
+  _prefix_elems: number,
+  _rstart_len: number,
+  _rend_len: number
+): number => 0;
+
+export const datastore_delete_by_index_scan_point_bsatn = (
+  _index_id: number,
+  _point: ArrayBuffer,
+  _point_len: number
+): number => 0;
+
+// `0` => iterator is empty and has been destroyed (see advanceIterRaw docs).
+export const row_iter_bsatn_advance = (
+  _iter: number,
+  _buffer: ArrayBuffer
+): number => 0;
+export const row_iter_bsatn_close = (_iter: number): void => {};
+
+export const datastore_insert_bsatn = (
+  _table_id: number,
+  _row: ArrayBuffer,
+  _row_len: number
+): number => 0;
+export const datastore_update_bsatn = (
+  _table_id: number,
+  _index_id: number,
+  _row: ArrayBuffer,
+  _row_len: number
+): number => 0;
+export const datastore_delete_all_by_eq_bsatn = (
+  _table_id: number,
+  _relation: ArrayBuffer,
+  _relation_len: number
+): number => 0;
+export const datastore_clear = (_table_id: number): bigint => 0n;
+
+export const volatile_nonatomic_schedule_immediate = (
+  _reducer_name: string,
+  _args: Uint8Array
+): void => {};
+export const console_log = (_level: number, _message: string): void => {};
+export const console_timer_start = (_name: string): number => 0;
+export const console_timer_end = (_span_id: number): void => {};
+export const identity = (): bigint => 0n;
+export const get_jwt_payload = (_connection_id: bigint): Uint8Array =>
+  new Uint8Array();
+export const register_hooks = (_hooks: unknown): void => {};
+
+export const procedure_http_request = (
+  _request: Uint8Array,
+  _body: Uint8Array | string
+): [Uint8Array, Uint8Array] => [new Uint8Array(), new Uint8Array()];
+export const procedure_start_mut_tx = (): bigint => 0n;
+export const procedure_commit_mut_tx = (): void => {};
+export const procedure_abort_mut_tx = (): void => {};

--- a/crates/bindings-typescript/tests/index_prefix_filter.test.ts
+++ b/crates/bindings-typescript/tests/index_prefix_filter.test.ts
@@ -1,0 +1,89 @@
+import { describe, expect, it, vi } from 'vitest';
+
+// `runtime.ts` and `procedures.ts` form an import cycle (procedures extends
+// runtime's ReducerCtxImpl). Vitest's loader evaluates the cycle in an order
+// that leaves the base class undefined. runtime only needs `callProcedure`, and
+// not on the table-view path under test, so stub procedures to break the cycle.
+vi.mock('../src/server/procedures', () => ({
+  callProcedure: () => {
+    throw new Error('callProcedure is not stubbed for this test');
+  },
+}));
+
+import { ModuleContext } from '../src/lib/schema';
+import { table } from '../src/lib/table';
+import { Range } from '../src/server/range';
+import { makeTableView } from '../src/server/runtime';
+import { t } from '../src/lib/type_builders';
+
+/**
+ * Regression test for clockworklabs/SpacetimeDB#5407:
+ *
+ *   Calling `.filter()` / `.delete()` on a multi-column btree index with a
+ *   single bare scalar (the documented one-column prefix scan) used to panic
+ *   with `TypeError: serializeTerm is not a function` inside `serializeRange`,
+ *   because a bare scalar has no `.length`, so `prefix_elems` and the serializer
+ *   index both became `NaN`.
+ *
+ * `filter(1n)` is the only *type-valid* way to express a one-column prefix on a
+ * `[u64, string]` index, so it must work; the full two-column key takes the
+ * separate point-scan branch. The mocked host iterator yields no rows, so a
+ * successful scan deserializes to an empty result rather than crashing.
+ */
+function tallyView() {
+  const ctx = new ModuleContext();
+  const tally = table(
+    {
+      name: 'tally',
+      indexes: [
+        {
+          accessor: 'by_board_def',
+          algorithm: 'btree',
+          columns: ['boardId', 'defId'] as const,
+        },
+      ] as const,
+    },
+    {
+      id: t.u64().primaryKey().autoInc(),
+      boardId: t.u64(),
+      defId: t.string(),
+      count: t.u64(),
+    }
+  );
+
+  const rawTableDef = tally.tableDef(ctx, 'tally');
+  const view = makeTableView(ctx.typespace, rawTableDef) as any;
+  return view.by_board_def;
+}
+
+describe('multi-column index one-column prefix scan', () => {
+  it('full two-column key works (point scan)', () => {
+    const index = tallyView();
+    expect(() => [...index.filter([1n, 'regolith'])]).not.toThrow();
+    expect([...index.filter([1n, 'regolith'])]).toEqual([]);
+  });
+
+  it('bare-scalar one-column prefix works (range scan)', () => {
+    const index = tallyView();
+    // `filter(1n)` is the documented one-column prefix form and the only
+    // type-valid way to express it; it must scan, not throw.
+    expect(() => [...index.filter(1n)]).not.toThrow();
+    expect([...index.filter(1n)]).toEqual([]);
+  });
+
+  it('bare Range on the first column works (range scan)', () => {
+    const index = tallyView();
+    const range = new Range<bigint>(
+      { tag: 'included', value: 1n },
+      { tag: 'excluded', value: 5n }
+    );
+    expect(() => [...index.filter(range)]).not.toThrow();
+    expect([...index.filter(range)]).toEqual([]);
+  });
+
+  it('delete() accepts a bare-scalar one-column prefix', () => {
+    const index = tallyView();
+    expect(() => index.delete(1n)).not.toThrow();
+    expect(index.delete(1n)).toBe(0);
+  });
+});

--- a/crates/bindings-typescript/vitest.config.ts
+++ b/crates/bindings-typescript/vitest.config.ts
@@ -1,7 +1,21 @@
+import { fileURLToPath } from 'node:url';
 import type { UserConfig } from 'vite';
 import { defineConfig } from 'vitest/config';
 
+const sysMock = fileURLToPath(
+  new URL('./tests/__mocks__/spacetime-sys.ts', import.meta.url)
+);
+
 export default defineConfig({
+  resolve: {
+    // The `spacetime:sys@*` virtual modules are injected by the SpacetimeDB V8
+    // host at runtime. Tests that import `src/server/runtime.ts` need a stub so
+    // those host syscalls resolve under Node/vitest.
+    alias: [
+      { find: 'spacetime:sys@2.0', replacement: sysMock },
+      { find: 'spacetime:sys@2.1', replacement: sysMock },
+    ],
+  },
   test: {
     include: ['tests/**/*.test.ts'],
     globals: true,


### PR DESCRIPTION
# Description of Changes

Fixes #5407.

A one-column prefix scan on a multi-column btree index — e.g. `filter(1n)` on a
`[u64, string]` index — panicked at runtime with `TypeError: serializeTerm is
not a function` inside `serializeRange`.

A bare scalar (or bare `Range`) has no `.length`, so in the multi-column
`filter`/`delete` accessor `range.length === numColumns` was `undefined === 2`
(falling into the range-scan branch), and inside `serializeRange`:

- `prefix_elems = range.length - 1` → `NaN` (prefix loop skipped),
- `serializeTerm = indexSerializers[range.length - 1]` → `indexSerializers[NaN]`
  → `undefined`,
- `serializeTerm(writer, term)` → **`TypeError: serializeTerm is not a function`**.

A bare scalar is the only *type-valid* way to express a one-column prefix on a
multi-column index — `filter([1n])` is rejected by the generated types and
`filter([1n, "x"])` is the full key — so there was previously **no** working way
to do a one-column prefix scan.

The fix normalizes a non-array `range` to a single-element array at the top of
the multi-column `filter`/`delete` before reading `.length`, so a bare scalar or
`Range` is treated as a one-column prefix and takes the range-scan branch
correctly. The full two-column key path is unchanged and still takes the
point-scan branch.

To regression-test the pure-JS index accessor under vitest, `makeTableView` is
now exported from `src/server/runtime.ts` (it is **not** re-exported from any
public entry point), the host-injected `spacetime:sys@*` virtual modules are
stubbed, and aliased in `vitest.config.ts`.

# API and ABI breaking changes

None. `makeTableView` is newly exported from `src/server/runtime.ts` but is not
re-exported from any public entry point. The host ABI is unchanged.

# Expected complexity level and risk

1 — a one-line input normalization on each of `filter`/`delete`, plus test-only
scaffolding. No change to the full-key path or the host syscall arguments.

# Testing

- [x] `npx vitest run tests/index_prefix_filter.test.ts` — bare scalar, bare
  `Range`, full two-column key, and `delete()` all scan without throwing (4 passed).
- [x] `npx vitest run` — full suite, 223 passed.
- [x] `tsc -p tsconfig.build.json` and `prettier --check` clean.
- [x] Reviewer: confirm the prefix-scan semantics against a real datastore
  (the unit test uses a stubbed host iterator that yields no rows).
