### PR TITLE
Change LLM_BENCHMARK_UPLOAD_URL to use inputs

### DIFF
--- a/.github/workflows/llm-benchmark-periodic.yml
+++ b/.github/workflows/llm-benchmark-periodic.yml
@@ -114,7 +114,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           LLM_VENDOR: openrouter
           LLM_BENCHMARK_API_KEY: ${{ secrets.LLM_BENCHMARK_API_KEY }}
-          LLM_BENCHMARK_UPLOAD_URL: ${{ secrets.LLM_BENCHMARK_UPLOAD_URL }}
+          LLM_BENCHMARK_UPLOAD_URL: ${{ inputs.LLM_BENCHMARK_UPLOAD_URL }}
           DOTNET_MULTILEVEL_LOOKUP: "0"
           DOTNET_CLI_HOME: ${{ runner.temp }}/dotnet-home
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"


### PR DESCRIPTION
# Description of Changes

LLM benchmark now pulls LLM_BENCHMARK_UPLOAD_URL from inputs instead of secrets

# API and ABI breaking changes

None

# Expected complexity level and risk

1
# Testing

Wait for CI to pass
