### PR TITLE
Remove LLM-benchmark timeout

### DIFF
--- a/.github/workflows/llm-benchmark-periodic.yml
+++ b/.github/workflows/llm-benchmark-periodic.yml
@@ -50,7 +50,7 @@ concurrency:
 jobs:
   run-benchmarks:
     runs-on: spacetimedb-new-runner-2
-    timeout-minutes: 180
+    timeout-minutes: 360
 
     steps:
       - name: Checkout repository

--- a/.github/workflows/llm-benchmark-periodic.yml
+++ b/.github/workflows/llm-benchmark-periodic.yml
@@ -50,7 +50,6 @@ concurrency:
 jobs:
   run-benchmarks:
     runs-on: spacetimedb-new-runner-2
-    timeout-minutes: 360
 
     steps:
       - name: Checkout repository


### PR DESCRIPTION
# Description of Changes

Periodic LLM benchmark jobs can take more than 3 hour, this PR remove the 3 hour limit in favor of Github's default to 6 hours

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Not tested, I need to merge to be able to test as it is a CI change
