### PR TITLE
Use vars instead of inputs for upload URL in periodic LLM benchmarck

### DIFF
--- a/.github/workflows/llm-benchmark-periodic.yml
+++ b/.github/workflows/llm-benchmark-periodic.yml
@@ -113,7 +113,7 @@ jobs:
           ANTHROPIC_API_KEY: ${{ secrets.ANTHROPIC_API_KEY }}
           LLM_VENDOR: openrouter
           LLM_BENCHMARK_API_KEY: ${{ secrets.LLM_BENCHMARK_API_KEY }}
-          LLM_BENCHMARK_UPLOAD_URL: ${{ inputs.LLM_BENCHMARK_UPLOAD_URL }}
+          LLM_BENCHMARK_UPLOAD_URL: ${{ vars.LLM_BENCHMARK_UPLOAD_URL }}
           DOTNET_MULTILEVEL_LOOKUP: "0"
           DOTNET_CLI_HOME: ${{ runner.temp }}/dotnet-home
           DOTNET_SKIP_FIRST_TIME_EXPERIENCE: "1"


### PR DESCRIPTION
# Description of Changes

LLM_BENCHMARK_UPLOAD_URL is set in `vars`, not `inputs`

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Wait for CI to complete
