### PR TITLE
core: Log database + reducer name on error

### DIFF
--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -1740,7 +1740,12 @@ fn log_reducer_error(
         .with_label_values(&replica_ctx.database_identity, module_hash, reducer)
         .inc();
 
-    log::info!("reducer returned error: {message}");
+    log::info!(
+        "reducer `{}` of database `{}` returned error: {}",
+        reducer,
+        replica_ctx.database_identity,
+        message
+    );
 
     let record = Record {
         ts: chrono::DateTime::from_timestamp_micros(timestamp.to_micros_since_unix_epoch()).unwrap(),


### PR DESCRIPTION
In addition to the error message, log the database identity and the
reducer name when a reducer returns an error.

This provides a useful correlation, for example when the error has
upstream effects such as causing elevated error rates in the proxy
connection establishment due to the module rejecting the connection on
purpose.

# Expected complexity level and risk

1

# Testing

Logging change only.
