### PR TITLE
Release - concurrency group tweaks

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -49,7 +49,7 @@ permissions:
   packages: write
 
 concurrency:
-  group: manual-release
+  group: manual-release-${{ inputs.release_tag }}${{ inputs.dry_run && format('-dry-run-{0}', github.run_id) || '' }}
   cancel-in-progress: true
 
 jobs:


### PR DESCRIPTION
# Description of Changes

- Dry runs effectively all get their own concurrency group, since they don't mutate anything anyway
- All release have the tag as part of the concurrency group, so we can hypothetically run multiple different versions at once (and it just seems clearer).

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

None