### PR TITLE
Allow sync-agent-skills.mjs to match Windows line ends

### DIFF
--- a/docs/scripts/sync-agent-skills.mjs
+++ b/docs/scripts/sync-agent-skills.mjs
@@ -11,13 +11,13 @@ const outputDir = path.join(
   'docs/static/.well-known/agent-skills'
 );
 function readFrontmatter(markdown, sourcePath) {
-  const match = markdown.match(/^---\n([\s\S]*?)\n---\n/);
+  const match = markdown.match(/^---\r?\n([\s\S]*?)\r?\n---\r?\n/);
   if (!match) {
     throw new Error(`${sourcePath} is missing YAML frontmatter`);
   }
 
   const frontmatter = {};
-  for (const line of match[1].split('\n')) {
+  for (const line of match[1].split(/\r?\n/)) {
     const field = line.match(/^([a-zA-Z0-9_-]+):\s*(.*)$/);
     if (field) {
       frontmatter[field[1]] = field[2].replace(/^"(.*)"$/, '$1');


### PR DESCRIPTION
# Description of Changes

The readFrontmatter regex in `docs/scripts/sync-agent-skills.mjs` uses `\n` to match line endings, which fails on Windows where files have CRLF (`\r\n`) endings. This causes `pnpm run build` to fail with:
```
Error: skills\cli\SKILL.md is missing YAML frontmatter
```
Fix: change `\n` → `\r?\n` in the frontmatter regex and use /\r?\n/ for line splitting so the script works on both Unix and Windows.

# API and ABI breaking changes

No API or ABI changes

# Expected complexity level and risk

1 - Trivial

# Testing

- [X] When used along side `bump-versions`, this prevents Windows from having the outlined issue.