### PR TITLE
feat: Add  module lifecycle reducer

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -4248,6 +4248,14 @@ dependencies = [
 ]
 
 [[package]]
+name = "module-test-stop"
+version = "0.0.0"
+dependencies = [
+ "log",
+ "spacetimedb",
+]
+
+[[package]]
 name = "multer"
 version = "3.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -44,6 +44,7 @@ members = [
   "modules/keynote-benchmarks",
   "modules/perf-test",
   "modules/module-test",
+  "modules/module-test-stop",
   "templates/basic-rs/spacetimedb",
   "templates/chat-console-rs/spacetimedb",
   "modules/sdk-test",

--- a/crates/bindings-csharp/Codegen/Module.cs
+++ b/crates/bindings-csharp/Codegen/Module.cs
@@ -1583,6 +1583,7 @@ record ReducerDeclaration
             ReducerKind.Init => "SpacetimeDB.Internal.Lifecycle.Init",
             ReducerKind.ClientConnected => "SpacetimeDB.Internal.Lifecycle.OnConnect",
             ReducerKind.ClientDisconnected => "SpacetimeDB.Internal.Lifecycle.OnDisconnect",
+            ReducerKind.Stop => "SpacetimeDB.Internal.Lifecycle.Stop",
             _ => "null"
         }}};
 

--- a/crates/bindings-csharp/Runtime/Attrs.cs
+++ b/crates/bindings-csharp/Runtime/Attrs.cs
@@ -193,6 +193,14 @@ namespace SpacetimeDB
         Init,
         ClientConnected,
         ClientDisconnected,
+
+        /// <summary>
+        /// Invoked exactly once, immediately before the database is permanently
+        /// destroyed (e.g. via `spacetime delete`, or a database reset). Never
+        /// invoked on an ordinary module update/hot-reload, since the database's
+        /// data survives those.
+        /// </summary>
+        Stop,
     }
 
     [AttributeUsage(AttributeTargets.Method, Inherited = false)]

--- a/crates/bindings-csharp/Runtime/Internal/Autogen/Lifecycle.g.cs
+++ b/crates/bindings-csharp/Runtime/Internal/Autogen/Lifecycle.g.cs
@@ -13,5 +13,6 @@ namespace SpacetimeDB.Internal
         Init,
         OnConnect,
         OnDisconnect,
+        Stop,
     }
 }

--- a/crates/bindings-macro/src/lib.rs
+++ b/crates/bindings-macro/src/lib.rs
@@ -147,6 +147,7 @@ mod sym {
     symbol!(repr);
     symbol!(sats);
     symbol!(scheduled);
+    symbol!(stop);
     symbol!(unique);
     symbol!(update);
     symbol!(default);

--- a/crates/bindings-macro/src/reducer.rs
+++ b/crates/bindings-macro/src/reducer.rs
@@ -17,16 +17,21 @@ enum LifecycleReducer {
     ClientConnected(Span),
     ClientDisconnected(Span),
     Update(Span),
+    Stop(Span),
 }
 impl LifecycleReducer {
     fn to_lifecycle_value(&self) -> Option<TokenStream> {
-        let (Self::Init(span) | Self::ClientConnected(span) | Self::ClientDisconnected(span) | Self::Update(span)) =
-            *self;
+        let (Self::Init(span)
+        | Self::ClientConnected(span)
+        | Self::ClientDisconnected(span)
+        | Self::Update(span)
+        | Self::Stop(span)) = *self;
         let name = match self {
             Self::Init(_) => "Init",
             Self::ClientConnected(_) => "OnConnect",
             Self::ClientDisconnected(_) => "OnDisconnect",
             Self::Update(_) => return None,
+            Self::Stop(_) => "Stop",
         };
         let ident = Ident::new(name, span);
         Some(quote_spanned!(span => spacetimedb::rt::LifecycleReducer::#ident))
@@ -47,6 +52,7 @@ impl ReducerArgs {
                 sym::client_connected => set_lifecycle(LifecycleReducer::ClientConnected)?,
                 sym::client_disconnected => set_lifecycle(LifecycleReducer::ClientDisconnected)?,
                 sym::update => set_lifecycle(LifecycleReducer::Update)?,
+                sym::stop => set_lifecycle(LifecycleReducer::Stop)?,
                 sym::name => {
                     check_duplicate(&args.name, &meta)?;
                     args.name = Some(meta.value()?.parse()?);

--- a/crates/bindings-typescript/src/lib/autogen/types.ts
+++ b/crates/bindings-typescript/src/lib/autogen/types.ts
@@ -155,6 +155,7 @@ export const Lifecycle = __t.enum('Lifecycle', {
   Init: __t.unit(),
   OnConnect: __t.unit(),
   OnDisconnect: __t.unit(),
+  Stop: __t.unit(),
 });
 export type Lifecycle = __Infer<typeof Lifecycle>;
 

--- a/crates/bindings-typescript/src/server/schema.ts
+++ b/crates/bindings-typescript/src/server/schema.ts
@@ -393,6 +393,38 @@ export class Schema<S extends UntypedSchemaDef> implements ModuleDefaultExport {
     return makeReducerExport(this.#ctx, opts, {}, fn, Lifecycle.OnDisconnect);
   }
 
+  /**
+   * Registers a reducer to be invoked exactly once, immediately before the
+   * database is permanently destroyed (e.g. via `spacetime delete`, or a
+   * database reset). It is never invoked on an ordinary module
+   * update/hot-reload, since the database's data survives those.
+   *
+   * @template S - The inferred schema type of the SpacetimeDB module.
+   * @param {Reducer<S, {}>} fn - The stop reducer function.
+   * @example
+   * ```typescript
+   * export const stop = spacetime.stop((ctx) => {
+   *   console.log('Database is being deleted');
+   * });
+   * ```
+   */
+  stop(fn: Reducer<S, {}>): ReducerExport<S, {}>;
+  stop(opts: ReducerOpts, fn: Reducer<S, {}>): ReducerExport<S, {}>;
+  stop(
+    ...args: [Reducer<S, {}>] | [ReducerOpts, Reducer<S, {}>]
+  ): ReducerExport<S, {}> {
+    let opts: ReducerOpts | undefined, fn: Reducer<S, {}>;
+    switch (args.length) {
+      case 1:
+        [fn] = args;
+        break;
+      case 2:
+        [opts, fn] = args;
+        break;
+    }
+    return makeReducerExport(this.#ctx, opts, {}, fn, Lifecycle.Stop);
+  }
+
   view<Ret extends ViewReturnTypeBuilder, F extends ViewFn<S, {}, Ret>>(
     opts: ViewOpts,
     ret: Ret,

--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -578,6 +578,16 @@ pub use spacetimedb_bindings_macro::table;
 /// If an error occurs in the disconnect reducer,
 /// the client is still recorded as disconnected.
 ///
+/// ### The `stop` reducer
+///
+/// This reducer is marked with `#[spacetimedb::reducer(stop)]`. It is run exactly once,
+/// immediately before the database is permanently destroyed - e.g. via `spacetime delete`,
+/// or a database reset.
+///
+/// It does **not** run when a module is updated or hot-reloaded (the database's data
+/// survives those), nor when a replica is scaled down or evicted while the database
+/// lives on elsewhere.
+///
 // TODO(docs): Move these docs to be on `table`, rather than `reducer`. This will reduce duplication with procedure docs.
 /// # Scheduled reducers
 ///

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -619,7 +619,12 @@ impl HostController {
     /// Release all resources of the [`ModuleHost`] identified by `replica_id`,
     /// and deregister it from the controller.
     #[tracing::instrument(level = "trace", skip_all)]
-    pub async fn exit_module_host(&self, replica_id: u64, timeout: Duration) -> Result<(), anyhow::Error> {
+    pub async fn exit_module_host(
+        &self,
+        replica_id: u64,
+        timeout: Duration,
+        is_final_teardown: bool,
+    ) -> Result<(), anyhow::Error> {
         let Some(lock) = self.hosts.lock().remove(&replica_id) else {
             return Ok(());
         };
@@ -653,6 +658,11 @@ impl HostController {
 
             // Ensure we clear the metrics even if the future is cancelled.
             defer!(remove_database_gauges(&database_identity, table_names));
+
+            if is_final_teardown {
+                info!("replica={replica_id} database={database_identity} invoking `stop` reducer");
+                let _ = module.call_module_stop().await;
+            }
 
             info!("replica={replica_id} database={database_identity} exiting module");
             module.exit().await;

--- a/crates/core/src/host/module_host.rs
+++ b/crates/core/src/host/module_host.rs
@@ -2204,6 +2204,62 @@ impl ModuleHost {
         )?
     }
 
+    /// Invoke the module's `stop` reducer, if it has one.
+    ///
+    /// This is called exactly once, immediately before a database is permanently
+    /// destroyed (e.g. by `spacetime delete`, or a database reset), and never on
+    /// an ordinary module update/hot-reload, since the database's data survives those.
+    pub(crate) fn call_module_stop_inner(
+        info: &ModuleInfo,
+        call_reducer: impl FnOnce(Option<MutTxId>, CallReducerParams) -> (ReducerCallResult, bool),
+        trapped_slot: &mut bool,
+    ) {
+        let Some((reducer_id, reducer_def)) = info.module_def.lifecycle_reducer(Lifecycle::Stop) else {
+            return;
+        };
+
+        let stdb = info.relational_db();
+        let owner_identity = info.owner_identity;
+        let workload = Workload::reducer_no_args(reducer_def.name.clone(), owner_identity, ConnectionId::ZERO);
+        let mut_tx = stdb.begin_mut_tx(IsolationLevel::Serializable, workload);
+
+        let params = match Self::call_reducer_params(
+            info,
+            owner_identity,
+            None,
+            None,
+            None,
+            None,
+            reducer_id,
+            reducer_def,
+            FunctionArgs::Nullary,
+        ) {
+            Ok(params) => params,
+            Err(e) => {
+                log::error!("failed to build call params for `stop` reducer: {e:#?}");
+                return;
+            }
+        };
+
+        let (result, trapped) = call_reducer(Some(mut_tx), params);
+        *trapped_slot = trapped;
+
+        if let Err(e) = result.outcome.into_result() {
+            log::error!("`stop` reducer did not commit cleanly, proceeding with deletion anyway: {e:#}");
+        }
+    }
+
+    /// Invoke the module's `stop` reducer, if it has one. See [`Self::call_module_stop_inner`].
+    pub async fn call_module_stop(&self) -> Result<(), NoSuchModule> {
+        call_instance!(
+            self,
+            "call_module_stop",
+            (),
+            |_, inst| inst.call_module_stop(),
+            |_, inst| inst.call_module_stop().await,
+        )
+    }
+
     /// Empty the system tables tracking clients without running any lifecycle reducers.
     pub async fn clear_all_clients(&self) -> anyhow::Result<()> {
         call_instance!(

--- a/crates/core/src/host/v8/mod.rs
+++ b/crates/core/src/host/v8/mod.rs
@@ -535,6 +535,10 @@ impl JsMainInstance {
         self.request(DisconnectClientRequest { client_id }).await
     }
 
+    pub async fn call_module_stop(&self) {
+        self.request(CallModuleStopRequest).await
+    }
+
     pub async fn init_database(&self, program: Program) -> anyhow::Result<InitDatabaseResult> {
         self.request(InitDatabaseRequest { program }).await
     }
@@ -657,6 +661,10 @@ js_main_request! {
     DisconnectClientRequest {
         client_id: ClientActorId,
     } => "disconnect_client", Result<(), ReducerCallError>, DisconnectClient
+}
+
+js_main_request! {
+    CallModuleStopRequest => "call_module_stop", (), CallModuleStop
 }
 
 js_main_request! {
@@ -860,6 +868,8 @@ enum JsMainWorkerRequest {
         reply_tx: JsReplyTx<Result<(), ReducerCallError>>,
         client_id: ClientActorId,
     },
+    /// See [`JsMainInstance::call_module_stop`].
+    CallModuleStop(JsReplyTx<()>),
     /// See [`JsMainInstance::init_database`].
     InitDatabase {
         reply_tx: JsReplyTx<anyhow::Result<InitDatabaseResult>>,
@@ -1487,6 +1497,12 @@ fn handle_main_worker_request(
                 (res, trapped)
             })
         }
+        JsMainWorkerRequest::CallModuleStop(reply_tx) => handle_worker_request("call_module_stop", reply_tx, || {
+            let call_reducer = |tx, params| instance_common.call_reducer_with_tx(tx, params, inst);
+            let mut trapped = false;
+            ModuleHost::call_module_stop_inner(&info, call_reducer, &mut trapped);
+            ((), trapped)
+        }),
         JsMainWorkerRequest::InitDatabase { reply_tx, program } => {
             handle_worker_request("init_database", reply_tx, || {
                 let call_reducer = |tx, params| instance_common.call_reducer_with_tx_offset(tx, params, inst);

--- a/crates/core/src/host/wasm_common/module_host_actor.rs
+++ b/crates/core/src/host/wasm_common/module_host_actor.rs
@@ -534,6 +534,14 @@ impl<T: WasmInstance> WasmModuleInstance<T> {
         res
     }
 
+    pub fn call_module_stop(&mut self) {
+        let module = &self.common.info.clone();
+        let call_reducer = |tx, params| self.call_reducer_with_tx(tx, params);
+        let mut trapped = false;
+        ModuleHost::call_module_stop_inner(module, call_reducer, &mut trapped);
+        self.trapped = trapped;
+    }
+
     pub fn disconnect_client(&mut self, client_id: ClientActorId) -> Result<(), ReducerCallError> {
         let module = &self.common.info.clone();
         let call_reducer = |tx, params| self.call_reducer_with_tx(tx, params);

--- a/crates/lib/src/db/raw_def/v9.rs
+++ b/crates/lib/src/db/raw_def/v9.rs
@@ -567,6 +567,9 @@ pub enum Lifecycle {
     OnConnect,
     /// The reducer will be invoked when a client disconnects.
     OnDisconnect,
+    /// The reducer will be invoked once, immediately before the database is
+    /// permanently deleted (e.g. via `spacetime delete` or a database reset).
+    Stop,
 }
 
 /// A procedure definition.

--- a/crates/schema/src/def/validate/v10.rs
+++ b/crates/schema/src/def/validate/v10.rs
@@ -1183,6 +1183,7 @@ mod tests {
         builder.add_lifecycle_reducer(Lifecycle::Init, "init", ProductType::unit());
         builder.add_lifecycle_reducer(Lifecycle::OnConnect, "on_connect", ProductType::unit());
         builder.add_lifecycle_reducer(Lifecycle::OnDisconnect, "on_disconnect", ProductType::unit());
+        builder.add_lifecycle_reducer(Lifecycle::Stop, "stop", ProductType::unit());
         builder.add_reducer("extra_reducer", ProductType::from([("a", AlgebraicType::U64)]));
         builder.add_reducer(
             "check_deliveries",
@@ -1362,6 +1363,10 @@ mod tests {
             def.reducers[&on_disconnect_name].lifecycle,
             Some(Lifecycle::OnDisconnect)
         );
+
+        let stop_name = expect_identifier("stop");
+        assert_eq!(&*def.reducers[&stop_name].name, &*stop_name);
+        assert_eq!(def.reducers[&stop_name].lifecycle, Some(Lifecycle::Stop));
 
         let extra_reducer_name = expect_identifier("extra_reducer");
         assert_eq!(&*def.reducers[&extra_reducer_name].name, &*extra_reducer_name);
@@ -1759,6 +1764,18 @@ mod tests {
 
         expect_error_matching!(result, ValidationError::DuplicateLifecycle { lifecycle } => {
             lifecycle == &Lifecycle::Init
+        });
+    }
+
+    #[test]
+    fn duplicate_stop_lifecycle() {
+        let mut builder = RawModuleDefV10Builder::new();
+        builder.add_lifecycle_reducer(Lifecycle::Stop, "stop1", ProductType::unit());
+        builder.add_lifecycle_reducer(Lifecycle::Stop, "stop2", ProductType::unit());
+        let result: Result<ModuleDef> = builder.finish().try_into();
+
+        expect_error_matching!(result, ValidationError::DuplicateLifecycle { lifecycle } => {
+            lifecycle == &Lifecycle::Stop
         });
     }
 

--- a/crates/schema/src/def/validate/v9.rs
+++ b/crates/schema/src/def/validate/v9.rs
@@ -1741,6 +1741,7 @@ mod tests {
         builder.add_reducer("init", ProductType::unit(), Some(Lifecycle::Init));
         builder.add_reducer("on_connect", ProductType::unit(), Some(Lifecycle::OnConnect));
         builder.add_reducer("on_disconnect", ProductType::unit(), Some(Lifecycle::OnDisconnect));
+        builder.add_reducer("stop", ProductType::unit(), Some(Lifecycle::Stop));
         builder.add_reducer("extra_reducer", ProductType::from([("a", AlgebraicType::U64)]), None);
         builder.add_reducer(
             "check_deliveries",
@@ -1908,6 +1909,10 @@ mod tests {
             def.reducers[&on_disconnect_name].lifecycle,
             Some(Lifecycle::OnDisconnect)
         );
+
+        let stop_name = expect_identifier("stop");
+        assert_eq!(&*def.reducers[&stop_name].name, &*stop_name);
+        assert_eq!(def.reducers[&stop_name].lifecycle, Some(Lifecycle::Stop));
 
         let extra_reducer_name = expect_identifier("extra_reducer");
         assert_eq!(&*def.reducers[&extra_reducer_name].name, &*extra_reducer_name);
@@ -2295,6 +2300,18 @@ mod tests {
 
         expect_error_matching!(result, ValidationError::DuplicateLifecycle { lifecycle } => {
             lifecycle == &Lifecycle::Init
+        });
+    }
+
+    #[test]
+    fn duplicate_stop_lifecycle() {
+        let mut builder = RawModuleDefV9Builder::new();
+        builder.add_reducer("stop1", ProductType::unit(), Some(Lifecycle::Stop));
+        builder.add_reducer("stop2", ProductType::unit(), Some(Lifecycle::Stop));
+        let result: Result<ModuleDef> = builder.finish().try_into();
+
+        expect_error_matching!(result, ValidationError::DuplicateLifecycle { lifecycle } => {
+            lifecycle == &Lifecycle::Stop
         });
     }
 

--- a/crates/standalone/src/lib.rs
+++ b/crates/standalone/src/lib.rs
@@ -327,8 +327,10 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
                     let desired_replicas = num_replicas as usize;
                     if desired_replicas == 0 {
                         log::info!("Decommissioning all replicas of database {database_identity}");
+                        // The database itself isn't being deleted, it's paused with zero
+                        // replicas and can be scaled back up later, so `stop` must not fire.
                         for instance in replicas {
-                            self.delete_replica(instance.id).await?;
+                            self.delete_replica(instance.id, false).await?;
                         }
                     } else if desired_replicas > replicas.len() {
                         let n = desired_replicas - replicas.len();
@@ -356,7 +358,7 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
                             n
                         );
                         for instance in replicas.into_iter().filter(|instance| !instance.leader).take(n) {
-                            self.delete_replica(instance.id).await?;
+                            self.delete_replica(instance.id, false).await?;
                         }
                     } else {
                         log::debug!(
@@ -403,8 +405,10 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
         };
         self.control_db.delete_database(database.id)?;
 
+        // The database is being permanently destroyed: run each replica's `stop`
+        // reducer, if any, before it goes away.
         for instance in self.control_db.get_replicas_by_database(database.id)? {
-            self.delete_replica(instance.id).await?;
+            self.delete_replica(instance.id, true).await?;
         }
 
         Ok(())
@@ -436,8 +440,10 @@ impl spacetimedb_client_api::ControlStateWriteAccess for StandaloneEnv {
             self.control_db.update_database(database)?;
         }
 
+        // The database's data is being wiped and reinitialized from scratch: run
+        // each replica's `stop` reducer, if any, before it goes away.
         for instance in self.control_db.get_replicas_by_database(database_id)? {
-            self.delete_replica(instance.id).await?;
+            self.delete_replica(instance.id, true).await?;
         }
         // Standalone only support a single replica.
         let num_replicas = 1;
@@ -559,9 +565,10 @@ impl StandaloneEnv {
         Ok(())
     }
 
-    async fn delete_replica(&self, replica_id: u64) -> Result<(), anyhow::Error> {
+    /// Delete a single replica.
+    async fn delete_replica(&self, replica_id: u64, is_final_teardown: bool) -> Result<(), anyhow::Error> {
         self.control_db.delete_replica(replica_id)?;
-        self.on_delete_replica(replica_id).await?;
+        self.on_delete_replica(replica_id, is_final_teardown).await?;
 
         Ok(())
     }
@@ -598,13 +605,13 @@ impl StandaloneEnv {
         Ok(())
     }
 
-    async fn on_delete_replica(&self, replica_id: u64) -> anyhow::Result<()> {
+    async fn on_delete_replica(&self, replica_id: u64, is_final_teardown: bool) -> anyhow::Result<()> {
         // TODO(cloutiertyler): We should think about how to clean up
         // replicas which have been deleted. This will just drop
         // them from memory, but will not remove them from disk.  We need
         // some kind of database lifecycle manager long term.
         self.host_controller
-            .exit_module_host(replica_id, Duration::from_secs(30))
+            .exit_module_host(replica_id, Duration::from_secs(30), is_final_teardown)
             .await?;
 
         Ok(())

--- a/crates/testing/src/modules.rs
+++ b/crates/testing/src/modules.rs
@@ -166,6 +166,33 @@ impl ModuleHandle {
             .expect("failed to collect log stream");
         String::from_utf8(bytes.into()).unwrap()
     }
+
+    /// Permanently delete this module's database - running its `stop` reducer,
+    /// if it has one - then return the module's log tail.
+    pub async fn delete_and_read_log(&self, size: Option<u32>) -> anyhow::Result<String> {
+        self.env.delete_database(&Identity::ZERO, &self.db_identity).await?;
+        Ok(self.read_log(size).await)
+    }
+
+    /// Publish new program bytes to this module's existing database identity,
+    /// exercising an ordinary hot-reload/update rather than a fresh publish.
+    pub async fn update(&self, program_bytes: Bytes, host_type: HostType) -> anyhow::Result<()> {
+        self.env
+            .publish_database(
+                &Identity::ZERO,
+                DatabaseDef {
+                    database_identity: self.db_identity,
+                    program_bytes,
+                    num_replicas: None,
+                    host_type,
+                    parent: None,
+                    organization: None,
+                },
+                MigrationPolicy::Compatible,
+            )
+            .await
+            .map(drop)
+    }
 }
 
 pub struct CompiledModule {
@@ -200,6 +227,10 @@ impl CompiledModule {
 
     pub fn path(&self) -> &Path {
         &self.path
+    }
+
+    pub fn host_type(&self) -> HostType {
+        self.host_type
     }
 
     pub fn program_bytes(&self) -> Bytes {

--- a/crates/testing/tests/standalone_integration_test.rs
+++ b/crates/testing/tests/standalone_integration_test.rs
@@ -136,6 +136,48 @@ fn test_calling_a_reducer_with_private_table() {
     );
 }
 
+#[test]
+#[serial]
+fn test_stop_reducer_fires_only_on_deletion() {
+    init();
+
+    let compiled = CompiledModule::compile("module-test-stop", CompilationMode::Debug);
+    let program_bytes = compiled.program_bytes();
+    let host_type = compiled.host_type();
+
+    compiled.with_module_async(DEFAULT_CONFIG, move |module| async move {
+        module.call_reducer_binary("ping", &product![]).await.unwrap();
+
+        let log_before_update = module.read_log(None).await;
+        assert!(
+            log_before_update.contains("PING"),
+            "expected `ping` to have logged: {log_before_update}"
+        );
+        assert!(
+            !log_before_update.contains("STOP"),
+            "`stop` must not fire before deletion: {log_before_update}"
+        );
+
+        module.update(program_bytes, host_type).await.unwrap();
+        let log_after_update = module.read_log(None).await;
+        assert!(
+            !log_after_update.contains("STOP"),
+            "`stop` must not fire on an ordinary module update: {log_after_update}"
+        );
+
+        let log_after_delete = module.delete_and_read_log(None).await.unwrap();
+        assert_eq!(
+            log_after_delete.matches("STOP").count(),
+            1,
+            "`stop` must fire exactly once, on deletion: {log_after_delete}"
+        );
+        assert!(
+            log_after_delete.find("PING").unwrap() < log_after_delete.find("STOP").unwrap(),
+            "`stop` must fire after prior reducer activity, immediately before teardown: {log_after_delete}"
+        );
+    });
+}
+
 /// Returns `true` if `line` was produced by the `repeating_test` or `nonrepeating_test` scheduled reducers.
 fn is_scheduled_test_log(line: &str) -> bool {
     line.starts_with("Timestamp: ") || line.starts_with("This reducers runs only once")

--- a/modules/module-test-stop/Cargo.toml
+++ b/modules/module-test-stop/Cargo.toml
@@ -1,0 +1,14 @@
+[package]
+name = "module-test-stop"
+version = "0.0.0"
+edition.workspace = true
+license-file = "LICENSE"
+
+[lib]
+crate-type = ["cdylib"]
+bench = false
+
+[dependencies]
+spacetimedb = { path = "../../crates/bindings" }
+
+log.workspace = true

--- a/modules/module-test-stop/LICENSE
+++ b/modules/module-test-stop/LICENSE
@@ -1,0 +1,1 @@
+../../licenses/BSL.txt

--- a/modules/module-test-stop/src/lib.rs
+++ b/modules/module-test-stop/src/lib.rs
@@ -1,0 +1,18 @@
+use spacetimedb::ReducerContext;
+
+// Minimal fixture module exercising the `stop` lifecycle reducer.
+
+#[spacetimedb::reducer(init)]
+pub fn init(_ctx: &ReducerContext) {
+    log::info!("INIT");
+}
+
+#[spacetimedb::reducer(stop)]
+pub fn stop(_ctx: &ReducerContext) {
+    log::info!("STOP");
+}
+
+#[spacetimedb::reducer]
+pub fn ping(_ctx: &ReducerContext) {
+    log::info!("PING");
+}


### PR DESCRIPTION
# Description of Changes


Fixes #5480 

Adds a `stop` module lifecycle reducer, the symmetric counterpart to `init`, invoked exactly once immediately before a database is permanently destroyed via `spacetime delete` or a reset. It does not fire on an ordinary module update/hot-reload or on replica scale-down, since the database's data survives both, and it's best-effort: a failing, trapping, or slow`stop` reducer is logged but never blocks the deletion it precedes.

Implemented via `#[reducer(stop)]` (Rust), `ReducerKind.Stop` (C#), and `spacetime.stop()` (TypeScript). Core changes: new `Lifecycle::Stop` variant, `ModuleHost::call_module_stop` (wired through both the WASM and V8/JS instance paths), and a new `is_final_teardown` flag on `HostController::exit_module_host`, set only by the standalone control plane's `delete_database`/`reset_database` paths (not replica scale-down/decommission).

Adds a `module-test-stop` fixture module and an integration test verifying `stop` fires exactly once on deletion and not on update.

# API and ABI breaking changes

None. This is a purely additive change: a new `Lifecycle` enum variant and a new reducer-kind/attribute surface in each binding. No existing behavior changes for modules that don't declare a `stop` reducer.

# Expected complexity level and risk

2.5 - touches the module lifecycle/shutdown path in `crates/core/src/host` The main risk surface is the `is_final_teardown` threading through `crates/standalone/src/lib.rs`'s four `delete_replica` call sites — getting one of those wrong could either misfire `stop` on routine replica scale-down or silently skip it on real deletion.

# Testing

- [x] `cargo test -p spacetimedb-schema` — new duplicate-lifecycle tests for `Stop` (v9 + v10)
- [x] `cargo fmt --check` and `cargo clippy -D warnings` clean on `spacetimedb-lib`, `spacetimedb-schema`, `spacetimedb-core`, `spacetimedb-standalone`, `spacetimedb-bindings-macro`, `spacetimedb`, `spacetimedb-testing`
- [x] New integration test `test_stop_reducer_fires_only_on_deletion` against a real compiled module, confirming `stop` does not fire on update and fires exactly once on deletion
- [x] TypeScript: `tsc --noEmit`, `eslint`, and `prettier --check` all clean; full `vitest` suite (232/232) passes
- [ ] Manual: publish a module with `stop`, confirm no fire across `spacetime publish`, exactly one fire on `spacetime delete`, and rejection on a direct `spacetime call <module> stop`
