### PR TITLE
commitlog: Fix trim logic in stream writer

### DIFF
--- a/crates/commitlog/src/stream/writer.rs
+++ b/crates/commitlog/src/stream/writer.rs
@@ -132,9 +132,9 @@ where
                                     "failed to truncate offset index for segment {last} containing trailing data: {e}"
                                 )
                             })?;
-                        segment.ftruncate(sofar.tx_range.end, sofar.size_in_bytes)?;
-                        segment.seek(io::SeekFrom::End(0))?;
                     }
+                    segment.ftruncate(sofar.tx_range.end, sofar.size_in_bytes)?;
+                    segment.seek(io::SeekFrom::End(0))?;
                     sofar
                 }
             },


### PR DESCRIPTION
StreamWriter::create_and_metadata truncates the segment if given OnTrailingData::Trim and there is a bad commit in the existing segment.

It did, however, only do that when there exists an offset index, and otherwise return the last-good metadata without actually modifying the file.