### PR TITLE
More effective views cleanup.

### DIFF
--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -2790,6 +2790,9 @@ impl MutTxId {
                 None => Some((call, state)),
             });
 
+        // The committed iterator above already applies tx-local overrides and
+        // removals for committed calls. This second half yields only tx-local
+        // inserts whose calls do not exist in committed state.
         let tx_only = self.view_instances.changes.iter().filter_map(|(call, state)| {
             if self.committed_state_write_lock.view_instance(call).is_some() {
                 None
@@ -2908,8 +2911,8 @@ impl MutTxId {
 
     /// Clean up materialized view arguments that have no subscribers and haven’t been used recently.
     ///
-    /// Each cleanup batch retains at most `batch_size` expired view calls while
-    /// deleting materialized rows. A `batch_size` of zero is treated as one.
+    /// Expired views are cleared in batches. Each loop iteration selects up to
+    /// `batch_size` expired view calls and deletes their materialized rows.
     ///
     /// `max_duration` is checked between batches, so cleanup always finishes at
     /// least one batch once it starts, even if that batch takes longer than
@@ -2928,8 +2931,6 @@ impl MutTxId {
         let is_expired = |state: &ViewInstanceState| !state.has_subscribers() && state.last_used < expiration_threshold;
         let mut cleaned = 0;
 
-        // Process expired calls in bounded batches so cleanup does not retain
-        // every expired call while deleting materialized rows.
         loop {
             let mut batch = self
                 .effective_view_instances()

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -2930,6 +2930,7 @@ impl MutTxId {
         let expiration_threshold = Timestamp::now() - expiration_duration;
         let is_expired = |state: &ViewInstanceState| !state.has_subscribers() && state.last_used < expiration_threshold;
         let mut cleaned = 0;
+        let batch_size = batch_size.max(1);
 
         loop {
             let mut batch = self
@@ -2939,13 +2940,6 @@ impl MutTxId {
                 .collect::<Vec<_>>();
             let backlog = batch.len() > batch_size;
             batch.truncate(batch_size);
-
-            if batch.is_empty() {
-                return Ok(ViewCleanupResult {
-                    cleaned,
-                    backlog: false,
-                });
-            }
 
             for call in batch {
                 let StViewRow { table_id, .. } = self.lookup_st_view(call.view_id)?;

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -2933,11 +2933,26 @@ impl MutTxId {
         let batch_size = batch_size.max(1);
 
         loop {
+            let mut unexpired_visited_building_batch = 0;
+            let filter_and_count_view_instance = |(call, state): (&ViewCallInfo, &ViewInstanceState)| {
+                if is_expired(state) {
+                    Some(call.clone())
+                } else {
+                    unexpired_visited_building_batch += 1;
+                    None
+                }
+            };
             let mut batch = self
                 .effective_view_instances()
-                .filter_map(|(call, state)| is_expired(state).then_some(call.clone()))
+                .filter_map(filter_and_count_view_instance)
                 .take(batch_size + 1)
                 .collect::<Vec<_>>();
+            log::info!(
+                "[{}]: Traversed {} unexpired views to collect and delete a batch of {} expired views",
+                self.ctx.database_identity,
+                unexpired_visited_building_batch,
+                batch.len()
+            );
             let backlog = batch.len() > batch_size;
             batch.truncate(batch_size);
 

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -2948,11 +2948,13 @@ impl MutTxId {
                 .take(batch_size + 1)
                 .collect::<Vec<_>>();
             log::info!(
-                "[{}]: Traversed {} unexpired views to collect and delete a batch of {} expired views",
-                self.ctx.database_identity,
-                unexpired_visited_building_batch,
-                batch.len()
-            );
+            // FIXME: Use a better datastructure for `view_instances` in `CommittedState` and `MutTxId`
+            // to avoid having to traverse live or recently-expired views to delete stale ones.
+            let mut batch = self
+                .effective_view_instances()
+                .filter_map(|(call, state)| is_expired(state).then_some(call.clone()))
+                .take(batch_size + 1)
+.collect::<Vec<_>>();
             let backlog = batch.len() > batch_size;
             batch.truncate(batch_size);
 

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -2944,19 +2944,22 @@ impl MutTxId {
                     None
                 }
             };
+            // FIXME: Use a better datastructure for `view_instances` in `CommittedState` and `MutTxId`
+            // to avoid having to traverse live or recently-expired views to delete stale ones.
+
             let mut batch = self
                 .effective_view_instances()
                 .filter_map(filter_and_count_view_instance)
                 .take(batch_size + 1)
                 .collect::<Vec<_>>();
+
             log::info!(
-            // FIXME: Use a better datastructure for `view_instances` in `CommittedState` and `MutTxId`
-            // to avoid having to traverse live or recently-expired views to delete stale ones.
-            let mut batch = self
-                .effective_view_instances()
-                .filter_map(|(call, state)| is_expired(state).then_some(call.clone()))
-                .take(batch_size + 1)
-.collect::<Vec<_>>();
+                "[{}]: Traversed {} unexpired views to collect and delete a batch of {} expired views",
+                self.ctx.database_identity,
+                unexpired_visited_building_batch,
+                batch.len()
+            );
+
             let backlog = batch.len() > batch_size;
             batch.truncate(batch_size);
 

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -145,6 +145,11 @@ impl MemoryUsage for ViewInstanceState {
     }
 }
 
+pub struct ViewCleanupResult {
+    pub cleaned: usize,
+    pub backlog: bool,
+}
+
 impl ViewInstanceState {
     fn new(args: ViewInstanceArgs, last_used: Timestamp) -> Self {
         Self {
@@ -797,7 +802,11 @@ impl MutTxId {
         self.drop_st_view_param(view_id)?;
         self.drop_st_view_column(view_id)?;
         self.drop_st_view_sub(view_id)?;
-        for call in self.effective_view_instances_for_view(view_id).into_keys() {
+        let calls = self
+            .effective_view_instances_for_view(view_id)
+            .map(|(call, _)| call.clone())
+            .collect::<Vec<_>>();
+        for call in calls {
             self.view_instances.remove(call);
         }
         self.drop_view_from_committed_read_set(view_id);
@@ -2771,32 +2780,33 @@ impl MutTxId {
         self.view_instances.get_cloned(&self.committed_state_write_lock, call)
     }
 
-    fn effective_view_instances(&self) -> HashMap<ViewCallInfo, ViewInstanceState> {
-        let mut instances = self
+    fn effective_view_instances(&self) -> impl Iterator<Item = (&ViewCallInfo, &ViewInstanceState)> + '_ {
+        let committed = self
             .committed_state_write_lock
             .view_instances()
-            .map(|(call, state)| (call.clone(), state.clone()))
-            .collect::<HashMap<_, _>>();
+            .filter_map(|(call, state)| match self.view_instances.changes.get(call) {
+                Some(Some(tx_state)) => Some((call, tx_state)),
+                Some(None) => None,
+                None => Some((call, state)),
+            });
 
-        for (call, state) in &self.view_instances.changes {
-            match state {
-                Some(state) => {
-                    instances.insert(call.clone(), state.clone());
-                }
-                None => {
-                    instances.remove(call);
-                }
+        let tx_only = self.view_instances.changes.iter().filter_map(|(call, state)| {
+            if self.committed_state_write_lock.view_instance(call).is_some() {
+                None
+            } else {
+                state.as_ref().map(|state| (call, state))
             }
-        }
+        });
 
-        instances
+        committed.chain(tx_only)
     }
 
-    fn effective_view_instances_for_view(&self, view_id: ViewId) -> HashMap<ViewCallInfo, ViewInstanceState> {
+    fn effective_view_instances_for_view(
+        &self,
+        view_id: ViewId,
+    ) -> impl Iterator<Item = (&ViewCallInfo, &ViewInstanceState)> + '_ {
         self.effective_view_instances()
-            .into_iter()
-            .filter(|(call, _)| call.view_id == view_id)
-            .collect()
+            .filter(move |(call, _)| call.view_id == view_id)
     }
 
     /// Is this view argument currently materialized?
@@ -2812,8 +2822,7 @@ impl MutTxId {
     /// Returns all materialized view instances for `view_id`.
     pub fn materialized_view_instances_for_view(&self, view_id: ViewId) -> Vec<ViewInstanceArgs> {
         self.effective_view_instances_for_view(view_id)
-            .into_values()
-            .map(|state| state.args)
+            .map(|(_, state)| state.args)
             .collect()
     }
 
@@ -2821,8 +2830,12 @@ impl MutTxId {
     #[cfg(any(test, feature = "test"))]
     pub fn active_subscribers_for_view(&self, view_id: ViewId) -> Vec<(Identity, u64)> {
         self.effective_view_instances_for_view(view_id)
-            .into_values()
-            .flat_map(|state| state.active_subscribers.into_iter())
+            .flat_map(|(_, state)| {
+                state
+                    .active_subscribers
+                    .iter()
+                    .map(|(identity, count)| (*identity, *count))
+            })
             .collect()
     }
 
@@ -2895,50 +2908,65 @@ impl MutTxId {
 
     /// Clean up materialized view arguments that have no subscribers and haven’t been used recently.
     ///
-    /// Returns a tuple `(cleaned, total_expired)`:
-    /// - `cleaned`: Number of expired materialized view arguments deleted in this run.
-    /// - `total_expired`: Total number of expired materialized view arguments found.
+    /// Each cleanup batch retains at most `batch_size` expired view calls while
+    /// deleting materialized rows. A `batch_size` of zero is treated as one.
+    ///
+    /// `max_duration` is checked between batches, so cleanup always finishes at
+    /// least one batch once it starts, even if that batch takes longer than
+    /// `max_duration`.
+    ///
+    /// Returns the number of calls cleaned and whether more expired work is
+    /// likely pending.
     pub fn clear_expired_views(
         &mut self,
         expiration_duration: Duration,
         max_duration: Duration,
-    ) -> Result<(usize, usize)> {
+        batch_size: usize,
+    ) -> Result<ViewCleanupResult> {
         let start = std::time::Instant::now();
         let expiration_threshold = Timestamp::now() - expiration_duration;
-        let mut cleaned_count = 0;
+        let is_expired = |state: &ViewInstanceState| !state.has_subscribers() && state.last_used < expiration_threshold;
+        let mut cleaned = 0;
 
-        let expired_items = self
-            .effective_view_instances()
-            .into_iter()
-            .filter_map(|(call, state)| {
-                (!state.has_subscribers() && state.last_used < expiration_threshold).then_some(call)
-            })
-            .collect::<Vec<_>>();
-
-        let total_expired = expired_items.len();
-
-        for call in expired_items {
-            if start.elapsed() >= max_duration {
-                break;
-            }
-
-            let StViewRow { table_id, .. } = self.lookup_st_view(call.view_id)?;
-            let table_id = table_id.expect("views have backing table");
-            let rows_to_delete = self
-                .iter_by_col_eq(table_id, VIEW_ARG_HASH_COL, &call.arg_hash)?
-                .map(|res| res.pointer())
+        // Process expired calls in bounded batches so cleanup does not retain
+        // every expired call while deleting materialized rows.
+        loop {
+            let mut batch = self
+                .effective_view_instances()
+                .filter_map(|(call, state)| is_expired(state).then_some(call.clone()))
+                .take(batch_size + 1)
                 .collect::<Vec<_>>();
+            let backlog = batch.len() > batch_size;
+            batch.truncate(batch_size);
 
-            for row_ptr in rows_to_delete {
-                self.delete(table_id, row_ptr)?;
+            if batch.is_empty() {
+                return Ok(ViewCleanupResult {
+                    cleaned,
+                    backlog: false,
+                });
             }
 
-            self.drop_view_call_from_committed_read_set(call.clone());
-            self.view_instances.remove(call);
-            cleaned_count += 1;
-        }
+            for call in batch {
+                let StViewRow { table_id, .. } = self.lookup_st_view(call.view_id)?;
+                let table_id = table_id.expect("views have backing table");
+                let rows_to_delete = self
+                    .iter_by_col_eq(table_id, VIEW_ARG_HASH_COL, &call.arg_hash)?
+                    .map(|res| res.pointer())
+                    .collect::<Vec<_>>();
 
-        Ok((cleaned_count, total_expired))
+                for row_ptr in rows_to_delete {
+                    self.delete(table_id, row_ptr)?;
+                }
+
+                self.drop_view_call_from_committed_read_set(call.clone());
+                self.view_instances.remove(call);
+                cleaned += 1;
+            }
+
+            if start.elapsed() >= max_duration || !backlog {
+                return Ok(ViewCleanupResult { cleaned, backlog });
+            }
+        }
     }
 
     /// Clear all rows from all view tables without dropping them.

--- a/crates/datastore/src/locking_tx_datastore/mut_tx.rs
+++ b/crates/datastore/src/locking_tx_datastore/mut_tx.rs
@@ -2809,6 +2809,8 @@ impl MutTxId {
         view_id: ViewId,
     ) -> impl Iterator<Item = (&ViewCallInfo, &ViewInstanceState)> + '_ {
         self.effective_view_instances()
+            // FIXME: use a better data structure to store view instances in `CommittedState` and `MutTxId`,
+            // so that this can behave like an index scan rather than a full scan and filter.
             .filter(move |(call, _)| call.view_id == view_id)
     }
 

--- a/crates/engine/src/relational_db.rs
+++ b/crates/engine/src/relational_db.rs
@@ -61,6 +61,7 @@ use spacetimedb_table::indexes::RowPointer;
 use spacetimedb_table::page_pool::PagePool;
 use spacetimedb_table::table::{RowRef, TableScanIter};
 use spacetimedb_table::table_index::IndexKey;
+use sqlparser::keywords::MIN;
 use std::borrow::Cow;
 use std::io;
 use std::ops::RangeBounds;
@@ -1126,17 +1127,27 @@ impl RelationalDB {
 /// Value is chosen arbitrarily; can be tuned later if needed.
 const VIEWS_EXPIRATION: std::time::Duration = std::time::Duration::from_secs(10 * 60);
 
+/// Normal interval between view cleanup runs.
+const VIEW_CLEANUP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10 * 60);
+
+/// Lower bound for adaptive cleanup retries when expired views remain.
+const MIN_VIEW_CLEANUP_INTERVAL: std::time::Duration = std::time::Duration::from_secs(10);
+
 /// Duration to budget for each view cleanup job,
-/// so that it doesn't hold transaction lock for to long.
+/// so that it doesn't hold transaction lock for too long.
 //TODO: Make this value configurable
 const VIEW_CLEANUP_BUDGET: std::time::Duration = std::time::Duration::from_millis(10);
 
-/// Spawn a background task that periodically cleans up expired views
+/// Spawn a background task that periodically cleans up expired views.
+///
+/// Each cleanup run has a fixed lock-hold budget. If a run leaves expired
+/// views behind, the next run is scheduled sooner, down to
+/// [`MIN_VIEW_CLEANUP_INTERVAL`]. Once cleanup catches up, the interval resets.
 pub fn spawn_view_cleanup_loop(
     db: Arc<RelationalDB>,
     handle: &spacetimedb_runtime::Handle,
 ) -> spacetimedb_runtime::AbortHandle {
-    fn run_view_cleanup(db: &RelationalDB) {
+    fn run_view_cleanup(db: &RelationalDB) -> bool {
         match db.with_auto_commit(Workload::Internal, |tx| {
             tx.clear_expired_views(VIEWS_EXPIRATION, VIEW_CLEANUP_BUDGET)
                 .map_err(DBError::from)
@@ -1151,6 +1162,7 @@ pub fn spawn_view_cleanup_loop(
                         total_expired - cleared
                     );
                 }
+                cleared < total_expired
             }
             Err(e) => {
                 log::error!(
@@ -1158,6 +1170,7 @@ pub fn spawn_view_cleanup_loop(
                     db.database_identity(),
                     e
                 );
+                false
             }
         }
     }
@@ -1165,13 +1178,21 @@ pub fn spawn_view_cleanup_loop(
     let handle_clone = handle.clone();
     handle
         .spawn(async move {
+            let mut interval = VIEW_CLEANUP_INTERVAL;
             loop {
                 // Offload actual cleanup to blocking thread pool, as `VIEW_CLEANUP_BUDGET` is defined
                 // in milliseconds, which may be too long for async tasks.
                 let db = db.clone();
-                handle_clone.spawn_blocking(move || run_view_cleanup(&db)).await;
+                let backlog = handle_clone.spawn_blocking(move || run_view_cleanup(&db)).await;
 
-                handle_clone.sleep(VIEWS_EXPIRATION).await;
+                // Calculate next cleanup interval based on backlog
+                interval = if backlog {
+                    (interval / 2).max(MIN_VIEW_CLEANUP_INTERVAL)
+                } else {
+                    VIEW_CLEANUP_INTERVAL
+                };
+
+                handle_clone.sleep(interval).await;
             }
         })
         .abort_handle()

--- a/crates/engine/src/relational_db.rs
+++ b/crates/engine/src/relational_db.rs
@@ -61,7 +61,6 @@ use spacetimedb_table::indexes::RowPointer;
 use spacetimedb_table::page_pool::PagePool;
 use spacetimedb_table::table::{RowRef, TableScanIter};
 use spacetimedb_table::table_index::IndexKey;
-use sqlparser::keywords::MIN;
 use std::borrow::Cow;
 use std::io;
 use std::ops::RangeBounds;
@@ -1138,6 +1137,9 @@ const MIN_VIEW_CLEANUP_INTERVAL: std::time::Duration = std::time::Duration::from
 //TODO: Make this value configurable
 const VIEW_CLEANUP_BUDGET: std::time::Duration = std::time::Duration::from_millis(10);
 
+/// Number of expired view calls to clean before checking the time budget.
+const VIEW_CLEANUP_BATCH_SIZE: usize = 1024;
+
 /// Spawn a background task that periodically cleans up expired views.
 ///
 /// Each cleanup run has a fixed lock-hold budget. If a run leaves expired
@@ -1147,22 +1149,25 @@ pub fn spawn_view_cleanup_loop(
     db: Arc<RelationalDB>,
     handle: &spacetimedb_runtime::Handle,
 ) -> spacetimedb_runtime::AbortHandle {
+    fn shorten_cleanup_interval(current: std::time::Duration) -> std::time::Duration {
+        (current / 2).max(MIN_VIEW_CLEANUP_INTERVAL)
+    }
+
     fn run_view_cleanup(db: &RelationalDB) -> bool {
         match db.with_auto_commit(Workload::Internal, |tx| {
-            tx.clear_expired_views(VIEWS_EXPIRATION, VIEW_CLEANUP_BUDGET)
+            tx.clear_expired_views(VIEWS_EXPIRATION, VIEW_CLEANUP_BUDGET, VIEW_CLEANUP_BATCH_SIZE)
                 .map_err(DBError::from)
         }) {
-            Ok((cleared, total_expired)) => {
-                if cleared != total_expired {
+            Ok(result) => {
+                if result.backlog {
                     // TODO: metrics
                     log::info!(
-                        "[{}] DATABASE: cleared {} expired views ({} remaining)",
+                        "[{}] DATABASE: cleared {} expired views (more pending)",
                         db.database_identity(),
-                        cleared,
-                        total_expired - cleared
+                        result.cleaned,
                     );
                 }
-                cleared < total_expired
+                result.backlog
             }
             Err(e) => {
                 log::error!(
@@ -1185,9 +1190,8 @@ pub fn spawn_view_cleanup_loop(
                 let db = db.clone();
                 let backlog = handle_clone.spawn_blocking(move || run_view_cleanup(&db)).await;
 
-                // Calculate next cleanup interval based on backlog
                 interval = if backlog {
-                    (interval / 2).max(MIN_VIEW_CLEANUP_INTERVAL)
+                    shorten_cleanup_interval(interval)
                 } else {
                     VIEW_CLEANUP_INTERVAL
                 };
@@ -2752,6 +2756,7 @@ mod tests {
         tx.clear_expired_views(
             Instant::now().saturating_duration_since(before_sender2),
             VIEW_CLEANUP_BUDGET,
+            VIEW_CLEANUP_BATCH_SIZE,
         )?;
         stdb.commit_tx(tx)?;
 
@@ -2809,7 +2814,7 @@ mod tests {
         // Cleanup should remove only the stale subscriber row and keep the shared
         // anonymous materialization because another subscriber is still live.
         let mut tx = begin_mut_tx(&stdb);
-        let (_cleaned, _total_expired) = tx.clear_expired_views(Duration::from_secs(1), VIEW_CLEANUP_BUDGET)?;
+        let _result = tx.clear_expired_views(Duration::from_secs(1), VIEW_CLEANUP_BUDGET, VIEW_CLEANUP_BATCH_SIZE)?;
         stdb.commit_tx(tx)?;
 
         assert_eq!(
@@ -2853,7 +2858,7 @@ mod tests {
         // With no remaining subscriber rows, cleanup should drop the shared
         // anonymous materialization and remove the bookkeeping row.
         let mut tx = begin_mut_tx(&stdb);
-        let (_cleaned, _total_expired) = tx.clear_expired_views(Duration::from_secs(1), VIEW_CLEANUP_BUDGET)?;
+        let _result = tx.clear_expired_views(Duration::from_secs(1), VIEW_CLEANUP_BUDGET, VIEW_CLEANUP_BATCH_SIZE)?;
         stdb.commit_tx(tx)?;
 
         assert!(


### PR DESCRIPTION
# Description of Changes

Existing View cleanup code is naive and doesn't anticipate large number of view subscribers, which could easily happen if clients are connecting via http sql call.

As a result I saw this log line:
>  [c2008d0c308db28e93c1d8785d6aa26cafdc78940da42414310a8a1cdc195fb0] DATABASE: cleared 0 expired views (585700 remaining)

We already have a due ticket to make it configuratable at database level: https://github.com/clockworklabs/SpacetimeDB/issues/3717 but I think that requires some ux decisions to make and little bit more work (I could be wrong).

This patch tries to mitigate it by doing two things:
  1. When a cleanup run leaves expired views behind,  nowthe loop runs more frequently until the backlog is drained, then returns to the normal interval.

  2. (More important) It changes expired view query paths to use iterators and clears expired materialized views in bounded batches, avoiding collection of the full expired-view set before deletion.



# API and ABI breaking changes
NA though there could be some noticeable latency sometimes as we are now clearing views more aggresively. 


# How complicated do you think these changes are? Grade on a scale from 1 to 5,
1.5

# Testing
No functional change, existing test should cover.
