### PR TITLE
ci: pin s3-upload-action to a full commit SHA

### DIFF
--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -132,7 +132,7 @@ jobs:
 
       # this will work for both PR and master
       - name: Upload criterion results to DO spaces
-        uses: shallwefootball/s3-upload-action@master
+        uses: shallwefootball/s3-upload-action@0d261a6f15b3b2e209dfebdecace4b100c04f95b # master
         with:
           aws_key_id: ${{ secrets.AWS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}
@@ -308,7 +308,7 @@ jobs:
 
       # this will work for both PR and master
       - name: Upload callgrind results to DO spaces
-        uses: shallwefootball/s3-upload-action@master
+        uses: shallwefootball/s3-upload-action@0d261a6f15b3b2e209dfebdecace4b100c04f95b # master
         with:
           aws_key_id: ${{ secrets.AWS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -47,7 +47,7 @@ jobs:
         run: pnpm build
 
       - name: Publish docs to S3
-        uses: shallwefootball/s3-upload-action@master
+        uses: shallwefootball/s3-upload-action@0d261a6f15b3b2e209dfebdecace4b100c04f95b # master
         with:
           aws_key_id: ${{ secrets.DOCS_AWS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.DOCS_AWS_SECRET_ACCESS_KEY}}

--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -157,7 +157,7 @@ jobs:
         id: extract_branch
 
       - name: Upload to AWS S3
-        uses: shallwefootball/s3-upload-action@master
+        uses: shallwefootball/s3-upload-action@0d261a6f15b3b2e209dfebdecace4b100c04f95b # master
         with:
           aws_key_id: ${{ secrets.AWS_KEY_ID }}
           aws_secret_access_key: ${{ secrets.AWS_SECRET_ACCESS_KEY}}


### PR DESCRIPTION
## What
Pin `shallwefootball/s3-upload-action` in `benchmarks.yml`, `package.yml` and `docs-publish.yaml` from the mutable `@master` branch to the commit it resolves to (4 usages).

## Why
Those steps are handed `AWS_KEY_ID`/`AWS_SECRET_ACCESS_KEY` directly as inputs, and `package.yml`'s `build-cli` job additionally holds DigiCert code-signing secrets. `@master` is a moving branch, so the exact third-party code that receives those secrets can change without any change here — the tj-actions/changed-files class of risk. Pinning to a full SHA closes that; behaviour unchanged.

I used AI assistance to identify this and draft the change; I verified it against the live workflows myself.