### PR TITLE
Use pnpm.cmd on Windows in typescript-test

### DIFF
--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -2,7 +2,7 @@
 
 use anyhow::{bail, Result};
 use clap::{CommandFactory, Parser, Subcommand};
-use duct::cmd;
+use duct::{cmd, Expression};
 use serde_json::Value;
 use std::ffi::OsStr;
 use std::ffi::OsString;
@@ -19,6 +19,24 @@ mod smoketest;
 mod util;
 
 use util::ensure_repo_root;
+
+/// On Windows, `pnpm` is installed as a `.cmd` shim which `CreateProcess` cannot
+/// find without going through the shell.  Wrapping with `cmd /c` fixes this.
+/// On Unix, we invoke `pnpm` directly.
+fn pnpm<I, S>(args: I) -> Expression
+where
+    I: IntoIterator<Item = S>,
+    S: AsRef<std::ffi::OsStr>,
+{
+    let args: Vec<std::ffi::OsString> = args.into_iter().map(|a| a.as_ref().to_os_string()).collect();
+    if cfg!(windows) {
+        let mut full: Vec<std::ffi::OsString> = vec!["/c".into(), "pnpm".into()];
+        full.extend(args);
+        cmd("cmd", full)
+    } else {
+        cmd("pnpm", args)
+    }
+}
 
 /// SpacetimeDB CI tasks
 ///
@@ -432,9 +450,9 @@ fn run_publish_checks() -> Result<()> {
 }
 
 fn run_typescript_tests() -> Result<()> {
-    cmd!("pnpm", "build").dir("crates/bindings-typescript").run()?;
-    cmd!("pnpm", "test").dir("crates/bindings-typescript").run()?;
-    cmd!("pnpm", "generate").dir("templates/chat-react-ts").run()?;
+    pnpm(["build"]).dir("crates/bindings-typescript").run()?;
+    pnpm(["test"]).dir("crates/bindings-typescript").run()?;
+    pnpm(["generate"]).dir("templates/chat-react-ts").run()?;
     let diff_status = cmd!(
         "bash",
         "tools/check-diff.sh",
@@ -444,19 +462,19 @@ fn run_typescript_tests() -> Result<()> {
     if !diff_status.status.success() {
         bail!("Bindings are dirty. Please generate bindings again and commit them to this branch.");
     }
-    cmd!("pnpm", "build").dir("templates/chat-react-ts").run()?;
-    cmd!("pnpm", "-r", "--filter", "./**", "run", "build")
+    pnpm(["build"]).dir("templates/chat-react-ts").run()?;
+    pnpm(["-r", "--filter", "./**", "run", "build"])
         .dir("templates")
         .run()?;
-    cmd!("pnpm", "-r", "--filter", "./**", "run", "build")
+    pnpm(["-r", "--filter", "./**", "run", "build"])
         .dir("crates/bindings-typescript")
         .run()?;
     Ok(())
 }
 
 fn run_docs_build() -> Result<()> {
-    cmd!("pnpm", "install").dir("docs").run()?;
-    cmd!("pnpm", "build").dir("docs").run()?;
+    pnpm(["install"]).dir("docs").run()?;
+    pnpm(["build"]).dir("docs").run()?;
     Ok(())
 }
 
@@ -482,7 +500,7 @@ fn main() -> Result<()> {
 
     match cli.cmd {
         Some(CiCmd::Test) => {
-            cmd!("pnpm", "build").dir("crates/bindings-typescript").run()?;
+            pnpm(["build"]).dir("crates/bindings-typescript").run()?;
 
             // TODO: This doesn't work on at least user Linux machines, because something here apparently uses `sudo`?
 
@@ -635,7 +653,7 @@ fn main() -> Result<()> {
             cmd!("dotnet", "csharpier", "--check", ".")
                 .dir("crates/bindings-csharp")
                 .run()?;
-            cmd!("pnpm", "lint").run()?;
+            pnpm(["lint"]).run()?;
             cmd!("cargo", "test", "--doc", "--target", "wasm32-unknown-unknown")
                 .dir("crates/bindings")
                 .run()?;
@@ -745,8 +763,8 @@ fn main() -> Result<()> {
                 );
             }
 
-            cmd!("pnpm", "install", "--recursive").run()?;
-            cmd!("pnpm", "generate-cli-docs").dir("docs").run()?;
+            pnpm(["install", "--recursive"]).run()?;
+            pnpm(["generate-cli-docs"]).dir("docs").run()?;
             let out = cmd!("git", "status", "--porcelain", "--", "docs").read()?;
             if out.is_empty() {
                 log::info!("No docs changes detected");


### PR DESCRIPTION
# Description of Changes

Closes: #4969

Fixes `cargo ci typescript-test` to work on Windows by using the correct `pnpm` executable name.

On Windows, `pnpm` is installed as `pnpm.cmd` (a batch file shim) rather than a bare `pnpm` executable. The `cmd!` macro from the `duct` crate invokes executables directly without shell resolution, so calling `"pnpm"` on Windows fails with "program not found". This adds a `pnpm` helper that returns `"pnpm.cmd"` on Windows and `"pnpm"` elsewhere, and updates all `cmd!("pnpm", ...)` call sites to use it.

# API and ABI breaking changes

No API or ABI changes. This is a CI change only.

# Expected complexity level and risk

1 - Trivial

# Testing

- [X] Tested running `cargo ci typescript-test` before and after changes, to confirm this resolves local Windows issues.