### PR TITLE
Add IntoIterator implementations for ProductType

### DIFF
--- a/crates/sats/src/layout.rs
+++ b/crates/sats/src/layout.rs
@@ -672,7 +672,7 @@ fn product_type_layout<C: FromIterator<ProductTypeElementLayout>>(ty: ProductTyp
     let mut max_child_align = 1;
 
     let mut fixed = true;
-    let elements = Vec::from(ty.elements)
+    let elements = ty
         .into_iter()
         .map(|elem| {
             let layout_type: AlgebraicTypeLayout = elem.algebraic_type.into();

--- a/crates/sats/src/product_type.rs
+++ b/crates/sats/src/product_type.rs
@@ -66,6 +66,24 @@ impl Deref for ProductType {
     }
 }
 
+impl IntoIterator for ProductType {
+    type Item = ProductTypeElement;
+    type IntoIter = std::vec::IntoIter<ProductTypeElement>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        Vec::from(self.elements).into_iter()
+    }
+}
+
+impl<'a> IntoIterator for &'a ProductType {
+    type Item = &'a ProductTypeElement;
+    type IntoIter = std::slice::Iter<'a, ProductTypeElement>;
+
+    fn into_iter(self) -> Self::IntoIter {
+        self.elements.iter()
+    }
+}
+
 impl std::fmt::Debug for ProductType {
     fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
         f.write_str("ProductType ")?;
@@ -358,3 +376,26 @@ where
 }
 
 impl<'a, I> ExactSizeIterator for ElementValuesWithType<'a, I> where I: ExactSizeIterator<Item = &'a AlgebraicValue> {}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn product_type_into_iterator() {
+        let product = ProductType::from([AlgebraicType::U8, AlgebraicType::String]);
+        let expected = vec![AlgebraicType::U8, AlgebraicType::String];
+
+        let borrowed = (&product)
+            .into_iter()
+            .map(|element| element.algebraic_type.clone())
+            .collect::<Vec<_>>();
+        let owned = product
+            .into_iter()
+            .map(|element| element.algebraic_type)
+            .collect::<Vec<_>>();
+
+        assert_eq!(borrowed, expected);
+        assert_eq!(owned, expected);
+    }
+}

--- a/crates/sats/src/proptest.rs
+++ b/crates/sats/src/proptest.rs
@@ -156,8 +156,7 @@ pub fn generate_algebraic_value(ty: AlgebraicType) -> impl Strategy<Value = Alge
 
 /// Generates a `ProductValue` typed at `ty`.
 pub fn generate_product_value(ty: ProductType) -> impl Strategy<Value = ProductValue> {
-    Vec::from(ty.elements)
-        .into_iter()
+    ty.into_iter()
         .map(|elem| generate_algebraic_value(elem.algebraic_type))
         .collect::<Vec<_>>()
         .prop_map_into()


### PR DESCRIPTION
# Description of Changes

Closes #1452.

- Implement consuming iteration for `ProductType`.
- Implement borrowed iteration for `&ProductType`.
- Use the new consuming iterator in the existing product-value generator and layout builder.
- Add a unit test covering both iterator forms.

# API and ABI breaking changes

None. These are additive trait implementations with no runtime or ABI changes.

# Expected complexity level and risk

1. This is a small, backward-compatible refactor localized to `spacetimedb-sats`.

# Testing

- [x] `cargo fmt --all -- --check`
- [x] `cargo test -p spacetimedb-sats`
- [x] `cargo clippy -p spacetimedb-sats --all-targets -- -D warnings`
- [x] `git diff --check`
