### PR TITLE
LLM Benchmark Fixes

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -11711,6 +11711,7 @@ dependencies = [
  "spacetimedb",
  "spacetimedb-data-structures",
  "spacetimedb-guard",
+ "spacetimedb-lib",
  "thiserror 2.0.17",
  "tokio",
  "urlencoding",

--- a/skills/csharp-server/SKILL.md
+++ b/skills/csharp-server/SKILL.md
@@ -88,7 +88,7 @@ The complete set of column attributes:
 ```csharp
 [PrimaryKey]          // primary key
 [AutoInc]             // auto-increment (use 0 as placeholder on insert)
-[Unique]              // unique constraint
+[Unique]              // unique constraint; indexes the column, enables .Find()
 [SpacetimeDB.Index.BTree]  // btree index (enables .Filter() on this column)
 ```
 
@@ -127,9 +127,10 @@ public static void DoReset(ReducerContext ctx) { ... }
 ## DB Operations
 
 ```csharp
-ctx.Db.Entity.Insert(new Entity { Name = "Sample" });             // Insert
+var row = ctx.Db.Entity.Insert(new Entity { Name = "Sample" });   // Insert; returns the row with AutoInc fields assigned
 ctx.Db.Entity.Id.Find(entityId);                                  // Find by PK → Entity? (nullable)
 ctx.Db.Entity.Identity.Find(ctx.Sender);                          // Find by unique column → Entity?
+if (ctx.Db.Entity.Id.Find(entityId) is { } entity) { ... }        // unwrap Entity? before member access
 ctx.Db.Item.AuthorId.Filter(authorId);                            // Filter by index → IEnumerable<Item>
 ctx.Db.Entity.Iter();                                             // All rows → IEnumerable<Entity>
 ctx.Db.Entity.Count;                                              // Count rows
@@ -191,7 +192,7 @@ var expiry = ctx.Timestamp + new TimeDuration(delayMicros);
 int roll = ctx.Rng.Next(1, 7);          // [1, 7): inclusive 1, exclusive 7
 double f = ctx.Rng.NextDouble();        // [0.0, 1.0)
 
-// Client: Timestamp → milliseconds since epoch
+// Timestamp → milliseconds since epoch
 timestamp.MicrosecondsSinceUnixEpoch / 1000
 ```
 

--- a/skills/typescript-server/SKILL.md
+++ b/skills/typescript-server/SKILL.md
@@ -174,6 +174,8 @@ Do not construct `Identity` values from strings (e.g. `'hex' as Identity`): seri
 ## Scheduled Tables
 
 ```typescript
+import { ScheduleAt } from 'spacetimedb';   // ScheduleAt comes from the root package
+
 const tick_timer = table({
   name: 'tick_timer',
   scheduled: (): any => tick,   // (): any => breaks circular dep

--- a/tools/xtask-llm-benchmark/Cargo.toml
+++ b/tools/xtask-llm-benchmark/Cargo.toml
@@ -12,6 +12,7 @@ workspace = true
 spacetimedb.workspace = true
 spacetimedb-guard.workspace = true
 spacetimedb-data-structures.workspace = true
+spacetimedb-lib.workspace = true
 
 anyhow.workspace = true
 serde.workspace = true

--- a/tools/xtask-llm-benchmark/src/benchmarks/auth/t_027_private_vs_public_table/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/auth/t_027_private_vs_public_table/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { schema, table, t } from 'spacetimedb/server';
 
-const userInternal = table({
+const user_internal = table({
   name: 'user_internal',
 }, {
   id: t.u64().primaryKey().autoInc(),
@@ -9,7 +9,7 @@ const userInternal = table({
   passwordHash: t.string(),
 });
 
-const userPublic = table({
+const user_public = table({
   name: 'user_public',
   public: true,
 }, {
@@ -17,19 +17,19 @@ const userPublic = table({
   name: t.string(),
 });
 
-const spacetimedb = schema({ userInternal, userPublic });
+const spacetimedb = schema({ user_internal, user_public });
 export default spacetimedb;
 
 export const register_user = spacetimedb.reducer(
   { name: t.string(), email: t.string(), passwordHash: t.string() },
   (ctx, { name, email, passwordHash }) => {
-    const internal = ctx.db.userInternal.insert({
+    const internal = ctx.db.user_internal.insert({
       id: 0n,
       name,
       email,
       passwordHash,
     });
-    ctx.db.userPublic.insert({
+    ctx.db.user_public.insert({
       id: internal.id,
       name,
     });

--- a/tools/xtask-llm-benchmark/src/benchmarks/auth/t_027_private_vs_public_table/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/auth/t_027_private_vs_public_table/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines a private table for sensitive data and a public table for client-visible data, with a reducer that copies safe fields from private to public.
 
 TABLES
-- userInternal
+- user_internal
   - private table (do not set public: true)
   - Fields:
     - id: number (u64, primary key, autoInc)
@@ -9,7 +9,7 @@ TABLES
     - email: string
     - passwordHash: string
 
-- userPublic
+- user_public
   - public table (set public: true)
   - Fields:
     - id: number (u64, primary key)
@@ -17,5 +17,5 @@ TABLES
 
 REDUCERS
 - register_user(ctx, { name: string, email: string, passwordHash: string })
-  - Insert into userInternal (id: 0n for autoInc)
-  - Also insert into userPublic with just the id and name (safe fields only)
+  - Insert into user_internal (id: 0n for autoInc)
+  - Also insert into user_public with just the id and name (safe fields only)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/answers/typescript.ts
@@ -1,8 +1,8 @@
 import { schema, table, t } from 'spacetimedb/server';
 
-const emptyTable = table({ name: 'empty_table' }, { id: t.i32().primaryKey() });
+const empty_table = table({ name: 'empty_table' }, { id: t.i32().primaryKey() });
 
-const spacetimedb = schema({ emptyTable });
+const spacetimedb = schema({ empty_table });
 export default spacetimedb;
 
 export const emptyReducerNoArgs = spacetimedb.reducer({}, ctx => {

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_000_empty_reducers/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines a table and these five empty reducers.
 
 TABLES
-- emptyTable
+- empty_table
   - Fields:
     - id: number (i32, primary key)
 

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_002_scheduled_table/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_002_scheduled_table/answers/typescript.ts
@@ -1,7 +1,7 @@
 import { ScheduleAt } from 'spacetimedb';
 import { table, schema, t } from 'spacetimedb/server';
 
-const tickTimer = table({
+const tick_timer = table({
   name: 'tick_timer',
   scheduled: (): any => tick,
 }, {
@@ -9,14 +9,14 @@ const tickTimer = table({
   scheduledAt: t.scheduleAt(),
 });
 
-const spacetimedb = schema({ tickTimer });
+const spacetimedb = schema({ tick_timer });
 export default spacetimedb;
 
-export const tick = spacetimedb.reducer({ timer: tickTimer.rowType }, (ctx, { timer }) => {
+export const tick = spacetimedb.reducer({ timer: tick_timer.rowType }, (ctx, { timer }) => {
 });
 
 export const init = spacetimedb.init(ctx => {
-  ctx.db.tickTimer.insert({
+  ctx.db.tick_timer.insert({
     scheduledId: 0n,
     scheduledAt: ScheduleAt.interval(50_000n),
   });

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_002_scheduled_table/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_002_scheduled_table/tasks/typescript.txt
@@ -1,12 +1,12 @@
 Write a SpacetimeDB backend module in TypeScript that defines a scheduled table and a scheduled reducer.
 
 TABLE
-- tickTimer
+- tick_timer
   - Fields:
     - scheduledId: bigint (u64, primary key, auto-increment)
     - scheduledAt: ScheduleAt
   - Scheduled: tick reducer, interval of 50ms
 
 REDUCERS
-- tick: scheduled reducer that receives the tickTimer row
+- tick: scheduled reducer that receives the tick_timer row
 - init: insert initial scheduled row with 50ms interval

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/answers/csharp.cs
@@ -2,7 +2,7 @@ using SpacetimeDB;
 
 public static partial class Module
 {
-    [Table(Accessor = "User")]
+    [Table(Accessor = "User", Public = true)]
     public partial struct User
     {
         [PrimaryKey] public int Id;

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(accessor = user)]
+#[table(accessor = user, public)]
 pub struct User {
     #[primary_key]
     pub id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/answers/typescript.ts
@@ -3,6 +3,7 @@ import { table, schema, t } from 'spacetimedb/server';
 const user = table(
   {
     name: 'user',
+    public: true,
   },
   {
     id: t.i32().primaryKey(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/tasks/csharp.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in C# that defines one table and a reducer that inserts a row.
 
 TABLE
-- User
+- User (public)
   - Struct: User
   - Fields:
     - Id: int (primary key)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/tasks/rust.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in Rust that defines one table and a reducer that inserts a row.
 
 TABLE
-- user
+- user (public)
   - Struct: User
   - Fields:
     - id: i32 (primary key)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_004_insert/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines one table and a reducer that inserts a row.
 
 TABLE
-- user
+- user (public)
   - Fields:
     - id: number (i32, primary key)
     - name: string

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/answers/csharp.cs
@@ -2,7 +2,7 @@ using SpacetimeDB;
 
 public static partial class Module
 {
-    [Table(Accessor = "User")]
+    [Table(Accessor = "User", Public = true)]
     public partial struct User
     {
         [PrimaryKey, AutoInc] public ulong Id;

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(accessor = user)]
+#[table(accessor = user, public)]
 pub struct User {
     #[primary_key]
     #[auto_inc]

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/answers/typescript.ts
@@ -3,6 +3,7 @@ import { table, schema, t } from 'spacetimedb/server';
 const user = table(
   {
     name: 'user',
+    public: true,
   },
   {
     id: t.u64().primaryKey().autoInc(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/tasks/csharp.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in C# that defines one table and two reducers: one that inserts a row and one that updates a row.
 
 TABLE
-- User
+- User (public)
   - Struct: User
   - Fields:
     - Id: ulong (primary key, auto-increment)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/tasks/rust.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in Rust that defines one table and two reducers: one that inserts a row and one that updates a row.
 
 TABLE
-- user
+- user (public)
   - Struct: User
   - Fields:
     - id: u64 (primary key, auto_inc)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_005_update/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines one table and two reducers: one that inserts a row and one that updates a row.
 
 TABLE
-- user
+- user (public)
   - Fields:
     - id: number (u64, primary key, autoInc)
     - name: string

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/answers/csharp.cs
@@ -2,7 +2,7 @@ using SpacetimeDB;
 
 public static partial class Module
 {
-    [Table(Accessor = "User")]
+    [Table(Accessor = "User", Public = true)]
     public partial struct User
     {
         [PrimaryKey, AutoInc] public ulong Id;

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(accessor = user)]
+#[table(accessor = user, public)]
 pub struct User {
     #[primary_key]
     #[auto_inc]

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/answers/typescript.ts
@@ -3,6 +3,7 @@ import { table, schema, t } from 'spacetimedb/server';
 const user = table(
   {
     name: 'user',
+    public: true,
   },
   {
     id: t.u64().primaryKey().autoInc(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/tasks/csharp.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in C# that defines one table and two reducers: one that inserts a row and one that deletes a row.
 
 TABLE
-- User
+- User (public)
   - Struct: User
   - Fields:
     - Id: ulong (primary key, auto-increment)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/tasks/rust.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in Rust that defines one table and two reducers: one that inserts a row and one that deletes a row.
 
 TABLE
-- user
+- user (public)
   - Struct: User
   - Fields:
     - id: u64 (primary key, auto_inc)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_006_delete/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines one table and two reducers: one that inserts a row and one that deletes a row.
 
 TABLE
-- user
+- user (public)
   - Fields:
     - id: number (u64, primary key, autoInc)
     - name: string

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/answers/csharp.cs
@@ -2,7 +2,7 @@ using SpacetimeDB;
 
 public static partial class Module
 {
-    [Table(Accessor = "User")]
+    [Table(Accessor = "User", Public = true)]
     public partial struct User
     {
         [PrimaryKey, AutoInc] public ulong Id;

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(accessor = user)]
+#[table(accessor = user, public)]
 pub struct User {
     #[primary_key]
     #[auto_inc]

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/answers/typescript.ts
@@ -3,6 +3,7 @@ import { table, schema, t } from 'spacetimedb/server';
 const user = table(
   {
     name: 'user',
+    public: true,
   },
   {
     id: t.u64().primaryKey().autoInc(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/tasks/csharp.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in C# that defines one table and a reducer that performs insert, update, and delete in one call.
 
 TABLE
-- User
+- User (public)
   - Struct: User
   - Fields:
     - Id: ulong (primary key, auto-increment)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/tasks/rust.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in Rust that defines one table and a reducer that performs insert, update, and delete in one call.
 
 TABLE
-- user
+- user (public)
   - Struct: User
   - Fields:
     - id: u64 (primary key, auto_inc)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_007_crud/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines one table and a reducer that performs insert, update, and delete in one call.
 
 TABLE
-- user
+- user (public)
   - Fields:
     - id: number (u64, primary key, autoInc)
     - name: string

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/answers/csharp.cs
@@ -11,7 +11,7 @@ public static partial class Module
         public bool Active;
     }
 
-    [Table(Accessor = "Result")]
+    [Table(Accessor = "Result", Public = true)]
     public partial struct Result
     {
         [PrimaryKey] public ulong Id;

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/answers/rust.rs
@@ -10,7 +10,7 @@ pub struct User {
     pub active: bool,
 }
 
-#[table(accessor = result)]
+#[table(accessor = result, public)]
 pub struct ResultRow {
     #[primary_key]
     pub id: u64,

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/answers/typescript.ts
@@ -15,6 +15,7 @@ const user = table(
 const result = table(
   {
     name: 'result',
+    public: true,
   },
   {
     id: t.u64().primaryKey(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/tasks/csharp.txt
@@ -9,7 +9,7 @@ TABLES
     - Age: int
     - Active: bool
 
-- Result
+- Result (public)
   - Struct: Result
   - Fields:
     - Id: ulong (primary key)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/tasks/rust.txt
@@ -9,7 +9,7 @@ TABLES
     - age: i32
     - active: bool
 
-- result
+- result (public)
   - Struct: ResultRow
   - Fields:
     - id: u64 (primary key)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_008_index_lookup/tasks/typescript.txt
@@ -8,7 +8,7 @@ TABLES
     - age: number (i32)
     - active: boolean
 
-- result
+- result (public)
   - Fields:
     - id: number (u64, primary key)
     - name: string

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/answers/csharp.cs
@@ -2,7 +2,7 @@ using SpacetimeDB;
 
 public static partial class Module
 {
-    [Table(Accessor = "User")]
+    [Table(Accessor = "User", Public = true)]
     public partial struct User
     {
         [PrimaryKey, AutoInc] public ulong Id;

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(accessor = user)]
+#[table(accessor = user, public)]
 pub struct User {
     #[primary_key]
     #[auto_inc]

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/answers/typescript.ts
@@ -3,6 +3,7 @@ import { table, schema, t } from 'spacetimedb/server';
 const user = table(
   {
     name: 'user',
+    public: true,
   },
   {
     id: t.u64().primaryKey().autoInc(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/tasks/csharp.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in C# that defines one table and an Init reducer that seeds rows on database initialization.
 
 TABLE
-- User
+- User (public)
   - Struct: User
   - Fields:
     - Id: ulong (primary key, auto-increment)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/tasks/rust.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in Rust that defines one table and an init reducer that seeds rows on database initialization.
 
 TABLE
-- user
+- user (public)
   - Struct: User
   - Fields:
     - id: u64 (primary key, auto_inc)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_009_init/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines one table and an init reducer that seeds rows on database initialization.
 
 TABLE
-- user
+- user (public)
   - Fields:
     - id: number (u64, primary key, autoInc)
     - name: string

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/answers/csharp.cs
@@ -2,7 +2,7 @@ using SpacetimeDB;
 
 public static partial class Module
 {
-    [Table(Accessor = "Result")]
+    [Table(Accessor = "Result", Public = true)]
     public partial struct Result
     {
         [PrimaryKey] public int Id;

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(accessor = result)]
+#[table(accessor = result, public)]
 pub struct ResultRow {
     #[primary_key]
     pub id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/answers/typescript.ts
@@ -2,6 +2,7 @@ import { table, schema, t } from 'spacetimedb/server';
 
 const result = table({
   name: 'result',
+  public: true,
 }, {
   id: t.i32().primaryKey(),
   sum: t.i32(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/tasks/csharp.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in C# that defines a table, a non-reducer helper function, and a reducer that uses the helper.
 
 TABLE
-- Result
+- Result (public)
   - Struct: Result
   - Fields:
     - Id: int (primary key)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/tasks/rust.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in Rust that defines a table, a non-reducer helper function, and a reducer that uses the helper.
 
 TABLE
-- result
+- result (public)
   - Struct: ResultRow
   - Fields:
     - id: i32 (primary key)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_011_helper_function/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines a table, a non-reducer helper function, and a reducer that uses the helper.
 
 TABLE
-- result
+- result (public)
   - Fields:
     - id: number (i32, primary key)
     - sum: number (i32)

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_039_cancel_schedule/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_039_cancel_schedule/answers/typescript.ts
@@ -1,7 +1,7 @@
 import { ScheduleAt } from 'spacetimedb';
 import { schema, table, t } from 'spacetimedb/server';
 
-const cleanupJob = table({
+const cleanup_job = table({
   name: 'cleanup_job',
   scheduled: (): any => runCleanup,
 }, {
@@ -9,16 +9,16 @@ const cleanupJob = table({
   scheduledAt: t.scheduleAt(),
 });
 
-const spacetimedb = schema({ cleanupJob });
+const spacetimedb = schema({ cleanup_job });
 export default spacetimedb;
 
 export const runCleanup = spacetimedb.reducer(
-  { timer: cleanupJob.rowType },
+  { timer: cleanup_job.rowType },
   (_ctx, _args) => {}
 );
 
 export const init = spacetimedb.init(ctx => {
-  ctx.db.cleanupJob.insert({
+  ctx.db.cleanup_job.insert({
     scheduledId: 0n,
     scheduledAt: ScheduleAt.interval(60_000_000n),
   });
@@ -27,6 +27,6 @@ export const init = spacetimedb.init(ctx => {
 export const cancelCleanup = spacetimedb.reducer(
   { scheduledId: t.u64() },
   (ctx, { scheduledId }) => {
-    ctx.db.cleanupJob.scheduledId.delete(scheduledId);
+    ctx.db.cleanup_job.scheduledId.delete(scheduledId);
   }
 );

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_039_cancel_schedule/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_039_cancel_schedule/tasks/typescript.txt
@@ -1,13 +1,13 @@
 Write a SpacetimeDB backend module in TypeScript that schedules a reducer and allows canceling it before it fires.
 
 TABLE
-- cleanupJob
+- cleanup_job
   - Fields:
     - scheduledId: u64 (primary key, auto-increment)
     - scheduledAt: scheduleAt
   - Scheduling: scheduled to call the run_cleanup reducer
 
 REDUCERS
-- run_cleanup: scheduled reducer triggered by cleanupJob (receives a cleanupJob row argument, does nothing)
-- init: inserts one row into cleanupJob with a 60-second interval (60_000_000n microseconds)
-- cancel_cleanup(ctx, { scheduledId: u64 }): deletes the cleanupJob row with the given scheduledId, canceling the pending scheduled call
+- run_cleanup: scheduled reducer triggered by cleanup_job (receives a cleanup_job row argument, does nothing)
+- init: inserts one row into cleanup_job with a 60-second interval (60_000_000n microseconds)
+- cancel_cleanup(ctx, { scheduledId: u64 }): deletes the cleanup_job row with the given scheduledId, canceling the pending scheduled call

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_040_lifecycle_player/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_040_lifecycle_player/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { schema, table, t } from 'spacetimedb/server';
 
-const onlinePlayer = table({
+const online_player = table({
   name: 'online_player',
   public: true,
 }, {
@@ -8,16 +8,16 @@ const onlinePlayer = table({
   connectedAt: t.timestamp(),
 });
 
-const spacetimedb = schema({ onlinePlayer });
+const spacetimedb = schema({ online_player });
 export default spacetimedb;
 
 export const clientConnected = spacetimedb.clientConnected(ctx => {
-  ctx.db.onlinePlayer.insert({
+  ctx.db.online_player.insert({
     identity: ctx.sender,
     connectedAt: ctx.timestamp,
   });
 });
 
 export const clientDisconnected = spacetimedb.clientDisconnected(ctx => {
-  ctx.db.onlinePlayer.identity.delete(ctx.sender);
+  ctx.db.online_player.identity.delete(ctx.sender);
 });

--- a/tools/xtask-llm-benchmark/src/benchmarks/basics/t_040_lifecycle_player/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/basics/t_040_lifecycle_player/tasks/typescript.txt
@@ -1,11 +1,11 @@
 Write a SpacetimeDB backend module in TypeScript that maintains a table of currently connected players using lifecycle reducers.
 
 TABLE
-- onlinePlayer (public)
+- online_player (public)
   - Fields:
     - identity: identity (primary key)
     - connectedAt: timestamp
 
 REDUCERS
-- clientConnected: lifecycle reducer (spacetimedb.clientConnected) that inserts an onlinePlayer row using ctx.sender as the identity and ctx.timestamp as connectedAt
-- clientDisconnected: lifecycle reducer (spacetimedb.clientDisconnected) that deletes the onlinePlayer row for ctx.sender
+- clientConnected: lifecycle reducer (spacetimedb.clientConnected) that inserts an online_player row using ctx.sender as the identity and ctx.timestamp as connectedAt
+- clientDisconnected: lifecycle reducer (spacetimedb.clientDisconnected) that deletes the online_player row for ctx.sender

--- a/tools/xtask-llm-benchmark/src/benchmarks/data_modeling/t_024_event_table/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/data_modeling/t_024_event_table/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { schema, table, t } from 'spacetimedb/server';
 
-const damageEvent = table({
+const damage_event = table({
   name: 'damage_event',
   public: true,
   event: true,
@@ -10,12 +10,12 @@ const damageEvent = table({
   source: t.string(),
 });
 
-const spacetimedb = schema({ damageEvent });
+const spacetimedb = schema({ damage_event });
 export default spacetimedb;
 
 export const deal_damage = spacetimedb.reducer(
   { entityId: t.u64(), damage: t.u32(), source: t.string() },
   (ctx, { entityId, damage, source }) => {
-    ctx.db.damageEvent.insert({ entityId, damage, source });
+    ctx.db.damage_event.insert({ entityId, damage, source });
   }
 );

--- a/tools/xtask-llm-benchmark/src/benchmarks/data_modeling/t_024_event_table/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/data_modeling/t_024_event_table/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines an event table for damage notifications and a reducer that publishes events to it.
 
 TABLES
-- damageEvent
+- damage_event
   - public event table (rows exist only for the duration of the transaction, set event: true)
   - Fields:
     - entityId: number (u64)
@@ -10,4 +10,4 @@ TABLES
 
 REDUCERS
 - deal_damage(ctx, { entityId: number (u64), damage: number (u32), source: string })
-  - Insert a row into the damageEvent event table
+  - Insert a row into the damage_event event table

--- a/tools/xtask-llm-benchmark/src/benchmarks/data_modeling/t_029_filter_and_aggregate/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/data_modeling/t_029_filter_and_aggregate/answers/typescript.ts
@@ -9,7 +9,7 @@ const order = table({
   fulfilled: t.bool(),
 });
 
-const categoryStats = table({
+const category_stats = table({
   name: 'category_stats',
 }, {
   category: t.string().primaryKey(),
@@ -17,7 +17,7 @@ const categoryStats = table({
   orderCount: t.u32(),
 });
 
-const spacetimedb = schema({ order, categoryStats });
+const spacetimedb = schema({ order, category_stats });
 export default spacetimedb;
 
 export const compute_stats = spacetimedb.reducer(
@@ -32,8 +32,8 @@ export const compute_stats = spacetimedb.reducer(
     }
 
     // Upsert: delete existing then insert
-    ctx.db.categoryStats.category.delete(category);
-    ctx.db.categoryStats.insert({
+    ctx.db.category_stats.category.delete(category);
+    ctx.db.category_stats.insert({
       category,
       totalAmount,
       orderCount,

--- a/tools/xtask-llm-benchmark/src/benchmarks/data_modeling/t_029_filter_and_aggregate/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/data_modeling/t_029_filter_and_aggregate/tasks/typescript.txt
@@ -8,7 +8,7 @@ TABLES
     - amount: number (u64)
     - fulfilled: boolean
 
-- categoryStats
+- category_stats
   - Fields:
     - category: string (primary key)
     - totalAmount: number (u64)
@@ -18,4 +18,4 @@ REDUCERS
 - compute_stats(ctx, { category: string })
   - Filter all orders matching the given category
   - Count the number of matching orders and sum their amounts
-  - Insert (or update if exists) a categoryStats row with the results
+  - Insert (or update if exists) a category_stats row with the results

--- a/tools/xtask-llm-benchmark/src/benchmarks/data_modeling/t_030_two_table_join/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/data_modeling/t_030_two_table_join/answers/typescript.ts
@@ -16,7 +16,7 @@ const order = table({
   amount: t.u32(),
 });
 
-const orderDetail = table({
+const order_detail = table({
   name: 'order_detail',
 }, {
   orderId: t.u64().primaryKey(),
@@ -25,7 +25,7 @@ const orderDetail = table({
   amount: t.u32(),
 });
 
-const spacetimedb = schema({ customer, order, orderDetail });
+const spacetimedb = schema({ customer, order, order_detail });
 export default spacetimedb;
 
 export const build_order_details = spacetimedb.reducer(
@@ -33,7 +33,7 @@ export const build_order_details = spacetimedb.reducer(
     for (const o of ctx.db.order.iter()) {
       const c = ctx.db.customer.id.find(o.customerId);
       if (c) {
-        ctx.db.orderDetail.insert({
+        ctx.db.order_detail.insert({
           orderId: o.id,
           customerName: c.name,
           product: o.product,

--- a/tools/xtask-llm-benchmark/src/benchmarks/data_modeling/t_030_two_table_join/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/data_modeling/t_030_two_table_join/tasks/typescript.txt
@@ -13,7 +13,7 @@ TABLES
     - product: string
     - amount: number (u32)
 
-- orderDetail
+- order_detail
   - Fields:
     - orderId: number (u64, primary key)
     - customerName: string
@@ -24,4 +24,4 @@ REDUCERS
 - build_order_details(ctx)
   - Iterate all orders
   - For each order, look up the customer by customerId
-  - If the customer is found, insert an orderDetail row with the joined data
+  - If the customer is found, insert an order_detail row with the joined data

--- a/tools/xtask-llm-benchmark/src/benchmarks/queries/t_032_range_query/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/queries/t_032_range_query/answers/typescript.ts
@@ -8,7 +8,7 @@ const product = table({
   price: t.u32().index('btree'),
 });
 
-const priceRangeResult = table({
+const price_range_result = table({
   name: 'price_range_result',
 }, {
   productId: t.u64().primaryKey(),
@@ -16,7 +16,7 @@ const priceRangeResult = table({
   price: t.u32(),
 });
 
-const spacetimedb = schema({ product, priceRangeResult });
+const spacetimedb = schema({ product, price_range_result });
 export default spacetimedb;
 
 export const find_in_price_range = spacetimedb.reducer(
@@ -24,7 +24,7 @@ export const find_in_price_range = spacetimedb.reducer(
   (ctx, { minPrice, maxPrice }) => {
     for (const p of ctx.db.product.iter()) {
       if (p.price >= minPrice && p.price <= maxPrice) {
-        ctx.db.priceRangeResult.insert({
+        ctx.db.price_range_result.insert({
           productId: p.id,
           name: p.name,
           price: p.price,

--- a/tools/xtask-llm-benchmark/src/benchmarks/queries/t_032_range_query/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/queries/t_032_range_query/tasks/typescript.txt
@@ -7,7 +7,7 @@ TABLES
     - name: string
     - price: number (u32, index btree)
 
-- priceRangeResult
+- price_range_result
   - Fields:
     - productId: number (u64, primary key)
     - name: string
@@ -16,4 +16,4 @@ TABLES
 REDUCERS
 - find_in_price_range(ctx, { minPrice: number (u32), maxPrice: number (u32) })
   - Iterate all products
-  - For each product where price >= minPrice AND price <= maxPrice, insert a priceRangeResult row
+  - For each product where price >= minPrice AND price <= maxPrice, insert a price_range_result row

--- a/tools/xtask-llm-benchmark/src/benchmarks/queries/t_034_find_first/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/queries/t_034_find_first/answers/typescript.ts
@@ -8,21 +8,21 @@ const task = table({
   completed: t.bool(),
 });
 
-const firstIncomplete = table({
+const first_incomplete = table({
   name: 'first_incomplete',
 }, {
   taskId: t.u64().primaryKey(),
   title: t.string(),
 });
 
-const spacetimedb = schema({ task, firstIncomplete });
+const spacetimedb = schema({ task, first_incomplete });
 export default spacetimedb;
 
 export const find_first_incomplete = spacetimedb.reducer(
   (ctx) => {
     for (const t of ctx.db.task.iter()) {
       if (!t.completed) {
-        ctx.db.firstIncomplete.insert({
+        ctx.db.first_incomplete.insert({
           taskId: t.id,
           title: t.title,
         });

--- a/tools/xtask-llm-benchmark/src/benchmarks/queries/t_034_find_first/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/queries/t_034_find_first/tasks/typescript.txt
@@ -7,7 +7,7 @@ TABLES
     - title: string
     - completed: boolean
 
-- firstIncomplete
+- first_incomplete
   - Fields:
     - taskId: number (u64, primary key)
     - title: string
@@ -16,4 +16,4 @@ REDUCERS
 - find_first_incomplete(ctx)
   - Iterate through the task table
   - Find the first task where completed is false
-  - If found, insert it into firstIncomplete
+  - If found, insert it into first_incomplete

--- a/tools/xtask-llm-benchmark/src/benchmarks/queries/t_035_select_distinct/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/queries/t_035_select_distinct/answers/typescript.ts
@@ -8,13 +8,13 @@ const order = table({
   amount: t.u32(),
 });
 
-const distinctCategory = table({
+const distinct_category = table({
   name: 'distinct_category',
 }, {
   category: t.string().primaryKey(),
 });
 
-const spacetimedb = schema({ order, distinctCategory });
+const spacetimedb = schema({ order, distinct_category });
 export default spacetimedb;
 
 export const collect_distinct_categories = spacetimedb.reducer(
@@ -24,7 +24,7 @@ export const collect_distinct_categories = spacetimedb.reducer(
       categories.add(o.category);
     }
     for (const category of categories) {
-      ctx.db.distinctCategory.insert({ category });
+      ctx.db.distinct_category.insert({ category });
     }
   }
 );

--- a/tools/xtask-llm-benchmark/src/benchmarks/queries/t_035_select_distinct/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/queries/t_035_select_distinct/tasks/typescript.txt
@@ -7,7 +7,7 @@ TABLES
     - category: string
     - amount: number (u32)
 
-- distinctCategory
+- distinct_category
   - Fields:
     - category: string (primary key)
 
@@ -15,4 +15,4 @@ REDUCERS
 - collect_distinct_categories(ctx)
   - Iterate all orders
   - Collect unique category values (use a Set)
-  - Insert each unique category into distinctCategory
+  - Insert each unique category into distinct_category

--- a/tools/xtask-llm-benchmark/src/benchmarks/queries/t_036_count_without_collect/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/queries/t_036_count_without_collect/answers/typescript.ts
@@ -8,14 +8,14 @@ const user = table({
   active: t.bool(),
 });
 
-const userStats = table({
+const user_stats = table({
   name: 'user_stats',
 }, {
   key: t.string().primaryKey(),
   count: t.u64(),
 });
 
-const spacetimedb = schema({ user, userStats });
+const spacetimedb = schema({ user, user_stats });
 export default spacetimedb;
 
 export const compute_user_counts = spacetimedb.reducer(
@@ -29,7 +29,7 @@ export const compute_user_counts = spacetimedb.reducer(
       }
     }
 
-    ctx.db.userStats.insert({ key: 'total', count: total });
-    ctx.db.userStats.insert({ key: 'active', count: active });
+    ctx.db.user_stats.insert({ key: 'total', count: total });
+    ctx.db.user_stats.insert({ key: 'active', count: active });
   }
 );

--- a/tools/xtask-llm-benchmark/src/benchmarks/queries/t_036_count_without_collect/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/queries/t_036_count_without_collect/tasks/typescript.txt
@@ -7,7 +7,7 @@ TABLES
     - name: string
     - active: boolean
 
-- userStats
+- user_stats
   - Fields:
     - key: string (primary key)
     - count: number (u64)
@@ -16,5 +16,5 @@ REDUCERS
 - compute_user_counts(ctx)
   - Count total users by iterating (do not collect into an array first)
   - Count active users by iterating and checking active === true
-  - Insert a userStats row with key="total" and the total count
-  - Insert a userStats row with key="active" and the active count
+  - Insert a user_stats row with key="total" and the total count
+  - Insert a user_stats row with key="active" and the active count

--- a/tools/xtask-llm-benchmark/src/benchmarks/queries/t_037_multi_column_filter/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/queries/t_037_multi_column_filter/answers/typescript.ts
@@ -1,6 +1,6 @@
 import { schema, table, t } from 'spacetimedb/server';
 
-const eventLog = table({
+const event_log = table({
   name: 'event_log',
   indexes: [{ accessor: 'byCategorySeverity', algorithm: 'btree', columns: ['category', 'severity'] }],
 }, {
@@ -10,22 +10,22 @@ const eventLog = table({
   message: t.string(),
 });
 
-const filteredEvent = table({
+const filtered_event = table({
   name: 'filtered_event',
 }, {
   eventId: t.u64().primaryKey(),
   message: t.string(),
 });
 
-const spacetimedb = schema({ eventLog, filteredEvent });
+const spacetimedb = schema({ event_log, filtered_event });
 export default spacetimedb;
 
 export const filter_events = spacetimedb.reducer(
   { category: t.string(), severity: t.u32() },
   (ctx, { category, severity }) => {
-    for (const e of ctx.db.eventLog.iter()) {
+    for (const e of ctx.db.event_log.iter()) {
       if (e.category === category && e.severity === severity) {
-        ctx.db.filteredEvent.insert({
+        ctx.db.filtered_event.insert({
           eventId: e.id,
           message: e.message,
         });

--- a/tools/xtask-llm-benchmark/src/benchmarks/queries/t_037_multi_column_filter/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/queries/t_037_multi_column_filter/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines an event log table with a multi-column BTree index and a result table, with a reducer that filters events by both category and severity level.
 
 TABLES
-- eventLog
+- event_log
   - Fields:
     - id: number (u64, primary key, autoInc)
     - category: string
@@ -9,12 +9,12 @@ TABLES
     - message: string
   - Index: multi-column btree index on (category, severity)
 
-- filteredEvent
+- filtered_event
   - Fields:
     - eventId: number (u64, primary key)
     - message: string
 
 REDUCERS
 - filter_events(ctx, { category: string, severity: number (u32) })
-  - Iterate all eventLog rows
-  - For each row where category matches AND severity matches, insert into filteredEvent
+  - Iterate all event_log rows
+  - For each row where category matches AND severity matches, insert into filtered_event

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/answers/rust.rs
@@ -6,7 +6,7 @@ pub struct Score {
     pub right: i32,
 }
 
-#[table(accessor = result)]
+#[table(accessor = result, public)]
 pub struct ResultRow {
     #[primary_key]
     pub id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/answers/typescript.ts
@@ -7,6 +7,7 @@ const Score = t.object('Score', {
 
 const result = table({
   name: 'result',
+  public: true,
 }, {
   id: t.i32().primaryKey(),
   value: Score,

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/tasks/rust.txt
@@ -7,7 +7,7 @@ TYPES
     - right: i32
 
 TABLE
-- result
+- result (public)
   - Struct: ResultRow
   - Fields:
     - id: i32 (primary key)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_012_spacetime_product_type/tasks/typescript.txt
@@ -6,7 +6,7 @@ TYPES
   - right: number (i32)
 
 TABLE
-- result
+- result (public)
   - Fields:
     - id: number (i32, primary key)
     - value: Score

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/answers/csharp.cs
@@ -11,7 +11,7 @@ public static partial class Module
     [Type]
     public partial record Shape : TaggedEnum<(Circle Circle, Rectangle Rectangle)> {}
 
-    [Table(Accessor = "Result")]
+    [Table(Accessor = "Result", Public = true)]
     public partial struct Result
     {
         [PrimaryKey] public int Id;

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/answers/rust.rs
@@ -12,7 +12,7 @@ pub enum Shape {
     Rectangle(Rect),
 }
 
-#[table(accessor = result)]
+#[table(accessor = result, public)]
 pub struct ResultRow {
     #[primary_key]
     pub id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/answers/typescript.ts
@@ -13,6 +13,7 @@ const Shape = t.enum('Shape', {
 const result = table(
   {
     name: 'result',
+    public: true,
   },
   {
     id: t.i32().primaryKey(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/tasks/csharp.txt
@@ -11,7 +11,7 @@ TYPES
 - Sum: Shape = Circle | Rectangle
 
 TABLE
-- Result
+- Result (public)
   - Struct: Result
   - Fields:
     - Id: int (primary key)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/tasks/rust.txt
@@ -11,7 +11,7 @@ TYPES
     - Rectangle(Rect)
 
 TABLE
-- result
+- result (public)
   - Struct: ResultRow
   - Fields:
     - id: i32 (primary key)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_013_spacetime_sum_type/tasks/typescript.txt
@@ -9,7 +9,7 @@ TYPES
   - rectangle: Rect
 
 TABLE
-- result
+- result (public)
   - Fields:
     - id: number (i32, primary key)
     - value: Shape

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/answers/csharp.cs
@@ -2,7 +2,7 @@ using SpacetimeDB;
 
 public static partial class Module
 {
-    [Table(Accessor = "Primitive")]
+    [Table(Accessor = "Primitive", Public = true)]
     public partial struct Primitive
     {
         [PrimaryKey, AutoInc] public ulong Id;

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/answers/rust.rs
@@ -1,6 +1,6 @@
 use spacetimedb::{reducer, table, ReducerContext, Table};
 
-#[table(accessor = primitive)]
+#[table(accessor = primitive, public)]
 pub struct Primitive {
     #[primary_key]
     #[auto_inc]

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/answers/typescript.ts
@@ -3,6 +3,7 @@ import { table, schema, t } from 'spacetimedb/server';
 const primitive = table(
   {
     name: 'primitive',
+    public: true,
   },
   {
     id: t.u64().primaryKey().autoInc(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/tasks/csharp.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in C# that defines one table and seeds one row.
 
 TABLE
-- Primitive
+- Primitive (public)
   - Struct: Primitive
   - Fields:
     - Id: ulong (primary key, auto-increment)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/tasks/rust.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in Rust that defines one table and seeds one row.
 
 TABLE
-- primitive
+- primitive (public)
   - Struct: Primitive
   - Fields:
     - id: u64 (primary key, auto_inc)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_014_elementary_columns/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines one table and seeds one row.
 
 TABLE
-- primitive
+- primitive (public)
   - Fields:
     - id: number (u64, primary key, autoInc)
     - count: number (i32)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/answers/rust.rs
@@ -12,7 +12,7 @@ pub struct Position {
     pub y: i32,
 }
 
-#[table(accessor = profile)]
+#[table(accessor = profile, public)]
 pub struct Profile {
     #[primary_key]
     #[auto_inc]

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/answers/typescript.ts
@@ -13,6 +13,7 @@ const Position = t.object('Position', {
 const profile = table(
   {
     name: 'profile',
+    public: true,
   },
   {
     id: t.u64().primaryKey().autoInc(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/tasks/rust.txt
@@ -11,7 +11,7 @@ TYPES
     - y: i32
 
 TABLE
-- profile
+- profile (public)
   - Struct: Profile
   - Fields:
     - id: u64 (primary key, auto_inc)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_015_product_type_columns/tasks/typescript.txt
@@ -9,7 +9,7 @@ TYPES
   - y: number (i32)
 
 TABLE
-- profile
+- profile (public)
   - Fields:
     - id: number (u64, primary key, autoInc)
     - home: Address

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/answers/csharp.cs
@@ -11,7 +11,7 @@ public static partial class Module
     [Type]
     public partial record Shape : TaggedEnum<(Circle Circle, Rectangle Rectangle)> {}
 
-    [Table(Accessor = "Drawing")]
+    [Table(Accessor = "Drawing", Public = true)]
     public partial struct Drawing
     {
         [PrimaryKey, AutoInc] public ulong Id;

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/answers/rust.rs
@@ -12,7 +12,7 @@ pub enum Shape {
     Rectangle(Rect),
 }
 
-#[table(accessor = drawing)]
+#[table(accessor = drawing, public)]
 pub struct Drawing {
     #[primary_key]
     #[auto_inc]

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/answers/typescript.ts
@@ -12,6 +12,7 @@ const Shape = t.enum('Shape', {
 
 const drawing = table({
   name: 'drawing',
+  public: true,
 }, {
   id: t.u64().primaryKey().autoInc(),
   a: Shape,

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/tasks/csharp.txt
@@ -11,7 +11,7 @@ TYPES
 - Sum: Shape = Circle | Rectangle
 
 TABLE
-- Drawing
+- Drawing (public)
   - Struct: Drawing
   - Fields:
     - Id: ulong (primary key, auto-increment)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/tasks/rust.txt
@@ -11,7 +11,7 @@ TYPES
     - Rectangle(Rect)
 
 TABLE
-- drawing
+- drawing (public)
   - Struct: Drawing
   - Fields:
     - id: u64 (primary key, auto_inc)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_016_sum_type_columns/tasks/typescript.txt
@@ -9,7 +9,7 @@ TYPES
   - rectangle: Rect
 
 TABLE
-- drawing
+- drawing (public)
   - Fields:
     - id: number (u64, primary key, autoInc)
     - a: Shape

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/answers/csharp.cs
@@ -2,7 +2,7 @@ using SpacetimeDB;
 
 public static partial class Module
 {
-    [Table(Accessor = "TickTimer", Scheduled = nameof(Tick), ScheduledAt = nameof(ScheduledAt))]
+    [Table(Accessor = "TickTimer", Public = true, Scheduled = nameof(Tick), ScheduledAt = nameof(ScheduledAt))]
     public partial struct TickTimer
     {
         [PrimaryKey, AutoInc] public ulong ScheduledId;

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/answers/rust.rs
@@ -1,7 +1,7 @@
 use spacetimedb::{reducer, table, ReducerContext, ScheduleAt, Table};
 use std::time::Duration;
 
-#[table(accessor = tick_timer, scheduled(tick))]
+#[table(accessor = tick_timer, public, scheduled(tick))]
 pub struct TickTimer {
     #[primary_key]
     #[auto_inc]

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/answers/typescript.ts
@@ -1,9 +1,10 @@
 import { ScheduleAt } from 'spacetimedb';
 import { table, schema, t } from 'spacetimedb/server';
 
-const tickTimer = table(
+const tick_timer = table(
   {
     name: 'tick_timer',
+    public: true,
     scheduled: (): any => tick,
   },
   {
@@ -12,16 +13,16 @@ const tickTimer = table(
   }
 );
 
-const spacetimedb = schema({ tickTimer });
+const spacetimedb = schema({ tick_timer });
 export default spacetimedb;
 
 export const tick = spacetimedb.reducer(
-  { schedule: tickTimer.rowType },
+  { schedule: tick_timer.rowType },
   (ctx, { schedule }) => {}
 );
 
 export const init = spacetimedb.init(ctx => {
-  ctx.db.tickTimer.insert({
+  ctx.db.tick_timer.insert({
     scheduledId: 0n,
     scheduledAt: ScheduleAt.interval(50_000n),
   });

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/tasks/csharp.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in C# that defines a scheduled table and seeds one schedule entry.
 
 TABLE
-- TickTimer
+- TickTimer (public)
   - Struct: TickTimer
   - Fields:
     - ScheduledId: ulong (primary key, auto-increment)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/tasks/rust.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in Rust that defines a scheduled table and seeds one schedule entry.
 
 TABLE
-- tick_timer
+- tick_timer (public)
   - Struct: TickTimer
   - Fields:
     - scheduled_id: u64 (primary key, auto-increment)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_017_scheduled_columns/tasks/typescript.txt
@@ -1,12 +1,12 @@
 Write a SpacetimeDB backend module in TypeScript that defines a scheduled table and seeds one schedule entry.
 
 TABLE
-- tickTimer
+- tick_timer (public)
   - Fields:
     - scheduledId: bigint (u64, primary key, auto-increment)
     - scheduledAt: ScheduleAt
   - Scheduled: tick reducer, interval of 50ms
 
 REDUCERS
-- tick: scheduled reducer that receives the tickTimer row
+- tick: scheduled reducer that receives the tick_timer row
 - init: insert initial scheduled row with 50ms interval

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/answers/rust.rs
@@ -2,6 +2,7 @@ use spacetimedb::{reducer, table, ReducerContext, Table};
 
 #[table(
     accessor = account,
+    public,
     index(accessor = by_name, btree(columns = [name]))
 )]
 pub struct Account {

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/answers/typescript.ts
@@ -2,6 +2,7 @@ import { table, schema, t } from 'spacetimedb/server';
 
 const account = table({
   name: 'account',
+  public: true,
   indexes: [{ accessor: 'byName', algorithm: 'btree', columns: ['name'] }],
 }, {
   id: t.u64().primaryKey().autoInc(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/tasks/rust.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in Rust that defines one table and seeds two rows.
 
 TABLE
-- account
+- account (public)
   - Struct: Account
   - Columns:
     - id: u64 (primary key, auto_inc)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_018_constraints/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines one table and seeds two rows.
 
 TABLE
-- account
+- account (public)
   - Fields:
     - id: number (u64, primary key, autoInc)
     - email: string (unique)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/answers/csharp.cs
@@ -16,7 +16,7 @@ public static partial class Module
         public string Title;
     }
 
-    [Table(Accessor = "Membership")]
+    [Table(Accessor = "Membership", Public = true)]
     [SpacetimeDB.Index.BTree(Accessor = "by_user",  Columns = new[] { nameof(UserId) })]
     [SpacetimeDB.Index.BTree(Accessor = "by_group", Columns = new[] { nameof(GroupId) })]
     public partial struct Membership

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/answers/rust.rs
@@ -18,6 +18,7 @@ pub struct Group {
 
 #[table(
     accessor = membership,
+    public,
     index(accessor = by_user,  btree(columns = [user_id])),
     index(accessor = by_group, btree(columns = [group_id]))
 )]

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/answers/typescript.ts
@@ -23,6 +23,7 @@ const group = table(
 const membership = table(
   {
     name: 'membership',
+    public: true,
     indexes: [
       { accessor: 'byUser', algorithm: 'btree', columns: ['userId'] },
       { accessor: 'byGroup', algorithm: 'btree', columns: ['groupId'] },

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/tasks/csharp.txt
@@ -13,7 +13,7 @@ TABLES
     - GroupId: ulong (primary key, auto-increment)
     - Title: string
 
-- Membership
+- Membership (public)
   - Struct: Membership
   - Fields:
     - Id: ulong (primary key, auto-increment)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/tasks/rust.txt
@@ -13,7 +13,7 @@ TABLES
     - group_id: u64 (primary key, auto_inc)
     - title: String
 
-- membership
+- membership (public)
   - Struct: Membership
   - Fields:
     - id: u64 (primary key, auto_inc)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_019_many_to_many/tasks/typescript.txt
@@ -11,7 +11,7 @@ TABLES
     - groupId: number (u64, primary key, autoInc)
     - title: string
 
-- membership
+- membership (public)
   - Fields:
     - id: number (u64, primary key, autoInc)
     - userId: number (u64)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/answers/csharp.cs
@@ -5,7 +5,7 @@ public static partial class Module
     [Table(Accessor = "Entity")]
     public partial struct Entity { [PrimaryKey, AutoInc] public ulong Id; }
 
-    [Table(Accessor = "Position")]
+    [Table(Accessor = "Position", Public = true)]
     public partial struct Position
     {
         [PrimaryKey] public int EntityId;
@@ -21,7 +21,7 @@ public static partial class Module
         public int VY;
     }
 
-    [Table(Accessor = "NextPosition")]
+    [Table(Accessor = "NextPosition", Public = true)]
     public partial struct NextPosition
     {
         [PrimaryKey] public int EntityId;

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/answers/rust.rs
@@ -7,7 +7,7 @@ pub struct Entity {
     pub id: u64,
 }
 
-#[table(accessor = position)]
+#[table(accessor = position, public)]
 pub struct Position {
     #[primary_key]
     pub entity_id: i32,
@@ -23,7 +23,7 @@ pub struct Velocity {
     pub vy: i32,
 }
 
-#[table(accessor = next_position)]
+#[table(accessor = next_position, public)]
 pub struct NextPosition {
     #[primary_key]
     pub entity_id: i32,

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/answers/typescript.ts
@@ -12,6 +12,7 @@ const entity = table(
 const position = table(
   {
     name: 'position',
+    public: true,
   },
   {
     entityId: t.i32().primaryKey(),
@@ -31,9 +32,10 @@ const velocity = table(
   }
 );
 
-const nextPosition = table(
+const next_position = table(
   {
     name: 'next_position',
+    public: true,
   },
   {
     entityId: t.i32().primaryKey(),
@@ -42,7 +44,7 @@ const nextPosition = table(
   }
 );
 
-const spacetimedb = schema({ entity, position, velocity, nextPosition });
+const spacetimedb = schema({ entity, position, velocity, next_position });
 export default spacetimedb;
 
 export const seed = spacetimedb.reducer(ctx => {
@@ -66,10 +68,10 @@ export const step = spacetimedb.reducer(ctx => {
         y: p.y + v.vy,
       };
 
-      if (ctx.db.nextPosition.entityId.find(p.entityId)) {
-        ctx.db.nextPosition.entityId.update(np);
+      if (ctx.db.next_position.entityId.find(p.entityId)) {
+        ctx.db.next_position.entityId.update(np);
       } else {
-        ctx.db.nextPosition.insert(np);
+        ctx.db.next_position.insert(np);
       }
     }
   }

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/tasks/csharp.txt
@@ -6,7 +6,7 @@ TABLES
   - Fields:
     - Id: ulong (primary key, auto-increment)
 
-- Position
+- Position (public)
   - Struct: Position
   - Fields:
     - EntityId: int (primary key) — NOT auto-increment, this is a foreign key to Entity
@@ -20,7 +20,7 @@ TABLES
     - VX: int
     - VY: int
 
-- NextPosition
+- NextPosition (public)
   - Struct: NextPosition
   - Fields:
     - EntityId: int (primary key) — NOT auto-increment, this is a foreign key to Entity

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/tasks/rust.txt
@@ -6,7 +6,7 @@ TABLES
   - Fields:
     - id: u64 (primary key, auto_inc)
 
-- position
+- position (public)
   - Struct: Position
   - Fields:
     - entity_id: i32 (primary key) — NOT auto_inc, this is a foreign key to entity
@@ -20,7 +20,7 @@ TABLES
     - vx: i32
     - vy: i32
 
-- next_position
+- next_position (public)
   - Struct: NextPosition
   - Fields:
     - entity_id: i32 (primary key) — NOT auto_inc, this is a foreign key to entity

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_020_ecs/tasks/typescript.txt
@@ -5,7 +5,7 @@ TABLES
   - Fields:
     - id: number (u64, primary key, autoInc)
 
-- position
+- position (public)
   - Fields:
     - entityId: number (i32, primary key) — NOT autoInc, this is a foreign key to entity
     - x: number (i32)
@@ -17,7 +17,7 @@ TABLES
     - vx: number (i32)
     - vy: number (i32)
 
-- nextPosition
+- next_position (public)
   - Fields:
     - entityId: number (i32, primary key) — NOT autoInc, this is a foreign key to entity
     - x: number (i32)
@@ -28,4 +28,4 @@ REDUCERS
   - Entity 1: position(0,0), velocity(1,0)
   - Entity 2: position(10,0), velocity(-2,3)
 
-- step: for each position, find velocity, compute next position (x+vx, y+vy), upsert to nextPosition
+- step: for each position, find velocity, compute next position (x+vx, y+vy), upsert to next_position

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/answers/csharp.cs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/answers/csharp.cs
@@ -2,7 +2,7 @@ using SpacetimeDB;
 
 public static partial class Module
 {
-    [Table(Accessor = "Log")]
+    [Table(Accessor = "Log", Public = true)]
     [SpacetimeDB.Index.BTree(Accessor = "by_user_day", Columns = new[] { nameof(UserId), nameof(Day) })]
     public partial struct Log
     {

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/answers/rust.rs
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/answers/rust.rs
@@ -2,6 +2,7 @@ use spacetimedb::{reducer, table, ReducerContext, Table};
 
 #[table(
     accessor = log,
+    public,
     index(accessor = by_user_day, btree(columns = [user_id, day]))
 )]
 pub struct Log {

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/answers/typescript.ts
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/answers/typescript.ts
@@ -2,6 +2,7 @@ import { table, schema, t } from 'spacetimedb/server';
 
 const log = table({
   name: 'log',
+  public: true,
   indexes: [{ accessor: 'byUserDay', algorithm: 'btree', columns: ['userId', 'day'] }],
 }, {
   id: t.u64().primaryKey().autoInc(),

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/tasks/csharp.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/tasks/csharp.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in C# that defines one table with a multi-column B-Tree index and seeds rows.
 
 TABLE
-- Log
+- Log (public)
   - Struct: Log
   - Fields:
     - Id: ulong (primary key, auto-increment)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/tasks/rust.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/tasks/rust.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in Rust that defines one table with a multi-column B-Tree index and seeds rows.
 
 TABLE
-- log
+- log (public)
   - Struct: Log
   - Fields:
     - id: u64 (primary key, auto_inc)

--- a/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/tasks/typescript.txt
+++ b/tools/xtask-llm-benchmark/src/benchmarks/schema/t_021_multi_column_index/tasks/typescript.txt
@@ -1,7 +1,7 @@
 Write a SpacetimeDB backend module in TypeScript that defines one table with a multi-column B-Tree index and seeds rows.
 
 TABLE
-- log
+- log (public)
   - Fields:
     - id: number (u64, primary key, autoInc)
     - userId: number (i32)

--- a/tools/xtask-llm-benchmark/src/eval/sql_fmt.rs
+++ b/tools/xtask-llm-benchmark/src/eval/sql_fmt.rs
@@ -25,7 +25,7 @@ pub fn casing_for_lang(lang: Lang) -> Casing {
 pub fn table_name(singular: &str, lang: Lang) -> String {
     match lang {
         Lang::CSharp => singular.to_upper_camel_case(),
-        Lang::TypeScript => singular.to_lower_camel_case(),
+        Lang::TypeScript => singular.to_snake_case(),
         Lang::Rust => singular.to_snake_case(),
     }
 }

--- a/tools/xtask-llm-benchmark/src/eval/sql_fmt.rs
+++ b/tools/xtask-llm-benchmark/src/eval/sql_fmt.rs
@@ -20,7 +20,7 @@ pub fn casing_for_lang(lang: Lang) -> Casing {
 
 /// Convert a singular lowercase table name to the appropriate convention for each language.
 /// - C#: PascalCase singular (e.g., "user" -> "User")
-/// - TypeScript: camelCase singular (e.g., "user" -> "user")
+/// - TypeScript: snake_case singular (e.g., "user" -> "user")
 /// - Rust: snake_case singular (e.g., "user" -> "user")
 pub fn table_name(singular: &str, lang: Lang) -> String {
     match lang {

--- a/tools/xtask-llm-benchmark/src/llm/prompt.rs
+++ b/tools/xtask-llm-benchmark/src/llm/prompt.rs
@@ -114,6 +114,24 @@ pub fn make_prompt_from_task(spec_file: &str, task_id: &str, lang: Lang) -> Resu
     })
 }
 
+fn find_tasks_file(task_root: &Path, lang: Lang) -> Option<PathBuf> {
+    let dir = task_root.join("tasks");
+    match lang {
+        Lang::CSharp => {
+            let p = dir.join("csharp.txt");
+            p.exists().then_some(p)
+        }
+        Lang::Rust => {
+            let p = dir.join("rust.txt");
+            p.exists().then_some(p)
+        }
+        Lang::TypeScript => {
+            let p = dir.join("typescript.txt");
+            p.exists().then_some(p)
+        }
+    }
+}
+
 #[cfg(test)]
 mod tests {
     #[test]
@@ -136,23 +154,5 @@ mod tests {
         assert!(parts.next().unwrap().parse::<u32>().is_ok(), "major not numeric: {v}");
         assert!(parts.next().unwrap().parse::<u32>().is_ok(), "minor not numeric: {v}");
         assert_eq!(parts.next(), None, "expected major.minor only: {v}");
-    }
-}
-
-fn find_tasks_file(task_root: &Path, lang: Lang) -> Option<PathBuf> {
-    let dir = task_root.join("tasks");
-    match lang {
-        Lang::CSharp => {
-            let p = dir.join("csharp.txt");
-            p.exists().then_some(p)
-        }
-        Lang::Rust => {
-            let p = dir.join("rust.txt");
-            p.exists().then_some(p)
-        }
-        Lang::TypeScript => {
-            let p = dir.join("typescript.txt");
-            p.exists().then_some(p)
-        }
     }
 }

--- a/tools/xtask-llm-benchmark/src/llm/prompt.rs
+++ b/tools/xtask-llm-benchmark/src/llm/prompt.rs
@@ -19,9 +19,19 @@ pub struct BuiltPrompt {
     pub search_enabled: bool,
 }
 
+/// SpacetimeDB version as "major.minor".
+fn spacetimedb_version() -> String {
+    let full = spacetimedb_lib::version::spacetimedb_lib_version();
+    let mut parts = full.splitn(3, '.');
+    match (parts.next(), parts.next()) {
+        (Some(major), Some(minor)) => format!("{major}.{minor}"),
+        _ => full.to_string(),
+    }
+}
+
 impl PromptBuilder {
     pub fn build_segmented(&self, mode: &str, context: &str) -> BuiltPrompt {
-        let version = "1.6";
+        let version = spacetimedb_version();
         let search_enabled = mode == "search";
 
         // SYSTEM: hygiene-only for Knowledge; hygiene + stricter output rules for Conformance.
@@ -102,6 +112,31 @@ pub fn make_prompt_from_task(spec_file: &str, task_id: &str, lang: Lang) -> Resu
         task_id: task_id.to_string(),
         instructions,
     })
+}
+
+#[cfg(test)]
+mod tests {
+    #[test]
+    fn prompt_uses_workspace_version() {
+        let pb = super::PromptBuilder {
+            lang: "TypeScript".into(),
+            task_id: "t_000".into(),
+            instructions: "test".into(),
+        };
+        let built = pb.build_segmented("no_context", "");
+        let task = &built.segments[0].text;
+        let expected = format!("SpacetimeDB {} syntax", super::spacetimedb_version());
+        assert!(task.contains(&expected), "prompt missing '{expected}': {task}");
+    }
+
+    #[test]
+    fn version_is_major_minor() {
+        let v = super::spacetimedb_version();
+        let mut parts = v.split('.');
+        assert!(parts.next().unwrap().parse::<u32>().is_ok(), "major not numeric: {v}");
+        assert!(parts.next().unwrap().parse::<u32>().is_ok(), "minor not numeric: {v}");
+        assert_eq!(parts.next(), None, "expected major.minor only: {v}");
+    }
 }
 
 fn find_tasks_file(task_root: &Path, lang: Lang) -> Option<PathBuf> {


### PR DESCRIPTION
# Description of Changes

Fixes the LLM benchmark so C# and TypeScript can actually pass. Both scored 0% in every periodic run while all golden answers publish; the causes were generally in the harness and task suite.

- The prompt hardcoded "Use valid SpacetimeDB 1.6 syntax" since the original benchmark PR (#3486), so models were instructed to write the pre-2.0 API. The version now comes from `spacetimedb-lib` at compile time.
- TypeScript task specs named tables camelCase while goldens use snake_case, and the eval layer camelized TS table names in SQL. All three now agree on snake_case (15 specs, `sql_fmt.rs`).
- Scorers read tables through anonymous `spacetime sql`, but no golden marked its tables public, so every data-parity check failed in every language and every run. The 17 tasks whose scorers read tables now say `(public)` in the spec and declare it in the goldens, in all three languages.
- Golden cleanup: schema keys match table names, and a few skill lines for failure patterns the runs exposed (C# nullable unwrap after `Find`, `Insert` returns the row, `ScheduleAt` import in the TS scheduled-table snippet).

Local results with gpt-5.4-mini in guidelines mode, full 47-task suite: C# 0% to ~94%, TypeScript 0% to ~99%, Rust 95.5% (its data-parity checks had been silently failing too).

# API and ABI breaking changes

None.

# Expected complexity level and risk

2. The tool changes are small (version lookup, one casing arm). The bulk of the diff is benchmark data: task specs and golden answers. Risk is that benchmark scores shift meaningfully after merge, which is the point.

# Testing

- [x] Goldens build and publish for all three languages after the spec/golden edits.
- [x] Full 47-task suite run locally per language with gpt-5.4-mini
- [x] `cargo test -p xtask-llm-benchmark`; new test asserts the prompt carries the workspace version.
- [ ] Reviewer: next periodic run shows C#/TS publishing and scoring instead of 0%.