### PR TITLE
`spacetime start` - Port available when in doubt

### DIFF
--- a/crates/standalone/src/subcommands/start.rs
+++ b/crates/standalone/src/subcommands/start.rs
@@ -316,7 +316,12 @@ pub fn is_port_available(host: &str, port: u16) -> bool {
 
     let sockets = match get_sockets_info(AddressFamilyFlags::IPV4 | AddressFamilyFlags::IPV6, ProtocolFlags::TCP) {
         Ok(s) => s,
-        Err(_) => return false, // if we can't inspect sockets, fail closed
+        Err(_) => {
+            log::warn!("Unable to check whether port {port} is available. Proceeding as though it is.");
+            // Default to allowing, because otherwise we can have cases where users are entirely unable to start servers.
+            // See https://github.com/clockworklabs/SpacetimeDB/issues/5556.
+            return true;
+        }
     };
 
     for si in sockets {


### PR DESCRIPTION
# Description of Changes

If we fail to check port availability, move forward as though it's available, to avoid being entirely borked in environments where we do not have permission to check port availability.

Closes #5556.

# API and ABI breaking changes

None really. Technically technically an API change for the CLI, but not in a way that causes meaningful pain.

# Expected complexity level and risk

1

# Testing

Existing CI only. I have not tested this specific branch.