### PR TITLE
Fix case sensitivity in choose_alliance command

### DIFF
--- a/docs/docs/00200-core-concepts/00100-databases/00500-migrations/00300-incremental-migrations.md
+++ b/docs/docs/00200-core-concepts/00100-databases/00500-migrations/00300-incremental-migrations.md
@@ -352,7 +352,7 @@ $ spacetime sql incr-migration-demo 'SELECT * FROM character'
  <snip>    | "Gefjon" | 3     | (Fighter = ())
 
 # We can set our alliance:
-$ spacetime call incr-migration-demo choose_alliance '{ "Good": {} }'
+$ spacetime call incr-migration-demo choose_alliance '{ "good": {} }'
 
 2025-01-07T16:13:53.816501Z  INFO: src/lib.rs:129: Setting alliance of Gefjon to Good
 


### PR DESCRIPTION
Corrected the casing of 'Good' to 'good' in the command example.

# Description of Changes

Fixed the casing otherwise the command would not work and show this error:

```bash
Error: Invalid arguments provided for reducer `choose_alliance` for database `yral-database-spacetime-4lbo7` resolving to identity `c2000bc0eb62dd948f318073cba2dd434656d08046b0e80c32c459bdb79b2877`.

The reducer has the following signature:
        choose_alliance(alliance: enum { good: {}, neutral: {}, evil: {} })

Caused by:
    0: Response text: invalid arguments for reducer choose_alliance: [0].Good: invalid arguments for function choose_alliance: [0].Good: [0].Good: unknown variant `Good`, expected , `good`one of `neutral`, `evil` at line 1 column 9
    1: HTTP status client error (400 Bad Request) for url (http://127.0.0.1:3000/v1/database/c2000bc0eb62dd948f318073cba2dd434656d08046b0e80c32c459bdb79b2877/call/choose_alliance)
```

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->
1

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

Tested locally
