### PR TITLE
Fix release flow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,9 +106,7 @@ jobs:
       - name: Checkout specific tag
         uses: actions/checkout@v4
         with:
-          # TODO: Before merging, update this!
-          # ref: ${{ github.event.inputs.release_tag }}
-          ref: jdetter/fix-release-flow
+          ref: ${{ github.event.inputs.release_tag }}
           submodules: recursive
 
       - name: Set up Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -106,7 +106,9 @@ jobs:
       - name: Checkout specific tag
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.release_tag }}
+          # TODO: Before merging, update this!
+          # ref: ${{ github.event.inputs.release_tag }}
+          ref: jdetter/fix-release-flow
           submodules: recursive
 
       - name: Set up Rust

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,6 +175,7 @@ jobs:
       - name: Install NuGet
         shell: bash
         run: |
+          sudo apt update
           sudo apt install -y mono-complete
           mkdir bin
           cd bin

--- a/tools/release/src/targets/crates.rs
+++ b/tools/release/src/targets/crates.rs
@@ -175,7 +175,13 @@ impl ReleaseTarget for CratesRelease {
         }
 
         println!("\nStarting publish process...");
-        let crates_io_version = self.version.strip_prefix('v').unwrap_or(&self.version);
+        let crates_io_version = self
+            .version
+            .strip_prefix('v')
+            .unwrap_or(&self.version)
+            .split('-')
+            .next()
+            .unwrap();
         for crate_name in &crates {
             self.publish_crate(crate_name, &manifest_map)?;
             self.wait_for_crate_available(crate_name, crates_io_version)?;

--- a/tools/release/src/targets/csharp.rs
+++ b/tools/release/src/targets/csharp.rs
@@ -34,6 +34,12 @@ fn run_cargo_ci_dlls() -> Result<(), String> {
 fn push_nuget_packages(version: &str, dry_run: bool) -> Result<(), String> {
     println!("\n=== Publishing NuGet Packages ===");
 
+    // The NuGet package version comes from the csproj `<Version>`, which is not bumped
+    // for a hotfix. So `dotnet pack` produces e.g. `SpacetimeDB.Runtime.2.7.0.nupkg`
+    // even when releasing tag `v2.7.0-hotfix2`. Strip the `-hotfix<N>` suffix so we look
+    // up the packages that were actually produced.
+    let version = version.split_once("-hotfix").map_or(version, |(base, _)| base);
+
     let packages = vec![
         format!(
             "crates/bindings-csharp/BSATN.Runtime/bin/Release/SpacetimeDB.BSATN.Runtime.{}.nupkg",
@@ -361,11 +367,14 @@ impl ReleaseTarget for CSharpRelease {
 
         println!("\n=== C# SDK Release Complete ===");
         if !self.dry_run {
+            // NuGet package versions come from the csproj `<Version>` and are not bumped
+            // for a hotfix, so report the base version here (see push_nuget_packages).
+            let package_version = version.split_once("-hotfix").map_or(version, |(base, _)| base);
             println!("NuGet packages published:");
-            println!("  - SpacetimeDB.BSATN.Runtime.{}", version);
-            println!("  - SpacetimeDB.Runtime.{}", version);
-            println!("  - SpacetimeDB.ClientSDK.{}", version);
-            println!("  - SpacetimeDB.ClientSDK.Godot.{}", version);
+            println!("  - SpacetimeDB.BSATN.Runtime.{}", package_version);
+            println!("  - SpacetimeDB.Runtime.{}", package_version);
+            println!("  - SpacetimeDB.ClientSDK.{}", package_version);
+            println!("  - SpacetimeDB.ClientSDK.Godot.{}", package_version);
             println!("\nUnity SDK published:");
             println!("  - Branch: release/latest");
             println!("  - Tag: v{}", version);


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

- Fixes issues in the crates.io release and csharp release related to handling the version suffix.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

1 - this is just a release change.

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [x] crates.io release succeeded: https://github.com/clockworklabs/SpacetimeDB/actions/runs/29951081568/job/89028804239
- [x] csharp release succeeded: https://github.com/clockworklabs/SpacetimeDB/actions/runs/29952327964 
