### PR TITLE
Bump version of `System.Security.Cryptography.Xml` to `10.0.10`

### DIFF
--- a/crates/bindings-csharp/Codegen.Tests/Codegen.Tests.csproj
+++ b/crates/bindings-csharp/Codegen.Tests/Codegen.Tests.csproj
@@ -31,7 +31,7 @@
     <PackageReference Include="Microsoft.CodeAnalysis.Workspaces.MSBuild" Version="4.14.0" />
     <PackageReference Include="Microsoft.Build.Tasks.Core" Version="17.11.48" PrivateAssets="all" />
     <PackageReference Include="Microsoft.Extensions.Logging" Version="9.0.0" />
-    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.9" PrivateAssets="all" />
+    <PackageReference Include="System.Security.Cryptography.Xml" Version="10.0.10" PrivateAssets="all" />
   </ItemGroup>
 
   <ItemGroup Condition="$(TargetFramework.StartsWith('net10.'))">


### PR DESCRIPTION
# Description of Changes

Previously was version `10.0.9`. NuGet marked this version as vulnerable and lists `10.0.10` as the next patched 10.x version.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

0

# Testing

Fixes CI.
