### PR TITLE
Do not update apt during C# release

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -175,7 +175,6 @@ jobs:
       - name: Install NuGet
         shell: bash
         run: |
-          sudo apt update
           sudo apt install -y mono-complete
           mkdir bin
           cd bin


### PR DESCRIPTION
# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

- We added this `apt update` during the last release because the apt cache was out of date. I've now added `sudo apt update` to the runner's `cloud-init` script so this happens when the runner starts up.

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

None

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

1 - This is a small efficiency improvement during the release process.

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [ ] Ran a dry-run release with this change (have not tested yet)
