### PR TITLE
Fix rows of exactly 1024 bytes getting ignored in C#

### DIFF
--- a/crates/bindings-csharp/Runtime/Internal/ITable.cs
+++ b/crates/bindings-csharp/Runtime/Internal/ITable.cs
@@ -33,10 +33,6 @@ internal abstract class RawTableIterBase<T>
                 if (ret == Errno.EXHAUSTED)
                 {
                     handle = FFI.RowIter.INVALID;
-                    if (buffer_len == requested_len)
-                    {
-                        buffer_len = 0;
-                    }
                 }
                 // On success, the only way `buffer_len == 0` is for the iterator to be exhausted.
                 // This happens when the host iterator was empty from the start.


### PR DESCRIPTION
# Description of Changes
In C#, a result of `Errno.EXHAUSTED` from `row_iter_bsatn_advance` was wrongly interpreted as "iterator is done, no bytes were written". This PR fixes it to match the contract correctly: `EXHAUSTED:  wrote zero or more bytes, and iterator is now done`.

# API and ABI breaking changes
No changes.

# Expected complexity level and risk
1. Trivial change.

# Testing
- [x] Tested that 1024 bytes rows aren't ignored anymore
