### PR TITLE
Update release-npm workflow for dryruns

### DIFF
--- a/tools/release/src/targets/npm.rs
+++ b/tools/release/src/targets/npm.rs
@@ -73,9 +73,7 @@ impl NpmRelease {
         }
         cmd.current_dir(sdk_dir);
         util::print_command(&cmd);
-        let status = cmd
-            .status()
-            .map_err(|e| format!("Failed to execute {}: {}", step, e))?;
+        let status = cmd.status().map_err(|e| format!("Failed to execute {}: {}", step, e))?;
 
         if !status.success() {
             return Err(format!("Failed to {}", step_err));

--- a/tools/release/src/targets/npm.rs
+++ b/tools/release/src/targets/npm.rs
@@ -37,7 +37,7 @@ impl NpmRelease {
 
         let sdk_dir = Path::new("sdks/typescript");
 
-        println!("Running pnpm publish in {}...", sdk_dir.display());
+        println!("Running npm release steps in {}...", sdk_dir.display());
         println!("Note: prepublishOnly script will build, test, and size up the package");
 
         // pnpm install first
@@ -52,6 +52,12 @@ impl NpmRelease {
             return Err("Failed to run pnpm install".to_string());
         }
 
+        let (step, step_err) = if self.dry_run {
+            ("pnpm run prepublishOnly", "run prepublish build/test/size checks")
+        } else {
+            ("pnpm publish", "publish package to npm")
+        };
+
         let mut cmd = Command::new("pnpm");
         // The publish step here runs from a directory that doesn't have a clean git worktree
         // so we disable pnpm's default git cleanliness/branch checks otherwise this will fail.
@@ -59,7 +65,9 @@ impl NpmRelease {
         // on the main/master branch (we're in a detached HEAD state at this point).
         // ERR_PNPM_GIT_UNKNOWN_BRANCH The Git HEAD may not attached to any branch, but your "publish-branch" is set to "master|main".
         if self.dry_run {
-            cmd.args(["publish", "--dry-run", "--no-git-checks"]);
+            // Run the pre-publish build/test/size checks, then pack the tarball
+            // locally instead of uploading it.
+            cmd.args(["run", "prepublishOnly"]);
         } else {
             cmd.args(["publish", "--no-git-checks"]);
         }
@@ -67,10 +75,24 @@ impl NpmRelease {
         util::print_command(&cmd);
         let status = cmd
             .status()
-            .map_err(|e| format!("Failed to execute pnpm publish: {}", e))?;
+            .map_err(|e| format!("Failed to execute {}: {}", step, e))?;
 
         if !status.success() {
-            return Err("Failed to publish package to npm".to_string());
+            return Err(format!("Failed to {}", step_err));
+        }
+
+        if self.dry_run {
+            // Pack the dry-run tarball.
+            cmd = Command::new("pnpm");
+            cmd.arg("pack");
+            cmd.current_dir(sdk_dir);
+            util::print_command(&cmd);
+            let status = cmd
+                .status()
+                .map_err(|e| format!("Failed to execute pnpm pack: {}", e))?;
+            if !status.success() {
+                return Err("Failed to pack package".to_string());
+            }
         }
 
         println!(


### PR DESCRIPTION
This PR addresses the npm dry-run failures observed in recent release-dry-run CI runs, where `pnpm publish --dry-run` contacts the npm registry and errors out for already-published versions like `spacetimedb@2.7.1`.

# Description of Changes

Updates `tools/release/src/targets/npm.rs` so that in dry-run mode the npm release target:
1. runs `pnpm run prepublishOnly` to execute the build/test/size checks
2. runs `pnpm pack` to create the tarball locally

The live `pnpm publish --no-git-checks` path is unchanged. This also makes the log and error messages accurate for whichever mode is running.

# API and ABI breaking changes

No changes.

# Expected complexity level and risk

Low. Only the dry-run branch of `tools/release/src/targets/npm.rs` is changed. The live npm publish path still runs `pnpm publish`.

# Testing

- [x] `cargo clippy -p spacetimedb-release` passes.
- [ ] The dry-run path should be exercised by running `cargo-release release npm v2.7.1 --dry-run` or the `release-dry-run` workflow on a branch.