### PR TITLE
CI - Fix dry run ref propagation

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -103,10 +103,10 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - name: Checkout specific tag
+      - name: Checkout release source
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.release_tag }}
+          ref: ${{ inputs.dry_run && github.sha || github.event.inputs.release_tag }}
           submodules: recursive
 
       - name: Set up Rust
@@ -145,10 +145,10 @@ jobs:
       NUGET_API_KEY: ${{ secrets.NUGET_API_KEY }}
 
     steps:
-      - name: Checkout specific tag
+      - name: Checkout release source
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.release_tag }}
+          ref: ${{ inputs.dry_run && github.sha || github.event.inputs.release_tag }}
           submodules: recursive
 
       - name: Set up Rust
@@ -223,10 +223,10 @@ jobs:
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     steps:
-      - name: Checkout specific tag
+      - name: Checkout release source
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.release_tag }}
+          ref: ${{ inputs.dry_run && github.sha || github.event.inputs.release_tag }}
           submodules: recursive
 
       - name: Set up Rust
@@ -284,10 +284,10 @@ jobs:
       packages: write
 
     steps:
-      - name: Checkout specific tag
+      - name: Checkout release source
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.release_tag }}
+          ref: ${{ inputs.dry_run && github.sha || github.event.inputs.release_tag }}
           submodules: recursive
 
       - name: Download cargo-release
@@ -332,10 +332,10 @@ jobs:
     if: ${{ inputs.release_docker }}
 
     steps:
-      - name: Checkout specific tag
+      - name: Checkout release source
         uses: actions/checkout@v4
         with:
-          ref: ${{ github.event.inputs.release_tag }}
+          ref: ${{ inputs.dry_run && github.sha || github.event.inputs.release_tag }}
           submodules: recursive
 
       - name: Download cargo-release


### PR DESCRIPTION
# Description of Changes

This updates the release workflow so that release dry runs check out the specific ref that the workflow is running from, rather than the release tag.

The rationale here is that dry runs are often used to specifically test a specific branch, so it's misleading to check out the release tag. Moreover, this prevents fixes like https://github.com/clockworklabs/SpacetimeDB/pull/5636 from passing a dry run because the code in that fix branch isn't actually being run.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

- [x] Essentially tested via https://github.com/clockworklabs/SpacetimeDB/pull/5636, which was not able to pass release dry runs without these changes