### PR TITLE
Remove sccache to reduce github actions cache churn

### DIFF
--- a/.github/actions/keynote-bench-setup/action.yml
+++ b/.github/actions/keynote-bench-setup/action.yml
@@ -19,15 +19,6 @@ runs:
       shell: bash
       run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
 
-    - name: Set up sccache
-      uses: mozilla-actions/sccache-action@v0.0.10
-
-    - name: Enable sccache
-      shell: bash
-      run: |
-        echo "SCCACHE_GHA_ENABLED=true" >>"$GITHUB_ENV"
-        echo "RUSTC_WRAPPER=sccache" >>"$GITHUB_ENV"
-
     - name: Cache Rust dependencies
       uses: Swatinem/rust-cache@v2
       with:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -110,15 +110,6 @@ jobs:
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
 
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Enable sccache
-        shell: bash
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >>"$GITHUB_ENV"
-          echo "RUSTC_WRAPPER=sccache" >>"$GITHUB_ENV"
-
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2
         with:
@@ -442,14 +433,6 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
-
-      - name: Set up sccache
-        uses: mozilla-actions/sccache-action@v0.0.10
-
-      - name: Enable sccache
-        run: |
-          echo "SCCACHE_GHA_ENABLED=true" >>"$GITHUB_ENV"
-          echo "RUSTC_WRAPPER=sccache" >>"$GITHUB_ENV"
 
       - name: Cache Rust dependencies
         uses: Swatinem/rust-cache@v2


### PR DESCRIPTION
# Description of Changes

Removing `sccache` from CI workflows since it's churning the github actions cache. This is causing us to evict the much higher value `rust-cache` entries quite frequently.

This is part of the work to break up https://github.com/clockworklabs/SpacetimeDB/pull/5612 into smaller reviewable chunks.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

N/A
