### PR TITLE
Fix caching for unity builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -804,10 +804,21 @@ jobs:
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full
+      UNITY_VERSION: 2022.3.32f1
     steps:
       - name: Checkout repository
         id: checkout-stdb
         uses: actions/checkout@v4
+
+      # Keep this before generation/hydration so ignored build outputs do not affect hashFiles.
+      - name: Restore Unity Library
+        id: restore-unity-library
+        uses: actions/cache/restore@v4
+        with:
+          path: demo/Blackholio/client-unity/Library
+          key: Unity-v2-${{ runner.os }}-${{ env.UNITY_VERSION }}-${{ hashFiles('demo/Blackholio/client-unity/**', 'sdks/csharp/**', 'crates/bindings-csharp/BSATN.Runtime/**', 'crates/bindings-csharp/Runtime/**', 'crates/bindings-csharp/Directory.Build.props', 'tools/regen/src/csharp.rs', 'global.json') }}
+          restore-keys: |
+            Unity-v2-${{ runner.os }}-${{ env.UNITY_VERSION }}-
 
       # Run cheap .NET tests first. If those fail, no need to run expensive Unity tests.
 
@@ -917,16 +928,10 @@ jobs:
           yq e -i '.dependencies["com.clockworklabs.spacetimedbsdk"] = "file:../../../../sdks/csharp"' manifest.json
           cat manifest.json
 
-      - uses: actions/cache@v3
-        with:
-          path: demo/Blackholio/client-unity/Library
-          key: Unity-${{ github.head_ref }}
-          restore-keys: Unity-
-
       - name: Run Unity tests
         uses: game-ci/unity-test-runner@v4
         with:
-          unityVersion: 2022.3.32f1 # Adjust Unity version to a valid tag
+          unityVersion: ${{ env.UNITY_VERSION }}
           projectPath: demo/Blackholio/client-unity # Path to the Unity project subdirectory
           githubToken: ${{ secrets.GITHUB_TOKEN }}
           testMode: playmode
@@ -936,6 +941,13 @@ jobs:
           UNITY_EMAIL: ${{ secrets.UNITY_EMAIL }}
           UNITY_PASSWORD: ${{ secrets.UNITY_PASSWORD }}
           UNITY_SERIAL: ${{ secrets.UNITY_SERIAL }}
+
+      - name: Save Unity Library
+        if: ${{ github.ref == 'refs/heads/master' && steps.restore-unity-library.outputs.cache-hit != 'true' }}
+        uses: actions/cache/save@v4
+        with:
+          path: demo/Blackholio/client-unity/Library
+          key: ${{ steps.restore-unity-library.outputs.cache-primary-key }}
 
   godot-testsuite:
     needs: [merge_queue_noop, lints]


### PR DESCRIPTION
# Description of Changes

This is part of the work to break up https://github.com/clockworklabs/SpacetimeDB/pull/5612 into smaller reviewable chunks.

Before this change, the cache key for the unity library was `Unity-${{ github.head_ref }}`. This meant every single PR experienced a cache miss, whether or not it changed any unity dependencies, and would subsequently do a full unity build and upload a new multi-GB entry to the actions cache. The actions cache isn't that big, so this was responsible for a huge amount of cache churn which in turn slowed all other builds down.

Now the cache key incorporates the proper dependencies, and the cache is only written to on pushes to master.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

N/A
