### PR TITLE
Capture and upload cargo `--timings` for ci builds

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -504,6 +504,14 @@ jobs:
       - name: Run ci lint
         run: cargo ci lint
 
+      - name: Upload public lint Cargo timing reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-timings-public-lints
+          path: ${{ github.workspace }}/target/cargo-timings/
+          retention-days: 30
+
   wasm_bindings:
     needs: [merge_queue_noop]
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -240,6 +240,14 @@ jobs:
           }
           cargo ci smoketests -- --test-threads=1          
 
+      - name: Upload Cargo timing reports
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: cargo-timings-smoketests-${{ matrix.name }}
+          path: ${{ github.workspace }}/target/cargo-timings/
+          retention-days: 30
+
   # this is a no-op version of the above check with a trivially-passing body.
   # we can't just let the check be entirely skipped because each matrix target is a required check,
   # and skipping this check means that the matrix isn't "populated" so the required checks wouldn't be met.

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -612,6 +612,7 @@ fn main() -> Result<()> {
             cmd!(
                 "cargo",
                 "clippy",
+                "--timings",
                 "--all",
                 "--tests",
                 "--benches",
@@ -623,6 +624,7 @@ fn main() -> Result<()> {
             cmd!(
                 "cargo",
                 "clippy",
+                "--timings",
                 "--no-default-features",
                 "--features=browser",
                 "-pspacetimedb-sdk",

--- a/tools/ci/src/smoketest.rs
+++ b/tools/ci/src/smoketest.rs
@@ -76,6 +76,7 @@ fn build_binaries() -> Result<()> {
     let mut cmd = Command::new("cargo");
     cmd.args([
         "build",
+        "--timings",
         "--release",
         "-p",
         "spacetimedb-cli",
@@ -120,6 +121,7 @@ fn build_precompiled_modules() -> Result<()> {
     let status = Command::new("cargo")
         .args([
             "build",
+            "--timings",
             "--workspace",
             "--release",
             "--target",


### PR DESCRIPTION
# Description of Changes

To inform our build caching strategy.

Captures and uploads `--timings` for smoketest builds and lints.

This is part of the work to break up https://github.com/clockworklabs/SpacetimeDB/pull/5612 into smaller reviewable chunks.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

N/A
