### PR TITLE
Add query builder as trait capability

### DIFF
--- a/crates/bindings/src/lib.rs
+++ b/crates/bindings/src/lib.rs
@@ -1585,6 +1585,23 @@ impl CtxDbRead for AnonymousViewContext {
     }
 }
 
+/// Contexts which provide access to the view query builder.
+pub trait CtxWithQueryBuilder {
+    fn query_builder(&self) -> &QueryBuilder;
+}
+
+impl CtxWithQueryBuilder for ViewContext {
+    fn query_builder(&self) -> &QueryBuilder {
+        &self.from
+    }
+}
+
+impl CtxWithQueryBuilder for AnonymousViewContext {
+    fn query_builder(&self) -> &QueryBuilder {
+        &self.from
+    }
+}
+
 /// Contexts which provide read-write access to the database.
 ///
 /// This trait is useful for writing reusable logic which is generic over the context type,


### PR DESCRIPTION
# Description of Changes

Adds the `from` property (query builder) to the capability traits for `Ctx`. Useful for writing generic functions over `ViewContext` or `AnonymousViewContext` that need access to the query builder.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1
