### PR TITLE
Release - Fix crates.io publish waiting

### DIFF
--- a/tools/release/src/targets/crates.rs
+++ b/tools/release/src/targets/crates.rs
@@ -78,7 +78,7 @@ impl CratesRelease {
 
         loop {
             let mut cmd = Command::new("cargo");
-            cmd.args(["info", &spec]);
+            cmd.args(["info", "--registry", "crates-io", &spec]);
             util::print_command(&cmd);
 
             let output = cmd


### PR DESCRIPTION
# Description of Changes

Apparently by default `cargo info` reports from the local workspace if available.

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

Will test with next release