### PR TITLE
Show full version in healthcheck

### DIFF
--- a/.github/workflows/package.yml
+++ b/.github/workflows/package.yml
@@ -64,6 +64,11 @@ jobs:
       - name: Install rust target
         run: rustup target add ${{ matrix.target }}
 
+      - name: Set release version
+        if: startsWith(github.ref, 'refs/tags/')
+        shell: bash
+        run: echo "SPACETIMEDB_VERSION=${GITHUB_REF_NAME#v}" >> "$GITHUB_ENV"
+
       - name: Add signtool.exe to PATH
         if: ${{ runner.os == 'Windows' }}
         shell: pwsh

--- a/Dockerfile
+++ b/Dockerfile
@@ -4,6 +4,8 @@ FROM rust:bookworm AS builder
 WORKDIR /usr/src/app
 COPY . .
 
+ARG SPACETIMEDB_RELEASE_VERSION
+
 # If we're in a git submodule, we'll have a corrupted/nonfunctional .git file instead of a proper .git directory.
 # To make the errors more sane, remove .git entirely.
 RUN if [ -f .git ]; then \
@@ -13,7 +15,11 @@ RUN if [ -f .git ]; then \
       exit 1; \
     fi
 
-RUN cargo build -p spacetimedb-standalone -p spacetimedb-cli --release --locked
+RUN if [ -n "$SPACETIMEDB_RELEASE_VERSION" ]; then \
+      SPACETIMEDB_VERSION="$SPACETIMEDB_RELEASE_VERSION" cargo build -p spacetimedb-standalone -p spacetimedb-cli --release --locked; \
+    else \
+      cargo build -p spacetimedb-standalone -p spacetimedb-cli --release --locked; \
+    fi
 
 FROM rust:bookworm
 
@@ -62,4 +68,3 @@ EXPOSE 3000
 
 # Define the entrypoint
 ENTRYPOINT ["spacetime"]
-

--- a/crates/client-api/src/routes/health.rs
+++ b/crates/client-api/src/routes/health.rs
@@ -3,7 +3,10 @@ use axum::extract::State;
 use axum::response::IntoResponse;
 use http::StatusCode;
 
-static VERSION: &str = env!("CARGO_PKG_VERSION");
+static VERSION: &str = match option_env!("SPACETIMEDB_VERSION") {
+    Some(version) => version,
+    None => env!("CARGO_PKG_VERSION"),
+};
 static PACKAGE_NAME: &str = env!("CARGO_PKG_NAME");
 
 pub async fn health<S: ControlStateDelegate + NodeDelegate>(

--- a/crates/client-api/src/routes/health.rs
+++ b/crates/client-api/src/routes/health.rs
@@ -3,11 +3,15 @@ use axum::extract::State;
 use axum::response::IntoResponse;
 use http::StatusCode;
 
-static VERSION: &str = match option_env!("SPACETIMEDB_VERSION") {
-    Some(version) => version,
-    None => env!("CARGO_PKG_VERSION"),
-};
+static VERSION: &str = selected_version(option_env!("SPACETIMEDB_VERSION"), env!("CARGO_PKG_VERSION"));
 static PACKAGE_NAME: &str = env!("CARGO_PKG_NAME");
+
+const fn selected_version(release_version: Option<&'static str>, cargo_version: &'static str) -> &'static str {
+    match release_version {
+        Some(version) => version,
+        None => cargo_version,
+    }
+}
 
 pub async fn health<S: ControlStateDelegate + NodeDelegate>(
     State(ctx): State<S>,
@@ -49,4 +53,19 @@ where
 {
     use axum::routing::get;
     axum::Router::new().route("/", get(health::<S>))
+}
+
+#[cfg(test)]
+mod tests {
+    use super::selected_version;
+
+    #[test]
+    fn selected_version_uses_release_version_when_present() {
+        assert_eq!(selected_version(Some("2.7.0-hotfix3"), "2.7.0"), "2.7.0-hotfix3");
+    }
+
+    #[test]
+    fn selected_version_falls_back_to_cargo_version() {
+        assert_eq!(selected_version(None, "2.8.0"), "2.8.0");
+    }
 }

--- a/tools/ci/src/main.rs
+++ b/tools/ci/src/main.rs
@@ -591,6 +591,7 @@ fn main() -> Result<()> {
                 "unreal"
             )
             .run()?;
+            cmd!("cargo", "test", "--manifest-path", "tools/release/Cargo.toml").run()?;
             // Bindings snapshot tests rely on the unstable feature,
             // as they compile and test APIs which are gated behind that feature,
             // e.g. procedures, HTTP handlers.

--- a/tools/release/src/targets/docker.rs
+++ b/tools/release/src/targets/docker.rs
@@ -4,6 +4,10 @@ use std::process::Command;
 use std::thread;
 use std::time::{Duration, Instant};
 
+fn healthcheck_version(release_version: &str) -> &str {
+    release_version.strip_prefix('v').unwrap_or(release_version)
+}
+
 pub struct DockerRelease {
     pub version: String,
     pub dry_run: bool,
@@ -111,7 +115,7 @@ impl DockerRelease {
         println!("Building for platforms: linux/amd64, linux/arm64");
 
         let version_tag = format!("{}:{}", image_repo, self.version);
-        let healthcheck_version = self.version.strip_prefix('v').unwrap_or(&self.version);
+        let healthcheck_version = healthcheck_version(&self.version);
 
         // Build and push the multi-platform image
         let mut cmd = Command::new("docker");
@@ -210,5 +214,20 @@ impl ReleaseTarget for DockerRelease {
 
     fn name(&self) -> &'static str {
         "docker"
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::healthcheck_version;
+
+    #[test]
+    fn healthcheck_version_strips_leading_v() {
+        assert_eq!(healthcheck_version("v2.7.0-hotfix3"), "2.7.0-hotfix3");
+    }
+
+    #[test]
+    fn healthcheck_version_keeps_version_without_leading_v() {
+        assert_eq!(healthcheck_version("2.7.0-hotfix3"), "2.7.0-hotfix3");
     }
 }

--- a/tools/release/src/targets/docker.rs
+++ b/tools/release/src/targets/docker.rs
@@ -111,6 +111,7 @@ impl DockerRelease {
         println!("Building for platforms: linux/amd64, linux/arm64");
 
         let version_tag = format!("{}:{}", image_repo, self.version);
+        let healthcheck_version = self.version.strip_prefix('v').unwrap_or(&self.version);
 
         // Build and push the multi-platform image
         let mut cmd = Command::new("docker");
@@ -121,6 +122,8 @@ impl DockerRelease {
             "linux/amd64,linux/arm64",
             "-t",
             &version_tag,
+            "--build-arg",
+            &format!("SPACETIMEDB_RELEASE_VERSION={healthcheck_version}"),
             "--push",
             ".",
         ]);


### PR DESCRIPTION
# Description of Changes
This adds "-hotfixN" to version when using `/v1/health`. It was [requested by Julien](https://discordapp.com/channels/931210784011321394/1375519127120117860/1529865235739967518) on Discord.

I'm not super familiar with Docker so I'm trusting on Codex for some things here.

I've added two small unit tests but I'm not testing the version being included when building via Docker because that test would be a lot. Maybe I'm wrong? 

# API and ABI breaking changes
No breaking changes.

# Expected complexity level and risk
2. Not really risky. The biggest would be that `/v1/health` still returns the same value as before ignoring the hotfix version.

# Testing
- [x] The new unit tests pass
