### PR TITLE
Remove `Swatinem/rust-cache`

### DIFF
--- a/.github/actions/keynote-bench-setup/action.yml
+++ b/.github/actions/keynote-bench-setup/action.yml
@@ -6,9 +6,6 @@ inputs:
     description: Path to the public SpacetimeDB checkout in the caller workspace
     required: false
     default: .
-  rust_cache_workspaces:
-    description: Workspace paths passed to Swatinem/rust-cache
-    required: true
 
 runs:
   using: composite
@@ -18,25 +15,6 @@ runs:
     - name: Set default rust toolchain
       shell: bash
       run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
-
-    - name: Cache Rust dependencies
-      uses: Swatinem/rust-cache@v2
-      with:
-        workspaces: ${{ inputs.rust_cache_workspaces }}
-        shared-key: spacetimedb
-        save-if: false
-        prefix-key: v1
-
-    - name: Check v8 outputs
-      shell: bash
-      run: |
-        find "${CARGO_TARGET_DIR}"/ -type f | grep '[/_]v8' || true
-        if ! [ -f "${CARGO_TARGET_DIR}"/release/gn_out/obj/librusty_v8.a ]; then
-          echo "Could not find v8 output file librusty_v8.a; rebuilding manually."
-          cargo clean --release -p v8 || true
-          cargo build --release -p v8
-        fi
-      working-directory: ${{ inputs.public_root }}
 
     - name: Build public keynote benchmark binaries
       shell: bash

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -128,27 +128,6 @@ jobs:
           path: ${{ env.CARGO_TARGET_DIR }}/release/gn_out/obj
           key: rusty-v8-v1-145.0.0-${{ env.TARGET_TRIPLE }}
 
-      - &cache-rusty-v8-debug
-        name: Cache rusty_v8 (debug)
-        uses: actions/cache@v4
-        with:
-          path: ${{ env.CARGO_TARGET_DIR }}/debug/gn_out/obj
-          key: rusty-v8-debug-v1-145.0.0-${{ env.TARGET_TRIPLE }}
-
-      - &restore-rusty-v8
-        name: Restore rusty_v8
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.CARGO_TARGET_DIR }}/release/gn_out/obj
-          key: rusty-v8-v1-145.0.0-${{ env.TARGET_TRIPLE }}
-
-      - &restore-rusty-v8-debug
-        name: Restore rusty_v8 (debug)
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ env.CARGO_TARGET_DIR }}/debug/gn_out/obj
-          key: rusty-v8-debug-v1-145.0.0-${{ env.TARGET_TRIPLE }}
-
       # v1 is a manual schema for invalidating this cache if its layout changes.
       # The openssl-src version in fixed and needs to be manually kept in sync with Cargo.lock.
       # It should hardly ever be updated, so prefer this over more auto-derivation machinery.
@@ -170,14 +149,6 @@ jobs:
           # Reuse the cached vendored output as a prebuilt OpenSSL installation.
           echo "OPENSSL_NO_VENDOR=1" >>"$GITHUB_ENV"
           echo "OPENSSL_DIR=${{ github.workspace }}/.ci-cache/openssl" >>"$GITHUB_ENV"
-
-      - &restore-openssl
-        name: Restore OpenSSL
-        id: cache-openssl
-        uses: actions/cache/restore@v4
-        with:
-          path: ${{ github.workspace }}/.ci-cache/openssl
-          key: openssl-v1-300.5.3+3.5.4-${{ env.TARGET_TRIPLE }}${{ env.OPENSSL_CACHE_SUFFIX }}
 
       - name: Build CLI and standalone
         shell: bash
@@ -264,8 +235,19 @@ jobs:
       - *set-default-rust-toolchain
 
       - *verify-openssl-assembler
-      - *restore-rusty-v8
-      - *restore-openssl
+      - &restore-rusty-v8
+        name: Restore rusty_v8
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CARGO_TARGET_DIR }}/release/gn_out/obj
+          key: rusty-v8-v1-145.0.0-${{ env.TARGET_TRIPLE }}
+      - &restore-openssl
+        name: Restore OpenSSL
+        id: cache-openssl
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.ci-cache/openssl
+          key: openssl-v1-300.5.3+3.5.4-${{ env.TARGET_TRIPLE }}${{ env.OPENSSL_CACHE_SUFFIX }}
       - *configure-cached-openssl
 
       - name: Install cargo-nextest
@@ -286,8 +268,6 @@ jobs:
           tar -czf smoketest-support.tar.gz \
             "target/debug/ci${EXE_SUFFIX}" \
             "${precompiled_modules[@]}"
-
-      - *prepare-openssl-cache
 
       - name: Upload Cargo timing reports
         if: always()
@@ -545,7 +525,12 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
-      - *restore-rusty-v8-debug
+      - &restore-rusty-v8-debug
+        name: Restore rusty_v8 (debug)
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CARGO_TARGET_DIR }}/debug/gn_out/obj
+          key: rusty-v8-debug-v1-145.0.0-${{ env.TARGET_TRIPLE }}
       - *restore-rusty-v8
       - *restore-openssl
       - *configure-cached-openssl
@@ -665,7 +650,11 @@ jobs:
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
       - run: echo ::add-matcher::.github/workflows/rust_matcher.json
 
-      - *cache-rusty-v8-debug
+      - name: Cache rusty_v8 (debug)
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CARGO_TARGET_DIR }}/debug/gn_out/obj
+          key: rusty-v8-debug-v1-145.0.0-${{ env.TARGET_TRIPLE }}
       - *restore-openssl
       - *configure-cached-openssl
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -119,13 +119,35 @@ jobs:
       # The v8 version is fixed and needs to be manually kept in sync with Cargo.lock.
       # It should hardly ever be updated, so prefer this over more auto-derivation machinery.
       # The target triple identifies OS and ABI.
-      # CI always uses release with default features, so no other inputs are needed.
+      # Release CI uses default features, so no other inputs are needed. Debug has a
+      # separate key because Cargo stores the native output under a different profile.
       - &cache-rusty-v8
         name: Cache rusty_v8
         uses: actions/cache@v4
         with:
           path: ${{ env.CARGO_TARGET_DIR }}/release/gn_out/obj
           key: rusty-v8-v1-145.0.0-${{ env.TARGET_TRIPLE }}
+
+      - &cache-rusty-v8-debug
+        name: Cache rusty_v8 (debug)
+        uses: actions/cache@v4
+        with:
+          path: ${{ env.CARGO_TARGET_DIR }}/debug/gn_out/obj
+          key: rusty-v8-debug-v1-145.0.0-${{ env.TARGET_TRIPLE }}
+
+      - &restore-rusty-v8
+        name: Restore rusty_v8
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CARGO_TARGET_DIR }}/release/gn_out/obj
+          key: rusty-v8-v1-145.0.0-${{ env.TARGET_TRIPLE }}
+
+      - &restore-rusty-v8-debug
+        name: Restore rusty_v8 (debug)
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CARGO_TARGET_DIR }}/debug/gn_out/obj
+          key: rusty-v8-debug-v1-145.0.0-${{ env.TARGET_TRIPLE }}
 
       # v1 is a manual schema for invalidating this cache if its layout changes.
       # The openssl-src version in fixed and needs to be manually kept in sync with Cargo.lock.
@@ -148,6 +170,14 @@ jobs:
           # Reuse the cached vendored output as a prebuilt OpenSSL installation.
           echo "OPENSSL_NO_VENDOR=1" >>"$GITHUB_ENV"
           echo "OPENSSL_DIR=${{ github.workspace }}/.ci-cache/openssl" >>"$GITHUB_ENV"
+
+      - &restore-openssl
+        name: Restore OpenSSL
+        id: cache-openssl
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.ci-cache/openssl
+          key: openssl-v1-300.5.3+3.5.4-${{ env.TARGET_TRIPLE }}${{ env.OPENSSL_CACHE_SUFFIX }}
 
       - name: Build CLI and standalone
         shell: bash
@@ -234,8 +264,8 @@ jobs:
       - *set-default-rust-toolchain
 
       - *verify-openssl-assembler
-      - *cache-rusty-v8
-      - *cache-openssl
+      - *restore-rusty-v8
+      - *restore-openssl
       - *configure-cached-openssl
 
       - name: Install cargo-nextest
@@ -492,6 +522,8 @@ jobs:
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full
+      TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      OPENSSL_CACHE_SUFFIX: ""
     steps:
       - name: Find Git ref
         env:
@@ -513,24 +545,10 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ github.workspace }}
-          shared-key: spacetimedb
-          # Let the smoketests job save the cache since it builds the most things
-          save-if: false
-          prefix-key: v1
-
-      - name: Check v8 outputs
-        shell: bash
-        run: |
-          find "${CARGO_TARGET_DIR}"/ -type f | grep '[/_]v8' || true
-          if ! [ -f "${CARGO_TARGET_DIR}"/release/gn_out/obj/librusty_v8.a ]; then
-            echo "Could not find v8 output file librusty_v8.a; rebuilding manually."
-            cargo clean --release -p v8 || true
-            cargo build --release -p v8
-          fi
+      - *restore-rusty-v8-debug
+      - *restore-rusty-v8
+      - *restore-openssl
+      - *configure-cached-openssl
 
       - uses: actions/setup-dotnet@v3
         with:
@@ -597,6 +615,8 @@ jobs:
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full
+      TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      OPENSSL_CACHE_SUFFIX: ""
     steps:
       - name: Find Git ref
         env:
@@ -619,13 +639,9 @@ jobs:
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ github.workspace }}
-          shared-key: spacetimedb-index-scan
-          cache-on-failure: false
-          prefix-key: v1
+      - *restore-rusty-v8
+      - *restore-openssl
+      - *configure-cached-openssl
 
       - name: Run index scan benchmark regression check
         run: cargo run --release -p spacetimedb-index-scan-gate
@@ -638,6 +654,8 @@ jobs:
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full
+      TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      OPENSSL_CACHE_SUFFIX: ""
     steps:
       - name: Checkout sources
         uses: actions/checkout@v3
@@ -647,14 +665,9 @@ jobs:
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
       - run: echo ::add-matcher::.github/workflows/rust_matcher.json
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ github.workspace }}
-          shared-key: spacetimedb
-          # Let the smoketests job save the cache since it builds the most things
-          save-if: false
-          prefix-key: v1
+      - *cache-rusty-v8-debug
+      - *restore-openssl
+      - *configure-cached-openssl
 
       - uses: actions/setup-dotnet@v3
         with:
@@ -700,14 +713,6 @@ jobs:
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ github.workspace }}
-          shared-key: spacetimedb
-          save-if: false
-          prefix-key: v1
-
       - name: Run CODEOWNERS check
         run: |
           cargo ci other-workflows codeowners-check \
@@ -722,6 +727,8 @@ jobs:
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full
+      TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      OPENSSL_CACHE_SUFFIX: ""
     steps:
       - uses: actions/checkout@v3
 
@@ -730,14 +737,9 @@ jobs:
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
       - run: echo ::add-matcher::.github/workflows/rust_matcher.json
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ github.workspace }}
-          shared-key: spacetimedb
-          # Let the smoketests job save the cache since it builds the most things
-          save-if: false
-          prefix-key: v1
+      - *restore-rusty-v8-debug
+      - *restore-openssl
+      - *configure-cached-openssl
 
       - name: Set up Node.js
         uses: actions/setup-node@v4
@@ -962,15 +964,6 @@ jobs:
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ github.workspace }}
-          shared-key: spacetimedb
-          # Let the smoketests job save the cache since it builds the most things
-          save-if: false
-          prefix-key: v1
-
       - name: Check for docs change
         run: |
           cargo ci cli-docs
@@ -988,6 +981,8 @@ jobs:
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full
+      TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      OPENSSL_CACHE_SUFFIX: ""
       UNITY_VERSION: 2022.3.32f1
     steps:
       - name: Checkout repository
@@ -1041,28 +1036,9 @@ jobs:
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ github.workspace }}
-          shared-key: spacetimedb
-          # Let the main CI job save the cache since it builds the most things
-          save-if: false
-          prefix-key: v1
-
-      # This step shouldn't be needed, but somehow we end up with caches that are missing librusty_v8.a.
-      # ChatGPT suspects that this could be due to different build invocations using the same target dir,
-      # and this makes sense to me because we only see it in this job where we mix `cargo build -p` with
-      # `cargo build --manifest-path` (which apparently build different dependency trees).
-      # However, we've been unable to fix it so... /shrug
-      - name: Check v8 outputs
-        run: |
-          find "${CARGO_TARGET_DIR}"/ -type f | grep '[/_]v8' || true
-          if ! [ -f "${CARGO_TARGET_DIR}"/release/gn_out/obj/librusty_v8.a ]; then
-            echo "Could not find v8 output file librusty_v8.a; rebuilding manually."
-            cargo clean --release -p v8 || true
-            cargo build --release -p v8
-          fi
+      - *restore-rusty-v8
+      - *restore-openssl
+      - *configure-cached-openssl
 
       - name: Install SpacetimeDB CLI from the local checkout
         run: |
@@ -1141,6 +1117,8 @@ jobs:
     runs-on: spacetimedb-new-runner-2
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      OPENSSL_CACHE_SUFFIX: ""
       UseLocalBsatnRuntime: true
     steps:
       - name: Checkout repository
@@ -1182,28 +1160,9 @@ jobs:
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ github.workspace }}
-          shared-key: spacetimedb
-          # Let the main CI job save the cache since it builds the most things
-          save-if: false
-          prefix-key: v1
-
-      # This step shouldn't be needed, but somehow we end up with caches that are missing librusty_v8.a.
-      # ChatGPT suspects that this could be due to different build invocations using the same target dir,
-      # and this makes sense to me because we only see it in this job where we mix `cargo build -p` with
-      # `cargo build --manifest-path` (which apparently build different dependency trees).
-      # However, we've been unable to fix it so... /shrug
-      - name: Check v8 outputs
-        run: |
-          find "${CARGO_TARGET_DIR}"/ -type f | grep '[/_]v8' || true
-          if ! [ -f "${CARGO_TARGET_DIR}"/release/gn_out/obj/librusty_v8.a ]; then
-            echo "Could not find v8 output file librusty_v8.a; rebuilding manually."
-            cargo clean --release -p v8 || true
-            cargo build --release -p v8
-          fi
+      - *restore-rusty-v8
+      - *restore-openssl
+      - *configure-cached-openssl
 
       - name: Install SpacetimeDB CLI from the local checkout
         run: |
@@ -1269,6 +1228,8 @@ jobs:
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full
+      TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      OPENSSL_CACHE_SUFFIX: ""
     steps:
       - name: Checkout repository
         id: checkout-stdb
@@ -1320,34 +1281,10 @@ jobs:
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ github.workspace }}
-          shared-key: spacetimedb
-          # Let the main CI job save the cache since it builds the most things
-          save-if: false
-          prefix-key: v1
-
-      # This step shouldn't be needed, but somehow we end up with caches that are missing librusty_v8.a.
-      # ChatGPT suspects that this could be due to different build invocations using the same target dir,
-      # and this makes sense to me because we only see it in this job where we mix `cargo build -p` with
-      # `cargo build --manifest-path` (which apparently build different dependency trees).
-      # However, we've been unable to fix it so... /shrug
-      - name: Check v8 outputs
-        run: |
-          find "${CARGO_TARGET_DIR}"/ -type f | grep '[/_]v8' || true
-          if ! [ -f "${CARGO_TARGET_DIR}"/debug/gn_out/obj/librusty_v8.a ]; then
-            echo "Could not find v8 output file librusty_v8.a; rebuilding manually."
-            cargo clean -p v8 || true
-            cargo build -p v8
-          fi
-          find "${CARGO_TARGET_DIR}"/ -type f | grep '[/_]v8' || true
-          if ! [ -f "${CARGO_TARGET_DIR}"/release/gn_out/obj/librusty_v8.a ]; then
-            echo "Could not find v8 output file librusty_v8.a; rebuilding manually."
-            cargo clean --release -p v8 || true
-            cargo build --release -p v8
-          fi
+      - *restore-rusty-v8-debug
+      - *restore-rusty-v8
+      - *restore-openssl
+      - *configure-cached-openssl
 
       - name: Install SpacetimeDB CLI from the local checkout
         run: |
@@ -1436,14 +1373,6 @@ jobs:
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ github.workspace }}
-          shared-key: spacetimedb
-          save-if: false
-          prefix-key: v1
-
       - name: Check global.json policy
         run: cargo ci global-json-policy
 
@@ -1457,6 +1386,8 @@ jobs:
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full
+      TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      OPENSSL_CACHE_SUFFIX: ""
     steps:
       - name: Find Git ref
         env:
@@ -1477,30 +1408,9 @@ jobs:
       - uses: dsherret/rust-toolchain-file@v1
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ github.workspace }}
-          shared-key: spacetimedb
-          cache-on-failure: false
-          cache-all-crates: true
-          cache-workspace-crates: true
-          prefix-key: v1
-
-      # This step shouldn't be needed, but somehow we end up with caches that are missing librusty_v8.a.
-      # ChatGPT suspects that this could be due to different build invocations using the same target dir,
-      # and this makes sense to me because we only see it in this job where we mix `cargo build -p` with
-      # `cargo build --manifest-path` (which apparently build different dependency trees).
-      # However, we've been unable to fix it so... /shrug
-      - name: Check v8 outputs
-        shell: bash
-        run: |
-          find "${CARGO_TARGET_DIR}"/ -type f | grep '[/_]v8' || true
-          if ! [ -f "${CARGO_TARGET_DIR}"/debug/gn_out/obj/librusty_v8.a ]; then
-            echo "Could not find v8 output file librusty_v8.a; rebuilding manually."
-            cargo clean -p v8 || true
-            cargo build -p v8
-          fi
+      - *restore-rusty-v8-debug
+      - *restore-openssl
+      - *configure-cached-openssl
 
       - name: Verify crates/smoketests/tests/smoketests/mod.rs lists all entries
         run: |
@@ -1553,7 +1463,10 @@ jobs:
     name: TypeScript - Tests
     runs-on: spacetimedb-new-runner-2
     env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full
+      TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      OPENSSL_CACHE_SUFFIX: ""
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
@@ -1611,33 +1524,9 @@ jobs:
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
 
-      - name: Cache Rust dependencies
-        uses: Swatinem/rust-cache@v2
-        with:
-          workspaces: ${{ github.workspace }}
-          shared-key: spacetimedb
-          # Let the main CI job save the cache since it builds the most things
-          save-if: false
-          prefix-key: v1
-
-      # # This step shouldn't be needed, but somehow we end up with caches that are missing librusty_v8.a.
-      # # ChatGPT suspects that this could be due to different build invocations using the same target dir,
-      # # and this makes sense to me because we only see it in this job where we mix `cargo build -p` with
-      # # `cargo build --manifest-path` (which apparently build different dependency trees).
-      # # However, we've been unable to fix it so... /shrug
-      # - name: Check v8 outputs
-      #   run: |
-      #     find "${CARGO_TARGET_DIR}"/ -type f | grep '[/_]v8' || true
-      #     if ! [ -f "${CARGO_TARGET_DIR}"/debug/gn_out/obj/librusty_v8.a ]; then
-      #       echo "Could not find v8 output file librusty_v8.a; rebuilding manually."
-      #       cargo clean -p v8 || true
-      #       cargo build -p v8
-      #     fi
-      #     if ! [ -f "${CARGO_TARGET_DIR}"/release/gn_out/obj/librusty_v8.a ]; then
-      #       echo "Could not find v8 output file librusty_v8.a; rebuilding manually."
-      #       cargo clean --release -p v8 || true
-      #       cargo build --release -p v8
-      #     fi
+      - *restore-rusty-v8-debug
+      - *restore-openssl
+      - *configure-cached-openssl
 
       # - name: Install SpacetimeDB CLI from the local checkout
       #   run: |

--- a/.github/workflows/llm-benchmark-periodic.yml
+++ b/.github/workflows/llm-benchmark-periodic.yml
@@ -50,6 +50,10 @@ concurrency:
 jobs:
   run-benchmarks:
     runs-on: spacetimedb-new-runner-2
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      OPENSSL_CACHE_SUFFIX: ""
 
     steps:
       - name: Checkout repository
@@ -58,7 +62,25 @@ jobs:
           fetch-depth: 1
 
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+
+      - name: Restore rusty_v8
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CARGO_TARGET_DIR }}/release/gn_out/obj
+          key: rusty-v8-v1-145.0.0-${{ env.TARGET_TRIPLE }}
+
+      - name: Restore OpenSSL
+        id: cache-openssl
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.ci-cache/openssl
+          key: openssl-v1-300.5.3+3.5.4-${{ env.TARGET_TRIPLE }}${{ env.OPENSSL_CACHE_SUFFIX }}
+
+      - name: Configure cached OpenSSL
+        if: steps.cache-openssl.outputs.cache-hit == 'true'
+        run: |
+          echo "OPENSSL_NO_VENDOR=1" >>"$GITHUB_ENV"
+          echo "OPENSSL_DIR=${{ github.workspace }}/.ci-cache/openssl" >>"$GITHUB_ENV"
 
       - name: Setup .NET SDK
         uses: actions/setup-dotnet@v4

--- a/.github/workflows/llm-benchmark-validate-goldens.yml
+++ b/.github/workflows/llm-benchmark-validate-goldens.yml
@@ -28,6 +28,10 @@ jobs:
   validate-goldens:
     runs-on: spacetimedb-new-runner-2
     timeout-minutes: 60
+    env:
+      CARGO_TARGET_DIR: ${{ github.workspace }}/target
+      TARGET_TRIPLE: x86_64-unknown-linux-gnu
+      OPENSSL_CACHE_SUFFIX: ""
 
     strategy:
       fail-fast: false
@@ -41,7 +45,25 @@ jobs:
           fetch-depth: 1
 
       - uses: dtolnay/rust-toolchain@stable
-      - uses: Swatinem/rust-cache@v2
+
+      - name: Restore rusty_v8
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ env.CARGO_TARGET_DIR }}/release/gn_out/obj
+          key: rusty-v8-v1-145.0.0-${{ env.TARGET_TRIPLE }}
+
+      - name: Restore OpenSSL
+        id: cache-openssl
+        uses: actions/cache/restore@v4
+        with:
+          path: ${{ github.workspace }}/.ci-cache/openssl
+          key: openssl-v1-300.5.3+3.5.4-${{ env.TARGET_TRIPLE }}${{ env.OPENSSL_CACHE_SUFFIX }}
+
+      - name: Configure cached OpenSSL
+        if: steps.cache-openssl.outputs.cache-hit == 'true'
+        run: |
+          echo "OPENSSL_NO_VENDOR=1" >>"$GITHUB_ENV"
+          echo "OPENSSL_DIR=${{ github.workspace }}/.ci-cache/openssl" >>"$GITHUB_ENV"
 
       - name: Setup .NET SDK
         if: matrix.lang == 'csharp'

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -73,11 +73,6 @@ jobs:
       - name: Set default rust toolchain
         run: rustup default $(rustup show active-toolchain | cut -d' ' -f1)
 
-      - name: Cache cargo
-        uses: swatinem/rust-cache@v2
-        with:
-          workspaces: ./
-
       - name: Install cargo-release
         run: |
           cargo install --path tools/release


### PR DESCRIPTION
# Description of Changes

Also add v8 and openssl cache restore to dependent jobs.

`rust-cache` build artifacts can be anywhere between 1GB and 3GB depending on the job. The actions cache itself is only 10GB. And these entries are not long-lived. They're being uploaded constantly for a few reasons:
1. The key is very broad and according to the `Swatinem/rust-cache` docs, it includes:
    > a hash of all `Cargo.lock` / `Cargo.toml` files found anywhere in the repository

    Therefore, even changing a crate that a particular job does not build can produce a new cache key.
2. GitHub caches are scoped by branch/ref. A cache written by a PR is generally not reused by master after merge. So essentially the same artifact is inserted into the cache twice, potentially consuming over half of the cache's available space.

We need to revisit caching at some point, but `rust-cache` is probably not the solution b/c of the above reasons. Ultimately we need to make sure that cache entries have a reasonable shelf-life, which they do not currently.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1

# Testing

N/A
