### PR TITLE
Package `ci-smoketests` binary in smoketests build

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -266,7 +266,7 @@ jobs:
           fi
 
           tar -czf smoketest-support.tar.gz \
-            "target/debug/ci${EXE_SUFFIX}" \
+            "target/debug/ci-smoketests${EXE_SUFFIX}" \
             "${precompiled_modules[@]}"
 
       - name: Upload Cargo timing reports
@@ -437,7 +437,7 @@ jobs:
           if [ -f ~/emsdk/emsdk_env.sh ]; then
             source ~/emsdk/emsdk_env.sh
           fi
-          ./target/debug/ci smoketests run-archive \
+          ./target/debug/ci-smoketests run-archive \
             --archive-file smoketest-nextest.tar.zst \
             -- \
             --partition hash:${{ matrix.partition }}/${{ env.PARTITION_COUNT }}
@@ -450,7 +450,7 @@ jobs:
           if (Test-Path "$env:USERPROFILE\emsdk\emsdk_env.ps1") {
             & "$env:USERPROFILE\emsdk\emsdk_env.ps1" | Out-Null
           }
-          .\target\debug\ci.exe smoketests run-archive `
+          .\target\debug\ci-smoketests.exe run-archive `
             --archive-file smoketest-nextest.tar.zst `
             -- `
             --partition hash:${{ matrix.partition }}/${{ env.PARTITION_COUNT }}

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -8853,7 +8853,6 @@ dependencies = [
  "reqwest 0.12.24",
  "serde_json",
  "socket2 0.5.10",
- "spacetimedb-core",
  "spacetimedb-guard",
  "tempfile",
  "tokio",

--- a/crates/smoketests/Cargo.toml
+++ b/crates/smoketests/Cargo.toml
@@ -17,7 +17,6 @@ reqwest = { workspace = true, features = ["blocking"] }
 which = "8.0.0"
 
 [dev-dependencies]
-spacetimedb-core.workspace = true
 cargo_metadata.workspace = true
 assert_cmd = "2"
 predicates = "3"

--- a/crates/smoketests/tests/smoketests/change_host_type.rs
+++ b/crates/smoketests/tests/smoketests/change_host_type.rs
@@ -1,5 +1,7 @@
-use spacetimedb::messages::control_db::HostType;
 use spacetimedb_smoketests::{require_local_server, require_pnpm, ModuleLanguage, Smoketest};
+
+const WASM_HOST_TYPE: &str = "0";
+const JS_HOST_TYPE: &str = "1";
 
 const TS_MODULE_BASIC: &str = r#"import { schema, t, table } from "spacetimedb/server";
 
@@ -107,21 +109,19 @@ fn test_repair_host_type() {
         .source(ModuleLanguage::TypeScript, "modules-basic-ts", TS_MODULE_BASIC)
         .run()
         .unwrap();
-    assert_host_type(&test, HostType::Js);
+    assert_host_type(&test, JS_HOST_TYPE);
     // Set the program kind to the wrong value.
-    test.sql_confirmed("update st_module set program_kind=0").unwrap();
-    assert_host_type(&test, HostType::Wasm);
+    test.sql_confirmed(&format!("update st_module set program_kind={WASM_HOST_TYPE}"))
+        .unwrap();
+    assert_host_type(&test, WASM_HOST_TYPE);
 
     // After restarting, the database both comes up and has the right host type.
     test.restart_server();
-    assert_host_type(&test, HostType::Js);
+    assert_host_type(&test, JS_HOST_TYPE);
 }
 
-fn assert_host_type(test: &Smoketest, host_type: HostType) {
+fn assert_host_type(test: &Smoketest, expected: &str) {
     let output = test.sql_confirmed("select program_kind from st_module").unwrap();
     let rows = output.lines().skip(2).map(|s| s.trim()).collect::<Vec<_>>();
-    match host_type {
-        HostType::Wasm => assert_eq!(&rows, &["0"]),
-        HostType::Js => assert_eq!(&rows, &["1"]),
-    }
+    assert_eq!(&rows, &[expected]);
 }


### PR DESCRIPTION
# Description of Changes

Accidentally reverted in #5687.

I noticed execution times for the smoketest shards increased after #5687, and I saw they were compiling the `ci-smoketests` binary instead of packaging it with the smoketests build.

# API and ABI breaking changes

N/A

# Expected complexity level and risk

1

# Testing

N/A
