### PR TITLE
Bugfix: The client can lose its identity token (and hence, access to user data) during first use.

### DIFF
--- a/crates/bindings-typescript/src/sdk/connection_manager.ts
+++ b/crates/bindings-typescript/src/sdk/connection_manager.ts
@@ -294,11 +294,37 @@ class ConnectionManagerImpl {
     }
   }
 
+  /**
+   * Builds a connection for `managed` from `builder`, adopting it as the
+   * entry's retained builder.
+   *
+   * `resumeSession` (the default) re-applies the session's current token to the
+   * builder first. This matters because the builder is a *long-lived template*:
+   * the application hands it over once, and every automatic rebuild — scheduled
+   * reconnect, resume-from-background, zombie-socket revival — reuses that same
+   * object. Its token, though, is a snapshot taken when the application built
+   * it, typically read out of storage at module load, before any session
+   * existed. Rebuilding from it verbatim would reconnect *anonymously* for any
+   * user whose token was issued during this page's lifetime, and the server
+   * would answer by minting a brand-new identity: a silent account switch, with
+   * no error raised on either side, curable only by a page reload.
+   *
+   * `state.token` is the token of the most recent connection (set below at
+   * build time, and again by `onConnect` when the server issues one), so
+   * re-applying it keeps every automatic rebuild on the same principal.
+   *
+   * Pass `resumeSession: false` when the caller is deliberately changing
+   * identity — see {@link rebuild} — so the builder's own token wins.
+   */
   #buildManagedConnection<T extends DbConnectionImpl<any>>(
     managed: ManagedConnection,
-    builder: DbConnectionBuilder<T>
+    builder: DbConnectionBuilder<T>,
+    { resumeSession = true }: { resumeSession?: boolean } = {}
   ): T {
     managed.builder = builder;
+    if (resumeSession && managed.state.token) {
+      builder.withToken(managed.state.token);
+    }
     const connection = builder.build();
     managed.connection = connection;
     this.#attachCallbacks(managed, builder);
@@ -436,7 +462,12 @@ class ConnectionManagerImpl {
     managed.connection = undefined;
 
     try {
-      return this.#buildManagedConnection(managed, builder) as T;
+      // `resumeSession: false`: this is the one path that exists precisely to
+      // *change* identity, so the replacement builder's token must win over the
+      // outgoing session's.
+      return this.#buildManagedConnection(managed, builder, {
+        resumeSession: false,
+      }) as T;
     } catch (error) {
       // The old connection is already torn down, so a failed rebuild would
       // otherwise leave the pool reporting a stale "live" connection. Surface

--- a/crates/bindings-typescript/tests/connection_manager_liveness.test.ts
+++ b/crates/bindings-typescript/tests/connection_manager_liveness.test.ts
@@ -12,7 +12,9 @@ type ErrorContextInterface = { isActive: boolean };
 class MockConnection {
   isActive = false;
   identity = undefined;
-  token = undefined;
+  // A real DbConnectionImpl is constructed with the builder's token and keeps
+  // it in this field, so the mock takes it the same way.
+  token: string | undefined;
   connectionId = ConnectionId.random();
   isDisconnectRequested = false;
   disconnected = false;
@@ -61,8 +63,14 @@ class MockConnection {
     else this.#onConnectError.add(cb);
   }
 
-  simulateConnect(): void {
+  /**
+   * @param issuedToken - the token the server hands back on connect, emulating
+   * a client being issued credentials it did not have when the builder was
+   * constructed.
+   */
+  simulateConnect(issuedToken?: string): void {
     this.isActive = true;
+    if (issuedToken !== undefined) this.token = issuedToken;
     for (const cb of this.#onConnect) cb(this);
   }
   simulateDisconnect(error?: Error): void {
@@ -75,6 +83,8 @@ class MockConnection {
 class MockBuilder {
   buildCount = 0;
   connections: MockConnection[] = [];
+  /** The token each `build()` will stamp onto its connection. */
+  token: string | undefined;
 
   #onConnect = new Set<(conn: MockConnection) => void>();
   #onDisconnect = new Set<
@@ -84,8 +94,14 @@ class MockBuilder {
     (ctx: ErrorContextInterface, error: Error) => void
   >();
 
+  withToken(token?: string): MockBuilder {
+    this.token = token;
+    return this;
+  }
+
   build(): MockConnection {
     const connection = new MockConnection();
+    connection.token = this.token;
     this.buildCount += 1;
     this.connections.push(connection);
     for (const cb of this.#onConnect) connection.register('connect', cb);
@@ -262,6 +278,42 @@ describe('ConnectionManager liveness recovery', () => {
     fire('doc:visibilitychange');
 
     expect(builder.buildCount).toBe(1);
+    ConnectionManager.release(key);
+  });
+
+  // The resume paths rebuild from the retained builder, whose token is a
+  // snapshot from before the session existed. Reconnecting anonymously here
+  // makes the server mint a new identity, so a user who merely switched tabs
+  // comes back as a stranger.
+  test('reviving a dead socket on resume keeps the session identity', () => {
+    const key = nextKey();
+    // A first-time visitor: no stored credentials when the builder was made.
+    const builder = new MockBuilder();
+    const first = retain(key, builder);
+    first.simulateConnect('session-token');
+
+    // Tab is backgrounded and the socket dies silently.
+    first.socketClosed = true;
+    fire('doc:visibilitychange');
+
+    expect(builder.buildCount).toBe(2);
+    expect(builder.connections[1].token).toBe('session-token');
+    ConnectionManager.release(key);
+  });
+
+  test('a stalled reconnect brought forward on resume keeps the session identity', () => {
+    const key = nextKey();
+    const builder = new MockBuilder();
+    const first = retain(key, builder);
+    first.simulateConnect('session-token');
+    first.simulateDisconnect();
+
+    // Timer still pending behind background throttling; focus fires it early.
+    vi.advanceTimersByTime(connectionManagerReconnectDelayMs(0) - 1);
+    fire('win:focus');
+
+    expect(builder.buildCount).toBe(2);
+    expect(builder.connections[1].token).toBe('session-token');
     ConnectionManager.release(key);
   });
 });

--- a/crates/bindings-typescript/tests/connection_manager_reconnect.test.ts
+++ b/crates/bindings-typescript/tests/connection_manager_reconnect.test.ts
@@ -13,10 +13,16 @@ type ErrorContextInterface = {
 class MockConnection {
   isActive = false;
   identity = undefined;
-  token = undefined;
+  // A real DbConnectionImpl is constructed with the builder's token and keeps
+  // it in this field, so the mock takes it the same way.
+  token: string | undefined;
   connectionId = ConnectionId.random();
   disconnected = false;
   isDisconnectRequested = false;
+
+  constructor(token?: string) {
+    this.token = token;
+  }
 
   #onConnectCallbacks = new Set<(conn: MockConnection) => void>();
   #onDisconnectCallbacks = new Set<
@@ -66,8 +72,16 @@ class MockConnection {
     };
   }
 
-  simulateConnect(): void {
+  /**
+   * @param issuedToken - the token the server hands back on connect. Passing
+   * one emulates a first-time client being issued credentials it did not have
+   * when the builder was constructed.
+   */
+  simulateConnect(issuedToken?: string): void {
     this.isActive = true;
+    if (issuedToken !== undefined) {
+      this.token = issuedToken;
+    }
     for (const cb of this.#onConnectCallbacks) {
       cb(this);
     }
@@ -107,6 +121,14 @@ class MockConnection {
 class MockBuilder {
   buildCount = 0;
   connections: MockConnection[] = [];
+  /** The token each `build()` will stamp onto its connection. */
+  token: string | undefined;
+  /** Every token this builder was asked to carry, oldest first. */
+  tokenHistory: (string | undefined)[] = [];
+
+  constructor(token?: string) {
+    this.token = token;
+  }
 
   #onConnectCallbacks = new Set<(conn: MockConnection) => void>();
   #onDisconnectCallbacks = new Set<
@@ -116,8 +138,14 @@ class MockBuilder {
     (ctx: ErrorContextInterface, error: Error) => void
   >();
 
+  withToken(token?: string): MockBuilder {
+    this.token = token;
+    this.tokenHistory.push(token);
+    return this;
+  }
+
   build(): MockConnection {
-    const connection = new MockConnection();
+    const connection = new MockConnection(this.token);
     this.buildCount += 1;
     this.connections.push(connection);
 
@@ -588,5 +616,196 @@ describe('ConnectionManager.rebuild', () => {
     vi.advanceTimersByTime(0); // let the deferred release run
 
     expect(ConnectionManager.rebuild(key, new MockBuilder() as any)).toBeNull();
+  });
+});
+
+describe('ConnectionManager session continuity across rebuilds', () => {
+  beforeEach(() => {
+    vi.useFakeTimers();
+  });
+
+  afterEach(() => {
+    vi.runOnlyPendingTimers();
+    vi.useRealTimers();
+  });
+
+  test('auto-reconnect reuses the token issued after the builder was built', () => {
+    const key = nextKey();
+    // A first-time visitor: nothing in storage, so the builder carries no token.
+    const builder = new MockBuilder();
+
+    const first = retainMock(key, builder);
+    expect(first.token).toBeUndefined();
+
+    // The server issues credentials on connect. From here on, this token *is*
+    // the player's identity.
+    first.simulateConnect('session-token');
+    expect(ConnectionManager.getSnapshot(key)?.token).toBe('session-token');
+
+    // The socket drops and the manager auto-reconnects from the retained
+    // builder — which still holds the empty token it was constructed with.
+    first.simulateDisconnect();
+    vi.advanceTimersByTime(connectionManagerReconnectDelayMs(0));
+
+    const second = builder.connections[1];
+    expect(builder.buildCount).toBe(2);
+    // Without the session token this reconnects anonymously and the server
+    // mints a brand-new identity, silently signing the user out.
+    expect(second.token).toBe('session-token');
+  });
+
+  test('resumed session survives repeated reconnects', () => {
+    const key = nextKey();
+    const builder = new MockBuilder();
+
+    retainMock(key, builder).simulateConnect('session-token');
+
+    for (let attempt = 0; attempt < 3; attempt++) {
+      const current = builder.connections[builder.buildCount - 1];
+      current.simulateDisconnect();
+      vi.advanceTimersByTime(connectionManagerReconnectDelayMs(attempt));
+      const rebuilt = builder.connections[builder.buildCount - 1];
+      expect(rebuilt.token).toBe('session-token');
+      rebuilt.simulateConnect('session-token');
+    }
+
+    ConnectionManager.release(key);
+  });
+
+  // Precedence rule: whatever the live session settled on outranks the token
+  // the builder was constructed with. Today a real client only adopts a
+  // server-issued token when it presented none (see the `!this.token` guard in
+  // `DbConnectionImpl#processServerMessage`), so the rotation below is
+  // hypothetical — it pins the rule for any future support for rotation.
+  test("the session token takes precedence over the builder's own token", () => {
+    const key = nextKey();
+    const builder = new MockBuilder('original-token');
+
+    const first = retainMock(key, builder);
+    // Hypothetical: the server hands back a different credential on connect.
+    first.simulateConnect('rotated-token');
+
+    first.simulateDisconnect();
+    vi.advanceTimersByTime(connectionManagerReconnectDelayMs(0));
+
+    expect(builder.connections[1].token).toBe('rotated-token');
+
+    ConnectionManager.release(key);
+  });
+
+  test('leaves the builder alone when no session has been established', () => {
+    const key = nextKey();
+    const builder = new MockBuilder('stored-token');
+
+    // Dropped before the server ever answered: there is no session to resume,
+    // so the builder's own token must survive untouched.
+    const first = retainMock(key, builder);
+    first.simulateConnectError(new Error('server unreachable'));
+    vi.advanceTimersByTime(connectionManagerReconnectDelayMs(0));
+
+    expect(builder.connections[1].token).toBe('stored-token');
+
+    ConnectionManager.release(key);
+  });
+
+  test('retain after a drop resumes the session rather than the stale builder', () => {
+    const key = nextKey();
+    const builder = new MockBuilder();
+
+    const first = retainMock(key, builder);
+    first.simulateConnect('session-token');
+    first.simulateDisconnect();
+
+    // A provider remount rebuilds through retain(), not the reconnect timer.
+    const second = retainMock(key, builder);
+    expect(second.token).toBe('session-token');
+
+    ConnectionManager.release(key);
+    ConnectionManager.release(key);
+  });
+
+  // A *replacement* builder arriving through retain() does not change identity,
+  // even when it carries a different token. rebuild() is the supported way to
+  // do that; retain() already ignores the builder outright whenever a
+  // connection is live, so honouring it only in the disconnected window would
+  // make identity depend on socket timing.
+  test('retain() with a replacement builder keeps the session identity', () => {
+    const key = nextKey();
+    const anonymous = new MockBuilder();
+
+    const first = retainMock(key, anonymous);
+    first.simulateConnect('anonymous-token');
+    first.simulateDisconnect();
+
+    const signedIn = new MockBuilder('signed-in-token');
+    const second = retainMock(key, signedIn);
+    expect(second.token).toBe('anonymous-token');
+
+    ConnectionManager.release(key);
+    ConnectionManager.release(key);
+  });
+
+  test('auto-reconnect with a replacement builder keeps the session identity', () => {
+    const key = nextKey();
+    const anonymous = new MockBuilder();
+
+    const first = retainMock(key, anonymous);
+    first.simulateConnect('anonymous-token');
+
+    // Swap the builder while the connection is live, then drop: the reconnect
+    // uses the replacement's callbacks but must not adopt its token.
+    ConnectionManager.release(key);
+    const signedIn = new MockBuilder('signed-in-token');
+    retainMock(key, signedIn);
+
+    first.simulateDisconnect();
+    vi.advanceTimersByTime(connectionManagerReconnectDelayMs(0));
+
+    expect(signedIn.connections[0].token).toBe('anonymous-token');
+
+    ConnectionManager.release(key);
+  });
+
+  test('rebuild() honours the replacement builder over the live session', () => {
+    const key = nextKey();
+    const anonymous = new MockBuilder();
+
+    const first = retainMock(key, anonymous);
+    first.simulateConnect('anonymous-token');
+
+    // Signing in: rebuild() is the documented way to change identity, so the
+    // session-resume must not drag the anonymous token along.
+    const signedIn = new MockBuilder('signed-in-token');
+    const second = ConnectionManager.rebuild(
+      key,
+      signedIn as any
+    ) as unknown as MockConnection;
+
+    expect(second.token).toBe('signed-in-token');
+    expect(signedIn.tokenHistory).toEqual([]);
+
+    ConnectionManager.release(key);
+  });
+
+  test('auto-reconnect after rebuild() keeps the new identity', () => {
+    const key = nextKey();
+    const anonymous = new MockBuilder();
+
+    retainMock(key, anonymous).simulateConnect('anonymous-token');
+
+    const signedIn = new MockBuilder('signed-in-token');
+    const second = ConnectionManager.rebuild(
+      key,
+      signedIn as any
+    ) as unknown as MockConnection;
+
+    // Drop *before* the new connection completes its handshake: the manager
+    // must not fall back to the identity rebuild() just replaced.
+    second.simulateDisconnect();
+    vi.advanceTimersByTime(connectionManagerReconnectDelayMs(0));
+
+    expect(signedIn.connections[1].token).toBe('signed-in-token');
+
+    ConnectionManager.release(key);
   });
 });


### PR DESCRIPTION
Imagine this session:

  1. User connects to Spacetime for the first time, through a webapp.
  2. They get issued an anonymous identity.
  3. They do some work.
  4. They lose their connection temporarily - from a network glitch, from the
       tab being put to sleep in the background, anything that doesn't involve
       a page-refresh - then we auto-reconnect.

After reconnecting, they should have access to their work again, right? They
won't, and it's due to an implicit lifecycle problem between connection
builders and connections.

Every shipped template builds the connection once, at module scope, and hands
it to the provider:

```tsx
const connectionBuilder = DbConnection.builder()
  .withUri(HOST)
  .withDatabaseName(DB_NAME)
  .withToken(localStorage.getItem(TOKEN_KEY) || undefined)
  .onConnect(onConnect)  // writes the issued token to localStorage
  .onDisconnect(onDisconnect)
  .onConnectError(onConnectError);

createRoot(document.getElementById('root')!).render(
  <SpacetimeDBProvider connectionBuilder={connectionBuilder}>
    <App />
  </SpacetimeDBProvider>
);
```

For a first-time visitor that `withToken(...)` reads an empty `localStorage`,
and the empty token is baked into the builder for good. ConnectionManager
retains that builder and rebuilds from it on every automatic reconnect. The
reconnect therefore goes out anonymously, the server mints a fresh Identity,
and the user silently becomes a stranger to their own data: rows keyed on
`ctx.sender` are still attached to an Identity the client can no longer reach,
and whatever the app does to set a user up runs again from scratch under the
new one.

Nothing errors on either side, and a reload re-runs the module, re-reads the
token and appears to fix it - so this presents as unreproducible flakiness
rather than a bug. It cannot bite a returning user, whose token is already in
storage when the builder is made, which is exactly why it survives ordinary
testing.

The manager already holds the right token in `managed.state.token`, so
`#buildManagedConnection` now re-applies it to the builder before building.
`rebuild()` opts out via `resumeSession: false`: it exists precisely to change
identity, so the replacement builder's token must still win.

- Fix all four rebuild paths at once: the reconnect timer, the resume
  listeners, zombie-socket revival, and retain() after a drop.
- Cover the fix with reconnect and liveness regression tests, including
  guards that rebuild() and never-connected entries are left alone.

# API and ABI breaking changes

None. `resumeSession` is an option on a private method.

One behaviour change worth calling out: handing `retain()` a *different*
builder carrying a different token no longer changes identity. It previously
did, but only when the swap landed while no connection was live - `retain()`
already ignores a replacement builder outright whenever a connection is live,
so identity depended on socket timing. `rebuild()` remains the supported way
to change identity deliberately.

# Expected complexity level and risk

2. The diff is small and confined to one private method, but it decides which
identity every automatic reconnect presents, so the risk is in the
interactions rather than the code: the reconnect, resume, revive and retain
paths all share that method, and getting the `rebuild()` opt-out wrong would
strand a signed-in user back on their anonymous session.

# Testing

- [x] `pnpm test` in `crates/bindings-typescript`: 300 passed / 29 files.
- [x] `pnpm lint` and `pnpm build:types` clean.
- [x] Reverting only `connection_manager.ts` fails 8 of the 11 new tests; the
other 3 are guards asserting behaviour the fix must not disturb, and pass
either way.
- [ ] Reviewer: on any shipped template with site data cleared, connect,
create state keyed on `ctx.sender`, then force a reconnect - toggle the network
off and on, or leave the tab backgrounded long enough for the socket to drop -
and confirm `ctx.sender` is unchanged. A quick tab switch will not reproduce
it; the connection has to actually go down.

# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
