### PR TITLE
Add cause to init failures

### DIFF
--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -314,6 +314,13 @@ impl HostInitError {
     }
 }
 
+fn validate_init_reducer_call_result(call_result: ReducerCallResult) -> anyhow::Result<()> {
+    if matches!(call_result.outcome, ReducerOutcome::BudgetExceeded) {
+        return Err(HostInitError::OutOfEnergy.into());
+    }
+    Result::from(call_result)
+}
+
 #[derive(Clone, Debug)]
 pub struct ProcedureCallResult {
     pub return_val: AlgebraicValue,
@@ -1273,10 +1280,7 @@ impl Host {
         if program_needs_init {
             let InitDatabaseResult { reducer, tx_offset } = launched.module_host.init_database(program).await?;
             if let Some(call_result) = reducer {
-                if matches!(call_result.outcome, ReducerOutcome::BudgetExceeded) {
-                    return Err(HostInitError::OutOfEnergy.into());
-                }
-                Result::from(call_result)?;
+                validate_init_reducer_call_result(call_result)?;
             }
             bootstrap_completion = Some(BootstrapCompletion::pending(
                 bootstrap_generation,
@@ -1662,4 +1666,38 @@ where
 
     let _ = WORKER_METRICS.v8_request_queue_length.remove_label_values(db);
     let _ = DB_METRICS.http_response_size_bytes.remove_label_values(db);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    fn reducer_call_result(outcome: ReducerOutcome) -> ReducerCallResult {
+        ReducerCallResult {
+            outcome,
+            execution_budget_used: FunctionBudget::ZERO,
+            execution_duration: Duration::ZERO,
+        }
+    }
+
+    #[test]
+    fn init_reducer_budget_exceeded_maps_to_out_of_energy_cause() {
+        let error = validate_init_reducer_call_result(reducer_call_result(ReducerOutcome::BudgetExceeded))
+            .expect_err("budget exceeded init reducer should fail host init");
+
+        assert_eq!(
+            HostInitError::metric_cause(&error),
+            ModuleHostInitFailureCause::OutOfEnergy
+        );
+    }
+
+    #[test]
+    fn init_reducer_failure_maps_to_other_cause() {
+        let error = validate_init_reducer_call_result(reducer_call_result(ReducerOutcome::Failed(Box::new(
+            Box::from("init failed"),
+        ))))
+        .expect_err("failed init reducer should fail host init");
+
+        assert_eq!(HostInitError::metric_cause(&error), ModuleHostInitFailureCause::Other);
+    }
 }

--- a/crates/core/src/host/host_controller.rs
+++ b/crates/core/src/host/host_controller.rs
@@ -21,7 +21,9 @@ use crate::subscription::module_subscription_manager::{spawn_send_worker, Subscr
 use crate::subscription::row_list_builder_pool::BsatnRowListBuilderPool;
 use crate::util::asyncify;
 use crate::util::jobs::{AllocatedJobCore, JobCores};
-use crate::worker_metrics::{record_module_host_init_attempt, record_module_host_init_failure, WORKER_METRICS};
+use crate::worker_metrics::{
+    record_module_host_init_attempt, record_module_host_init_failure, ModuleHostInitFailureCause, WORKER_METRICS,
+};
 use anyhow::{anyhow, bail, Context};
 use async_trait::async_trait;
 use durability::{Durability, EmptyHistory};
@@ -289,6 +291,25 @@ impl From<&EventStatus> for ReducerOutcome {
                 ReducerOutcome::Failed(Box::new((&**e).into()))
             }
             EventStatus::OutOfEnergy => ReducerOutcome::BudgetExceeded,
+        }
+    }
+}
+
+#[derive(Debug, thiserror::Error)]
+enum HostInitError {
+    #[error("init reducer ran out of energy")]
+    OutOfEnergy,
+}
+
+impl HostInitError {
+    fn metric_cause(error: &anyhow::Error) -> ModuleHostInitFailureCause {
+        if error
+            .downcast_ref::<Self>()
+            .is_some_and(|error| matches!(error, Self::OutOfEnergy))
+        {
+            ModuleHostInitFailureCause::OutOfEnergy
+        } else {
+            ModuleHostInitFailureCause::Other
         }
     }
 }
@@ -769,7 +790,20 @@ impl HostController {
 
         Host::try_init(self, database, replica_id)
             .await
-            .inspect_err(|_| record_module_host_init_failure(database_identity))
+            .inspect_err(|error| {
+                let cause = HostInitError::metric_cause(error);
+                match cause {
+                    ModuleHostInitFailureCause::OutOfEnergy => {
+                        log::debug!(
+                            "failed to init replica {replica_id} for {database_identity} due to out of energy error from init reducer: {error}"
+                        );
+                    }
+                    ModuleHostInitFailureCause::Other => {
+                        log::warn!("failed to init replica {replica_id} for {database_identity}: {error:#}");
+                    }
+                }
+                record_module_host_init_failure(database_identity, cause)
+            })
             .with_context(|| format!("failed to init replica {} for {}", replica_id, database_identity))
     }
 }
@@ -1239,6 +1273,9 @@ impl Host {
         if program_needs_init {
             let InitDatabaseResult { reducer, tx_offset } = launched.module_host.init_database(program).await?;
             if let Some(call_result) = reducer {
+                if matches!(call_result.outcome, ReducerOutcome::BudgetExceeded) {
+                    return Err(HostInitError::OutOfEnergy.into());
+                }
                 Result::from(call_result)?;
             }
             bootstrap_completion = Some(BootstrapCompletion::pending(

--- a/crates/core/src/worker_metrics/mod.rs
+++ b/crates/core/src/worker_metrics/mod.rs
@@ -191,10 +191,32 @@ pub fn record_module_host_init_attempt(database_identity: Identity) {
         .inc();
 }
 
-pub fn record_module_host_init_failure(database_identity: Identity) {
+/// Causes of module host initialization failure.
+///
+/// These values are metric labels, so changes may require changes to dashboards and alerting rules.
+#[derive(Clone, Copy, Debug, Eq, PartialEq, Hash)]
+pub enum ModuleHostInitFailureCause {
+    /// The module's init reducer ran out of energy.
+    OutOfEnergy,
+    /// Any failure not covered by a more specific cause.
+    Other,
+}
+
+impl ModuleHostInitFailureCause {
+    pub const ALL: [Self; 2] = [Self::OutOfEnergy, Self::Other];
+
+    pub const fn as_str(self) -> &'static str {
+        match self {
+            Self::OutOfEnergy => "out_of_energy",
+            Self::Other => "other",
+        }
+    }
+}
+
+pub fn record_module_host_init_failure(database_identity: Identity, cause: ModuleHostInitFailureCause) {
     WORKER_METRICS
         .module_host_init_failures
-        .with_label_values(&database_identity)
+        .with_label_values(&database_identity, cause.as_str())
         .inc();
 }
 
@@ -518,7 +540,7 @@ metrics_group!(
 
         #[name = spacetime_module_host_init_failures_total]
         #[help = "The cumulative number of failed module host initialization attempts"]
-        #[labels(database_identity: Identity)]
+        #[labels(database_identity: Identity, cause: str)]
         pub module_host_init_failures: IntCounterVec,
 
         #[name = spacetime_reducer_wait_time_sec]
@@ -895,6 +917,22 @@ mod tests {
     fn client_disconnect_cause_labels_are_unique() {
         let mut labels = HashSet::new();
         for cause in ClientDisconnectCause::ALL {
+            assert!(labels.insert(cause.as_str()), "duplicate label for {cause:?}");
+        }
+    }
+
+    #[test]
+    fn client_reject_cause_labels_are_unique() {
+        let mut labels = HashSet::new();
+        for cause in ClientRejectCause::ALL {
+            assert!(labels.insert(cause.as_str()), "duplicate label for {cause:?}");
+        }
+    }
+
+    #[test]
+    fn module_host_init_failure_cause_labels_are_unique() {
+        let mut labels = HashSet::new();
+        for cause in ModuleHostInitFailureCause::ALL {
             assert!(labels.insert(cause.as_str()), "duplicate label for {cause:?}");
         }
     }


### PR DESCRIPTION
# Description of Changes
Adds a cause to `spacetime_module_host_init_failures_total`. This should allow us to filter out or ignore failed restarts due to out-of-energy.

**Note on naming:** The issue asks for a `reason` but I named it `cause` to stay consistent with `ClientDisconnectCause` and `ClientRejectCause`.

I'm also adding a new unit `client_reject_cause_labels_are_unique` test because we were testing `ClientDisconnectCause` but not `ClientRejectCause`.

# API and ABI breaking changes
I'm not 100% sure how these systems work. This PR changes the Prometheus metric label set for `spacetime_module_host_init_failures_total` from `spacetime_module_host_init_failures_total{database_identity="..."}` to `spacetime_module_host_init_failures_total{database_identity="...", cause="..."}` where the supported causes are `out_of_energy` and `other` (which should never happen).

I understand this might be a breaking change for our dashboards that show this metric without accounting for the new cause label?

# Expected complexity level and risk
2.

# Testing
- [x] New unit tests pass