### PR TITLE
Remove Emscripten installation from linux smoketests

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -344,16 +344,6 @@ jobs:
         with:
           run_install: true
 
-      # Install emscripten for C++ module compilation tests.
-      - name: Install emscripten (Linux)
-        if: runner.os == 'Linux'
-        shell: bash
-        run: |
-          git clone https://github.com/emscripten-core/emsdk.git ~/emsdk
-          cd ~/emsdk
-          ./emsdk install 4.0.21
-          ./emsdk activate 4.0.21
-
       - name: Install emscripten (Windows)
         if: runner.os == 'Windows'
         shell: pwsh


### PR DESCRIPTION
# Description of Changes

Now that the public linux smoketests no longer test c++ modules

# API and ABI breaking changes

None

# Expected complexity level and risk

1

# Testing

N/A
