### PR TITLE
SDK Performance Boost

### DIFF
--- a/sdks/csharp/src/BSATNHelpers.cs
+++ b/sdks/csharp/src/BSATNHelpers.cs
@@ -1,4 +1,5 @@
 using SpacetimeDB.BSATN;
+using System.Collections.Generic;
 using System.IO;
 
 namespace SpacetimeDB
@@ -15,7 +16,22 @@ namespace SpacetimeDB
         /// <param name="bsatn"></param>
         /// <returns></returns>
         public static T Decode<T>(System.Collections.Generic.List<byte> bsatn) where T : IStructuralReadWrite, new() =>
-            Decode<T>(bsatn.ToArray());
+            Decode<T>((IReadOnlyList<byte>)bsatn);
+
+        /// <summary>
+        /// Decode an element of a BSATN-serializable type from a readonly byte list.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="bsatn"></param>
+        /// <returns></returns>
+        public static T Decode<T>(IReadOnlyList<byte> bsatn) where T : IStructuralReadWrite, new()
+        {
+            using Stream stream = bsatn is byte[] bytes
+                ? new MemoryStream(bytes)
+                : new ListStream(bsatn);
+            using var reader = new BinaryReader(stream);
+            return IStructuralReadWrite.Read<T>(reader);
+        }
 
         /// <summary>
         /// Decode an element of a BSATN-serializable type from a byte array.

--- a/sdks/csharp/src/BSATNHelpers.cs
+++ b/sdks/csharp/src/BSATNHelpers.cs
@@ -69,7 +69,7 @@ namespace SpacetimeDB
             return IStructuralReadWrite.Read<T>(reader);
         }
 
-        private static MemoryStream MakePooledListStream(System.Collections.Generic.List<byte> bsatn, out byte[] pooledBuffer)
+        public static MemoryStream MakePooledListStream(System.Collections.Generic.List<byte> bsatn, out byte[] pooledBuffer)
         {
             pooledBuffer = ArrayPool<byte>.Shared.Rent(bsatn.Count);
             bsatn.CopyTo(pooledBuffer);

--- a/sdks/csharp/src/BSATNHelpers.cs
+++ b/sdks/csharp/src/BSATNHelpers.cs
@@ -1,4 +1,5 @@
 using SpacetimeDB.BSATN;
+using System.Buffers;
 using System.Collections.Generic;
 using System.IO;
 
@@ -6,33 +7,6 @@ namespace SpacetimeDB
 {
     public static class BSATNHelpers
     {
-        /// <summary>
-        /// Decode an element of a BSATN-serializable type from a list of bytes.
-        ///
-        /// This method performs several allocations. Prefer calling <c>IStructuralReadWrite.Read<T>(BinaryReader)</c> when
-        /// deserializing many items from a buffer.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="bsatn"></param>
-        /// <returns></returns>
-        public static T Decode<T>(System.Collections.Generic.List<byte> bsatn) where T : IStructuralReadWrite, new() =>
-            Decode<T>((IReadOnlyList<byte>)bsatn);
-
-        /// <summary>
-        /// Decode an element of a BSATN-serializable type from a readonly byte list.
-        /// </summary>
-        /// <typeparam name="T"></typeparam>
-        /// <param name="bsatn"></param>
-        /// <returns></returns>
-        public static T Decode<T>(IReadOnlyList<byte> bsatn) where T : IStructuralReadWrite, new()
-        {
-            using Stream stream = bsatn is byte[] bytes
-                ? new MemoryStream(bytes)
-                : new ListStream(bsatn);
-            using var reader = new BinaryReader(stream);
-            return IStructuralReadWrite.Read<T>(reader);
-        }
-
         /// <summary>
         /// Decode an element of a BSATN-serializable type from a byte array.
         ///
@@ -47,6 +21,59 @@ namespace SpacetimeDB
             using var stream = new MemoryStream(bsatn);
             using var reader = new BinaryReader(stream);
             return IStructuralReadWrite.Read<T>(reader);
+        }
+
+        /// <summary>
+        /// Decode an element of a BSATN-serializable type from a list of bytes.
+        ///
+        /// This method performs several allocations. Prefer calling <c>IStructuralReadWrite.Read<T>(BinaryReader)</c> when
+        /// deserializing many items from a buffer.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="bsatn"></param>
+        /// <returns></returns>
+        public static T Decode<T>(System.Collections.Generic.List<byte> bsatn) where T : IStructuralReadWrite, new()
+        {
+            using var stream = MakePooledListStream(bsatn, out var pooledBuffer);
+            try
+            {
+                using var reader = new BinaryReader(stream);
+                return IStructuralReadWrite.Read<T>(reader);
+            }
+            finally
+            {
+                ArrayPool<byte>.Shared.Return(pooledBuffer);
+            }
+        }
+
+        /// <summary>
+        /// Decode an element of a BSATN-serializable type from a readonly byte list.
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="bsatn"></param>
+        /// <returns></returns>
+        public static T Decode<T>(IReadOnlyList<byte> bsatn) where T : IStructuralReadWrite, new()
+        {
+            if (bsatn is byte[] bytes)
+            {
+                return Decode<T>(bytes);
+            }
+
+            if (bsatn is System.Collections.Generic.List<byte> list)
+            {
+                return Decode<T>(list);
+            }
+
+            using var stream = new ListStream(bsatn);
+            using var reader = new BinaryReader(stream);
+            return IStructuralReadWrite.Read<T>(reader);
+        }
+
+        private static MemoryStream MakePooledListStream(System.Collections.Generic.List<byte> bsatn, out byte[] pooledBuffer)
+        {
+            pooledBuffer = ArrayPool<byte>.Shared.Rent(bsatn.Count);
+            bsatn.CopyTo(pooledBuffer);
+            return new MemoryStream(pooledBuffer, 0, bsatn.Count, writable: false);
         }
     }
 }

--- a/sdks/csharp/src/CompressionHelpers.cs
+++ b/sdks/csharp/src/CompressionHelpers.cs
@@ -55,10 +55,14 @@ namespace SpacetimeDB
 
             // The stream will never be empty. It will at least contain the compression algo.
             var compression = (CompressionAlgos)stream.ReadByte();
-            // Conditionally decompress and decode.
+
+            if (compression == CompressionAlgos.None)
+            {
+                return new ServerMessage.BSATN().Read(new BinaryReader(stream));
+            }
+
             Stream decompressedStream = compression switch
             {
-                CompressionAlgos.None => stream,
                 CompressionAlgos.Brotli => BrotliReader(stream),
                 CompressionAlgos.Gzip => GzipReader(stream),
                 _ => throw new InvalidOperationException("Unknown compression type"),
@@ -67,10 +71,13 @@ namespace SpacetimeDB
             // TODO: consider pooling these.
             // DO NOT TRY TO TAKE THIS OUT. The BrotliStream ReadByte() implementation allocates an array
             // PER BYTE READ. You have to do it all at once to avoid that problem.
-            MemoryStream memoryStream = new MemoryStream();
-            decompressedStream.CopyTo(memoryStream);
-            memoryStream.Seek(0, SeekOrigin.Begin);
-            return new ServerMessage.BSATN().Read(new BinaryReader(memoryStream));
+            using (decompressedStream)
+            using (MemoryStream memoryStream = new MemoryStream())
+            {
+                decompressedStream.CopyTo(memoryStream);
+                memoryStream.Seek(0, SeekOrigin.Begin);
+                return new ServerMessage.BSATN().Read(new BinaryReader(memoryStream));
+            }
         }
 
         /// <summary>

--- a/sdks/csharp/src/ListStream.cs
+++ b/sdks/csharp/src/ListStream.cs
@@ -10,10 +10,10 @@ using SpacetimeDB;
 /// </summary>
 internal class ListStream : Stream
 {
-    private List<byte> list;
+    private IReadOnlyList<byte> list;
     private int pos;
 
-    public ListStream(List<byte> data)
+    public ListStream(IReadOnlyList<byte> data)
     {
         this.list = data;
         this.pos = 0;
@@ -36,16 +36,28 @@ internal class ListStream : Stream
 
     public override int Read(byte[] buffer, int offset, int count)
     {
+        var readable = Math.Min(count, Math.Min(buffer.Length - offset, list.Count - pos));
+        if (readable <= 0)
+        {
+            return 0;
+        }
+
+        if (list is List<byte> byteList)
+        {
+            byteList.CopyTo(pos, buffer, offset, readable);
+            pos += readable;
+            return readable;
+        }
+
         int listPos = pos;
-        int listEnd = Math.Min(list.Count, listPos + count);
         int bufPos = offset;
-        int bufLength = buffer.Length;
-        for (; listPos < listEnd && bufPos < bufLength; listPos++, bufPos++)
+        int listEnd = pos + readable;
+        for (; listPos < listEnd; listPos++, bufPos++)
         {
             buffer[bufPos] = list[listPos];
         }
-        pos = listPos;
-        return bufPos - offset;
+        pos += readable;
+        return readable;
     }
 
     public override int Read(Span<byte> buffer)

--- a/sdks/csharp/src/MultiDictionary.cs
+++ b/sdks/csharp/src/MultiDictionary.cs
@@ -242,7 +242,7 @@ namespace SpacetimeDB
         /// <param name="wasInserted">Will be populated with inserted KVPs.</param>
         /// <param name="wasUpdated">Will be populated with updated KVPs.</param>
         /// <param name="wasRemoved">Will be populated with removed KVPs.</param>
-        public void Apply(MultiDictionaryDelta<TKey, TValue> delta, List<KeyValuePair<TKey, TValue>> wasInserted, List<(TKey Key, TValue OldValue, TValue NewValue)> wasUpdated, List<KeyValuePair<TKey, TValue>> wasRemoved)
+        public readonly void Apply(MultiDictionaryDelta<TKey, TValue> delta, List<KeyValuePair<TKey, TValue>> wasInserted, List<(TKey Key, TValue OldValue, TValue NewValue)> wasUpdated, List<KeyValuePair<TKey, TValue>> wasRemoved)
         {
             foreach (var (key, their) in delta.Entries)
             {

--- a/sdks/csharp/src/MultiDictionary.cs
+++ b/sdks/csharp/src/MultiDictionary.cs
@@ -1,5 +1,4 @@
 using System;
-using System.Linq;
 using System.Text;
 using System.Collections.Generic;
 using System.Diagnostics;
@@ -55,7 +54,18 @@ namespace SpacetimeDB
         /// <summary>
         /// Return the count WITH multiplicities.
         /// </summary>
-        public readonly uint Count => RawDict.Select(item => item.Value.Multiplicity).Aggregate(0u, (a, b) => a + b);
+        public readonly uint Count
+        {
+            get
+            {
+                uint count = 0;
+                foreach (var item in RawDict)
+                {
+                    count += item.Value.Multiplicity;
+                }
+                return count;
+            }
+        }
 
         /// <summary>
         /// Add a key-value-pair to the multidictionary.
@@ -113,7 +123,8 @@ namespace SpacetimeDB
         /// </summary>
         /// <param name="key"></param>
         /// <returns></returns>
-        public uint Multiplicity(TKey key) => RawDict.ContainsKey(key) ? RawDict[key].Multiplicity : 0;
+        public uint Multiplicity(TKey key) =>
+            RawDict.TryGetValue(key, out var result) ? result.Multiplicity : 0;
 
         /// <summary>
         /// The value associated with a key.
@@ -171,8 +182,10 @@ namespace SpacetimeDB
         {
             get
             {
-
-                return RawDict.Select(item => item.Value.Value);
+                foreach (var item in RawDict)
+                {
+                    yield return item.Value.Value;
+                }
             }
         }
 
@@ -180,7 +193,10 @@ namespace SpacetimeDB
         {
             get
             {
-                return RawDict.Select(item => new KeyValuePair<TKey, TValue>(item.Key, item.Value.Value));
+                foreach (var item in RawDict)
+                {
+                    yield return new KeyValuePair<TKey, TValue>(item.Key, item.Value.Value);
+                }
             }
         }
 
@@ -191,31 +207,32 @@ namespace SpacetimeDB
         /// <returns></returns>
         public readonly IEnumerable<KeyValuePair<TKey, TValue>> WillRemove(MultiDictionaryDelta<TKey, TValue> delta)
         {
-            var self = this;
-            return delta.Entries.Where(their =>
+            foreach (var their in delta.Entries)
             {
                 if (their.Value.IsValueChange)
                 {
                     // Value changes are translated to Updates, not removals.
-                    return false;
+                    continue;
                 }
                 var theirNonValueChange = their.Value.NonValueChange;
                 if (theirNonValueChange.Delta >= 0)
                 {
                     // Adds can't result in removals.
-                    return false;
+                    continue;
                 }
-                if (self.RawDict.TryGetValue(their.Key, out var mine))
+                if (RawDict.TryGetValue(their.Key, out var mine))
                 {
                     var resultMultiplicity = (int)mine.Multiplicity + theirNonValueChange.Delta;
-                    return resultMultiplicity <= 0; // if < 0, we have a problem, but that's caught in Apply.
+                    if (resultMultiplicity <= 0) // if < 0, we have a problem, but that's caught in Apply.
+                    {
+                        yield return new KeyValuePair<TKey, TValue>(their.Key, theirNonValueChange.Value);
+                    }
                 }
                 else
                 {
                     Log.Warn($"Want to remove row with key {their.Key}, but it doesn't exist!");
-                    return false;
                 }
-            }).Select(entry => new KeyValuePair<TKey, TValue>(entry.Key, entry.Value.NonValueChange.Value));
+            }
         }
 
         /// <summary>

--- a/sdks/csharp/src/MultiDictionary.cs
+++ b/sdks/csharp/src/MultiDictionary.cs
@@ -328,7 +328,7 @@ namespace SpacetimeDB
         /// Raise a debug assertion failure in debug mode, otherwise just warn and keep going.
         /// </summary>
         /// <param name="message"></param>
-        private void PseudoThrow(string message)
+        private static void PseudoThrow(string message)
         {
             Log.Warn(message);
             Debug.Assert(false, message);

--- a/sdks/csharp/src/ProcedureCallbacks.cs
+++ b/sdks/csharp/src/ProcedureCallbacks.cs
@@ -98,7 +98,7 @@ namespace SpacetimeDB
             var callbackResult = result.Status switch
             {
                 ProcedureStatus.Returned(var bytes) =>
-                    ProcedureCallbackResult<T>.Success(BSATNHelpers.Decode<T>(bytes.ToArray())),
+                    ProcedureCallbackResult<T>.Success(BSATNHelpers.Decode<T>(bytes)),
                 ProcedureStatus.InternalError(var error) =>
                     ProcedureCallbackResult<T>.Failure(new Exception($"Procedure failed: {error}")),
                 _ => ProcedureCallbackResult<T>.Failure(new Exception("Unknown procedure status"))

--- a/sdks/csharp/src/SpacetimeDBClient.cs
+++ b/sdks/csharp/src/SpacetimeDBClient.cs
@@ -1,4 +1,5 @@
 using System;
+using System.Buffers;
 using System.Collections.Concurrent;
 using System.Collections.Generic;
 using System.IO;
@@ -404,13 +405,20 @@ namespace SpacetimeDB
                 return dbOps;
             }
 
-            string DecodeReducerError(IReadOnlyList<byte> bytes)
+            string DecodeReducerError(List<byte> bytes)
             {
                 try
                 {
-                    using var stream = new ListStream(bytes);
-                    using var reader = new BinaryReader(stream);
-                    return new SpacetimeDB.BSATN.String().Read(reader);
+                    using var stream = BSATNHelpers.MakePooledListStream(bytes, out var pooledBuffer);
+                    try
+                    {
+                        using var reader = new BinaryReader(stream);
+                        return new SpacetimeDB.BSATN.String().Read(reader);
+                    }
+                    finally
+                    {
+                        ArrayPool<byte>.Shared.Return(pooledBuffer);
+                    }
                 }
                 catch
                 {

--- a/sdks/csharp/src/SpacetimeDBClient.cs
+++ b/sdks/csharp/src/SpacetimeDBClient.cs
@@ -408,7 +408,7 @@ namespace SpacetimeDB
             {
                 try
                 {
-                    using var stream = new MemoryStream(bytes.ToArray());
+                    using var stream = new ListStream(bytes);
                     using var reader = new BinaryReader(stream);
                     return new SpacetimeDB.BSATN.String().Read(reader);
                 }

--- a/sdks/csharp/src/Table.cs
+++ b/sdks/csharp/src/Table.cs
@@ -2,7 +2,6 @@ using System;
 using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
-using System.Linq;
 using System.Threading.Tasks;
 #if UNITY_5_3_OR_NEWER
 using UnityEngine;
@@ -154,7 +153,7 @@ namespace SpacetimeDB
             }
 
             public IEnumerable<Row> Filter(Column value) =>
-                cache.TryGetValue(value, out var rows) ? rows : Enumerable.Empty<Row>();
+                cache.TryGetValue(value, out var rows) ? rows : Array.Empty<Row>();
         }
 
         /// <summary>
@@ -415,7 +414,7 @@ namespace SpacetimeDB
 
         public int Count => (int)Entries.CountDistinct;
 
-        public IEnumerable<Row> Iter() => Entries.Entries.Select(entry => (Row)entry.Value);
+        public IEnumerable<Row> Iter() => Entries.Values;
 
         public Task<Row[]> RemoteQuery(string query) =>
             conn.RemoteQuery<Row>($"SELECT {RemoteTableName}.* FROM {RemoteTableName} {query}");
@@ -504,42 +503,16 @@ namespace SpacetimeDB
             // in order to avoid keys an error with the same key already added.
             foreach (var (_, value) in wasRemoved)
             {
-                if (value is Row oldRow)
-                {
-                    OnInternalDeleteHandler.Invoke(oldRow);
-                }
+                OnInternalDeleteHandler.Invoke(value);
             }
             foreach (var (_, value) in wasInserted)
             {
-                if (value is Row newRow)
-                {
-                    OnInternalInsertHandler.Invoke(newRow);
-                }
-                else
-                {
-                    throw new Exception($"Invalid row type for table {RemoteTableName}: {value.GetType().Name}");
-                }
+                OnInternalInsertHandler.Invoke(value);
             }
             foreach (var (_, oldValue, newValue) in wasUpdated)
             {
-                if (oldValue is Row oldRow)
-                {
-                    OnInternalDeleteHandler.Invoke(oldRow);
-                }
-                else
-                {
-                    throw new Exception($"Invalid row type for table {RemoteTableName}: {oldValue.GetType().Name}");
-                }
-
-
-                if (newValue is Row newRow)
-                {
-                    OnInternalInsertHandler.Invoke(newRow);
-                }
-                else
-                {
-                    throw new Exception($"Invalid row type for table {RemoteTableName}: {newValue.GetType().Name}");
-                }
+                OnInternalDeleteHandler.Invoke(oldValue);
+                OnInternalInsertHandler.Invoke(newValue);
             }
         }
 

--- a/sdks/csharp/src/WebSocket.cs
+++ b/sdks/csharp/src/WebSocket.cs
@@ -3,7 +3,6 @@ using SpacetimeDB.ClientApi;
 
 using System;
 using System.Collections.Concurrent;
-using System.Linq;
 using System.Net.Sockets;
 using System.Net.WebSockets;
 using System.Runtime.InteropServices;
@@ -31,10 +30,11 @@ namespace SpacetimeDB
 
         // WebSocket buffer for incoming messages
         private static readonly int MAXMessageSize = 0x4000000; // 64MB
+        private static readonly int InitialReceiveBufferSize = 16 * 1024;
 
         // Connection parameters
         private readonly ConnectOptions _options;
-        private readonly byte[] _receiveBuffer = new byte[MAXMessageSize];
+        private byte[] _receiveBuffer = new byte[InitialReceiveBufferSize];
         private readonly ConcurrentQueue<Action> dispatchQueue = new();
 
         protected ClientWebSocket Ws = new();
@@ -365,15 +365,17 @@ namespace SpacetimeDB
                             return;
                         }
 
+                        EnsureReceiveCapacity(count + 1);
                         receiveResult = await Ws.ReceiveAsync(
-                            new ArraySegment<byte>(_receiveBuffer, count, MAXMessageSize - count),
+                            new ArraySegment<byte>(_receiveBuffer, count, _receiveBuffer.Length - count),
                             CancellationToken.None);
                         count += receiveResult.Count;
                     }
 
                     if (OnMessage != null)
                     {
-                        var message = _receiveBuffer.Take(count).ToArray();
+                        var message = new byte[count];
+                        Buffer.BlockCopy(_receiveBuffer, 0, message, 0, count);
                         // directly invoke message handling
                         OnMessage(message, startReceive);
                     }
@@ -423,6 +425,23 @@ namespace SpacetimeDB
             }
 #endif
             return Task.CompletedTask;
+        }
+
+        private void EnsureReceiveCapacity(int minimumCapacity)
+        {
+            if (_receiveBuffer.Length >= minimumCapacity)
+            {
+                return;
+            }
+
+            var newCapacity = _receiveBuffer.Length;
+            do
+            {
+                newCapacity = Math.Min(newCapacity * 2, MAXMessageSize);
+            }
+            while (newCapacity < minimumCapacity);
+
+            Array.Resize(ref _receiveBuffer, newCapacity);
         }
 
         /// <summary>

--- a/sdks/csharp/tests~/PerformanceBenchmarks/PerformanceBenchmarks.csproj
+++ b/sdks/csharp/tests~/PerformanceBenchmarks/PerformanceBenchmarks.csproj
@@ -1,0 +1,16 @@
+<Project Sdk="Microsoft.NET.Sdk">
+
+  <PropertyGroup>
+    <OutputType>Exe</OutputType>
+    <TargetFramework>net8.0</TargetFramework>
+    <ImplicitUsings>enable</ImplicitUsings>
+    <Nullable>enable</Nullable>
+    <IsPackable>false</IsPackable>
+  </PropertyGroup>
+
+  <ItemGroup>
+    <PackageReference Include="BenchmarkDotNet" Version="0.14.0" />
+    <ProjectReference Include="../../SpacetimeDB.ClientSDK.csproj" />
+  </ItemGroup>
+
+</Project>

--- a/sdks/csharp/tests~/PerformanceBenchmarks/Program.cs
+++ b/sdks/csharp/tests~/PerformanceBenchmarks/Program.cs
@@ -1,0 +1,120 @@
+using BenchmarkDotNet.Attributes;
+using BenchmarkDotNet.Jobs;
+using BenchmarkDotNet.Running;
+using SpacetimeDB;
+using SpacetimeDB.BSATN;
+
+BenchmarkSwitcher.FromAssembly(typeof(Program).Assembly).Run(args);
+
+[MemoryDiagnoser]
+[SimpleJob(RuntimeMoniker.Net80, launchCount: 1, warmupCount: 5, iterationCount: 10)]
+public class ReducerProcedurePayloadBenchmarks
+{
+    private readonly PerfRows.BSATN rowsRW = new();
+    private List<PerfRow> rows = [];
+    private byte[] encodedBytes = [];
+    private List<byte> encodedList = [];
+    private IReadOnlyList<byte> encodedReadOnlyList = [];
+
+    [Params(1, 100, 10_000)]
+    public int RowCount { get; set; }
+
+    [GlobalSetup]
+    public void GlobalSetup()
+    {
+        rows = Enumerable.Range(0, RowCount).Select(i => new PerfRow { Id = (uint)i }).ToList();
+        encodedBytes = IStructuralReadWrite.ToBytes(rowsRW, new PerfRows { Rows = rows });
+        encodedList = encodedBytes.ToList();
+        encodedReadOnlyList = encodedList;
+    }
+
+    [Benchmark(Baseline = true)]
+    public PerfRows XUnitReducerProcedureShape()
+    {
+        var encoded = IStructuralReadWrite.ToBytes(rowsRW, new PerfRows { Rows = rows }).ToList();
+        return BSATNHelpers.Decode<PerfRows>(encoded);
+    }
+
+    [Benchmark]
+    public PerfRows SerializeAndDecodeFromByteArray()
+    {
+        var encoded = IStructuralReadWrite.ToBytes(rowsRW, new PerfRows { Rows = rows });
+        return BSATNHelpers.Decode<PerfRows>(encoded);
+    }
+
+    [Benchmark]
+    public List<byte> SerializeToListOnly() =>
+        IStructuralReadWrite.ToBytes(rowsRW, new PerfRows { Rows = rows }).ToList();
+
+    [Benchmark]
+    public PerfRows DecodeFromListOnly() =>
+        BSATNHelpers.Decode<PerfRows>(encodedList);
+
+    [Benchmark]
+    public PerfRows DecodeFromReadOnlyListOnly() =>
+        BSATNHelpers.Decode<PerfRows>(encodedReadOnlyList);
+
+    [Benchmark]
+    public PerfRows DecodeFromByteArrayOnly() =>
+        BSATNHelpers.Decode<PerfRows>(encodedBytes);
+
+    public sealed class PerfRow : IStructuralReadWrite, IEquatable<PerfRow>
+    {
+        public uint Id;
+
+        public void ReadFields(BinaryReader reader)
+        {
+            Id = new U32().Read(reader);
+        }
+
+        public void WriteFields(BinaryWriter writer)
+        {
+            new U32().Write(writer, Id);
+        }
+
+        public object GetSerializer() => new BSATN();
+
+        public bool Equals(PerfRow? other) => other != null && Id == other.Id;
+
+        public override bool Equals(object? obj) => obj is PerfRow other && Equals(other);
+
+        public override int GetHashCode() => Id.GetHashCode();
+
+        public readonly struct BSATN : IReadWrite<PerfRow>
+        {
+            public PerfRow Read(BinaryReader reader) => new() { Id = new U32().Read(reader) };
+
+            public void Write(BinaryWriter writer, PerfRow value) => new U32().Write(writer, value.Id);
+
+            public AlgebraicType GetAlgebraicType(ITypeRegistrar registrar) => throw new NotImplementedException();
+        }
+    }
+
+    public sealed class PerfRows : IStructuralReadWrite
+    {
+        public List<PerfRow> Rows = [];
+
+        public void ReadFields(BinaryReader reader)
+        {
+            Rows = new SpacetimeDB.BSATN.List<PerfRow, PerfRow.BSATN>().Read(reader);
+        }
+
+        public void WriteFields(BinaryWriter writer)
+        {
+            new SpacetimeDB.BSATN.List<PerfRow, PerfRow.BSATN>().Write(writer, Rows);
+        }
+
+        public object GetSerializer() => new BSATN();
+
+        public readonly struct BSATN : IReadWrite<PerfRows>
+        {
+            public PerfRows Read(BinaryReader reader) =>
+                new() { Rows = new SpacetimeDB.BSATN.List<PerfRow, PerfRow.BSATN>().Read(reader) };
+
+            public void Write(BinaryWriter writer, PerfRows value) =>
+                new SpacetimeDB.BSATN.List<PerfRow, PerfRow.BSATN>().Write(writer, value.Rows);
+
+            public AlgebraicType GetAlgebraicType(ITypeRegistrar registrar) => throw new NotImplementedException();
+        }
+    }
+}

--- a/sdks/csharp/tests~/PerformanceTests.cs
+++ b/sdks/csharp/tests~/PerformanceTests.cs
@@ -73,21 +73,70 @@ public sealed class PerformanceTests
     [Theory]
     [InlineData(false)]
     [InlineData(true)]
-    public void WebsocketMessageDecodeBaseline(bool brotli)
+    public void InitialConnectionDecodeBaseline(bool brotli)
     {
-        var message = new ServerMessage.InitialConnection(new InitialConnection
-        {
-            Identity = Identity.From(Convert.FromBase64String("l0qzG1GPRtC1mwr+54q98tv0325gozLc6cNzq4vrzqY=")),
-            Token = "token",
-            ConnectionId = ConnectionId.From(Convert.FromBase64String("Vd4dFzcEzhLHJ6uNL8VXFg=="))
-                ?? throw new InvalidDataException("connection id"),
-        });
+        var message = MakeInitialConnectionMessage();
         var bytes = EncodeServerMessage(message, brotli);
 
-        Measure($"DecompressDecodeMessage brotli={brotli}", 10_000, () =>
+        Measure($"DecompressDecodeMessage initial_connection brotli={brotli}", 10_000, () =>
         {
             _ = CompressionHelpers.DecompressDecodeMessage(bytes);
         });
+    }
+
+    [Theory]
+    [InlineData(1, false)]
+    [InlineData(1, true)]
+    [InlineData(100, false)]
+    [InlineData(100, true)]
+    [InlineData(10_000, false)]
+    [InlineData(10_000, true)]
+    public void TransactionUpdateDecodeBaseline(int rowCount, bool brotli)
+    {
+        var message = MakeTransactionUpdateMessage(rowCount);
+        var bytes = EncodeServerMessage(message, brotli);
+        var decoded = CompressionHelpers.DecompressDecodeMessage(bytes);
+
+        AssertTransactionUpdateRows(decoded, rowCount);
+        Measure($"DecompressDecodeMessage transaction_update rows={rowCount} brotli={brotli} compressedBytes={bytes.Length}", Iterations(rowCount), () =>
+        {
+            _ = CompressionHelpers.DecompressDecodeMessage(bytes);
+        });
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(10_000)]
+    public void BrotliInflateToMemoryStreamBaseline(int rowCount)
+    {
+        var message = MakeTransactionUpdateMessage(rowCount);
+        var bytes = EncodeServerMessage(message, brotli: true);
+
+        Measure($"Brotli inflate transaction_update rows={rowCount} compressedBytes={bytes.Length}", Iterations(rowCount), () =>
+        {
+            using var input = new MemoryStream(bytes);
+            Assert.Equal((int)CompressionHelpers.CompressionAlgos.Brotli, input.ReadByte());
+            using var brotli = new BrotliStream(input, CompressionMode.Decompress);
+            using var output = new MemoryStream();
+            brotli.CopyTo(output);
+        });
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(10_000)]
+    public void BrotliAndUncompressedTransactionUpdateDecodeEquivalence(int rowCount)
+    {
+        var message = MakeTransactionUpdateMessage(rowCount);
+
+        var decodedUncompressed = CompressionHelpers.DecompressDecodeMessage(EncodeServerMessage(message, brotli: false));
+        var decodedBrotli = CompressionHelpers.DecompressDecodeMessage(EncodeServerMessage(message, brotli: true));
+
+        AssertTransactionUpdateRows(decodedUncompressed, rowCount);
+        AssertTransactionUpdateRows(decodedBrotli, rowCount);
+        Assert.Equal(GetTransactionUpdateRowsData(decodedUncompressed), GetTransactionUpdateRowsData(decodedBrotli));
     }
 
     private void Measure(string name, int iterations, Action action)
@@ -115,7 +164,6 @@ public sealed class PerformanceTests
         output.WriteLine(
             $"{name}: mean={meanMicroseconds:F2}us allocated={allocatedBytesPerOp}B/op gen0={GC.CollectionCount(0) - gen0} gen1={GC.CollectionCount(1) - gen1} iterations={iterations}"
         );
-        Assert.True(iterations > 0);
     }
 
     private static int Iterations(int rowCount) =>
@@ -138,6 +186,58 @@ public sealed class PerformanceTests
         }
         bytes.AddRange(stream.ToArray());
         return new BsatnRowList(new RowSizeHint.FixedSize(sizeof(uint)), bytes);
+    }
+
+    private static ServerMessage MakeInitialConnectionMessage() =>
+        new ServerMessage.InitialConnection(new InitialConnection
+        {
+            Identity = Identity.From(Convert.FromBase64String("l0qzG1GPRtC1mwr+54q98tv0325gozLc6cNzq4vrzqY=")),
+            Token = "token",
+            ConnectionId = ConnectionId.From(Convert.FromBase64String("Vd4dFzcEzhLHJ6uNL8VXFg=="))
+                ?? throw new InvalidDataException("connection id"),
+        });
+
+    private static ServerMessage MakeTransactionUpdateMessage(int rowCount) =>
+        new ServerMessage.TransactionUpdate(new TransactionUpdate
+        {
+            QuerySets =
+            [
+                new QuerySetUpdate
+                {
+                    QuerySetId = new QuerySetId(1),
+                    Tables =
+                    [
+                        new TableUpdate
+                        {
+                            TableName = "perf_row",
+                            Rows =
+                            [
+                                new TableUpdateRows.PersistentTable(new PersistentTableRows
+                                {
+                                    Inserts = MakeRowList(rowCount),
+                                    Deletes = new BsatnRowList(new RowSizeHint.FixedSize(sizeof(uint)), []),
+                                }),
+                            ],
+                        },
+                    ],
+                },
+            ],
+        });
+
+    private static void AssertTransactionUpdateRows(ServerMessage message, int expectedRowCount)
+    {
+        var rowsData = GetTransactionUpdateRowsData(message);
+        Assert.Equal(expectedRowCount * sizeof(uint), rowsData.Count);
+    }
+
+    private static List<byte> GetTransactionUpdateRowsData(ServerMessage message)
+    {
+        var update = Assert.IsType<ServerMessage.TransactionUpdate>(message);
+        var querySet = Assert.Single(update.TransactionUpdate_.QuerySets);
+        var table = Assert.Single(querySet.Tables);
+        var rows = Assert.Single(table.Rows);
+        var persistentRows = Assert.IsType<TableUpdateRows.PersistentTable>(rows);
+        return persistentRows.PersistentTable_.Inserts.RowsData;
     }
 
     private static byte[] EncodeServerMessage(ServerMessage message, bool brotli)

--- a/sdks/csharp/tests~/PerformanceTests.cs
+++ b/sdks/csharp/tests~/PerformanceTests.cs
@@ -1,0 +1,222 @@
+using System.Diagnostics;
+using System.IO.Compression;
+using SpacetimeDB;
+using SpacetimeDB.BSATN;
+using SpacetimeDB.ClientApi;
+using Xunit;
+using Xunit.Abstractions;
+
+public sealed class PerformanceTests
+{
+    private readonly ITestOutputHelper output;
+
+    public PerformanceTests(ITestOutputHelper output)
+    {
+        this.output = output;
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(10_000)]
+    public void ParseRowListBaseline(int rowCount)
+    {
+        var rowList = MakeRowList(rowCount);
+
+        Measure($"ParseRowList rows={rowCount}", Iterations(rowCount), () =>
+        {
+            var (reader, count) = CompressionHelpers.ParseRowList(rowList);
+            for (var i = 0; i < count; i++)
+            {
+                new PerfRow.BSATN().Read(reader);
+            }
+        });
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(10_000)]
+    public void MultiDictionaryApplyBaseline(int rowCount)
+    {
+        Measure($"MultiDictionary.Apply rows={rowCount}", Iterations(rowCount), () =>
+        {
+            var dict = new MultiDictionary<uint, PerfRow>(EqualityComparer<uint>.Default, EqualityComparer<PerfRow>.Default);
+            var delta = new MultiDictionaryDelta<uint, PerfRow>(EqualityComparer<uint>.Default, EqualityComparer<PerfRow>.Default);
+            for (uint i = 0; i < rowCount; i++)
+            {
+                delta.Add(i, new PerfRow { Id = i });
+            }
+
+            var inserted = new List<KeyValuePair<uint, PerfRow>>();
+            var updated = new List<(uint key, PerfRow oldValue, PerfRow newValue)>();
+            var removed = new List<KeyValuePair<uint, PerfRow>>();
+            dict.Apply(delta, inserted, updated, removed);
+        });
+    }
+
+    [Theory]
+    [InlineData(1)]
+    [InlineData(100)]
+    [InlineData(10_000)]
+    public void PayloadSerializationAndProcedureDecodeBaseline(int rowCount)
+    {
+        var rows = Enumerable.Range(0, rowCount).Select(i => new PerfRow { Id = (uint)i }).ToList();
+
+        Measure($"Reducer/procedure payload rows={rowCount}", Iterations(rowCount), () =>
+        {
+            var encoded = IStructuralReadWrite.ToBytes(new PerfRows.BSATN(), new PerfRows { Rows = rows }).ToList();
+            _ = BSATNHelpers.Decode<PerfRows>(encoded);
+        });
+    }
+
+    [Theory]
+    [InlineData(false)]
+    [InlineData(true)]
+    public void WebsocketMessageDecodeBaseline(bool brotli)
+    {
+        var message = new ServerMessage.InitialConnection(new InitialConnection
+        {
+            Identity = Identity.From(Convert.FromBase64String("l0qzG1GPRtC1mwr+54q98tv0325gozLc6cNzq4vrzqY=")),
+            Token = "token",
+            ConnectionId = ConnectionId.From(Convert.FromBase64String("Vd4dFzcEzhLHJ6uNL8VXFg=="))
+                ?? throw new InvalidDataException("connection id"),
+        });
+        var bytes = EncodeServerMessage(message, brotli);
+
+        Measure($"DecompressDecodeMessage brotli={brotli}", 10_000, () =>
+        {
+            _ = CompressionHelpers.DecompressDecodeMessage(bytes);
+        });
+    }
+
+    private void Measure(string name, int iterations, Action action)
+    {
+        action();
+        GC.Collect();
+        GC.WaitForPendingFinalizers();
+        GC.Collect();
+
+        var gen0 = GC.CollectionCount(0);
+        var gen1 = GC.CollectionCount(1);
+        var allocatedBefore = GC.GetAllocatedBytesForCurrentThread();
+        var stopwatch = Stopwatch.StartNew();
+
+        for (var i = 0; i < iterations; i++)
+        {
+            action();
+        }
+
+        stopwatch.Stop();
+        var allocatedBytes = GC.GetAllocatedBytesForCurrentThread() - allocatedBefore;
+        var meanMicroseconds = stopwatch.Elapsed.TotalMilliseconds * 1000 / iterations;
+        var allocatedBytesPerOp = allocatedBytes / iterations;
+
+        output.WriteLine(
+            $"{name}: mean={meanMicroseconds:F2}us allocated={allocatedBytesPerOp}B/op gen0={GC.CollectionCount(0) - gen0} gen1={GC.CollectionCount(1) - gen1} iterations={iterations}"
+        );
+        Assert.True(iterations > 0);
+    }
+
+    private static int Iterations(int rowCount) =>
+        rowCount switch
+        {
+            <= 1 => 10_000,
+            <= 100 => 1_000,
+            _ => 10,
+        };
+
+    private static BsatnRowList MakeRowList(int rowCount)
+    {
+        var bytes = new List<byte>(rowCount * sizeof(uint));
+        using var stream = new MemoryStream();
+        using var writer = new BinaryWriter(stream);
+        var rowRW = new PerfRow.BSATN();
+        for (uint i = 0; i < rowCount; i++)
+        {
+            rowRW.Write(writer, new PerfRow { Id = i });
+        }
+        bytes.AddRange(stream.ToArray());
+        return new BsatnRowList(new RowSizeHint.FixedSize(sizeof(uint)), bytes);
+    }
+
+    private static byte[] EncodeServerMessage(ServerMessage message, bool brotli)
+    {
+        using var output = new MemoryStream();
+        output.WriteByte(brotli ? (byte)1 : (byte)0);
+        if (brotli)
+        {
+            using (var compressed = new BrotliStream(output, CompressionMode.Compress, leaveOpen: true))
+            using (var writer = new BinaryWriter(compressed))
+            {
+                new ServerMessage.BSATN().Write(writer, message);
+            }
+        }
+        else
+        {
+            using var writer = new BinaryWriter(output);
+            new ServerMessage.BSATN().Write(writer, message);
+        }
+        return output.ToArray();
+    }
+
+    public sealed class PerfRow : IStructuralReadWrite, IEquatable<PerfRow>
+    {
+        public uint Id;
+
+        public void ReadFields(BinaryReader reader)
+        {
+            Id = new U32().Read(reader);
+        }
+
+        public void WriteFields(BinaryWriter writer)
+        {
+            new U32().Write(writer, Id);
+        }
+
+        public object GetSerializer() => new BSATN();
+
+        public bool Equals(PerfRow? other) => other != null && Id == other.Id;
+
+        public override bool Equals(object? obj) => obj is PerfRow other && Equals(other);
+
+        public override int GetHashCode() => Id.GetHashCode();
+
+        public readonly struct BSATN : IReadWrite<PerfRow>
+        {
+            public PerfRow Read(BinaryReader reader) => new() { Id = new U32().Read(reader) };
+
+            public void Write(BinaryWriter writer, PerfRow value) => new U32().Write(writer, value.Id);
+
+            public AlgebraicType GetAlgebraicType(ITypeRegistrar registrar) => throw new NotImplementedException();
+        }
+    }
+
+    public sealed class PerfRows : IStructuralReadWrite
+    {
+        public List<PerfRow> Rows = new();
+
+        public void ReadFields(BinaryReader reader)
+        {
+            Rows = new SpacetimeDB.BSATN.List<PerfRow, PerfRow.BSATN>().Read(reader);
+        }
+
+        public void WriteFields(BinaryWriter writer)
+        {
+            new SpacetimeDB.BSATN.List<PerfRow, PerfRow.BSATN>().Write(writer, Rows);
+        }
+
+        public object GetSerializer() => new BSATN();
+
+        public readonly struct BSATN : IReadWrite<PerfRows>
+        {
+            public PerfRows Read(BinaryReader reader) =>
+                new() { Rows = new SpacetimeDB.BSATN.List<PerfRow, PerfRow.BSATN>().Read(reader) };
+
+            public void Write(BinaryWriter writer, PerfRows value) =>
+                new SpacetimeDB.BSATN.List<PerfRow, PerfRow.BSATN>().Write(writer, value.Rows);
+
+            public AlgebraicType GetAlgebraicType(ITypeRegistrar registrar) => throw new NotImplementedException();
+        }
+    }
+}

--- a/sdks/csharp/tests~/PerformanceTests.cs
+++ b/sdks/csharp/tests~/PerformanceTests.cs
@@ -169,9 +169,9 @@ public sealed class PerformanceTests
     private static int Iterations(int rowCount) =>
         rowCount switch
         {
-            <= 1 => 10_000,
-            <= 100 => 1_000,
-            _ => 10,
+            <= 1 => 50_000,
+            <= 100 => 10_000,
+            _ => 1_000,
         };
 
     private static BsatnRowList MakeRowList(int rowCount)

--- a/sdks/csharp/tests~/Tests.cs
+++ b/sdks/csharp/tests~/Tests.cs
@@ -128,4 +128,33 @@ public class Tests
             }
         });
     }
+
+    [Fact]
+    public static void BSATNHelpersDecodeListMatchesByteArray()
+    {
+        var expectedRows = new PerformanceTests.PerfRows
+        {
+            Rows =
+            [
+                new PerformanceTests.PerfRow { Id = 1 },
+                new PerformanceTests.PerfRow { Id = 2 },
+                new PerformanceTests.PerfRow { Id = 10_000 },
+            ],
+        };
+        var bytes = IStructuralReadWrite.ToBytes(new PerformanceTests.PerfRows.BSATN(), expectedRows);
+        var list = bytes.ToList();
+
+        var decodedFromBytes = BSATNHelpers.Decode<PerformanceTests.PerfRows>(bytes);
+        var decodedFromList = BSATNHelpers.Decode<PerformanceTests.PerfRows>(list);
+        var decodedFromReadOnlyList = BSATNHelpers.Decode<PerformanceTests.PerfRows>((IReadOnlyList<byte>)list);
+
+        Assert.Equal(
+            decodedFromBytes.Rows.Select(row => row.Id),
+            decodedFromList.Rows.Select(row => row.Id)
+        );
+        Assert.Equal(
+            decodedFromBytes.Rows.Select(row => row.Id),
+            decodedFromReadOnlyList.Rows.Select(row => row.Id)
+        );
+    }
 }

--- a/sdks/csharp/tests~/tests.csproj
+++ b/sdks/csharp/tests~/tests.csproj
@@ -5,12 +5,17 @@
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>enable</Nullable>
     <AssemblyName>SpacetimeDB.Tests</AssemblyName>
+    <DefaultItemExcludes>$(DefaultItemExcludes);**/bin~/**;**/obj~/**;PerformanceBenchmarks/**</DefaultItemExcludes>
 
     <IsPackable>false</IsPackable>
     <IsTestProject>true</IsTestProject>
   </PropertyGroup>
 
   <ItemGroup>
+    <Compile Remove="**/bin~/**/*.cs" />
+    <Compile Remove="**/obj~/**/*.cs" />
+    <Compile Remove="PerformanceBenchmarks/**/*.cs" />
+
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.6.0" />
     <PackageReference Include="Verify.XUnit" Version="25.0.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="2.4.5">


### PR DESCRIPTION
# Description of Changes
It cleans up a couple of things to achieve better performance in the C# SDK:
1. It replaces the usage of LINQ (with direct for loops, for example);
2. Reduces the total amount of allocations by pooling arrays and avoiding some calls to `.ToArray()`;
3. Reduces the initial size of websockets buffers and resizes them when necessary (this also reduces a lot of allocations).

# API and ABI breaking changes
No changes. It's all internal.

# Rollback safety impact
n/a

# Expected complexity level and risk
3. We need to make sure BSATN decoding stays consistent for all paths (I added a unit test for this) and that websockets behavior stays the same as before (just less memory hungry).

# Testing
- [x] Run benchmarks
- [x] Tests all still pass

## Benchmarks
I added two benchmarks:

**xUnit Benchmarks:**
| Benchmark | Rows / Variant | Master mean | PR mean | Time delta | Master alloc | PR alloc | Alloc delta |
|---|---:|---:|---:|---:|---:|---:|---:|
| DecompressDecodeMessage transaction_update | 1, uncompressed | 0.49 us | 0.41 us | -16.3% | 1,544 B | 1,200 B | -344 B |
| DecompressDecodeMessage transaction_update | 100, uncompressed | 2.87 us | 2.74 us | -4.5% | 2,128 B | 1,592 B | -536 B |
| DecompressDecodeMessage transaction_update | 10,000, uncompressed | 89.01 us | 85.28 us | -4.2% | 81,328 B | 41,192 B | -40,136 B |
| DecompressDecodeMessage transaction_update | 1, brotli | 2.22 us | 1.46 us | -34.2% | 67,232 B | 1,672 B | -65,560 B |
| DecompressDecodeMessage transaction_update | 100, brotli | 5.36 us | 4.61 us | -14.0% | 67,816 B | 2,256 B | -65,560 B |
| DecompressDecodeMessage transaction_update | 10,000, brotli | 197.16 us | 195.17 us | -1.0% | 147,017 B | 81,457 B | -65,560 B |
| Reducer/procedure payload | 1 | 0.23 us | 0.25 us | +8.7% | 936 B | 904 B | -32 B |
| Reducer/procedure payload | 100 | 4.55 us | 4.61 us | +1.3% | 5,840 B | 5,408 B | -432 B |
| Reducer/procedure payload | 10,000 | 233.89 us | 300.59 us | +28.5% | 571,663 B | 531,630 B | -40,033 B |
| DecompressDecodeMessage initial_connection | uncompressed | 0.13 us | 0.09 us | -30.8% | 728 B | 384 B | -344 B |
| DecompressDecodeMessage initial_connection | brotli | 1.46 us | 0.45 us | -69.2% | 66,416 B | 856 B | -65,560 B |
| Brotli inflate transaction_update | 1 | 1.13 us | 1.13 us | 0.0% | 936 B | 936 B | 0 B |
| Brotli inflate transaction_update | 100 | 1.98 us | 1.96 us | -1.0% | 1,128 B | 1,128 B | 0 B |
| Brotli inflate transaction_update | 10,000 | 109.13 us | 108.40 us | -0.7% | 40,728 B | 40,710 B | -18 B |
| MultiDictionary.Apply | 1 | 0.15 us | 0.15 us | 0.0% | 872 B | 872 B | 0 B |
| MultiDictionary.Apply | 100 | 8.42 us | 8.41 us | -0.1% | 43,544 B | 43,544 B | 0 B |
| MultiDictionary.Apply | 10,000 | 1,202.86 us | 1,174.74 us | -2.3% | 4,234,208 B | 4,234,253 B | +45 B |
| ParseRowList | 1 | 0.05 us | 0.05 us | 0.0% | 224 B | 224 B | 0 B |
| ParseRowList | 100 | 3.22 us | 3.28 us | +1.9% | 2,600 B | 2,600 B | 0 B |
| ParseRowList | 10,000 | 244.97 us | 276.34 us | +12.8% | 240,200 B | 240,200 B | 0 B |

**BenchmarkDotNet:**
I started with the xUnit benchmark from above and I liked the look of the allocation deltas a lot. But the reducer/procedure time delta didn't look so nice, so I also added this BenchmarkDotNet project that should be a little more accurate and the equivalent benchmark (the first three) now look a lot more flat.

| Benchmark | Rows | Master mean | PR mean | Time delta | Master alloc | PR alloc | Alloc delta |
|---|---:|---:|---:|---:|---:|---:|---:|
| XUnitReducerProcedureShape | 1 | 103.57 ns | 112.14 ns | +8.3% | 936 B | 904 B | -32 B |
| XUnitReducerProcedureShape | 100 | 1.394 us | 1.422 us | +2.0% | 5,840 B | 5,408 B | -432 B |
| XUnitReducerProcedureShape | 10,000 | 130.733 us | 131.045 us | +0.2% | 571,663 B | 531,631 B | -40,032 B |
| SerializeAndDecodeFromByteArray | 1 | 85.93 ns | 82.72 ns | -3.7% | 840 B | 840 B | 0 B |
| SerializeAndDecodeFromByteArray | 100 | 1.359 us | 1.376 us | +1.3% | 4,944 B | 4,944 B | 0 B |
| SerializeAndDecodeFromByteArray | 10,000 | 124.907 us | 133.552 us | +6.9% | 491,566 B | 491,566 B | 0 B |
| SerializeToListOnly | 1 | 56.57 ns | 57.33 ns | +1.3% | 536 B | 536 B | 0 B |
| SerializeToListOnly | 100 | 830.12 ns | 845.00 ns | +1.8% | 1,872 B | 1,872 B | 0 B |
| SerializeToListOnly | 10,000 | 75.081 us | 77.035 us | +2.6% | 211,288 B | 211,288 B | 0 B |
| DecodeFromListOnly | 1 | 45.78 ns | 53.04 ns | +15.9% | 400 B | 368 B | -32 B |
| DecodeFromListOnly | 100 | 582.62 ns | 584.81 ns | +0.4% | 3,968 B | 3,536 B | -432 B |
| DecodeFromListOnly | 10,000 | 56.498 us | 52.541 us | -7.0% | 360,373 B | 320,340 B | -40,033 B |
| DecodeFromByteArrayOnly | 1 | 41.55 ns | 41.80 ns | +0.6% | 368 B | 368 B | 0 B |
| DecodeFromByteArrayOnly | 100 | 565.05 ns | 566.06 ns | +0.2% | 3,536 B | 3,536 B | 0 B |
| DecodeFromByteArrayOnly | 10,000 | 50.594 us | 55.436 us | +9.6% | 320,340 B | 320,340 B | 0 B |