### PR TITLE
solve the net.git-fetch-with-cli in .cargo/config.toml #5186 problem

### DIFF
--- a/.cargo/config.toml
+++ b/.cargo/config.toml
@@ -19,3 +19,6 @@ linker = "lld-link"
 # Without this, the linker complains that libc functions are undefined -
 # it probably signals to rustc and lld-link that libucrt should be included.
 rustflags = ["-Ctarget-feature=+crt-static"]
+
+[net]
+git-fetch-with-cli = true


### PR DESCRIPTION
Fixes intermittend SSL error when fetching the iai-calllgrind fit dependcy in ci , caused by cargo's default libgit2-based git client. Shellling out to the system git binary avoids this , Fixes #5186 problem

# Description of Changes

<!-- Please describe your change, mention any related tickets, and so on here. -->

# API and ABI breaking changes

<!-- If this is an API or ABI breaking change, please apply the
corresponding GitHub label. -->

# Expected complexity level and risk

<!--
How complicated do you think these changes are? Grade on a scale from 1 to 5,
where 1 is a trivial change, and 5 is a deep-reaching and complex change.

This complexity rating applies not only to the complexity apparent in the diff,
but also to its interactions with existing and future code.

If you answered more than a 2, explain what is complex about the PR,
and what other components it interacts with in potentially concerning ways.  -->

# Testing

<!-- Describe any testing you've done, and any testing you'd like your reviewers to do,
so that you're confident that all the changes work as expected! -->

- [ ] <!-- maybe a test you want to do -->
- [ ] <!-- maybe a test you want a reviewer to do, so they can check it off when they're satisfied. -->
