### PR TITLE
feat(typescript): add useRow hook for Vue and React to fix issue #5060

### DIFF
--- a/crates/bindings-typescript/src/react/index.ts
+++ b/crates/bindings-typescript/src/react/index.ts
@@ -1,5 +1,6 @@
 export * from './SpacetimeDBProvider.ts';
 export { useSpacetimeDB } from './useSpacetimeDB.ts';
 export { useTable } from './useTable.ts';
+export { useRow } from './useRow.ts';
 export { useReducer } from './useReducer.ts';
 export { useProcedure } from './useProcedure.ts';

--- a/crates/bindings-typescript/src/react/useRow.ts
+++ b/crates/bindings-typescript/src/react/useRow.ts
@@ -1,0 +1,23 @@
+import { useMemo } from 'react';
+import { useTable, type UseTableCallbacks } from './useTable';
+import type { UntypedTableDef, RowType } from '../lib/table';
+import type { Prettify } from '../lib/type_util';
+import type { Query } from '../lib/query';
+
+/**
+ * React hook to subscribe to a view or table in SpacetimeDB and receive a single live row.
+ *
+ * This is particularly useful for views that return `t.option(Row)`.
+ *
+ * @param query - A query builder expression (table reference or filtered query).
+ * @param callbacks - Optional callbacks for row insert, delete, and update events.
+ * @returns A tuple of [row, isReady], where row is `undefined` if not found.
+ */
+export function useRow<TableDef extends UntypedTableDef>(
+  query: Query<TableDef>,
+  callbacks?: UseTableCallbacks<Prettify<RowType<TableDef>>>
+): [Prettify<RowType<TableDef>> | undefined, boolean] {
+  const [rows, isReady] = useTable(query, callbacks);
+  const row = useMemo(() => rows[0] ?? undefined, [rows]);
+  return [row, isReady];
+}

--- a/crates/bindings-typescript/src/vue/index.ts
+++ b/crates/bindings-typescript/src/vue/index.ts
@@ -1,5 +1,6 @@
 export * from './SpacetimeDBProvider.ts';
 export { useSpacetimeDB } from './useSpacetimeDB.ts';
 export { useTable } from './useTable.ts';
+export { useRow } from './useRow.ts';
 export { useReducer } from './useReducer.ts';
 export { useProcedure } from './useProcedure.ts';

--- a/crates/bindings-typescript/src/vue/useRow.ts
+++ b/crates/bindings-typescript/src/vue/useRow.ts
@@ -1,0 +1,26 @@
+import { computed, type Ref, type DeepReadonly } from 'vue';
+import { useTable, type UseTableCallbacks } from './useTable';
+import type { UntypedTableDef, RowType } from '../lib/table';
+import type { Prettify } from '../lib/type_util';
+import type { Query } from '../lib/query';
+
+/**
+ * Vue composable to subscribe to a view or table in SpacetimeDB and receive a single live row.
+ *
+ * This is particularly useful for views that return `t.option(Row)`.
+ *
+ * @param query - A query builder expression (table reference or filtered query).
+ * @param callbacks - Optional callbacks for row insert, delete, and update events.
+ * @returns A tuple of [row, isReady], where row is `undefined` if not found.
+ */
+export function useRow<TableDef extends UntypedTableDef>(
+  query: Query<TableDef>,
+  callbacks?: UseTableCallbacks<Prettify<RowType<TableDef>>>
+): [
+  DeepReadonly<Ref<Prettify<RowType<TableDef>> | undefined>>,
+  DeepReadonly<Ref<boolean>>,
+] {
+  const [rows, isReady] = useTable(query, callbacks);
+  const row = computed(() => rows.value[0] ?? undefined);
+  return [row, isReady];
+}


### PR DESCRIPTION
# Description of Changes

Added a new `useRow` hook for the React and Vue bindings to provide a cleaner developer experience when querying single rows or views that return `t.option()`. 

Previously, because the SpacetimeDB host runtime represents all views as tables, the client-generated SDK would type `t.option()` views as returning an array. This forced developers to manually unwrap the array (e.g. `userData?.value[0] ?? undefined`). The new `useRow` hook wraps `useTable` and automatically returns the first element or `undefined`.

Fixes #5060

# API and ABI breaking changes

None. This is purely an additive feature for the client SDKs.

# Expected complexity level and risk

**1**

This is a trivial, additive change. It simply introduces a thin wrapper around the existing `useTable` hook to extract the first element.

# Testing

- [x] Verified the TypeScript bindings compile without errors via `pnpm run build` locally.
- [ ] Reviewers can check that `useRow` functions as intended in an actual React or Vue app when subscribing to a table or view.
