### PR TITLE
fix(testing): recover from lock poisoning in memoized! macro to preve…

### DIFF
--- a/crates/testing/src/sdk.rs
+++ b/crates/testing/src/sdk.rs
@@ -155,7 +155,7 @@ macro_rules! memoized {
 
         MEMOIZED
             .lock()
-            .unwrap()
+            .unwrap_or_else(|e| e.into_inner())
             .get_or_insert_default()
             .entry(($($key_tuple,)*))
             .or_insert_with_key(|($($key_tuple,)*)| -> $value_ty { $body })


### PR DESCRIPTION
This PR allows the test harness to gracefully recover from lock poisoning (Issue #5841).

Previously, if a test panicked while compiling a module inside the memoized! macro, it would poison the Mutex holding the MEMOIZED compilation cache. Any subsequent tests attempting to access the cache would panic with a PoisonError, causing unrelated tests to fail and masking the original error.

This replaces .lock().unwrap() with .lock().unwrap_or_else(|e| e.into_inner()) on the cache mutex. This safely recovers the lock after a panic, allowing unrelated tests to continue compiling and running their own modules instead of failing in cascade.

## Rollback safety impact
n/a