### PR TITLE
CI - Use new runner label

### DIFF
--- a/.github/workflows/attach-artifacts.yml
+++ b/.github/workflows/attach-artifacts.yml
@@ -9,7 +9,7 @@ on:
 
 jobs:
   upload-assets:
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     permissions:
       contents: write  # needed to modify releases
 

--- a/.github/workflows/benchmarks.yml
+++ b/.github/workflows/benchmarks.yml
@@ -181,7 +181,7 @@ jobs:
     # Fortunately, we can run on standard GitHub Actions infra because we don't care
     # about other stuff running on the machine!
     # runs-on: benchmarks-runner
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     timeout-minutes: 20 # on a successful run, runs in 8 minutes
     container:
       image: rust:1.93.0

--- a/.github/workflows/check-merge-labels.yml
+++ b/.github/workflows/check-merge-labels.yml
@@ -10,7 +10,7 @@ permissions: read-all
 jobs:
   label_checks:
     name: Check merge labels
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     steps:
       - if: github.event_name == 'pull_request' && contains(github.event.pull_request.labels.*.name, 'do not merge')
         run: |

--- a/.github/workflows/check-pr-base.yml
+++ b/.github/workflows/check-pr-base.yml
@@ -13,7 +13,7 @@ concurrency:
 jobs:
   check_base_ref:
     name: Based on `master`
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     steps:
       - id: not_based_on_master
         if: |
@@ -26,7 +26,7 @@ jobs:
   release_dependencies:
     if: ${{ github.event_name == 'pull_request' }}
     name: Check release dependencies
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     permissions:
       contents: read
       pull-requests: read

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,7 +24,7 @@ permissions:
 jobs:
   merge_queue_noop:
     name: Merge queue no-op/reuse
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     permissions:
       actions: write
       contents: read
@@ -94,7 +94,7 @@ jobs:
     needs: [merge_queue_noop, lints]
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}
     name: Upload build artifacts (Linux)
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     timeout-minutes: 15
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
@@ -324,7 +324,7 @@ jobs:
   smoketest_build_linux:
     needs: [upload-build-artifacts-linux]
     name: Build smoketests (Linux)
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     timeout-minutes: 15
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
@@ -409,7 +409,7 @@ jobs:
       fail-fast: false
       matrix:
         partition: [1]
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     timeout-minutes: 30
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
@@ -584,7 +584,7 @@ jobs:
           - name: Windows 2/4
           - name: Windows 3/4
           - name: Windows 4/4
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     steps:
       - name: Skip duplicate merge queue smoketest
         run: echo "Merge queue commit has the same tree as the PR head; smoketest already ran for the PR."
@@ -593,7 +593,7 @@ jobs:
     needs: [merge_queue_noop, lints, upload-build-artifacts-linux]
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}
     name: Test Suite
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
 
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
@@ -763,7 +763,7 @@ jobs:
     needs: [merge_queue_noop]
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}
     name: Lints
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full
@@ -814,7 +814,7 @@ jobs:
   codeowners_check:
     if: ${{ github.event_name == 'pull_request' }}
     name: CODEOWNERS check
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     permissions:
       contents: read
       pull-requests: read
@@ -849,7 +849,7 @@ jobs:
     needs: [merge_queue_noop, upload-build-artifacts-linux]
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}
     name: Build and test wasm bindings
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full
@@ -873,7 +873,7 @@ jobs:
     needs: [merge_queue_noop]
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}
     name: Check that packages are publishable
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     permissions: read-all
     env:
       RUST_BACKTRACE: full
@@ -901,7 +901,7 @@ jobs:
     strategy:
       matrix:
         include:
-          - { target: x86_64-unknown-linux-gnu, runner: spacetimedb-new-runner-2 }
+          - { target: x86_64-unknown-linux-gnu, runner: spacetimedb-linux }
           - { target: aarch64-apple-darwin, runner: macos-latest }
           - { target: x86_64-pc-windows-msvc, runner: windows-latest }
     runs-on: ${{ matrix.runner }}
@@ -950,7 +950,7 @@ jobs:
           - { target: x86_64-unknown-linux-gnu }
           - { target: aarch64-apple-darwin }
           - { target: x86_64-pc-windows-msvc }
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     steps:
       - name: Skip duplicate merge queue update test
         run: echo "Merge queue commit has the same tree as the PR head; update-flow already ran for the PR."
@@ -959,7 +959,7 @@ jobs:
     name: Unreal Engine Tests
     # This can't go on e.g. ubuntu-latest because that runner runs out of disk space. ChatGPT suggested that the general solution tends to be to use
     # a custom runner.
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     # Disable the tests because they are very flaky at the moment.
     # TODO: Remove this line and re-enable the `if` line just below here.
     if: false
@@ -1053,7 +1053,7 @@ jobs:
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}
     name: Check CLI docs
     permissions: read-all
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full
@@ -1319,7 +1319,7 @@ jobs:
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}
     permissions:
       contents: read
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       ARTIFACT_SUFFIX: linux
@@ -1426,7 +1426,7 @@ jobs:
   csharp-testsuite:
     needs: [merge_queue_noop, lints, upload-build-artifacts-linux]
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     timeout-minutes: 30
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
@@ -1549,7 +1549,7 @@ jobs:
     needs: [merge_queue_noop]
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}
     name: Verify global.json files are symlinks
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     permissions:
       contents: read
     env:
@@ -1590,7 +1590,7 @@ jobs:
     needs: [merge_queue_noop]
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}
     name: Check smoketests/mod.rs is complete
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     permissions:
       contents: read
     env:
@@ -1624,7 +1624,7 @@ jobs:
     needs: [merge_queue_noop]
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}
     name: Docs build
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     env:
       RUST_BACKTRACE: full
     steps:
@@ -1659,7 +1659,7 @@ jobs:
     needs: [merge_queue_noop, upload-build-artifacts-linux]
     if: ${{ needs.merge_queue_noop.outputs.skip != 'true' }}
     name: TypeScript - Tests
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       RUST_BACKTRACE: full

--- a/.github/workflows/cla-gate.yml
+++ b/.github/workflows/cla-gate.yml
@@ -17,7 +17,7 @@ permissions:
 jobs:
   publish-cla-gate-status:
     name: CLA status
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     if: github.event_name != 'status' || github.event.context == 'license/cla'
 
     steps:

--- a/.github/workflows/discord-posts.yml
+++ b/.github/workflows/discord-posts.yml
@@ -11,7 +11,7 @@ permissions:
 
 jobs:
   resolvePush:
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     outputs:
       is_pr_merge: ${{ steps.resolve.outputs.is_pr_merge }}
       is_external: ${{ steps.resolve.outputs.is_external }}
@@ -80,7 +80,7 @@ jobs:
 
   discordNotification:
     needs: resolvePush
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     if: needs.resolvePush.outputs.is_pr_merge == 'true'
     env:
       GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -157,7 +157,7 @@ jobs:
     needs:
       - resolvePush
       - discordNotification
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     if: ${{ always() && (needs.resolvePush.result == 'failure' || needs.discordNotification.result == 'failure') }}
     steps:
       - name: Send failure notification
@@ -172,7 +172,7 @@ jobs:
 
   warnDirectPush:
     needs: resolvePush
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     if: needs.resolvePush.outputs.is_pr_merge != 'true'
     steps:
       - name: Warn about non-PR push
@@ -197,7 +197,7 @@ jobs:
 
   invokePrivate:
     needs: resolvePush
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     if: needs.resolvePush.outputs.is_pr_merge == 'true'
     permissions:
       contents: read

--- a/.github/workflows/docs-publish.yaml
+++ b/.github/workflows/docs-publish.yaml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/docs-update-llms.yaml
+++ b/.github/workflows/docs-update-llms.yaml
@@ -14,7 +14,7 @@ on:
 
 jobs:
   update-llms:
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     steps:
       - name: Checkout repository
         uses: actions/checkout@v3

--- a/.github/workflows/internal-tests.yml
+++ b/.github/workflows/internal-tests.yml
@@ -27,7 +27,7 @@ jobs:
     # Skip if this is an external contribution. GitHub secrets will be empty, so the step would fail anyway.
     if: ${{ (github.event_name == 'pull_request' || (github.event_name == 'push' && github.ref == 'refs/heads/master'))
       && (github.event_name != 'pull_request' || !github.event.pull_request.head.repo.fork) }}
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     env:
       TARGET_OWNER: clockworklabs
       TARGET_REPO: SpacetimeDBPrivate

--- a/.github/workflows/llm-benchmark-periodic.yml
+++ b/.github/workflows/llm-benchmark-periodic.yml
@@ -50,7 +50,7 @@ concurrency:
 jobs:
   prepare_matrix:
     name: Prepare benchmark matrix
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     outputs:
       languages: ${{ steps.matrix.outputs.languages }}
     steps:
@@ -64,7 +64,7 @@ jobs:
   run-benchmarks:
     name: Run benchmarks (${{ matrix.lang }})
     needs: prepare_matrix
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target
       TARGET_TRIPLE: x86_64-unknown-linux-gnu

--- a/.github/workflows/llm-benchmark-validate-goldens.yml
+++ b/.github/workflows/llm-benchmark-validate-goldens.yml
@@ -26,7 +26,7 @@ concurrency:
 
 jobs:
   validate-goldens:
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     timeout-minutes: 60
     env:
       CARGO_TARGET_DIR: ${{ github.workspace }}/target

--- a/.github/workflows/pr_approval_check.yml
+++ b/.github/workflows/pr_approval_check.yml
@@ -29,7 +29,7 @@ concurrency:
 jobs:
   publish-approval-status:
     name: Set approval status
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     # Disabled until we can spend some more focus on making this work consistently.
     # See https://github.com/clockworklabs/SpacetimeDB/pull/4673.
     if: false

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -60,7 +60,7 @@ concurrency:
 jobs:
   validate-release-invoker:
     name: Validate release invoker
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     steps:
       - name: Reject direct public release invocations
         env:
@@ -80,7 +80,7 @@ jobs:
   # try to fail during this step to prevent partial releases.
   build-cargo-release:
     needs: validate-release-invoker
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     steps:
       - name: Checkout
         uses: actions/checkout@v4
@@ -109,7 +109,7 @@ jobs:
 
   release-crates:
     needs: build-cargo-release
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     if: ${{ inputs.release_crates }}
     env:
       CARGO_TERM_COLOR: always
@@ -151,7 +151,7 @@ jobs:
 
   release-csharp:
     needs: build-cargo-release
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     if: ${{ inputs.release_csharp }}
     env:
       CARGO_TERM_COLOR: always
@@ -230,7 +230,7 @@ jobs:
 
   release-cpp:
     needs: build-cargo-release
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     if: ${{ inputs.release_cpp }}
     env:
       CARGO_TERM_COLOR: always
@@ -286,7 +286,7 @@ jobs:
 
   release-npm:
     needs: build-cargo-release
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     if: ${{ inputs.release_npm }}
     env:
       CARGO_TERM_COLOR: always
@@ -339,7 +339,7 @@ jobs:
 
   release-docker:
     needs: build-cargo-release
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     env:
       CARGO_TERM_COLOR: always
       GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
@@ -380,7 +380,7 @@ jobs:
 
   update-mirror-latest-version:
     needs: validate-release-invoker
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     if: ${{ !inputs.dry_run && inputs.update_mirror_latest_version }}
 
     steps:
@@ -422,7 +422,7 @@ jobs:
       - release-npm
       - release-docker
       - update-mirror-latest-version
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     if: >-
       ${{
         always()

--- a/.github/workflows/retry-cla-assistant.yml
+++ b/.github/workflows/retry-cla-assistant.yml
@@ -31,7 +31,7 @@ permissions:
 jobs:
   retry-cla:
     name: Retry CLA Assistant if it is the only blocker
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
 
     steps:
       - name: Check out trusted base code

--- a/.github/workflows/tag-release.yml
+++ b/.github/workflows/tag-release.yml
@@ -30,7 +30,7 @@ jobs:
   # Internal/team announcement (simple)
   announce-release:
     name: Announce GitHub release (Internal)
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     if: >-
       ${{
         github.event_name == 'release'
@@ -52,7 +52,7 @@ jobs:
   # Public announcement with full release notes
   public-discord-notification:
     name: Announce GitHub release (Public)
-    runs-on: spacetimedb-new-runner-2
+    runs-on: spacetimedb-linux
     steps:
       - name: Send Discord notification
         env:


### PR DESCRIPTION
# Description of Changes

Make things use `spacetimedb-linux` instead of the old confusing runner label.

# API and ABI breaking changes

None

# Rollback safety impact

n/a

# Expected complexity level and risk

1

# Testing
- [x] CI is running on this branch