### PR TITLE
Upgrade jsonwebtoken to the latest version

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -335,10 +335,10 @@ dependencies = [
  "axum-core",
  "bytes",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper",
  "hyper-util",
  "itoa",
  "matchit",
@@ -351,7 +351,7 @@ dependencies = [
  "serde_json",
  "serde_path_to_error",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower",
  "tower-layer",
@@ -368,13 +368,13 @@ dependencies = [
  "async-trait",
  "bytes",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "pin-project-lite",
  "rustversion",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tower-layer",
  "tower-service",
  "tracing",
@@ -392,8 +392,8 @@ dependencies = [
  "fastrand",
  "futures-util",
  "headers",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "mime",
  "multer",
@@ -426,6 +426,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a17bd29f7c70f32e9387f4d4acfa5ea7b7749ef784fb78cf382df97069337b8c"
 
 [[package]]
+name = "base16ct"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "4c7f02d4ea65f2c1853089ffd8d2787bdbc63de2f0d29dedbcf8ccdfa0ccd4cf"
+
+[[package]]
 name = "base64"
 version = "0.21.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -446,6 +452,12 @@ dependencies = [
  "outref",
  "vsimd",
 ]
+
+[[package]]
+name = "base64ct"
+version = "1.8.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2af50177e190e07a26ab74f8b1efbfe2ef87da2116221318cb1c2e82baf7de06"
 
 [[package]]
 name = "basic-rs-template-module"
@@ -885,7 +897,7 @@ version = "0.1.0"
 dependencies = [
  "anyhow",
  "clap 4.5.50",
- "reqwest 0.12.24",
+ "reqwest",
  "serde",
  "serde_json",
 ]
@@ -1327,6 +1339,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "const-oid"
+version = "0.9.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c2459377285ad874054d797f3ccebf984978aa39129f6eafde5cdc8315b612f8"
+
+[[package]]
 name = "constant_time_eq"
 version = "0.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1676,6 +1694,18 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "460fbee9c2c2f33933d720630a6a0bac33ba7053db5344fac858d4b8952d77d5"
 
 [[package]]
+name = "crypto-bigint"
+version = "0.5.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "0dc92fb57ca44df6db8059111ab3af99a63d5d0f8375d9972e319a379c6bab76"
+dependencies = [
+ "generic-array",
+ "rand_core 0.6.4",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "crypto-common"
 version = "0.1.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1692,6 +1722,33 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0b51940c54c6ca015d3add383571ec5610114466eb67aa0a27096e1dcf3c9e29"
 dependencies = [
  "smallvec",
+]
+
+[[package]]
+name = "curve25519-dalek"
+version = "4.1.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "97fb8b7c4503de7d6ae7b42ab72a5a59857b4c937ec27a3d4539dba95b5ab2be"
+dependencies = [
+ "cfg-if",
+ "cpufeatures",
+ "curve25519-dalek-derive",
+ "digest",
+ "fiat-crypto",
+ "rustc_version",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
+name = "curve25519-dalek-derive"
+version = "0.1.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f46882e17999c6cc590af592290432be3bce0428cb0d5f8b6715e4dc7b383eb3"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.107",
 ]
 
 [[package]]
@@ -1815,6 +1872,17 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a9efff8990a82c1ae664292507e1a5c6749ddd2312898cdf9cd7cb1fd4bc64c6"
 
 [[package]]
+name = "der"
+version = "0.7.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e7c1832837b905bbfb5101e07cc24c8deddf52f93225eee6ead5f4d63d53ddcb"
+dependencies = [
+ "const-oid",
+ "pem-rfc7468",
+ "zeroize",
+]
+
+[[package]]
 name = "deranged"
 version = "0.5.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1911,6 +1979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9ed9a281f7bc9b7576e61468ba615a66a5c8cfdff42420a70aa82701a3b1e292"
 dependencies = [
  "block-buffer",
+ "const-oid",
  "crypto-common",
  "subtle",
 ]
@@ -2031,6 +2100,44 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "d0881ea181b1df73ff77ffaaf9c7544ecc11e82fba9b5f27b262a3c73a332555"
 
 [[package]]
+name = "ecdsa"
+version = "0.16.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ee27f32b5c5292967d2d4a9d7f1e0b0aed2c15daded5a60300e4abb9d8020bca"
+dependencies = [
+ "der",
+ "digest",
+ "elliptic-curve",
+ "rfc6979",
+ "signature",
+ "spki",
+]
+
+[[package]]
+name = "ed25519"
+version = "2.2.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "115531babc129696a58c64a4fef0a8bf9e9698629fb97e9e40767d235cfbcd53"
+dependencies = [
+ "pkcs8",
+ "signature",
+]
+
+[[package]]
+name = "ed25519-dalek"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "70e796c081cee67dc755e1a36a0a172b897fab85fc3f6bc48307991f64e4eca9"
+dependencies = [
+ "curve25519-dalek",
+ "ed25519",
+ "serde",
+ "sha2",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "educe"
 version = "0.4.23"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2047,6 +2154,27 @@ name = "either"
 version = "1.15.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "48c757948c5ede0e46177b7add2e67155f70e33c07fea8284df6576da70b3719"
+
+[[package]]
+name = "elliptic-curve"
+version = "0.13.8"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b5e6043086bf7973472e0c7dff2142ea0b680d30e18d9cc40f267efbf222bd47"
+dependencies = [
+ "base16ct",
+ "crypto-bigint",
+ "digest",
+ "ff",
+ "generic-array",
+ "group",
+ "hkdf",
+ "pem-rfc7468",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "sec1",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "embedded-io"
@@ -2318,6 +2446,22 @@ dependencies = [
  "rustix 0.38.44",
  "windows-sys 0.48.0",
 ]
+
+[[package]]
+name = "ff"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c0b50bfb653653f9ca9095b427bed08ab8d75a137839d9ad64eb11810d5b6393"
+dependencies = [
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
+name = "fiat-crypto"
+version = "0.2.9"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "28dea519a9695b9977216879a3ebfddf92f1c08c05d984f8996aecd6ecdc811d"
 
 [[package]]
 name = "filetime"
@@ -2614,6 +2758,7 @@ checksum = "4bb6743198531e02858aeaea5398fcc883e71851fcbcb5a2f773e2fb6cb1edf2"
 dependencies = [
  "typenum",
  "version_check",
+ "zeroize",
 ]
 
 [[package]]
@@ -2623,10 +2768,8 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "335ff9f135e4384c8150d6f27c6daed433577f86b4750418338c01a1a2528592"
 dependencies = [
  "cfg-if",
- "js-sys",
  "libc",
  "wasi",
- "wasm-bindgen",
 ]
 
 [[package]]
@@ -2711,7 +2854,7 @@ dependencies = [
  "futures-core",
  "futures-sink",
  "gloo-utils",
- "http 1.3.1",
+ "http",
  "js-sys",
  "pin-project",
  "serde",
@@ -2763,31 +2906,23 @@ dependencies = [
 ]
 
 [[package]]
+name = "group"
+version = "0.13.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f0f9ef7462f7c099f518d754361858f86d8a07af53ba9af0fe635bbccb151a63"
+dependencies = [
+ "ff",
+ "rand_core 0.6.4",
+ "subtle",
+]
+
+[[package]]
 name = "gzip-header"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "95cc527b92e6029a62960ad99aa8a6660faa4555fe5f731aab13aa6a921795a2"
 dependencies = [
  "crc32fast",
-]
-
-[[package]]
-name = "h2"
-version = "0.3.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "0beca50380b1fc32983fc1cb4587bfa4bb9e78fc259aad4a0032d2080309222d"
-dependencies = [
- "bytes",
- "fnv",
- "futures-core",
- "futures-sink",
- "futures-util",
- "http 0.2.12",
- "indexmap 2.12.0",
- "slab",
- "tokio",
- "tokio-util",
- "tracing",
 ]
 
 [[package]]
@@ -2801,7 +2936,7 @@ dependencies = [
  "fnv",
  "futures-core",
  "futures-sink",
- "http 1.3.1",
+ "http",
  "indexmap 2.12.0",
  "slab",
  "tokio",
@@ -2892,7 +3027,7 @@ dependencies = [
  "base64 0.22.1",
  "bytes",
  "headers-core",
- "http 1.3.1",
+ "http",
  "httpdate",
  "mime",
  "sha1",
@@ -2904,7 +3039,7 @@ version = "0.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "54b4a22553d4242c49fddb9ba998a99962b5cc6f22cb5a3482bec22522403ce4"
 dependencies = [
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -2941,6 +3076,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7f24254aa9a54b5c858eaee2f5bccdb46aaf0e486a595ed5fd8f86ba55232a70"
 
 [[package]]
+name = "hkdf"
+version = "0.12.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7b5f8eb2ad728638ea2c7d47a21db23b7b58a72ed6a38256b8a1849f15fbbdf7"
+dependencies = [
+ "hmac",
+]
+
+[[package]]
 name = "hmac"
 version = "0.12.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2960,17 +3104,6 @@ dependencies = [
 
 [[package]]
 name = "http"
-version = "0.2.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "601cbb57e577e2f5ef5be8e7b83f0f63994f25aa94d673e54a92d5c516d101f1"
-dependencies = [
- "bytes",
- "fnv",
- "itoa",
-]
-
-[[package]]
-name = "http"
 version = "1.3.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f4a85d31aea989eead29a3aaf9e1115a180df8282431156e533de47660892565"
@@ -2982,23 +3115,12 @@ dependencies = [
 
 [[package]]
 name = "http-body"
-version = "0.4.6"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7ceab25649e9960c0311ea418d17bee82c0dcec1bd053b5f9a66e265a693bed2"
-dependencies = [
- "bytes",
- "http 0.2.12",
- "pin-project-lite",
-]
-
-[[package]]
-name = "http-body"
 version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1efedce1fb8e6913f23e0c92de8e62cd5b772a67e7b3946df930a62566c93184"
 dependencies = [
  "bytes",
- "http 1.3.1",
+ "http",
 ]
 
 [[package]]
@@ -3009,8 +3131,8 @@ checksum = "b021d93e26becf5dc7e1b75b1bed1fd93124b374ceb73f43d4d4eafec896a64a"
 dependencies = [
  "bytes",
  "futures-core",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "pin-project-lite",
 ]
 
@@ -3034,30 +3156,6 @@ checksum = "135b12329e5e3ce057a9f972339ea52bc954fe1e9358ef27f95e89716fbc5424"
 
 [[package]]
 name = "hyper"
-version = "0.14.32"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "41dfc780fdec9373c01bae43289ea34c972e40ee3c9f6b3c8801a35f35586ce7"
-dependencies = [
- "bytes",
- "futures-channel",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "httparse",
- "httpdate",
- "itoa",
- "pin-project-lite",
- "socket2 0.5.10",
- "tokio",
- "tower-service",
- "tracing",
- "want",
-]
-
-[[package]]
-name = "hyper"
 version = "1.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "eb3aa54a13a0dfe7fbe3a59e0c76093041720fdc77b110cc0fc260fafb4dc51e"
@@ -3066,9 +3164,9 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-core",
- "h2 0.4.12",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "httparse",
  "httpdate",
  "itoa",
@@ -3085,8 +3183,8 @@ version = "0.27.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e3c93eb611681b207e1fe55d5a71ecf91572ec8a6705cdb6857f7d8d5242cf58"
 dependencies = [
- "http 1.3.1",
- "hyper 1.7.0",
+ "http",
+ "hyper",
  "hyper-util",
  "rustls",
  "rustls-pki-types",
@@ -3097,26 +3195,13 @@ dependencies = [
 
 [[package]]
 name = "hyper-tls"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "d6183ddfa99b85da61a140bea0efc93fdf56ceaa041b37d553518030827f9905"
-dependencies = [
- "bytes",
- "hyper 0.14.32",
- "native-tls",
- "tokio",
- "tokio-native-tls",
-]
-
-[[package]]
-name = "hyper-tls"
 version = "0.6.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "70206fc6890eaca9fde8a0bf71caa2ddfc9fe045ac9e5c70df101a7dbde866e0"
 dependencies = [
  "bytes",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper",
  "hyper-util",
  "native-tls",
  "tokio",
@@ -3135,15 +3220,15 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
- "hyper 1.7.0",
+ "http",
+ "http-body",
+ "hyper",
  "ipnet",
  "libc",
  "percent-encoding",
  "pin-project-lite",
  "socket2 0.6.1",
- "system-configuration 0.6.1",
+ "system-configuration",
  "tokio",
  "tower-service",
  "tracing",
@@ -3692,6 +3777,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "jsonwebtoken"
+version = "10.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+dependencies = [
+ "base64 0.22.1",
+ "ed25519-dalek",
+ "getrandom 0.2.16",
+ "hmac",
+ "js-sys",
+ "p256",
+ "p384",
+ "pem",
+ "rand 0.8.5",
+ "rsa",
+ "serde",
+ "serde_json",
+ "sha2",
+ "signature",
+ "simple_asn1",
+ "zeroize",
+]
+
+[[package]]
 name = "junction"
 version = "1.3.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3715,7 +3824,7 @@ name = "keynote-bench-harness"
 version = "0.1.0"
 dependencies = [
  "anyhow",
- "reqwest 0.12.24",
+ "reqwest",
  "serde_json",
  "tempfile",
 ]
@@ -3775,6 +3884,9 @@ name = "lazy_static"
 version = "1.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "bbd2bcb4c963f2ddae06a2efc7e9f3591312473c50c6685e1f298068316e66fe"
+dependencies = [
+ "spin",
+]
 
 [[package]]
 name = "lean_string"
@@ -4124,7 +4236,7 @@ dependencies = [
  "bytes",
  "encoding_rs",
  "futures-util",
- "http 1.3.1",
+ "http",
  "httparse",
  "memchr",
  "mime",
@@ -4395,6 +4507,22 @@ dependencies = [
 ]
 
 [[package]]
+name = "num-bigint-dig"
+version = "0.8.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "e661dda6640fad38e827a6d4a310ff4763082116fe217f279885c97f511bb0b7"
+dependencies = [
+ "lazy_static",
+ "libm",
+ "num-integer",
+ "num-iter",
+ "num-traits",
+ "rand 0.8.5",
+ "smallvec",
+ "zeroize",
+]
+
+[[package]]
 name = "num-complex"
 version = "0.4.6"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4468,6 +4596,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "071dfc062690e90b734c0b2273ce72ad0ffa95f0c74596bc250dcfd960262841"
 dependencies = [
  "autocfg",
+ "libm",
 ]
 
 [[package]]
@@ -5158,6 +5287,30 @@ dependencies = [
 ]
 
 [[package]]
+name = "p256"
+version = "0.13.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c9863ad85fa8f4460f9c48cb909d38a0d689dba1f6f6988a5e3e0d31071bcd4b"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
+name = "p384"
+version = "0.13.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "fe42f1670a52a47d448f14b6a5c61dd78fce51856e68edaa38f7ae3a46b8d6b6"
+dependencies = [
+ "ecdsa",
+ "elliptic-curve",
+ "primeorder",
+ "sha2",
+]
+
+[[package]]
 name = "papaya"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -5274,6 +5427,15 @@ checksum = "1d30c53c26bc5b31a98cd02d20f25a7c8567146caf63ed593a9d87b2775291be"
 dependencies = [
  "base64 0.22.1",
  "serde_core",
+]
+
+[[package]]
+name = "pem-rfc7468"
+version = "0.7.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "88b39c9bfcfc231068454382784bb460aae594343fb030d46e9f50a645418412"
+dependencies = [
+ "base64ct",
 ]
 
 [[package]]
@@ -5454,6 +5616,27 @@ name = "pin-utils"
 version = "0.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
+
+[[package]]
+name = "pkcs1"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "c8ffb9f10fa047879315e6625af03c164b16962a5368d724ed16323b68ace47f"
+dependencies = [
+ "der",
+ "pkcs8",
+ "spki",
+]
+
+[[package]]
+name = "pkcs8"
+version = "0.10.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f950b2377845cebe5cf8b5165cb3cc1a5e0fa5cfa3e1f7f55707d8fd82e0a7b7"
+dependencies = [
+ "der",
+ "spki",
+]
 
 [[package]]
 name = "pkg-config"
@@ -5650,6 +5833,15 @@ checksum = "479ca8adacdd7ce8f1fb39ce9ecccbfe93a3f1344b3d0d97f20bc0196208f62b"
 dependencies = [
  "proc-macro2",
  "syn 2.0.107",
+]
+
+[[package]]
+name = "primeorder"
+version = "0.13.6"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "353e1ca18966c16d9deb1c69278edbc5f194139612772bd9537af60ac231e1e6"
+dependencies = [
+ "elliptic-curve",
 ]
 
 [[package]]
@@ -6275,46 +6467,6 @@ dependencies = [
 
 [[package]]
 name = "reqwest"
-version = "0.11.27"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "dd67538700a17451e7cba03ac727fb961abb7607553461627b97de0b89cf4a62"
-dependencies = [
- "base64 0.21.7",
- "bytes",
- "encoding_rs",
- "futures-core",
- "futures-util",
- "h2 0.3.27",
- "http 0.2.12",
- "http-body 0.4.6",
- "hyper 0.14.32",
- "hyper-tls 0.5.0",
- "ipnet",
- "js-sys",
- "log",
- "mime",
- "native-tls",
- "once_cell",
- "percent-encoding",
- "pin-project-lite",
- "rustls-pemfile",
- "serde",
- "serde_json",
- "serde_urlencoded",
- "sync_wrapper 0.1.2",
- "system-configuration 0.5.1",
- "tokio",
- "tokio-native-tls",
- "tower-service",
- "url",
- "wasm-bindgen",
- "wasm-bindgen-futures",
- "web-sys",
- "winreg",
-]
-
-[[package]]
-name = "reqwest"
 version = "0.12.24"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9d0946410b9f7b082a427e4ef5c8ff541a88b357bc6c637c40db3a68ac70a36f"
@@ -6325,13 +6477,13 @@ dependencies = [
  "futures-channel",
  "futures-core",
  "futures-util",
- "h2 0.4.12",
- "http 1.3.1",
- "http-body 1.0.1",
+ "h2",
+ "http",
+ "http-body",
  "http-body-util",
- "hyper 1.7.0",
+ "hyper",
  "hyper-rustls",
- "hyper-tls 0.6.0",
+ "hyper-tls",
  "hyper-util",
  "js-sys",
  "log",
@@ -6343,7 +6495,7 @@ dependencies = [
  "serde",
  "serde_json",
  "serde_urlencoded",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tokio-native-tls",
  "tokio-util",
@@ -6365,6 +6517,16 @@ checksum = "6a067ab3b5ca3b4dc307d0de9cf75f9f5e6ca9717b192b2f28a36c83e5de9e76"
 dependencies = [
  "potential_utf",
  "serde_core",
+]
+
+[[package]]
+name = "rfc6979"
+version = "0.4.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f8dd2a808d456c4a54e300a23e9f5a67e122c3024119acbfd73e3bf664491cb2"
+dependencies = [
+ "hmac",
+ "subtle",
 ]
 
 [[package]]
@@ -6868,6 +7030,26 @@ dependencies = [
 ]
 
 [[package]]
+name = "rsa"
+version = "0.9.10"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b8573f03f5883dcaebdfcf4725caa1ecb9c15b2ef50c43a07b816e06799bb12d"
+dependencies = [
+ "const-oid",
+ "digest",
+ "num-bigint-dig",
+ "num-integer",
+ "num-traits",
+ "pkcs1",
+ "pkcs8",
+ "rand_core 0.6.4",
+ "signature",
+ "spki",
+ "subtle",
+ "zeroize",
+]
+
+[[package]]
 name = "rusqlite"
 version = "0.29.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6956,15 +7138,6 @@ dependencies = [
  "rustls-webpki",
  "subtle",
  "zeroize",
-]
-
-[[package]]
-name = "rustls-pemfile"
-version = "1.0.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1c74cae0a4cf6ccbbf5f359f08efdf8ee7e1dc532573bf0db71968cb56b1448c"
-dependencies = [
- "base64 0.21.7",
 ]
 
 [[package]]
@@ -7160,6 +7333,20 @@ name = "seahash"
 version = "4.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "1c107b6f4780854c8b126e228ea8869f4d7b71260f962fefb57b996b8959ba6b"
+
+[[package]]
+name = "sec1"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d3e97a565f76233a6003f9f5c54be1d9c5bdfa3eccfb189469f11ec4901c47dc"
+dependencies = [
+ "base16ct",
+ "der",
+ "generic-array",
+ "pkcs8",
+ "subtle",
+ "zeroize",
+]
 
 [[package]]
 name = "second-stack"
@@ -7469,6 +7656,16 @@ dependencies = [
 ]
 
 [[package]]
+name = "signature"
+version = "2.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "77549399552de45a898a580c1b41d445bf730df867cc44e6c0233bbc4b8329de"
+dependencies = [
+ "digest",
+ "rand_core 0.6.4",
+]
+
+[[package]]
 name = "simd-adler32"
 version = "0.3.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7616,7 +7813,7 @@ dependencies = [
  "bytemuck",
  "bytes",
  "getrandom 0.2.16",
- "http 1.3.1",
+ "http",
  "insta",
  "log",
  "rand 0.8.5",
@@ -7634,11 +7831,11 @@ name = "spacetimedb-auth"
 version = "2.9.0"
 dependencies = [
  "anyhow",
+ "jsonwebtoken",
  "serde",
  "serde_json",
  "serde_with",
  "spacetimedb-data-structures",
- "spacetimedb-jsonwebtoken",
  "spacetimedb-lib",
 ]
 
@@ -7723,12 +7920,13 @@ dependencies = [
  "futures",
  "git2",
  "glob",
- "http 1.3.1",
+ "http",
  "ignore",
  "indicatif",
  "is-terminal",
  "itertools 0.12.1",
  "json5",
+ "jsonwebtoken",
  "mimalloc",
  "names",
  "notify",
@@ -7736,7 +7934,7 @@ dependencies = [
  "percent-encoding",
  "pretty_assertions",
  "regex",
- "reqwest 0.12.24",
+ "reqwest",
  "rolldown",
  "rolldown_common",
  "rolldown_error",
@@ -7750,7 +7948,6 @@ dependencies = [
  "spacetimedb-codegen",
  "spacetimedb-data-structures",
  "spacetimedb-fs-utils",
- "spacetimedb-jsonwebtoken",
  "spacetimedb-lib",
  "spacetimedb-paths",
  "spacetimedb-schema",
@@ -7788,12 +7985,13 @@ dependencies = [
  "derive_more 0.99.20",
  "futures",
  "headers",
- "http 1.3.1",
+ "http",
  "http-body-util",
  "humantime",
- "hyper 1.7.0",
+ "hyper",
  "hyper-util",
  "jemalloc_pprof",
+ "jsonwebtoken",
  "log",
  "mime",
  "pretty_assertions",
@@ -7808,7 +8006,6 @@ dependencies = [
  "spacetimedb-core",
  "spacetimedb-data-structures",
  "spacetimedb-datastore",
- "spacetimedb-jsonwebtoken",
  "spacetimedb-lib",
  "spacetimedb-paths",
  "spacetimedb-schema",
@@ -7919,11 +8116,12 @@ dependencies = [
  "flate2",
  "futures",
  "futures-util",
- "http 1.3.1",
+ "http",
  "http-body-util",
  "humantime",
  "indexmap 2.12.0",
  "itertools 0.12.1",
+ "jsonwebtoken",
  "lazy_static",
  "log",
  "memchr",
@@ -7939,7 +8137,7 @@ dependencies = [
  "rayon",
  "rayon-core",
  "regex",
- "reqwest 0.12.24",
+ "reqwest",
  "rustc-demangle",
  "rustc-hash",
  "scopeguard",
@@ -7960,8 +8158,6 @@ dependencies = [
  "spacetimedb-engine",
  "spacetimedb-execution",
  "spacetimedb-expr",
- "spacetimedb-jsonwebtoken",
- "spacetimedb-jwks",
  "spacetimedb-lib",
  "spacetimedb-memory-usage",
  "spacetimedb-metrics",
@@ -8176,7 +8372,7 @@ dependencies = [
 name = "spacetimedb-guard"
 version = "2.9.0"
 dependencies = [
- "reqwest 0.12.24",
+ "reqwest",
  "tempfile",
 ]
 
@@ -8188,35 +8384,6 @@ dependencies = [
  "spacetimedb-sats",
  "spacetimedb-testing",
  "tikv-jemallocator",
-]
-
-[[package]]
-name = "spacetimedb-jsonwebtoken"
-version = "9.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f626b7b56a60c3ec4552bc928a4e26b12ec76af826c0b152a87811fb4a68544f"
-dependencies = [
- "base64 0.22.1",
- "js-sys",
- "pem",
- "ring",
- "serde",
- "serde_json",
- "simple_asn1",
-]
-
-[[package]]
-name = "spacetimedb-jwks"
-version = "0.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b87fbe70b43e34cb9ee9db5e6fdffab259932fa931fcf8283fd9e92d7c117c93"
-dependencies = [
- "base64 0.22.1",
- "reqwest 0.11.27",
- "serde",
- "spacetimedb-jsonwebtoken",
- "thiserror 1.0.69",
- "tokio",
 ]
 
 [[package]]
@@ -8285,7 +8452,7 @@ dependencies = [
  "async-trait",
  "axum",
  "futures",
- "http 1.3.1",
+ "http",
  "log",
  "pgwire",
  "spacetimedb-auth",
@@ -8457,7 +8624,7 @@ dependencies = [
  "gloo-storage",
  "gloo-utils",
  "home",
- "http 1.3.1",
+ "http",
  "js-sys",
  "log",
  "native-tls",
@@ -8489,7 +8656,7 @@ dependencies = [
  "fs_extra",
  "predicates",
  "regex",
- "reqwest 0.12.24",
+ "reqwest",
  "serde_json",
  "socket2 0.5.10",
  "spacetimedb-guard",
@@ -8552,7 +8719,7 @@ dependencies = [
  "async-trait",
  "axum",
  "clap 4.5.50",
- "http 1.3.1",
+ "http",
  "log",
  "netstat2",
  "once_cell",
@@ -8663,7 +8830,7 @@ dependencies = [
  "http-body-util",
  "indicatif",
  "log",
- "reqwest 0.12.24",
+ "reqwest",
  "self-replace",
  "semver",
  "serde",
@@ -8682,6 +8849,16 @@ name = "spin"
 version = "0.9.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6980e8d7511241f8acf4aebddbb1ff938df5eebe98691418c4468d0b72a96a67"
+
+[[package]]
+name = "spki"
+version = "0.7.3"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d91ed6c858b01f942cd56b37a94b3e0a1798290327d1236e4d9cf4eaca44d29d"
+dependencies = [
+ "base64ct",
+ "der",
+]
 
 [[package]]
 name = "sqllogictest"
@@ -8897,12 +9074,6 @@ dependencies = [
 
 [[package]]
 name = "sync_wrapper"
-version = "0.1.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2047c6ded9c721764247e62cd3b03c09ffc529b2ba5b10ec482ae507a4a70160"
-
-[[package]]
-name = "sync_wrapper"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "0bf256ce5efdfa370213c1dabab5935a12e49f2c58d15e9eac2870d3b4f27263"
@@ -8956,34 +9127,13 @@ dependencies = [
 
 [[package]]
 name = "system-configuration"
-version = "0.5.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ba3a3adc5c275d719af8cb4272ea1c4a6d668a777f37e115f6d11ddbc1c8e0e7"
-dependencies = [
- "bitflags 1.3.2",
- "core-foundation 0.9.4",
- "system-configuration-sys 0.5.0",
-]
-
-[[package]]
-name = "system-configuration"
 version = "0.6.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3c879d448e9d986b661742763247d3693ed13609438cf3d006f51f5368a5ba6b"
 dependencies = [
  "bitflags 2.10.0",
  "core-foundation 0.9.4",
- "system-configuration-sys 0.6.0",
-]
-
-[[package]]
-name = "system-configuration-sys"
-version = "0.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a75fb188eb626b924683e3b95e3a48e63551fcfb51949de2f06a9d91dbee93c9"
-dependencies = [
- "core-foundation-sys",
- "libc",
+ "system-configuration-sys",
 ]
 
 [[package]]
@@ -9474,7 +9624,7 @@ dependencies = [
  "bytes",
  "futures-channel",
  "futures-util",
- "http 1.3.1",
+ "http",
  "httparse",
  "js-sys",
  "thiserror 2.0.17",
@@ -9608,7 +9758,7 @@ dependencies = [
  "futures-core",
  "futures-util",
  "pin-project-lite",
- "sync_wrapper 1.0.2",
+ "sync_wrapper",
  "tokio",
  "tower-layer",
  "tower-service",
@@ -9623,8 +9773,8 @@ checksum = "1e9cd434a998747dd2c4276bc96ee2e0c7a2eadf3cae88e52be55a05fa9053f5"
 dependencies = [
  "bitflags 2.10.0",
  "bytes",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "http-body-util",
  "pin-project-lite",
  "tower-layer",
@@ -9640,8 +9790,8 @@ dependencies = [
  "bitflags 2.10.0",
  "bytes",
  "futures-util",
- "http 1.3.1",
- "http-body 1.0.1",
+ "http",
+ "http-body",
  "iri-string",
  "pin-project-lite",
  "tower",
@@ -9852,7 +10002,7 @@ checksum = "4793cb5e56680ecbb1d843515b23b6de9a75eb04b66643e256a396d43be33c13"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http",
  "httparse",
  "log",
  "rand 0.9.2",
@@ -9869,7 +10019,7 @@ checksum = "eadc29d668c91fcc564941132e17b28a7ceb2f3ebf0b9dae3e03fd7a6748eb0d"
 dependencies = [
  "bytes",
  "data-encoding",
- "http 1.3.1",
+ "http",
  "httparse",
  "log",
  "native-tls",
@@ -11186,16 +11336,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "winreg"
-version = "0.50.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "524e57b2c537c0f9b1e69f1965311ec12182b4122e45035b1508cd24d2adadb1"
-dependencies = [
- "cfg-if",
- "windows-sys 0.48.0",
-]
-
-[[package]]
 name = "winsafe"
 version = "0.0.19"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -11284,7 +11424,7 @@ dependencies = [
  "futures",
  "heck 0.5.0",
  "regex",
- "reqwest 0.12.24",
+ "reqwest",
  "serde",
  "serde_json",
  "spacetimedb",

--- a/Cargo.lock
+++ b/Cargo.lock
@@ -3778,9 +3778,9 @@ dependencies = [
 
 [[package]]
 name = "jsonwebtoken"
-version = "10.4.0"
+version = "11.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "eba32bfb4ffdeaca3e34431072faf01745c9b26d25504aa7a6cf5684334fc4fc"
+checksum = "881733cbc631fc9e472e24447ce32a64bedf2da498d6d8570b08edc87de71f65"
 dependencies = [
  "base64 0.22.1",
  "ed25519-dalek",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,7 +251,7 @@ is-terminal = "0.4"
 itertools = "0.12"
 itoa = "1"
 json5 = "0.4"
-jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
+jsonwebtoken = { version = "11.0.0", features = ["rust_crypto"] }
 junction = "1"
 lazy_static = "1.4.0"
 lean_string = "0.5.1"

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -251,9 +251,8 @@ is-terminal = "0.4"
 itertools = "0.12"
 itoa = "1"
 json5 = "0.4"
-jsonwebtoken = { package = "spacetimedb-jsonwebtoken", version = "9.3.0" }
+jsonwebtoken = { version = "10.4.0", features = ["rust_crypto"] }
 junction = "1"
-jwks = { package = "spacetimedb-jwks", version = "0.1.3" }
 lazy_static = "1.4.0"
 lean_string = "0.5.1"
 log = "0.4.17"

--- a/crates/auth/src/identity.rs
+++ b/crates/auth/src/identity.rs
@@ -40,7 +40,10 @@ pub struct SpacetimeIdentityClaims {
     /// The unix timestamp the token was issued at
     #[serde_as(as = "serde_with::TimestampSeconds")]
     pub iat: SystemTime,
+    // Older no-expiration tokens were serialized as `"exp": null`.
+    // Keep accepting those during validation, but omit the claim for new no-expiration tokens.
     #[serde_as(as = "Option<serde_with::TimestampSeconds>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub exp: Option<SystemTime>,
 
     #[serde(flatten)]
@@ -86,7 +89,9 @@ pub struct IncomingClaims {
     /// The unix timestamp the token was issued at
     #[serde_as(as = "serde_with::TimestampSeconds")]
     pub iat: SystemTime,
+    // See `SpacetimeIdentityClaims::exp`: absent and null both mean no expiration.
     #[serde_as(as = "Option<serde_with::TimestampSeconds>")]
+    #[serde(skip_serializing_if = "Option::is_none")]
     pub exp: Option<SystemTime>,
 
     /// All remaining claims from the JWT payload

--- a/crates/client-api/src/auth.rs
+++ b/crates/client-api/src/auth.rs
@@ -367,7 +367,8 @@ mod tests {
             .as_object()
             .ok_or_else(|| anyhow::anyhow!("Failed to parse JWT payload as object"))?;
         let keys: HashSet<String> = as_object.keys().map(|s| s.to_string()).collect();
-        let expected_keys = vec!["iss", "sub", "aud", "iat", "exp", "hex_identity"]
+        // No-expiration tokens used to include `"exp": null`; new tokens omit it.
+        let expected_keys = vec!["iss", "sub", "aud", "iat", "hex_identity"]
             .into_iter()
             .map(|s| s.to_string())
             .collect::<HashSet<String>>();

--- a/crates/core/Cargo.toml
+++ b/crates/core/Cargo.toml
@@ -101,7 +101,6 @@ url.workspace = true
 v8.workspace = true
 wasmtime.workspace = true
 wasmtime-internal-fiber.workspace = true
-jwks.workspace = true
 async_cache = "0.3.1"
 faststr = "0.2.23"
 core_affinity = "0.8"

--- a/crates/core/src/auth/token_validation.rs
+++ b/crates/core/src/auth/token_validation.rs
@@ -6,13 +6,13 @@ use faststr::FastStr;
 use jsonwebtoken::decode_header;
 pub use jsonwebtoken::errors::Error as JwtError;
 pub use jsonwebtoken::errors::ErrorKind as JwtErrorKind;
-use jsonwebtoken::{decode, Validation};
+use jsonwebtoken::jwk::JwkSet;
+use jsonwebtoken::{decode, AlgorithmFamily, Validation};
 pub use jsonwebtoken::{DecodingKey, EncodingKey};
-use jwks::Jwks;
 use lazy_static::lazy_static;
-use serde::Serialize;
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
-use std::time::Duration;
+use std::time::{Duration, SystemTime};
 use thiserror;
 
 use super::identity::{IncomingClaims, SpacetimeIdentityClaims};
@@ -29,10 +29,9 @@ pub enum TokenValidationError {
     #[error("Specified key ID not found in JWKs")]
     KeyIDNotFound,
 
-    #[error(transparent)]
-    JwkError(#[from] jwks::JwkError),
-    #[error(transparent)]
-    JwksError(#[from] jwks::JwksError),
+    #[error("OIDC/JWKS request failed: {0}")]
+    OidcRequestError(#[from] reqwest::Error),
+
     // The other case is a catch-all for unexpected errors.
     #[error(transparent)]
     Other(#[from] anyhow::Error),
@@ -146,20 +145,44 @@ lazy_static! {
 impl TokenValidator for DecodingKey {
     async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims, TokenValidationError> {
         let mut validation = Validation::new(jsonwebtoken::Algorithm::ES256);
-        validation.algorithms = vec![
-            jsonwebtoken::Algorithm::ES256,
-            jsonwebtoken::Algorithm::RS256,
-            jsonwebtoken::Algorithm::HS256,
-        ];
+        validation.algorithms = match self.family() {
+            AlgorithmFamily::Ec => vec![jsonwebtoken::Algorithm::ES256],
+            AlgorithmFamily::Rsa => vec![jsonwebtoken::Algorithm::RS256],
+            AlgorithmFamily::Hmac => vec![jsonwebtoken::Algorithm::HS256],
+            AlgorithmFamily::Ed => {
+                // Preserve the pre-upgrade policy: SpacetimeDB only accepted ES256, RS256, and HS256 here.
+                return Err(TokenValidationError::TokenError(JwtErrorKind::InvalidAlgorithm.into()));
+            }
+        };
         validation.set_required_spec_claims(&REQUIRED_CLAIMS);
 
         // TODO: We should require a specific audience at some point.
         validation.validate_aud = false;
 
+        // Note, `jsonwebtoken` rejects `"exp": null` before deserializing claims.
+        // However, older SpacetimeDB tokens used `"exp": null` to encoded no expiration.
+        // Those tokens may still be cached by clients, so we verify the signature with the crate
+        // but preserve our historical `None` means no expiry semantics below.
+        validation.validate_exp = false;
+
         let data = decode::<IncomingClaims>(token, self, &validation)?;
         let claims = data.claims;
+        validate_expiration(&claims)?;
         claims.try_into().map_err(TokenValidationError::Other)
     }
+}
+
+fn validate_expiration(claims: &IncomingClaims) -> Result<(), JwtError> {
+    if let Some(exp) = claims.exp {
+        // Match jsonwebtoken's default 60s leeway while allowing `None`/`null` to mean no expiration.
+        if SystemTime::now()
+            .duration_since(exp)
+            .is_ok_and(|elapsed| elapsed > Duration::from_secs(60))
+        {
+            return Err(JwtErrorKind::ExpiredSignature.into());
+        }
+    }
+    Ok(())
 }
 
 #[async_trait]
@@ -209,7 +232,7 @@ impl async_cache::Fetcher<Arc<JwksValidator>> for KeyFetcher {
         let raw_issuer = key.deref();
         log::info!("Fetching key for issuer {}", raw_issuer);
         let oidc_url = format!("{}/.well-known/openid-configuration", raw_issuer.trim_end_matches('/'));
-        let key_or_error = Jwks::from_oidc_url(oidc_url).await;
+        let key_or_error = JsonWebKeySet::from_oidc_url(&oidc_url).await;
         // TODO: We should probably add debouncing to avoid spamming the logs.
         // Alternatively we could add a backoff before retrying.
         if let Err(e) = &key_or_error {
@@ -246,12 +269,10 @@ pub struct OidcTokenValidator;
 
 // Get the issuer out of a token without validating the signature.
 fn get_raw_issuer(token: &str) -> Result<Box<str>, TokenValidationError> {
-    let mut validation = Validation::new(jsonwebtoken::Algorithm::ES256);
-    validation.set_required_spec_claims(&REQUIRED_CLAIMS);
-    validation.validate_aud = false;
-    // We are disabling signature validation, because we need to get the issuer before we can validate.
-    validation.insecure_disable_signature_validation();
-    let data = decode::<IncomingClaims>(token, &DecodingKey::from_secret(b"fake"), &validation)?;
+    // We need the issuer before we know which key to use.
+    // This intentionally does not validate the token.
+    // Callers must only use it for key discovery and must verify the token afterwards.
+    let data = jsonwebtoken::dangerous::insecure_decode::<IncomingClaims>(token)?;
     Ok(data.claims.issuer)
 }
 
@@ -262,7 +283,7 @@ impl TokenValidator for OidcTokenValidator {
         let raw_issuer = get_raw_issuer(token)?;
         let oidc_url = format!("{}/.well-known/openid-configuration", raw_issuer.trim_end_matches('/'));
         log::debug!("Fetching key for issuer {}", raw_issuer.clone());
-        let key_or_error = Jwks::from_oidc_url(oidc_url).await;
+        let key_or_error = JsonWebKeySet::from_oidc_url(&oidc_url).await;
         // TODO: We should probably add debouncing to avoid spamming the logs.
         // Alternatively we could add a backoff before retrying.
         if let Err(e) = &key_or_error {
@@ -280,40 +301,45 @@ impl TokenValidator for OidcTokenValidator {
 
 struct JwksValidator {
     pub issuer: Box<str>,
-    pub keyset: Jwks,
+    pub keyset: JsonWebKeySet,
 }
 
 #[async_trait]
 impl TokenValidator for JwksValidator {
     async fn validate_token(&self, token: &str) -> Result<SpacetimeIdentityClaims, TokenValidationError> {
         let header = decode_header(token)?;
-        if let Some(kid) = header.kid {
-            let key = self
-                .keyset
-                .keys
-                .get(&kid)
-                .ok_or_else(|| TokenValidationError::KeyIDNotFound)?;
-            let validator = BasicTokenValidator {
-                public_key: key.decoding_key.clone(),
-                issuer: Some(self.issuer.clone()),
-            };
-            return validator.validate_token(token).await;
+        if let Some(kid) = header.kid.as_deref() {
+            if let Some(key) = self.keyset.key_with_id(kid) {
+                return self.validate_with_key(token, key).await;
+            }
+
+            log::debug!("Key id {kid} not found in JWKS. Trying keys without key ids.");
+            let mut last_error = TokenValidationError::KeyIDNotFound;
+            for key in self.keyset.keys_without_ids() {
+                match self.validate_with_key(token, key).await {
+                    Ok(claims) => return Ok(claims),
+                    Err(e) => {
+                        last_error = e;
+                        log::debug!("Validating with key without kid failed");
+                    }
+                }
+            }
+            return Err(last_error);
         }
         log::debug!("No key id in header. Trying all keys.");
         // TODO: Consider returning an error if no kid is given?
         // For now, lets just try all the keys.
         let mut last_error = TokenValidationError::Other(anyhow::anyhow!("No kid found"));
-        for (kid, key) in &self.keyset.keys {
-            log::debug!("Trying key {kid}");
-            let validator = BasicTokenValidator {
-                public_key: key.decoding_key.clone(),
-                issuer: Some(self.issuer.clone()),
-            };
-            match validator.validate_token(token).await {
+        for key in &self.keyset.keys {
+            match &key.kid {
+                Some(kid) => log::debug!("Trying key {kid}"),
+                None => log::debug!("Trying key without kid"),
+            }
+            match self.validate_with_key(token, key).await {
                 Ok(claims) => return Ok(claims),
                 Err(e) => {
                     last_error = e;
-                    log::debug!("Validating with key {kid} failed");
+                    log::debug!("Validating with JWKS key failed");
                     continue;
                 }
             }
@@ -323,14 +349,92 @@ impl TokenValidator for JwksValidator {
     }
 }
 
+impl JwksValidator {
+    async fn validate_with_key(
+        &self,
+        token: &str,
+        key: &JsonWebKey,
+    ) -> Result<SpacetimeIdentityClaims, TokenValidationError> {
+        let validator = BasicTokenValidator {
+            public_key: key.decoding_key.clone(),
+            issuer: Some(self.issuer.clone()),
+        };
+        validator.validate_token(token).await
+    }
+}
+
+#[derive(Deserialize)]
+struct OidcConfig {
+    jwks_uri: String,
+}
+
+struct JsonWebKeySet {
+    keys: Vec<JsonWebKey>,
+}
+
+struct JsonWebKey {
+    kid: Option<Box<str>>,
+    decoding_key: DecodingKey,
+}
+
+impl JsonWebKeySet {
+    async fn from_oidc_url(oidc_url: &str) -> Result<Self, TokenValidationError> {
+        // We used to depend on the `jwks` crate for this small amount of glue code.
+        // Keep the fetch path local so the jsonwebtoken 10 upgrade does not force in
+        // jwks' reqwest 0.13/rustls dependency tree alongside the workspace reqwest.
+        validate_url_scheme(oidc_url)?;
+        let client = reqwest::Client::default();
+        let oidc_config = client.get(oidc_url).send().await?.json::<OidcConfig>().await?;
+        let jwks = client.get(oidc_config.jwks_uri).send().await?.json::<JwkSet>().await?;
+        jwks.try_into()
+    }
+}
+
+impl TryFrom<JwkSet> for JsonWebKeySet {
+    type Error = TokenValidationError;
+
+    fn try_from(jwks: JwkSet) -> Result<Self, Self::Error> {
+        let mut keys = Vec::with_capacity(jwks.keys.len());
+        for jwk in jwks.keys {
+            // `kid` is optional in both JWT headers and JWKs.
+            // Use it as a fast path when present,
+            // but keep JWKs without `kid` so standards-compliant providers work.
+            let kid = jwk.common.key_id.clone().map(Into::into);
+            let decoding_key = DecodingKey::from_jwk(&jwk)?;
+            keys.push(JsonWebKey { kid, decoding_key });
+        }
+        Ok(Self { keys })
+    }
+}
+
+impl JsonWebKeySet {
+    fn key_with_id(&self, kid: &str) -> Option<&JsonWebKey> {
+        self.keys.iter().find(|key| key.kid.as_deref() == Some(kid))
+    }
+
+    fn keys_without_ids(&self) -> impl Iterator<Item = &JsonWebKey> {
+        self.keys.iter().filter(|key| key.kid.is_none())
+    }
+}
+
+fn validate_url_scheme(url: &str) -> Result<(), TokenValidationError> {
+    if url.starts_with("http://") || url.starts_with("https://") {
+        Ok(())
+    } else {
+        Err(TokenValidationError::Other(anyhow::anyhow!(
+            "Invalid OIDC URL scheme: {url}"
+        )))
+    }
+}
+
 #[cfg(test)]
 mod tests {
     use std::time::Duration;
 
     use crate::auth::identity::{IncomingClaims, SpacetimeIdentityClaims};
     use crate::auth::token_validation::{
-        BasicTokenValidator, CachingOidcTokenValidator, FullTokenValidator, OidcTokenValidator, TokenSigner,
-        TokenValidator,
+        BasicTokenValidator, CachingOidcTokenValidator, FullTokenValidator, JwtErrorKind, OidcTokenValidator,
+        TokenSigner, TokenValidationError, TokenValidator,
     };
     use crate::auth::JwtKeys;
     use base64::Engine;
@@ -426,6 +530,53 @@ mod tests {
         Ok(())
     }
 
+    #[tokio::test]
+    async fn accept_legacy_null_exp_tokens() -> anyhow::Result<()> {
+        let kp = JwtKeys::generate()?;
+        let issuer = "test1";
+        let subject = "test_subject";
+        let orig_claims = LegacyIdentityClaims {
+            identity: Identity::from_claims(issuer, subject),
+            subject: subject.into(),
+            issuer: issuer.into(),
+            audience: [].into(),
+            iat: std::time::SystemTime::now(),
+            exp: None,
+        };
+        let token = kp.private.sign(&orig_claims)?;
+
+        let parsed_claims = kp.public.validate_token(&token).await?;
+        assert_eq!(&*parsed_claims.issuer, issuer);
+        assert_eq!(&*parsed_claims.subject, subject);
+        assert_eq!(parsed_claims.identity, Identity::from_claims(issuer, subject));
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn reject_explicit_expired_tokens() -> anyhow::Result<()> {
+        let kp = JwtKeys::generate()?;
+        let issuer = "test1";
+        let subject = "test_subject";
+        let orig_claims = LegacyIdentityClaims {
+            identity: Identity::from_claims(issuer, subject),
+            subject: subject.into(),
+            issuer: issuer.into(),
+            audience: [].into(),
+            iat: std::time::SystemTime::now(),
+            exp: Some(std::time::SystemTime::now() - Duration::from_secs(120)),
+        };
+        let token = kp.private.sign(&orig_claims)?;
+
+        let err = kp.public.validate_token(&token).await.unwrap_err();
+        match err {
+            TokenValidationError::TokenError(err) => {
+                assert_eq!(err.kind(), &JwtErrorKind::ExpiredSignature);
+            }
+            err => anyhow::bail!("expected expired signature, got {err:?}"),
+        }
+        Ok(())
+    }
+
     async fn assert_validation_fails<T: TokenValidator>(validator: &T, token: &str) -> anyhow::Result<()> {
         let result = validator.validate_token(token).await;
         if let Ok(claims) = result {
@@ -490,6 +641,25 @@ mod tests {
     #[derive(Deserialize, Serialize, Clone)]
     struct OIDCConfig {
         jwks_uri: String,
+    }
+
+    #[serde_with::serde_as]
+    #[derive(Serialize)]
+    struct LegacyIdentityClaims {
+        #[serde(rename = "hex_identity")]
+        identity: Identity,
+        #[serde(rename = "sub")]
+        subject: Box<str>,
+        #[serde(rename = "iss")]
+        issuer: Box<str>,
+        #[serde(rename = "aud")]
+        audience: Box<[Box<str>]>,
+        #[serde_as(as = "serde_with::TimestampSeconds")]
+        iat: std::time::SystemTime,
+        // This intentionally lacks `skip_serializing_if`.
+        // It models no-expiration tokens minted by the previous JWT fork as `"exp": null`.
+        #[serde_as(as = "Option<serde_with::TimestampSeconds>")]
+        exp: Option<std::time::SystemTime>,
     }
 
     async fn oidc_config_handler(config: OIDCConfig) -> Json<OIDCConfig> {
@@ -576,9 +746,19 @@ mod tests {
         }
     }
 
-    #[derive(Debug, Default, Copy, Clone)]
+    #[derive(Debug, Copy, Clone)]
     struct TestOptions {
         pub issuer_trailing_slash: bool,
+        pub jwks_key_ids: bool,
+    }
+
+    impl Default for TestOptions {
+        fn default() -> Self {
+            Self {
+                issuer_trailing_slash: false,
+                jwks_key_ids: true,
+            }
+        }
     }
 
     async fn run_oidc_test<T: TokenValidator>(validator: T, opts: &TestOptions) -> anyhow::Result<()> {
@@ -586,10 +766,10 @@ mod tests {
         let mut kp1 = JwtKeys::generate()?;
         let mut kp2 = JwtKeys::generate()?;
 
-        // Note: our fetcher library requires these, even though they are optional in the spec.
-        // We should replace the jwks fetcher at some point, but most OIDC providers will have these.
-        kp1.kid = Some("key1".to_string());
-        kp2.kid = Some("key2".to_string());
+        if opts.jwks_key_ids {
+            kp1.kid = Some("key1".to_string());
+            kp2.kid = Some("key2".to_string());
+        }
 
         // We won't put this in the keyset.
         let invalid_kp = JwtKeys::generate()?;
@@ -646,6 +826,19 @@ mod tests {
     async fn test_issuer_slash() -> anyhow::Result<()> {
         let opts = TestOptions {
             issuer_trailing_slash: true,
+            ..Default::default()
+        };
+
+        run_oidc_test(OidcTokenValidator, &opts).await?;
+        run_oidc_test(CachingOidcTokenValidator::get_default(), &opts).await?;
+        Ok(())
+    }
+
+    #[tokio::test]
+    async fn test_oidc_flow_without_jwks_key_ids() -> anyhow::Result<()> {
+        let opts = TestOptions {
+            jwks_key_ids: false,
+            ..Default::default()
         };
 
         run_oidc_test(OidcTokenValidator, &opts).await?;

--- a/crates/core/src/auth/token_validation.rs
+++ b/crates/core/src/auth/token_validation.rs
@@ -847,6 +847,47 @@ mod tests {
     }
 
     #[tokio::test]
+    async fn test_oidc_flow_with_mixed_type_custom_jwt_headers() -> anyhow::Result<()> {
+        let mut kp = JwtKeys::generate()?;
+        kp.kid = Some("key1".to_string());
+
+        let handle = OIDCServerHandle::start_new(keyset_to_json([kp.clone()])?).await?;
+        let issuer = handle.base_url;
+        let subject = "test_subject";
+        let orig_claims = IncomingClaims {
+            identity: None,
+            subject: subject.into(),
+            issuer: issuer.clone().into(),
+            audience: [].into(),
+            iat: std::time::SystemTime::now(),
+            exp: None,
+            extra: None,
+        };
+
+        let mut extras = jsonwebtoken::Extras::default();
+        extras.insert(
+            "oiat",
+            std::time::SystemTime::now()
+                .duration_since(std::time::UNIX_EPOCH)?
+                .as_secs(),
+        );
+        extras.insert("clerk_bool", true);
+        extras.insert("clerk_object", serde_json::json!({ "nested": "value" }));
+        let header = jsonwebtoken::Header {
+            kid: kp.kid.clone(),
+            extras,
+            ..jsonwebtoken::Header::new(jsonwebtoken::Algorithm::ES256)
+        };
+        let token = jsonwebtoken::encode(&header, &orig_claims, &kp.private)?;
+
+        let validated_claims = OidcTokenValidator.validate_token(&token).await?;
+        assert_eq!(&*validated_claims.issuer, &*issuer);
+        assert_eq!(&*validated_claims.subject, subject);
+        assert_eq!(validated_claims.identity, Identity::from_claims(&issuer, subject));
+        Ok(())
+    }
+
+    #[tokio::test]
     async fn test_caching_oidc_flow() -> anyhow::Result<()> {
         for _ in 0..10 {
             let v = CachingOidcTokenValidator::get_default();


### PR DESCRIPTION
# Description of Changes

This updates jsonwebtoken to v11 (reverting the revert in https://github.com/clockworklabs/SpacetimeDB/pull/5578), and adds a unit test for the issue with custom header fields that made us revert it last time.

This also has a corresponding private pr: https://github.com/clockworklabs/SpacetimeDBPrivate/pull/3920

# Rollback safety impact

n/a

# Expected complexity level and risk

2, since we were surprised by breakage last time we trying to update.

# Testing

This has some unit tests to catch the previous issue.
