### PR TITLE
Release - npm release runs on github-provided runner

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -286,7 +286,8 @@ jobs:
 
   release-npm:
     needs: build-cargo-release
-    runs-on: spacetimedb-linux
+    # This **MUST** be on a GitHub-provided runner! Otherwise the "trusted publishers" workflow does not work!
+    runs-on: ubuntu-latest
     if: ${{ inputs.release_npm }}
     env:
       CARGO_TERM_COLOR: always


### PR DESCRIPTION
# Description of Changes

I completely forgot that this needs to run on a github-provided runner for the "trusted publishers" flow to work. Moving this one back to ubuntu-latest.

# API and ABI breaking changes

None

# Rollback safety impact

n/a

# Expected complexity level and risk

1

# Testing

None. We'll have to test with a release.