### PR TITLE
Install pnpm with ./.github/actions/setup-pnpm

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -328,7 +328,7 @@ jobs:
           npm --version
 
       - name: Install pnpm
-        run: npm install -g pnpm
+        uses: ./.github/actions/setup-pnpm
 
       - name: Run NPM release (dry-run)
         if: ${{ inputs.dry_run }}
@@ -473,5 +473,6 @@ jobs:
             --arg tag "$RELEASE_TAG" \
             --arg url "$url" \
             --arg body "$body" \
-            '{release_tag: $tag, release_url: $url, release_body: $body, dry_run: "false"}' \
+            --arg dry_run "false" \
+            '{release_tag: $tag, release_url: $url, release_body: $body, dry_run: $dry_run}' \
           | gh workflow run tag-release.yml --repo clockworklabs/SpacetimeDB --ref master --json


### PR DESCRIPTION
# Description of Changes

Use the repository’s pinned pnpm setup action in the npm release job instead of globally installing the latest pnpm version.

# API and ABI breaking changes

None

# Rollback safety impact

n/a

# Expected complexity level and risk

1 - trival

# Testing

Will be tested through the Cargo Release Dry Run CI job. If the job passes, then this worked.
